### PR TITLE
feat(analytics): add product analytics trackEvent and wire key events

### DIFF
--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@shared/lib/cn";
+import { trackEvent, ANALYTICS_EVENTS } from "./analytics";
 
 export const ONBOARDING_DONE_KEY = "hub_onboarding_done_v1";
 
@@ -324,7 +325,17 @@ export function OnboardingWizard({ onDone }) {
 
   const TOTAL = 4;
 
+  // Wizard mounts exactly once per onboarding attempt — emit start event here
+  // rather than in a parent so the signal is colocated with the flow itself.
+  useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+  }, []);
+
   const handleDone = () => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+      startModule: startModule || "none",
+      providedName: Boolean(name.trim()),
+    });
     if (name.trim()) {
       try {
         localStorage.setItem("hub_user_name", name.trim());

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -1,0 +1,90 @@
+// Lightweight product analytics sink.
+//
+// Currently this is a console logger only — it gives us a single place to
+// wire `trackEvent` calls from the product and later swap the transport to
+// PostHog / Amplitude / a proxy endpoint without touching call sites.
+//
+// Contract:
+//   - `trackEvent(name, payload?)` is fire-and-forget. It never throws
+//     and never returns a Promise that callers need to await.
+//   - Payload is expected to be a small plain object with NO sensitive
+//     data (no tokens, emails, amounts linked to a real identity, etc.).
+//
+// When we add a real provider we will only change this file.
+
+/** @typedef {{ eventName: string, payload: object, timestamp: string }} AnalyticsEvent */
+
+/**
+ * Canonical event names used across the app. Using the constants avoids
+ * typos and makes it easy to grep for every call site.
+ */
+export const ANALYTICS_EVENTS = Object.freeze({
+  ONBOARDING_STARTED: "onboarding_started",
+  ONBOARDING_COMPLETED: "onboarding_completed",
+  EXPENSE_ADDED: "expense_added",
+  EXPENSE_DELETED: "expense_deleted",
+  BUDGET_SET: "budget_set",
+  ANALYTICS_OPENED: "analytics_opened",
+  BANK_CONNECT_STARTED: "bank_connect_started",
+  BANK_CONNECT_SUCCESS: "bank_connect_success",
+  PAYWALL_VIEWED: "paywall_viewed",
+});
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   track: (event: AnalyticsEvent) => void,
+ * }} AnalyticsProvider
+ */
+
+/** @type {AnalyticsProvider[]} */
+const providers = [];
+
+/**
+ * Register a transport (e.g. PostHog / Amplitude wrapper). Providers must
+ * be resilient — any thrown error is swallowed so analytics can never
+ * break the UI.
+ * @param {AnalyticsProvider} provider
+ */
+export function registerAnalyticsProvider(provider) {
+  if (!provider || typeof provider.track !== "function") return;
+  providers.push(provider);
+}
+
+/** Clear all registered providers. Primarily useful in tests. */
+export function resetAnalyticsProviders() {
+  providers.length = 0;
+}
+
+function safeDispatch(event) {
+  for (const p of providers) {
+    try {
+      p.track(event);
+    } catch (err) {
+      // Never let a misbehaving provider impact the UI.
+      console.warn(`[analytics] provider "${p.name}" failed`, err);
+    }
+  }
+}
+
+/**
+ * Record a product event. Fire-and-forget — safe to call from any UI
+ * handler without awaiting.
+ *
+ * @param {string} eventName - Canonical event name, see `ANALYTICS_EVENTS`.
+ * @param {object} [payload] - Minimal, non-sensitive metadata.
+ */
+export function trackEvent(eventName, payload = {}) {
+  if (!eventName || typeof eventName !== "string") return;
+  const event = {
+    eventName,
+    payload: payload && typeof payload === "object" ? payload : {},
+    timestamp: new Date().toISOString(),
+  };
+  try {
+    // Stage 1: just log. Real transports will be registered via
+    // `registerAnalyticsProvider` once we pick a vendor.
+    console.log("[analytics]", event);
+  } catch {}
+  safeDispatch(event);
+}

