### PR TITLE
fix(ui): Button — aria-hidden застосовується до LoadingSpinner SVG

### DIFF
--- a/src/shared/components/ui/Button.jsx
+++ b/src/shared/components/ui/Button.jsx
@@ -108,7 +108,7 @@ export const Button = forwardRef(function Button(
     >
       {loading ? (
         <>
-          <LoadingSpinner className="animate-spin" aria-hidden="true" />
+          <LoadingSpinner className="animate-spin" />
           {!iconOnly && (
             <span className="opacity-0" aria-hidden="true">
               {children}
@@ -123,10 +123,13 @@ export const Button = forwardRef(function Button(
   );
 });
 
-// Loading spinner component
+// Loading spinner component. Always decorative — SR announcement is handled by
+// the sr-only "Завантаження…" sibling in Button.
 function LoadingSpinner({ className }) {
   return (
     <svg
+      aria-hidden="true"
+      focusable="false"
       className={cn("h-4 w-4", className)}
       viewBox="0 0 24 24"
       fill="none"


### PR DESCRIPTION
## Summary

Follow-up до #111. Devin Review зазначив, що `aria-hidden="true"`, який я передавав у `<LoadingSpinner />`, мовчки відкидався: компонент деструктурує тільки `{ className }` і не форвардить рештy пропів на `<svg>`. Через це декоративний спіннер залишався «видимим» для assistive tech, а поруч ще й озвучувався sr-only «Завантаження…» — дублювання.

Фікс: переношу `aria-hidden="true"` + `focusable="false"` прямо на `<svg>` усередині `LoadingSpinner`. Спіннер завжди декоративний; анонс стану робить sr-only-текст поруч.

## Review & Testing Checklist for Human

- [ ] У screen reader під час `loading` озвучується тільки «Завантаження…», спіннер не потрапляє в accessibility tree.

### Notes

- Жодних візуальних змін.
- Альтернативний варіант (форвардити `...props` у спіннер) навмисне не обрано — spinner завжди декоративний, простіше і безпечніше задати атрибут на місці.

Link to Devin session: https://app.devin.ai/sessions/666dae1c6c2b4958b08de65172cd97af
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
