### PR TITLE
fix(ux): secondary findings — «Мілі» typo + module card label contrast

### DIFF
--- a/src/core/dashboard/ModuleCard.jsx
+++ b/src/core/dashboard/ModuleCard.jsx
@@ -68,7 +68,7 @@ export function ModuleCard({ config, onClick, dragProps, isDragging }) {
             {config.icon}
           </div>
           <div className="flex-1 min-w-0">
-            <span className="text-[11px] font-bold text-muted uppercase tracking-wider">
+            <span className="text-[11px] font-bold text-text uppercase tracking-wider">
               {config.label}
             </span>
           </div>

--- a/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
@@ -5,7 +5,7 @@ export function MealTypePicker({ mealType, setForm }) {
   return (
     <div className="mb-4">
       <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
-        Мілі
+        Прийом їжі
       </div>
       <div className="flex gap-2 flex-wrap">
         {MEAL_TYPES.map((mt) => (


### PR DESCRIPTION
## Summary

Дрібний follow-up до #163 з secondary findings з UX-аудиту.

| Фікс | Файл | Було | Стало |
|---|---|---|---|
| typo у заголовку вибору типу прийому їжі | `src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx` | `Мілі` | `Прийом їжі` |
| brand-label на module-card був `text-muted` — на empty-state (до появи даних) вся картка йшла одним сірим тоном, втрачалась ідентичність модуля | `src/core/dashboard/ModuleCard.jsx` | `text-[11px] font-bold text-muted uppercase` | `text-[11px] font-bold text-text uppercase` |

Решту secondary findings з аудиту перевірив — вони вже закриті в main:

- **FAB AI без aria-label** → `HubFloatingActions` вже має `aria-label="Відкрити AI-асистента"`.
- **legacy `#/payments` redirect** → `FinykApp.jsx:217-226` вже робить `history.replaceState` на `#budgets`.
- **header brand-text opacity** → `<h1>Sergeant</h1>` у `HubHeader` вже `text-text` (повна контрастність).
- **undiscoverable swipe між модулями** → свайп між модулями не реалізований; всередині Фініка свайп між вкладками існує як bonus-gesture, bottom-tab bar — основний UI.

## Review & Testing Checklist for Human

- [ ] Відкрити AddMealSheet → заголовок над чипами типу прийому їжі читається як «Прийом їжі», не «Мілі».
- [ ] На Hub Dashboard подивитися на пустий стан будь-якого модуля (або після `localStorage.clear()` перезавантажити): бренд-лейбл «Фінік / Фізрук / Рутина / Харчування» на картці тепер контрастний, не злипається з описом.

### Notes

Міні-PR — 2 рядки. lint + typecheck + 588 тестів + build проходять локально.

Link to Devin session: https://app.devin.ai/sessions/b1292bdb759747c9bc481ef0b1b6b33f
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
