### PR TITLE
fix(routine): keep historical streaks, remove 500-day cap, clean routineDay query

### DIFF
--- a/src/modules/routine/RoutineApp.jsx
+++ b/src/modules/routine/RoutineApp.jsx
@@ -172,10 +172,17 @@ export default function RoutineApp({ onBackToHub, onOpenModule } = {}) {
 
   useEffect(() => {
     try {
-      const q = new URLSearchParams(window.location.search).get("routineDay");
+      const params = new URLSearchParams(window.location.search);
+      const q = params.get("routineDay");
       if (q && /^\d{4}-\d{2}-\d{2}$/.test(q)) {
         setSelectedDay(q);
         setTimeMode("day");
+        // Видаляємо параметр після застосування, щоб back-навігація чи
+        // рефреш не запускали стрибок у "day"-режим повторно.
+        params.delete("routineDay");
+        const qs = params.toString();
+        const next = `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`;
+        window.history.replaceState(null, "", next);
       }
     } catch {
       /* noop */

--- a/src/modules/routine/lib/streaks.js
+++ b/src/modules/routine/lib/streaks.js
@@ -13,13 +13,23 @@ function dateKeyMinusDays(baseKey, daysBack) {
 
 /**
  * Поточна серія: від сьогодні назад, лише дні де звичка запланована; зупинка на першому без відмітки.
+ * Межа ітерацій — за найдавнішою відомою подією звички (startDate / найдавніша відмітка),
+ * щоб рідкі рекурентності (monthly / custom) не обривали стрік передчасно.
  */
 export function streakForHabit(habit, completionsForHabit, todayKey) {
   const set = new Set(completionsForHabit || []);
+  if (set.size === 0) return 0;
+  // Нижня межа: найдавніша відома дата (старт звички або перша відмітка).
+  let earliest = null;
+  for (const k of set) if (earliest === null || k < earliest) earliest = k;
+  const startKey = habit.startDate || earliest || todayKey;
+  const minKey = earliest && earliest < startKey ? earliest : startKey;
+  // Жорсткий safety-cap на випадок битих дат (20 років), аж ніяк не 500 днів.
   let streak = 0;
   let dayOffset = 0;
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < 20 * 366; i++) {
     const key = dateKeyMinusDays(todayKey, dayOffset);
+    if (key < minKey) break;
     if (!habitScheduledOnDate(habit, key)) {
       dayOffset += 1;
       continue;
@@ -37,32 +47,28 @@ export function streakForHabit(habit, completionsForHabit, todayKey) {
 export function maxStreakAllTime(habit, completionsForHabit) {
   const sorted = [...(completionsForHabit || [])].sort();
   if (sorted.length === 0) return 0;
-  let best = 0;
-  let cur = 0;
-  let prev = null;
-  for (const key of sorted) {
-    if (!habitScheduledOnDate(habit, key)) continue;
-    if (prev === null) {
-      cur = 1;
-    } else {
-      let gap = false;
-      const d = parseDateKey(prev);
+  // Всі історичні відмітки враховуються — користувач позначив виконання, незалежно
+  // від поточного розкладу. Раніше при зміні розкладу (напр. daily→weekly) історичні стріки
+  // безшумно втрачались. Геп все ще визначаємо за поточним розкладом (історичний розклад не
+  // зберігається), оскільки для пропущених днів користувач сам вирішує, чи вони повинні збивати стрік.
+  let best = 1;
+  let cur = 1;
+  let prev = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const key = sorted[i];
+    let gap = false;
+    const d = parseDateKey(prev);
+    d.setDate(d.getDate() + 1);
+    while (dateKeyFromDate(d) < key) {
+      const dk = dateKeyFromDate(d);
+      if (habitScheduledOnDate(habit, dk)) {
+        gap = true;
+        break;
+      }
       d.setDate(d.getDate() + 1);
-      while (dateKeyFromDate(d) < key) {
-        const dk = dateKeyFromDate(d);
-        if (habitScheduledOnDate(habit, dk)) {
-          gap = true;
-          break;
-        }
-        d.setDate(d.getDate() + 1);
-      }
-      if (gap) {
-        cur = 1;
-      } else {
-        cur += 1;
-      }
     }
-    best = Math.max(best, cur);
+    cur = gap ? 1 : cur + 1;
+    if (cur > best) best = cur;
     prev = key;
   }
   return best;

--- a/src/modules/routine/lib/streaks.test.js
+++ b/src/modules/routine/lib/streaks.test.js
@@ -37,6 +37,47 @@ describe("routine/streaks", () => {
     expect(maxStreakAllTime(h, completions)).toBe(3);
   });
 
+  it("maxStreakAllTime keeps historical completions after schedule narrowing", () => {
+    // Звичка зараз weekly (пн/ср/пт), але раніше була daily і користувач
+    // виконував її щодня. Історичний best streak не має зникати.
+    const h = {
+      id: "h",
+      archived: false,
+      recurrence: "weekly",
+      startDate: "2026-01-01",
+      endDate: null,
+      weekdays: [0, 2, 4], // пн, ср, пт (ISO 0-based)
+    };
+    const completions = [
+      "2026-01-05", // пн
+      "2026-01-06", // вт (не заплановано зараз)
+      "2026-01-07", // ср
+      "2026-01-08", // чт (не заплановано)
+      "2026-01-09", // пт
+    ];
+    expect(maxStreakAllTime(h, completions)).toBe(5);
+  });
+
+  it("streakForHabit terminates for monthly habits with long history", () => {
+    // Раніше магічний ліміт 500 ітерацій обривав multi-year monthly-стрік.
+    const h = {
+      id: "h",
+      archived: false,
+      recurrence: "monthly",
+      startDate: "2023-01-15",
+      endDate: null,
+    };
+    const completions = [];
+    for (let y = 2023; y <= 2026; y++) {
+      for (let m = 1; m <= 12; m++) {
+        if (y === 2026 && m > 1) break;
+        completions.push(`${y}-${String(m).padStart(2, "0")}-15`);
+      }
+    }
+    // Сьогодні — 15 січ 2026; 37 послідовних місячних виконань підряд.
+    expect(streakForHabit(h, completions, "2026-01-15")).toBe(37);
+  });
+
   it("completionRateForRange returns scheduled/completed/rate", () => {
     const h1 = dailyHabit("h1");
     const h2 = dailyHabit("h2");


### PR DESCRIPTION
## Summary

Виправляю логічні баги та UX-дрібницю у модулі **Routine** (виявлені під час code-review). PR самодостатній — зачіпає лише `src/modules/routine/**`.

**Логіка**
- **L7 — `maxStreakAllTime` тихо втрачав історичні стріки при зміні розкладу.** `habitScheduledOnDate(habit, key)` з поточним розкладом фільтрував самі відмітки користувача — якщо звичка була щоденною, а стала weekly(пн/ср/пт), виконання у вт/чт викидалися, і 7-денний стрік ставав 3-денним. Прибрано фільтр з ітерації відміток: користувач позначив виконання → воно враховується. Геп між сусідніми відмітками все ще визначаємо за поточним розкладом (історичний не зберігається), але це значно м'якше за повний skip.
- **L8 — магічний ліміт 500 ітерацій у `streakForHabit`.** Для `monthly` 500 днів ≈ 16 запланованих подій; для `custom` з рідкісною weekday — ще менше. Multi-year стріки обривалися без підстав. Замінено на data-driven нижню межу: ітеруємо назад до `max(habit.startDate, earliestCompletion)` + safety-cap 20 років на випадок битих дат.

**UX**
- **U5 — `?routineDay=YYYY-MM-DD` не прибирався з URL.** Після застосування параметр лишався у query-string, тож browser back / refresh / повторне відкриття ре-активували day-режим і скидали вибір користувача. Після зчитування робимо `history.replaceState` з очищеним query (інші параметри зберігаються).

## Review & Testing Checklist for Human

- [ ] Змінити розклад активної звички з daily на weekly — перевірити, що «Найкращий стрік» у статистиці не обнулився до поточного.
- [ ] Створити monthly-звичку з відмітками 12+ місяців підряд — стрік має показувати повне число, а не обрізане.
- [ ] Відкрити `?routineDay=2025-06-15`, переключитися на інший режим, натиснути Back — параметр у URL уже відсутній, тому поведінка більше не стрибає назад у day(2025-06-15).

### Notes
- Додано 2 нових юніт-тести у `streaks.test.js` для L7/L8.
- `npm run lint`, `npm run typecheck`, `npm test` (552 passed) — зелені локально.


Link to Devin session: https://app.devin.ai/sessions/ac509c115785486382c47fcd6b0c5b8c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
