### PR TITLE
fix(nutrition): defensive normalization for pantry, shopping list, water &amp; prefs storage

### DIFF
--- a/src/modules/nutrition/lib/nutritionStorage.js
+++ b/src/modules/nutrition/lib/nutritionStorage.js
@@ -54,8 +54,10 @@ export function loadNutritionPrefs(key = NUTRITION_PREFS_KEY) {
   if (!p || typeof p !== "object" || Array.isArray(p))
     return defaultNutritionPrefs();
   try {
+    const defaults = defaultNutritionPrefs();
+    const waterGoalMl = optionalPositiveNumber(p.waterGoalMl);
     return {
-      ...defaultNutritionPrefs(),
+      ...defaults,
       ...p,
       servings: p.servings != null ? Number(p.servings) || 1 : 1,
       timeMinutes: p.timeMinutes != null ? Number(p.timeMinutes) || 25 : 25,
@@ -82,6 +84,7 @@ export function loadNutritionPrefs(key = NUTRITION_PREFS_KEY) {
         p.reminderHour != null && Number.isFinite(Number(p.reminderHour))
           ? Math.min(23, Math.max(0, Math.floor(Number(p.reminderHour))))
           : 12,
+      waterGoalMl: waterGoalMl != null ? waterGoalMl : defaults.waterGoalMl,
     };
   } catch {
     return defaultNutritionPrefs();
@@ -96,6 +99,39 @@ export function makeDefaultPantry() {
   return { id: "home", name: "Дім", items: [], text: "" };
 }
 
+function sanitizePantryItem(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const name = String(raw.name || "").trim();
+  if (!name) return null;
+  const qtyNum = Number(raw.qty);
+  const qty = raw.qty == null || !Number.isFinite(qtyNum) ? null : qtyNum;
+  return {
+    name,
+    qty,
+    unit: raw.unit == null ? null : String(raw.unit),
+    notes: raw.notes == null ? null : String(raw.notes),
+  };
+}
+
+export function normalizePantries(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  const seenIds = new Set();
+  for (const p of raw) {
+    if (!p || typeof p !== "object") continue;
+    let id = p.id != null ? String(p.id).trim() : "";
+    if (!id || seenIds.has(id)) id = `p_${Date.now()}_${out.length}`;
+    seenIds.add(id);
+    const name = String(p.name || "Склад").trim() || "Склад";
+    const items = Array.isArray(p.items)
+      ? p.items.map(sanitizePantryItem).filter(Boolean)
+      : [];
+    const text = p.text == null ? "" : String(p.text);
+    out.push({ id, name, items, text });
+  }
+  return out;
+}
+
 export function loadActivePantryId(activeKey = NUTRITION_ACTIVE_PANTRY_KEY) {
   const v = nutritionStorage.readRaw(activeKey, null);
   return v ? String(v) : "home";
@@ -106,7 +142,8 @@ export function loadPantries(
   activeKey = NUTRITION_ACTIVE_PANTRY_KEY,
 ) {
   const parsed = nutritionStorage.readJSON(key, null);
-  if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  const normalized = normalizePantries(parsed);
+  if (normalized.length > 0) return normalized;
 
   // Legacy v0 pantry migration is handled by storageManager (nutrition_001_migrate_legacy_pantry).
   // By the time this code runs after app boot, the v1 key already has data if any v0 data existed.

--- a/src/modules/nutrition/lib/nutritionStorage.test.js
+++ b/src/modules/nutrition/lib/nutritionStorage.test.js
@@ -3,10 +3,14 @@ import {
   NUTRITION_ACTIVE_PANTRY_KEY,
   NUTRITION_LOG_KEY,
   NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  defaultNutritionPrefs,
   loadActivePantryId,
   loadNutritionLog,
+  loadNutritionPrefs,
   loadPantries,
   normalizeNutritionLog,
+  normalizePantries,
   persistPantries,
 } from "./nutritionStorage.js";
 import { storageManager } from "@shared/lib/storageManager.js";
@@ -127,5 +131,168 @@ describe("loadNutritionLog", () => {
     const log = loadNutritionLog(NUTRITION_LOG_KEY);
     expect(log["2026-03-03"].meals[0].mealType).toBe("breakfast");
     expect(log["2026-03-03"].meals[0].id).toMatch(/^meal_/);
+  });
+
+  it("returns empty log when JSON is corrupted (does not crash UI)", () => {
+    globalThis.localStorage.setItem(NUTRITION_LOG_KEY, "{not json");
+    expect(loadNutritionLog(NUTRITION_LOG_KEY)).toEqual({});
+  });
+});
+
+describe("loadPantries — reload & edge cases", () => {
+  it("survives a reload — same data comes back", () => {
+    persistPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      [
+        {
+          id: "home",
+          name: "Дім",
+          items: [{ name: "Молоко", qty: 1, unit: "л", notes: null }],
+          text: "",
+        },
+      ],
+      "home",
+    );
+    const pantries = loadPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+    );
+    expect(pantries).toHaveLength(1);
+    expect(pantries[0].items[0].name).toBe("Молоко");
+    expect(loadActivePantryId(NUTRITION_ACTIVE_PANTRY_KEY)).toBe("home");
+  });
+
+  it("falls back to default pantry when storage holds empty array", () => {
+    globalThis.localStorage.setItem(NUTRITION_PANTRIES_KEY, JSON.stringify([]));
+    const pantries = loadPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+    );
+    expect(pantries).toHaveLength(1);
+    expect(pantries[0].id).toBe("home");
+  });
+
+  it("falls back to default pantry when JSON is corrupted", () => {
+    globalThis.localStorage.setItem(NUTRITION_PANTRIES_KEY, "{not json");
+    const pantries = loadPantries(
+      NUTRITION_PANTRIES_KEY,
+      NUTRITION_ACTIVE_PANTRY_KEY,
+    );
+    expect(pantries).toHaveLength(1);
+    expect(pantries[0].id).toBe("home");
+  });
+});
+
+describe("normalizePantries", () => {
+  it("filters non-object entries and invalid items", () => {
+    const out = normalizePantries([
+      null,
+      "oops",
+      { id: "a", name: "A", items: [null, { name: "" }, { name: "Хліб" }] },
+      { items: [{ name: "Сир" }] },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].items.map((i) => i.name)).toEqual(["Хліб"]);
+    expect(out[1].name).toBe("Склад");
+    expect(out[1].id).toBeTruthy();
+  });
+
+  it("deduplicates pantry ids (re-assigns colliding ones)", () => {
+    const out = normalizePantries([
+      { id: "same", name: "A", items: [] },
+      { id: "same", name: "B", items: [] },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].id).not.toBe(out[1].id);
+  });
+
+  it("returns empty array for non-array input", () => {
+    expect(normalizePantries(null)).toEqual([]);
+    expect(normalizePantries({})).toEqual([]);
+    expect(normalizePantries("x")).toEqual([]);
+  });
+});
+
+describe("loadNutritionPrefs — prefs survive corrupted / partial data", () => {
+  it("returns defaults when nothing is stored", () => {
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
+      defaultNutritionPrefs(),
+    );
+  });
+
+  it("returns defaults when JSON is corrupted", () => {
+    globalThis.localStorage.setItem(NUTRITION_PREFS_KEY, "{not json");
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
+      defaultNutritionPrefs(),
+    );
+  });
+
+  it("returns defaults when stored value is an array (type mismatch)", () => {
+    globalThis.localStorage.setItem(NUTRITION_PREFS_KEY, JSON.stringify([1]));
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY)).toEqual(
+      defaultNutritionPrefs(),
+    );
+  });
+
+  it("merges partial prefs with defaults (prefs are not lost)", () => {
+    globalThis.localStorage.setItem(
+      NUTRITION_PREFS_KEY,
+      JSON.stringify({ goal: "lean", servings: 3 }),
+    );
+    const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
+    expect(prefs.goal).toBe("lean");
+    expect(prefs.servings).toBe(3);
+    // default fields preserved
+    expect(prefs.timeMinutes).toBe(25);
+    expect(prefs.waterGoalMl).toBe(2000);
+    expect(prefs.mealTemplates).toEqual([]);
+  });
+
+  it("falls back to default waterGoalMl on invalid / non-positive values", () => {
+    for (const bad of [null, "abc", -100, 0, undefined]) {
+      globalThis.localStorage.setItem(
+        NUTRITION_PREFS_KEY,
+        JSON.stringify({ waterGoalMl: bad }),
+      );
+      expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).waterGoalMl).toBe(2000);
+    }
+  });
+
+  it("clamps reminderHour into [0,23]", () => {
+    globalThis.localStorage.setItem(
+      NUTRITION_PREFS_KEY,
+      JSON.stringify({ reminderHour: 99 }),
+    );
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(23);
+
+    globalThis.localStorage.setItem(
+      NUTRITION_PREFS_KEY,
+      JSON.stringify({ reminderHour: -5 }),
+    );
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(0);
+
+    globalThis.localStorage.setItem(
+      NUTRITION_PREFS_KEY,
+      JSON.stringify({ reminderHour: "nope" }),
+    );
+    expect(loadNutritionPrefs(NUTRITION_PREFS_KEY).reminderHour).toBe(12);
+  });
+
+  it("filters invalid mealTemplates entries", () => {
+    globalThis.localStorage.setItem(
+      NUTRITION_PREFS_KEY,
+      JSON.stringify({
+        mealTemplates: [
+          null,
+          { id: "1", name: "", mealType: "snack" },
+          { id: "2", name: "Омлет", mealType: "breakfast" },
+          "oops",
+        ],
+      }),
+    );
+    const prefs = loadNutritionPrefs(NUTRITION_PREFS_KEY);
+    expect(prefs.mealTemplates).toHaveLength(1);
+    expect(prefs.mealTemplates[0].name).toBe("Омлет");
   });
 });

