### PR TITLE
fix(finyk): restore Analytics page navigation

### DIFF
--- a/src/modules/finyk/constants.js
+++ b/src/modules/finyk/constants.js
@@ -274,6 +274,7 @@ export const PAGES = [
   { id: "overview", label: "🏠 Огляд" },
   { id: "transactions", label: "📋 Транзакції" },
   { id: "budgets", label: "📅 Планування" },
+  { id: "analytics", label: "📊 Аналітика" },
   { id: "assets", label: "🏦 Активи та пасиви" },
 ];
 


### PR DESCRIPTION
### Motivation
- The Finyk Statistics/Analytics page at `#/analytics` fell back to the overview because the hash router validates routes against the `PAGES` list and `analytics` was missing.

### Description
- Add `{ id: "analytics", label: "📊 Аналітика" }` to the shared `PAGES` array in `src/modules/finyk/constants.js` so `useHashRouter` accepts `#/analytics` as a valid page.

### Testing
- Ran `npm test` which executed the test suite with vitest and all tests passed (28 files, 156 tests).
- Ran `npm run lint` which failed due to pre-existing unrelated lint errors in other Finyk files and not due to this change.
- Attempted `npm test -- --runInBand` which failed because vitest does not support the `--runInBand` flag (not related to the code change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3558f81148330b2af50e8fe50ded9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
