### PR TITLE
Daily Finyk summary + soft reminders on hub dashboard

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -169,8 +169,16 @@ function AppInner() {
   // модуль+hash без прокидування `onOpenModule` через дерево.
   useEffect(() => {
     const onHubOpen = (ev) => {
-      const { module, hash } = ev.detail || {};
+      const { module, hash, action } = ev.detail || {};
       if (!VALID_MODULES.has(module)) return;
+      if (action && VALID_ACTIONS.has(action)) {
+        try {
+          localStorage.setItem(PWA_ACTION_KEY, action);
+        } catch {
+          /* noop */
+        }
+        setPwaAction(action);
+      }
       openModule(module, hash ? { hash } : undefined);
     };
     window.addEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);

--- a/src/core/DailyFinykSummaryCard.jsx
+++ b/src/core/DailyFinykSummaryCard.jsx
@@ -1,0 +1,322 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { openHubModule, openHubModuleWithAction } from "@shared/lib/hubNav";
+import {
+  computeDailyFinykSummary,
+  DAILY_SUMMARY_DISMISS_KEY,
+  isDailySummaryDismissedToday,
+} from "./lib/dailyFinykSummary.js";
+
+const STORAGE_WATCH_KEYS = new Set([
+  "finyk_tx_cache",
+  "finyk_manual_expenses_v1",
+  "finyk_tx_cats",
+  "finyk_tx_splits",
+  "finyk_hidden_txs",
+  "finyk_custom_cats_v1",
+  "hub_routine_v1",
+  "fizruk_workouts_v1",
+  "nutrition_log_v1",
+  DAILY_SUMMARY_DISMISS_KEY,
+]);
+
+function formatUAH(n) {
+  return `${Math.round(n).toLocaleString("uk-UA")} ₴`;
+}
+
+function CoinsIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="8" cy="8" r="6" />
+      <path d="M18.09 10.37A6 6 0 1 1 10.34 18" />
+      <path d="M7 6h1v4" />
+      <path d="M16.71 13.88l.7.71-2.82 2.82" />
+    </svg>
+  );
+}
+
+function PlusIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function CloseIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function requestAddExpense() {
+  openHubModuleWithAction("finyk", "add_expense");
+}
+
+function useDailySummary() {
+  const [summary, setSummary] = useState(() => computeDailyFinykSummary());
+  const [dismissed, setDismissed] = useState(() =>
+    isDailySummaryDismissedToday(),
+  );
+
+  const refresh = useCallback(() => {
+    setSummary(computeDailyFinykSummary());
+    setDismissed(isDailySummaryDismissedToday());
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === null || STORAGE_WATCH_KEYS.has(e.key)) refresh();
+    };
+    window.addEventListener("storage", onStorage);
+
+    // Легке автооновлення кожні 5 хв, щоб ранішній стан змінився на вечірній
+    // (наприклад, reminder_no_expenses після 18:00) без перезавантаження.
+    const id = setInterval(refresh, 5 * 60 * 1000);
+
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  const dismissToday = useCallback(() => {
+    const todayKey = computeDailyFinykSummary().todayKey;
+    safeWriteLS(DAILY_SUMMARY_DISMISS_KEY, {
+      date: todayKey,
+      at: Date.now(),
+    });
+    setDismissed(true);
+  }, []);
+
+  return { summary, dismissed, dismissToday, refresh };
+}
+
+function Header({ eyebrow, title, onDismiss, dismissLabel }) {
+  return (
+    <div className="flex items-start justify-between gap-2 mb-2">
+      <div className="min-w-0">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-brand-600/80 dark:text-brand-400/80">
+          {eyebrow}
+        </p>
+        <h3 className="text-base font-bold text-text leading-snug">{title}</h3>
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={dismissLabel || "Згорнути до завтра"}
+          title={dismissLabel || "Згорнути до завтра"}
+          className={cn(
+            "shrink-0 w-7 h-7 rounded-lg flex items-center justify-center",
+            "text-muted hover:text-text",
+            "hover:bg-line/40 dark:hover:bg-white/5 transition-colors",
+          )}
+        >
+          <CloseIcon />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function HasExpensesContent({ summary }) {
+  const { todaySpent, topCategory, txCount } = summary;
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2">
+        <span className="text-3xl font-bold tabular-nums text-text leading-none">
+          {formatUAH(todaySpent)}
+        </span>
+        <span className="text-xs text-muted pb-1">
+          {txCount} {txCount === 1 ? "запис" : "записів"}
+        </span>
+      </div>
+
+      {topCategory && (
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2",
+            "rounded-xl border border-brand-100/60 bg-white/60 dark:bg-white/5 dark:border-brand-800/30",
+            "px-3 py-2",
+          )}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+              Топ категорія
+            </span>
+            <span className="text-sm font-medium text-text truncate">
+              {topCategory.label}
+            </span>
+          </div>
+          <div className="text-right shrink-0">
+            <div className="text-sm font-semibold tabular-nums text-text">
+              {formatUAH(topCategory.amount)}
+            </div>
+            <div className="text-[10px] text-muted">{topCategory.pct}%</div>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={requestAddExpense}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
+            "bg-brand-500 hover:bg-brand-600 active:bg-brand-700",
+            "text-white text-xs font-semibold transition-colors",
+          )}
+        >
+          <PlusIcon />
+          Додати витрату
+        </button>
+        <button
+          type="button"
+          onClick={() => openHubModule("finyk")}
+          className={cn(
+            "inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg",
+            "text-xs font-medium text-muted hover:text-text",
+            "hover:bg-line/40 dark:hover:bg-white/5 transition-colors",
+          )}
+        >
+          Відкрити Фінік →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ReminderContent({ kind }) {
+  const copy = kind === "reminder_active_day"
+    ? {
+        text: "Активний день — не забудь зафіксувати витрати. Хочеш додати зараз?",
+      }
+    : kind === "reminder_no_expenses"
+      ? {
+          text: "Сьогодні витрат ще не було. Якщо щось витратив — пара секунд на запис.",
+        }
+      : {
+          text: "Сьогодні витрат ще не було. Додавай їх, коли зручно.",
+        };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-text/90 leading-relaxed">{copy.text}</p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={requestAddExpense}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
+            "bg-brand-500 hover:bg-brand-600 active:bg-brand-700",
+            "text-white text-xs font-semibold transition-colors",
+          )}
+        >
+          <PlusIcon />
+          Додати витрату
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function DailyFinykSummaryCard() {
+  const { summary, dismissed, dismissToday } = useDailySummary();
+
+  // Додатковий guard: якщо користувач ховав цей блок з hub-prefs — поважаємо.
+  const hubPrefs = useMemo(() => safeReadLS("hub_prefs_v1", {}) || {}, []);
+  if (hubPrefs.showDailyFinykSummary === false) return null;
+
+  if (summary.status === "hidden") return null;
+  if (dismissed) return null;
+
+  const showReminder =
+    summary.status === "reminder_no_expenses" ||
+    summary.status === "reminder_active_day" ||
+    summary.status === "quiet";
+
+  const eyebrow = "Фінік · сьогодні";
+  const title = summary.status === "has_expenses"
+    ? formatUAH(summary.todaySpent)
+    : summary.status === "reminder_active_day"
+      ? "Активний день"
+      : summary.status === "reminder_no_expenses"
+        ? "Нагадування про витрати"
+        : "Сьогодні";
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-2xl border p-4",
+        "bg-gradient-to-br from-brand-50/80 to-teal-50/40",
+        "dark:from-brand-900/20 dark:to-teal-900/10",
+        "border-brand-100/60 dark:border-brand-800/30",
+        "shadow-card",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
+            "bg-white/70 dark:bg-white/10 text-brand-600 dark:text-brand-400",
+            "shadow-sm",
+          )}
+        >
+          <CoinsIcon />
+        </div>
+        <div className="flex-1 min-w-0">
+          <Header
+            eyebrow={eyebrow}
+            title={summary.status === "has_expenses" ? "Витрати за сьогодні" : title}
+            onDismiss={dismissToday}
+          />
+
+          {summary.status === "has_expenses" && (
+            <HasExpensesContent summary={summary} />
+          )}
+
+          {showReminder && <ReminderContent kind={summary.status} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/core/DailyFinykSummaryCard.jsx
+++ b/src/core/DailyFinykSummaryCard.jsx
@@ -226,17 +226,18 @@ function HasExpensesContent({ summary }) {
 }
 
 function ReminderContent({ kind }) {
-  const copy = kind === "reminder_active_day"
-    ? {
-        text: "Активний день — не забудь зафіксувати витрати. Хочеш додати зараз?",
-      }
-    : kind === "reminder_no_expenses"
+  const copy =
+    kind === "reminder_active_day"
       ? {
-          text: "Сьогодні витрат ще не було. Якщо щось витратив — пара секунд на запис.",
+          text: "Активний день — не забудь зафіксувати витрати. Хочеш додати зараз?",
         }
-      : {
-          text: "Сьогодні витрат ще не було. Додавай їх, коли зручно.",
-        };
+      : kind === "reminder_no_expenses"
+        ? {
+            text: "Сьогодні витрат ще не було. Якщо щось витратив — пара секунд на запис.",
+          }
+        : {
+            text: "Сьогодні витрат ще не було. Додавай їх, коли зручно.",
+          };
 
   return (
     <div className="space-y-3">
@@ -275,13 +276,14 @@ export function DailyFinykSummaryCard() {
     summary.status === "quiet";
 
   const eyebrow = "Фінік · сьогодні";
-  const title = summary.status === "has_expenses"
-    ? formatUAH(summary.todaySpent)
-    : summary.status === "reminder_active_day"
-      ? "Активний день"
-      : summary.status === "reminder_no_expenses"
-        ? "Нагадування про витрати"
-        : "Сьогодні";
+  const title =
+    summary.status === "has_expenses"
+      ? formatUAH(summary.todaySpent)
+      : summary.status === "reminder_active_day"
+        ? "Активний день"
+        : summary.status === "reminder_no_expenses"
+          ? "Нагадування про витрати"
+          : "Сьогодні";
 
   return (
     <div
@@ -306,7 +308,9 @@ export function DailyFinykSummaryCard() {
         <div className="flex-1 min-w-0">
           <Header
             eyebrow={eyebrow}
-            title={summary.status === "has_expenses" ? "Витрати за сьогодні" : title}
+            title={
+              summary.status === "has_expenses" ? "Витрати за сьогодні" : title
+            }
             onDismiss={dismissToday}
           />
 

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -7,6 +7,7 @@ import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { HubRecommendations } from "./HubRecommendations.jsx";
 import { WeeklyDigestCard } from "./WeeklyDigestCard.jsx";
 import { CoachInsightCard } from "./CoachInsightCard.jsx";
+import { DailyFinykSummaryCard } from "./DailyFinykSummaryCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
 import {
   DndContext,
@@ -623,6 +624,9 @@ export function HubDashboard({ onOpenModule, onOpenChat }) {
     <div className="space-y-5">
       {/* Daily Progress Hero */}
       <DailyProgressHero />
+
+      {/* Daily Finyk Summary (today's spend + top category, soft reminders) */}
+      <DailyFinykSummaryCard />
 
       {/* Smart Recommendations */}
       <HubRecommendations onOpenModule={onOpenModule} />

--- a/src/core/lib/dailyFinykSummary.js
+++ b/src/core/lib/dailyFinykSummary.js
@@ -178,9 +178,8 @@ export function computeDailyFinykSummary({
   })();
   const txCategories = readLS("finyk_tx_cats", {}) || {};
   const txSplitsRaw = readLS("finyk_tx_splits", {}) || {};
-  const txSplits = txSplitsRaw && typeof txSplitsRaw === "object"
-    ? txSplitsRaw
-    : {};
+  const txSplits =
+    txSplitsRaw && typeof txSplitsRaw === "object" ? txSplitsRaw : {};
   const hiddenIds = new Set(readLS("finyk_hidden_txs", []) || []);
   const customCategories = readLS("finyk_custom_cats_v1", []) || [];
   const transferIds = new Set(
@@ -239,9 +238,7 @@ export function computeDailyFinykSummary({
   if (catEntries.length > 0 && todaySpent > 0) {
     const [catId, amount] = catEntries[0];
     const roundedAmount = Math.round(amount);
-    const pct = todaySpent > 0
-      ? Math.round((amount / todaySpent) * 100)
-      : 0;
+    const pct = todaySpent > 0 ? Math.round((amount / todaySpent) * 100) : 0;
     topCategory = {
       id: catId,
       label: resolveCatLabel(catId, customCategories),

--- a/src/core/lib/dailyFinykSummary.js
+++ b/src/core/lib/dailyFinykSummary.js
@@ -1,0 +1,314 @@
+/**
+ * Підрахунок щоденного зведення по Фініку (витрати за сьогодні + топ-категорія)
+ * та легкі "sticky" сигнали для Hub-дашборду.
+ *
+ * Чиста функція: приймає `now` та `readLS` (за замовчуванням — localStorage),
+ * не має побічних ефектів, легко тестується без дата-mocking.
+ *
+ * Дизайн-принципи нагадувань (м'які, не токсичні, без гейміфікації):
+ * - ніколи не показуємо reminder новим користувачам (без історії витрат)
+ * - reminder про "активний день без записів" з'являється лише якщо в інших
+ *   модулях (routine/fizruk/nutrition) вже є активність сьогодні — тобто
+ *   користувач явно в застосунку, але витрати забув
+ * - reminder "не додано витрат сьогодні" активується лише з вечора (>=18:00)
+ *   і лише якщо у користувача є регулярність (витрати принаймні у 3 з
+ *   останніх 7 днів) — щоб не набридати нерегулярним користувачам
+ * - усі нагадування dismissible на один день
+ */
+
+import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants.js";
+
+const ALL_CATS = [...MCC_CATEGORIES, ...INCOME_CATEGORIES];
+
+const BUILTIN_LABELS = {
+  food: "🛒 Продукти",
+  cafe: "🍽️ Кафе та ресторани",
+  transport: "🚗 Транспорт",
+  entertainment: "🎭 Розваги",
+  health: "⚕️ Здоров'я",
+  shopping: "🛍️ Покупки",
+  utilities: "💡 Комунальні",
+  other: "💳 Інше",
+};
+
+export const DAILY_SUMMARY_DISMISS_KEY = "hub_daily_finyk_dismissed_v1";
+
+function defaultReadLS(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return fallback;
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function localDateKey(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function resolveCatLabel(catIdOrMcc, customCategories) {
+  if (!catIdOrMcc || catIdOrMcc === "other") return BUILTIN_LABELS.other;
+  const str = String(catIdOrMcc);
+  const byId = [...ALL_CATS, ...(customCategories || [])].find(
+    (c) => c.id === str,
+  );
+  if (byId) return byId.label ?? byId.name ?? str;
+  if (BUILTIN_LABELS[str]) return BUILTIN_LABELS[str];
+  const mcc = Number(str);
+  if (Number.isFinite(mcc) && mcc > 0) {
+    const byMcc = MCC_CATEGORIES.find(
+      (c) => Array.isArray(c.mccs) && c.mccs.includes(mcc),
+    );
+    if (byMcc) return byMcc.label;
+  }
+  return str;
+}
+
+function txTimestampMs(tx) {
+  const t = Number(tx?.time);
+  if (!Number.isFinite(t)) return NaN;
+  return t > 1e10 ? t : t * 1000;
+}
+
+function toDayKeyFromTs(ts) {
+  const d = new Date(ts);
+  if (!Number.isFinite(d.getTime())) return null;
+  return localDateKey(d);
+}
+
+/**
+ * Повертає набір ключів днів (YYYY-MM-DD), в які користувач додавав витрати
+ * протягом останніх `days` днів (не враховуючи сьогодні).
+ */
+function collectExpenseDaysWithin(
+  { bankTxs, manualExpenses, hiddenIds, transferIds },
+  todayKey,
+  days,
+) {
+  const keys = new Set();
+  const now = Date.now();
+  const minMs = now - days * 86_400_000;
+
+  for (const tx of bankTxs) {
+    if (!tx || (tx.amount ?? 0) >= 0) continue;
+    if (hiddenIds.has(tx.id) || transferIds.has(tx.id)) continue;
+    const ms = txTimestampMs(tx);
+    if (!Number.isFinite(ms) || ms < minMs) continue;
+    const key = toDayKeyFromTs(ms);
+    if (key && key !== todayKey) keys.add(key);
+  }
+
+  for (const me of manualExpenses) {
+    const d = me?.date ? new Date(`${me.date}T00:00:00`) : null;
+    if (!d || !Number.isFinite(d.getTime())) continue;
+    if (d.getTime() < minMs) continue;
+    const key = localDateKey(d);
+    if (key !== todayKey) keys.add(key);
+  }
+
+  return keys;
+}
+
+function isActivityTodayFromModules(now, readLS) {
+  const todayKey = localDateKey(now);
+
+  // Routine: будь-яка звичка позначена сьогодні
+  const routine = readLS("hub_routine_v1", null);
+  if (routine && Array.isArray(routine.habits) && routine.completions) {
+    for (const h of routine.habits) {
+      if (h?.archived) continue;
+      const arr = routine.completions[h.id];
+      if (Array.isArray(arr) && arr.includes(todayKey)) return true;
+    }
+  }
+
+  // Fizruk: тренування, що почалось сьогодні
+  const workoutsRaw = readLS("fizruk_workouts_v1", null);
+  const workouts = Array.isArray(workoutsRaw)
+    ? workoutsRaw
+    : Array.isArray(workoutsRaw?.workouts)
+      ? workoutsRaw.workouts
+      : [];
+  for (const w of workouts) {
+    if (!w?.startedAt) continue;
+    const ts = new Date(w.startedAt);
+    if (!Number.isFinite(ts.getTime())) continue;
+    if (localDateKey(ts) === todayKey) return true;
+  }
+
+  // Nutrition: щонайменше один прийом їжі сьогодні
+  const log = readLS("nutrition_log_v1", null);
+  const meals = log?.[todayKey]?.meals;
+  if (Array.isArray(meals) && meals.length > 0) return true;
+
+  return false;
+}
+
+/**
+ * Основна функція. Повертає опис того, що показати на дашборді.
+ *
+ * Можливі значення `status`:
+ * - `hidden`       — картку взагалі не показуємо (новий користувач без історії)
+ * - `has_expenses` — є витрати сьогодні, показуємо суму + топ-категорію
+ * - `quiet`        — витрат сьогодні нема, користувач нерегулярний, показуємо
+ *                    просто neutral-стан ("Сьогодні витрат ще не було")
+ * - `reminder_no_expenses` — м'яке нагадування: увечері, користувач регулярний
+ * - `reminder_active_day`  — є активність в інших модулях, але фіністс пустий
+ */
+export function computeDailyFinykSummary({
+  now = new Date(),
+  readLS = defaultReadLS,
+} = {}) {
+  const todayKey = localDateKey(now);
+  const hour = now.getHours();
+
+  const txCache = readLS("finyk_tx_cache", null);
+  const bankTxs = Array.isArray(txCache?.txs)
+    ? txCache.txs
+    : Array.isArray(txCache)
+      ? txCache
+      : [];
+  const manualExpenses = (() => {
+    const v = readLS("finyk_manual_expenses_v1", []);
+    return Array.isArray(v) ? v : [];
+  })();
+  const txCategories = readLS("finyk_tx_cats", {}) || {};
+  const txSplitsRaw = readLS("finyk_tx_splits", {}) || {};
+  const txSplits = txSplitsRaw && typeof txSplitsRaw === "object"
+    ? txSplitsRaw
+    : {};
+  const hiddenIds = new Set(readLS("finyk_hidden_txs", []) || []);
+  const customCategories = readLS("finyk_custom_cats_v1", []) || [];
+  const transferIds = new Set(
+    Object.entries(txCategories)
+      .filter(([, v]) => v === "internal_transfer")
+      .map(([k]) => k),
+  );
+
+  // ── Агрегація сьогоднішніх витрат ────────────────────────────────────────
+  let todaySpent = 0;
+  let txCount = 0;
+  const catAmounts = {};
+
+  for (const tx of bankTxs) {
+    if (!tx || (tx.amount ?? 0) >= 0) continue;
+    if (hiddenIds.has(tx.id) || transferIds.has(tx.id)) continue;
+    const ms = txTimestampMs(tx);
+    if (!Number.isFinite(ms)) continue;
+    if (localDateKey(new Date(ms)) !== todayKey) continue;
+
+    const splits = Array.isArray(txSplits[tx.id]) ? txSplits[tx.id] : null;
+    if (splits && splits.length > 0) {
+      for (const s of splits) {
+        if (!s || !s.categoryId || s.categoryId === "internal_transfer") {
+          continue;
+        }
+        const amt = Math.abs(Number(s.amount) || 0);
+        if (amt <= 0) continue;
+        todaySpent += amt;
+        catAmounts[s.categoryId] = (catAmounts[s.categoryId] || 0) + amt;
+      }
+      txCount++;
+    } else {
+      const amt = Math.abs(tx.amount / 100);
+      todaySpent += amt;
+      const catId = txCategories[tx.id] || tx.mcc || "other";
+      const key = String(catId);
+      catAmounts[key] = (catAmounts[key] || 0) + amt;
+      txCount++;
+    }
+  }
+
+  for (const me of manualExpenses) {
+    if (!me || !me.date || me.date !== todayKey) continue;
+    const amt = Math.abs(Number(me.amount) || 0);
+    if (amt <= 0) continue;
+    todaySpent += amt;
+    const key = String(me.category || "other");
+    catAmounts[key] = (catAmounts[key] || 0) + amt;
+    txCount++;
+  }
+
+  // ── Топ-категорія ────────────────────────────────────────────────────────
+  let topCategory = null;
+  const catEntries = Object.entries(catAmounts).sort(([, a], [, b]) => b - a);
+  if (catEntries.length > 0 && todaySpent > 0) {
+    const [catId, amount] = catEntries[0];
+    const roundedAmount = Math.round(amount);
+    const pct = todaySpent > 0
+      ? Math.round((amount / todaySpent) * 100)
+      : 0;
+    topCategory = {
+      id: catId,
+      label: resolveCatLabel(catId, customCategories),
+      amount: roundedAmount,
+      pct,
+    };
+  }
+
+  // ── Історія (для прийняття рішення про reminder) ─────────────────────────
+  const recentDays = collectExpenseDaysWithin(
+    { bankTxs, manualExpenses, hiddenIds, transferIds },
+    todayKey,
+    7,
+  );
+  const hasAnyHistory =
+    bankTxs.some((t) => (t?.amount ?? 0) < 0) || manualExpenses.length > 0;
+
+  if (todaySpent > 0 && topCategory) {
+    return {
+      status: "has_expenses",
+      todayKey,
+      todaySpent: Math.round(todaySpent),
+      txCount,
+      topCategory,
+    };
+  }
+
+  // Немає витрат сьогодні — вирішуємо, який meaningful state показати.
+  if (!hasAnyHistory) {
+    return { status: "hidden", todayKey, todaySpent: 0, txCount: 0 };
+  }
+
+  const activeToday = isActivityTodayFromModules(now, readLS);
+  const isRegular = recentDays.size >= 3;
+  const isEvening = hour >= 18;
+
+  if (activeToday) {
+    return {
+      status: "reminder_active_day",
+      todayKey,
+      todaySpent: 0,
+      txCount: 0,
+    };
+  }
+
+  if (isRegular && isEvening) {
+    return {
+      status: "reminder_no_expenses",
+      todayKey,
+      todaySpent: 0,
+      txCount: 0,
+    };
+  }
+
+  return {
+    status: "quiet",
+    todayKey,
+    todaySpent: 0,
+    txCount: 0,
+  };
+}
+
+export function isDailySummaryDismissedToday({
+  now = new Date(),
+  readLS = defaultReadLS,
+} = {}) {
+  const todayKey = localDateKey(now);
+  const v = readLS(DAILY_SUMMARY_DISMISS_KEY, null);
+  return Boolean(v && v.date === todayKey);
+}

--- a/src/core/lib/dailyFinykSummary.test.js
+++ b/src/core/lib/dailyFinykSummary.test.js
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  computeDailyFinykSummary,
+  isDailySummaryDismissedToday,
+  DAILY_SUMMARY_DISMISS_KEY,
+} from "./dailyFinykSummary.js";
+
+function setLS(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+function clearAll() {
+  localStorage.clear();
+}
+
+function ts(date) {
+  return Math.floor(date.getTime() / 1000);
+}
+
+function makeNow() {
+  // Фіксуємо момент часу "сьогодні 20:00" — достатньо для reminder_no_expenses
+  const n = new Date();
+  n.setHours(20, 0, 0, 0);
+  return n;
+}
+
+describe("computeDailyFinykSummary", () => {
+  beforeEach(clearAll);
+  afterEach(clearAll);
+
+  it("повертає `hidden` якщо немає жодної історії витрат", () => {
+    const r = computeDailyFinykSummary({ now: makeNow() });
+    expect(r.status).toBe("hidden");
+  });
+
+  it("рахує сьогоднішні витрати з банківських транзакцій", () => {
+    const now = makeNow();
+    const todayTs = ts(now);
+    setLS("finyk_tx_cache", {
+      txs: [
+        {
+          id: "t1",
+          amount: -25000, // 250 грн
+          time: todayTs,
+          mcc: 5411,
+          description: "Сільпо",
+        },
+        {
+          id: "t2",
+          amount: -15000, // 150 грн
+          time: todayTs - 60,
+          mcc: 5812,
+          description: "Кафе",
+        },
+      ],
+    });
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.status).toBe("has_expenses");
+    expect(r.todaySpent).toBe(400);
+    expect(r.txCount).toBe(2);
+    expect(r.topCategory).toBeDefined();
+    expect(r.topCategory.amount).toBe(250);
+    expect(r.topCategory.pct).toBe(63);
+  });
+
+  it("рахує також ручні витрати (finyk_manual_expenses_v1)", () => {
+    const now = makeNow();
+    const todayKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    setLS("finyk_manual_expenses_v1", [
+      { id: "m1", amount: 100, category: "food", date: todayKey },
+      { id: "m2", amount: 50, category: "transport", date: todayKey },
+    ]);
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.status).toBe("has_expenses");
+    expect(r.todaySpent).toBe(150);
+    expect(r.topCategory.id).toBe("food");
+  });
+
+  it("ігнорує внутрішні перекази (internal_transfer)", () => {
+    const now = makeNow();
+    const todayTs = ts(now);
+    setLS("finyk_tx_cache", {
+      txs: [
+        { id: "tr1", amount: -50000, time: todayTs },
+        { id: "t2", amount: -10000, time: todayTs, mcc: 5411 },
+      ],
+    });
+    setLS("finyk_tx_cats", { tr1: "internal_transfer", t2: "food" });
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.todaySpent).toBe(100);
+    expect(r.txCount).toBe(1);
+  });
+
+  it("ігнорує приховані транзакції (finyk_hidden_txs)", () => {
+    const now = makeNow();
+    const todayTs = ts(now);
+    setLS("finyk_tx_cache", {
+      txs: [
+        { id: "t1", amount: -20000, time: todayTs, mcc: 5411 },
+        { id: "t2", amount: -10000, time: todayTs, mcc: 5411 },
+      ],
+    });
+    setLS("finyk_hidden_txs", ["t1"]);
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.todaySpent).toBe(100);
+  });
+
+  it("ігнорує транзакції з інших днів", () => {
+    const now = makeNow();
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "t1", amount: -50000, time: ts(yesterday), mcc: 5411 }],
+    });
+
+    const r = computeDailyFinykSummary({ now });
+    // Історія є, але сьогодні пусто → не `hidden`; залежить від інших умов
+    expect(r.todaySpent).toBe(0);
+    expect(["quiet", "reminder_no_expenses", "reminder_active_day"]).toContain(
+      r.status,
+    );
+  });
+
+  it("повертає `reminder_no_expenses` увечері якщо користувач регулярний", () => {
+    const now = makeNow();
+    // 4 дні з витратами за останні 7 днів
+    const txs = [];
+    for (let i = 1; i <= 4; i++) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      txs.push({ id: `t${i}`, amount: -10000, time: ts(d), mcc: 5411 });
+    }
+    setLS("finyk_tx_cache", { txs });
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.status).toBe("reminder_no_expenses");
+  });
+
+  it("повертає `quiet` зранку навіть для регулярних (щоб не набридати)", () => {
+    const morning = new Date();
+    morning.setHours(9, 0, 0, 0);
+    const txs = [];
+    for (let i = 1; i <= 4; i++) {
+      const d = new Date(morning);
+      d.setDate(d.getDate() - i);
+      txs.push({ id: `t${i}`, amount: -10000, time: ts(d), mcc: 5411 });
+    }
+    setLS("finyk_tx_cache", { txs });
+
+    const r = computeDailyFinykSummary({ now: morning });
+    expect(r.status).toBe("quiet");
+  });
+
+  it("повертає `reminder_active_day` якщо є активність в інших модулях", () => {
+    const now = makeNow();
+    const todayKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    // Історія Фініка (щоб не був `hidden`), але без транзакцій сьогодні
+    const yest = new Date(now);
+    yest.setDate(yest.getDate() - 1);
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "t1", amount: -10000, time: ts(yest), mcc: 5411 }],
+    });
+    // Routine: звичка позначена сьогодні
+    setLS("hub_routine_v1", {
+      habits: [{ id: "h1", name: "Читати" }],
+      completions: { h1: [todayKey] },
+    });
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.status).toBe("reminder_active_day");
+  });
+
+  it("не реагує на завтрашні дати", () => {
+    const now = makeNow();
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "t1", amount: -50000, time: ts(tomorrow), mcc: 5411 }],
+    });
+
+    const r = computeDailyFinykSummary({ now });
+    expect(r.todaySpent).toBe(0);
+  });
+
+  it("не падає на битих даних у localStorage", () => {
+    localStorage.setItem("finyk_tx_cache", "не-json");
+    const r = computeDailyFinykSummary({ now: makeNow() });
+    expect(r.status).toBe("hidden");
+  });
+});
+
+describe("isDailySummaryDismissedToday", () => {
+  beforeEach(clearAll);
+  afterEach(clearAll);
+
+  it("повертає false за замовчуванням", () => {
+    expect(isDailySummaryDismissedToday()).toBe(false);
+  });
+
+  it("повертає true якщо сьогодні був dismiss", () => {
+    const now = new Date();
+    const todayKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    setLS(DAILY_SUMMARY_DISMISS_KEY, { date: todayKey, at: Date.now() });
+    expect(isDailySummaryDismissedToday({ now })).toBe(true);
+  });
+
+  it("повертає false якщо dismiss був вчора", () => {
+    const now = new Date();
+    const yest = new Date(now);
+    yest.setDate(yest.getDate() - 1);
+    const yKey = `${yest.getFullYear()}-${String(yest.getMonth() + 1).padStart(2, "0")}-${String(yest.getDate()).padStart(2, "0")}`;
+    setLS(DAILY_SUMMARY_DISMISS_KEY, { date: yKey, at: Date.now() });
+    expect(isDailySummaryDismissedToday({ now })).toBe(false);
+  });
+});

