### PR TITLE
feat(onboarding): 30-second first-value FTUX flow

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -149,7 +149,6 @@ function AppInner() {
           onDismissInstall={dismiss}
           onboarding={ui.onboarding}
           setOnboarding={ui.setOnboarding}
-          onSetPwaAction={setPwaAction}
           onOpenModule={openModule}
           iosVisible={iosVisible}
           onDismissIos={iosDismiss}
@@ -161,6 +160,7 @@ function AppInner() {
           onSync={sync.pushAll}
           onPull={sync.pullAll}
           user={user}
+          onShowAuth={() => setShowAuth(true)}
         />
 
         <HubFloatingActions onOpenChat={() => ui.openChat()} />

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -7,6 +7,9 @@ import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard.jsx";
 import { HubInsightsPanel } from "./HubInsightsPanel.jsx";
 import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
+import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
+import { detectFirstRealEntry } from "./onboarding/firstRealEntry.js";
+import { isSoftAuthDismissed } from "./onboarding/vibePicks.js";
 import {
   DndContext,
   closestCenter,
@@ -395,9 +398,21 @@ function WeeklyDigestFooter({ onExpand }) {
 // ═══════════════════════════════════════════════════════════════════════════
 // MAIN HUB DASHBOARD
 // ═══════════════════════════════════════════════════════════════════════════
-export function HubDashboard({ onOpenModule, onOpenChat }) {
+export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   const [order, setOrder] = useState(loadOrder);
   useMondayAutoDigest();
+
+  // Soft auth prompt appears only once the user has typed in real data and
+  // has no account yet — an "offer to save", never a toll gate.
+  const hasRealEntry = detectFirstRealEntry();
+  const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
+    isSoftAuthDismissed(),
+  );
+  const showSoftAuth =
+    !user &&
+    hasRealEntry &&
+    !softAuthDismissed &&
+    typeof onShowAuth === "function";
 
   const { focus, rest, dismiss } = useDashboardFocus();
 
@@ -444,6 +459,13 @@ export function HubDashboard({ onOpenModule, onOpenChat }) {
   return (
     <div className="space-y-4">
       <DateHeader />
+
+      {showSoftAuth && (
+        <SoftAuthPromptCard
+          onOpenAuth={onShowAuth}
+          onDismiss={() => setSoftAuthDismissed(true)}
+        />
+      )}
 
       {/* Today focus — the ONE primary action on the dashboard */}
       <TodayFocusCard

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -3,6 +3,12 @@ import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { trackEvent, ANALYTICS_EVENTS } from "./analytics";
+import {
+  ALL_MODULES,
+  markFirstActionPending,
+  saveVibePicks,
+} from "./onboarding/vibePicks.js";
+import { seedDemoForModules } from "./onboarding/demoSeeds.js";
 
 export const ONBOARDING_DONE_KEY = "hub_onboarding_done_v1";
 
@@ -78,34 +84,34 @@ function StepDots({ total, current }) {
   );
 }
 
-function WelcomeStep({ name, setName, onNext }) {
+// Step 0 — Value prop. No name field, no form. The goal of this screen
+// is to answer "what is this?" in one sentence and then get out of the way.
+function SplashStep({ onNext }) {
   return (
     <div className="flex flex-col items-center text-center space-y-5">
       <div className="w-20 h-20 rounded-3xl bg-brand-500/10 text-brand-600 flex items-center justify-center">
         <Icon name="sparkle" size={40} strokeWidth={1.8} aria-hidden />
       </div>
       <div>
-        <h2 className="text-2xl font-bold text-text">Вітаємо в Sergeant!</h2>
+        <h2 className="text-2xl font-bold text-text">Життя в одному екрані.</h2>
         <p className="text-sm text-muted mt-2 leading-relaxed">
-          Почнемо з головного — грошей. Це займе менше хвилини.
+          Гроші, тренування, звички та їжа — одне місце, одна статистика, один
+          AI-помічник.
         </p>
       </div>
-      <div className="w-full space-y-1.5 text-left">
-        <label
-          htmlFor="onboarding-display-name"
-          className="text-xs font-semibold text-muted uppercase tracking-wider"
-        >
-          Як вас звати?
-        </label>
-        <input
-          id="onboarding-display-name"
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={"Ваше ім'я (необов'язково)"}
-          className="w-full min-h-[44px] bg-panelHi border border-line rounded-2xl px-4 py-3 text-[16px] md:text-sm text-text placeholder:text-subtle outline-none focus:border-brand-500/50 focus:ring-2 focus:ring-brand-500/30 transition-colors"
-        />
-      </div>
+      <ul className="w-full space-y-2 text-left text-sm text-muted">
+        <li className="flex items-start gap-2">
+          <span className="mt-0.5 text-brand-600">•</span>
+          <span>
+            Без акаунту. Дані живуть на телефоні, поки сам не вирішиш
+            синхронізувати.
+          </span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="mt-0.5 text-brand-600">•</span>
+          <span>Працює офлайн, встановлюється як додаток.</span>
+        </li>
+      </ul>
       <Button
         type="button"
         onClick={onNext}
@@ -113,69 +119,111 @@ function WelcomeStep({ name, setName, onNext }) {
         size="lg"
         className="w-full"
       >
-        Далі
+        Спробувати за 30 секунд
         <Icon name="chevron-right" size={16} />
       </Button>
     </div>
   );
 }
 
-// The three "first value" paths a new user can pick. Keep copy short: every
-// extra word is a decision the user has to make before they see any value.
-function QuickStartStep({ onPick, onBack }) {
-  const options = [
-    {
-      id: "bank",
-      icon: "credit-card",
-      title: "Підключити Monobank",
-      desc: "Автоматичні транзакції за 30 секунд",
-    },
-    {
-      id: "manual",
-      icon: "edit",
-      title: "Додати першу витрату",
-      desc: "Швидко, без входу в банк",
-    },
-    {
-      id: "demo",
-      icon: "sparkle",
-      title: "Спробувати з демо",
-      desc: "Пара тижнів прикладів — щоб побачити, як це виглядає",
-    },
-  ];
+// Step 1 — Vibe picker. Multi-select across the 4 modules, preselected
+// to "all" so the lazy user still gets a full dashboard, but motivated
+// users can narrow to just what they came for.
+const VIBE_OPTIONS = [
+  {
+    id: "finyk",
+    icon: "credit-card",
+    title: "Фінік",
+    desc: "Куди зникають гроші",
+    accent: "text-finyk bg-finyk-soft",
+  },
+  {
+    id: "fizruk",
+    icon: "dumbbell",
+    title: "Фізрук",
+    desc: "Тренування без хаосу",
+    accent: "text-fizruk bg-fizruk-soft",
+  },
+  {
+    id: "routine",
+    icon: "check",
+    title: "Рутина",
+    desc: "Звички та стріки",
+    accent: "text-routine bg-routine-soft",
+  },
+  {
+    id: "nutrition",
+    icon: "utensils",
+    title: "Харчування",
+    desc: "Фото → калорії",
+    accent: "text-nutrition bg-nutrition-soft",
+  },
+];
 
+function VibePickerStep({ picks, togglePick, onNext, onBack }) {
+  const hasPicks = picks.length > 0;
   return (
     <div className="space-y-4">
       <div className="text-center">
         <div className="w-14 h-14 mx-auto rounded-2xl bg-brand-500/10 text-brand-600 flex items-center justify-center mb-2">
           <Icon name="target" size={28} strokeWidth={1.8} />
         </div>
-        <h2 className="text-xl font-bold text-text">Швидкий старт</h2>
+        <h2 className="text-xl font-bold text-text">
+          Що тобі зараз болить найбільше?
+        </h2>
         <p className="text-sm text-muted mt-1">
-          Оберіть, з чого почнемо у Фініку
+          Обери одне або кілька — решту ввімкнеш потім.
         </p>
       </div>
       <div className="space-y-2">
-        {options.map((o) => (
-          <button
-            key={o.id}
-            type="button"
-            onClick={() => onPick(o.id)}
-            className="w-full text-left px-4 py-3 rounded-2xl border border-line bg-panelHi hover:border-brand-500/50 hover:bg-brand-500/5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
-          >
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 shrink-0 rounded-2xl bg-brand-500/10 text-brand-600 flex items-center justify-center">
-                <Icon name={o.icon} size={20} />
-              </div>
-              <div className="min-w-0">
-                <div className="text-sm font-semibold text-text">{o.title}</div>
-                <div className="text-xs text-muted mt-0.5 truncate">
-                  {o.desc}
+        {VIBE_OPTIONS.map((o) => {
+          const active = picks.includes(o.id);
+          return (
+            <button
+              key={o.id}
+              type="button"
+              onClick={() => togglePick(o.id)}
+              aria-pressed={active}
+              className={cn(
+                "w-full text-left px-4 py-3 rounded-2xl border transition-all",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+                active
+                  ? "border-brand-500/60 bg-brand-500/5 shadow-card"
+                  : "border-line bg-panelHi hover:border-brand-500/40",
+              )}
+            >
+              <div className="flex items-center gap-3">
+                <div
+                  className={cn(
+                    "w-10 h-10 shrink-0 rounded-2xl flex items-center justify-center",
+                    o.accent,
+                  )}
+                >
+                  <Icon name={o.icon} size={20} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-semibold text-text">
+                    {o.title}
+                  </div>
+                  <div className="text-xs text-muted mt-0.5 truncate">
+                    {o.desc}
+                  </div>
+                </div>
+                <div
+                  className={cn(
+                    "w-5 h-5 shrink-0 rounded-md border flex items-center justify-center transition-colors",
+                    active
+                      ? "bg-brand-500 border-brand-500 text-white"
+                      : "border-line",
+                  )}
+                  aria-hidden
+                >
+                  {active && <Icon name="check" size={14} />}
                 </div>
               </div>
-            </div>
-          </button>
-        ))}
+            </button>
+          );
+        })}
       </div>
       <div className="flex gap-2 pt-1">
         <Button
@@ -187,6 +235,17 @@ function QuickStartStep({ onPick, onBack }) {
         >
           Назад
         </Button>
+        <Button
+          type="button"
+          onClick={onNext}
+          variant="primary"
+          size="md"
+          className="flex-[2]"
+          disabled={!hasPicks}
+        >
+          Показати мій хаб
+          <Icon name="chevron-right" size={16} />
+        </Button>
       </div>
     </div>
   );
@@ -194,33 +253,41 @@ function QuickStartStep({ onPick, onBack }) {
 
 export function OnboardingWizard({ onDone }) {
   const [step, setStep] = useState(0);
-  const [name, setName] = useState("");
+  const [picks, setPicks] = useState(() => [...ALL_MODULES]);
 
   const TOTAL = 2;
 
-  // Wizard mounts exactly once per onboarding attempt — emit start event here
-  // rather than in a parent so the signal is colocated with the flow itself.
   useEffect(() => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
   }, []);
 
-  const finish = (intent) => {
-    trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
-      intent,
-      providedName: Boolean(name.trim()),
+  const togglePick = (id) => {
+    setPicks((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+    );
+  };
+
+  const finish = () => {
+    const chosen = picks.length > 0 ? picks : [...ALL_MODULES];
+    saveVibePicks(chosen);
+    const seededCounts = seedDemoForModules(chosen);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_VIBE_PICKED, {
+      picks: chosen,
+      picksCount: chosen.length,
     });
-    if (name.trim()) {
-      try {
-        localStorage.setItem("hub_user_name", name.trim());
-      } catch {
-        /* ignore */
-      }
-    }
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_DEMO_RENDERED, {
+      seededCounts,
+    });
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+      intent: "vibe_demo",
+      picksCount: chosen.length,
+    });
+    markFirstActionPending();
     markOnboardingDone();
-    // Every quick-start path currently lands in Finyk — banks, manual
-    // entry and demo data all live there. Keeping the module id explicit
-    // makes it trivial to branch later (e.g. "спробувати фізрук з демо").
-    onDone("finyk", { intent });
+    // Stay on the hub dashboard so the user's "aha" is the whole populated
+    // hub, not a single module. The FirstActionSheet will appear on top of
+    // the dashboard a tick later via the `first_action_pending` flag.
+    onDone(null, { intent: "vibe_demo", picks: chosen });
   };
 
   return (
@@ -237,31 +304,27 @@ export function OnboardingWizard({ onDone }) {
           <button
             type="button"
             onClick={() => {
-              // "Пропустити" — still fire a completion event so funnels can
-              // distinguish skipped vs explicit quick-start picks.
+              // Skip is an escape hatch for returning users who already know
+              // the product. Name its cost honestly so casual skippers
+              // understand why the hub is empty.
               trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
                 intent: "skipped",
-                providedName: Boolean(name.trim()),
               });
               markOnboardingDone();
               onDone(null, { intent: "skipped" });
             }}
             className="text-xs text-muted hover:text-text transition-colors px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
           >
-            Пропустити
+            Пропустити до пустого хабу
           </button>
         </div>
 
-        {step === 0 && (
-          <WelcomeStep
-            name={name}
-            setName={setName}
-            onNext={() => setStep(1)}
-          />
-        )}
+        {step === 0 && <SplashStep onNext={() => setStep(1)} />}
         {step === 1 && (
-          <QuickStartStep
-            onPick={(intent) => finish(intent)}
+          <VibePickerStep
+            picks={picks}
+            togglePick={togglePick}
+            onNext={finish}
             onBack={() => setStep(0)}
           />
         )}

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -31,6 +31,16 @@ export const ANALYTICS_EVENTS = Object.freeze({
   // Activation funnel — fired at most once per user to measure time-to-value.
   FIRST_EXPENSE_ADDED: "first_expense_added",
   FIRST_INSIGHT_SEEN: "first_insight_seen",
+  // 30-second FTUX funnel. Each step narrows the gap between "first open"
+  // and "user felt real value", so every transition has a named event.
+  ONBOARDING_VIBE_PICKED: "onboarding_vibe_picked",
+  ONBOARDING_DEMO_RENDERED: "onboarding_demo_rendered",
+  ONBOARDING_FIRST_ACTION_SHOWN: "onboarding_first_action_shown",
+  ONBOARDING_FIRST_ACTION_PICKED: "onboarding_first_action_picked",
+  FIRST_REAL_ENTRY: "first_real_entry",
+  AUTH_PROMPT_SHOWN: "auth_prompt_shown",
+  AUTH_PROMPT_DISMISSED: "auth_prompt_dismissed",
+  AUTH_AFTER_VALUE: "auth_after_value",
 });
 
 /**

--- a/src/core/app/HubMainContent.jsx
+++ b/src/core/app/HubMainContent.jsx
@@ -1,13 +1,15 @@
+import { useEffect, useState } from "react";
 import { Icon } from "@shared/components/ui/Icon";
 import { HubDashboard } from "../HubDashboard.jsx";
 import { HubReports } from "../HubReports.jsx";
 import { HubSettingsPage } from "../HubSettingsPage.jsx";
 import { OnboardingWizard } from "../OnboardingWizard.jsx";
+import { FirstActionSheet } from "../onboarding/FirstActionSheet.jsx";
 import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
 import {
-  enableFinykManualOnly,
-  seedFinykDemoData,
-} from "../../modules/finyk/lib/demoData.js";
+  isFirstActionPending,
+  clearFirstActionPending,
+} from "../onboarding/vibePicks.js";
 
 export function HubMainContent({
   updateAvailable,
@@ -17,7 +19,6 @@ export function HubMainContent({
   onDismissInstall,
   onboarding,
   setOnboarding,
-  onSetPwaAction,
   onOpenModule,
   iosVisible,
   onDismissIos,
@@ -29,7 +30,19 @@ export function HubMainContent({
   onSync,
   onPull,
   user,
+  onShowAuth,
 }) {
+  // The first-action sheet is the third beat of the FTUX flow: wizard →
+  // demo-populated dashboard → quick-win sheet. It is controlled by a
+  // localStorage flag so a refresh mid-flow doesn't swallow it.
+  const [firstActionOpen, setFirstActionOpen] = useState(false);
+
+  useEffect(() => {
+    if (!onboarding && isFirstActionPending()) {
+      setFirstActionOpen(true);
+    }
+  }, [onboarding]);
+
   return (
     <>
       {updateAvailable && (
@@ -113,13 +126,26 @@ export function HubMainContent({
         <OnboardingWizard
           onDone={(startModuleId, opts = {}) => {
             setOnboarding(false);
-            if (opts.intent === "demo") {
-              seedFinykDemoData();
-            } else if (opts.intent === "manual") {
-              enableFinykManualOnly();
-              onSetPwaAction("add_expense");
+            if (opts.intent === "vibe_demo") {
+              // Wizard already seeded demo data and flipped the pending
+              // first-action flag. We land on the hub dashboard so the
+              // user sees a populated dashboard before the quick-win
+              // sheet appears.
+              setFirstActionOpen(true);
+            } else if (startModuleId) {
+              // Legacy paths / external callers: if a module id is
+              // explicitly passed, open it immediately.
+              onOpenModule(startModuleId);
             }
-            if (startModuleId) onOpenModule(startModuleId);
+          }}
+        />
+      )}
+
+      {firstActionOpen && (
+        <FirstActionSheet
+          onClose={() => {
+            clearFirstActionPending();
+            setFirstActionOpen(false);
           }}
         />
       )}
@@ -129,7 +155,12 @@ export function HubMainContent({
       <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
         {hubView === "dashboard" && (
           <div className="flex flex-col gap-5 pt-2">
-            <HubDashboard onOpenModule={onOpenModule} onOpenChat={onOpenChat} />
+            <HubDashboard
+              onOpenModule={onOpenModule}
+              onOpenChat={onOpenChat}
+              user={user}
+              onShowAuth={onShowAuth}
+            />
           </div>
         )}
 

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { openHubModuleWithAction, openHubModule } from "@shared/lib/hubNav";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
+
+/**
+ * Per-module "one tap to your first real entry" cards. Each option routes
+ * into its module with a PWA action (the same handler PWA shortcuts use),
+ * so a single tap lands the user on an already-open input.
+ *
+ * Routine is an exception: it doesn't have a dedicated PWA action, so we
+ * just open the module. The module lands on the habit list where a demo
+ * habit is ready to tap.
+ */
+const ACTIONS = {
+  finyk: {
+    icon: "credit-card",
+    title: "Додай витрату",
+    desc: "5 секунд, будь-яка сума",
+    accent: "text-finyk bg-finyk-soft",
+    run: () => openHubModuleWithAction("finyk", "add_expense"),
+  },
+  fizruk: {
+    icon: "dumbbell",
+    title: "Увімкни розминку",
+    desc: "10 хв, таймер сам",
+    accent: "text-fizruk bg-fizruk-soft",
+    run: () => openHubModuleWithAction("fizruk", "start_workout"),
+  },
+  nutrition: {
+    icon: "utensils",
+    title: "Сфоткай обід",
+    desc: "Калорії порахую я",
+    accent: "text-nutrition bg-nutrition-soft",
+    run: () => openHubModuleWithAction("nutrition", "add_meal"),
+  },
+  routine: {
+    icon: "check",
+    title: "Відмітити звичку",
+    desc: "Почни стрік сьогодні",
+    accent: "text-routine bg-routine-soft",
+    run: () => openHubModule("routine"),
+  },
+};
+
+export function FirstActionSheet({ onClose }) {
+  const picks = useMemo(() => {
+    const raw = getVibePicks();
+    return raw.length > 0 ? raw : Object.keys(ACTIONS);
+  }, []);
+
+  useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_SHOWN, {
+      picks,
+    });
+  }, [picks]);
+
+  const dismiss = () => {
+    clearFirstActionPending();
+    onClose?.();
+  };
+
+  const pick = (id) => {
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
+      module: id,
+    });
+    // Close the sheet first so the module opens without a stacked dialog.
+    clearFirstActionPending();
+    onClose?.();
+    const action = ACTIONS[id];
+    if (action) action.run();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[450] flex items-end sm:items-center justify-center p-4 pb-safe"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Перша дія"
+    >
+      <button
+        type="button"
+        aria-label="Закрити"
+        onClick={dismiss}
+        className="absolute inset-0 bg-bg/70 backdrop-blur-sm"
+      />
+      <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-4 animate-onboarding-enter">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-text">
+              Одна дія — і хаб твій.
+            </h2>
+            <p className="text-sm text-muted mt-1 leading-snug">
+              Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-muted hover:text-text p-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+            aria-label="Закрити"
+          >
+            <Icon name="close" size={18} />
+          </button>
+        </div>
+        <div className="space-y-2">
+          {picks
+            .filter((id) => ACTIONS[id])
+            .map((id) => {
+              const a = ACTIONS[id];
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => pick(id)}
+                  className={cn(
+                    "w-full text-left px-4 py-3 rounded-2xl border border-line bg-panelHi",
+                    "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={cn(
+                        "w-10 h-10 shrink-0 rounded-2xl flex items-center justify-center",
+                        a.accent,
+                      )}
+                    >
+                      <Icon name={a.icon} size={20} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-semibold text-text">
+                        {a.title}
+                      </div>
+                      <div className="text-xs text-muted mt-0.5 truncate">
+                        {a.desc}
+                      </div>
+                    </div>
+                    <Icon
+                      name="chevron-right"
+                      size={16}
+                      className="text-muted"
+                    />
+                  </div>
+                </button>
+              );
+            })}
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="w-full text-sm text-muted hover:text-text px-3 py-2 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+        >
+          Пізніше — хочу спочатку подивитися
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/core/onboarding/SoftAuthPromptCard.jsx
+++ b/src/core/onboarding/SoftAuthPromptCard.jsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { dismissSoftAuth } from "./vibePicks.js";
+
+/**
+ * Inline dashboard card offering cloud sync *after* the user has logged
+ * their first real entry. Intentionally not a modal — we never interrupt
+ * the user; they can ignore it until they're ready.
+ */
+export function SoftAuthPromptCard({ onOpenAuth, onDismiss }) {
+  useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.AUTH_PROMPT_SHOWN, { placement: "dashboard" });
+  }, []);
+
+  const handleOpenAuth = () => {
+    trackEvent(ANALYTICS_EVENTS.AUTH_AFTER_VALUE);
+    onOpenAuth();
+  };
+
+  const handleDismiss = () => {
+    trackEvent(ANALYTICS_EVENTS.AUTH_PROMPT_DISMISSED);
+    dismissSoftAuth();
+    onDismiss?.();
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-2xl border border-brand-500/30",
+        "bg-gradient-to-br from-brand-500/10 via-panel to-panel p-4",
+        "shadow-card",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="w-10 h-10 shrink-0 rounded-2xl bg-brand-500/15 text-brand-600 flex items-center justify-center">
+          <Icon name="cloud-check" size={20} aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-text">
+            Зберегти на всіх пристроях?
+          </p>
+          <p className="text-xs text-muted mt-1 leading-relaxed">
+            Акаунт синхронізує твої дані між телефоном і браузером. 20 секунд.
+          </p>
+          <div className="flex items-center gap-2 mt-3">
+            <Button
+              type="button"
+              onClick={handleOpenAuth}
+              variant="primary"
+              size="sm"
+            >
+              Створити акаунт
+            </Button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="text-xs text-muted hover:text-text px-3 py-2 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+            >
+              Пізніше
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/core/onboarding/demoSeeds.js
+++ b/src/core/onboarding/demoSeeds.js
@@ -1,0 +1,260 @@
+// Unified demo-data seed for the FTUX "instant value" moment.
+//
+// When a new user picks a "vibe" (one or more modules), we seed ~2 weeks of
+// realistic-but-obviously-fake data into the matching localStorage keys so
+// the dashboard renders populated cards within a few hundred ms — no API
+// calls, no typing. Every seeder is **idempotent** and will not overwrite
+// existing user data; if we see real data for a module we silently skip it.
+//
+// Seeded data is marked with the flag below so the UI can surface a subtle
+// "demo" pill and replace each card's values with real numbers the moment
+// the user logs something of their own.
+
+import {
+  seedFinykDemoData,
+  enableFinykManualOnly,
+} from "../../modules/finyk/lib/demoData.js";
+
+export const DEMO_SEEDED_FLAG_KEY = "hub_demo_seeded_v1";
+
+const FIZRUK_WORKOUTS_KEY = "fizruk_workouts_v1";
+const ROUTINE_STATE_KEY = "hub_routine_v1";
+const NUTRITION_LOG_KEY = "nutrition_log_v1";
+
+function safeReadJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return parsed === null || parsed === undefined ? fallback : parsed;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeWriteJSON(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function toLocalISODate(date) {
+  const d = date instanceof Date ? date : new Date(date);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function daysAgo(n) {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+// ─── Fizruk ──────────────────────────────────────────────────────────────
+
+const FIZRUK_DEMO_WORKOUTS = [
+  { offset: 1, name: "Верх тіла", durationMin: 42, exercises: 5 },
+  { offset: 3, name: "Ноги + кор", durationMin: 38, exercises: 4 },
+  { offset: 5, name: "Кардіо", durationMin: 25, exercises: 2 },
+  { offset: 8, name: "Верх тіла", durationMin: 45, exercises: 6 },
+  { offset: 11, name: "Ноги + кор", durationMin: 40, exercises: 5 },
+];
+
+function seedFizrukDemoData() {
+  const existing = safeReadJSON(FIZRUK_WORKOUTS_KEY, null);
+  const existingArr = Array.isArray(existing)
+    ? existing
+    : existing && Array.isArray(existing.workouts)
+      ? existing.workouts
+      : [];
+  if (existingArr.length > 0) return 0;
+
+  const workouts = FIZRUK_DEMO_WORKOUTS.map((w) => {
+    const finishedAt = daysAgo(w.offset);
+    const startedAt = new Date(finishedAt.getTime() - w.durationMin * 60000);
+    return {
+      id: `demo-wo-${finishedAt.getTime()}`,
+      demo: true,
+      name: w.name,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationSec: w.durationMin * 60,
+      exercises: Array.from({ length: w.exercises }).map((_, i) => ({
+        id: `demo-ex-${finishedAt.getTime()}-${i}`,
+        name: "Вправа",
+        sets: [
+          { reps: 10, weight: 10, done: true },
+          { reps: 10, weight: 10, done: true },
+          { reps: 8, weight: 12, done: true },
+        ],
+      })),
+    };
+  });
+
+  return safeWriteJSON(FIZRUK_WORKOUTS_KEY, {
+    schemaVersion: 1,
+    workouts,
+  })
+    ? workouts.length
+    : 0;
+}
+
+// ─── Routine (habits + completions) ──────────────────────────────────────
+
+const ROUTINE_DEMO_HABITS = [
+  { name: "Випити воду", emoji: "💧" },
+  { name: "10 хв читання", emoji: "📖" },
+  { name: "Прогулянка", emoji: "🚶" },
+];
+
+function seedRoutineDemoData() {
+  const existing = safeReadJSON(ROUTINE_STATE_KEY, null);
+  if (
+    existing &&
+    Array.isArray(existing.habits) &&
+    existing.habits.length > 0
+  ) {
+    return 0;
+  }
+
+  const createdAt = toLocalISODate(daysAgo(14));
+  const habits = ROUTINE_DEMO_HABITS.map((h, i) => ({
+    id: `demo-habit-${i}-${Date.now()}`,
+    demo: true,
+    name: `${h.emoji} ${h.name}`,
+    recurrence: "daily",
+    startDate: createdAt,
+    endDate: null,
+    timeOfDay: "",
+    reminderTimes: [],
+    weekdays: [0, 1, 2, 3, 4, 5, 6],
+    createdAt,
+  }));
+
+  // Mark most days complete for habit 0 ("water") so streak + heatmap
+  // both light up immediately. Thinner pattern on the other two keeps
+  // the lead/laggard charts looking meaningful.
+  const completions = {};
+  for (let i = 0; i < habits.length; i++) {
+    const habit = habits[i];
+    const density = i === 0 ? 13 : i === 1 ? 9 : 6;
+    const dates = [];
+    for (let d = 0; d < density; d++) {
+      dates.push(toLocalISODate(daysAgo(d)));
+    }
+    completions[habit.id] = dates;
+  }
+
+  const next = {
+    schemaVersion: 3,
+    prefs: {
+      showFizrukInCalendar: true,
+      showFinykSubscriptionsInCalendar: true,
+      routineRemindersEnabled: false,
+    },
+    tags: [],
+    categories: [],
+    habits,
+    completions,
+    pushupsByDate: {},
+    habitOrder: habits.map((h) => h.id),
+    completionNotes: {},
+  };
+
+  return safeWriteJSON(ROUTINE_STATE_KEY, next) ? habits.length : 0;
+}
+
+// ─── Nutrition (meal log) ────────────────────────────────────────────────
+
+const NUTRITION_DEMO_MEALS = [
+  { offset: 0, meal: "breakfast", name: "Омлет з авокадо", kcal: 420 },
+  { offset: 0, meal: "lunch", name: "Куряча грудка + рис", kcal: 580 },
+  { offset: 1, meal: "breakfast", name: "Вівсянка з ягодами", kcal: 380 },
+  { offset: 1, meal: "dinner", name: "Лосось з овочами", kcal: 520 },
+  { offset: 2, meal: "lunch", name: "Паста болоньєзе", kcal: 640 },
+  { offset: 3, meal: "snack", name: "Банан + горіхи", kcal: 280 },
+  { offset: 4, meal: "dinner", name: "Салат Цезар", kcal: 450 },
+];
+
+function seedNutritionDemoData() {
+  const existing = safeReadJSON(NUTRITION_LOG_KEY, null);
+  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+    if (Object.keys(existing).length > 0) return 0;
+  }
+
+  const log = {};
+  for (const m of NUTRITION_DEMO_MEALS) {
+    const dateKey = toLocalISODate(daysAgo(m.offset));
+    if (!log[dateKey]) log[dateKey] = { items: [] };
+    log[dateKey].items.push({
+      id: `demo-meal-${dateKey}-${log[dateKey].items.length}`,
+      demo: true,
+      name: m.name,
+      mealType: m.meal,
+      createdAt: daysAgo(m.offset).toISOString(),
+      macros: {
+        kcal: m.kcal,
+        // Rough split — good enough for the ring to fill convincingly.
+        protein_g: Math.round(m.kcal * 0.22 * 0.25),
+        fat_g: Math.round(m.kcal * 0.28 * 0.11),
+        carbs_g: Math.round(m.kcal * 0.5 * 0.25),
+      },
+    });
+  }
+
+  return safeWriteJSON(NUTRITION_LOG_KEY, log)
+    ? NUTRITION_DEMO_MEALS.length
+    : 0;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────
+
+const SEEDERS = {
+  finyk: () => {
+    enableFinykManualOnly();
+    return seedFinykDemoData();
+  },
+  fizruk: seedFizrukDemoData,
+  routine: seedRoutineDemoData,
+  nutrition: seedNutritionDemoData,
+};
+
+/**
+ * Seed demo data for every module the user picked during onboarding.
+ * Idempotent — skips modules that already have real data. Returns a map
+ * of module id → count of entries seeded (0 for skipped/failed modules).
+ *
+ * @param {Array<"finyk"|"fizruk"|"routine"|"nutrition">} moduleIds
+ */
+export function seedDemoForModules(moduleIds) {
+  const result = {};
+  for (const id of moduleIds || []) {
+    const seeder = SEEDERS[id];
+    if (!seeder) continue;
+    try {
+      result[id] = seeder();
+    } catch {
+      result[id] = 0;
+    }
+  }
+  try {
+    localStorage.setItem(DEMO_SEEDED_FLAG_KEY, "1");
+  } catch {
+    /* noop */
+  }
+  return result;
+}
+
+export function wasDemoSeeded() {
+  try {
+    return localStorage.getItem(DEMO_SEEDED_FLAG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}

--- a/src/core/onboarding/firstRealEntry.js
+++ b/src/core/onboarding/firstRealEntry.js
@@ -1,0 +1,85 @@
+// Detects the user's first *real* (non-demo) entry across any module and
+// emits the `first_real_entry` event exactly once. This is the single
+// source of truth for the "aha" moment that qualifies someone to see the
+// soft auth prompt.
+//
+// Everything here is read-only scans of localStorage — no subscriptions,
+// no polling — because the dashboard already re-renders on every module
+// storage event (fizruk-storage, hub-routine-storage, nutrition-log, etc).
+// We re-check on each render and fire the first-entry event once.
+
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { isFirstRealEntryDone, markFirstRealEntryDone } from "./vibePicks.js";
+
+function safeReadJSON(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function hasNonDemoItem(list) {
+  if (!Array.isArray(list)) return false;
+  return list.some((item) => item && typeof item === "object" && !item.demo);
+}
+
+/**
+ * Returns true if the user has at least one non-demo entry anywhere.
+ * Called on every dashboard render; O(modules) and cheap (no reserialize).
+ */
+export function hasAnyRealEntry() {
+  // Finyk — manual expenses.
+  const manual = safeReadJSON("finyk_manual_expenses_v1");
+  if (hasNonDemoItem(manual)) return true;
+  // A synced monobank tx cache counts as real data by definition.
+  const finykCache = safeReadJSON("finyk_tx_cache");
+  if (
+    finykCache &&
+    Array.isArray(finykCache.transactions) &&
+    finykCache.transactions.length > 0
+  ) {
+    return true;
+  }
+
+  // Fizruk — workouts.
+  const fizruk = safeReadJSON("fizruk_workouts_v1");
+  const workouts = Array.isArray(fizruk)
+    ? fizruk
+    : fizruk && Array.isArray(fizruk.workouts)
+      ? fizruk.workouts
+      : [];
+  if (hasNonDemoItem(workouts)) return true;
+
+  // Routine — habits. Demo habits are marked `demo: true`; any habit
+  // without the flag counts as real (user-created).
+  const routine = safeReadJSON("hub_routine_v1");
+  if (routine && hasNonDemoItem(routine.habits)) return true;
+
+  // Nutrition — meal log is keyed by date; inspect items across all days.
+  const nutrition = safeReadJSON("nutrition_log_v1");
+  if (nutrition && typeof nutrition === "object" && !Array.isArray(nutrition)) {
+    for (const day of Object.values(nutrition)) {
+      if (day && hasNonDemoItem(day.items)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Call on every render of the dashboard. If the user has a real entry and
+ * we haven't fired yet, fire `first_real_entry` and persist the flag so
+ * this becomes a no-op for all future renders.
+ *
+ * @returns {boolean} true if the user now has at least one real entry
+ */
+export function detectFirstRealEntry() {
+  if (isFirstRealEntryDone()) return true;
+  if (!hasAnyRealEntry()) return false;
+  markFirstRealEntryDone();
+  trackEvent(ANALYTICS_EVENTS.FIRST_REAL_ENTRY);
+  return true;
+}

--- a/src/core/onboarding/vibePicks.js
+++ b/src/core/onboarding/vibePicks.js
@@ -1,0 +1,110 @@
+// Stores which Hub modules the user picked during onboarding ("vibes").
+// Everything here is synchronous localStorage access — the wizard runs
+// before React Query / cloud sync, so we keep it dependency-free.
+
+export const VIBE_PICKS_KEY = "hub_onboarding_vibes_v1";
+export const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
+export const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
+export const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
+
+/** @typedef {"finyk" | "fizruk" | "routine" | "nutrition"} HubModuleId */
+
+/** @type {HubModuleId[]} */
+export const ALL_MODULES = ["finyk", "fizruk", "routine", "nutrition"];
+
+/**
+ * @param {unknown} raw
+ * @returns {HubModuleId[]}
+ */
+function sanitizePicks(raw) {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const v of raw) {
+    if (typeof v !== "string") continue;
+    if (!ALL_MODULES.includes(/** @type {HubModuleId} */ (v))) continue;
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(/** @type {HubModuleId} */ (v));
+  }
+  return out;
+}
+
+/** @returns {HubModuleId[]} */
+export function getVibePicks() {
+  try {
+    const raw = localStorage.getItem(VIBE_PICKS_KEY);
+    if (!raw) return [];
+    return sanitizePicks(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @param {HubModuleId[]} picks
+ */
+export function saveVibePicks(picks) {
+  try {
+    const clean = sanitizePicks(picks);
+    localStorage.setItem(VIBE_PICKS_KEY, JSON.stringify(clean));
+  } catch {
+    /* noop */
+  }
+}
+
+export function markFirstActionPending() {
+  try {
+    localStorage.setItem(FIRST_ACTION_PENDING_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}
+
+export function clearFirstActionPending() {
+  try {
+    localStorage.removeItem(FIRST_ACTION_PENDING_KEY);
+  } catch {
+    /* noop */
+  }
+}
+
+export function isFirstActionPending() {
+  try {
+    return localStorage.getItem(FIRST_ACTION_PENDING_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markFirstRealEntryDone() {
+  try {
+    localStorage.setItem(FIRST_REAL_ENTRY_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}
+
+export function isFirstRealEntryDone() {
+  try {
+    return localStorage.getItem(FIRST_REAL_ENTRY_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function isSoftAuthDismissed() {
+  try {
+    return localStorage.getItem(SOFT_AUTH_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function dismissSoftAuth() {
+  try {
+    localStorage.setItem(SOFT_AUTH_DISMISSED_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the auth-wall-first / Finyk-only onboarding with a 30-second "first value" flow. Goal: user understands what the hub is and sees their preferred modules populated within ~30 s of cold-start — no account required.

**New flow**

1. **Splash** (OnboardingWizard step 0) — one-sentence value prop, no name field, no auth.
2. **Vibe picker** (step 1) — multi-select 4 modules (Фінік / Фізрук / Рутина / Харчування), preselect all. "Пропустити" is now named honestly: "Пропустити до пустого хабу".
3. **Instant demo** — on finish, `seedDemoForModules()` seeds ~2 weeks of realistic demo data into each picked module's `localStorage`. Idempotent — never overwrites real data. All items are tagged `demo: true`.
4. **First-action sheet** — bottom sheet with one quick-win card per picked module (add expense / start workout / log meal / tick habit), each routing via the existing `hubNav` + PWA-action pipeline.
5. **Soft auth prompt** — inline dashboard card, shown only after the user has logged their first **non-demo** entry. Never a modal. Dismissible.

**Analytics**

Adds the full FTUX funnel to `ANALYTICS_EVENTS`: `onboarding_vibe_picked`, `onboarding_demo_rendered`, `onboarding_first_action_shown`, `onboarding_first_action_picked`, `first_real_entry`, `auth_prompt_shown`, `auth_prompt_dismissed`, `auth_after_value`.

**Files**

- `src/core/OnboardingWizard.jsx` — rewritten: splash + multi-select vibe picker, no name field.
- `src/core/onboarding/vibePicks.js` — localStorage for picks + pending-first-action + first-real-entry + soft-auth-dismissed flags.
- `src/core/onboarding/demoSeeds.js` — unified idempotent seeder for all 4 modules (delegates Finyk to existing `seedFinykDemoData`).
- `src/core/onboarding/FirstActionSheet.jsx` — quick-win sheet rendered on the hub post-wizard.
- `src/core/onboarding/SoftAuthPromptCard.jsx` — inline "save on all devices" card.
- `src/core/onboarding/firstRealEntry.js` — cross-module non-demo-data detector, fires `first_real_entry` once.
- `src/core/analytics.js` — new event constants.
- `src/core/app/HubMainContent.jsx` — renders `FirstActionSheet` when pending; drops obsolete `onSetPwaAction` prop and per-intent finyk-only branch.
- `src/core/HubDashboard.jsx` — renders `SoftAuthPromptCard` above the focus card when applicable.
- `src/core/App.jsx` — passes `onShowAuth` through to the dashboard.

`npm run lint`, `npm run typecheck`, `npm test` (581 tests), and `npm run build` all pass locally.

## Review & Testing Checklist for Human

- [ ] Cold-start in a clean browser profile (or wipe `localStorage`): confirm you land on the splash, not on `AuthPage`. Check that the vibe picker multi-select works and "Показати мій хаб" is disabled when all four are deselected.
- [ ] After finishing the wizard: dashboard should render with populated cards for **only** the modules you picked. Each card's numbers should come from seeded demo data; unpicked modules stay as empty module cards.
- [ ] First-action sheet appears on top of the dashboard. Tapping a card should close the sheet and route into the correct module with the right PWA action (Finyk → add expense, Fizruk → start workout, Nutrition → add meal, Routine → module root).
- [ ] Add one **real** entry in any module (e.g. a Finyk manual expense). Return to the hub dashboard — the `SoftAuthPromptCard` should appear. Dismissing it should persist across reloads. "Створити акаунт" should open the existing `AuthPage`.
- [ ] Returning user with existing data should still bypass onboarding (`shouldShowOnboarding` guards on real data).
- [ ] Idempotency: running the wizard a second time on an account that already has real data should not clobber it (seeders check for existing data first).

### Notes

- Routine doesn't have a dedicated PWA action in `usePwaActions`, so its first-action card just opens the module. Adding an `add_habit` action type is a follow-up.
- Demo items are marked `demo: true`; downstream UI can opt in to a "demo" pill without touching this PR.
- `AuthPage` is unchanged — it's now only reachable via the header's "Create account" or the soft auth prompt. Moving it under a `/sign-in` route is a future cleanup.


Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
