### PR TITLE
fix(fizruk): collapse workout after finish, keep in history until deleted

### DIFF
--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
@@ -6,6 +6,11 @@ import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
 
 function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
+  // An ended workout is always "Завершене" — even if it happens to be the
+  // currently-selected row — so it no longer looks like it's "hanging in
+  // active" after the user pressed «Завершити».
+  const isEnded = Boolean(w.endedAt);
+  const isActive = !isEnded && activeWorkoutId === w.id;
   return (
     <button
       key={w.id}
@@ -23,13 +28,13 @@ function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
           <span className="text-xs text-subtle">
             {(w.items || []).length} вправ
           </span>
-          {activeWorkoutId === w.id ? (
-            <span className="text-[10px] px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/20">
-              Активне
-            </span>
-          ) : w.endedAt ? (
+          {isEnded ? (
             <span className="text-[10px] px-2 py-0.5 rounded-full bg-panelHi text-subtle border border-line">
               Завершене
+            </span>
+          ) : isActive ? (
+            <span className="text-[10px] px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/20">
+              Активне
             </span>
           ) : (
             <span className="text-[10px] px-2 py-0.5 rounded-full bg-warning/10 text-warning border border-warning/20">
@@ -139,6 +144,12 @@ export function WorkoutJournalSection({
               const sum = summarizeWorkoutForFinish(activeWorkout);
               const wid = activeWorkout.id;
               endWorkout(wid);
+              // Collapse the expanded active workout panel immediately —
+              // a finished session should live on in the history list as a
+              // "Завершене" entry, not keep occupying the "Активне" slot.
+              // The workout itself is not deleted: it can only be removed
+              // via explicit delete (swipe / "Видалити" confirm dialog).
+              setActiveWorkoutId(null);
               if (sum) {
                 setFinishFlash({
                   step: "wellbeing",


### PR DESCRIPTION
## Summary

Після натискання «Завершити» у фізруку тренування більше не «висить» в активних.

Що було: після `endWorkout` великий `ActiveWorkoutPanel` залишався розкритим, бо `activeWorkoutId` не скидався — воно ж і було «активним», просто з проставленим `endedAt`. У списку «Останні тренування» той самий запис показувався з лейблом **Активне** (через `activeWorkoutId === w.id`), а не **Завершене**. Закрити його можна було тільки видаленням.

Що зараз:

- <ref_snippet file="/home/ubuntu/repos/Sergeant/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx" lines="138-158" /> — одразу після успішного завершення викликається `setActiveWorkoutId(null)`. `ActiveWorkoutPanel` згортається, з'являється звичний flash із самопочуттям/підсумком (`WorkoutFinishSheets`). Запис тренування **залишається** у списку — його можна видалити лише явно через свайп / діалог «Видалити».
- <ref_snippet file="/home/ubuntu/repos/Sergeant/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx" lines="8-45" /> — `WorkoutRow` тепер визначає лейбл за `endedAt` у першу чергу: завершене тренування завжди показується як **Завершене**, навіть якщо на ньому випадково стоїть фокус (наприклад, коли користувач клацнув по ньому у списку, щоб переглянути).

Видалення — єдиний шлях прибрати тренування повністю (свайп ліворуч або підтвердження у `ConfirmDialog`), логіка не змінювалась.

## Review & Testing Checklist for Human

- [ ] У фізруку почати тренування → натиснути «Завершити» → переконатися, що `ActiveWorkoutPanel` зникає (згортається), у журналі лишається запис зі статусом **Завершене**, а flash із самопочуттям/підсумком відкривається як раніше.
- [ ] Натиснути на щойно завершене тренування у списку «Останні тренування» — воно відкривається у read-only вигляді, але лейбл лишається **Завершене**, а не перемикається на «Активне».
- [ ] Видалення працює як раніше: свайп ліворуч по рядку у списку і «Видалити» з активної панелі → запис зникає (це єдиний шлях прибрати тренування).
- [ ] Новий workout без `endedAt` досі показує **Активне** (поки `activeWorkoutId` = його id) та **Чернетка** для інших незавершених.

### Notes

- Локально: `npm run lint`, `npm run typecheck`, `npm test` (303 tests), `npm run format:check` — усе зелене.
- Зміни ізольовані в `WorkoutJournalSection.jsx`; `useWorkouts`, `WorkoutFinishSheets`, логіка видалення не змінювались.

Link to Devin session: https://app.devin.ai/sessions/bb985e014df6469ea570b9c58310017e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
