### PR TITLE
refactor(core/hub): focus dashboard on one primary action

### DIFF
--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -29,13 +29,12 @@ import {
   SortableContext,
   useSortable,
   arrayMove,
-  rectSortingStrategy,
+  verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
 const DASHBOARD_ORDER_KEY = STORAGE_KEYS.DASHBOARD_ORDER;
 const DEFAULT_ORDER = ["finyk", "fizruk", "routine", "nutrition"];
-const DRAG_HINT_KEY = "hub_drag_hint_seen_v1";
 
 function loadOrder() {
   const saved = safeReadLS(DASHBOARD_ORDER_KEY, null);
@@ -246,9 +245,12 @@ function DateHeader() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// MODULE CARD — calm surface with colored left accent
+// MODULE ROW — compact "Today at a glance" list item
+// One icon + label, one number, one thin progress bar. Neutral text; the
+// module's color shows only as a 1px leading accent, so four rows read as a
+// single list rather than four competing heroes.
 // ═══════════════════════════════════════════════════════════════════════════
-function ModuleCard({ config, onClick, dragProps, isDragging }) {
+function ModuleRow({ config, onClick, dragProps, isDragging }) {
   const preview = config.getPreview();
   const showProgress =
     config.hasGoal && preview.progress !== undefined && preview.progress > 0;
@@ -258,70 +260,65 @@ function ModuleCard({ config, onClick, dragProps, isDragging }) {
       type="button"
       onClick={onClick}
       className={cn(
-        "group relative w-full text-left overflow-hidden",
-        "p-4 rounded-2xl border border-line/60 bg-panel",
-        "shadow-card transition-shadow duration-200",
-        "hover:shadow-float",
-        "active:scale-[0.98]",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2",
+        "group relative w-full text-left",
+        "flex items-center gap-3 px-3 py-2.5",
+        "bg-panel hover:bg-panelHi transition-colors",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-inset",
         isDragging && "opacity-70 shadow-float z-50 cursor-grabbing",
       )}
       {...dragProps}
     >
-      {/* Left accent bar — the only color on the card */}
       <div
         className={cn(
-          "absolute left-0 top-3 bottom-3 w-1 rounded-r-full",
+          "absolute left-0 top-2 bottom-2 w-0.5 rounded-r-full",
           config.accentClass,
         )}
         aria-hidden
       />
 
-      <div className="pl-2">
-        <div className="flex items-center gap-2 mb-2.5">
+      <div
+        className={cn(
+          "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
+          config.iconClass,
+        )}
+      >
+        {config.icon}
+      </div>
+
+      <span className="text-xs font-semibold text-text truncate">
+        {config.label}
+      </span>
+
+      <div className="ml-auto flex items-center gap-2 min-w-0">
+        {showProgress && (
           <div
-            className={cn(
-              "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
-              config.iconClass,
-            )}
+            className="w-12 sm:w-16 h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden shrink-0"
+            aria-hidden
           >
-            {config.icon}
-          </div>
-          <span className="text-[11px] font-semibold text-muted uppercase tracking-wider truncate">
-            {config.label}
-          </span>
-        </div>
-
-        <div className="space-y-1">
-          {preview.main ? (
-            <>
-              <p className="text-xl font-bold text-text tabular-nums leading-tight">
-                {preview.main}
-              </p>
-              {preview.sub && (
-                <p className="text-xs text-muted leading-snug truncate">
-                  {preview.sub}
-                </p>
+            <div
+              className={cn(
+                "h-full rounded-full transition-all duration-700 ease-out",
+                config.accentClass,
               )}
-            </>
-          ) : (
-            <p className="text-sm text-muted leading-snug">
-              {preview.sub || config.description}
-            </p>
-          )}
-
-          {showProgress && (
-            <div className="mt-2.5 h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden">
-              <div
-                className={cn(
-                  "h-full rounded-full transition-all duration-700 ease-out",
-                  config.accentClass,
-                )}
-                style={{ width: `${Math.min(preview.progress, 100)}%` }}
-              />
-            </div>
-          )}
-        </div>
+              style={{ width: `${Math.min(preview.progress, 100)}%` }}
+            />
+          </div>
+        )}
+        {preview.main ? (
+          <span className="text-sm font-semibold text-text tabular-nums truncate">
+            {preview.main}
+          </span>
+        ) : (
+          <span className="text-xs text-muted truncate">
+            {preview.sub || config.description}
+          </span>
+        )}
+        <Icon
+          name="chevron-right"
+          size={14}
+          strokeWidth={2.5}
+          className="text-muted shrink-0"
+        />
       </div>
     </button>
   );
@@ -350,7 +347,7 @@ function SortableCard({ id, onOpenModule }) {
 
   return (
     <div ref={setNodeRef} style={style}>
-      <ModuleCard
+      <ModuleRow
         config={cfg}
         onClick={() => onOpenModule(id)}
         isDragging={isDragging}
@@ -383,9 +380,11 @@ function useMondayAutoDigest() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// WEEKLY DIGEST FOOTER — compact link when no fresh digest
+// WEEKLY DIGEST FOOTER — always-collapsed link on the dashboard. Renders a
+// small "fresh" dot when a live digest exists so users still notice it
+// without letting the full card hijack the primary block on Mondays.
 // ═══════════════════════════════════════════════════════════════════════════
-function WeeklyDigestFooter({ onExpand }) {
+function WeeklyDigestFooter({ onExpand, fresh }) {
   return (
     <button
       type="button"
@@ -396,7 +395,15 @@ function WeeklyDigestFooter({ onExpand }) {
         "hover:bg-panelHi transition-colors",
       )}
     >
-      <span>Тижневий звіт</span>
+      <span className="flex items-center gap-2">
+        Тижневий звіт
+        {fresh && (
+          <span
+            className="inline-block w-1.5 h-1.5 rounded-full bg-primary"
+            aria-label="Новий звіт"
+          />
+        )}
+      </span>
       <Icon name="chevron-right" size={14} strokeWidth={2.5} />
     </button>
   );
@@ -448,34 +455,25 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
         const newIndex = prev.indexOf(over.id);
         const next = arrayMove(prev, oldIndex, newIndex);
         saveOrder(next);
-        try {
-          localStorage.setItem(DRAG_HINT_KEY, "1");
-        } catch {}
         return next;
       });
     }
   }, []);
 
-  const [showDragHint, setShowDragHint] = useState(() => {
-    try {
-      return localStorage.getItem(DRAG_HINT_KEY) !== "1";
-    } catch {
-      return false;
-    }
-  });
-  useEffect(() => {
-    if (!showDragHint) return;
-    const t = setTimeout(() => setShowDragHint(false), 6000);
-    return () => clearTimeout(t);
-  }, [showDragHint]);
-
   const [digestExpanded, setDigestExpanded] = useState(false);
   const digestFresh = hasLiveWeeklyDigest();
-  const renderDigestCard = digestFresh || digestExpanded;
 
   return (
     <div className="space-y-4">
       <DateHeader />
+
+      {/* Today focus — the ONE primary action on the dashboard. Rendered
+          before any banner so it is always the first thing the user sees. */}
+      <TodayFocusCard
+        focus={focus}
+        onAction={onOpenModule}
+        onDismiss={dismiss}
+      />
 
       {showDemoBanner && (
         <DemoModeBanner
@@ -493,33 +491,19 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
         />
       )}
 
-      {/* Today focus — the ONE primary action on the dashboard */}
-      <TodayFocusCard
-        focus={focus}
-        onAction={onOpenModule}
-        onDismiss={dismiss}
-      />
-
-      {/* Module grid */}
+      {/* Today at a glance — compact module list (replaces the 2×2 grid) */}
       <section className="space-y-2">
-        <div className="flex items-center justify-between px-0.5 min-h-[18px]">
-          <h2 className="text-[11px] font-semibold text-muted uppercase tracking-wider">
-            Модулі
-          </h2>
-          {showDragHint && (
-            <span className="text-[10px] text-subtle">
-              Утримуй, щоб переставити
-            </span>
-          )}
-        </div>
+        <h2 className="px-0.5 text-[11px] font-semibold text-muted uppercase tracking-wider">
+          Сьогодні
+        </h2>
 
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
         >
-          <SortableContext items={order} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-2 gap-3">
+          <SortableContext items={order} strategy={verticalListSortingStrategy}>
+            <div className="rounded-2xl border border-line/60 bg-panel overflow-hidden divide-y divide-line/60">
               {order.map((id) => (
                 <SortableCard key={id} id={id} onOpenModule={onOpenModule} />
               ))}
@@ -536,11 +520,16 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
         onDismiss={dismiss}
       />
 
-      {/* Weekly digest — full card only when fresh/newly generated */}
-      {renderDigestCard ? (
+      {/* Weekly digest — always a footer link on the dashboard; expands
+          inline on demand. Prevents Monday auto-generation from hijacking
+          the primary block. */}
+      {digestExpanded ? (
         <WeeklyDigestCard />
       ) : (
-        <WeeklyDigestFooter onExpand={() => setDigestExpanded(true)} />
+        <WeeklyDigestFooter
+          fresh={digestFresh}
+          onExpand={() => setDigestExpanded(true)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Applies the low-risk subset of a UX review of `HubDashboard` to reduce cognitive load and make the "what should I do right now?" answer unambiguous.

Changes are all local to `src/core/HubDashboard.jsx`:

1. **`TodayFocusCard` is always first.** `DemoModeBanner` and `SoftAuthPromptCard` now render **below** the focus card, so the primary next-best-action can never be pushed below the fold by onboarding chrome.
2. **2×2 module grid → compact vertical list.** `ModuleCard` is replaced by a compact `ModuleRow` inside a single bordered container (`divide-y`). Each row = icon + label + one number + thin progress bar + chevron. Reads as a scannable status line instead of four competing heroes, and drops the perceived weight of four simultaneous accent colors. Drag-reorder is preserved; `SortableContext` strategy switched to `verticalListSortingStrategy`.
3. **Weekly Digest is always a footer on the dashboard.** Deleted the `digestFresh` → full-card branch that caused the weekly digest to hijack the primary block every Monday / after auto-generation. The footer now carries a small "fresh" dot (`bg-primary`) when a live digest exists, and still expands inline on click into `WeeklyDigestCard`.
4. **Dropped the inline "Утримуй, щоб переставити" drag hint** (plus its `showDragHint` state, 6s timeout, and `DRAG_HINT_KEY` localStorage write). Reorder is a power-user gesture; surfacing it on every cold open added noise for the 99% case.

No behavioral changes to the recommendation engine, coach insight, or weekly-digest generation logic. No props changed on `HubDashboard` itself.

Verification on my side:
- `npm run lint` — passes
- `npm run typecheck` — passes
- `npm test` — 588/588 passing
- Not UI-tested yet (happy to do an end-to-end test pass if you want — just say the word).

## Review & Testing Checklist for Human

- [ ] Mobile visual check: open the dashboard on a narrow viewport and confirm `TodayFocusCard` + the "Сьогодні" module list both fit above the fold on a typical phone.
- [ ] Drag-reorder still works on the new vertical list (long-press on touch, 8 px threshold on mouse). Reordering should persist across reload via `STORAGE_KEYS.DASHBOARD_ORDER`.
- [ ] Weekly digest: on Monday, the dashboard stays quiet — footer-only with a fresh dot, not the giant card. Clicking the footer expands `WeeklyDigestCard` inline.
- [ ] Progress bars render correctly for modules with `hasGoal: true` (routine, nutrition) at the new 48–64 px width, and are hidden when `progress` is 0 or goal data is missing.
- [ ] Onboarding flow: demo banner / soft-auth prompt still appear when their conditions are met, just *below* the focus card now.

### Notes

The full UX writeup this PR implements a subset of is in the originating session. Items deliberately **left for a follow-up** (so this PR stays small and reversible):

- Elevate `TodayFocusCard` visually with a module-tinted background wash (would require adding a `-soft`/10-20% opacity variant per module).
- Move drag-reorder out of the dashboard entirely and into Settings → "Упорядкувати модулі".
- Reward-style empty state for `TodayFocusCard` (streak / on-track number instead of the current neutral "нічого термінового").
- Audit/remove `src/core/dashboard/DailyProgressHero.jsx` + `src/core/dashboard/ModuleCard.jsx` if they are fully superseded.
- Auto-open `HubInsightsPanel` once per day when a coach insight is present.

Link to Devin session: https://app.devin.ai/sessions/1ebe05a4b3d14f92871734caf84a78a2
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
