### PR TITLE
fix(core): address Devin Review feedback on #149

### DIFF
--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -272,12 +272,17 @@ export function useCoachInsight() {
     } catch {}
   }
 
+  // `query.refetch` is a stable reference in react-query v5; depending on
+  // the whole `query` object would recreate `refresh` on every state
+  // transition (isFetching flip, etc.) and defeat its `useCallback`.
+  const { refetch } = query;
+
   const refresh = useCallback(() => {
     // Drop stale cache entries from prior days so they can't be resurrected
     // via `initialData` on a remount.
     queryClient.invalidateQueries({ queryKey: ["coach", "insight"] });
-    return query.refetch();
-  }, [queryClient, query]);
+    return refetch();
+  }, [queryClient, refetch]);
 
   return {
     insight: query.data ?? null,

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -360,6 +360,16 @@ export function useWeeklyDigest(selectedWeekKey) {
     queryFn: () => loadDigest(weekKey) ?? null,
     staleTime: Infinity,
     gcTime: Infinity,
+    // React Query wraps even a synchronous `queryFn` in a Promise, so
+    // without `initialData` `query.data` is `undefined` for one render
+    // and `WeeklyDigestCard` would briefly render its empty state. Seed
+    // synchronously from localStorage so the first paint matches the
+    // pre-migration behavior (old code used `useState(() => loadDigest(...))`).
+    initialData: () => loadDigest(weekKey) ?? undefined,
+    initialDataUpdatedAt: () => {
+      const existing = loadDigest(weekKey);
+      return existing ? Date.now() : undefined;
+    },
   });
 
   const mutation = useMutation({


### PR DESCRIPTION
## Summary

Addresses the two findings Devin Review posted on #149 after merge.

### 1. `useCoachInsight` — unstable `refresh` callback

The `useCallback` for `refresh` listed the whole `query` object as a dependency. In react-query v5 the query result is a **new reference on every render**, so `refresh` was recreated every render and its `useCallback` was effectively a no-op. This is the same anti-pattern the pre-migration code explicitly warned about for `mutation` — the fix switches the dependency to the stable `query.refetch` reference.

```diff
-  const refresh = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["coach", "insight"] });
-    return query.refetch();
-  }, [queryClient, query]);
+  const { refetch } = query;
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["coach", "insight"] });
+    return refetch();
+  }, [queryClient, refetch]);
```

### 2. `useWeeklyDigest` — one-frame empty-state flash

The old code initialized the digest synchronously via `useState(() => loadDigest(weekKey))`, so the persisted digest was available on the first render. The migrated `useQuery` didn't provide `initialData`, and react-query wraps even a synchronous `queryFn` in a Promise — so `query.data` was `undefined` for one render, and `WeeklyDigestCard` briefly rendered its "generate report" / "no report saved" empty state before the real digest appeared. Fixed by seeding `initialData` from localStorage, mirroring the pattern already used in `useCoachInsight`.

```diff
   const query = useQuery({
     queryKey: weeklyDigestQueryKey(weekKey),
     queryFn: () => loadDigest(weekKey) ?? null,
     staleTime: Infinity,
     gcTime: Infinity,
+    initialData: () => loadDigest(weekKey) ?? undefined,
+    initialDataUpdatedAt: () => {
+      const existing = loadDigest(weekKey);
+      return existing ? Date.now() : undefined;
+    },
   });
```

## Review & Testing Checklist for Human

- [ ] Open a week that already has a saved digest (or "Попередні тижні" → any past week) and confirm the card paints the digest immediately on mount, with no flash of the "generate report" / "no report saved" state.
- [ ] Verify today's coach insight still paints instantly from localStorage and that the refresh (🔄) button still invalidates and regenerates the insight.

### Notes

No behavior change beyond the two first-paint / callback-stability fixes; UI, public hook APIs, storage format, and invalidation semantics are unchanged. Lint, typecheck, and the full test suite pass locally.

Link to Devin session: https://app.devin.ai/sessions/643f18aa0f9c4c388fc1658adfbf8c7b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
