### PR TITLE
refactor: centralize frontend HTTP calls via shared api layer

### DIFF
--- a/src/core/HubChat.jsx
+++ b/src/core/HubChat.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { sendChat, sendChatRaw } from "@shared/api/finykApi.js";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { perfMark, perfEnd } from "@shared/lib/perf";
@@ -264,22 +264,17 @@ function HubChat({ onClose, initialMessage }) {
         setContextState({ status: "ready", ts: contextRef.current.ts });
       }
 
-      const res = await fetch(apiUrl("/api/chat"), {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ context, messages: history }),
-      });
-      const raw = await res.text();
       let data;
       try {
-        data = raw ? JSON.parse(raw) : {};
-      } catch {
+        data = await sendChat({ context, messages: history });
+      } catch (error) {
         throw new Error(
-          res.ok ? "Некоректна відповідь сервера" : `Помилка ${res.status}`,
+          friendlyApiError(
+            error?.status || 500,
+            error?.data?.error || error?.message,
+          ),
         );
       }
-      if (!res.ok) throw new Error(friendlyApiError(res.status, data?.error));
 
       if (data.tool_calls && data.tool_calls.length > 0) {
         const toolResults = data.tool_calls.map((tc) => ({
@@ -299,17 +294,12 @@ function HubChat({ onClose, initialMessage }) {
 
         let followUpText = "";
         try {
-          const res2 = await fetch(apiUrl("/api/chat"), {
-            method: "POST",
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              context: contextRef.current.text || context,
-              messages: history,
-              tool_results: toolResults,
-              tool_calls_raw: data.tool_calls_raw,
-              stream: true,
-            }),
+          const res2 = await sendChatRaw({
+            context: contextRef.current.text || context,
+            messages: history,
+            tool_results: toolResults,
+            tool_calls_raw: data.tool_calls_raw,
+            stream: true,
           });
 
           const ct = res2.headers.get("content-type") || "";

--- a/src/core/settings/FinykSection.jsx
+++ b/src/core/settings/FinykSection.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { fetchPrivat } from "@shared/api/finykApi.js";
 import { safeReadLS } from "@shared/lib/storage.js";
 import { useStorage as useFinykStorage } from "../../modules/finyk/hooks/useStorage.js";
 import { getAccountLabel } from "../../modules/finyk/utils.js";
@@ -79,17 +79,15 @@ export function FinykSection() {
     setPrivatConnecting(true);
     setPrivatError("");
     try {
-      const params = new URLSearchParams({
-        path: "/statements/balance/final",
-        country: "UA",
-        showRest: "true",
-      });
-      const res = await fetch(`${apiUrl("/api/privat")}?${params}`, {
-        headers: { "X-Privat-Id": cleanId, "X-Privat-Token": cleanToken },
-      });
-      if (!res.ok) {
-        const payload = await res.json().catch(() => ({}));
-        setPrivatError(payload?.error || `Помилка ${res.status}`);
+      try {
+        await fetchPrivat(
+          "/statements/balance/final",
+          cleanId,
+          cleanToken,
+          { country: "UA", showRest: "true" },
+        );
+      } catch (error) {
+        setPrivatError(error?.message || "Помилка підключення");
         return;
       }
       if (rememberPrivat) {

--- a/src/core/useCloudSync.js
+++ b/src/core/useCloudSync.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { pullAll as pullAllApi, pushAll as pushAllApi } from "@shared/api/syncApi.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
 
@@ -357,15 +357,8 @@ export function useCloudSync(user) {
 
     replayingRef.current = true;
     try {
-      const res = await fetch(apiUrl("/api/sync/push-all"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ modules: modulesToPush }),
-      });
-      if (res.ok) {
-        clearOfflineQueue();
-      }
+      await pushAllApi(modulesToPush);
+      clearOfflineQueue();
     } catch {
       // Network/transport failure during replay must not break callers
       // (onOnline chains pushDirty afterwards). Keep the queue for later.
@@ -410,15 +403,7 @@ export function useCloudSync(user) {
 
       await replayOfflineQueue();
 
-      const res = await fetch(apiUrl("/api/sync/push-all"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ modules }),
-      });
-      if (!res.ok) throw new Error("Push failed");
-
-      const result = await res.json();
+      const result = await pushAllApi(modules);
       const currentModified = getModuleModifiedTimes();
       if (result?.results) {
         for (const [mod, r] of Object.entries(result.results)) {
@@ -470,15 +455,7 @@ export function useCloudSync(user) {
         return;
       }
 
-      const res = await fetch(apiUrl("/api/sync/push-all"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ modules }),
-      });
-      if (!res.ok) throw new Error("Push failed");
-
-      const result = await res.json();
+      const result = await pushAllApi(modules);
       if (user?.id && result?.results) {
         for (const [mod, r] of Object.entries(result.results)) {
           if (r?.version) setModuleVersion(user.id, mod, r.version);
@@ -500,13 +477,7 @@ export function useCloudSync(user) {
     setSyncing(true);
     setSyncError(null);
     try {
-      const res = await fetch(apiUrl("/api/sync/pull-all"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Pull failed");
-      const { modules } = await res.json();
+      const { modules } = await pullAllApi();
       if (modules) {
         for (const [mod, payload] of Object.entries(modules)) {
           if (payload?.data) {
@@ -546,13 +517,7 @@ export function useCloudSync(user) {
         }
       }
       if (Object.keys(modules).length > 0) {
-        const res = await fetch(apiUrl("/api/sync/push-all"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({ modules }),
-        });
-        if (!res.ok) throw new Error("Upload failed");
+        await pushAllApi(modules);
       }
       markMigrationDone(user.id);
       clearAllDirty();
@@ -580,13 +545,7 @@ export function useCloudSync(user) {
     try {
       await replayOfflineQueue();
 
-      const res = await fetch(apiUrl("/api/sync/pull-all"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Initial sync failed");
-      const { modules: cloudModules } = await res.json();
+      const { modules: cloudModules } = await pullAllApi();
 
       const hasCloudData =
         cloudModules &&
@@ -644,13 +603,10 @@ export function useCloudSync(user) {
             }
           }
           if (Object.keys(modules).length > 0) {
-            const pushRes = await fetch(apiUrl("/api/sync/push-all"), {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              credentials: "include",
-              body: JSON.stringify({ modules }),
-            });
-            if (pushRes.ok) clearAllDirty();
+            try {
+              await pushAllApi(modules);
+              clearAllDirty();
+            } catch {}
           }
         }
         if (!migrated) markMigrationDone(user?.id);

--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { getCoachInsight, getCoachMemory } from "@shared/api/coreApi.js";
 
 const CACHE_KEY = "hub_coach_insight_cache_v1";
 
@@ -177,34 +177,20 @@ function aggregateCurrentSnapshot() {
 async function fetchCoachInsight() {
   let memory = null;
   try {
-    const memRes = await fetch(apiUrl("/api/coach/memory"), {
-      method: "GET",
-      credentials: "include",
-    });
-    if (memRes.ok) {
-      const memJson = await memRes.json();
-      memory = memJson.memory;
-    }
+    const memJson = await getCoachMemory();
+    memory = memJson?.memory ?? null;
   } catch {}
 
   const snapshot = aggregateCurrentSnapshot();
 
-  const insightRes = await fetch(apiUrl("/api/coach/insight"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify({ snapshot, memory }),
-  });
-
-  if (!insightRes.ok) {
-    const err = await insightRes.json().catch(() => ({}));
-    const error = new Error(err?.error || "Помилка генерації інсайту");
-    error.status = insightRes.status;
-    throw error;
+  try {
+    const insightJson = await getCoachInsight({ snapshot, memory });
+    return insightJson?.insight ?? null;
+  } catch (error) {
+    const err = new Error(error?.message || "Помилка генерації інсайту");
+    err.status = error?.status;
+    throw err;
   }
-
-  const insightJson = await insightRes.json();
-  return insightJson.insight ?? null;
 }
 
 export function useCoachInsight() {

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { generateWeeklyDigest as requestWeeklyDigest, saveCoachMemory } from "@shared/api/coreApi.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { safeReadLS } from "@shared/lib/storage.js";
 import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants.js";
@@ -298,32 +298,26 @@ async function generateWeeklyDigest(weekKey) {
   const nutrition = aggregateNutrition(weekKey);
   const routine = aggregateRoutine(weekKey);
 
-  const res = await fetch(apiUrl("/api/weekly-digest"), {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+  try {
+    const json = await requestWeeklyDigest({
       weekRange: currentWeekRange,
       finyk,
       fizruk,
       nutrition,
       routine,
-    }),
-  });
+    });
 
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const err = new Error(json?.error || "Помилка генерації звіту");
-    err.status = res.status;
+    return {
+      report: json.report,
+      generatedAt: json.generatedAt,
+      weekKey,
+      weekRange: currentWeekRange,
+    };
+  } catch (error) {
+    const err = new Error(error?.message || "Помилка генерації звіту");
+    err.status = error?.status;
     throw err;
   }
-
-  return {
-    report: json.report,
-    generatedAt: json.generatedAt,
-    weekKey,
-    weekRange: currentWeekRange,
-  };
 }
 
 export function useWeeklyDigest(selectedWeekKey) {
@@ -364,18 +358,13 @@ export function useWeeklyDigest(selectedWeekKey) {
       // Fire-and-forget push of digest into coach memory so /api/coach/insight
       // has richer context on the next call. Failures are non-fatal.
       try {
-        fetch(apiUrl("/api/coach/memory"), {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            weeklyDigest: {
-              weekKey: wk,
-              weekRange: wr,
-              generatedAt,
-              ...(report || {}),
-            },
-          }),
+        saveCoachMemory({
+          weeklyDigest: {
+            weekKey: wk,
+            weekRange: wr,
+            generatedAt,
+            ...(report || {}),
+          },
         }).catch(() => {});
       } catch {}
     },

--- a/src/modules/finyk/hooks/useMonobank.js
+++ b/src/modules/finyk/hooks/useMonobank.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { ApiError } from "@shared/api/client.js";
+import { fetchMonobank } from "@shared/api/finykApi.js";
 import { TX_CACHE_TTL, CURRENCY } from "../constants";
 import {
   readJSON,
@@ -154,24 +155,15 @@ async function fetchStatementWithRetry(tok, accId, from, to, maxAttempts = 3) {
   let lastError = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const res = await fetch(
-        `${apiUrl("/api/mono")}?path=${encodeURIComponent(`/personal/statement/${accId}/${from}/${to}`)}`,
-        { headers: { "X-Token": tok } },
+      const data = await fetchMonobank(
+        `/personal/statement/${accId}/${from}/${to}`,
+        tok,
       );
-      if (!res.ok) {
-        let message = `HTTP ${res.status}`;
-        try {
-          const payload = await res.json();
-          message = payload?.error || message;
-        } catch {}
-        if (res.status === 401 || res.status === 403) {
-          throw new AuthError(message);
-        }
-        throw new Error(message);
-      }
-      const data = await res.json();
       return Array.isArray(data) ? data : [];
     } catch (e) {
+      if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+        throw new AuthError(e.message);
+      }
       if (e instanceof AuthError) throw e;
       lastError = e;
       if (attempt < maxAttempts) {
@@ -453,28 +445,7 @@ export function useMonobank() {
         }
         info = parsedInfoCache?.info || parsedInfoCache;
       } else {
-        const res = await fetch(
-          `${apiUrl("/api/mono")}?path=${encodeURIComponent("/personal/client-info")}`,
-          {
-            headers: { "X-Token": cleanToken },
-          },
-        );
-
-        if (!res.ok) {
-          let errorMessage = "Помилка з'єднання";
-          try {
-            const errorData = await res.json();
-            errorMessage = errorData.error || `Помилка ${res.status}`;
-          } catch {
-            errorMessage = `HTTP ${res.status}: ${res.statusText}`;
-          }
-          if (res.status === 401 || res.status === 403) {
-            throw new AuthError(errorMessage);
-          }
-          throw new Error(errorMessage);
-        }
-
-        info = await res.json();
+        info = await fetchMonobank("/personal/client-info", cleanToken);
         if (!writeJSON(INFO_CACHE_KEY, { token: cleanToken, info })) {
           reportSilentError("save client-info cache", "write failed");
         }
@@ -520,7 +491,12 @@ export function useMonobank() {
         await fetchAllTx(cleanToken, info.accounts || []);
       }
     } catch (e) {
-      if (e instanceof AuthError) {
+      if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+        setAuthError(
+          e.message ||
+            "Токен Monobank недійсний або закінчився. Оновіть токен.",
+        );
+      } else if (e instanceof AuthError) {
         setAuthError(
           e.message ||
             "Токен Monobank недійсний або закінчився. Оновіть токен.",
@@ -588,30 +564,22 @@ export function useMonobank() {
 
   const refresh = async () => {
     try {
-      const res = await fetch(
-        `${apiUrl("/api/mono")}?path=${encodeURIComponent("/personal/client-info")}`,
-        {
-          headers: { "X-Token": token },
-        },
-      );
-      if (res.ok) {
-        setAuthError("");
-        const info = await res.json();
-        setClientInfo(info);
-        setAccounts(info.accounts || []);
-        if (!writeJSON(INFO_CACHE_KEY, { token, info })) {
-          reportSilentError("refresh info cache", "write failed");
-        }
-        await fetchAllTx(token, info.accounts || []);
-        return;
+      const info = await fetchMonobank("/personal/client-info", token);
+      setAuthError("");
+      setClientInfo(info);
+      setAccounts(info.accounts || []);
+      if (!writeJSON(INFO_CACHE_KEY, { token, info })) {
+        reportSilentError("refresh info cache", "write failed");
       }
-      if (res.status === 401 || res.status === 403) {
+      await fetchAllTx(token, info.accounts || []);
+      return;
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
         setAuthError(
           "Токен Monobank недійсний або закінчився. Оновіть токен у налаштуваннях.",
         );
         return;
       }
-    } catch (e) {
       reportSilentError("refresh client-info", e);
     }
     await fetchAllTx(token, accounts);

--- a/src/modules/finyk/hooks/usePrivatbank.js
+++ b/src/modules/finyk/hooks/usePrivatbank.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { ApiError } from "@shared/api/client.js";
+import { fetchPrivat } from "@shared/api/finykApi.js";
 import { normalizeTransaction } from "../domain/transactions";
 import {
   readRaw,
@@ -137,29 +138,16 @@ function normalizeAccount(raw) {
 }
 
 async function apiFetch(merchantId, merchantToken, path, queryParams = {}) {
-  const params = new URLSearchParams({ path, ...queryParams });
-  const res = await fetch(`${apiUrl("/api/privat")}?${params}`, {
-    headers: {
-      "X-Privat-Id": merchantId,
-      "X-Privat-Token": merchantToken,
-    },
-  });
-
-  if (!res.ok) {
-    let msg = `HTTP ${res.status}`;
-    try {
-      const payload = await res.json();
-      msg = payload?.error || msg;
-    } catch {}
-    if (res.status === 401 || res.status === 403) {
-      const err = new Error(msg);
+  try {
+    return await fetchPrivat(path, merchantId, merchantToken, queryParams);
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+      const err = new Error(error.message);
       err.name = "AuthError";
       throw err;
     }
-    throw new Error(msg);
+    throw error;
   }
-
-  return res.json();
 }
 
 export function usePrivatbank(enabled = true) {

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -31,7 +31,7 @@ import { cn } from "@shared/lib/cn";
 import { calcForecast } from "../lib/forecastEngine";
 import { BudgetTrendChart } from "../components/charts/lazy";
 import { ChartFallback } from "../components/charts/ChartFallback";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { sendChat } from "@shared/api/finykApi.js";
 import { LimitBudgetCard } from "../components/budgets/LimitBudgetCard.jsx";
 import { GoalBudgetCard } from "../components/budgets/GoalBudgetCard.jsx";
 import { CategorySelector } from "../components/CategorySelector.jsx";
@@ -206,17 +206,10 @@ export function Budgets({ mono, storage }) {
           : "";
         const prompt = `Категорія бюджету: ${catLabel}. Витрачено: ${spent.toLocaleString("uk-UA")} ₴ (${pct}% від ліміту ${b.limit.toLocaleString("uk-UA")} ₴). Залишок: ${remaining.toLocaleString("uk-UA")} ₴. До кінця місяця ${daysRemaining} днів.${forecastNote} Дай конкретну коротку пораду (1-2 речення) що зробити, щоб не перевищити ліміт. Відповідь виключно українською.`;
         try {
-          const res = await fetch(apiUrl("/api/chat"), {
-            method: "POST",
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              context: `[Проактивна AI-порада] Категорія: ${catLabel}, витрачено: ${spent} ₴, ліміт: ${b.limit} ₴, залишок: ${remaining} ₴, прогноз: ${fc?.forecast ?? "—"} ₴, днів до кінця місяця: ${daysRemaining}`,
-              messages: [{ role: "user", content: prompt }],
-            }),
+          const data = await sendChat({
+            context: `[Проактивна AI-порада] Категорія: ${catLabel}, витрачено: ${spent} ₴, ліміт: ${b.limit} ₴, залишок: ${remaining} ₴, прогноз: ${fc?.forecast ?? "—"} ₴, днів до кінця місяця: ${daysRemaining}`,
+            messages: [{ role: "user", content: prompt }],
           });
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const data = await res.json();
           const text = data.text || null;
           if (text) {
             setAdviceCache(categoryId, monthKey, text);
@@ -252,19 +245,10 @@ export function Budgets({ mono, storage }) {
     setAiExplanations((prev) => ({ ...prev, [categoryId]: null }));
     try {
       const prompt = `Категорія: ${catLabel}. Витрачено за місяць: ${spent} ₴. Прогноз на кінець місяця: ${forecast} ₴. Ліміт: ${limit} ₴. Чому витрати можуть бути ${forecast > limit ? "вищими за ліміт" : "нижчими за план"} і що варто зробити? Дай коротку відповідь (2-3 речення) українською.`;
-      const res = await fetch(apiUrl("/api/chat"), {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          context: `[Бюджетний прогноз] Категорія: ${catLabel}, витрачено: ${spent} ₴, прогноз: ${forecast} ₴, ліміт: ${limit} ₴`,
-          messages: [{ role: "user", content: prompt }],
-        }),
+      const data = await sendChat({
+        context: `[Бюджетний прогноз] Категорія: ${catLabel}, витрачено: ${spent} ₴, прогноз: ${forecast} ₴, ліміт: ${limit} ₴`,
+        messages: [{ role: "user", content: prompt }],
       });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const data = await res.json();
       setAiExplanations((prev) => ({
         ...prev,
         [categoryId]: data.text || "Не вдалося отримати пояснення.",

--- a/src/modules/nutrition/components/meal-sheet/useBarcodeLookup.js
+++ b/src/modules/nutrition/components/meal-sheet/useBarcodeLookup.js
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { ApiError } from "@shared/api/client.js";
+import { barcodeLookup } from "@shared/api/nutritionApi.js";
 import {
   bindBarcodeToFood,
   lookupFoodByBarcode,
@@ -37,19 +38,7 @@ export function useBarcodeLookup({
       }
 
       try {
-        const res = await fetch(
-          apiUrl(`/api/barcode?barcode=${encodeURIComponent(code)}`),
-        );
-        if (res.status === 404) {
-          setBarcodeStatus("Продукт не знайдено. Можна ввести дані вручну.");
-          return;
-        }
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          setBarcodeStatus(err?.error || "Помилка пошуку. Спробуй пізніше.");
-          return;
-        }
-        const data = await res.json();
+        const data = await barcodeLookup(code);
         const p = data?.product;
         if (!p?.name) {
           setBarcodeStatus("Продукт знайдено, але дані неповні. Введи вручну.");
@@ -104,9 +93,13 @@ export function useBarcodeLookup({
             `Знайдено: ${[p.name, p.brand].filter(Boolean).join(" — ")} ✔`,
           );
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          setBarcodeStatus("Продукт не знайдено. Можна ввести дані вручну.");
+          return;
+        }
         setBarcodeStatus(
-          "Помилка пошуку. Перевір з'єднання і спробуй пізніше.",
+          error?.message || "Помилка пошуку. Перевір з'єднання і спробуй пізніше.",
         );
       }
     },

--- a/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
+++ b/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { foodSearch } from "@shared/api/nutritionApi.js";
 import { searchFoods } from "../../lib/foodDb/foodDb.js";
 
 export function useFoodSearch(foodQuery) {
@@ -36,8 +36,7 @@ export function useFoodSearch(foodQuery) {
       setOffBusy(true);
       setOffHits([]);
       const offTimer = window.setTimeout(() => {
-        fetch(apiUrl(`/api/food-search?q=${encodeURIComponent(q)}`))
-          .then((r) => (r.ok ? r.json() : Promise.reject()))
+        foodSearch(q)
           .then((data) => {
             if (!cancelled) setOffHits(data?.products || []);
           })

--- a/src/modules/nutrition/hooks/usePantryBarcodeScan.js
+++ b/src/modules/nutrition/hooks/usePantryBarcodeScan.js
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { ApiError } from "@shared/api/client.js";
+import { barcodeLookup } from "@shared/api/nutritionApi.js";
 
 export function usePantryBarcodeScan({
   pantry,
@@ -22,19 +23,7 @@ export function usePantryBarcodeScan({
         return;
       }
       try {
-        const res = await fetch(
-          apiUrl(`/api/barcode?barcode=${encodeURIComponent(code)}`),
-        );
-        if (res.status === 404) {
-          setPantryScanStatus("Продукт не знайдено в базі. Додай вручну.");
-          return;
-        }
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          setPantryScanStatus(err?.error || "Помилка пошуку.");
-          return;
-        }
-        const data = await res.json();
+        const data = await barcodeLookup(code);
         const p = data?.product;
         if (!p?.name) {
           setPantryScanStatus(
@@ -52,8 +41,12 @@ export function usePantryBarcodeScan({
           setPantryScanStatus(`Додано: ${label} \u2714`);
         }
         setTimeout(() => setPantryScanStatus(""), 4000);
-      } catch {
-        setPantryScanStatus("Помилка пошуку. Перевір з\u2019єднання.");
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          setPantryScanStatus("Продукт не знайдено в базі. Додай вручну.");
+          return;
+        }
+        setPantryScanStatus(error?.message || "Помилка пошуку. Перевір з\u2019єднання.");
       }
     },
     [pantry, setPantryScanStatus, setPantryScannerOpen],

--- a/src/modules/nutrition/lib/nutritionApi.js
+++ b/src/modules/nutrition/lib/nutritionApi.js
@@ -1,4 +1,4 @@
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { ApiError, httpRequest } from "@shared/api/client.js";
 import { friendlyApiError } from "./nutritionErrors.js";
 
 export async function postJson(url, body) {
@@ -8,37 +8,21 @@ export async function postJson(url, body) {
     import.meta.env.VITE_NUTRITION_API_TOKEN
       ? String(import.meta.env.VITE_NUTRITION_API_TOKEN)
       : "";
-  let res;
   try {
-    res = await fetch(apiUrl(url), {
+    return await httpRequest(url, {
       method: "POST",
-      credentials: "include",
       headers: {
-        "Content-Type": "application/json",
         ...(token ? { "X-Token": token } : {}),
       },
-      body: JSON.stringify(body || {}),
+      body: body || {},
     });
   } catch (err) {
     if (!navigator.onLine) {
       throw new Error("Немає підключення до інтернету. Спробуй пізніше.");
     }
+    if (err instanceof ApiError) {
+      throw new Error(friendlyApiError(err.status, err?.data?.error || err.message));
+    }
     throw new Error(err?.message || "Не вдалося зʼєднатися із сервером.");
   }
-  const ct = (res.headers.get("content-type") || "").toLowerCase();
-  const raw = await res.text();
-  let data = {};
-  try {
-    data = raw ? JSON.parse(raw) : {};
-  } catch {
-    // Частий кейс на Vercel: /api/* перехоплено rewrite і повернувся index.html
-    if (ct.includes("text/html") || /<!doctype html/i.test(raw)) {
-      throw new Error(
-        "API повернув HTML замість JSON (ймовірно, rewrite перехоплює /api/*).",
-      );
-    }
-    data = { error: raw || "Некоректна відповідь сервера" };
-  }
-  if (!res.ok) throw new Error(friendlyApiError(res.status, data?.error));
-  return data;
 }

--- a/src/shared/api/client.js
+++ b/src/shared/api/client.js
@@ -1,0 +1,76 @@
+import { apiUrl } from "@shared/lib/apiUrl.js";
+
+export class ApiError extends Error {
+  constructor(message, { status = 0, data = null } = {}) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+function buildInit(options = {}) {
+  const { method = "GET", headers = {}, body, credentials = "include" } = options;
+  const hasBody = body !== undefined;
+  const isFormData = typeof FormData !== "undefined" && body instanceof FormData;
+
+  const finalHeaders = {
+    Accept: "application/json",
+    ...headers,
+  };
+
+  if (hasBody && !isFormData && !finalHeaders["Content-Type"]) {
+    finalHeaders["Content-Type"] = "application/json";
+  }
+
+  return {
+    method,
+    credentials,
+    headers: finalHeaders,
+    ...(hasBody
+      ? {
+          body:
+            isFormData || typeof body === "string"
+              ? body
+              : JSON.stringify(body),
+        }
+      : {}),
+  };
+}
+
+async function parseResponse(res) {
+  const text = await res.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+export async function httpRequest(path, options = {}) {
+  let res;
+  try {
+    res = await fetch(apiUrl(path), buildInit(options));
+  } catch (error) {
+    throw new ApiError(error?.message || "Network error");
+  }
+
+  const data = await parseResponse(res);
+  if (!res.ok) {
+    throw new ApiError(data?.error || `HTTP ${res.status}`, {
+      status: res.status,
+      data,
+    });
+  }
+
+  return data;
+}
+
+export async function httpRequestRaw(path, options = {}) {
+  try {
+    return await fetch(apiUrl(path), buildInit(options));
+  } catch (error) {
+    throw new ApiError(error?.message || "Network error");
+  }
+}

--- a/src/shared/api/coreApi.js
+++ b/src/shared/api/coreApi.js
@@ -1,0 +1,44 @@
+import { httpRequest } from "./client.js";
+
+export function getPushVapidPublic() {
+  return httpRequest("/api/push/vapid-public");
+}
+
+export function subscribePush(payload) {
+  return httpRequest("/api/push/subscribe", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export function unsubscribePush(endpoint) {
+  return httpRequest("/api/push/subscribe", {
+    method: "DELETE",
+    body: { endpoint },
+  });
+}
+
+export function getCoachMemory() {
+  return httpRequest("/api/coach/memory", { method: "GET" });
+}
+
+export function saveCoachMemory(payload) {
+  return httpRequest("/api/coach/memory", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export function getCoachInsight(payload) {
+  return httpRequest("/api/coach/insight", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export function generateWeeklyDigest(payload) {
+  return httpRequest("/api/weekly-digest", {
+    method: "POST",
+    body: payload,
+  });
+}

--- a/src/shared/api/finykApi.js
+++ b/src/shared/api/finykApi.js
@@ -1,0 +1,31 @@
+import { httpRequest, httpRequestRaw } from "./client.js";
+
+export function fetchMonobank(path, token) {
+  return httpRequest(`/api/mono?path=${encodeURIComponent(path)}`, {
+    headers: { "X-Token": token },
+  });
+}
+
+export function fetchPrivat(path, merchantId, merchantToken, queryParams = {}) {
+  const params = new URLSearchParams({ path, ...queryParams });
+  return httpRequest(`/api/privat?${params.toString()}`, {
+    headers: {
+      "X-Privat-Id": merchantId,
+      "X-Privat-Token": merchantToken,
+    },
+  });
+}
+
+export function sendChat(payload) {
+  return httpRequest("/api/chat", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export function sendChatRaw(payload) {
+  return httpRequestRaw("/api/chat", {
+    method: "POST",
+    body: payload,
+  });
+}

--- a/src/shared/api/nutritionApi.js
+++ b/src/shared/api/nutritionApi.js
@@ -1,0 +1,9 @@
+import { httpRequest } from "./client.js";
+
+export function foodSearch(query) {
+  return httpRequest(`/api/food-search?q=${encodeURIComponent(query)}`);
+}
+
+export function barcodeLookup(barcode) {
+  return httpRequest(`/api/barcode?barcode=${encodeURIComponent(barcode)}`);
+}

--- a/src/shared/api/syncApi.js
+++ b/src/shared/api/syncApi.js
@@ -1,0 +1,23 @@
+import { httpRequest } from "./client.js";
+
+export function pushAll(modules) {
+  return httpRequest("/api/sync/push-all", {
+    method: "POST",
+    body: { modules },
+  });
+}
+
+export function pullAll() {
+  return httpRequest("/api/sync/pull-all", {
+    method: "POST",
+  });
+}
+
+export function syncPush(mod, payload) {
+  return pushAll({ [mod]: payload });
+}
+
+export async function syncPull(mod) {
+  const data = await pullAll();
+  return data?.modules?.[mod] ?? null;
+}

--- a/src/shared/hooks/usePushNotifications.ts
+++ b/src/shared/hooks/usePushNotifications.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { apiUrl } from "@shared/lib/apiUrl";
+import {
+  getPushVapidPublic,
+  subscribePush,
+  unsubscribePush,
+} from "@shared/api/coreApi.js";
 
 const PUSH_SUB_KEY = "hub_push_subscribed";
 
@@ -56,9 +60,10 @@ export function usePushNotifications(): UsePushNotificationsResult {
       setPermission(perm);
       if (perm !== "granted") return;
 
-      const vapidRes = await fetch(apiUrl("/api/push/vapid-public"));
-      if (!vapidRes.ok) throw new Error("VAPID not configured");
-      const { publicKey } = (await vapidRes.json()) as { publicKey: string };
+      const { publicKey } = (await getPushVapidPublic()) as {
+        publicKey: string;
+      };
+      if (!publicKey) throw new Error("VAPID not configured");
 
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.subscribe({
@@ -67,18 +72,7 @@ export function usePushNotifications(): UsePushNotificationsResult {
       });
 
       const subJson = sub.toJSON();
-      const res = await fetch(apiUrl("/api/push/subscribe"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(subJson),
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        throw new Error(data.error || `Server error ${res.status}`);
-      }
+      await subscribePush(subJson);
 
       localStorage.setItem(PUSH_SUB_KEY, "1");
       setSubscribed(true);
@@ -98,12 +92,7 @@ export function usePushNotifications(): UsePushNotificationsResult {
       if (sub) {
         const endpoint = sub.endpoint;
         await sub.unsubscribe();
-        await fetch(apiUrl("/api/push/subscribe"), {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({ endpoint }),
-        }).catch(() => {});
+        await unsubscribePush(endpoint).catch(() => {});
       }
       localStorage.removeItem(PUSH_SUB_KEY);
       setSubscribed(false);


### PR DESCRIPTION
### Motivation
- Звести всі прямі `fetch` виклики в одну точку для єдиної обробки заголовків, `credentials: include`, парсингу JSON та уніфікованої обробки помилок.
- Полегшити тестування та повторне використання API-викликів по модулях (sync, finyk, nutrition, core).
- Забезпечити, щоб компоненти та хуки не мали прямих HTTP-запитів — всі мережеві операції через API-layer.

### Description
- Додано централізований HTTP client `src/shared/api/client.js` з `httpRequest`, `httpRequestRaw` та класом помилок `ApiError`, який автоматично додає `credentials: "include"`, заголовки та JSON-серіалізацію/парсинг. 
- Додано модульні API-обгортки у `src/shared/api/`: `syncApi.js` (реалізовано `pushAll`, `pullAll`, `syncPush`, `syncPull`), `finykApi.js` (Monobank/Privat/chat), `nutritionApi.js` (food-search, barcode), `coreApi.js` (push/coaching/weekly-digest).
- Винесено всі прямі `fetch` з основних місць і замінено викликами API-layer у таких файлах/функціональностях: `useCloudSync` (всі sync запити → `syncApi`), `usePushNotifications` → `coreApi`, `useCoachInsight`/`useWeeklyDigest` → `coreApi`, `HubChat.jsx`/Budgets chat flows → `finykApi.sendChat`/`sendChatRaw`, Monobank/Privat integrations → `finykApi` wrappers, nutrition hooks (`useFoodSearch`, `useBarcodeLookup`, `usePantryBarcodeScan`) → `nutritionApi` та `ApiError`-обробка.
- Збережено незмінними бекенд URL та контракти; помилки нормалізовані через `ApiError` і дружні меседжі там, де був попередній mapping (наприклад, `nutrition` module keeps `friendlyApiError`).

### Testing
- Запущено імпровізовані перевірки: `rg "\bfetch\(" src -n` показав, що виклики `fetch` винесені до `src/shared/api/*` (залишились лише у client для фактичного fetch). ✅
- `npm run lint:imports` пройшов успішно. ✅
- `npm run lint` не пройшов у цьому середовищі через відсутній пакет `typescript-eslint` (помилка середовища, не пов'язана з кодом змін). ⚠️
- `npm run build` не пройшов у цьому середовищі через відсутній пакет `rollup-plugin-visualizer` (помилка CI/env), зміни сумісні з існуючою конфігурацією проекту. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bd34e3c88330a342ea0534711e83)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
