### PR TITLE
feat(finyk): extract analytics selectors into domain layer

### DIFF
--- a/src/modules/finyk/domain/selectors.js
+++ b/src/modules/finyk/domain/selectors.js
@@ -1,3 +1,7 @@
+// Pure analytics selectors for the Finyk module.
+// Every function here is a pure projection from the passed-in data —
+// no `localStorage`, no `window`, no side effects — so it is safe to
+// wrap in `useMemo` or call from tests.
 import {
   getTxStatAmount,
   getCategory,
@@ -45,19 +49,54 @@ function getCatColor(categoryId, customCategories = [], idx = 0) {
   return FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
 }
 
-export function getMonthlySummary(
-  transactions,
-  { excludedTxIds = new Set(), txSplits = {} } = {},
-) {
+// Turn a "YYYY-MM" string or a {year, month} object into a predicate
+// that matches a tx's local calendar month. Returns null when no month
+// filter is requested — callers should treat null as "include all".
+function buildMonthPredicate(month) {
+  if (!month) return null;
+  let y;
+  let m;
+  if (typeof month === "string") {
+    const [ys, ms] = month.split("-");
+    y = Number(ys);
+    m = Number(ms);
+  } else if (typeof month === "object") {
+    y = Number(month.year);
+    m = Number(month.month);
+  }
+  if (!Number.isFinite(y) || !Number.isFinite(m)) return null;
+  return (tx) => {
+    if (!tx || !tx.time) return false;
+    const ts = tx.time > 1e10 ? tx.time : tx.time * 1000;
+    const d = new Date(ts);
+    return d.getFullYear() === y && d.getMonth() + 1 === m;
+  };
+}
+
+// Normalize the optional filter bag so selectors can accept either a
+// plain options object or a shorthand month string as their second arg.
+function normalizeOpts(optsOrMonth) {
+  if (optsOrMonth == null) return {};
+  if (typeof optsOrMonth === "string") return { month: optsOrMonth };
+  return optsOrMonth;
+}
+
+// Aggregated totals for a list of transactions (optionally scoped to
+// a single calendar month). Pure — never touches storage.
+export function getMonthlySummary(transactions, optsOrMonth) {
+  const opts = normalizeOpts(optsOrMonth);
+  const { excludedTxIds = new Set(), txSplits = {}, month = null } = opts;
   const list = Array.isArray(transactions) ? transactions : [];
   const excluded =
     excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const inMonth = buildMonthPredicate(month);
   let spent = 0;
   let income = 0;
   let txCount = 0;
 
   for (const tx of list) {
     if (!tx || excluded.has(tx.id)) continue;
+    if (inMonth && !inMonth(tx)) continue;
     txCount++;
     if (tx.amount < 0) spent += getTxStatAmount(tx, txSplits);
     else income += tx.amount / 100;
@@ -65,7 +104,17 @@ export function getMonthlySummary(
 
   spent = Math.round(spent);
   income = Math.round(income);
-  return { spent, income, balance: income - spent, txCount };
+  // `spent`/`income` keep backwards compatibility with existing callers,
+  // `totalExpense`/`totalIncome` expose the same numbers under the
+  // public selector contract.
+  return {
+    spent,
+    income,
+    balance: income - spent,
+    txCount,
+    totalExpense: spent,
+    totalIncome: income,
+  };
 }
 
 // Heaviest step of category analytics: iterates every expense transaction
@@ -79,16 +128,19 @@ export function computeCategorySpendIndex(
     txSplits = {},
     customCategories = [],
     excludedTxIds = new Set(),
+    month = null,
   } = {},
 ) {
   const list = Array.isArray(transactions) ? transactions : [];
   const excluded =
     excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const inMonth = buildMonthPredicate(month);
   const catSpend = {};
   let totalSpent = 0;
 
   for (const tx of list) {
     if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;
+    if (inMonth && !inMonth(tx)) continue;
     const splits = txSplits[tx.id];
     if (splits && splits.length > 0) {
       for (const s of splits) {
@@ -157,11 +209,87 @@ export function selectCategoryDistributionFromIndex(
   }));
 }
 
-export function getTopCategories(transactions, opts = {}, limit = 5) {
+// Top spending categories. Supports both the documented selector shape
+// `getTopCategories(txs, limit)` and the legacy `(txs, opts, limit)` form
+// used by older hooks/tests.
+export function getTopCategories(transactions, optsOrLimit = {}, maybeLimit) {
+  let opts = {};
+  let limit = 5;
+  if (typeof optsOrLimit === "number") {
+    limit = optsOrLimit;
+  } else {
+    opts = optsOrLimit || {};
+    if (typeof maybeLimit === "number") limit = maybeLimit;
+  }
   const index = computeCategorySpendIndex(transactions, opts);
   return selectTopCategoriesFromIndex(
     index,
     opts.customCategories || [],
     limit,
   );
+}
+
+// Full `category → amount` distribution (returned as a sorted array of
+// `{ categoryId, label, spent, pct, color }`).
+export function getCategoryDistribution(transactions, opts = {}) {
+  const index = computeCategorySpendIndex(transactions, opts);
+  return selectCategoryDistributionFromIndex(
+    index,
+    opts.customCategories || [],
+  );
+}
+
+// Compare two monthly summaries and return the absolute and percentage
+// delta for both spend and income.
+export function getTrendComparison(currentMonthTx, previousMonthTx, opts = {}) {
+  const { excludedTxIds = new Set(), txSplits = {} } = opts;
+  const curr = getMonthlySummary(currentMonthTx, { excludedTxIds, txSplits });
+  const prev = getMonthlySummary(previousMonthTx, { excludedTxIds, txSplits });
+  const diff = curr.spent - prev.spent;
+  const diffPct = prev.spent > 0 ? Math.round((diff / prev.spent) * 100) : null;
+  const incomeDiff = curr.income - prev.income;
+  const incomeDiffPct =
+    prev.income > 0 ? Math.round((incomeDiff / prev.income) * 100) : null;
+
+  return {
+    currentSpent: curr.spent,
+    prevSpent: prev.spent,
+    diff,
+    diffPct,
+    currentIncome: curr.income,
+    prevIncome: prev.income,
+    incomeDiff,
+    incomeDiffPct,
+  };
+}
+
+// Top merchants by aggregated expense. Deterministic, pure sort — useful
+// both in the UI and in tests.
+export function getTopMerchants(transactions, opts = {}, maybeLimit) {
+  const {
+    excludedTxIds = new Set(),
+    month = null,
+    limit: optsLimit,
+  } = typeof opts === "number" ? { limit: opts } : opts || {};
+  const limit = typeof maybeLimit === "number" ? maybeLimit : (optsLimit ?? 10);
+  const list = Array.isArray(transactions) ? transactions : [];
+  const excluded =
+    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const inMonth = buildMonthPredicate(month);
+  const merchants = {};
+
+  for (const tx of list) {
+    if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;
+    if (inMonth && !inMonth(tx)) continue;
+    const name = (tx.description || "").trim();
+    if (!name) continue;
+    if (!merchants[name]) merchants[name] = { name, count: 0, total: 0 };
+    merchants[name].count++;
+    merchants[name].total += Math.abs(tx.amount / 100);
+  }
+
+  return Object.values(merchants)
+    .map((m) => ({ ...m, total: Math.round(m.total) }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, limit);
 }

--- a/src/modules/finyk/hooks/useAnalytics.js
+++ b/src/modules/finyk/hooks/useAnalytics.js
@@ -1,11 +1,9 @@
 import { useMemo } from "react";
-import {
-  getTopMerchants,
-  getMonthlySpendSeries,
-  getMonthlyTrendComparison,
-} from "../lib/finykStats";
+import { getMonthlySpendSeries } from "../lib/finykStats";
 import {
   getMonthlySummary,
+  getTopMerchants,
+  getTrendComparison,
   computeCategorySpendIndex,
   selectTopCategoriesFromIndex,
   selectCategoryDistributionFromIndex,
@@ -76,7 +74,7 @@ export function useAnalytics({ mono, storage, monthlyHistory = [] }) {
     if (monthlyHistory.length < 2) return null;
     const curr = monthlyHistory[monthlyHistory.length - 1];
     const prev = monthlyHistory[monthlyHistory.length - 2];
-    return getMonthlyTrendComparison(
+    return getTrendComparison(
       curr?.transactions || [],
       prev?.transactions || [],
       { excludedTxIds, txSplits },

--- a/src/modules/finyk/lib/finykStats.js
+++ b/src/modules/finyk/lib/finykStats.js
@@ -2,6 +2,9 @@ import { normalizeTransaction } from "../domain/transactions";
 import {
   getMonthlySummary,
   getTopCategories,
+  getCategoryDistribution,
+  getTrendComparison,
+  getTopMerchants,
   computeCategorySpendIndex,
   selectCategoryDistributionFromIndex,
 } from "../domain/selectors";
@@ -50,10 +53,17 @@ export function getCatColor(categoryId, customCategories = [], idx = 0) {
 export {
   getMonthlySummary,
   getTopCategories,
+  getCategoryDistribution,
+  getTrendComparison,
+  getTopMerchants,
   computeCategorySpendIndex,
   selectCategoryDistributionFromIndex,
 };
 export { selectTopCategoriesFromIndex } from "../domain/selectors";
+
+// Legacy alias — retained so existing imports keep working while callers
+// migrate to the shorter `getTrendComparison` name.
+export const getMonthlyTrendComparison = getTrendComparison;
 
 export function getRecentTransactions(
   transactions,
@@ -87,26 +97,6 @@ export function getRecentTransactions(
   return all.slice(0, limit);
 }
 
-export function getMonthlyTrendComparison(
-  currentTx,
-  prevTx,
-  { excludedTxIds = new Set(), txSplits = {} } = {},
-) {
-  const curr = getMonthlySummary(currentTx, { excludedTxIds, txSplits });
-  const prev = getMonthlySummary(prevTx, { excludedTxIds, txSplits });
-  const diff = curr.spent - prev.spent;
-  const diffPct = prev.spent > 0 ? Math.round((diff / prev.spent) * 100) : null;
-
-  return {
-    currentSpent: curr.spent,
-    prevSpent: prev.spent,
-    diff,
-    diffPct,
-    currentIncome: curr.income,
-    prevIncome: prev.income,
-  };
-}
-
 export function getMonthlySpendSeries(monthlyData) {
   if (!Array.isArray(monthlyData)) return [];
   return monthlyData.map(({ month, transactions, excludedTxIds, txSplits }) => {
@@ -126,37 +116,4 @@ export function getMonthlySpendSeries(monthlyData) {
         : month;
     return { month, label, spent, income };
   });
-}
-
-export function getCategoryDistribution(transactions, opts = {}) {
-  const index = computeCategorySpendIndex(transactions, opts);
-  return selectCategoryDistributionFromIndex(
-    index,
-    opts.customCategories || [],
-  );
-}
-
-export function getTopMerchants(
-  transactions,
-  { excludedTxIds = new Set() } = {},
-  limit = 10,
-) {
-  const list = Array.isArray(transactions) ? transactions : [];
-  const excluded =
-    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
-  const merchants = {};
-
-  for (const tx of list) {
-    if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;
-    const name = (tx.description || "").trim();
-    if (!name) continue;
-    if (!merchants[name]) merchants[name] = { name, count: 0, total: 0 };
-    merchants[name].count++;
-    merchants[name].total += Math.abs(tx.amount / 100);
-  }
-
-  return Object.values(merchants)
-    .map((m) => ({ ...m, total: Math.round(m.total) }))
-    .sort((a, b) => b.total - a.total)
-    .slice(0, limit);
 }

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -14,7 +14,7 @@ import { useAnalytics } from "../hooks/useAnalytics";
 import { CategoryPieChart } from "../components/charts/lazy";
 import { ChartFallback } from "../components/charts/ChartFallback";
 import { MerchantList } from "../components/analytics/MerchantList";
-import { getMonthlyTrendComparison } from "../lib/finykStats";
+import { getTrendComparison } from "../domain/selectors";
 
 function readTxCache(year, month) {
   try {
@@ -219,7 +219,7 @@ export function Analytics({ mono, storage }) {
   // and the filters that actually affect totals (excluded ids + splits).
   const comparison = useMemo(() => {
     if (!prevTx.length && !historyCache[prevKey]) return null;
-    return getMonthlyTrendComparison(activeTx, prevTx, {
+    return getTrendComparison(activeTx, prevTx, {
       excludedTxIds: storage.excludedTxIds,
       txSplits: storage.txSplits,
     });

--- a/src/modules/finyk/pages/Overview.jsx
+++ b/src/modules/finyk/pages/Overview.jsx
@@ -11,6 +11,7 @@ import {
   resolveExpenseCategoryMeta,
 } from "../utils";
 import { getSubscriptionAmountMeta } from "../domain/subscriptionUtils.js";
+import { getMonthlySummary } from "../domain/selectors";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { cn } from "@shared/lib/cn";
 import { THEME_HEX } from "@shared/lib/themeHex.js";
@@ -119,13 +120,13 @@ export function Overview({
     () => calcFinykSpendingTotal(statTx, { txSplits }),
     [statTx, txSplits],
   );
-  const income = useMemo(
-    () =>
-      statTx
-        .filter((t) => t.amount > 0)
-        .reduce((s, t) => s + t.amount / 100, 0),
-    [statTx],
+  // Pure selector keeps summary math out of the component; rounded totals
+  // match the spend/income totals shown on the Analytics page.
+  const monthlySummary = useMemo(
+    () => getMonthlySummary(realTx, { excludedTxIds, txSplits }),
+    [realTx, excludedTxIds, txSplits],
   );
+  const income = monthlySummary.income;
   const projectedSpend =
     daysPassed > 0 ? (spent / daysPassed) * daysInMonth : 0;
 


### PR DESCRIPTION
## Summary

Консолідує шар selectors для аналітики Finyk у `src/modules/finyk/domain/selectors.js` — усі обчислення живуть в одному файлі як чисті функції без side-effects та без доступу до `localStorage`.

Публічне API selectors:

- `getMonthlySummary(transactions, optsOrMonth)` — повертає `{ spent, income, balance, txCount, totalExpense, totalIncome }`. Приймає і legacy-об'єкт опцій (`excludedTxIds`, `txSplits`), і нову форму з `month` (рядок `"YYYY-MM"` або `{ year, month }`).
- `getTopCategories(transactions, limit = 5)` — топ-категорії витрат; підтримує і legacy-форму `(txs, opts, limit)` для сумісності.
- `getCategoryDistribution(transactions, opts)` — переміщено з `lib/finykStats.js`.
- `getTrendComparison(currentMonthTx, previousMonthTx, opts)` — перейменований/розширений `getMonthlyTrendComparison` (legacy-назва зберігається як alias у `finykStats`).
- `getTopMerchants(transactions, opts)` — переміщено з `lib/finykStats.js`.

Решта змін:

- `lib/finykStats.js` тепер re-експортує selectors (бекап-сумісність для існуючих імпортів, включно з `getMonthlyTrendComparison`).
- `hooks/useAnalytics.js` — імпорти зведені до `domain/selectors`; обчислення залишаються в `useMemo`, як і раніше.
- `pages/Analytics.jsx` — переведено на `getTrendComparison` з selectors.
- `pages/Overview.jsx` — інлайн-обчислення `income` через `filter/reduce` замінено на `getMonthlySummary(...).income`, обгорнутий у `useMemo`.

## Review & Testing Checklist for Human

- [ ] Відкрити сторінку **Finyk → Аналітика** для поточного місяця й переконатися, що summary/категорії/мерчанти/порівняння відображаються так само, як раніше.
- [ ] Перемкнутися на попередні місяці — блок "Порівняння з попереднім місяцем" повинен показувати ті ж значення, що й до змін (використовує `getTrendComparison`).
- [ ] Перевірити **Finyk → Огляд**: поле "Дохід" має залишатися таким самим (тепер приходить із selector замість локального reduce).

### Notes

- `spent`/`income` у поверненні `getMonthlySummary` збережено поряд з новими `totalExpense`/`totalIncome`, щоб не ламати існуючих споживачів.
- Усі selectors — чисті, без `localStorage`/`window`; перевірено `grep`-ом.
- `npm run lint`, `npm run typecheck`, `npm test` (256 tests) і `npm run format:check` — локально проходять.

Link to Devin session: https://app.devin.ai/sessions/bb985e014df6469ea570b9c58310017e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
