### PR TITLE
feat(hub): cross-module deep-link bus + 3 low-risk quick wins

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -7,6 +7,7 @@ import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { ToastProvider } from "@shared/hooks/useToast";
 import { ToastContainer } from "@shared/components/ui/Toast";
 import { Icon } from "@shared/components/ui/Icon";
+import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/hubNav";
 import { AuthProvider, useAuth } from "./AuthContext.jsx";
 import { useCloudSync } from "./useCloudSync.js";
 import { HubDashboard } from "./HubDashboard.jsx";
@@ -161,6 +162,19 @@ function AppInner() {
       return () =>
         navigator.serviceWorker.removeEventListener("message", onMessage);
     }
+  }, [openModule]);
+
+  // Крос-модульний deep-link через `openHubModule(...)` з @shared/lib/hubNav —
+  // дозволяє будь-якому компоненту будь-якого модуля стрибнути в інший
+  // модуль+hash без прокидування `onOpenModule` через дерево.
+  useEffect(() => {
+    const onHubOpen = (ev) => {
+      const { module, hash } = ev.detail || {};
+      if (!VALID_MODULES.has(module)) return;
+      openModule(module, hash ? { hash } : undefined);
+    };
+    window.addEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
+    return () => window.removeEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
   }, [openModule]);
 
   if (migrationPending) {

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -17,6 +17,7 @@ import {
 } from "../utils";
 import { getDebtTxRole, getReceivableTxRole } from "../domain/debtEngine";
 import { cn } from "@shared/lib/cn";
+import { openHubModule } from "@shared/lib/hubNav";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech as parseExpenseVoice } from "../../../core/lib/speechParsers.js";
@@ -422,6 +423,17 @@ export function Assets({
         />
         {open.subscriptions && (
           <div className="mb-3 space-y-0">
+            {subscriptions.length > 0 && (
+              <button
+                type="button"
+                onClick={() => openHubModule("routine", "")}
+                className="w-full text-[11px] text-muted hover:text-text transition-colors pb-2 flex items-center justify-center gap-1.5"
+              >
+                <span aria-hidden>📅</span>
+                <span>Побачити у календарі Рутини</span>
+                <span aria-hidden>→</span>
+              </button>
+            )}
             {subscriptions.map((sub, i) => (
               <SubCard
                 key={sub.id}

--- a/src/modules/fizruk/components/workouts/WorkoutFinishSheets.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutFinishSheets.jsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { openHubModule } from "@shared/lib/hubNav";
 import { formatDurShort } from "../../lib/workoutUi";
 
 export function WorkoutFinishSheets({
@@ -213,24 +214,38 @@ export function WorkoutFinishSheets({
                   </span>
                 </div>
               )}
-            <div className="flex gap-2 p-3 bg-panel">
-              <Button
-                variant="ghost"
-                className="flex-1 h-12 min-h-[44px] rounded-full"
-                type="button"
-                onClick={() =>
-                  setFinishFlash((f) => f && { ...f, collapsed: true })
-                }
-              >
-                Згорнути
-              </Button>
+            <div className="flex flex-col gap-2 p-3 bg-panel">
               <button
                 type="button"
-                className="fizruk-cta-accent flex-1 py-3 rounded-full text-[15px]"
-                onClick={() => setFinishFlash(null)}
+                className="w-full text-xs text-muted hover:text-text transition-colors py-1.5 flex items-center justify-center gap-1.5"
+                onClick={() => {
+                  setFinishFlash(null);
+                  openHubModule("nutrition", "log");
+                }}
               >
-                Готово
+                <span aria-hidden>🥩</span>
+                <span>Додати білок після тренування</span>
+                <span aria-hidden>→</span>
               </button>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  className="flex-1 h-12 min-h-[44px] rounded-full"
+                  type="button"
+                  onClick={() =>
+                    setFinishFlash((f) => f && { ...f, collapsed: true })
+                  }
+                >
+                  Згорнути
+                </Button>
+                <button
+                  type="button"
+                  className="fizruk-cta-accent flex-1 py-3 rounded-full text-[15px]"
+                  onClick={() => setFinishFlash(null)}
+                >
+                  Готово
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/src/modules/nutrition/components/ShoppingListCard.jsx
+++ b/src/modules/nutrition/components/ShoppingListCard.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Card } from "@shared/components/ui/Card";
 import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
+import { openHubModule } from "@shared/lib/hubNav";
 import { getTotalCount } from "../lib/shoppingListStorage.js";
 
 const CATEGORY_ICONS = {
@@ -253,6 +254,16 @@ export function ShoppingListCard({
             Список покупок порожній. Вибери джерело і натисни кнопку генерації.
           </div>
         )}
+
+        <button
+          type="button"
+          onClick={() => openHubModule("finyk", "/analytics")}
+          className="w-full text-[11px] text-muted hover:text-text transition-colors pt-1 flex items-center justify-center gap-1.5"
+        >
+          <span aria-hidden>💸</span>
+          <span>Скільки витратив на їжу цього місяця?</span>
+          <span aria-hidden>→</span>
+        </button>
       </div>
     </Card>
   );

--- a/src/shared/lib/hubNav.js
+++ b/src/shared/lib/hubNav.js
@@ -1,0 +1,33 @@
+/**
+ * Крос-модульна навігація всередині Hub.
+ *
+ * Замість прокидування `onOpenModule` через дерево кожного модуля — крихітний
+ * подієвий шинний канал. Слухач встановлюється в `core/App.jsx` і викликає
+ * існуючий `openModule(id, { hash })`. Будь-який глибокий компонент може
+ * викликати `openHubModule("finyk", "/analytics")` без додаткових пропсів.
+ *
+ * Це НЕ замінює існуючі `onOpenModule` пропси (напр. у `RoutineCalendarPanel`) —
+ * вони лишаються як є. Це доповнювальний, опційний канал.
+ */
+
+export const HUB_OPEN_MODULE_EVENT = "hub:open-module";
+
+const VALID_HUB_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
+
+/**
+ * Перемкнути активний модуль Hub (з опційним hash для вкладки всередині).
+ * @param {"finyk"|"fizruk"|"routine"|"nutrition"} moduleId
+ * @param {string} [hash] — наприклад `"/analytics"` для Фініка або `"log"` для Nutrition.
+ */
+export function openHubModule(moduleId, hash) {
+  if (!VALID_HUB_MODULES.has(moduleId)) return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(HUB_OPEN_MODULE_EVENT, {
+        detail: { module: moduleId, hash: hash || "" },
+      }),
+    );
+  } catch {
+    /* noop — SSR / disabled CustomEvent */
+  }
+}


### PR DESCRIPTION
## Summary

Посилюю відчуття єдиного хабу трьома точковими крос-модульними лінками через **крихітний event-bus**, щоб не прокидувати `onOpenModule` через дерево кожного модуля.

### Foundation — `@shared/lib/hubNav.js` (~33 рядків)

Новий файл + один `useEffect`-слухач у `core/App.jsx`. Будь-який глибокий компонент може викликати `openHubModule("finyk", "/analytics")`, і `App.jsx` пошле це в існуючий `openModule(id, { hash })` (який уже підтримує hash-deep-link — використовується `RoutineCalendarPanel`). Існуючі `onOpenModule` пропси **не чіпав** — вони працюють як раніше.

### 3 quick wins

1. **fizruk → nutrition** (`WorkoutFinishSheets.jsx`): після завершення тренування у підсумковому шіті додав маленьку кнопку **«🥩 Додати білок після тренування →»** → відкриває Nutrition `#log`. Дзеркалить існуючу рекомендацію `nutrition_post_workout_protein` з `recommendationEngine`.

2. **nutrition → finyk** (`ShoppingListCard.jsx`): під картою Списку покупок — тонкий лінк **«💸 Скільки витратив на їжу цього місяця? →»** → Finyk Аналітика (`#/analytics`). Раніше цього напрямку не було взагалі.

3. **finyk → routine** (`Assets.jsx`, секція «🔄 Підписки»): коли секція відкрита і є підписки — маленький текст **«📅 Побачити у календарі Рутини →»**. Підписки вже рендеряться як події календаря через `finykSubscriptionCalendar` + `hubRoutineSync`; просто робимо зв'язок видимим з боку Фініка.

**Обсяг:** 5 файлів, +99 / −14 рядків. Жодних нових систем стейту, жодних змін у `recommendationEngine`, `hubRoutineSync`, `openModule`, `RoutineCalendarPanel`.

## Review & Testing Checklist for Human

- [ ] Натиснути «🥩 Додати білок» після завершення тренування у Фізруці → має відкритись Nutrition на вкладці «Журнал».
- [ ] У Nutrition на вкладці «Покупки» натиснути «💸 Скільки витратив на їжу?» → має відкритись Finyk → «Аналітика».
- [ ] У Finyk → «Активи» → розкрити «🔄 Підписки» → клацнути «📅 Побачити у календарі Рутини» → відкривається Рутина (календар — дефолтна вкладка).
- [ ] Існуючі переходи з Рутини (календар → `fizruk#plan`, клік на підписку → `finyk#/assets`) не зламались.

### Notes

- `openHubModule` мовчки ігнорує невалідний module (whitelist `finyk|fizruk|routine|nutrition`), тож додавати нові лінки у майбутньому безпечно.
- Hash-формат різний між модулями (Finyk — `/analytics`, Nutrition — `log`, Fizruk — `workouts`) — це існуюча домовленість, не моя. `hubNav` просто прокидує рядок без валідації.
- Локально пройшло: `lint` ✓, `typecheck` ✓, `test` (424 tests) ✓, `build` ✓.

Link to Devin session: https://app.devin.ai/sessions/02a9fbcc5e6740b2985f5c7ba1679f1a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
