### PR TITLE
Fizruk: dashboard hero redesign, quick-stats, measurements help, and modal/layout fixes

### DIFF
--- a/src/modules/fizruk/FizrukApp.jsx
+++ b/src/modules/fizruk/FizrukApp.jsx
@@ -60,7 +60,7 @@ export default function FizrukApp() {
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       {/* Header */}
       <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line/60 z-40 relative" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
-        <div className="flex h-14 items-center px-4 sm:px-5 gap-3">
+        <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
           {isAtlas || isExercise ? (
             <button
               type="button"

--- a/src/modules/fizruk/pages/Dashboard.jsx
+++ b/src/modules/fizruk/pages/Dashboard.jsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/workoutStats";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
+const SHEET_BOTTOM_PADDING = "calc(env(safe-area-inset-bottom, 16px) + 72px)";
 
 function formatDurShort(sec) {
   const m = Math.floor(sec / 60);
@@ -167,6 +168,13 @@ export function Dashboard({ onOpenAtlas }) {
     return Math.round(sum / done.length);
   }, [workouts]);
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Доброго ранку";
+    if (hour < 18) return "Доброго дня";
+    return "Доброго вечора";
+  }, []);
+
   const picksFromTemplate = (tpl) =>
     (tpl?.exerciseIds || []).map(id => exercises.find(e => e.id === id)).filter(Boolean);
 
@@ -250,14 +258,52 @@ export function Dashboard({ onOpenAtlas }) {
           aria-label="Привітання"
         >
           <p className="text-[11px] font-bold tracking-widest uppercase text-accent">
-            СЬОГОДНІ {new Date().toLocaleDateString("uk-UA", { day: "numeric", month: "long" }).toUpperCase()}
+            {greeting} · {today}
           </p>
-          <h1 className="text-[28px] font-black text-white mt-3 leading-tight">
-            Твій прогрес<br />зібраний в одному<br />спокійному місці
-          </h1>
-          <p className="text-sm text-white/55 mt-3 leading-relaxed">
-            Логуй підходи, запускай шаблони і дивись, як росте обсяг.
-          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Тиждень</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{dashMetrics.week}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">План</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{plan.picked.length}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Сер. час</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{avgDurationSec ? formatDurShort(avgDurationSec) : "—"}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#workouts"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Тренування
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#progress"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Прогрес
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#measurements"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Заміри
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenAtlas?.()}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Атлас
+            </button>
+          </div>
           <div className="mt-6 flex flex-col gap-3">
             <button
               type="button"
@@ -680,7 +726,7 @@ export function Dashboard({ onOpenAtlas }) {
       </div>
 
       {planConfirmOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -689,7 +735,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div id="plan-confirm-title" className="text-lg font-extrabold text-text">Увага</div>
             <p className="text-sm text-subtle mt-2 leading-relaxed">
@@ -717,7 +763,7 @@ export function Dashboard({ onOpenAtlas }) {
 
       {/* Pushup modal */}
       {pushupModalOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -726,7 +772,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div className="w-10 h-1 bg-line rounded-full mx-auto mb-4" aria-hidden />
             <div id="pushup-modal-title" className="text-lg font-extrabold text-text mb-4">Додати відтискання</div>

--- a/src/modules/fizruk/pages/Measurements.jsx
+++ b/src/modules/fizruk/pages/Measurements.jsx
@@ -1,6 +1,5 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Button } from "@shared/components/ui/Button";
-import { cn } from "@shared/lib/cn";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
 
 const inp = "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
@@ -9,26 +8,22 @@ export function Measurements() {
   const { entries, addEntry, deleteEntry } = useMeasurements();
   const [form, setForm] = useState(() => Object.fromEntries(MEASURE_FIELDS.map(f => [f.id, ""])));
 
-  const latest = entries[0] || null;
-  const deltas = useMemo(() => {
-    const prev = entries[1] || null;
-    if (!latest || !prev) return {};
-    const out = {};
-    for (const f of MEASURE_FIELDS) {
-      const a = Number(latest[f.id]);
-      const b = Number(prev[f.id]);
-      if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
-      const d = a - b;
-      if (d === 0) continue;
-      out[f.id] = d;
-    }
-    return out;
-  }, [entries, latest]);
-
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Заміри</div>
+
+        <div className="text-xs text-subtle">
+          Потрібна підказка?{" "}
+          <a
+            href="https://www.wikihow.com/Take-Body-Measurements"
+            target="_blank"
+            rel="noreferrer"
+            className="text-success font-semibold underline"
+          >
+            Як правильно робити заміри
+          </a>
+        </div>
 
         <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">Додати замір</div>
@@ -66,35 +61,6 @@ export function Measurements() {
           </div>
         </div>
 
-        {latest && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-xs font-bold text-subtle uppercase tracking-widest">Останній замір</div>
-                <div className="text-xs text-subtle mt-1">{new Date(latest.at).toLocaleString("uk-UA", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</div>
-              </div>
-              <div className="text-xs text-subtle">
-                {Object.keys(deltas).length ? "Δ від попереднього" : ""}
-              </div>
-            </div>
-            <div className="mt-3 grid grid-cols-2 gap-2">
-              {MEASURE_FIELDS.map(f => (
-                <div key={f.id} className="bg-bg border border-line rounded-2xl p-3">
-                  <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">{f.label}</div>
-                  <div className="text-lg font-extrabold tabular-nums text-text mt-1">
-                    {Number.isFinite(Number(latest[f.id])) ? Number(latest[f.id]).toLocaleString("uk-UA") : "—"} {f.unit}
-                  </div>
-                  {deltas[f.id] != null && (
-                    <div className={cn("text-xs font-semibold mt-1", deltas[f.id] > 0 ? "text-warning" : "text-success")}>
-                      {deltas[f.id] > 0 ? "+" : ""}{deltas[f.id].toFixed(1)} {f.unit}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
         <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
           <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest">Історія</div>
@@ -126,4 +92,3 @@ export function Measurements() {
     </div>
   );
 }
-

--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -149,6 +149,22 @@ export function Progress() {
 
   const hasAny = (workouts?.length || 0) > 0 || (entries?.length || 0) > 0;
 
+  const quickStats = useMemo(() => {
+    const done = (workouts || []).filter(w => w.endedAt);
+    const latestTs = done.reduce((mx, w) => {
+      const ts = w.startedAt ? Date.parse(w.startedAt) : NaN;
+      return Number.isFinite(ts) ? Math.max(mx, ts) : mx;
+    }, 0);
+    const latestWorkoutAt = latestTs
+      ? new Date(latestTs).toLocaleDateString("uk-UA", { day: "numeric", month: "short" })
+      : "—";
+    return {
+      doneCount: done.length,
+      prsCount: prs.length,
+      latestWorkoutAt,
+    };
+  }, [workouts, prs.length]);
+
   const exportCsv = () => {
     const rows = [["startedAt", "endedAt", "workout_id", "exercise", "type", "detail", "energy_1_5", "mood_1_5"]];
     for (const w of workouts || []) {
@@ -184,6 +200,21 @@ export function Progress() {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Прогрес</div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Тренувань</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.doneCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">PR вправ</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.prsCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останнє</div>
+            <div className="text-sm font-bold text-text mt-1">{quickStats.latestWorkoutAt}</div>
+          </div>
+        </div>
 
         {!hasAny && (
           <div className="bg-panel border border-line/60 rounded-2xl p-8 shadow-card text-center">


### PR DESCRIPTION
### Motivation
- Refresh the Dashboard hero to surface a contextual greeting, quick metrics and faster navigation actions. 
- Provide quick summary stats on the Progress page for faster data glanceability. 
- Simplify the Measurements UI and add a help link to guide users on taking measurements. 
- Fix header sizing and bottom-sheet layout/presence issues for modal sheets to avoid overlap with safe-area insets.

### Description
- Adjusted app header sizing in `FizrukApp.jsx` by replacing fixed `h-14` with `min-h-[68px]` and adding vertical padding for better safe-area support. 
- Reworked the Dashboard hero in `Dashboard.jsx` to add a `greeting` computed by hour, replace the long static copy with compact metric cards and action buttons, and reflow buttons for quick navigation. 
- Introduced `SHEET_BOTTOM_PADDING` and applied it to bottom sheets instead of raw `env(...)` inline values, and increased sheet `z-index` from `70` to `100` for `planConfirm` and `pushupModal`. 
- Simplified `Measurements.jsx` by removing the previous latest/deltas summary and unused imports, and added a help link to an external guide for taking body measurements. 
- Added a `quickStats` `useMemo` in `Progress.jsx` and rendered three compact stat cards (`doneCount`, `prsCount`, `latestWorkoutAt`) at the top of the page.

### Testing
- No automated tests were added or modified for this change.
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18ddef483308cf7cd1da7ad7a1e)