--- a/src/modules/finyk/hooks/useMonobank.js
+++ b/src/modules/finyk/hooks/useMonobank.js
@@ -9,6 +9,7 @@ import {
   removeItem,
 } from "../lib/finykStorage.js";
 import { normalizeTransaction } from "../domain/transactions";
+import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 /**
  * @typedef {{
@@ -436,6 +437,13 @@ export function useMonobank() {
       return;
     }
 
+    // Fire before the network call so we measure attempts, not just
+    // successes. Payload stays minimal — no token, no personal data.
+    trackEvent(ANALYTICS_EVENTS.BANK_CONNECT_STARTED, {
+      bank: "monobank",
+      forceRefresh: Boolean(forceRefresh),
+    });
+
     try {
       let info;
       const parsedInfoCache = readJSON(INFO_CACHE_KEY, null);
@@ -486,6 +494,11 @@ export function useMonobank() {
         removeItem(REMEMBER_KEY);
       }
       setToken(cleanToken);
+
+      trackEvent(ANALYTICS_EVENTS.BANK_CONNECT_SUCCESS, {
+        bank: "monobank",
+        accountsTotal: Array.isArray(info.accounts) ? info.accounts.length : 0,
+      });
 
       const cache = forceRefresh ? null : loadCache();
       if (cache) {

--- a/src/modules/finyk/hooks/useStorage.js
+++ b/src/modules/finyk/hooks/useStorage.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { DEFAULT_SUBSCRIPTIONS, INTERNAL_TRANSFER_ID } from "../constants";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
+import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 import {
   normalizeFinykBackup,
   normalizeFinykSyncPayload,
@@ -82,11 +83,19 @@ export function useStorage({ onImportFeedback } = {}) {
       category: expense.category || "інше",
     };
     setManualExpenses((prev) => [entry, ...prev]);
+    // Product analytics: payload intentionally minimal (category + flag
+    // whether a custom description was provided) — no amounts, no text.
+    trackEvent(ANALYTICS_EVENTS.EXPENSE_ADDED, {
+      category: entry.category,
+      hasDescription: Boolean(entry.description),
+      source: "manual",
+    });
     return entry;
   };
 
   const removeManualExpense = (id) => {
     setManualExpenses((prev) => prev.filter((e) => e.id !== id));
+    trackEvent(ANALYTICS_EVENTS.EXPENSE_DELETED, { source: "manual" });
   };
 
   const editManualExpense = (id, patch) => {

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -16,6 +16,7 @@ import { ChartFallback } from "../components/charts/ChartFallback";
 import { MerchantList } from "../components/analytics/MerchantList";
 import { getTrendComparison } from "../domain/selectors";
 import { readJSON } from "../lib/finykStorage.js";
+import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 function readTxCache(year, month) {
   const cache = readJSON(`finyk_tx_cache_${year}_${month}`, null);
@@ -130,6 +131,12 @@ export function Analytics({ mono, storage }) {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1);
+
+  // Fire-and-forget: record that the analytics view was opened. Intentionally
+  // runs once on mount (no month dep) so re-selecting months doesn't spam.
+  useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.ANALYTICS_OPENED, { module: "finyk" });
+  }, []);
 
   const isCurrentMonth =
     year === now.getFullYear() && month === now.getMonth() + 1;

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -27,6 +27,7 @@ import { CategorySelector } from "../components/CategorySelector.jsx";
 import { CategoryManager } from "../components/CategoryManager.jsx";
 import { calculateSafeToSpendPerDay } from "../hooks/useBudget.js";
 import { readJSON, writeJSON } from "../lib/finykStorage.js";
+import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
@@ -330,6 +331,10 @@ export function Budgets({ mono, storage }) {
         ...b,
         { ...newB, limit: limitVal, id: crypto.randomUUID() },
       ]);
+      trackEvent(ANALYTICS_EVENTS.BUDGET_SET, {
+        type: "limit",
+        categoryId: newB.categoryId,
+      });
       resetForm();
     } else if (newB.type === "goal") {
       if (!newB.name || !newB.name.trim()) {
@@ -355,6 +360,7 @@ export function Budgets({ mono, storage }) {
           id: crypto.randomUUID(),
         },
       ]);
+      trackEvent(ANALYTICS_EVENTS.BUDGET_SET, { type: "goal" });
       resetForm();
     }
   };


### PR DESCRIPTION
## Summary

Додає перший етап product analytics для Hub/Finyk.

Новий модуль: <ref_file file="/home/ubuntu/repos/Sergeant/src/core/analytics.js" />

- `trackEvent(eventName, payload)` — fire-and-forget. Структура логу: `{ eventName, payload, timestamp }`.
- На етапі 1 — лише `console.log("[analytics]", event)`. Поверх додано `registerAnalyticsProvider(...)` і `resetAnalyticsProviders()` — архітектурна заготовка для PostHog / Amplitude без змін у call-сайтах.
- Константи `ANALYTICS_EVENTS` з усіма канонічними іменами подій (включно з `paywall_viewed` на майбутнє).
- Сама функція ніколи не кидає, не блокує UI і терпима до битих провайдерів (помилки ловляться і логуються).

Інтеграція (мінімальні, нечутливі payload — без токенів/сум/тексту):

- **onboarding_started / onboarding_completed** — <ref_file file="/home/ubuntu/repos/Sergeant/src/core/OnboardingWizard.jsx" />: `useEffect` на mount і виклик у `handleDone`.
- **expense_added / expense_deleted** — <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/hooks/useStorage.js" />: у `addManualExpense` і `removeManualExpense`. Payload містить лише `category`, `hasDescription`, `source: "manual"`.
- **budget_set** — <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/pages/Budgets.jsx" />: в `addBudget` для обох гілок (`type: "limit"` + `categoryId` / `type: "goal"`).
- **analytics_opened** — <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/pages/Analytics.jsx" />: `useEffect(() => trackEvent(...), [])` — один раз на монтування, без спаму при перемиканні місяця.
- **bank_connect_started / bank_connect_success** — <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/hooks/useMonobank.js" />: `_started` перед мережевим запитом, `_success` після успішного збереження токена/акаунтів. Payload: `bank: "monobank"`, `forceRefresh`, `accountsTotal`.

UI і існуючі props не змінюються.

## Review & Testing Checklist for Human

- [ ] Відкрити DevTools → Console, пройти Finyk-флоу: підключити Monobank → побачити послідовно `[analytics] { eventName: 'bank_connect_started' }` і `bank_connect_success`.
- [ ] Додати і видалити ручну витрату — у консолі мають з'явитися `expense_added` і `expense_deleted` (без самої суми/опису).
- [ ] Створити ліміт бюджету та ціль — два різні виклики `budget_set` (type: `limit` / `goal`).
- [ ] Відкрити вкладку Аналітика — один `analytics_opened` на монтування; перемикання місяця не має створювати нових.
- [ ] Запустити онбординг (очистити `hub_onboarding_done_v1`) і пройти його до кінця — `onboarding_started` при відкритті майстра, `onboarding_completed` при натисканні "Почати!".

### Notes

- Всі payload-и мінімальні й не містять чутливих даних (токен, суми, опис, mcc).
- Локально пройшли `npm run lint`, `npm run typecheck`, `npm test` (292 tests), `npm run format:check`.
- Наступний крок (окремий PR): реальний провайдер (PostHog/Amplitude) — підключається через `registerAnalyticsProvider(...)` у точці входу додатку, без змін у місцях виклику `trackEvent`.

Link to Devin session: https://app.devin.ai/sessions/bb985e014df6469ea570b9c58310017e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