--- a/src/modules/nutrition/lib/shoppingListStorage.js
+++ b/src/modules/nutrition/lib/shoppingListStorage.js
@@ -4,45 +4,91 @@ export const SHOPPING_LIST_KEY = "nutrition_shopping_list_v1";
 
 export function loadShoppingList(key = SHOPPING_LIST_KEY) {
   const parsed = nutritionStorage.readJSON(key, null);
-  if (!parsed || typeof parsed !== "object") return { categories: [] };
   return normalizeShoppingList(parsed);
 }
 
 export function persistShoppingList(list, key = SHOPPING_LIST_KEY) {
-  return nutritionStorage.writeJSON(key, list || { categories: [] });
+  return nutritionStorage.writeJSON(key, normalizeShoppingList(list));
+}
+
+function normalizeItemKey(name) {
+  return String(name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function makeItemId() {
+  return `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizeItem(raw, seenIds) {
+  if (!raw || typeof raw !== "object") return null;
+  const itemName = String(raw.name || "").trim();
+  if (!itemName) return null;
+  let id = raw.id != null ? String(raw.id).trim() : "";
+  if (!id || seenIds.has(id)) id = makeItemId();
+  while (seenIds.has(id)) id = makeItemId();
+  seenIds.add(id);
+  return {
+    id,
+    name: itemName,
+    quantity: String(raw.quantity || "").trim(),
+    note: String(raw.note || "").trim(),
+    checked: Boolean(raw.checked),
+  };
+}
+
+function mergeItem(existing, next) {
+  // Keep first id; prefer checked=true so user progress is not lost on merge.
+  return {
+    ...existing,
+    quantity: existing.quantity || next.quantity,
+    note: existing.note || next.note,
+    checked: existing.checked || next.checked,
+  };
 }
 
 export function normalizeShoppingList(raw) {
   const obj = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
-  const categories = Array.isArray(obj.categories)
-    ? obj.categories
-        .map((cat) => {
-          if (!cat || typeof cat !== "object") return null;
-          const name = String(cat.name || "Інше").trim();
-          const items = Array.isArray(cat.items)
-            ? cat.items
-                .map((item) => {
-                  if (!item || typeof item !== "object") return null;
-                  const id = item.id
-                    ? String(item.id)
-                    : `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-                  const itemName = String(item.name || "").trim();
-                  if (!itemName) return null;
-                  return {
-                    id,
-                    name: itemName,
-                    quantity: String(item.quantity || "").trim(),
-                    note: String(item.note || "").trim(),
-                    checked: Boolean(item.checked),
-                  };
-                })
-                .filter(Boolean)
-            : [];
-          if (items.length === 0) return null;
-          return { name, items };
-        })
-        .filter(Boolean)
-    : [];
+  const rawCategories = Array.isArray(obj.categories) ? obj.categories : [];
+  const seenIds = new Set();
+  const byCategory = new Map();
+
+  for (const cat of rawCategories) {
+    if (!cat || typeof cat !== "object") continue;
+    const name = String(cat.name || "Інше").trim() || "Інше";
+    const rawItems = Array.isArray(cat.items) ? cat.items : [];
+
+    const bucket = byCategory.get(name) || {
+      name,
+      items: [],
+      byKey: new Map(),
+    };
+    for (const rawItem of rawItems) {
+      const item = sanitizeItem(rawItem, seenIds);
+      if (!item) continue;
+      const key = normalizeItemKey(item.name);
+      const existingIdx = bucket.byKey.get(key);
+      if (existingIdx == null) {
+        bucket.byKey.set(key, bucket.items.length);
+        bucket.items.push(item);
+      } else {
+        bucket.items[existingIdx] = mergeItem(bucket.items[existingIdx], item);
+      }
+    }
+    if (bucket.items.length > 0 && !byCategory.has(name)) {
+      byCategory.set(name, bucket);
+    } else if (bucket.items.length > 0) {
+      byCategory.set(name, bucket);
+    }
+  }
+
+  const categories = [];
+  for (const { name, items } of byCategory.values()) {
+    if (items.length === 0) continue;
+    categories.push({ name, items });
+  }
   return { categories };
 }
 

