### PR TITLE
feat(ui): micro-delights for Finyk — page transitions, tap feedback, success icon pop

### DIFF
--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -571,69 +571,74 @@ export default function App({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        {page === "overview" && (
-          <SectionErrorBoundary
-            key="page-overview"
-            title="Не вдалось показати «Огляд»"
-          >
-            <Overview
-              mono={mergedMono}
-              storage={storage}
-              onNavigate={navigate}
-              onCategoryClick={(catId) => {
-                setCategoryFilter(catId);
-                navigate("transactions");
-              }}
-              showBalance={showBalance}
-            />
-          </SectionErrorBoundary>
-        )}
-        {page === "transactions" && (
-          <SectionErrorBoundary
-            key="page-transactions"
-            title="Не вдалось показати «Операції»"
-          >
-            <Transactions
-              mono={mergedMono}
-              storage={storage}
-              showBalance={showBalance}
-              categoryFilter={categoryFilter}
-              onClearCategoryFilter={() => setCategoryFilter(null)}
-              onEditManualExpense={(id) => {
-                setEditingManualExpenseId(String(id));
-                setShowExpenseSheet(true);
-              }}
-            />
-          </SectionErrorBoundary>
-        )}
-        {page === "budgets" && (
-          <SectionErrorBoundary
-            key="page-budgets"
-            title="Не вдалось показати «Планування»"
-          >
-            <Budgets mono={mergedMono} storage={storage} />
-          </SectionErrorBoundary>
-        )}
-        {page === "analytics" && (
-          <SectionErrorBoundary
-            key="page-analytics"
-            title="Не вдалось показати «Аналітику»"
-          >
-            <Analytics mono={mergedMono} storage={storage} />
-          </SectionErrorBoundary>
-        )}
-        {page === "assets" && (
-          <SectionErrorBoundary
-            key="page-assets"
-            title="Не вдалось показати «Активи»"
-          >
-            <Assets
-              mono={mergedMono}
-              storage={storage}
-              showBalance={showBalance}
-            />
-          </SectionErrorBoundary>
-        )}
+        <div
+          key={`page-${page}`}
+          className="flex-1 overflow-hidden flex flex-col min-h-0 motion-safe:animate-fade-in"
+        >
+          {page === "overview" && (
+            <SectionErrorBoundary
+              key="page-overview"
+              title="Не вдалось показати «Огляд»"
+            >
+              <Overview
+                mono={mergedMono}
+                storage={storage}
+                onNavigate={navigate}
+                onCategoryClick={(catId) => {
+                  setCategoryFilter(catId);
+                  navigate("transactions");
+                }}
+                showBalance={showBalance}
+              />
+            </SectionErrorBoundary>
+          )}
+          {page === "transactions" && (
+            <SectionErrorBoundary
+              key="page-transactions"
+              title="Не вдалось показати «Операції»"
+            >
+              <Transactions
+                mono={mergedMono}
+                storage={storage}
+                showBalance={showBalance}
+                categoryFilter={categoryFilter}
+                onClearCategoryFilter={() => setCategoryFilter(null)}
+                onEditManualExpense={(id) => {
+                  setEditingManualExpenseId(String(id));
+                  setShowExpenseSheet(true);
+                }}
+              />
+            </SectionErrorBoundary>
+          )}
+          {page === "budgets" && (
+            <SectionErrorBoundary
+              key="page-budgets"
+              title="Не вдалось показати «Планування»"
+            >
+              <Budgets mono={mergedMono} storage={storage} />
+            </SectionErrorBoundary>
+          )}
+          {page === "analytics" && (
+            <SectionErrorBoundary
+              key="page-analytics"
+              title="Не вдалось показати «Аналітику»"
+            >
+              <Analytics mono={mergedMono} storage={storage} />
+            </SectionErrorBoundary>
+          )}
+          {page === "assets" && (
+            <SectionErrorBoundary
+              key="page-assets"
+              title="Не вдалось показати «Активи»"
+            >
+              <Assets
+                mono={mergedMono}
+                storage={storage}
+                showBalance={showBalance}
+              />
+            </SectionErrorBoundary>
+          )}
+        </div>
       </div>
 
       {(page === "overview" ||
@@ -644,7 +649,7 @@ export default function App({
             setEditingManualExpenseId(null);
             setShowExpenseSheet(true);
           }}
-          className="fixed bottom-[calc(58px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-emerald-500 text-white shadow-lg flex items-center justify-center text-2xl hover:bg-emerald-600 active:scale-95 transition-all z-20"
+          className="fixed bottom-[calc(58px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-emerald-500 text-white shadow-lg flex items-center justify-center text-2xl hover:bg-emerald-600 hover:shadow-xl hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
           aria-label="Додати витрату"
         >
           +
@@ -717,20 +722,20 @@ export default function App({
                 aria-current={active ? "page" : undefined}
                 aria-label={item.label}
                 className={cn(
-                  "relative flex-1 flex flex-col items-center justify-center gap-0.5 transition-all min-h-[48px] focus:outline-none",
+                  "relative flex-1 flex flex-col items-center justify-center gap-0.5 transition-all duration-200 ease-smooth min-h-[48px] active:scale-95 focus:outline-none",
                   active ? "text-emerald-600" : "text-muted hover:text-text",
                 )}
               >
                 {active && (
                   <span
-                    className="absolute top-0 left-1/2 -translate-x-1/2 w-10 h-0.5 rounded-full bg-emerald-500"
+                    className="absolute top-0 left-1/2 -translate-x-1/2 w-10 h-0.5 rounded-full bg-emerald-500 motion-safe:animate-scale-in"
                     aria-hidden
                   />
                 )}
                 <span
                   className={cn(
-                    "flex items-center justify-center w-8 h-6 rounded-lg transition-colors",
-                    active && "bg-emerald-500/12",
+                    "flex items-center justify-center w-8 h-6 rounded-lg transition-all duration-200 ease-smooth",
+                    active && "bg-emerald-500/12 motion-safe:animate-scale-in",
                   )}
                 >
                   {NAV_ICONS[item.id]}

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -87,7 +87,7 @@ export function ManualExpenseSheet({ open, onClose, onSave, initialExpense }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm motion-safe:animate-fade-in">
       <div
         className="w-full max-w-lg bg-panel rounded-t-3xl p-5 pb-safe-area-bottom space-y-4 animate-slide-up"
         style={{ marginBottom: kbInsetPx }}
@@ -182,10 +182,10 @@ export function ManualExpenseSheet({ open, onClose, onSave, initialExpense }) {
                 <button
                   key={cat}
                   onClick={() => setForm((f) => ({ ...f, category: cat }))}
-                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 ease-smooth active:scale-95 ${
                     form.category === cat
-                      ? "bg-emerald-500 text-white border-emerald-500"
-                      : "bg-panelHi text-muted border-line hover:border-muted/50"
+                      ? "bg-emerald-500 text-white border-emerald-500 shadow-sm"
+                      : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
                   }`}
                 >
                   {cat}

--- a/src/shared/components/ui/ConfirmDialog.jsx
+++ b/src/shared/components/ui/ConfirmDialog.jsx
@@ -38,7 +38,7 @@ export function ConfirmDialog({
     >
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-text/40 backdrop-blur-sm"
+        className="absolute inset-0 bg-text/40 backdrop-blur-sm motion-safe:animate-fade-in"
         onClick={onCancel}
         aria-hidden
       />

--- a/src/shared/components/ui/Toast.jsx
+++ b/src/shared/components/ui/Toast.jsx
@@ -8,6 +8,13 @@ const VARIANT = {
   info: "bg-primary text-white",
 };
 
+const ICON_WRAP = {
+  success: "motion-safe:animate-check-pop",
+  error: "",
+  warning: "",
+  info: "",
+};
+
 const ICON = {
   success: (
     <svg
@@ -98,7 +105,14 @@ export function ToastContainer() {
           )}
           role="alert"
         >
-          {ICON[t.type]}
+          <span
+            className={cn(
+              "shrink-0 inline-flex items-center justify-center",
+              ICON_WRAP[t.type],
+            )}
+          >
+            {ICON[t.type]}
+          </span>
           <span className="min-w-0 flex-1 leading-snug">{t.msg}</span>
           {t.action?.onClick && (
             <button


### PR DESCRIPTION
## Summary

Мінімальні, якісні UX-покращення у Finyk-флоу (додавання витрати, видалення, навігація) без редизайну та без зміни логіки. Використовуються лише вже існуючі анімації з `tailwind.config.js` (`fade-in`, `slide-up`, `scale-in`, `check-pop`) — нові keyframes не додавалися. Усі нові анімації обмежені `motion-safe:` префіксом, тож користувачі з `prefers-reduced-motion` їх не побачать.

### Що змінилося

**Навігація (bottom nav → перемикання сторінок)**
- Контент сторінки плавно `fade-in` при зміні вкладки (обгортка з `key={page}`).
- Tap-фідбек на кнопках нижньої навігації: `active:scale-95` + smooth-транзишн.
- Активний індикатор (підкладка іконки + верхня риска) з’являється з `animate-scale-in`.

**Додавання витрати (ManualExpenseSheet + FAB)**
- FAB: додано `hover:scale-105`, `hover:shadow-xl`, `focus-visible:ring`, smooth easing. Залишено наявні `active:scale-95` та колірні стани.
- Backdrop bottom-sheet’у фейдиться разом з появою (sheet вже мав `animate-slide-up`).
- Категорійні «пігулки» отримали `active:scale-95` + `shadow-sm` у вибраному стані та плавний перехід між станами.

**Видалення + success feedback**
- Тост-повідомлення типу `success` тепер пульсує check-іконкою (`animate-check-pop`) — приємний сигнал після додавання/оновлення/undo видалення витрати.
- Backdrop `ConfirmDialog` фейдиться (sheet вже мав `slide-in-from-bottom-4`).

### Що НЕ змінювалося
- Логіка додавання / редагування / видалення витрат.
- Роутінг (`useHashRouter`), storage-хуки, тости-API.
- Дизайн-токени, кольори, розміри, типографіка.

### Ризик
Зелений — лише додані класи Tailwind (animation/transition/scale/focus-ring) та одна обгортка-`div` над контентом сторінок для keyed fade-in. Тести, типчек, лінт і білд пройдено локально.

## Review & Testing Checklist for Human

- [ ] Перевірити перемикання вкладок нижньої навігації: контент має плавно з’являтися без різких стрибків, активний індикатор виникає м’яко.
- [ ] Додати ручну витрату з FAB → побачити toast «Витрату додано!» з лагідною check-pop анімацією на іконці.
- [ ] Видалити ручну витрату свайпом вліво → з’являється toast «Витрату видалено» з кнопкою Undo; Undo повертає транзакцію.
- [ ] На мобільному (або вузькому вікні) натискання по нижньому меню / FAB / категорійних пігулках дає легкий scale-фідбек без «смикання».
- [ ] Увімкнути OS `prefers-reduced-motion` → нові fade/scale анімації не програються (завдяки `motion-safe:`), UI залишається функціональним.

### Notes
Нових keyframes/CSS-варіантів не додавалося — лише вже визначені у `tailwind.config.js` (`fade-in`, `scale-in`, `check-pop`).

Link to Devin session: https://app.devin.ai/sessions/82185ffd9e194c29bbc66d25cd6ef869
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
