### PR TITLE
fix(ai-quota): fail-open when quota store is unavailable

### DIFF
--- a/server/aiQuota.js
+++ b/server/aiQuota.js
@@ -21,13 +21,35 @@ function effectiveLimits() {
   };
 }
 
+async function safeSessionUser(req) {
+  try {
+    return await getSessionUser(req);
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        msg: "ai_quota_session_lookup_failed",
+        error: e?.message || String(e),
+      }),
+    );
+    return null;
+  }
+}
+
 /**
  * Перевірка та збільшення денного лічильника AI для залогіненого користувача або IP.
- * Повертає false, якщо відповідь вже відправлена (429/503).
+ * Повертає false, якщо відповідь вже відправлена (429).
+ *
+ * Квота зберігається в Postgres (ai_usage_daily). Якщо сховище тимчасово недоступне
+ * (немає DATABASE_URL, впала БД, відсутня таблиця тощо) — fail-open: пропускаємо запит
+ * і логуємо подію. Це advisory-ліміт, а не механізм безпеки: upstream (Anthropic) і
+ * роут-специфічні `checkRateLimit` все одно захищають від зловживань.
  */
 export async function assertAiQuota(req, res) {
+  if (isAiQuotaDisabled()) return true;
+
   const { user: userLimit, anon: anonLimit } = effectiveLimits();
-  const sessionUser = await getSessionUser(req);
+  const sessionUser = await safeSessionUser(req);
   const limit = sessionUser ? userLimit : anonLimit;
 
   if (limit == null) return true;
@@ -38,6 +60,12 @@ export async function assertAiQuota(req, res) {
       code: "AI_QUOTA",
     });
     return false;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    logQuotaStoreUnavailable("database_url_missing");
+    setRemainingHeader(res, "unknown");
+    return true;
   }
 
   const subject = sessionUser ? `u:${sessionUser.id}` : `ip:${getIp(req)}`;
@@ -53,26 +81,34 @@ export async function assertAiQuota(req, res) {
       });
       return false;
     }
-    try {
-      res.setHeader("X-AI-Quota-Remaining", String(result.remaining));
-    } catch {
-      /* ignore */
-    }
+    setRemainingHeader(res, String(result.remaining));
     return true;
   } catch (e) {
-    console.error(
-      JSON.stringify({
-        level: "error",
-        msg: "ai_quota_db",
-        error: e?.message || String(e),
-      }),
-    );
-    res.status(503).json({
-      error: "Не вдалося перевірити квоту AI. Спробуй пізніше.",
-      code: "AI_QUOTA_DB",
-    });
-    return false;
+    logQuotaStoreUnavailable("db_error", e);
+    // Fail-open: краще пропустити запит, ніж блокувати всі AI-фічі через збій сховища квот.
+    setRemainingHeader(res, "unknown");
+    return true;
   }
+}
+
+function setRemainingHeader(res, value) {
+  try {
+    res.setHeader("X-AI-Quota-Remaining", value);
+  } catch {
+    /* ignore */
+  }
+}
+
+function logQuotaStoreUnavailable(reason, e) {
+  console.error(
+    JSON.stringify({
+      level: "error",
+      msg: "ai_quota_store_unavailable",
+      reason,
+      error: e?.message || (e ? String(e) : undefined),
+      code: e?.code,
+    }),
+  );
 }
 
 async function consumeQuota(subject, day, limit) {

--- a/server/aiQuota.test.js
+++ b/server/aiQuota.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("./auth.js", () => ({
+  getSessionUser: vi.fn(),
+}));
+
+vi.mock("./db.js", () => {
+  const pool = { connect: vi.fn() };
+  return { default: pool, pool };
+});
+
+import { getSessionUser } from "./auth.js";
+import pool from "./db.js";
+import { assertAiQuota } from "./aiQuota.js";
+
+function makeRes() {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+function makeReq(headers = {}) {
+  return {
+    headers,
+    socket: { remoteAddress: "1.2.3.4" },
+  };
+}
+
+const ENV_VARS = [
+  "AI_QUOTA_DISABLED",
+  "AI_DAILY_USER_LIMIT",
+  "AI_DAILY_ANON_LIMIT",
+  "DATABASE_URL",
+];
+const savedEnv = {};
+
+beforeEach(() => {
+  for (const k of ENV_VARS) savedEnv[k] = process.env[k];
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const k of ENV_VARS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe("assertAiQuota", () => {
+  it("returns true (no-op) when AI_QUOTA_DISABLED=1", async () => {
+    process.env.AI_QUOTA_DISABLED = "1";
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(getSessionUser).not.toHaveBeenCalled();
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("fails open when DATABASE_URL is missing", async () => {
+    delete process.env.DATABASE_URL;
+    process.env.AI_QUOTA_DISABLED = "0";
+    getSessionUser.mockResolvedValue(null);
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["X-AI-Quota-Remaining"]).toBe("unknown");
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the quota DB call throws", async () => {
+    process.env.DATABASE_URL = "postgres://ignored";
+    process.env.AI_QUOTA_DISABLED = "0";
+    getSessionUser.mockResolvedValue(null);
+    pool.connect.mockRejectedValue(
+      Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }),
+    );
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeUndefined();
+    expect(res.headers["X-AI-Quota-Remaining"]).toBe("unknown");
+  });
+
+  it("fails open when getSessionUser throws", async () => {
+    process.env.DATABASE_URL = "postgres://ignored";
+    process.env.AI_QUOTA_DISABLED = "0";
+    getSessionUser.mockRejectedValue(new Error("auth db down"));
+    pool.connect.mockRejectedValue(new Error("db down"));
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["X-AI-Quota-Remaining"]).toBe("unknown");
+  });
+
+  it("returns 429 when daily limit is reached", async () => {
+    process.env.DATABASE_URL = "postgres://ignored";
+    process.env.AI_QUOTA_DISABLED = "0";
+    process.env.AI_DAILY_ANON_LIMIT = "2";
+    getSessionUser.mockResolvedValue(null);
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ request_count: 2 }] }) // SELECT
+      .mockResolvedValueOnce({}); // ROLLBACK
+    pool.connect.mockResolvedValue(client);
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(false);
+    expect(res.statusCode).toBe(429);
+    expect(res.body?.code).toBe("AI_QUOTA");
+  });
+
+  it("returns true and sets remaining header on success", async () => {
+    process.env.DATABASE_URL = "postgres://ignored";
+    process.env.AI_QUOTA_DISABLED = "0";
+    process.env.AI_DAILY_ANON_LIMIT = "10";
+    getSessionUser.mockResolvedValue(null);
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ request_count: 3 }] }) // SELECT
+      .mockResolvedValueOnce({}) // UPDATE
+      .mockResolvedValueOnce({}); // COMMIT
+    pool.connect.mockResolvedValue(client);
+    const res = makeRes();
+    const ok = await assertAiQuota(makeReq(), res);
+    expect(ok).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["X-AI-Quota-Remaining"]).toBe("6");
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "node",
-    include: ["src/**/*.test.{js,jsx,ts,tsx}", "server/api/**/*.test.{js,ts}"],
+    include: ["src/**/*.test.{js,jsx,ts,tsx}", "server/**/*.test.{js,ts}"],
     passWithNoTests: false,
     setupFiles: ["src/test/setup.js"],
   },


