### PR TITLE
feat(routine): add `add_habit` PWA action + FTUX lands on habit form

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -219,7 +219,12 @@ function AppInner() {
               />
             )}
             {activeModule === "routine" && (
-              <RoutineApp onBackToHub={goToHub} onOpenModule={openModule} />
+              <RoutineApp
+                onBackToHub={goToHub}
+                onOpenModule={openModule}
+                pwaAction={pwaAction}
+                onPwaActionConsumed={clearPwaAction}
+              />
             )}
             {activeModule === "nutrition" && (
               <NutritionApp

--- a/src/core/hooks/usePwaActions.ts
+++ b/src/core/hooks/usePwaActions.ts
@@ -1,12 +1,17 @@
 import { useCallback, useState } from "react";
 import { PWA_ACTION_KEY, consumePwaAction } from "../app/pwaAction.js";
 
-export type PwaAction = "add_expense" | "start_workout" | "add_meal";
+export type PwaAction =
+  | "add_expense"
+  | "start_workout"
+  | "add_meal"
+  | "add_habit";
 
 const VALID_ACTIONS = new Set<PwaAction>([
   "add_expense",
   "start_workout",
   "add_meal",
+  "add_habit",
 ]);
 
 function isPwaAction(value: string | null): value is PwaAction {

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
-import { openHubModuleWithAction, openHubModule } from "@shared/lib/hubNav";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
 
@@ -9,10 +9,6 @@ import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
  * Per-module "one tap to your first real entry" cards. Each option routes
  * into its module with a PWA action (the same handler PWA shortcuts use),
  * so a single tap lands the user on an already-open input.
- *
- * Routine is an exception: it doesn't have a dedicated PWA action, so we
- * just open the module. The module lands on the habit list where a demo
- * habit is ready to tap.
  */
 const ACTIONS = {
   finyk: {
@@ -38,10 +34,10 @@ const ACTIONS = {
   },
   routine: {
     icon: "check",
-    title: "Відмітити звичку",
+    title: "Створити звичку",
     desc: "Почни стрік сьогодні",
     accent: "text-routine bg-routine-soft",
-    run: () => openHubModule("routine"),
+    run: () => openHubModuleWithAction("routine", "add_habit"),
   },
 };
 

--- a/src/modules/routine/RoutineApp.jsx
+++ b/src/modules/routine/RoutineApp.jsx
@@ -117,7 +117,12 @@ function groupEventsForList(events) {
   });
 }
 
-export default function RoutineApp({ onBackToHub, onOpenModule } = {}) {
+export default function RoutineApp({
+  onBackToHub,
+  onOpenModule,
+  pwaAction,
+  onPwaActionConsumed,
+} = {}) {
   const [routine, setRoutine] = useRoutineState();
   const toast = useToast();
   const [finykCalendarTick, setFinykCalendarTick] = useState(0);
@@ -169,6 +174,20 @@ export default function RoutineApp({ onBackToHub, onOpenModule } = {}) {
   const [habitDraft, setHabitDraft] = useState(emptyHabitDraft);
   const [tagDraft, setTagDraft] = useState("");
   const [catDraft, setCatDraft] = useState({ name: "", emoji: "" });
+  // Monotonic tick bumped whenever something asks us to focus the habit
+  // form (e.g. the `add_habit` PWA action or the FTUX first-action
+  // sheet). A tick — not a bool — so repeated triggers always fire.
+  const [habitFormFocusTick, setHabitFormFocusTick] = useState(0);
+
+  // Handle the `add_habit` PWA action: switch to the Settings tab
+  // (where the habit form lives) and bump the focus tick so the form
+  // scrolls itself into view and puts the caret in the name input.
+  useEffect(() => {
+    if (pwaAction !== "add_habit") return;
+    setMainTab("settings");
+    setHabitFormFocusTick((t) => t + 1);
+    onPwaActionConsumed?.();
+  }, [pwaAction, onPwaActionConsumed]);
 
   useEffect(() => {
     try {
@@ -608,6 +627,7 @@ export default function RoutineApp({ onBackToHub, onOpenModule } = {}) {
             catDraft={catDraft}
             setCatDraft={setCatDraft}
             onOpenCalendar={() => setMainTab("calendar")}
+            habitFormFocusTick={habitFormFocusTick}
             hidden={mainTab !== "settings"}
           />
         </main>

--- a/src/modules/routine/components/RoutineSettingsSection.jsx
+++ b/src/modules/routine/components/RoutineSettingsSection.jsx
@@ -34,6 +34,8 @@ export function RoutineSettingsSection({
   catDraft,
   setCatDraft,
   onOpenCalendar,
+  habitFormFocusTick,
+  onHabitFormFocusHandled,
   hidden: panelHidden,
 }) {
   const toast = useToast();
@@ -106,6 +108,8 @@ export function RoutineSettingsSection({
         editingId={editingId}
         onSave={saveHabit}
         onCancel={cancelEdit}
+        focusTick={habitFormFocusTick}
+        onFocusHandled={onHabitFormFocusHandled}
       />
 
       <TagsSection

--- a/src/modules/routine/components/RoutineSettingsSection.jsx
+++ b/src/modules/routine/components/RoutineSettingsSection.jsx
@@ -35,7 +35,6 @@ export function RoutineSettingsSection({
   setCatDraft,
   onOpenCalendar,
   habitFormFocusTick,
-  onHabitFormFocusHandled,
   hidden: panelHidden,
 }) {
   const toast = useToast();
@@ -109,7 +108,6 @@ export function RoutineSettingsSection({
         onSave={saveHabit}
         onCancel={cancelEdit}
         focusTick={habitFormFocusTick}
-        onFocusHandled={onHabitFormFocusHandled}
       />
 
       <TagsSection

--- a/src/modules/routine/components/settings/HabitForm.jsx
+++ b/src/modules/routine/components/settings/HabitForm.jsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -16,13 +16,46 @@ export function HabitForm({
   editingId,
   onSave,
   onCancel,
+  // One-shot trigger set by the `add_habit` PWA action and the FTUX
+  // first-action sheet. When it flips truthy we scroll the form into
+  // view and focus the name input, then the parent resets it. Using a
+  // monotonic tick rather than a bool keeps repeated triggers reliable
+  // (focus-again would otherwise be a no-op if bool stayed `true`).
+  focusTick,
+  onFocusHandled,
 }) {
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
   const endId = `${fieldIds}-end`;
+  const sectionRef = useRef(null);
+  const nameRef = useRef(null);
+
+  useEffect(() => {
+    if (!focusTick) return;
+    const section = sectionRef.current;
+    const name = nameRef.current;
+    if (section && typeof section.scrollIntoView === "function") {
+      section.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    if (name && typeof name.focus === "function") {
+      // Defer to the next frame so the scroll-into-view doesn't steal
+      // focus by re-rendering the parent tab panel.
+      requestAnimationFrame(() => {
+        try {
+          name.focus({ preventScroll: true });
+        } catch {
+          name.focus();
+        }
+      });
+    }
+    onFocusHandled?.();
+  }, [focusTick, onFocusHandled]);
 
   return (
-    <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3">
+    <section
+      ref={sectionRef}
+      className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3"
+    >
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         {editingId ? "Редагувати звичку" : "Нова звичка"}
       </h2>
@@ -40,6 +73,7 @@ export function HabitForm({
           aria-label="Емодзі"
         />
         <Input
+          ref={nameRef}
           className="routine-touch-field min-w-0 flex-1"
           placeholder="Назва"
           value={habitDraft.name}

--- a/src/modules/routine/components/settings/HabitForm.jsx
+++ b/src/modules/routine/components/settings/HabitForm.jsx
@@ -16,13 +16,12 @@ export function HabitForm({
   editingId,
   onSave,
   onCancel,
-  // One-shot trigger set by the `add_habit` PWA action and the FTUX
-  // first-action sheet. When it flips truthy we scroll the form into
-  // view and focus the name input, then the parent resets it. Using a
-  // monotonic tick rather than a bool keeps repeated triggers reliable
-  // (focus-again would otherwise be a no-op if bool stayed `true`).
+  // Monotonic tick bumped by the parent (`RoutineApp`) when the
+  // `add_habit` PWA action or the FTUX first-action sheet wants us to
+  // scroll into view and focus the name input. A tick — not a bool —
+  // so repeated triggers keep re-firing without the parent having to
+  // reset anything.
   focusTick,
-  onFocusHandled,
 }) {
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
@@ -48,8 +47,7 @@ export function HabitForm({
         }
       });
     }
-    onFocusHandled?.();
-  }, [focusTick, onFocusHandled]);
+  }, [focusTick]);
 
   return (
     <section

--- a/src/shared/lib/hubNav.ts
+++ b/src/shared/lib/hubNav.ts
@@ -13,7 +13,11 @@
 export const HUB_OPEN_MODULE_EVENT = "hub:open-module";
 
 export type HubModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
-export type HubModuleAction = "add_expense" | "start_workout" | "add_meal";
+export type HubModuleAction =
+  | "add_expense"
+  | "start_workout"
+  | "add_meal"
+  | "add_habit";
 
 export interface HubOpenModuleDetail {
   module: HubModuleId;
@@ -48,6 +52,7 @@ const VALID_HUB_ACTIONS = new Set<HubModuleAction>([
   "add_expense",
   "start_workout",
   "add_meal",
+  "add_habit",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

PR 2/4 of the FTUX polish batch after #165/#166. Tightens the 30-second budget for the Routine module's first-action path.

**Problem.** Routine was the only module whose FirstActionSheet card just opened the module home via `openHubModule("routine")`, not a dedicated PWA action. A fresh user then still had to find the Settings tab and tap through to the habit form before their "first real entry" was possible. For Finyk / Fizruk / Nutrition the tap lands on an input; for Routine it landed on a calendar.

**Fix.** New `add_habit` action threaded all the way through to an auto-focused habit form:

- <ref_snippet file="/home/ubuntu/Sergeant/src/core/hooks/usePwaActions.ts" lines="4-15" /> and <ref_snippet file="/home/ubuntu/Sergeant/src/shared/lib/hubNav.ts" lines="16-20" /> accept the new action; the HUB_OPEN_MODULE_EVENT listener in `App.jsx` already routes it to the active module.
- `RoutineApp` consumes `pwaAction`: switches to the Settings tab (where the habit form lives) and bumps a monotonic `habitFormFocusTick`. A tick — not a bool — so the focus still fires if the user taps "add habit" twice in a row. <ref_snippet file="/home/ubuntu/Sergeant/src/modules/routine/RoutineApp.jsx" lines="177-190" />
- `HabitForm` scrolls itself into view and focuses the name input on tick changes, deferred to `requestAnimationFrame` so scroll-into-view doesn't steal the focus off the input. <ref_snippet file="/home/ubuntu/Sergeant/src/modules/routine/components/settings/HabitForm.jsx" lines="12-52" />
- `FirstActionSheet` swaps the routine card to `openHubModuleWithAction("routine", "add_habit")`. The card copy changes from "Відмітити звичку" to "Створити звичку" — we aren't ticking an existing habit, we're creating one. <ref_snippet file="/home/ubuntu/Sergeant/src/core/onboarding/FirstActionSheet.jsx" lines="35-41" />

## Review & Testing Checklist for Human

- [ ] **Fresh profile → FTUX picks Routine → first-action sheet → tap "Створити звичку".** Module should open directly on the Settings tab with the habit form scrolled into view and the caret in the Name field.
- [ ] **Existing user, already in Routine on another tab, triggers the flow twice.** The form should re-focus the second time too — the tick bumps rather than going idempotent.
- [ ] **No regression on other modules' PWA actions.** `add_expense`, `start_workout`, `add_meal` all still route correctly (they weren't touched but the shared action union is).

### Notes

- `Input` already forwards refs (`forwardRef<HTMLInputElement, …>`), so attaching `nameRef` is a drop-in.
- No change to the PWA manifest — the `add_habit` action is only used via the in-app hub nav channel today. Adding a shortcut manifest entry can be a follow-up if wanted.
- `npm run lint`, `npm run typecheck`, `npm run build` all pass locally.
- Pre-existing `server/aiQuota.test.js` / `server/httpCommon.test.js` failures (missing `pino`) are unrelated, same as on `main`.

Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
