### PR TITLE
refactor(finyk): централізований finykStorage замість прямих localStorage викликів

### DIFF
--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useMonobank } from "./hooks/useMonobank";
 import { usePrivatbank } from "./hooks/usePrivatbank";
 import { useStorage } from "./hooks/useStorage";
+import { readRaw, writeRaw } from "./lib/finykStorage.js";
 import { PAGES } from "./constants";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -162,28 +163,18 @@ export default function App({
   const [page, navigate] = useHashRouter();
   const [tokenInput, setTokenInput] = useState("");
   const [showToken, setShowToken] = useState(false);
-  const [rememberToken, setRememberToken] = useState(() => {
-    try {
-      return !!localStorage.getItem("finyk_token_remembered");
-    } catch {
-      return false;
-    }
-  });
+  const [rememberToken, setRememberToken] = useState(
+    () => !!readRaw("finyk_token_remembered", ""),
+  );
   const [categoryFilter, setCategoryFilter] = useState(null);
-  const [showBalance, setShowBalance] = useState(() => {
-    try {
-      return localStorage.getItem("finyk_show_balance_v1") !== "0";
-    } catch {
-      return true;
-    }
-  });
+  const [showBalance, setShowBalance] = useState(
+    () => readRaw("finyk_show_balance_v1", "1") !== "0",
+  );
   const [showExpenseSheet, setShowExpenseSheet] = useState(false);
   const [editingManualExpenseId, setEditingManualExpenseId] = useState(null);
 
   useEffect(() => {
-    try {
-      localStorage.setItem("finyk_show_balance_v1", showBalance ? "1" : "0");
-    } catch {}
+    writeRaw("finyk_show_balance_v1", showBalance ? "1" : "0");
   }, [showBalance]);
 
   useEffect(() => {

--- a/src/modules/finyk/hooks/useMonobank.js
+++ b/src/modules/finyk/hooks/useMonobank.js
@@ -1,7 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 import { TX_CACHE_TTL, CURRENCY } from "../constants";
-import { safeJsonSet } from "@shared/lib/storageQuota.js";
+import {
+  readJSON,
+  writeJSON,
+  readRaw,
+  writeRaw,
+  removeItem,
+} from "../lib/finykStorage.js";
 import { normalizeTransaction } from "../domain/transactions";
 
 /**
@@ -50,33 +56,25 @@ function reportSilentError(scope, error) {
 // Migration from "finto_*" keys to "finyk_*" is handled by storageManager (finyk_001_rename_finto_keys).
 
 function loadCache() {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const cache = JSON.parse(raw);
-    if (Date.now() - cache.timestamp > TX_CACHE_TTL) return null;
-    if (!cache.txs || cache.txs.length === 0) return null;
-    return cache;
-  } catch {
+  const cache = readJSON(CACHE_KEY, null);
+  if (!cache || typeof cache !== "object") return null;
+  if (!cache.timestamp || Date.now() - cache.timestamp > TX_CACHE_TTL)
     return null;
-  }
+  if (!Array.isArray(cache.txs) || cache.txs.length === 0) return null;
+  return cache;
 }
 
 function loadAnyCache() {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const cache = JSON.parse(raw);
-    if (!cache.txs || cache.txs.length === 0) return null;
-    return cache;
-  } catch {
-    return null;
-  }
+  const cache = readJSON(CACHE_KEY, null);
+  if (!cache || typeof cache !== "object") return null;
+  if (!Array.isArray(cache.txs) || cache.txs.length === 0) return null;
+  return cache;
 }
 
 function saveCache(txs) {
-  const res = safeJsonSet(CACHE_KEY, { txs, timestamp: Date.now() });
-  if (res.ok) notifyHubFinykCache();
+  if (writeJSON(CACHE_KEY, { txs, timestamp: Date.now() })) {
+    notifyHubFinykCache();
+  }
 }
 
 /** Останній повний знімок — якщо поточний кеш зіпсований (мало транзакцій), відновлюємо звідси */
@@ -84,19 +82,14 @@ const LAST_GOOD_KEY = "finyk_tx_cache_last_good";
 
 function saveLastGoodBackup(txs) {
   if (!txs || txs.length < 3) return;
-  safeJsonSet(LAST_GOOD_KEY, { txs, timestamp: Date.now() });
+  writeJSON(LAST_GOOD_KEY, { txs, timestamp: Date.now() });
 }
 
 function loadLastGoodBackup() {
-  try {
-    const raw = localStorage.getItem(LAST_GOOD_KEY);
-    if (!raw) return null;
-    const c = JSON.parse(raw);
-    if (!c.txs || c.txs.length === 0) return null;
-    return c;
-  } catch {
-    return null;
-  }
+  const c = readJSON(LAST_GOOD_KEY, null);
+  if (!c || typeof c !== "object") return null;
+  if (!Array.isArray(c.txs) || c.txs.length === 0) return null;
+  return c;
 }
 
 function dedupeByIdSort(txs) {
@@ -217,23 +210,26 @@ async function fetchStatementWithRetry(tok, accId, from, to, maxAttempts = 3) {
  */
 export function useMonobank() {
   const [token, setToken] = useState(() => {
+    const rememberedToken = readRaw(REMEMBER_KEY, "");
+    if (rememberedToken) return rememberedToken;
+
+    let sessionToken = "";
     try {
-      const rememberedToken = localStorage.getItem(REMEMBER_KEY);
-      if (rememberedToken) return rememberedToken;
-
-      const sessionToken = sessionStorage.getItem(TOKEN_KEY);
-      if (sessionToken) return sessionToken;
-
-      const legacyToken = localStorage.getItem(TOKEN_KEY);
-      if (legacyToken) {
-        sessionStorage.setItem(TOKEN_KEY, legacyToken);
-        localStorage.removeItem(TOKEN_KEY);
-        return legacyToken;
-      }
-      return "";
+      sessionToken = sessionStorage.getItem(TOKEN_KEY) || "";
     } catch {
-      return "";
+      sessionToken = "";
     }
+    if (sessionToken) return sessionToken;
+
+    const legacyToken = readRaw(TOKEN_KEY, "");
+    if (legacyToken) {
+      try {
+        sessionStorage.setItem(TOKEN_KEY, legacyToken);
+      } catch {}
+      removeItem(TOKEN_KEY);
+      return legacyToken;
+    }
+    return "";
   });
   const [clientInfo, setClientInfo] = useState(null);
   const [accounts, setAccounts] = useState([]);
@@ -442,13 +438,12 @@ export function useMonobank() {
 
     try {
       let info;
-      const infoCache = localStorage.getItem(INFO_CACHE_KEY);
-      if (!forceRefresh && infoCache) {
-        const parsed = JSON.parse(infoCache);
-        if (parsed?.token && parsed.token !== cleanToken) {
+      const parsedInfoCache = readJSON(INFO_CACHE_KEY, null);
+      if (!forceRefresh && parsedInfoCache) {
+        if (parsedInfoCache?.token && parsedInfoCache.token !== cleanToken) {
           throw new Error("Кеш профілю належить іншому токену");
         }
-        info = parsed?.info || parsed;
+        info = parsedInfoCache?.info || parsedInfoCache;
       } else {
         const res = await fetch(
           `${apiUrl("/api/mono")}?path=${encodeURIComponent("/personal/client-info")}`,
@@ -472,13 +467,8 @@ export function useMonobank() {
         }
 
         info = await res.json();
-        try {
-          localStorage.setItem(
-            INFO_CACHE_KEY,
-            JSON.stringify({ token: cleanToken, info }),
-          );
-        } catch (e) {
-          reportSilentError("save client-info cache", e);
+        if (!writeJSON(INFO_CACHE_KEY, { token: cleanToken, info })) {
+          reportSilentError("save client-info cache", "write failed");
         }
       }
 
@@ -486,14 +476,14 @@ export function useMonobank() {
       setAccounts(info.accounts || []);
       try {
         sessionStorage.setItem(TOKEN_KEY, cleanToken);
-        localStorage.removeItem(TOKEN_KEY);
-        if (remember) {
-          localStorage.setItem(REMEMBER_KEY, cleanToken);
-        } else {
-          localStorage.removeItem(REMEMBER_KEY);
-        }
       } catch (e) {
-        reportSilentError("save token", e);
+        reportSilentError("save session token", e);
+      }
+      removeItem(TOKEN_KEY);
+      if (remember) {
+        writeRaw(REMEMBER_KEY, cleanToken);
+      } else {
+        removeItem(REMEMBER_KEY);
       }
       setToken(cleanToken);
 
@@ -533,25 +523,20 @@ export function useMonobank() {
   const fetchMonth = async (year, month) => {
     const cacheKey = `finyk_tx_cache_${year}_${month}`;
     const legacyKey = `finto_tx_cache_${year}_${month}`;
-    try {
-      let raw = localStorage.getItem(cacheKey);
-      if (!raw) {
-        raw = localStorage.getItem(legacyKey);
-        if (raw) {
-          try {
-            localStorage.setItem(cacheKey, raw);
-            localStorage.removeItem(legacyKey);
-          } catch {}
-        }
+
+    let cached = readJSON(cacheKey, null);
+    if (!cached) {
+      const legacy = readJSON(legacyKey, null);
+      if (legacy) {
+        writeJSON(cacheKey, legacy);
+        removeItem(legacyKey);
+        cached = legacy;
       }
-      if (raw) {
-        const cached = JSON.parse(raw);
-        if (cached.txs && cached.txs.length > 0) {
-          setHistoryTx(cached.txs);
-          return;
-        }
-      }
-    } catch {}
+    }
+    if (cached && Array.isArray(cached.txs) && cached.txs.length > 0) {
+      setHistoryTx(cached.txs);
+      return;
+    }
 
     setLoadingHistory(true);
     try {
@@ -581,12 +566,7 @@ export function useMonobank() {
       ).sort((a, b) => b.time - a.time);
       setHistoryTx(unique);
       if (unique.length > 0) {
-        try {
-          localStorage.setItem(
-            cacheKey,
-            JSON.stringify({ txs: unique, timestamp: Date.now() }),
-          );
-        } catch {}
+        writeJSON(cacheKey, { txs: unique, timestamp: Date.now() });
       }
     } finally {
       setLoadingHistory(false);
@@ -606,10 +586,8 @@ export function useMonobank() {
         const info = await res.json();
         setClientInfo(info);
         setAccounts(info.accounts || []);
-        try {
-          localStorage.setItem(INFO_CACHE_KEY, JSON.stringify({ token, info }));
-        } catch (e) {
-          reportSilentError("refresh info cache", e);
+        if (!writeJSON(INFO_CACHE_KEY, { token, info })) {
+          reportSilentError("refresh info cache", "write failed");
         }
         await fetchAllTx(token, info.accounts || []);
         return;
@@ -630,10 +608,7 @@ export function useMonobank() {
   connectRef.current = connect;
   useEffect(() => {
     if (token) {
-      let isRemembered = false;
-      try {
-        isRemembered = localStorage.getItem(REMEMBER_KEY) === token;
-      } catch {}
+      const isRemembered = readRaw(REMEMBER_KEY, "") === token;
       connectRef.current(token, false, isRemembered);
     }
   }, [token]);
@@ -682,23 +657,21 @@ export function useMonobank() {
     });
     try {
       sessionStorage.removeItem(TOKEN_KEY);
-      localStorage.removeItem(TOKEN_KEY); // legacy fallback
-      localStorage.removeItem(REMEMBER_KEY);
-      localStorage.removeItem("finto_token");
-      localStorage.removeItem(CACHE_KEY);
-      localStorage.removeItem(LAST_GOOD_KEY);
-      localStorage.removeItem(INFO_CACHE_KEY);
     } catch (e) {
       reportSilentError("disconnect cleanup", e);
     }
+    removeItem(TOKEN_KEY); // legacy fallback
+    removeItem(REMEMBER_KEY);
+    removeItem("finto_token");
+    removeItem(CACHE_KEY);
+    removeItem(LAST_GOOD_KEY);
+    removeItem(INFO_CACHE_KEY);
     notifyHubFinykCache();
   };
 
   const clearTxCache = () => {
-    try {
-      localStorage.removeItem(CACHE_KEY);
-      localStorage.removeItem(LAST_GOOD_KEY);
-    } catch {}
+    removeItem(CACHE_KEY);
+    removeItem(LAST_GOOD_KEY);
     notifyHubFinykCache();
     setTransactions([]);
     setLastUpdated(null);

--- a/src/modules/finyk/hooks/usePrivatbank.js
+++ b/src/modules/finyk/hooks/usePrivatbank.js
@@ -1,6 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 import { normalizeTransaction } from "../domain/transactions";
+import {
+  readRaw,
+  writeRaw,
+  removeItem,
+  readJSON,
+  writeJSON,
+} from "../lib/finykStorage.js";
 
 const PRIVAT_ID_KEY = "finyk_privat_id";
 const PRIVAT_TOKEN_KEY = "finyk_privat_token";
@@ -9,87 +16,73 @@ const PRIVAT_BALANCE_KEY = "finyk_privat_balance_cache";
 const PRIVAT_CACHE_TTL = 30 * 60 * 1000;
 
 function loadStoredCreds() {
-  try {
-    const id =
-      localStorage.getItem(PRIVAT_ID_KEY) ||
-      sessionStorage.getItem(PRIVAT_ID_KEY) ||
-      "";
-    const token =
-      localStorage.getItem(PRIVAT_TOKEN_KEY) ||
-      sessionStorage.getItem(PRIVAT_TOKEN_KEY) ||
-      "";
-    return { id, token };
-  } catch {
-    return { id: "", token: "" };
+  let id = readRaw(PRIVAT_ID_KEY, "");
+  let token = readRaw(PRIVAT_TOKEN_KEY, "");
+  if (!id) {
+    try {
+      id = sessionStorage.getItem(PRIVAT_ID_KEY) || "";
+    } catch {
+      id = "";
+    }
   }
+  if (!token) {
+    try {
+      token = sessionStorage.getItem(PRIVAT_TOKEN_KEY) || "";
+    } catch {
+      token = "";
+    }
+  }
+  return { id, token };
 }
 
 function saveCreds(id, token, remember) {
-  try {
-    if (remember) {
-      localStorage.setItem(PRIVAT_ID_KEY, id);
-      localStorage.setItem(PRIVAT_TOKEN_KEY, token);
+  if (remember) {
+    writeRaw(PRIVAT_ID_KEY, id);
+    writeRaw(PRIVAT_TOKEN_KEY, token);
+    try {
       sessionStorage.removeItem(PRIVAT_ID_KEY);
       sessionStorage.removeItem(PRIVAT_TOKEN_KEY);
-    } else {
+    } catch {}
+  } else {
+    try {
       sessionStorage.setItem(PRIVAT_ID_KEY, id);
       sessionStorage.setItem(PRIVAT_TOKEN_KEY, token);
-      localStorage.removeItem(PRIVAT_ID_KEY);
-      localStorage.removeItem(PRIVAT_TOKEN_KEY);
-    }
-  } catch {}
+    } catch {}
+    removeItem(PRIVAT_ID_KEY);
+    removeItem(PRIVAT_TOKEN_KEY);
+  }
 }
 
 function clearCreds() {
+  removeItem(PRIVAT_ID_KEY);
+  removeItem(PRIVAT_TOKEN_KEY);
   try {
-    localStorage.removeItem(PRIVAT_ID_KEY);
-    localStorage.removeItem(PRIVAT_TOKEN_KEY);
     sessionStorage.removeItem(PRIVAT_ID_KEY);
     sessionStorage.removeItem(PRIVAT_TOKEN_KEY);
   } catch {}
 }
 
 function loadTxCache() {
-  try {
-    const raw = localStorage.getItem(PRIVAT_CACHE_KEY);
-    if (!raw) return null;
-    const c = JSON.parse(raw);
-    if (Date.now() - c.timestamp > PRIVAT_CACHE_TTL) return null;
-    if (!c.txs || c.txs.length === 0) return null;
-    return c;
-  } catch {
-    return null;
-  }
+  const c = readJSON(PRIVAT_CACHE_KEY, null);
+  if (!c || typeof c !== "object") return null;
+  if (!c.timestamp || Date.now() - c.timestamp > PRIVAT_CACHE_TTL) return null;
+  if (!Array.isArray(c.txs) || c.txs.length === 0) return null;
+  return c;
 }
 
 function saveTxCache(txs) {
-  try {
-    localStorage.setItem(
-      PRIVAT_CACHE_KEY,
-      JSON.stringify({ txs, timestamp: Date.now() }),
-    );
-  } catch {}
+  writeJSON(PRIVAT_CACHE_KEY, { txs, timestamp: Date.now() });
 }
 
 function loadBalanceCache() {
-  try {
-    const raw = localStorage.getItem(PRIVAT_BALANCE_KEY);
-    if (!raw) return null;
-    const c = JSON.parse(raw);
-    if (Date.now() - c.timestamp > PRIVAT_CACHE_TTL) return null;
-    return c.accounts || null;
-  } catch {
-    return null;
-  }
+  const c = readJSON(PRIVAT_BALANCE_KEY, null);
+  if (!c || typeof c !== "object") return null;
+  if (!c.timestamp || Date.now() - c.timestamp > PRIVAT_CACHE_TTL) return null;
+  return Array.isArray(c.accounts) ? c.accounts : null;
 }
 
 function saveBalanceCache(accounts) {
-  try {
-    localStorage.setItem(
-      PRIVAT_BALANCE_KEY,
-      JSON.stringify({ accounts, timestamp: Date.now() }),
-    );
-  } catch {}
+  writeJSON(PRIVAT_BALANCE_KEY, { accounts, timestamp: Date.now() });
 }
 
 function fmtDate(isoDate) {
@@ -390,17 +383,13 @@ export function usePrivatbank(enabled = true) {
       lastSuccess: null,
       lastError: "",
     });
-    try {
-      localStorage.removeItem(PRIVAT_CACHE_KEY);
-      localStorage.removeItem(PRIVAT_BALANCE_KEY);
-    } catch {}
+    removeItem(PRIVAT_CACHE_KEY);
+    removeItem(PRIVAT_BALANCE_KEY);
   };
 
   const clearCache = () => {
-    try {
-      localStorage.removeItem(PRIVAT_CACHE_KEY);
-      localStorage.removeItem(PRIVAT_BALANCE_KEY);
-    } catch {}
+    removeItem(PRIVAT_CACHE_KEY);
+    removeItem(PRIVAT_BALANCE_KEY);
     setTransactions([]);
     setAccounts([]);
     setLastUpdated(null);

--- a/src/modules/finyk/hooks/useStorage.js
+++ b/src/modules/finyk/hooks/useStorage.js
@@ -7,8 +7,12 @@ import {
   FINYK_BACKUP_VERSION,
 } from "../lib/finykBackup.js";
 import { toLocalISODate } from "@shared/lib/date";
-import { safeJsonSet } from "@shared/lib/storageQuota.js";
-import { finykStorageManager } from "../lib/storageManager";
+import {
+  readJSON,
+  writeJSON,
+  writeJSONDebounced,
+  finykStorageManager,
+} from "../lib/finykStorage.js";
 
 function reportSilentError(scope, error) {
   console.warn(`[finyk] ${scope}`, error);
@@ -20,22 +24,9 @@ try {
   reportSilentError("storage migrations", error);
 }
 function usePersist(key, defaultVal) {
-  const [val, setVal] = useState(() => {
-    try {
-      return finykStorageManager.getJSON(key, defaultVal);
-    } catch {
-      return defaultVal;
-    }
-  });
+  const [val, setVal] = useState(() => readJSON(key, defaultVal));
   useEffect(() => {
-    const res = safeJsonSet(key, val);
-    if (!res.ok) {
-      // Не ламаємо UX, але і не мовчимо повністю.
-      console.warn(
-        `[finyk] localStorage write failed for "${key}"`,
-        res.reason,
-      );
-    }
+    writeJSONDebounced(key, val);
   }, [key, val]);
   return [val, setVal];
 }
@@ -79,14 +70,7 @@ export function useStorage({ onImportFeedback } = {}) {
     [],
   );
   const networthSnapshotRef = useRef(
-    (() => {
-      try {
-        const saved = localStorage.getItem("finyk_networth_last_snap");
-        return saved ? JSON.parse(saved) : { date: null, value: null };
-      } catch {
-        return { date: null, value: null };
-      }
-    })(),
+    readJSON("finyk_networth_last_snap", { date: null, value: null }),
   );
 
   const addManualExpense = (expense) => {
@@ -433,12 +417,7 @@ export function useStorage({ onImportFeedback } = {}) {
         if (changePct < 0.01) return;
       }
       networthSnapshotRef.current = { date: today, value: rounded };
-      try {
-        localStorage.setItem(
-          "finyk_networth_last_snap",
-          JSON.stringify({ date: today, value: rounded }),
-        );
-      } catch {}
+      writeJSON("finyk_networth_last_snap", { date: today, value: rounded });
       const key = `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, "0")}`;
       setNetworthHistory((prev) => {
         const filtered = prev.filter((s) => s.month !== key);

--- a/src/modules/finyk/lib/finykBackup.js
+++ b/src/modules/finyk/lib/finykBackup.js
@@ -1,5 +1,6 @@
 import { DEFAULT_SUBSCRIPTIONS } from "../constants.js";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
+import { readJSON, writeJSON } from "./finykStorage.js";
 
 /** Версія формату експорту JSON (бекап). */
 export const FINYK_BACKUP_VERSION = 2;
@@ -7,14 +8,7 @@ export const FINYK_BACKUP_VERSION = 2;
 const DEFAULT_MONTHLY_PLAN = { income: "", expense: "", savings: "" };
 
 function readJsonFromLocalStorage(key, fallback) {
-  if (typeof localStorage === "undefined") return fallback;
-  try {
-    const s = localStorage.getItem(key);
-    if (s === null) return fallback;
-    return JSON.parse(s);
-  } catch {
-    return fallback;
-  }
+  return readJSON(key, fallback);
 }
 
 /**
@@ -65,12 +59,11 @@ const FINYK_FIELD_TO_STORAGE_KEY = {
  * Записує нормалізований бекап Фініка в localStorage (після normalizeFinykBackup).
  */
 export function persistFinykNormalizedToStorage(normalized) {
-  if (typeof localStorage === "undefined") return;
   for (const [field, storageKey] of Object.entries(
     FINYK_FIELD_TO_STORAGE_KEY,
   )) {
     if (normalized[field] !== undefined) {
-      localStorage.setItem(storageKey, JSON.stringify(normalized[field]));
+      writeJSON(storageKey, normalized[field]);
     }
   }
   notifyFinykRoutineCalendarSync();

--- a/src/modules/finyk/lib/finykStorage.js
+++ b/src/modules/finyk/lib/finykStorage.js
@@ -1,0 +1,277 @@
+/**
+ * Централізований storage-шар модуля ФІНІК.
+ *
+ * Мета: прибрати хаотичні виклики localStorage з компонентів/хуків і забезпечити:
+ *  - безпечне читання/запис (try/catch + дефолтні значення);
+ *  - debounce запису + пропуск ідентичних значень;
+ *  - стабільну інтеграцію з існуючими міграціями (`storageManager.js`) та ключами.
+ *
+ * Ключі залишаються ті самі, що вже використовуються застосунком — цей модуль
+ * лише агрегує доступ до них. Міграції з "finto_*" у "finyk_*" виконуються
+ * через shared `storageManager` та `finyk_002_rename_finto_user_data`.
+ */
+
+import { safeJsonSet } from "@shared/lib/storageQuota.js";
+import { finykStorageManager } from "./storageManager.js";
+
+/** Стандартні ключі доменних сутностей ФІНІК. Не змінювати без міграції. */
+export const FINYK_STORAGE_KEYS = Object.freeze({
+  transactions: "finyk_manual_expenses_v1",
+  categories: "finyk_custom_cats_v1",
+  budget: "finyk_budgets",
+});
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+function reportStorageError(scope, error) {
+  try {
+    console.warn(`[finykStorage] ${scope}`, error);
+  } catch {
+    /* ignore logging errors */
+  }
+}
+
+function hasLocalStorage() {
+  return typeof localStorage !== "undefined" && localStorage !== null;
+}
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value === undefined ? null : value);
+  } catch (error) {
+    reportStorageError("JSON.stringify", error);
+    return undefined;
+  }
+}
+
+/** Остання успішно записана JSON-репрезентація — для change-detection. */
+const lastWrittenCache = new Map();
+/** Значення, що очікують запису (по ключу). */
+const pendingValues = new Map();
+/** Таймери debounce (по ключу). */
+const pendingTimers = new Map();
+
+/**
+ * Безпечне читання JSON зі сховища.
+ * Повертає `fallback` якщо значення відсутнє, сховище недоступне, або JSON биті.
+ */
+export function readJSON(key, fallback = null) {
+  if (!hasLocalStorage()) return fallback;
+  const k = String(key);
+  let raw;
+  try {
+    raw = localStorage.getItem(k);
+  } catch (error) {
+    reportStorageError(`read("${k}")`, error);
+    return fallback;
+  }
+  if (raw === null || raw === undefined) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed === undefined ? fallback : parsed;
+  } catch (error) {
+    reportStorageError(`JSON.parse("${k}")`, error);
+    return fallback;
+  }
+}
+
+/**
+ * Безпечний запис JSON у сховище. Використовує shared квотний guard.
+ * Повертає true у разі успіху.
+ */
+export function writeJSON(key, value) {
+  if (!hasLocalStorage()) return false;
+  const k = String(key);
+  try {
+    const res = safeJsonSet(k, value);
+    if (res && res.ok) {
+      const serialized = safeStringify(value);
+      if (serialized !== undefined) lastWrittenCache.set(k, serialized);
+      return true;
+    }
+    reportStorageError(`write("${k}")`, res?.reason || res?.error || "unknown");
+    return false;
+  } catch (error) {
+    reportStorageError(`write("${k}")`, error);
+    return false;
+  }
+}
+
+/** Безпечне читання сирого рядка (без JSON.parse). */
+export function readRaw(key, fallback = null) {
+  if (!hasLocalStorage()) return fallback;
+  const k = String(key);
+  try {
+    const v = localStorage.getItem(k);
+    return v === null || v === undefined ? fallback : v;
+  } catch (error) {
+    reportStorageError(`readRaw("${k}")`, error);
+    return fallback;
+  }
+}
+
+/** Безпечний запис сирого рядка. */
+export function writeRaw(key, value) {
+  if (!hasLocalStorage()) return false;
+  const k = String(key);
+  try {
+    localStorage.setItem(k, String(value ?? ""));
+    return true;
+  } catch (error) {
+    reportStorageError(`writeRaw("${k}")`, error);
+    return false;
+  }
+}
+
+/** Безпечне видалення ключа. */
+export function removeItem(key) {
+  if (!hasLocalStorage()) return false;
+  const k = String(key);
+  // Скасовуємо відкладений запис, якщо є — інакше пізніше перезапише null.
+  const timer = pendingTimers.get(k);
+  if (timer) {
+    clearTimeout(timer);
+    pendingTimers.delete(k);
+  }
+  pendingValues.delete(k);
+  lastWrittenCache.delete(k);
+  try {
+    localStorage.removeItem(k);
+    return true;
+  } catch (error) {
+    reportStorageError(`remove("${k}")`, error);
+    return false;
+  }
+}
+
+/**
+ * Запис із debounce + пропуском, якщо значення не змінилось.
+ * Якщо сторінка ховається/закривається — буфер гарантовано скидається.
+ * @param {string} key
+ * @param {unknown} value
+ * @param {number} [delay=500]
+ */
+export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
+  if (!hasLocalStorage()) return;
+  const k = String(key);
+  const nextStr = safeStringify(value);
+  if (nextStr === undefined) return;
+
+  const lastStr = lastWrittenCache.get(k);
+  const hasPending = pendingTimers.has(k);
+  if (!hasPending && lastStr === nextStr) {
+    return; // Дані не змінились — запис не потрібен.
+  }
+
+  pendingValues.set(k, value);
+
+  if (pendingTimers.has(k)) {
+    clearTimeout(pendingTimers.get(k));
+  }
+  const timer = setTimeout(() => {
+    pendingTimers.delete(k);
+    if (!pendingValues.has(k)) return;
+    const pending = pendingValues.get(k);
+    pendingValues.delete(k);
+    writeJSON(k, pending);
+  }, Math.max(0, Number(delay) || DEFAULT_DEBOUNCE_MS));
+  pendingTimers.set(k, timer);
+}
+
+/** Скинути всі відкладені записи негайно. */
+export function flushPendingWrites() {
+  const keys = Array.from(pendingTimers.keys());
+  for (const k of keys) {
+    const timer = pendingTimers.get(k);
+    if (timer) clearTimeout(timer);
+    pendingTimers.delete(k);
+    if (pendingValues.has(k)) {
+      const value = pendingValues.get(k);
+      pendingValues.delete(k);
+      writeJSON(k, value);
+    }
+  }
+}
+
+// Гарантований flush при закритті вкладки / втраті видимості.
+if (typeof window !== "undefined") {
+  try {
+    const flush = () => {
+      try {
+        flushPendingWrites();
+      } catch {
+        /* ignore flush errors */
+      }
+    };
+    window.addEventListener("beforeunload", flush);
+    window.addEventListener("pagehide", flush);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") flush();
+      });
+    }
+  } catch {
+    /* ignore listener errors */
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Доменний API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Повертає список вручну доданих транзакцій (finyk_manual_expenses_v1).
+ * @returns {Array<object>}
+ */
+export function getTransactions() {
+  const v = readJSON(FINYK_STORAGE_KEYS.transactions, []);
+  return Array.isArray(v) ? v : [];
+}
+
+/**
+ * Зберігає список вручну доданих транзакцій (debounced + skip-if-equal).
+ * @param {Array<object>} transactions
+ */
+export function saveTransactions(transactions) {
+  const value = Array.isArray(transactions) ? transactions : [];
+  writeJSONDebounced(FINYK_STORAGE_KEYS.transactions, value);
+}
+
+/**
+ * Повертає кастомні категорії користувача (finyk_custom_cats_v1).
+ * @returns {Array<object>}
+ */
+export function getCategories() {
+  const v = readJSON(FINYK_STORAGE_KEYS.categories, []);
+  return Array.isArray(v) ? v : [];
+}
+
+/**
+ * Зберігає кастомні категорії користувача (debounced + skip-if-equal).
+ * @param {Array<object>} categories
+ */
+export function saveCategories(categories) {
+  const value = Array.isArray(categories) ? categories : [];
+  writeJSONDebounced(FINYK_STORAGE_KEYS.categories, value);
+}
+
+/**
+ * Повертає конфіг бюджетів (finyk_budgets).
+ * @returns {Array<object>}
+ */
+export function getBudget() {
+  const v = readJSON(FINYK_STORAGE_KEYS.budget, []);
+  return Array.isArray(v) ? v : [];
+}
+
+/**
+ * Зберігає конфіг бюджетів (debounced + skip-if-equal).
+ * @param {Array<object>} budget
+ */
+export function saveBudget(budget) {
+  const value = Array.isArray(budget) ? budget : [];
+  writeJSONDebounced(FINYK_STORAGE_KEYS.budget, value);
+}
+
+// Реекспорт менеджера міграцій — щоб споживачі імпортували все з одного модуля.
+export { finykStorageManager };

--- a/src/modules/finyk/lib/finykStorage.js
+++ b/src/modules/finyk/lib/finykStorage.js
@@ -168,13 +168,16 @@ export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
   if (pendingTimers.has(k)) {
     clearTimeout(pendingTimers.get(k));
   }
-  const timer = setTimeout(() => {
-    pendingTimers.delete(k);
-    if (!pendingValues.has(k)) return;
-    const pending = pendingValues.get(k);
-    pendingValues.delete(k);
-    writeJSON(k, pending);
-  }, Math.max(0, Number(delay) || DEFAULT_DEBOUNCE_MS));
+  const timer = setTimeout(
+    () => {
+      pendingTimers.delete(k);
+      if (!pendingValues.has(k)) return;
+      const pending = pendingValues.get(k);
+      pendingValues.delete(k);
+      writeJSON(k, pending);
+    },
+    Math.max(0, Number(delay) || DEFAULT_DEBOUNCE_MS),
+  );
   pendingTimers.set(k, timer);
 }
 

--- a/src/modules/finyk/lib/finykStorage.test.js
+++ b/src/modules/finyk/lib/finykStorage.test.js
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  FINYK_STORAGE_KEYS,
+  readJSON,
+  writeJSON,
+  readRaw,
+  writeRaw,
+  removeItem,
+  writeJSONDebounced,
+  flushPendingWrites,
+  getTransactions,
+  saveTransactions,
+  getCategories,
+  saveCategories,
+  getBudget,
+  saveBudget,
+} from "./finykStorage.js";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+afterEach(() => {
+  flushPendingWrites();
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("readJSON", () => {
+  it("повертає fallback для відсутнього ключа", () => {
+    expect(readJSON("missing", { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("повертає fallback при биттих даних без падіння", () => {
+    localStorage.setItem("bad", "{not json");
+    expect(readJSON("bad", [])).toEqual([]);
+  });
+
+  it("читає валідний JSON", () => {
+    localStorage.setItem("ok", JSON.stringify({ x: 42 }));
+    expect(readJSON("ok")).toEqual({ x: 42 });
+  });
+});
+
+describe("writeJSON + readJSON", () => {
+  it("серіалізує та десеріалізує значення", () => {
+    const value = { foo: "bar", nums: [1, 2, 3] };
+    expect(writeJSON("roundtrip", value)).toBe(true);
+    expect(readJSON("roundtrip")).toEqual(value);
+  });
+});
+
+describe("readRaw / writeRaw", () => {
+  it("зберігає рядок без JSON обгортки", () => {
+    writeRaw("pref", "1");
+    expect(readRaw("pref")).toBe("1");
+    expect(readRaw("other", "def")).toBe("def");
+  });
+});
+
+describe("removeItem", () => {
+  it("видаляє ключ", () => {
+    writeRaw("tmp", "hello");
+    expect(readRaw("tmp")).toBe("hello");
+    removeItem("tmp");
+    expect(readRaw("tmp", null)).toBeNull();
+  });
+});
+
+describe("writeJSONDebounced", () => {
+  it("затримує запис, не записує однакові значення повторно", async () => {
+    vi.useFakeTimers();
+    writeJSONDebounced("k", { a: 1 }, 200);
+    // Ще не записано.
+    expect(localStorage.getItem("k")).toBeNull();
+    vi.advanceTimersByTime(199);
+    expect(localStorage.getItem("k")).toBeNull();
+    vi.advanceTimersByTime(2);
+    expect(JSON.parse(localStorage.getItem("k"))).toEqual({ a: 1 });
+
+    // Той самий payload — debounce не повинен нічого планувати повторно.
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    writeJSONDebounced("k", { a: 1 }, 200);
+    vi.advanceTimersByTime(500);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("останнє значення перемагає при швидких послідовних викликах", () => {
+    vi.useFakeTimers();
+    writeJSONDebounced("q", 1, 300);
+    writeJSONDebounced("q", 2, 300);
+    writeJSONDebounced("q", 3, 300);
+    vi.advanceTimersByTime(301);
+    expect(JSON.parse(localStorage.getItem("q"))).toBe(3);
+  });
+});
+
+describe("flushPendingWrites", () => {
+  it("скидає всі відкладені записи одразу", () => {
+    vi.useFakeTimers();
+    writeJSONDebounced("pending", "value", 500);
+    expect(localStorage.getItem("pending")).toBeNull();
+    flushPendingWrites();
+    expect(JSON.parse(localStorage.getItem("pending"))).toBe("value");
+  });
+});
+
+describe("Domain API", () => {
+  it("transactions: default/get/save", () => {
+    expect(getTransactions()).toEqual([]);
+    saveTransactions([{ id: "1" }]);
+    flushPendingWrites();
+    expect(getTransactions()).toEqual([{ id: "1" }]);
+    expect(
+      JSON.parse(localStorage.getItem(FINYK_STORAGE_KEYS.transactions)),
+    ).toEqual([{ id: "1" }]);
+  });
+
+  it("categories: default/get/save", () => {
+    expect(getCategories()).toEqual([]);
+    saveCategories([{ id: "c1", name: "Food" }]);
+    flushPendingWrites();
+    expect(getCategories()).toEqual([{ id: "c1", name: "Food" }]);
+  });
+
+  it("budget: default/get/save", () => {
+    expect(getBudget()).toEqual([]);
+    saveBudget([{ id: "b1", limit: 100 }]);
+    flushPendingWrites();
+    expect(getBudget()).toEqual([{ id: "b1", limit: 100 }]);
+  });
+
+  it("коректно обробляє биті дані у storage", () => {
+    localStorage.setItem(FINYK_STORAGE_KEYS.transactions, "corrupted");
+    localStorage.setItem(FINYK_STORAGE_KEYS.categories, "{bad");
+    localStorage.setItem(FINYK_STORAGE_KEYS.budget, "not json either");
+    expect(getTransactions()).toEqual([]);
+    expect(getCategories()).toEqual([]);
+    expect(getBudget()).toEqual([]);
+  });
+});

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -15,16 +15,12 @@ import { CategoryPieChart } from "../components/charts/lazy";
 import { ChartFallback } from "../components/charts/ChartFallback";
 import { MerchantList } from "../components/analytics/MerchantList";
 import { getMonthlyTrendComparison } from "../lib/finykStats";
+import { readJSON } from "../lib/finykStorage.js";
 
 function readTxCache(year, month) {
-  try {
-    const raw = localStorage.getItem(`finyk_tx_cache_${year}_${month}`);
-    if (!raw) return null;
-    const { txs } = JSON.parse(raw);
-    return Array.isArray(txs) ? txs : null;
-  } catch {
-    return null;
-  }
+  const cache = readJSON(`finyk_tx_cache_${year}_${month}`, null);
+  if (!cache || typeof cache !== "object") return null;
+  return Array.isArray(cache.txs) ? cache.txs : null;
 }
 
 // Презентаційний контейнер-секція. memo, бо приймає лише `title/className/children`

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -26,6 +26,7 @@ import { GoalBudgetCard } from "../components/budgets/GoalBudgetCard.jsx";
 import { CategorySelector } from "../components/CategorySelector.jsx";
 import { CategoryManager } from "../components/CategoryManager.jsx";
 import { calculateSafeToSpendPerDay } from "../hooks/useBudget.js";
+import { readJSON, writeJSON } from "../lib/finykStorage.js";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
@@ -116,28 +117,23 @@ export function Budgets({ mono, storage }) {
 
   const getAdviceCache = useCallback(
     (categoryId, monthKey) => {
-      try {
-        const raw = localStorage.getItem(
-          PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey,
-        );
-        if (!raw) return null;
-        const { text, ts } = JSON.parse(raw);
-        if (Date.now() - ts > PROACTIVE_CACHE_TTL) return null;
-        return text;
-      } catch {
-        return null;
-      }
+      const cached = readJSON(
+        PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey,
+        null,
+      );
+      if (!cached || typeof cached !== "object") return null;
+      const { text, ts } = cached;
+      if (!ts || Date.now() - ts > PROACTIVE_CACHE_TTL) return null;
+      return text;
     },
     [PROACTIVE_CACHE_TTL],
   );
 
   const setAdviceCache = useCallback((categoryId, monthKey, text) => {
-    try {
-      localStorage.setItem(
-        PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey,
-        JSON.stringify({ text, ts: Date.now() }),
-      );
-    } catch {}
+    writeJSON(PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey, {
+      text,
+      ts: Date.now(),
+    });
   }, []);
 
   const forecasts = useMemo(() => {


### PR DESCRIPTION
## Summary

Винесено всю роботу зі сховищем модуля **ФІНІК** у єдиний шар `src/modules/finyk/lib/finykStorage.js`.
Компоненти і хуки більше не чіпають `localStorage` напряму — це прибирає дублювання try/catch-логіки, централізує обробку биттих даних і дає змогу робити debounced-записи без змін у споживачах.

### Що зроблено

- **Новий модуль `finykStorage.js`** з безпечним API:
  - `readJSON / writeJSON` — JSON із try/catch та дефолтами;
  - `readRaw / writeRaw / removeItem` — для простих рядкових налаштувань (токени, прапорці);
  - `writeJSONDebounced(key, value, delay=500)` — debounce + **skip-if-equal** (не пише, якщо дані не змінились);
  - `flushPendingWrites()` + автоматичний flush на `beforeunload` / `pagehide` / `visibilitychange:hidden`, щоб не втратити дані користувача;
  - `getTransactions / saveTransactions`, `getCategories / saveCategories`, `getBudget / saveBudget` — доменний API (ключі `finyk_manual_expenses_v1`, `finyk_custom_cats_v1`, `finyk_budgets`);
  - реекспорт `finykStorageManager` (міграції `finto_*` → `finyk_*` не зачіпаються).

- **Рефакторинг існуючих місць** (прямі `localStorage.*` замінено на finykStorage):
  - `hooks/useStorage.js` — `usePersist` тепер використовує `readJSON` + `writeJSONDebounced`; networth-snapshot теж через storage-шар;
  - `hooks/useMonobank.js` — кеш транзакцій/інформації, токен-прапорець `remembered`, disconnect/clearCache (sessionStorage для ad-hoc токена збережено);
  - `hooks/usePrivatbank.js` — credentials (з розмежуванням local vs session), tx/balance кеш, clearCache;
  - `FinykApp.jsx` — `finyk_show_balance_v1`, `finyk_token_remembered`;
  - `pages/Budgets.jsx` — кеш проактивних порад (TTL 24 год);
  - `pages/Analytics.jsx` — читання `finyk_tx_cache_<y>_<m>`;
  - `lib/finykBackup.js` — `readJsonFromLocalStorage` та `persistFinykNormalizedToStorage` через finykStorage.

- **Ключі не змінюються** — існуючі дані користувачів читаються тими ж іменами; міграції `storageManager` залишились недоторканими.

- **Unit-тести** `lib/finykStorage.test.js` (13 кейсів): fallback на биті дані, round-trip, debounce + skip-if-equal, last-wins, flush, domain API.

### Безпека / дані

- Усі функції обгорнуто в try/catch — жодне виключення з `JSON.parse` чи quota не падає в UI.
- При биттих даних повертається дефолт (порожній масив/`null`), не створюється виключення.
- Запис через `safeJsonSet` (shared quota guard) — якщо бракує місця, пишеться m warn, стан UI не ламається.
- Debounced-записи flush-аться при закритті сторінки, тож дані не втрачаються.

## Review & Testing Checklist for Human

- [ ] Переконатися, що після оновлення на нову версію існуючі дані (транзакції, бюджети, кастомні категорії, networth-історія) читаються без втрат.
- [ ] Перевірити Monobank-флоу: підключення з «запам'ятати токен» і без (session vs local), `Clear cache`, `Disconnect`.
- [ ] Перевірити Privatbank-флоу: підключення з remember=true/false, `Clear cache`.
- [ ] Перевірити прапорці `showBalance` і `rememberToken` — перемикач має переживати перезавантаження.
- [ ] Перевірити Budgets → проактивні поради (TTL 24 год, кеш не зникає між перезавантаженнями).

### Notes

- `sessionStorage`-шлях для токенів Monobank/Privatbank навмисно залишений як є — це окрема поверхня від `localStorage` і саме вона забезпечує режим «не запам'ятовувати».
- `storageManager.js` (міграції) свідомо не рефакторився — він працює на рівень нижче і викликається один раз при ініціалізації.
- CI: `lint`, `typecheck`, `test` (269 passed), `build` — усі зелені локально.


Link to Devin session: https://app.devin.ai/sessions/2f695b5380564846ad39ce3ce2beb9ad
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
