### PR TITLE
fix(nutrition): preserve foodId on meal edit, one-shot hash redirect, water-reset timer cleanup

### DIFF
--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -129,11 +129,18 @@ export function AddMealSheet({
     const mealLabel =
       MEAL_TYPES.find((m) => m.id === form.mealType)?.label || "Прийом їжі";
     const source = photoResult ? "photo" : "manual";
+    // Пріоритет foodId: новий вибір з pickedFood → інакше зберігаємо foodId з оригінальної страви.
+    // Раніше при простому редагуванні страви з продуктом зв'язок з foodDb втрачався, бо pickedFood
+    // скидається в null при відкритті схита.
+    const effectiveFoodId = pickedFood?.id ?? initialMeal?.foodId ?? null;
+    const hasAmount = pickedFood || initialMeal?.amount_g != null;
     const macroSource = photoResult
       ? "photoAI"
       : pickedFood
         ? "productDb"
-        : "manual";
+        : initialMeal?.foodId
+          ? "productDb"
+          : "manual";
     onSave({
       id:
         initialMeal?.id ||
@@ -145,9 +152,8 @@ export function AddMealSheet({
       macros: { kcal, protein_g, fat_g, carbs_g },
       source,
       macroSource,
-      ...(pickedFood
-        ? { amount_g: Number(pickedGrams) || 100, foodId: pickedFood.id }
-        : {}),
+      ...(effectiveFoodId ? { foodId: effectiveFoodId } : {}),
+      ...(hasAmount ? { amount_g: Number(pickedGrams) || 100 } : {}),
     });
   }
 

--- a/src/modules/nutrition/components/WaterTrackerCard.jsx
+++ b/src/modules/nutrition/components/WaterTrackerCard.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { useWaterTracker } from "../hooks/useWaterTracker.js";
 
@@ -11,15 +11,29 @@ function fmt(ml) {
 export function WaterTrackerCard({ goalMl = 2000 }) {
   const { todayMl, add, reset } = useWaterTracker();
   const [resetPending, setResetPending] = useState(false);
+  const resetTimerRef = useRef(null);
 
   const pct = goalMl > 0 ? Math.min(100, (todayMl / goalMl) * 100) : 0;
   const done = todayMl >= goalMl && goalMl > 0;
+
+  useEffect(() => {
+    // Очищуємо pending-таймер при unmount, щоб не тригернути setState на
+    // розмонтованому компоненті.
+    return () => {
+      if (resetTimerRef.current !== null) {
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
       <div className="flex items-center justify-between gap-2 mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-lg leading-none">💧</span>
+          <span className="text-lg leading-none" aria-hidden="true">
+            💧
+          </span>
           <div>
             <div className="text-sm font-semibold text-text leading-none">
               Вода
@@ -27,7 +41,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
             <div className="text-[11px] text-subtle mt-0.5">
               {fmt(todayMl)}
               {goalMl > 0 && ` / ${fmt(goalMl)}`}
-              {done && " ✓"}
+              {done && <span aria-hidden="true"> ✓</span>}
             </div>
           </div>
         </div>
@@ -36,17 +50,33 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
             type="button"
             onClick={() => {
               if (resetPending) {
+                if (resetTimerRef.current !== null) {
+                  clearTimeout(resetTimerRef.current);
+                  resetTimerRef.current = null;
+                }
                 reset();
                 setResetPending(false);
               } else {
+                // Скидаємо попередній таймер, якщо користувач натиснув двічі
+                // поспіль — інакше перше повернення в idle зніматиме нове pending.
+                if (resetTimerRef.current !== null) {
+                  clearTimeout(resetTimerRef.current);
+                }
                 setResetPending(true);
-                setTimeout(() => setResetPending(false), 2500);
+                resetTimerRef.current = window.setTimeout(() => {
+                  setResetPending(false);
+                  resetTimerRef.current = null;
+                }, 2500);
               }
             }}
             className="text-[11px] text-subtle hover:text-danger transition-colors px-2 py-1 rounded-lg"
-            aria-label="Скинути воду за сьогодні"
+            aria-label={
+              resetPending
+                ? "Підтвердити скидання води за сьогодні"
+                : "Скинути воду за сьогодні"
+            }
           >
-            {resetPending ? "Скинути?" : "↺"}
+            {resetPending ? "Скинути?" : <span aria-hidden="true">↺</span>}
           </button>
         )}
       </div>

--- a/src/modules/nutrition/hooks/useNutritionHashRoute.js
+++ b/src/modules/nutrition/hooks/useNutritionHashRoute.js
@@ -8,13 +8,19 @@ export function useNutritionHashRoute() {
   const [activePage, setActivePage] = useState(() => parseNutritionHash().page);
 
   useEffect(() => {
+    // One-time normalization on mount: handle legacy `#products` → `#pantry`
+    // by rewriting the URL in place, without triggering an extra render cycle
+    // via the hashchange listener below (the state already holds the correct
+    // page because parseNutritionHash maps `products` to `pantry`).
+    const initial = parseNutritionHash();
+    if (initial.redirectFrom === "products") setNutritionHash("pantry");
+
     const onHash = () => {
       const p = parseNutritionHash();
       setActivePage(p.page);
       if (p.redirectFrom === "products") setNutritionHash("pantry");
     };
     window.addEventListener("hashchange", onHash);
-    onHash();
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
 


### PR DESCRIPTION
## Summary

Виправляю логічні баги та дрібні UX-проблеми у модулі **Nutrition** (виявлені під час code-review). PR самодостатній — зачіпає лише `src/modules/nutrition/**`.

**Логіка**
- **L9 — `foodId` губився при редагуванні страви.** `AddMealSheet` скидає `pickedFood` у `null` при відкритті (бо страва вже існує і повторний пошук продукту користувачу не потрібен), але `onSave` робив `...(pickedFood ? {foodId: pickedFood.id} : {})` — якщо користувач просто редагує назву чи час страви, створеної з продукту, то зв'язок з foodDb щезав і macroSource ставав `manual`. Тепер: `effectiveFoodId = pickedFood?.id ?? initialMeal?.foodId`, та `macroSource` лишається `productDb`, коли foodId успадковано від `initialMeal`.
- **L10 — зайвий hashchange-цикл на mount у `useNutritionHashRoute`.** `onHash()` викликався одразу після реєстрації слухача. Якщо URL = `#products`, це тригерило `setNutritionHash("pantry")` → `hashchange` → повторний `onHash` → повторний рендер (guard у `setNutritionHash` рятує від нескінченного циклу, але зайвий рендер лишався). Тепер редірект обробляється синхронно всередині initial-ефекту — без виклику `onHash()` на mount. `useState` initializer уже повертає правильну сторінку (`parseNutritionHash` мапить `products → pantry`), тож UI корректний з першого рендеру.

**UX**
- **U6 — `setTimeout` без cleanup у `WaterTrackerCard`.** Подвійний клік не скидав попередній таймер — перший повертав у idle нове pending, і ефект "натисни ще раз, щоб скинути" зникав передчасно. Unmount під час pending також міг тригернути `setState` на розмонтованому компоненті. Додано `useRef` для handle таймера + cleanup у `useEffect(() => () => clearTimeout(...))`. Повторний клік у `pending`-режимі тепер скасовує старий таймер перед виконанням `reset()`.
- **U7 — застарілий `aria-label` та озвучення декоративних іконок.** У режимі `resetPending` текст кнопки змінювався на «Скинути?», але `aria-label` лишався «Скинути воду за сьогодні» — screen-reader давав неточну підказку дії. Тепер лейбл перемикається на «Підтвердити скидання води за сьогодні». Декоративні гліфи (`💧`, `✓`, `↺`) загорнуто у `<span aria-hidden="true">`, щоб VoiceOver/TalkBack не озвучував їх разом із текстом.

## Review & Testing Checklist for Human

- [ ] Створити страву з продукту (foodDb), відредагувати назву чи час без повторного вибору продукту → у збереженій страві `foodId` і `macroSource: "productDb"` збережено.
- [ ] Відкрити `#products` у nutrition-модулі: URL одразу нормалізується до `#pantry`, без миготіння сторінки.
- [ ] Додати воду, натиснути кнопку reset (↺) → текст «Скинути?» → почекати 2.5 с → має повернутись до «↺». Одразу натиснути ще раз «Скинути?» → reset виконано без пропусків.

### Notes
- `npm run lint`, `npm run typecheck`, `npm test` (552 passed) — зелені локально.
- U7 — мінімальний a11y-патч, не повне переосмислення компонента.


Link to Devin session: https://app.devin.ai/sessions/ac509c115785486382c47fcd6b0c5b8c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
