### PR TITLE
refactor(finyk): migrate Budgets AI advice to React Query

### DIFF
--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -1,11 +1,5 @@
-import {
-  useMemo,
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-  Suspense,
-} from "react";
+import { useMemo, useState, useCallback, Suspense } from "react";
+import { useMutation, useQueries } from "@tanstack/react-query";
 import { Button } from "@shared/components/ui/Button";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -41,6 +35,102 @@ import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
+
+// ─── React Query integration for AI chat lookups ──────────────────────────
+//
+// The Budgets page issues two kinds of AI requests:
+//
+//  1. **Proactive advice** (one request per at-risk category on the current
+//     month) — eligible for a 24h cache backed by localStorage. The query is
+//     keyed by `[monthKey, categoryId]` so the cache rolls over naturally
+//     when the month changes.
+//  2. **On-demand forecast explanation** (user clicks "Пояснити" on a
+//     forecast card) — fired through `useMutation`. The text is stored in
+//     per-category local state; we don't cache across sessions because the
+//     button wording ("🔄 Пояснити знову") makes regeneration explicit.
+
+const PROACTIVE_CACHE_PREFIX = "finyk_proactive_v1_";
+const PROACTIVE_CACHE_TTL = 24 * 60 * 60 * 1000;
+
+const proactiveCacheKey = (categoryId, monthKey) =>
+  `${PROACTIVE_CACHE_PREFIX}${categoryId}_${monthKey}`;
+
+export const proactiveAdviceQueryKey = (monthKey, categoryId) => [
+  "finyk",
+  "proactive-advice",
+  monthKey,
+  categoryId,
+];
+
+function loadProactiveAdviceFromLS(categoryId, monthKey) {
+  const cached = readJSON(proactiveCacheKey(categoryId, monthKey), null);
+  if (!cached || typeof cached !== "object") return null;
+  const { text, ts } = cached;
+  if (!text || !ts || Date.now() - ts > PROACTIVE_CACHE_TTL) return null;
+  return { text, ts };
+}
+
+function saveProactiveAdviceToLS(categoryId, monthKey, text) {
+  writeJSON(proactiveCacheKey(categoryId, monthKey), {
+    text,
+    ts: Date.now(),
+  });
+}
+
+async function fetchProactiveAdvice({
+  categoryId,
+  monthKey,
+  catLabel,
+  spent,
+  limit,
+  remaining,
+  pct,
+  forecast,
+  forecastNote,
+  daysRemaining,
+}) {
+  const prompt = `Категорія бюджету: ${catLabel}. Витрачено: ${spent.toLocaleString(
+    "uk-UA",
+  )} ₴ (${pct}% від ліміту ${limit.toLocaleString(
+    "uk-UA",
+  )} ₴). Залишок: ${remaining.toLocaleString(
+    "uk-UA",
+  )} ₴. До кінця місяця ${daysRemaining} днів.${forecastNote} Дай конкретну коротку пораду (1-2 речення) що зробити, щоб не перевищити ліміт. Відповідь виключно українською.`;
+  const res = await fetch(apiUrl("/api/chat"), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      context: `[Проактивна AI-порада] Категорія: ${catLabel}, витрачено: ${spent} ₴, ліміт: ${limit} ₴, залишок: ${remaining} ₴, прогноз: ${
+        forecast ?? "—"
+      } ₴, днів до кінця місяця: ${daysRemaining}`,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  const text = data.text || null;
+  if (text) saveProactiveAdviceToLS(categoryId, monthKey, text);
+  return text;
+}
+
+async function fetchCategoryExplanation({ catLabel, spent, forecast, limit }) {
+  const prompt = `Категорія: ${catLabel}. Витрачено за місяць: ${spent} ₴. Прогноз на кінець місяця: ${forecast} ₴. Ліміт: ${limit} ₴. Чому витрати можуть бути ${
+    forecast > limit ? "вищими за ліміт" : "нижчими за план"
+  } і що варто зробити? Дай коротку відповідь (2-3 речення) українською.`;
+  const res = await fetch(apiUrl("/api/chat"), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      context: `[Бюджетний прогноз] Категорія: ${catLabel}, витрачено: ${spent} ₴, прогноз: ${forecast} ₴, ліміт: ${limit} ₴`,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return data.text || "Не вдалося отримати пояснення.";
+}
 
 export function Budgets({ mono, storage }) {
   const { realTx, loadingTx } = mono;
@@ -106,35 +196,6 @@ export function Budgets({ mono, storage }) {
   const [formError, setFormError] = useState("");
 
   const [aiExplanations, setAiExplanations] = useState({});
-  const [aiLoading, setAiLoading] = useState({});
-
-  const [proactiveAdvice, setProactiveAdvice] = useState({});
-  const [proactiveLoading, setProactiveLoading] = useState({});
-  const fetchedInSession = useRef(new Set());
-
-  const PROACTIVE_CACHE_PREFIX = "finyk_proactive_v1_";
-  const PROACTIVE_CACHE_TTL = 24 * 60 * 60 * 1000;
-
-  const getAdviceCache = useCallback(
-    (categoryId, monthKey) => {
-      const cached = readJSON(
-        PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey,
-        null,
-      );
-      if (!cached || typeof cached !== "object") return null;
-      const { text, ts } = cached;
-      if (!ts || Date.now() - ts > PROACTIVE_CACHE_TTL) return null;
-      return text;
-    },
-    [PROACTIVE_CACHE_TTL],
-  );
-
-  const setAdviceCache = useCallback((categoryId, monthKey, text) => {
-    writeJSON(PROACTIVE_CACHE_PREFIX + categoryId + "_" + monthKey, {
-      text,
-      ts: Date.now(),
-    });
-  }, []);
 
   const forecasts = useMemo(() => {
     if (limitBudgets.length === 0) return [];
@@ -153,131 +214,124 @@ export function Budgets({ mono, storage }) {
     [forecasts, now],
   );
 
-  useEffect(() => {
-    if (!atRiskKey) return;
-
+  // Derive the exact set of (monthKey, categoryId) pairs that need proactive
+  // advice, along with the prompt context for each. The resulting array drives
+  // `useQueries` below, so a category entering/leaving the at-risk set just
+  // adds/removes an observer — no manual fetch orchestration needed.
+  const proactiveItems = useMemo(() => {
+    if (!atRiskKey) return [];
     const [monthKey, idsStr] = atRiskKey.split("|");
+    if (!monthKey) return [];
     const atRiskIds = idsStr ? idsStr.split(",").filter(Boolean) : [];
-
+    if (atRiskIds.length === 0) return [];
     const forecastByCategory = {};
     for (const fc of forecasts) forecastByCategory[fc.categoryId] = fc;
-
     const { daysLeft: daysRemaining } = getCurrentMonthContext(now);
-
-    const toFetch = [];
-    const preloaded = {};
-
+    const items = [];
     for (const categoryId of atRiskIds) {
-      const sessionKey = `${monthKey}:${categoryId}`;
-      if (fetchedInSession.current.has(sessionKey)) continue;
-      const cached = getAdviceCache(categoryId, monthKey);
-      if (cached) {
-        preloaded[categoryId] = cached;
-        fetchedInSession.current.add(sessionKey);
-      } else {
-        toFetch.push(categoryId);
-      }
-    }
-
-    if (Object.keys(preloaded).length > 0) {
-      setProactiveAdvice((prev) => ({ ...prev, ...preloaded }));
-    }
-
-    if (toFetch.length === 0) return;
-
-    for (const id of toFetch) fetchedInSession.current.add(`${monthKey}:${id}`);
-
-    const loadingMap = {};
-    for (const id of toFetch) loadingMap[id] = true;
-    setProactiveLoading((prev) => ({ ...prev, ...loadingMap }));
-
-    Promise.all(
-      toFetch.map(async (categoryId) => {
-        const b = limitBudgets.find((x) => x.categoryId === categoryId);
-        if (!b) return;
-        const cat = resolveExpenseCategoryMeta(categoryId, customCategories);
-        const catLabel = cat?.label || categoryId;
-        const spent = calcSpent(b);
-        const remaining = Math.max(0, b.limit - spent);
-        const pct = b.limit > 0 ? Math.round((spent / b.limit) * 100) : 0;
-        const fc = forecastByCategory[categoryId];
-        const forecastNote = fc
-          ? ` Прогноз на кінець місяця: ${fc.forecast.toLocaleString("uk-UA")} ₴ (${fc.overLimit ? `перевищення на ${fc.overPercent}%` : "в межах ліміту"}).`
-          : "";
-        const prompt = `Категорія бюджету: ${catLabel}. Витрачено: ${spent.toLocaleString("uk-UA")} ₴ (${pct}% від ліміту ${b.limit.toLocaleString("uk-UA")} ₴). Залишок: ${remaining.toLocaleString("uk-UA")} ₴. До кінця місяця ${daysRemaining} днів.${forecastNote} Дай конкретну коротку пораду (1-2 речення) що зробити, щоб не перевищити ліміт. Відповідь виключно українською.`;
-        try {
-          const res = await fetch(apiUrl("/api/chat"), {
-            method: "POST",
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              context: `[Проактивна AI-порада] Категорія: ${catLabel}, витрачено: ${spent} ₴, ліміт: ${b.limit} ₴, залишок: ${remaining} ₴, прогноз: ${fc?.forecast ?? "—"} ₴, днів до кінця місяця: ${daysRemaining}`,
-              messages: [{ role: "user", content: prompt }],
-            }),
-          });
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const data = await res.json();
-          const text = data.text || null;
-          if (text) {
-            setAdviceCache(categoryId, monthKey, text);
-            setProactiveAdvice((prev) => ({ ...prev, [categoryId]: text }));
-          }
-        } catch {
-          fetchedInSession.current.delete(`${monthKey}:${categoryId}`);
-        } finally {
-          setProactiveLoading((prev) => ({ ...prev, [categoryId]: false }));
-        }
-      }),
-    );
-  }, [
-    atRiskKey,
-    calcSpent,
-    customCategories,
-    forecasts,
-    getAdviceCache,
-    limitBudgets,
-    now,
-    setAdviceCache,
-  ]);
-
-  const explainCategory = async (
-    categoryId,
-    catLabel,
-    spent,
-    forecast,
-    limit,
-  ) => {
-    if (aiLoading[categoryId]) return;
-    setAiLoading((prev) => ({ ...prev, [categoryId]: true }));
-    setAiExplanations((prev) => ({ ...prev, [categoryId]: null }));
-    try {
-      const prompt = `Категорія: ${catLabel}. Витрачено за місяць: ${spent} ₴. Прогноз на кінець місяця: ${forecast} ₴. Ліміт: ${limit} ₴. Чому витрати можуть бути ${forecast > limit ? "вищими за ліміт" : "нижчими за план"} і що варто зробити? Дай коротку відповідь (2-3 речення) українською.`;
-      const res = await fetch(apiUrl("/api/chat"), {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          context: `[Бюджетний прогноз] Категорія: ${catLabel}, витрачено: ${spent} ₴, прогноз: ${forecast} ₴, ліміт: ${limit} ₴`,
-          messages: [{ role: "user", content: prompt }],
-        }),
+      const b = limitBudgets.find((x) => x.categoryId === categoryId);
+      if (!b) continue;
+      const cat = resolveExpenseCategoryMeta(categoryId, customCategories);
+      const catLabel = cat?.label || categoryId;
+      const spent = calcSpent(b);
+      const remaining = Math.max(0, b.limit - spent);
+      const pct = b.limit > 0 ? Math.round((spent / b.limit) * 100) : 0;
+      const fc = forecastByCategory[categoryId];
+      const forecastNote = fc
+        ? ` Прогноз на кінець місяця: ${fc.forecast.toLocaleString("uk-UA")} ₴ (${fc.overLimit ? `перевищення на ${fc.overPercent}%` : "в межах ліміту"}).`
+        : "";
+      items.push({
+        categoryId,
+        monthKey,
+        catLabel,
+        spent,
+        limit: b.limit,
+        remaining,
+        pct,
+        forecast: fc?.forecast,
+        forecastNote,
+        daysRemaining,
       });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const data = await res.json();
-      setAiExplanations((prev) => ({
-        ...prev,
-        [categoryId]: data.text || "Не вдалося отримати пояснення.",
-      }));
-    } catch {
+    }
+    return items;
+  }, [atRiskKey, limitBudgets, forecasts, customCategories, calcSpent, now]);
+
+  // One query per at-risk category. Seeded synchronously from localStorage so
+  // the UI paints cached advice with no spinner. `staleTime` is set to the
+  // 24h TTL and `initialDataUpdatedAt` is the LS timestamp, so a cached entry
+  // older than a day is considered stale and re-fetched automatically —
+  // matching the pre-migration manual TTL check.
+  const proactiveQueries = useQueries({
+    queries: proactiveItems.map((item) => ({
+      queryKey: proactiveAdviceQueryKey(item.monthKey, item.categoryId),
+      queryFn: () => fetchProactiveAdvice(item),
+      staleTime: PROACTIVE_CACHE_TTL,
+      gcTime: PROACTIVE_CACHE_TTL,
+      retry: false,
+      initialData: () => {
+        const cached = loadProactiveAdviceFromLS(
+          item.categoryId,
+          item.monthKey,
+        );
+        return cached?.text ?? undefined;
+      },
+      initialDataUpdatedAt: () => {
+        const cached = loadProactiveAdviceFromLS(
+          item.categoryId,
+          item.monthKey,
+        );
+        return cached?.ts ?? undefined;
+      },
+    })),
+  });
+
+  const proactiveAdvice = {};
+  const proactiveLoading = {};
+  proactiveItems.forEach((item, i) => {
+    const q = proactiveQueries[i];
+    proactiveAdvice[item.categoryId] = q?.data ?? null;
+    proactiveLoading[item.categoryId] = Boolean(q?.isFetching);
+  });
+
+  // On-demand explanation: single shared mutation, per-category result stored
+  // in local state so each forecast card renders independently. `variables`
+  // carries the categoryId so we can derive per-card loading state from
+  // `mutation.isPending && mutation.variables?.categoryId === fc.categoryId`.
+  const explainMutation = useMutation({
+    mutationFn: ({ catLabel, spent, forecast, limit }) =>
+      fetchCategoryExplanation({ catLabel, spent, forecast, limit }),
+    onSuccess: (text, { categoryId }) => {
+      setAiExplanations((prev) => ({ ...prev, [categoryId]: text }));
+    },
+    onError: (_err, { categoryId }) => {
       setAiExplanations((prev) => ({
         ...prev,
         [categoryId]: "Помилка з'єднання з AI.",
       }));
-    } finally {
-      setAiLoading((prev) => ({ ...prev, [categoryId]: false }));
-    }
-  };
+    },
+  });
+
+  const isExplaining = useCallback(
+    (categoryId) =>
+      explainMutation.isPending &&
+      explainMutation.variables?.categoryId === categoryId,
+    [explainMutation.isPending, explainMutation.variables],
+  );
+
+  const explainCategory = useCallback(
+    (categoryId, catLabel, spent, forecast, limit) => {
+      if (isExplaining(categoryId)) return;
+      setAiExplanations((prev) => ({ ...prev, [categoryId]: null }));
+      explainMutation.mutate({
+        categoryId,
+        catLabel,
+        spent,
+        forecast,
+        limit,
+      });
+    },
+    [explainMutation, isExplaining],
+  );
 
   const resetForm = () => {
     setNewB({
@@ -568,7 +622,7 @@ export function Budgets({ mono, storage }) {
                 customCategories,
               );
               const explanation = aiExplanations[fc.categoryId];
-              const loading = aiLoading[fc.categoryId];
+              const loading = isExplaining(fc.categoryId);
               return (
                 <div
                   key={fc.categoryId}


### PR DESCRIPTION
## Summary

Extends the React Query migration (#149, #156) to the Budgets page. Both AI chat lookups — **proactive at-risk advice** and **on-demand forecast explanations** — are now managed via `@tanstack/react-query`. UI, storage format, and visible behavior are unchanged; only the wiring underneath the AI call sites is different.

### Cache strategy

| Query / mutation | Key | Source | `staleTime` | `gcTime` |
| --- | --- | --- | --- | --- |
| Proactive advice | `['finyk', 'proactive-advice', monthKey, categoryId]` | `POST /api/chat` + 24h LS cache `finyk_proactive_v1_<id>_<month>` | `24h` | `24h` |
| Forecast explanation | mutation (no cache) | `POST /api/chat` | — | — |

- The proactive advice query is **seeded synchronously from localStorage** via `initialData`, with `initialDataUpdatedAt` carrying the cached timestamp. `staleTime: 24h` then tells React Query to treat cached entries older than a day as stale and refetch them — this is the exact TTL semantics of the pre-migration manual cache.
- `queryFn` is the single place that writes back to localStorage on success, so there's no render-phase side effect.
- The forecast explanation is intentionally **not cached** across sessions. The button wording ("🔄 Пояснити знову") makes regeneration explicit, and per-category results live in local `aiExplanations` state so each forecast card renders independently.

### Invalidation logic

- **Proactive advice** — React Query itself drives invalidation:
  1. When a new category enters `atRiskKey`, `useQueries` adds a fresh observer → cache miss → fetch.
  2. When a category leaves `atRiskKey`, the observer unmounts; the entry remains cached until `gcTime` or a month rollover expires it.
  3. Month rollover changes `monthKey` → query key changes → new cache entry, old one garbage-collected after 24h.
- **Forecast explanation** — single shared `useMutation`; per-category loading is derived from `mutation.isPending && variables.categoryId === fc.categoryId`.

### Before / after

Proactive advice: 75-line `useEffect` + `useRef(Set)` session dedup + `getAdviceCache`/`setAdviceCache` + two `useState` maps

```jsx
// BEFORE
const [proactiveAdvice, setProactiveAdvice] = useState({});
const [proactiveLoading, setProactiveLoading] = useState({});
const fetchedInSession = useRef(new Set());
const getAdviceCache = useCallback(/* 12 lines */, [PROACTIVE_CACHE_TTL]);
const setAdviceCache = useCallback(/* 6 lines */, []);

useEffect(() => {
  if (!atRiskKey) return;
  const [monthKey, idsStr] = atRiskKey.split("|");
  const atRiskIds = idsStr ? idsStr.split(",").filter(Boolean) : [];
  /* 60 lines: dedup via ref + cache lookup + toFetch list +
     loading map + Promise.all(fetch → setAdviceCache → setProactiveAdvice)
     + error cleanup via fetchedInSession.current.delete */
}, [atRiskKey, calcSpent, customCategories, forecasts, getAdviceCache,
    limitBudgets, now, setAdviceCache]);
```

```jsx
// AFTER
const proactiveItems = useMemo(/* derive [{monthKey, categoryId, …}] from atRiskKey */, [...]);

const proactiveQueries = useQueries({
  queries: proactiveItems.map((item) => ({
    queryKey: proactiveAdviceQueryKey(item.monthKey, item.categoryId),
    queryFn: () => fetchProactiveAdvice(item),   // writes-through to LS on success
    staleTime: PROACTIVE_CACHE_TTL,
    gcTime: PROACTIVE_CACHE_TTL,
    retry: false,
    initialData: () => loadProactiveAdviceFromLS(item.categoryId, item.monthKey)?.text,
    initialDataUpdatedAt: () => loadProactiveAdviceFromLS(item.categoryId, item.monthKey)?.ts,
  })),
});

const proactiveAdvice = {};
const proactiveLoading = {};
proactiveItems.forEach((item, i) => {
  proactiveAdvice[item.categoryId] = proactiveQueries[i]?.data ?? null;
  proactiveLoading[item.categoryId] = Boolean(proactiveQueries[i]?.isFetching);
});
```

Forecast explanation:

```jsx
// BEFORE — imperative, two state maps
const [aiExplanations, setAiExplanations] = useState({});
const [aiLoading, setAiLoading] = useState({});

const explainCategory = async (categoryId, catLabel, spent, forecast, limit) => {
  if (aiLoading[categoryId]) return;
  setAiLoading((prev) => ({ ...prev, [categoryId]: true }));
  setAiExplanations((prev) => ({ ...prev, [categoryId]: null }));
  try {
    const res = await fetch(apiUrl("/api/chat"), { /* … */ });
    if (!res.ok) throw new Error(`HTTP ${res.status}`);
    const data = await res.json();
    setAiExplanations((prev) => ({ ...prev, [categoryId]: data.text || "…" }));
  } catch {
    setAiExplanations((prev) => ({ ...prev, [categoryId]: "Помилка з'єднання з AI." }));
  } finally {
    setAiLoading((prev) => ({ ...prev, [categoryId]: false }));
  }
};
```

```jsx
// AFTER — one mutation, per-card loading derived from variables
const explainMutation = useMutation({
  mutationFn: ({ catLabel, spent, forecast, limit }) =>
    fetchCategoryExplanation({ catLabel, spent, forecast, limit }),
  onSuccess: (text, { categoryId }) =>
    setAiExplanations((prev) => ({ ...prev, [categoryId]: text })),
  onError: (_err, { categoryId }) =>
    setAiExplanations((prev) => ({
      ...prev,
      [categoryId]: "Помилка з'єднання з AI.",
    })),
});

const isExplaining = (categoryId) =>
  explainMutation.isPending &&
  explainMutation.variables?.categoryId === categoryId;
```

## Review & Testing Checklist for Human

- [ ] Trigger the at-risk state (e.g. a limit category >=80% spent, or forecast over limit) and confirm the proactive advice still loads, persists across refresh within 24h, and regenerates after a day.
- [ ] Click "Пояснити" on multiple forecast cards; confirm only the card whose button was clicked shows the "AI аналізує…" state, and each card renders its own explanation.

### Notes

- localStorage contract (`finyk_proactive_v1_<categoryId>_<monthKey>`) is unchanged — existing cached advice survives the upgrade.
- Only removed: `useRef`, `useEffect`, the two `aiLoading`/`proactiveAdvice`/`proactiveLoading` `useState` maps, and the local `getAdviceCache`/`setAdviceCache` callbacks. No behavior change.
- Lint, typecheck, and the full test suite (552 tests) pass locally.
- No UI component was touched in this PR.

Link to Devin session: https://app.devin.ai/sessions/643f18aa0f9c4c388fc1658adfbf8c7b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
