### PR TITLE
ux: ship 10 quick-win friction fixes (onboarding, add flows, nav)

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -158,6 +158,7 @@ function AppInner() {
         <HubHeader
           hubView={ui.hubView}
           onOpenSearch={() => ui.setSearchOpen(true)}
+          onOpenChat={() => ui.openChat()}
           user={user}
           syncing={sync.syncing}
           lastSync={sync.lastSync}
@@ -194,7 +195,9 @@ function AppInner() {
           onShowAuth={openAuth}
         />
 
-        <HubFloatingActions onOpenChat={() => ui.openChat()} />
+        {/* Primary quick-add surface for the hub. AI chat moved to the
+            header — see `HubHeader` / `HubHeaderWithProps` (`onOpenChat`). */}
+        <HubFloatingActions />
 
         <HubModals
           chatOpen={ui.chatOpen}

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -9,11 +9,13 @@ import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
 import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
 import { DemoModeBanner } from "./onboarding/DemoModeBanner.jsx";
+import { FirstActionHeroCard } from "./onboarding/FirstActionSheet.jsx";
 import { detectFirstRealEntry } from "./onboarding/firstRealEntry.js";
 import {
   isSoftAuthDismissed,
   isDemoBannerDismissed,
   dismissDemoBanner,
+  isFirstActionPending,
 } from "./onboarding/vibePicks.js";
 import { wasDemoSeeded } from "./onboarding/demoSeeds.js";
 import { useFirstEntryCelebration } from "./onboarding/useFirstEntryCelebration.js";
@@ -409,6 +411,12 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   const [order, setOrder] = useState(loadOrder);
   useMondayAutoDigest();
 
+  // Inline FTUX hero — replaces the old post-wizard `FirstActionSheet`
+  // modal. Reads the localStorage flag once; dismiss clears the flag.
+  const [firstActionVisible, setFirstActionVisible] = useState(() =>
+    isFirstActionPending(),
+  );
+
   // Soft auth prompt appears only once the user has typed in real data and
   // has no account yet — an "offer to save", never a toll gate.
   const hasRealEntry = detectFirstRealEntry();
@@ -477,21 +485,25 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
     <div className="space-y-4">
       <DateHeader />
 
-      {showDemoBanner && (
+      {/* Banner budget: one system card at a time on the dashboard.
+          Priority: first-action hero (post-wizard FTUX) > demo banner >
+          soft-auth nudge. Prevents the cold-start where two or three
+          "meta" cards push real data below the fold. */}
+      {firstActionVisible ? (
+        <FirstActionHeroCard onDismiss={() => setFirstActionVisible(false)} />
+      ) : showDemoBanner ? (
         <DemoModeBanner
           onDismiss={() => {
             dismissDemoBanner();
             setDemoBannerDismissed(true);
           }}
         />
-      )}
-
-      {showSoftAuth && (
+      ) : showSoftAuth ? (
         <SoftAuthPromptCard
           onOpenAuth={onShowAuth}
           onDismiss={() => setSoftAuthDismissed(true)}
         />
-      )}
+      ) : null}
 
       {/* Today focus — the ONE primary action on the dashboard */}
       <TodayFocusCard

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -334,7 +334,11 @@ function VibePickerStep({ picks, togglePick, onNext, onBack }) {
 
 export function OnboardingWizard({ onDone }) {
   const [step, setStep] = useState(0);
-  const [picks, setPicks] = useState(() => [...ALL_MODULES]);
+  // Start empty so the vibe picker's question ("Що тобі зараз болить?") is an
+  // actual choice. Preselecting everything made the default answer
+  // "все", which defeated the narrowing and rendered the demo + first
+  // action flow generic.
+  const [picks, setPicks] = useState(() => []);
 
   const TOTAL = 2;
 
@@ -382,22 +386,24 @@ export function OnboardingWizard({ onDone }) {
       <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-5 animate-onboarding-enter">
         <div className="flex items-center justify-between">
           <StepDots total={TOTAL} current={step} />
-          <button
-            type="button"
-            onClick={() => {
-              // Skip is an escape hatch for returning users who already know
-              // the product. Name its cost honestly so casual skippers
-              // understand why the hub is empty.
-              trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
-                intent: "skipped",
-              });
-              markOnboardingDone();
-              onDone(null, { intent: "skipped" });
-            }}
-            className="text-xs text-muted hover:text-text transition-colors px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
-          >
-            Пропустити до пустого хабу
-          </button>
+          {step === 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                // Skip is an escape hatch for returning users who already
+                // know the product. Only show it on the splash step — on
+                // the vibe picker the primary CTA already gates progress.
+                trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+                  intent: "skipped",
+                });
+                markOnboardingDone();
+                onDone(null, { intent: "skipped" });
+              }}
+              className="text-xs text-muted hover:text-text transition-colors px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+            >
+              Пропустити
+            </button>
+          )}
         </div>
 
         {step === 0 && <SplashStep onNext={() => setStep(1)} />}

--- a/src/core/app/HubFloatingActions.jsx
+++ b/src/core/app/HubFloatingActions.jsx
@@ -1,23 +1,126 @@
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
 
 /**
- * Compact circular FAB for the AI assistant. Sits above the safe-area inset
- * on the bottom-right so it doesn't fight the content column for attention.
+ * Cross-module "+ Додати" speed dial. Tapping the primary FAB reveals 4
+ * contextual add actions — the shortest path from the hub to a real entry
+ * in any module. Replaces the previous AI-chat-only FAB; the AI assistant
+ * now lives in the header (see `HubHeader`).
  */
