### PR TITLE
fix(observability): defer @sentry/react to after hydration

### DIFF
--- a/src/core/ErrorBoundary.jsx
+++ b/src/core/ErrorBoundary.jsx
@@ -1,0 +1,50 @@
+import { Component } from "react";
+import { captureException } from "./sentry.js";
+
+/**
+ * Лайтвейтний корневий ErrorBoundary — zero-cost у головному бандлі.
+ *
+ * Навмисно не використовує `Sentry.ErrorBoundary` з `@sentry/react`, бо той
+ * статично підтягує весь SDK (~30–40 KB gzip) у initial chunk — див. правило
+ * 2.3 у `.agents/skills/vercel-react-best-practices/AGENTS.md`
+ * («Defer Non-Critical Third-Party Libraries»).
+ *
+ * `captureException` з `./sentry.js` — no-op, поки Sentry не завантажений
+ * динамічним імпортом. Коли SDK буде готовий (див. `initSentry`), виклики
+ * автоматично перенаправляться в реальний `Sentry.captureException`.
+ */
+export class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+    this.resetError = () => this.setState({ error: null });
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // Lazy-forward: якщо Sentry SDK ще не підтягнувся, це no-op;
+    // якщо вже підтягнувся — піде у Sentry.captureException.
+    try {
+      captureException(error, {
+        contexts: { react: { componentStack: info?.componentStack } },
+      });
+    } catch {
+      /* noop — error boundary не має ламатись через телеметрію */
+    }
+  }
+
+  render() {
+    const { error } = this.state;
+    const { fallback: Fallback, children } = this.props;
+    if (error) {
+      if (typeof Fallback === "function") {
+        return <Fallback error={error} resetError={this.resetError} />;
+      }
+      return Fallback || null;
+    }
+    return children;
+  }
+}

--- a/src/core/sentry.js
+++ b/src/core/sentry.js
@@ -1,6 +1,5 @@
-import * as Sentry from "@sentry/react";
-
 let initialized = false;
