### PR TITLE
feat(state): introduce @tanstack/react-query and migrate AI server hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@tanstack/react-query": "^5.99.0",
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
         "better-auth": "^1.6.4",
@@ -3288,6 +3289,32 @@
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-query": "^5.99.0",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "better-auth": "^1.6.4",

--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 
 const CACHE_KEY = "hub_coach_insight_cache_v1";
@@ -173,69 +174,74 @@ function aggregateCurrentSnapshot() {
   return { finyk, fizruk, nutrition, routine };
 }
 
+async function fetchCoachInsight() {
+  let memory = null;
+  try {
+    const memRes = await fetch(apiUrl("/api/coach/memory"), {
+      method: "GET",
+      credentials: "include",
+    });
+    if (memRes.ok) {
+      const memJson = await memRes.json();
+      memory = memJson.memory;
+    }
+  } catch {}
+
+  const snapshot = aggregateCurrentSnapshot();
+
+  const insightRes = await fetch(apiUrl("/api/coach/insight"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ snapshot, memory }),
+  });
+
+  if (!insightRes.ok) {
+    const err = await insightRes.json().catch(() => ({}));
+    const error = new Error(err?.error || "Помилка генерації інсайту");
+    error.status = insightRes.status;
+    throw error;
+  }
+
+  const insightJson = await insightRes.json();
+  return insightJson.insight ?? null;
+}
+
 export function useCoachInsight() {
   const [insight, setInsight] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
 
-  const loadInsight = useCallback(async (force = false) => {
-    const todayKey = localDateKey();
-    if (!force) {
-      const cached = safeParseLS(CACHE_KEY, null);
-      if (cached?.date === todayKey && cached?.text) {
-        setInsight(cached.text);
-        return cached.text;
-      }
-    }
-
-    setLoading(true);
-    setError(null);
-    try {
-      let memory = null;
+  const mutation = useMutation({
+    mutationFn: fetchCoachInsight,
+    onSuccess: (text) => {
+      if (!text) return;
       try {
-        const memRes = await fetch(apiUrl("/api/coach/memory"), {
-          method: "GET",
-          credentials: "include",
-        });
-        if (memRes.ok) {
-          const memJson = await memRes.json();
-          memory = memJson.memory;
-        }
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ date: localDateKey(), text }),
+        );
       } catch {}
+      setInsight(text);
+    },
+  });
 
-      const snapshot = aggregateCurrentSnapshot();
-
-      const insightRes = await fetch(apiUrl("/api/coach/insight"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ snapshot, memory }),
-      });
-
-      if (!insightRes.ok) {
-        const err = await insightRes.json().catch(() => ({}));
-        throw new Error(err?.error || "Помилка генерації інсайту");
+  const loadInsight = useCallback(
+    async (force = false) => {
+      const todayKey = localDateKey();
+      if (!force) {
+        const cached = safeParseLS(CACHE_KEY, null);
+        if (cached?.date === todayKey && cached?.text) {
+          setInsight(cached.text);
+          return cached.text;
+        }
       }
-
-      const insightJson = await insightRes.json();
-      const text = insightJson.insight;
-      if (text) {
-        try {
-          localStorage.setItem(
-            CACHE_KEY,
-            JSON.stringify({ date: todayKey, text }),
-          );
-        } catch {}
-        setInsight(text);
-        return text;
+      try {
+        return await mutation.mutateAsync();
+      } catch {
+        return null;
       }
-    } catch (e) {
-      setError(e?.message || "Помилка завантаження");
-    } finally {
-      setLoading(false);
-    }
-    return null;
-  }, []);
+    },
+    [mutation],
+  );
 
   useEffect(() => {
     const todayKey = localDateKey();
@@ -245,7 +251,15 @@ export function useCoachInsight() {
       return;
     }
     loadInsight();
-  }, [loadInsight]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  return { insight, loading, error, refresh: () => loadInsight(true) };
+  return {
+    insight,
+    loading: mutation.isPending,
+    error: mutation.error
+      ? mutation.error.message || "Помилка завантаження"
+      : null,
+    refresh: () => loadInsight(true),
+  };
 }

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -1,4 +1,5 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { safeReadLS } from "@shared/lib/storage.js";
@@ -290,10 +291,42 @@ export function aggregateRoutine(weekKey) {
   };
 }
 
