### PR TITLE
feat(auth): move AuthPage to /sign-in so the splash is the true cold-start

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -1,5 +1,5 @@
-import { useEffect, lazy, Suspense, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, lazy, Suspense } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { cn } from "@shared/lib/cn";
 import ModuleErrorBoundary from "./ModuleErrorBoundary";
 import { useDarkMode } from "@shared/hooks/useDarkMode";
@@ -44,9 +44,39 @@ export default function App() {
   );
 }
 
+// Auth lives at `/sign-in` rather than as an in-page overlay. This keeps
+// the FTUX splash (`/`) as the true cold-start surface — the old
+// `showAuth` boolean meant that a first-time visitor who tapped
+// "Вже маю акаунт" bounced into the auth form with no URL change, so
+// the back button, deep links, and shared URLs all misbehaved. Having
+// a named route also lets us link straight to sign-in from emails,
+// push-notification landing pages, etc.
+const SIGN_IN_PATH = "/sign-in";
+
+// Tiny effect-only component so the redirect is a declarative render,
+// not a `navigate()` call in the middle of AppInner — keeps the render
+// phase free of side effects and avoids the React warning.
+function RedirectHome() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate("/", { replace: true });
+  }, [navigate]);
+  return <PageLoader />;
+}
+
 function AppInner() {
-  const [showAuth, setShowAuth] = useState(false);
   const [searchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const onSignInRoute = location.pathname === SIGN_IN_PATH;
+
+  const openAuth = useCallback(() => {
+    navigate(SIGN_IN_PATH);
+  }, [navigate]);
+
+  const leaveAuth = useCallback(() => {
+    navigate("/");
+  }, [navigate]);
 
   const { activeModule, openModule, goToHub, moduleAnimClass } =
     useHubNavigation();
@@ -100,11 +130,21 @@ function AppInner() {
     );
   }
 
-  if (showAuth && !user) {
+  // `/sign-in` is a URL-addressable auth entry. Already-authenticated
+  // users landing here (e.g. from a stale link or from tapping "Вже маю
+  // акаунт" after logging in on another tab) get redirected straight
+  // back to `/` — no need to re-prompt for credentials they already
+  // have. We defer the redirect until `authLoading` settles, otherwise
+  // a freshly-mounted session would briefly bounce the user away from
+  // the form before `user` hydrates.
+  if (onSignInRoute) {
+    if (!authLoading && user) {
+      return <RedirectHome />;
+    }
     return (
       <Suspense fallback={<PageLoader />}>
         <div className="page-enter">
-          <AuthPage onContinueWithoutAccount={() => setShowAuth(false)} />
+          <AuthPage onContinueWithoutAccount={leaveAuth} />
         </div>
       </Suspense>
     );
@@ -125,7 +165,7 @@ function AppInner() {
           onPull={sync.pullAll}
           onLogout={logout}
           authLoading={authLoading}
-          onShowAuth={() => setShowAuth(true)}
+          onShowAuth={openAuth}
           dark={dark}
           onToggleDark={toggleDark}
         />
@@ -151,7 +191,7 @@ function AppInner() {
           onSync={sync.pushAll}
           onPull={sync.pullAll}
           user={user}
-          onShowAuth={() => setShowAuth(true)}
+          onShowAuth={openAuth}
         />
 
         <HubFloatingActions onOpenChat={() => ui.openChat()} />


### PR DESCRIPTION
## Summary

PR 3/4 of the FTUX polish batch after #161. Makes sign-in URL-addressable instead of an anonymous in-page overlay.

**Problem.** `AuthPage` used to live behind a local `showAuth` boolean in `AppInner`. Tapping "Вже маю акаунт" from the splash swapped the render tree but did nothing to the URL. That broke three things at once:
- Back button: `splash → auth → back` left the splash entirely instead of returning to it.
- Deep links / bookmarks / push-notification landing pages couldn't target the sign-in form.
- The splash never saw a clean cold-start because auth + splash shared `/`.

**Fix.** Sign-in is now addressable at `/sign-in`:

- `onShowAuth` callers navigate to `/sign-in` instead of flipping local state. <ref_snippet file="/home/ubuntu/Sergeant/src/core/App.jsx" lines="73-79" />
- Authenticated users landing on `/sign-in` (stale link, post-logout bounce, second tab) get redirected to `/` via a render-phase-safe `<RedirectHome />`. The redirect waits for `authLoading` to settle so a hydrating session doesn't yank the form out from under a mid-submit user. <ref_snippet file="/home/ubuntu/Sergeant/src/core/App.jsx" lines="133-151" />
- "Продовжити без акаунту" navigates back to `/` instead of toggling a hidden boolean.

No route config changes in `main.jsx` needed — we already render under a single `<BrowserRouter>` and the existing `?module=…` on `/` keeps working untouched.

## Review & Testing Checklist for Human

- [ ] **Splash → "Вже маю акаунт".** URL should change to `/sign-in`. Browser back button should return to the splash at `/`.
- [ ] **Direct visit to `/sign-in`.** Form renders for logged-out users; logged-in users bounce to `/` (loader briefly visible).
- [ ] **Deep-link after logout.** Log out, open `/sign-in` in a new tab — form renders, not the splash.
- [ ] **"Продовжити без акаунту"** from `/sign-in` lands on `/` (the splash or the hub, depending on onboarding state).

### Notes

- The `authLoading` guard is load-bearing — without it, a freshly-mounted tab on `/sign-in` would flash-redirect to `/` before the Better Auth session rehydrates.
- `npm run lint`, `npm run typecheck` pass. Pre-existing `server/*.test.js` failures on missing `pino` are unrelated to this PR (same state as on `main`).

Link to Devin session: https://app.devin.ai/sessions/98a885ebe4f240baa1cbd2544a92cf82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
