### PR TITLE
fix(nutrition): preserve FTUX demo flag through meal normalization

### DIFF
--- a/src/modules/nutrition/lib/nutritionStorage.js
+++ b/src/modules/nutrition/lib/nutritionStorage.js
@@ -258,7 +258,14 @@ export function normalizeMeal(m, idx) {
       ? String(raw.foodId).trim()
       : null;
 
-  return {
+  // Pass the FTUX demo flag through untouched. Seeded meals carry
+  // `demo: true` so cross-module detectors (see `firstRealEntry.js`) can
+  // tell seeded data apart from real entries. Because `useNutritionLog`
+  // immediately persists the normalized log back to localStorage, any
+  // property dropped here is lost on the first module visit — which is
+  // what used to silently re-classify demo meals as real entries and
+  // trip the soft-auth prompt.
+  const out = {
     id,
     name,
     time,
@@ -270,6 +277,8 @@ export function normalizeMeal(m, idx) {
     amount_g,
     foodId,
   };
+  if (raw.demo === true) out.demo = true;
+  return out;
 }
 
 export function normalizeNutritionLog(raw) {


### PR DESCRIPTION
## Summary

Hotfix for a real bug Devin Review flagged on #165.

**Chain of events without this fix**
1. Onboarding seeds nutrition meals with `demo: true` (for the cross-module detector in `firstRealEntry.hasAnyRealEntry`).
2. User opens the Харчування module.
3. `useNutritionLog` calls `loadNutritionLog → normalizeNutritionLog → normalizeMeal`.
4. `normalizeMeal` returned a fixed shape **without** `demo`, silently stripping the flag.
5. The same hook then persists the normalized log back to localStorage (<ref_snippet file="/home/ubuntu/Sergeant/src/modules/nutrition/hooks/useNutritionLog.js" lines="101-102" />), overwriting the seeded meals with de-flagged copies.
6. User returns to the dashboard; `hasAnyRealEntry` finds meals without `demo: true`, classifies them as real entries, hides the demo banner, and pops the soft-auth prompt early — the exact opposite of #165's gating.

**Fix** — one line. `normalizeMeal` passes `demo` through when it's strictly `true`:

<ref_snippet file="/home/ubuntu/Sergeant/src/modules/nutrition/lib/nutritionStorage.js" lines="261-282" />

This matches how finyk / fizruk / routine already behave — they store entries as-is, so the flag survives.

## Review & Testing Checklist for Human

- [ ] **Fresh profile → onboarding → open Харчування → back to dashboard.** Before: soft-auth card pops, demo banner gone. After: demo banner still there, soft-auth stays hidden.
- [ ] **Real meals still work.** Add a real meal; it should NOT pick up `demo: true` from anywhere (only strict `=== true` values pass through). Confirm no stray demo marks on user-created meals.
- [ ] **Existing users are unaffected.** Users with real meals in their log have never had `demo: true` on any record, so nothing changes for them.

### Notes

- Strict `=== true` check avoids any accidental coercion — `"true"`, `1`, or missing stays non-demo.
- Pre-existing `server/aiQuota.test.js` / `server/httpCommon.test.js` failures on missing `pino` are unrelated (same state as on `main`).
- `npm run lint`, `npm run typecheck`, and the nutrition + onboarding test suites all pass (83 tests).

Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