--- a/src/modules/nutrition/lib/shoppingListStorage.test.js
+++ b/src/modules/nutrition/lib/shoppingListStorage.test.js
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  SHOPPING_LIST_KEY,
+  getCheckedItems,
+  getTotalCount,
+  loadShoppingList,
+  normalizeShoppingList,
+  persistShoppingList,
+  removeCheckedItems,
+  toggleShoppingItem,
+} from "./shoppingListStorage.js";
+
+function createLocalStorageMock() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(String(k)) ? store.get(String(k)) : null),
+    setItem: (k, v) => void store.set(String(k), String(v)),
+    removeItem: (k) => void store.delete(String(k)),
+    clear: () => void store.clear(),
+    _dump: () => Object.fromEntries(store.entries()),
+  };
+}
+
+beforeEach(() => {
+  globalThis.localStorage = createLocalStorageMock();
+});
+
+describe("normalizeShoppingList", () => {
+  it("returns empty list for null / non-object / array input", () => {
+    expect(normalizeShoppingList(null)).toEqual({ categories: [] });
+    expect(normalizeShoppingList(undefined)).toEqual({ categories: [] });
+    expect(normalizeShoppingList("oops")).toEqual({ categories: [] });
+    expect(normalizeShoppingList([1, 2, 3])).toEqual({ categories: [] });
+  });
+
+  it("drops categories without valid items", () => {
+    const out = normalizeShoppingList({
+      categories: [
+        { name: "Овочі", items: [] },
+        { name: "Інше", items: [{}] },
+        null,
+        { name: "Only text", items: [{ name: "" }] },
+      ],
+    });
+    expect(out.categories).toEqual([]);
+  });
+
+  it("dedupes items by normalized name within the same category", () => {
+    const out = normalizeShoppingList({
+      categories: [
+        {
+          name: "Овочі",
+          items: [
+            { id: "a", name: "Огірок", quantity: "2", checked: false },
+            { id: "b", name: " огірок ", quantity: "", checked: true },
+            { id: "c", name: "ОГІРОК", checked: false },
+            { id: "d", name: "Помідор" },
+          ],
+        },
+      ],
+    });
+    const cat = out.categories[0];
+    expect(cat.items.map((i) => i.name.toLowerCase())).toEqual([
+      "огірок",
+      "помідор",
+    ]);
+    // merged: quantity kept from first, checked OR-ed true from duplicate
+    const cucumber = cat.items[0];
+    expect(cucumber.quantity).toBe("2");
+    expect(cucumber.checked).toBe(true);
+  });
+
+  it("merges categories that share the same name", () => {
+    const out = normalizeShoppingList({
+      categories: [
+        { name: "Молочне", items: [{ name: "Молоко" }] },
+        { name: "Молочне", items: [{ name: "Сир" }] },
+        { name: "Молочне", items: [{ name: "Молоко", checked: true }] },
+      ],
+    });
+    expect(out.categories).toHaveLength(1);
+    expect(out.categories[0].items.map((i) => i.name)).toEqual([
+      "Молоко",
+      "Сир",
+    ]);
+    expect(out.categories[0].items[0].checked).toBe(true);
+  });
+
+  it("assigns a fresh id to items missing an id or colliding with an earlier one", () => {
+    const out = normalizeShoppingList({
+      categories: [
+        { name: "A", items: [{ id: "dup", name: "Х" }] },
+        { name: "B", items: [{ id: "dup", name: "Y" }, { name: "Z" }] },
+      ],
+    });
+    const ids = out.categories.flatMap((c) => c.items.map((i) => i.id));
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.every((id) => id && typeof id === "string")).toBe(true);
+  });
+
+  it("coerces non-string quantity / note fields to strings", () => {
+    const out = normalizeShoppingList({
+      categories: [
+        {
+          name: "Інше",
+          items: [{ name: "Хліб", quantity: 2, note: 42, checked: "yes" }],
+        },
+      ],
+    });
+    const item = out.categories[0].items[0];
+    expect(item.quantity).toBe("2");
+    expect(item.note).toBe("42");
+    expect(item.checked).toBe(true);
+  });
+});
+
+describe("loadShoppingList", () => {
+  it("returns empty list when nothing stored", () => {
+    expect(loadShoppingList()).toEqual({ categories: [] });
+  });
+
+  it("returns empty list for corrupted JSON (does not crash UI)", () => {
+    globalThis.localStorage.setItem(SHOPPING_LIST_KEY, "{not json");
+    expect(loadShoppingList()).toEqual({ categories: [] });
+  });
+
+  it("returns empty list when stored value is non-object", () => {
+    globalThis.localStorage.setItem(SHOPPING_LIST_KEY, JSON.stringify("hello"));
+    expect(loadShoppingList()).toEqual({ categories: [] });
+  });
+
+  it("normalizes on read and removes duplicates that were persisted", () => {
+    globalThis.localStorage.setItem(
+      SHOPPING_LIST_KEY,
+      JSON.stringify({
+        categories: [
+          {
+            name: "A",
+            items: [
+              { id: "1", name: "X" },
+              { id: "2", name: "x" },
+            ],
+          },
+        ],
+      }),
+    );
+    const loaded = loadShoppingList();
+    expect(loaded.categories).toHaveLength(1);
+    expect(loaded.categories[0].items).toHaveLength(1);
+  });
+});
+
+describe("persistShoppingList", () => {
+  it("persists a normalized copy (no duplicates on disk)", () => {
+    persistShoppingList({
+      categories: [
+        {
+          name: "Інше",
+          items: [
+            { id: "1", name: "Хліб" },
+            { id: "2", name: "хліб" },
+          ],
+        },
+      ],
+    });
+    const stored = JSON.parse(
+      globalThis.localStorage.getItem(SHOPPING_LIST_KEY),
+    );
+    expect(stored.categories[0].items).toHaveLength(1);
+  });
+
+  it("persists empty list on nullish input", () => {
+    persistShoppingList(null);
+    const stored = JSON.parse(
+      globalThis.localStorage.getItem(SHOPPING_LIST_KEY),
+    );
+    expect(stored).toEqual({ categories: [] });
+  });
+});
+
+describe("toggleShoppingItem", () => {
+  it("toggles a single item by id within a category", () => {
+    const list = {
+      categories: [
+        {
+          name: "A",
+          items: [
+            { id: "1", name: "X", checked: false },
+            { id: "2", name: "Y", checked: false },
+          ],
+        },
+      ],
+    };
+    const next = toggleShoppingItem(list, "A", "1");
+    expect(next.categories[0].items[0].checked).toBe(true);
+    expect(next.categories[0].items[1].checked).toBe(false);
+  });
+});
+
+describe("getTotalCount / getCheckedItems / removeCheckedItems", () => {
+  const list = {
+    categories: [
+      {
+        name: "A",
+        items: [
+          { id: "1", name: "X", checked: true },
+          { id: "2", name: "Y", checked: false },
+        ],
+      },
+      {
+        name: "B",
+        items: [{ id: "3", name: "Z", checked: true }],
+      },
+    ],
+  };
+
+  it("returns totals", () => {
+    expect(getTotalCount(list)).toEqual({ total: 3, checked: 2 });
+  });
+
+  it("returns all checked items", () => {
+    expect(getCheckedItems(list).map((i) => i.id)).toEqual(["1", "3"]);
+  });
+
+  it("removes only checked items and drops empty categories", () => {
+    const out = removeCheckedItems(list);
+    expect(out.categories).toHaveLength(1);
+    expect(out.categories[0].name).toBe("A");
+    expect(out.categories[0].items.map((i) => i.id)).toEqual(["2"]);
+  });
+});

