### PR TITLE
refactor(fizruk): quick wins + read-only finished workout

### DIFF
--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.jsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.jsx
@@ -154,6 +154,7 @@ export function ActiveWorkoutPanel({
   const { getDefaultForGroup } = useRestSettings();
   const [groupSelectMode, setGroupSelectMode] = useState(false);
   const [groupSelected, setGroupSelected] = useState(new Set());
+  const isReadOnly = Boolean(activeWorkout?.endedAt);
 
   const groups = useMemo(
     () => activeWorkout?.groups || [],
@@ -358,13 +359,16 @@ export function ActiveWorkoutPanel({
                 );
               })()}
             </div>
-            <button
-              type="button"
-              className="text-xs text-danger/80 hover:text-danger"
-              onClick={() => removeItem(activeWorkout.id, it.id)}
-            >
-              ✕
-            </button>
+            {!isReadOnly && (
+              <button
+                type="button"
+                className="text-xs text-danger/80 hover:text-danger"
+                onClick={() => removeItem(activeWorkout.id, it.id)}
+                aria-label="Видалити вправу з тренування"
+              >
+                ✕
+              </button>
+            )}
           </div>
 
           <div className="mt-2">
@@ -373,8 +377,9 @@ export function ActiveWorkoutPanel({
                 Тип
               </div>
               <select
-                className="w-full h-10 bg-transparent text-sm text-text outline-none"
+                className="w-full h-10 bg-transparent text-sm text-text outline-none disabled:opacity-70"
                 value={it.type || "strength"}
+                disabled={isReadOnly}
                 onChange={(e) => {
                   const t = e.target.value;
                   if (t === "strength")
@@ -416,11 +421,13 @@ export function ActiveWorkoutPanel({
               {(it.sets || []).map((s, idx) => (
                 <div key={idx} className="grid grid-cols-3 gap-2">
                   <input
-                    className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
+                    className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none read-only:opacity-70 read-only:cursor-not-allowed"
                     type="number"
                     inputMode="decimal"
                     placeholder="кг"
+                    aria-label="Вага в кілограмах"
                     value={s.weightKg || ""}
+                    readOnly={isReadOnly}
                     onFocus={(e) => e.target.select()}
                     onChange={(e) => {
                       const next = [...(it.sets || [])];
@@ -433,11 +440,13 @@ export function ActiveWorkoutPanel({
                     }}
                   />
                   <input
-                    className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
+                    className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none read-only:opacity-70 read-only:cursor-not-allowed"
                     type="number"
                     inputMode="numeric"
                     placeholder="повт."
+                    aria-label="Кількість повторень"
                     value={s.reps || ""}
+                    readOnly={isReadOnly}
                     onFocus={(e) => e.target.select()}
                     onKeyDown={(e) => {
                       if (e.key !== "Enter") return;
@@ -461,7 +470,8 @@ export function ActiveWorkoutPanel({
                   />
                   <button
                     type="button"
-                    className="h-10 rounded-xl border border-line text-xs text-subtle hover:text-danger hover:border-danger/40 transition-colors"
+                    className="h-10 rounded-xl border border-line text-xs text-subtle hover:text-danger hover:border-danger/40 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-subtle disabled:hover:border-line"
+                    disabled={isReadOnly}
                     onClick={() => {
                       const next = (it.sets || []).filter((_, i) => i !== idx);
                       updateItem(activeWorkout.id, it.id, { sets: next });
@@ -471,38 +481,40 @@ export function ActiveWorkoutPanel({
                   </button>
                 </div>
               ))}
-              <div className="flex gap-2">
-                <Button
-                  variant="ghost"
-                  className="flex-1 h-10 min-h-[44px]"
-                  type="button"
-                  onClick={() =>
-                    updateItem(activeWorkout.id, it.id, {
-                      sets: [...(it.sets || []), { weightKg: 0, reps: 0 }],
-                    })
-                  }
-                >
-                  + Підхід
-                </Button>
-                <VoiceMicButton
-                  size="md"
-                  label="Голосовий ввід підходу"
-                  onResult={(transcript) => {
-                    const parsed = parseWorkoutSetSpeech(transcript);
-                    if (!parsed) return;
-                    const newSet = {
-                      weightKg: parsed.weight ?? 0,
-                      reps: parsed.reps ?? 0,
-                    };
-                    updateItem(activeWorkout.id, it.id, {
-                      sets: [...(it.sets || []), newSet],
-                    });
-                    if (!activeWorkout.endedAt && !group) {
-                      setRestTimer({ remaining: defSec, total: defSec });
+              {!isReadOnly && (
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    className="flex-1 h-10 min-h-[44px]"
+                    type="button"
+                    onClick={() =>
+                      updateItem(activeWorkout.id, it.id, {
+                        sets: [...(it.sets || []), { weightKg: 0, reps: 0 }],
+                      })
                     }
-                  }}
-                />
-              </div>
+                  >
+                    + Підхід
+                  </Button>
+                  <VoiceMicButton
+                    size="md"
+                    label="Голосовий ввід підходу"
+                    onResult={(transcript) => {
+                      const parsed = parseWorkoutSetSpeech(transcript);
+                      if (!parsed) return;
+                      const newSet = {
+                        weightKg: parsed.weight ?? 0,
+                        reps: parsed.reps ?? 0,
+                      };
+                      updateItem(activeWorkout.id, it.id, {
+                        sets: [...(it.sets || []), newSet],
+                      });
+                      if (!activeWorkout.endedAt && !group) {
+                        setRestTimer({ remaining: defSec, total: defSec });
+                      }
+                    }}
+                  />
+                </div>
+              )}
               {!activeWorkout.endedAt && !group && (
                 <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-line/60">
                   <div className="flex items-center justify-between w-full gap-1">
@@ -543,11 +555,13 @@ export function ActiveWorkoutPanel({
           {it.type === "time" && (
             <div className="mt-2 grid grid-cols-2 gap-2">
               <input
-                className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
+                className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none read-only:opacity-70 read-only:cursor-not-allowed"
                 type="number"
                 inputMode="numeric"
                 placeholder="сек"
+                aria-label="Тривалість у секундах"
                 value={it.durationSec || ""}
+                readOnly={isReadOnly}
                 onFocus={(e) => e.target.select()}
                 onChange={(e) =>
                   updateItem(activeWorkout.id, it.id, {
@@ -566,11 +580,13 @@ export function ActiveWorkoutPanel({
             <div className="mt-2 space-y-2">
               <div className="grid grid-cols-2 gap-2">
                 <input
-                  className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
+                  className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none read-only:opacity-70 read-only:cursor-not-allowed"
                   type="number"
                   inputMode="numeric"
                   placeholder="метри"
+                  aria-label="Дистанція в метрах"
                   value={it.distanceM || ""}
+                  readOnly={isReadOnly}
                   onFocus={(e) => e.target.select()}
                   onChange={(e) =>
                     updateItem(activeWorkout.id, it.id, {
@@ -580,11 +596,13 @@ export function ActiveWorkoutPanel({
                   }
                 />
                 <input
-                  className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
+                  className="h-10 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none read-only:opacity-70 read-only:cursor-not-allowed"
                   type="number"
                   inputMode="numeric"
                   placeholder="сек"
+                  aria-label="Тривалість у секундах"
                   value={it.durationSec || ""}
+                  readOnly={isReadOnly}
                   onFocus={(e) => e.target.select()}
                   onChange={(e) =>
                     updateItem(activeWorkout.id, it.id, {
@@ -625,6 +643,7 @@ export function ActiveWorkoutPanel({
       groupSelectMode,
       groupSelected,
       handleToggleGroupSelect,
+      isReadOnly,
       itemIdToGroup,
       lastByExerciseId,
       musclesUk,

--- a/src/modules/fizruk/hooks/useWorkouts.js
+++ b/src/modules/fizruk/hooks/useWorkouts.js
@@ -231,7 +231,9 @@ export function useWorkouts() {
   );
 
   /**
-   * Add an exercise item to a workout. Prepends to the items list.
+   * Add an exercise item to a workout. Appends to the items list so that the
+   * stored order matches the order in which the user (or a template) added
+   * exercises — users read the workout log top-to-bottom chronologically.
    * @param {string} workoutId
    * @param {Partial<WorkoutItem>} item - Item data; `id` is generated if absent.
    * @returns {string} The generated item ID.
@@ -244,7 +246,7 @@ export function useWorkouts() {
           if (w.id !== workoutId) return w;
           return {
             ...w,
-            items: [{ id: itemId, ...item }, ...(w.items || [])],
+            items: [...(w.items || []), { id: itemId, ...item }],
           };
         }),
       );

--- a/src/modules/fizruk/lib/fizrukStorage.js
+++ b/src/modules/fizruk/lib/fizrukStorage.js
@@ -9,7 +9,9 @@ export const CUSTOM_EXERCISES_KEY = "fizruk_custom_exercises_v1";
 export const MEASUREMENTS_STORAGE_KEY = "fizruk_measurements_v1";
 export const TEMPLATES_STORAGE_KEY = "fizruk_workout_templates_v1";
 export const SELECTED_TEMPLATE_STORAGE_KEY = "fizruk_selected_template_id_v1";
-export const ACTIVE_WORKOUT_STORAGE_KEY = "fizruk_active_workout_id_v1";
+export const ACTIVE_WORKOUT_KEY = "fizruk_active_workout_id_v1";
+/** @deprecated Використовуй `ACTIVE_WORKOUT_KEY`. Залишено на перехідний період. */
+export const ACTIVE_WORKOUT_STORAGE_KEY = ACTIVE_WORKOUT_KEY;
 export const PLAN_TEMPLATE_STORAGE_KEY = "fizruk_plan_template_v1";
 export const MONTHLY_PLAN_STORAGE_KEY = "fizruk_monthly_plan_v1";
 

--- a/src/modules/fizruk/lib/workoutStats.js
+++ b/src/modules/fizruk/lib/workoutStats.js
@@ -104,7 +104,8 @@ export function personalRecordsExerciseCount(workouts) {
   return Object.keys(by).length;
 }
 
-function mondayStartMs(d) {
+/** Початок поточного ISO-тижня (Пн 00:00) у мс. */
+export function mondayStartMs(d) {
   const x = new Date(d);
   const day = (x.getDay() + 6) % 7;
   x.setHours(0, 0, 0, 0);

--- a/src/modules/fizruk/lib/workoutUi.js
+++ b/src/modules/fizruk/lib/workoutUi.js
@@ -1,6 +1,6 @@
 /** UI helpers for workout logging (pure, no React). */
 
-export const ACTIVE_WORKOUT_KEY = "fizruk_active_workout_id_v1";
+export { ACTIVE_WORKOUT_KEY } from "./fizrukStorage.js";
 /** @deprecated Використовуй клас `fizruk-sheet-pad` у index.css */
 export const SHEET_BOTTOM_PADDING =
   "calc(env(safe-area-inset-bottom, 16px) + 72px)";
@@ -39,10 +39,4 @@ export function formatRestClock(sec) {
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
-export function mondayStartMs(d) {
-  const x = new Date(d);
-  const day = (x.getDay() + 6) % 7;
-  x.setHours(0, 0, 0, 0);
-  x.setDate(x.getDate() - day);
-  return x.getTime();
-}
+export { mondayStartMs } from "./workoutStats.js";

--- a/src/modules/fizruk/pages/Workouts.jsx
+++ b/src/modules/fizruk/pages/Workouts.jsx
@@ -267,9 +267,6 @@ export function Workouts() {
         }
       }
       if (tpl?.id) templateApi.markTemplateUsed(tpl.id);
-      try {
-        localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
-      } catch {}
       setActiveWorkoutId(w.id);
       setMode("log");
     },
@@ -304,9 +301,6 @@ export function Workouts() {
     const [hh, mm] = (retroTime || "12:00").split(":").map(Number);
     const startedAt = new Date(y, mo - 1, d, hh, mm, 0, 0).toISOString();
     const w = createWorkoutWithTimes({ startedAt });
-    try {
-      localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
-    } catch {}
     setActiveWorkoutId(w.id);
     setRetroOpen(false);
   }, [retroDate, retroTime, createWorkoutWithTimes]);


### PR DESCRIPTION
## Summary

Низькоризиковий рефакторинг після аудиту Fizruk. Об'єднує 2 quick-win'и і read-only для завершеного тренування в один PR.

**Quick wins (P0 #1, #2, P2 #14, #18)**

- `ACTIVE_WORKOUT_KEY` тепер живе в одному місці — `lib/fizrukStorage.js`. `lib/workoutUi.js` реекспортує для сумісності (`ACTIVE_WORKOUT_STORAGE_KEY` залишено як `@deprecated` alias).
- `mondayStartMs` так само об'єднаний: канонічне визначення в `lib/workoutStats.js`, `workoutUi.js` реекспортує.
- Прибрав дублюючі `localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id)` в `Workouts.jsx` (2 місця) — useEffect уже персистить `activeWorkoutId`, ручні write'и були надлишкові. Writes з `Dashboard.jsx` / `FizrukApp.jsx` залишені (cross-page hand-off).
- `useWorkouts.addItem` тепер **appends** замість prepend. Це фіксить порядок у шаблонах: якщо в шаблоні [Жим → Тяга → Присід], так само з'являлось і в журналі після запуску. Раніше виходило в reverse-порядку.

**Read-only завершене тренування (P0 #3)**

- Коли `activeWorkout.endedAt` встановлено, `ActiveWorkoutPanel` тепер:
  - ставить `readOnly` на всі числові inputs (`кг`, `повт.`, `сек`, `метри`) + візуальне затемнення через `read-only:opacity-70 read-only:cursor-not-allowed`
  - `disabled` на type-селекторі (Силова/Час/Дистанція)
  - ховає кнопки "+ Підхід", голосовий мікрофон, "Видалити" підхід, "✕" прибрати вправу
- **Залишається доступним для редагування**: поле `datetime-local` "Завершення" в секції "Час тренування" — його лейбл явно написаний "можна виправити після занесення", це свідомо.
- Додав `aria-label` на числові inputs — screen reader раніше чув лише "edit text".

**Не в цьому PR** (свідомо, щоб обсяг був маленький):

- Рефакторинг ActiveWorkoutPanel на менші компоненти (P1 #5).
- Virtuoso heights (P0 #4).
- Routing consolidation (P1 #7).
- AudioContext витік (P1 #9).
- Undo для "Видалити тренування" (P1 #12).

## Review & Testing Checklist for Human

- [ ] Відкрити **завершене** тренування: переконатись, що kg/reps/сек/метри **не редагуються** (readonly), а "+ Підхід", голосовий мік, "Видалити" підхід, "✕" прибрати вправу **приховані**.
- [ ] Відкрити **активне** (не завершене) тренування: всі вище — редагуються/видимі, як і раніше.
- [ ] У завершеному тренуванні поле "Завершення" (datetime-local) все ще редагується — це свідомо.
- [ ] Запустити тренування з шаблону ≥2 вправ: переконатись, що вправи в журналі йдуть у тому ж порядку, в якому вони в шаблоні (раніше йшли зворотньо).
- [ ] Вручну додати 2–3 вправи з каталогу — порядок у списку має відповідати порядку додавання (зверху вниз = від першої до останньої).
- [ ] Перезавантажити сторінку з активним тренуванням: панель має відновитись (переконуємось, що useEffect persistence не зламався після прибрання ручних setItem).

### Notes

Lint і тести: `npm run lint` (0 errors, 0 warnings), `vitest run src/modules/fizruk` — 7 файлів / 42 тести pass.

Пов'язано з повним аудитом модуля — решта знайденого (P1/P2) у подальших PR за пріоритетом користувача.

Link to Devin session: https://app.devin.ai/sessions/50723cf5b7a34daf9a55747047594216
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
