### PR TITLE
feat(finyk): unified Transaction model and normalizeTransaction

### DIFF
--- a/src/modules/finyk/domain/transactions.js
+++ b/src/modules/finyk/domain/transactions.js
@@ -1,25 +1,73 @@
 /**
- * @typedef {'monobank'|'privatbank'|'manual'|'unknown'} TransactionSource
+ * Уніфікована модель транзакції Фініка.
+ *
+ * Нормалізована форма ОДНА для всіх джерел: manual, monobank, ai, import.
+ * Включає канонічні поля (date/categoryId/type/merchant/note) та legacy-поля
+ * (time/description/mcc/_source/_accountId…), щоб не ламати існуючий UI
+ * та сумісність зі старими даними в localStorage.
+ *
+ * amount — у signed minor units (копійках), як і раніше. UI-код навколо
+ * очікує саме такий формат, тож одиниці зберігаємо, а нові поля лише додаємо.
  */
 
 /**
- * Unified transaction entity for Finyk domain.
- *
+ * @typedef {'expense'|'income'|'transfer'} TransactionType
+ */
+
+/**
+ * Канонічні джерела транзакцій.
+ * @typedef {'manual'|'mono'|'ai'|'import'} TransactionSource
+ */
+
+/**
  * @typedef {Object} Transaction
  * @property {string} id
- * @property {number} time Unix timestamp in seconds
- * @property {number} amount Signed amount in minor units (kopecks)
+ * @property {number} amount Signed amount in minor units (kopecks).
+ * @property {string} date ISO-8601 datetime string.
+ * @property {string} categoryId Category id (empty string if невідома).
+ * @property {TransactionType} type 'expense' | 'income' | 'transfer'
+ * @property {string} [merchant] Merchant name (опційно).
+ * @property {string} [note] Freeform note (опційно).
+ * @property {TransactionSource} source Канонічне джерело.
+ *
+ * Legacy/back-compat (для існуючого UI та персистованих даних):
+ * @property {number} time Unix timestamp in seconds.
  * @property {string} description
  * @property {number} mcc
  * @property {string|null} accountId
- * @property {TransactionSource} source
  * @property {boolean} manual
  * @property {string|undefined} manualId
  * @property {Object|undefined} raw
+ * @property {string} _source Оригінальна назва джерела (monobank/privatbank/…).
+ * @property {string|null} _accountId
+ * @property {boolean} _manual
+ * @property {string|undefined} _manualId
  */
 
