### PR TITLE
fix(core): BudgetSchema приймає goal-бюджети, useAllFlags кешує снапшот

### DIFF
--- a/src/core/lib/featureFlags.test.js
+++ b/src/core/lib/featureFlags.test.js
@@ -60,4 +60,16 @@ describe("featureFlags", () => {
       expect(all[f.id]).toBe(f.defaultValue);
     }
   });
+
+  it("getAllFlags повертає ту саму ref до зміни (useSyncExternalStore contract)", async () => {
+    const { getAllFlags, setFlag } = await loadFresh();
+    const a = getAllFlags();
+    const b = getAllFlags();
+    expect(a).toBe(b);
+    setFlag("finyk_subscriptions_category", true);
+    const c = getAllFlags();
+    expect(c).not.toBe(a);
+    const d = getAllFlags();
+    expect(d).toBe(c);
+  });
 });

--- a/src/core/lib/featureFlags.ts
+++ b/src/core/lib/featureFlags.ts
@@ -101,9 +101,20 @@ export function resetFlags(): void {
   flagsStore.reset();
 }
 
+// Кеш снапшоту всіх флагів. `useSyncExternalStore` вимагає реф-стабільний
+// результат від `getSnapshot` між оновленнями store'а — інакше React
+// вважає, що state змінився, і ганяє ре-рендери/лупить у concurrent mode.
+let cachedAllFlagsSnapshot: Record<string, boolean> | null = null;
+flagsStore.subscribe(() => {
+  cachedAllFlagsSnapshot = null;
+});
+
 /** Повертає поточні значення з підставленими defaults — зручно для UI. */
 export function getAllFlags(): Record<string, boolean> {
-  return { ...defaults(), ...flagsStore.get() };
+  if (cachedAllFlagsSnapshot) return cachedAllFlagsSnapshot;
+  const snapshot = { ...defaults(), ...flagsStore.get() };
+  cachedAllFlagsSnapshot = snapshot;
+  return snapshot;
 }
 
 /**
@@ -122,8 +133,8 @@ export function useFlag(id: FlagId | string): boolean {
 export function useAllFlags(): Record<string, boolean> {
   return useSyncExternalStore(
     (onChange) => flagsStore.subscribe(onChange),
-    () => getAllFlags(),
-    () => getAllFlags(),
+    getAllFlags,
+    getAllFlags,
   );
 }
 

--- a/src/modules/finyk/domain/schemas.test.js
+++ b/src/modules/finyk/domain/schemas.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { BudgetSchema, BudgetsSchema } from "./schemas";
+
+describe("BudgetSchema", () => {
+  it("приймає limit-бюджет з валідним числовим limit", () => {
+    const r = BudgetSchema.safeParse({
+      id: "b1",
+      type: "limit",
+      limit: 500,
+      categoryId: "food",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("приймає goal-бюджет з порожнім limit (legacy-форма)", () => {
+    // Goal-бюджети успадковують `limit: ""` із initial-state форми у
+    // Budgets.jsx. Раніше такі записи мовчки фільтрувалися у getBudget().
+    const r = BudgetSchema.safeParse({
+      id: "g1",
+      type: "goal",
+      limit: "",
+      target: 10000,
+      current: 2500,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.limit).toBeUndefined();
+  });
+
+  it("приймає goal-бюджет без поля limit взагалі", () => {
+    const r = BudgetSchema.safeParse({
+      id: "g2",
+      type: "goal",
+      target: 5000,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("нормалізує string-числа у limit", () => {
+    const r = BudgetSchema.safeParse({ id: "b3", limit: "750" });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.limit).toBe(750);
+  });
+
+  it("дропає запис без id", () => {
+    const r = BudgetSchema.safeParse({ limit: 100 });
+    expect(r.success).toBe(false);
+  });
+
+  it("масив: валідні goal + limit записи обидва проходять", () => {
+    const r = BudgetsSchema.safeParse([
+      { id: "g1", type: "goal", limit: "", target: 10000 },
+      { id: "l1", type: "limit", limit: 500, categoryId: "food" },
+    ]);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveLength(2);
+  });
+});

--- a/src/modules/finyk/domain/schemas.ts
+++ b/src/modules/finyk/domain/schemas.ts
@@ -6,15 +6,29 @@ import { z } from "zod";
 
 export const BudgetTypeSchema = z.enum(["limit", "goal"]);
 
+// Goal-бюджети не мають ліміту (у формі `limit` лишається "" після spread
+// з initial-state у Budgets.jsx), тому `limit` опціональний. Preprocess
+// нормалізує "" / null / NaN до undefined — без цього legacy goal-записи
+// мовчки відфільтровувалися б у `getBudget()`.
+const optionalNumberSchema = z.preprocess((v) => {
+  if (v === "" || v === null || v === undefined) return undefined;
+  if (typeof v === "number") return Number.isFinite(v) ? v : undefined;
+  if (typeof v === "string") {
+    const parsed = Number(v);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return v;
+}, z.number().finite().optional());
+
 export const BudgetSchema = z
   .object({
     id: z.string().min(1),
     type: BudgetTypeSchema.optional(),
-    limit: z.number().finite(),
+    limit: optionalNumberSchema,
     categoryId: z.string().optional(),
     label: z.string().optional(),
-    target: z.number().finite().optional(),
-    current: z.number().finite().optional(),
+    target: optionalNumberSchema,
+    current: optionalNumberSchema,
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

Два фікси з [Devin Review #124](https://github.com/Skords-01/Sergeant/pull/124) — обидва реальні функціональні баги, не стилістика.

### 1. BudgetSchema тихо дропає goal-бюджети
**Симптом**: `getBudget()` повертає порожній список після merge #124, якщо у користувача є goal-бюджети (ціль накопичення).

**Причина**: у формі `Budgets.jsx:71` initial-state має `limit: ""`. `validateGoalBudgetForm` у `budget.ts:354` робить `{ ...form, type: "goal", ... }` — порожній рядок зберігається у LS. `BudgetSchema.limit = z.number().finite()` (required) відкидає такі записи, і `getBudget()` у fallback-лупі мовчки їх фільтрує.

**Фікс** (`src/modules/finyk/domain/schemas.ts`):
- `limit`, `target`, `current` — через спільний `optionalNumberSchema` з `z.preprocess`:
  - `""` / `null` / `NaN` → `undefined`
  - string-число → number
  - інше — пропускається у базову перевірку `z.number().finite().optional()`
- додано `schemas.test.js` (6 тестів) — перевіряє legacy goal-запис, string-числа, дроп запису без `id`, мікс goal+limit у масиві.

### 2. `useAllFlags` порушував `useSyncExternalStore` contract
**Симптом**: Settings → «Експериментальне» міг зайво ре-рендеритись / потенційний infinite loop у React concurrent mode.

**Причина**: `getAllFlags()` повертав `{ ...defaults(), ...flagsStore.get() }` — новий object ref на кожен виклик. React порівнює snapshot'и через `Object.is` і вважає, що state завжди змінився.

**Фікс** (`src/core/lib/featureFlags.ts`):
- модульний кеш `cachedAllFlagsSnapshot`, який інвалідується підпискою на `flagsStore` (вона notify'ється при `set` / `reset` / `reload`).
- `useAllFlags` тепер передає `getAllFlags` напряму (без inline-обгортки) — відповідає React-docs "getSnapshot result should be cached".
- новий тест у `featureFlags.test.js`: та сама ref до зміни, нова ref після `setFlag`, знову стабільна після.

**Тести**: 513 pass (було 506 + 7 нових). Lint / typecheck / prettier — зелені.

## Review & Testing Checklist for Human

Ризик: yellow (фіксить регресію читання бюджетів).

- [ ] Відкрити користувацький акаунт з goal-бюджетом — вони знов відображаються (це головна регресія, яку PR закриває).
- [ ] Settings → «Експериментальне»: тогли перемикаються, зберігаються, reload переживає.
- [ ] Створити новий goal-бюджет → перевірити, що він з'являється у списку одразу й після reload.

### Notes
- PR #124 залишається у main; цей PR — виключно таргетні фікси поверх нього.
- Preprocess пропускає `number` без змін, тож існуючі limit-бюджети на це не реагують.

Link to Devin session: https://app.devin.ai/sessions/8b51273c4f0a471bae72667276b92d4d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
