### PR TITLE
refactor(storage): shared createModuleStorage(prefix) для finyk/fizruk/nutrition/routine

### DIFF
--- a/src/modules/finyk/lib/finykStorage.js
+++ b/src/modules/finyk/lib/finykStorage.js
@@ -1,17 +1,17 @@
 /**
  * Централізований storage-шар модуля ФІНІК.
  *
- * Мета: прибрати хаотичні виклики localStorage з компонентів/хуків і забезпечити:
- *  - безпечне читання/запис (try/catch + дефолтні значення);
- *  - debounce запису + пропуск ідентичних значень;
- *  - стабільну інтеграцію з існуючими міграціями (`storageManager.js`) та ключами.
+ * Тонкий wrapper над shared `createModuleStorage(prefix)` — вся логіка
+ * safe-parse, debounce + skip-if-equal, guaranteed flush on page hide
+ * живе у `@shared/lib/createModuleStorage.js`. Тут лишився тільки доменний API
+ * (getTransactions/saveTransactions, getCategories/saveCategories,
+ * getBudget/saveBudget) і реекспорт менеджера міграцій.
  *
- * Ключі залишаються ті самі, що вже використовуються застосунком — цей модуль
- * лише агрегує доступ до них. Міграції з "finto_*" у "finyk_*" виконуються
- * через shared `storageManager` та `finyk_002_rename_finto_user_data`.
+ * Ключі залишаються ті самі, що вже використовуються застосунком. Міграції
+ * "finto_*" → "finyk_*" виконуються через shared `storageManager`.
  */
 
-import { safeJsonSet } from "@shared/lib/storageQuota.js";
+import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
 import { finykStorageManager } from "./storageManager.js";
 
 /** Стандартні ключі доменних сутностей ФІНІК. Не змінювати без міграції. */
@@ -21,202 +21,17 @@ export const FINYK_STORAGE_KEYS = Object.freeze({
   budget: "finyk_budgets",
 });
 
-const DEFAULT_DEBOUNCE_MS = 500;
+const storage = createModuleStorage({ name: "finyk" });
 
-function reportStorageError(scope, error) {
-  try {
-    console.warn(`[finykStorage] ${scope}`, error);
-  } catch {
-    /* ignore logging errors */
-  }
-}
-
-function hasLocalStorage() {
-  return typeof localStorage !== "undefined" && localStorage !== null;
-}
-
-function safeStringify(value) {
-  try {
-    return JSON.stringify(value === undefined ? null : value);
-  } catch (error) {
-    reportStorageError("JSON.stringify", error);
-    return undefined;
-  }
-}
-
-/** Остання успішно записана JSON-репрезентація — для change-detection. */
-const lastWrittenCache = new Map();
-/** Значення, що очікують запису (по ключу). */
-const pendingValues = new Map();
-/** Таймери debounce (по ключу). */
-const pendingTimers = new Map();
-
-/**
- * Безпечне читання JSON зі сховища.
- * Повертає `fallback` якщо значення відсутнє, сховище недоступне, або JSON биті.
- */
-export function readJSON(key, fallback = null) {
-  if (!hasLocalStorage()) return fallback;
-  const k = String(key);
-  let raw;
-  try {
-    raw = localStorage.getItem(k);
-  } catch (error) {
-    reportStorageError(`read("${k}")`, error);
-    return fallback;
-  }
-  if (raw === null || raw === undefined) return fallback;
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed === undefined ? fallback : parsed;
-  } catch (error) {
-    reportStorageError(`JSON.parse("${k}")`, error);
-    return fallback;
-  }
-}
-
-/**
- * Безпечний запис JSON у сховище. Використовує shared квотний guard.
- * Повертає true у разі успіху.
- */
-export function writeJSON(key, value) {
-  if (!hasLocalStorage()) return false;
-  const k = String(key);
-  try {
-    const res = safeJsonSet(k, value);
-    if (res && res.ok) {
-      const serialized = safeStringify(value);
-      if (serialized !== undefined) lastWrittenCache.set(k, serialized);
-      return true;
-    }
-    reportStorageError(`write("${k}")`, res?.reason || res?.error || "unknown");
-    return false;
-  } catch (error) {
-    reportStorageError(`write("${k}")`, error);
-    return false;
-  }
-}
-
-/** Безпечне читання сирого рядка (без JSON.parse). */
-export function readRaw(key, fallback = null) {
-  if (!hasLocalStorage()) return fallback;
-  const k = String(key);
-  try {
-    const v = localStorage.getItem(k);
-    return v === null || v === undefined ? fallback : v;
-  } catch (error) {
-    reportStorageError(`readRaw("${k}")`, error);
-    return fallback;
-  }
-}
-
-/** Безпечний запис сирого рядка. */
-export function writeRaw(key, value) {
-  if (!hasLocalStorage()) return false;
-  const k = String(key);
-  try {
-    localStorage.setItem(k, String(value ?? ""));
-    return true;
-  } catch (error) {
-    reportStorageError(`writeRaw("${k}")`, error);
-    return false;
-  }
-}
-
-/** Безпечне видалення ключа. */
-export function removeItem(key) {
-  if (!hasLocalStorage()) return false;
-  const k = String(key);
-  // Скасовуємо відкладений запис, якщо є — інакше пізніше перезапише null.
-  const timer = pendingTimers.get(k);
-  if (timer) {
-    clearTimeout(timer);
-    pendingTimers.delete(k);
-  }
-  pendingValues.delete(k);
-  lastWrittenCache.delete(k);
-  try {
-    localStorage.removeItem(k);
-    return true;
-  } catch (error) {
-    reportStorageError(`remove("${k}")`, error);
-    return false;
-  }
-}
-
-/**
- * Запис із debounce + пропуском, якщо значення не змінилось.
- * Якщо сторінка ховається/закривається — буфер гарантовано скидається.
- * @param {string} key
- * @param {unknown} value
- * @param {number} [delay=500]
- */
-export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
-  if (!hasLocalStorage()) return;
-  const k = String(key);
-  const nextStr = safeStringify(value);
-  if (nextStr === undefined) return;
-
-  const lastStr = lastWrittenCache.get(k);
-  const hasPending = pendingTimers.has(k);
-  if (!hasPending && lastStr === nextStr) {
-    return; // Дані не змінились — запис не потрібен.
-  }
-
-  pendingValues.set(k, value);
-
-  if (pendingTimers.has(k)) {
-    clearTimeout(pendingTimers.get(k));
-  }
-  const timer = setTimeout(
-    () => {
-      pendingTimers.delete(k);
-      if (!pendingValues.has(k)) return;
-      const pending = pendingValues.get(k);
-      pendingValues.delete(k);
-      writeJSON(k, pending);
-    },
-    Math.max(0, Number(delay) || DEFAULT_DEBOUNCE_MS),
-  );
-  pendingTimers.set(k, timer);
-}
-
-/** Скинути всі відкладені записи негайно. */
-export function flushPendingWrites() {
-  const keys = Array.from(pendingTimers.keys());
-  for (const k of keys) {
-    const timer = pendingTimers.get(k);
-    if (timer) clearTimeout(timer);
-    pendingTimers.delete(k);
-    if (pendingValues.has(k)) {
-      const value = pendingValues.get(k);
-      pendingValues.delete(k);
-      writeJSON(k, value);
-    }
-  }
-}
-
-// Гарантований flush при закритті вкладки / втраті видимості.
-if (typeof window !== "undefined") {
-  try {
-    const flush = () => {
-      try {
-        flushPendingWrites();
-      } catch {
-        /* ignore flush errors */
-      }
-    };
-    window.addEventListener("beforeunload", flush);
-    window.addEventListener("pagehide", flush);
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", () => {
-        if (document.visibilityState === "hidden") flush();
-      });
-    }
-  } catch {
-    /* ignore listener errors */
-  }
-}
+export const {
+  readJSON,
+  writeJSON,
+  readRaw,
+  writeRaw,
+  removeItem,
+  writeJSONDebounced,
+  flushPendingWrites,
+} = storage;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Доменний API

