### PR TITLE
polish(ui): уніфікація empty states і a11y полір shared UI

### DIFF
--- a/src/core/HubSearch.jsx
+++ b/src/core/HubSearch.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 
 function safeParseLS(key, fallback) {
   try {
@@ -294,18 +295,19 @@ export function HubSearch({ onClose, onOpenModule }) {
 
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
         {query.trim().length >= 2 && results.length === 0 && (
-          <div className="py-12 text-center text-muted text-sm">
-            <p className="text-3xl mb-2">🔍</p>
-            <p>Нічого не знайдено за «{query}»</p>
-          </div>
+          <EmptyState
+            icon={<Icon name="search" size={22} strokeWidth={1.6} />}
+            title="Нічого не знайдено"
+            description={`За запитом «${query}» нічого не знайшлося. Спробуй іншу фразу.`}
+          />
         )}
 
         {query.trim().length < 2 && (
-          <div className="py-12 text-center text-muted text-sm space-y-1">
-            <p className="text-3xl mb-2">🔎</p>
-            <p className="font-medium">Глобальний пошук</p>
-            <p className="text-xs">Транзакції, тренування, звички, їжа</p>
-          </div>
+          <EmptyState
+            icon={<Icon name="search" size={22} strokeWidth={1.6} />}
+            title="Глобальний пошук"
+            description="Транзакції, тренування, звички, їжа — все в одному місці."
+          />
         )}
 
         {Object.entries(grouped).map(([moduleId, group]) => (

--- a/src/modules/finyk/pages/Overview.jsx
+++ b/src/modules/finyk/pages/Overview.jsx
@@ -21,6 +21,7 @@ import { getCategorySpendList } from "../domain/categories";
 import { filterStatTransactions } from "../domain/transactions";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { Icon } from "@shared/components/ui/Icon";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 import { THEME_HEX } from "@shared/lib/themeHex.js";
 import { SyncStatusBadge } from "../components/SyncStatusBadge";
@@ -1006,17 +1007,20 @@ export function Overview({
             </Suspense>
           </div>
         ) : (
-          <div className="bg-panel border border-dashed border-line/60 rounded-2xl p-8 text-center shadow-card">
-            <p className="text-sm text-subtle">
-              Поки немає витрат за категоріями цього місяця.
-            </p>
-            <button
-              type="button"
-              onClick={() => onNavigate("transactions")}
-              className="mt-4 text-sm font-medium text-primary hover:underline"
-            >
-              Переглянути операції
-            </button>
+          <div className="bg-panel border border-dashed border-line/60 rounded-2xl shadow-card">
+            <EmptyState
+              title="Поки немає витрат"
+              description="Цього місяця витрат за категоріями ще немає."
+              action={
+                <button
+                  type="button"
+                  onClick={() => onNavigate("transactions")}
+                  className="text-sm font-medium text-primary hover:underline"
+                >
+                  Переглянути операції
+                </button>
+              }
+            />
           </div>
         )}
 

--- a/src/modules/fizruk/components/workouts/WorkoutCatalogSection.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutCatalogSection.jsx
@@ -1,4 +1,5 @@
 import { Input } from "@shared/components/ui/Input";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 
 export function WorkoutCatalogSection({
@@ -41,9 +42,11 @@ export function WorkoutCatalogSection({
 
       <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
         {grouped.length === 0 ? (
-          <div className="p-6 text-center text-sm text-subtle">
-            Поки немає вправ. Додай першу через кнопку &quot;+ Додати&quot;.
-          </div>
+          <EmptyState
+            compact
+            title="Поки немає вправ"
+            description="Додай першу через кнопку «+ Додати»."
+          />
         ) : (
           grouped.map((g) => {
             const isOpen = open[g.id] ?? false;

--- a/src/modules/fizruk/pages/Exercise.jsx
+++ b/src/modules/fizruk/pages/Exercise.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { epley1rm, suggestNextSet } from "../lib/workoutStats";
@@ -551,9 +552,11 @@ export function Exercise({ exerciseId }) {
             Історія сетів
           </div>
           {history.length === 0 ? (
-            <div className="text-sm text-subtle text-center py-6">
-              Ще немає записів по цій вправі
-            </div>
+            <EmptyState
+              compact
+              title="Поки немає записів"
+              description="Заверши хоча б один підхід — історія зʼявиться тут."
+            />
           ) : (
             <div className="space-y-2">
               {history.slice(0, 20).map(({ workout, item }) => (

--- a/src/modules/fizruk/pages/Measurements.jsx
+++ b/src/modules/fizruk/pages/Measurements.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
 
 const inp =
@@ -232,9 +233,11 @@ export function Measurements() {
             </div>
           ))}
           {(entries || []).length === 0 && (
-            <div className="p-6 text-center text-sm text-subtle">
-              Поки замірів немає
-            </div>
+            <EmptyState
+              compact
+              title="Поки замірів немає"
+              description="Додай перший запис, щоб бачити динаміку показників."
+            />
           )}
         </div>
       </div>

--- a/src/modules/fizruk/pages/PlanCalendar.jsx
+++ b/src/modules/fizruk/pages/PlanCalendar.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
@@ -211,9 +212,11 @@ export function PlanCalendar() {
             як у блоці відновлення).
           </p>
           {recoveryRows.length === 0 ? (
-            <p className="text-xs text-subtle">
-              Немає даних — потрібні завершені тренування з вправами.
-            </p>
+            <EmptyState
+              compact
+              title="Поки що порожньо"
+              description="Потрібні завершені тренування з вправами — дані зʼявляться автоматично."
+            />
           ) : (
             <ul className="space-y-2 max-h-64 overflow-y-auto">
               {recoveryRows.map((r) => (

--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useMeasurements } from "../hooks/useMeasurements";
@@ -482,9 +483,11 @@ export function Progress() {
             Обʼєм по мʼязах
           </div>
           {weeklyByMuscle.top.length === 0 ? (
-            <div className="text-sm text-subtle text-center py-6">
-              Немає даних за останні 4 тижні
-            </div>
+            <EmptyState
+              compact
+              title="Поки що порожньо"
+              description="Немає даних за останні 4 тижні."
+            />
           ) : (
             <div className="space-y-2">
               {weeklyByMuscle.top.map((m) => (
@@ -566,11 +569,19 @@ export function Progress() {
               )}
 
               {filtered.length === 0 ? (
-                <div className="text-sm text-subtle text-center py-6">
-                  {prs.length === 0
-                    ? "Поки немає силових PR"
-                    : "Немає PR для цієї групи м'язів"}
-                </div>
+                <EmptyState
+                  compact
+                  title={
+                    prs.length === 0
+                      ? "Поки немає силових PR"
+                      : "Немає PR для цієї групи мʼязів"
+                  }
+                  description={
+                    prs.length === 0
+                      ? "Заверши сети з вагою — рекорди зʼявляться тут автоматично."
+                      : "Спробуй іншу групу або скинь фільтр."
+                  }
+                />
               ) : (
                 <div className="space-y-2">
                   {filtered.map((p) => {

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -5,6 +5,7 @@ import { cn } from "@shared/lib/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { Icon } from "@shared/components/ui/Icon";
+import { EmptyState } from "@shared/components/ui/EmptyState";
 import {
   searchMealsByName,
   getMacrosForDateRange,
@@ -371,7 +372,7 @@ export function LogCard({
               Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
             </div>
             {statsRows.length === 0 ? (
-              <div className="text-xs text-muted">Немає даних</div>
+              <div className="text-xs text-muted">Поки що порожньо</div>
             ) : (
               (() => {
                 const kcals = statsRows.map((r) => Number(r.kcal) || 0);
@@ -450,9 +451,27 @@ export function LogCard({
         </div>
 
         {meals.length === 0 ? (
-          <div className="text-center text-muted text-sm py-8">
-            Поки немає записів. Додайте перший прийом їжі.
-          </div>
+          <EmptyState
+            compact
+            icon={
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M3 3h18v4H3zM5 7v14h14V7" />
+                <path d="M9 11h6M9 15h6" />
+              </svg>
+            }
+            title="Поки немає записів"
+            description="Додайте перший прийом їжі, щоб почати вести журнал."
+          />
         ) : (
           <VirtualMealList
             groups={groups}

--- a/src/shared/components/ui/Button.jsx
+++ b/src/shared/components/ui/Button.jsx
@@ -90,6 +90,8 @@ export const Button = forwardRef(function Button(
       ref={ref}
       type={type}
       disabled={isDisabled}
+      aria-busy={loading || undefined}
+      aria-live={loading ? "polite" : undefined}
       className={cn(
         // Base styles
         "inline-flex items-center justify-center",
@@ -106,8 +108,13 @@ export const Button = forwardRef(function Button(
     >
       {loading ? (
         <>
-          <LoadingSpinner className="animate-spin" />
-          {!iconOnly && <span className="opacity-0">{children}</span>}
+          <LoadingSpinner className="animate-spin" aria-hidden="true" />
+          {!iconOnly && (
+            <span className="opacity-0" aria-hidden="true">
+              {children}
+            </span>
+          )}
+          <span className="sr-only">Завантаження…</span>
         </>
       ) : (
         children

--- a/src/shared/components/ui/Input.jsx
+++ b/src/shared/components/ui/Input.jsx
@@ -50,6 +50,7 @@ export const Input = forwardRef(function Input(
       )}
       <input
         ref={ref}
+        aria-invalid={error ? true : undefined}
         className={cn(
           "w-full text-text placeholder:text-subtle/70",
           "outline-none transition-all duration-200",
@@ -87,6 +88,7 @@ export const Textarea = forwardRef(function Textarea(
     <textarea
       ref={ref}
       rows={rows}
+      aria-invalid={error ? true : undefined}
       className={cn(
         "w-full px-4 py-3 text-base text-text placeholder:text-subtle/70 rounded-2xl",
         "outline-none transition-all duration-200 resize-none",


### PR DESCRIPTION
## Summary

Low-risk UI polish: уніфіковано дрібні ad-hoc empty-state divs на спільний `<EmptyState compact />` і додано a11y-атрибути до shared примітивів. Без редизайну, без зміни UX — тільки прибирання візуальної неоднорідності і невеликі поліпшення для assistive tech.

**Shared UI (a11y):**
- `Button`: додано `aria-busy={loading}` + прихований `sr-only` текст «Завантаження…» щоб screen readers повідомляли стан. Візуально нічого не змінилось.
- `Input` / `Textarea`: додано `aria-invalid` коли `error` truthy.

**Уніфікація empty states** (ad-hoc `text-center text-subtle py-*` → `<EmptyState compact />`):
- `nutrition/LogCard` — головний empty журналу + уніфіковано текст у статистичних кейсах («Поки що порожньо»)
- `fizruk/Progress` — обʼєм по мʼязах, PR board
- `fizruk/Exercise` — історія сетів
- `fizruk/Measurements` — список замірів
- `fizruk/PlanCalendar` — таблиця відновлення
- `fizruk/WorkoutCatalogSection` — порожній каталог вправ
- `core/HubSearch` — порожній запит + «нічого не знайдено» (використовують іконку пошуку з shared Icon)
- `finyk/Overview` — витрати по категоріях (CTA «Переглянути операції» збережена через `action` проп)

## Review & Testing Checklist for Human

- [ ] Візуально перевірити, що empty-state блоки виглядають ок у нутриції, фізрука (Progress/Exercise/Measurements/PlanCalendar), каталозі вправ, HubSearch та Overview фініка. Розмір може трохи відрізнятися (у `EmptyState compact` інший вертикальний ритм ніж у `py-6/8`).
- [ ] Перевірити, що кнопка з `loading` у скринрідері озвучується як «busy» і що фокус-стани не зламались.

### Notes

- Текст у LogCard статистиці був «Немає даних» / «Поки що порожньо» — уніфіковано на один варіант («Поки що порожньо»), бо обидва означали одне і те ж.
- `Input`/`Textarea` — `aria-invalid` виставляється тільки коли є `error`, щоб не засмічувати DOM.
- Не чіпав `RoutineCalendarPanel` (там empty-state вже з інтерактивними кнопками фільтрів) — щоб не вийти за межу «quick wins».

**Локально**: `format:check` / `lint` / `typecheck` зелені, `npm test` — 424/424, `npm run build` — ок.

Link to Devin session: https://app.devin.ai/sessions/666dae1c6c2b4958b08de65172cd97af
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