-export function useWeeklyDigest(selectedWeekKey) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+async function generateWeeklyDigest(weekKey) {
+  const currentWeekRange = getWeekRange(new Date(weekKey + "T12:00:00"));
+  const finyk = aggregateFinyk(weekKey);
+  const fizruk = aggregateFizruk(weekKey);
+  const nutrition = aggregateNutrition(weekKey);
+  const routine = aggregateRoutine(weekKey);
 
+  const res = await fetch(apiUrl("/api/weekly-digest"), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      weekRange: currentWeekRange,
+      finyk,
+      fizruk,
+      nutrition,
+      routine,
+    }),
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error(json?.error || "Помилка генерації звіту");
+    err.status = res.status;
+    throw err;
+  }
+
+  return {
+    report: json.report,
+    generatedAt: json.generatedAt,
+    weekKey,
+    weekRange: currentWeekRange,
+  };
+}
+
+export function useWeeklyDigest(selectedWeekKey) {
   const currentWeekKey = getWeekKey();
   const weekKey = selectedWeekKey || currentWeekKey;
   const weekRange = getWeekRange(new Date(weekKey + "T12:00:00"));
@@ -316,45 +349,20 @@ export function useWeeklyDigest(selectedWeekKey) {
       window.removeEventListener("hub-weekly-digest-updated", handler);
   }, [weekKey]);
 
-  const generate = useCallback(async () => {
-    if (!isCurrentWeek) return null;
-    setLoading(true);
-    setError(null);
-    try {
-      const currentWeekRange = getWeekRange(new Date(weekKey + "T12:00:00"));
-      const finyk = aggregateFinyk(weekKey);
-      const fizruk = aggregateFizruk(weekKey);
-      const nutrition = aggregateNutrition(weekKey);
-      const routine = aggregateRoutine(weekKey);
-
-      const res = await fetch(apiUrl("/api/weekly-digest"), {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          weekRange: currentWeekRange,
-          finyk,
-          fizruk,
-          nutrition,
-          routine,
-        }),
-      });
-
-      const json = await res.json();
-      if (!res.ok) {
-        setError(json?.error || "Помилка генерації звіту");
-        return null;
-      }
-
+  const mutation = useMutation({
+    mutationFn: generateWeeklyDigest,
+    onSuccess: ({ report, generatedAt, weekKey: wk, weekRange: wr }) => {
       const newDigest = {
-        ...json.report,
-        generatedAt: json.generatedAt,
-        weekKey,
-        weekRange: currentWeekRange,
+        ...report,
+        generatedAt,
+        weekKey: wk,
+        weekRange: wr,
       };
-      saveDigest(weekKey, newDigest);
+      saveDigest(wk, newDigest);
       setDigest(newDigest);
 
+      // Fire-and-forget push of digest into coach memory so /api/coach/insight
+      // has richer context on the next call. Failures are non-fatal.
       try {
         fetch(apiUrl("/api/coach/memory"), {
           method: "POST",
@@ -362,28 +370,36 @@ export function useWeeklyDigest(selectedWeekKey) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             weeklyDigest: {
-              weekKey,
-              weekRange: currentWeekRange,
-              generatedAt: json.generatedAt,
-              ...(json.report || {}),
+              weekKey: wk,
+              weekRange: wr,
+              generatedAt,
+              ...(report || {}),
             },
           }),
         }).catch(() => {});
       } catch {}
+    },
+  });
 
-      return newDigest;
-    } catch (e) {
-      setError(e?.message || "Помилка мережі");
+  const generate = async () => {
+    if (!isCurrentWeek) return null;
+    try {
+      const result = await mutation.mutateAsync(weekKey);
+      return {
+        ...result.report,
+        generatedAt: result.generatedAt,
+        weekKey: result.weekKey,
+        weekRange: result.weekRange,
+      };
+    } catch {
       return null;
-    } finally {
-      setLoading(false);
     }
-  }, [weekKey, isCurrentWeek]);
+  };
 
   return {
     digest,
-    loading,
-    error,
+    loading: mutation.isPending,
+    error: mutation.error ? mutation.error.message || "Помилка мережі" : null,
     weekKey,
     weekRange,
     generate,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClientProvider } from "@tanstack/react-query";
 import App from "./core/App";
 import "./index.css";
 import { storageManager } from "@shared/lib/storageManager.js";
+import { createAppQueryClient } from "@shared/lib/queryClient.js";
+
+const queryClient = createAppQueryClient();
 
 storageManager.runAll();
 
@@ -39,9 +43,11 @@ class ErrorBoundary extends React.Component {
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <ErrorBoundary>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </ErrorBoundary>,
 );
 

