### PR TITLE
fix(hub): use safeReadLS in aggregateFizruk to avoid render-path crashes

### DIFF
--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -139,16 +139,13 @@ export function aggregateFinyk(weekKey) {
 }
 
 export function aggregateFizruk(weekKey) {
-  const raw = localStorage.getItem("fizruk_workouts_v1");
-  if (!raw) return null;
-
-  let workouts = [];
-  try {
-    const p = JSON.parse(raw);
-    workouts = Array.isArray(p) ? p : (p?.workouts ?? []);
-  } catch {
-    return null;
-  }
+  // Storage shape is historically either an array or { workouts: [...] }, so
+  // we read the raw value through `safeReadLS` (handles SecurityError / quota
+  // exceptions) and then normalize.
+  const parsed = safeReadLS("fizruk_workouts_v1", null);
+  if (!parsed) return null;
+  const workouts = Array.isArray(parsed) ? parsed : (parsed?.workouts ?? []);
+  if (!Array.isArray(workouts) || workouts.length === 0) return null;
 
   const monday = new Date(`${weekKey}T00:00:00`);
   const sunday = new Date(monday);


### PR DESCRIPTION
## Summary

Follow-up на PR #120 — Devin Review справедливо помітив, що `aggregateFizruk` єдина з чотирьох `aggregate*`-функцій читає localStorage напряму через `localStorage.getItem("fizruk_workouts_v1")` без try/catch. Коли ця функція викликалась тільки всередині `generate()` — це було безпечно (там загальний try/catch). Але в PR #120 ми її експортували і почали кликати на render-path через `buildSlides → useMemo` в `WeeklyDigestStories`. У браузерах з обмеженим сховищем (SecurityError, приватний режим у деяких конфігураціях, квота) виняток тепер міг би впасти через `useMemo` і крешнути компонент.

Фікс — привести `aggregateFizruk` до того ж патерну, що й `aggregateFinyk`/`aggregateNutrition`/`aggregateRoutine`: читати через `safeReadLS`. Вона й так робить JSON.parse під власним try/catch і повертає fallback на будь-якій помилці, тож можна прибрати самописний try/catch.

## Review & Testing Checklist for Human

- [ ] Відкрити Hub → тижневий дайджест → «Переглянути як сторіс». Слайд «Тренування» має показати правильні числа (к-ть тренувань, обсяг, топ-вправи), якщо вони є в `fizruk_workouts_v1`.
- [ ] Edge case: localStorage порожній або тільки формат-`{workouts: []}` без записів — слайд Fizruk має просто не рендеритись.

### Notes

- Зовнішня поведінка не змінюється: обидва історичні формати (`Array` і `{workouts: [...]}`) далі підтримуються, як раніше.
- 481 unit-тест зелений, lint/typecheck чисті.


Link to Devin session: https://app.devin.ai/sessions/e976f46bd8884d06b99600ec0569dc29
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