+let sentryModule = null;
 
 function parseRate(val, fallback) {
   if (val == null || val === "") return fallback;
@@ -9,14 +8,24 @@ function parseRate(val, fallback) {
 }
 
 /**
- * Ініціалізує Sentry в браузері, якщо задано VITE_SENTRY_DSN.
- * Без DSN — no-op (dev/preview без моніторингу).
+ * Лениво завантажує `@sentry/react` і ініціалізує Sentry у браузері.
+ *
+ * Навмисно через динамічний `import()`, щоб SDK (~30–40 KB gzip) не
+ * потрапляв у головний бандл — аналітика/error tracking не повинні
+ * блокувати hydration (див. правило 2.3 у
+ * `.agents/skills/vercel-react-best-practices/AGENTS.md`).
+ *
+ * Без `VITE_SENTRY_DSN` — no-op і жодного чанку не підтягується.
  */
-export function initSentry() {
+export async function initSentry() {
+  if (initialized) return;
   const dsn = import.meta.env.VITE_SENTRY_DSN;
-  if (!dsn || initialized) return;
+  if (!dsn) return;
 
-  Sentry.init({
+  const mod = await import("@sentry/react");
+  sentryModule = mod;
+
+  mod.init({
     dsn,
     environment:
       import.meta.env.VITE_SENTRY_ENVIRONMENT ||
@@ -24,16 +33,12 @@ export function initSentry() {
       "production",
     release: import.meta.env.VITE_SENTRY_RELEASE,
     integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration({
-        // Не маскуємо текст — у застосунку немає PII окрім введених юзером даних;
-        // їх можна окремо замаскувати beforeSend-ом при потребі.
+      mod.browserTracingIntegration(),
+      mod.replayIntegration({
         maskAllText: false,
         blockAllMedia: true,
       }),
     ],
-    // `VITE_SENTRY_*_SAMPLE_RATE=0` має справді вимикати трейсинг/реплей,
-    // тому fallback виноситься через parseRate, а не через `|| 0.x`.
     tracesSampleRate: parseRate(
       import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE,
       0.1,
@@ -44,7 +49,6 @@ export function initSentry() {
     ),
     replaysOnErrorSampleRate: 1.0,
     beforeSend(event) {
-      // Приховуємо cookies/авто-налаштування, щоб не відправляти sid.
       if (event.request?.cookies) delete event.request.cookies;
       return event;
     },
@@ -53,4 +57,16 @@ export function initSentry() {
   initialized = true;
 }
 
-export { Sentry };
+/**
+ * Lazy-forward wrapper: поки SDK не завантажений — no-op, потім
+ * делегує у реальний `Sentry.captureException`. Використовується
+ * локальним `ErrorBoundary`, щоб не змушувати його залежати від SDK.
+ */
+export function captureException(error, hint) {
+  if (!sentryModule) return;
+  try {
+    sentryModule.captureException(error, hint);
+  } catch {
+    /* noop */
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,11 +5,11 @@ import App from "./core/App";
 import "./index.css";
 import { storageManager } from "@shared/lib/storageManager.js";
 import { createAppQueryClient } from "@shared/lib/queryClient.js";
-import { initSentry, Sentry } from "./core/sentry.js";
+import { ErrorBoundary } from "./core/ErrorBoundary.jsx";
+import { initSentry } from "./core/sentry.js";
 
 const queryClient = createAppQueryClient();
 
-initSentry();
 storageManager.runAll();
 
 function ErrorFallback({ error, resetError }) {
@@ -34,14 +34,28 @@ function ErrorFallback({ error, resetError }) {
 }
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <Sentry.ErrorBoundary fallback={ErrorFallback}>
+  <ErrorBoundary fallback={ErrorFallback}>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
     </QueryClientProvider>
-  </Sentry.ErrorBoundary>,
+  </ErrorBoundary>,
 );
+
+// Sentry init відкладаємо до після hydration — SDK (~30–40 KB gzip) не
+// повинен блокувати TTI, а до його готовності `captureException` у
+// нашому локальному ErrorBoundary просто no-op.
+const scheduleInit = () => {
+  void initSentry();
+};
+if (typeof window !== "undefined") {
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(scheduleInit, { timeout: 2000 });
+  } else {
+    setTimeout(scheduleInit, 0);
+  }
+}
 
 if ("serviceWorker" in navigator) {
   import("virtual:pwa-register").then(({ registerSW }) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -121,6 +121,11 @@ export default defineConfig(({ mode }) => {
               if (id.includes("react-virtuoso")) return "vendor-virtuoso";
               if (id.includes("@zxing")) return "vendor-zxing";
               if (id.includes("react-markdown")) return "vendor-markdown";
+              // Ізольований chunk для Sentry, щоб SDK (~30–40 KB gzip) не
+              // потрапляв у загальний `vendor`, який шериться між eager-
+              // імпортами main bundle. Див. правило 2.3 у
+              // `.agents/skills/vercel-react-best-practices/AGENTS.md`.
+              if (id.includes("@sentry")) return "vendor-sentry";
               return "vendor";
             }
           },


### PR DESCRIPTION
## Summary

Fixes bundle-size regression from #130 flagged by Devin Review on `src/main.jsx` / `src/core/sentry.js`: `@sentry/react` was statically imported into the root `main.jsx`, forcing the SDK into the eagerly-loaded vendor bundle even when `VITE_SENTRY_DSN` is unset. Violates [AGENTS.md §2.3 "Defer Non-Critical Third-Party Libraries"](../blob/main/.agents/skills/vercel-react-best-practices/AGENTS.md).

**Changes:**

- `src/core/ErrorBoundary.jsx` *(new)* — lightweight local class-based boundary replacing `Sentry.ErrorBoundary` at the root. `componentDidCatch` forwards errors to Sentry via a lazy wrapper (no-op until SDK is loaded).
- `src/core/sentry.js` — static `import * as Sentry from "@sentry/react"` → dynamic `await import("@sentry/react")` inside `initSentry()`. Stores resolved module in a module-level variable. New exported `captureException(error, hint)` helper is a no-op before SDK init.
- `src/main.jsx` — replaces `<Sentry.ErrorBoundary>` with `<ErrorBoundary>`. `initSentry()` is now scheduled via `requestIdleCallback` (fallback `setTimeout`) so it runs **after** hydration instead of during module evaluation.
- `vite.config.js` — new dedicated `vendor-sentry` chunk (`id.includes("@sentry")`) to isolate the SDK from the shared `vendor` chunk. Without this, `manualChunks` collapses the dynamic import into `vendor`, which is eagerly loaded.

**Bundle impact (`npm run build`):**

| Build                  | `index` main  | `vendor` shared | `vendor-sentry`            |
|------------------------|---------------|-----------------|----------------------------|
| DSN **unset** (before) | 340.98 KB     | 326.85 KB       | — (bundled into `vendor`)  |
| DSN **unset** (after)  | 340.98 KB     | 326.85 KB       | **0.04 KB** loader stub    |
| DSN **set** (after)    | 341.65 KB     | 327.89 KB       | 356.75 KB (119.5 KB gzip) lazy |

Main bundle is unchanged; the SDK is now fetched only *after* hydration when a DSN is actually configured.

## Review & Testing Checklist for Human

- [ ] Smoke-test in dev (`npm run dev`) — app loads, no console errors, ErrorBoundary UI still renders if a component throws.
- [ ] Smoke-test with `VITE_SENTRY_DSN` set in a preview env — network tab should show `vendor-sentry-*.js` loaded after first paint (not blocking), and a thrown error should still reach Sentry.
- [ ] Verify `requestIdleCallback` fallback on Safari (no `requestIdleCallback`) — `setTimeout(…, 0)` path is exercised; Sentry still initialises.

### Notes

- Local checks pass: `npm run lint && npm run typecheck && npm test` (543/543).
- ErrorFallback UI is identical to the previous version; only the boundary class changed.
- No new runtime deps.


Link to Devin session: https://app.devin.ai/sessions/5d5073eef40a4f8fb9b6b1dd604700b6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
