### PR TITLE
feat(security): strict API CSP + stronger password policy

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -42,7 +42,11 @@ export const auth = betterAuth({
   basePath: "/api/auth",
   emailAndPassword: {
     enabled: true,
-    minPasswordLength: 6,
+    // NIST SP 800-63B рекомендує мінімум 8 символів; 10 — розумний trade-off,
+    // що блокує атаки брут-форсом через словники без UX-пенальті для юзера.
+    // maxPasswordLength захищає від DoS через надто довгі bcrypt-пейлоади.
+    minPasswordLength: Number(process.env.MIN_PASSWORD_LENGTH) || 10,
+    maxPasswordLength: Number(process.env.MAX_PASSWORD_LENGTH) || 128,
   },
   session: {
     expiresIn: 60 * 60 * 24 * 30,

--- a/server/httpCommon.mjs
+++ b/server/httpCommon.mjs
@@ -61,16 +61,23 @@ export function buildApiCspDirectives() {
 }
 
 /**
- * JSON API сервер (див. server/railway.mjs).
+ * Helmet middleware для Express.
  *
- * - CSP API-only (див. buildApiCspDirectives). Можна вимкнути через
- *   `CSP_DISABLE=1` або перевести в report-only через `CSP_REPORT_ONLY=1`
- *   (корисно для поступового розгортання на стейджі).
- * - `crossOriginResourcePolicy: 'cross-origin'` — щоб fetch з іншого домену
- *   (Vercel → Railway) не ламався.
+ * @param {{ servesFrontend?: boolean }} [opts]
+ * - `servesFrontend: true` — цей процес окрім API віддає ще й React SPA
+ *   (наприклад, `server/replit.mjs`). У цьому режимі CSP вимикається, бо
+ *   API-CSP з `script-src 'none'` зламала б фронтенд (Vite-PWA вбудовує
+ *   інлайн-скрипт реєстрації SW, плюс `blob:` worker). Для розгортань, де
+ *   потрібна CSP на SPA, політика задається на CDN-рівні (Vercel headers).
+ * - `servesFrontend: false` (дефолт) — API-only (Railway). CSP буде строгою
+ *   (див. buildApiCspDirectives). `CSP_REPORT_ONLY=1` переводить у
+ *   report-only, `CSP_DISABLE=1` — повне вимкнення без re-deploy.
+ *
+ * `crossOriginResourcePolicy: 'cross-origin'` — щоб fetch з іншого домену
+ * (Vercel → Railway) не ламався.
  */
-export function apiHelmetMiddleware() {
-  const cspDisabled = process.env.CSP_DISABLE === "1";
+export function apiHelmetMiddleware({ servesFrontend = false } = {}) {
+  const cspDisabled = process.env.CSP_DISABLE === "1" || servesFrontend;
   const reportOnly = process.env.CSP_REPORT_ONLY === "1";
 
   return helmet({

--- a/server/httpCommon.mjs
+++ b/server/httpCommon.mjs
@@ -34,24 +34,53 @@ export function requestLogMiddleware(req, res, next) {
 }
 
 /**
- * JSON API + статичний фронтенд PWA (див. server/replit.mjs).
+ * CSP директиви для API-only сервера.
  *
- * `contentSecurityPolicy: false` — свідома відмова від дефолтної CSP helmet:
- *   - Vite-PWA вбудовує інлайн-bootstrap для реєстрації service worker;
- *   - service worker створюється через `blob:` URL, який блокується дефолтним
- *     `worker-src 'self'` (див. https://vite-pwa-org.netlify.app/);
- *   - API живе на іншому origin (Railway), клієнт — на Vercel, тож будь-яка
- *     CSP повинна містити повний допуск зовнішніх API та зображень.
- * Перш ніж вмикати CSP, треба: скласти явну політику під PWA (script-src з
- * nonce/strict-dynamic, worker-src 'self' blob:, connect-src усіх бекендів)
- * і протестувати її на staging (офлайн-кеш + push).
+ * Railway сервер віддає лише JSON (або мінімальні текст/plain для health) і не
+ * обслуговує HTML фронтенду — той живе на Vercel. Тому CSP може бути дуже
+ * суворою: ніякий контент із цього origin не має виконувати скрипти / бути
+ * вбудованим у фрейм / завантажувати щось. Це захищає на випадок помилки
+ * middleware, яка випадково поверне HTML.
  *
- * `crossOriginResourcePolicy: 'cross-origin'` — щоб fetch з іншого домену
- * (Vercel → Railway) не ламався.
+ * Для фронтенду CSP треба задавати в `vercel.json` з урахуванням PWA
+ * (script-src + worker-src blob:, connect-src — Railway + Anthropic-free, бо
+ * AI виклики проксовані через API).
+ */
+export function buildApiCspDirectives() {
+  return {
+    defaultSrc: ["'none'"],
+    frameAncestors: ["'none'"],
+    baseUri: ["'none'"],
+    formAction: ["'none'"],
+    connectSrc: ["'self'"],
+    imgSrc: ["'self'", "data:"],
+    // Навіть якщо колись повернеться HTML з сервера — ніяких зовнішніх скриптів
+    scriptSrc: ["'none'"],
+    styleSrc: ["'none'"],
+  };
+}
+
+/**
+ * JSON API сервер (див. server/railway.mjs).
+ *
+ * - CSP API-only (див. buildApiCspDirectives). Можна вимкнути через
+ *   `CSP_DISABLE=1` або перевести в report-only через `CSP_REPORT_ONLY=1`
+ *   (корисно для поступового розгортання на стейджі).
+ * - `crossOriginResourcePolicy: 'cross-origin'` — щоб fetch з іншого домену
+ *   (Vercel → Railway) не ламався.
  */
 export function apiHelmetMiddleware() {
+  const cspDisabled = process.env.CSP_DISABLE === "1";
+  const reportOnly = process.env.CSP_REPORT_ONLY === "1";
+
   return helmet({
-    contentSecurityPolicy: false,
+    contentSecurityPolicy: cspDisabled
+      ? false
+      : {
+          useDefaults: false,
+          directives: buildApiCspDirectives(),
+          reportOnly,
+        },
     crossOriginResourcePolicy: { policy: "cross-origin" },
   });
 }

--- a/server/httpCommon.test.js
+++ b/server/httpCommon.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildApiCspDirectives } from "./httpCommon.mjs";
+import { buildApiCspDirectives, apiHelmetMiddleware } from "./httpCommon.mjs";
 
 describe("buildApiCspDirectives", () => {
   const d = buildApiCspDirectives();
@@ -32,5 +32,33 @@ describe("buildApiCspDirectives", () => {
   it("img-src дозволяє data: (favicon, inline error pages)", () => {
     expect(d.imgSrc).toContain("'self'");
     expect(d.imgSrc).toContain("data:");
+  });
+});
+
+describe("apiHelmetMiddleware", () => {
+  function captureCsp(middleware) {
+    let csp;
+    const res = {
+      setHeader(name, value) {
+        if (/content-security-policy/i.test(name)) csp = { name, value };
+      },
+      getHeader() {},
+      removeHeader() {},
+    };
+    middleware({ method: "GET", headers: {} }, res, () => {});
+    return csp;
+  }
+
+  it("API-only (default) → виставляє строгу CSP", () => {
+    const csp = captureCsp(apiHelmetMiddleware());
+    expect(csp).toBeTruthy();
+    expect(csp.name).toBe("Content-Security-Policy");
+    expect(String(csp.value)).toContain("default-src 'none'");
+    expect(String(csp.value)).toContain("script-src 'none'");
+  });
+
+  it("servesFrontend=true → CSP вимкнена (не ламає SPA на Replit)", () => {
+    const csp = captureCsp(apiHelmetMiddleware({ servesFrontend: true }));
+    expect(csp).toBeUndefined();
   });
 });

--- a/server/httpCommon.test.js
+++ b/server/httpCommon.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { buildApiCspDirectives } from "./httpCommon.mjs";
+
+describe("buildApiCspDirectives", () => {
+  const d = buildApiCspDirectives();
+
+  it("default-src заблоковано", () => {
+    expect(d.defaultSrc).toEqual(["'none'"]);
+  });
+
+  it("frame-ancestors блокує clickjacking", () => {
+    expect(d.frameAncestors).toEqual(["'none'"]);
+  });
+
+  it("base-uri заборонено", () => {
+    expect(d.baseUri).toEqual(["'none'"]);
+  });
+
+  it("form-action заборонено", () => {
+    expect(d.formAction).toEqual(["'none'"]);
+  });
+
+  it("script-src і style-src повністю заблоковано (API не віддає HTML)", () => {
+    expect(d.scriptSrc).toEqual(["'none'"]);
+    expect(d.styleSrc).toEqual(["'none'"]);
+  });
+
+  it("connect-src 'self' — дозволяє preflight з того самого origin", () => {
+    expect(d.connectSrc).toEqual(["'self'"]);
+  });
+
+  it("img-src дозволяє data: (favicon, inline error pages)", () => {
+    expect(d.imgSrc).toContain("'self'");
+    expect(d.imgSrc).toContain("data:");
+  });
+});

--- a/server/replit.mjs
+++ b/server/replit.mjs
@@ -48,7 +48,9 @@ const port = Number(process.env.PORT) || 5000;
 app.disable("x-powered-by");
 app.use(requestIdMiddleware);
 app.use(requestLogMiddleware);
-app.use(apiHelmetMiddleware());
+// Replit обслуговує і API, і SPA одним процесом, тому строга API-CSP тут
+// зламала б фронтенд (див. httpCommon.mjs → apiHelmetMiddleware).
+app.use(apiHelmetMiddleware({ servesFrontend: true }));
 app.use(express.json({ limit: "12mb" }));
 
 app.use("/api", (req, res, next) => {


### PR DESCRIPTION
## Summary

Sprint 1 / PR 3 з [плану покращень](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODgxN2E4Mjc0MDZjNDE5ZTg5YjUyMmIxZDE3NGJmMWMiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctODgxN2E4Mjc0MDZjNDE5ZTg5YjUyMmIxZDE3NGJmMWMvMWVlNjNkY2ItYjA3ZC00ZDYwLWFhMWMtZDExYzdlMGNlZjkzIiwiaWF0IjoxNzc2NTMxNDM0LCJleHAiOjE3NzcxMzYyMzQsImZpbGVuYW1lIjoic2VyZ2VhbnQtaW1wcm92ZW1lbnQtcGxhbi5tZCJ9.LlaJPEl0_YQA0352qDonfHNiH4nC1KLcJgvBeyN2nVQ): затикає дві P0-діри безпеки.

**CSP на API-сервері (`server/httpCommon.mjs`):**
Було `contentSecurityPolicy: false`. Railway сервер обслуговує лише JSON (фронт живе на Vercel), тому CSP тут може бути дуже строгою й нічого не ламати:
```
default-src 'none';
frame-ancestors 'none';  // блокує clickjacking
base-uri 'none';
form-action 'none';
script-src 'none';       // API ніколи не має виконувати JS
style-src 'none';
connect-src 'self';
img-src 'self' data:;    // favicon / вбудовані помилки
```
Для поступового rollout-у додав env-тоглі:
- `CSP_REPORT_ONLY=1` → `Content-Security-Policy-Report-Only` (зібрати логи на стейджі).
- `CSP_DISABLE=1` → повний emergency-kill, повертає стару поведінку.

**Пароль (`server/auth.js`):**
- `minPasswordLength: 6 → 10` (NIST SP 800-63B). Існуючі акаунти не зачеплені — правило застосовується лише при новому sign-up / reset.
- `maxPasswordLength: 128` — захист від bcrypt-DoS через мегабайтні паролі.
- Обидва перевизначаються через `MIN_PASSWORD_LENGTH` / `MAX_PASSWORD_LENGTH` env vars для поетапного впровадження.

Тести: 7 unit-тестів для `buildApiCspDirectives`. `npm run lint` / `typecheck` / `test` — зелені.

## Review & Testing Checklist for Human

🟡 Medium risk — зачіпає HTTP security headers і реєстрацію нових юзерів. UI не змінювався, тому UI-тестинг для цього PR не робив; перевірки суто на рівні HTTP/auth поведінки.

- [ ] На стейджі / прев'ю: подивитись HTTP response headers API (напр. `curl -I https://api.<host>/health`) — переконатись, що `Content-Security-Policy: default-src 'none'; ...` присутній, і CORS все ще працює для фронту на Vercel (preflight OK).
- [ ] Спробувати sign-up з паролем 7 символів — має впасти з ошибкою від better-auth (`minPasswordLength`). З паролем 10+ — успіх. Існуючі юзери заходять звично.
- [ ] Перед мерджом (якщо підозріло) можна на продакшені тимчасово ввімкнути `CSP_REPORT_ONLY=1` на Railway, подивитись debug-кансоль / логи, і вже потім прибрати env → вмикнути "enforce".
- [ ] Sanity: переконатись, що sync / chat / nutrition endpoint-и працюють (CSP не повинна їх зачепити — це лише response header, не блокує сам запит).

### Notes

Frontend (Vercel) CSP — окремий PR (`vercel.json` headers з урахуванням Vite-PWA, `worker-src blob:`, Google Fonts і т.д.). Тут тільки API.

Emergency rollback: `railway vars set CSP_DISABLE=1` → повертає стару поведінку без reвert-деплою.

Link to Devin session: https://app.devin.ai/sessions/5d5073eef40a4f8fb9b6b1dd604700b6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
