### PR TITLE
feat(api): додати каркас централізованого HTTP-клієнта (shared/api) — PR 1/5

### DIFF
--- a/src/shared/api/ApiError.test.ts
+++ b/src/shared/api/ApiError.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { ApiError, isApiError } from "./ApiError";
+
+describe("ApiError", () => {
+  it("витягує serverMessage із body.error", () => {
+    const err = new ApiError({
+      kind: "http",
+      message: "HTTP 500",
+      status: 500,
+      body: { error: "boom" },
+      url: "/api/x",
+    });
+    expect(err.serverMessage).toBe("boom");
+    expect(err.status).toBe(500);
+    expect(err.kind).toBe("http");
+    expect(err.name).toBe("ApiError");
+  });
+
+  it("ігнорує не-рядковий body.error", () => {
+    const err = new ApiError({
+      kind: "http",
+      message: "HTTP 500",
+      status: 500,
+      body: { error: 42 },
+      url: "/api/x",
+    });
+    expect(err.serverMessage).toBeUndefined();
+  });
+
+  it("isAuth=true для 401/403", () => {
+    const e401 = new ApiError({
+      kind: "http",
+      message: "x",
+      status: 401,
+      url: "/",
+    });
+    const e403 = new ApiError({
+      kind: "http",
+      message: "x",
+      status: 403,
+      url: "/",
+    });
+    const e500 = new ApiError({
+      kind: "http",
+      message: "x",
+      status: 500,
+      url: "/",
+    });
+    expect(e401.isAuth).toBe(true);
+    expect(e403.isAuth).toBe(true);
+    expect(e500.isAuth).toBe(false);
+  });
+
+  it("isOffline=true лише для network + navigator.onLine=false", () => {
+    const originalNavigator = globalThis.navigator;
+    const setOnline = (value: boolean) =>
+      Object.defineProperty(globalThis, "navigator", {
+        value: { onLine: value },
+        configurable: true,
+        writable: true,
+      });
+
+    setOnline(false);
+    const netErr = new ApiError({
+      kind: "network",
+      message: "x",
+      url: "/",
+    });
+    const httpErr = new ApiError({
+      kind: "http",
+      message: "x",
+      status: 500,
+      url: "/",
+    });
+    expect(netErr.isOffline).toBe(true);
+    expect(httpErr.isOffline).toBe(false);
+    setOnline(true);
+    expect(netErr.isOffline).toBe(false);
+    Object.defineProperty(globalThis, "navigator", {
+      value: originalNavigator,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("isApiError type-guard", () => {
+    const err = new ApiError({ kind: "network", message: "x", url: "/" });
+    expect(isApiError(err)).toBe(true);
+    expect(isApiError(new Error("plain"))).toBe(false);
+    expect(isApiError(null)).toBe(false);
+    expect(isApiError({ kind: "http" })).toBe(false);
+  });
+});

--- a/src/shared/api/ApiError.ts
+++ b/src/shared/api/ApiError.ts
@@ -1,0 +1,67 @@
+/**
+ * Уніфікований клас помилок для всіх запитів через `@shared/api`.
+ *
+ * `kind` дозволяє викликачам розрізнити транспортну помилку мережі,
+ * невдалий HTTP-статус і некоректну (нерозпарсену) відповідь —
+ * не парсячи `message` текстово.
+ */
+export type ApiErrorKind = "http" | "network" | "parse" | "aborted";
+
+export interface ApiErrorInit {
+  kind: ApiErrorKind;
+  message: string;
+  status?: number;
+  body?: unknown;
+  bodyText?: string;
+  url: string;
+  cause?: unknown;
+}
+
+export class ApiError extends Error {
+  readonly kind: ApiErrorKind;
+  /** HTTP-статус; `0` для мережевих/парсингових/aborted помилок. */
+  readonly status: number;
+  /** Розпарсене тіло відповіді (JSON), якщо парсинг вдався. */
+  readonly body: unknown;
+  /** Сирий текст відповіді, якщо був прочитаний (для HTML-фолбеку тощо). */
+  readonly bodyText: string;
+  /** URL запиту — зручно логувати без витоку токенів. */
+  readonly url: string;
+  /** `body?.error`, якщо сервер повернув стандартну форму помилки. */
+  readonly serverMessage?: string;
+
+  constructor(init: ApiErrorInit) {
+    super(init.message, init.cause !== undefined ? { cause: init.cause } : {});
+    this.name = "ApiError";
+    this.kind = init.kind;
+    this.status = init.status ?? 0;
+    this.body = init.body;
+    this.bodyText = init.bodyText ?? "";
+    this.url = init.url;
+    const maybeServerMessage =
+      init.body && typeof init.body === "object"
+        ? (init.body as { error?: unknown }).error
+        : undefined;
+    this.serverMessage =
+      typeof maybeServerMessage === "string" ? maybeServerMessage : undefined;
+  }
+
+  /** Сервер відповів 401/403 — повторний запит без нових credentials безглуздий. */
+  get isAuth(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+
+  /** Справжня втрата мережі, а не помилка сервера — сигнал для offline-черги. */
+  get isOffline(): boolean {
+    return (
+      this.kind === "network" &&
+      typeof navigator !== "undefined" &&
+      navigator.onLine === false
+    );
+  }
+}
+
+/** Type-guard для використання у `.catch`/`instanceof`-чеках. */
+export function isApiError(err: unknown): err is ApiError {
+  return err instanceof ApiError;
+}

--- a/src/shared/api/endpoints/barcode.ts
+++ b/src/shared/api/endpoints/barcode.ts
@@ -1,0 +1,22 @@
+import { http } from "../httpClient";
+
+export interface BarcodeProduct {
+  name?: string;
+  brand?: string;
+  servingGrams?: number;
+  kcal_100g?: number;
+  protein_100g?: number;
+  fat_100g?: number;
+  carbs_100g?: number;
+  partial?: boolean;
+}
+
+export interface BarcodeLookupResponse {
+  product?: BarcodeProduct | null;
+  error?: string;
+}
+
+export const barcodeApi = {
+  lookup: (barcode: string) =>
+    http.get<BarcodeLookupResponse>("/api/barcode", { query: { barcode } }),
+};

--- a/src/shared/api/endpoints/chat.ts
+++ b/src/shared/api/endpoints/chat.ts
@@ -1,0 +1,37 @@
+import { http, request } from "../httpClient";
+
+export interface ChatMessage {
+  role: "user" | "assistant" | string;
+  content: string;
+}
+
+export interface ChatRequestPayload {
+  context: string;
+  messages: ChatMessage[];
+  tool_results?: unknown;
+  tool_calls_raw?: unknown;
+  stream?: boolean;
+}
+
+export interface ChatResponse {
+  text?: string;
+  tool_calls?: Array<{ id: string; [key: string]: unknown }>;
+  tool_calls_raw?: unknown;
+  error?: string;
+}
+
+export const chatApi = {
+  /** Звичайний non-streaming JSON-запит. */
+  send: (payload: ChatRequestPayload) =>
+    http.post<ChatResponse>("/api/chat", payload),
+  /**
+   * SSE-стрім. Повертає сирий `Response`, щоб викликач сам керував
+   * `ReadableStream` (напр. через `consumeHubChatSse`).
+   */
+  stream: (payload: ChatRequestPayload) =>
+    request<Response>("/api/chat", {
+      method: "POST",
+      body: payload,
+      parse: "raw",
+    }),
+};

--- a/src/shared/api/endpoints/coach.ts
+++ b/src/shared/api/endpoints/coach.ts
@@ -1,0 +1,14 @@
+import { http } from "../httpClient";
+
+export interface CoachInsightPayload {
+  snapshot: unknown;
+  memory: unknown;
+}
+
+export const coachApi = {
+  getMemory: () => http.get<{ memory?: unknown }>("/api/coach/memory"),
+  postInsight: (payload: CoachInsightPayload) =>
+    http.post<{ insight?: string | null }>("/api/coach/insight", payload),
+  postMemory: (payload: unknown) =>
+    http.post<unknown>("/api/coach/memory", payload),
+};

--- a/src/shared/api/endpoints/foodSearch.ts
+++ b/src/shared/api/endpoints/foodSearch.ts
@@ -1,0 +1,21 @@
+import { http } from "../httpClient";
+
+export interface FoodSearchProduct {
+  id?: string | number;
+  name?: string;
+  brand?: string;
+  [key: string]: unknown;
+}
+
+export interface FoodSearchResponse {
+  products?: FoodSearchProduct[];
+  error?: string;
+}
+
+export const foodSearchApi = {
+  search: (query: string, opts?: { signal?: AbortSignal }) =>
+    http.get<FoodSearchResponse>("/api/food-search", {
+      query: { q: query },
+      signal: opts?.signal,
+    }),
+};

--- a/src/shared/api/endpoints/mono.ts
+++ b/src/shared/api/endpoints/mono.ts
@@ -1,0 +1,35 @@
+import { http } from "../httpClient";
+
+export interface MonoAccount {
+  id: string;
+  currencyCode?: number;
+  [key: string]: unknown;
+}
+
+export interface MonoClientInfo {
+  accounts?: MonoAccount[];
+  [key: string]: unknown;
+}
+
+export type MonoStatementEntry = Record<string, unknown>;
+
+export const monoApi = {
+  clientInfo: (token: string, opts?: { signal?: AbortSignal }) =>
+    http.get<MonoClientInfo>("/api/mono", {
+      query: { path: "/personal/client-info" },
+      headers: { "X-Token": token },
+      signal: opts?.signal,
+    }),
+  statement: (
+    token: string,
+    accId: string,
+    from: number,
+    to: number,
+    opts?: { signal?: AbortSignal },
+  ) =>
+    http.get<MonoStatementEntry[]>("/api/mono", {
+      query: { path: `/personal/statement/${accId}/${from}/${to}` },
+      headers: { "X-Token": token },
+      signal: opts?.signal,
+    }),
+};

--- a/src/shared/api/endpoints/nutrition.ts
+++ b/src/shared/api/endpoints/nutrition.ts
@@ -1,0 +1,18 @@
+import { http } from "../httpClient";
+
+/**
+ * Nutrition-специфічний POST: додає заголовок `X-Token`, якщо
+ * задано `VITE_NUTRITION_API_TOKEN`. Повертає розпарсений JSON.
+ */
+export const nutritionApi = {
+  postJson: <T = unknown>(url: string, body: unknown): Promise<T> => {
+    const rawToken =
+      typeof import.meta !== "undefined" &&
+      import.meta.env?.VITE_NUTRITION_API_TOKEN
+        ? String(import.meta.env.VITE_NUTRITION_API_TOKEN)
+        : "";
+    return http.post<T>(url, body ?? {}, {
+      headers: rawToken ? { "X-Token": rawToken } : {},
+    });
+  },
+};

--- a/src/shared/api/endpoints/privat.ts
+++ b/src/shared/api/endpoints/privat.ts
@@ -1,0 +1,35 @@
+import { http } from "../httpClient";
+import type { QueryValue } from "../types";
+
+export interface PrivatCredentials {
+  merchantId: string;
+  merchantToken: string;
+}
+
+/**
+ * Усі виклики до Privatbank ідуть через наш проксі `/api/privat?path=…`
+ * і передають `X-Privat-Id` / `X-Privat-Token` у заголовках.
+ */
+export const privatApi = {
+  request: <T = unknown>(
+    creds: PrivatCredentials,
+    path: string,
+    query?: Record<string, QueryValue>,
+    opts?: { signal?: AbortSignal },
+  ) =>
+    http.get<T>("/api/privat", {
+      query: { path, ...(query ?? {}) },
+      headers: {
+        "X-Privat-Id": creds.merchantId,
+        "X-Privat-Token": creds.merchantToken,
+      },
+      signal: opts?.signal,
+    }),
+  balanceFinal: (creds: PrivatCredentials, opts?: { signal?: AbortSignal }) =>
+    privatApi.request(
+      creds,
+      "/statements/balance/final",
+      { country: "UA", showRest: "true" },
+      opts,
+    ),
+};

--- a/src/shared/api/endpoints/push.ts
+++ b/src/shared/api/endpoints/push.ts
@@ -1,0 +1,10 @@
+import { http } from "../httpClient";
+
+export const pushApi = {
+  getVapidPublic: () =>
+    http.get<{ publicKey: string }>("/api/push/vapid-public"),
+  subscribe: (subscription: PushSubscriptionJSON) =>
+    http.post<unknown>("/api/push/subscribe", subscription),
+  unsubscribe: (endpoint: string) =>
+    http.del<unknown>("/api/push/subscribe", { endpoint }),
+};

--- a/src/shared/api/endpoints/sync.ts
+++ b/src/shared/api/endpoints/sync.ts
@@ -1,0 +1,33 @@
+import { http } from "../httpClient";
+
+export interface ModulePushPayload {
+  data: unknown;
+  clientUpdatedAt: string;
+}
+
+export interface ModulePushResult {
+  version?: number;
+  ok?: boolean;
+  error?: string;
+  status?: string;
+}
+
+export interface PushAllResult {
+  results?: Record<string, ModulePushResult>;
+}
+
+export interface ModulePullPayload {
+  data?: unknown;
+  version?: number;
+  serverUpdatedAt?: string;
+}
+
+export interface PullAllResult {
+  modules?: Record<string, ModulePullPayload>;
+}
+
+export const syncApi = {
+  pushAll: (modules: Record<string, ModulePushPayload>) =>
+    http.post<PushAllResult>("/api/sync/push-all", { modules }),
+  pullAll: () => http.post<PullAllResult>("/api/sync/pull-all"),
+};

--- a/src/shared/api/endpoints/weeklyDigest.ts
+++ b/src/shared/api/endpoints/weeklyDigest.ts
@@ -1,0 +1,20 @@
+import { http } from "../httpClient";
+
+export interface WeeklyDigestPayload {
+  weekRange: unknown;
+  finyk: unknown;
+  fizruk: unknown;
+  nutrition: unknown;
+  routine: unknown;
+}
+
+export interface WeeklyDigestResponse {
+  report?: unknown;
+  generatedAt?: string;
+  error?: string;
+}
+
+export const weeklyDigestApi = {
+  generate: (payload: WeeklyDigestPayload) =>
+    http.post<WeeklyDigestResponse>("/api/weekly-digest", payload),
+};

--- a/src/shared/api/httpClient.test.ts
+++ b/src/shared/api/httpClient.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { http, request } from "./httpClient";
+import { ApiError } from "./ApiError";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function mockFetchOnce(res: Response | Error | DOMException): FetchMock {
+  const fn = vi.fn(async () => {
+    if (res instanceof Response) return res;
+    throw res;
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function textResponse(text: string, init: ResponseInit = {}): Response {
+  return new Response(text, {
+    status: 200,
+    headers: { "content-type": "text/html" },
+    ...init,
+  });
+}
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("httpClient — успішні запити", () => {
+  it("GET: парсить JSON і повертає тіло", async () => {
+    mockFetchOnce(jsonResponse({ hello: "world" }));
+    const data = await http.get<{ hello: string }>("/api/ping");
+    expect(data).toEqual({ hello: "world" });
+  });
+
+  it("за замовчуванням credentials: 'include' та Accept: application/json", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/ping");
+    const init = fn.mock.calls[0][1] as RequestInit;
+    expect(init.credentials).toBe("include");
+    const headers = init.headers as Headers;
+    expect(headers.get("Accept")).toBe("application/json");
+  });
+
+  it("POST: автоматично серіалізує plain-обʼєкт і ставить Content-Type", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.post("/api/x", { a: 1 });
+    const init = fn.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ a: 1 }));
+    const headers = init.headers as Headers;
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("мерджить кастомні заголовки поверх дефолтів (X-Token)", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/mono", { headers: { "X-Token": "secret" } });
+    const headers = (fn.mock.calls[0][1] as RequestInit).headers as Headers;
+    expect(headers.get("X-Token")).toBe("secret");
+    expect(headers.get("Accept")).toBe("application/json");
+  });
+
+  it("додає query-параметри до URL", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/search", {
+      query: { q: "hello world", limit: 10, skip: undefined },
+    });
+    const url = fn.mock.calls[0][0] as string;
+    expect(url).toContain("q=hello+world");
+    expect(url).toContain("limit=10");
+    expect(url).not.toContain("skip=");
+  });
+
+  it("для FormData не встановлює Content-Type і не серіалізує", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    const fd = new FormData();
+    fd.append("file", new Blob(["x"]), "f.txt");
+    await http.post("/api/upload", fd);
+    const init = fn.mock.calls[0][1] as RequestInit;
+    expect(init.body).toBe(fd);
+    const headers = init.headers as Headers;
+    expect(headers.get("Content-Type")).toBeNull();
+  });
+
+  it("parse: 'raw' повертає Response без читання body", async () => {
+    const res = jsonResponse({ should: "not-be-read" });
+    mockFetchOnce(res);
+    const out = await http.raw("/api/stream");
+    expect(out).toBe(res);
+    expect(out.bodyUsed).toBe(false);
+  });
+
+  it("parse: 'text' повертає сирий текст", async () => {
+    mockFetchOnce(textResponse("<!doctype html><html></html>"));
+    const out = await request<string>("/api/x", { parse: "text" });
+    expect(out).toContain("<html>");
+  });
+
+  it("повертає null для порожнього тіла на 2xx", async () => {
+    mockFetchOnce(new Response(null, { status: 204 }));
+    const out = await http.get("/api/noop");
+    expect(out).toBeNull();
+  });
+});
+
+describe("httpClient — помилки", () => {
+  it("HTTP-помилка: ApiError.kind='http', .status, .serverMessage", async () => {
+    mockFetchOnce(jsonResponse({ error: "bad thing" }, { status: 400 }));
+    await expect(http.get("/api/x")).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "http",
+      status: 400,
+      serverMessage: "bad thing",
+    });
+  });
+
+  it("HTTP-помилка без JSON-body: message = 'HTTP N'", async () => {
+    mockFetchOnce(new Response("boom", { status: 500 }));
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+    expect((err as ApiError).message).toBe("HTTP 500");
+    expect((err as ApiError).bodyText).toBe("boom");
+  });
+
+  it("network-помилка: ApiError.kind='network', status=0", async () => {
+    mockFetchOnce(new TypeError("failed to fetch"));
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("network");
+    expect((err as ApiError).status).toBe(0);
+  });
+
+  it("abort-помилка: ApiError.kind='aborted'", async () => {
+    const abortErr = new DOMException("aborted", "AbortError");
+    mockFetchOnce(abortErr);
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("aborted");
+  });
+
+  it("HTML замість JSON на 2xx → ApiError.kind='parse', bodyText збережено", async () => {
+    mockFetchOnce(textResponse("<!doctype html><html></html>"));
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("parse");
+    expect((err as ApiError).bodyText).toContain("<html>");
+  });
+
+  it("isAuth для 401/403 HTTP-помилки", async () => {
+    mockFetchOnce(jsonResponse({ error: "forbidden" }, { status: 403 }));
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect((err as ApiError).isAuth).toBe(true);
+  });
+});
+
+describe("httpClient — AbortSignal", () => {
+  it("прокидає signal у fetch", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    const ac = new AbortController();
+    await http.get("/api/x", { signal: ac.signal });
+    const init = fn.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeDefined();
+  });
+
+  it("timeoutMs кидає aborted-помилку", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(
+      (_url: unknown, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const e = new DOMException("aborted", "AbortError");
+            reject(e);
+          });
+        }),
+    ) as unknown as typeof fetch;
+    const p = http.get("/api/slow", { timeoutMs: 50 });
+    vi.advanceTimersByTime(100);
+    const err = await p.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).kind).toBe("aborted");
+    vi.useRealTimers();
+  });
+});

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -1,0 +1,239 @@
+import { apiUrl } from "@shared/lib/apiUrl";
+import { ApiError } from "./ApiError";
+import type { QueryValue, RequestOptions } from "./types";
+
+const JSON_MIME = "application/json";
+
+function buildUrl(path: string, query?: Record<string, QueryValue>): string {
+  const base = apiUrl(path);
+  if (!query) return base;
+  const entries = Object.entries(query).filter(
+    ([, v]) => v !== undefined && v !== null,
+  );
+  if (entries.length === 0) return base;
+  const params = new URLSearchParams();
+  for (const [k, v] of entries) params.append(k, String(v));
+  const sep = base.includes("?") ? "&" : "?";
+  return `${base}${sep}${params.toString()}`;
+}
+
+function isBodylessInit(body: unknown): boolean {
+  return (
+    body == null ||
+    typeof body === "string" ||
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
+  );
+}
+
+function serializeBody(body: unknown): BodyInit | null | undefined {
+  if (body == null) return undefined;
+  if (isBodylessInit(body)) return body as BodyInit;
+  return JSON.stringify(body);
+}
+
+function buildHeaders(opts: RequestOptions): Headers {
+  const h = new Headers();
+  h.set("Accept", JSON_MIME);
+  // Ставимо Content-Type тільки якщо тіло — не-примітив і ми його серіалізуємо самі.
+  // Для FormData/Blob браузер виставить правильний тип сам.
+  if (opts.body != null && !isBodylessInit(opts.body)) {
+    h.set("Content-Type", JSON_MIME);
+  }
+  if (opts.headers) {
+    for (const [k, v] of Object.entries(opts.headers)) {
+      if (v !== undefined && v !== null) h.set(k, v);
+    }
+  }
+  return h;
+}
+
+function combineSignals(
+  userSignal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): { signal: AbortSignal | undefined; cancel: () => void } {
+  if (!timeoutMs) return { signal: userSignal, cancel: () => {} };
+  const ac = new AbortController();
+  const onUserAbort = () => ac.abort(userSignal?.reason);
+  if (userSignal) {
+    if (userSignal.aborted) ac.abort(userSignal.reason);
+    else userSignal.addEventListener("abort", onUserAbort, { once: true });
+  }
+  const timer = setTimeout(() => ac.abort(new Error("timeout")), timeoutMs);
+  return {
+    signal: ac.signal,
+    cancel: () => {
+      clearTimeout(timer);
+      userSignal?.removeEventListener("abort", onUserAbort);
+    },
+  };
+}
+
+function looksLikeJson(contentType: string | null, text: string): boolean {
+  if (contentType && contentType.toLowerCase().includes(JSON_MIME)) return true;
+  const trimmed = text.trimStart();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+function safeParseJson(
+  text: string,
+  contentType: string | null,
+): { body: unknown; parseFailed: boolean } {
+  if (text.length === 0) return { body: null, parseFailed: false };
+  if (!looksLikeJson(contentType, text)) {
+    return { body: undefined, parseFailed: true };
+  }
+  try {
+    return { body: JSON.parse(text), parseFailed: false };
+  } catch {
+    return { body: undefined, parseFailed: true };
+  }
+}
+
+function networkMessage(cause: unknown): string {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return "Немає підключення до інтернету. Спробуй пізніше.";
+  }
+  const msg = cause instanceof Error ? cause.message : "";
+  return msg || "Мережева помилка";
+}
+
+/**
+ * Основна точка входу HTTP-клієнта.
+ * Усі ендпоінт-обгортки у `endpoints/` проходять через неї.
+ */
+export async function request<T = unknown>(
+  path: string,
+  opts: RequestOptions = {},
+): Promise<T> {
+  const url = buildUrl(path, opts.query);
+  const { signal, cancel } = combineSignals(opts.signal, opts.timeoutMs);
+
+  const init: RequestInit = {
+    method: opts.method ?? (opts.body != null ? "POST" : "GET"),
+    credentials: opts.credentials ?? "include",
+    headers: buildHeaders(opts),
+    body: serializeBody(opts.body),
+    signal,
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (cause) {
+    cancel();
+    const name =
+      cause && typeof (cause as { name?: unknown }).name === "string"
+        ? (cause as { name: string }).name
+        : "";
+    if (name === "AbortError") {
+      throw new ApiError({
+        kind: "aborted",
+        message: "Запит скасовано",
+        url,
+        cause,
+      });
+    }
+    throw new ApiError({
+      kind: "network",
+      message: networkMessage(cause),
+      url,
+      cause,
+    });
+  }
+
+  // Raw-режим: споживач сам керує body (наприклад, SSE-стрім).
+  if (opts.parse === "raw") {
+    cancel();
+    return res as unknown as T;
+  }
+
+  let bodyText = "";
+  try {
+    bodyText = await res.text();
+  } catch (cause) {
+    cancel();
+    throw new ApiError({
+      kind: "network",
+      message: networkMessage(cause),
+      url,
+      cause,
+    });
+  }
+  cancel();
+
+  const ct = res.headers.get("content-type");
+  const { body, parseFailed } = safeParseJson(bodyText, ct);
+
+  if (!res.ok) {
+    const serverMessage =
+      body && typeof body === "object"
+        ? (body as { error?: unknown }).error
+        : undefined;
+    throw new ApiError({
+      kind: "http",
+      message:
+        typeof serverMessage === "string" && serverMessage.length > 0
+          ? serverMessage
+          : `HTTP ${res.status}`,
+      status: res.status,
+      body,
+      bodyText,
+      url,
+    });
+  }
+
+  if (opts.parse === "text") return bodyText as unknown as T;
+
+  if (parseFailed) {
+    throw new ApiError({
+      kind: "parse",
+      message: "Некоректна відповідь сервера",
+      url,
+      bodyText,
+    });
+  }
+
+  return body as T;
+}
+
+/** Тонкий набір шорткатів. Усі мають дефолт `credentials: "include"`. */
+export const http = {
+  get<T = unknown>(path: string, opts?: RequestOptions): Promise<T> {
+    return request<T>(path, { ...opts, method: "GET" });
+  },
+  post<T = unknown>(
+    path: string,
+    body?: unknown,
+    opts?: RequestOptions,
+  ): Promise<T> {
+    return request<T>(path, { ...opts, method: "POST", body });
+  },
+  put<T = unknown>(
+    path: string,
+    body?: unknown,
+    opts?: RequestOptions,
+  ): Promise<T> {
+    return request<T>(path, { ...opts, method: "PUT", body });
+  },
+  patch<T = unknown>(
+    path: string,
+    body?: unknown,
+    opts?: RequestOptions,
+  ): Promise<T> {
+    return request<T>(path, { ...opts, method: "PATCH", body });
+  },
+  del<T = unknown>(
+    path: string,
+    body?: unknown,
+    opts?: RequestOptions,
+  ): Promise<T> {
+    return request<T>(path, { ...opts, method: "DELETE", body });
+  },
+  /** Повертає сирий `Response` — для SSE/стрімінгу. */
+  raw(path: string, opts?: RequestOptions): Promise<Response> {
+    return request<Response>(path, { ...opts, parse: "raw" });
+  },
+};

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,24 @@
+export { ApiError, isApiError } from "./ApiError";
+export type { ApiErrorKind, ApiErrorInit } from "./ApiError";
+export { http, request } from "./httpClient";
+export type {
+  HttpMethod,
+  ParseMode,
+  QueryValue,
+  RequestOptions,
+} from "./types";
+
+export { syncApi } from "./endpoints/sync";
+export type { PushAllResult, PullAllResult } from "./endpoints/sync";
+export { coachApi } from "./endpoints/coach";
+export type { CoachInsightPayload } from "./endpoints/coach";
+export { chatApi } from "./endpoints/chat";
+export type { ChatRequestPayload, ChatResponse } from "./endpoints/chat";
+export { weeklyDigestApi } from "./endpoints/weeklyDigest";
+export type { WeeklyDigestPayload } from "./endpoints/weeklyDigest";
+export { pushApi } from "./endpoints/push";
+export { nutritionApi } from "./endpoints/nutrition";
+export { barcodeApi } from "./endpoints/barcode";
+export { foodSearchApi } from "./endpoints/foodSearch";
+export { monoApi } from "./endpoints/mono";
+export { privatApi } from "./endpoints/privat";

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,29 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/**
+ * Як саме парсити успішну відповідь:
+ * - `json` (дефолт) — `res.text()` + `JSON.parse`, кидає `ApiError { kind: "parse" }` на поганий JSON.
+ * - `text` — повертає сирий текст.
+ * - `raw`  — повертає `Response` без споживання body. Потрібно для SSE/стрімінгу.
+ */
+export type ParseMode = "json" | "text" | "raw";
+
+export type QueryValue = string | number | boolean | undefined | null;
+
+export interface RequestOptions {
+  method?: HttpMethod;
+  /**
+   * Тіло запиту. Автоматично JSON.stringify для plain-обʼєктів;
+   * `FormData`/`Blob`/`string`/`ArrayBuffer` передаються як є.
+   */
+  body?: unknown;
+  headers?: Record<string, string>;
+  query?: Record<string, QueryValue>;
+  signal?: AbortSignal;
+  /** Дефолт — `"include"`. */
+  credentials?: RequestCredentials;
+  /** Дефолт — `"json"`. */
+  parse?: ParseMode;
+  /** Якщо задано, запит буде скасовано після N мс. Без дефолту (щоб не ламати SSE). */
+  timeoutMs?: number;
+}


### PR DESCRIPTION
## Summary

Перший крок із п'яти згідно плану рефакторингу (`centralized-api-refactor.uk.md`). **Лише каркас — жодного споживача ще не мігровано**, тому регресій у runtime не повинно бути.

Додано `src/shared/api/`:

- **`ApiError`** — уніфікований клас помилок із `kind` (`http` / `network` / `parse` / `aborted`), `status`, `body`, `bodyText`, `serverMessage`, `isAuth`, `isOffline`. Plus `isApiError()` type-guard.
- **`httpClient`** — `request()` + шорткати `http.{get,post,put,patch,del,raw}`:
  - дефолт `credentials: "include"`, `Accept: application/json`
  - автоматичний JSON-парсинг; `parse: "text"` і `parse: "raw"` — escape hatches (raw залишає `Response` незайманим, саме цим далі користуватиметься `HubChat` SSE)
  - builder для query-параметрів, мердж кастомних заголовків (щоб зберегти `X-Token`, `X-Privat-*`)
  - pass-through для `FormData` / `Blob` / `ReadableStream` без нашого Content-Type
  - `AbortSignal` і опціональний `timeoutMs` (без дефолту — щоб не ламати стрімінг)
  - `navigator.onLine === false` → українізоване повідомлення «Немає підключення до інтернету. Спробуй пізніше.»
- **`endpoints/`** — тонкі типізовані обгортки на кожне сімейство: `sync`, `coach`, `chat` (`send` + `stream`), `weeklyDigest`, `push`, `nutrition`, `barcode`, `foodSearch`, `mono`, `privat`.
- **Тести** — `ApiError.test.ts` (5), `httpClient.test.ts` (17). Покриває успіхи / HTTP-помилки / network / abort / parse / кастомні заголовки / FormData / query / `parse: "raw"` / timeout.

Реалізація виконана у стилі "drop-in" — існуючі тести, що мокають `global.fetch` (напр. `useCloudSync.behavior.test.js`), не зачеплені, бо клієнт під капотом усе одно кличе `fetch`.

## Review & Testing Checklist for Human

- [ ] Переглянути `httpClient.ts` (особливо `combineSignals` для `timeoutMs` + user-signal) — чи немає витоку `setTimeout`, якщо запит завершиться раніше.
- [ ] Перевірити, що `parse: "raw"` дійсно не споживає body (`res.bodyUsed === false`) — критично для наступної міграції SSE у `HubChat`.
- [ ] Підтвердити, що назви ендпоінт-обгорток (`syncApi.pushAll`, `chatApi.stream`, `monoApi.statement`, …) узгоджені з наявними шляхами бекенду в `server/` — бо тут вони ще нікого не викликають, тільки описують контракти.
- [ ] Перевірити `privatApi.request()` — чи сигнатура `(creds, path, query?, opts?)` зручна для міграції `usePrivatbank` у PR 3, чи краще прокинути `balanceFinal/statement` як окремі методи.

### Test plan

1. `npm test` — усі 565 тестів мають проходити (+22 нові, разом 587). Локально — green.
2. `npm run typecheck` + `npm run lint` — обидва green локально.
3. `npm run build` — збирається без ворнінгів; бандл-вплив близький до нуля, бо споживачів немає.
4. Ручна перевірка — `grep "from \"@shared/api\"" src` має бути порожнім: так, ми ще нікого не мігрували.

### Notes

- Наступні PR (за планом): **PR 2** — core (useCloudSync, useCoachInsight, useWeeklyDigest, HubChat, Budgets); **PR 3** — банки (useMonobank, usePrivatbank, FinykSection); **PR 4** — nutrition + push; **PR 5** — ESLint-правило проти прямого `fetch`.
- Жодного файлу поза `src/shared/api/` не зачеплено — PR безпечно відкотити одним revert'ом, якщо виявиться щось неочевидне.
- Tree-shaking: `index.ts` — це per-module `export` без великих констант, тож невикористані ендпоінти не повинні потрапляти у бандл після міграції.

Link to Devin session: https://app.devin.ai/sessions/7e6d6cdee91141ecae418fbb5f1649e9
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