--- a/src/modules/fizruk/lib/fizrukStorage.js
+++ b/src/modules/fizruk/lib/fizrukStorage.js
@@ -1,5 +1,9 @@
 /** Shared parsing/serialization for Fizruk localStorage (workouts + custom exercises). */
 
+import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
+
+const storage = createModuleStorage({ name: "fizruk" });
+
 export const WORKOUTS_STORAGE_KEY = "fizruk_workouts_v1";
 export const CUSTOM_EXERCISES_KEY = "fizruk_custom_exercises_v1";
 export const MEASUREMENTS_STORAGE_KEY = "fizruk_measurements_v1";
@@ -36,7 +40,9 @@ export function parseWorkoutsFromStorage(raw) {
     const p = JSON.parse(raw);
     if (Array.isArray(p)) return p;
     if (p && Array.isArray(p.workouts)) return p.workouts;
-  } catch {}
+  } catch {
+    /* повертаємо [] на битий JSON */
+  }
   return [];
 }
 
@@ -54,7 +60,9 @@ export function parseCustomExercisesFromStorage(raw) {
     const p = JSON.parse(raw);
     if (Array.isArray(p)) return p;
     if (p && Array.isArray(p.exercises)) return p.exercises;
-  } catch {}
+  } catch {
+    /* повертаємо [] на битий JSON */
+  }
   return [];
 }
 
