### PR TITLE
Fix Tailwind circular @apply causing Vite build failure

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -889,7 +889,8 @@ textarea {
 }
 
 .tooltip.visible {
-  @apply opacity-100 visible;
+  @apply opacity-100;
+  visibility: visible;
   transform: translateY(0);
 }
 


### PR DESCRIPTION
### Motivation
- Fix production build failure caused by Tailwind/PostCSS circular dependency when `@apply visible` was used inside a `.visible` selector.

### Description
- Replace `@apply opacity-100 visible;` in `src/index.css` with `@apply opacity-100;` and `visibility: visible;` to avoid circular utility application while preserving tooltip behavior.

### Testing
- Ran `npm run build` and the production build (Vite + PWA service worker) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34860fb58833081db011627483a42)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
