### PR TITLE
harden useCloudSync against network/race edge cases

### DIFF
--- a/src/core/useCloudSync.hardening.test.js
+++ b/src/core/useCloudSync.hardening.test.js
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the cloud-sync hardening quick wins:
+ *   - offline queue coalescing + size cap
+ *   - tolerant replay (skips corrupted entries, doesn't crash)
+ *   - strict per-module success check (no silent drops on partial fail)
+ *   - invalid-date defense in conflict resolution
+ *
+ * These tests cover the pure helpers that the hook delegates to. The React
+ * hook itself is exercised in useCloudSync.behavior.test.js via events; the
+ * async network flows are covered here at the helper level because jsdom
+ * can't reliably stub fetch across module boundaries.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getOfflineQueue,
+  __internal_isModulePushSuccess as isOk,
+  __internal_collectQueuedModules as collectQueued,
+  __internal_addToOfflineQueue as enqueue,
+  __internal_parseDateSafe as parseDate,
+} from "./useCloudSync.js";
+import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("isModulePushSuccess", () => {
+  it("treats missing/non-object result as failure", () => {
+    expect(isOk(null)).toBe(false);
+    expect(isOk(undefined)).toBe(false);
+    expect(isOk("ok")).toBe(false);
+    expect(isOk(0)).toBe(false);
+  });
+
+  it("treats explicit conflict as failure", () => {
+    expect(isOk({ conflict: true, version: 5 })).toBe(false);
+  });
+
+  it("treats explicit error as failure", () => {
+    expect(isOk({ error: "boom" })).toBe(false);
+  });
+
+  it("treats ok:false as failure", () => {
+    expect(isOk({ ok: false, version: 3 })).toBe(false);
+  });
+
+  it("treats a version-only result as success", () => {
+    expect(isOk({ version: 3 })).toBe(true);
+  });
+
+  it("treats empty object as success (server accepted)", () => {
+    expect(isOk({})).toBe(true);
+  });
+});
+
+describe("parseDateSafe", () => {
+  it("returns null for empty/nullish", () => {
+    expect(parseDate(null)).toBeNull();
+    expect(parseDate(undefined)).toBeNull();
+    expect(parseDate("")).toBeNull();
+  });
+
+  it("returns null for unparseable strings", () => {
+    expect(parseDate("not a date")).toBeNull();
+    expect(parseDate("2024-13-40T99:99:99Z")).toBeNull();
+  });
+
+  it("returns a Date for valid ISO strings", () => {
+    const d = parseDate("2024-01-15T10:30:00.000Z");
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.toISOString()).toBe("2024-01-15T10:30:00.000Z");
+  });
+});
+
+describe("collectQueuedModules (corruption tolerance)", () => {
+  it("returns {} for non-array input", () => {
+    expect(collectQueued(null)).toEqual({});
+    expect(collectQueued(undefined)).toEqual({});
+    expect(collectQueued("bad")).toEqual({});
+    expect(collectQueued({ not: "array" })).toEqual({});
+  });
+
+  it("skips entries that are not objects", () => {
+    const q = [null, "string", 42, { type: "push", modules: {} }];
+    expect(collectQueued(q)).toEqual({});
+  });
+
+  it("skips entries with wrong type", () => {
+    const q = [
+      { type: "pull", modules: { finyk: { data: {} } } },
+      { type: "unknown", modules: { fizruk: { data: {} } } },
+    ];
+    expect(collectQueued(q)).toEqual({});
+  });
+
+  it("skips entries with missing/non-object modules", () => {
+    const q = [
+      { type: "push" },
+      { type: "push", modules: null },
+      { type: "push", modules: "oops" },
+    ];
+    expect(collectQueued(q)).toEqual({});
+  });
+
+  it("skips unknown module names", () => {
+    const q = [
+      {
+        type: "push",
+        modules: {
+          not_a_real_module: { data: { foo: "bar" } },
+          finyk: { data: { x: 1 } },
+        },
+      },
+    ];
+    const out = collectQueued(q);
+    expect(out).toHaveProperty("finyk");
+    expect(out).not.toHaveProperty("not_a_real_module");
+  });
+
+  it("later entries overwrite earlier ones for the same module", () => {
+    const q = [
+      { type: "push", modules: { finyk: { data: { v: 1 } } } },
+      { type: "push", modules: { finyk: { data: { v: 2 } } } },
+    ];
+    expect(collectQueued(q)).toEqual({ finyk: { data: { v: 2 } } });
+  });
+
+  it("merges payloads across modules from multiple entries", () => {
+    const q = [
+      { type: "push", modules: { finyk: { data: { a: 1 } } } },
+      { type: "push", modules: { fizruk: { data: { b: 2 } } } },
+      { type: "push", modules: { routine: { data: { c: 3 } } } },
+    ];
+    expect(Object.keys(collectQueued(q)).sort()).toEqual([
+      "finyk",
+      "fizruk",
+      "routine",
+    ]);
+  });
+});
+
+describe("addToOfflineQueue coalescing", () => {
+  it("merges consecutive push entries into the last row", () => {
+    enqueue({ type: "push", modules: { finyk: { data: { v: 1 } } } });
+    enqueue({ type: "push", modules: { fizruk: { data: { v: 2 } } } });
+    const q = getOfflineQueue();
+    expect(q).toHaveLength(1);
+    expect(Object.keys(q[0].modules).sort()).toEqual(["finyk", "fizruk"]);
+  });
+
+  it("later merged module payload overwrites earlier one", () => {
+    enqueue({ type: "push", modules: { finyk: { data: { v: 1 } } } });
+    enqueue({ type: "push", modules: { finyk: { data: { v: 2 } } } });
+    const q = getOfflineQueue();
+    expect(q).toHaveLength(1);
+    expect(q[0].modules.finyk.data.v).toBe(2);
+  });
+
+  it("caps queue length when many non-coalescing entries accumulate", () => {
+    // Force non-push entries that don't coalesce so we can exercise the cap.
+    for (let i = 0; i < 120; i++) {
+      enqueue({ type: `other-${i}`, payload: i });
+    }
+    const q = getOfflineQueue();
+    expect(q.length).toBeLessThanOrEqual(50);
+    // Oldest entries should be dropped, newest preserved.
+    const last = q[q.length - 1];
+    expect(last.type).toBe("other-119");
+  });
+
+  it("does not coalesce into a non-push last entry", () => {
+    enqueue({ type: "other", payload: {} });
+    enqueue({ type: "push", modules: { finyk: { data: {} } } });
+    const q = getOfflineQueue();
+    expect(q).toHaveLength(2);
+    expect(q[0].type).toBe("other");
+    expect(q[1].type).toBe("push");
+  });
+
+  it("is idempotent wrt queue contents when coalescing repeated pushes", () => {
+    const payload = { finyk: { data: { v: "same" } } };
+    enqueue({ type: "push", modules: payload });
+    enqueue({ type: "push", modules: payload });
+    enqueue({ type: "push", modules: payload });
+    const q = getOfflineQueue();
+    expect(q).toHaveLength(1);
+    expect(q[0].modules.finyk.data.v).toBe("same");
+  });
+});
+
+describe("offline queue + corruption end-to-end", () => {
+  it("getOfflineQueue tolerates entirely corrupted storage", () => {
+    localStorage.setItem(STORAGE_KEYS.SYNC_OFFLINE_QUEUE, "{not json");
+    expect(getOfflineQueue()).toEqual([]);
+  });
+
+  it("collectQueuedModules tolerates a mix of valid and corrupted entries", () => {
+    const q = [
+      null,
+      { type: "push", modules: { finyk: { data: { v: 1 } } } },
+      "garbage",
+      { type: "push", modules: "not-an-object" },
+      { type: "push", modules: { fizruk: { data: { v: 2 } } } },
+      { malformed: true },
+    ];
+    const out = collectQueued(q);
+    expect(Object.keys(out).sort()).toEqual(["finyk", "fizruk"]);
+  });
+});

