### PR TITLE
feat(finyk): поступове впровадження TypeScript у core-логіку

### DIFF
--- a/src/modules/finyk/domain/budget.ts
+++ b/src/modules/finyk/domain/budget.ts
@@ -1,23 +1,51 @@
 import { getTxStatAmount } from "../utils";
+import type {
+  Budget,
+  MonthBudgetSummary,
+  MonthlyPlan,
+  RemainingBudget,
+  Transaction,
+  TxSplitsMap,
+} from "./types";
 
-export function calculateRemainingBudget(budget, spent) {
+export type { Budget, MonthBudgetSummary, RemainingBudget } from "./types";
+
+export function calculateRemainingBudget(
+  budget: Pick<Budget, "limit"> & Partial<Budget>,
+  spent: number,
+): RemainingBudget {
   const limit = budget.limit || 0;
   const remaining = Math.max(0, limit - spent);
   const pct = limit > 0 ? Math.min(100, Math.round((spent / limit) * 100)) : 0;
   return { remaining, pct, isOver: spent > limit };
 }
 
-export function calculateSafeToSpendPerDay(remaining, daysLeft) {
+export function calculateSafeToSpendPerDay(
+  remaining: number,
+  daysLeft: number,
+): number {
   if (daysLeft <= 0) return 0;
   return Math.max(0, Math.floor(remaining / daysLeft));
 }
 
+export interface MonthBudgetOptions {
+  excludedTxIds?: Set<string> | Iterable<string>;
+  txSplits?: TxSplitsMap;
+  monthlyPlan?: MonthlyPlan;
+}
+
 export function getMonthBudgetSummary(
-  transactions,
-  { excludedTxIds = new Set(), txSplits = {}, monthlyPlan = {} } = {},
-) {
+  transactions: readonly Transaction[] | null | undefined,
+  {
+    excludedTxIds = new Set<string>(),
+    txSplits = {},
+    monthlyPlan = {},
+  }: MonthBudgetOptions = {},
+): MonthBudgetSummary {
   const excluded =
-    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds || []);
+    excludedTxIds instanceof Set
+      ? excludedTxIds
+      : new Set<string>(excludedTxIds || []);
   const statTx = Array.isArray(transactions)
     ? transactions.filter((t) => t && !excluded.has(t.id))
     : [];

--- a/src/modules/finyk/domain/selectors.ts
+++ b/src/modules/finyk/domain/selectors.ts
@@ -7,8 +7,32 @@ import {
   getCategory,
   resolveExpenseCategoryMeta,
 } from "../utils";
+import type {
+  AnalyticsResult,
+  Category,
+  CategorySpendIndex,
+  MerchantStat,
+  MonthFilter,
+  MonthlySummary,
+  SelectorOptions,
+  TopCategory,
+  Transaction,
+  TrendComparison,
+  TxSplit,
+  TxSplitsMap,
+} from "./types";
 
-const CAT_COLORS = {
+export type {
+  AnalyticsResult,
+  CategorySpendIndex,
+  MerchantStat,
+  MonthlySummary,
+  SelectorOptions,
+  TopCategory,
+  TrendComparison,
+} from "./types";
+
+const CAT_COLORS: Record<string, string> = {
   food: "#10b981",
   restaurant: "#f59e0b",
   transport: "#3b82f6",
@@ -27,7 +51,7 @@ const CAT_COLORS = {
   other: "#94a3b8",
 };
 
-const FALLBACK_COLORS = [
+const FALLBACK_COLORS: readonly string[] = [
   "#6366f1",
   "#10b981",
   "#f59e0b",
@@ -40,7 +64,11 @@ const FALLBACK_COLORS = [
   "#e879f9",
 ];
 
-function getCatColor(categoryId, customCategories = [], idx = 0) {
+function getCatColor(
+  categoryId: string,
+  customCategories: Category[] = [],
+  idx = 0,
+): string {
   if (CAT_COLORS[categoryId]) return CAT_COLORS[categoryId];
   const custom = Array.isArray(customCategories)
     ? customCategories.find((c) => c.id === categoryId)
@@ -49,13 +77,15 @@ function getCatColor(categoryId, customCategories = [], idx = 0) {
   return FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
 }
 
+type MonthPredicate = (tx: Transaction | null | undefined) => boolean;
+
 // Turn a "YYYY-MM" string or a {year, month} object into a predicate
 // that matches a tx's local calendar month. Returns null when no month
 // filter is requested — callers should treat null as "include all".
-function buildMonthPredicate(month) {
+function buildMonthPredicate(month: MonthFilter): MonthPredicate | null {
   if (!month) return null;
-  let y;
-  let m;
+  let y: number;
+  let m: number;
   if (typeof month === "string") {
     const [ys, ms] = month.split("-");
     y = Number(ys);
@@ -63,6 +93,8 @@ function buildMonthPredicate(month) {
   } else if (typeof month === "object") {
     y = Number(month.year);
     m = Number(month.month);
+  } else {
+    return null;
   }
   if (!Number.isFinite(y) || !Number.isFinite(m)) return null;
   return (tx) => {
@@ -75,20 +107,35 @@ function buildMonthPredicate(month) {
 
 // Normalize the optional filter bag so selectors can accept either a
 // plain options object or a shorthand month string as their second arg.
-function normalizeOpts(optsOrMonth) {
+function normalizeOpts(
+  optsOrMonth: SelectorOptions | string | null | undefined,
+): SelectorOptions {
   if (optsOrMonth == null) return {};
   if (typeof optsOrMonth === "string") return { month: optsOrMonth };
   return optsOrMonth;
 }
 
+function toExcludedSet(
+  excluded: SelectorOptions["excludedTxIds"],
+): Set<string> {
+  if (excluded instanceof Set) return excluded;
+  return new Set<string>(excluded || []);
+}
+
 // Aggregated totals for a list of transactions (optionally scoped to
 // a single calendar month). Pure — never touches storage.
-export function getMonthlySummary(transactions, optsOrMonth) {
+export function getMonthlySummary(
+  transactions: readonly Transaction[] | null | undefined,
+  optsOrMonth?: SelectorOptions | string | null,
+): MonthlySummary {
   const opts = normalizeOpts(optsOrMonth);
-  const { excludedTxIds = new Set(), txSplits = {}, month = null } = opts;
+  const {
+    excludedTxIds = new Set<string>(),
+    txSplits = {} as TxSplitsMap,
+    month = null,
+  } = opts;
   const list = Array.isArray(transactions) ? transactions : [];
-  const excluded =
-    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const excluded = toExcludedSet(excludedTxIds);
   const inMonth = buildMonthPredicate(month);
   let spent = 0;
   let income = 0;
@@ -122,26 +169,25 @@ export function getMonthlySummary(transactions, optsOrMonth) {
 // Shared by `getTopCategories` / `getCategoryDistribution` / hooks so the
 // transaction list is scanned at most once per (tx + filters) change.
 export function computeCategorySpendIndex(
-  transactions,
+  transactions: readonly Transaction[] | null | undefined,
   {
     txCategories = {},
-    txSplits = {},
-    customCategories = [],
-    excludedTxIds = new Set(),
+    txSplits = {} as TxSplitsMap,
+    customCategories = [] as Category[],
+    excludedTxIds = new Set<string>(),
     month = null,
-  } = {},
-) {
+  }: SelectorOptions = {},
+): CategorySpendIndex {
   const list = Array.isArray(transactions) ? transactions : [];
-  const excluded =
-    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const excluded = toExcludedSet(excludedTxIds);
   const inMonth = buildMonthPredicate(month);
-  const catSpend = {};
+  const catSpend: Record<string, number> = {};
   let totalSpent = 0;
 
   for (const tx of list) {
     if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;
     if (inMonth && !inMonth(tx)) continue;
-    const splits = txSplits[tx.id];
+    const splits: TxSplit[] | undefined = txSplits[tx.id];
     if (splits && splits.length > 0) {
       for (const s of splits) {
         if (!s.categoryId || !s.amount) continue;
@@ -167,7 +213,10 @@ export function computeCategorySpendIndex(
 // Pure projection of a precomputed spend index into a sorted category list.
 // Cheap (O(k log k) on distinct categories), so it can be re-derived
 // whenever `customCategories` (labels/colors) change without re-scanning txs.
-function buildCategoryList({ catSpend, totalSpent }, customCategories = []) {
+function buildCategoryList(
+  { catSpend, totalSpent }: CategorySpendIndex,
+  customCategories: Category[] = [],
+): TopCategory[] {
   return Object.entries(catSpend)
     .map(([categoryId, rawSpent], idx) => {
       const meta = resolveExpenseCategoryMeta(categoryId, customCategories) || {
@@ -187,19 +236,19 @@ function buildCategoryList({ catSpend, totalSpent }, customCategories = []) {
 
 // Slice a precomputed category index into top-N entries.
 export function selectTopCategoriesFromIndex(
-  index,
-  customCategories = [],
+  index: CategorySpendIndex,
+  customCategories: Category[] = [],
   limit = 5,
-) {
+): TopCategory[] {
   return buildCategoryList(index, customCategories).slice(0, limit);
 }
 
 // Build a full distribution view (up to 20 categories) with pct
 // rebased on the displayed slice.
 export function selectCategoryDistributionFromIndex(
-  index,
-  customCategories = [],
-) {
+  index: CategorySpendIndex,
+  customCategories: Category[] = [],
+): TopCategory[] {
   const top = buildCategoryList(index, customCategories).slice(0, 20);
   const totalSpent = top.reduce((s, c) => s + c.spent, 0);
   return top.map((c, idx) => ({
@@ -212,8 +261,12 @@ export function selectCategoryDistributionFromIndex(
 // Top spending categories. Supports both the documented selector shape
 // `getTopCategories(txs, limit)` and the legacy `(txs, opts, limit)` form
 // used by older hooks/tests.
-export function getTopCategories(transactions, optsOrLimit = {}, maybeLimit) {
-  let opts = {};
+export function getTopCategories(
+  transactions: readonly Transaction[] | null | undefined,
+  optsOrLimit: SelectorOptions | number = {},
+  maybeLimit?: number,
+): TopCategory[] {
+  let opts: SelectorOptions = {};
   let limit = 5;
   if (typeof optsOrLimit === "number") {
     limit = optsOrLimit;
@@ -231,7 +284,10 @@ export function getTopCategories(transactions, optsOrLimit = {}, maybeLimit) {
 
 // Full `category → amount` distribution (returned as a sorted array of
 // `{ categoryId, label, spent, pct, color }`).
-export function getCategoryDistribution(transactions, opts = {}) {
+export function getCategoryDistribution(
+  transactions: readonly Transaction[] | null | undefined,
+  opts: SelectorOptions = {},
+): TopCategory[] {
   const index = computeCategorySpendIndex(transactions, opts);
   return selectCategoryDistributionFromIndex(
     index,
@@ -241,10 +297,21 @@ export function getCategoryDistribution(transactions, opts = {}) {
 
 // Compare two monthly summaries and return the absolute and percentage
 // delta for both spend and income.
-export function getTrendComparison(currentMonthTx, previousMonthTx, opts = {}) {
-  const { excludedTxIds = new Set(), txSplits = {} } = opts;
-  const curr = getMonthlySummary(currentMonthTx, { excludedTxIds, txSplits });
-  const prev = getMonthlySummary(previousMonthTx, { excludedTxIds, txSplits });
+export function getTrendComparison(
+  currentMonthTx: readonly Transaction[] | null | undefined,
+  previousMonthTx: readonly Transaction[] | null | undefined,
+  opts: Pick<SelectorOptions, "excludedTxIds" | "txSplits"> = {},
+): TrendComparison {
+  const { excludedTxIds = new Set<string>(), txSplits = {} as TxSplitsMap } =
+    opts;
+  const curr: AnalyticsResult = getMonthlySummary(currentMonthTx, {
+    excludedTxIds,
+    txSplits,
+  });
+  const prev: AnalyticsResult = getMonthlySummary(previousMonthTx, {
+    excludedTxIds,
+    txSplits,
+  });
   const diff = curr.spent - prev.spent;
   const diffPct = prev.spent > 0 ? Math.round((diff / prev.spent) * 100) : null;
   const incomeDiff = curr.income - prev.income;
@@ -263,20 +330,29 @@ export function getTrendComparison(currentMonthTx, previousMonthTx, opts = {}) {
   };
 }
 
+interface TopMerchantsOptions extends SelectorOptions {
+  limit?: number;
+}
+
 // Top merchants by aggregated expense. Deterministic, pure sort — useful
 // both in the UI and in tests.
-export function getTopMerchants(transactions, opts = {}, maybeLimit) {
+export function getTopMerchants(
+  transactions: readonly Transaction[] | null | undefined,
+  opts: TopMerchantsOptions | number = {},
+  maybeLimit?: number,
+): MerchantStat[] {
   const {
-    excludedTxIds = new Set(),
+    excludedTxIds = new Set<string>(),
     month = null,
     limit: optsLimit,
-  } = typeof opts === "number" ? { limit: opts } : opts || {};
+  } = typeof opts === "number"
+    ? ({ limit: opts } as TopMerchantsOptions)
+    : opts || {};
   const limit = typeof maybeLimit === "number" ? maybeLimit : (optsLimit ?? 10);
   const list = Array.isArray(transactions) ? transactions : [];
-  const excluded =
-    excludedTxIds instanceof Set ? excludedTxIds : new Set(excludedTxIds);
+  const excluded = toExcludedSet(excludedTxIds);
   const inMonth = buildMonthPredicate(month);
-  const merchants = {};
+  const merchants: Record<string, MerchantStat> = {};
 
   for (const tx of list) {
     if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;

--- a/src/modules/finyk/domain/transactions.ts
+++ b/src/modules/finyk/domain/transactions.ts
@@ -10,47 +10,52 @@
  * очікує саме такий формат, тож одиниці зберігаємо, а нові поля лише додаємо.
  */
 
-/**
- * @typedef {'expense'|'income'|'transfer'} TransactionType
- */
-
-/**
- * Канонічні джерела транзакцій.
- * @typedef {'manual'|'mono'|'ai'|'import'} TransactionSource
- */
-
-/**
- * @typedef {Object} Transaction
- * @property {string} id
- * @property {number} amount Signed amount in minor units (kopecks).
- * @property {string} date ISO-8601 datetime string.
- * @property {string} categoryId Category id (empty string if невідома).
- * @property {TransactionType} type 'expense' | 'income' | 'transfer'
- * @property {string} [merchant] Merchant name (опційно).
- * @property {string} [note] Freeform note (опційно).
- * @property {TransactionSource} source Канонічне джерело.
- *
- * Legacy/back-compat (для існуючого UI та персистованих даних):
- * @property {number} time Unix timestamp in seconds.
- * @property {string} description
- * @property {number} mcc
- * @property {string|null} accountId
- * @property {boolean} manual
- * @property {string|undefined} manualId
- * @property {Object|undefined} raw
- * @property {string} _source Оригінальна назва джерела (monobank/privatbank/…).
- * @property {string|null} _accountId
- * @property {boolean} _manual
- * @property {string|undefined} _manualId
- */
-
 import { INTERNAL_TRANSFER_ID } from "../constants";
+import type { Transaction, TransactionSource, TransactionType } from "./types";
+
+// Re-export types for back-compat (domain consumers можуть імпортувати з
+// transactions так само, як раніше користувалися @typedef-ами).
+export type { Transaction, TransactionSource, TransactionType } from "./types";
+
+interface NormalizeDefaults {
+  source?: TransactionSource | string;
+  accountId?: string | null;
+  categoryId?: string;
+}
+
+// Довільний "сирий" інпут — використовуємо індексний тип, щоб не плодити any.
+// Поля опційні та неточно типізовані, бо приходять з різних джерел.
+type RawTxInput = {
+  id?: string | number;
+  amount?: number | string;
+  time?: number | string;
+  date?: string | number | Date;
+  createdAt?: string | number | Date;
+  description?: string;
+  mcc?: number | string;
+  categoryId?: string;
+  category?: string;
+  merchant?: string;
+  merchantName?: string;
+  note?: string;
+  comment?: string;
+  type?: string;
+  source?: string;
+  _source?: string;
+  manual?: boolean;
+  _manual?: boolean;
+  manualId?: string | number;
+  _manualId?: string | number;
+  accountId?: string | null;
+  _accountId?: string | null;
+  raw?: { category?: string } & Record<string, unknown>;
+} & Record<string, unknown>;
 
 // Внутрішні category ids, які трактуються як переказ між власними рахунками.
 const TRANSFER_CATEGORY_IDS = new Set([INTERNAL_TRANSFER_ID, "transfer"]);
 
 // Назви джерел у "сирому" вигляді → канонічні TransactionSource.
-const SOURCE_ALIASES = {
+const SOURCE_ALIASES: Record<string, TransactionSource> = {
   manual: "manual",
   mono: "mono",
   monobank: "mono",
@@ -65,7 +70,7 @@ const SOURCE_ALIASES = {
  * Приводить довільне значення дати/часу до unix timestamp (секунди).
  * Підтримує: number (мс або сек), Date, ISO-рядок, YYYY-MM-DD тощо.
  */
-function toSafeTimestampSeconds(input) {
+function toSafeTimestampSeconds(input: unknown): number {
   if (typeof input === "number" && Number.isFinite(input)) {
     // Якщо це мілісекунди (10^10 межа для секунд — приблизно 2286 рік).
     return input > 10_000_000_000
@@ -73,14 +78,14 @@ function toSafeTimestampSeconds(input) {
       : Math.floor(input);
   }
   if (input instanceof Date) return Math.floor(input.getTime() / 1000);
-  const parsed = new Date(input || Date.now()).getTime();
+  const parsed = new Date((input as string | number) || Date.now()).getTime();
   return Number.isFinite(parsed)
     ? Math.floor(parsed / 1000)
     : Math.floor(Date.now() / 1000);
 }
 
 // Мінімум до копійок; число → round; інше → 0. Уникаємо -0.
-function toSafeAmountMinorUnits(input) {
+function toSafeAmountMinorUnits(input: unknown): number {
   const n = Number(input);
   if (!Number.isFinite(n)) return 0;
   const rounded = Math.round(n);
@@ -88,7 +93,10 @@ function toSafeAmountMinorUnits(input) {
 }
 
 // Канонічне джерело з будь-якого alias, з фолбеком на defaults/manual-детект.
-function resolveSource(input, defaults) {
+function resolveSource(
+  input: RawTxInput,
+  defaults: NormalizeDefaults,
+): TransactionSource {
   const raw =
     input?.source ??
     input?._source ??
@@ -101,7 +109,11 @@ function resolveSource(input, defaults) {
 
 // Тип транзакції: якщо категорія — внутрішній переказ → 'transfer';
 // інакше за знаком суми.
-function resolveType(categoryId, amount, explicitType) {
+function resolveType(
+  categoryId: string,
+  amount: number,
+  explicitType: string | undefined,
+): TransactionType {
   if (
     explicitType === "expense" ||
     explicitType === "income" ||
@@ -114,7 +126,7 @@ function resolveType(categoryId, amount, explicitType) {
 }
 
 // Витягує categoryId з різних форм сирого input.
-function resolveCategoryId(input) {
+function resolveCategoryId(input: RawTxInput | null | undefined): string {
   if (!input) return "";
   if (typeof input.categoryId === "string" && input.categoryId) {
     return input.categoryId;
@@ -127,7 +139,10 @@ function resolveCategoryId(input) {
 }
 
 // merchant: явне поле > merchantName/vendor > опис для банківських джерел.
-function resolveMerchant(input, source) {
+function resolveMerchant(
+  input: RawTxInput | null | undefined,
+  source: TransactionSource,
+): string | undefined {
   if (!input) return undefined;
   if (typeof input.merchant === "string" && input.merchant.trim()) {
     return input.merchant.trim();
@@ -147,7 +162,10 @@ function resolveMerchant(input, source) {
 }
 
 // note: явне поле > comment > для manual — description.
-function resolveNote(input, source) {
+function resolveNote(
+  input: RawTxInput | null | undefined,
+  source: TransactionSource,
+): string | undefined {
   if (!input) return undefined;
   if (typeof input.note === "string" && input.note.trim()) {
     return input.note.trim();
@@ -163,20 +181,16 @@ function resolveNote(input, source) {
 }
 
 /**
- * Нормалізує довільну “сиру” транзакцію у єдину модель Transaction.
+ * Нормалізує довільну "сиру" транзакцію у єдину модель Transaction.
  *
  * Генерує id, приводить date до ISO, гарантує що amount — number,
  * заповнює дефолти відсутніх полів та зберігає legacy-поля для сумісності.
- *
- * @param {Object} input
- * @param {Object} [defaults]
- * @param {TransactionSource|string} [defaults.source]
- * @param {string|null} [defaults.accountId]
- * @param {string} [defaults.categoryId]
- * @returns {Transaction}
  */
-export function normalizeTransaction(input, defaults = {}) {
-  const tx = input || {};
+export function normalizeTransaction(
+  input: RawTxInput | null | undefined,
+  defaults: NormalizeDefaults = {},
+): Transaction {
+  const tx: RawTxInput = input || {};
   const source = resolveSource(tx, defaults);
 
   const manual = Boolean(tx.manual ?? tx._manual ?? source === "manual");
@@ -234,13 +248,18 @@ export function normalizeTransaction(input, defaults = {}) {
   };
 }
 
-export function normalizeTransactions(items, defaults = {}) {
+export function normalizeTransactions(
+  items: readonly RawTxInput[] | null | undefined,
+  defaults: NormalizeDefaults = {},
+): Transaction[] {
   const list = Array.isArray(items) ? items : [];
   return list.map((tx) => normalizeTransaction(tx, defaults));
 }
 
-export function dedupeAndSortTransactions(items) {
-  const map = new Map();
+export function dedupeAndSortTransactions(
+  items: readonly RawTxInput[] | null | undefined,
+): Transaction[] {
+  const map = new Map<string, Transaction>();
   for (const tx of normalizeTransactions(items)) map.set(tx.id, tx);
   return Array.from(map.values()).sort((a, b) => (b.time || 0) - (a.time || 0));
 }
@@ -249,12 +268,19 @@ export function dedupeAndSortTransactions(items) {
  * Перетворює збережену manual-витрату (`addManualExpense`-entry) у
  * нормалізовану Transaction. Зберігає amount у копійках зі знаком "витрата"
  * та проставляє categoryId з поля `category`.
- *
- * @param {{ id:string|number, date?:string, description?:string, amount:number, category?:string }} entry
- * @returns {Transaction}
  */
-export function manualExpenseToTransaction(entry) {
-  const e = entry || {};
+export interface ManualExpenseEntry {
+  id: string | number;
+  date?: string;
+  description?: string;
+  amount?: number | string;
+  category?: string;
+}
+
+export function manualExpenseToTransaction(
+  entry: ManualExpenseEntry | null | undefined,
+): Transaction {
+  const e: ManualExpenseEntry = entry || { id: "" };
   const time = e.date ? Math.floor(new Date(e.date).getTime() / 1000) : 0;
   return normalizeTransaction(
     {

--- a/src/modules/finyk/domain/types.ts
+++ b/src/modules/finyk/domain/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared domain types for the Finyk module.
+ *
+ * These types are intentionally loose (optional fields, string unions kept
+ * open where the existing runtime accepts legacy data) so that gradual TS
+ * adoption does not break existing JS callers or persisted localStorage
+ * payloads.
+ */
+
+/** Канонічний тип транзакції. */
+export type TransactionType = "expense" | "income" | "transfer";
+
+/** Канонічне джерело транзакції. */
+export type TransactionSource = "manual" | "mono" | "ai" | "import";
+
+/**
+ * Уніфікована модель транзакції Фініка.
+ *
+ * amount — у signed minor units (копійках). Окрім канонічних полів
+ * лишаємо legacy-поля (time/description/mcc/_source/_accountId…),
+ * щоб не ламати UI та персистовані дані.
+ */
+export interface Transaction {
+  // Канонічні поля
+  id: string;
+  amount: number;
+  date: string;
+  categoryId: string;
+  type: TransactionType;
+  merchant?: string;
+  note?: string;
+  source: TransactionSource;
+
+  // Legacy/back-compat
+  time: number;
+  description: string;
+  mcc: number;
+  accountId: string | null;
+  manual: boolean;
+  manualId?: string;
+  raw?: unknown;
+
+  _source: string;
+  _accountId: string | null;
+  _manual: boolean;
+  _manualId?: string;
+}
+
+/** Базова категорія витрат / доходів. */
+export interface Category {
+  id: string;
+  label: string;
+  mccs?: number[];
+  keywords?: string[];
+  color?: string;
+}
+
+/** Тип бюджету. */
+export type BudgetType = "limit" | "goal";
+
+/**
+ * Конфіг одного бюджету (з finyk_budgets).
+ * Схема тримається сумісною з існуючими сутностями у UI.
+ */
+export interface Budget {
+  id: string;
+  type?: BudgetType;
+  limit: number;
+  categoryId?: string;
+  label?: string;
+  /** Для goal-бюджетів. */
+  target?: number;
+  current?: number;
+  [extra: string]: unknown;
+}
+
+/** План місячних доходів/витрат. */
+export interface MonthlyPlan {
+  income?: number;
+  expense?: number;
+}
+
+/** Split однієї транзакції на декілька категорій. */
+export interface TxSplit {
+  categoryId: string;
+  amount: number;
+}
+
+export type TxSplitsMap = Record<string, TxSplit[] | undefined>;
+export type TxCategoriesMap = Record<string, string | undefined>;
+
+/** Фільтр календарного місяця: "YYYY-MM" або {year, month}. */
+export type MonthFilter = string | { year: number; month: number } | null;
+
+/** Опції для аналітичних селекторів. */
+export interface SelectorOptions {
+  excludedTxIds?: Set<string> | Iterable<string>;
+  txSplits?: TxSplitsMap;
+  txCategories?: TxCategoriesMap;
+  customCategories?: Category[];
+  month?: MonthFilter;
+}
+
+/**
+ * Агрегат витрат/доходів за місяць — основний результат analytics-селекторів.
+ */
+export interface AnalyticsResult {
+  spent: number;
+  income: number;
+  balance: number;
+  txCount: number;
+  /** Публічна назва `spent` (контракт селекторів). */
+  totalExpense: number;
+  /** Публічна назва `income` (контракт селекторів). */
+  totalIncome: number;
+}
+
+/** Alias: результат getMonthlySummary. */
+export type MonthlySummary = AnalyticsResult;
+
+/** Попередньо обчислений індекс витрат по категоріях. */
+export interface CategorySpendIndex {
+  catSpend: Record<string, number>;
+  totalSpent: number;
+}
+
+/** Елемент топ-категорій / розподілу по категоріях. */
+export interface TopCategory {
+  categoryId: string;
+  label: string;
+  spent: number;
+  pct: number;
+  color: string;
+}
+
+/** Порівняння поточного місяця з попереднім. */
+export interface TrendComparison {
+  currentSpent: number;
+  prevSpent: number;
+  diff: number;
+  diffPct: number | null;
+  currentIncome: number;
+  prevIncome: number;
+  incomeDiff: number;
+  incomeDiffPct: number | null;
+}
+
+/** Елемент топу мерчантів. */
+export interface MerchantStat {
+  name: string;
+  count: number;
+  total: number;
+}
+
+/** Агрегат місячного бюджету. */
+export interface MonthBudgetSummary {
+  totalPlan: number;
+  planIncome: number;
+  totalFact: number;
+  totalRemaining: number;
+  safePerDay: number;
+  isOverall: boolean;
+  daysLeft: number;
+}
+
+/** Результат обчислень calculateRemainingBudget. */
+export interface RemainingBudget {
+  remaining: number;
+  pct: number;
+  isOver: boolean;
+}

--- a/src/modules/finyk/lib/finykStorage.ts
+++ b/src/modules/finyk/lib/finykStorage.ts
@@ -13,17 +13,21 @@
 
 import { safeJsonSet } from "@shared/lib/storageQuota.js";
 import { finykStorageManager } from "./storageManager.js";
+import type { Budget, Category, Transaction } from "../domain/types";
 
 /** Стандартні ключі доменних сутностей ФІНІК. Не змінювати без міграції. */
 export const FINYK_STORAGE_KEYS = Object.freeze({
   transactions: "finyk_manual_expenses_v1",
   categories: "finyk_custom_cats_v1",
   budget: "finyk_budgets",
-});
+} as const);
+
+export type FinykStorageKey =
+  (typeof FINYK_STORAGE_KEYS)[keyof typeof FINYK_STORAGE_KEYS];
 
 const DEFAULT_DEBOUNCE_MS = 500;
 
-function reportStorageError(scope, error) {
+function reportStorageError(scope: string, error: unknown): void {
   try {
     console.warn(`[finykStorage] ${scope}`, error);
   } catch {
@@ -31,11 +35,11 @@ function reportStorageError(scope, error) {
   }
 }
 
-function hasLocalStorage() {
+function hasLocalStorage(): boolean {
   return typeof localStorage !== "undefined" && localStorage !== null;
 }
 
-function safeStringify(value) {
+function safeStringify(value: unknown): string | undefined {
   try {
     return JSON.stringify(value === undefined ? null : value);
   } catch (error) {
@@ -45,20 +49,23 @@ function safeStringify(value) {
 }
 
 /** Остання успішно записана JSON-репрезентація — для change-detection. */
-const lastWrittenCache = new Map();
+const lastWrittenCache = new Map<string, string>();
 /** Значення, що очікують запису (по ключу). */
-const pendingValues = new Map();
+const pendingValues = new Map<string, unknown>();
 /** Таймери debounce (по ключу). */
-const pendingTimers = new Map();
+const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 /**
  * Безпечне читання JSON зі сховища.
  * Повертає `fallback` якщо значення відсутнє, сховище недоступне, або JSON биті.
  */
-export function readJSON(key, fallback = null) {
+export function readJSON<T = unknown>(
+  key: string,
+  fallback: T | null = null as T | null,
+): T | null {
   if (!hasLocalStorage()) return fallback;
   const k = String(key);
-  let raw;
+  let raw: string | null;
   try {
     raw = localStorage.getItem(k);
   } catch (error) {
@@ -67,8 +74,8 @@ export function readJSON(key, fallback = null) {
   }
   if (raw === null || raw === undefined) return fallback;
   try {
-    const parsed = JSON.parse(raw);
-    return parsed === undefined ? fallback : parsed;
+    const parsed = JSON.parse(raw) as T | undefined;
+    return parsed === undefined ? fallback : (parsed as T);
   } catch (error) {
     reportStorageError(`JSON.parse("${k}")`, error);
     return fallback;
@@ -79,11 +86,13 @@ export function readJSON(key, fallback = null) {
  * Безпечний запис JSON у сховище. Використовує shared квотний guard.
  * Повертає true у разі успіху.
  */
-export function writeJSON(key, value) {
+export function writeJSON(key: string, value: unknown): boolean {
   if (!hasLocalStorage()) return false;
   const k = String(key);
   try {
-    const res = safeJsonSet(k, value);
+    const res = safeJsonSet(k, value) as
+      | { ok?: boolean; reason?: string; error?: unknown }
+      | undefined;
     if (res && res.ok) {
       const serialized = safeStringify(value);
       if (serialized !== undefined) lastWrittenCache.set(k, serialized);
@@ -98,7 +107,10 @@ export function writeJSON(key, value) {
 }
 
 /** Безпечне читання сирого рядка (без JSON.parse). */
-export function readRaw(key, fallback = null) {
+export function readRaw(
+  key: string,
+  fallback: string | null = null,
+): string | null {
   if (!hasLocalStorage()) return fallback;
   const k = String(key);
   try {
@@ -111,7 +123,7 @@ export function readRaw(key, fallback = null) {
 }
 
 /** Безпечний запис сирого рядка. */
-export function writeRaw(key, value) {
+export function writeRaw(key: string, value: unknown): boolean {
   if (!hasLocalStorage()) return false;
   const k = String(key);
   try {
@@ -124,7 +136,7 @@ export function writeRaw(key, value) {
 }
 
 /** Безпечне видалення ключа. */
-export function removeItem(key) {
+export function removeItem(key: string): boolean {
   if (!hasLocalStorage()) return false;
   const k = String(key);
   // Скасовуємо відкладений запис, якщо є — інакше пізніше перезапише null.
@@ -147,11 +159,12 @@ export function removeItem(key) {
 /**
  * Запис із debounce + пропуском, якщо значення не змінилось.
  * Якщо сторінка ховається/закривається — буфер гарантовано скидається.
- * @param {string} key
- * @param {unknown} value
- * @param {number} [delay=500]
  */
-export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
+export function writeJSONDebounced(
+  key: string,
+  value: unknown,
+  delay: number = DEFAULT_DEBOUNCE_MS,
+): void {
   if (!hasLocalStorage()) return;
   const k = String(key);
   const nextStr = safeStringify(value);
@@ -165,8 +178,9 @@ export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
 
   pendingValues.set(k, value);
 
-  if (pendingTimers.has(k)) {
-    clearTimeout(pendingTimers.get(k));
+  const existing = pendingTimers.get(k);
+  if (existing) {
+    clearTimeout(existing);
   }
   const timer = setTimeout(
     () => {
@@ -182,7 +196,7 @@ export function writeJSONDebounced(key, value, delay = DEFAULT_DEBOUNCE_MS) {
 }
 
 /** Скинути всі відкладені записи негайно. */
-export function flushPendingWrites() {
+export function flushPendingWrites(): void {
   const keys = Array.from(pendingTimers.keys());
   for (const k of keys) {
     const timer = pendingTimers.get(k);
@@ -199,7 +213,7 @@ export function flushPendingWrites() {
 // Гарантований flush при закритті вкладки / втраті видимості.
 if (typeof window !== "undefined") {
   try {
-    const flush = () => {
+    const flush = (): void => {
       try {
         flushPendingWrites();
       } catch {
@@ -224,54 +238,52 @@ if (typeof window !== "undefined") {
 
 /**
  * Повертає список вручну доданих транзакцій (finyk_manual_expenses_v1).
- * @returns {Array<object>}
  */
-export function getTransactions() {
-  const v = readJSON(FINYK_STORAGE_KEYS.transactions, []);
+export function getTransactions(): Transaction[] {
+  const v = readJSON<Transaction[]>(FINYK_STORAGE_KEYS.transactions, []);
   return Array.isArray(v) ? v : [];
 }
 
 /**
  * Зберігає список вручну доданих транзакцій (debounced + skip-if-equal).
- * @param {Array<object>} transactions
  */
-export function saveTransactions(transactions) {
+export function saveTransactions(
+  transactions: readonly Transaction[] | null | undefined,
+): void {
   const value = Array.isArray(transactions) ? transactions : [];
   writeJSONDebounced(FINYK_STORAGE_KEYS.transactions, value);
 }
 
 /**
  * Повертає кастомні категорії користувача (finyk_custom_cats_v1).
- * @returns {Array<object>}
  */
-export function getCategories() {
-  const v = readJSON(FINYK_STORAGE_KEYS.categories, []);
+export function getCategories(): Category[] {
+  const v = readJSON<Category[]>(FINYK_STORAGE_KEYS.categories, []);
   return Array.isArray(v) ? v : [];
 }
 
 /**
  * Зберігає кастомні категорії користувача (debounced + skip-if-equal).
- * @param {Array<object>} categories
  */
-export function saveCategories(categories) {
+export function saveCategories(
+  categories: readonly Category[] | null | undefined,
+): void {
   const value = Array.isArray(categories) ? categories : [];
   writeJSONDebounced(FINYK_STORAGE_KEYS.categories, value);
 }
 
 /**
  * Повертає конфіг бюджетів (finyk_budgets).
- * @returns {Array<object>}
  */
-export function getBudget() {
-  const v = readJSON(FINYK_STORAGE_KEYS.budget, []);
+export function getBudget(): Budget[] {
+  const v = readJSON<Budget[]>(FINYK_STORAGE_KEYS.budget, []);
   return Array.isArray(v) ? v : [];
 }
 
 /**
  * Зберігає конфіг бюджетів (debounced + skip-if-equal).
- * @param {Array<object>} budget
  */
-export function saveBudget(budget) {
+export function saveBudget(budget: readonly Budget[] | null | undefined): void {
   const value = Array.isArray(budget) ? budget : [];
   writeJSONDebounced(FINYK_STORAGE_KEYS.budget, value);
 }


### PR DESCRIPTION
## Summary

Поступове додавання TypeScript до core-логіки модуля `finyk` без повного переписування — лише сам доменний шар і storage. Публічний API, JS-імпорти, legacy-поля та персистовані дані в `localStorage` не змінено.

Що зроблено:

- Новий файл типів `src/modules/finyk/domain/types.ts` з єдиним джерелом правди для доменних моделей:
  - `Transaction`, `TransactionType`, `TransactionSource`
  - `Budget`, `BudgetType`, `MonthlyPlan`
  - `Category`
  - `AnalyticsResult` / `MonthlySummary`, `CategorySpendIndex`, `TopCategory`, `TrendComparison`, `MerchantStat`, `MonthBudgetSummary`, `RemainingBudget`
  - `SelectorOptions`, `TxSplit`, `TxSplitsMap`, `TxCategoriesMap`, `MonthFilter`
- `src/modules/finyk/domain/transactions.js` → `transactions.ts`
  - Типізовано `normalizeTransaction`, `normalizeTransactions`, `dedupeAndSortTransactions`, `manualExpenseToTransaction`.
  - JSDoc `@typedef`-и замінено на справжні TS-типи.
  - Введено локальний тип `RawTxInput` для "сирих" транзакцій (замість `any`).
- `src/modules/finyk/domain/selectors.js` → `selectors.ts`
  - Типізовано `getMonthlySummary`, `computeCategorySpendIndex`, `selectTopCategoriesFromIndex`, `selectCategoryDistributionFromIndex`, `getTopCategories`, `getCategoryDistribution`, `getTrendComparison`, `getTopMerchants`.
  - Збережено всі легасі-форми виклику (наприклад, `getTopCategories(txs, limit)` і `(txs, opts, limit)`).
- `src/modules/finyk/domain/budget.js` → `budget.ts`
  - Типізовано `calculateRemainingBudget`, `calculateSafeToSpendPerDay`, `getMonthBudgetSummary`.
- `src/modules/finyk/lib/finykStorage.js` → `finykStorage.ts`
  - Типізовано generic `readJSON<T>`, `writeJSON`, `readRaw`, `writeRaw`, `removeItem`, `writeJSONDebounced`, `flushPendingWrites`.
  - Типізовано доменний API: `getTransactions/saveTransactions`, `getCategories/saveCategories`, `getBudget/saveBudget`. `FINYK_STORAGE_KEYS` тепер `as const` з `FinykStorageKey`.

Налаштування TS (за вимогою — без revolutionary changes):
- Вже існуючий `tsconfig.json` з `allowJs: true`, `strict: false`, `noImplicitAny: false` залишено без змін.
- `strict` **не** вмикали, `any` уникали (де реально чіпляє runtime поведінку, використано `unknown` + локальні типи).
- UI/компоненти/hooks/тести не переписано — лише core.

Перевірки:
- `npm run format:check` — ok
- `npm run lint` — ok (eslint + перевірка імпортів)
- `npm run typecheck` — ok (`tsc --noEmit` по трьох tsconfig-ах)
- `npm test` — ok, 292 тести проходять без змін
- `npm run build` — ok, Vite prod build успішний

## Review & Testing Checklist for Human

- [ ] Переконатись, що існуючі `.js`/`.jsx` імпорти зі `./transactions.js`, `./finykStorage.js`, `./selectors`, `./budget` у тестах та хуках (finykStorage.test.js, transactions.test.js, useAnalytics, useBudget, useMonobank, usePrivatbank, FinykApp.jsx, pages/*.jsx, lib/finykStats.js, lib/finykBackup.js) коректно резолвляться Vite/Vitest після перейменування `.js` → `.ts` (я перевірив локально `npm run build` та `npm test`, все працює).
- [ ] Швидко прокликати сторінки Фініка (Overview, Transactions, Analytics, Budgets) у dev/preview — переконатись, що нічого не зламалось у рантаймі.
- [ ] Подивитись на `domain/types.ts`: чи задовольняють сигнатури `Budget`/`Category` існуючі дані у вашому `localStorage`; за потреби розширити поля (вони лишені опційними + `[extra]: unknown` у `Budget`).

### Notes

- Навмисно НЕ вмикали `strict`/`noImplicitAny` — відповідно до обмежень у задачі, щоб уникнути лавини помилок у `.js` файлах поза scope.
- `lib/finykStats.js`, `hooks/*.js`, `lib/finykBackup.js` свідомо залишені на JS — це поза обмеженням задачі (тільки core). Їх можна конвертувати окремим PR пізніше.
- Legacy-поля транзакції (`time`, `description`, `mcc`, `_source`, `_accountId`, `_manual`, `_manualId`, `accountId`, `manual`, `manualId`, `raw`) залишено в інтерфейсі `Transaction` — існуючий UI на них зав'язаний.


Link to Devin session: https://app.devin.ai/sessions/18b8007e5eb64d5fad208792108f66c4
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
