### PR TITLE
fix(routine): стабілізація completion/reorder/tag edge cases

### DIFF
--- a/src/modules/routine/lib/routineStorage.extended.test.js
+++ b/src/modules/routine/lib/routineStorage.extended.test.js
@@ -26,6 +26,7 @@ import {
   applyRoutineBackupPayload,
   ROUTINE_STORAGE_KEY,
 } from "./routineStorage.js";
+import { completionNoteKey } from "./completionNoteKey.js";
 
 beforeEach(() => {
   localStorage.clear();
@@ -251,6 +252,243 @@ describe("tags and categories", () => {
     s = deleteCategory(s, cid);
     expect(s.categories).toHaveLength(0);
     expect(s.habits[0].categoryId).toBeNull();
+  });
+});
+
+describe("edge cases: double completion in one day", () => {
+  it("повторний toggle після вже відміченого — знімає відмітку (off)", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    expect(s.completions[id] || []).not.toContain("2024-06-15");
+  });
+  it("три послідовні toggle: on → off → on залишає рівно одну відмітку", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    const count = (s.completions[id] || []).filter(
+      (k) => k === "2024-06-15",
+    ).length;
+    expect(count).toBe(1);
+  });
+  it("дублікати з legacy-даних санітизуються при завантаженні", () => {
+    const id = "legacy";
+    const raw = {
+      schemaVersion: 3,
+      habits: [
+        {
+          id,
+          name: "Legacy",
+          archived: false,
+          recurrence: "daily",
+          startDate: "2024-01-01",
+        },
+      ],
+      completions: { [id]: ["2024-06-15", "2024-06-15", "bad", "2024-06-14"] },
+      habitOrder: [id],
+    };
+    localStorage.setItem(ROUTINE_STORAGE_KEY, JSON.stringify(raw));
+    const s = loadRoutineState();
+    expect(s.completions[id]).toEqual(["2024-06-14", "2024-06-15"]);
+  });
+  it("markAllScheduledHabitsComplete стає no-op після дедуплікації", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    const s2 = markAllScheduledHabitsComplete(s, "2024-06-15");
+    expect(s2).toBe(s);
+  });
+  it("toggleHabitCompletion дедуплікує передувало-дубльований масив", () => {
+    // Симулюємо пошкоджений state з дублем прямо в пам'яті
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = {
+      ...s,
+      completions: { ...s.completions, [id]: ["2024-06-15", "2024-06-15"] },
+    };
+    const s2 = toggleHabitCompletion(s, id, "2024-06-15");
+    expect(s2.completions[id]).not.toContain("2024-06-15");
+  });
+});
+
+describe("edge cases: reorder after delete", () => {
+  it("видалення середньої звички зберігає порядок решти", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    s = createHabit(s, { name: "C" });
+    const [a, b, c] = s.habits.map((h) => h.id);
+    s = deleteHabit(s, b);
+    expect(s.habitOrder).toEqual([a, c]);
+    expect(s.habitOrder).not.toContain(b);
+  });
+  it("moveHabitInOrder після delete не тягне видалений id назад", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    s = createHabit(s, { name: "C" });
+    const [a, _b, c] = s.habits.map((h) => h.id);
+    s = deleteHabit(s, _b);
+    s = moveHabitInOrder(s, c, -1);
+    expect(s.habitOrder).toEqual([c, a]);
+  });
+  it("setHabitOrder ігнорує id видаленої звички", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    const [a, b] = s.habits.map((h) => h.id);
+    s = deleteHabit(s, a);
+    s = setHabitOrder(s, [a, b]);
+    expect(s.habitOrder).toEqual([b]);
+  });
+});
+
+describe("edge cases: archived habits isolation", () => {
+  it("moveHabitInOrder не пересуває архівовану звичку", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    const [a] = s.habits.map((h) => h.id);
+    const orderBefore = [...s.habitOrder];
+    s = setHabitArchived(s, a, true);
+    // move has no effect for archived ids
+    const s2 = moveHabitInOrder(s, a, 1);
+    expect(s2).toBe(s);
+    expect(s2.habitOrder).toEqual(orderBefore);
+  });
+  it("markAllScheduledHabitsComplete пропускає архівовані", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    const [a, b] = s.habits.map((h) => h.id);
+    s = setHabitArchived(s, b, true);
+    s = markAllScheduledHabitsComplete(s, "2024-06-15");
+    expect(s.completions[a]).toContain("2024-06-15");
+    expect(s.completions[b] || []).not.toContain("2024-06-15");
+  });
+  it("setHabitOrder відкидає архівовані id", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    const [a, b] = s.habits.map((h) => h.id);
+    s = setHabitArchived(s, a, true);
+    s = setHabitOrder(s, [a, b]);
+    expect(s.habitOrder).toEqual([b]);
+  });
+});
+
+describe("edge cases: delete tag/category used in habits", () => {
+  it("deleteTag видаляє посилання у кількох звичках", () => {
+    let s = createTag(fresh(), "t1");
+    const tid = s.tags[0].id;
+    s = createHabit(s, { name: "A", tagIds: [tid] });
+    s = createHabit(s, { name: "B", tagIds: [tid] });
+    s = deleteTag(s, tid);
+    for (const h of s.habits) {
+      expect(h.tagIds).not.toContain(tid);
+    }
+  });
+  it("deleteCategory скидає categoryId у всіх звичках, які її використовують", () => {
+    let s = createCategory(fresh(), "C");
+    const cid = s.categories[0].id;
+    s = createHabit(s, { name: "A", categoryId: cid });
+    s = createHabit(s, { name: "B", categoryId: cid });
+    s = createHabit(s, { name: "C", categoryId: null });
+    s = deleteCategory(s, cid);
+    for (const h of s.habits) {
+      expect(h.categoryId).toBeNull();
+    }
+  });
+  it("deleteTag не чіпає теги інших звичок", () => {
+    let s = createTag(fresh(), "t1");
+    s = createTag(s, "t2");
+    const [t1, t2] = s.tags.map((t) => t.id);
+    s = createHabit(s, { name: "A", tagIds: [t1, t2] });
+    s = deleteTag(s, t1);
+    expect(s.habits[0].tagIds).toEqual([t2]);
+    expect(s.tags.map((t) => t.id)).toEqual([t2]);
+  });
+});
+
+describe("edge cases: completion notes cleanup", () => {
+  it("deleteHabit прибирає всі completionNotes для цієї звички", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    const [a, b] = s.habits.map((h) => h.id);
+    s = setCompletionNote(s, a, "2024-06-15", "note-a-1");
+    s = setCompletionNote(s, a, "2024-06-14", "note-a-2");
+    s = setCompletionNote(s, b, "2024-06-15", "note-b");
+    s = deleteHabit(s, a);
+    const keys = Object.keys(s.completionNotes);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toBe(completionNoteKey(b, "2024-06-15"));
+  });
+  it("setCompletionNote не створює нотатку для неіснуючої звички", () => {
+    const s1 = fresh();
+    const s2 = setCompletionNote(s1, "ghost", "2024-06-15", "hi");
+    expect(s2).toBe(s1);
+    expect(Object.keys(s2.completionNotes || {})).toHaveLength(0);
+  });
+  it("setCompletionNote з порожнім текстом без існуючої нотатки — no-op", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    const before = s;
+    s = setCompletionNote(s, id, "2024-06-15", "");
+    expect(s).toBe(before);
+  });
+  it("setCompletionNote чистить існуючу нотатку навіть для архівованої звички", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = setCompletionNote(s, id, "2024-06-15", "note");
+    s = setHabitArchived(s, id, true);
+    s = setCompletionNote(s, id, "2024-06-15", "");
+    expect(Object.keys(s.completionNotes)).toHaveLength(0);
+  });
+  it("toggle off → toggle on зберігає раніше записану нотатку (UX не змінюється)", () => {
+    let s = createHabit(fresh(), { name: "A" });
+    const id = s.habits[0].id;
+    s = toggleHabitCompletion(s, id, "2024-06-15");
+    s = setCompletionNote(s, id, "2024-06-15", "stay");
+    s = toggleHabitCompletion(s, id, "2024-06-15"); // off
+    s = toggleHabitCompletion(s, id, "2024-06-15"); // on
+    const k = completionNoteKey(id, "2024-06-15");
+    expect(s.completionNotes[k]).toBe("stay");
+  });
+});
+
+describe("edge cases: loadRoutineState sanitization", () => {
+  it("коерсить completions як не-об'єкт у порожню мапу", () => {
+    const raw = {
+      schemaVersion: 3,
+      habits: [],
+      completions: "not-an-object",
+    };
+    localStorage.setItem(ROUTINE_STORAGE_KEY, JSON.stringify(raw));
+    const s = loadRoutineState();
+    expect(s.completions).toEqual({});
+  });
+  it("коерсить не-масив completions[id] у порожній масив", () => {
+    const id = "h1";
+    const raw = {
+      schemaVersion: 3,
+      habits: [
+        {
+          id,
+          name: "A",
+          archived: false,
+          recurrence: "daily",
+          startDate: "2024-01-01",
+        },
+      ],
+      completions: { [id]: "oops" },
+    };
+    localStorage.setItem(ROUTINE_STORAGE_KEY, JSON.stringify(raw));
+    const s = loadRoutineState();
+    expect(s.completions[id]).toEqual([]);
   });
 });
 

