### PR TITLE
fix(finyk/analytics): off-by-one місяця, колір доходу, дрібніші фікси

### DIFF
--- a/src/modules/finyk/domain/selectors.js
+++ b/src/modules/finyk/domain/selectors.js
@@ -201,10 +201,15 @@ export function selectCategoryDistributionFromIndex(
   customCategories = [],
 ) {
   const top = buildCategoryList(index, customCategories).slice(0, 20);
-  const totalSpent = top.reduce((s, c) => s + c.spent, 0);
+  // pct рахуємо від повної суми витрат (а не від видимої топ-20),
+  // щоб «довгий хвіст» не інфлейтив долю показаних категорій.
+  const total =
+    typeof index?.totalSpent === "number" && index.totalSpent > 0
+      ? index.totalSpent
+      : top.reduce((s, c) => s + c.spent, 0);
   return top.map((c, idx) => ({
     ...c,
-    pct: totalSpent > 0 ? Math.round((c.spent / totalSpent) * 100) : 0,
+    pct: total > 0 ? Math.round((c.spent / total) * 100) : 0,
     color: c.color || getCatColor(c.categoryId, customCategories, idx),
   }));
 }
@@ -265,6 +270,13 @@ export function getTrendComparison(currentMonthTx, previousMonthTx, opts = {}) {
 
 // Top merchants by aggregated expense. Deterministic, pure sort — useful
 // both in the UI and in tests.
+// Ключ для групування мерчантів: нормалізовані пробіли + регістр, щоб
+// «АТБ», «атб», «АТБ  » зливалися в один запис. Для відображення
+// використовується перша зустрінута форма.
+function merchantGroupKey(name) {
+  return name.replace(/\s+/g, " ").trim().toLocaleLowerCase("uk-UA");
+}
+
 export function getTopMerchants(transactions, opts = {}, maybeLimit) {
   const {
     excludedTxIds = new Set(),
@@ -281,11 +293,13 @@ export function getTopMerchants(transactions, opts = {}, maybeLimit) {
   for (const tx of list) {
     if (!tx || excluded.has(tx.id) || tx.amount >= 0) continue;
     if (inMonth && !inMonth(tx)) continue;
-    const name = (tx.description || "").trim();
-    if (!name) continue;
-    if (!merchants[name]) merchants[name] = { name, count: 0, total: 0 };
-    merchants[name].count++;
-    merchants[name].total += Math.abs(tx.amount / 100);
+    const raw = (tx.description || "").trim();
+    if (!raw) continue;
+    const key = merchantGroupKey(raw);
+    if (!key) continue;
+    if (!merchants[key]) merchants[key] = { name: raw, count: 0, total: 0 };
+    merchants[key].count++;
+    merchants[key].total += Math.abs(tx.amount / 100);
   }
 
   return Object.values(merchants)

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -18,8 +18,11 @@ import { getTrendComparison } from "../domain/selectors";
 import { readJSON } from "../lib/finykStorage.js";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
-function readTxCache(year, month) {
-  const cache = readJSON(`finyk_tx_cache_${year}_${month}`, null);
+// `fetchMonth` приймає 0-based місяць (як у `new Date(y, m, 1)`).
+// Сторінка оперує 1-based (1..12), тож тут нормалізуємо.
+function readTxCache(year, month1Based) {
+  const m0 = month1Based - 1;
+  const cache = readJSON(`finyk_tx_cache_${year}_${m0}`, null);
   if (!cache || typeof cache !== "object") return null;
   return Array.isArray(cache.txs) ? cache.txs : null;
 }
@@ -95,10 +98,19 @@ const MonthNav = memo(function MonthNav({ year, month, onChange }) {
 
 // Рядок порівняння метрики з попереднім місяцем. Чиста функція від пропсів —
 // memo знімає перерендер при оновленнях сусідніх секцій Analytics.
-const ComparisonRow = memo(function ComparisonRow({ label, current, prev }) {
+// `kind` визначає семантику знаку: для "expense" зростання — погано
+// (червоне), для "income" — добре (зелене).
+const ComparisonRow = memo(function ComparisonRow({
+  label,
+  current,
+  prev,
+  kind = "expense",
+}) {
   const diff = current - prev;
   const pct = prev > 0 ? Math.round((diff / prev) * 100) : null;
   const up = diff > 0;
+  const upIsGood = kind === "income";
+  const good = diff === 0 ? null : up === upIsGood;
 
   return (
     <div className="flex items-center justify-between text-sm">
@@ -111,11 +123,11 @@ const ComparisonRow = memo(function ComparisonRow({ label, current, prev }) {
           <span
             className={cn(
               "text-xs",
-              diff === 0
+              good === null
                 ? "text-muted"
-                : up
-                  ? "text-danger"
-                  : "text-emerald-600",
+                : good
+                  ? "text-emerald-600"
+                  : "text-danger",
             )}
           >
             {up ? "+" : ""}
@@ -150,12 +162,10 @@ export function Analytics({ mono, storage }) {
   const prevYear = month === 1 ? year - 1 : year;
   const prevMonth = month === 1 ? 12 : month - 1;
   const prevKey = `${prevYear}-${String(prevMonth).padStart(2, "0")}`;
-  const isPrevCurrent =
-    prevYear === now.getFullYear() && prevMonth === now.getMonth() + 1;
 
-  const ensureMonth = (y, m, key) => {
+  const ensureMonth = (y, m1, key) => {
     if (fetchingRef.current.has(key)) return;
-    const cached = readTxCache(y, m);
+    const cached = readTxCache(y, m1);
     if (cached) {
       setHistoryCache((prev) =>
         prev[key] ? prev : { ...prev, [key]: cached },
@@ -164,10 +174,11 @@ export function Analytics({ mono, storage }) {
     }
     fetchingRef.current.add(key);
     setLoading(true);
+    // `fetchMonth` очікує 0-based місяць (як `Date.getMonth()`).
     mono
-      .fetchMonth(y, m)
+      .fetchMonth(y, m1 - 1)
       .then(() => {
-        const txs = readTxCache(y, m) || [];
+        const txs = readTxCache(y, m1) || [];
         setHistoryCache((prev) => ({ ...prev, [key]: txs }));
       })
       .catch(() => {
@@ -186,11 +197,11 @@ export function Analytics({ mono, storage }) {
   }, [year, month, isCurrentMonth, monthKey]);
 
   useEffect(() => {
-    if (!isPrevCurrent && !historyCache[prevKey]) {
+    if (!historyCache[prevKey]) {
       ensureMonth(prevYear, prevMonth, prevKey);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prevYear, prevMonth, isPrevCurrent, prevKey]);
+  }, [prevYear, prevMonth, prevKey]);
 
   // Transactions for the selected month: live list for the current month,
   // on-demand cached list otherwise. Stable reference while month + cache
@@ -200,10 +211,10 @@ export function Analytics({ mono, storage }) {
     return historyCache[monthKey] || [];
   }, [isCurrentMonth, mono.realTx, historyCache, monthKey]);
 
-  const prevTx = useMemo(() => {
-    if (isPrevCurrent) return mono.realTx || [];
-    return historyCache[prevKey] || [];
-  }, [isPrevCurrent, mono.realTx, historyCache, prevKey]);
+  const prevTx = useMemo(
+    () => historyCache[prevKey] || [],
+    [historyCache, prevKey],
+  );
 
   // Stable adapter object passed into useAnalytics. Rebuilding this on every
   // render would bust the hook's internal useMemo deps, so memoize it.
@@ -221,11 +232,22 @@ export function Analytics({ mono, storage }) {
   // Depends on the selected month's tx list, the previous month's tx list
   // and the filters that actually affect totals (excluded ids + splits).
   const comparison = useMemo(() => {
-    if (!prevTx.length && !historyCache[prevKey]) return null;
-    return getTrendComparison(activeTx, prevTx, {
+    // Попередній місяць ще не вичитаний — не показувати секцію.
+    if (!(prevKey in historyCache)) return null;
+    const c = getTrendComparison(activeTx, prevTx, {
       excludedTxIds: storage.excludedTxIds,
       txSplits: storage.txSplits,
     });
+    // Обидві сторони порожні — порівнювати немає чого.
+    if (
+      c.currentSpent === 0 &&
+      c.prevSpent === 0 &&
+      c.currentIncome === 0 &&
+      c.prevIncome === 0
+    ) {
+      return null;
+    }
+    return c;
   }, [
     activeTx,
     prevTx,
@@ -301,6 +323,7 @@ export function Analytics({ mono, storage }) {
                 label="Дохід"
                 current={comparison.currentIncome}
                 prev={comparison.prevIncome}
+                kind="income"
               />
             </div>
           </Section>

--- a/src/shared/lib/createModuleStorage.js
+++ b/src/shared/lib/createModuleStorage.js
@@ -172,7 +172,7 @@ export function createModuleStorage({
         pendingValues.delete(k);
         writeJSON(k, val);
       },
-      Math.max(0, Number(delay) || 0),
+      Math.max(0, Number(delay) || defaultDebounceMs),
     );
     pendingTimers.set(k, timer);
   }


### PR DESCRIPTION
## Summary

Виправив баги на сторінці **ФІНІК → Статистика**, знайдені під час код-рев'ю.

### 🔴 1. Зсув на +1 місяць при перегляді минулих місяців

У <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/pages/Analytics.jsx" /> місяць зберігається як **1-based** (1..12), але `mono.fetchMonth` очікує **0-based** (як `Date.getMonth()`) і використовує аргумент прямо у `new Date(y, m, 1)` — тож запит `fetchMonth(2025, 3)` повертав квітневі транзакції замість березневих. Ключ кешу теж відрізнявся від того, що пише `Transactions.jsx` (0-based) → подвійний кеш у localStorage для того самого місяця.

Фікс: в Analytics на межі з `fetchMonth` / `readTxCache` конвертуємо 1-based → 0-based. Публічний API `fetchMonth` не чіпав — інші місця ним користуються правильно.

### 🟡 2. Дохід позначався червоним при зростанні

`ComparisonRow` завжди фарбував `diff > 0` як `text-danger`. Для рядка «Витрати» це правильно, для «Дохід» — ні. Додав пропс `kind` (`"expense"` за замовчуванням, `"income"` інвертує семантику): для доходу зростання тепер зелене, падіння — червоне.

### 🟢 Дрібніше

- <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/finyk/domain/selectors.js" /> — `selectCategoryDistributionFromIndex` тепер рахує `pct` від **повної** суми витрат (через `index.totalSpent`), а не від видимої top-20. «Довгий хвіст» більше не інфлейтить частку показаних категорій на пай-чарті.
- `getTopMerchants` групує за нормалізованим ключем (`trim` + `collapse spaces` + `toLocaleLowerCase("uk-UA")`). Варіанти написання «АТБ»/«атб»/«АТБ  » зливаються в один запис; для відображення використовується перша зустрінута форма.
- В Analytics видалена недосяжна гілка `isPrevCurrent` (MonthNav забороняє йти в майбутнє, тож попередній місяць ніколи не дорівнює поточному).
- `comparison` секція тепер повертає `null`, якщо всі чотири метрики = 0 (раніше показувала порожній блок «0 ₴ vs 0 ₴», коли запит за попередній місяць повернув `[]`).

### 🔁 Бонус: Devin Review регрес з PR #97

Фабрика <ref_file file="/home/ubuntu/repos/Sergeant/src/shared/lib/createModuleStorage.js" /> у debounce-колбеку мала `Math.max(0, Number(delay) || 0)` — для `delay = 0 / null / NaN` давала 0мс замість дефолтних 500мс (контракт попередньої реалізації у finyk). Повернено на `defaultDebounceMs`.

## Review & Testing Checklist for Human

Ризик: 🟡 yellow — зачіпає відображення даних у статистиці.

- [ ] Перевірити Статистику у ФІНІКУ: перегорнути 2-3 місяці назад і переконатись, що суми/категорії/мерчанти збігаються з тими, що показує сторінка «Транзакції» за той самий місяць.
- [ ] Перевірити, що «Дохід» при зростанні зелений (+%), при падінні — червоний.
- [ ] Очистити старі дубльовані ключі кешу `finyk_tx_cache_YYYY_M` (якщо у LS є пари на один місяць — 0-based буде в Transactions і тепер в Analytics, 1-based застарілі можна видалити). Автоматичної міграції навмисно не робив, бо кеш безшумно перезапишеться при наступному відкритті місяця.
- [ ] Чарт розподілу категорій: перевірити, що при >20 категоріях видимі частки сумарно можуть бути <100% — це тепер очікувана поведінка («довгий хвіст» не ховається).

### Notes
- Перезапис `fetchMonth` (щоб прийняв 1-based) був би інвазивнішим і зачіпав би Transactions/Overview/кеш-ключі. Тому фікс локалізовано на стороні Analytics.
- Всі 303 тести зелені, лінт + typecheck + build зелені.

Link to Devin session: https://app.devin.ai/sessions/2f695b5380564846ad39ce3ce2beb9ad
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
