### PR TITLE
Use sessionStorage for Monobank token, tighten cache checks and add silent error reporting

### DIFF
--- a/src/modules/finyk/hooks/useMonobank.js
+++ b/src/modules/finyk/hooks/useMonobank.js
@@ -3,6 +3,11 @@ import { TX_CACHE_TTL, CURRENCY } from "../constants";
 
 const CACHE_KEY = "finyk_tx_cache";
 const INFO_CACHE_KEY = "finyk_info_cache";
+const TOKEN_KEY = "finyk_token";
+
+function reportSilentError(scope, error) {
+  console.warn(`[finyk] ${scope}`, error);
+}
 
 // Міграція старих ключів
 try {
@@ -139,7 +144,16 @@ async function fetchStatementWithRetry(tok, accId, from, to, maxAttempts = 3) {
 export function useMonobank() {
   const [token, setToken] = useState(() => {
     try {
-      return localStorage.getItem("finyk_token") || "";
+      const sessionToken = sessionStorage.getItem(TOKEN_KEY);
+      if (sessionToken) return sessionToken;
+
+      const legacyToken = localStorage.getItem(TOKEN_KEY);
+      if (legacyToken) {
+        sessionStorage.setItem(TOKEN_KEY, legacyToken);
+        localStorage.removeItem(TOKEN_KEY);
+        return legacyToken;
+      }
+      return "";
     } catch {
       return "";
     }
@@ -338,7 +352,11 @@ export function useMonobank() {
       let info;
       const infoCache = localStorage.getItem(INFO_CACHE_KEY);
       if (!forceRefresh && infoCache) {
-        info = JSON.parse(infoCache);
+        const parsed = JSON.parse(infoCache);
+        if (parsed?.token && parsed.token !== cleanToken) {
+          throw new Error("Кеш профілю належить іншому токену");
+        }
+        info = parsed?.info || parsed;
       } else {
         const res = await fetch(`/api/mono?path=${encodeURIComponent("/personal/client-info")}`, {
           headers: { "X-Token": cleanToken },
@@ -357,15 +375,20 @@ export function useMonobank() {
 
         info = await res.json();
         try {
-          localStorage.setItem(INFO_CACHE_KEY, JSON.stringify(info));
-        } catch {}
+          localStorage.setItem(INFO_CACHE_KEY, JSON.stringify({ token: cleanToken, info }));
+        } catch (e) {
+          reportSilentError("save client-info cache", e);
+        }
       }
 
       setClientInfo(info);
       setAccounts(info.accounts || []);
       try {
-        localStorage.setItem("finyk_token", cleanToken);
-      } catch {}
+        sessionStorage.setItem(TOKEN_KEY, cleanToken);
+        localStorage.removeItem(TOKEN_KEY);
+      } catch (e) {
+        reportSilentError("save token", e);
+      }
       setToken(cleanToken);
 
       const cache = forceRefresh ? null : loadCache();
@@ -435,11 +458,13 @@ export function useMonobank() {
         const info = await res.json();
         setClientInfo(info);
         setAccounts(info.accounts || []);
-        try { localStorage.setItem(INFO_CACHE_KEY, JSON.stringify(info)); } catch {}
+        try { localStorage.setItem(INFO_CACHE_KEY, JSON.stringify({ token, info })); } catch (e) { reportSilentError("refresh info cache", e); }
         await fetchAllTx(token, info.accounts || []);
         return;
       }
-    } catch {}
+    } catch (e) {
+      reportSilentError("refresh client-info", e);
+    }
     await fetchAllTx(token, accounts);
   };
 
@@ -457,11 +482,15 @@ export function useMonobank() {
       accountsOk: 0,
     });
     try {
+      sessionStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(TOKEN_KEY); // legacy fallback
       localStorage.removeItem("finto_token");
       localStorage.removeItem(CACHE_KEY);
       localStorage.removeItem(LAST_GOOD_KEY);
       localStorage.removeItem(INFO_CACHE_KEY);
-    } catch {}
+    } catch (e) {
+      reportSilentError("disconnect cleanup", e);
+    }
   };
 
   const clearTxCache = () => {

--- a/src/modules/finyk/hooks/useStorage.js
+++ b/src/modules/finyk/hooks/useStorage.js
@@ -1,6 +1,10 @@
 import { useState, useEffect } from "react";
 import { DEFAULT_SUBSCRIPTIONS, INTERNAL_TRANSFER_ID } from "../constants";
 
+function reportSilentError(scope, error) {
+  console.warn(`[finyk] ${scope}`, error);
+}
+
 // Одноразова міграція ключів finto_* → finyk_*
 const LEGACY_KEYS = [
   ["finto_hidden",           "finyk_hidden"],
@@ -116,7 +120,7 @@ export function useStorage() {
     const reader = new FileReader();
     reader.onload = (e) => {
       try { applyData(JSON.parse(e.target.result)); alert("Дані імпортовано!"); }
-      catch { alert("Помилка: невірний формат файлу"); }
+      catch (err) { reportSilentError("import data", err); alert("Помилка: невірний формат файлу"); }
     };
     reader.readAsText(file);
   };
@@ -144,7 +148,7 @@ export function useStorage() {
       if (data.mp) setMonthlyPlan(data.mp);
       window.history.replaceState({}, "", window.location.pathname);
       return true;
-    } catch { return false; }
+    } catch (err) { reportSilentError("load sync from url", err); return false; }
   };
 
   // Транзакції позначені як внутрішній переказ — виключаємо зі статистики


### PR DESCRIPTION
### Motivation
- Keep Monobank token scoped to the session instead of persistent `localStorage` and avoid leaking tokens across devices or installs.
- Prevent using stale or mismatched cached client-info when switching tokens.
- Improve observability of silent failures during local storage operations and decoding to aid debugging without crashing the app.

### Description
- Prefer `sessionStorage` for the Monobank token, migrate any legacy `localStorage` token into `sessionStorage`, and remove legacy keys during `disconnect` using the `TOKEN_KEY` constant and `sessionStorage` APIs.
- Store the client-info cache as `{ token, info }` under `INFO_CACHE_KEY` and validate the cached token against the active token to avoid using profile data that belongs to a different token.
- Introduce `reportSilentError(scope, error)` and replace empty `catch {}` blocks with logging where appropriate to surface non-fatal storage/fetch errors while keeping user flow uninterrupted.
- Add token migration for existing legacy keys and update cache save/load paths to use the new structure; update `connect`, `refresh`, `disconnect`, and cache-writing logic accordingly.
- In `useStorage.js` add `reportSilentError` and use it when JSON import or URL sync decoding fails, and keep the one-time legacy key migration list intact.

### Testing
- Ran unit and integration tests via `npm test` and the test suite completed successfully.
- Ran linter checks with `npm run lint` which passed without new violations.
- Built the application with `npm run build` and the production build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1597686c83308011f1fa18c6d758)