### PR TITLE
fix(state): depend on stable mutateAsync in useCoachInsight

### DIFF
--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -224,6 +224,12 @@ export function useCoachInsight() {
     },
   });
 
+  const { mutateAsync } = mutation;
+
+  // Depending on the whole `mutation` object would recreate `loadInsight`
+  // on every state transition (isPending flip, etc.), which in turn makes
+  // `refresh` below unstable and defeats its `useCallback`. `mutateAsync`
+  // is a stable reference in react-query v5, so we depend on it directly.
   const loadInsight = useCallback(
     async (force = false) => {
       const todayKey = localDateKey();
@@ -235,12 +241,12 @@ export function useCoachInsight() {
         }
       }
       try {
-        return await mutation.mutateAsync();
+        return await mutateAsync();
       } catch {
         return null;
       }
     },
-    [mutation],
+    [mutateAsync],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Фолоу-ап до #136. Devin Review слушно зауважив, що мій попередній фікс у `useCoachInsight` — неповний:

- `loadInsight` у <ref_file file="/home/ubuntu/repos/Sergeant/src/core/useCoachInsight.js" /> залежав від `[mutation]` (весь об'єкт), який змінює посилку на кожен `isPending`-флік з react-query.
- Через це `loadInsight` перестворюється часто, і `refresh = useCallback(() => loadInsight(true), [loadInsight])` успадковує ту саму нестабільність → `useCallback` стає no-op.

Це той самий клас помилки, що й у `useWeeklyDigest` до #136.

### Зміна

У `useCoachInsight.js` деструктурую `const { mutateAsync } = mutation;` і використовую його в `loadInsight` замість `mutation.mutateAsync`. `mutateAsync` — стабільна посилка в react-query v5, тому `[mutateAsync]` як deps робить `loadInsight` (а з ним і `refresh`) по-справжньому стабільними.

Жодних змін у поведінці хука: кеш дня, авто-завантаження на mount, force-refresh через кнопку — усе те саме.

## Review & Testing Checklist for Human

- [ ] `CoachInsightCard`: кнопка "Оновити" працює; між рендерами `refresh` — та сама посилка, якщо споживач колись захоче покласти її у `useEffect` deps, він отримає очікувану стабільність.
- [ ] Lint / typecheck / 543 тести локально зелені — підтверди у CI.

### Notes

- Окремих юніт-тестів на referential stability поки немає; додаватиму разом із загальним тест-сьютом для react-query-layer'а.
- Залишився ще один напрямок react-query-міграції з першої серії — `useCloudSync` (складний, окремим PR).

Link to Devin session: https://app.devin.ai/sessions/dd10f4d2af354b3180d48b21fb8b5a0d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
