### PR TITLE
fix(foodDb): ensureSeedFoods тепер merge для існуючих баз

### DIFF
--- a/src/modules/nutrition/lib/foodDb/foodDb.js
+++ b/src/modules/nutrition/lib/foodDb/foodDb.js
@@ -86,12 +86,23 @@ export async function ensureSeedFoods() {
       r.onerror = () => reject(r.error);
     });
     db.close();
-    if (count > 0) return true;
-    return await replaceAllFoodsFromList(
-      SEED_FOODS_UK.map((x) =>
-        makeFoodProduct({ name: x.name, per100: x.per100 }),
-      ),
-    );
+
+    if (count === 0) {
+      return await replaceAllFoodsFromList(
+        SEED_FOODS_UK.map((x) =>
+          makeFoodProduct({ name: x.name, per100: x.per100 }),
+        ),
+      );
+    }
+
+    // Merge: додати тільки ті seeds, яких ще немає в базі
+    const existing = await listFoods(5000);
+    const byNorm = new Map(existing.map((x) => [normText(x.norm || x.name), x]));
+    for (const seed of SEED_FOODS_UK) {
+      if (byNorm.has(normText(seed.name))) continue;
+      await upsertFood(makeFoodProduct({ name: seed.name, per100: seed.per100 }));
+    }
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
Раніше функція виходила якщо в базі вже були продукти, тому нові seeds (груша, ківі тощо) не з'являлись у існуючих користувачів. Тепер при наявній базі перевіряє кожен seed по нормалізованій назві і додає лише відсутні продукти.

https://claude.ai/code/session_01XjE4gGZo4AfFnuihTnz3Jj