### PR TITLE
fix(settings): minor post-split quick wins (dedupe routine sub, reactive hub pref)

### DIFF
--- a/src/core/settings/GeneralSection.jsx
+++ b/src/core/settings/GeneralSection.jsx
@@ -7,7 +7,7 @@ import {
   SettingsSubGroup,
   ToggleRow,
 } from "./SettingsPrimitives.jsx";
-import { loadHubPrefs, saveHubPref } from "./hubPrefs.js";
+import { useHubPref } from "./hubPrefs.js";
 
 export function GeneralSection({
   dark,
@@ -18,20 +18,12 @@ export function GeneralSection({
   user,
 }) {
   const [orderReset, setOrderReset] = useState(false);
-  const [showCoach, setShowCoach] = useState(
-    () => loadHubPrefs().showCoach !== false,
-  );
+  const [showCoach, setShowCoach] = useHubPref("showCoach", true);
 
   const handleResetOrder = () => {
     resetDashboardOrder();
     setOrderReset(true);
     setTimeout(() => setOrderReset(false), 2000);
-  };
-
-  const handleToggleCoach = (e) => {
-    const val = e.target.checked;
-    setShowCoach(val);
-    saveHubPref("showCoach", val);
   };
 
   return (
@@ -41,8 +33,8 @@ export function GeneralSection({
         <ToggleRow
           label="Показувати AI-коуч"
           description="Блок з щоденною порадою коуча на головному екрані."
-          checked={showCoach}
-          onChange={handleToggleCoach}
+          checked={showCoach !== false}
+          onChange={(e) => setShowCoach(e.target.checked)}
         />
       </SettingsSubGroup>
       <SettingsSubGroup title="Дашборд — порядок блоків">

--- a/src/core/settings/NotificationsSection.jsx
+++ b/src/core/settings/NotificationsSection.jsx
@@ -2,11 +2,8 @@ import { useEffect, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast.jsx";
-import {
-  loadRoutineState,
-  setPref,
-} from "../../modules/routine/lib/routineStorage.js";
 import { requestRoutineNotificationPermission } from "../../modules/routine/hooks/useRoutineReminders.js";
+import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
 import { useMonthlyPlan } from "../../modules/fizruk/hooks/useMonthlyPlan.js";
 import {
   loadNutritionPrefs,
@@ -28,19 +25,7 @@ export function NotificationsSection() {
   );
   const { warning: toastWarning } = useToast();
 
-  const [routine, setRoutine] = useState(() => loadRoutineState());
-  useEffect(() => {
-    const handler = () => setRoutine(loadRoutineState());
-    const storageHandler = (e) => {
-      if (e.key === "hub_routine_v1" || e.key === null) handler();
-    };
-    window.addEventListener("hub-routine-storage", handler);
-    window.addEventListener("storage", storageHandler);
-    return () => {
-      window.removeEventListener("hub-routine-storage", handler);
-      window.removeEventListener("storage", storageHandler);
-    };
-  }, []);
+  const { routine, updatePref: updateRoutinePref } = useRoutineState();
 
   const monthlyPlan = useMonthlyPlan();
 
@@ -70,10 +55,6 @@ export function NotificationsSection() {
     } catch {
       setPermStatus("denied");
     }
-  };
-
-  const updateRoutinePref = (key, value) => {
-    setRoutine((s) => setPref(s, key, value));
   };
 
   const handleRoutineToggle = async (checked) => {

--- a/src/core/settings/RoutineSection.jsx
+++ b/src/core/settings/RoutineSection.jsx
@@ -1,29 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
-import {
-  loadRoutineState,
-  setPref,
-} from "../../modules/routine/lib/routineStorage.js";
+import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
 import { SettingsGroup, ToggleRow } from "./SettingsPrimitives.jsx";
 
 export function RoutineSection() {
-  const [routine, setRoutine] = useState(() => loadRoutineState());
-
-  useEffect(() => {
-    const handler = () => setRoutine(loadRoutineState());
-    const storageHandler = (e) => {
-      if (e.key === "hub_routine_v1" || e.key === null) handler();
-    };
-    window.addEventListener("hub-routine-storage", handler);
-    window.addEventListener("storage", storageHandler);
-    return () => {
-      window.removeEventListener("hub-routine-storage", handler);
-      window.removeEventListener("storage", storageHandler);
-    };
-  }, []);
-
-  const updatePref = useCallback((key, value) => {
-    setRoutine((s) => setPref(s, key, value));
-  }, []);
+  const { routine, updatePref } = useRoutineState();
 
   return (
     <SettingsGroup title="Рутина" emoji="✅">

--- a/src/core/settings/hubPrefs.js
+++ b/src/core/settings/hubPrefs.js
@@ -1,4 +1,7 @@
-export const HUB_PREFS_KEY = "hub_prefs_v1";
+import { useEffect, useState } from "react";
+import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
+
+export const HUB_PREFS_KEY = STORAGE_KEYS.HUB_PREFS;
 
 export function loadHubPrefs() {
   try {
@@ -20,4 +23,32 @@ export function saveHubPref(key, value) {
   } catch {
     /* quota or serialization — safe to ignore */
   }
+}
+
+/**
+ * Reactive single-pref hook that stays in sync with cross-tab `storage`
+ * events and the same-tab StorageEvent dispatched by `saveHubPref`.
+ */
+export function useHubPref(key, defaultValue) {
+  const read = () => {
+    const prefs = loadHubPrefs();
+    return key in prefs ? prefs[key] : defaultValue;
+  };
+  const [value, setValue] = useState(read);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === HUB_PREFS_KEY || e.key === null) setValue(read());
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const update = (next) => {
+    setValue(next);
+    saveHubPref(key, next);
+  };
+
+  return [value, update];
 }

--- a/src/modules/routine/hooks/useRoutineState.js
+++ b/src/modules/routine/hooks/useRoutineState.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ROUTINE_EVENT,
+  ROUTINE_STORAGE_KEY,
+  loadRoutineState,
+  setPref,
+} from "../lib/routineStorage.js";
+
+/**
+ * Reactive routine state with cross-tab (`storage`) and same-tab
+ * (`hub-routine-storage`) sync. Extracted from settings sections that
+ * previously duplicated this subscription.
+ */
+export function useRoutineState() {
+  const [routine, setRoutine] = useState(() => loadRoutineState());
+
+  useEffect(() => {
+    const handler = () => setRoutine(loadRoutineState());
+    const storageHandler = (e) => {
+      if (e.key === ROUTINE_STORAGE_KEY || e.key === null) handler();
+    };
+    window.addEventListener(ROUTINE_EVENT, handler);
+    window.addEventListener("storage", storageHandler);
+    return () => {
+      window.removeEventListener(ROUTINE_EVENT, handler);
+      window.removeEventListener("storage", storageHandler);
+    };
+  }, []);
+
+  const updatePref = useCallback((key, value) => {
+    setRoutine((s) => setPref(s, key, value));
+  }, []);
+
+  return { routine, setRoutine, updatePref };
+}


### PR DESCRIPTION
## Summary

Точкові quick-win правки після розбиття `HubSettingsPage` на секції (c843b3b). Без нового редизайну, без великого рефакторингу, зовнішній UX не змінюється.

### Перевірено (регресій нема)
- Порядок секцій `General → AIDigest → Notifications → Routine → Fizruk → Finyk` відповідає оригіналу.
- `defaultOpen` на `SettingsGroup` / `SettingsSubGroup` усюди збігається з до-split станом (зокрема: `Сповіщення`, саб-групи `Звички/Тренування/Харчування`, `Резервна копія Hub`, `Резервні копії та дані` у Фізрук).
- Стани секцій не губляться при згортанні сусідніх — `SettingsGroup` анімує `grid-template-rows`, діти не розмонтовуються.
- Confirm-модалки на критичних діях присутні: очистка кешу Фініка, вихід з Monobank, відʼєднання ПриватБанку.
- Усі toggle-перемикачі зберігаються у відповідні сховища (`hubPrefs`, `routineStorage`, `nutritionStorage`, `useMonthlyPlan`) і виживають reload.

### Точкові фікси

1. **Дубльована підписка на routine-state** між `RoutineSection` і `NotificationsSection` винесена у новий хук `useRoutineState` (у `src/modules/routine/hooks/`). Підписується на `ROUTINE_EVENT` (same-tab) і `storage` (cross-tab) через константи з `routineStorage.js`, а не магічні стрінги.
2. **Реактивний `useHubPref(key, default)` у `hubPrefs.js`** — `GeneralSection` (`showCoach`) тепер реагує на `StorageEvent`, що диспатчиться `saveHubPref`, та на cross-tab зміни. Раніше стан читався лише разово на маунті.
3. **Уніфіковано джерело `HUB_PREFS_KEY`** — `hubPrefs.js` тепер бере ключ з `STORAGE_KEYS.HUB_PREFS` замість дубльованого літералу `"hub_prefs_v1"`.

### Що свідомо не чіпав
- `NotificationsSection` `handleRoutineToggle` завжди викликає `requestRoutineNotificationPermission` (на відміну від Fizruk/Nutrition, які перевіряють `permStatus !== "granted"` перед запитом). Це передіснуюча поведінка, до сплітa, і функція ідемпотентна при вже виданому дозволі — не квалифікується як регресія.
- `FinykSection` має багато локального стану навколо ПриватБанку, але фіча за `PRIVAT_ENABLED = false`; без потреби не чіпав.

## Review & Testing Checklist for Human
- [ ] Відкрити Hub Settings → `Загальні` → перемкнути «Показувати AI-коуч», перезавантажити сторінку — стан має збігатися.
- [ ] Відкрити Hub Settings у двох вкладках → перемкнути toggle у одній → переконатися, що інша оновлюється (cross-tab via `storage`).
- [ ] `Рутина`: перемкнути «Показувати тренування з Фізрука в календарі» і «Показувати планові платежі підписок Фініка в календарі» — перевірити, що Hub-календар оновлюється відповідно.
- [ ] `Сповіщення`: перемкнути toggle «Нагадування про звички», «Нагадування про тренування», «Нагадування про їжу» з відсутнім дозволом на notifications — має зʼявлятися toast-попередження, toggle не вмикатися.
- [ ] Фінік: «Очистити кеш транзакцій» і «Вийти з Monobank» → відкривається confirm-модалка; `Скасувати` нічого не робить, `Підтвердити` виконує дію + reload.

### Notes
Діффи по файлам мінімальні; жодних стилів/верстки не чіпав.

Link to Devin session: https://app.devin.ai/sessions/18f5b2c1feb4468b862b2953261a2177
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
