### PR TITLE
fix(finyk): logic & UX bugs (fmtDate, PWA action, hash format, swipe, ternary)

### DIFF
--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -132,7 +132,9 @@ const ALL_PAGE_IDS = PAGES.map((p) => p.id);
 
 function useHashRouter(defaultPage = "overview") {
   const getPage = useCallback(() => {
-    let p = window.location.hash.replace("#/", "") || defaultPage;
+    // Accept both `#page` (canonical, matches fizruk/nutrition) and legacy `#/page`.
+    let p =
+      window.location.hash.replace(/^#\/?/, "").split("/")[0] || defaultPage;
     if (p === "payments") p = "budgets";
     return p;
   }, [defaultPage]);
@@ -143,7 +145,7 @@ function useHashRouter(defaultPage = "overview") {
     return () => window.removeEventListener("hashchange", handler);
   }, [getPage]);
   const navigate = (p) => {
-    window.location.hash = `/${p}`;
+    window.location.hash = p;
   };
   return [ALL_PAGE_IDS.includes(page) ? page : defaultPage, navigate];
 }
@@ -195,24 +197,30 @@ export default function App({
   useEffect(() => {
     if (window.location.search.includes("sync=")) {
       const ok = storage.loadFromUrl();
-      if (ok) showToast("✅ Налаштування синхронізовано!");
-      else showToast("❌ Не вдалось завантажити синк-дані", "error");
-    }
-    if (pwaAction === "add_expense") {
-      navigate("transactions");
-      setShowExpenseSheet(true);
-      onPwaActionConsumed?.();
+      if (ok) showToast("Налаштування синхронізовано!");
+      else showToast("Не вдалось завантажити синк-дані", "error");
     }
     // Одноразово при монтуванні: ?sync= у URL
     // eslint-disable-next-line react-hooks/exhaustive-deps -- storage/showToast не повинні перезапускати імпорт з URL
   }, []);
 
   useEffect(() => {
-    if (window.location.hash === "#/payments") {
+    if (pwaAction === "add_expense") {
+      navigate("transactions");
+      setShowExpenseSheet(true);
+      onPwaActionConsumed?.();
+    }
+    // `navigate` — стабільна локальна функція useHashRouter, не ре-створюється між рендерами.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pwaAction, onPwaActionConsumed]);
+
+  useEffect(() => {
+    const h = window.location.hash;
+    if (h === "#/payments" || h === "#payments") {
       window.history.replaceState(
         null,
         "",
-        `${window.location.pathname}#/budgets`,
+        `${window.location.pathname}#budgets`,
       );
     }
   }, []);
@@ -251,7 +259,10 @@ export default function App({
     touchStartX.current = null;
     touchStartY.current = null;
 
-    if (Math.abs(dx) < 100 || Math.abs(dy) > Math.abs(dx) * 0.85) return;
+    // Require a clearly horizontal swipe so vertical scrolls in nested lists
+    // (transactions, budgets) never trigger tab switches: |dx| must exceed
+    // both a comfortable threshold (60px) AND ~1.5× the vertical travel.
+    if (Math.abs(dx) < 60 || Math.abs(dx) < Math.abs(dy) * 1.5) return;
     const curIdx = NAV_IDS.indexOf(page);
     if (curIdx === -1) return;
     const next = curIdx + (dx > 0 ? 1 : -1);

--- a/src/modules/finyk/hooks/useUnifiedFinanceData.js
+++ b/src/modules/finyk/hooks/useUnifiedFinanceData.js
@@ -41,9 +41,7 @@ export function useUnifiedFinanceData({ mono, privat }) {
           ? "partial"
           : mono.syncState?.status === "loading" || privat.loadingTx
             ? "loading"
-            : mono.syncState?.status === "success"
-              ? "success"
-              : mono.syncState?.status;
+            : mono.syncState?.status;
     const combinedSyncState = {
       ...mono.syncState,
       status: combinedSyncStatus,

--- a/src/modules/finyk/utils.js
+++ b/src/modules/finyk/utils.js
@@ -83,7 +83,12 @@ export function fmtAmt(amount, cc = CURRENCY.UAH) {
 
 export function fmtDate(ts) {
   const d = new Date(ts * 1000);
-  const diff = Math.floor((Date.now() - d) / 86400000);
+  // Compare by calendar day at midnight, not elapsed milliseconds, so a
+  // transaction at 23:50 and a read at 00:10 render as "Вчора", not "Сьогодні".
+  const d0 = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const diff = Math.round((today - d0) / 86400000);
   const t = d.toLocaleTimeString("uk-UA", {
     hour: "2-digit",
     minute: "2-digit",

--- a/src/modules/finyk/utils.test.js
+++ b/src/modules/finyk/utils.test.js
@@ -110,6 +110,21 @@ describe("fmtDate", () => {
     const yesterdaySec = Math.floor(Date.now() / 1000) - 86400;
     expect(fmtDate(yesterdaySec)).toMatch(/^Вчора/);
   });
+  it("групує за календарним днем, а не за 24-годинним інтервалом", () => {
+    // О 00:30 транзакція, зроблена вчора о 23:50 (≈40 хв тому), має бути «Вчора».
+    vi.setSystemTime(new Date("2024-06-15T00:30:00"));
+    const lateYesterdayTs = Math.floor(
+      new Date("2024-06-14T23:50:00").getTime() / 1000,
+    );
+    expect(fmtDate(lateYesterdayTs)).toMatch(/^Вчора/);
+
+    // О 23:00 транзакція о 01:00 того ж дня (≈22 год тому) — «Сьогодні».
+    vi.setSystemTime(new Date("2024-06-15T23:00:00"));
+    const earlyTodayTs = Math.floor(
+      new Date("2024-06-15T01:00:00").getTime() / 1000,
+    );
+    expect(fmtDate(earlyTodayTs)).toMatch(/^Сьогодні/);
+  });
 });
 
 describe("getAccountLabel", () => {


### PR DESCRIPTION
## Summary

Виправляю логічні баги та UX-дрібниці у модулі **Finyk** (виявлені під час code-review). PR самодостатній — зачіпає лише `src/modules/finyk/**`.

**Логіка**
- **L1 — `fmtDate` групував транзакції за 24-годинним інтервалом.** Транзакція о 23:50, побачена о 00:30 наступного дня (≈40 хв потому), показувалась як "Сьогодні". Переведено на календарне порівняння через `setHours(0,0,0,0)` + `Math.round` (відповідає логіці `Transactions.jsx`). Додано юніт-тест на межу опівночі.
- **L2 — `pwaAction="add_expense"` ігнорувався після mount.** Обробник сидів у `useEffect(…, [])` разом із `?sync=`-імпортом, тож пізніший prop не тригерив відкриття sheet'а. Розділено на два ефекти: `?sync=` — одноразово при mount, `pwaAction` — з правильним deps `[pwaAction, onPwaActionConsumed]`.
- **L3 — зайвий тернар у `useUnifiedFinanceData`:** `… === "success" ? "success" : mono.syncState?.status` — обидві гілки повертали те саме. Прибрано.

**UX**
- **U1 — різний hash-формат між модулями.** Finyk писав `#/page`, Fizruk/Nutrition — `#page` — ламає deep-links. `useHashRouter` тепер пише канонічне `#page`, а парсер приймає обидва формати (бекворд-compat для існуючих закладок `#/overview`). Редірект `#/payments → #budgets` теж оновлено.
- **U2 — надто ліберальний поріг свайпу.** `|dy| > |dx| * 0.85` пропускав рухи під ~40° — конфлікт з вертикальним скролом списку операцій. Посилено: потрібен `|dx| ≥ 60` **і** `|dx| ≥ |dy| * 1.5`.
- **U3 — дублікатні емодзі у toast-ах.** `showToast` вже рендерить іконку по `type: success|error`, а текст мав свої `✅`/`❌` — прибрано.

## Review & Testing Checklist for Human

- [ ] Відкрити існуюче посилання виду `https://…/#/transactions` — має відкрити сторінку операцій (legacy формат приймається).
- [ ] Нова навігація в модулі записує URL без слеша (`#/transactions` → `#transactions` після кліку).
- [ ] Горизонтальні свайпи між вкладками працюють; вертикальний скрол у списку транзакцій не «перестрибує» вкладку.
- [ ] Тригер PWA-ярлика «Додати витрату» відкриває bottom-sheet, навіть якщо модуль уже відкритий.
- [ ] Тости при синхронізації (`?sync=`) мають одну іконку, а не дві.

### Notes
Коміт охоплює лише Finyk. Fizruk / Routine / Nutrition будуть окремими PR.


Link to Devin session: https://app.devin.ai/sessions/ac509c115785486382c47fcd6b0c5b8c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
