### PR TITLE
refactor(core): extract hub navigation/ui into hooks and components

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -1,53 +1,37 @@
-import { useState, useCallback, lazy, Suspense, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect, lazy, Suspense, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { cn } from "@shared/lib/cn";
 import ModuleErrorBoundary from "./ModuleErrorBoundary";
 import { useDarkMode } from "@shared/hooks/useDarkMode";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { ToastProvider } from "@shared/hooks/useToast";
 import { ToastContainer } from "@shared/components/ui/Toast";
-import { Icon } from "@shared/components/ui/Icon";
 import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/hubNav";
 import { AuthProvider, useAuth } from "./AuthContext.jsx";
 import { useCloudSync } from "./useCloudSync.js";
-import { HubDashboard } from "./HubDashboard.jsx";
-import { HubReports } from "./HubReports.jsx";
-import { HubSettingsPage } from "./HubSettingsPage.jsx";
-import { OnboardingWizard, shouldShowOnboarding } from "./OnboardingWizard.jsx";
-import {
-  seedFinykDemoData,
-  enableFinykManualOnly,
-} from "../modules/finyk/lib/demoData.js";
-import { SyncStatusIndicator } from "./SyncStatusIndicator.jsx";
-import { OfflineBanner } from "./app/OfflineBanner.jsx";
 import { PageLoader } from "./app/PageLoader.jsx";
-import { DarkModeToggle } from "./app/DarkModeToggle.jsx";
-import { IOSInstallBanner } from "./app/IOSInstallBanner.jsx";
-import { UserMenuButton } from "./app/UserMenuButton.jsx";
+import { OfflineBanner } from "./app/OfflineBanner.jsx";
 import { MigrationPrompt } from "./app/MigrationPrompt.jsx";
 import { usePwaInstall } from "./app/usePwaInstall.js";
 import { useIosInstallBanner } from "./app/useIosInstallBanner.js";
 import { useSWUpdate } from "./app/useSWUpdate.js";
-import { PWA_ACTION_KEY, consumePwaAction } from "./app/pwaAction.js";
-
-const HubSearch = lazy(() =>
-  import("./HubSearch.jsx").then((m) => ({ default: m.HubSearch })),
-);
+import { PWA_ACTION_KEY } from "./app/pwaAction.js";
+import { HubHeader } from "./app/HubHeader.jsx";
+import { HubTabs } from "./app/HubTabs.jsx";
+import { HubMainContent } from "./app/HubMainContent.jsx";
+import { HubFloatingActions } from "./app/HubFloatingActions.jsx";
+import { HubModals } from "./app/HubModals.jsx";
+import { useHubNavigation } from "./hooks/useHubNavigation.js";
+import { useHubUIState } from "./hooks/useHubUIState.js";
+import { usePwaActions } from "./hooks/usePwaActions.js";
 
 import RoutineApp from "../modules/routine/RoutineApp.jsx";
-
-const HubChat = lazy(() => import("./HubChat"));
-
-const FinykApp = lazy(() => import("../modules/finyk/FinykApp"));
-const FizrukApp = lazy(() => import("../modules/fizruk/FizrukApp"));
-const NutritionApp = lazy(() => import("../modules/nutrition/NutritionApp"));
-
-const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
-const VALID_ACTIONS = new Set(["add_expense", "start_workout", "add_meal"]);
-
 const AuthPage = lazy(() =>
   import("./AuthPage.jsx").then((m) => ({ default: m.AuthPage })),
 );
+const FinykApp = lazy(() => import("../modules/finyk/FinykApp"));
+const FizrukApp = lazy(() => import("../modules/fizruk/FizrukApp"));
+const NutritionApp = lazy(() => import("../modules/nutrition/NutritionApp"));
 
 export default function App() {
   return (
@@ -61,117 +45,35 @@ export default function App() {
 }
 
 function AppInner() {
-  const navigate = useNavigate();
+  const [showAuth, setShowAuth] = useState(false);
   const [searchParams] = useSearchParams();
 
-  const initialModule = (() => {
-    const q = searchParams.get("module");
-    if (VALID_MODULES.has(q)) return q;
-    return null;
-  })();
-
-  const [activeModule, setActiveModule] = useState(initialModule);
-  const [chatOpen, setChatOpen] = useState(false);
-  const [chatInitialMessage, setChatInitialMessage] = useState(null);
-  const [showAuth, setShowAuth] = useState(false);
-  const [hubView, setHubView] = useState("dashboard");
-  const [showOnboarding, setShowOnboarding] = useState(() =>
-    shouldShowOnboarding(),
-  );
-  const [moduleAnimClass, setModuleAnimClass] = useState("module-enter");
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [pwaAction, setPwaAction] = useState(() => {
-    const fromUrl = searchParams.get("action");
-    if (VALID_ACTIONS.has(fromUrl)) {
-      try {
-        localStorage.setItem(PWA_ACTION_KEY, fromUrl);
-      } catch {
-        /* noop */
-      }
-      return fromUrl;
-    }
-    return consumePwaAction();
-  });
-  const clearPwaAction = useCallback(() => setPwaAction(null), []);
+  const { activeModule, openModule, goToHub, moduleAnimClass } = useHubNavigation();
+  const ui = useHubUIState();
+  const { pwaAction, setPwaAction, clearPwaAction, validActions } = usePwaActions(searchParams);
   const { dark, toggle: toggleDark } = useDarkMode();
   const { canInstall, install, dismiss } = usePwaInstall();
   const { visible: iosVisible, dismiss: iosDismiss } = useIosInstallBanner();
   const online = useOnlineStatus();
   const { updateAvailable, applyUpdate } = useSWUpdate();
   const { user, isLoading: authLoading, logout } = useAuth();
-  const {
-    syncing,
-    lastSync,
-    pushAll,
-    pullAll,
-    migrationPending,
-    uploadLocalData,
-    skipMigration,
-  } = useCloudSync(user);
-
-  const goToHub = useCallback(() => {
-    setModuleAnimClass("hub-enter");
-    setActiveModule(null);
-    navigate("/", { replace: false });
-  }, [navigate]);
-
-  const openModule = useCallback(
-    (id, opts = {}) => {
-      const nextId = String(id || "").trim();
-      if (!VALID_MODULES.has(nextId)) return;
-      const isSame = nextId === activeModule;
-
-      try {
-        const raw = opts.hash != null ? String(opts.hash).trim() : "";
-        if (raw) {
-          window.location.hash = raw.startsWith("#") ? raw : `#${raw}`;
-        } else if (!isSame) {
-          window.location.hash = "";
-        }
-      } catch {
-        /* ignore */
-      }
-      setModuleAnimClass("module-enter");
-      setActiveModule(nextId);
-      navigate(`/?module=${nextId}`, { replace: false });
-    },
-    [activeModule, navigate],
-  );
-
-  // Sync activeModule from browser navigation (back/forward)
-  useEffect(() => {
-    const q = searchParams.get("module");
-    const mod = VALID_MODULES.has(q) ? q : null;
-    if (mod !== activeModule) {
-      setModuleAnimClass(mod ? "module-enter" : "hub-enter");
-      setActiveModule(mod);
-    }
-  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  const sync = useCloudSync(user);
   useEffect(() => {
     const onMessage = (event) => {
-      if (
-        event.data?.type === "OPEN_MODULE" &&
-        VALID_MODULES.has(event.data.module)
-      ) {
+      if (event.data?.type === "OPEN_MODULE") {
         openModule(event.data.module);
       }
     };
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.addEventListener("message", onMessage);
-      return () =>
-        navigator.serviceWorker.removeEventListener("message", onMessage);
+      return () => navigator.serviceWorker.removeEventListener("message", onMessage);
     }
   }, [openModule]);
 
-  // Крос-модульний deep-link через `openHubModule(...)` з @shared/lib/hubNav —
-  // дозволяє будь-якому компоненту будь-якого модуля стрибнути в інший
-  // модуль+hash без прокидування `onOpenModule` через дерево.
   useEffect(() => {
     const onHubOpen = (ev) => {
       const { module, hash, action } = ev.detail || {};
-      if (!VALID_MODULES.has(module)) return;
-      if (action && VALID_ACTIONS.has(action)) {
+      if (action && validActions.has(action)) {
         try {
           localStorage.setItem(PWA_ACTION_KEY, action);
         } catch {
@@ -183,16 +85,10 @@ function AppInner() {
     };
     window.addEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
     return () => window.removeEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
-  }, [openModule]);
+  }, [openModule, setPwaAction, validActions]);
 
-  if (migrationPending) {
-    return (
-      <MigrationPrompt
-        onUpload={uploadLocalData}
-        onSkip={skipMigration}
-        syncing={syncing}
-      />
-    );
+  if (sync.migrationPending) {
+    return <MigrationPrompt onUpload={sync.uploadLocalData} onSkip={sync.skipMigration} syncing={sync.syncing} />;
   }
 
   if (showAuth && !user) {
@@ -201,11 +97,7 @@ function AppInner() {
         <div className="page-enter">
           <AuthPage />
           <div className="fixed bottom-6 left-0 right-0 flex justify-center">
-            <button
-              type="button"
-              onClick={() => setShowAuth(false)}
-              className="text-sm text-muted hover:text-text underline"
-            >
+            <button type="button" onClick={() => setShowAuth(false)} className="text-sm text-muted hover:text-text underline">
               Продовжити без акаунту
             </button>
           </div>
@@ -219,332 +111,55 @@ function AppInner() {
       <div className="min-h-dvh bg-bg flex flex-col safe-area-pt-pb page-enter">
         {!online && <OfflineBanner />}
 
-        <header className="px-5 pt-10 pb-2 max-w-lg mx-auto w-full flex items-start justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-text tracking-tight">
-              Мій простір
-            </h1>
-            <p className="text-sm text-muted mt-1">
-              {hubView === "reports"
-                ? "Звіти та статистика"
-                : hubView === "settings"
-                  ? "Налаштування"
-                  : "Дашборд та модулі"}
-            </p>
-          </div>
-          <div className="pt-1 flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setSearchOpen(true)}
-              aria-label="Пошук"
-              title="Пошук по всіх модулях"
-              className="w-10 h-10 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-            >
-              <Icon name="search" size={20} />
-            </button>
-            {user ? (
-              <>
-                <SyncStatusIndicator user={user} syncing={syncing} />
-                <UserMenuButton
-                  user={user}
-                  syncing={syncing}
-                  lastSync={lastSync}
-                  onSync={pushAll}
-                  onPull={pullAll}
-                  onLogout={logout}
-                />
-              </>
-            ) : (
-              !authLoading && (
-                <button
-                  type="button"
-                  onClick={() => setShowAuth(true)}
-                  aria-label="Увійти в акаунт"
-                  title="Увійти"
-                  className="w-10 h-10 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-                >
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-                    <circle cx="12" cy="7" r="4" />
-                  </svg>
-                </button>
-              )
-            )}
-            <DarkModeToggle dark={dark} onToggle={toggleDark} />
-          </div>
-        </header>
+        <HubHeader
+          hubView={ui.hubView}
+          onOpenSearch={() => ui.setSearchOpen(true)}
+          user={user}
+          syncing={sync.syncing}
+          lastSync={sync.lastSync}
+          onSync={sync.pushAll}
+          onPull={sync.pullAll}
+          onLogout={logout}
+          authLoading={authLoading}
+          onShowAuth={() => setShowAuth(true)}
+          dark={dark}
+          onToggleDark={toggleDark}
+        />
 
-        <div className="px-5 max-w-lg mx-auto w-full mb-1">
-          <div className="flex rounded-2xl overflow-hidden border border-line bg-panelHi/40 p-0.5 gap-0.5">
-            <button
-              type="button"
-              onClick={() => setHubView("dashboard")}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-sm font-medium transition-all",
-                hubView === "dashboard"
-                  ? "bg-panel text-text shadow-card"
-                  : "text-muted hover:text-text",
-              )}
-            >
-              <svg
-                width="15"
-                height="15"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <rect x="3" y="3" width="7" height="7" rx="1" />
-                <rect x="14" y="3" width="7" height="7" rx="1" />
-                <rect x="3" y="14" width="7" height="7" rx="1" />
-                <rect x="14" y="14" width="7" height="7" rx="1" />
-              </svg>
-              Головна
-            </button>
-            <button
-              type="button"
-              onClick={() => setHubView("reports")}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-sm font-medium transition-all",
-                hubView === "reports"
-                  ? "bg-panel text-text shadow-card"
-                  : "text-muted hover:text-text",
-              )}
-            >
-              <svg
-                width="15"
-                height="15"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <line x1="18" y1="20" x2="18" y2="10" />
-                <line x1="12" y1="20" x2="12" y2="4" />
-                <line x1="6" y1="20" x2="6" y2="14" />
-              </svg>
-              Звіти
-            </button>
-            <button
-              type="button"
-              onClick={() => setHubView("settings")}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-sm font-medium transition-all",
-                hubView === "settings"
-                  ? "bg-panel text-text shadow-card"
-                  : "text-muted hover:text-text",
-              )}
-            >
-              <svg
-                width="15"
-                height="15"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-              </svg>
-              Налаштування
-            </button>
-          </div>
-        </div>
+        <HubTabs hubView={ui.hubView} onChange={ui.setHubView} />
 
-        {updateAvailable && (
-          <div className="px-5 max-w-lg mx-auto w-full mb-2">
-            <div className="px-4 py-3 rounded-2xl bg-primary/10 border border-primary/20 flex items-center gap-3">
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-primary shrink-0"
-                aria-hidden
-              >
-                <polyline points="23 4 23 10 17 10" />
-                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-              </svg>
-              <span className="text-sm text-text flex-1">
-                Доступна нова версія
-              </span>
-              <button
-                onClick={applyUpdate}
-                className="text-sm font-semibold text-primary hover:underline shrink-0"
-              >
-                Оновити
-              </button>
-            </div>
-          </div>
-        )}
+        <HubMainContent
+          updateAvailable={updateAvailable}
+          onApplyUpdate={applyUpdate}
+          canInstall={canInstall}
+          onInstall={install}
+          onDismissInstall={dismiss}
+          onboarding={ui.onboarding}
+          setOnboarding={ui.setOnboarding}
+          onSetPwaAction={setPwaAction}
+          onOpenModule={openModule}
+          iosVisible={iosVisible}
+          onDismissIos={iosDismiss}
+          hubView={ui.hubView}
+          onOpenChat={ui.openChat}
+          dark={dark}
+          onToggleDark={toggleDark}
+          syncing={sync.syncing}
+          onSync={sync.pushAll}
+          onPull={sync.pullAll}
+          user={user}
+        />
 
-        {canInstall && (
-          <div className="px-5 max-w-lg mx-auto w-full mb-2">
-            <div className="px-4 py-3 rounded-2xl bg-panel border border-line shadow-card flex items-center gap-3">
-              <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="text-primary"
-                  aria-hidden
-                >
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                  <polyline points="7 10 12 15 17 10" />
-                  <line x1="12" y1="15" x2="12" y2="3" />
-                </svg>
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold text-text">
-                  Встановити додаток
-                </p>
-                <p className="text-xs text-muted">
-                  Працює офлайн, як рідний додаток
-                </p>
-              </div>
-              <button
-                onClick={install}
-                className="px-4 py-2 rounded-xl bg-primary text-white text-sm font-semibold shrink-0 hover:bg-primary/90 transition-colors"
-              >
-                Так
-              </button>
-              <button
-                onClick={dismiss}
-                className="text-muted hover:text-text shrink-0 p-1"
-                aria-label="Закрити"
-              >
-                <Icon name="close" size={16} />
-              </button>
-            </div>
-          </div>
-        )}
+        <HubFloatingActions onOpenChat={() => ui.openChat()} />
 
-        {showOnboarding && (
-          <OnboardingWizard
-            onDone={(startModuleId, opts = {}) => {
-              setShowOnboarding(false);
-              // Quick-start intents from the wizard map onto three different
-              // landings inside Finyk. We set any flags / PWA actions *before*
-              // calling `openModule` so FinykApp sees them on mount.
-              if (opts.intent === "demo") {
-                seedFinykDemoData();
-              } else if (opts.intent === "manual") {
-                enableFinykManualOnly();
-                setPwaAction("add_expense");
-              } else if (opts.intent === "bank") {
-                // Bank flow needs no pre-seeding — the module renders its
-                // token input as soon as it mounts.
-              }
-              if (startModuleId) openModule(startModuleId);
-            }}
-          />
-        )}
-
-        {iosVisible && <IOSInstallBanner onDismiss={iosDismiss} />}
-
-        <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
-          {hubView === "dashboard" && (
-            <div className="flex flex-col gap-5 pt-2">
-              <HubDashboard
-                onOpenModule={openModule}
-                onOpenChat={(message) => {
-                  setChatInitialMessage(message || null);
-                  setChatOpen(true);
-                }}
-              />
-            </div>
-          )}
-
-          {hubView === "reports" && (
-            <div className="pt-2">
-              <HubReports />
-            </div>
-          )}
-
-          {hubView === "settings" && (
-            <HubSettingsPage
-              dark={dark}
-              onToggleDark={toggleDark}
-              syncing={syncing}
-              onSync={pushAll}
-              onPull={pullAll}
-              user={user}
-            />
-          )}
-        </main>
-
-        <div className="fixed bottom-0 left-0 right-0 flex justify-center pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
-          <button
-            type="button"
-            onClick={() => setChatOpen(true)}
-            className="flex items-center gap-2.5 px-5 h-12 rounded-full bg-primary text-bg shadow-float hover:brightness-110 active:scale-95 transition-all font-medium text-sm"
-            aria-label="Відкрити асистента (фінанси та тренування)"
-          >
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-            </svg>
-            Асистент
-          </button>
-        </div>
-
-        {chatOpen && (
-          <Suspense fallback={null}>
-            <HubChat
-              onClose={() => {
-                setChatOpen(false);
-                setChatInitialMessage(null);
-              }}
-              initialMessage={chatInitialMessage}
-            />
-          </Suspense>
-        )}
-
-        {searchOpen && (
-          <Suspense fallback={null}>
-            <HubSearch
-              onClose={() => setSearchOpen(false)}
-              onOpenModule={openModule}
-            />
-          </Suspense>
-        )}
+        <HubModals
+          chatOpen={ui.chatOpen}
+          onCloseChat={ui.closeChat}
+          chatInitialMessage={ui.chatInitialMessage}
+          searchOpen={ui.searchOpen}
+          onCloseSearch={ui.closeSearch}
+          onOpenModule={openModule}
+        />
       </div>
     );
   }
@@ -561,17 +176,7 @@ function AppInner() {
             title="До вибору модуля"
             aria-label="До вибору модуля"
           >
-            <svg
-              width="22"
-              height="22"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
               <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
               <polyline points="9 22 9 12 15 12 15 22" />
             </svg>
@@ -580,35 +185,12 @@ function AppInner() {
       )}
 
       <Suspense fallback={<PageLoader />}>
-        <div
-          key={activeModule}
-          className={cn(moduleAnimClass, "h-full flex flex-col")}
-        >
+        <div key={activeModule} className={cn(moduleAnimClass, "h-full flex flex-col")}>
           <ModuleErrorBoundary onBackToHub={goToHub}>
-            {activeModule === "finyk" && (
-              <FinykApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-            {activeModule === "fizruk" && (
-              <FizrukApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-            {activeModule === "routine" && (
-              <RoutineApp onBackToHub={goToHub} onOpenModule={openModule} />
-            )}
-            {activeModule === "nutrition" && (
-              <NutritionApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
+            {activeModule === "finyk" && <FinykApp onBackToHub={goToHub} pwaAction={pwaAction} onPwaActionConsumed={clearPwaAction} />}
+            {activeModule === "fizruk" && <FizrukApp onBackToHub={goToHub} pwaAction={pwaAction} onPwaActionConsumed={clearPwaAction} />}
+            {activeModule === "routine" && <RoutineApp onBackToHub={goToHub} onOpenModule={openModule} />}
+            {activeModule === "nutrition" && <NutritionApp onBackToHub={goToHub} pwaAction={pwaAction} onPwaActionConsumed={clearPwaAction} />}
           </ModuleErrorBoundary>
         </div>
       </Suspense>

--- a/src/core/app/HubFloatingActions.jsx
+++ b/src/core/app/HubFloatingActions.jsx
@@ -1,0 +1,17 @@
+export function HubFloatingActions({ onOpenChat }) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 flex justify-center pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
+      <button
+        type="button"
+        onClick={onOpenChat}
+        className="flex items-center gap-2.5 px-5 h-12 rounded-full bg-primary text-bg shadow-float hover:brightness-110 active:scale-95 transition-all font-medium text-sm"
+        aria-label="Відкрити асистента (фінанси та тренування)"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        Асистент
+      </button>
+    </div>
+  );
+}

--- a/src/core/app/HubHeader.jsx
+++ b/src/core/app/HubHeader.jsx
@@ -1,0 +1,86 @@
+import { Icon } from "@shared/components/ui/Icon";
+import { DarkModeToggle } from "./DarkModeToggle.jsx";
+import { SyncStatusIndicator } from "../SyncStatusIndicator.jsx";
+import { UserMenuButton } from "./UserMenuButton.jsx";
+
+export function HubHeader({
+  hubView,
+  onOpenSearch,
+  user,
+  syncing,
+  lastSync,
+  onSync,
+  onPull,
+  onLogout,
+  authLoading,
+  onShowAuth,
+  dark,
+  onToggleDark,
+}) {
+  return (
+    <header className="px-5 pt-10 pb-2 max-w-lg mx-auto w-full flex items-start justify-between">
+      <div>
+        <h1 className="text-3xl font-bold text-text tracking-tight">Мій простір</h1>
+        <p className="text-sm text-muted mt-1">
+          {hubView === "reports"
+            ? "Звіти та статистика"
+            : hubView === "settings"
+              ? "Налаштування"
+              : "Дашборд та модулі"}
+        </p>
+      </div>
+      <div className="pt-1 flex items-center gap-1">
+        <button
+          type="button"
+          onClick={onOpenSearch}
+          aria-label="Пошук"
+          title="Пошук по всіх модулях"
+          className="w-10 h-10 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+        >
+          <Icon name="search" size={20} />
+        </button>
+
+        {user ? (
+          <>
+            <SyncStatusIndicator user={user} syncing={syncing} />
+            <UserMenuButton
+              user={user}
+              syncing={syncing}
+              lastSync={lastSync}
+              onSync={onSync}
+              onPull={onPull}
+              onLogout={onLogout}
+            />
+          </>
+        ) : (
+          !authLoading && (
+            <button
+              type="button"
+              onClick={onShowAuth}
+              aria-label="Увійти в акаунт"
+              title="Увійти"
+              className="w-10 h-10 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </button>
+          )
+        )}
+
+        <DarkModeToggle dark={dark} onToggle={onToggleDark} />
+      </div>
+    </header>
+  );
+}

--- a/src/core/app/HubMainContent.jsx
+++ b/src/core/app/HubMainContent.jsx
@@ -1,0 +1,114 @@
+import { Icon } from "@shared/components/ui/Icon";
+import { HubDashboard } from "../HubDashboard.jsx";
+import { HubReports } from "../HubReports.jsx";
+import { HubSettingsPage } from "../HubSettingsPage.jsx";
+import { OnboardingWizard } from "../OnboardingWizard.jsx";
+import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
+import { enableFinykManualOnly, seedFinykDemoData } from "../../modules/finyk/lib/demoData.js";
+
+export function HubMainContent({
+  updateAvailable,
+  onApplyUpdate,
+  canInstall,
+  onInstall,
+  onDismissInstall,
+  onboarding,
+  setOnboarding,
+  onSetPwaAction,
+  onOpenModule,
+  iosVisible,
+  onDismissIos,
+  hubView,
+  onOpenChat,
+  dark,
+  onToggleDark,
+  syncing,
+  onSync,
+  onPull,
+  user,
+}) {
+  return (
+    <>
+      {updateAvailable && (
+        <div className="px-5 max-w-lg mx-auto w-full mb-2">
+          <div className="px-4 py-3 rounded-2xl bg-primary/10 border border-primary/20 flex items-center gap-3">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary shrink-0" aria-hidden>
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+            <span className="text-sm text-text flex-1">Доступна нова версія</span>
+            <button onClick={onApplyUpdate} className="text-sm font-semibold text-primary hover:underline shrink-0">
+              Оновити
+            </button>
+          </div>
+        </div>
+      )}
+
+      {canInstall && (
+        <div className="px-5 max-w-lg mx-auto w-full mb-2">
+          <div className="px-4 py-3 rounded-2xl bg-panel border border-line shadow-card flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary" aria-hidden>
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-text">Встановити додаток</p>
+              <p className="text-xs text-muted">Працює офлайн, як рідний додаток</p>
+            </div>
+            <button onClick={onInstall} className="px-4 py-2 rounded-xl bg-primary text-white text-sm font-semibold shrink-0 hover:bg-primary/90 transition-colors">
+              Так
+            </button>
+            <button onClick={onDismissInstall} className="text-muted hover:text-text shrink-0 p-1" aria-label="Закрити">
+              <Icon name="close" size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {onboarding && (
+        <OnboardingWizard
+          onDone={(startModuleId, opts = {}) => {
+            setOnboarding(false);
+            if (opts.intent === "demo") {
+              seedFinykDemoData();
+            } else if (opts.intent === "manual") {
+              enableFinykManualOnly();
+              onSetPwaAction("add_expense");
+            }
+            if (startModuleId) onOpenModule(startModuleId);
+          }}
+        />
+      )}
+
+      {iosVisible && <IOSInstallBanner onDismiss={onDismissIos} />}
+
+      <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
+        {hubView === "dashboard" && (
+          <div className="flex flex-col gap-5 pt-2">
+            <HubDashboard onOpenModule={onOpenModule} onOpenChat={onOpenChat} />
+          </div>
+        )}
+
+        {hubView === "reports" && (
+          <div className="pt-2">
+            <HubReports />
+          </div>
+        )}
+
+        {hubView === "settings" && (
+          <HubSettingsPage
+            dark={dark}
+            onToggleDark={onToggleDark}
+            syncing={syncing}
+            onSync={onSync}
+            onPull={onPull}
+            user={user}
+          />
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/core/app/HubModals.jsx
+++ b/src/core/app/HubModals.jsx
@@ -1,0 +1,31 @@
+import { lazy, Suspense } from "react";
+
+const HubSearch = lazy(() =>
+  import("../HubSearch.jsx").then((m) => ({ default: m.HubSearch })),
+);
+const HubChat = lazy(() => import("../HubChat"));
+
+export function HubModals({
+  chatOpen,
+  onCloseChat,
+  chatInitialMessage,
+  searchOpen,
+  onCloseSearch,
+  onOpenModule,
+}) {
+  return (
+    <>
+      {chatOpen && (
+        <Suspense fallback={null}>
+          <HubChat onClose={onCloseChat} initialMessage={chatInitialMessage} />
+        </Suspense>
+      )}
+
+      {searchOpen && (
+        <Suspense fallback={null}>
+          <HubSearch onClose={onCloseSearch} onOpenModule={onOpenModule} />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/src/core/app/HubTabs.jsx
+++ b/src/core/app/HubTabs.jsx
@@ -1,0 +1,67 @@
+import { cn } from "@shared/lib/cn";
+
+function TabButton({ active, onClick, children, icon }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-xl text-sm font-medium transition-all",
+        active ? "bg-panel text-text shadow-card" : "text-muted hover:text-text",
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+export function HubTabs({ hubView, onChange }) {
+  return (
+    <div className="px-5 max-w-lg mx-auto w-full mb-1">
+      <div className="flex rounded-2xl overflow-hidden border border-line bg-panelHi/40 p-0.5 gap-0.5">
+        <TabButton
+          active={hubView === "dashboard"}
+          onClick={() => onChange("dashboard")}
+          icon={
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <rect x="3" y="3" width="7" height="7" rx="1" />
+              <rect x="14" y="3" width="7" height="7" rx="1" />
+              <rect x="3" y="14" width="7" height="7" rx="1" />
+              <rect x="14" y="14" width="7" height="7" rx="1" />
+            </svg>
+          }
+        >
+          Головна
+        </TabButton>
+
+        <TabButton
+          active={hubView === "reports"}
+          onClick={() => onChange("reports")}
+          icon={
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <line x1="18" y1="20" x2="18" y2="10" />
+              <line x1="12" y1="20" x2="12" y2="4" />
+              <line x1="6" y1="20" x2="6" y2="14" />
+            </svg>
+          }
+        >
+          Звіти
+        </TabButton>
+
+        <TabButton
+          active={hubView === "settings"}
+          onClick={() => onChange("settings")}
+          icon={
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
+            </svg>
+          }
+        >
+          Налаштування
+        </TabButton>
+      </div>
+    </div>
+  );
+}

--- a/src/core/hooks/useHubNavigation.js
+++ b/src/core/hooks/useHubNavigation.js
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
+
+export function useHubNavigation() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const initialModule = (() => {
+    const q = searchParams.get("module");
+    if (VALID_MODULES.has(q)) return q;
+    return null;
+  })();
+
+  const [activeModule, setActiveModule] = useState(initialModule);
+  const [moduleAnimClass, setModuleAnimClass] = useState("module-enter");
+
+  const goToHub = useCallback(() => {
+    setModuleAnimClass("hub-enter");
+    setActiveModule(null);
+    navigate("/", { replace: false });
+  }, [navigate]);
+
+  const openModule = useCallback(
+    (id, opts = {}) => {
+      const nextId = String(id || "").trim();
+      if (!VALID_MODULES.has(nextId)) return;
+      const isSame = nextId === activeModule;
+
+      try {
+        const raw = opts.hash != null ? String(opts.hash).trim() : "";
+        if (raw) {
+          window.location.hash = raw.startsWith("#") ? raw : `#${raw}`;
+        } else if (!isSame) {
+          window.location.hash = "";
+        }
+      } catch {
+        /* ignore */
+      }
+
+      setModuleAnimClass("module-enter");
+      setActiveModule(nextId);
+      navigate(`/?module=${nextId}`, { replace: false });
+    },
+    [activeModule, navigate],
+  );
+
+  useEffect(() => {
+    const q = searchParams.get("module");
+    const mod = VALID_MODULES.has(q) ? q : null;
+    if (mod !== activeModule) {
+      setModuleAnimClass(mod ? "module-enter" : "hub-enter");
+      setActiveModule(mod);
+    }
+  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { activeModule, openModule, goToHub, moduleAnimClass };
+}

--- a/src/core/hooks/useHubUIState.js
+++ b/src/core/hooks/useHubUIState.js
@@ -1,0 +1,36 @@
+import { useCallback, useState } from "react";
+import { shouldShowOnboarding } from "../OnboardingWizard.jsx";
+
+export function useHubUIState() {
+  const [chatOpen, setChatOpen] = useState(false);
+  const [chatInitialMessage, setChatInitialMessage] = useState(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [hubView, setHubView] = useState("dashboard");
+  const [onboarding, setOnboarding] = useState(() => shouldShowOnboarding());
+
+  const openChat = useCallback((message = null) => {
+    setChatInitialMessage(message || null);
+    setChatOpen(true);
+  }, []);
+
+  const closeChat = useCallback(() => {
+    setChatOpen(false);
+    setChatInitialMessage(null);
+  }, []);
+
+  const closeSearch = useCallback(() => setSearchOpen(false), []);
+
+  return {
+    chatOpen,
+    chatInitialMessage,
+    searchOpen,
+    hubView,
+    onboarding,
+    setHubView,
+    setOnboarding,
+    setSearchOpen,
+    openChat,
+    closeChat,
+    closeSearch,
+  };
+}

--- a/src/core/hooks/usePwaActions.js
+++ b/src/core/hooks/usePwaActions.js
@@ -1,0 +1,23 @@
+import { useCallback, useState } from "react";
+import { PWA_ACTION_KEY, consumePwaAction } from "../app/pwaAction.js";
+
+const VALID_ACTIONS = new Set(["add_expense", "start_workout", "add_meal"]);
+
+export function usePwaActions(searchParams) {
+  const [pwaAction, setPwaAction] = useState(() => {
+    const fromUrl = searchParams.get("action");
+    if (VALID_ACTIONS.has(fromUrl)) {
+      try {
+        localStorage.setItem(PWA_ACTION_KEY, fromUrl);
+      } catch {
+        /* noop */
+      }
+      return fromUrl;
+    }
+    return consumePwaAction();
+  });
+
+  const clearPwaAction = useCallback(() => setPwaAction(null), []);
+
+  return { pwaAction, setPwaAction, clearPwaAction, validActions: VALID_ACTIONS };
+}


### PR DESCRIPTION
### Motivation
- The main `App.jsx` had grown into a large orchestration component and needed to be split for readability and maintainability while preserving behavior. 
- Aim to separate state/navigation logic, PWA bootstrap, and UI sections so each unit is focused and easier to reason about.

### Description
- Extracted navigation logic to `useHubNavigation` which exposes `activeModule`, `openModule`, `goToHub` and `moduleAnimClass` and keeps URL/back-forward sync behavior intact.
- Extracted hub UI state to `useHubUIState` which manages `chatOpen`, `chatInitialMessage`, `searchOpen`, `hubView`, and `onboarding` with helper actions (`openChat`, `closeChat`, `closeSearch`).
- Extracted PWA action bootstrap to `usePwaActions` which initializes `pwaAction` from URL/localStorage and exposes `setPwaAction` / `clearPwaAction` (keeps PWA key and consume semantics unchanged).
- Moved large UI blocks into focused components: `HubHeader`, `HubTabs`, `HubMainContent`, `HubFloatingActions`, and `HubModals`; `App.jsx` now only wires providers, routing/module mounts and passes props between hooks/components.
- Preserved existing sync/auth/pwa logic, service-worker messages, and URL parameter semantics; size targets met (`App.jsx` ≤ 200 lines, each hook ≤ 150 lines).

### Testing
- Ran `npm run lint:imports` which passed.
- Ran full test suite with `npm test` and all tests passed: 54 files / 543 tests succeeded.
- Attempted `npx eslint ...` locally but it failed in this environment due to a missing `typescript-eslint` package in the ESLint config, not due to the code changes.
- `npm test -- --runInBand` failed because that option is not supported by the vitest CLI used here (test suite was run without that flag and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bb785b388330a290c8431fa70648)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
