### PR TITLE
fix(state): restore useCallback stability on react-query hook returns

### DIFF
--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -254,12 +254,14 @@ export function useCoachInsight() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const refresh = useCallback(() => loadInsight(true), [loadInsight]);
+
   return {
     insight,
     loading: mutation.isPending,
     error: mutation.error
       ? mutation.error.message || "Помилка завантаження"
       : null,
-    refresh: () => loadInsight(true),
+    refresh,
   };
 }

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
@@ -381,10 +381,17 @@ export function useWeeklyDigest(selectedWeekKey) {
     },
   });
 
-  const generate = async () => {
+  const { mutateAsync } = mutation;
+
+  // `mutateAsync` is a stable reference from react-query, so `generate`
+  // stays referentially stable across renders as long as
+  // `weekKey`/`isCurrentWeek` don't change. Consumers (e.g.
+  // `useMondayAutoDigest`) rely on this to avoid re-running effects that
+  // trigger additional AI calls.
+  const generate = useCallback(async () => {
     if (!isCurrentWeek) return null;
     try {
-      const result = await mutation.mutateAsync(weekKey);
+      const result = await mutateAsync(weekKey);
       return {
         ...result.report,
         generatedAt: result.generatedAt,
@@ -394,7 +401,7 @@ export function useWeeklyDigest(selectedWeekKey) {
     } catch {
       return null;
     }
-  };
+  }, [weekKey, isCurrentWeek, mutateAsync]);
 
   return {
     digest,


### PR DESCRIPTION
## Summary

Hotfix до #132. Devin Review справедливо вказав, що `generate` у `useWeeklyDigest` втратив `useCallback`-обгортку під час міграції на react-query. Це — реальна регресія:

- `useMondayAutoDigest` у <ref_snippet file="/home/ubuntu/repos/Sergeant/src/core/HubDashboard.jsx" lines="563-580" /> тримає `generate` у `useEffect` залежностях.
- Без `useCallback` `generate` стає новою функцією на кожному рендері → `useEffect` перезапускається → `setTimeout(3000)` скидається → якщо AI-запит довший за 3с, після `isPending: true` може вилетіти ще один `generate()` → дублікат виклику до дорогого `/api/weekly-digest`.

Зміни:
1. **`src/core/useWeeklyDigest.js`** — `generate` знову в `useCallback([weekKey, isCurrentWeek, mutateAsync])`. `mutateAsync` витягнуто деструктурингом, бо react-query обіцяє стабільну посилку саме на ньому.
2. **`src/core/useCoachInsight.js`** — `refresh` теж винесено в `useCallback(..., [loadInsight])`. Зараз `refresh` в консьюмерах не у deps, але це гігієна — інакше той самий баг чекає першого, хто додасть його в залежності.

## Review & Testing Checklist for Human

- [ ] `HubDashboard` у понеділок 00:00: дайджест має згенеруватись один раз, не два.
- [ ] У довго відкритих вкладках не має бути повторних POST до `/api/weekly-digest` без явної дії користувача.
- [ ] Lint / typecheck / 543 тести локально зелені — підтверди в CI.

### Notes

- Переписати консьюмер (прибрати `generate` з deps) було б коротше, але крихкіше — наступний автор впав би в ту саму пастку. Стабільне API хука — правильний шар для фіксу.
- Тестів на сам хук `useWeeklyDigest` немає. Не став додавати тут, щоб фікс був мінімальним; окремим PR додам покриття для react-query-layer'а.

Link to Devin session: https://app.devin.ai/sessions/dd10f4d2af354b3180d48b21fb8b5a0d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
