### PR TITLE
refactor(finyk): стабільність — shape guards, dedupe, per-page error boundaries

### DIFF
--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -6,6 +6,7 @@ import { readRaw, writeRaw } from "./lib/finykStorage.js";
 import { PAGES } from "./constants";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
+import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
 import { Overview } from "./pages/Overview.jsx";
@@ -549,40 +550,67 @@ export default function App({
         onTouchEnd={handleTouchEnd}
       >
         {page === "overview" && (
-          <Overview
-            mono={mergedMono}
-            storage={storage}
-            onNavigate={navigate}
-            onCategoryClick={(catId) => {
-              setCategoryFilter(catId);
-              navigate("transactions");
-            }}
-            showBalance={showBalance}
-          />
+          <SectionErrorBoundary
+            key="page-overview"
+            title="Не вдалось показати «Огляд»"
+          >
+            <Overview
+              mono={mergedMono}
+              storage={storage}
+              onNavigate={navigate}
+              onCategoryClick={(catId) => {
+                setCategoryFilter(catId);
+                navigate("transactions");
+              }}
+              showBalance={showBalance}
+            />
+          </SectionErrorBoundary>
         )}
         {page === "transactions" && (
-          <Transactions
-            mono={mergedMono}
-            storage={storage}
-            showBalance={showBalance}
-            categoryFilter={categoryFilter}
-            onClearCategoryFilter={() => setCategoryFilter(null)}
-            onEditManualExpense={(id) => {
-              setEditingManualExpenseId(String(id));
-              setShowExpenseSheet(true);
-            }}
-          />
+          <SectionErrorBoundary
+            key="page-transactions"
+            title="Не вдалось показати «Операції»"
+          >
+            <Transactions
+              mono={mergedMono}
+              storage={storage}
+              showBalance={showBalance}
+              categoryFilter={categoryFilter}
+              onClearCategoryFilter={() => setCategoryFilter(null)}
+              onEditManualExpense={(id) => {
+                setEditingManualExpenseId(String(id));
+                setShowExpenseSheet(true);
+              }}
+            />
+          </SectionErrorBoundary>
         )}
-        {page === "budgets" && <Budgets mono={mergedMono} storage={storage} />}
+        {page === "budgets" && (
+          <SectionErrorBoundary
+            key="page-budgets"
+            title="Не вдалось показати «Планування»"
+          >
+            <Budgets mono={mergedMono} storage={storage} />
+          </SectionErrorBoundary>
+        )}
         {page === "analytics" && (
-          <Analytics mono={mergedMono} storage={storage} />
+          <SectionErrorBoundary
+            key="page-analytics"
+            title="Не вдалось показати «Аналітику»"
+          >
+            <Analytics mono={mergedMono} storage={storage} />
+          </SectionErrorBoundary>
         )}
         {page === "assets" && (
-          <Assets
-            mono={mergedMono}
-            storage={storage}
-            showBalance={showBalance}
-          />
+          <SectionErrorBoundary
+            key="page-assets"
+            title="Не вдалось показати «Активи»"
+          >
+            <Assets
+              mono={mergedMono}
+              storage={storage}
+              showBalance={showBalance}
+            />
+          </SectionErrorBoundary>
         )}
       </div>
 

--- a/src/modules/finyk/domain/transactions.test.js
+++ b/src/modules/finyk/domain/transactions.test.js
@@ -184,6 +184,24 @@ describe("normalizeTransactions / dedupeAndSortTransactions", () => {
     ]);
     expect(result.map((t) => t.id)).toEqual(["b", "a"]);
   });