--- a/src/core/useCloudSync.js
+++ b/src/core/useCloudSync.js
@@ -61,6 +61,36 @@ const MODULE_MODIFIED_KEY = STORAGE_KEYS.SYNC_MODULE_MODIFIED;
 const OFFLINE_QUEUE_KEY = STORAGE_KEYS.SYNC_OFFLINE_QUEUE;
 const MIGRATION_DONE_KEY = STORAGE_KEYS.SYNC_MIGRATION_DONE;
 
+// Hard cap on offline queue length. Beyond this we drop the oldest entries to
+// keep localStorage usage bounded for users offline for extended periods.
+const MAX_OFFLINE_QUEUE = 50;
+
+export function __internal_parseDateSafe(value) {
+  return parseDateSafe(value);
+}
+
+function parseDateSafe(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// A module push result is considered successful only when the server did not
+// signal a conflict, an error, or ok:false. Any ambiguous shape is treated as
+// non-success so we keep the module dirty and retry later instead of dropping
+// unsynced changes.
+export function __internal_isModulePushSuccess(r) {
+  return isModulePushSuccess(r);
+}
+
+function isModulePushSuccess(r) {
+  if (!r || typeof r !== "object") return false;
+  if (r.conflict) return false;
+  if (r.error) return false;
+  if (r.ok === false) return false;
+  return true;
+}
+
 const ALL_TRACKED_KEYS = new Set(
   Object.values(SYNC_MODULES).flatMap((m) => m.keys),
 );
@@ -129,11 +159,66 @@ export function getOfflineQueue() {
   return Array.isArray(q) ? q : [];
 }
 
+export function __internal_addToOfflineQueue(entry) {
+  return addToOfflineQueue(entry);
+}
+
 function addToOfflineQueue(entry) {
-  const queue = getOfflineQueue();
+  let queue = getOfflineQueue();
+  // Coalesce consecutive push entries: merge new module payloads into the last
+  // queued push instead of pushing a fresh row. This prevents queue growth and
+  // duplicate work on replay when many small changes happen while offline.
+  if (
+    entry &&
+    entry.type === "push" &&
+    entry.modules &&
+    typeof entry.modules === "object" &&
+    queue.length > 0
+  ) {
+    const last = queue[queue.length - 1];
+    if (
+      last &&
+      last.type === "push" &&
+      last.modules &&
+      typeof last.modules === "object"
+    ) {
+      last.modules = { ...last.modules, ...entry.modules };
+      last.ts = new Date().toISOString();
+      safeWriteLS(OFFLINE_QUEUE_KEY, queue);
+      emitStatusEvent();
+      return;
+    }
+  }
   queue.push({ ...entry, ts: new Date().toISOString() });
+  if (queue.length > MAX_OFFLINE_QUEUE) {
+    queue = queue.slice(queue.length - MAX_OFFLINE_QUEUE);
+  }
   safeWriteLS(OFFLINE_QUEUE_KEY, queue);
   emitStatusEvent();
+}
+
+// Extract the last-known module payloads from a queue, tolerating corrupted
+// rows (non-objects, wrong types, unknown module names, missing data).
+// Later entries overwrite earlier ones for the same module since the queue is
+// append-ordered.
+export function __internal_collectQueuedModules(queue) {
+  return collectQueuedModules(queue);
+}
+
+function collectQueuedModules(queue) {
+  const modulesToPush = {};
+  if (!Array.isArray(queue)) return modulesToPush;
+  for (const entry of queue) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.type !== "push") continue;
+    if (!entry.modules || typeof entry.modules !== "object") continue;
+    for (const [mod, payload] of Object.entries(entry.modules)) {
+      if (!SYNC_MODULES[mod]) continue;
+      if (!payload || typeof payload !== "object") continue;
+      modulesToPush[mod] = payload;
+    }
+  }
+  return modulesToPush;
 }
 
 function clearOfflineQueue() {
@@ -252,19 +337,26 @@ export function useCloudSync(user) {
   const [syncError, setSyncError] = useState(null);
   const [migrationPending, setMigrationPending] = useState(false);
   const syncingRef = useRef(false);
+  const replayingRef = useRef(false);
 
   const replayOfflineQueue = useCallback(async () => {
+    // Guard against re-entry: if an "online" event fires twice in quick
+    // succession, or replay is triggered concurrently from initialSync and
+    // pushDirty, we must not fire duplicate push requests for the same queue.
+    if (replayingRef.current) return;
     const queue = getOfflineQueue();
     if (queue.length === 0) return;
 
-    const modulesToPush = {};
-    for (const entry of queue) {
-      if (entry.type === "push" && entry.modules) {
-        Object.assign(modulesToPush, entry.modules);
-      }
+    const modulesToPush = collectQueuedModules(queue);
+    if (Object.keys(modulesToPush).length === 0) {
+      // Queue contained only corrupted/unknown entries — drop it so we don't
+      // keep retrying nothing forever.
+      clearOfflineQueue();
+      return;
     }
 
-    if (Object.keys(modulesToPush).length > 0) {
+    replayingRef.current = true;
+    try {
       const res = await fetch(apiUrl("/api/sync/push-all"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -274,6 +366,11 @@ export function useCloudSync(user) {
       if (res.ok) {
         clearOfflineQueue();
       }
+    } catch {
+      // Network/transport failure during replay must not break callers
+      // (onOnline chains pushDirty afterwards). Keep the queue for later.
+    } finally {
+      replayingRef.current = false;
     }
   }, []);
 
@@ -286,18 +383,21 @@ export function useCloudSync(user) {
     syncingRef.current = true;
     setSyncing(true);
     setSyncError(null);
-    try {
-      const modifiedTimes = getModuleModifiedTimes();
-      const modules = {};
-      for (const mod of dirtyMods) {
-        const data = collectModuleData(mod);
-        if (data && Object.keys(data).length > 0) {
-          modules[mod] = {
-            data,
-            clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
-          };
-        }
+    // Snapshot modified timestamps at push-start. After the server responds we
+    // only clear a module's dirty flag if its modifiedAt hasn't advanced —
+    // otherwise a change that happened mid-request would be silently dropped.
+    const modifiedSnapshot = getModuleModifiedTimes();
+    const modules = {};
+    for (const mod of dirtyMods) {
+      const data = collectModuleData(mod);
+      if (data && Object.keys(data).length > 0) {
+        modules[mod] = {
+          data,
+          clientUpdatedAt: modifiedSnapshot[mod] || new Date().toISOString(),
+        };
       }
+    }
+    try {
       if (Object.keys(modules).length === 0) {
         clearAllDirty();
         return;
@@ -319,26 +419,23 @@ export function useCloudSync(user) {
       if (!res.ok) throw new Error("Push failed");
 
       const result = await res.json();
-      if (user?.id && result?.results) {
+      const currentModified = getModuleModifiedTimes();
+      if (result?.results) {
         for (const [mod, r] of Object.entries(result.results)) {
-          if (r?.version) setModuleVersion(user.id, mod, r.version);
-          if (!r?.conflict) clearDirtyModule(mod);
+          if (user?.id && r?.version) setModuleVersion(user.id, mod, r.version);
+          if (!isModulePushSuccess(r)) continue;
+          // Only clear dirty if no newer change landed while we were pushing.
+          if (currentModified[mod] === modifiedSnapshot[mod]) {
+            clearDirtyModule(mod);
+          }
         }
       }
 
       setLastSync(new Date());
     } catch (err) {
-      const modifiedTimes = getModuleModifiedTimes();
-      const modules = {};
-      for (const mod of dirtyMods) {
-        const data = collectModuleData(mod);
-        if (data && Object.keys(data).length > 0) {
-          modules[mod] = {
-            data,
-            clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
-          };
-        }
-      }
+      // Re-queue the exact payload we attempted to push rather than
+      // re-collecting, which would race with changes that happened during the
+      // failed request.
       if (Object.keys(modules).length > 0) {
         addToOfflineQueue({ type: "push", modules });
       }
@@ -520,12 +617,8 @@ export function useCloudSync(user) {
           if (!payload?.data) continue;
           const localVersion = user?.id ? getModuleVersion(user.id, mod) : 0;
           const cloudVersion = payload.version ?? 0;
-          const localModified = modifiedTimes[mod]
-            ? new Date(modifiedTimes[mod])
-            : null;
-          const cloudModified = payload.serverUpdatedAt
-            ? new Date(payload.serverUpdatedAt)
-            : null;
+          const localModified = parseDateSafe(modifiedTimes[mod]);
+          const cloudModified = parseDateSafe(payload.serverUpdatedAt);
 
           if (
             cloudVersion > localVersion ||


### PR DESCRIPTION
## Summary

Quick-win defensive fixes for `useCloudSync` that reduce the risk of silent data loss and duplicate work around network edge cases, without touching the hook's public API or the overall sync architecture.

Covered scenarios:

1. **offline → online replay** — replay now coalesces module payloads by module name (last write wins per module), tolerates corrupted queue entries, and swallows transport errors so a failing replay no longer short-circuits the chained `pushDirty` in `onOnline`.
2. **retry after temporary error** — `pushDirty` now re-queues the exact payload it tried to push instead of re-collecting from localStorage (which raced with mid-request changes).
3. **partial fail of one module** — a module's dirty flag is cleared only when the server response is unambiguously successful (`!conflict && !error && ok !== false`). Previously an `{ error: "..." }` result would silently clear dirty.
4. **race conditions with fast changes** — `pushDirty` now snapshots `modifiedAt` per module at push-start and only clears the dirty flag if `modifiedAt` hasn't advanced during the request. Writes that land mid-request stay dirty and get pushed on the next cycle.
5. **corrupted queue state** — replay tolerates non-array queue, non-object entries, wrong `type`, missing `modules`, and unknown module names. If the queue ends up containing only corrupted rows, it's dropped instead of being retried forever.
6. **repeated sync events don't duplicate actions** — `replayOfflineQueue` is guarded with a `replayingRef` so rapid `online` events or a concurrent `initialSync + pushDirty` can't fire duplicate push requests for the same queue.

Additional hardening:
- Offline queue is capped at 50 entries; over the cap, oldest are dropped. Consecutive `push` entries are coalesced into the last row to prevent unbounded growth for long-offline users.
- Initial-sync conflict resolution uses `parseDateSafe()` instead of raw `new Date()`, so corrupted `serverUpdatedAt` / `modifiedAt` strings produce `null` (comparison short-circuits) instead of `Invalid Date` silently returning `false`.

No changes to `useCloudSync`'s returned API (`syncing`, `lastSync`, `syncError`, `pushAll`, `pullAll`, `migrationPending`, `uploadLocalData`, `skipMigration`) or to the wire format sent to the server.

## Review & Testing Checklist for Human

- [ ] **Mid-push change retention** — open a tracked module, go online, trigger a push, and write to a tracked key while the request is in flight (or throttle the network). Verify the newly written value survives and gets pushed on the next cycle instead of being cleared by the in-flight response.
- [ ] **Partial server failure behavior** — if the backend ever returns `{ results: { finyk: { error: "..." } } }` or `{ ok: false }` for some modules, confirm those modules stay dirty and get retried. Previously they would be silently cleared.
- [ ] **Offline queue cap on long offline sessions** — going offline and making many changes across modules should no longer grow `hub_sync_offline_queue` without bound; coalesced into one row per contiguous push sequence.
- [ ] **Initial sync with corrupted timestamps** — if `serverUpdatedAt` is malformed (e.g. `"invalid"`), the conflict-resolution branch now falls back to version-only comparison instead of silently skipping the update.

### Notes

- Four internal helpers are exported as `__internal_*` for unit tests only. They are not part of the hook's public API and can be removed/renamed without impact.
- The new tests live in `src/core/useCloudSync.hardening.test.js` (23 tests). Full suite: 347 passing.
- Lint + typecheck + format:check all pass locally.


Link to Devin session: https://app.devin.ai/sessions/7a45487197774086a8bf35ab58bcefcc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
