### PR TITLE
refactor(core): migrate weekly digest &amp; coach insight to React Query

### DIFF
--- a/src/core/WeeklyDigestCard.jsx
+++ b/src/core/WeeklyDigestCard.jsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import {
   useWeeklyDigest,
-  listDigestHistory,
+  useDigestHistory,
   getWeekKey,
 } from "./useWeeklyDigest.js";
 import { WeeklyDigestStories } from "./WeeklyDigestStories.jsx";
@@ -303,25 +303,13 @@ export function WeeklyDigestCard() {
   const currentWeekKey = getWeekKey();
   const [selectedWeekKey, setSelectedWeekKey] = useState(currentWeekKey);
   const [showHistory, setShowHistory] = useState(false);
-  const [history, setHistory] = useState(() => listDigestHistory());
   const [storiesOpen, setStoriesOpen] = useState(false);
 
   const { digest, loading, error, weekRange, generate, isCurrentWeek } =
     useWeeklyDigest(selectedWeekKey);
+  const { data: history = [] } = useDigestHistory();
 
-  useEffect(() => {
-    const handler = () => setHistory(listDigestHistory());
-    window.addEventListener("hub-weekly-digest-updated", handler);
-    return () =>
-      window.removeEventListener("hub-weekly-digest-updated", handler);
-  }, []);
-
-  const handleGenerate = async () => {
-    const result = await generate();
-    if (result) {
-      setHistory(listDigestHistory());
-    }
-  };
+  const handleGenerate = () => generate();
 
   const isPast = selectedWeekKey !== currentWeekKey;
 

--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 
 const CACHE_KEY = "hub_coach_insight_cache_v1";
@@ -207,67 +207,82 @@ async function fetchCoachInsight() {
   return insightJson.insight ?? null;
 }
 
-export function useCoachInsight() {
-  const [insight, setInsight] = useState(null);
+// React Query key factory — exported so other callers (e.g. the weekly
+// digest mutation) can invalidate the insight when the underlying data
+// signature changes.
+export const coachInsightQueryKey = (todayKey = localDateKey()) => [
+  "coach",
+  "insight",
+  todayKey,
+];
 
-  const mutation = useMutation({
-    mutationFn: fetchCoachInsight,
-    onSuccess: (text) => {
-      if (!text) return;
-      try {
-        localStorage.setItem(
-          CACHE_KEY,
-          JSON.stringify({ date: localDateKey(), text }),
-        );
-      } catch {}
-      setInsight(text);
+// Seed the query from localStorage only when the cached date matches the
+// *current* calendar day. At midnight the query key rolls over, producing a
+// fresh cache entry, and stale cross-day localStorage is ignored.
+function loadInitialInsight(todayKey) {
+  const cached = safeParseLS(CACHE_KEY, null);
+  if (cached?.date === todayKey && typeof cached?.text === "string") {
+    return cached.text;
+  }
+  return undefined;
+}
+
+export function useCoachInsight() {
+  const queryClient = useQueryClient();
+  const todayKey = localDateKey();
+  const queryKey = coachInsightQueryKey(todayKey);
+
+  const query = useQuery({
+    queryKey,
+    queryFn: fetchCoachInsight,
+    // The snapshot depends on localStorage that can change during a session
+    // (new transaction, new workout, etc.), but regenerating costs an AI
+    // call — so we keep the day's insight cached until the user explicitly
+    // refreshes or the date-keyed cache rolls at midnight.
+    staleTime: Infinity,
+    gcTime: 24 * 60 * 60_000,
+    initialData: () => loadInitialInsight(todayKey),
+    // Without a fetched-at marker, React Query would still consider the
+    // seeded data stale and refetch on mount. We only want to refetch when
+    // there was no cached insight for today.
+    initialDataUpdatedAt: () => {
+      const cached = safeParseLS(CACHE_KEY, null);
+      if (cached?.date !== todayKey) return undefined;
+      return Date.now();
     },
   });
 
-  const { mutateAsync } = mutation;
-
-  // Depending on the whole `mutation` object would recreate `loadInsight`
-  // on every state transition (isPending flip, etc.), which in turn makes
-  // `refresh` below unstable and defeats its `useCallback`. `mutateAsync`
-  // is a stable reference in react-query v5, so we depend on it directly.
-  const loadInsight = useCallback(
-    async (force = false) => {
-      const todayKey = localDateKey();
-      if (!force) {
-        const cached = safeParseLS(CACHE_KEY, null);
-        if (cached?.date === todayKey && cached?.text) {
-          setInsight(cached.text);
-          return cached.text;
-        }
+  // Write-through to localStorage so cross-session hydration keeps working.
+  // We do this in a subscription-free callback rather than an effect to
+  // avoid an extra render and to stay in sync with `data` changes from
+  // both mount-time `initialData` and fresh fetches.
+  if (
+    typeof query.data === "string" &&
+    query.data.length > 0 &&
+    !query.isFetching
+  ) {
+    try {
+      const cached = safeParseLS(CACHE_KEY, null);
+      if (cached?.date !== todayKey || cached?.text !== query.data) {
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ date: todayKey, text: query.data }),
+        );
       }
-      try {
-        return await mutateAsync();
-      } catch {
-        return null;
-      }
-    },
-    [mutateAsync],
-  );
+    } catch {}
+  }
 
-  useEffect(() => {
-    const todayKey = localDateKey();
-    const cached = safeParseLS(CACHE_KEY, null);
-    if (cached?.date === todayKey && cached?.text) {
-      setInsight(cached.text);
-      return;
-    }
-    loadInsight();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const refresh = useCallback(() => loadInsight(true), [loadInsight]);
+  const refresh = useCallback(() => {
+    // Drop stale cache entries from prior days so they can't be resurrected
+    // via `initialData` on a remount.
+    queryClient.invalidateQueries({ queryKey: ["coach", "insight"] });
+    return query.refetch();
+  }, [queryClient, query]);
 
   return {
-    insight,
-    loading: mutation.isPending,
-    error: mutation.error
-      ? mutation.error.message || "Помилка завантаження"
-      : null,
+    insight: query.data ?? null,
+    loading: query.isPending || query.isFetching,
+    error: query.error ? query.error.message || "Помилка завантаження" : null,
     refresh,
   };
 }

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiUrl } from "@shared/lib/apiUrl.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { safeReadLS } from "@shared/lib/storage.js";
@@ -75,9 +75,6 @@ export function listDigestHistory() {
 function saveDigest(weekKey, data) {
   try {
     localStorage.setItem(`${DIGEST_PREFIX}${weekKey}`, JSON.stringify(data));
-    window.dispatchEvent(
-      new CustomEvent("hub-weekly-digest-updated", { detail: { weekKey } }),
-    );
   } catch {}
 }
 
@@ -326,28 +323,44 @@ async function generateWeeklyDigest(weekKey) {
   };
 }
 
+// ─── React Query integration ─────────────────────────────────────────────
+//
+// localStorage is the source of truth for persisted digests; React Query
+// caches it in memory so multiple mounted consumers (dashboard card,
+// settings panel, Monday auto-digest) share a single observable copy. The
+// mutation writes through to both localStorage and the query cache, which
+// replaces the previous `hub-weekly-digest-updated` CustomEvent fan-out.
+
+export const weeklyDigestQueryKey = (weekKey) => ["weekly-digest", weekKey];
+export const weeklyDigestHistoryQueryKey = ["weekly-digest", "history"];
+
+export function useDigestHistory() {
+  return useQuery({
+    queryKey: weeklyDigestHistoryQueryKey,
+    queryFn: listDigestHistory,
+    // Pure localStorage read — only mutates when the generation mutation
+    // invalidates this key explicitly.
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
 export function useWeeklyDigest(selectedWeekKey) {
+  const queryClient = useQueryClient();
   const currentWeekKey = getWeekKey();
   const weekKey = selectedWeekKey || currentWeekKey;
   const weekRange = getWeekRange(new Date(weekKey + "T12:00:00"));
   const isCurrentWeek = weekKey === currentWeekKey;
 
-  const [digest, setDigest] = useState(() => loadDigest(weekKey));
-
-  useEffect(() => {
-    setDigest(loadDigest(weekKey));
-  }, [weekKey]);
-
-  useEffect(() => {
-    const handler = (e) => {
-      if (!e.detail?.weekKey || e.detail.weekKey === weekKey) {
-        setDigest(loadDigest(weekKey));
-      }
-    };
-    window.addEventListener("hub-weekly-digest-updated", handler);
-    return () =>
-      window.removeEventListener("hub-weekly-digest-updated", handler);
-  }, [weekKey]);
+  const query = useQuery({
+    queryKey: weeklyDigestQueryKey(weekKey),
+    // Synchronous localStorage read. Any update flows through
+    // `setQueryData` from the mutation below, so this effectively runs
+    // once per weekKey per session.
+    queryFn: () => loadDigest(weekKey) ?? null,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
 
   const mutation = useMutation({
     mutationFn: generateWeeklyDigest,
@@ -359,7 +372,15 @@ export function useWeeklyDigest(selectedWeekKey) {
         weekRange: wr,
       };
       saveDigest(wk, newDigest);
-      setDigest(newDigest);
+      // Fan out to every observer of this week's digest — dashboard,
+      // settings, stories. Replaces the CustomEvent broadcast.
+      queryClient.setQueryData(weeklyDigestQueryKey(wk), newDigest);
+      // Picker + history list must pick up the new entry.
+      queryClient.invalidateQueries({ queryKey: weeklyDigestHistoryQueryKey });
+      // The generated digest is also pushed into the coach memory (below),
+      // so today's coach insight is now based on stale context. Drop it so
+      // the next mount / refresh regenerates with the richer context.
+      queryClient.invalidateQueries({ queryKey: ["coach", "insight"] });
 
       // Fire-and-forget push of digest into coach memory so /api/coach/insight
       // has richer context on the next call. Failures are non-fatal.
@@ -404,7 +425,7 @@ export function useWeeklyDigest(selectedWeekKey) {
   }, [weekKey, isCurrentWeek, mutateAsync]);
 
   return {
-    digest,
+    digest: query.data ?? null,
     loading: mutation.isPending,
     error: mutation.error ? mutation.error.message || "Помилка мережі" : null,
     weekKey,


### PR DESCRIPTION
## Summary

Migrates the read-side of the two AI hub hooks — `useWeeklyDigest` and
`useCoachInsight` — from hand-rolled `useState` + `useEffect` +
`CustomEvent` plumbing to `@tanstack/react-query`. Both hooks were already
using `useMutation` for writes; this PR adds `useQuery` for reads so all
consumers share a single observable cache.

**UI is unchanged.** Public hook APIs, `STORAGE_KEYS` and the
`hub_coach_insight_cache_v1` localStorage contract are preserved so the
upgrade is drop-in.

### Cache strategy

| Query key                                | Source                                                  | `staleTime` | `gcTime` |
| ---------------------------------------- | ------------------------------------------------------- | ----------- | -------- |
| `['weekly-digest', weekKey]`             | `localStorage["hub_weekly_digest_<weekKey>"]`           | `Infinity`  | `Infinity` |
| `['weekly-digest', 'history']`           | enumerated `localStorage` keys                          | `Infinity`  | `Infinity` |
| `['coach', 'insight', localDateKey()]`   | `POST /api/coach/insight` (+ `GET /api/coach/memory`)   | `Infinity`  | 24h      |

- The weekly digest queries have `staleTime: Infinity` because
  `localStorage` is the source of truth — the generation mutation is the
  single writer and fans out via `setQueryData`, so we never need to
  refetch on focus/remount.
- The coach insight is keyed by today's local date (`YYYY-MM-DD`), so the
  cache rolls over at midnight automatically — no timers, no effects.
  `initialData` is seeded from `localStorage` only when the cached date
  matches today, which gives an instant paint on mount with no spinner.

### Invalidation logic

- **Weekly digest `onSuccess`**
  1. `queryClient.setQueryData(['weekly-digest', wk], newDigest)` —
     instant fan-out to every observer (dashboard card, settings panel,
     stories). Replaces the previous `hub-weekly-digest-updated`
     `CustomEvent`.
  2. `queryClient.invalidateQueries({ queryKey: ['weekly-digest', 'history'] })` —
     the "Попередні тижні" picker re-reads localStorage.
  3. `queryClient.invalidateQueries({ queryKey: ['coach', 'insight'] })` —
     the new digest is pushed into `/api/coach/memory`, so today's cached
     insight is now based on stale context and should be regenerated on
     next mount / refresh.
- **Coach insight `refresh`** — invalidates the `['coach', 'insight']`
  family and `refetch()`s the current query.

### Before / after

`useCoachInsight` — read side

```jsx
// BEFORE — manual state + daily useEffect + mutation
const [insight, setInsight] = useState(null);
const mutation = useMutation({ mutationFn: fetchCoachInsight, onSuccess: ... });

useEffect(() => {
  const todayKey = localDateKey();
  const cached = safeParseLS(CACHE_KEY, null);
  if (cached?.date === todayKey && cached?.text) {
    setInsight(cached.text);
    return;
  }
  loadInsight();
}, []);

const refresh = useCallback(() => loadInsight(true), [loadInsight]);
```

```jsx
// AFTER — single useQuery keyed by today's date
const todayKey = localDateKey();
const query = useQuery({
  queryKey: coachInsightQueryKey(todayKey),
  queryFn: fetchCoachInsight,
  staleTime: Infinity,
  gcTime: 24 * 60 * 60_000,
  initialData: () => loadInitialInsight(todayKey),
  initialDataUpdatedAt: () => {
    const cached = safeParseLS(CACHE_KEY, null);
    return cached?.date === todayKey ? Date.now() : undefined;
  },
});

const refresh = useCallback(() => {
  queryClient.invalidateQueries({ queryKey: ['coach', 'insight'] });
  return query.refetch();
}, [queryClient, query]);
```

`useWeeklyDigest` — fan-out on mutation success

```jsx
// BEFORE — CustomEvent across hook instances
function saveDigest(weekKey, data) {
  localStorage.setItem(`${DIGEST_PREFIX}${weekKey}`, JSON.stringify(data));
  window.dispatchEvent(
    new CustomEvent("hub-weekly-digest-updated", { detail: { weekKey } }),
  );
}

useEffect(() => {
  const handler = (e) => {
    if (!e.detail?.weekKey || e.detail.weekKey === weekKey) {
      setDigest(loadDigest(weekKey));
    }
  };
  window.addEventListener("hub-weekly-digest-updated", handler);
  return () => window.removeEventListener("hub-weekly-digest-updated", handler);
}, [weekKey]);
```

```jsx
// AFTER — React Query cache IS the fan-out
const query = useQuery({
  queryKey: weeklyDigestQueryKey(weekKey),
  queryFn: () => loadDigest(weekKey) ?? null,
  staleTime: Infinity,
  gcTime: Infinity,
});

const mutation = useMutation({
  mutationFn: generateWeeklyDigest,
  onSuccess: ({ report, generatedAt, weekKey: wk, weekRange: wr }) => {
    const newDigest = { ...report, generatedAt, weekKey: wk, weekRange: wr };
    saveDigest(wk, newDigest);
    queryClient.setQueryData(weeklyDigestQueryKey(wk), newDigest);
    queryClient.invalidateQueries({ queryKey: weeklyDigestHistoryQueryKey });
    queryClient.invalidateQueries({ queryKey: ['coach', 'insight'] });
    // ... existing fire-and-forget coach-memory push
  },
});
```

`WeeklyDigestCard` — history picker

```jsx
// BEFORE
const [history, setHistory] = useState(() => listDigestHistory());
useEffect(() => {
  const handler = () => setHistory(listDigestHistory());
  window.addEventListener("hub-weekly-digest-updated", handler);
  return () => window.removeEventListener("hub-weekly-digest-updated", handler);
}, []);
```

```jsx
// AFTER
const { data: history = [] } = useDigestHistory();
```

## Review & Testing Checklist for Human

- [ ] Generate a weekly digest from the hub dashboard and confirm the
      settings screen's "AI Звіт тижня" section reflects the new digest
      without a page reload (this is the fan-out path that used to go
      through the CustomEvent).
- [ ] Generate a digest, then open the coach insight card — the previous
      insight should still be visible until you hit the refresh button,
      and refresh should regenerate with the new digest in memory.
- [ ] Confirm the "Попередні тижні" picker in the dashboard card shows
      the newly generated week immediately after generation.
- [ ] Spot-check localStorage keys: `hub_weekly_digest_<weekKey>` and
      `hub_coach_insight_cache_v1` should still be populated so the
      upgrade is backwards-compatible for existing users.
- [ ] Verify the Monday auto-digest path (`useMondayAutoDigest` in
      `HubDashboard.jsx`) — if run on Monday without an existing digest,
      it should still fire once after the 3s delay.

### Notes

- The public hook API (`digest / loading / error / generate / weekKey /
  weekRange / isCurrentWeek` and `insight / loading / error / refresh`)
  is unchanged. All four existing consumers
  (`WeeklyDigestCard`, `WeeklyDigestStories`, `AIDigestSection`,
  `CoachInsightCard`, `HubDashboard`) compile and lint clean without
  other edits.
- `listDigestHistory` is still exported for any external callers but is
  now primarily consumed via the new `useDigestHistory()` helper so
  invalidation works for free.
- Not converting these hooks to TypeScript in this PR — that's tracked
  by the ongoing `src/core` TS migration (#145, #146).
- `npm run lint`, `npm run typecheck`, and `npm test` all pass locally
  (543/543 tests).


Link to Devin session: https://app.devin.ai/sessions/643f18aa0f9c4c388fc1658adfbf8c7b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
