### PR TITLE
chore(ui): replace arbitrary text-[Npx] sizes with scale tokens

### DIFF
--- a/src/core/DailyFinykSummaryCard.jsx
+++ b/src/core/DailyFinykSummaryCard.jsx
@@ -134,7 +134,7 @@ function Header({ eyebrow, title, onDismiss, dismissLabel }) {
   return (
     <div className="flex items-start justify-between gap-2 mb-2">
       <div className="min-w-0">
-        <p className="text-[10px] font-semibold uppercase tracking-widest text-brand-600/80 dark:text-brand-400/80">
+        <p className="text-2xs font-semibold uppercase tracking-widest text-brand-600/80 dark:text-brand-400/80">
           {eyebrow}
         </p>
         <h3 className="text-base font-bold text-text leading-snug">{title}</h3>
@@ -180,7 +180,7 @@ function HasExpensesContent({ summary }) {
           )}
         >
           <div className="flex items-center gap-2 min-w-0">
-            <span className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+            <span className="text-2xs font-semibold text-muted uppercase tracking-wider">
               Топ категорія
             </span>
             <span className="text-sm font-medium text-text truncate">
@@ -191,7 +191,7 @@ function HasExpensesContent({ summary }) {
             <div className="text-sm font-semibold tabular-nums text-text">
               {formatUAH(topCategory.amount)}
             </div>
-            <div className="text-[10px] text-muted">{topCategory.pct}%</div>
+            <div className="text-2xs text-muted">{topCategory.pct}%</div>
           </div>
         </div>
       )}

