### PR TITLE
Add quick-stats cards and UI/UX tweaks across Dashboard, Measurements, Progress and Workouts

### DIFF
--- a/src/modules/fizruk/pages/Dashboard.jsx
+++ b/src/modules/fizruk/pages/Dashboard.jsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/workoutStats";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
+const SHEET_BOTTOM_PADDING = "calc(env(safe-area-inset-bottom, 16px) + 72px)";
 
 function formatDurShort(sec) {
   const m = Math.floor(sec / 60);
@@ -167,6 +168,13 @@ export function Dashboard({ onOpenAtlas }) {
     return Math.round(sum / done.length);
   }, [workouts]);
 
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Доброго ранку";
+    if (hour < 18) return "Доброго дня";
+    return "Доброго вечора";
+  }, []);
+
   const picksFromTemplate = (tpl) =>
     (tpl?.exerciseIds || []).map(id => exercises.find(e => e.id === id)).filter(Boolean);
 
@@ -250,14 +258,52 @@ export function Dashboard({ onOpenAtlas }) {
           aria-label="Привітання"
         >
           <p className="text-[11px] font-bold tracking-widest uppercase text-accent">
-            СЬОГОДНІ {new Date().toLocaleDateString("uk-UA", { day: "numeric", month: "long" }).toUpperCase()}
+            {greeting} · {today}
           </p>
-          <h1 className="text-[28px] font-black text-white mt-3 leading-tight">
-            Твій прогрес<br />зібраний в одному<br />спокійному місці
-          </h1>
-          <p className="text-sm text-white/55 mt-3 leading-relaxed">
-            Логуй підходи, запускай шаблони і дивись, як росте обсяг.
-          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Тиждень</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{dashMetrics.week}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">План</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{plan.picked.length}</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wide text-white/60">Сер. час</p>
+              <p className="text-xl font-black text-white tabular-nums mt-1">{avgDurationSec ? formatDurShort(avgDurationSec) : "—"}</p>
+            </div>
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#workouts"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Тренування
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#progress"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Прогрес
+            </button>
+            <button
+              type="button"
+              onClick={() => { window.location.hash = "#measurements"; }}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Заміри
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenAtlas?.()}
+              className="rounded-xl border border-white/20 bg-white/10 py-2.5 text-sm font-semibold text-white active:scale-[0.98]"
+            >
+              Атлас
+            </button>
+          </div>
           <div className="mt-6 flex flex-col gap-3">
             <button
               type="button"
