### PR TITLE
Fix duplicated quick stats block on Progress page

### DIFF
--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -236,36 +236,6 @@ export function Progress() {
           </div>
         </div>
 
-        <div className="grid grid-cols-3 gap-2">
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Тренувань</div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.doneCount}</div>
-          </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">PR вправ</div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.prsCount}</div>
-          </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останнє</div>
-            <div className="text-sm font-bold text-text mt-1">{quickStats.latestWorkoutAt}</div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-3 gap-2">
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Тренувань</div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.doneCount}</div>
-          </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">PR вправ</div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">{quickStats.prsCount}</div>
-          </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">Останнє</div>
-            <div className="text-sm font-bold text-text mt-1">{quickStats.latestWorkoutAt}</div>
-          </div>
-        </div>
-
         {!hasAny && (
           <div className="bg-panel border border-line/60 rounded-2xl p-8 shadow-card text-center">
             <div className="text-3xl mb-3">📈</div>


### PR DESCRIPTION
### Motivation
- Remove duplicated quick-stats UI blocks on the Progress page so the summary cards (`Тренувань`, `PR вправ`, `Останнє`) are shown only once instead of being repeated.

### Description
- Deleted the extra repeated `grid grid-cols-3` render blocks in `src/modules/fizruk/pages/Progress.jsx` and kept a single stats block to avoid visual duplication.

### Testing
- Ran `npm run build` which completed successfully (import check passed and Vite produced a production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2c3196d88330b44933f3548c9a19)