--- a/src/modules/nutrition/lib/waterStorage.js
+++ b/src/modules/nutrition/lib/waterStorage.js
@@ -4,26 +4,50 @@ import { nutritionStorage } from "./nutritionStorageInstance.js";
 export const WATER_LOG_KEY = "nutrition_water_v1";
 export const DEFAULT_WATER_GOAL_ML = 2000;
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function sanitizeMl(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.floor(n);
+}
+
+export function normalizeWaterLog(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (!ISO_DATE_RE.test(k)) continue;
+    const ml = sanitizeMl(v);
+    if (ml > 0) out[k] = ml;
+  }
+  return out;
+}
+
 export function loadWaterLog(key = WATER_LOG_KEY) {
-  const v = nutritionStorage.readJSON(key, {});
-  return v && typeof v === "object" && !Array.isArray(v) ? v : {};
+  return normalizeWaterLog(nutritionStorage.readJSON(key, {}));
 }
 
 export function saveWaterLog(log, key = WATER_LOG_KEY) {
-  return nutritionStorage.writeJSON(key, log || {});
+  return nutritionStorage.writeJSON(key, normalizeWaterLog(log));
 }
 
 export function getTodayWaterMl(log) {
-  return Number(log?.[toLocalISODate()] || 0);
+  const today = toLocalISODate();
+  const n = Number(log?.[today]);
+  return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
 export function addWaterMl(log, ml) {
+  const delta = sanitizeMl(ml);
+  if (delta <= 0) return normalizeWaterLog(log);
+  const base = normalizeWaterLog(log);
   const today = toLocalISODate();
-  return { ...log, [today]: Number(log?.[today] || 0) + Number(ml) };
+  return { ...base, [today]: (base[today] || 0) + delta };
 }
 
 export function resetTodayWater(log) {
+  const base = normalizeWaterLog(log);
   const today = toLocalISODate();
-  const { [today]: _removed, ...rest } = log;
+  const { [today]: _removed, ...rest } = base;
   return rest;
 }

--- a/src/modules/nutrition/lib/waterStorage.test.js
+++ b/src/modules/nutrition/lib/waterStorage.test.js
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WATER_LOG_KEY,
+  addWaterMl,
+  getTodayWaterMl,
+  loadWaterLog,
+  normalizeWaterLog,
+  resetTodayWater,
+  saveWaterLog,
+} from "./waterStorage.js";
+
+function createLocalStorageMock() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(String(k)) ? store.get(String(k)) : null),
+    setItem: (k, v) => void store.set(String(k), String(v)),
+    removeItem: (k) => void store.delete(String(k)),
+    clear: () => void store.clear(),
+    _dump: () => Object.fromEntries(store.entries()),
+  };
+}
+
+beforeEach(() => {
+  globalThis.localStorage = createLocalStorageMock();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("normalizeWaterLog", () => {
+  it("returns empty object for non-object / array / null", () => {
+    expect(normalizeWaterLog(null)).toEqual({});
+    expect(normalizeWaterLog(undefined)).toEqual({});
+    expect(normalizeWaterLog("oops")).toEqual({});
+    expect(normalizeWaterLog([1, 2, 3])).toEqual({});
+  });
+
+  it("drops non-ISO date keys", () => {
+    const out = normalizeWaterLog({
+      "2026-04-18": 500,
+      foo: 100,
+      "not-a-date": 200,
+      "2026/04/18": 300,
+    });
+    expect(out).toEqual({ "2026-04-18": 500 });
+  });
+
+  it("drops non-numeric, zero and negative values", () => {
+    const out = normalizeWaterLog({
+      "2026-04-18": "abc",
+      "2026-04-19": -100,
+      "2026-04-20": 0,
+      "2026-04-21": 250,
+      "2026-04-22": null,
+    });
+    expect(out).toEqual({ "2026-04-21": 250 });
+  });
+
+  it("coerces numeric strings to integers", () => {
+    expect(normalizeWaterLog({ "2026-04-18": "500" })).toEqual({
+      "2026-04-18": 500,
+    });
+    expect(normalizeWaterLog({ "2026-04-18": 123.9 })).toEqual({
+      "2026-04-18": 123,
+    });
+  });
+});
+
+describe("loadWaterLog", () => {
+  it("returns empty object when storage is empty", () => {
+    expect(loadWaterLog()).toEqual({});
+  });
+
+  it("returns empty object when storage is corrupted JSON", () => {
+    globalThis.localStorage.setItem(WATER_LOG_KEY, "{not json");
+    expect(loadWaterLog()).toEqual({});
+  });
+
+  it("normalizes stored log on read", () => {
+    globalThis.localStorage.setItem(
+      WATER_LOG_KEY,
+      JSON.stringify({
+        "2026-04-18": 500,
+        "2026-04-19": "bad",
+        random: 999,
+      }),
+    );
+    expect(loadWaterLog()).toEqual({ "2026-04-18": 500 });
+  });
+
+  it("returns empty object when stored value is not an object", () => {
+    globalThis.localStorage.setItem(WATER_LOG_KEY, JSON.stringify("hi"));
+    expect(loadWaterLog()).toEqual({});
+  });
+});
+
+describe("saveWaterLog", () => {
+  it("persists normalized log and strips bad entries", () => {
+    saveWaterLog({ "2026-04-18": 500, bogus: "x" });
+    const stored = JSON.parse(globalThis.localStorage.getItem(WATER_LOG_KEY));
+    expect(stored).toEqual({ "2026-04-18": 500 });
+  });
+
+  it("persists empty object for nullish input", () => {
+    saveWaterLog(null);
+    const stored = JSON.parse(globalThis.localStorage.getItem(WATER_LOG_KEY));
+    expect(stored).toEqual({});
+  });
+});
+
+describe("getTodayWaterMl", () => {
+  it("returns 0 when log is empty / corrupted", () => {
+    expect(getTodayWaterMl({})).toBe(0);
+    expect(getTodayWaterMl(null)).toBe(0);
+    expect(getTodayWaterMl(undefined)).toBe(0);
+  });
+
+  it("returns 0 when today's value is non-numeric", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    expect(getTodayWaterMl({ "2026-04-18": "abc" })).toBe(0);
+  });
+
+  it("returns today's water and ignores yesterday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    expect(getTodayWaterMl({ "2026-04-17": 9999, "2026-04-18": 500 })).toBe(
+      500,
+    );
+  });
+});
+
+describe("addWaterMl — day change", () => {
+  it("ignores non-positive / non-numeric deltas", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    expect(addWaterMl({}, 0)).toEqual({});
+    expect(addWaterMl({}, -100)).toEqual({});
+    expect(addWaterMl({}, "abc")).toEqual({});
+    expect(addWaterMl({}, null)).toEqual({});
+  });
+
+  it("accumulates within the same day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    const a = addWaterMl({}, 250);
+    const b = addWaterMl(a, 300);
+    expect(b).toEqual({ "2026-04-18": 550 });
+  });
+
+  it("starts fresh at 0 when the day changes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T23:55:00"));
+    const prev = addWaterMl({}, 500);
+    expect(getTodayWaterMl(prev)).toBe(500);
+
+    vi.setSystemTime(new Date("2026-04-19T00:05:00"));
+    expect(getTodayWaterMl(prev)).toBe(0);
+
+    const next = addWaterMl(prev, 200);
+    expect(next["2026-04-18"]).toBe(500);
+    expect(next["2026-04-19"]).toBe(200);
+    expect(getTodayWaterMl(next)).toBe(200);
+  });
+
+  it("drops corrupted entries from the log while adding", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    const next = addWaterMl({ "2026-04-17": "bad", bogus: 1 }, 100);
+    expect(next).toEqual({ "2026-04-18": 100 });
+  });
+});
+
+describe("resetTodayWater", () => {
+  it("clears only today's entry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    const log = { "2026-04-17": 800, "2026-04-18": 500 };
+    expect(resetTodayWater(log)).toEqual({ "2026-04-17": 800 });
+  });
+
+  it("is safe on corrupted log", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T10:00:00"));
+    expect(resetTodayWater(null)).toEqual({});
+    expect(resetTodayWater({ bogus: 1, "2026-04-18": 300 })).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Стабілізація nutrition storage layer після переходу на shared storage: модуль тепер стійко переживає reload і некоректні дані в `localStorage`. Без зміни UX і без великого рефакторингу — лише defensive normalization у storage-шарі та точкові fallback-и.

**Що виправлено:**

- **Water tracker (`waterStorage.js`)**
  - `normalizeWaterLog` відкидає не-ISO ключі (`foo`, `2026/04/18`, …), не-числові значення (`"abc"`, `null`), нулі та від'ємні.
  - `loadWaterLog` / `saveWaterLog` завжди проганяють log через нормалізацію — сміття не накопичується й не потрапляє в UI (`NaN` у `todayMl` неможливий).
  - `addWaterMl` ігнорує невалідні delta (`0`, `-100`, `"abc"`, `null`) і одразу чистить log; `resetTodayWater` також нормалізує.
  - На зміну дня (після 00:00) `getTodayWaterMl` повертає `0` для нового ключа, а попередні дні лишаються в log — закрито тестом `starts fresh at 0 when the day changes`.

- **Shopping list (`shoppingListStorage.js`)**
  - `normalizeShoppingList` дедуплікує items по нормалізованому імені (`" огірок "` ≡ `"ОГІРОК"`) у межах категорії; дублікати зливаються, `checked` OR-иться (прогрес юзера не губиться).
  - Категорії з однаковою назвою тепер зливаються в одну (раніше `toggleShoppingItem` матчив лише першу).
  - Колізії `id` (пусті, дубльовані) переназначаються свіжими — `toggleShoppingItem` завжди торкається саме одного елемента.
  - `loadShoppingList` / `persistShoppingList` обидва проходять через нормалізацію, тож дублікати не осідають на диску.

- **Nutrition prefs (`nutritionStorage.js → loadNutritionPrefs`)**
  - `waterGoalMl` валідовано як позитивне число; `null`/`"abc"`/`-100`/`0` → fallback `2000`. Раніше `...p` затирав default на `null`.

- **Pantry (`nutritionStorage.js → normalizePantries`, `loadPantries`)**
  - На reload фільтруються не-object записи; items без імені відкидаються; qty нормалізується до числа або `null`.
  - Колізії `id` пантрі переназначаються, щоб `updatePantry` не плутав склади.
  - Empty-array / corrupted-JSON у сховищі → default pantry (покрито тестами).

**Що не змінилось:**

- UX, компоненти, публічний API хуків (`useNutritionPantries`, `useShoppingList`, `useWaterTracker`) — незмінні.
- Формат даних на диску сумісний: нові версії лише дочищають сміття під час читання/запису.

## Review & Testing Checklist for Human

- [ ] Відкрити pantry з існуючими даними, додати/видалити item, зробити reload → все на місці, активна пантрі та сама.
- [ ] Згенерувати shopping list двічі поспіль з тим же рецептом → без дублікатів, check-стан зберігається на items, які вже були відмічені.
- [ ] Додати воду ввечері (≥21:00), наступного ранку відкрити — `todayMl` має бути `0`, вчорашнє значення лишається в історії (не впливає на UI).
- [ ] Відкрити DevTools → Application → Local Storage, вручну зіпсувати один із ключів (`nutrition_water_v1`, `nutrition_shopping_list_v1`, `nutrition_pantries_v1`, `nutrition_prefs_v1`) до `{not json` → reload → UI не валиться, дефолти підтягуються.
- [ ] Перевірити, що `waterGoalMl` у налаштуваннях лишається між reload і що ручне зіпсуття цього значення не ламає WaterTrackerCard.

### Notes

- 49 нових unit-тестів: `waterStorage.test.js` (19), `shoppingListStorage.test.js` (14), розширення `nutritionStorage.test.js` (+16). Всього `373 passed`.
- `npm run lint`, `npm run typecheck`, `npm run format:check` — усі зелені.
- Жодна загальна логіка shared storage (`createModuleStorage`, `storageManager`, `storage.js`) не змінювалась — правки локалізовано в nutrition-модулі, як просив бриф.


Link to Devin session: https://app.devin.ai/sessions/c23696023e8447ffa85fca2649f3fcc1
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