@@ -680,7 +726,7 @@ export function Dashboard({ onOpenAtlas }) {
       </div>
 
       {planConfirmOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="plan-confirm-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -689,7 +735,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div id="plan-confirm-title" className="text-lg font-extrabold text-text">Увага</div>
             <p className="text-sm text-subtle mt-2 leading-relaxed">
@@ -717,7 +763,7 @@ export function Dashboard({ onOpenAtlas }) {
 
       {/* Pushup modal */}
       {pushupModalOpen && (
-        <div className="fixed inset-0 z-[70] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
+        <div className="fixed inset-0 z-[100] flex items-end justify-center" role="dialog" aria-modal="true" aria-labelledby="pushup-modal-title">
           <button
             type="button"
             className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -726,7 +772,7 @@ export function Dashboard({ onOpenAtlas }) {
           />
           <div
             className="relative w-full max-w-4xl bg-panel border-t border-line rounded-t-3xl p-5 shadow-soft"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 16px)" }}
+            style={{ paddingBottom: SHEET_BOTTOM_PADDING }}
           >
             <div className="w-10 h-1 bg-line rounded-full mx-auto mb-4" aria-hidden />
             <div id="pushup-modal-title" className="text-lg font-extrabold text-text mb-4">Додати відтискання</div>

--- a/src/modules/fizruk/pages/Measurements.jsx
+++ b/src/modules/fizruk/pages/Measurements.jsx
@@ -25,10 +25,34 @@ export function Measurements() {
     return out;
   }, [entries, latest]);
 
+  const stats = useMemo(() => {
+    const total = entries?.length || 0;
+    const latestAt = latest?.at ? new Date(latest.at).toLocaleDateString("uk-UA", { day: "numeric", month: "short" }) : "—";
+    const filledLatest = latest
+      ? MEASURE_FIELDS.filter(f => latest[f.id] != null && latest[f.id] !== "").length
+      : 0;
+    return { total, latestAt, filledLatest };
+  }, [entries, latest]);
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Заміри</div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Записів</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{stats.total}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останній</div>
+            <div className="text-sm font-bold text-text mt-1">{stats.latestAt}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Полів</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{stats.filledLatest}</div>
+          </div>
+        </div>
 
         <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">Додати замір</div>
@@ -126,4 +150,3 @@ export function Measurements() {
     </div>
   );
 }
-

--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -149,6 +149,22 @@ export function Progress() {
 
   const hasAny = (workouts?.length || 0) > 0 || (entries?.length || 0) > 0;
 
+  const quickStats = useMemo(() => {
+    const done = (workouts || []).filter(w => w.endedAt);
+    const latestTs = done.reduce((mx, w) => {
+      const ts = w.startedAt ? Date.parse(w.startedAt) : NaN;
+      return Number.isFinite(ts) ? Math.max(mx, ts) : mx;
+    }, 0);
+    const latestWorkoutAt = latestTs
+      ? new Date(latestTs).toLocaleDateString("uk-UA", { day: "numeric", month: "short" })
+      : "—";
+    return {
+      doneCount: done.length,
+      prsCount: prs.length,
+      latestWorkoutAt,
+    };
+  }, [workouts, prs.length]);
+
   const exportCsv = () => {
     const rows = [["startedAt", "endedAt", "workout_id", "exercise", "type", "detail", "energy_1_5", "mood_1_5"]];
     for (const w of workouts || []) {
@@ -184,6 +200,21 @@ export function Progress() {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 pb-[calc(88px+env(safe-area-inset-bottom,0px))] space-y-3">
         <div className="text-sm font-semibold text-muted">Прогрес</div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Тренувань</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.doneCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">PR вправ</div>
+            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.prsCount}</div>
+          </div>
+          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останнє</div>
+            <div className="text-sm font-bold text-text mt-1">{quickStats.latestWorkoutAt}</div>
+          </div>
+        </div>
 
         {!hasAny && (
           <div className="bg-panel border border-line/60 rounded-2xl p-8 shadow-card text-center">

--- a/src/modules/fizruk/pages/Workouts.jsx
+++ b/src/modules/fizruk/pages/Workouts.jsx
@@ -69,6 +69,14 @@ function formatRestClock(sec) {
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
+function mondayStartMs(d) {
+  const x = new Date(d);
+  const day = (x.getDay() + 6) % 7;
+  x.setHours(0, 0, 0, 0);
+  x.setDate(x.getDate() - day);
+  return x.getTime();
+}
+
 export function Workouts() {
   const { search, primaryGroupsUk, musclesUk, musclesByPrimaryGroup, addExercise, removeExercise } = useExerciseCatalog();
   const rec = useRecovery();
@@ -103,6 +111,20 @@ export function Workouts() {
   const list = useMemo(() => search(q), [search, q]);
   const pickList = useMemo(() => search(pickQ).slice(0, 60), [search, pickQ]);
   const activeWorkout = workouts.find(w => w.id === activeWorkoutId) || null;
+  const workoutQuickStats = useMemo(() => {
+    const done = (workouts || []).filter(w => w.endedAt);
+    const weekStart = mondayStartMs(Date.now());
+    const thisWeekDone = done.filter(w => {
+      const ts = w.startedAt ? Date.parse(w.startedAt) : NaN;
+      return Number.isFinite(ts) && ts >= weekStart;
+    }).length;
+    const activeItems = (activeWorkout?.items || []).length;
+    return {
+      doneCount: done.length,
+      thisWeekDone,
+      activeItems,
+    };
+  }, [workouts, activeWorkout]);
 
   const activeDuration = useMemo(() => {
     if (!activeWorkout?.startedAt) return null;
@@ -247,6 +269,21 @@ export function Workouts() {
 
         {mode === "log" && (
           <div className="space-y-3">
+            <div className="grid grid-cols-3 gap-2">
+              <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+                <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Завершено</div>
+                <div className="text-lg font-extrabold text-text tabular-nums mt-1">{workoutQuickStats.doneCount}</div>
+              </div>
+              <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+                <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Цей тиждень</div>
+                <div className="text-lg font-extrabold text-text tabular-nums mt-1">{workoutQuickStats.thisWeekDone}</div>
+              </div>
+              <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+                <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">В активному</div>
+                <div className="text-lg font-extrabold text-text tabular-nums mt-1">{workoutQuickStats.activeItems}</div>
+              </div>
+            </div>
+
             <div className="flex gap-2">
               <Button
                 className="flex-1 h-12"
@@ -266,6 +303,27 @@ export function Workouts() {
                 + Вправа
               </Button>
             </div>
+
+            {!activeWorkout && (
+              <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card text-center">
+                <div className="text-sm font-semibold text-text">Немає активного тренування</div>
+                <div className="text-xs text-subtle mt-1">Створи нове або запусти готовий шаблон</div>
+                <div className="mt-3 flex gap-2">
+                  <Button
+                    className="flex-1 h-11"
+                    onClick={() => {
+                      const w = createWorkout();
+                      setActiveWorkoutId(w.id);
+                    }}
+                  >
+                    + Нове
+                  </Button>
+                  <Button variant="ghost" className="flex-1 h-11" onClick={() => setMode("templates")}>
+                    Шаблони
+                  </Button>
+                </div>
+              </div>
+            )}
 
             {activeWorkout && (
               <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
@@ -513,7 +571,16 @@ export function Workouts() {
                     <div className="text-sm font-semibold text-text">
                       {new Date(w.startedAt).toLocaleDateString("uk-UA", { month: "short", day: "numeric" })}
                     </div>
-                    <div className="text-xs text-subtle">{(w.items || []).length} вправ</div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-subtle">{(w.items || []).length} вправ</span>
+                      {activeWorkoutId === w.id ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/20">Активне</span>
+                      ) : w.endedAt ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-panelHi text-subtle border border-line">Завершене</span>
+                      ) : (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-warning/10 text-warning border border-warning/20">Чернетка</span>
+                      )}
+                    </div>
                   </div>
                 </button>
               ))}


### PR DESCRIPTION
### Motivation
- Provide immediate at-a-glance metrics across several pages so users can quickly see recent activity and key counts. 
- Improve onboarding and discovery by adding a time-aware greeting and quick navigation actions on the Dashboard. 
- Fix modal sheet layout and stacking to better account for safe area insets and overlay z-index issues.

### Description
- Added small quick-stats card grids to `Dashboard`, `Measurements`, `Progress`, and the `Workouts` log view that surface counts and recent dates. 
- Introduced a dynamic `greeting` on the Dashboard and multiple new buttons for quick navigation and actions. 
- Centralized sheet bottom padding into `SHEET_BOTTOM_PADDING` and updated modal containers to use it, and increased modal overlay `z-index` from `70` to `100` to ensure proper stacking. 
- Added `mondayStartMs` helper and `workoutQuickStats`/`quickStats`/`stats` memoized computations to compute weekly and aggregate metrics used by the new UI cards. 
- Small UI/UX tweaks in `Workouts` list items to show activity badges (Active / Completed / Draft) and provide an empty-state card when there is no active workout.

### Testing
- Ran the project's unit test suite with `yarn test` and the suite passed. 
- Ran linting with `yarn lint` and a production build with `yarn build`, both of which completed without errors. 
- Existing automated checks (tests/lint/build) all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18ddef483308cf7cd1da7ad7a1e)