### PR TITLE
fix(nutrition): invalidate food-search cache after save & clear stale error on retype

### DIFF
--- a/src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx
+++ b/src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@shared/components/ui/Button";
 import { upsertFood } from "../../lib/foodDb/foodDb.js";
 
@@ -9,6 +10,7 @@ export function SaveAsFood({
   setFoodQuery,
   setFoodErr,
 }) {
+  const queryClient = useQueryClient();
   return (
     <div className="mt-3 mb-1">
       <Button
@@ -48,6 +50,13 @@ export function SaveAsFood({
             setFoodErr(res.error || "Не вдалося зберегти продукт.");
             return;
           }
+          // Bust the local food-search cache so the next search (including
+          // the refetch triggered by `setFoodQuery(name)` below) sees the
+          // freshly saved product instead of 5 min of stale IndexedDB
+          // results.
+          queryClient.invalidateQueries({
+            queryKey: ["nutrition", "food-search", "local"],
+          });
           setPickedFood(res.product);
           setPickedGrams("100");
           setFoodQuery(name);

--- a/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
+++ b/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
@@ -63,6 +63,14 @@ export function useFoodSearch(foodQuery) {
   // and consumers don't have to track where it lives.
   const [foodErr, setFoodErr] = useState("");
 
+  // Any pending save-food error is stale the moment the user starts typing
+  // a new search. The pre-react-query implementation did this implicitly on
+  // the fetch-effect; restore it explicitly here.
+  useEffect(() => {
+    if (foodErr) setFoodErr("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trimmed]);
+
   return {
     foodHits: trimmed && localQuery === trimmed ? (local.data ?? []) : [],
     offHits: trimmed && offQuery === trimmed ? (off.data ?? []) : [],


### PR DESCRIPTION
## Summary

Хотфікс 2 регресій з #138, які знайшов Devin Review.

### 🔴 Кеш локального пошуку не інвалідується після `upsertFood`

У #138 я додав `staleTime: 5 хв` на `["nutrition","food-search","local",...]`. `SaveAsFood` пише нову їжу в IndexedDB, але без інвалідації кешу наступні пошуки ті самі 5 хв бачили старі результати без щойно збереженого продукту.

**Фікс:** у <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx" /> після успішного `upsertFood` викликаю `queryClient.invalidateQueries({ queryKey: ["nutrition","food-search","local"] })` до `setFoodQuery(name)` — тоді авто-рефетч через зміну query бачить вже чистий кеш. OFF-кеш не чіпаю, бо IndexedDB-write його не впливає.

### 🟡 `foodErr` не скидався на новий пошук

Раніше `setFoodErr("")` викликався на початку `useEffect`-фетчу при зміні `foodQuery`. У react-query-версії `foodErr` — просто локальний `useState`, який жодним хуком не скидався. Якщо зберегти їжу не вийшло (наприклад, "Не вдалося зберегти продукт"), повідомлення висіло у `FoodPickerSection` поки шітку не закрили.

**Фікс:** у <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/components/meal-sheet/useFoodSearch.js" /> додав `useEffect(() => { if (foodErr) setFoodErr(""); }, [trimmed])` — ідентично попередній поведінці.

## Review & Testing Checklist for Human

- [ ] Зберегти новий продукт у `AddMealSheet` → одразу в тому ж сеансі знайти його по назві (має з'явитись без очікування staleTime).
- [ ] Спровокувати "Не вдалося зберегти" → почати новий пошук → повідомлення має зникнути.
- [ ] Інші споживачі `["nutrition","food-search","local"]` (пошук у редагуванні страви, інші точки входу) — перевірити, що invalidation не зламав UX.
- [ ] Lint / typecheck / 543 тести локально зелені — підтвердити в CI.

### Notes

- Юніт-тестів на `useFoodSearch` немає (і раніше не було). Додам разом з тестами на інші react-query-хуки окремим PR.
- Наступним PR беру легкі модульні хуки (`useBarcodeLookup`, `usePantryBarcodeScan`) → react-query, як ти попросив.

Link to Devin session: https://app.devin.ai/sessions/dd10f4d2af354b3180d48b21fb8b5a0d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
