### PR TITLE
feat(onboarding): celebrate first real entry with a success toast

### DIFF
--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -16,6 +16,7 @@ import {
   dismissDemoBanner,
 } from "./onboarding/vibePicks.js";
 import { wasDemoSeeded } from "./onboarding/demoSeeds.js";
+import { useFirstEntryCelebration } from "./onboarding/useFirstEntryCelebration.js";
 import {
   DndContext,
   closestCenter,
@@ -411,6 +412,7 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   // Soft auth prompt appears only once the user has typed in real data and
   // has no account yet — an "offer to save", never a toll gate.
   const hasRealEntry = detectFirstRealEntry();
+  useFirstEntryCelebration(hasRealEntry);
   const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
     isSoftAuthDismissed(),
   );

--- a/src/core/onboarding/useFirstEntryCelebration.js
+++ b/src/core/onboarding/useFirstEntryCelebration.js
@@ -15,7 +15,13 @@ import { useEffect, useRef } from "react";
 import { useToast } from "@shared/hooks/useToast";
 
 export function useFirstEntryCelebration(hasRealEntry) {
-  const toast = useToast();
+  // Narrow to the stable `success` callback rather than the whole
+  // context value: `ToastProvider` re-memos the context on every toast
+  // emission (because `toasts` is in its dep array), so depending on
+  // `toast` would re-run this effect each time any toast appears or
+  // dismisses anywhere in the app. `success` itself is a stable
+  // `useCallback`, so this keeps the effect narrowly reactive.
+  const { success } = useToast();
   const firedRef = useRef(false);
   // Snapshot the value at mount. If the user already had real data when
   // the dashboard first rendered, they're not a FTUX user — suppress the
@@ -30,6 +36,6 @@ export function useFirstEntryCelebration(hasRealEntry) {
     }
     if (!hasRealEntry) return;
     firedRef.current = true;
-    toast.success("Готово. Це вже твої дані.", 4000);
-  }, [hasRealEntry, toast]);
+    success("Готово. Це вже твої дані.", 4000);
+  }, [hasRealEntry, success]);
 }

--- a/src/core/onboarding/useFirstEntryCelebration.js
+++ b/src/core/onboarding/useFirstEntryCelebration.js
@@ -1,0 +1,35 @@
+// Fires a one-shot "first success" toast the render after the user logs
+// their very first real entry. This is the moment the 30-second FTUX
+// promise actually pays off: demo data becomes *their* data. Without a
+// celebration here the transition is silent and easy to miss.
+//
+// Contract:
+//   - Consumes the boolean returned by `detectFirstRealEntry()` (already
+//     persists its own idempotency flag).
+//   - Fires exactly once, client-side, per browser profile. Subsequent
+//     sessions (where the flag is already persisted on mount) stay quiet.
+//   - Skipped on the session where the user landed already having real
+//     data — we don't want the toast to congratulate existing users.
+
+import { useEffect, useRef } from "react";
+import { useToast } from "@shared/hooks/useToast";
+
+export function useFirstEntryCelebration(hasRealEntry) {
+  const toast = useToast();
+  const firedRef = useRef(false);
+  // Snapshot the value at mount. If the user already had real data when
+  // the dashboard first rendered, they're not a FTUX user — suppress the
+  // celebration for good in this session.
+  const initialRef = useRef(hasRealEntry);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    if (initialRef.current) {
+      firedRef.current = true;
+      return;
+    }
+    if (!hasRealEntry) return;
+    firedRef.current = true;
+    toast.success("Готово. Це вже твої дані.", 4000);
+  }, [hasRealEntry, toast]);
+}


### PR DESCRIPTION
## Summary

Third landing in the FTUX polish series. Closes the loop the earlier PRs set up: when a fresh user's first non-demo entry lands on the dashboard, we fire a one-shot `"Готово. Це вже твої дані."` toast, matching the design spec from #161.

Before this, the transition from seeded demo state to real data was silent — the demo banner disappeared and the soft-auth card appeared, but the moment itself had no affordance. Now the app explicitly acknowledges the "first success".

**Implementation** — new hook at <ref_file file="/home/ubuntu/Sergeant/src/core/onboarding/useFirstEntryCelebration.js" />, consumed from `HubDashboard`:

- Consumes the boolean already returned by `detectFirstRealEntry()` — no new storage, no duplicated analytics.
- Two refs guard idempotency:
  - `firedRef` keeps the toast from re-firing on subsequent renders in the same session.
  - `initialRef` snapshots the value on mount; if the user already had real data when the dashboard first rendered, they're not a FTUX user and we stay quiet.
- Uses the `ToastProvider` already mounted at the App root (<ref_snippet file="/home/ubuntu/Sergeant/src/core/App.jsx" lines="36-45" />), so no provider wiring or dependencies were touched.

## Review & Testing Checklist for Human

- [ ] **Fresh profile → first real entry fires the toast.** In a clean browser profile, finish onboarding, then add a real entry via the first-action sheet (any module). The `"Готово. Це вже твої дані."` toast should appear exactly once.
- [ ] **Reload after first entry stays quiet.** Refresh the page while still on the dashboard — the toast must NOT re-fire. The persisted first-real-entry flag suppresses it and `initialRef` also catches this case for defense in depth.
- [ ] **Existing users don't get congratulated.** A profile with pre-existing Finyk/Fizruk/routine/nutrition data must NOT see the toast on their next dashboard mount.
- [ ] **Analytics still fire exactly once.** `FIRST_REAL_ENTRY` event is emitted by `detectFirstRealEntry` (unchanged by this PR). Verify it isn't double-fired.

### Notes

- No change to `firstRealEntry.js`, storage keys, or analytics events — purely additive UI hook.
- Pre-existing test failures on `server/aiQuota.test.js` and `server/httpCommon.test.js` (missing `pino`) are unrelated; same state as on `main`.
- `npm run lint`, `npm run typecheck`, `npm run build` all pass locally.

Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
