### PR TITLE
fix(docker): skip prepare script in Dockerfile.api to avoid husky failure

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,7 +4,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY server ./server
 


### PR DESCRIPTION
## Summary
The Docker build for `Dockerfile.api` was failing with `sh: husky: not found` because `npm ci --omit=dev` still runs lifecycle scripts, and the `prepare` script tries to execute `husky` — which is a devDependency that isn't installed in production.

Fix: add `--ignore-scripts` to the `npm ci` invocation in `Dockerfile.api`. The API image doesn't need git hooks, so skipping lifecycle scripts is both correct and slightly faster.

Verified locally: `docker build -f Dockerfile.api -t hub-api .` now completes successfully.

## Review & Testing Checklist for Human
- [ ] Confirm no production dependency in this repo relies on a postinstall lifecycle script to function at runtime (quick sanity check; typical for this stack but worth a glance).
- [ ] Re-run the Railway / Docker build pipeline and confirm the image builds and the API starts with `node server/railway.mjs`.

### Notes
- Only `Dockerfile.api` is touched. The husky setup in `package.json` and `.husky/pre-commit` remains unchanged for local development.
- An alternative fix is to move `husky` to `dependencies`, but that would ship dev tooling into the production image, so `--ignore-scripts` is the cleaner approach here.

Link to Devin session: https://app.devin.ai/sessions/dd10f4d2af354b3180d48b21fb8b5a0d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