--- a/src/modules/routine/lib/routineStorage.js
+++ b/src/modules/routine/lib/routineStorage.js
@@ -33,6 +33,28 @@ function normalizeReminderTimesStorage(rt) {
   return rt.filter((t) => typeof t === "string" && /^\d{2}:\d{2}$/.test(t));
 }
 
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Prune duplicates and invalid date keys from a single habit's completion list. */
+function normalizeCompletionList(list) {
+  if (!Array.isArray(list)) return [];
+  const seen = new Set();
+  for (const v of list) {
+    if (typeof v === "string" && DATE_KEY_RE.test(v)) seen.add(v);
+  }
+  return [...seen].sort();
+}
+
+/** Coerce the whole completions map into `{ [habitId]: sortedUniqueDateKeys }`. */
+function normalizeCompletionsMap(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out = {};
+  for (const [k, v] of Object.entries(raw)) {
+    out[k] = normalizeCompletionList(v);
+  }
+  return out;
+}
+
 function normalizeHabit(h) {
   if (!h || typeof h !== "object") return h;
   const created = h.createdAt
@@ -119,8 +141,7 @@ export function loadRoutineState() {
     tags: Array.isArray(p.tags) ? p.tags : [],
     categories: Array.isArray(p.categories) ? p.categories : [],
     habits: Array.isArray(p.habits) ? p.habits.map(normalizeHabit) : [],
-    completions:
-      typeof p.completions === "object" && p.completions ? p.completions : {},
+    completions: normalizeCompletionsMap(p.completions),
     pushupsByDate:
       typeof p.pushupsByDate === "object" && p.pushupsByDate
         ? p.pushupsByDate
@@ -266,17 +287,14 @@ export function setPref(state, key, value) {
 export function toggleHabitCompletion(state, habitId, dateKey) {
   const habit = state.habits.find((h) => h.id === habitId);
   if (!habit) return state;
-  const cur = Array.isArray(state.completions[habitId])
-    ? [...state.completions[habitId]]
-    : [];
-  const i = cur.indexOf(dateKey);
-  if (i >= 0) {
-    cur.splice(i, 1);
+  const curSet = new Set(normalizeCompletionList(state.completions[habitId]));
+  if (curSet.has(dateKey)) {
+    curSet.delete(dateKey);
   } else {
     if (!habitScheduledOnDate(habit, dateKey)) return state;
-    cur.push(dateKey);
+    curSet.add(dateKey);
   }
-  cur.sort();
+  const cur = [...curSet].sort();
   const next = {
     ...state,
     completions: { ...state.completions, [habitId]: cur },
@@ -292,11 +310,10 @@ export function markAllScheduledHabitsComplete(state, dateKey) {
   let changed = false;
   for (const h of active) {
     if (!habitScheduledOnDate(h, dateKey)) continue;
-    const cur = Array.isArray(completions[h.id]) ? [...completions[h.id]] : [];
-    if (cur.includes(dateKey)) continue;
-    cur.push(dateKey);
-    cur.sort();
-    completions[h.id] = cur;
+    const set = new Set(normalizeCompletionList(completions[h.id]));
+    if (set.has(dateKey)) continue;
+    set.add(dateKey);
+    completions[h.id] = [...set].sort();
     changed = true;
   }
   if (!changed) return state;
@@ -312,10 +329,16 @@ export function setHabitArchived(state, id, archived) {
 export function deleteHabit(state, id) {
   const completions = { ...state.completions };
   delete completions[id];
+  const notes = { ...(state.completionNotes || {}) };
+  const prefix = `${id}__`;
+  for (const k of Object.keys(notes)) {
+    if (k.startsWith(prefix)) delete notes[k];
+  }
   const next = {
     ...state,
     habits: state.habits.filter((h) => h.id !== id),
     completions,
+    completionNotes: notes,
     habitOrder: (state.habitOrder || []).filter((x) => x !== id),
   };
   saveRoutineState(next);
@@ -375,8 +398,14 @@ export function setCompletionNote(state, habitId, dateKey, text) {
   const k = completionNoteKey(habitId, dateKey);
   const notes = { ...(state.completionNotes || {}) };
   const t = (text || "").trim();
-  if (!t) delete notes[k];
-  else notes[k] = t.slice(0, 500);
+  if (!t) {
+    if (!(k in notes)) return state;
+    delete notes[k];
+  } else {
+    const habitExists = state.habits.some((h) => h.id === habitId);
+    if (!habitExists) return state;
+    notes[k] = t.slice(0, 500);
+  }
   const next = { ...state, completionNotes: notes };
   saveRoutineState(next);
   return next;
@@ -412,8 +441,7 @@ export function applyRoutineBackupPayload(parsed) {
     tags: Array.isArray(d.tags) ? d.tags : [],
     categories: Array.isArray(d.categories) ? d.categories : [],
     habits: Array.isArray(d.habits) ? d.habits.map(normalizeHabit) : [],
-    completions:
-      typeof d.completions === "object" && d.completions ? d.completions : {},
+    completions: normalizeCompletionsMap(d.completions),
     pushupsByDate:
       typeof d.pushupsByDate === "object" && d.pushupsByDate
         ? d.pushupsByDate


### PR DESCRIPTION
## Summary

Локальні, мінімально інвазивні виправлення у `src/modules/routine/lib/routineStorage.js` + розширені unit-тести. UX не змінюється.

Знайдені дрібні баги:

1. **Orphan completion notes після `deleteHabit`.** Видалення звички прибирало `habits`, `completions`, `habitOrder`, але лишало записи у `completionNotes` з префіксом `habitId__…` назавжди у сховищі.
2. **Дублікати дат у `completions[habitId]`.** `toggleHabitCompletion` використовував `indexOf`/`splice`, тож якщо legacy-дані або імпортований бекап мали дублі — toggle off знімав лише одну позицію, завжди лишаючи зайву. Відповідно `includes(dateKey)` у консьюмерах зберігав фантом «зроблено».
3. **Несанітизовані `completions` при load/import.** `loadRoutineState` і `applyRoutineBackupPayload` довіряли формі `completions` «як є» — непередбачені типи (рядок/об'єкт/число) могли пройти до `habitScheduledOnDate`/`includes` і ламати стан.
4. **Сирітські нотатки через `setCompletionNote` для неіснуючої звички.** Виклик із `habitId`, якого немає у `habits`, мовчки створював запис, який не можна було ні показати, ні відредагувати.

Виправлення (тільки routine/lib/routineStorage.js):

- `deleteHabit` прибирає всі `completionNotes` з префіксом `<habitId>__`.
- Додано внутрішні `normalizeCompletionList` / `normalizeCompletionsMap`: коерція у масиви, відкидання невалідних ключів (`^\d{4}-\d{2}-\d{2}$`), дедуплікація, сортування. Підставлено у `loadRoutineState` і `applyRoutineBackupPayload`.
- `toggleHabitCompletion` і `markAllScheduledHabitsComplete` побудовано через `Set(normalizeCompletionList(...))` — стійко до пре-існуючих дублікатів.
- `setCompletionNote` відкидає створення нотатки, якщо `habitId` відсутній у `state.habits`. Очищення (`text=""`) для неіснуючого ключа — no-op (повертає те саме посилання на state).

Охоплення тестами (26 → 47 тестів у `routineStorage.extended.test.js`):

- подвійне completion / three-toggle on→off→on;
- санітизація дублів/невалідних дат з legacy-даних під час `loadRoutineState`;
- reorder після delete (середня, крайні);
- ізоляція archived у `moveHabitInOrder` / `markAllScheduledHabitsComplete` / `setHabitOrder`;
- `deleteTag` / `deleteCategory` з множинними посиланнями у habits;
- cleanup нотаток на `deleteHabit`;
- `setCompletionNote` на ghost-habit і збереження нотатки через цикл off→on.

Охоплені edge cases (з ТЗ):

- [x] подвійне completion в один день
- [x] toggle completion on/off
- [x] mark all scheduled complete
- [x] reorder після delete
- [x] delete tag/category, що використовуються у habits
- [x] archived habits не у активних списках
- [x] completion notes коректно очищаються і не ламають стан

## Review & Testing Checklist for Human

- [ ] Перевірити, що існуючі локальні дані з нотатками до видалених звичок не зникнуть несподівано (нові дані мігруватимуть лише на новому `deleteHabit`). Для старих orphan-нотаток очищення буде при наступному видаленні відповідної звички. Якщо потрібна масова очистка — скажіть, додам одноразову фінальну санацію у `finalizeLoadedRoutineState`.
- [ ] Прогнати `npm run check` локально (format, lint, typecheck, tests, build) на своїй машині.
- [ ] Швидкий сенс-тест UI: toggle звички в календарі (on→off→on), перевірити нотатку; видалити звичку з нотатками — переконатись, що інші нотатки не зачеплено.
- [ ] Переконатись, що вимоги «не переписувати routine module» дотримані — усі зміни локалізовані у `routineStorage.js` + тести.

### Notes

- UX не змінювався.
- Сигнатури публічних функцій не змінилися.
- Зміна у `setCompletionNote` (ghost-habit reject) — захисна; зі звичайного UI-флоу завжди передається існуючий `habitId`.

Link to Devin session: https://app.devin.ai/sessions/666dae1c6c2b4958b08de65172cd97af
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
