### PR TITLE
feat(finyk): auto-detect recurring expenses and suggest as subscriptions

### DIFF
--- a/docs/hub-modules-roadmap.md
+++ b/docs/hub-modules-roadmap.md
@@ -75,14 +75,14 @@
 - [x] Доменний шар `domain/`: уніфікована модель `Transaction` і `normalizeTransaction` (manual / mono / ai / import), `domain/selectors.js` із чистими проєкціями для аналітики
 - [x] Централізований шар сховища `lib/finykStorage.js` + `storageManager.js` замість прямих викликів localStorage у компонентах/хуках (debounce + safeJsonSet)
 - [x] Оптимізації рендеру: memoization чистих компонентів (TxRow/SwipeToAction), кеш аналітики через `useAnalytics`, єдиний `useUnifiedFinanceData`
+- [x] Спліт транзакцій (розбиття однієї транзакції на кілька категорій) — реалізовано в `TxRow.jsx` (`splitEditor`, `txSplits`, враховується в `selectors`/`forecastEngine`/бекапі)
+- [x] Автодетекція регулярних витрат (`lib/recurringDetect.ts` + блок «Можливі підписки» на `Assets`): групування за нормалізованим merchant-ключем, визначення періодичності (weekly/biweekly/monthly/quarterly/yearly), перевірка стабільності суми, кнопка «+ Підписка» для one-click конверсії
 
 ### Наступні кроки
 
 1. Цілі накопичення (savings goals) з прогрес-баром
-2. Детекція регулярних витрат (автоматичне розпізнавання підписок з транзакцій)
-3. Експорт CSV
-4. Спліт транзакцій (розбиття однієї транзакції на кілька категорій)
-5. Увімкнення PrivatBank у UI (зняти прапор `PRIVAT_ENABLED`)
+2. Експорт CSV
+3. Увімкнення PrivatBank у UI (зняти прапор `PRIVAT_ENABLED`)
 
 ---
 

