### PR TITLE
fix(onboarding): flag Finyk demo entries + fix nutrition seed shape + dashboard demo banner + splash ticker

### DIFF
--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -8,8 +8,14 @@ import { HubInsightsPanel } from "./HubInsightsPanel.jsx";
 import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
 import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
+import { DemoModeBanner } from "./onboarding/DemoModeBanner.jsx";
 import { detectFirstRealEntry } from "./onboarding/firstRealEntry.js";
-import { isSoftAuthDismissed } from "./onboarding/vibePicks.js";
+import {
+  isSoftAuthDismissed,
+  isDemoBannerDismissed,
+  dismissDemoBanner,
+} from "./onboarding/vibePicks.js";
+import { wasDemoSeeded } from "./onboarding/demoSeeds.js";
 import {
   DndContext,
   closestCenter,
@@ -414,6 +420,15 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
     !softAuthDismissed &&
     typeof onShowAuth === "function";
 
+  // Demo banner: only while we're still showing seeded FTUX data and the
+  // user hasn't contributed anything of their own yet. Dismissible; once
+  // there's a real entry or the user closes it, it stays gone.
+  const [demoBannerDismissed, setDemoBannerDismissed] = useState(() =>
+    isDemoBannerDismissed(),
+  );
+  const showDemoBanner =
+    !hasRealEntry && !demoBannerDismissed && wasDemoSeeded();
+
   const { focus, rest, dismiss } = useDashboardFocus();
 
   const sensors = useSensors(
@@ -459,6 +474,15 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   return (
     <div className="space-y-4">
       <DateHeader />
+
+      {showDemoBanner && (
+        <DemoModeBanner
+          onDismiss={() => {
+            dismissDemoBanner();
+            setDemoBannerDismissed(true);
+          }}
+        />
+      )}
 
       {showSoftAuth && (
         <SoftAuthPromptCard

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -84,6 +84,86 @@ function StepDots({ total, current }) {
   );
 }
 
+// A tiny auto-cycling preview of what a "full" Sergeant screen looks like:
+// one metric per module, rotating on a 2.2s interval. Purely decorative —
+// it exists so the user sees concrete numbers (not just words) in the first
+// second of the splash, which is what sells the "life in one screen" pitch.
+const SPLASH_TICKER_ITEMS = [
+  {
+    icon: "credit-card",
+    accent: "text-finyk bg-finyk-soft",
+    metric: "−320 грн",
+    label: "на каву цього тижня",
+  },
+  {
+    icon: "dumbbell",
+    accent: "text-fizruk bg-fizruk-soft",
+    metric: "5 трен.",
+    label: "за останні 14 днів",
+  },
+  {
+    icon: "check",
+    accent: "text-routine bg-routine-soft",
+    metric: "7 днів",
+    label: "стрік — «випити воду»",
+  },
+  {
+    icon: "utensils",
+    accent: "text-nutrition bg-nutrition-soft",
+    metric: "420 ккал",
+    label: "сніданок сьогодні",
+  },
+];
+
+function SplashTicker() {
+  const [idx, setIdx] = useState(0);
+  useEffect(() => {
+    const t = setInterval(
+      () => setIdx((i) => (i + 1) % SPLASH_TICKER_ITEMS.length),
+      2200,
+    );
+    return () => clearInterval(t);
+  }, []);
+  const item = SPLASH_TICKER_ITEMS[idx];
+  return (
+    <div
+      className={cn(
+        "w-full rounded-2xl border border-line bg-surface",
+        "px-4 py-3 flex items-center gap-3",
+      )}
+      aria-live="polite"
+    >
+      <div
+        key={`icon-${idx}`}
+        className={cn(
+          "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
+          "animate-fade-in",
+          item.accent,
+        )}
+      >
+        <Icon name={item.icon} size={20} strokeWidth={2} aria-hidden />
+      </div>
+      <div key={`text-${idx}`} className="animate-fade-in text-left">
+        <div className="text-base font-semibold text-text leading-tight">
+          {item.metric}
+        </div>
+        <div className="text-xs text-muted leading-tight">{item.label}</div>
+      </div>
+      <div className="ml-auto flex items-center gap-1" aria-hidden>
+        {SPLASH_TICKER_ITEMS.map((_, i) => (
+          <span
+            key={i}
+            className={cn(
+              "rounded-full transition-all",
+              i === idx ? "w-1.5 h-1.5 bg-brand-500" : "w-1 h-1 bg-line",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // Step 0 — Value prop. No name field, no form. The goal of this screen
 // is to answer "what is this?" in one sentence and then get out of the way.
 function SplashStep({ onNext }) {
@@ -99,6 +179,7 @@ function SplashStep({ onNext }) {
           AI-помічник.
         </p>
       </div>
+      <SplashTicker />
       <ul className="w-full space-y-2 text-left text-sm text-muted">
         <li className="flex items-start gap-2">
           <span className="mt-0.5 text-brand-600">•</span>

--- a/src/core/onboarding/DemoModeBanner.jsx
+++ b/src/core/onboarding/DemoModeBanner.jsx
@@ -1,0 +1,52 @@
+// Shown on the hub dashboard while the user is still exploring seeded
+// demo data and hasn't logged anything real yet. Purpose: set expectations
+// ("ці цифри — приклад") so the user doesn't mistake demo numbers for
+// their own and isn't surprised when they disappear after the first real
+// entry. Dismissible — users who already get it shouldn't see it again.
+
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+
+export function DemoModeBanner({ onDismiss }) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-brand-500/20 bg-brand-500/5",
+        "px-4 py-3 flex items-start gap-3",
+      )}
+      role="status"
+    >
+      <div
+        className={cn(
+          "shrink-0 w-8 h-8 rounded-full",
+          "bg-brand-500/15 text-brand-600",
+          "flex items-center justify-center",
+        )}
+      >
+        <Icon name="sparkle" size={16} strokeWidth={2} aria-hidden />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-text leading-snug">
+          Це приклад даних за 2 тижні.
+        </p>
+        <p className="text-xs text-muted mt-0.5 leading-snug">
+          Додай що-небудь своє — і цифри стануть твоїми.
+        </p>
+      </div>
+      {typeof onDismiss === "function" && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Закрити підказку"
+          className={cn(
+            "shrink-0 w-7 h-7 rounded-full text-muted hover:text-text",
+            "hover:bg-line/50 flex items-center justify-center",
+            "transition-colors",
+          )}
+        >
+          <Icon name="close" size={14} strokeWidth={2} aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/core/onboarding/demoSeeds.js
+++ b/src/core/onboarding/demoSeeds.js
@@ -188,23 +188,28 @@ function seedNutritionDemoData() {
     if (Object.keys(existing).length > 0) return 0;
   }
 
+  // Rough macro split that's close enough to a real meal for the rings
+  // and daily totals to render convincingly.
+  const splitMacros = (kcal) => ({
+    kcal,
+    protein_g: Math.round((kcal * 0.22) / 4),
+    fat_g: Math.round((kcal * 0.28) / 9),
+    carbs_g: Math.round((kcal * 0.5) / 4),
+  });
+
   const log = {};
   for (const m of NUTRITION_DEMO_MEALS) {
     const dateKey = toLocalISODate(daysAgo(m.offset));
-    if (!log[dateKey]) log[dateKey] = { items: [] };
-    log[dateKey].items.push({
-      id: `demo-meal-${dateKey}-${log[dateKey].items.length}`,
+    // IMPORTANT: `normalizeNutritionLog` reads each day as `{ meals: [] }`;
+    // any other shape (e.g. `{ items: [] }`) is silently dropped on load.
+    if (!log[dateKey]) log[dateKey] = { meals: [] };
+    log[dateKey].meals.push({
+      id: `demo-meal-${dateKey}-${log[dateKey].meals.length}`,
       demo: true,
       name: m.name,
       mealType: m.meal,
-      createdAt: daysAgo(m.offset).toISOString(),
-      macros: {
-        kcal: m.kcal,
-        // Rough split — good enough for the ring to fill convincingly.
-        protein_g: Math.round(m.kcal * 0.22 * 0.25),
-        fat_g: Math.round(m.kcal * 0.28 * 0.11),
-        carbs_g: Math.round(m.kcal * 0.5 * 0.25),
-      },
+      source: "manual",
+      macros: splitMacros(m.kcal),
     });
   }
 

--- a/src/core/onboarding/firstRealEntry.js
+++ b/src/core/onboarding/firstRealEntry.js
@@ -58,11 +58,12 @@ export function hasAnyRealEntry() {
   const routine = safeReadJSON("hub_routine_v1");
   if (routine && hasNonDemoItem(routine.habits)) return true;
 
-  // Nutrition — meal log is keyed by date; inspect items across all days.
+  // Nutrition — meal log is keyed by date; inspect meals across all days.
+  // The day shape is `{ meals: [...] }` (see `normalizeNutritionLog`).
   const nutrition = safeReadJSON("nutrition_log_v1");
   if (nutrition && typeof nutrition === "object" && !Array.isArray(nutrition)) {
     for (const day of Object.values(nutrition)) {
-      if (day && hasNonDemoItem(day.items)) return true;
+      if (day && hasNonDemoItem(day.meals)) return true;
     }
   }
 

--- a/src/core/onboarding/vibePicks.js
+++ b/src/core/onboarding/vibePicks.js
@@ -6,6 +6,7 @@ export const VIBE_PICKS_KEY = "hub_onboarding_vibes_v1";
 export const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
 export const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
 export const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
+export const DEMO_BANNER_DISMISSED_KEY = "hub_demo_banner_dismissed_v1";
 
 /** @typedef {"finyk" | "fizruk" | "routine" | "nutrition"} HubModuleId */
 
@@ -88,6 +89,22 @@ export function markFirstRealEntryDone() {
 export function isFirstRealEntryDone() {
   try {
     return localStorage.getItem(FIRST_REAL_ENTRY_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function dismissDemoBanner() {
+  try {
+    localStorage.setItem(DEMO_BANNER_DISMISSED_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}
+
+export function isDemoBannerDismissed() {
+  try {
+    return localStorage.getItem(DEMO_BANNER_DISMISSED_KEY) === "1";
   } catch {
     return false;
   }

--- a/src/modules/finyk/lib/demoData.js
+++ b/src/modules/finyk/lib/demoData.js
@@ -81,6 +81,11 @@ function demoEntry(base, offsetDays, payload) {
   const d = new Date(base.getTime() - offsetDays * 86400000);
   return {
     id: `demo-${d.getTime()}-${Math.round(payload.amount)}`,
+    // Flag every demo entry so cross-module detectors (e.g.
+    // `firstRealEntry.hasAnyRealEntry`) can tell seeded FTUX data apart
+    // from real user transactions — otherwise the soft-auth card would
+    // pop on the first dashboard render.
+    demo: true,
     date: d.toISOString(),
     description: payload.description,
     amount: payload.amount,


### PR DESCRIPTION
## Summary

Follow-up polish on the 30-second FTUX flow shipped in #161. Two bugs in the demo-seeding path and two visible-design improvements.

**Bug 1 — Finyk demo entries missing `demo: true` (flagged by Devin Review on #161).**
`demoEntry()` in <ref_snippet file="/home/ubuntu/Sergeant/src/modules/finyk/lib/demoData.js" lines="80-94" /> used to omit the `demo` flag. `firstRealEntry.hasAnyRealEntry` treats any item without `demo: true` as a real user entry → the soft-auth card popped on the very first dashboard render, the opposite of its intent. Fixed by adding `demo: true` to the returned shape.

**Bug 2 — Nutrition seeder wrote the wrong day shape (caught during the audit).**
The seeder was writing `{ items: [] }` per day, but `normalizeNutritionLog` only reads `{ meals: [] }` and silently drops everything else. Result: after onboarding, the nutrition card rendered empty even though seeding "succeeded". Fixed in <ref_snippet file="/home/ubuntu/Sergeant/src/core/onboarding/demoSeeds.js" lines="185-219" />, and the matching `firstRealEntry` scan now reads `day.meals` instead of `day.items`.

**Design 1 — Demo banner on the dashboard.**
New <ref_file file="/home/ubuntu/Sergeant/src/core/onboarding/DemoModeBanner.jsx" />, rendered above the today-focus card when `wasDemoSeeded() && !hasAnyRealEntry()`. Sets expectations ("це приклад, додай що-небудь своє — і цифри стануть твоїми") so users never mistake demo numbers for their own and aren't surprised when they clear out after the first real entry. Dismissible; dismiss state is persisted so it doesn't come back across sessions.

**Design 2 — Animated metric ticker on the splash screen.**
<ref_snippet file="/home/ubuntu/Sergeant/src/core/OnboardingWizard.jsx" lines="87-165" /> — a small rotating preview of one metric per module (−320 грн · 5 трен. · 7 днів стрік · 420 ккал), 2.2 s per slide. Uses the existing Tailwind `fade-in` keyframe, no new animation infra. Makes the first second of first-open *show* what "life in one screen" means rather than just say it.

## Review & Testing Checklist for Human

- [ ] **Fresh profile → onboarding → dashboard.** In a clean browser profile (or DevTools → Application → Clear site data) verify the splash ticker animates, picking any combination of modules seeds demo data, and the new "це приклад" banner appears on the dashboard. Dismissing the banner should keep it gone across a full page reload.
- [ ] **Nutrition card actually populates.** With Harvest/nutrition module picked, open Харчування from the dashboard and confirm today's demo meals show up (previously the list was empty despite seeding). Macro totals should be non-zero.
- [ ] **Soft-auth prompt timing.** With Фінік picked and demo seeded, the `SoftAuthPromptCard` must NOT appear on first render. It should appear only after you add a real expense from the Fin-first-action sheet.
- [ ] **Existing users are unaffected.** Users who already have real data (finyk_manual_expenses with `demo: undefined`, existing nutrition log, etc.) must not suddenly see the demo banner — `wasDemoSeeded()` gates on the seeder's own flag, and `hasAnyRealEntry` ignores the flag only when `item.demo === true`.
- [ ] **Animations in reduced-motion environments.** The metric ticker still announces changes via `aria-live="polite"` but the visual fade depends on the `animate-fade-in` utility; confirm nothing breaks with `prefers-reduced-motion` on.

### Notes

- Two pre-existing test suites fail on `main` as well (`server/aiQuota.test.js` and `server/httpCommon.test.js`, both on `Cannot find package 'pino'`). Not introduced here; verified by checking out `main` and re-running the same file. The 58 other test files and all 573 passing tests continue to pass.
- `npm run lint`, `npm run typecheck`, and `npm run build` all pass locally.
- Deliberately kept scope tight: no new PwaActions, no social auth, no success toast — those were listed in the backlog but are independent enough to land as their own PRs if wanted.

Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