@@ -67,14 +75,8 @@ export function serializeCustomExercisesToStorage(exercises) {
 
 /** Full backup blob for export/import. */
 export function buildFizrukBackupPayload() {
-  const workoutsRaw =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem(WORKOUTS_STORAGE_KEY)
-      : null;
-  const customRaw =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem(CUSTOM_EXERCISES_KEY)
-      : null;
+  const workoutsRaw = storage.readRaw(WORKOUTS_STORAGE_KEY, null);
+  const customRaw = storage.readRaw(CUSTOM_EXERCISES_KEY, null);
   return {
     kind: "fizruk-backup",
     exportedAt: new Date().toISOString(),
@@ -90,26 +92,23 @@ export function applyFizrukBackupPayload(data, { replace = false } = {}) {
   const w = Array.isArray(data.workouts) ? data.workouts : [];
   const c = Array.isArray(data.customExercises) ? data.customExercises : [];
   if (replace) {
-    localStorage.setItem(WORKOUTS_STORAGE_KEY, serializeWorkoutsToStorage(w));
-    localStorage.setItem(
+    storage.writeRaw(WORKOUTS_STORAGE_KEY, serializeWorkoutsToStorage(w));
+    storage.writeRaw(
       CUSTOM_EXERCISES_KEY,
       serializeCustomExercisesToStorage(c),
     );
     return { workouts: w.length, customExercises: c.length };
   }
   const existingW = parseWorkoutsFromStorage(
-    localStorage.getItem(WORKOUTS_STORAGE_KEY),
+    storage.readRaw(WORKOUTS_STORAGE_KEY, null),
   );
   const existingC = parseCustomExercisesFromStorage(
-    localStorage.getItem(CUSTOM_EXERCISES_KEY),
+    storage.readRaw(CUSTOM_EXERCISES_KEY, null),
   );
   const mergedW = mergeWorkoutsById(existingW, w);
   const mergedC = mergeCustomById(existingC, c);
-  localStorage.setItem(
-    WORKOUTS_STORAGE_KEY,
-    serializeWorkoutsToStorage(mergedW),
-  );
-  localStorage.setItem(
+  storage.writeRaw(WORKOUTS_STORAGE_KEY, serializeWorkoutsToStorage(mergedW));
+  storage.writeRaw(
     CUSTOM_EXERCISES_KEY,
     serializeCustomExercisesToStorage(mergedC),
   );
@@ -139,12 +138,7 @@ function mergeCustomById(a, b) {
 export function buildFizrukFullBackupPayload() {
   const data = {};
   for (const k of FIZRUK_FULL_BACKUP_KEYS) {
-    try {
-      data[k] =
-        typeof localStorage !== "undefined" ? localStorage.getItem(k) : null;
-    } catch {
-      data[k] = null;
-    }
+    data[k] = storage.readRaw(k, null);
   }
   return {
     kind: "fizruk-full-backup",
@@ -162,6 +156,6 @@ export function applyFizrukFullBackupPayload(parsed) {
   if (!d || typeof d !== "object") throw new Error("Невірний формат файлу");
   for (const k of FIZRUK_FULL_BACKUP_KEYS) {
     const v = d[k];
-    if (typeof v === "string") localStorage.setItem(k, v);
+    if (typeof v === "string") storage.writeRaw(k, v);
   }
 }

--- a/src/modules/nutrition/lib/nutritionStorage.js
+++ b/src/modules/nutrition/lib/nutritionStorage.js
@@ -121,8 +121,13 @@ export function persistPantries(
   pantries,
   activeId,
 ) {
-  const a = nutritionStorage.writeJSON(key, Array.isArray(pantries) ? pantries : []);
-  const b = activeId ? nutritionStorage.writeRaw(activeKey, String(activeId)) : true;
+  const a = nutritionStorage.writeJSON(
+    key,
+    Array.isArray(pantries) ? pantries : [],
+  );
+  const b = activeId
+    ? nutritionStorage.writeRaw(activeKey, String(activeId))
+    : true;
   return a && b;
 }
 

--- a/src/modules/nutrition/lib/nutritionStorage.js
+++ b/src/modules/nutrition/lib/nutritionStorage.js
@@ -5,7 +5,7 @@ import {
   macrosToTotals,
   normalizeMacrosNullable,
 } from "./macros.js";
-import { safeJsonSet, safeSetItem } from "@shared/lib/storageQuota.js";
+import { nutritionStorage } from "./nutritionStorageInstance.js";
 import {
   isMealTypeId,
   labelForMealType,
@@ -50,12 +50,10 @@ export function defaultNutritionPrefs() {
 }
 
 export function loadNutritionPrefs(key = NUTRITION_PREFS_KEY) {
+  const p = nutritionStorage.readJSON(key, null);
+  if (!p || typeof p !== "object" || Array.isArray(p))
+    return defaultNutritionPrefs();
   try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return defaultNutritionPrefs();
-    const p = JSON.parse(raw);
-    if (!p || typeof p !== "object" || Array.isArray(p))
-      return defaultNutritionPrefs();
     return {
       ...defaultNutritionPrefs(),
       ...p,
@@ -91,7 +89,7 @@ export function loadNutritionPrefs(key = NUTRITION_PREFS_KEY) {
 }
 
 export function persistNutritionPrefs(prefs, key = NUTRITION_PREFS_KEY) {
-  return safeJsonSet(key, prefs || defaultNutritionPrefs()).ok;
+  return nutritionStorage.writeJSON(key, prefs || defaultNutritionPrefs());
 }
 
 export function makeDefaultPantry() {
@@ -99,30 +97,21 @@ export function makeDefaultPantry() {
 }
 
 export function loadActivePantryId(activeKey = NUTRITION_ACTIVE_PANTRY_KEY) {
-  try {
-    const v = localStorage.getItem(activeKey);
-    return v ? String(v) : "home";
-  } catch {
-    return "home";
-  }
+  const v = nutritionStorage.readRaw(activeKey, null);
+  return v ? String(v) : "home";
 }
 
 export function loadPantries(
   key = NUTRITION_PANTRIES_KEY,
   activeKey = NUTRITION_ACTIVE_PANTRY_KEY,
 ) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
-    }
-  } catch {}
+  const parsed = nutritionStorage.readJSON(key, null);
+  if (Array.isArray(parsed) && parsed.length > 0) return parsed;
 
   // Legacy v0 pantry migration is handled by storageManager (nutrition_001_migrate_legacy_pantry).
   // By the time this code runs after app boot, the v1 key already has data if any v0 data existed.
   const fallback = makeDefaultPantry();
-  safeSetItem(activeKey, fallback.id);
+  nutritionStorage.writeRaw(activeKey, fallback.id);
   return [fallback];
 }
 
@@ -132,9 +121,9 @@ export function persistPantries(
   pantries,
   activeId,
 ) {
-  const a = safeJsonSet(key, Array.isArray(pantries) ? pantries : []);
-  const b = activeId ? safeSetItem(activeKey, String(activeId)) : { ok: true };
-  return a.ok && b.ok;
+  const a = nutritionStorage.writeJSON(key, Array.isArray(pantries) ? pantries : []);
+  const b = activeId ? nutritionStorage.writeRaw(activeKey, String(activeId)) : true;
+  return a && b;
 }
 
 export function updatePantry(pantries, activeId, fn) {
@@ -263,18 +252,12 @@ export function normalizeNutritionLog(raw) {
 // ─────────────────────────────────────────────
 
 export function loadNutritionLog(key = NUTRITION_LOG_KEY) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    return normalizeNutritionLog(parsed);
-  } catch {
-    return {};
-  }
+  const parsed = nutritionStorage.readJSON(key, null);
+  return normalizeNutritionLog(parsed);
 }
 
 export function persistNutritionLog(log, key = NUTRITION_LOG_KEY) {
-  return safeJsonSet(key, log || {}).ok;
+  return nutritionStorage.writeJSON(key, log || {});
 }
 
 export function addLogEntry(log, date, meal) {

--- a/src/modules/nutrition/lib/nutritionStorageInstance.js
+++ b/src/modules/nutrition/lib/nutritionStorageInstance.js
@@ -1,0 +1,11 @@
+/**
+ * Єдиний екземпляр shared `createModuleStorage` для модуля Харчування.
+ *
+ * Імпортується з різних файлів (nutritionStorage, waterStorage,
+ * shoppingListStorage, …) щоб усі вони використовували спільні буфери
+ * pending/last-written і єдиний механізм flush-on-hide.
+ */
+
+import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
+
+export const nutritionStorage = createModuleStorage({ name: "nutrition" });

--- a/src/modules/nutrition/lib/shoppingListStorage.js
+++ b/src/modules/nutrition/lib/shoppingListStorage.js
@@ -1,24 +1,15 @@
+import { nutritionStorage } from "./nutritionStorageInstance.js";
+
 export const SHOPPING_LIST_KEY = "nutrition_shopping_list_v1";
 
 export function loadShoppingList(key = SHOPPING_LIST_KEY) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return { categories: [] };
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return { categories: [] };
-    return normalizeShoppingList(parsed);
-  } catch {
-    return { categories: [] };
-  }
+  const parsed = nutritionStorage.readJSON(key, null);
+  if (!parsed || typeof parsed !== "object") return { categories: [] };
+  return normalizeShoppingList(parsed);
 }
 
 export function persistShoppingList(list, key = SHOPPING_LIST_KEY) {
-  try {
-    localStorage.setItem(key, JSON.stringify(list || { categories: [] }));
-    return true;
-  } catch {
-    return false;
-  }
+  return nutritionStorage.writeJSON(key, list || { categories: [] });
 }
 
 export function normalizeShoppingList(raw) {

--- a/src/modules/nutrition/lib/waterStorage.js
+++ b/src/modules/nutrition/lib/waterStorage.js
@@ -1,19 +1,16 @@
-import { safeJsonSet } from "@shared/lib/storageQuota.js";
 import { toLocalISODate } from "@shared/lib/date.js";
+import { nutritionStorage } from "./nutritionStorageInstance.js";
 
 export const WATER_LOG_KEY = "nutrition_water_v1";
 export const DEFAULT_WATER_GOAL_ML = 2000;
 
 export function loadWaterLog(key = WATER_LOG_KEY) {
-  try {
-    return JSON.parse(localStorage.getItem(key) || "{}") || {};
-  } catch {
-    return {};
-  }
+  const v = nutritionStorage.readJSON(key, {});
+  return v && typeof v === "object" && !Array.isArray(v) ? v : {};
 }
 
 export function saveWaterLog(log, key = WATER_LOG_KEY) {
-  return safeJsonSet(key, log).ok;
+  return nutritionStorage.writeJSON(key, log || {});
 }
 
 export function getTodayWaterMl(log) {

--- a/src/modules/routine/lib/routineStorage.js
+++ b/src/modules/routine/lib/routineStorage.js
@@ -5,7 +5,9 @@ import {
   habitScheduledOnDate,
 } from "./hubCalendarAggregate.js";
 import { completionNoteKey } from "./completionNoteKey.js";
-import { safeJsonSet } from "@shared/lib/storageQuota.js";
+import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
+
+const storage = createModuleStorage({ name: "routine" });
 
 export const ROUTINE_STORAGE_KEY = "hub_routine_v1";
 
@@ -106,35 +108,30 @@ function finalizeLoadedRoutineState(state) {
  * @returns {{ schemaVersion: number, habits: Array, completions: Record<string,Record<string,boolean>>, tags: Array, categories: Array, prefs: object, pushupsByDate: Record<string,number>, habitOrder: string[], completionNotes: object }}
  */
 export function loadRoutineState() {
-  try {
-    const raw = localStorage.getItem(ROUTINE_STORAGE_KEY);
-    if (!raw) {
-      return finalizeLoadedRoutineState(defaultState());
-    }
-    const p = JSON.parse(raw);
-    const merged = {
-      ...defaultState(),
-      ...p,
-      prefs: { ...defaultState().prefs, ...(p.prefs || {}) },
-      tags: Array.isArray(p.tags) ? p.tags : [],
-      categories: Array.isArray(p.categories) ? p.categories : [],
-      habits: Array.isArray(p.habits) ? p.habits.map(normalizeHabit) : [],
-      completions:
-        typeof p.completions === "object" && p.completions ? p.completions : {},
-      pushupsByDate:
-        typeof p.pushupsByDate === "object" && p.pushupsByDate
-          ? p.pushupsByDate
-          : {},
-      habitOrder: Array.isArray(p.habitOrder) ? p.habitOrder : [],
-      completionNotes:
-        typeof p.completionNotes === "object" && p.completionNotes
-          ? p.completionNotes
-          : {},
-    };
-    return finalizeLoadedRoutineState(merged);
-  } catch {
+  const p = storage.readJSON(ROUTINE_STORAGE_KEY, null);
+  if (!p || typeof p !== "object" || Array.isArray(p)) {
     return finalizeLoadedRoutineState(defaultState());
   }
+  const merged = {
+    ...defaultState(),
+    ...p,
+    prefs: { ...defaultState().prefs, ...(p.prefs || {}) },
+    tags: Array.isArray(p.tags) ? p.tags : [],
+    categories: Array.isArray(p.categories) ? p.categories : [],
+    habits: Array.isArray(p.habits) ? p.habits.map(normalizeHabit) : [],
+    completions:
+      typeof p.completions === "object" && p.completions ? p.completions : {},
+    pushupsByDate:
+      typeof p.pushupsByDate === "object" && p.pushupsByDate
+        ? p.pushupsByDate
+        : {},
+    habitOrder: Array.isArray(p.habitOrder) ? p.habitOrder : [],
+    completionNotes:
+      typeof p.completionNotes === "object" && p.completionNotes
+        ? p.completionNotes
+        : {},
+  };
+  return finalizeLoadedRoutineState(merged);
 }
 
 /**
@@ -143,26 +140,21 @@ export function loadRoutineState() {
  * @returns {boolean} `true` on success, `false` if localStorage threw (e.g. quota exceeded)
  */
 export function saveRoutineState(next) {
-  const res = safeJsonSet(ROUTINE_STORAGE_KEY, next);
-  if (res.ok) {
+  const ok = storage.writeJSON(ROUTINE_STORAGE_KEY, next);
+  if (ok) {
     emitRoutineStorage();
     return true;
   }
   try {
-    const e = res.error;
-    try {
-      window.dispatchEvent(
-        new CustomEvent(ROUTINE_STORAGE_ERROR, {
-          detail: { message: String(e?.message || e || "save failed") },
-        }),
-      );
-    } catch {
-      /* noop */
-    }
-    return false;
+    window.dispatchEvent(
+      new CustomEvent(ROUTINE_STORAGE_ERROR, {
+        detail: { message: "save failed" },
+      }),
+    );
   } catch {
-    return false;
+    /* noop */
   }
+  return false;
 }
 
 export function createTag(state, name) {

--- a/src/shared/lib/createModuleStorage.js
+++ b/src/shared/lib/createModuleStorage.js
@@ -1,0 +1,210 @@
+/**
+ * Фабрика централізованого storage-шару для модуля.
+ *
+ * Кожен модуль (finyk/fizruk/nutrition/routine) отримує ізольований екземпляр
+ * зі своїми Map-ами pending/last-written, щоб debounce одного модуля не впливав
+ * на інший. Ключі localStorage передаються абсолютні (повні назви) — фабрика
+ * не додає префіксів автоматично, щоб не ламати сумісність існуючих даних.
+ *
+ * Публічний API (як у finykStorage):
+ *  - readJSON(key, fallback)
+ *  - writeJSON(key, value)
+ *  - readRaw(key, fallback)
+ *  - writeRaw(key, value)
+ *  - removeItem(key)
+ *  - writeJSONDebounced(key, value, delay?)
+ *  - flushPendingWrites()
+ */
+
+import { safeJsonSet } from "./storageQuota.js";
+
+export const DEFAULT_DEBOUNCE_MS = 500;
+
+/**
+ * Створює ізольований storage-API для модуля.
+ * @param {{ name?: string, defaultDebounceMs?: number }} [opts]
+ */
+export function createModuleStorage({
+  name = "storage",
+  defaultDebounceMs = DEFAULT_DEBOUNCE_MS,
+} = {}) {
+  const moduleName = String(name);
+  const lastWrittenCache = new Map();
+  const pendingValues = new Map();
+  const pendingTimers = new Map();
+
+  function reportError(scope, error) {
+    try {
+      console.warn(`[${moduleName}Storage] ${scope}`, error);
+    } catch {
+      /* ignore logging errors */
+    }
+  }
+
+  function hasLocalStorage() {
+    return typeof localStorage !== "undefined" && localStorage !== null;
+  }
+
+  function safeStringify(value) {
+    try {
+      return JSON.stringify(value === undefined ? null : value);
+    } catch (error) {
+      reportError("JSON.stringify", error);
+      return undefined;
+    }
+  }
+
+  function readJSON(key, fallback = null) {
+    if (!hasLocalStorage()) return fallback;
+    const k = String(key);
+    let raw;
+    try {
+      raw = localStorage.getItem(k);
+    } catch (error) {
+      reportError(`read("${k}")`, error);
+      return fallback;
+    }
+    if (raw === null || raw === undefined) return fallback;
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed === undefined ? fallback : parsed;
+    } catch (error) {
+      reportError(`JSON.parse("${k}")`, error);
+      return fallback;
+    }
+  }
+
+  function writeJSON(key, value) {
+    if (!hasLocalStorage()) return false;
+    const k = String(key);
+    try {
+      const res = safeJsonSet(k, value);
+      if (res && res.ok) {
+        const serialized = safeStringify(value);
+        if (serialized !== undefined) lastWrittenCache.set(k, serialized);
+        return true;
+      }
+      reportError(`write("${k}")`, res?.reason || res?.error || "unknown");
+      return false;
+    } catch (error) {
+      reportError(`write("${k}")`, error);
+      return false;
+    }
+  }
+
+  function readRaw(key, fallback = null) {
+    if (!hasLocalStorage()) return fallback;
+    const k = String(key);
+    try {
+      const v = localStorage.getItem(k);
+      return v === null || v === undefined ? fallback : v;
+    } catch (error) {
+      reportError(`readRaw("${k}")`, error);
+      return fallback;
+    }
+  }
+
+  function writeRaw(key, value) {
+    if (!hasLocalStorage()) return false;
+    const k = String(key);
+    try {
+      localStorage.setItem(k, String(value ?? ""));
+      return true;
+    } catch (error) {
+      reportError(`writeRaw("${k}")`, error);
+      return false;
+    }
+  }
+
+  function removeItem(key) {
+    if (!hasLocalStorage()) return false;
+    const k = String(key);
+    // Скасовуємо відкладений запис, інакше пізніше перезапише null після видалення.
+    const timer = pendingTimers.get(k);
+    if (timer) {
+      clearTimeout(timer);
+      pendingTimers.delete(k);
+    }
+    pendingValues.delete(k);
+    lastWrittenCache.delete(k);
+    try {
+      localStorage.removeItem(k);
+      return true;
+    } catch (error) {
+      reportError(`remove("${k}")`, error);
+      return false;
+    }
+  }
+
+  function flushKey(k) {
+    if (!pendingValues.has(k)) return;
+    const value = pendingValues.get(k);
+    pendingValues.delete(k);
+    const timer = pendingTimers.get(k);
+    if (timer) {
+      clearTimeout(timer);
+      pendingTimers.delete(k);
+    }
+    writeJSON(k, value);
+  }
+
+  function writeJSONDebounced(key, value, delay = defaultDebounceMs) {
+    if (!hasLocalStorage()) return;
+    const k = String(key);
+    const nextStr = safeStringify(value);
+    if (nextStr === undefined) return;
+
+    const lastStr = lastWrittenCache.get(k);
+    const hasPending = pendingTimers.has(k);
+    if (!hasPending && lastStr === nextStr) {
+      return; // Дані не змінились — запис не потрібен.
+    }
+
+    pendingValues.set(k, value);
+
+    if (pendingTimers.has(k)) {
+      clearTimeout(pendingTimers.get(k));
+    }
+    const timer = setTimeout(() => {
+      pendingTimers.delete(k);
+      const val = pendingValues.get(k);
+      pendingValues.delete(k);
+      writeJSON(k, val);
+    }, Math.max(0, Number(delay) || 0));
+    pendingTimers.set(k, timer);
+  }
+
+  function flushPendingWrites() {
+    const keys = Array.from(pendingValues.keys());
+    for (const k of keys) flushKey(k);
+  }
+
+  // Гарантований flush на приховуванні сторінки — щоб не втратити останні зміни.
+  if (
+    typeof window !== "undefined" &&
+    typeof window.addEventListener === "function"
+  ) {
+    const flush = () => flushPendingWrites();
+    try {
+      window.addEventListener("beforeunload", flush);
+      window.addEventListener("pagehide", flush);
+      if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", () => {
+          if (document.visibilityState === "hidden") flush();
+        });
+      }
+    } catch {
+      /* SSR / restricted env */
+    }
+  }
+
+  return {
+    readJSON,
+    writeJSON,
+    readRaw,
+    writeRaw,
+    removeItem,
+    writeJSONDebounced,
+    flushPendingWrites,
+  };
+}

--- a/src/shared/lib/createModuleStorage.js
+++ b/src/shared/lib/createModuleStorage.js
@@ -165,12 +165,15 @@ export function createModuleStorage({
     if (pendingTimers.has(k)) {
       clearTimeout(pendingTimers.get(k));
     }
-    const timer = setTimeout(() => {
-      pendingTimers.delete(k);
-      const val = pendingValues.get(k);
-      pendingValues.delete(k);
-      writeJSON(k, val);
-    }, Math.max(0, Number(delay) || 0));
+    const timer = setTimeout(
+      () => {
+        pendingTimers.delete(k);
+        const val = pendingValues.get(k);
+        pendingValues.delete(k);
+        writeJSON(k, val);
+      },
+      Math.max(0, Number(delay) || 0),
+    );
     pendingTimers.set(k, timer);
   }
 

--- a/src/shared/lib/createModuleStorage.test.js
+++ b/src/shared/lib/createModuleStorage.test.js
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createModuleStorage } from "./createModuleStorage.js";
+
+let storage;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+  storage = createModuleStorage({ name: "test" });
+});
+afterEach(() => {
+  storage.flushPendingWrites();
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("createModuleStorage: readJSON", () => {
+  it("повертає fallback на відсутній ключ", () => {
+    expect(storage.readJSON("x", { a: 1 })).toEqual({ a: 1 });
+  });
+  it("повертає fallback на битий JSON", () => {
+    localStorage.setItem("bad", "{not json");
+    expect(storage.readJSON("bad", [])).toEqual([]);
+  });
+  it("читає валідний JSON", () => {
+    localStorage.setItem("ok", JSON.stringify({ n: 7 }));
+    expect(storage.readJSON("ok")).toEqual({ n: 7 });
+  });
+});
+
+describe("createModuleStorage: writeJSON round-trip", () => {
+  it("серіалізує та десеріалізує значення", () => {
+    expect(storage.writeJSON("k", { foo: "bar" })).toBe(true);
+    expect(storage.readJSON("k")).toEqual({ foo: "bar" });
+  });
+});
+
+describe("createModuleStorage: raw/remove", () => {
+  it("readRaw/writeRaw без JSON", () => {
+    storage.writeRaw("pref", "1");
+    expect(storage.readRaw("pref")).toBe("1");
+    expect(storage.readRaw("missing", "def")).toBe("def");
+  });
+  it("removeItem видаляє ключ", () => {
+    storage.writeRaw("t", "hello");
+    storage.removeItem("t");
+    expect(storage.readRaw("t", null)).toBeNull();
+  });
+});
+
+describe("createModuleStorage: debounce + skip-if-equal", () => {
+  it("затримує запис, пропускає ідентичне значення", () => {
+    vi.useFakeTimers();
+    storage.writeJSONDebounced("k", { a: 1 }, 200);
+    expect(localStorage.getItem("k")).toBeNull();
+    vi.advanceTimersByTime(201);
+    expect(JSON.parse(localStorage.getItem("k"))).toEqual({ a: 1 });
+
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    storage.writeJSONDebounced("k", { a: 1 }, 200);
+    vi.advanceTimersByTime(500);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("останнє значення перемагає", () => {
+    vi.useFakeTimers();
+    storage.writeJSONDebounced("q", 1, 300);
+    storage.writeJSONDebounced("q", 2, 300);
+    storage.writeJSONDebounced("q", 3, 300);
+    vi.advanceTimersByTime(301);
+    expect(JSON.parse(localStorage.getItem("q"))).toBe(3);
+  });
+
+  it("flushPendingWrites одразу скидає буфер", () => {
+    vi.useFakeTimers();
+    storage.writeJSONDebounced("p", "v", 500);
+    expect(localStorage.getItem("p")).toBeNull();
+    storage.flushPendingWrites();
+    expect(JSON.parse(localStorage.getItem("p"))).toBe("v");
+  });
+
+  it("removeItem скасовує pending write", () => {
+    vi.useFakeTimers();
+    storage.writeJSONDebounced("rm", "value", 500);
+    storage.removeItem("rm");
+    vi.advanceTimersByTime(1000);
+    expect(localStorage.getItem("rm")).toBeNull();
+  });
+});
+
+describe("createModuleStorage: ізоляція між модулями", () => {
+  it("debounce-буфер одного модуля не впливає на інший", () => {
+    vi.useFakeTimers();
+    const a = createModuleStorage({ name: "a" });
+    const b = createModuleStorage({ name: "b" });
+    a.writeJSONDebounced("same", "A", 100);
+    b.writeJSONDebounced("same", "B", 100);
+    // b перезапише a, бо ключ один — але pending-стан ізольований.
+    vi.advanceTimersByTime(101);
+    // Останнє застосоване = B (оскільки обидва записали).
+    expect(JSON.parse(localStorage.getItem("same"))).toBe("B");
+    a.flushPendingWrites();
+    b.flushPendingWrites();
+  });
+});


### PR DESCRIPTION
## Summary

Прибрано дублювання safe-parse / safe-write логіки між модулями. Екстраговано спільну фабрику `createModuleStorage({ name })` у `@shared/lib`, а всі модульні storage-хелпери тепер тонкі wrapper-и над нею.

### Що зроблено
- Створено <ref_file file="/home/ubuntu/repos/Sergeant/src/shared/lib/createModuleStorage.js" /> — ізольований (per-module) storage-шар з API, що вже стояв у finyk:
  - `readJSON(key, fallback)` / `writeJSON(key, value)` — safe JSON + quota guard через `safeJsonSet`
  - `readRaw(key, fallback)` / `writeRaw(key, value)` — для string-ключів
  - `removeItem(key)` — скасовує pending-таймер і видаляє
  - `writeJSONDebounced(key, value, delay?)` — debounce + skip-if-equal (за `JSON.stringify`-ключем)
  - `flushPendingWrites()` — миттєвий flush усіх pending
  - гарантований flush на `beforeunload` / `pagehide` / `visibilitychange=hidden`
- 11 unit-тестів для фабрики (<ref_file file="/home/ubuntu/repos/Sergeant/src/shared/lib/createModuleStorage.test.js" />): read/write, raw, debounce, skip-if-equal, flush, remove-cancels-pending, ізоляція між модулями.
- Міграція модулів на фабрику (публічні API без змін):
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/lib/finykStorage.js" /> — 280→95 LOC, делегує на інстанс `createModuleStorage({ name: "finyk" })`, доменний API тотожний (`getTransactions/saveTransactions`, `getCategories/saveCategories`, `getBudget/saveBudget`)
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/fizruk/lib/fizrukStorage.js" /> — `parseWorkouts*`/`serialize*` прибрали прямі `localStorage.getItem/setItem`, backup/restore тепер через `storage.readRaw/writeRaw`
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/lib/nutritionStorage.js" /> — `loadNutritionPrefs/persist`, `loadPantries/persist`, `loadNutritionLog/persist`, `loadActivePantryId` через спільний інстанс
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/lib/nutritionStorageInstance.js" /> — єдиний екземпляр для `nutritionStorage.js`, `waterStorage.js`, `shoppingListStorage.js` (щоб buffers були спільні)
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/lib/waterStorage.js" />, <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/lib/shoppingListStorage.js" /> — через shared instance
  - <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/routine/lib/routineStorage.js" /> — `loadRoutineState/saveRoutineState` через фабрику; `ROUTINE_STORAGE_ERROR` подія зберігається на невдалий запис

### Чого НЕ зачіпав
- Ключі localStorage (усі залишились: `finyk_*`, `fizruk_*`, `nutrition_*`, `hub_routine_v1`) — нічого мігрувати не треба, дані користувачів сумісні.
- `storageManager` міграцій.
- `storageQuota.safeJsonSet` — фабрика використовує його під капотом.
- Виклики storage-API з компонентів/хуків — публічні сигнатури незмінні.

### Метрики
- Видалено ~327 рядків, додано ~503 (з них 173 — нова фабрика з JSDoc, 110 — тести).
- Net по існуючих модулях: **-228 LOC** дублювання.
- Всі 303 тести зелені (було 292 до цього PR, +11 нових для фабрики).

## Review & Testing Checklist for Human

Ризик: 🟡 yellow — зачіпає storage-шари 4 модулів, міграція має бути lossless.

- [ ] Ручна перевірка модуля ФІНІК: відкрити/додати транзакцію/категорію/бюджет, переконатись що при перезавантаженні все на місці.
- [ ] Ручна перевірка модуля ФІЗРУК: перевірити що тренування/кастомні вправи/заміри вичитуються; зробити експорт → імпорт (backup payload).
- [ ] Ручна перевірка модуля Харчування: пантрі + активна пантрі; журнал прийомів; shopping list; water log — підвантаження й збереження.
- [ ] Ручна перевірка модуля Рутина: звички/теги/категорії/completions зберігаються між сесіями; подія `ROUTINE_STORAGE_ERROR` все ще стріляє при quota exceeded.
- [ ] Підтвердити що ключі у `localStorage` після оновлення ті самі (DevTools → Application → Local Storage).

### Notes
- Кожен модуль отримує свій екземпляр `createModuleStorage` → pending-буфери та `lastWrittenCache` ізольовані між модулями. Для `nutrition` створений спільний інстанс (`nutritionStorageInstance`) щоб water/shopping/pantry використовували один буфер pending writes.
- Якщо десь побачите warning `[fizrukStorage] ...`/`[routineStorage] ...` у консолі — це нова діагностика, раніше деякі помилки мовчки проковтувались.

Link to Devin session: https://app.devin.ai/sessions/2f695b5380564846ad39ce3ce2beb9ad
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
