### PR TITLE
fix(fizruk): cardio distanceM, hash normalization, shared AudioContext

### DIFF
--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -111,8 +111,9 @@ const VALID_FIZRUK_PAGES = [
 ];
 
 function parseHash() {
-  const raw = (window.location.hash || "").replace(/^#/, "").trim();
-  if (!raw || raw.startsWith("/")) return { page: "dashboard" };
+  // Accept both `#page` (canonical) and legacy `#/page` so deep-links keep working.
+  const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
+  if (!raw) return { page: "dashboard" };
   const [page, ...rest] = raw.split("/").filter(Boolean);
   if (page === "exercise" && rest[0]) return { page, exerciseId: rest[0] };
   if (!VALID_FIZRUK_PAGES.includes(page)) return { page: "dashboard" };
@@ -173,6 +174,22 @@ export default function FizrukApp({
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
 
+  // Normalize URL on mount so an invalid/legacy hash (e.g. `#/foo`) that
+  // silently falls back to dashboard doesn't persist after refresh.
+  useEffect(() => {
+    const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
+    const canonical = route.page === "exercise" ? raw : route.page;
+    if (raw !== canonical) {
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}#${canonical}`,
+      );
+    }
+    // Run only on mount — route changes after mount go through setHash().
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     if (pwaAction === "start_workout") {
       setHash("workouts");
@@ -218,14 +235,14 @@ export default function FizrukApp({
         type: isCardio ? "distance" : "strength",
         sets: isCardio ? undefined : [{ weightKg: suggestedWeight, reps: 0 }],
         durationSec: 0,
-        distanceM: isCardio ? 0 : 0,
+        ...(isCardio ? { distanceM: 0 } : {}),
       });
     }
     try {
       localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
       sessionStorage.setItem("fizruk_workouts_mode", "log");
     } catch {}
-    window.location.hash = "#workouts";
+    setHash("workouts");
   };
 
   const headerTitle = isAtlas

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -179,7 +179,9 @@ export default function FizrukApp({
   useEffect(() => {
     const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
     const canonical = route.page === "exercise" ? raw : route.page;
-    if (raw !== canonical) {
+    // Guard the empty-hash case: a clean URL without any fragment must stay
+    // clean. We only normalize legacy/invalid hashes like `#/foo`.
+    if (raw && raw !== canonical) {
       window.history.replaceState(
         null,
         "",

--- a/src/modules/fizruk/pages/Workouts.tsx
+++ b/src/modules/fizruk/pages/Workouts.tsx
@@ -20,14 +20,33 @@ import {
   summarizeWorkoutForFinish,
 } from "../lib/workoutUi";
 
-function playRestCompletionSound() {
+// Shared AudioContext reused across beeps. Creating/closing one per call
+// races with quick successive rest-timer completions and fights iOS' audio
+// session. Lazily created on first call (after a user gesture) and kept open
+// for the lifetime of the page; browsers GC it on unload.
+let sharedAudioCtx: AudioContext | null = null;
+function getAudioCtx(): AudioContext | null {
   try {
-    const ctx = new (
+    if (sharedAudioCtx && sharedAudioCtx.state !== "closed")
+      return sharedAudioCtx;
+    const Ctor =
       window.AudioContext ||
       (window as unknown as { webkitAudioContext: typeof AudioContext })
-        .webkitAudioContext
-    )();
-    const playBeep = (freq, startTime, duration) => {
+        .webkitAudioContext;
+    sharedAudioCtx = new Ctor();
+    return sharedAudioCtx;
+  } catch {
+    return null;
+  }
+}
+
+function playRestCompletionSound() {
+  const ctx = getAudioCtx();
+  if (!ctx) return;
+  try {
+    // iOS can suspend the context between beeps; resume is a noop if running.
+    if (ctx.state === "suspended") void ctx.resume();
+    const playBeep = (freq: number, startTime: number, duration: number) => {
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.connect(gain);
@@ -43,11 +62,6 @@ function playRestCompletionSound() {
     playBeep(880, t, 0.15);
     playBeep(1100, t + 0.18, 0.15);
     playBeep(1320, t + 0.36, 0.3);
-    setTimeout(() => {
-      try {
-        ctx.close();
-      } catch {}
-    }, 1500);
   } catch {}
 }
 


### PR DESCRIPTION
## Summary

Виправляю логічні баги та UX-дрібниці у модулі **Fizruk** (виявлені під час code-review). PR самодостатній — зачіпає лише `src/modules/fizruk/**`.

**Логіка**
- **L4 — `distanceM: isCardio ? 0 : 0`.** Обидві гілки повертали `0`, тож у `workout.items` силові вправи отримували безглузде поле `distanceM: 0`. Замінено на conditional spread: `...(isCardio ? { distanceM: 0 } : {})` — silove не забруднюється, cardio має явне значення.
- **L5 — `parseHash` тихо повертав `dashboard` для невалідних/legacy `#/…` hash'ів.** UI показував dashboard, але URL лишався `#/foo` → рефреш відтворював розсинхронізацію. Тепер парсер приймає обидва формати (`#page` та legacy `#/page`), а на mount окремий effect робить `history.replaceState`, щоб URL відобразив реальну сторінку.
- **L6 — `window.location.hash = "#workouts"`** у `handleStartProgramWorkout` обходив guard у `setHash()`. Замінено на `setHash("workouts")`.

**UX**
- **U4 — AudioContext на кожен beep.** Створював новий контекст, далі `setTimeout(close, 1500)` — швидкі повторні таймери ризикували закрити контекст між beeps. iOS до того ж гасить suspended-контексти. Зроблено module-level `sharedAudioCtx` + `getAudioCtx()` з lazy-init і `ctx.resume()` на suspended. Більше не закриваємо — браузер GC'не на unload.

## Review & Testing Checklist for Human

- [ ] Запустити програмне тренування з cardio + strength вправами. Strength-items у storage не мають `distanceM` (було `0`), cardio — мають.
- [ ] Відкрити `/?module=fizruk#/atlas` (legacy формат) — має завантажитись Atlas; після mount URL має нормалізуватись до `#atlas`.
- [ ] Завершити restTimer 3-4 рази поспіль — звук не має пропадати, консоль без AudioContext warnings.
- [ ] На iOS після блокування/розблокування екрана beep відтворюється (resume з suspended).

### Notes
Попередній PR #150 (finyk) уже влитий у main — цей PR чистий, без крос-модульних конфліктів.


Link to Devin session: https://app.devin.ai/sessions/ac509c115785486382c47fcd6b0c5b8c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