--- a/src/shared/lib/hubNav.js
+++ b/src/shared/lib/hubNav.js
@@ -31,3 +31,25 @@ export function openHubModule(moduleId, hash) {
     /* noop — SSR / disabled CustomEvent */
   }
 }
+
+const VALID_HUB_ACTIONS = new Set(["add_expense", "start_workout", "add_meal"]);
+
+/**
+ * Відкрити модуль із запитом на дію (така ж семантика як у PWA shortcuts).
+ * Використовується, напр., для кнопки "Додати витрату" на hub-дашборді.
+ * @param {"finyk"|"fizruk"|"routine"|"nutrition"} moduleId
+ * @param {"add_expense"|"start_workout"|"add_meal"} action
+ */
+export function openHubModuleWithAction(moduleId, action) {
+  if (!VALID_HUB_MODULES.has(moduleId)) return;
+  if (!VALID_HUB_ACTIONS.has(action)) return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(HUB_OPEN_MODULE_EVENT, {
+        detail: { module: moduleId, hash: "", action },
+      }),
+    );
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary

Додає легкий sticky-блок на hub-дашборд, щоб користувач мав привід відкривати застосунок щодня, **без** гейміфікації, стріків чи токсичних механік.

Новий блок `DailyFinykSummaryCard` рендериться між `DailyProgressHero` та `HubRecommendations` і має 5 можливих станів, які обирає чиста функція `computeDailyFinykSummary`:

