### PR TITLE
Dashboard: Add dynamic greeting, compact cards, and safer modal sheet spacing

### DIFF
--- a/src/modules/fizruk/pages/Dashboard.jsx
+++ b/src/modules/fizruk/pages/Dashboard.jsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/workoutStats";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
+const SHEET_BOTTOM_PADDING = "calc(env(safe-area-inset-bottom, 16px) + 72px)";
 
 function formatDurShort(sec) {
   const m = Math.floor(sec / 60);
@@ -167,6 +168,13 @@ export function Dashboard({ onOpenAtlas }) {
     return Math.round(sum / done.length);
   }, [workouts]);
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Доброго ранку";
+    if (hour < 18) return "Доброго дня";
+    return "Доброго вечора";
+  }, []);
+
   const picksFromTemplate = (tpl) =>
     (tpl?.exerciseIds || []).map(id => exercises.find(e => e.id === id)).filter(Boolean);
 
@@ -250,14 +258,52 @@ export function Dashboard({ onOpenAtlas }) {
           aria-label="Привітання"
         >
           <p className="text-[11px] font-bold tracking-widest uppercase text-accent">
-            СЬОГОДНІ {new Date().toLocaleDateString("uk-UA", { day: "numeric", month: "long" }).toUpperCase()}
+            {greeting} · {today}
           </p>
-          <h1 className="text-[28px] font-black text-white mt-3 leading-tight">
-            Твій прогрес<br />зібраний в одному<br />спокійному місці
-          </h1>
-          <p className="text-sm text-white/55 mt-3 leading-relaxed">
-            Логуй підходи, запускай шаблони і дивись, як росте обсяг.
-          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Тиждень</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{dashMetrics.week}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">План</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{plan.picked.length}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Сер. час</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{avgDurationSec ? formatDurShort(avgDurationSec) : "—"}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#workouts"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Тренування
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#progress"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Прогрес
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#measurements"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Заміри
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenAtlas?.()}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Атлас
+            </button>
+          </div>
           <div className="mt-6 flex flex-col gap-3">
             <button
               type="button"
@@ -680,7 +726,7 @@ export function Dashboard({ onOpenAtlas }) {
       </div>
 
       {planConfirmOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -689,7 +735,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div id="plan-confirm-title" className="text-lg font-extrabold text-text">Увага</div>
             <p className="text-sm text-subtle mt-2 leading-relaxed">
@@ -717,7 +763,7 @@ export function Dashboard({ onOpenAtlas }) {
 
       {/* Pushup modal */}
       {pushupModalOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -726,7 +772,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div className="w-10 h-1 bg-line rounded-full mx-auto mb-4" aria-hidden />
             <div id="pushup-modal-title" className="text-lg font-extrabold text-text mb-4">Додати відтискання</div>


### PR DESCRIPTION
### Motivation
- Refresh the dashboard header to show a time-aware greeting and surface key metrics and navigation actions in a compact, actionable layout.
- Improve bottom-sheet layout on devices with safe-area insets and ensure modals are above other content by increasing z-index.

### Description
- Added `SHEET_BOTTOM_PADDING` constant set to `calc(env(safe-area-inset-bottom, 16px) + 72px)` and applied it to bottom sheet `paddingBottom` for plan confirm and pushup modals to account for safe-area and sheet controls. 
- Increased modal container `z-` index from `70` to `100` for both plan confirm and pushup modals. 
- Introduced a time-aware greeting computed with `useMemo` and replaced the large static header copy with a compact header that shows the greeting plus `today`. 
- Replaced the hero text with small metric cards (week, picked plan count, average duration) and quick navigation buttons for `#workouts`, `#progress`, `#measurements`, and the atlas opener.

### Testing
- Ran the existing unit/integration test suite with `yarn test` and all tests passed. 
- Performed a local build with `yarn build` to verify no runtime or type errors and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18ddef483308cf7cd1da7ad7a1e)