### PR TITLE
refactor(hub): split HubDashboard.jsx + collapse hero-card CSS duplication

### DIFF
--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -1,7 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
-import { cn } from "@shared/lib/cn";
-import { ProgressRing } from "@shared/components/ui/ProgressRing";
-import { Icon } from "@shared/components/ui/Icon";
+import { useState, useCallback, useEffect } from "react";
 import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { HubRecommendations } from "./HubRecommendations.jsx";
@@ -19,26 +16,26 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
-  useSortable,
   arrayMove,
   rectSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { DailyProgressHero } from "./dashboard/DailyProgressHero.jsx";
+import { SortableCard } from "./dashboard/ModuleCard.jsx";
+import { MODULE_ORDER_DEFAULT } from "./dashboard/moduleConfigs.jsx";
 
 const DASHBOARD_ORDER_KEY = STORAGE_KEYS.DASHBOARD_ORDER;
-const DEFAULT_ORDER = ["finyk", "fizruk", "routine", "nutrition"];
 const HUB_PREFS_KEY = STORAGE_KEYS.HUB_PREFS;
 
 function loadOrder() {
   const saved = safeReadLS(DASHBOARD_ORDER_KEY, null);
   if (
     Array.isArray(saved) &&
-    saved.length === DEFAULT_ORDER.length &&
-    DEFAULT_ORDER.every((id) => saved.includes(id))
+    saved.length === MODULE_ORDER_DEFAULT.length &&
+    MODULE_ORDER_DEFAULT.every((id) => saved.includes(id))
   ) {
     return saved;
   }
-  return [...DEFAULT_ORDER];
+  return [...MODULE_ORDER_DEFAULT];
 }
 
 function saveOrder(order) {
@@ -49,511 +46,6 @@ export function resetDashboardOrder() {
   safeRemoveLS(DASHBOARD_ORDER_KEY);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE CONFIGURATIONS — Updated with new brand colors
-// ═══════════════════════════════════════════════════════════════════════════
-const MODULE_CONFIGS = {
-  finyk: {
-    icon: (
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect x="2" y="4" width="20" height="16" rx="2" />
-        <path d="M6 8h.01M6 12h.01M6 16h.01M10 8h8M10 12h8M10 16h8" />
-      </svg>
-    ),
-    label: "Фінік",
-    module: "finyk",
-    colorClass: "bg-finyk-soft text-finyk",
-    borderClass: "border-brand-200/60",
-    hoverGradient: "from-brand-50 to-teal-50/50",
-    ringVariant: "finyk",
-    description: "Транзакції та бюджети",
-    getPreview: () => {
-      // Quick finance preview from localStorage
-      try {
-        const data = localStorage.getItem("finyk_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.todaySpent
-              ? `${stats.todaySpent.toLocaleString()} грн`
-              : null,
-            sub: stats.budgetLeft
-              ? `Залишок: ${stats.budgetLeft.toLocaleString()}`
-              : null,
-          };
-        }
-      } catch {}
-      return { main: null, sub: "Відстежуй витрати" };
-    },
-  },
-  fizruk: {
-    icon: (
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M6.5 6.5a3.5 3.5 0 1 0 7 0 3.5 3.5 0 1 0-7 0" />
-        <path d="M3 20v-1a7 7 0 0 1 7-7" />
-        <path d="M14 14l2 2 4-4" />
-      </svg>
-    ),
-    label: "Фізрук",
-    module: "fizruk",
-    colorClass: "bg-fizruk-soft text-fizruk",
-    borderClass: "border-teal-200/60",
-    hoverGradient: "from-teal-50 to-brand-50/50",
-    ringVariant: "fizruk",
-    description: "Тренування та прогрес",
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("fizruk_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.weekWorkouts ? `${stats.weekWorkouts} тренувань` : null,
-            sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
-          };
-        }
-      } catch {}
-      return { main: null, sub: "Плануй тренування" };
-    },
-  },
-  routine: {
-    icon: (
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" />
-        <path d="m9 12 2 2 4-4" />
-      </svg>
-    ),
-    label: "Рутина",
-    module: "routine",
-    colorClass: "bg-routine-surface text-routine",
-    borderClass: "border-coral-200/60",
-    hoverGradient: "from-coral-50 to-routine-surface/50",
-    ringVariant: "routine",
-    description: "Звички та щоденні цілі",
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("routine_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main:
-              stats.todayDone !== undefined
-                ? `${stats.todayDone}/${stats.todayTotal}`
-                : null,
-            sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
-            progress: stats.todayTotal
-              ? (stats.todayDone / stats.todayTotal) * 100
-              : 0,
-          };
-        }
-      } catch {}
-      return { main: null, sub: "Формуй звички", progress: 0 };
-    },
-  },
-  nutrition: {
-    icon: (
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M2 2a26.6 26.6 0 0 1 10 20c.9-6.82 1.5-9.5 4-14" />
-        <path d="M16 8c4 0 6-2 6-6-4 0-6 2-6 6" />
-        <path d="M17.41 3.59a10 10 0 1 0 3 3" />
-      </svg>
-    ),
-    label: "Харчування",
-    module: "nutrition",
-    colorClass: "bg-nutrition-soft text-nutrition",
-    borderClass: "border-lime-200/60",
-    hoverGradient: "from-lime-50 to-nutrition-soft/50",
-    ringVariant: "nutrition",
-    description: "КБЖВ та раціон",
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("nutrition_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.todayCal ? `${stats.todayCal} ккал` : null,
-            sub: stats.calGoal ? `Ціль: ${stats.calGoal} ккал` : null,
-            progress: stats.calGoal
-              ? (stats.todayCal / stats.calGoal) * 100
-              : 0,
-          };
-        }
-      } catch {}
-      return { main: null, sub: "Рахуй калорії", progress: 0 };
-    },
-  },
-};
-
-// ═══════════════════════════════════════════════════════════════════════════
-// DAILY PROGRESS HERO — Shows overall day progress with enhanced visuals
-// ═══════════════════════════════════════════════════════════════════════════
-const PROGRESS_STORAGE_KEYS = [
-  "routine_quick_stats",
-  "nutrition_quick_stats",
-  "fizruk_quick_stats",
-];
-
-function readDailyProgress() {
-  let total = 0;
-  let completed = 0;
-
-  try {
-    const routineData = localStorage.getItem("routine_quick_stats");
-    if (routineData) {
-      const stats = JSON.parse(routineData);
-      total += stats.todayTotal || 0;
-      completed += stats.todayDone || 0;
-    }
-  } catch {
-    /* ignore */
-  }
-
-  try {
-    const nutritionData = localStorage.getItem("nutrition_quick_stats");
-    if (nutritionData) {
-      const stats = JSON.parse(nutritionData);
-      if (stats.calGoal) {
-        total += 1;
-        if (stats.todayCal >= stats.calGoal * 0.8) completed += 1;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-
-  try {
-    const fizrukData = localStorage.getItem("fizruk_quick_stats");
-    if (fizrukData) {
-      const stats = JSON.parse(fizrukData);
-      if (stats.plannedToday) {
-        total += 1;
-        if (stats.completedToday) completed += 1;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-
-  return { total: total || 4, completed };
-}
-
-function DailyProgressHero() {
-  const [progress, setProgress] = useState(() => ({ total: 0, completed: 0 }));
-  const [isComplete, setIsComplete] = useState(false);
-
-  useEffect(() => {
-    const refresh = () => {
-      const next = readDailyProgress();
-      setProgress((prev) => {
-        const wasComplete = prev.completed === prev.total && prev.total > 0;
-        const nowComplete = next.completed === next.total && next.total > 0;
-        if (nowComplete && !wasComplete) {
-          setIsComplete(true);
-          setTimeout(() => setIsComplete(false), 2000);
-        }
-        return next;
-      });
-    };
-
-    refresh();
-
-    // Cross-tab + cross-module sync: when any module updates its quick-stats
-    // cache via localStorage, the hero reflects it without a full re-mount.
-    const onStorage = (e) => {
-      if (!e.key || PROGRESS_STORAGE_KEYS.includes(e.key)) refresh();
-    };
-    window.addEventListener("storage", onStorage);
-    const onFocus = () => refresh();
-    window.addEventListener("focus", onFocus);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      window.removeEventListener("focus", onFocus);
-    };
-  }, []);
-
-  const percentage =
-    progress.total > 0
-      ? Math.round((progress.completed / progress.total) * 100)
-      : 0;
-
-  const greeting = useMemo(() => {
-    const hour = new Date().getHours();
-    if (hour < 12) return "Добрий ранок";
-    if (hour < 17) return "Добрий день";
-    return "Добрий вечір";
-  }, []);
-
-  const motivationalText = useMemo(() => {
-    if (percentage === 0) return "Час почати день!";
-    if (percentage < 25) return "Гарний початок!";
-    if (percentage < 50) return "Так тримати!";
-    if (percentage < 75) return "Чудовий прогрес!";
-    if (percentage < 100) return "Майже все!";
-    return "День завершено!";
-  }, [percentage]);
-
-  return (
-    <div
-      role="region"
-      aria-label="Прогрес дня"
-      className={cn(
-        "relative overflow-hidden rounded-3xl border shadow-card p-5",
-        "bg-gradient-to-br from-white via-brand-50/20 to-teal-50/30",
-        "dark:from-panel dark:via-panel dark:to-panel",
-        "border-brand-100/60 dark:border-brand-800/30",
-        "transition-all duration-500",
-        isComplete && "animate-success-ring",
-      )}
-    >
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {`${motivationalText}. Виконано ${progress.completed} з ${progress.total} завдань. ${percentage}%.`}
-      </div>
-      <div className="relative flex items-center gap-5">
-        {/* Progress Ring — glow comes from ProgressRing itself */}
-        <div
-          className={cn(
-            "relative",
-            percentage === 100 && "animate-celebration-pop",
-          )}
-        >
-          <ProgressRing
-            value={progress.completed}
-            max={progress.total}
-            size="lg"
-            variant="brand"
-            animate
-          >
-            <div className="flex flex-col items-center">
-              <span className="text-2xl font-bold text-brand-600 dark:text-brand-400 tabular-nums leading-none">
-                {percentage}%
-              </span>
-            </div>
-          </ProgressRing>
-        </div>
-
-        {/* Text content with enhanced typography */}
-        <div className="flex-1 min-w-0">
-          <p className="text-[10px] font-semibold text-brand-600/70 dark:text-brand-400/70 uppercase tracking-widest mb-1">
-            {greeting}
-          </p>
-          <h1 className="text-xl font-bold text-text mb-1.5 text-balance leading-tight">
-            {motivationalText}
-          </h1>
-          <div className="flex items-center gap-2">
-            <p className="text-sm text-muted">
-              <span className="font-semibold text-brand-600 dark:text-brand-400 tabular-nums">
-                {progress.completed}
-              </span>
-              <span className="mx-1">/</span>
-              <span className="tabular-nums">{progress.total}</span>
-              <span className="ml-1.5">завдань</span>
-            </p>
-            {percentage === 100 && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-100 dark:bg-brand-900/30 text-brand-700 dark:text-brand-400 text-[10px] font-semibold">
-                <Icon name="check" size={10} strokeWidth={3} />
-                Виконано
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE CARD — Interactive card with preview data and enhanced visuals
-// ═══════════════════════════════════════════════════════════════════════════
-function ModuleCard({ config, onClick, dragProps, isDragging }) {
-  const preview = config.getPreview();
-
-  // Module-specific gradient classes
-  const moduleGradients = {
-    finyk: "module-card-finyk",
-    fizruk: "module-card-fizruk",
-    routine: "module-card-routine",
-    nutrition: "module-card-nutrition",
-  };
-
-  const moduleGlows = {
-    finyk: "hover-glow",
-    fizruk: "hover-glow-teal",
-    routine: "hover-glow-coral",
-    nutrition: "hover-glow-lime",
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "group relative w-full text-left",
-        "p-4 rounded-2xl border",
-        "shadow-card transition-all duration-200 ease-smooth",
-        "hover:shadow-float hover:-translate-y-1",
-        "active:scale-[0.97] active:shadow-card",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        moduleGradients[config.module] || "bg-panel",
-        moduleGlows[config.module],
-        isDragging &&
-          "opacity-80 scale-[0.97] shadow-float z-50 cursor-grabbing rotate-1",
-      )}
-      {...dragProps}
-    >
-      <div className="relative">
-        {/* Header row */}
-        <div className="flex items-center gap-2.5 mb-3">
-          <div
-            className={cn(
-              "w-10 h-10 rounded-xl flex items-center justify-center shrink-0",
-              "transition-transform duration-200 ease-smooth",
-              "group-hover:scale-105",
-              "shadow-sm",
-              config.colorClass,
-            )}
-          >
-            {config.icon}
-          </div>
-          <div className="flex-1 min-w-0">
-            <span className="text-[11px] font-bold text-muted uppercase tracking-wider">
-              {config.label}
-            </span>
-          </div>
-          <div
-            className={cn(
-              "w-7 h-7 rounded-lg flex items-center justify-center",
-              "bg-line/30 dark:bg-white/5",
-              "group-hover:bg-line/50 dark:group-hover:bg-white/10",
-              "transition-all duration-200",
-              "group-hover:translate-x-0.5",
-            )}
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-muted group-hover:text-text transition-colors"
-              aria-hidden
-            >
-              <path d="M9 18l6-6-6-6" />
-            </svg>
-          </div>
-        </div>
-
-        {/* Preview content */}
-        <div className="space-y-1.5">
-          {preview.main ? (
-            <>
-              <p className="text-xl font-bold text-text tabular-nums leading-tight">
-                {preview.main}
-              </p>
-              {preview.sub && (
-                <p className="text-xs text-muted leading-snug">{preview.sub}</p>
-              )}
-            </>
-          ) : (
-            <p className="text-sm text-muted leading-snug">
-              {preview.sub || config.description}
-            </p>
-          )}
-
-          {/* Mini progress bar */}
-          {preview.progress !== undefined && preview.progress > 0 && (
-            <div className="mt-2.5 h-1.5 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden">
-              <div
-                className={cn(
-                  "h-full rounded-full transition-all duration-700 ease-out",
-                  config.module === "routine" && "bg-routine",
-                  config.module === "nutrition" && "bg-nutrition",
-                  config.module === "fizruk" && "bg-fizruk",
-                  config.module === "finyk" && "bg-finyk",
-                )}
-                style={{ width: `${Math.min(preview.progress, 100)}%` }}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-    </button>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// SORTABLE CARD WRAPPER
-// ═══════════════════════════════════════════════════════════════════════════
-function SortableCard({ id, onOpenModule }) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
-  const cfg = MODULE_CONFIGS[id];
-  if (!cfg) return null;
-
-  return (
-    <div ref={setNodeRef} style={style}>
-      <ModuleCard
-        config={cfg}
-        onClick={() => onOpenModule(id)}
-        isDragging={isDragging}
-        dragProps={{ ...attributes, ...listeners }}
-      />
-    </div>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MONDAY AUTO DIGEST HOOK
-// ═══════════════════════════════════════════════════════════════════════════
 function useMondayAutoDigest() {
   const { generate } = useWeeklyDigest();
 
@@ -573,9 +65,6 @@ function useMondayAutoDigest() {
   }, [generate]);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// MAIN HUB DASHBOARD
-// ═══════════════════════════════════════════════════════════════════════════
 export function HubDashboard({ onOpenModule, onOpenChat }) {
   const [order, setOrder] = useState(loadOrder);
   useMondayAutoDigest();
@@ -616,22 +105,12 @@ export function HubDashboard({ onOpenModule, onOpenChat }) {
 
   return (
     <div className="space-y-5">
-      {/* Daily Progress Hero */}
       <DailyProgressHero />
-
-      {/* Daily Finyk Summary (today's spend + top category, soft reminders) */}
       <DailyFinykSummaryCard />
-
-      {/* Smart Recommendations */}
       <HubRecommendations onOpenModule={onOpenModule} />
-
-      {/* AI Coach Insight */}
       {showCoach && <CoachInsightCard onOpenChat={onOpenChat} />}
-
-      {/* Weekly Digest */}
       <WeeklyDigestCard />
 
-      {/* Module Cards Grid */}
       <section className="space-y-3">
         <div className="flex items-center justify-between px-0.5">
           <h2 className="text-xs font-semibold text-muted uppercase tracking-wider">

--- a/src/core/dashboard/DailyProgressHero.jsx
+++ b/src/core/dashboard/DailyProgressHero.jsx
@@ -1,0 +1,172 @@
+/**
+ * Daily Progress Hero — aggregate progress ring shown at the top of the hub
+ * dashboard.
+ *
+ * Listens to `storage` and `focus` events so the hero reflects updates written
+ * by any module (routine, nutrition, fizruk) without a full re-mount.
+ */
+
+import { useState, useEffect, useMemo } from "react";
+import { cn } from "@shared/lib/cn";
+import { ProgressRing } from "@shared/components/ui/ProgressRing";
+import { Icon } from "@shared/components/ui/Icon";
+
+export const PROGRESS_STORAGE_KEYS = [
+  "routine_quick_stats",
+  "nutrition_quick_stats",
+  "fizruk_quick_stats",
+];
+
+function parseStats(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readDailyProgress() {
+  let total = 0;
+  let completed = 0;
+
+  const routine = parseStats("routine_quick_stats");
+  if (routine) {
+    total += routine.todayTotal || 0;
+    completed += routine.todayDone || 0;
+  }
+
+  const nutrition = parseStats("nutrition_quick_stats");
+  if (nutrition && nutrition.calGoal) {
+    total += 1;
+    if (nutrition.todayCal >= nutrition.calGoal * 0.8) completed += 1;
+  }
+
+  const fizruk = parseStats("fizruk_quick_stats");
+  if (fizruk && fizruk.plannedToday) {
+    total += 1;
+    if (fizruk.completedToday) completed += 1;
+  }
+
+  return { total: total || 4, completed };
+}
+
+export function DailyProgressHero() {
+  const [progress, setProgress] = useState(() => ({ total: 0, completed: 0 }));
+  const [isComplete, setIsComplete] = useState(false);
+
+  useEffect(() => {
+    const refresh = () => {
+      const next = readDailyProgress();
+      setProgress((prev) => {
+        const wasComplete = prev.completed === prev.total && prev.total > 0;
+        const nowComplete = next.completed === next.total && next.total > 0;
+        if (nowComplete && !wasComplete) {
+          setIsComplete(true);
+          setTimeout(() => setIsComplete(false), 2000);
+        }
+        return next;
+      });
+    };
+
+    refresh();
+
+    const onStorage = (e) => {
+      if (!e.key || PROGRESS_STORAGE_KEYS.includes(e.key)) refresh();
+    };
+    const onFocus = () => refresh();
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, []);
+
+  const percentage =
+    progress.total > 0
+      ? Math.round((progress.completed / progress.total) * 100)
+      : 0;
+
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Добрий ранок";
+    if (hour < 17) return "Добрий день";
+    return "Добрий вечір";
+  }, []);
+
+  const motivationalText = useMemo(() => {
+    if (percentage === 0) return "Час почати день!";
+    if (percentage < 25) return "Гарний початок!";
+    if (percentage < 50) return "Так тримати!";
+    if (percentage < 75) return "Чудовий прогрес!";
+    if (percentage < 100) return "Майже все!";
+    return "День завершено!";
+  }, [percentage]);
+
+  return (
+    <div
+      role="region"
+      aria-label="Прогрес дня"
+      className={cn(
+        "relative overflow-hidden rounded-3xl border shadow-card p-5",
+        "bg-gradient-to-br from-white via-brand-50/20 to-teal-50/30",
+        "dark:from-panel dark:via-panel dark:to-panel",
+        "border-brand-100/60 dark:border-brand-800/30",
+        "transition-all duration-500",
+        isComplete && "animate-success-ring",
+      )}
+    >
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {`${motivationalText}. Виконано ${progress.completed} з ${progress.total} завдань. ${percentage}%.`}
+      </div>
+      <div className="relative flex items-center gap-5">
+        <div
+          className={cn(
+            "relative",
+            percentage === 100 && "animate-celebration-pop",
+          )}
+        >
+          <ProgressRing
+            value={progress.completed}
+            max={progress.total}
+            size="lg"
+            variant="brand"
+            animate
+          >
+            <div className="flex flex-col items-center">
+              <span className="text-2xl font-bold text-brand-600 dark:text-brand-400 tabular-nums leading-none">
+                {percentage}%
+              </span>
+            </div>
+          </ProgressRing>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-[10px] font-semibold text-brand-600/70 dark:text-brand-400/70 uppercase tracking-widest mb-1">
+            {greeting}
+          </p>
+          <h1 className="text-xl font-bold text-text mb-1.5 text-balance leading-tight">
+            {motivationalText}
+          </h1>
+          <div className="flex items-center gap-2">
+            <p className="text-sm text-muted">
+              <span className="font-semibold text-brand-600 dark:text-brand-400 tabular-nums">
+                {progress.completed}
+              </span>
+              <span className="mx-1">/</span>
+              <span className="tabular-nums">{progress.total}</span>
+              <span className="ml-1.5">завдань</span>
+            </p>
+            {percentage === 100 && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-100 dark:bg-brand-900/30 text-brand-700 dark:text-brand-400 text-[10px] font-semibold">
+                <Icon name="check" size={10} strokeWidth={3} />
+                Виконано
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/core/dashboard/ModuleCard.jsx
+++ b/src/core/dashboard/ModuleCard.jsx
@@ -1,0 +1,154 @@
+/**
+ * Hub Dashboard — ModuleCard and SortableCard.
+ *
+ * `ModuleCard` renders one module tile with icon, preview snippet and optional
+ * mini progress bar. `SortableCard` wraps it in `@dnd-kit/sortable` machinery
+ * so the dashboard order can be rearranged by the user.
+ */
+
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { MODULE_CONFIGS } from "./moduleConfigs.jsx";
+
+const MODULE_GRADIENTS = {
+  finyk: "module-card-finyk",
+  fizruk: "module-card-fizruk",
+  routine: "module-card-routine",
+  nutrition: "module-card-nutrition",
+};
+
+const MODULE_GLOWS = {
+  finyk: "hover-glow",
+  fizruk: "hover-glow-teal",
+  routine: "hover-glow-coral",
+  nutrition: "hover-glow-lime",
+};
+
+const PROGRESS_BAR_COLORS = {
+  routine: "bg-routine",
+  nutrition: "bg-nutrition",
+  fizruk: "bg-fizruk",
+  finyk: "bg-finyk",
+};
+
+export function ModuleCard({ config, onClick, dragProps, isDragging }) {
+  const preview = config.getPreview();
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group relative w-full text-left",
+        "p-4 rounded-2xl border",
+        "shadow-card transition-all duration-200 ease-smooth",
+        "hover:shadow-float hover:-translate-y-1",
+        "active:scale-[0.97] active:shadow-card",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        MODULE_GRADIENTS[config.module] || "bg-panel",
+        MODULE_GLOWS[config.module],
+        isDragging &&
+          "opacity-80 scale-[0.97] shadow-float z-50 cursor-grabbing rotate-1",
+      )}
+      {...dragProps}
+    >
+      <div className="relative">
+        <div className="flex items-center gap-2.5 mb-3">
+          <div
+            className={cn(
+              "w-10 h-10 rounded-xl flex items-center justify-center shrink-0",
+              "transition-transform duration-200 ease-smooth",
+              "group-hover:scale-105",
+              "shadow-sm",
+              config.colorClass,
+            )}
+          >
+            {config.icon}
+          </div>
+          <div className="flex-1 min-w-0">
+            <span className="text-[11px] font-bold text-muted uppercase tracking-wider">
+              {config.label}
+            </span>
+          </div>
+          <div
+            className={cn(
+              "w-7 h-7 rounded-lg flex items-center justify-center",
+              "bg-line/30 dark:bg-white/5",
+              "group-hover:bg-line/50 dark:group-hover:bg-white/10",
+              "transition-all duration-200",
+              "group-hover:translate-x-0.5",
+            )}
+          >
+            <Icon
+              name="chevron-right"
+              size={14}
+              strokeWidth={2.5}
+              className="text-muted group-hover:text-text transition-colors"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          {preview.main ? (
+            <>
+              <p className="text-xl font-bold text-text tabular-nums leading-tight">
+                {preview.main}
+              </p>
+              {preview.sub && (
+                <p className="text-xs text-muted leading-snug">{preview.sub}</p>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-muted leading-snug">
+              {preview.sub || config.description}
+            </p>
+          )}
+
+          {preview.progress !== undefined && preview.progress > 0 && (
+            <div className="mt-2.5 h-1.5 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all duration-700 ease-out",
+                  PROGRESS_BAR_COLORS[config.module],
+                )}
+                style={{ width: `${Math.min(preview.progress, 100)}%` }}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function SortableCard({ id, onOpenModule }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const cfg = MODULE_CONFIGS[id];
+  if (!cfg) return null;
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <ModuleCard
+        config={cfg}
+        onClick={() => onOpenModule(id)}
+        isDragging={isDragging}
+        dragProps={{ ...attributes, ...listeners }}
+      />
+    </div>
+  );
+}

--- a/src/core/dashboard/moduleConfigs.jsx
+++ b/src/core/dashboard/moduleConfigs.jsx
@@ -1,0 +1,106 @@
+/**
+ * Hub Dashboard — module configuration map.
+ *
+ * Single source of truth for the four module tiles on the hub dashboard:
+ * icon, label, module id, styling classes, and a `getPreview()` reader that
+ * summarises the latest quick-stats each module writes to localStorage.
+ */
+
+import { Icon } from "@shared/components/ui/Icon";
+
+function safeReadJSON(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export const MODULE_CONFIGS = {
+  finyk: {
+    icon: <Icon name="credit-card" size={18} />,
+    label: "Фінік",
+    module: "finyk",
+    colorClass: "bg-finyk-soft text-finyk",
+    borderClass: "border-brand-200/60",
+    hoverGradient: "from-brand-50 to-teal-50/50",
+    ringVariant: "finyk",
+    description: "Транзакції та бюджети",
+    getPreview: () => {
+      const stats = safeReadJSON("finyk_quick_stats");
+      if (!stats) return { main: null, sub: "Відстежуй витрати" };
+      return {
+        main: stats.todaySpent
+          ? `${stats.todaySpent.toLocaleString()} грн`
+          : null,
+        sub: stats.budgetLeft
+          ? `Залишок: ${stats.budgetLeft.toLocaleString()}`
+          : null,
+      };
+    },
+  },
+  fizruk: {
+    icon: <Icon name="dumbbell" size={18} />,
+    label: "Фізрук",
+    module: "fizruk",
+    colorClass: "bg-fizruk-soft text-fizruk",
+    borderClass: "border-teal-200/60",
+    hoverGradient: "from-teal-50 to-brand-50/50",
+    ringVariant: "fizruk",
+    description: "Тренування та прогрес",
+    getPreview: () => {
+      const stats = safeReadJSON("fizruk_quick_stats");
+      if (!stats) return { main: null, sub: "Плануй тренування" };
+      return {
+        main: stats.weekWorkouts ? `${stats.weekWorkouts} тренувань` : null,
+        sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
+      };
+    },
+  },
+  routine: {
+    icon: <Icon name="check" size={18} strokeWidth={2.5} />,
+    label: "Рутина",
+    module: "routine",
+    colorClass: "bg-routine-surface text-routine",
+    borderClass: "border-coral-200/60",
+    hoverGradient: "from-coral-50 to-routine-surface/50",
+    ringVariant: "routine",
+    description: "Звички та щоденні цілі",
+    getPreview: () => {
+      const stats = safeReadJSON("routine_quick_stats");
+      if (!stats) return { main: null, sub: "Формуй звички", progress: 0 };
+      return {
+        main:
+          stats.todayDone !== undefined
+            ? `${stats.todayDone}/${stats.todayTotal}`
+            : null,
+        sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
+        progress: stats.todayTotal
+          ? (stats.todayDone / stats.todayTotal) * 100
+          : 0,
+      };
+    },
+  },
+  nutrition: {
+    icon: <Icon name="utensils" size={18} />,
+    label: "Харчування",
+    module: "nutrition",
+    colorClass: "bg-nutrition-soft text-nutrition",
+    borderClass: "border-lime-200/60",
+    hoverGradient: "from-lime-50 to-nutrition-soft/50",
+    ringVariant: "nutrition",
+    description: "КБЖВ та раціон",
+    getPreview: () => {
+      const stats = safeReadJSON("nutrition_quick_stats");
+      if (!stats) return { main: null, sub: "Рахуй калорії", progress: 0 };
+      return {
+        main: stats.todayCal ? `${stats.todayCal} ккал` : null,
+        sub: stats.calGoal ? `Ціль: ${stats.calGoal} ккал` : null,
+        progress: stats.calGoal ? (stats.todayCal / stats.calGoal) * 100 : 0,
+      };
+    },
+  },
+};
+
+export const MODULE_ORDER_DEFAULT = ["finyk", "fizruk", "routine", "nutrition"];

--- a/src/index.css
+++ b/src/index.css
@@ -154,38 +154,10 @@
   }
 
   /* ═══════════════════════════════════════════════════════════════════════
-     MODULE HERO CARDS — Branded surfaces for each module
+     MODULE HERO SURFACES — Branded headers for module routes.
+     Card variants (finyk/fizruk/routine/nutrition) are the primary API.
+     The remaining rules below style sub-areas that aren't just cards.
      ═══════════════════════════════════════════════════════════════════════ */
-
-  /* Фінік — Emerald finance hero */
-  .finyk-hero-card {
-    @apply rounded-3xl p-5 border bg-hero-emerald shadow-card;
-    border-color: rgba(167, 243, 208, 0.5); /* brand-200/50 */
-  }
-  .dark .finyk-hero-card {
-    @apply bg-panel;
-    border-color: rgba(6, 95, 70, 0.3); /* brand-800/30 */
-    background-image: linear-gradient(
-      135deg,
-      rgba(16, 185, 129, 0.1) 0%,
-      transparent 100%
-    );
-  }
-
-  /* Фізрук — Teal fitness hero */
-  .fizruk-hero-card {
-    @apply rounded-3xl p-5 border bg-hero-teal shadow-card;
-    border-color: rgba(153, 246, 228, 0.5); /* teal-200/50 */
-  }
-  .dark .fizruk-hero-card {
-    @apply bg-panel;
-    border-color: rgba(15, 118, 110, 0.3); /* teal-800/30 */
-    background-image: linear-gradient(
-      135deg,
-      rgba(20, 184, 166, 0.1) 0%,
-      transparent 100%
-    );
-  }
 
   .fizruk-cta-accent {
     @apply bg-teal-500 text-white font-semibold rounded-2xl
@@ -202,36 +174,6 @@
     background-image: linear-gradient(
       135deg,
       rgba(20, 184, 166, 0.15) 0%,
-      transparent 100%
-    );
-  }
-
-  /* Рутина — Coral habit hero */
-  .routine-hero-card {
-    @apply rounded-3xl p-5 border bg-hero-coral shadow-card;
-    border-color: rgba(255, 212, 203, 0.5); /* coral-200/50 */
-  }
-  .dark .routine-hero-card {
-    @apply bg-panel;
-    border-color: rgba(162, 51, 51, 0.3); /* coral-800/30 */
-    background-image: linear-gradient(
-      135deg,
-      rgba(249, 112, 102, 0.1) 0%,
-      transparent 100%
-    );
-  }
-
-  /* Харчування — Lime nutrition hero */
-  .nutrition-hero-card {
-    @apply rounded-3xl p-5 border bg-hero-lime shadow-card;
-    border-color: rgba(223, 249, 157, 0.5); /* lime-200/50 */
-  }
-  .dark .nutrition-hero-card {
-    @apply bg-panel;
-    border-color: rgba(70, 98, 18, 0.3); /* lime-800/30 */
-    background-image: linear-gradient(
-      135deg,
-      rgba(146, 204, 23, 0.1) 0%,
       transparent 100%
     );
   }

--- a/src/modules/routine/components/RoutineCalendarPanel.jsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { WeekDayStrip } from "./WeekDayStrip.jsx";
 import { HabitDetailSheet } from "./HabitDetailSheet.jsx";
@@ -106,7 +107,12 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
       hidden={panelHidden}
       className="space-y-4"
     >
-      <section className="routine-hero-card" aria-label="Огляд періоду">
+      <Card
+        as="section"
+        variant="routine"
+        padding="lg"
+        aria-label="Огляд періоду"
+      >
         <p
           className={cn(
             "text-[11px] font-bold tracking-widest uppercase",
@@ -160,7 +166,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
             </div>
           </div>
         </div>
-      </section>
+      </Card>
 
       <DayReportSheet
         open={dayReportOpen}

--- a/src/shared/components/ui/Card.tsx
+++ b/src/shared/components/ui/Card.tsx
@@ -45,11 +45,15 @@ const variants: Record<CardVariant, string> = {
   elevated: "bg-panel border border-line rounded-3xl shadow-float",
   ghost: "bg-transparent border border-transparent rounded-3xl",
 
-  // Module hero cards
-  finyk: "rounded-3xl border border-brand-200/50 bg-hero-emerald shadow-card",
-  fizruk: "rounded-3xl border border-teal-200/50 bg-hero-teal shadow-card",
-  routine: "rounded-3xl border border-coral-200/50 bg-hero-coral shadow-card",
-  nutrition: "rounded-3xl border border-lime-200/50 bg-hero-lime shadow-card",
+  // Module hero cards — branded surface in light, subtle tinted panel in dark.
+  finyk:
+    "rounded-3xl border border-brand-200/50 bg-hero-emerald shadow-card dark:border-brand-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(16,185,129,0.1)_0%,transparent_100%)]",
+  fizruk:
+    "rounded-3xl border border-teal-200/50 bg-hero-teal shadow-card dark:border-teal-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.1)_0%,transparent_100%)]",
+  routine:
+    "rounded-3xl border border-coral-200/50 bg-hero-coral shadow-card dark:border-[rgba(162,51,51,0.3)] dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(249,112,102,0.1)_0%,transparent_100%)]",
+  nutrition:
+    "rounded-3xl border border-lime-200/50 bg-hero-lime shadow-card dark:border-[rgba(70,98,18,0.3)] dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(146,204,23,0.1)_0%,transparent_100%)]",
 
   // Soft module cards (less prominent)
   "finyk-soft":


### PR DESCRIPTION
## Summary

Follow-up to #147 that pays down two items from the design review:

### 1. Split `HubDashboard.jsx` (661 → 140 LOC)
Extract into three focused files under `src/core/dashboard/`:
- **`moduleConfigs.jsx`** — `MODULE_CONFIGS` map (finyk/fizruk/routine/nutrition) with `getPreview()` readers pulling quick-stats from localStorage. Inline `<svg>` icons replaced with `<Icon>` (`credit-card`, `dumbbell`, `check`, `utensils`).
- **`DailyProgressHero.jsx`** — the aggregate progress hero, `readDailyProgress()` reader and `PROGRESS_STORAGE_KEYS`. Same behaviour as before (`aria-live` region, cross-tab `storage` + `focus` sync).
- **`ModuleCard.jsx`** — `ModuleCard` and its `SortableCard` wrapper. Gradient / glow / progress-bar lookup tables moved to module scope (no longer redeclared per render). Chevron also switched to `<Icon name="chevron-right" />`.

`HubDashboard.jsx` now just wires the hub together: order persistence, dnd-kit sensors, Monday auto-digest hook, render tree.

### 2. Collapse hero-card CSS duplication
`.finyk-hero-card` / `.fizruk-hero-card` / `.routine-hero-card` / `.nutrition-hero-card` (and their `.dark` overrides) **duplicated the Card component variants**. Both the CSS classes and `<Card variant="...">` described the same surface, and `index.css` was the lone home of the dark-mode tint.

- `src/index.css` — drop the 4 × 2 rule blocks (-~60 LOC)
- `src/shared/components/ui/Card.tsx` — bake the dark-mode border + subtle branded gradient overlay into the variant strings using Tailwind arbitrary properties (`dark:[background-image:linear-gradient(...)]`), so `<Card variant="fizruk" padding="lg">` on its own matches the old CSS class pixel-for-pixel
- `RoutineCalendarPanel.jsx` — the only non-CSS call-site of `routine-hero-card` migrated to `<Card as="section" variant="routine" padding="lg">`

Net effect: **one source of truth** for module hero surfaces, callers can drop the `-hero-card` class names.

## Review & Testing Checklist for Human

- [ ] **Dark-mode Card variants** — open hub + each module route in dark mode. Card with `variant="finyk|fizruk|routine|nutrition"` should have the same subtle branded gradient overlay as before the refactor (10% brand colour → transparent on `bg-panel`). This is the highest-risk change because the tint moved from `.dark .X-hero-card` in CSS to `dark:[background-image:...]` in the variant.
- [ ] **Routine calendar hero** — `RoutineCalendarPanel`'s period-overview section (coral tinted card at the top) should look identical in both themes; it no longer uses `routine-hero-card`.
- [ ] **Hub dashboard tiles** — 4 module tiles render with the new `<Icon>` glyphs (wallet-like rectangle for Фінік, barbell for Фізрук, check for Рутина, cutlery for Харчування). They were 4 inline `<svg>` blocks before; visually they should read the same.
- [ ] **DnD reorder** — long-press on a module tile, drag to a new position; dashboard order must persist in localStorage after reload (no regressions vs. pre-split behaviour).
- [ ] **Daily progress hero** — open routine, tick a habit, return to the hub; ring percentage + `aria-live` announcement must still update without a reload.

### Notes
- No behaviour changes, only file layout + single-source-of-truth cleanup. 543 vitest tests all green; typecheck + eslint + `vite build` all clean.
- Card variant strings intentionally use `dark:[background-image:...]` arbitrary values to keep the gradient overlay co-located with the other variant utilities. If we ever extract brand tints into Tailwind theme plugins this becomes cleaner, but that's out of scope for this PR.
- `HubDashboard.jsx` is still `.jsx` — TypeScript migration is tracked separately per the original audit.


Link to Devin session: https://app.devin.ai/sessions/92dfa81f79d04e9c80ad66b3a9ec2b23
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