| Стан | Коли показується | Що бачить користувач |
|---|---|---|
| `has_expenses` | Є витрати за сьогодні | Сума за сьогодні + топ-категорія з % + CTA "Додати витрату" |
| `reminder_active_day` | Витрат нема, але сьогодні є активність у Routine / Fizruk / Nutrition | М'яке "Активний день — не забудь зафіксувати витрати" |
| `reminder_no_expenses` | Витрат нема, вже `>=18:00`, і користувач регулярний (витрачав у 3+ з останніх 7 днів) | "Сьогодні витрат ще не було. Пара секунд на запис." |
| `quiet` | Витрат нема, не вечір або нерегулярний | Нейтральне "Сьогодні витрат ще не було" |
| `hidden` | Новий користувач без історії | Нічого не показується |

Антиспам-гарантії:
- новим користувачам — взагалі нічого не показуємо
- reminder "немає витрат" — лише після 18:00 **і** лише для регулярних користувачів
- reminder "активний день" — лише якщо в інших модулях є підтверджена активність сьогодні
- будь-який стан можна згорнути на день кнопкою × (`hub_daily_finyk_dismissed_v1`)
- глобальний опт-аут через `hub_prefs_v1.showDailyFinykSummary = false`

Кнопка "Додати витрату" перевикористовує існуючий `add_expense` flow: новий helper `openHubModuleWithAction("finyk", "add_expense")` з `hubNav`, який App.jsx ловить і одночасно ставить `pwaAction` + відкриває Фінік. Жодних додаткових пропсів через дерево.

