### PR TITLE
feat(server): domain-метрики та module-tag у handler'ах

### DIFF
--- a/server/api/barcode.js
+++ b/server/api/barcode.js
@@ -1,5 +1,20 @@
 import { setCorsHeaders } from "./lib/cors.js";
 import { checkRateLimit } from "./lib/rateLimit.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import {
+  barcodeLookupsTotal,
+  externalHttpRequestsTotal,
+} from "../obs/metrics.js";
+
+/** Емітить і барcode-domain метрику, і загальний outbound HTTP. */
+function recordLookup(source, outcome) {
+  try {
+    barcodeLookupsTotal.inc({ source, outcome });
+    externalHttpRequestsTotal.inc({ upstream: source, outcome });
+  } catch {
+    /* metrics must never break a request */
+  }
+}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Source 1: Open Food Facts (no key, 100 req/min, global crowdsourced DB)
@@ -54,17 +69,30 @@ function normalizeOFF(product) {
 
 async function lookupOFF(barcode) {
   const url = `${OFF_BASE}/${barcode}.json?fields=${OFF_FIELDS}`;
-  const r = await fetch(url, {
-    headers: {
-      "User-Agent":
-        "Sergeant-NutritionApp/1.0 (https://sergeant.2dmanager.com.ua)",
-    },
-    signal: AbortSignal.timeout(7000),
-  });
-  if (!r.ok) return null;
-  const data = await r.json();
-  if (data?.status !== 1 || !data?.product) return null;
-  return normalizeOFF(data.product);
+  try {
+    const r = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Sergeant-NutritionApp/1.0 (https://sergeant.2dmanager.com.ua)",
+      },
+      signal: AbortSignal.timeout(7000),
+    });
+    if (!r.ok) {
+      recordLookup("off", "miss");
+      return null;
+    }
+    const data = await r.json();
+    if (data?.status !== 1 || !data?.product) {
+      recordLookup("off", "miss");
+      return null;
+    }
+    const product = normalizeOFF(data.product);
+    recordLookup("off", product ? "hit" : "miss");
+    return product;
+  } catch (e) {
+    recordLookup("off", "error");
+    throw e;
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -132,22 +160,36 @@ async function lookupUSDA(barcode) {
   const key = process.env.USDA_FDC_API_KEY || "DEMO_KEY";
   // Search Branded Foods by GTIN/UPC (barcode is stored in gtinUpc field)
   const url = `${FDC_BASE}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&pageSize=5&api_key=${key}`;
-  const r = await fetch(url, {
-    headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
-    signal: AbortSignal.timeout(7000),
-  });
-  if (!r.ok) return null;
-  const data = await r.json();
-  const foods = data?.foods;
-  if (!Array.isArray(foods) || foods.length === 0) return null;
+  try {
+    const r = await fetch(url, {
+      headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
+      signal: AbortSignal.timeout(7000),
+    });
+    if (!r.ok) {
+      recordLookup("usda", "miss");
+      return null;
+    }
+    const data = await r.json();
+    const foods = data?.foods;
+    if (!Array.isArray(foods) || foods.length === 0) {
+      recordLookup("usda", "miss");
+      return null;
+    }
 
-  // Prefer exact gtinUpc match, fallback to first result
-  const exact = foods.find(
-    (f) =>
-      String(f.gtinUpc || "").replace(/^0+/, "") === barcode.replace(/^0+/, ""),
-  );
-  const food = exact || foods[0];
-  return normalizeUSDA(food);
+    // Prefer exact gtinUpc match, fallback to first result
+    const exact = foods.find(
+      (f) =>
+        String(f.gtinUpc || "").replace(/^0+/, "") ===
+        barcode.replace(/^0+/, ""),
+    );
+    const food = exact || foods[0];
+    const product = normalizeUSDA(food);
+    recordLookup("usda", product ? "hit" : "miss");
+    return product;
+  } catch (e) {
+    recordLookup("usda", "error");
+    throw e;
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -157,38 +199,54 @@ async function lookupUSDA(barcode) {
 // ──────────────────────────────────────────────────────────────────────────────
 async function lookupUPCitemdb(barcode) {
   const url = `https://api.upcitemdb.com/prod/trial/lookup?upc=${encodeURIComponent(barcode)}`;
-  const r = await fetch(url, {
-    headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
-    signal: AbortSignal.timeout(6000),
-  });
-  if (!r.ok) return null;
-  const data = await r.json();
-  const item = Array.isArray(data?.items) ? data.items[0] : null;
-  if (!item) return null;
+  try {
+    const r = await fetch(url, {
+      headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!r.ok) {
+      recordLookup("upcitemdb", "miss");
+      return null;
+    }
+    const data = await r.json();
+    const item = Array.isArray(data?.items) ? data.items[0] : null;
+    if (!item) {
+      recordLookup("upcitemdb", "miss");
+      return null;
+    }
 
-  const name = item.title || null;
-  if (!name) return null;
+    const name = item.title || null;
+    if (!name) {
+      recordLookup("upcitemdb", "miss");
+      return null;
+    }
 
-  const brand = item.brand || null;
+    const brand = item.brand || null;
 
-  return {
-    name,
-    brand,
-    kcal_100g: null,
-    protein_100g: null,
-    fat_100g: null,
-    carbs_100g: null,
-    servingSize: null,
-    servingGrams: null,
-    source: "upcitemdb",
-    partial: true, // no nutrition data — frontend should prompt user to fill in macros
-  };
+    recordLookup("upcitemdb", "hit");
+    return {
+      name,
+      brand,
+      kcal_100g: null,
+      protein_100g: null,
+      fat_100g: null,
+      carbs_100g: null,
+      servingSize: null,
+      servingGrams: null,
+      source: "upcitemdb",
+      partial: true, // no nutrition data — frontend should prompt user to fill in macros
+    };
+  } catch (e) {
+    recordLookup("upcitemdb", "error");
+    throw e;
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Handler
 // ──────────────────────────────────────────────────────────────────────────────
 export default async function handler(req, res) {
+  setRequestModule("barcode");
   setCorsHeaders(res, req, {
     methods: "GET, OPTIONS",
     allowHeaders: "Content-Type",

--- a/server/api/chat.js
+++ b/server/api/chat.js
@@ -2,8 +2,40 @@ import { assertAiQuota } from "../aiQuota.js";
 import { setCorsHeaders } from "./lib/cors.js";
 import { validateBody } from "./lib/validate.js";
 import { ChatRequestSchema } from "./lib/schemas.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import { aiTokensTotal, externalHttpRequestsTotal } from "../obs/metrics.js";
 
 const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+
+/** Облік токенів з Anthropic-відповіді (usage.input_tokens / output_tokens). */
+function recordAnthropicUsage(model, data) {
+  try {
+    const usage = data?.usage;
+    if (!usage) return;
+    if (Number.isFinite(usage.input_tokens)) {
+      aiTokensTotal.inc(
+        { provider: "anthropic", model, kind: "prompt" },
+        usage.input_tokens,
+      );
+    }
+    if (Number.isFinite(usage.output_tokens)) {
+      aiTokensTotal.inc(
+        { provider: "anthropic", model, kind: "completion" },
+        usage.output_tokens,
+      );
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+function recordAnthropicOutcome(outcome) {
+  try {
+    externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome });
+  } catch {
+    /* ignore */
+  }
+}
 
 const TOOLS = [
   {
@@ -211,6 +243,7 @@ const SYSTEM_PREFIX = `Ти персональний асистент додат
 `;
 
 export default async function handler(req, res) {
+  setRequestModule("chat");
   setCorsHeaders(res, req, {
     allowHeaders: "Content-Type",
     methods: "POST, OPTIONS",
@@ -289,10 +322,16 @@ export default async function handler(req, res) {
 
       const data = await response.json();
       if (!response.ok) {
+        recordAnthropicOutcome(
+          response.status === 429 ? "rate_limited" : "error",
+        );
         return res
           .status(response.status)
           .json({ error: data?.error?.message || "AI error" });
       }
+
+      recordAnthropicOutcome("ok");
+      recordAnthropicUsage(payload.model, data);
 
       const text = (data?.content || [])
         .filter((b) => b.type === "text")
@@ -325,10 +364,16 @@ export default async function handler(req, res) {
 
     const data = await response.json();
     if (!response.ok) {
+      recordAnthropicOutcome(
+        response.status === 429 ? "rate_limited" : "error",
+      );
       return res
         .status(response.status)
         .json({ error: data?.error?.message || "AI error" });
     }
+
+    recordAnthropicOutcome("ok");
+    recordAnthropicUsage("claude-sonnet-4-6", data);
 
     const content = data?.content || [];
     const toolUses = content.filter((b) => b.type === "tool_use");

--- a/server/api/coach.js
+++ b/server/api/coach.js
@@ -2,6 +2,8 @@ import pool from "../db.js";
 import { getSessionUser } from "../auth.js";
 import { assertAiQuota } from "../aiQuota.js";
 import { setCorsHeaders } from "./lib/cors.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import { aiTokensTotal, externalHttpRequestsTotal } from "../obs/metrics.js";
 
 const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
 
@@ -128,6 +130,7 @@ function buildMemorySummary(memory) {
 }
 
 export default async function coachHandler(req, res) {
+  setRequestModule("coach");
   setCorsHeaders(res, req, {
     allowHeaders: "Content-Type",
     methods: "GET, POST, OPTIONS",
@@ -237,9 +240,46 @@ ${snapshotText}
 
     const aiData = await aiRes.json();
     if (!aiRes.ok) {
+      try {
+        externalHttpRequestsTotal.inc({
+          upstream: "anthropic",
+          outcome: aiRes.status === 429 ? "rate_limited" : "error",
+        });
+      } catch {
+        /* ignore */
+      }
       return res
         .status(aiRes.status)
         .json({ error: aiData?.error?.message || "AI error" });
+    }
+
+    try {
+      externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome: "ok" });
+      const usage = aiData?.usage;
+      if (usage) {
+        if (Number.isFinite(usage.input_tokens)) {
+          aiTokensTotal.inc(
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              kind: "prompt",
+            },
+            usage.input_tokens,
+          );
+        }
+        if (Number.isFinite(usage.output_tokens)) {
+          aiTokensTotal.inc(
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              kind: "completion",
+            },
+            usage.output_tokens,
+          );
+        }
+      }
+    } catch {
+      /* ignore */
     }
 
     const text = (aiData?.content || [])

--- a/server/api/food-search.js
+++ b/server/api/food-search.js
@@ -1,4 +1,5 @@
 import { setCorsHeaders } from "./lib/cors.js";
+import { setRequestModule } from "../obs/requestContext.js";
 import { checkRateLimit } from "./lib/rateLimit.js";
 
 const OFF_SEARCH = "https://world.openfoodfacts.org/api/v2/search";
@@ -240,6 +241,7 @@ async function fetchUSDA(query, signal) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     methods: "GET, OPTIONS",
     allowHeaders: "Content-Type",

--- a/server/api/mono.js
+++ b/server/api/mono.js
@@ -1,6 +1,18 @@
 import { setCorsHeaders } from "./lib/cors.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import { logger } from "../obs/logger.js";
+import { externalHttpRequestsTotal } from "../obs/metrics.js";
+
+function recordMono(outcome) {
+  try {
+    externalHttpRequestsTotal.inc({ upstream: "monobank", outcome });
+  } catch {
+    /* ignore */
+  }
+}
 
 export default async function handler(req, res) {
+  setRequestModule("finyk");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "GET, POST, OPTIONS",
@@ -36,6 +48,7 @@ export default async function handler(req, res) {
     });
 
     if (!response.ok) {
+      recordMono(response.status === 429 ? "rate_limited" : "error");
       const errorText = await response.text();
       return res.status(response.status).json({
         error: response.status === 429 ? "Занадто багато запитів" : errorText,
@@ -43,9 +56,14 @@ export default async function handler(req, res) {
     }
 
     const data = await response.json();
+    recordMono("ok");
     res.status(200).json(data);
   } catch (e) {
-    console.error("API Error:", e);
+    recordMono("error");
+    logger.error({
+      msg: "mono_proxy_failed",
+      err: { message: e?.message || String(e), code: e?.code },
+    });
     res.status(500).json({ error: "Помилка сервера" });
   }
 }

--- a/server/api/nutrition/analyze-photo.js
+++ b/server/api/nutrition/analyze-photo.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import { validateBody } from "../lib/validate.js";
 import { AnalyzePhotoSchema } from "../lib/schemas.js";
@@ -31,6 +32,7 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
 `;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/backup-download.js
+++ b/server/api/nutrition/backup-download.js
@@ -1,4 +1,5 @@
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import {
   checkRateLimit,
   requireNutritionTokenIfConfigured,
@@ -18,6 +19,7 @@ function safeKeyFromToken(req) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/backup-upload.js
+++ b/server/api/nutrition/backup-upload.js
@@ -1,4 +1,5 @@
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import {
   checkRateLimit,
   requireNutritionTokenIfConfigured,
@@ -19,6 +20,7 @@ function safeKeyFromToken(req) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/day-hint.js
+++ b/server/api/nutrition/day-hint.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -22,6 +23,7 @@ function normalizeHint(text) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/day-plan.js
+++ b/server/api/nutrition/day-plan.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -110,6 +111,7 @@ function normalizeDayPlan(parsed) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/lib/anthropicFetch.js
+++ b/server/api/nutrition/lib/anthropicFetch.js
@@ -1,4 +1,38 @@
+import {
+  aiTokensTotal,
+  externalHttpRequestsTotal,
+} from "../../../obs/metrics.js";
+
 const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+
+function recordOutcome(outcome) {
+  try {
+    externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome });
+  } catch {
+    /* ignore */
+  }
+}
+
+function recordUsage(model, data) {
+  try {
+    const usage = data?.usage;
+    if (!usage) return;
+    if (Number.isFinite(usage.input_tokens)) {
+      aiTokensTotal.inc(
+        { provider: "anthropic", model, kind: "prompt" },
+        usage.input_tokens,
+      );
+    }
+    if (Number.isFinite(usage.output_tokens)) {
+      aiTokensTotal.inc(
+        { provider: "anthropic", model, kind: "completion" },
+        usage.output_tokens,
+      );
+    }
+  } catch {
+    /* ignore */
+  }
+}
 
 export async function anthropicMessages(
   apiKey,
@@ -39,10 +73,19 @@ export async function anthropicMessages(
       // Ретраїмо тільки тимчасові/перевантажені стани.
       if (shouldRetryStatus(response.status) && attempt < maxAttempts) continue;
 
+      if (response.ok) {
+        recordOutcome("ok");
+        recordUsage(payload?.model || "unknown", data);
+      } else {
+        recordOutcome(response.status === 429 ? "rate_limited" : "error");
+      }
       return { response, data };
     } catch (e) {
       // На явний timeout (AbortError) краще не "допалювати" запити.
-      if (isAbortError(e) || attempt >= maxAttempts) throw e;
+      if (isAbortError(e) || attempt >= maxAttempts) {
+        recordOutcome(isAbortError(e) ? "timeout" : "error");
+        throw e;
+      }
       continue;
     } finally {
       clearTimeout(t);

--- a/server/api/nutrition/parse-pantry.js
+++ b/server/api/nutrition/parse-pantry.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import { validateBody } from "../lib/validate.js";
 import { ParsePantrySchema } from "../lib/schemas.js";
@@ -37,6 +38,7 @@ const SYSTEM = `Ти помічник з харчування. Відповід�
 `;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/recommend-recipes.js
+++ b/server/api/nutrition/recommend-recipes.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -36,6 +37,7 @@ const SYSTEM = `Ти шеф-кухар і нутріціолог. Відпові
 `;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/refine-photo.js
+++ b/server/api/nutrition/refine-photo.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -29,6 +30,7 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
 `;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/shopping-list.js
+++ b/server/api/nutrition/shopping-list.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -43,6 +44,7 @@ const SYSTEM = `Ти помічник з планування покупок і 
 - Якщо список покупок порожній (все є в коморі) — поверни порожній масив categories`;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/nutrition/week-plan.js
+++ b/server/api/nutrition/week-plan.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../../aiQuota.js";
 import { setCorsHeaders } from "../lib/cors.js";
+import { setRequestModule } from "../../obs/requestContext.js";
 import { extractJsonFromText } from "../lib/jsonSafe.js";
 import {
   anthropicMessages,
@@ -51,6 +52,7 @@ const SYSTEM = `Ти шеф-кухар і планувальник харчув�
 Максимум 7 днів. Не вигадуй екзотичні інгредієнти поза списком — дозволено додати сіль, олію, базові спеції.`;
 
 export default async function handler(req, res) {
+  setRequestModule("nutrition");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Token, Content-Type",
     methods: "POST, OPTIONS",

--- a/server/api/privat.js
+++ b/server/api/privat.js
@@ -1,6 +1,10 @@
 import { setCorsHeaders } from "./lib/cors.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import { logger } from "../obs/logger.js";
+import { externalHttpRequestsTotal } from "../obs/metrics.js";
 
 export default async function handler(req, res) {
+  setRequestModule("finyk");
   setCorsHeaders(res, req, {
     allowHeaders: "X-Privat-Id, X-Privat-Token, Content-Type",
     methods: "GET, OPTIONS",
@@ -62,6 +66,14 @@ export default async function handler(req, res) {
     });
 
     if (!response.ok) {
+      try {
+        externalHttpRequestsTotal.inc({
+          upstream: "privatbank",
+          outcome: response.status === 429 ? "rate_limited" : "error",
+        });
+      } catch {
+        /* ignore */
+      }
       let errorText = "";
       try {
         errorText = await response.text();
@@ -76,10 +88,26 @@ export default async function handler(req, res) {
       });
     }
 
+    try {
+      externalHttpRequestsTotal.inc({ upstream: "privatbank", outcome: "ok" });
+    } catch {
+      /* ignore */
+    }
     const data = await response.json();
     res.status(200).json(data);
   } catch (e) {
-    console.error("PrivatBank API Error:", e);
+    try {
+      externalHttpRequestsTotal.inc({
+        upstream: "privatbank",
+        outcome: "error",
+      });
+    } catch {
+      /* ignore */
+    }
+    logger.error({
+      msg: "privat_proxy_failed",
+      err: { message: e?.message || String(e), code: e?.code },
+    });
     res.status(500).json({ error: "Помилка сервера" });
   }
 }

--- a/server/api/push.js
+++ b/server/api/push.js
@@ -2,6 +2,17 @@ import webpush from "web-push";
 import pool from "../db.js";
 import { auth } from "../auth.js";
 import { fromNodeHeaders } from "better-auth/node";
+import { setRequestModule } from "../obs/requestContext.js";
+import { logger } from "../obs/logger.js";
+import { pushSendsTotal } from "../obs/metrics.js";
+
+function recordSend(outcome) {
+  try {
+    pushSendsTotal.inc({ outcome });
+  } catch {
+    /* ignore */
+  }
+}
 
 const VAPID_PUBLIC = process.env.VAPID_PUBLIC_KEY;
 const VAPID_PRIVATE = process.env.VAPID_PRIVATE_KEY;
@@ -24,6 +35,7 @@ async function getSession(req) {
 
 /** GET /api/push/vapid-public — повертає публічний VAPID ключ для підписки */
 export async function vapidPublic(req, res) {
+  setRequestModule("push");
   if (!VAPID_PUBLIC) {
     return res.status(503).json({ error: "Push not configured" });
   }
@@ -32,6 +44,7 @@ export async function vapidPublic(req, res) {
 
 /** POST /api/push/subscribe — зберегти підписку */
 export async function subscribe(req, res) {
+  setRequestModule("push");
   if (!VAPID_PUBLIC)
     return res.status(503).json({ error: "Push not configured" });
   const user = await getSession(req);
@@ -51,13 +64,17 @@ export async function subscribe(req, res) {
     );
     res.json({ ok: true });
   } catch (e) {
-    console.error("[push] subscribe error", e);
+    logger.error({
+      msg: "push_subscribe_failed",
+      err: { message: e?.message || String(e), code: e?.code },
+    });
     res.status(500).json({ error: "DB error" });
   }
 }
 
 /** DELETE /api/push/subscribe — видалити підписку */
 export async function unsubscribe(req, res) {
+  setRequestModule("push");
   const user = await getSession(req);
   if (!user) return res.status(401).json({ error: "Unauthorized" });
 
@@ -71,7 +88,10 @@ export async function unsubscribe(req, res) {
     );
     res.json({ ok: true });
   } catch (e) {
-    console.error("[push] unsubscribe error", e);
+    logger.error({
+      msg: "push_unsubscribe_failed",
+      err: { message: e?.message || String(e), code: e?.code },
+    });
     res.status(500).json({ error: "DB error" });
   }
 }
@@ -82,6 +102,7 @@ export async function unsubscribe(req, res) {
  * Захищений API_SECRET щоб не дозволяти довільні запити.
  */
 export async function sendPush(req, res) {
+  setRequestModule("push");
   const secret = req.headers["x-api-secret"];
   if (!secret || secret !== process.env.API_SECRET) {
     return res.status(401).json({ error: "Unauthorized" });
@@ -118,11 +139,25 @@ export async function sendPush(req, res) {
         try {
           await webpush.sendNotification(sub, payload);
           sent++;
+          recordSend("ok");
         } catch (e) {
           if (e.statusCode === 404 || e.statusCode === 410) {
             stale.push(row.endpoint);
+            recordSend("invalid_endpoint");
+          } else if (e.statusCode === 429) {
+            recordSend("rate_limited");
+            logger.warn({
+              msg: "push_rate_limited",
+              status: e.statusCode,
+              err: { message: e?.message },
+            });
           } else {
-            console.warn("[push] send error", e.statusCode, e.message);
+            recordSend("error");
+            logger.warn({
+              msg: "push_send_error",
+              status: e.statusCode,
+              err: { message: e?.message },
+            });
           }
         }
       }),
@@ -137,7 +172,10 @@ export async function sendPush(req, res) {
 
     res.json({ sent, stale: stale.length });
   } catch (e) {
-    console.error("[push] sendPush error", e);
+    logger.error({
+      msg: "push_send_failed",
+      err: { message: e?.message || String(e), code: e?.code },
+    });
     res.status(500).json({ error: "Internal error" });
   }
 }

--- a/server/api/sync.js
+++ b/server/api/sync.js
@@ -1,10 +1,21 @@
 import pool from "../db.js";
 import { getSessionUser } from "../auth.js";
+import { setRequestModule } from "../obs/requestContext.js";
+import { syncConflictsTotal } from "../obs/metrics.js";
+
+function recordConflict(module) {
+  try {
+    syncConflictsTotal.inc({ module });
+  } catch {
+    /* ignore */
+  }
+}
 
 const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
 const MAX_BLOB_SIZE = 5 * 1024 * 1024;
 
 export async function syncPush(req, res) {
+  setRequestModule("sync");
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
@@ -43,6 +54,7 @@ export async function syncPush(req, res) {
   );
 
   if (result.rows.length === 0) {
+    recordConflict(module);
     const existing = await pool.query(
       `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
       [user.id, module],
@@ -65,6 +77,7 @@ export async function syncPush(req, res) {
 }
 
 export async function syncPull(req, res) {
+  setRequestModule("sync");
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
@@ -116,6 +129,7 @@ export async function syncPull(req, res) {
 }
 
 export async function syncPullAll(req, res) {
+  setRequestModule("sync");
   if (req.method !== "POST" && req.method !== "GET") {
     return res.status(405).json({ error: "Method not allowed" });
   }
@@ -152,6 +166,7 @@ export async function syncPullAll(req, res) {
 }
 
 export async function syncPushAll(req, res) {
+  setRequestModule("sync");
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
@@ -191,6 +206,7 @@ export async function syncPushAll(req, res) {
         [user.id, mod, blob, clientTs],
       );
       if (r.rows.length === 0) {
+        recordConflict(mod);
         const existing = await client.query(
           `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
           [user.id, mod],

--- a/server/api/weekly-digest.js
+++ b/server/api/weekly-digest.js
@@ -1,5 +1,6 @@
 import { assertAiQuota } from "../aiQuota.js";
 import { setCorsHeaders } from "./lib/cors.js";
+import { setRequestModule } from "../obs/requestContext.js";
 
 function extractJsonObject(raw) {
   if (typeof raw !== "string") return null;
@@ -49,6 +50,7 @@ function extractJsonObject(raw) {
 }
 
 export default async function handler(req, res) {
+  setRequestModule("weekly-digest");
   setCorsHeaders(res, req, {
     allowHeaders: "Content-Type",
     methods: "POST, OPTIONS",


### PR DESCRIPTION
## Summary

Другий крок observability-rollout'у поверх фундаменту з #162. Інструментую handler'и, щоб кожен запит у логах і Sentry-подіях ніс `module`, а також наповнюю domain-метрики реальними подіями.

### Що додано

**`setRequestModule` у кожному handler'і** — `module` тепер автоматично в кожному log-записі й Sentry-tag:
- `server/api/barcode.js` → `barcode`
- `server/api/sync.js` (push/pull/pushAll/pullAll) → `sync`
- `server/api/push.js` (subscribe/unsubscribe/sendPush/vapidPublic) → `push`
- `server/api/chat.js` → `chat`
- `server/api/coach.js` → `coach`
- `server/api/mono.js`, `server/api/privat.js` → `finyk`
- `server/api/weekly-digest.js` → `weekly-digest`
- `server/api/food-search.js` + усі `server/api/nutrition/*.js` → `nutrition`

**Domain-метрики**
- `barcode_lookups_total{source=off|usda|upcitemdb, outcome=hit|miss|error}` — по каскаду джерел
- `sync_conflicts_total{module}` — у всіх точках конфлікту (`syncPush`, `syncPushAll`)
- `push_sends_total{outcome=ok|invalid_endpoint|rate_limited|error}` у `sendPush`
- `ai_tokens_total{provider=anthropic, model, kind=prompt|completion}` — з `usage.input_tokens`/`output_tokens` Anthropic-відповідей
- `external_http_requests_total{upstream, outcome}` для `anthropic`, `monobank`, `privatbank`, `off`, `usda`, `upcitemdb`

**Shared helper**
- `server/api/nutrition/lib/anthropicFetch.js` тепер централізовано веде облік токенів і outbound-HTTP outcome — усі nutrition-хендлери автоматично отримали метрики через нього.

**Заміна `console.*` на structured logger**
- `server/api/push.js` (subscribe/unsubscribe/sendPush помилки + rate-limit warning)
- `server/api/mono.js`, `server/api/privat.js` (fetch-помилки)

### Чого тут немає
- Міграції handler'ів на `AppError` і централізовий `errorHandler` — лишаю наступним кроком, щоб не змішувати зміни повернення помилок з інструментацією.
- SSE-streaming у `chat.js` не парсить `usage`-подію — це вимагає парсити SSE-stream і вихід за рамки цього PR.

## Review & Testing Checklist for Human

- [ ] Перевірити, що після деплою у `/metrics` з'являються нові series: `barcode_lookups_total`, `sync_conflicts_total`, `push_sends_total`, `ai_tokens_total`, `external_http_requests_total`.
- [ ] На реальному запиті до `/api/barcode?code=...` переконатися, що в логах з'являється `"module":"barcode"` і що `barcode_lookups_total` інкрементується з коректним `source`.
- [ ] На Anthropic-запиті (`/api/chat`, `/api/nutrition/day-plan`, etc.) перевірити, що `ai_tokens_total{kind="prompt"}` і `{kind="completion"}` інкрементуються приблизно на значення з `usage.input_tokens` / `output_tokens`.
- [ ] Конфлікт синку (повторний push зі старим `clientUpdatedAt`) має відобразитися як `sync_conflicts_total{module="..."}`.

### Notes

Всі зміни були прогнані локально: `npm run lint`, `npm run typecheck`, `npm test` (60 test files passed), `npm run format:check`, `npm run build` — усе зелене.


Link to Devin session: https://app.devin.ai/sessions/3ddc5b1fcadf4cac88400b60a881e9ae
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
