### PR TITLE
fix(fizruk): дозволити згорнути завершене тренування з активного слота

### DIFF
--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.jsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.jsx
@@ -146,6 +146,7 @@ export function ActiveWorkoutPanel({
   setRestTimer,
   onFinishClick,
   onDeleteWorkout,
+  onCollapse,
 }) {
   const dtFieldsId = useId();
   const workoutStartId = `${dtFieldsId}-started`;
@@ -735,7 +736,11 @@ export function ActiveWorkoutPanel({
     <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <div className="text-sm font-bold text-text">Активне тренування</div>
+          <div className="text-sm font-bold text-text">
+            {activeWorkout.endedAt
+              ? "Завершене тренування"
+              : "Активне тренування"}
+          </div>
           <div className="text-xs text-subtle mt-0.5">
             {new Date(activeWorkout.startedAt).toLocaleString("uk-UA", {
               month: "short",
@@ -757,6 +762,17 @@ export function ActiveWorkoutPanel({
               onClick={onFinishClick}
             >
               Завершити
+            </Button>
+          ) : onCollapse ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-9 px-4"
+              type="button"
+              onClick={onCollapse}
+              aria-label="Згорнути завершене тренування"
+            >
+              Згорнути
             </Button>
           ) : (
             <span className="text-xs text-subtle">Завершено</span>

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.jsx
@@ -11,12 +11,14 @@ function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
   // currently-selected row — so it no longer looks like it's "hanging in
   // active" after the user pressed «Завершити».
   const isEnded = Boolean(w.endedAt);
-  const isActive = !isEnded && activeWorkoutId === w.id;
+  const isSelected = activeWorkoutId === w.id;
+  const isActive = !isEnded && isSelected;
   return (
     <button
       key={w.id}
-      onClick={() => setActiveWorkoutId(w.id)}
-      className={`w-full text-left px-4 py-3 border-b border-line last:border-0 hover:bg-panelHi transition-colors${activeWorkoutId === w.id ? " bg-text/5" : ""}`}
+      onClick={() => setActiveWorkoutId(isSelected ? null : w.id)}
+      aria-pressed={isSelected}
+      className={`w-full text-left px-4 py-3 border-b border-line last:border-0 hover:bg-panelHi transition-colors${isSelected ? " bg-text/5" : ""}`}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="text-sm font-semibold text-text">
@@ -183,6 +185,7 @@ export function WorkoutJournalSection({
               }, 0);
             }}
             onDeleteWorkout={() => setDeleteWorkoutConfirm(true)}
+            onCollapse={() => setActiveWorkoutId(null)}
           />
         </SectionErrorBoundary>
       )}


### PR DESCRIPTION
## Summary

Коли користувач тапав по завершеному тренуванню в списку «Останні тренування», воно відкривалось у верхній панелі «Активне тренування» і там «залипало»: не було способу його згорнути або прибрати без видалення.

Зміни у `src/modules/fizruk/`:

- `components/workouts/ActiveWorkoutPanel.jsx` — коли `activeWorkout.endedAt` встановлено:
  - заголовок панелі тепер «Завершене тренування» (а не «Активне тренування»), щоб статус не вводив в оману;
  - замість статичного тексту «Завершено» показуємо кнопку «Згорнути», яка викликає новий пропс `onCollapse`. Кнопка «Видалити» залишається без змін — видалення має бути явним.
- `components/workouts/WorkoutJournalSection.jsx`:
  - передаємо `onCollapse={() => setActiveWorkoutId(null)}` у `ActiveWorkoutPanel`;
  - у списку тренувань клік по вже виділеному рядку тепер тоггл — повторний тап по тому ж тренуванню знімає виділення і згортає панель. Для доступності додано `aria-pressed`.

Активний flow «Завершити» не чіпаю: `WorkoutJournalSection.finish.test.jsx` проходить без змін.

## Review & Testing Checklist for Human

- [ ] Відкрити Fizruk → «Тренування» → «Журнал». Натиснути на завершене тренування в «Останні тренування» — воно має відкриватись зверху з заголовком «Завершене тренування», без кнопки «Завершити», але з кнопкою «Згорнути».
- [ ] Натиснути «Згорнути» — панель має зникнути, рядок у списку розвиділитись. Тренування НЕ має зникнути зі списку (не видаляється).
- [ ] Повторний тап по тому ж рядку в списку — також згортає панель (toggle).
- [ ] Активне (незавершене) тренування поводиться як раніше: кнопка «Завершити» на місці, `onCollapse` не показується.

### Notes

- Кнопка «Видалити» свідомо залишена поруч зі «Згорнути» — це різні дії. Згорнути = сховати з активного слота, Видалити = видалити з історії.


Link to Devin session: https://app.devin.ai/sessions/50723cf5b7a34daf9a55747047594216
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
