### PR TITLE
Dashboard: Add time-based greeting, summary cards and quick action buttons to hero

### DIFF
--- a/src/modules/fizruk/pages/Dashboard.jsx
+++ b/src/modules/fizruk/pages/Dashboard.jsx
@@ -167,6 +167,13 @@ export function Dashboard({ onOpenAtlas }) {
     return Math.round(sum / done.length);
   }, [workouts]);
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Доброго ранку";
+    if (hour < 18) return "Доброго дня";
+    return "Доброго вечора";
+  }, []);
+
   const picksFromTemplate = (tpl) =>
     (tpl?.exerciseIds || []).map(id => exercises.find(e => e.id === id)).filter(Boolean);
 
@@ -250,14 +257,52 @@ export function Dashboard({ onOpenAtlas }) {
           aria-label="Привітання"
         >
           <p className="text-[11px] font-bold tracking-widest uppercase text-accent">
-            СЬОГОДНІ {new Date().toLocaleDateString("uk-UA", { day: "numeric", month: "long" }).toUpperCase()}
+            {greeting} · {today}
           </p>
-          <h1 className="text-[28px] font-black text-white mt-3 leading-tight">
-            Твій прогрес<br />зібраний в одному<br />спокійному місці
-          </h1>
-          <p className="text-sm text-white/55 mt-3 leading-relaxed">
-            Логуй підходи, запускай шаблони і дивись, як росте обсяг.
-          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Тиждень</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{dashMetrics.week}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">План</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{plan.picked.length}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Сер. час</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{avgDurationSec ? formatDurShort(avgDurationSec) : "—"}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#workouts"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Тренування
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#progress"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Прогрес
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#measurements"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Заміри
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenAtlas?.()}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Атлас
+            </button>
+          </div>
           <div className="mt-6 flex flex-col gap-3">
             <button
               type="button"


### PR DESCRIPTION
### Motivation

- Improve the Dashboard hero to give a friendlier, time-aware greeting and surface key metrics and actions to speed up navigation.
- Provide quick visibility into weekly volume, selected plan size and average session duration so users can act from the landing area.
- Make common destinations (workouts, progress, measurements, atlas) reachable with one tap.

### Description

- Added a time-based greeting computed in `greeting` (`useMemo`) that returns "Доброго ранку", "Доброго дня" or "Доброго вечора` depending on the current hour and replaced the old static header with `{greeting} · {today}`.
- Introduced a 3-card compact metrics row that displays weekly volume (`dashMetrics.week`), plan count (`plan.picked.length`) and average duration (`avgDurationSec` formatted with `formatDurShort`).
- Added a grid of quick action buttons for `#workouts`, `#progress`, `#measurements` and an `Атлас` button that calls `onOpenAtlas`, while keeping the main call-to-action buttons for starting/opening workouts.
- Adjusted hero layout and styles to accommodate the new cards and buttons while preserving existing CTA behavior.

### Testing

- Ran the project's test suite with `yarn test` and the build/type checks with `yarn build`, and both completed successfully.
- Verified that the new UI renders without runtime errors in the development build and that navigation buttons update `window.location.hash` or call `onOpenAtlas` as intended.
- No changes to existing automated tests were required for this UI-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18ddef483308cf7cd1da7ad7a1e)