--- a/src/shared/lib/queryClient.js
+++ b/src/shared/lib/queryClient.js
@@ -1,0 +1,46 @@
+/**
+ * Shared QueryClient for @tanstack/react-query.
+ *
+ * Defaults tuned for a PWA that often works offline:
+ *  - retry only for transient network errors (not for 4xx);
+ *  - `staleTime` 60s — агресивне повторне використання кешу для вкладок,
+ *    що часто ре-маунтяться (модалки, переходи між Hub і модулями);
+ *  - `gcTime` 5хв — тримаємо дані в пам'яті після того, як
+ *    останній observer відписався, але не надовго, щоб не тримати
+ *    застарілі дані після логауту.
+ *
+ * Мутації не ретраяться — серверні AI-ендпоінти дорогі, не хочемо
+ * повторювати випадково.
+ */
+
+import { QueryClient } from "@tanstack/react-query";
+
+function isRetriableError(error) {
+  if (!error) return false;
+  const status = error?.status ?? error?.response?.status;
+  if (typeof status === "number") {
+    // 408 Request Timeout, 429 Too Many Requests, 5xx
+    return status === 408 || status === 429 || status >= 500;
+  }
+  // Мережеві помилки (TypeError: Failed to fetch, AbortError і т.ін.)
+  return true;
+}
+
+export function createAppQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: (failureCount, error) => {
+          if (failureCount >= 2) return false;
+          return isRetriableError(error);
+        },
+        staleTime: 60_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Додав `@tanstack/react-query` як інфраструктуру для серверного стану й перевів на неї два AI-хуки як еталонний патерн. Більше серверних хуків (`useCloudSync`, `useNutritionLog` і т.ін.) — окремими PR-ами, щоб дифи залишалися читабельними.

Що змінено:

1. **Новий `src/shared/lib/queryClient.js`** — спільний `QueryClient` з дефолтами під PWA:
   - retry тільки для транзієнтних помилок (408 / 429 / 5xx / network errors), максимум 1 повтор;
   - `staleTime: 60s`, `gcTime: 5m`, `refetchOnWindowFocus: false`;
   - мутації не ретраяться (AI-ендпоінти дорогі — не хочемо дублювати виклики).
2. **`src/main.jsx`** — обгорнув `<App/>` у `<QueryClientProvider>`.
3. **`src/core/useWeeklyDigest.js`** — `generate()` переведено на `useMutation`. Серверний POST до `/api/weekly-digest` тепер керується react-query: `isPending` → `loading`, `mutation.error` → `error`. localStorage-read (`digest` по `weekKey`) і подія `hub-weekly-digest-updated` залишились без змін — це персистенс, а не серверний стан. Fire-and-forget push у `/api/coach/memory` зберіг поведінку.
4. **`src/core/useCoachInsight.js`** — POST `/api/coach/insight` також переведено на `useMutation`. Кеш "сьогоднішнього" інсайту в localStorage + auto-load на mount працює так само.

Публічний API хуків (повертані поля `digest`/`insight`, `loading`, `error`, `generate`/`refresh`, `weekKey`, `weekRange`, `isCurrentWeek`) не змінився — споживачі (`HubDashboard`, `WeeklyDigestCard`, `CoachInsightCard`) рендеряться без правок.

## Review & Testing Checklist for Human

- [ ] Перевір `HubDashboard`: натисни "Згенерувати" у картці тижневого дайджесту — має відпрацювати POST `/api/weekly-digest`, картка оновитись, стан зберегтись між reload'ами.
- [ ] Перевір `CoachInsightCard`: на mount має з'явитись інсайт з кешу або підвантажитись із сервера; кнопка "Оновити" робить force-reload.
- [ ] Перевір, що при offline або 5xx від AI-ендпоінтів показується `error` і немає нескінченних ретраїв (mutations.retry = false).
- [ ] CI: лінт / typecheck / 543 тести / build локально зелені — підтверди, що так само в CI.

### Notes

- Не переводив `useCloudSync` — він має власну складну машину станів (dirty tracking, offline queue, conflict resolution). Переніс його react-query-логіку окремо, щоб не роздувати діф і не ризикувати з sync-pipeline.
- DevTools (`@tanstack/react-query-devtools`) не додавав — вони тягнуть великий бандл; якщо треба, додам окремо за flag'ом `import.meta.env.DEV`.
- Чому `staleTime: 60s` — поточні серверні виклики (digest, insight) не є "живими" даними; 1 хвилина — розумний баланс між зайвими запитами і свіжістю. Для queries, де треба свіжіше, можна передавати `staleTime` локально.

Link to Devin session: https://app.devin.ai/sessions/dd10f4d2af354b3180d48b21fb8b5a0d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
