### PR TITLE
fix(fizruk): stabilize workout finish flow edge cases

### DIFF
--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.finish.test.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.finish.test.jsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+// Mock the heavy ActiveWorkoutPanel down to a tiny probe that surfaces the
+// onFinishClick callback as a single button. This keeps the test focused on
+// WorkoutJournalSection's finish flow, not ActiveWorkoutPanel internals.
+vi.mock("../workouts/ActiveWorkoutPanel", () => ({
+  ActiveWorkoutPanel: ({ onFinishClick }) => (
+    <button type="button" data-testid="finish-btn" onClick={onFinishClick}>
+      Завершити
+    </button>
+  ),
+}));
+
+// Virtuoso isn't relevant to the finish flow and needs ResizeObserver etc.
+// Replace it with a plain mapper so the journal list renders trivially.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({ data, itemContent }) => (
+    <div data-testid="journal-list">
+      {(data || []).map((d, i) => (
+        <div key={d?.id ?? i}>{itemContent(i, d)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+import { WorkoutJournalSection } from "./WorkoutJournalSection.jsx";
+
+function baseProps(overrides = {}) {
+  const active = overrides.activeWorkout ?? {
+    id: "w-active",
+    startedAt: new Date("2025-01-01T10:00:00Z").toISOString(),
+    endedAt: null,
+    items: [],
+    groups: [],
+    warmup: null,
+    cooldown: null,
+    note: "",
+  };
+  return {
+    activeWorkout: active,
+    activeDuration: "00:42",
+    workouts: [active],
+    activeWorkoutId: active?.id ?? null,
+    setActiveWorkoutId: vi.fn(),
+    retroOpen: false,
+    setRetroOpen: vi.fn(),
+    retroDate: "",
+    setRetroDate: vi.fn(),
+    retroTime: "",
+    setRetroTime: vi.fn(),
+    createWorkout: vi.fn(),
+    setMode: vi.fn(),
+    musclesUk: {},
+    recBy: {},
+    lastByExerciseId: {},
+    setRestTimer: vi.fn(),
+    updateWorkout: vi.fn(),
+    updateItem: vi.fn(),
+    removeItem: vi.fn(),
+    setFinishFlash: vi.fn(),
+    endWorkout: vi.fn(() => ({
+      ...active,
+      endedAt: new Date().toISOString(),
+    })),
+    setDeleteWorkoutConfirm: vi.fn(),
+    summarizeWorkoutForFinish: vi.fn(() => ({
+      durationSec: 42,
+      exercises: 0,
+      setsDone: 0,
+      volumeKg: 0,
+    })),
+    submitRetroWorkout: vi.fn(),
+    deleteWorkout: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("WorkoutJournalSection – Завершити finish flow", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("clears the rest timer and opens the wellbeing sheet on Завершити", () => {
+    const props = baseProps();
+    render(<WorkoutJournalSection {...props} />);
+
+    fireEvent.click(screen.getByTestId("finish-btn"));
+
+    expect(props.endWorkout).toHaveBeenCalledWith("w-active");
+    expect(props.setActiveWorkoutId).toHaveBeenCalledWith(null);
+    expect(props.setRestTimer).toHaveBeenCalledWith(null);
+    expect(props.setFinishFlash).toHaveBeenCalledTimes(1);
+    const flash = props.setFinishFlash.mock.calls[0][0];
+    expect(flash).toMatchObject({
+      step: "wellbeing",
+      workoutId: "w-active",
+      energy: null,
+      mood: null,
+    });
+  });
+
+  it("is idempotent on rapid double-click — finish sheet opens only once", () => {
+    const props = baseProps();
+    render(<WorkoutJournalSection {...props} />);
+
+    const btn = screen.getByTestId("finish-btn");
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    // endWorkout is idempotent on the data side, but the side effects that
+    // drive the UI (opening the finish sheet, clearing the rest timer) must
+    // not run a second time.
+    expect(props.setFinishFlash).toHaveBeenCalledTimes(1);
+    expect(props.setRestTimer).toHaveBeenCalledTimes(1);
+    expect(props.setActiveWorkoutId).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the shown workout is already finished", () => {
+    const ended = {
+      id: "w-ended",
+      startedAt: new Date("2025-01-01T10:00:00Z").toISOString(),
+      endedAt: new Date("2025-01-01T11:00:00Z").toISOString(),
+      items: [],
+      groups: [],
+      warmup: null,
+      cooldown: null,
+      note: "",
+    };
+    const props = baseProps({
+      activeWorkout: ended,
+      activeWorkoutId: ended.id,
+    });
+    render(<WorkoutJournalSection {...props} />);
+
+    fireEvent.click(screen.getByTestId("finish-btn"));
+
+    expect(props.endWorkout).not.toHaveBeenCalled();
+    expect(props.setFinishFlash).not.toHaveBeenCalled();
+    expect(props.setRestTimer).not.toHaveBeenCalled();
+    expect(props.setActiveWorkoutId).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { Button } from "@shared/components/ui/Button";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -88,6 +89,10 @@ export function WorkoutJournalSection({
     workoutList.length * JOURNAL_ITEM_HEIGHT,
     MAX_JOURNAL_HEIGHT,
   );
+  // Guard the finish flow against double-click re-entry — the state updates
+  // inside onFinishClick are async, so React may still render the "Завершити"
+  // button for one more frame while a second click is already queued.
+  const finishingRef = useRef(false);
 
   return (
     <div className="space-y-3">
@@ -141,6 +146,12 @@ export function WorkoutJournalSection({
             updateWorkout={updateWorkout}
             setRestTimer={setRestTimer}
             onFinishClick={() => {
+              // Ignore re-entry from rapid double-clicks and from any stray
+              // invocation on an already-ended workout (e.g. when viewing
+              // a finished session from the history list).
+              if (finishingRef.current) return;
+              if (!activeWorkout || activeWorkout.endedAt) return;
+              finishingRef.current = true;
               const sum = summarizeWorkoutForFinish(activeWorkout);
               const wid = activeWorkout.id;
               endWorkout(wid);
@@ -150,6 +161,10 @@ export function WorkoutJournalSection({
               // The workout itself is not deleted: it can only be removed
               // via explicit delete (swipe / "Видалити" confirm dialog).
               setActiveWorkoutId(null);
+              // A dangling rest timer from the last set must not keep ticking
+              // after finish — otherwise it eventually beeps/vibrates long
+              // after the session is over.
+              setRestTimer?.(null);
               if (sum) {
                 setFinishFlash({
                   step: "wellbeing",
@@ -160,6 +175,12 @@ export function WorkoutJournalSection({
                   mood: null,
                 });
               }
+              // Release the guard on the next tick — by then React has
+              // already committed `activeWorkoutId = null` and the button
+              // is unmounted, so any further clicks are impossible anyway.
+              setTimeout(() => {
+                finishingRef.current = false;
+              }, 0);
             }}
             onDeleteWorkout={() => setDeleteWorkoutConfirm(true)}
           />

--- a/src/modules/fizruk/hooks/useWorkouts.js
+++ b/src/modules/fizruk/hooks/useWorkouts.js
@@ -92,6 +92,7 @@ export function makeDefaultCooldown() {
  *
  * @returns {{
  *   workouts: Workout[],
+ *   loaded: boolean,
  *   createWorkout: () => Workout,
  *   createWorkoutWithTimes: (opts: { startedAt: string }) => Workout,
  *   updateWorkout: (id: string, patch: Partial<Workout>) => void,
@@ -104,6 +105,7 @@ export function makeDefaultCooldown() {
  */
 export function useWorkouts() {
   const [workouts, setWorkouts] = useState([]);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     try {
@@ -111,6 +113,7 @@ export function useWorkouts() {
       const parsed = parseWorkoutsFromStorage(raw);
       if (Array.isArray(parsed)) setWorkouts(parsed);
     } catch {}
+    setLoaded(true);
   }, []);
 
   /**
@@ -310,6 +313,7 @@ export function useWorkouts() {
 
   return {
     workouts: sorted,
+    loaded,
     createWorkout,
     createWorkoutWithTimes,
     updateWorkout,

--- a/src/modules/fizruk/hooks/useWorkouts.test.jsx
+++ b/src/modules/fizruk/hooks/useWorkouts.test.jsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWorkouts } from "./useWorkouts.js";
+import {
+  WORKOUTS_STORAGE_KEY,
+  serializeWorkoutsToStorage,
+} from "../lib/fizrukStorage.js";
+
+function seedWorkouts(workouts) {
+  localStorage.setItem(
+    WORKOUTS_STORAGE_KEY,
+    serializeWorkoutsToStorage(workouts),
+  );
+}
+
+describe("useWorkouts – finish flow edge cases", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("eventually reports loaded=true after mount", async () => {
+    seedWorkouts([]);
+    const { result } = renderHook(() => useWorkouts());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+  });
+
+  it("endWorkout sets endedAt on first call and keeps it idempotent on re-call", async () => {
+    const { result } = renderHook(() => useWorkouts());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    let created;
+    act(() => {
+      created = result.current.createWorkout();
+    });
+    await waitFor(() =>
+      expect(result.current.workouts.map((w) => w.id)).toContain(created.id),
+    );
+
+    act(() => {
+      result.current.endWorkout(created.id);
+    });
+    await waitFor(() =>
+      expect(
+        result.current.workouts.find((w) => w.id === created.id)?.endedAt,
+      ).toBeTruthy(),
+    );
+    const firstEndedAt = result.current.workouts.find(
+      (w) => w.id === created.id,
+    ).endedAt;
+
+    // Re-ending must NOT bump endedAt: the workout is already ended.
+    act(() => {
+      result.current.endWorkout(created.id);
+    });
+    const after = result.current.workouts.find((w) => w.id === created.id);
+    expect(after?.endedAt).toBe(firstEndedAt);
+  });
+
+  it("endWorkout is a no-op for an unknown id", async () => {
+    const { result } = renderHook(() => useWorkouts());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    act(() => {
+      result.current.endWorkout("does-not-exist");
+    });
+    expect(result.current.workouts).toHaveLength(0);
+  });
+
+  it("loads existing workouts from storage and re-ending them is idempotent", async () => {
+    const existing = {
+      id: "pre-existing",
+      startedAt: new Date("2025-01-01T10:00:00Z").toISOString(),
+      endedAt: null,
+      items: [],
+      groups: [],
+      warmup: null,
+      cooldown: null,
+      note: "",
+    };
+    seedWorkouts([existing]);
+
+    const { result } = renderHook(() => useWorkouts());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    await waitFor(() =>
+      expect(result.current.workouts.map((w) => w.id)).toContain(
+        "pre-existing",
+      ),
+    );
+
+    act(() => {
+      result.current.endWorkout("pre-existing");
+    });
+    await waitFor(() =>
+      expect(
+        result.current.workouts.find((w) => w.id === "pre-existing")?.endedAt,
+      ).toBeTruthy(),
+    );
+    const firstEndedAt = result.current.workouts.find(
+      (w) => w.id === "pre-existing",
+    ).endedAt;
+
+    act(() => {
+      result.current.endWorkout("pre-existing");
+    });
+    const again = result.current.workouts.find((w) => w.id === "pre-existing");
+    expect(again?.endedAt).toBe(firstEndedAt);
+  });
+});

--- a/src/modules/fizruk/pages/Workouts.jsx
+++ b/src/modules/fizruk/pages/Workouts.jsx
@@ -67,6 +67,7 @@ export function Workouts() {
   const rec = useRecovery();
   const {
     workouts,
+    loaded: workoutsLoaded,
     createWorkout,
     createWorkoutWithTimes,
     updateWorkout,
@@ -130,6 +131,15 @@ export function Workouts() {
       else localStorage.setItem(ACTIVE_WORKOUT_KEY, activeWorkoutId);
     } catch {}
   }, [activeWorkoutId]);
+
+  // Clear a stale activeWorkoutId that no longer matches any workout
+  // (e.g. the workout was deleted on another device before sync).
+  useEffect(() => {
+    if (!workoutsLoaded || !activeWorkoutId) return;
+    if (!workouts.some((w) => w.id === activeWorkoutId)) {
+      setActiveWorkoutId(null);
+    }
+  }, [workoutsLoaded, activeWorkoutId, workouts]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary

Точкові стабілізаційні фікси сценаріїв після натискання "Завершити" у модулі fizruk. Без рефакторингів і без зміни UX.

### Що виправлено

1. **Rest timer після finish.** `onFinishClick` у `WorkoutJournalSection` тепер викликає `setRestTimer(null)`, тож завислий таймер від останнього підходу не продовжує цокати/пікати після завершення тренування.
2. **Повторне/подвійне натискання «Завершити».** Додано `finishingRef` + ранній `if (activeWorkout.endedAt) return;` у `onFinishClick`. `endWorkout` уже був ідемпотентний на рівні даних, але побічні ефекти (`setFinishFlash`, `setRestTimer`) могли спрацювати двічі при швидкому double-click, поки React ще не перемалював кнопку. Тепер `WorkoutFinishSheets` відкривається рівно один раз.
3. **Застарілий `activeWorkoutId` у localStorage.** `useWorkouts` тепер повертає прапорець `loaded`. `Workouts.jsx` після завершення завантаження чистить `activeWorkoutId`, якщо відповідного тренування немає у списку (наприклад, його видалили на іншому пристрої).

### Перевірені сценарії (згідно з тикетом)

- завершення тренування — без регресій, очікувана поведінка.
- повторне натискання "Завершити" — guarded, фініш-шит не дублюється.
- відкриття щойно завершеного тренування зі списку — кнопка "Завершити" на такому тренуванні все одно no-op завдяки `endedAt`-guard.
- повернення до списку після завершення — `activeWorkoutId` коректно скидається в `null`.
- rest timer після finish — явно обнуляється.
- `WorkoutFinishSheets` двічі — неможливо завдяки ref-guard.
- некоректний `activeWorkoutId` — чиститься після того, як список завантажений.

### Тести

- `src/modules/fizruk/hooks/useWorkouts.test.jsx` — чотири нові тести: `loaded` стає `true`, `endWorkout` ідемпотентний для новоствореного та для завантаженого зі сховища тренування, `endWorkout` — no-op для невідомого id.
- `src/modules/fizruk/components/workouts/WorkoutJournalSection.finish.test.jsx` — три нові тести: side-effects `onFinishClick` (endWorkout/setActiveWorkoutId(null)/setRestTimer(null)/setFinishFlash з очікуваним payload), ідемпотентність на подвійний клік, no-op на завершеному тренуванні.

Всі 331 тест проходять (+7 нових), `npm run lint` і `npm run typecheck` чисті, prettier-format перевірено.

## Review & Testing Checklist for Human

- [ ] Відкрий активне тренування, запусти rest timer, натисни "Завершити" — таймер має одразу зникнути, а `WorkoutFinishSheets` — відкритися один раз.
- [ ] Спробуй подвійний клік по "Завершити" — sheet не повинен блимати / відкриватися двічі.
- [ ] Завершити → у списку клікнути по щойно завершеному тренуванні — має відкритися з плашкою "Завершено", без кнопки "Завершити".
- [ ] Руками підміни `fizruk_active_workout_id_v1` у localStorage на неіснуючий id і перезавантаж сторінку Workouts — ключ має очиститися, UI показує «Немає активного тренування».
- [ ] `npm test` локально — усі 331 тест зелені.

### Notes

- Зміна `useWorkouts` — адитивна (додане поле `loaded` у повернутому обʼєкті). Існуючі споживачі в `Dashboard.jsx` / `FizrukApp.jsx` продовжують деструктурувати лише потрібні їм поля, тому зворотна сумісність збережена.
- Повернене значення `endWorkout` залишене як було — наразі ніхто його не використовує, а його асинхронна природа (result-з-редʼюсера) — тема для окремого PR, якщо виникне потреба.


Link to Devin session: https://app.devin.ai/sessions/76f11207703e47808db79a49cabb1310
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