+import { INTERNAL_TRANSFER_ID } from "../constants";
+
+// Внутрішні category ids, які трактуються як переказ між власними рахунками.
+const TRANSFER_CATEGORY_IDS = new Set([INTERNAL_TRANSFER_ID, "transfer"]);
+
+// Назви джерел у "сирому" вигляді → канонічні TransactionSource.
+const SOURCE_ALIASES = {
+  manual: "manual",
+  mono: "mono",
+  monobank: "mono",
+  ai: "ai",
+  "ai-analysis": "ai",
+  import: "import",
+  privat: "import",
+  privatbank: "import",
+};
+
+/**
+ * Приводить довільне значення дати/часу до unix timestamp (секунди).
+ * Підтримує: number (мс або сек), Date, ISO-рядок, YYYY-MM-DD тощо.
+ */
 function toSafeTimestampSeconds(input) {
   if (typeof input === "number" && Number.isFinite(input)) {
+    // Якщо це мілісекунди (10^10 межа для секунд — приблизно 2286 рік).
     return input > 10_000_000_000
       ? Math.floor(input / 1000)
       : Math.floor(input);
@@ -31,44 +79,155 @@ function toSafeTimestampSeconds(input) {
     : Math.floor(Date.now() / 1000);
 }
 
+// Мінімум до копійок; число → round; інше → 0. Уникаємо -0.
+function toSafeAmountMinorUnits(input) {
+  const n = Number(input);
+  if (!Number.isFinite(n)) return 0;
+  const rounded = Math.round(n);
+  return rounded === 0 ? 0 : rounded;
+}
+
+// Канонічне джерело з будь-якого alias, з фолбеком на defaults/manual-детект.
+function resolveSource(input, defaults) {
+  const raw =
+    input?.source ??
+    input?._source ??
+    defaults?.source ??
+    (input?._manual || input?.manual ? "manual" : null);
+  if (!raw) return "import";
+  const key = String(raw).toLowerCase();
+  return SOURCE_ALIASES[key] || "import";
+}
+
+// Тип транзакції: якщо категорія — внутрішній переказ → 'transfer';
+// інакше за знаком суми.
+function resolveType(categoryId, amount, explicitType) {
+  if (
+    explicitType === "expense" ||
+    explicitType === "income" ||
+    explicitType === "transfer"
+  ) {
+    return explicitType;
+  }
+  if (categoryId && TRANSFER_CATEGORY_IDS.has(categoryId)) return "transfer";
+  return amount > 0 ? "income" : "expense";
+}
+
+// Витягує categoryId з різних форм сирого input.
+function resolveCategoryId(input) {
+  if (!input) return "";
+  if (typeof input.categoryId === "string" && input.categoryId) {
+    return input.categoryId;
+  }
+  // manual-транзакції зберігають id категорії у raw.category або в полі category.
+  const raw = input.raw && typeof input.raw === "object" ? input.raw : null;
+  const fromRaw = raw && typeof raw.category === "string" ? raw.category : "";
+  const fromInput = typeof input.category === "string" ? input.category : "";
+  return fromRaw || fromInput || "";
+}
+
+// merchant: явне поле > merchantName/vendor > опис для банківських джерел.
+function resolveMerchant(input, source) {
+  if (!input) return undefined;
+  if (typeof input.merchant === "string" && input.merchant.trim()) {
+    return input.merchant.trim();
+  }
+  if (typeof input.merchantName === "string" && input.merchantName.trim()) {
+    return input.merchantName.trim();
+  }
+  // Для mono/import description ≈ merchant; для manual краще не дублювати.
+  if (
+    (source === "mono" || source === "import") &&
+    typeof input.description === "string"
+  ) {
+    const d = input.description.trim();
+    return d || undefined;
+  }
+  return undefined;
+}
+
+// note: явне поле > comment > для manual — description.
+function resolveNote(input, source) {
+  if (!input) return undefined;
+  if (typeof input.note === "string" && input.note.trim()) {
+    return input.note.trim();
+  }
+  if (typeof input.comment === "string" && input.comment.trim()) {
+    return input.comment.trim();
+  }
+  if (source === "manual" && typeof input.description === "string") {
+    const d = input.description.trim();
+    return d || undefined;
+  }
+  return undefined;
+}
+
 /**
- * Normalizes any provider/manual transaction into unified domain Transaction.
+ * Нормалізує довільну “сиру” транзакцію у єдину модель Transaction.
+ *
+ * Генерує id, приводить date до ISO, гарантує що amount — number,
+ * заповнює дефолти відсутніх полів та зберігає legacy-поля для сумісності.
  *
  * @param {Object} input
  * @param {Object} [defaults]
+ * @param {TransactionSource|string} [defaults.source]
+ * @param {string|null} [defaults.accountId]
+ * @param {string} [defaults.categoryId]
  * @returns {Transaction}
  */
 export function normalizeTransaction(input, defaults = {}) {
   const tx = input || {};
-  const source =
-    tx.source ||
-    tx._source ||
-    defaults.source ||
-    (tx._manual ? "manual" : "unknown");
+  const source = resolveSource(tx, defaults);
 
   const manual = Boolean(tx.manual ?? tx._manual ?? source === "manual");
   const manualId = tx.manualId ?? tx._manualId;
   const accountId = tx.accountId ?? tx._accountId ?? defaults.accountId ?? null;
-  const amount = Number(tx.amount);
-  const normalizedAmount = Number.isFinite(amount) ? Math.round(amount) : 0;
+  const normalizedAmount = toSafeAmountMinorUnits(tx.amount);
   const time = toSafeTimestampSeconds(tx.time ?? tx.date ?? tx.createdAt);
+  const date = new Date(time * 1000).toISOString();
 
+  const categoryId =
+    resolveCategoryId(tx) ||
+    (defaults.categoryId ? String(defaults.categoryId) : "");
+  const type = resolveType(categoryId, normalizedAmount, tx.type);
+  const merchant = resolveMerchant(tx, source);
+  const note = resolveNote(tx, source);
+
+  // Стабільний id: або власний, або детермінований від source/time/amount + рандомний хвіст.
   const fallbackId = `${source}_${time}_${normalizedAmount}_${Math.random().toString(36).slice(2, 8)}`;
 
+  // legacy _source: якщо на вхід приходив оригінальний label (monobank/privatbank/unknown)
+  // — зберігаємо його для існуючих перевірок у UI (TxRow і т.п.).
+  const legacySource =
+    typeof tx._source === "string" && tx._source
+      ? tx._source
+      : typeof tx.source === "string" && tx.source
+        ? tx.source
+        : typeof defaults.source === "string" && defaults.source
+          ? defaults.source
+          : source;
+
   return {
+    // Канонічні поля — єдиний формат для всіх споживачів логіки.
     id: String(tx.id || fallbackId),
-    time,
     amount: normalizedAmount,
+    date,
+    categoryId,
+    type,
+    merchant,
+    note,
+    source,
+
+    // Legacy-поля для сумісності з існуючим UI та старими даними.
+    time,
     description: String(tx.description || ""),
     mcc: Number.isFinite(Number(tx.mcc)) ? Number(tx.mcc) : 0,
     accountId: accountId == null ? null : String(accountId),
-    source,
     manual,
     manualId: manualId == null ? undefined : String(manualId),
     raw: tx.raw || undefined,
 
-    // Backward-compatible fields used across module UI.
-    _source: source,
+    _source: legacySource,
     _accountId: accountId == null ? null : String(accountId),
     _manual: manual,
     _manualId: manualId == null ? undefined : String(manualId),
@@ -84,4 +243,31 @@ export function dedupeAndSortTransactions(items) {
   const map = new Map();
   for (const tx of normalizeTransactions(items)) map.set(tx.id, tx);
   return Array.from(map.values()).sort((a, b) => (b.time || 0) - (a.time || 0));
+}
+
+/**
+ * Перетворює збережену manual-витрату (`addManualExpense`-entry) у
+ * нормалізовану Transaction. Зберігає amount у копійках зі знаком "витрата"
+ * та проставляє categoryId з поля `category`.
+ *
+ * @param {{ id:string|number, date?:string, description?:string, amount:number, category?:string }} entry
+ * @returns {Transaction}
+ */
+export function manualExpenseToTransaction(entry) {
+  const e = entry || {};
+  const time = e.date ? Math.floor(new Date(e.date).getTime() / 1000) : 0;
+  return normalizeTransaction(
+    {
+      id: `manual_${e.id}`,
+      manual: true,
+      manualId: e.id,
+      time,
+      // UI зберігає amount як додатнє число у гривнях → конвертуємо у мінус-копійки.
+      amount: -Math.abs(Math.round(Number(e.amount || 0) * 100)),
+      description: e.description || "",
+      mcc: 0,
+      raw: { category: e.category },
+    },
+    { source: "manual", accountId: null, categoryId: e.category || "" },
+  );
 }

--- a/src/modules/finyk/domain/transactions.test.js
+++ b/src/modules/finyk/domain/transactions.test.js
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  normalizeTransaction,
+  normalizeTransactions,
+  manualExpenseToTransaction,
+  dedupeAndSortTransactions,
+} from "./transactions.js";
+import { INTERNAL_TRANSFER_ID } from "../constants.js";
+
+describe("normalizeTransaction — канонічні поля", () => {
+  it("додає date як ISO-рядок з time у секундах", () => {
+    const tx = normalizeTransaction({
+      id: "x",
+      time: 1700000000,
+      amount: -1234,
+      description: "АТБ",
+    });
+    expect(typeof tx.date).toBe("string");
+    expect(tx.date).toBe(new Date(1700000000 * 1000).toISOString());
+  });
+
+  it("приймає мс у time та коректно конвертує у секунди", () => {
+    const ms = 1700000000000;
+    const tx = normalizeTransaction({ id: "x", time: ms, amount: 0 });
+    expect(tx.time).toBe(Math.floor(ms / 1000));
+    expect(tx.date).toBe(new Date(ms).toISOString());
+  });
+
+  it("приймає ISO-рядок у date і конвертує у time/date", () => {
+    const tx = normalizeTransaction({
+      id: "x",
+      date: "2024-01-15T10:30:00.000Z",
+      amount: 100,
+    });
+    expect(tx.date).toBe("2024-01-15T10:30:00.000Z");
+    expect(tx.time).toBe(
+      Math.floor(Date.parse("2024-01-15T10:30:00.000Z") / 1000),
+    );
+  });
+
+  it("гарантує amount як number навіть зі string-входу", () => {
+    const tx = normalizeTransaction({ id: "x", amount: "12.7" });
+    expect(typeof tx.amount).toBe("number");
+    expect(tx.amount).toBe(13);
+  });
+
+  it("0 для невалідного amount", () => {
+    const tx = normalizeTransaction({ id: "x", amount: "abc" });
+    expect(tx.amount).toBe(0);
+  });
+
+  it("генерує id, якщо його немає", () => {
+    const tx = normalizeTransaction({ amount: 100, time: 1700000000 });
+    expect(typeof tx.id).toBe("string");
+    expect(tx.id.length).toBeGreaterThan(0);
+  });
+
+  it("type='expense' для від'ємного amount без явної категорії", () => {
+    const tx = normalizeTransaction({ id: "x", amount: -500 });
+    expect(tx.type).toBe("expense");
+  });
+
+  it("type='income' для додатного amount", () => {
+    const tx = normalizeTransaction({ id: "x", amount: 500 });
+    expect(tx.type).toBe("income");
+  });
+
+  it("type='transfer' для INTERNAL_TRANSFER_ID, незалежно від суми", () => {
+    const tx = normalizeTransaction({
+      id: "x",
+      amount: -100,
+      categoryId: INTERNAL_TRANSFER_ID,
+    });
+    expect(tx.type).toBe("transfer");
+  });
+
+  it("повертає merchant з description для mono-джерела", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: -100, description: "Сільпо" },
+      { source: "monobank" },
+    );
+    expect(tx.merchant).toBe("Сільпо");
+  });
+
+  it("note береться з description для manual", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: -100, description: "Кава" },
+      { source: "manual" },
+    );
+    expect(tx.note).toBe("Кава");
+  });
+
+  it("явні merchant і note мають перевагу", () => {
+    const tx = normalizeTransaction({
+      id: "x",
+      amount: -100,
+      description: "Опис",
+      merchant: "Magaz",
+      note: "коментар",
+    });
+    expect(tx.merchant).toBe("Magaz");
+    expect(tx.note).toBe("коментар");
+  });
+});
+
+describe("normalizeTransaction — джерела", () => {
+  it("'monobank' → 'mono'", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: 1 },
+      { source: "monobank" },
+    );
+    expect(tx.source).toBe("mono");
+    expect(tx._source).toBe("monobank"); // legacy збережено
+  });
+
+  it("'privatbank' → 'import'", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: 1 },
+      { source: "privatbank" },
+    );
+    expect(tx.source).toBe("import");
+    expect(tx._source).toBe("privatbank");
+  });
+
+  it("'manual' лишається 'manual'", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: 1 },
+      { source: "manual" },
+    );
+    expect(tx.source).toBe("manual");
+  });
+
+  it("'ai' лишається 'ai'", () => {
+    const tx = normalizeTransaction({ id: "x", amount: 1 }, { source: "ai" });
+    expect(tx.source).toBe("ai");
+  });
+
+  it("невідоме джерело → 'import'", () => {
+    const tx = normalizeTransaction({ id: "x", amount: 1 });
+    expect(tx.source).toBe("import");
+  });
+});
+
+describe("normalizeTransaction — back-compat поля", () => {
+  it("зберігає _accountId, _manual, _manualId для UI", () => {
+    const tx = normalizeTransaction(
+      { id: "x", amount: -100, manual: true, manualId: "m1" },
+      { source: "manual", accountId: "acc-1" },
+    );
+    expect(tx._accountId).toBe("acc-1");
+    expect(tx._manual).toBe(true);
+    expect(tx._manualId).toBe("m1");
+    expect(tx.accountId).toBe("acc-1");
+  });
+
+  it("description і mcc лишаються як в legacy-форматі", () => {
+    const tx = normalizeTransaction({
+      id: "x",
+      amount: -100,
+      description: "АТБ",
+      mcc: 5411,
+    });
+    expect(tx.description).toBe("АТБ");
+    expect(tx.mcc).toBe(5411);
+  });
+});
+
+describe("normalizeTransactions / dedupeAndSortTransactions", () => {
+  it("normalize-ить масив", () => {
+    const list = normalizeTransactions([
+      { id: "a", time: 1, amount: 1 },
+      { id: "b", time: 2, amount: -1 },
+    ]);
+    expect(list).toHaveLength(2);
+    expect(list[0].source).toBe("import");
+  });
+
+  it("дедуплікує за id та сортує за time desc", () => {
+    const result = dedupeAndSortTransactions([
+      { id: "a", time: 1, amount: 1 },
+      { id: "a", time: 1, amount: 999 }, // дубль
+      { id: "b", time: 5, amount: 2 },
+    ]);
+    expect(result.map((t) => t.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("manualExpenseToTransaction", () => {
+  it("конвертує гривні в копійки зі знаком витрати", () => {
+    const tx = manualExpenseToTransaction({
+      id: "1",
+      date: "2024-06-15T12:00:00.000Z",
+      description: "Кава",
+      amount: 75,
+      category: "food",
+    });
+    expect(tx.amount).toBe(-7500);
+    expect(tx.source).toBe("manual");
+    expect(tx.type).toBe("expense");
+    expect(tx.categoryId).toBe("food");
+    expect(tx._manual).toBe(true);
+    expect(tx._manualId).toBe("1");
+    expect(tx.id).toBe("manual_1");
+  });
+
+  it("обробляє відсутній amount як 0", () => {
+    const tx = manualExpenseToTransaction({
+      id: "2",
+      date: "2024-06-15T12:00:00.000Z",
+    });
+    expect(tx.amount).toBe(0);
+  });
+});

--- a/src/modules/finyk/lib/finykStats.js
+++ b/src/modules/finyk/lib/finykStats.js
@@ -1,4 +1,4 @@
-import { normalizeTransaction } from "../domain/transactions";
+import { manualExpenseToTransaction } from "../domain/transactions";
 import {
   getMonthlySummary,
   getTopCategories,
@@ -65,19 +65,7 @@ export function getRecentTransactions(
   const excluded =
     excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
 
-  const normalizedManual = manual.map((e) =>
-    normalizeTransaction(
-      {
-        id: `manual_${e.id}`,
-        time: e.date ? Math.floor(new Date(e.date).getTime() / 1000) : 0,
-        amount: -(Math.abs(e.amount) * 100),
-        description: e.description || "",
-        mcc: 0,
-        raw: { category: e.category },
-      },
-      { source: "manual", accountId: null },
-    ),
-  );
+  const normalizedManual = manual.map((e) => manualExpenseToTransaction(e));
 
   const all = [
     ...list.filter((tx) => tx && !excluded.has(tx.id)),

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { GroupedVirtuoso } from "react-virtuoso";
 import { TxListItem } from "../components/TxListItem";
 import { getCategory, getIncomeCategory } from "../utils";
-import { normalizeTransaction } from "../domain/transactions";
+import { manualExpenseToTransaction } from "../domain/transactions";
 import { mergeExpenseCategoryDefinitions } from "../constants";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -203,21 +203,7 @@ export function Transactions({
         const ts = new Date(e.date).getTime();
         return ts >= monthStart && ts < monthEnd;
       })
-      .map((e) =>
-        normalizeTransaction(
-          {
-            id: `manual_${e.id}`,
-            manual: true,
-            manualId: e.id,
-            time: Math.floor(new Date(e.date).getTime() / 1000),
-            amount: -Math.abs(Math.round(e.amount * 100)),
-            description: e.description,
-            mcc: 0,
-            raw: { category: e.category },
-          },
-          { source: "manual", accountId: null },
-        ),
-      );
+      .map((e) => manualExpenseToTransaction(e));
   }, [manualExpenses, selMonth]);
 
   const activeTx = useMemo(


### PR DESCRIPTION
## Summary

Уніфікує модель транзакції в модулі `finyk` так, щоб усі джерела (manual, monobank, AI, import/інші банки) приводилися до одного канонічного формату через `normalizeTransaction`. Сумісність зі старим UI та `localStorage` збережена — додано нові поля поверх legacy.

### Що змінено

- **`src/modules/finyk/domain/transactions.js`** — розширено `Transaction` typedef і `normalizeTransaction`:
  - Канонічні поля згідно специфікації: `id` (string), `amount` (number, signed minor units), `date` (ISO string), `categoryId` (string), `type` (`'expense'|'income'|'transfer'`), `merchant` (optional), `note` (optional), `source` (`'manual'|'mono'|'ai'|'import'`).
  - Legacy-поля для існуючого UI лишаються: `time`, `description`, `mcc`, `accountId`, `manual`, `manualId`, `raw`, `_source`, `_accountId`, `_manual`, `_manualId`.
  - `normalizeTransaction` приймає різні форми вхідної дати (мс/сек/`Date`/ISO-рядок), коерсить `amount` до числа, генерує `id` за відсутності, та проставляє дефолти.
  - `source` мапиться через таблицю псевдонімів: `monobank → mono`, `privat[bank] → import`, `ai/ai-analysis → ai`, `manual → manual`. Оригінальна назва зберігається в `_source` (щоб не ламати, напр., `tx._source === 'privatbank'` у `TxRow`).
  - `type` обчислюється: `INTERNAL_TRANSFER_ID` → `transfer`, інакше за знаком `amount`. Можна перевизначити явним `input.type`.
- Додано `manualExpenseToTransaction(entry)` — DRY-хелпер для конверсії збережених у `localStorage` ручних витрат у нормалізовану транзакцію (раніше дублювалось у двох місцях).
- **`src/modules/finyk/pages/Transactions.jsx`** і **`src/modules/finyk/lib/finykStats.js`** — використовують `manualExpenseToTransaction` замість inline-нормалізації.
- **monobank** (`hooks/useMonobank.js`) і **privatbank** (`hooks/usePrivatbank.js`) уже виходили через `normalizeTransaction(..., { source: 'monobank'|'privatbank' })` — тепер автоматично отримують канонічний `source` `mono`/`import` плюс нові поля.
- **AI / sync-шар**: спеціальних потоків AI-транзакцій у репо немає, але `normalizeTransaction(input, { source: 'ai' })` тепер коректно повертає `source: 'ai'` і канонічні поля — готово для майбутнього wiring.
- **Сумісність із localStorage**: жодних змін у формі persisted даних. `manualExpenses`, `finyk_tx_cache` тощо лишаються як є; вся нормалізація відбувається при читанні через `normalizeTransaction`. Старі кешовані mono-транзакції без `source` тепер дефолтяться у `'import'`, але legacy `_source` все ще читається з вхідних даних.
- **Тести**: новий файл `src/modules/finyk/domain/transactions.test.js` з 23 unit-тестами на канонічні поля, мапінг джерел, back-compat, dedupe і manual-конверсію.

### Перевірено локально

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 279/279 pass (33 файли)
- `npm run build` — pass

## Review & Testing Checklist for Human

- [ ] Перевірити, що список транзакцій (`Transactions` page) відображається без візуальних регресій: ручні витрати, mono, privat — усі з’являються як раніше з тими самими підписами/іконками.
- [ ] Додати ручну витрату через `ManualExpenseSheet` — переконатись, що вона з’являється у списку, в аналітиці й бюджетах так само, як до змін.
- [ ] Перевірити, що в `TxRow` префікси для PrivatBank (`tx._source === "privatbank"`) і відмітки manual ще працюють — `_source` лишається у legacy форматі.
- [ ] Перевірити імпорт/sync (бекап через `finykBackup.js` і `?sync=`-URL) — структура persisted даних не мала змінитись.

### Notes

- `amount` навмисно лишено як signed minor units (копійки) — змінювати одиниці зламало б увесь UI/розрахунки (`fmtAmt`, `getMonthlySummary`, `getMonoDebt`, etc.). У задачі вказано лише тип `number`, а одиниці зберігаються як прийнято в кодовій базі.
- `categoryId` для існуючих manual-витрат береться з поля `category` (як уже зберігається у `manualExpenses`); для mono/privat default — `""` (override-категорії й далі обчислюються UI-кодом через `getCategory(...)`).
- Готовність до `'ai'`: щоб додати AI-аналіз, достатньо викликати `normalizeTransaction(rawAi, { source: 'ai' })` і поклавши результат у спільний масив транзакцій.


Link to Devin session: https://app.devin.ai/sessions/d04f2f546a324827b0ae2c9b819f1e72
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