+
+  it("толерує null/undefined/не-об'єкти у вхідному списку", () => {
+    const result = dedupeAndSortTransactions([
+      null,
+      undefined,
+      "garbage",
+      42,
+      { id: "a", time: 3, amount: 1 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("a");
+  });
+
+  it("повертає порожній масив для не-масиву", () => {
+    expect(dedupeAndSortTransactions(null)).toEqual([]);
+    expect(dedupeAndSortTransactions(undefined)).toEqual([]);
+    expect(dedupeAndSortTransactions({})).toEqual([]);
+  });
 });
 
 describe("manualExpenseToTransaction", () => {

--- a/src/modules/finyk/domain/transactions.ts
+++ b/src/modules/finyk/domain/transactions.ts
@@ -273,11 +273,21 @@ export function filterStatTransactions(
   return transactions.filter((t) => t && !excluded.has(t.id));
 }
 
+// Захищаємось від "сирих" входів з неправильною формою: нормалізуємо
+// лише валідні об'єкти, пропускаємо пусті/null/недійсні записи та гарантуємо
+// унікальність за стабільним id. Остання транзакція з тим же id виграє —
+// це важливо для merge між cache + network, коли сервер повернув свіжу копію.
 export function dedupeAndSortTransactions(
   items: readonly RawTxInput[] | null | undefined,
 ): Transaction[] {
+  if (!Array.isArray(items)) return [];
+  const safe = items.filter(
+    (tx): tx is RawTxInput => tx != null && typeof tx === "object",
+  );
   const map = new Map<string, Transaction>();
-  for (const tx of normalizeTransactions(items)) map.set(tx.id, tx);
+  for (const tx of normalizeTransactions(safe)) {
+    if (tx.id) map.set(tx.id, tx);
+  }
   return Array.from(map.values()).sort((a, b) => (b.time || 0) - (a.time || 0));
 }
 

--- a/src/modules/finyk/hooks/useStorage.js
+++ b/src/modules/finyk/hooks/useStorage.js
@@ -24,8 +24,27 @@ try {
 } catch (error) {
   reportSilentError("storage migrations", error);
 }
+// Визначаємо "очікувану форму" за дефолтом: array / plain-object / скаляр.
+// Це дозволяє тихо відкинути пошкоджений JSON у localStorage (наприклад,
+// коли ключ випадково був перезаписаний іншим модулем або ручною правкою)
+// і ввімкнути модуль з дефолтом, замість того щоб падати на мапах/фільтрах.
+function matchesShape(value, defaultVal) {
+  if (Array.isArray(defaultVal)) return Array.isArray(value);
+  if (defaultVal && typeof defaultVal === "object") {
+    return value != null && typeof value === "object" && !Array.isArray(value);
+  }
+  return true;
+}
+
 function usePersist(key, defaultVal) {
-  const [val, setVal] = useState(() => readJSON(key, defaultVal));
+  const [val, setVal] = useState(() => {
+    const stored = readJSON(key, defaultVal);
+    if (!matchesShape(stored, defaultVal)) {
+      reportSilentError(`usePersist shape mismatch ("${key}")`, stored);
+      return defaultVal;
+    }
+    return stored;
+  });
   useEffect(() => {
     writeJSONDebounced(key, val);
   }, [key, val]);


### PR DESCRIPTION
## Summary
Мінімально інвазивні правки стабільності модуля finyk, без зміни UX.

- **Shape guard у `usePersist` (`useStorage.js`)** — якщо в `localStorage` під finyk-ключем лежить значення не тієї форми (наприклад масив замість об'єкта через ручну правку / міграцію / конфлікт), тихо падаємо на дефолт і логгимо warning. Раніше це могло впасти у `.map`/`.filter` на першому рендері.
- **`dedupeAndSortTransactions` стійке до сміття** — ігнорує `null`/`undefined`/рядки/числа в масиві і не-масив на вході, пропускає записи без `id`. Захист від побитих кешів monobank/privatbank і бекап-файлів.
- **Error boundary на кожну сторінку finyk** — `Overview`, `Transactions`, `Budgets`, `Analytics`, `Assets` кожен у власному `SectionErrorBoundary`. Ренедер-виключення на одній сторінці не валить весь модуль, користувач бачить локальне повідомлення і може перейти в іншу вкладку. Попередньо падіння однієї сторінки вибивало в `ModuleErrorBoundary` з верненням у хаб.
- **Юніт-тести** — `dedupeAndSortTransactions` тепер має тести для null/undefined/garbage/non-array inputs.

Що лишається як було (і не чіпалось навмисне):
- `finykStorage` вже тихо ловить `JSON.parse` і має fallback — вже достатньо defensive.
- `useMonobank` retry/online/offline/cache/last-good-backup merge — вже коректно обробляє offline→online і часткові фейли рахунків.
- `normalizeTransaction` вже захищений від NaN/negative/bad date.
- `normalizeFinykBackup` суворо валідує імпорт (уже кидає з зрозумілими помилками).

## Review & Testing Checklist for Human
- [ ] Перемкнись між усіма 5 вкладками модуля — жодної зміни UX/стилів не має бути.
- [ ] Перевір імпорт бекапу і sync-лінку — помилки показуються тостом без падіння модуля.
- [ ] Якщо спеціально зіпсувати `localStorage` ключ (наприклад `finyk_budgets = '{"broken":true}'`) — модуль стартує з дефолтом і у консолі видно `[finyk] usePersist shape mismatch (...)`.

### Notes
Ніяких нових alert'ів — помилки тихо логгуються через наявний `reportSilentError`.

Link to Devin session: https://app.devin.ai/sessions/d04f2f546a324827b0ae2c9b819f1e72
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