--- a/src/core/HubChat.jsx
+++ b/src/core/HubChat.jsx
@@ -421,7 +421,7 @@ function HubChat({ onClose, initialMessage }) {
               </div>
               <div
                 className={cn(
-                  "text-[10px]",
+                  "text-2xs",
                   hasData ? "text-subtle" : "text-warning",
                 )}
               >
@@ -429,20 +429,20 @@ function HubChat({ onClose, initialMessage }) {
                   ? "Фінік · Фізрук · Рутина · Харчування"
                   : "Mono не підключено"}
               </div>
-              <div className="text-[10px] text-subtle mt-0.5">
+              <div className="text-2xs text-subtle mt-0.5">
                 {contextState.status === "building"
                   ? "Готую контекст…"
                   : contextState.status === "ready"
                     ? "Контекст готовий"
                     : ""}
               </div>
-              <div className="text-[10px] text-subtle mt-0.5">
+              <div className="text-2xs text-subtle mt-0.5">
                 Сесія: {sessionInfo.historyCount}/10 · ~
                 {Math.round(sessionInfo.chars / 100) / 10}k символів
               </div>
               <p
                 id="hub-chat-privacy"
-                className="text-[10px] text-subtle mt-1 leading-snug max-w-[min(100%,280px)]"
+                className="text-2xs text-subtle mt-1 leading-snug max-w-[min(100%,280px)]"
               >
                 Запит і короткий контекст (фінанси, тренування, звички,
                 харчування) відправляються на сервер до AI. Не діліться чужим

--- a/src/core/HubInsightsPanel.jsx
+++ b/src/core/HubInsightsPanel.jsx
@@ -114,7 +114,7 @@ function CoachRow({ insight, loading, error, onDiscuss, onRefresh }) {
       />
       <div className="pl-1">
         <div className="flex items-center justify-between gap-2 mb-1">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+          <span className="text-2xs font-semibold uppercase tracking-wider text-muted">
             Коуч
           </span>
           <button
@@ -201,7 +201,7 @@ export function HubInsightsPanel({
       >
         <span className="flex items-center gap-2 text-xs font-semibold text-text">
           Інсайти
-          <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-panelHi text-[10px] font-bold text-muted">
+          <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-panelHi text-2xs font-bold text-muted">
             {total}
           </span>
         </span>

--- a/src/core/HubRecommendations.jsx
+++ b/src/core/HubRecommendations.jsx
@@ -67,7 +67,7 @@ export function HubRecommendations({ onOpenModule }) {
           Рекомендації
         </h2>
         {visible.length > 1 && (
-          <span className="text-[10px] text-subtle bg-panelHi px-2 py-0.5 rounded-full">
+          <span className="text-2xs text-subtle bg-panelHi px-2 py-0.5 rounded-full">
             {visible.length}
           </span>
         )}

--- a/src/core/TodayFocusCard.jsx
+++ b/src/core/TodayFocusCard.jsx
@@ -234,7 +234,7 @@ export function TodayFocusCard({ focus, onAction, onDismiss, onOpenReports }) {
 
       <div className="pl-3">
         <div className="flex items-start justify-between gap-3 mb-1">
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-muted">
+          <span className="text-2xs font-semibold uppercase tracking-widest text-muted">
             Зараз
           </span>
           {onDismiss && (

--- a/src/core/WeeklyDigestCard.jsx
+++ b/src/core/WeeklyDigestCard.jsx
@@ -128,7 +128,7 @@ function ModuleBlock({ moduleKey, data }) {
                     <div key={i} className="flex items-start gap-1.5">
                       <span
                         className={cn(
-                          "text-[10px] font-bold mt-0.5 shrink-0",
+                          "text-2xs font-bold mt-0.5 shrink-0",
                           cfg.colorClass,
                         )}
                       >
@@ -269,12 +269,12 @@ function DigestContent({
             {Array.isArray(digest.overallRecommendations) &&
               digest.overallRecommendations.length > 0 && (
                 <div className="rounded-xl border border-primary/20 bg-primary/5 px-3 py-2.5 space-y-1.5">
-                  <p className="text-[10px] font-bold text-primary uppercase tracking-wider">
+                  <p className="text-2xs font-bold text-primary uppercase tracking-wider">
                     Загальні рекомендації
                   </p>
                   {digest.overallRecommendations.map((rec, i) => (
                     <div key={i} className="flex items-start gap-1.5">
-                      <span className="text-[10px] font-bold text-primary mt-0.5 shrink-0">
+                      <span className="text-2xs font-bold text-primary mt-0.5 shrink-0">
                         ★
                       </span>
                       <span className="text-[11px] text-text leading-snug">
@@ -378,7 +378,7 @@ export function WeeklyDigestCard() {
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           {digest?.generatedAt && (
-            <span className="text-[10px] text-subtle">
+            <span className="text-2xs text-subtle">
               {new Date(digest.generatedAt).toLocaleDateString("uk-UA", {
                 day: "numeric",
                 month: "short",
@@ -438,7 +438,7 @@ export function WeeklyDigestCard() {
               >
                 {h.weekRange}
                 {h.weekKey === currentWeekKey && (
-                  <span className="ml-1 text-[9px] opacity-70">поточний</span>
+                  <span className="ml-1 text-2xs opacity-70">поточний</span>
                 )}
               </button>
             ))}

--- a/src/core/WeeklyDigestStories.jsx
+++ b/src/core/WeeklyDigestStories.jsx
@@ -360,7 +360,7 @@ function NutritionSlide({ slide }) {
 
       <div className="grid grid-cols-3 gap-2 mb-4">
         <div className="rounded-xl bg-white/15 border border-white/20 px-3 py-2 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-white/75 font-bold">
+          <div className="text-2xs uppercase tracking-wider text-white/75 font-bold">
             Білки
           </div>
           <div className="text-[20px] font-black tabular-nums mt-0.5">
@@ -368,7 +368,7 @@ function NutritionSlide({ slide }) {
           </div>
         </div>
         <div className="rounded-xl bg-white/15 border border-white/20 px-3 py-2 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-white/75 font-bold">
+          <div className="text-2xs uppercase tracking-wider text-white/75 font-bold">
             Жири
           </div>
           <div className="text-[20px] font-black tabular-nums mt-0.5">
@@ -376,7 +376,7 @@ function NutritionSlide({ slide }) {
           </div>
         </div>
         <div className="rounded-xl bg-white/15 border border-white/20 px-3 py-2 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-white/75 font-bold">
+          <div className="text-2xs uppercase tracking-wider text-white/75 font-bold">
             Вугл.
           </div>
           <div className="text-[20px] font-black tabular-nums mt-0.5">
@@ -438,7 +438,7 @@ function RoutineSlide({ slide }) {
             <div className="text-[28px] font-black leading-none tabular-nums">
               {agg?.overallRate ?? 0}%
             </div>
-            <div className="text-[10px] uppercase tracking-wider font-bold text-white/75 mt-0.5">
+            <div className="text-2xs uppercase tracking-wider font-bold text-white/75 mt-0.5">
               виконано
             </div>
           </div>

--- a/src/core/app/UserMenuButton.jsx
+++ b/src/core/app/UserMenuButton.jsx
@@ -105,7 +105,7 @@ export function UserMenuButton({
               Завантажити з хмари
             </button>
             {lastSync && (
-              <p className="px-3 text-[10px] text-muted">
+              <p className="px-3 text-2xs text-muted">
                 Остання синхр.: {lastSync.toLocaleTimeString("uk-UA")}
               </p>
             )}

--- a/src/core/settings/AIDigestSection.tsx
+++ b/src/core/settings/AIDigestSection.tsx
@@ -39,7 +39,7 @@ export function AIDigestSection() {
           <p className="text-xs font-semibold text-text">Поточний тиждень</p>
           <p className="text-[11px] text-muted mt-0.5">{weekRange}</p>
           {generatedAt && (
-            <p className="text-[10px] text-subtle mt-1">
+            <p className="text-2xs text-subtle mt-1">
               Згенеровано: {generatedAt}
             </p>
           )}

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -538,7 +538,7 @@ export default function App({
               <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
                 ФІНІК
               </span>
-              <span className="text-[10px] text-subtle font-medium hidden sm:block truncate">
+              <span className="text-2xs text-subtle font-medium hidden sm:block truncate">
                 Monobank · бюджети
               </span>
             </div>
@@ -777,7 +777,7 @@ export default function App({
                 >
                   {NAV_ICONS[item.id]}
                 </span>
-                <span className="text-[10px] leading-none font-semibold">
+                <span className="text-2xs leading-none font-semibold">
                   {item.label}
                 </span>
               </button>

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -298,7 +298,7 @@ export function ManualExpenseSheet({
               role="group"
               aria-label="Нещодавні мерчанти"
             >
-              <span className="text-[10px] text-subtle uppercase tracking-wide font-semibold w-full">
+              <span className="text-2xs text-subtle uppercase tracking-wide font-semibold w-full">
                 Нещодавнє
               </span>
               {merchantSuggestions.map((m) => (

--- a/src/modules/finyk/components/SyncStatusBadge.jsx
+++ b/src/modules/finyk/components/SyncStatusBadge.jsx
@@ -73,7 +73,7 @@ function SyncStatusBadgeComponent({
       )}
       {error && !isLoading && (
         <span
-          className="text-danger/80 text-[10px] truncate max-w-[160px]"
+          className="text-danger/80 text-2xs truncate max-w-[160px]"
           title={error}
         >
           {error}

--- a/src/modules/finyk/components/TxRow.jsx
+++ b/src/modules/finyk/components/TxRow.jsx
@@ -132,32 +132,32 @@ function TxRowImpl({
         <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
           <span className="text-xs text-subtle">{catName}</span>
           {cat.id === INTERNAL_TRANSFER_ID && (
-            <span className="text-[9px] bg-muted/15 text-muted px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-2xs bg-muted/15 text-muted px-1.5 py-0.5 rounded-full font-semibold">
               не в статистиці
             </span>
           )}
           {overrideCatId && cat.id !== INTERNAL_TRANSFER_ID && (
-            <span className="text-[9px] bg-text/8 text-muted px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-2xs bg-text/8 text-muted px-1.5 py-0.5 rounded-full font-semibold">
               змін.
             </span>
           )}
           {existingSplits.length > 0 && (
-            <span className="text-[9px] bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-2xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold">
               ⅔ спліт
             </span>
           )}
           {isCreditCard && (
-            <span className="text-[9px] bg-danger/8 text-danger px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-2xs bg-danger/8 text-danger px-1.5 py-0.5 rounded-full font-semibold">
               💳 {accountName}
             </span>
           )}
           {!isCreditCard && account && (
-            <span className="text-[9px] text-subtle/50 px-1 py-0.5">
+            <span className="text-2xs text-subtle/50 px-1 py-0.5">
               {accountName}
             </span>
           )}
           {tx._source === "privatbank" && (
-            <span className="text-[9px] bg-green-500/10 text-green-700 dark:text-green-400 px-1.5 py-0.5 rounded-full font-semibold shrink-0">
+            <span className="text-2xs bg-green-500/10 text-green-700 dark:text-green-400 px-1.5 py-0.5 rounded-full font-semibold shrink-0">
               П24
             </span>
           )}
@@ -210,7 +210,7 @@ function TxRowImpl({
               {hideAmount ? "••••" : fmtAmt(tx.amount, CURRENCY.UAH)}
             </div>
             {tx.currencyCode !== CURRENCY.UAH && tx.operationAmount && (
-              <div className="text-[10px] text-subtle/70 tabular-nums">
+              <div className="text-2xs text-subtle/70 tabular-nums">
                 {hideAmount
                   ? "••••"
                   : fmtAmt(tx.operationAmount, tx.currencyCode)}

--- a/src/modules/finyk/components/analytics/MerchantList.jsx
+++ b/src/modules/finyk/components/analytics/MerchantList.jsx
@@ -33,7 +33,7 @@ function MerchantListComponent({ merchants = [], className }) {
                     style={{ width: `${barPct}%` }}
                   />
                 </div>
-                <span className="text-[10px] text-subtle shrink-0">
+                <span className="text-2xs text-subtle shrink-0">
                   {m.count} разів
                 </span>
               </div>

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -283,19 +283,19 @@ export function Analytics({ mono, storage }) {
           ) : (
             <div className="grid grid-cols-3 gap-3">
               <div className="text-center">
-                <div className="text-[10px] text-subtle mb-1">Витрати</div>
+                <div className="text-2xs text-subtle mb-1">Витрати</div>
                 <div className="text-sm font-bold tabular-nums text-danger">
                   {summary.spent.toLocaleString("uk-UA")} ₴
                 </div>
               </div>
               <div className="text-center">
-                <div className="text-[10px] text-subtle mb-1">Дохід</div>
+                <div className="text-2xs text-subtle mb-1">Дохід</div>
                 <div className="text-sm font-bold tabular-nums text-emerald-600">
                   {summary.income.toLocaleString("uk-UA")} ₴
                 </div>
               </div>
               <div className="text-center">
-                <div className="text-[10px] text-subtle mb-1">Баланс</div>
+                <div className="text-2xs text-subtle mb-1">Баланс</div>
                 <div
                   className={cn(
                     "text-sm font-bold tabular-nums",

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -189,7 +189,7 @@ export function Assets({
                 return (
                   <div key={i}>
                     {suggested && !isLinked && (
-                      <div className="text-[10px] font-semibold text-success px-1 pt-1">
+                      <div className="text-2xs font-semibold text-success px-1 pt-1">
                         ↑ Поповнення картки
                       </div>
                     )}

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -430,7 +430,7 @@ export function Budgets({ mono, storage }) {
               {/* Fact row */}
               <div className="grid grid-cols-3 gap-2 text-center">
                 <div>
-                  <div className="text-[10px] text-subtle mb-0.5">
+                  <div className="text-2xs text-subtle mb-0.5">
                     Дохід (план)
                   </div>
                   <div className="text-sm font-semibold tabular-nums">
@@ -440,7 +440,7 @@ export function Budgets({ mono, storage }) {
                   </div>
                 </div>
                 <div>
-                  <div className="text-[10px] text-subtle mb-0.5">
+                  <div className="text-2xs text-subtle mb-0.5">
                     Витрати (факт)
                   </div>
                   <div
@@ -453,7 +453,7 @@ export function Budgets({ mono, storage }) {
                   </div>
                 </div>
                 <div>
-                  <div className="text-[10px] text-subtle mb-0.5">Залишок</div>
+                  <div className="text-2xs text-subtle mb-0.5">Залишок</div>
                   <div
                     className={cn(
                       "text-sm font-semibold tabular-nums",
@@ -628,7 +628,7 @@ export function Budgets({ mono, storage }) {
                       >
                         {fc.forecast.toLocaleString("uk-UA")} ₴
                       </span>
-                      <span className="text-[10px] text-subtle tabular-nums">
+                      <span className="text-2xs text-subtle tabular-nums">
                         ліміт {fc.limit.toLocaleString("uk-UA")} ₴
                       </span>
                     </div>
@@ -655,7 +655,7 @@ export function Budgets({ mono, storage }) {
                     />
                   </Suspense>
 
-                  <div className="flex items-center justify-between text-[10px] text-subtle mt-1 mb-2">
+                  <div className="flex items-center justify-between text-2xs text-subtle mt-1 mb-2">
                     <span>Факт: {fc.spent.toLocaleString("uk-UA")} ₴</span>
                     <span>≈{fc.avgPerDay.toLocaleString("uk-UA")} ₴/день</span>
                     <span>Залишилось: {fc.daysRemaining} дн.</span>

--- a/src/modules/finyk/pages/overview/MonthPulseCard.jsx
+++ b/src/modules/finyk/pages/overview/MonthPulseCard.jsx
@@ -56,7 +56,7 @@ export function MonthPulseCard({
       <div className="flex justify-between items-start gap-4">
         <div>
           <div className="text-xs text-subtle font-medium">Витрати</div>
-          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight">
+          <div className="text-2xl font-bold tabular-nums mt-1 leading-tight">
             {showBalance
               ? spent.toLocaleString("uk-UA", { maximumFractionDigits: 0 })
               : "••••"}
@@ -67,7 +67,7 @@ export function MonthPulseCard({
         </div>
         <div className="text-right">
           <div className="text-xs text-subtle font-medium">Дохід</div>
-          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight text-success">
+          <div className="text-2xl font-bold tabular-nums mt-1 leading-tight text-success">
             {showBalance ? (
               <>
                 +

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -334,7 +334,7 @@ export default function FizrukApp({
           )}
           <div className="min-w-0 flex-1">
             {!isAtlas && !isExercise && (
-              <span className="text-[9px] text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
+              <span className="text-2xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
                 ОСОБИСТИЙ ЖУРНАЛ
               </span>
             )}
@@ -342,7 +342,7 @@ export default function FizrukApp({
               {headerTitle}
             </span>
             {!isAtlas && !isExercise && (
-              <span className="text-[10px] text-subtle font-medium truncate">
+              <span className="text-2xs text-subtle font-medium truncate">
                 {isPlan
                   ? "Календар · нагадування · відновлення"
                   : page === "programs"
@@ -485,7 +485,7 @@ export default function FizrukApp({
                   </span>
                   <span
                     className={cn(
-                      "text-[10px] leading-none font-semibold",
+                      "text-2xs leading-none font-semibold",
                       active ? "text-text" : "text-muted",
                     )}
                   >

--- a/src/modules/fizruk/components/PhotoProgress.tsx
+++ b/src/modules/fizruk/components/PhotoProgress.tsx
@@ -195,10 +195,10 @@ function CompareSlider({ beforeSrc, afterSrc }) {
           </svg>
         </div>
       </div>
-      <div className="absolute top-2 left-2 text-[10px] font-bold text-white bg-black/50 rounded px-1.5 py-0.5">
+      <div className="absolute top-2 left-2 text-2xs font-bold text-white bg-black/50 rounded px-1.5 py-0.5">
         ДО
       </div>
-      <div className="absolute top-2 right-2 text-[10px] font-bold text-white bg-black/50 rounded px-1.5 py-0.5">
+      <div className="absolute top-2 right-2 text-2xs font-bold text-white bg-black/50 rounded px-1.5 py-0.5">
         ПІСЛЯ
       </div>
     </div>
@@ -296,7 +296,7 @@ export function PhotoProgress() {
             <div>
               <label
                 htmlFor={compareBeforeId}
-                className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
               >
                 До
               </label>
@@ -318,7 +318,7 @@ export function PhotoProgress() {
             <div>
               <label
                 htmlFor={compareAfterId}
-                className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
               >
                 Після
               </label>
@@ -369,7 +369,7 @@ export function PhotoProgress() {
             <div>
               <label
                 htmlFor={addDateId}
-                className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
               >
                 Дата
               </label>
@@ -384,7 +384,7 @@ export function PhotoProgress() {
             <div>
               <label
                 htmlFor={addNoteId}
-                className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
               >
                 Нотатка
               </label>
@@ -475,7 +475,7 @@ export function PhotoProgress() {
                   />
                   <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors" />
                   <div className="absolute bottom-0 left-0 right-0 px-1.5 pb-1 pt-3 bg-gradient-to-t from-black/60 to-transparent">
-                    <p className="text-[9px] text-white font-semibold leading-tight">
+                    <p className="text-2xs text-white font-semibold leading-tight">
                       {p.date}
                     </p>
                     {p.note && (

--- a/src/modules/fizruk/components/WeeklyVolumeChart.tsx
+++ b/src/modules/fizruk/components/WeeklyVolumeChart.tsx
@@ -111,7 +111,7 @@ export function WeeklyVolumeChart({
             <text
               x={4}
               y={t.y + 4}
-              className="fill-subtle text-[9px] font-medium"
+              className="fill-subtle text-2xs font-medium"
             >
               {t.lab}
             </text>
@@ -144,7 +144,7 @@ export function WeeklyVolumeChart({
               x={x}
               y={h - 6}
               textAnchor="middle"
-              className="fill-muted text-[9px] font-semibold"
+              className="fill-muted text-2xs font-semibold"
             >
               {lab}
             </text>

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -155,7 +155,7 @@ export function WorkoutTemplatesSection({
             aria-label="Назва шаблону"
           />
           <div>
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
               Додати вправу з каталогу
             </div>
             <Input
@@ -185,7 +185,7 @@ export function WorkoutTemplatesSection({
 
           <div>
             <div className="flex items-center justify-between mb-2">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                 Порядок ({orderIds.length})
               </div>
               {orderIds.length >= 2 && !groupSelectMode && (
@@ -280,7 +280,7 @@ export function WorkoutTemplatesSection({
                       </span>
                       {group && (
                         <span
-                          className={`text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${group.type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
+                          className={`text-2xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${group.type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
                         >
                           {group.type === "circuit" ? "Коло" : "СС"}
                         </span>
@@ -288,7 +288,7 @@ export function WorkoutTemplatesSection({
                       {group && !groupSelectMode && (
                         <button
                           type="button"
-                          className="text-[10px] text-danger/60 hover:text-danger px-1"
+                          className="text-2xs text-danger/60 hover:text-danger px-1"
                           title="Прибрати з групи"
                           onClick={() => handleRemoveGroup(group.id)}
                         >

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -82,7 +82,7 @@ function WarmupCooldownChecklist({ title, items, onToggle, onInit, color }) {
       >
         <span>{title}</span>
         <span
-          className={`ml-2 text-[10px] font-bold tabular-nums ${doneCount === total ? "text-success" : color.text}`}
+          className={`ml-2 text-2xs font-bold tabular-nums ${doneCount === total ? "text-success" : color.text}`}
         >
           {doneCount}/{total}
         </span>
@@ -127,7 +127,7 @@ function WarmupCooldownChecklist({ title, items, onToggle, onInit, color }) {
 function SupersetBadge({ type }) {
   return (
     <span
-      className={`text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
+      className={`text-2xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
     >
       {type === "circuit" ? "Коло" : "Суперсет"}
     </span>
@@ -373,7 +373,7 @@ export function ActiveWorkoutPanel({
 
           <div className="mt-2">
             <div className="rounded-2xl border border-line bg-panelHi px-3">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest pt-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
                 Тип
               </div>
               <select
@@ -518,10 +518,10 @@ export function ActiveWorkoutPanel({
               {!activeWorkout.endedAt && !group && (
                 <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-line/60">
                   <div className="flex items-center justify-between w-full gap-1">
-                    <span className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+                    <span className="text-2xs font-bold text-subtle uppercase tracking-widest">
                       Таймер відпочинку
                     </span>
-                    <span className="text-[9px] text-muted">
+                    <span className="text-2xs text-muted">
                       {catLabel} · реком. {defSec}с
                     </span>
                   </div>
@@ -615,7 +615,7 @@ export function ActiveWorkoutPanel({
               {cardioMetrics && (
                 <div className="grid grid-cols-2 gap-2">
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
-                    <div className="text-[9px] font-bold text-subtle uppercase tracking-widest">
+                    <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                       Темп
                     </div>
                     <div className="text-sm font-bold text-text tabular-nums">
@@ -623,7 +623,7 @@ export function ActiveWorkoutPanel({
                     </div>
                   </div>
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
-                    <div className="text-[9px] font-bold text-subtle uppercase tracking-widest">
+                    <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                       Швидкість
                     </div>
                     <div className="text-sm font-bold text-text tabular-nums">
@@ -688,12 +688,12 @@ export function ActiveWorkoutPanel({
           <div className="flex items-center justify-between gap-2 px-1">
             <SupersetBadge type={group.type} />
             <div className="flex items-center gap-1.5">
-              <span className="text-[10px] text-subtle">
+              <span className="text-2xs text-subtle">
                 {groupItems.length} вправи разом
               </span>
               <button
                 type="button"
-                className="text-[10px] text-danger/70 hover:text-danger px-1"
+                className="text-2xs text-danger/70 hover:text-danger px-1"
                 onClick={() => handleRemoveGroup(group.id)}
                 title="Розгрупувати"
               >
@@ -704,7 +704,7 @@ export function ActiveWorkoutPanel({
           {groupItems.map((gIt) => renderItem(gIt))}
           {!activeWorkout?.endedAt && (
             <div className="flex flex-wrap items-center gap-2 px-1 pt-1 border-t border-success/20">
-              <span className="text-[10px] font-bold text-subtle uppercase tracking-widest w-full">
+              <span className="text-2xs font-bold text-subtle uppercase tracking-widest w-full">
                 Спільний таймер відпочинку між колами
               </span>
               <button
@@ -814,7 +814,7 @@ export function ActiveWorkoutPanel({
         </summary>
         <div className="mt-2 space-y-2">
           <label
-            className="block text-[10px] text-subtle"
+            className="block text-2xs text-subtle"
             htmlFor={workoutStartId}
           >
             Початок
@@ -832,7 +832,7 @@ export function ActiveWorkoutPanel({
           {activeWorkout.endedAt ? (
             <>
               <label
-                className="block text-[10px] text-subtle"
+                className="block text-2xs text-subtle"
                 htmlFor={workoutEndId}
               >
                 Завершення (можна виправити після занесення)

--- a/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -116,7 +116,7 @@ export function AddExerciseSheet({
             />
 
             <div className="rounded-2xl border border-line bg-panelHi px-3">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest pt-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
                 Основна група
               </div>
               <select
@@ -141,7 +141,7 @@ export function AddExerciseSheet({
             </div>
 
             <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                 Обладнання
               </div>
               <div className="py-2 flex flex-wrap gap-2">
@@ -173,7 +173,7 @@ export function AddExerciseSheet({
             </div>
 
             <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                 Основні мʼязи
               </div>
               <div className="flex flex-wrap gap-1.5 mt-2">
@@ -201,7 +201,7 @@ export function AddExerciseSheet({
             </div>
 
             <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                 Супутні мʼязи
               </div>
               <div className="flex flex-wrap gap-1.5 mt-2">

--- a/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
+++ b/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
@@ -47,7 +47,7 @@ export function RestTimerOverlay({ restTimer, onCancel }) {
             </svg>
           </div>
           <div>
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Відпочинок
             </div>
             <div

--- a/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -43,7 +43,7 @@ export function WorkoutFinishSheets({
               Оціни по шкалі 1–5 (можна пропустити).
             </p>
             <div>
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Енергія
               </div>
               <div className="flex flex-wrap gap-2">
@@ -68,7 +68,7 @@ export function WorkoutFinishSheets({
               </div>
             </div>
             <div>
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Настрій
               </div>
               <div className="flex flex-wrap gap-2">
@@ -175,7 +175,7 @@ export function WorkoutFinishSheets({
               </div>
               <div className="grid grid-cols-3 gap-2 mt-3">
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
-                  <div className="text-[10px] uppercase tracking-wide text-white/60">
+                  <div className="text-2xs uppercase tracking-wide text-white/60">
                     Час
                   </div>
                   <div className="text-sm font-black text-white tabular-nums mt-0.5">
@@ -183,7 +183,7 @@ export function WorkoutFinishSheets({
                   </div>
                 </div>
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
-                  <div className="text-[10px] uppercase tracking-wide text-white/60">
+                  <div className="text-2xs uppercase tracking-wide text-white/60">
                     Вправ
                   </div>
                   <div className="text-lg font-black text-white tabular-nums">
@@ -191,7 +191,7 @@ export function WorkoutFinishSheets({
                   </div>
                 </div>
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
-                  <div className="text-[10px] uppercase tracking-wide text-white/60">
+                  <div className="text-2xs uppercase tracking-wide text-white/60">
                     Обʼєм
                   </div>
                   <div className="text-sm font-black text-white tabular-nums mt-0.5">

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -32,15 +32,15 @@ function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
             {(w.items || []).length} вправ
           </span>
           {isEnded ? (
-            <span className="text-[10px] px-2 py-0.5 rounded-full bg-panelHi text-subtle border border-line">
+            <span className="text-2xs px-2 py-0.5 rounded-full bg-panelHi text-subtle border border-line">
               Завершене
             </span>
           ) : isActive ? (
-            <span className="text-[10px] px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/20">
+            <span className="text-2xs px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/20">
               Активне
             </span>
           ) : (
-            <span className="text-[10px] px-2 py-0.5 rounded-full bg-warning/10 text-warning border border-warning/20">
+            <span className="text-2xs px-2 py-0.5 rounded-full bg-warning/10 text-warning border border-warning/20">
               Чернетка
             </span>
           )}
@@ -217,7 +217,7 @@ export function WorkoutJournalSection({
             </p>
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+                <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
                   Дата
                 </div>
                 <input
@@ -228,7 +228,7 @@ export function WorkoutJournalSection({
                 />
               </div>
               <div>
-                <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+                <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
                   Час початку
                 </div>
                 <input

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -38,7 +38,7 @@ function ScoreButton({ value, selected, onClick, label }) {
       <span className="text-base leading-none">{value}</span>
       <span
         className={cn(
-          "text-[9px] leading-none truncate max-w-full px-1",
+          "text-2xs leading-none truncate max-w-full px-1",
           selected ? "text-white/80" : "text-muted",
         )}
       >
@@ -204,7 +204,7 @@ export function Body({ onOpenMeasurements }) {
               <div>
                 <label
                   htmlFor="body-weight"
-                  className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                  className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
                 >
                   Вага (кг)
                 </label>
@@ -226,7 +226,7 @@ export function Body({ onOpenMeasurements }) {
               <div>
                 <label
                   htmlFor="body-sleep"
-                  className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                  className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
                 >
                   Сон (год)
                 </label>
@@ -248,7 +248,7 @@ export function Body({ onOpenMeasurements }) {
             </div>
 
             <div>
-              <p className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Рівень енергії
               </p>
               <div
@@ -274,7 +274,7 @@ export function Body({ onOpenMeasurements }) {
             </div>
 
             <div>
-              <p className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Настрій
               </p>
               <div className="flex gap-1.5" role="group" aria-label="Настрій">
@@ -298,7 +298,7 @@ export function Body({ onOpenMeasurements }) {
             <div>
               <label
                 htmlFor="body-note"
-                className="text-[10px] font-bold text-subtle uppercase tracking-widest block mb-1"
+                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
               >
                 Нотатка (необов&apos;язково)
               </label>

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -288,14 +288,14 @@ export function Dashboard({
           <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
             {greeting} · {today}
           </p>
-          <h1 className="text-[26px] font-black text-white mt-3 leading-tight">
+          <h1 className="text-2xl font-black text-white mt-3 leading-tight">
             Твій прогрес
             <br />
             зібраний в одному місці
           </h1>
           <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-2">
             <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
-              <p className="text-[10px] uppercase tracking-wide text-white/60">
+              <p className="text-2xs uppercase tracking-wide text-white/60">
                 Тиждень
               </p>
               <p className="text-xl font-black text-white tabular-nums mt-1">
@@ -303,7 +303,7 @@ export function Dashboard({
               </p>
             </div>
             <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
-              <p className="text-[10px] uppercase tracking-wide text-white/60">
+              <p className="text-2xs uppercase tracking-wide text-white/60">
                 Серія
               </p>
               <p className="text-xl font-black text-white tabular-nums mt-1">
@@ -311,7 +311,7 @@ export function Dashboard({
               </p>
             </div>
             <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
-              <p className="text-[10px] uppercase tracking-wide text-white/60">
+              <p className="text-2xs uppercase tracking-wide text-white/60">
                 Сер. час
               </p>
               <p className="text-xl font-black text-white tabular-nums mt-1">
@@ -319,7 +319,7 @@ export function Dashboard({
               </p>
             </div>
             <div className="rounded-2xl bg-white/10 border border-white/15 p-3 text-center">
-              <p className="text-[10px] uppercase tracking-wide text-white/60">
+              <p className="text-2xs uppercase tracking-wide text-white/60">
                 Місяць
               </p>
               <p className="text-xl font-black text-white tabular-nums mt-1">
@@ -370,7 +370,7 @@ export function Dashboard({
                   <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
                     Швидкий старт
                   </h2>
-                  <span className="text-[10px] text-muted">
+                  <span className="text-2xs text-muted">
                     {recentlyUsed.length > 0
                       ? "Нещодавно використані"
                       : "Останні шаблони"}
@@ -506,7 +506,7 @@ export function Dashboard({
 
           {recoveryOpen && (
             <>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-subtle mb-3 mt-3">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-subtle mb-3 mt-3">
                 <span className="inline-flex items-center gap-1">
                   <span className="w-2 h-2 rounded-full bg-success" /> готово
                 </span>
@@ -541,7 +541,7 @@ export function Dashboard({
               />
 
               <div className="mt-4 pt-3 border-t border-line/60">
-                <p className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+                <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                   Пріоритет після відпочинку
                 </p>
                 <div className="flex flex-wrap gap-2">
@@ -592,7 +592,7 @@ export function Dashboard({
                   <div className="text-2xs font-semibold text-subtle uppercase tracking-wide mt-2">
                     {card.label}
                   </div>
-                  <div className="text-[9px] text-muted mt-0.5 leading-snug">
+                  <div className="text-2xs text-muted mt-0.5 leading-snug">
                     {card.sub}
                   </div>
                 </div>
@@ -687,7 +687,7 @@ export function Dashboard({
             </p>
           )}
           <div className="rounded-2xl border border-line bg-panelHi px-3">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest pt-2">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
               Мій шаблон
             </div>
             <select

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -49,7 +49,7 @@ function LoadCalculator({ oneRM }) {
         <div className="text-xs font-bold text-subtle uppercase tracking-widest">
           Калькулятор навантаження
         </div>
-        <div className="text-[10px] text-subtle">1RM = {fmt(oneRM, 0)} кг</div>
+        <div className="text-2xs text-subtle">1RM = {fmt(oneRM, 0)} кг</div>
       </div>
       <div className="space-y-3">
         {CALC_ZONES.map((zone) => (
@@ -65,7 +65,7 @@ function LoadCalculator({ oneRM }) {
               <span className={cn("text-xs font-bold", zone.color)}>
                 {zone.goal}
               </span>
-              <span className="text-[10px] text-subtle">{zone.desc}</span>
+              <span className="text-2xs text-subtle">{zone.desc}</span>
             </div>
             <div className="grid grid-cols-4 gap-1">
               {zone.percents.map((pct) => {
@@ -75,13 +75,13 @@ function LoadCalculator({ oneRM }) {
                     key={pct}
                     className="text-center bg-panel/60 rounded-lg py-1.5 px-1"
                   >
-                    <div className="text-[10px] text-subtle leading-none mb-0.5">
+                    <div className="text-2xs text-subtle leading-none mb-0.5">
                       {pct}%
                     </div>
                     <div className="text-sm font-bold text-text tabular-nums leading-tight">
                       {kg > 0 ? `${kg}` : "—"}
                     </div>
-                    <div className="text-[9px] text-muted leading-none">кг</div>
+                    <div className="text-2xs text-muted leading-none">кг</div>
                   </div>
                 );
               })}
@@ -89,7 +89,7 @@ function LoadCalculator({ oneRM }) {
           </div>
         ))}
       </div>
-      <p className="text-[9px] text-muted mt-2 text-center">
+      <p className="text-2xs text-muted mt-2 text-center">
         Ваги округлені до найближчих 2.5 кг
       </p>
     </div>
@@ -440,7 +440,7 @@ export function Exercise({ exerciseId }) {
 
         <div className="grid grid-cols-2 gap-3">
           <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Особистий рекорд
             </div>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
@@ -452,7 +452,7 @@ export function Exercise({ exerciseId }) {
                 : "Немає силових сетів"}
             </div>
             {best.bestSet?._at && (
-              <div className="text-[10px] text-subtle/70 mt-1">
+              <div className="text-2xs text-subtle/70 mt-1">
                 {new Date(best.bestSet._at).toLocaleDateString("uk-UA", {
                   day: "numeric",
                   month: "short",
@@ -462,7 +462,7 @@ export function Exercise({ exerciseId }) {
             )}
           </div>
           <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Наступного разу
             </div>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
@@ -474,12 +474,12 @@ export function Exercise({ exerciseId }) {
                 : "Заповни сети, щоб зʼявилась рекомендація"}
             </div>
             {suggestedNext?.altWeightKg != null && (
-              <div className="text-[10px] text-fizruk mt-1">
+              <div className="text-2xs text-fizruk mt-1">
                 {`або ${fmt(suggestedNext.altWeightKg, 1)} × ${suggestedNext.altReps} повт.`}
               </div>
             )}
             {suggestedNext && best.lastTop && (
-              <div className="text-[10px] text-subtle/70 mt-1">
+              <div className="text-2xs text-subtle/70 mt-1">
                 {`зараз: ${best.lastTop.weightKg ?? 0} × ${best.lastTop.reps ?? 0}`}
               </div>
             )}
@@ -525,7 +525,7 @@ export function Exercise({ exerciseId }) {
               unit="хв/км"
               color="rgb(234 88 12)"
             />
-            <div className="text-[10px] text-subtle mt-1">
+            <div className="text-2xs text-subtle mt-1">
               Менше — краще (швидший темп)
             </div>
           </div>
@@ -575,7 +575,7 @@ export function Exercise({ exerciseId }) {
                     </div>
                     <div
                       className={cn(
-                        "text-[10px] px-2 py-1 rounded-full border",
+                        "text-2xs px-2 py-1 rounded-full border",
                         item.type === "strength"
                           ? "border-line text-subtle"
                           : "border-line text-subtle",

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -80,7 +80,7 @@ export function Measurements() {
 
         <div className="grid grid-cols-3 gap-2">
           <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Записів
             </div>
             <div className="text-lg font-extrabold text-text tabular-nums mt-1">
@@ -88,7 +88,7 @@ export function Measurements() {
             </div>
           </div>
           <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Останній
             </div>
             <div className="text-sm font-bold text-text mt-1">
@@ -96,7 +96,7 @@ export function Measurements() {
             </div>
           </div>
           <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
-            <div className="text-[10px] font-semibold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Полів
             </div>
             <div className="text-lg font-extrabold text-text tabular-nums mt-1">
@@ -112,7 +112,7 @@ export function Measurements() {
           <div className="grid grid-cols-2 gap-2">
             {MEASURE_FIELDS.map((f) => (
               <div key={f.id} className="space-y-1">
-                <div className="text-[10px] font-bold text-subtle uppercase tracking-widest px-1">
+                <div className="text-2xs font-bold text-subtle uppercase tracking-widest px-1">
                   {f.label} · {f.unit}
                 </div>
                 <input
@@ -169,7 +169,7 @@ export function Measurements() {
                   key={f.id}
                   className="bg-bg border border-line rounded-2xl p-3"
                 >
-                  <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+                  <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
                     {f.label}
                   </div>
                   <div className="text-lg font-extrabold tabular-nums text-text mt-1">

--- a/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -142,7 +142,7 @@ export function PlanCalendar() {
             </button>
           </div>
 
-          <div className="grid grid-cols-7 gap-1 text-center text-[10px] font-semibold text-subtle mb-2">
+          <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
             {WEEKDAYS.map((w) => (
               <div key={w}>{w}</div>
             ))}
@@ -181,7 +181,7 @@ export function PlanCalendar() {
                 >
                   <span className="text-xs font-bold text-text">{day}</span>
                   {tpl && (
-                    <span className="text-[9px] text-subtle leading-tight line-clamp-1 mt-0.5 px-0.5">
+                    <span className="text-2xs text-subtle leading-tight line-clamp-1 mt-0.5 px-0.5">
                       {tpl.name}
                     </span>
                   )}
@@ -198,7 +198,7 @@ export function PlanCalendar() {
               );
             })}
           </div>
-          <p className="text-[10px] text-subtle mt-3">
+          <p className="text-2xs text-subtle mt-3">
             Натисни день, щоб призначити або зняти шаблон.
           </p>
         </section>

--- a/src/modules/fizruk/pages/Programs.tsx
+++ b/src/modules/fizruk/pages/Programs.tsx
@@ -64,11 +64,11 @@ export function Programs({
                           {prog.name}
                         </h2>
                         {isActive && (
-                          <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/25">
+                          <span className="text-2xs font-bold px-2 py-0.5 rounded-full bg-success/15 text-success border border-success/25">
                             Активна
                           </span>
                         )}
-                        <span className="text-[10px] text-subtle border border-line/60 rounded-full px-2 py-0.5">
+                        <span className="text-2xs text-subtle border border-line/60 rounded-full px-2 py-0.5">
                           {prog.days} дн/тиждень
                         </span>
                       </div>
@@ -88,7 +88,7 @@ export function Programs({
                         <div
                           key={i}
                           className={cn(
-                            "flex-1 text-center rounded py-1 text-[9px] font-bold transition-colors",
+                            "flex-1 text-center rounded py-1 text-2xs font-bold transition-colors",
                             hasSession
                               ? isToday && isActive
                                 ? "bg-success text-white"
@@ -168,7 +168,7 @@ export function Programs({
 function ProgramDetails({ prog, exercises }) {
   return (
     <div className="border-t border-line/60 px-4 pb-4 pt-3 space-y-3 bg-bg/50">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
         Розклад та вправи
       </div>
       {prog.schedule.map((schedEntry) => {
@@ -183,14 +183,14 @@ function ProgramDetails({ prog, exercises }) {
             className="rounded-xl bg-panel border border-line/40 p-3"
           >
             <div className="flex items-center gap-2 mb-2">
-              <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-fizruk/10 text-success border border-success/20">
+              <span className="text-2xs font-bold px-2 py-0.5 rounded-full bg-fizruk/10 text-success border border-success/20">
                 День {schedEntry.day}
               </span>
               <span className="text-sm font-semibold text-text">
                 {schedEntry.name}
               </span>
             </div>
-            <div className="flex items-center gap-3 mb-2 text-[10px] text-subtle">
+            <div className="flex items-center gap-3 mb-2 text-2xs text-subtle">
               <span>
                 Відпочинок:{" "}
                 <span className="font-semibold text-text">

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -373,7 +373,7 @@ export function Progress() {
             </div>
             <div className="grid grid-cols-3 gap-2">
               <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-[10px] text-subtle uppercase tracking-wide">
+                <div className="text-2xs text-subtle uppercase tracking-wide">
                   Сьогодні
                 </div>
                 <div className="text-lg font-black text-text tabular-nums">
@@ -381,7 +381,7 @@ export function Progress() {
                 </div>
               </div>
               <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-[10px] text-subtle uppercase tracking-wide">
+                <div className="text-2xs text-subtle uppercase tracking-wide">
                   Тиждень
                 </div>
                 <div className="text-lg font-black text-text tabular-nums">
@@ -389,7 +389,7 @@ export function Progress() {
                 </div>
               </div>
               <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-[10px] text-subtle uppercase tracking-wide">
+                <div className="text-2xs text-subtle uppercase tracking-wide">
                   Місяць
                 </div>
                 <div className="text-lg font-black text-text tabular-nums">
@@ -403,7 +403,7 @@ export function Progress() {
         {/* Weight + fat cards */}
         <div className="grid grid-cols-2 gap-3">
           <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Вага
             </div>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
@@ -430,7 +430,7 @@ export function Progress() {
             </div>
           </div>
           <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               % жиру
             </div>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
@@ -649,7 +649,7 @@ export function Progress() {
                             </span>
                           )}
                           {p.muscleGroupLabel && (
-                            <span className="ml-auto text-[10px] px-2 py-0.5 rounded-full bg-fizruk/10 text-fizruk/70 font-medium shrink-0">
+                            <span className="ml-auto text-2xs px-2 py-0.5 rounded-full bg-fizruk/10 text-fizruk/70 font-medium shrink-0">
                               {p.muscleGroupLabel}
                             </span>
                           )}

--- a/src/modules/nutrition/components/DailyPlanCard.jsx
+++ b/src/modules/nutrition/components/DailyPlanCard.jsx
@@ -62,13 +62,13 @@ function MacroRatioBar({ prefs }) {
 
   return (
     <div className="mt-3 space-y-1.5">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
         Відсоткове співвідношення макро
       </div>
       <div className="flex rounded-lg overflow-hidden h-5">
         {pctP > 0 && (
           <div
-            className="bg-blue-500 flex items-center justify-center text-[9px] font-bold text-white"
+            className="bg-blue-500 flex items-center justify-center text-2xs font-bold text-white"
             style={{ width: `${pctP}%` }}
           >
             {pctP}%
@@ -76,7 +76,7 @@ function MacroRatioBar({ prefs }) {
         )}
         {pctF > 0 && (
           <div
-            className="bg-yellow-500 flex items-center justify-center text-[9px] font-bold text-white"
+            className="bg-yellow-500 flex items-center justify-center text-2xs font-bold text-white"
             style={{ width: `${pctF}%` }}
           >
             {pctF}%
@@ -84,7 +84,7 @@ function MacroRatioBar({ prefs }) {
         )}
         {pctC > 0 && (
           <div
-            className="bg-green-500 flex items-center justify-center text-[9px] font-bold text-white"
+            className="bg-green-500 flex items-center justify-center text-2xs font-bold text-white"
             style={{ width: `${pctC}%` }}
           >
             {pctC}%
@@ -92,15 +92,15 @@ function MacroRatioBar({ prefs }) {
         )}
       </div>
       <div className="flex gap-3 flex-wrap">
-        <span className="flex items-center gap-1 text-[10px] text-subtle">
+        <span className="flex items-center gap-1 text-2xs text-subtle">
           <span className="w-2 h-2 rounded-sm bg-blue-500" /> Б {pctP}% · {prot}
           г · {Math.round(protKcal)} ккал
         </span>
-        <span className="flex items-center gap-1 text-[10px] text-subtle">
+        <span className="flex items-center gap-1 text-2xs text-subtle">
           <span className="w-2 h-2 rounded-sm bg-yellow-500" /> Ж {pctF}% ·{" "}
           {fat}г · {Math.round(fatKcal)} ккал
         </span>
-        <span className="flex items-center gap-1 text-[10px] text-subtle">
+        <span className="flex items-center gap-1 text-2xs text-subtle">
           <span className="w-2 h-2 rounded-sm bg-green-500" /> В {pctC}% ·{" "}
           {carb}г · {Math.round(carbKcal)} ккал
         </span>
@@ -271,7 +271,7 @@ export function DailyPlanCard({
                 )}
               >
                 <div>{preset.label}</div>
-                <div className="text-[10px] opacity-70 mt-0.5">
+                <div className="text-2xs opacity-70 mt-0.5">
                   ~{preset.kcal} ккал
                 </div>
               </button>

--- a/src/modules/nutrition/components/ItemEditSheet.jsx
+++ b/src/modules/nutrition/components/ItemEditSheet.jsx
@@ -58,7 +58,7 @@ export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
                 Кількість
               </div>
               <Input
@@ -72,7 +72,7 @@ export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
               />
             </div>
             <div>
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
                 Одиниця
               </div>
               <Input

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -191,7 +191,7 @@ export function LogCard({
         </div>
 
         <div className="rounded-2xl border border-line/50 bg-panel/40 px-3 py-3 space-y-2">
-          <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
             Пошук по журналу
           </div>
           <Input
@@ -224,14 +224,14 @@ export function LogCard({
                         {meal.name}
                       </div>
                       <div className="flex gap-1.5 mt-0.5 flex-wrap">
-                        <span className="text-[10px] text-subtle">{date}</span>
+                        <span className="text-2xs text-subtle">{date}</span>
                         {mac.kcal != null && (
-                          <span className="text-[10px] text-nutrition font-bold">
+                          <span className="text-2xs text-nutrition font-bold">
                             {Math.round(mac.kcal)} ккал
                           </span>
                         )}
                         {mac.protein_g != null && (
-                          <span className="text-[10px] text-subtle">
+                          <span className="text-2xs text-subtle">
                             Б{Math.round(mac.protein_g)}
                           </span>
                         )}
@@ -279,7 +279,7 @@ export function LogCard({
         <button
           type="button"
           onClick={() => setWeekOpen((v) => !v)}
-          className="flex items-center gap-2 text-[10px] font-bold text-subtle uppercase tracking-widest w-full text-left py-1"
+          className="flex items-center gap-2 text-2xs font-bold text-subtle uppercase tracking-widest w-full text-left py-1"
         >
           <Icon
             name="chevron-right"
@@ -309,7 +309,7 @@ export function LogCard({
                 <tbody>
                   {weekRows.map((r) => (
                     <tr key={r.date} className="border-t border-line/40">
-                      <td className="py-1 pr-2 font-mono text-[10px]">
+                      <td className="py-1 pr-2 font-mono text-2xs">
                         {r.date.slice(5)}
                       </td>
                       <td className="py-1 pr-2">{Math.round(r.kcal)}</td>
@@ -326,7 +326,7 @@ export function LogCard({
 
         <div className="rounded-2xl border border-line/50 bg-panel/40 px-3 py-3 space-y-3">
           <div className="flex items-center justify-between gap-2">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Аналітика (тренди)
             </div>
             <div className="flex gap-2">
@@ -356,11 +356,11 @@ export function LogCard({
               { key: "carbs_g", label: "Сер. В/день", v: statsAvg.carbs_g },
             ].map((x) => (
               <div key={x.key} className="bg-panelHi rounded-2xl px-2 py-3">
-                <div className="text-[10px] text-subtle">{x.label}</div>
+                <div className="text-2xs text-subtle">{x.label}</div>
                 <div className="text-base font-extrabold text-text tabular-nums">
                   {Math.round(Number(x.v) || 0)}
                 </div>
-                <div className="text-[10px] text-subtle">
+                <div className="text-2xs text-subtle">
                   на {statsAvg.denom} активн. днів
                 </div>
               </div>
@@ -368,7 +368,7 @@ export function LogCard({
           </div>
 
           <div className="bg-panelHi rounded-2xl px-3 py-3">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
               Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
             </div>
             {statsRows.length === 0 ? (
@@ -397,7 +397,7 @@ export function LogCard({
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Топ страв
               </div>
               {statsTop.length === 0 ? (
@@ -421,7 +421,7 @@ export function LogCard({
               )}
             </div>
             <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                 Розподіл прийомів
               </div>
               {Object.keys(statsMealTypes).length === 0 ? (
@@ -610,7 +610,7 @@ function MealRow({ meal, onRemove, onEdit }) {
           )}
           {sourceLabel && (
             <span
-              className="text-[10px] px-1.5 py-0.5 rounded-full bg-line/60 text-subtle font-bold uppercase tracking-wider shrink-0"
+              className="text-2xs px-1.5 py-0.5 rounded-full bg-line/60 text-subtle font-bold uppercase tracking-wider shrink-0"
               title="Походження КБЖВ"
             >
               {sourceLabel}

--- a/src/modules/nutrition/components/NutritionBottomNav.jsx
+++ b/src/modules/nutrition/components/NutritionBottomNav.jsx
@@ -142,7 +142,7 @@ export function NutritionBottomNav({ activePage, setActivePage }) {
 
               <span
                 className={cn(
-                  "text-[10px] leading-none font-semibold transition-colors",
+                  "text-2xs leading-none font-semibold transition-colors",
                   active ? "text-text" : "text-muted",
                 )}
               >

--- a/src/modules/nutrition/components/NutritionDashboard.jsx
+++ b/src/modules/nutrition/components/NutritionDashboard.jsx
@@ -108,7 +108,7 @@ function MiniBar({ rows, targetKcal }) {
             </div>
             <span
               className={cn(
-                "text-[9px] leading-none",
+                "text-2xs leading-none",
                 isToday ? "text-text font-bold" : "text-muted",
               )}
             >
@@ -189,11 +189,11 @@ export function NutritionDashboard({
                       </span>
                     </div>
                   </div>
-                  <div className="text-[10px] text-subtle font-semibold leading-none">
+                  <div className="text-2xs text-subtle font-semibold leading-none">
                     {m.label}
                   </div>
                   {target > 0 && (
-                    <div className="text-[9px] text-muted leading-none">
+                    <div className="text-2xs text-muted leading-none">
                       / {target}
                       {m.unit}
                     </div>
@@ -211,7 +211,7 @@ export function NutritionDashboard({
                   key={m.key}
                   className="rounded-xl border border-nutrition/20 bg-nutrition/8 px-2 py-2.5 text-center"
                 >
-                  <div className="text-[10px] text-nutrition/70 font-bold uppercase tracking-wide leading-none mb-1">
+                  <div className="text-2xs text-nutrition/70 font-bold uppercase tracking-wide leading-none mb-1">
                     {m.label}
                   </div>
                   <div className="text-sm font-extrabold text-text leading-none">

--- a/src/modules/nutrition/components/NutritionHeader.jsx
+++ b/src/modules/nutrition/components/NutritionHeader.jsx
@@ -65,7 +65,7 @@ export function NutritionHeader({ busy: _busy, onBackToHub }) {
         )}
 
         <div className="min-w-0 flex-1">
-          <span className="text-[9px] text-lime-600/80 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
+          <span className="text-2xs text-lime-600/80 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
             ХАРЧУВАННЯ
           </span>
           <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">

--- a/src/modules/nutrition/components/NutritionPantrySelector.jsx
+++ b/src/modules/nutrition/components/NutritionPantrySelector.jsx
@@ -3,7 +3,7 @@ export function NutritionPantrySelector({ pantry, busy }) {
   return (
     <div className="rounded-2xl bg-nutrition/10 border border-nutrition/20 px-4 py-3 mb-4 flex items-center gap-3">
       <div className="min-w-0 flex-1">
-        <div className="text-[10px] font-bold text-nutrition/70 uppercase tracking-widest mb-0.5">
+        <div className="text-2xs font-bold text-nutrition/70 uppercase tracking-widest mb-0.5">
           Активний склад
         </div>
         <div className="text-base font-extrabold text-text leading-tight">

--- a/src/modules/nutrition/components/PantryManagerSheet.jsx
+++ b/src/modules/nutrition/components/PantryManagerSheet.jsx
@@ -87,7 +87,7 @@ export function PantryManagerSheet({
                       {p.name || "Склад"}
                     </div>
                     {active ? (
-                      <span className="text-[10px] px-2 py-0.5 rounded-full bg-nutrition/15 text-nutrition border border-nutrition/25">
+                      <span className="text-2xs px-2 py-0.5 rounded-full bg-nutrition/15 text-nutrition border border-nutrition/25">
                         Активний
                       </span>
                     ) : null}
@@ -116,7 +116,7 @@ export function PantryManagerSheet({
           </div>
 
           <div className="rounded-2xl border border-line bg-panelHi p-4">
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               {pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"}
             </div>
             <div className="mt-2">

--- a/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
+++ b/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
@@ -128,7 +128,7 @@ export function PhotoAnalyzeCard({
                 key={m.label}
                 className="rounded-xl border border-nutrition/20 bg-nutrition/8 px-2 py-2 text-center"
               >
-                <div className="text-[10px] text-nutrition/70 font-bold uppercase tracking-wide leading-none mb-1">
+                <div className="text-2xs text-nutrition/70 font-bold uppercase tracking-wide leading-none mb-1">
                   {m.label}
                 </div>
                 <div className="text-sm font-extrabold text-text leading-none">

--- a/src/modules/nutrition/components/RecipesCard.jsx
+++ b/src/modules/nutrition/components/RecipesCard.jsx
@@ -463,7 +463,7 @@ export function RecipesCard({
                     </div>
                     {r.macros?.kcal != null && (
                       <div className="shrink-0 rounded-xl border border-line bg-bg px-3 py-2 text-xs text-subtle">
-                        <div className="text-[10px] text-subtle">≈ ккал</div>
+                        <div className="text-2xs text-subtle">≈ ккал</div>
                         <div className="text-sm font-semibold text-text">
                           {fmtMacro(r.macros.kcal)}
                         </div>

--- a/src/modules/nutrition/components/ShoppingListCard.jsx
+++ b/src/modules/nutrition/components/ShoppingListCard.jsx
@@ -72,7 +72,7 @@ export function ShoppingListCard({
               )}
             >
               <div>Рецепти</div>
-              <div className="text-[10px] opacity-70 mt-0.5">
+              <div className="text-2xs opacity-70 mt-0.5">
                 {hasRecipes ? `${recipes.length} рецептів` : "немає рецептів"}
               </div>
             </button>
@@ -88,7 +88,7 @@ export function ShoppingListCard({
               )}
             >
               <div>Тижневий план</div>
-              <div className="text-[10px] opacity-70 mt-0.5">
+              <div className="text-2xs opacity-70 mt-0.5">
                 {hasWeekPlan ? `${weekPlan.days.length} днів` : "немає плану"}
               </div>
             </button>

--- a/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
@@ -12,7 +12,7 @@ export function BarcodeSection({
 }) {
   return (
     <div className="mb-4 rounded-2xl border border-line/50 bg-panel/40 px-3 py-3">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Штрихкод
       </div>
       <div className="flex flex-wrap gap-2 items-center">

--- a/src/modules/nutrition/components/meal-sheet/FoodHitRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodHitRow.jsx
@@ -10,7 +10,7 @@ export function FoodHitRow({ p, badge, onPick }) {
           <div className="text-sm text-text font-semibold truncate">
             {[p.name, p.brand].filter(Boolean).join(" · ")}
             {badge && (
-              <span className="ml-1 text-[10px] text-subtle">{badge}</span>
+              <span className="ml-1 text-2xs text-subtle">{badge}</span>
             )}
           </div>
           <div className="text-xs font-semibold text-nutrition shrink-0">

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -51,11 +51,11 @@ export function FoodPickerSection({
   return (
     <div className="mb-4 space-y-2">
       <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
           Продукт
         </div>
         {(foodBusy || offBusy) && (
-          <span className="text-[10px] text-subtle flex items-center gap-1.5">
+          <span className="text-2xs text-subtle flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 border border-nutrition/40 border-t-nutrition rounded-full animate-spin" />
             пошук…
           </span>
@@ -89,7 +89,7 @@ export function FoodPickerSection({
                 {offHits.length > 0 && (
                   <>
                     {foodHits.length > 0 && (
-                      <li className="px-3 py-1.5 text-[10px] text-subtle bg-panelHi/50 font-semibold uppercase tracking-widest">
+                      <li className="px-3 py-1.5 text-2xs text-subtle bg-panelHi/50 font-semibold uppercase tracking-widest">
                         🌍 Open Food Facts
                       </li>
                     )}
@@ -124,7 +124,7 @@ export function FoodPickerSection({
                   .filter(Boolean)
                   .join(" · ")}
                 {pickedFood.source === "off" && (
-                  <span className="ml-1 text-[10px] text-subtle">🌍</span>
+                  <span className="ml-1 text-2xs text-subtle">🌍</span>
                 )}
               </div>
               <div className="text-[11px] text-subtle mt-0.5">

--- a/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
@@ -10,7 +10,7 @@ export function FromPantryRow({
   if (!pantryItems || pantryItems.length === 0) return null;
   return (
     <div className="mb-4 rounded-2xl border border-line/50 bg-panel/40 px-3 py-3">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Зі складу
         {fromPantryItem && (
           <span className="ml-2 text-nutrition font-semibold normal-case tracking-normal">
@@ -47,7 +47,7 @@ export function FromPantryRow({
             >
               {item.name}
               {item.qty != null && (
-                <span className="ml-1 text-[10px] opacity-70">
+                <span className="ml-1 text-2xs opacity-70">
                   {item.qty}
                   {item.unit || "г"}
                 </span>

--- a/src/modules/nutrition/components/meal-sheet/MacroChip.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MacroChip.jsx
@@ -3,13 +3,13 @@ import { cn } from "@shared/lib/cn";
 export function MacroChip({ label, value, unit = "г", color }) {
   return (
     <div className={cn("flex flex-col items-center px-3 py-2 min-w-0", color)}>
-      <span className="text-[10px] font-bold uppercase tracking-widest opacity-70">
+      <span className="text-2xs font-bold uppercase tracking-widest opacity-70">
         {label}
       </span>
       <span className="text-base font-extrabold leading-tight">
         {value != null ? Math.round(value) : "—"}
       </span>
-      <span className="text-[10px] opacity-60">{unit}</span>
+      <span className="text-2xs opacity-60">{unit}</span>
     </div>
   );
 }

--- a/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
@@ -39,7 +39,7 @@ export function MacrosEditor({
   return (
     <div className="mb-1">
       <div className="flex items-center justify-between mb-2">
-        <div className="text-[10px] font-bold text-subtle uppercase tracking-widest">
+        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
           {pickedFood ? "КБЖВ (редагувати вручну)" : "КБЖВ"}
         </div>
         {hasPhotoMacros && (
@@ -69,7 +69,7 @@ export function MacrosEditor({
           { key: "carbs_g", label: "Вуглев. г", placeholder: "60" },
         ].map(({ key, label, placeholder }) => (
           <div key={key}>
-            <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
               {label}
             </div>
             <Input

--- a/src/modules/nutrition/components/meal-sheet/MealTemplatesRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MealTemplatesRow.jsx
@@ -2,7 +2,7 @@ export function MealTemplatesRow({ mealTemplates, setForm, onSelected }) {
   if (!Array.isArray(mealTemplates) || mealTemplates.length === 0) return null;
   return (
     <div className="mb-4">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Шаблони
       </div>
       <div className="flex flex-wrap gap-2">

--- a/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
@@ -4,7 +4,7 @@ import { MEAL_TYPES } from "../../lib/mealTypes.js";
 export function MealTypePicker({ mealType, setForm }) {
   return (
     <div className="mb-4">
-      <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-2">
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Прийом їжі
       </div>
       <div className="flex gap-2 flex-wrap">

--- a/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
@@ -25,7 +25,7 @@ export function NameTimeRow({ form, field, setForm }) {
   return (
     <div className="grid grid-cols-[1fr_auto] gap-3 mb-4">
       <div>
-        <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1 flex items-center gap-2">
+        <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1 flex items-center gap-2">
           Назва страви
           <VoiceMicButton
             size="sm"
@@ -42,7 +42,7 @@ export function NameTimeRow({ form, field, setForm }) {
         />
       </div>
       <div>
-        <div className="text-[10px] font-bold text-subtle uppercase tracking-widest mb-1">
+        <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
           Час
         </div>
         <Input

--- a/src/modules/routine/RoutineApp.jsx
+++ b/src/modules/routine/RoutineApp.jsx
@@ -490,7 +490,7 @@ export default function RoutineApp({
           <div className="min-w-0 flex-1">
             <span
               className={cn(
-                "text-[9px] font-bold tracking-widest uppercase block leading-none mb-0.5",
+                "text-2xs font-bold tracking-widest uppercase block leading-none mb-0.5",
                 C.eyebrow,
               )}
             >
@@ -499,7 +499,7 @@ export default function RoutineApp({
             <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
               РУТИНА
             </span>
-            <span className="text-[10px] text-subtle font-medium truncate">
+            <span className="text-2xs text-subtle font-medium truncate">
               Звички · план Фізрука · один розклад
             </span>
           </div>

--- a/src/modules/routine/components/DayProgressRing.jsx
+++ b/src/modules/routine/components/DayProgressRing.jsx
@@ -49,7 +49,7 @@ export function DayProgressRing({ completed, scheduled, onClick }) {
           </span>
         </div>
       </div>
-      <span className="text-[10px] text-subtle font-medium group-hover:text-text transition-colors">
+      <span className="text-2xs text-subtle font-medium group-hover:text-text transition-colors">
         Денний звіт
       </span>
     </button>

--- a/src/modules/routine/components/DayReportSheet.jsx
+++ b/src/modules/routine/components/DayReportSheet.jsx
@@ -78,7 +78,7 @@ export function DayReportSheet({
 
         {done.length > 0 && (
           <div className="mb-4">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-subtle mb-2">
+            <p className="text-2xs font-bold uppercase tracking-widest text-subtle mb-2">
               Виконано ({done.length})
             </p>
             <ul className="space-y-1.5">
@@ -109,7 +109,7 @@ export function DayReportSheet({
 
         {missed.length > 0 && (
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-widest text-subtle mb-2">
+            <p className="text-2xs font-bold uppercase tracking-widest text-subtle mb-2">
               Пропущено ({missed.length})
             </p>
             <ul className="space-y-1.5">

--- a/src/modules/routine/components/HabitDetailSheet.jsx
+++ b/src/modules/routine/components/HabitDetailSheet.jsx
@@ -189,13 +189,13 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               {tag.map((t) => (
                 <span
                   key={t}
-                  className="text-[10px] px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine/12 border border-routine-line/50 dark:border-routine/25 text-routine-kicker dark:text-routine font-medium"
+                  className="text-2xs px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine/12 border border-routine-line/50 dark:border-routine/25 text-routine-kicker dark:text-routine font-medium"
                 >
                   {t}
                 </span>
               ))}
               {category && (
-                <span className="text-[10px] px-2 py-0.5 rounded-full bg-panelHi border border-line/60 text-muted font-medium">
+                <span className="text-2xs px-2 py-0.5 rounded-full bg-panelHi border border-line/60 text-muted font-medium">
                   {category}
                 </span>
               )}
@@ -235,19 +235,19 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               <p className="text-2xl font-black text-text tabular-nums">
                 {currentStreak}
               </p>
-              <p className="text-[10px] text-subtle mt-0.5">Поточна серія</p>
+              <p className="text-2xs text-subtle mt-0.5">Поточна серія</p>
             </div>
             <div className={C.statCard}>
               <p className="text-2xl font-black text-text tabular-nums">
                 {bestStreak}
               </p>
-              <p className="text-[10px] text-subtle mt-0.5">Макс серія</p>
+              <p className="text-2xs text-subtle mt-0.5">Макс серія</p>
             </div>
             <div className={C.statCard}>
               <p className="text-2xl font-black text-text tabular-nums">
                 {totalDone}
               </p>
-              <p className="text-[10px] text-subtle mt-0.5">Разів виконано</p>
+              <p className="text-2xs text-subtle mt-0.5">Разів виконано</p>
             </div>
             <div className={C.statCard}>
               <div className="flex items-baseline justify-center gap-1.5">
@@ -262,7 +262,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
                   </span>
                 )}
                 {pct90 !== null && (
-                  <span className="text-[10px] text-subtle tabular-nums">
+                  <span className="text-2xs text-subtle tabular-nums">
                     {pct90}%
                   </span>
                 )}
@@ -270,9 +270,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
                   <span className="text-sm text-muted">—</span>
                 )}
               </div>
-              <p className="text-[10px] text-subtle mt-0.5">
-                % за 7 / 30 / 90 д
-              </p>
+              <p className="text-2xs text-subtle mt-0.5">% за 7 / 30 / 90 д</p>
             </div>
           </div>
         </section>
@@ -308,7 +306,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
             {WEEKDAY_LABELS.map((wd) => (
               <div
                 key={wd}
-                className="text-center text-[9px] text-subtle font-medium pb-1"
+                className="text-center text-2xs text-subtle font-medium pb-1"
               >
                 {wd}
               </div>
@@ -345,7 +343,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               );
             })}
           </div>
-          <div className="flex items-center gap-3 mt-2 text-[9px] text-subtle">
+          <div className="flex items-center gap-3 mt-2 text-2xs text-subtle">
             <span className="flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded bg-routine-surface2 dark:bg-routine/15 border border-routine-ring/40 dark:border-routine/30" />
               Виконано

--- a/src/modules/routine/components/HabitHeatmap.jsx
+++ b/src/modules/routine/components/HabitHeatmap.jsx
@@ -196,7 +196,7 @@ export function HabitHeatmap({ habits, completions }) {
           </span>
         </div>
       ) : (
-        <div className="mt-3 flex items-center gap-2 text-[9px] text-subtle/70 select-none">
+        <div className="mt-3 flex items-center gap-2 text-2xs text-subtle/70 select-none">
           <span>менше</span>
           {[
             "bg-panelHi dark:bg-line/25",

--- a/src/modules/routine/components/HabitLeadersBlock.jsx
+++ b/src/modules/routine/components/HabitLeadersBlock.jsx
@@ -33,7 +33,7 @@ export function HabitLeadersBlock({ habits, completions }) {
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div className="rounded-xl border border-routine-line/40 dark:border-routine/20 bg-routine-surface/30 dark:bg-routine/8 p-3">
-          <p className="text-[10px] uppercase tracking-wide text-subtle mb-1">
+          <p className="text-2xs uppercase tracking-wide text-subtle mb-1">
             Найстабільніша
           </p>
           <p className="text-sm font-semibold text-text truncate">
@@ -45,7 +45,7 @@ export function HabitLeadersBlock({ habits, completions }) {
         </div>
         {worst && (
           <div className="rounded-xl border border-line/50 bg-panel p-3">
-            <p className="text-[10px] uppercase tracking-wide text-subtle mb-1">
+            <p className="text-2xs uppercase tracking-wide text-subtle mb-1">
               Найслабша
             </p>
             <p className="text-sm font-semibold text-text truncate">

--- a/src/modules/routine/components/PushupsWidget.jsx
+++ b/src/modules/routine/components/PushupsWidget.jsx
@@ -66,7 +66,7 @@ export function PushupsWidget() {
 
         {recentHistory.some((d) => d.total > 0) && (
           <div className="mt-4 pt-3 border-t border-line/60">
-            <p className="text-[10px] text-subtle mb-2">Останні 7 днів</p>
+            <p className="text-2xs text-subtle mb-2">Останні 7 днів</p>
             <div className="flex items-end gap-1 h-10">
               {recentHistory.map((d) => {
                 const max = Math.max(...recentHistory.map((x) => x.total), 1);

--- a/src/modules/routine/components/RoutineCalendarPanel.jsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.jsx
@@ -130,7 +130,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
           />
           <div className="flex-1 grid grid-cols-2 gap-2 w-full sm:grid-cols-2 lg:grid-cols-4">
             <div className={C.statCard}>
-              <p className="text-[10px] uppercase tracking-wide text-subtle">
+              <p className="text-2xs uppercase tracking-wide text-subtle">
                 Подій у зрізі
               </p>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -138,7 +138,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-[10px] uppercase tracking-wide text-subtle">
+              <p className="text-2xs uppercase tracking-wide text-subtle">
                 Звичок активних
               </p>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -146,18 +146,18 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-[10px] uppercase tracking-wide text-subtle">
+              <p className="text-2xs uppercase tracking-wide text-subtle">
                 Виконання
               </p>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {Math.round(completionRate.rate * 100)}%
               </p>
-              <p className="text-[9px] text-subtle tabular-nums">
+              <p className="text-2xs text-subtle tabular-nums">
                 {completionRate.completed}/{completionRate.scheduled}
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-[10px] uppercase tracking-wide text-subtle">
+              <p className="text-2xs uppercase tracking-wide text-subtle">
                 Поточна серія
               </p>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -206,7 +206,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
       </div>
 
       <div className="rounded-2xl border border-line/60 bg-panel/80 p-3 shadow-card">
-        <p className="mb-2 text-[10px] font-bold uppercase tracking-widest text-subtle">
+        <p className="mb-2 text-2xs font-bold uppercase tracking-widest text-subtle">
           Тиждень
         </p>
         <WeekDayStrip
@@ -220,7 +220,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
           onShiftWeek={shiftWeekStrip}
         />
         {timeMode === "day" && (
-          <p className="mt-2 text-center text-[10px] text-subtle">
+          <p className="mt-2 text-center text-2xs text-subtle">
             Обрано один день — натисни «Сьогодні» або «Тиждень», щоб повернути
             зріз
           </p>
@@ -236,7 +236,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
       />
 
       <div className="flex flex-wrap gap-1.5 items-center">
-        <span className="text-[10px] font-bold text-subtle uppercase tracking-widest w-full sm:w-auto">
+        <span className="text-2xs font-bold text-subtle uppercase tracking-widest w-full sm:w-auto">
           Теги
         </span>
         <button
@@ -334,7 +334,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
 
       {timeMode === "month" && (
         <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
-          <div className="grid grid-cols-7 gap-1 text-center text-[10px] font-semibold text-subtle mb-2">
+          <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
             {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"].map((d) => (
               <div key={d}>{d}</div>
             ))}
@@ -377,7 +377,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
                     <span className="flex items-center gap-0.5" aria-hidden>
                       <span className={cn("w-1.5 h-1.5 rounded-full", C.dot)} />
                       {n > 1 && (
-                        <span className="text-[9px] text-subtle tabular-nums">
+                        <span className="text-2xs text-subtle tabular-nums">
                           {n}
                         </span>
                       )}

--- a/src/modules/routine/components/RoutineStatsPanel.jsx
+++ b/src/modules/routine/components/RoutineStatsPanel.jsx
@@ -63,7 +63,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
         </p>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
           <div className={C.statCard}>
-            <p className="text-[10px] uppercase tracking-wide text-subtle">
+            <p className="text-2xs uppercase tracking-wide text-subtle">
               Серія сьогодні
             </p>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -71,7 +71,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
             </p>
           </div>
           <div className={C.statCard}>
-            <p className="text-[10px] uppercase tracking-wide text-subtle">
+            <p className="text-2xs uppercase tracking-wide text-subtle">
               Макс. серія
             </p>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -79,35 +79,35 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
             </p>
           </div>
           <div className={C.statCard}>
-            <p className="text-[10px] uppercase tracking-wide text-subtle">
+            <p className="text-2xs uppercase tracking-wide text-subtle">
               7 днів
             </p>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r7.rate * 100)}%
             </p>
-            <p className="text-[9px] text-subtle tabular-nums">
+            <p className="text-2xs text-subtle tabular-nums">
               {summary.r7.completed}/{summary.r7.scheduled}
             </p>
           </div>
           <div className={C.statCard}>
-            <p className="text-[10px] uppercase tracking-wide text-subtle">
+            <p className="text-2xs uppercase tracking-wide text-subtle">
               30 днів
             </p>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r30.rate * 100)}%
             </p>
-            <p className="text-[9px] text-subtle tabular-nums">
+            <p className="text-2xs text-subtle tabular-nums">
               {summary.r30.completed}/{summary.r30.scheduled}
             </p>
           </div>
           <div className={cn(C.statCard, "col-span-2 sm:col-span-1")}>
-            <p className="text-[10px] uppercase tracking-wide text-subtle">
+            <p className="text-2xs uppercase tracking-wide text-subtle">
               90 днів
             </p>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r90.rate * 100)}%
             </p>
-            <p className="text-[9px] text-subtle tabular-nums">
+            <p className="text-2xs text-subtle tabular-nums">
               {summary.r90.completed}/{summary.r90.scheduled}
             </p>
           </div>

--- a/src/modules/routine/components/WeekDayStrip.jsx
+++ b/src/modules/routine/components/WeekDayStrip.jsx
@@ -42,14 +42,14 @@ export function WeekDayStrip({
               type="button"
               onClick={() => onSelectDay(k)}
               className={cn(
-                "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-[10px] font-semibold transition-colors sm:text-[11px]",
+                "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-[11px]",
                 isSel
                   ? "border-routine-ring dark:border-routine/40 bg-routine-surface2 dark:bg-routine/15 text-text shadow-sm ring-1 ring-routine-line/50 dark:ring-routine/30"
                   : "border-transparent bg-panelHi/50 text-muted hover:bg-panelHi hover:text-text",
                 isToday && !isSel && "ring-1 ring-routine/40",
               )}
             >
-              <span className="text-[9px] uppercase tracking-wide text-subtle">
+              <span className="text-2xs uppercase tracking-wide text-subtle">
                 {short[i]}
               </span>
               <span className="tabular-nums text-sm text-text">{dom}</span>

--- a/src/modules/routine/components/settings/ActiveHabitsSection.jsx
+++ b/src/modules/routine/components/settings/ActiveHabitsSection.jsx
@@ -41,7 +41,7 @@ export function ActiveHabitsSection({
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Активні звички
       </h2>
-      <p className="text-[10px] text-subtle leading-snug">
+      <p className="text-2xs text-subtle leading-snug">
         Порядок у списку = порядок у календарі. На десктопі можна перетягнути;
         на телефоні — кнопки ↑↓. Для клавіатури та скрінрідерів зручніші кнопки
         ↑↓.

--- a/src/modules/routine/components/settings/ArchivedHabitsSection.jsx
+++ b/src/modules/routine/components/settings/ArchivedHabitsSection.jsx
@@ -14,7 +14,7 @@ export function ArchivedHabitsSection({
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Архів
       </h2>
-      <p className="text-[10px] text-subtle">
+      <p className="text-2xs text-subtle">
         Не показуються в календарі; відмітки збережені.
       </p>
       <ul className="space-y-2">

--- a/src/modules/routine/components/settings/CategoriesSection.jsx
+++ b/src/modules/routine/components/settings/CategoriesSection.jsx
@@ -108,7 +108,7 @@ export function CategoriesSection({
                       {c.emoji ? `${c.emoji} ` : ""}
                       {c.name}
                     </span>
-                    <span className="shrink-0 text-[10px] text-subtle bg-panel border border-line/50 rounded-full px-2 py-0.5">
+                    <span className="shrink-0 text-2xs text-subtle bg-panel border border-line/50 rounded-full px-2 py-0.5">
                       {habitCount}{" "}
                       {habitCount === 1
                         ? "звичка"

--- a/src/modules/routine/components/settings/HabitForm.jsx
+++ b/src/modules/routine/components/settings/HabitForm.jsx
@@ -116,7 +116,7 @@ export function HabitForm({
         className="flex items-center gap-1 text-xs text-muted hover:text-text transition-colors"
       >
         <span>{showAdvanced ? "Менше опцій" : "Більше опцій"}</span>
-        <span aria-hidden className="text-[10px]">
+        <span aria-hidden className="text-2xs">
           {showAdvanced ? "▲" : "▼"}
         </span>
       </button>
@@ -194,7 +194,7 @@ export function HabitForm({
                   </option>
                 ))}
               </select>
-              <span className="block text-[10px] text-subtle mt-1 leading-snug">
+              <span className="block text-2xs text-subtle mt-1 leading-snug">
                 Один тег на звичку (поле tagIds у даних — масив для сумісності).
               </span>
             </label>

--- a/src/modules/routine/components/settings/HabitListItem.jsx
+++ b/src/modules/routine/components/settings/HabitListItem.jsx
@@ -47,7 +47,7 @@ export const HabitListItem = memo(function HabitListItem({
           <span className="text-sm font-medium">
             {h.emoji} {h.name}
           </span>
-          <p className="text-[10px] text-subtle mt-0.5">
+          <p className="text-2xs text-subtle mt-0.5">
             {recLabel}
             {h.timeOfDay ? ` · ${h.timeOfDay}` : ""}
             {h.startDate ? ` · з ${h.startDate}` : ""}


### PR DESCRIPTION
## Summary

Polish-only pass (first slice of the cross-module UI-consistency audit). No redesign, no layout changes — just collapses three arbitrary font-size utilities onto the Tailwind scale that's already defined in `tailwind.config.js`.

| Before | After | Shift |
|---|---|---|
| `text-[10px]` (191 uses) | `text-2xs` | none — `2xs` is already defined as `10px / 14px` |
| `text-[9px]` (38 uses) | `text-2xs` | +1 px — unifies micro labels that were 1 px smaller for no reason |
| `text-[26px]` (3 uses, Fizruk Dashboard hero) | `text-2xl` | −2 px — matches Atlas hero (`text-2xl font-black`) |

No changes to colors, weights, layouts, components, or APIs. Diff is 232 inserts / 234 deletes across 69 files, all one-liners.

Other findings from the audit (duplicated `h-9 px-3 rounded-xl …` "secondary" buttons, 83 hand-rolled cards bypassing `<Card>`, focus-ring opacity drift, etc.) are intentionally deferred to follow-up PRs because those require component migrations with more review surface.

Local checks:
- `npm run lint` — passes
- `npm run typecheck` — passes
- `npm test` — 604 / 604 pass
- `npm run build` — passes
- `npm run format:check` — passes

## Review & Testing Checklist for Human

- [ ] Spot-check the Fizruk Dashboard greeting title (was `text-[26px]`, now `text-2xl`) — confirm the 2 px reduction reads OK on mobile.
- [ ] Spot-check a few micro-label spots that were `text-[9px]` (RoutineStatsPanel tabular numbers, RoutineCalendarPanel day numbers) — confirm the +1 px bump is acceptable.
- [ ] Scan one screen per module (Finyk / Fizruk / Routine / Nutrition) in both light and dark mode for any unintended line-wrap regressions where `10px` chips might now wrap.

### Notes

Risk: **green**. Pure token unification, no structural changes. If any of the `text-[9px]` → `text-2xs` jumps look too tall in practice, the revert is a trivial one-line sed.

Follow-ups (not in this PR, sized separately):
1. Promote `<Button>` primitive for the 4 duplicated "secondary small" class strings (Workouts / Body / Programs / WorkoutJournalSection) and all icon buttons.
2. Promote `<Card>` primitive for the 83 hand-rolled panels; normalize border opacity to solid `border-line`.
3. Standardize focus-ring opacity to `/45`; remove per-element overrides.
4. Replace raw `bg-emerald-500` FAB in `FinykApp.jsx` with `<Button variant="finyk">`.

Full audit document was attached in the preceding thread.

Link to Devin session: https://app.devin.ai/sessions/5b1aebe8911c40058c2847104209824e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