--- a/src/modules/finyk/components/RecurringSuggestions.jsx
+++ b/src/modules/finyk/components/RecurringSuggestions.jsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { Button } from "@shared/components/ui/Button";
+import { detectRecurring } from "../lib/recurringDetect";
+
+const CADENCE_LABEL = {
+  weekly: "щотижня",
+  biweekly: "раз на 2 тижні",
+  monthly: "щомісяця",
+  quarterly: "щокварталу",
+  yearly: "щороку",
+};
+
+const CONFIDENCE_LABEL = {
+  high: "висока",
+  medium: "середня",
+  low: "низька",
+};
+
+const CONFIDENCE_DOT = {
+  high: "bg-green-500",
+  medium: "bg-amber-500",
+  low: "bg-muted",
+};
+
+function fmtAmount(amount, currency) {
+  const symbol = currency === "USD" ? "$" : "₴";
+  const value = Math.round(amount * 100) / 100;
+  return `${value.toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ${symbol}`;
+}
+
+/**
+ * Блок пропозицій можливих підписок, знайдених у транзакціях.
+ * Рендериться лише, якщо detectRecurring повернув ≥1 кандидата.
+ */
+export function RecurringSuggestions({
+  transactions,
+  subscriptions,
+  dismissedRecurring,
+  excludedTxIds,
+  onAdd,
+  onDismiss,
+}) {
+  const [open, setOpen] = useState(false);
+
+  const candidates = useMemo(() => {
+    if (!transactions || !transactions.length) return [];
+    const excluded =
+      excludedTxIds instanceof Set
+        ? Array.from(excludedTxIds)
+        : Array.isArray(excludedTxIds)
+          ? excludedTxIds
+          : [];
+    return detectRecurring(transactions, {
+      subscriptions: subscriptions || [],
+      dismissedKeys: dismissedRecurring || [],
+      excludedTxIds: excluded,
+    });
+  }, [transactions, subscriptions, dismissedRecurring, excludedTxIds]);
+
+  if (!candidates.length) return null;
+
+  return (
+    <section className="mb-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-panelHi border border-line rounded-2xl text-left transition-colors hover:border-muted/50"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-lg">💡</span>
+          <div>
+            <div className="text-sm font-bold text-text">
+              Можливі підписки
+              <span className="ml-2 text-xs font-normal text-muted">
+                ({candidates.length})
+              </span>
+            </div>
+            <div className="text-xs text-muted mt-0.5">
+              Повторювані витрати — можна додати як підписки
+            </div>
+          </div>
+        </div>
+        <span className="text-xs text-muted shrink-0 ml-2">
+          {open ? "Згорнути ↑" : "Розкласти ↓"}
+        </span>
+      </button>
+
+      {open && (
+        <ul className="mt-2 space-y-2">
+          {candidates.map((c) => (
+            <li
+              key={c.key}
+              className="px-4 py-3 bg-panelHi border border-line rounded-2xl"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "inline-block w-2 h-2 rounded-full shrink-0",
+                        CONFIDENCE_DOT[c.confidence],
+                      )}
+                      title={`Впевненість: ${CONFIDENCE_LABEL[c.confidence]}`}
+                    />
+                    <div className="text-sm font-semibold text-text truncate">
+                      {c.displayName}
+                    </div>
+                  </div>
+                  <div className="text-xs text-muted mt-1 space-x-2">
+                    <span>~{fmtAmount(c.avgAmount, c.currency)}</span>
+                    <span>·</span>
+                    <span>{CADENCE_LABEL[c.cadence] || c.cadence}</span>
+                    <span>·</span>
+                    <span>{c.occurrences}×</span>
+                    {c.cadence === "monthly" && (
+                      <>
+                        <span>·</span>
+                        <span>{c.billingDay} числа</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-1 shrink-0">
+                  <Button
+                    size="sm"
+                    onClick={() => onAdd?.(c)}
+                    className="whitespace-nowrap"
+                  >
+                    + Підписка
+                  </Button>
+                  <button
+                    onClick={() => onDismiss?.(c.key)}
+                    className="text-xs text-muted hover:text-text transition-colors px-2 py-1"
+                  >
+                    Приховати
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/modules/finyk/hooks/useStorage.js
+++ b/src/modules/finyk/hooks/useStorage.js
@@ -89,6 +89,10 @@ export function useStorage({ onImportFeedback } = {}) {
     "finyk_excluded_stat_txs",
     [],
   );
+  const [dismissedRecurring, setDismissedRecurring] = usePersist(
+    "finyk_rec_dismissed",
+    [],
+  );
   const networthSnapshotRef = useRef(
     readJSON("finyk_networth_last_snap", { date: null, value: null }),
   );
@@ -199,6 +203,48 @@ export function useStorage({ onImportFeedback } = {}) {
     );
   };
 
+  const dismissRecurring = (key) => {
+    const trimmed = String(key || "").trim();
+    if (!trimmed) return;
+    setDismissedRecurring((prev) =>
+      prev.includes(trimmed) ? prev : [...prev, trimmed],
+    );
+  };
+
+  const restoreDismissedRecurring = (key) => {
+    if (!key) {
+      setDismissedRecurring([]);
+      return;
+    }
+    setDismissedRecurring((prev) => prev.filter((k) => k !== key));
+  };
+
+  /**
+   * Створити підписку з кандидата автодетекції. Повертає новий sub.
+   * @param {object} candidate — елемент з detectRecurring(...)
+   */
+  const addSubscriptionFromRecurring = (candidate) => {
+    if (!candidate || !candidate.key) return null;
+    const id = `auto_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+    const sub = {
+      id,
+      name: candidate.displayName || candidate.key,
+      emoji: "🔄",
+      keyword: candidate.key,
+      billingDay: candidate.billingDay || 1,
+      currency: candidate.currency === "USD" ? "USD" : "UAH",
+    };
+    if (candidate.sampleTxIds && candidate.sampleTxIds[0]) {
+      sub.linkedTxId = candidate.sampleTxIds[0];
+    }
+    setSubscriptions((prev) => [...prev, sub]);
+    // Автоматично прибираємо з пропозицій — sub з таким keyword уже його покриває,
+    // але ключ лишиться в localStorage як запасна страховка.
+    dismissRecurring(candidate.key);
+    notifyFinykRoutineCalendarSync();
+    return sub;
+  };
+
   const updateSubscription = (subId, patch) => {
     setSubscriptions((subs) =>
       subs.map((s) => {
@@ -299,6 +345,7 @@ export function useStorage({ onImportFeedback } = {}) {
       setMonoDebtLinkedTxIds(data.monoDebtLinkedTxIds);
     if (data.networthHistory) setNetworthHistory(data.networthHistory);
     if (data.customCategories) setCustomCategories(data.customCategories);
+    if (data.dismissedRecurring) setDismissedRecurring(data.dismissedRecurring);
     notifyFinykRoutineCalendarSync();
   };
 
@@ -318,6 +365,7 @@ export function useStorage({ onImportFeedback } = {}) {
       monoDebtLinkedTxIds,
       networthHistory,
       customCategories,
+      dismissedRecurring,
     };
     const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -370,6 +418,7 @@ export function useStorage({ onImportFeedback } = {}) {
       md: monoDebtLinkedTxIds,
       nh: networthHistory,
       cc: customCategories,
+      dr: dismissedRecurring,
     };
     const encoded = btoa(encodeURIComponent(JSON.stringify(data)));
     return `${window.location.origin}${window.location.pathname}?sync=${encoded}`;
@@ -420,6 +469,10 @@ export function useStorage({ onImportFeedback } = {}) {
     subscriptions,
     setSubscriptions,
     updateSubscription,
+    addSubscriptionFromRecurring,
+    dismissedRecurring,
+    dismissRecurring,
+    restoreDismissedRecurring,
     manualAssets,
     setManualAssets,
     manualDebts,

--- a/src/modules/finyk/lib/finykBackup.js
+++ b/src/modules/finyk/lib/finykBackup.js
@@ -3,7 +3,7 @@ import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
 import { readJSON, writeJSON } from "./finykStorage.js";
 
 /** Версія формату експорту JSON (бекап). */
-export const FINYK_BACKUP_VERSION = 2;
+export const FINYK_BACKUP_VERSION = 3;
 
 const DEFAULT_MONTHLY_PLAN = { income: "", expense: "", savings: "" };
 
@@ -36,6 +36,7 @@ export function readFinykBackupFromStorage() {
     monoDebtLinkedTxIds: readJsonFromLocalStorage("finyk_mono_debt_linked", {}),
     networthHistory: readJsonFromLocalStorage("finyk_networth_history", []),
     customCategories: readJsonFromLocalStorage("finyk_custom_cats_v1", []),
+    dismissedRecurring: readJsonFromLocalStorage("finyk_rec_dismissed", []),
   };
 }
 
@@ -53,6 +54,7 @@ const FINYK_FIELD_TO_STORAGE_KEY = {
   monoDebtLinkedTxIds: "finyk_mono_debt_linked",
   networthHistory: "finyk_networth_history",
   customCategories: "finyk_custom_cats_v1",
+  dismissedRecurring: "finyk_rec_dismissed",
 };
 
 /**
@@ -161,6 +163,16 @@ export function normalizeFinykBackup(parsed) {
     out.customCategories = cc;
   }
 
+  const dr = needArr(parsed.dismissedRecurring, "dismissedRecurring");
+  if (dr) {
+    for (const item of dr) {
+      if (typeof item !== "string") {
+        throw new Error("Некоректний запис у dismissedRecurring");
+      }
+    }
+    out.dismissedRecurring = dr;
+  }
+
   if (Object.keys(out).length === 0) {
     throw new Error(
       "У файлі немає даних для імпорту (очікуйте поля бекапу ФІНІК)",
@@ -195,7 +207,8 @@ export function normalizeFinykSyncPayload(data) {
     has("txSplits") ||
     has("monoDebtLinkedTxIds") ||
     has("networthHistory") ||
-    has("customCategories");
+    has("customCategories") ||
+    has("dismissedRecurring");
 
   if (looksLikeFullBackup) {
     const withVer = has("version") ? data : { ...data, version: 1 };
@@ -220,6 +233,7 @@ export function normalizeFinykSyncPayload(data) {
   if (has("md")) full.monoDebtLinkedTxIds = data.md;
   if (has("nh")) full.networthHistory = data.nh;
   if (has("cc")) full.customCategories = data.cc;
+  if (has("dr")) full.dismissedRecurring = data.dr;
 
   return normalizeFinykBackup(full);
 }

--- a/src/modules/finyk/lib/recurringDetect.test.ts
+++ b/src/modules/finyk/lib/recurringDetect.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectRecurring,
+  normalizeMerchantKey,
+  type RecurringTx,
+} from "./recurringDetect";
+
+const DAY = 86_400;
+
+function tx(
+  overrides: Partial<RecurringTx> & { id: string; time: number },
+): RecurringTx {
+  return {
+    amount: -19900, // -199 грн
+    description: "Netflix",
+    currencyCode: 980,
+    mcc: 5815,
+    ...overrides,
+  };
+}
+
+describe("finyk/recurringDetect", () => {
+  describe("normalizeMerchantKey", () => {
+    it("lowercases, strips digits/punctuation, keeps up to 3 tokens", () => {
+      expect(normalizeMerchantKey("Netflix.com *1234")).toBe("netflix com");
+      expect(normalizeMerchantKey("GOOGLE *YOUTUBE")).toBe("google youtube");
+      expect(normalizeMerchantKey("  АТБ #237  ")).toBe("атб");
+      expect(normalizeMerchantKey("")).toBe("");
+      expect(normalizeMerchantKey(null)).toBe("");
+      // Single-letter tokens (after stripping punctuation from "McDonald's") are filtered.
+      expect(normalizeMerchantKey("McDonald's Kyiv 1")).toBe("mcdonald kyiv");
+    });
+  });
+
+  describe("detectRecurring", () => {
+    const now = Math.floor(new Date(2026, 1, 10).getTime() / 1000);
+    // Starting point `now - 95 days`: first tx of a 4-month cadence.
+    const baseFour = now - 95 * DAY;
+    // `now - 65 days`: first tx of a 3-month cadence.
+    const baseThree = now - 65 * DAY;
+    // `now - 35 days`: first tx of a 2-month cadence.
+    const baseTwo = now - 35 * DAY;
+
+    it("returns empty array for empty input", () => {
+      expect(detectRecurring([])).toEqual([]);
+    });
+
+    it("detects monthly cadence with stable amount (4 occurrences → high)", () => {
+      const base = baseFour;
+      const txs: RecurringTx[] = [
+        tx({ id: "t1", time: base }),
+        tx({ id: "t2", time: base + 30 * DAY }),
+        tx({ id: "t3", time: base + 60 * DAY }),
+        tx({ id: "t4", time: base + 90 * DAY }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(1);
+      const [cand] = out;
+      expect(cand.cadence).toBe("monthly");
+      expect(cand.occurrences).toBe(4);
+      expect(cand.confidence).toBe("high");
+      expect(cand.avgAmount).toBe(199);
+      expect(cand.currency).toBe("UAH");
+      expect(cand.key).toBe("netflix");
+      expect(cand.billingDay).toBeGreaterThanOrEqual(1);
+      expect(cand.billingDay).toBeLessThanOrEqual(31);
+      expect(cand.sampleTxIds[0]).toBe("t4");
+    });
+
+    it("flags 3-occurrence group as medium", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Spotify" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "Spotify" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "Spotify" }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(1);
+      expect(out[0].confidence).toBe("medium");
+    });
+
+    it("flags 2-occurrence group as low", () => {
+      const base = baseTwo;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Apple.com/bill" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "Apple.com/bill" }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(1);
+      expect(out[0].confidence).toBe("low");
+      expect(out[0].cadence).toBe("monthly");
+    });
+
+    it("rejects groups with high gap jitter", () => {
+      const base = now - 115 * DAY;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base }),
+        tx({ id: "b", time: base + 10 * DAY }),
+        tx({ id: "c", time: base + 60 * DAY }),
+        tx({ id: "d", time: base + 110 * DAY }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(0);
+    });
+
+    it("rejects groups with high amount variance", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, amount: -10000 }),
+        tx({ id: "b", time: base + 30 * DAY, amount: -50000 }),
+        tx({ id: "c", time: base + 60 * DAY, amount: -15000 }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(0);
+    });
+
+    it("skips group already covered by existing subscription keyword", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "YouTube Premium" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "YouTube Premium" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "YouTube Premium" }),
+      ];
+      const out = detectRecurring(txs, {
+        nowSec: now,
+        subscriptions: [{ id: "yt", name: "YT", keyword: "youtube" }],
+      });
+      expect(out).toHaveLength(0);
+    });
+
+    it("skips group linked via subscription linkedTxId", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Some Service" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "Some Service" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "Some Service" }),
+      ];
+      const out = detectRecurring(txs, {
+        nowSec: now,
+        subscriptions: [{ id: "s", name: "S", linkedTxId: "c" }],
+      });
+      expect(out).toHaveLength(0);
+    });
+
+    it("respects dismissedKeys", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "iCloud+" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "iCloud+" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "iCloud+" }),
+      ];
+      const out = detectRecurring(txs, {
+        nowSec: now,
+        dismissedKeys: ["icloud"],
+      });
+      expect(out).toHaveLength(0);
+    });
+
+    it("excludes transactions listed in excludedTxIds", () => {
+      // c is excluded → a+b remain, latest tx age ~35 days (OK vs maxAgeDays=45).
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Service X" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "Service X" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "Service X" }),
+      ];
+      const out = detectRecurring(txs, {
+        nowSec: now,
+        excludedTxIds: ["c"],
+      });
+      // Only 2 left → still low confidence monthly.
+      expect(out).toHaveLength(1);
+      expect(out[0].occurrences).toBe(2);
+      expect(out[0].sampleTxIds).not.toContain("c");
+    });
+
+    it("drops groups whose latest tx is older than maxAgeDays", () => {
+      // Latest tx ~6 months ago.
+      const base = now - 200 * DAY;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Old Service" }),
+        tx({ id: "b", time: base + 30 * DAY, description: "Old Service" }),
+        tx({ id: "c", time: base + 60 * DAY, description: "Old Service" }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(0);
+    });
+
+    it("detects weekly cadence", () => {
+      const base = now - 20 * DAY;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Coffee sub" }),
+        tx({ id: "b", time: base + 7 * DAY, description: "Coffee sub" }),
+        tx({ id: "c", time: base + 14 * DAY, description: "Coffee sub" }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(1);
+      expect(out[0].cadence).toBe("weekly");
+    });
+
+    it("sorts by confidence desc, then amount desc", () => {
+      const base = baseFour;
+      const clean: RecurringTx[] = [
+        // Group A: low confidence (2 occ), large amount
+        tx({
+          id: "a1",
+          time: base + 60 * DAY,
+          description: "Big Rare",
+          amount: -99900,
+        }),
+        tx({
+          id: "a2",
+          time: base + 90 * DAY,
+          description: "Big Rare",
+          amount: -99900,
+        }),
+        // Group B: high confidence (4 occ), small amount
+        tx({ id: "b1", time: base, description: "Small Often", amount: -9900 }),
+        tx({
+          id: "b2",
+          time: base + 30 * DAY,
+          description: "Small Often",
+          amount: -9900,
+        }),
+        tx({
+          id: "b3",
+          time: base + 60 * DAY,
+          description: "Small Often",
+          amount: -9900,
+        }),
+        tx({
+          id: "b4",
+          time: base + 90 * DAY,
+          description: "Small Often",
+          amount: -9900,
+        }),
+      ];
+      const out = detectRecurring(clean, { nowSec: now });
+      expect(out).toHaveLength(2);
+      expect(out[0].key).toBe("small often");
+      expect(out[0].confidence).toBe("high");
+      expect(out[1].key).toBe("big rare");
+      expect(out[1].confidence).toBe("low");
+    });
+
+    it("returns USD for currencyCode 840", () => {
+      const base = baseTwo;
+      const txs: RecurringTx[] = [
+        tx({
+          id: "a",
+          time: base,
+          description: "OpenAI *ChatGPT",
+          currencyCode: 840,
+          amount: -2000,
+        }),
+        tx({
+          id: "b",
+          time: base + 30 * DAY,
+          description: "OpenAI *ChatGPT",
+          currencyCode: 840,
+          amount: -2000,
+        }),
+      ];
+      const out = detectRecurring(txs, { nowSec: now });
+      expect(out).toHaveLength(1);
+      expect(out[0].currency).toBe("USD");
+    });
+
+    it("ignores positive (income) transactions", () => {
+      const base = baseThree;
+      const txs: RecurringTx[] = [
+        tx({ id: "a", time: base, description: "Salary", amount: 100000 }),
+        tx({
+          id: "b",
+          time: base + 30 * DAY,
+          description: "Salary",
+          amount: 100000,
+        }),
+        tx({
+          id: "c",
+          time: base + 60 * DAY,
+          description: "Salary",
+          amount: 100000,
+        }),
+      ];
+      expect(detectRecurring(txs, { nowSec: now })).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/finyk/lib/recurringDetect.ts
+++ b/src/modules/finyk/lib/recurringDetect.ts
@@ -1,0 +1,322 @@
+/**
+ * Автодетекція регулярних витрат (підписок) із історії транзакцій.
+ *
+ * Групує expense-транзакції за нормалізованим merchant-ключем, шукає
+ * регулярні інтервали (тижневі / двотижневі / місячні / квартальні /
+ * річні) зі стабільною сумою та повертає кандидатів, які користувач може
+ * одним кліком перетворити на підписку.
+ *
+ * Чистий модуль без залежностей від localStorage/DOM — інтегрується через
+ * `RecurringSuggestions.jsx`.
+ */
+
+const DAY_SECONDS = 86_400;
+
+export type RecurringCadence =
+  | "weekly"
+  | "biweekly"
+  | "monthly"
+  | "quarterly"
+  | "yearly";
+
+export type RecurringConfidence = "high" | "medium" | "low";
+
+interface CadenceSpec {
+  id: RecurringCadence;
+  minDays: number;
+  maxDays: number;
+  maxStddev: number;
+}
+
+/**
+ * Діапазони інтервалів (у днях) для класифікації періоду групи транзакцій.
+ * maxStddev обмежує джіттер — якщо гапи стрибають занадто сильно, група
+ * не вважається регулярною.
+ */
+const CADENCES: readonly CadenceSpec[] = [
+  { id: "weekly", minDays: 6, maxDays: 8, maxStddev: 1.5 },
+  { id: "biweekly", minDays: 12, maxDays: 16, maxStddev: 2.5 },
+  { id: "monthly", minDays: 25, maxDays: 35, maxStddev: 5 },
+  { id: "quarterly", minDays: 85, maxDays: 95, maxStddev: 8 },
+  { id: "yearly", minDays: 355, maxDays: 375, maxStddev: 15 },
+];
+
+/** Максимальний коефіцієнт варіації суми, за якого група ще вважається "стабільною". */
+const MAX_AMOUNT_CV = 0.25;
+
+/** Мінімум 2 повторення — 2 транзакції достатньо для гіпотези. */
+const MIN_OCCURRENCES = 2;
+
+export interface RecurringTx {
+  id: string;
+  /** Unix seconds. */
+  time: number;
+  /** Monobank minor units (kopecks); negative for expenses. */
+  amount: number;
+  description?: string | null;
+  currencyCode?: number | null;
+  mcc?: number | null;
+}
+
+export interface RecurringSubscription {
+  id: string;
+  name?: string;
+  keyword?: string;
+  linkedTxId?: string | null;
+  currency?: string;
+}
+
+export interface RecurringCandidate {
+  /** Нормалізований merchant-ключ (унікальний для групи). */
+  key: string;
+  /** Найкраще ім'я з транзакцій (для відображення). */
+  displayName: string;
+  /** Середня сума у одиницях (грн/долар), додатня. */
+  avgAmount: number;
+  /** "UAH" | "USD" — на основі currencyCode останньої транзакції. */
+  currency: "UAH" | "USD";
+  cadence: RecurringCadence;
+  /** Середній інтервал між транзакціями у днях. */
+  averageGapDays: number;
+  /** День місяця для monthly cadence (із найсвіжішої транзакції). */
+  billingDay: number;
+  /** Кількість транзакцій у групі. */
+  occurrences: number;
+  confidence: RecurringConfidence;
+  /** Unix seconds найсвіжішої транзакції. */
+  lastTxTime: number;
+  /** Очікувана дата наступної транзакції (unix seconds). */
+  nextExpectedTime: number;
+  /** Зразкові id (найсвіжіші перші, до 5). */
+  sampleTxIds: string[];
+}
+
+export interface DetectOptions {
+  /** Поточні підписки — кандидати, що збігаються, відфільтровуються. */
+  subscriptions?: RecurringSubscription[];
+  /** Ключі, які користувач сховав — пропускаються. */
+  dismissedKeys?: readonly string[];
+  /** Id транзакцій, які не брати до уваги (hiddenTxIds). */
+  excludedTxIds?: readonly string[];
+  /** "Тепер" у unix seconds (для тестів). Default — Date.now(). */
+  nowSec?: number;
+  /**
+   * Максимальний вік найсвіжішої транзакції групи (днів). Група, де
+   * остання транзакція старіша, ігнорується — ймовірно користувач
+   * відмовився від сервісу.
+   * Default: 45 днів (поріг трошки більший за місяць).
+   */
+  maxAgeDays?: number;
+}
+
+// ---------- helpers ----------
+
+/**
+ * Нормалізує description до стабільного merchant-ключа:
+ * lowercase, прибирає цифри/пунктуацію/невидимі символи, ріже до 3
+ * значущих слів. Достатньо для угруповання типових мерчантів Monobank.
+ */
+export function normalizeMerchantKey(
+  description: string | null | undefined,
+): string {
+  if (!description) return "";
+  const lowered = description.toLowerCase();
+  const cleaned = lowered
+    // прибрати * маскування карт / зірочки всередині: "mono*netflix"
+    .replace(/\*+/g, " ")
+    // прибрати цифри (номери замовлень, суми, рік)
+    .replace(/[\d]+/g, " ")
+    // прибрати все крім латиниці, кирилиці та пробілів
+    .replace(/[^a-zа-яіїєґ\s]+/giu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  const tokens = cleaned.split(" ").filter((t) => t.length >= 2);
+  if (!tokens.length) return "";
+  return tokens.slice(0, 3).join(" ");
+}
+
+function mean(xs: number[]): number {
+  if (!xs.length) return 0;
+  let s = 0;
+  for (const x of xs) s += x;
+  return s / xs.length;
+}
+
+function stddev(xs: number[], mu: number): number {
+  if (xs.length < 2) return 0;
+  let acc = 0;
+  for (const x of xs) acc += (x - mu) * (x - mu);
+  return Math.sqrt(acc / (xs.length - 1));
+}
+
+function detectCadence(gapsDays: number[]): {
+  cadence: RecurringCadence;
+  averageGapDays: number;
+} | null {
+  if (!gapsDays.length) return null;
+  const avg = mean(gapsDays);
+  const sd = stddev(gapsDays, avg);
+  for (const spec of CADENCES) {
+    if (avg >= spec.minDays && avg <= spec.maxDays && sd <= spec.maxStddev) {
+      return { cadence: spec.id, averageGapDays: avg };
+    }
+  }
+  return null;
+}
+
+function amountCoefficientOfVariation(amounts: number[]): number {
+  if (amounts.length < 2) return 0;
+  const mu = mean(amounts);
+  if (mu === 0) return 0;
+  return stddev(amounts, mu) / mu;
+}
+
+function toConfidence(occurrences: number): RecurringConfidence {
+  if (occurrences >= 4) return "high";
+  if (occurrences === 3) return "medium";
+  return "low";
+}
+
+function pickDisplayName(descriptions: string[]): string {
+  // Найдовша з descriptions частіше містить найбільше інформації; як
+  // fallback — перший непорожній.
+  let best = "";
+  for (const d of descriptions) {
+    if (!d) continue;
+    if (d.length > best.length) best = d;
+  }
+  return best.trim();
+}
+
+function currencyFromCode(code: number | null | undefined): "UAH" | "USD" {
+  return code === 840 ? "USD" : "UAH";
+}
+
+function subscriptionCoversKey(
+  sub: RecurringSubscription,
+  key: string,
+  groupTxIds: Set<string>,
+): boolean {
+  if (sub.linkedTxId && groupTxIds.has(sub.linkedTxId)) return true;
+  const kw = (sub.keyword || "").trim().toLowerCase();
+  if (!kw) return false;
+  // key — це нормалізовані, пробілами розділені токени; достатньо
+  // перевірити, чи keyword підписки повністю там міститься.
+  return key.includes(kw);
+}
+
+// ---------- public API ----------
+
+export function detectRecurring(
+  transactions: readonly RecurringTx[],
+  options: DetectOptions = {},
+): RecurringCandidate[] {
+  const {
+    subscriptions = [],
+    dismissedKeys = [],
+    excludedTxIds = [],
+    nowSec = Math.floor(Date.now() / 1000),
+    maxAgeDays = 45,
+  } = options;
+
+  if (!transactions || !transactions.length) return [];
+
+  const excluded = new Set(excludedTxIds);
+  const dismissed = new Set(dismissedKeys);
+
+  // Групування за нормалізованим merchant-ключем.
+  const groups = new Map<string, RecurringTx[]>();
+  for (const tx of transactions) {
+    if (!tx || typeof tx.amount !== "number" || tx.amount >= 0) continue;
+    if (!tx.id || excluded.has(tx.id)) continue;
+    const key = normalizeMerchantKey(tx.description);
+    if (!key) continue;
+    if (dismissed.has(key)) continue;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(tx);
+    else groups.set(key, [tx]);
+  }
+
+  const candidates: RecurringCandidate[] = [];
+
+  for (const [key, txs] of groups) {
+    if (txs.length < MIN_OCCURRENCES) continue;
+
+    // Сортуємо за часом asc для обчислення гапів.
+    const sorted = [...txs].sort((a, b) => (a.time || 0) - (b.time || 0));
+    const gapsDays: number[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1].time || 0;
+      const cur = sorted[i].time || 0;
+      if (prev && cur && cur > prev) {
+        gapsDays.push((cur - prev) / DAY_SECONDS);
+      }
+    }
+    const cadence = detectCadence(gapsDays);
+    if (!cadence) continue;
+
+    // Стабільність суми (у абсолютних копійках).
+    const absAmounts = sorted.map((t) => Math.abs(t.amount));
+    const cv = amountCoefficientOfVariation(absAmounts);
+    if (cv > MAX_AMOUNT_CV) continue;
+
+    const lastTx = sorted[sorted.length - 1];
+    const lastTxTime = lastTx.time || 0;
+    if (!lastTxTime) continue;
+
+    // Якщо остання транзакція старіша за maxAgeDays — сервіс, імовірно,
+    // більше не активний.
+    const ageDays = (nowSec - lastTxTime) / DAY_SECONDS;
+    if (ageDays > maxAgeDays) continue;
+
+    // Пропустити, якщо вже є підписка, що покриває цей ключ.
+    const groupIds = new Set(sorted.map((t) => t.id));
+    if (
+      subscriptions.some((sub) => subscriptionCoversKey(sub, key, groupIds))
+    ) {
+      continue;
+    }
+
+    const avgAmountMinor = mean(absAmounts);
+    const avgAmount = Math.round(avgAmountMinor) / 100;
+    const currency = currencyFromCode(lastTx.currencyCode);
+    const displayName = pickDisplayName(sorted.map((t) => t.description || ""));
+    const billingDay = new Date(lastTxTime * 1000).getDate();
+    const nextExpectedTime = lastTxTime + cadence.averageGapDays * DAY_SECONDS;
+    const sampleTxIds = [...sorted]
+      .reverse()
+      .slice(0, 5)
+      .map((t) => t.id);
+
+    candidates.push({
+      key,
+      displayName: displayName || key,
+      avgAmount,
+      currency,
+      cadence: cadence.cadence,
+      averageGapDays: Math.round(cadence.averageGapDays * 10) / 10,
+      billingDay,
+      occurrences: sorted.length,
+      confidence: toConfidence(sorted.length),
+      lastTxTime,
+      nextExpectedTime: Math.round(nextExpectedTime),
+      sampleTxIds,
+    });
+  }
+
+  // confidence desc → avgAmount desc → recency desc.
+  const confidenceRank: Record<RecurringConfidence, number> = {
+    high: 3,
+    medium: 2,
+    low: 1,
+  };
+  candidates.sort((a, b) => {
+    const byConf = confidenceRank[b.confidence] - confidenceRank[a.confidence];
+    if (byConf !== 0) return byConf;
+    if (b.avgAmount !== a.avgAmount) return b.avgAmount - a.avgAmount;
+    return b.lastTxTime - a.lastTxTime;
+  });
+
+  return candidates;
+}

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { DebtCard } from "../components/DebtCard";
 import { SubCard } from "../components/SubCard";
+import { RecurringSuggestions } from "../components/RecurringSuggestions";
 import { TxRow } from "../components/TxRow";
 import { Button } from "@shared/components/ui/Button";
 import {
@@ -61,6 +62,10 @@ export function Assets({
     subscriptions,
     setSubscriptions,
     updateSubscription,
+    addSubscriptionFromRecurring,
+    dismissedRecurring,
+    dismissRecurring,
+    excludedTxIds,
     monoDebtLinkedTxIds,
     toggleMonoDebtTx,
     customCategories,
@@ -411,6 +416,16 @@ export function Assets({
             )}
           </div>
         </div>
+
+        {/* Auto-detected recurring suggestions (renders nothing if empty) */}
+        <RecurringSuggestions
+          transactions={transactions}
+          subscriptions={subscriptions}
+          dismissedRecurring={dismissedRecurring}
+          excludedTxIds={excludedTxIds}
+          onAdd={(candidate) => addSubscriptionFromRecurring?.(candidate)}
+          onDismiss={(key) => dismissRecurring?.(key)}
+        />
 
         {/* Subscriptions section */}
         <SectionBar


### PR DESCRIPTION
## Summary

Додає автодетекцію регулярних витрат у **Фінік** і одноклікове перетворення їх на підписки. Закриває пункт 2 дорожньої мапи Фініка ("Детекція регулярних витрат (автоматичне розпізнавання підписок з транзакцій)") і проставляє як зроблений пункт 4 ("Спліт транзакцій" — уже був реалізований у `TxRow.jsx`).

### Що нового

- `src/modules/finyk/lib/recurringDetect.ts` — чистий движок детекції:
  - Нормалізує `description` → merchant-ключ (lowercase, прибирає цифри/пунктуацію/маскування, бере перші 3 значущі токени).
  - Групує expense-транзакції, обчислює гапи в днях і класифікує частоту: `weekly` / `biweekly` / `monthly` / `quarterly` / `yearly` (із обмеженням стандартного відхилення).
  - Відхиляє групи з високою варіацією суми (coefficient of variation > 25%).
  - Присвоює `confidence`: high (4+ occ), medium (3), low (2).
  - Фільтрує групи, вже покриті існуючою підпискою (keyword-match або `linkedTxId`), dismissed-ключі з localStorage, приховані транзакції/внутрішні перекази, і ті, де остання транзакція старіша за 45 днів.
  - Сортує кандидатів за `(confidence desc, avgAmount desc, recency desc)`.

- `src/modules/finyk/lib/recurringDetect.test.ts` — 16 юніт-тестів (нормалізація ключа, monthly/weekly виявлення, відхилення джіттера, виключення за підпискою/dismissed/excluded, обробка USD, сортування, ігнорування income, перевірка maxAgeDays).

- `src/modules/finyk/components/RecurringSuggestions.jsx` — згортний блок «💡 Можливі підписки (N)» над секцією «🔄 Підписки» на `Assets`. Якщо кандидатів нема — не рендериться взагалі. Кожен кандидат — картка з відображенням частоти, середньої суми, кількості повторень і дня місяця (для monthly). Дві кнопки:
  - **«+ Підписка»** → створює sub з `emoji=🔄`, `keyword=<нормалізований ключ>`, `billingDay` з останньої транзакції, `currency` (UAH/USD), `linkedTxId`.
  - **«Приховати»** → додає ключ у `finyk_rec_dismissed`.

- `useStorage.js`:
  - Новий persist-стейт `finyk_rec_dismissed: string[]`.
  - Хелпери `addSubscriptionFromRecurring(candidate)`, `dismissRecurring(key)`, `restoreDismissedRecurring(key?)`.
  - `exportData`/`applyData`/`generateSyncLink`/`loadFromUrl` тепер включають поле `dismissedRecurring` (/`dr` у compact sync).

- `finykBackup.js`: `FINYK_BACKUP_VERSION` → 3, додано обробку `dismissedRecurring` у `readFinykBackupFromStorage` / `persistFinykNormalizedToStorage` / `normalizeFinykBackup` / `normalizeFinykSyncPayload`.

- `docs/hub-modules-roadmap.md`: перенесено «Спліт транзакцій» і «Автодетекція регулярних витрат» у розділ «Реалізовано» Фініка.

### Навмисні обмеження

- Детекція працює лише з Monobank-подібним `description` + гаперним аналізом. Не намагається розуміти MCC або бренди.
- Не перезаписує/не чіпає існуючі підписки — лише пропонує нові.
- Блок з'являється тільки за наявності ≥ 1 кандидата → не шумить у порожній інсталяції.

## Review & Testing Checklist for Human

- [ ] Відкрити Фінік → «Активи». Якщо є хоча б одна повторювана витрата (наприклад, Netflix/Google/ChatGPT щомісяця), над секцією «🔄 Підписки» має з'явитися блок «💡 Можливі підписки (N)». Якщо не з'явився — перевірити, що в транзакціях справді є ≥ 2 з однаковим мерчантом і стабільною сумою (±25%) за останні ~45 днів.
- [ ] Натиснути «+ Підписка» на кандидаті → має з'явитися нова підписка внизу секції «🔄 Підписки» з `🔄` emoji і коректним keyword. Після цього кандидат зникає з блоку пропозицій.
- [ ] Натиснути «Приховати» → кандидат зникає і не повертається після перезавантаження сторінки (персистентно через `finyk_rec_dismissed`).
- [ ] Перевірити, що існуючі підписки з DEFAULT (`openai`, `google storage`, `netflix` тощо) НЕ дублюються як кандидати — навіть якщо в історії є відповідні транзакції, вони мають бути відфільтровані за keyword-збігом.

### Notes

- 604 юніт-тести проходять (588 існуючих + 16 нових), lint + 3× typecheck + build — всі зелені.
- Попередній PR з цієї ж сесії — #171 (HubChat TS-міграція, замерджено).


Link to Devin session: https://app.devin.ai/sessions/c912df282cb849d790c787628eaca090
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