### PR DESCRIPTION
## Summary

Користувач повідомив: «пише що не вдалося перевірити квоту АІ при будь-якій дії повʼязаній з ШІ в хабі та модулях».

Причина — у `server/aiQuota.js`: якщо запит до `ai_usage_daily` у Postgres падає (БД недоступна, немає `DATABASE_URL`, не застосовано міграцію 002 тощо), `assertAiQuota` віддавав `503` з повідомленням `"Не вдалося перевірити квоту AI. Спробуй пізніше."` і блокував геть усі AI-ендпоінти (HubChat, Coach, Weekly Digest, всі nutrition-AI-ручки).

AI-квота — це advisory денний ліміт, а не механізм безпеки: у кожному AI-роуті вже є per-IP `checkRateLimit`, а вище — ліміти Anthropic. Тому вбудована деградація має бути **fail-open**, а не fail-closed.

Що зроблено у `server/aiQuota.js`:
- Якщо `AI_QUOTA_DISABLED=1` — повертаємо `true` без жодних звернень до БД/сесії.
- Якщо `DATABASE_URL` не заданий — логуємо `ai_quota_store_unavailable` / `database_url_missing`, ставимо `X-AI-Quota-Remaining: unknown` і пропускаємо запит.
- Якщо запит до `ai_usage_daily` кидає помилку — логуємо з `reason=db_error` і теж пропускаємо (замість попереднього `503 AI_QUOTA_DB`).
- `getSessionUser` обгорнули в `safeSessionUser`, щоб падіння auth-БД не підіймалося у 500 та не ламало увесь AI — просто трактуємо запит як анонімний.
- Решта логіки (ліміт 0 → `429 AI_QUOTA`, перевищення денного ліміту → `429 AI_QUOTA`, успіх → `X-AI-Quota-Remaining`) залишена без змін.

Додано `server/aiQuota.test.js` з 6 тестами: disabled, no-`DATABASE_URL`, DB throws, `getSessionUser` throws, 429 при перевищенні, success-path із лічильником. Для цього розширено `include` у `vitest.config.js` на `server/**/*.test.{js,ts}` (раніше був лише `server/api/**`).

## Review & Testing Checklist for Human

- [ ] Перевір, що після деплою AI-дії знову працюють (HubChat, `/api/coach`, `/api/weekly-digest`, будь-який `/api/nutrition/*` AI-ендпоінт) навіть якщо Postgres має якусь тимчасову проблему з `ai_usage_daily`.
- [ ] У Railway/Vercel логах шукай `ai_quota_store_unavailable` — якщо він стабільно з’являється у проді, значить міграція `002_ai_usage_daily.sql` не застосована або втрачений доступ до БД, і це треба окремо полагодити (fail-open приховує, але не лікує першопричину).
- [ ] Мануально підтвердити, що при `AI_QUOTA_DISABLED=1` і при досягненні денного ліміту поведінка не змінилася (має бути 429 `AI_QUOTA`).
- [ ] Перевір, що `X-AI-Quota-Remaining: unknown` у відповідях не ламає клієнт — ніде явно не парситься як число.

### Notes

- Семантична зміна: `AI_QUOTA_DB` 503-код більше не віддається — замість нього запит просто проходить. Якщо десь зовні (моніторинг/алерти) очікують саме цей код — треба перейти на лог `ai_quota_store_unavailable`.
- Ніякі SQL-міграції цей PR не чіпає; таблиця `ai_usage_daily` і міграція `002_*.sql` залишаються як є.


Link to Devin session: https://app.devin.ai/sessions/a4e8f6e278e14d77ab65faa3581381a7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