-export function HubFloatingActions({ onOpenChat }) {
+const ACTIONS = [
+  {
+    id: "expense",
+    icon: "credit-card",
+    label: "Витрата",
+    accent: "text-finyk bg-finyk-soft",
+    run: () => openHubModuleWithAction("finyk", "add_expense"),
+  },
+  {
+    id: "meal",
+    icon: "utensils",
+    label: "Прийом їжі",
+    accent: "text-nutrition bg-nutrition-soft",
+    run: () => openHubModuleWithAction("nutrition", "add_meal"),
+  },
+  {
+    id: "habit",
+    icon: "check",
+    label: "Звичка",
+    accent: "text-routine bg-routine-soft",
+    run: () => openHubModuleWithAction("routine", "add_habit"),
+  },
+  {
+    id: "workout",
+    icon: "dumbbell",
+    label: "Тренування",
+    accent: "text-fizruk bg-fizruk-soft",
+    run: () => openHubModuleWithAction("fizruk", "start_workout"),
+  },
+];
+
+export function HubFloatingActions() {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef(null);
+
+  // Click-outside + Escape close. Matches the ambient dismissal pattern
+  // used by the rest of the hub's popovers.
+  useEffect(() => {
+    if (!open) return;
+    const onDocDown = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("touchstart", onDocDown, { passive: true });
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("touchstart", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const runAction = (action) => {
+    setOpen(false);
+    action.run();
+  };
+
   return (
     <div
-      className="fixed right-5 z-40 pointer-events-none"
+      ref={rootRef}
+      className="fixed right-5 z-40 flex flex-col items-end gap-2 pointer-events-none"
       style={{ bottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))" }}
     >
+      {open && (
+        <div
+          role="menu"
+          aria-label="Швидке додавання"
+          className="pointer-events-auto flex flex-col items-end gap-2 animate-fade-in"
+        >
+          {ACTIONS.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              role="menuitem"
+              onClick={() => runAction(a)}
+              className="group flex items-center gap-3 pl-3 pr-2 h-11 rounded-full bg-panel border border-line shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+            >
+              <span className="text-sm font-medium text-text whitespace-nowrap">
+                {a.label}
+              </span>
+              <span
+                className={cn(
+                  "w-8 h-8 rounded-full flex items-center justify-center",
+                  a.accent,
+                )}
+                aria-hidden
+              >
+                <Icon name={a.icon} size={16} strokeWidth={2} />
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
       <button
         type="button"
-        onClick={onOpenChat}
-        aria-label="Відкрити AI-асистента"
-        title="Асистент"
-        className="pointer-events-auto w-14 h-14 flex items-center justify-center rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={open ? "Закрити меню додавання" : "Додати"}
+        title="Додати"
+        className={cn(
+          "pointer-events-auto w-14 h-14 flex items-center justify-center rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          open && "rotate-45",
+        )}
       >
-        <Icon name="sparkle" size={22} strokeWidth={2} />
+        <Icon name="plus" size={26} strokeWidth={2.5} />
       </button>
     </div>
   );

--- a/src/core/app/HubHeader.jsx
+++ b/src/core/app/HubHeader.jsx
@@ -8,6 +8,7 @@ const ICON_BUTTON_CLS =
 export function HubHeader({
   hubView,
   onOpenSearch,
+  onOpenChat,
   user,
   syncing,
   lastSync,
@@ -37,6 +38,17 @@ export function HubHeader({
         </p>
       </div>
       <div className="pt-1 flex items-center gap-1">
+        {onOpenChat && (
+          <button
+            type="button"
+            onClick={onOpenChat}
+            aria-label="Відкрити AI-асистента"
+            title="Асистент"
+            className={ICON_BUTTON_CLS}
+          >
+            <Icon name="sparkle" size={20} />
+          </button>
+        )}
         <button
           type="button"
           onClick={onOpenSearch}

--- a/src/core/app/HubMainContent.jsx
+++ b/src/core/app/HubMainContent.jsx
@@ -1,15 +1,9 @@
-import { useEffect, useState } from "react";
 import { Icon } from "@shared/components/ui/Icon";
 import { HubDashboard } from "../HubDashboard.jsx";
 import { HubReports } from "../HubReports.jsx";
 import { HubSettingsPage } from "../HubSettingsPage.jsx";
 import { OnboardingWizard } from "../OnboardingWizard.jsx";
-import { FirstActionSheet } from "../onboarding/FirstActionSheet.jsx";
 import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
-import {
-  isFirstActionPending,
-  clearFirstActionPending,
-} from "../onboarding/vibePicks.js";
 
 export function HubMainContent({
   updateAvailable,
@@ -32,20 +26,22 @@ export function HubMainContent({
   user,
   onShowAuth,
 }) {
-  // The first-action sheet is the third beat of the FTUX flow: wizard →
-  // demo-populated dashboard → quick-win sheet. It is controlled by a
-  // localStorage flag so a refresh mid-flow doesn't swallow it.
-  const [firstActionOpen, setFirstActionOpen] = useState(false);
-
-  useEffect(() => {
-    if (!onboarding && isFirstActionPending()) {
-      setFirstActionOpen(true);
-    }
-  }, [onboarding]);
+  // Post-wizard FTUX is now a non-blocking hero card rendered inline on
+  // the dashboard (see `FirstActionHeroCard`), not a third stacked modal.
+  // The wizard just flips the `first_action_pending` flag and lands the
+  // user on the populated hub.
+  //
+  // Banner budget: at most one chrome banner above the hub content.
+  // Priority: update > install (PWA) > iOS install. This prevents a cold
+  // start where update + install + iOS stack three banners before any
+  // real data is visible.
+  const showUpdate = !!updateAvailable;
+  const showInstall = !showUpdate && !!canInstall;
+  const showIos = !showUpdate && !showInstall && iosVisible;
 
   return (
     <>
-      {updateAvailable && (
+      {showUpdate && (
         <div className="px-5 max-w-lg mx-auto w-full mb-2">
           <div className="px-4 py-3 rounded-2xl bg-primary/10 border border-primary/20 flex items-center gap-3">
             <svg
@@ -76,7 +72,7 @@ export function HubMainContent({
         </div>
       )}
 
-      {canInstall && (
+      {showInstall && (
         <div className="px-5 max-w-lg mx-auto w-full mb-2">
           <div className="px-4 py-3 rounded-2xl bg-panel border border-line shadow-card flex items-center gap-3">
             <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
@@ -126,31 +122,17 @@ export function HubMainContent({
         <OnboardingWizard
           onDone={(startModuleId, opts = {}) => {
             setOnboarding(false);
-            if (opts.intent === "vibe_demo") {
-              // Wizard already seeded demo data and flipped the pending
-              // first-action flag. We land on the hub dashboard so the
-              // user sees a populated dashboard before the quick-win
-              // sheet appears.
-              setFirstActionOpen(true);
-            } else if (startModuleId) {
+            if (opts.intent !== "vibe_demo" && startModuleId) {
               // Legacy paths / external callers: if a module id is
-              // explicitly passed, open it immediately.
+              // explicitly passed, open it immediately. vibe_demo lands
+              // on the dashboard where the inline hero card picks up.
               onOpenModule(startModuleId);
             }
           }}
         />
       )}
 
-      {firstActionOpen && (
-        <FirstActionSheet
-          onClose={() => {
-            clearFirstActionPending();
-            setFirstActionOpen(false);
-          }}
-        />
-      )}
-
-      {iosVisible && <IOSInstallBanner onDismiss={onDismissIos} />}
+      {showIos && <IOSInstallBanner onDismiss={onDismissIos} />}
 
       <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
         {hubView === "dashboard" && (

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -6,7 +6,7 @@ import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
 
 /**
- * Per-module "one tap to your first real entry" cards. Each option routes
+ * Per-module "one tap to your first real entry" tiles. Each option routes
  * into its module with a PWA action (the same handler PWA shortcuts use),
  * so a single tap lands the user on an already-open input.
  */
@@ -41,7 +41,13 @@ const ACTIONS = {
   },
 };
 
-export function FirstActionSheet({ onClose }) {
+/**
+ * Inline FTUX hero card rendered on the Hub dashboard when a first action
+ * is pending. Replaces the old blocking `FirstActionSheet` modal so the
+ * user sees their populated hub plus the quick-win CTAs in the same view
+ * (no dialog to dismiss before touching their data).
+ */
+export function FirstActionHeroCard({ onDismiss }) {
   const picks = useMemo(() => {
     const raw = getVibePicks();
     return raw.length > 0 ? raw : Object.keys(ACTIONS);
@@ -55,103 +61,85 @@ export function FirstActionSheet({ onClose }) {
 
   const dismiss = () => {
     clearFirstActionPending();
-    onClose?.();
+    onDismiss?.();
   };
 
   const pick = (id) => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
       module: id,
     });
-    // Close the sheet first so the module opens without a stacked dialog.
     clearFirstActionPending();
-    onClose?.();
+    onDismiss?.();
     const action = ACTIONS[id];
     if (action) action.run();
   };
 
+  const visible = picks.filter((id) => ACTIONS[id]);
+  if (visible.length === 0) return null;
+
   return (
-    <div
-      className="fixed inset-0 z-[450] flex items-end sm:items-center justify-center p-4 pb-safe"
-      role="dialog"
-      aria-modal="true"
+    <section
+      className="relative bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3"
       aria-label="Перша дія"
     >
-      <button
-        type="button"
-        aria-label="Закрити"
-        onClick={dismiss}
-        className="absolute inset-0 bg-bg/70 backdrop-blur-sm"
-      />
-      <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-4 animate-onboarding-enter">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 className="text-xl font-bold text-text">
-              Одна дія — і хаб твій.
-            </h2>
-            <p className="text-sm text-muted mt-1 leading-snug">
-              Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
-            </p>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle">
+            Старт
           </div>
-          <button
-            type="button"
-            onClick={dismiss}
-            className="text-muted hover:text-text p-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
-            aria-label="Закрити"
-          >
-            <Icon name="close" size={18} />
-          </button>
-        </div>
-        <div className="space-y-2">
-          {picks
-            .filter((id) => ACTIONS[id])
-            .map((id) => {
-              const a = ACTIONS[id];
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => pick(id)}
-                  className={cn(
-                    "w-full text-left px-4 py-3 rounded-2xl border border-line bg-panelHi",
-                    "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
-                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
-                  )}
-                >
-                  <div className="flex items-center gap-3">
-                    <div
-                      className={cn(
-                        "w-10 h-10 shrink-0 rounded-2xl flex items-center justify-center",
-                        a.accent,
-                      )}
-                    >
-                      <Icon name={a.icon} size={20} />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-semibold text-text">
-                        {a.title}
-                      </div>
-                      <div className="text-xs text-muted mt-0.5 truncate">
-                        {a.desc}
-                      </div>
-                    </div>
-                    <Icon
-                      name="chevron-right"
-                      size={16}
-                      className="text-muted"
-                    />
-                  </div>
-                </button>
-              );
-            })}
+          <h2 className="text-base font-bold text-text mt-0.5">
+            Одна дія — і хаб твій
+          </h2>
+          <p className="text-xs text-muted mt-0.5 leading-snug">
+            Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
+          </p>
         </div>
         <button
           type="button"
           onClick={dismiss}
-          className="w-full text-sm text-muted hover:text-text px-3 py-2 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text p-1.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+          aria-label="Сховати"
         >
-          Пізніше — хочу спочатку подивитися
+          <Icon name="close" size={16} />
         </button>
       </div>
-    </div>
+      <div className="space-y-2">
+        {visible.map((id) => {
+          const a = ACTIONS[id];
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => pick(id)}
+              className={cn(
+                "w-full text-left px-3 py-2.5 rounded-xl border border-line bg-panelHi",
+                "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+              )}
+            >
+              <div className="flex items-center gap-3">
+                <div
+                  className={cn(
+                    "w-9 h-9 shrink-0 rounded-xl flex items-center justify-center",
+                    a.accent,
+                  )}
+                >
+                  <Icon name={a.icon} size={18} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-semibold text-text">
+                    {a.title}
+                  </div>
+                  <div className="text-xs text-muted mt-0.5 truncate">
+                    {a.desc}
+                  </div>
+                </div>
+                <Icon name="chevron-right" size={16} className="text-muted" />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -6,16 +6,80 @@ import { useVisualKeyboardInset } from "@shared/hooks/useVisualKeyboardInset";
 import { toLocalISODate } from "@shared/lib/date";
 import { CANONICAL_TO_MANUAL_LABEL } from "../domain/personalization";
 
+// Manual-expense categories. Labels map to the MCC canonical ids used
+// across the rest of Finyk (see `MANUAL_CATEGORY_ID_MAP`), so manual
+// entries and bank transactions share one taxonomy for analytics and
+// budgets. Emojis mirror the MCC labels for visual consistency.
 const CATEGORIES = [
-  "їжа",
-  "транспорт",
-  "розваги",
-  "здоров'я",
-  "одяг",
-  "комунальні",
-  "техніка",
-  "інше",
+  "🍴 їжа",
+  "🛍 продукти",
+  "🍔 кафе та ресторани",
+  "🚗 транспорт",
+  "🎮 розваги",
+  "💊 здоров'я",
+  "🛍️ покупки",
+  "🏠 комунальні",
+  "📱 техніка",
+  "🎵 підписки",
+  "📚 навчання",
+  "✈️ подорожі",
+  "🏷 інше",
 ];
+const DEFAULT_CATEGORY = "🏷 інше";
+
+// Legacy labels (pre-emoji). Old manual expenses stored category as e.g.
+// "їжа". When loaded for edit, we upgrade the string to its emoji
+// counterpart so the picker highlights it; saved value still round-trips
+// through `MANUAL_CATEGORY_ID_MAP` for personalization/analytics.
+const LEGACY_CATEGORY_UPGRADE = {
+  їжа: "🍴 їжа",
+  транспорт: "🚗 транспорт",
+  розваги: "🎮 розваги",
+  "здоров'я": "💊 здоров'я",
+  одяг: "🛍️ покупки",
+  комунальні: "🏠 комунальні",
+  техніка: "📱 техніка",
+  інше: "🏷 інше",
+};
+
+function upgradeCategory(raw) {
+  if (!raw) return DEFAULT_CATEGORY;
+  if (CATEGORIES.includes(raw)) return raw;
+  const up = LEGACY_CATEGORY_UPGRADE[raw];
+  return up || raw;
+}
+
+// Strips leading emoji + space so "🍴 їжа" → "їжа", used as a human-readable
+// fallback description when the user leaves the name empty. We accept any
+// run of non-letter / non-digit grapheme chunks so compound emoji (zwj
+// sequences, variation selectors) all get peeled off.
+function stripEmoji(label) {
+  const str = String(label || "");
+  let i = 0;
+  while (i < str.length && !/[\p{L}\p{N}]/u.test(str[i])) i++;
+  return str.slice(i).trim();
+}
+
+// Amount suggestion pills. Defaults give a first-run user sane round
+// values; once the user has spending history we merge in the top-3
+// distinct recent amounts (see `mergeAmountSuggestions`).
+const DEFAULT_AMOUNTS = [50, 100, 200, 500];
+
+function mergeAmountSuggestions(frequentMerchants) {
+  const fromMerchants = [];
+  for (const m of frequentMerchants || []) {
+    if (!m || typeof m.total !== "number" || !m.count) continue;
+    const avg = Math.round(m.total / m.count);
+    if (avg > 0 && !fromMerchants.includes(avg)) fromMerchants.push(avg);
+    if (fromMerchants.length >= 3) break;
+  }
+  const merged = [...fromMerchants];
+  for (const v of DEFAULT_AMOUNTS) {
+    if (!merged.includes(v)) merged.push(v);
+    if (merged.length >= 6) break;
+  }
+  return merged.slice(0, 6);
+}
 
 const formInp =
   "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
@@ -68,7 +132,7 @@ export function ManualExpenseSheet({
   const [form, setForm] = useState({
     description: "",
     amount: "",
-    category: "інше",
+    category: DEFAULT_CATEGORY,
     date: toLocalISODate(),
   });
   const [error, setError] = useState("");
@@ -83,22 +147,24 @@ export function ManualExpenseSheet({
           description: String(initialExpense.description || ""),
           amount:
             initialExpense.amount != null ? String(initialExpense.amount) : "",
-          category: initialExpense.category || "інше",
+          category: upgradeCategory(initialExpense.category),
           date: toLocalISODate(d),
         });
       } else {
-        // Для нової витрати беремо або явно вказану категорію (клік по картці
-        // "часте" з dashboard'у), або найчастішу категорію користувача, якщо
-        // вона є у списку кнопок; інакше — дефолтне "інше".
-        let startCategory = "інше";
-        if (initialCategory && CATEGORIES.includes(initialCategory)) {
-          startCategory = initialCategory;
+        // Пріоритет: явна initialCategory (клік з дашборду) > найчастіша
+        // категорія з статистики > дефолт ("інше"). Будь-яка legacy
+        // мітка ("їжа", "транспорт") оновлюється до emoji-версії.
+        let startCategory = DEFAULT_CATEGORY;
+        if (initialCategory) {
+          startCategory = upgradeCategory(initialCategory);
         } else if (frequentCategories.length > 0) {
           const top = frequentCategories[0];
           const topLabel =
-            top.manualLabel && CATEGORIES.includes(top.manualLabel)
-              ? top.manualLabel
-              : CANONICAL_TO_MANUAL_LABEL[top.id];
+            top.manualLabel && typeof top.manualLabel === "string"
+              ? upgradeCategory(top.manualLabel)
+              : CANONICAL_TO_MANUAL_LABEL[top.id]
+                ? upgradeCategory(CANONICAL_TO_MANUAL_LABEL[top.id])
+                : null;
           if (topLabel && CATEGORIES.includes(topLabel)) {
             startCategory = topLabel;
           }
@@ -121,6 +187,11 @@ export function ManualExpenseSheet({
     () => sortCategoriesByFrequency(frequentCategories),
     [frequentCategories],
   );
+
+  const amountSuggestions = useMemo(
+    () => mergeAmountSuggestions(frequentMerchants),
+    [frequentMerchants],
+  );
   // Ховаємо зі списку пропозицій мерчанта, якого вже введено у полі description.
   const merchantSuggestions = useMemo(() => {
     if (!frequentMerchants.length) return [];
@@ -136,17 +207,19 @@ export function ManualExpenseSheet({
 
   const handleSubmit = () => {
     const amt = parseFloat(form.amount);
-    if (!form.description.trim()) {
-      setError("Вкажіть назву витрати");
-      return;
-    }
     if (!form.amount || isNaN(amt) || amt <= 0) {
       setError("Вкажіть суму більше 0");
       return;
     }
+    // Description is now optional: if empty we fall back to the category
+    // label (without the emoji prefix) so the ledger still has a
+    // human-readable line. Keeps the 5-second-add promise while staying
+    // searchable.
+    const trimmedDesc = form.description.trim();
+    const description = trimmedDesc || stripEmoji(form.category);
     onSave?.({
       ...(initialExpense?.id ? { id: String(initialExpense.id) } : {}),
-      description: form.description.trim(),
+      description,
       amount: amt,
       category: form.category,
       // "YYYY-MM-DD" як local date може з’їхати при toISOString() в UTC.
@@ -184,7 +257,10 @@ export function ManualExpenseSheet({
                 htmlFor={descId}
                 className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
               >
-                Назва
+                Назва{" "}
+                <span className="text-subtle normal-case">
+                  · необов&apos;язково
+                </span>
               </label>
               <input
                 id={descId}
@@ -259,6 +335,26 @@ export function ManualExpenseSheet({
             >
               Сума ₴
             </label>
+            {amountSuggestions.length > 0 && (
+              <div
+                className="flex flex-wrap gap-1.5 mb-2"
+                role="group"
+                aria-label="Швидкі суми"
+              >
+                {amountSuggestions.map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    onClick={() =>
+                      setForm((f) => ({ ...f, amount: String(v) }))
+                    }
+                    className="px-2.5 py-1 rounded-full text-[11px] font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                  >
+                    {v.toLocaleString("uk-UA")} ₴
+                  </button>
+                ))}
+              </div>
+            )}
             <input
               id={amountId}
               className={formInp}

--- a/src/modules/finyk/domain/personalization.ts
+++ b/src/modules/finyk/domain/personalization.ts
@@ -94,28 +94,38 @@ export const MANUAL_CATEGORY_ID_MAP: Record<string, string> = {
 
 // Зворотний пошук: canonical id → відповідний manual-label, який є серед
 // кнопок у ManualExpenseSheet (щоб при кліку по картці у dashboard виставляти
-// коректний вибір у списку).
+// коректний вибір у списку). Повертаємо нові emoji-labels — `ManualExpenseSheet`
+// also runs them through `upgradeCategory` to stay tolerant of legacy strings.
 export const CANONICAL_TO_MANUAL_LABEL: Record<string, string> = {
-  food: "їжа",
-  restaurant: "їжа",
-  transport: "транспорт",
-  entertainment: "розваги",
-  health: "здоров'я",
-  shopping: "одяг",
-  utilities: "комунальні",
-  // "підписки" відсутні серед кнопок ManualExpenseSheet, тому мапимо у "інше"
-  // замість "техніка" — інакше subscription-мерчанти зберігались би як shopping
-  // (round-trip `техніка` → `shopping`).
-  subscriptions: "інше",
-  sport: "розваги",
-  beauty: "розваги",
-  travel: "розваги",
-  education: "розваги",
-  other: "інше",
+  food: "🍴 їжа",
+  restaurant: "🍔 кафе та ресторани",
+  transport: "🚗 транспорт",
+  entertainment: "🎮 розваги",
+  health: "💊 здоров'я",
+  shopping: "🛍️ покупки",
+  utilities: "🏠 комунальні",
+  subscriptions: "🎵 підписки",
+  sport: "🎮 розваги",
+  beauty: "🛍️ покупки",
+  travel: "✈️ подорожі",
+  education: "📚 навчання",
+  other: "🏷 інше",
 };
 
+// Labels in `ManualExpenseSheet` are now emoji-prefixed (e.g. "🍴 їжа").
+// Strip leading non-letter / non-digit runs (emoji, ZWJ sequences,
+// variation selectors, whitespace) before lookup so map keys stay
+// stable across legacy and new entries.
+function stripLeadingSymbols(str: string): string {
+  let i = 0;
+  while (i < str.length && !/[\p{L}\p{N}]/u.test(str[i])) i++;
+  return str.slice(i);
+}
+
 function normalizeManualLabel(label: string | undefined | null): string {
-  return (label || "").trim().toLocaleLowerCase("uk-UA");
+  return stripLeadingSymbols((label || "").trim())
+    .trim()
+    .toLocaleLowerCase("uk-UA");
 }
 
 /** Підпис manual-категорії → canonical id або сам підпис (для custom). */

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -254,19 +254,27 @@ export function AddMealSheet({
                 відредагуєте на наступному кроці.
               </p>
 
-              <MealTemplatesRow
-                mealTemplates={mealTemplates}
-                setForm={setForm}
-                onSelected={() => setStep("fill")}
-              />
+              {/* Templates / pantry rows disappear when empty so a
+                  first-time user sees search + barcode as the whole step
+                  (no half-broken UI). They come back automatically once
+                  the user saves a template or stocks the pantry. */}
+              {mealTemplates.length > 0 && (
+                <MealTemplatesRow
+                  mealTemplates={mealTemplates}
+                  setForm={setForm}
+                  onSelected={() => setStep("fill")}
+                />
+              )}
 
-              <FromPantryRow
-                pantryItems={pantryItems}
-                fromPantryItem={fromPantryItem}
-                setFromPantryItem={setFromPantryItem}
-                setForm={setForm}
-                setFoodQuery={setFoodQuery}
-              />
+              {pantryItems.length > 0 && (
+                <FromPantryRow
+                  pantryItems={pantryItems}
+                  fromPantryItem={fromPantryItem}
+                  setFromPantryItem={setFromPantryItem}
+                  setForm={setForm}
+                  setFoodQuery={setFoodQuery}
+                />
+              )}
 
               <FoodPickerSection
                 form={form}

--- a/src/modules/routine/components/settings/HabitForm.jsx
+++ b/src/modules/routine/components/settings/HabitForm.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -26,8 +26,18 @@ export function HabitForm({
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
   const endId = `${fieldIds}-end`;
+  const advancedId = `${fieldIds}-advanced`;
   const sectionRef = useRef(null);
   const nameRef = useRef(null);
+  // Minimal-first UX: emoji + name + regularity are visible on first
+  // render. Dates, reminders, tags and categories live behind a
+  // "Більше опцій" disclosure. When editing an existing habit we open
+  // the advanced block so the user doesn't lose track of values they
+  // already set.
+  const [showAdvanced, setShowAdvanced] = useState(() => Boolean(editingId));
+  useEffect(() => {
+    if (editingId) setShowAdvanced(true);
+  }, [editingId]);
 
   useEffect(() => {
     if (!focusTick) return;
@@ -98,98 +108,120 @@ export function HabitForm({
         </select>
       </label>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <label className="block text-xs text-subtle" htmlFor={startId}>
-          Початок (дата)
-          <Input
-            id={startId}
-            type="date"
-            className="routine-touch-field mt-1 w-full"
-            value={habitDraft.startDate || ""}
-            onChange={(e) =>
-              setHabitDraft((d) => ({ ...d, startDate: e.target.value }))
-            }
+      <button
+        type="button"
+        onClick={() => setShowAdvanced((v) => !v)}
+        aria-expanded={showAdvanced}
+        aria-controls={advancedId}
+        className="flex items-center gap-1 text-xs text-muted hover:text-text transition-colors"
+      >
+        <span>{showAdvanced ? "Менше опцій" : "Більше опцій"}</span>
+        <span aria-hidden className="text-[10px]">
+          {showAdvanced ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {showAdvanced && (
+        <div id={advancedId} className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="block text-xs text-subtle" htmlFor={startId}>
+              Початок (дата)
+              <Input
+                id={startId}
+                type="date"
+                className="routine-touch-field mt-1 w-full"
+                value={habitDraft.startDate || ""}
+                onChange={(e) =>
+                  setHabitDraft((d) => ({ ...d, startDate: e.target.value }))
+                }
+              />
+            </label>
+            <label className="block text-xs text-subtle" htmlFor={endId}>
+              Кінець (необовʼязково)
+              <Input
+                id={endId}
+                type="date"
+                className="routine-touch-field mt-1 w-full"
+                value={habitDraft.endDate || ""}
+                onChange={(e) =>
+                  setHabitDraft((d) => ({ ...d, endDate: e.target.value }))
+                }
+              />
+            </label>
+          </div>
+
+          <ReminderPresets
+            habitDraft={habitDraft}
+            setHabitDraft={setHabitDraft}
           />
-        </label>
-        <label className="block text-xs text-subtle" htmlFor={endId}>
-          Кінець (необовʼязково)
-          <Input
-            id={endId}
-            type="date"
-            className="routine-touch-field mt-1 w-full"
-            value={habitDraft.endDate || ""}
-            onChange={(e) =>
-              setHabitDraft((d) => ({ ...d, endDate: e.target.value }))
-            }
-          />
-        </label>
-      </div>
 
-      <ReminderPresets habitDraft={habitDraft} setHabitDraft={setHabitDraft} />
+          {habitDraft.recurrence === "weekly" && (
+            <WeekdayPicker
+              weekdays={habitDraft.weekdays}
+              onChange={(next) =>
+                setHabitDraft((d) => ({ ...d, weekdays: next }))
+              }
+            />
+          )}
 
-      {habitDraft.recurrence === "weekly" && (
-        <WeekdayPicker
-          weekdays={habitDraft.weekdays}
-          onChange={(next) => setHabitDraft((d) => ({ ...d, weekdays: next }))}
-        />
-      )}
+          {(habitDraft.recurrence === "once" ||
+            habitDraft.recurrence === "monthly") && (
+            <p className="text-[11px] text-subtle leading-snug">
+              {habitDraft.recurrence === "once"
+                ? "Подія зʼявиться лише в день «Початок». Кінець можна залишити порожнім."
+                : "Орієнтир — день місяця з «Початок». У коротких місяцях (наприклад 31 → лютий) — останній день місяця."}
+            </p>
+          )}
 
-      {(habitDraft.recurrence === "once" ||
-        habitDraft.recurrence === "monthly") && (
-        <p className="text-[11px] text-subtle leading-snug">
-          {habitDraft.recurrence === "once"
-            ? "Подія зʼявиться лише в день «Початок». Кінець можна залишити порожнім."
-            : "Орієнтир — день місяця з «Початок». У коротких місяцях (наприклад 31 → лютий) — останній день місяця."}
-        </p>
-      )}
+          {routine.tags.length > 0 && (
+            <label className="block text-xs text-subtle">
+              Тег
+              <select
+                className="routine-touch-select mt-1"
+                value={habitDraft.tagIds[0] || ""}
+                onChange={(e) => {
+                  const id = e.target.value;
+                  setHabitDraft((d) => ({
+                    ...d,
+                    tagIds: id ? [id] : [],
+                  }));
+                }}
+              >
+                <option value="">— без тегу —</option>
+                {routine.tags.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+              <span className="block text-[10px] text-subtle mt-1 leading-snug">
+                Один тег на звичку (поле tagIds у даних — масив для сумісності).
+              </span>
+            </label>
+          )}
 
-      {routine.tags.length > 0 && (
-        <label className="block text-xs text-subtle">
-          Тег
-          <select
-            className="routine-touch-select mt-1"
-            value={habitDraft.tagIds[0] || ""}
-            onChange={(e) => {
-              const id = e.target.value;
-              setHabitDraft((d) => ({
-                ...d,
-                tagIds: id ? [id] : [],
-              }));
-            }}
-          >
-            <option value="">— без тегу —</option>
-            {routine.tags.map((t) => (
-              <option key={t.id} value={t.id}>
-                {t.name}
-              </option>
-            ))}
-          </select>
-          <span className="block text-[10px] text-subtle mt-1 leading-snug">
-            Один тег на звичку (поле tagIds у даних — масив для сумісності).
-          </span>
-        </label>
-      )}
-
-      {routine.categories.length > 0 && (
-        <label className="block text-xs text-subtle">
-          Категорія
-          <select
-            className="routine-touch-select mt-1"
-            value={habitDraft.categoryId || ""}
-            onChange={(e) => {
-              const id = e.target.value;
-              setHabitDraft((d) => ({ ...d, categoryId: id || null }));
-            }}
-          >
-            <option value="">— без категорії —</option>
-            {routine.categories.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.emoji ? `${c.emoji} ` : ""}
-                {c.name}
-              </option>
-            ))}
-          </select>
-        </label>
+          {routine.categories.length > 0 && (
+            <label className="block text-xs text-subtle">
+              Категорія
+              <select
+                className="routine-touch-select mt-1"
+                value={habitDraft.categoryId || ""}
+                onChange={(e) => {
+                  const id = e.target.value;
+                  setHabitDraft((d) => ({ ...d, categoryId: id || null }));
+                }}
+              >
+                <option value="">— без категорії —</option>
+                {routine.categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.emoji ? `${c.emoji} ` : ""}
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
       )}
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

Ships all 10 quick wins from the UX friction audit in a single cohesive diff. Focus areas: onboarding, add flows (expense, meal, habit) and hub navigation. No architectural rewrites — each change is scoped to the specific friction it removes.

**Onboarding**
1. **QW1** — Skip button on the wizard splash now reads `Пропустити` instead of `Пропустити до пустого хабу`, and it only shows on step 0 (was visible on the vibe picker too, competing with the primary CTA). `src/core/OnboardingWizard.jsx`
2. **QW2** — Vibe picker starts with an empty selection so the question "Що тобі зараз болить?" is an actual choice. Previously all 4 modules were preselected, which made the default answer "все" and neutralised demo seeding. `src/core/OnboardingWizard.jsx`
3. **QW3** — Post‑wizard first‑action tiles are now an **inline** `FirstActionHeroCard` on the dashboard instead of a third stacked modal. Wizard just flips the `first_action_pending` flag; user lands on the hub and the hero picks up. `src/core/onboarding/FirstActionSheet.jsx`, `src/core/app/HubMainContent.jsx`, `src/core/HubDashboard.jsx`

**Add flows**
4. **QW4** — `ManualExpenseSheet` no longer requires a description. Leaving it empty falls back to the category label (emoji stripped) so the ledger still has a human‑readable line. Label clarified with `· необов'язково`. `src/modules/finyk/components/ManualExpenseSheet.jsx`
5. **QW5** — Amount suggestion pills above the amount input: 50 / 100 / 200 / 500 ₴ by default, blended with the user's most recent distinct amounts from merchant history. Tap to fill. `src/modules/finyk/components/ManualExpenseSheet.jsx`
6. **QW7** — `HabitForm` now shows a minimal first screen (emoji + name + regularity) and tucks dates, reminders, weekday picker, tags and categories behind a `Більше опцій` disclosure. Auto‑expanded when editing an existing habit. `src/modules/routine/components/settings/HabitForm.jsx`
7. **QW9** — `AddMealSheet` step 1 hides `MealTemplatesRow` and `FromPantryRow` when they're empty so a first‑time user sees search + barcode as the whole step (no half‑broken UI). They come back once the user saves a template or stocks the pantry. `src/modules/nutrition/components/AddMealSheet.jsx`
8. **QW10** — Expense categories extended from 8 to 13 entries with emoji prefixes and mapped to Finyk's canonical MCC taxonomy (food / restaurant / transport / health / shopping / utilities / subscriptions / travel / education / other). `normalizeManualLabel` strips emoji + ZWJ + variation selectors so legacy rows still look up correctly. `CANONICAL_TO_MANUAL_LABEL` returns the new emoji labels; `ManualExpenseSheet` runs them through `upgradeCategory` for backward compatibility. `src/modules/finyk/components/ManualExpenseSheet.jsx`, `src/modules/finyk/domain/personalization.ts`

**Navigation + chrome**
9. **QW6** — Hub FAB swapped: the primary floating button is now a `+ Додати` speed dial with 4 actions (expense / meal / habit / workout) routing through `openHubModuleWithAction`. AI chat moved to a header icon next to search. `src/core/app/HubFloatingActions.jsx`, `src/core/app/HubHeader.jsx`, `src/core/App.jsx`
10. **QW8** — Banner budget: at most **one** system banner at a time.
    - Hub chrome: priority update > install (PWA) > iOS install.
    - Dashboard: priority first‑action hero > demo banner > soft‑auth nudge.
    Previously all three could stack on cold start and push real content below the fold. `src/core/app/HubMainContent.jsx`, `src/core/HubDashboard.jsx`

## Review & Testing Checklist for Human

- [ ] **Fresh onboarding E2E**: clear localStorage → open app → confirm (a) splash has just `Пропустити`, (b) vibe picker requires an explicit choice, (c) after picking vibes you land on the populated hub with an inline hero card (not a modal), (d) dismissing the hero doesn't bring it back on reload.
- [ ] **Expense 5‑second add**: open `+ Додати → Витрата`, enter only an amount (e.g. tap the `100 ₴` pill), pick a category, save. Check the ledger line reads the category label, not "undefined". Also verify recent‑amount pills appear after a few real entries.
- [ ] **Category round‑trip**: add an expense with one of the new categories (e.g. `✈️ подорожі`), re‑open the ledger, tap to edit, confirm the same category is still selected. Also verify an older pre‑upgrade entry (legacy `одяг`, `техніка`, etc.) still opens with a valid category and saves back fine.
- [ ] **Habit minimal add**: Routine → Settings → "Нова звичка". Confirm only emoji + name + `Регулярність` + `Більше опцій` show by default. Expand, fill dates / reminder, save. Edit the same habit and confirm the advanced block auto‑expands with your values.
- [ ] **Meal source step on empty data**: clear meal templates + pantry, open `+ Додати → Прийом їжі`. Confirm step 1 shows only food search + barcode + "Ввести вручну" (no empty templates/pantry rails). Save one template, reopen — row reappears.
- [ ] **FAB + chat**: confirm the bottom‑right FAB is the `+` speed dial and the header has a sparkle icon that opens the AI chat. Speed dial closes on outside click and on `Esc`.
- [ ] **Banner budget**: force two banner conditions at once (e.g. `canInstall` + `iosVisible`, or demo mode + soft‑auth) and confirm only the higher‑priority one renders.

### Notes

- All 588 unit tests pass; `npm run lint`, `npm run typecheck` and `npm run build` are green locally.
- Structural follow‑ups from the audit (unified bottom nav across modules, collapsing Fizruk's 9 sub‑pages) are intentionally **out of scope** for this PR — those need design sign‑off and will land separately.
- `FirstActionSheet` now exports `FirstActionHeroCard` (the inline variant). The default `FirstActionSheet` modal is gone; callers that imported the named modal will need to switch to the hero card or remove the usage. No in‑repo callers remain.
- Emoji/ZWJ handling in `stripEmoji` / `stripLeadingSymbols` uses a char‑by‑char loop instead of a class like `[\p{Emoji_Presentation}\u200D\uFE0F]+` to sidestep ESLint's `no-misleading-character-class` rule on grapheme clusters.


Link to Devin session: https://app.devin.ai/sessions/349679106ce34c2d83ccc29d7c263de7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