### Що змінено

- `src/core/lib/dailyFinykSummary.js` — чиста функція агрегації (банківські tx + ручні витрати + splits), resolver топ-категорії, правила вибору стану.
- `src/core/DailyFinykSummaryCard.jsx` — UI: іконка, заголовок-eyebrow, dismiss ×, різний контент на стан, CTA "Додати витрату" + "Відкрити Фінік →".
- `src/core/HubDashboard.jsx` — вставка картки у дашборд.
- `src/shared/lib/hubNav.js` + `src/core/App.jsx` — `openHubModuleWithAction` + обробник у головному слухачі `HUB_OPEN_MODULE_EVENT`.
- `src/core/lib/dailyFinykSummary.test.js` — 14 unit-тестів (усі стани, граничні випадки, ігнор переказів / прихованих / чужих днів).

### CI / перевірки локально
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — **453 passed**
- `npm run build` — pass

## Review & Testing Checklist for Human

- [ ] Відкрити hub-дашборд як новий користувач (чистий localStorage) — картка НЕ повинна з'являтися
- [ ] Додати одну ручну витрату сьогодні через Фінік → на hub'і з'явиться сума + топ-категорія
- [ ] Натиснути "Додати витрату" на картці — відкривається ManualExpenseSheet у Фініку
- [ ] Тапнути × на картці → зникає до наступного дня, після зміни дати в системі повертається
- [ ] (Опційно) Перевести годинник на `>=18:00` з витратами 3+ днів в останньому тижні і без витрат сьогодні — має зʼявитися варіант "Нагадування про витрати"

### Notes

- Активність у інших модулях визначається як: будь-яка habit-completion сьогодні в `hub_routine_v1`, workout з `startedAt` сьогодні у `fizruk_workouts_v1`, або `>=1` meal у `nutrition_log_v1[todayKey]`.
- Картка оновлюється через `storage` event і раз на 5 хвилин, щоб ранковий `quiet` перейшов у вечірній `reminder_no_expenses` без перезавантаження вкладки.
- Жодних нових залежностей. Усе на існуючому tailwind brand-палітру і shared storage helpers.

Link to Devin session: https://app.devin.ai/sessions/defb7ed320344849b682150b831233ef
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
