### PR TITLE
Add quick stats cards, greeting, and safe-area sheet padding; raise modal z-index

### DIFF
--- a/src/modules/fizruk/pages/Dashboard.jsx
+++ b/src/modules/fizruk/pages/Dashboard.jsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/workoutStats";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
+const SHEET_BOTTOM_PADDING = "calc(env(safe-area-inset-bottom, 16px) + 72px)";
 
 function formatDurShort(sec) {
   const m = Math.floor(sec / 60);
@@ -167,6 +168,13 @@ export function Dashboard({ onOpenAtlas }) {
     return Math.round(sum / done.length);
   }, [workouts]);
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Доброго ранку";
+    if (hour < 18) return "Доброго дня";
+    return "Доброго вечора";
+  }, []);
+
   const picksFromTemplate = (tpl) =>
     (tpl?.exerciseIds || []).map(id => exercises.find(e => e.id === id)).filter(Boolean);
 
@@ -250,14 +258,52 @@ export function Dashboard({ onOpenAtlas }) {
           aria-label="Привітання"
         >
           <p className="text-[11px] font-bold tracking-widest uppercase text-accent">
-            СЬОГОДНІ {new Date().toLocaleDateString("uk-UA", { day: "numeric", month: "long" }).toUpperCase()}
+            {greeting} · {today}
           </p>
-          <h1 className="text-[28px] font-black text-white mt-3 leading-tight">
-            Твій прогрес<br />зібраний в одному<br />спокійному місці
-          </h1>
-          <p className="text-sm text-white/55 mt-3 leading-relaxed">
-            Логуй підходи, запускай шаблони і дивись, як росте обсяг.
-          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Тиждень</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{dashMetrics.week}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">План</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{plan.picked.length}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Сер. час</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{avgDurationSec ? formatDurShort(avgDurationSec) : "—"}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#workouts"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Тренування
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#progress"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Прогрес
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#measurements"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Заміри
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenAtlas?.()}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Атлас
+            </button>
+          </div>
           <div className="mt-6 flex flex-col gap-3">
             <button
               type="button"
@@ -680,7 +726,7 @@ export function Dashboard({ onOpenAtlas }) {
       </div>
 
       {planConfirmOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -689,7 +735,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div id="plan-confirm-title" className="text-lg font-extrabold text-text">Увага</div>
             <p className="text-sm text-subtle mt-2 leading-relaxed">
@@ -717,7 +763,7 @@ export function Dashboard({ onOpenAtlas }) {
 
       {/* Pushup modal */}
       {pushupModalOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -726,7 +772,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div className="w-10 h-1 bg-line rounded-full mx-auto mb-4" aria-hidden />
             <div id="pushup-modal-title" className="text-lg font-extrabold text-text mb-4">Додати відтискання</div>

--- a/src/modules/fizruk/pages/Measurements.jsx
+++ b/src/modules/fizruk/pages/Measurements.jsx
@@ -25,10 +25,38 @@ export function Measurements() {
     return out;
   }, [entries, latest]);
 
+  const stats = useMemo(() => {
+    const latestAt = latest?.at ? new Date(latest.at).toLocaleDateString("uk-UA", { day: "numeric", month: "short" }) : "—";
+    const filledLatest = latest
+      ? MEASURE_FIELDS.filter(f => latest[f.id] != null && latest[f.id] !== "").length
+      : 0;
+    return { latestAt, filledLatest };
+  }, [latest]);
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Заміри</div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <a
+            href="https://www.wikihow.com/Take-Body-Measurements"
+            target="_blank"
+            rel="noreferrer"
+            className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center flex flex-col items-center justify-center min-h-[76px]"
+          >
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Підказка</div>
+            <div className="text-sm font-bold text-success mt-1">Як робити заміри</div>
+          </a>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center min-h-[76px]">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останній</div>
+            <div className="text-sm font-bold text-text mt-1">{stats.latestAt}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center min-h-[76px]">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Полів</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{stats.filledLatest}</div>
+          </div>
+        </div>
 
         <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">Додати замір</div>
@@ -126,4 +154,3 @@ export function Measurements() {
     </div>
   );
 }
-

--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -149,6 +149,22 @@ export function Progress() {
 
   const hasAny = (workouts?.length || 0) > 0 || (entries?.length || 0) > 0;
 
+  const quickStats = useMemo(() => {
+    const done = (workouts || []).filter(w => w.endedAt);
+    const latestTs = done.reduce((mx, w) => {
+      const ts = w.startedAt ? Date.parse(w.startedAt) : NaN;
+      return Number.isFinite(ts) ? Math.max(mx, ts) : mx;
+    }, 0);
+    const latestWorkoutAt = latestTs
+      ? new Date(latestTs).toLocaleDateString("uk-UA", { day: "numeric", month: "short" })
+      : "—";
+    return {
+      doneCount: done.length,
+      prsCount: prs.length,
+      latestWorkoutAt,
+    };
+  }, [workouts, prs.length]);
+
   const exportCsv = () => {
     const rows = [["startedAt", "endedAt", "workout_id", "exercise", "type", "detail", "energy_1_5", "mood_1_5"]];
     for (const w of workouts || []) {
@@ -184,6 +200,21 @@ export function Progress() {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Прогрес</div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Тренувань</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.doneCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">PR вправ</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.prsCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останнє</div>
+            <div className="text-sm font-bold text-text mt-1">{quickStats.latestWorkoutAt}</div>
+          </div>
+        </div>
 
         {!hasAny && (
           <div className="bg-panel border border-line/60 rounded-2xl p-8 shadow-card text-center">


### PR DESCRIPTION
### Motivation
- Improve the top-level dashboard and progress pages with quick, glanceable stats and a contextual greeting to surface key user metrics faster.
- Make bottom sheets respect device safe-area insets consistently and ensure sheets appear above overlays by increasing modal z-index.
- Provide small UX helpers in Measurements to show last measurement date and how many fields were filled.

### Description
- Added a time-of-day `greeting` and replaced the large static greeting block with concise summary cards and quick action buttons in `Dashboard.jsx`.
- Introduced `SHEET_BOTTOM_PADDING` constant and applied it to sheet containers, and raised sheet modal `z-index` from `70` to `100` in `Dashboard.jsx` for both the plan confirmation and pushup modal sheets.
- Added compact summary cards to `Measurements.jsx` showing a link to measurement tips, the latest measurement date, and count of filled fields via a new `stats` `useMemo`.
- Added `quickStats` `useMemo` and summary tiles to `Progress.jsx` to display number of done workouts, PRs, and last workout date.

### Testing
- Ran the existing test suite with `npm test` and it completed successfully; no new automated tests were added for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18ddef483308cf7cd1da7ad7a1e)