### PR TITLE
chore(stability): guard JSON imports + search against corrupted data

### DIFF
--- a/src/core/HubSearch.jsx
+++ b/src/core/HubSearch.jsx
@@ -43,10 +43,12 @@ function searchFinyk(query) {
   const txList = safeParseLS("finyk_tx_cache", []);
   if (Array.isArray(txList)) {
     for (const tx of txList) {
+      if (!tx || typeof tx !== "object") continue;
       const desc = (tx.description || tx.comment || "").toLowerCase();
       const mcc = String(tx.mcc || "");
       if (desc.includes(q) || mcc.includes(q)) {
-        const amount = (tx.amount ?? 0) / 100;
+        const amtRaw = Number(tx.amount);
+        const amount = (Number.isFinite(amtRaw) ? amtRaw : 0) / 100;
         const sign = amount < 0 ? "−" : "+";
         results.push({
           id: `finyk_tx_${tx.id || tx.time}`,
@@ -64,13 +66,16 @@ function searchFinyk(query) {
   const subs = safeParseLS("finyk_subs", []);
   if (Array.isArray(subs)) {
     for (const s of subs) {
+      if (!s || typeof s !== "object") continue;
       if ((s.name || "").toLowerCase().includes(q)) {
+        const amtRaw = Number(s.amount);
+        const amt = Number.isFinite(amtRaw) && amtRaw > 0 ? amtRaw : 0;
         results.push({
           id: `finyk_sub_${s.id}`,
           module: "finyk",
           moduleLabel: "Фінік",
           title: s.name,
-          subtitle: `Підписка · ${s.amount ? (s.amount / 100).toFixed(0) + " ₴" : ""}`,
+          subtitle: `Підписка · ${amt ? (amt / 100).toFixed(0) + " ₴" : ""}`,
           icon: "🔄",
         });
       }
@@ -89,9 +94,11 @@ function searchFizruk(query) {
   );
   if (workouts.length > 0) {
     for (const w of workouts) {
+      if (!w || typeof w !== "object") continue;
       const note = (w.note || "").toLowerCase();
-      const exercises = (w.items || []).map((i) =>
-        (i.exerciseName || i.name || "").toLowerCase(),
+      const itemsRaw = Array.isArray(w.items) ? w.items : [];
+      const exercises = itemsRaw.map((i) =>
+        ((i && (i.exerciseName || i.name)) || "").toLowerCase(),
       );
       const matchNote = note.includes(q);
       const matchExercise = exercises.some((e) => e.includes(q));
@@ -99,9 +106,9 @@ function searchFizruk(query) {
         const dateLabel = w.startedAt
           ? localDateKey(new Date(w.startedAt))
           : "";
-        const exNames = (w.items || [])
+        const exNames = itemsRaw
           .slice(0, 2)
-          .map((i) => i.exerciseName || i.name || "")
+          .map((i) => (i && (i.exerciseName || i.name)) || "")
           .filter(Boolean);
         results.push({
           id: `fizruk_w_${w.id}`,
@@ -109,7 +116,7 @@ function searchFizruk(query) {
           moduleLabel: "Фізрук",
           title: w.note || exNames.join(", ") || "Тренування",
           subtitle:
-            dateLabel + (w.items?.length ? ` · ${w.items.length} вправ` : ""),
+            dateLabel + (itemsRaw.length ? ` · ${itemsRaw.length} вправ` : ""),
           icon: "🏋️",
         });
       }
@@ -121,6 +128,7 @@ function searchFizruk(query) {
     localStorage.getItem("fizruk_custom_exercises_v1"),
   );
   for (const e of exercises) {
+    if (!e || typeof e !== "object") continue;
     if (
       (e.name || "").toLowerCase().includes(q) ||
       (Array.isArray(e.muscles) ? e.muscles : [])
@@ -154,6 +162,7 @@ function searchRoutine(query) {
 
   const habits = Array.isArray(state.habits) ? state.habits : [];
   for (const h of habits) {
+    if (!h || typeof h !== "object") continue;
     if (
       (h.name || "").toLowerCase().includes(q) ||
       (h.note || "").toLowerCase().includes(q) ||

--- a/src/modules/fizruk/lib/fizrukStorage.test.js
+++ b/src/modules/fizruk/lib/fizrukStorage.test.js
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  applyFizrukFullBackupPayload,
+  buildFizrukFullBackupPayload,
+  parseWorkoutsFromStorage,
+  parseCustomExercisesFromStorage,
+  WORKOUTS_STORAGE_KEY,
+  CUSTOM_EXERCISES_KEY,
+} from "./fizrukStorage.js";
+
+describe("fizrukStorage – defensive parsing/import", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("parseWorkoutsFromStorage", () => {
+    it("returns [] for null / empty / undefined", () => {
+      expect(parseWorkoutsFromStorage(null)).toEqual([]);
+      expect(parseWorkoutsFromStorage("")).toEqual([]);
+      expect(parseWorkoutsFromStorage(undefined)).toEqual([]);
+    });
+    it("returns [] for malformed JSON", () => {
+      expect(parseWorkoutsFromStorage("{not json")).toEqual([]);
+      expect(parseWorkoutsFromStorage("not even close")).toEqual([]);
+    });
+    it("accepts legacy plain-array shape", () => {
+      expect(parseWorkoutsFromStorage('[{"id":"a"}]')).toEqual([{ id: "a" }]);
+    });
+    it("accepts new {schemaVersion, workouts} shape", () => {
+      const raw = JSON.stringify({ schemaVersion: 1, workouts: [{ id: "b" }] });
+      expect(parseWorkoutsFromStorage(raw)).toEqual([{ id: "b" }]);
+    });
+    it("returns [] when inner shape is unexpected (e.g. {workouts:'oops'})", () => {
+      expect(
+        parseWorkoutsFromStorage(JSON.stringify({ workouts: "oops" })),
+      ).toEqual([]);
+    });
+  });
+
+  describe("parseCustomExercisesFromStorage", () => {
+    it("returns [] for null / malformed JSON", () => {
+      expect(parseCustomExercisesFromStorage(null)).toEqual([]);
+      expect(parseCustomExercisesFromStorage("broken")).toEqual([]);
+    });
+    it("accepts legacy and new shapes", () => {
+      expect(parseCustomExercisesFromStorage('[{"id":"x"}]')).toEqual([
+        { id: "x" },
+      ]);
+      const newShape = JSON.stringify({
+        schemaVersion: 1,
+        exercises: [{ id: "y" }],
+      });
+      expect(parseCustomExercisesFromStorage(newShape)).toEqual([{ id: "y" }]);
+    });
+  });
+
+  describe("applyFizrukFullBackupPayload", () => {
+    it("throws on null / undefined / non-object", () => {
+      expect(() => applyFizrukFullBackupPayload(null)).toThrow();
+      expect(() => applyFizrukFullBackupPayload(undefined)).toThrow();
+      expect(() => applyFizrukFullBackupPayload(123)).toThrow();
+      expect(() => applyFizrukFullBackupPayload("string")).toThrow();
+    });
+
+    it("throws when `data` is missing or not an object", () => {
+      expect(() => applyFizrukFullBackupPayload({})).toThrow();
+      expect(() => applyFizrukFullBackupPayload({ data: null })).toThrow();
+      expect(() => applyFizrukFullBackupPayload({ data: 42 })).toThrow();
+    });
+
+    it("silently ignores non-string values inside data and only writes strings", () => {
+      applyFizrukFullBackupPayload({
+        data: {
+          [WORKOUTS_STORAGE_KEY]: 123, // ignored
+          [CUSTOM_EXERCISES_KEY]: JSON.stringify({
+            schemaVersion: 1,
+            exercises: [{ id: "e1" }],
+          }),
+        },
+      });
+      expect(localStorage.getItem(WORKOUTS_STORAGE_KEY)).toBeNull();
+      const c = parseCustomExercisesFromStorage(
+        localStorage.getItem(CUSTOM_EXERCISES_KEY),
+      );
+      expect(c).toEqual([{ id: "e1" }]);
+    });
+
+    it("round-trips buildFizrukFullBackupPayload -> applyFizrukFullBackupPayload", () => {
+      localStorage.setItem(
+        WORKOUTS_STORAGE_KEY,
+        JSON.stringify({
+          schemaVersion: 1,
+          workouts: [{ id: "w1", startedAt: "2024-01-01T00:00:00Z" }],
+        }),
+      );
+      const payload = buildFizrukFullBackupPayload();
+      // reset and re-apply
+      localStorage.clear();
+      applyFizrukFullBackupPayload(payload);
+      const workouts = parseWorkoutsFromStorage(
+        localStorage.getItem(WORKOUTS_STORAGE_KEY),
+      );
+      expect(workouts).toEqual([
+        { id: "w1", startedAt: "2024-01-01T00:00:00Z" },
+      ]);
+    });
+  });
+});

--- a/src/modules/fizruk/pages/Progress.jsx
+++ b/src/modules/fizruk/pages/Progress.jsx
@@ -215,8 +215,20 @@ export function Progress() {
   };
 
   const importJson = async (file) => {
-    const text = await file.text();
-    const parsed = JSON.parse(text);
+    let text;
+    try {
+      text = await file.text();
+    } catch (err) {
+      console.error("[fizruk] importJson: failed to read file", err);
+      throw err;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      console.error("[fizruk] importJson: invalid JSON", err);
+      throw new Error("Невірний формат файлу");
+    }
     applyFizrukFullBackupPayload(parsed);
     window.location.reload();
   };

--- a/src/modules/nutrition/hooks/useNutritionLog.js
+++ b/src/modules/nutrition/hooks/useNutritionLog.js
@@ -164,26 +164,45 @@ export function useNutritionLog() {
   /**
    * Replace the entire log with data parsed from a JSON string.
    * Garbage-collects orphaned photo thumbnails.
+   * Returns `false` on malformed JSON instead of throwing, so the UI
+   * can show an import-failure toast without unmounting.
    * @param {string} text - JSON string of a full `NutritionLog`.
+   * @returns {boolean}
    */
   const replaceLogFromJsonText = useCallback((text) => {
-    const parsed = JSON.parse(text);
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      console.error("[nutrition] replaceLogFromJsonText: invalid JSON", err);
+      return false;
+    }
     setNutritionLog((_prev) => {
       const next = normalizeNutritionLog(parsed);
       const keep = collectMealIds(next);
       void gcMealThumbnails(keep, { maxDeletes: 2000 });
       return next;
     });
+    return true;
   }, []);
 
   /**
    * Merge data from a JSON string into the existing log.
    * Existing meals are preserved; imported meals are appended.
+   * Returns `false` on malformed JSON instead of throwing.
    * @param {string} text - JSON string of a `NutritionLog` to merge.
+   * @returns {boolean}
    */
   const mergeLogFromJsonText = useCallback((text) => {
-    const parsed = JSON.parse(text);
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      console.error("[nutrition] mergeLogFromJsonText: invalid JSON", err);
+      return false;
+    }
     setNutritionLog((log) => mergeNutritionLogs(log, parsed));
+    return true;
   }, []);
 
   /**

--- a/src/modules/nutrition/hooks/useNutritionLog.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionLog.test.jsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useNutritionLog } from "./useNutritionLog.js";
+import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage.js";
+
+describe("useNutritionLog – defensive imports", () => {
+  let errorSpy;
+
+  beforeEach(() => {
+    localStorage.clear();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("replaceLogFromJsonText returns false and does not throw on malformed JSON", () => {
+    const { result } = renderHook(() => useNutritionLog());
+    let ok;
+    act(() => {
+      ok = result.current.replaceLogFromJsonText("{not: valid json");
+    });
+    expect(ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    // previous state preserved (empty log)
+    expect(result.current.nutritionLog).toEqual({});
+  });
+
+  it("mergeLogFromJsonText returns false on malformed JSON and preserves existing log", async () => {
+    const seeded = {
+      "2025-01-01": {
+        meals: [
+          {
+            id: "m1",
+            name: "Toast",
+            time: "09:00",
+            mealType: "breakfast",
+            label: "",
+            macros: { kcal: 100, protein_g: 5, fat_g: 2, carbs_g: 15 },
+            source: "manual",
+            macroSource: "manual",
+            amount_g: null,
+            foodId: null,
+          },
+        ],
+      },
+    };
+    localStorage.setItem(NUTRITION_LOG_KEY, JSON.stringify(seeded));
+
+    const { result } = renderHook(() => useNutritionLog());
+    await waitFor(() =>
+      expect(result.current.nutritionLog["2025-01-01"]?.meals?.length).toBe(1),
+    );
+
+    let ok;
+    act(() => {
+      ok = result.current.mergeLogFromJsonText("not json at all");
+    });
+    expect(ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(result.current.nutritionLog["2025-01-01"].meals).toHaveLength(1);
+  });
+
+  it("replaceLogFromJsonText returns true on valid JSON and applies normalized log", async () => {
+    const { result } = renderHook(() => useNutritionLog());
+    const payload = {
+      "2025-02-03": {
+        meals: [
+          {
+            id: "x",
+            name: "Apple",
+            time: "10:00",
+            mealType: "snack",
+            label: "",
+            macros: { kcal: 50, protein_g: 0, fat_g: 0, carbs_g: 12 },
+            source: "manual",
+            macroSource: "manual",
+          },
+        ],
+      },
+    };
+    let ok;
+    act(() => {
+      ok = result.current.replaceLogFromJsonText(JSON.stringify(payload));
+    });
+    expect(ok).toBe(true);
+    await waitFor(() =>
+      expect(result.current.nutritionLog["2025-02-03"]?.meals?.length).toBe(1),
+    );
+  });
+
+  it("replaceLogFromJsonText ignores non-object JSON (array / null) without throwing", () => {
+    const { result } = renderHook(() => useNutritionLog());
+    let ok1;
+    act(() => {
+      ok1 = result.current.replaceLogFromJsonText("null");
+    });
+    expect(ok1).toBe(true);
+    expect(result.current.nutritionLog).toEqual({});
+
+    let ok2;
+    act(() => {
+      ok2 = result.current.replaceLogFromJsonText("[1,2,3]");
+    });
+    expect(ok2).toBe(true);
+    expect(result.current.nutritionLog).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Низькоризикові defensive-фіксації, щоб UI не падав від поганих або пошкоджених даних. Без рефакторингу і без зміни UX.

### Fixes

1. **`useNutritionLog.replaceLogFromJsonText` / `mergeLogFromJsonText`** — `JSON.parse` більше не кидає нагору: при битому JSON функції повертають `false`, а помилка логується через `console.error`. Існуючий стан журналу зберігається без змін. <ref_snippet file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/hooks/useNutritionLog.js" lines="164-206" />

2. **`Progress.jsx` (fizruk) `importJson`** — окремі try/catch для `file.text()` і `JSON.parse`, щоб користувач бачив зрозумілу помилку, а не silent reject. Старий caller `.catch(() => alert(...))` працює як і раніше. <ref_snippet file="/home/ubuntu/repos/Sergeant/src/modules/fizruk/pages/Progress.jsx" lines="217-234" />

3. **`HubSearch.jsx`** — guard'и на `null`/`undefined`/не-об'єктні записи в кешах `finyk_tx_cache`, `finyk_subs`, `fizruk_workouts_v1`, `fizruk_custom_exercises_v1`, `hub_routine_v1.habits`. `tx.amount` / `sub.amount` переводяться через `Number.isFinite`, щоб нечислові значення не ламали форматування. <ref_file file="/home/ubuntu/repos/Sergeant/src/core/HubSearch.jsx" />

### Tests (+15)

- <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/hooks/useNutritionLog.test.jsx" /> — malformed JSON (merge/replace) не кидає, логується, стан зберігається; валідний JSON застосовується; `null`/масив толерується.
- <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/fizruk/lib/fizrukStorage.test.js" /> — `parseWorkoutsFromStorage`/`parseCustomExercisesFromStorage` повертають `[]` на битий JSON та legacy/new shapes; `applyFizrukFullBackupPayload` кидає на non-object, тихо ігнорує не-рядкові значення в `data`, round-trip build→apply працює.

Всі **439 тестів** зелені, `npm run lint` і `npm run typecheck` чисті.

Окремо пересвідчився, що вже наявні захисні шари не зачеплено: `normalizeFinykBackup` + `normalizeFinykSyncPayload` продовжують гейтити `applyData`, `parseWorkoutsFromStorage` має try/catch, `HubChat` historyWrite обгорнуто, `useCloudSync.collectQueuedModules`/`applyModuleData` вже вміють обробляти пошкоджену чергу. Тому цей PR — саме точкові доважки, а не переписування.

## Review & Testing Checklist for Human

- [ ] Спробуй імпорт фейкового JSON (не-JSON, валідний JSON але чужий формат, порожній файл, масив замість об'єкта) у **Fizruk → Прогрес → Імпорт**: очікується alert "Не вдалося імпортувати файл", без білого екрану, без reload. У console має бути `[fizruk] importJson: invalid JSON`.
- [ ] Якщо хтось руками поб'є `localStorage['finyk_tx_cache']` (напр. `"[null, 1, {}]"`) і відкриє Hub Search — не має падати, а просто не знаходити нічого дивного.
- [ ] Nutrition: `replaceLogFromJsonText`/`mergeLogFromJsonText` зараз не використовуються у UI (проп'си є, але в `LogCard.jsx` вони під `_`), тож візуальної регресії бути не має; зміна — лише повернення `boolean` замість викиду.

### Notes

- Не міняв UX і не чіпав вже-коректні шляхи.
- `normalizeNutritionLog` вже відкидає не-об'єктний parse (array/null → `{}`), тому `replaceLogFromJsonText("null")` тепер коректно скидає журнал у `{}` — це покрито тестом.

Link to Devin session: https://app.devin.ai/sessions/76f11207703e47808db79a49cabb1310
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
