### PR TITLE
feat(obs): domain metrics, error tracking, latency histograms

### DIFF
--- a/server/api/barcode.js
+++ b/server/api/barcode.js
@@ -3,17 +3,25 @@ import { checkRateLimit } from "./lib/rateLimit.js";
 import { setRequestModule } from "../obs/requestContext.js";
 import {
   barcodeLookupsTotal,
+  externalHttpDurationMs,
   externalHttpRequestsTotal,
 } from "../obs/metrics.js";
 
 /** Емітить і барcode-domain метрику, і загальний outbound HTTP. */
-function recordLookup(source, outcome) {
+function recordLookup(source, outcome, ms) {
   try {
     barcodeLookupsTotal.inc({ source, outcome });
     externalHttpRequestsTotal.inc({ upstream: source, outcome });
+    if (ms != null) {
+      externalHttpDurationMs.observe({ upstream: source, outcome }, ms);
+    }
   } catch {
     /* metrics must never break a request */
   }
+}
+
+function elapsedMs(start) {
+  return Number(process.hrtime.bigint() - start) / 1e6;
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -69,6 +77,7 @@ function normalizeOFF(product) {
 
 async function lookupOFF(barcode) {
   const url = `${OFF_BASE}/${barcode}.json?fields=${OFF_FIELDS}`;
+  const start = process.hrtime.bigint();
   try {
     const r = await fetch(url, {
       headers: {
@@ -78,19 +87,23 @@ async function lookupOFF(barcode) {
       signal: AbortSignal.timeout(7000),
     });
     if (!r.ok) {
-      recordLookup("off", "miss");
+      recordLookup("off", "miss", elapsedMs(start));
       return null;
     }
     const data = await r.json();
     if (data?.status !== 1 || !data?.product) {
-      recordLookup("off", "miss");
+      recordLookup("off", "miss", elapsedMs(start));
       return null;
     }
     const product = normalizeOFF(data.product);
-    recordLookup("off", product ? "hit" : "miss");
+    recordLookup("off", product ? "hit" : "miss", elapsedMs(start));
     return product;
   } catch (e) {
-    recordLookup("off", "error");
+    recordLookup(
+      "off",
+      e?.name === "TimeoutError" ? "timeout" : "error",
+      elapsedMs(start),
+    );
     throw e;
   }
 }
@@ -160,19 +173,20 @@ async function lookupUSDA(barcode) {
   const key = process.env.USDA_FDC_API_KEY || "DEMO_KEY";
   // Search Branded Foods by GTIN/UPC (barcode is stored in gtinUpc field)
   const url = `${FDC_BASE}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&pageSize=5&api_key=${key}`;
+  const start = process.hrtime.bigint();
   try {
     const r = await fetch(url, {
       headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
       signal: AbortSignal.timeout(7000),
     });
     if (!r.ok) {
-      recordLookup("usda", "miss");
+      recordLookup("usda", "miss", elapsedMs(start));
       return null;
     }
     const data = await r.json();
     const foods = data?.foods;
     if (!Array.isArray(foods) || foods.length === 0) {
-      recordLookup("usda", "miss");
+      recordLookup("usda", "miss", elapsedMs(start));
       return null;
     }
 
@@ -184,10 +198,14 @@ async function lookupUSDA(barcode) {
     );
     const food = exact || foods[0];
     const product = normalizeUSDA(food);
-    recordLookup("usda", product ? "hit" : "miss");
+    recordLookup("usda", product ? "hit" : "miss", elapsedMs(start));
     return product;
   } catch (e) {
-    recordLookup("usda", "error");
+    recordLookup(
+      "usda",
+      e?.name === "TimeoutError" ? "timeout" : "error",
+      elapsedMs(start),
+    );
     throw e;
   }
 }
@@ -199,31 +217,32 @@ async function lookupUSDA(barcode) {
 // ──────────────────────────────────────────────────────────────────────────────
 async function lookupUPCitemdb(barcode) {
   const url = `https://api.upcitemdb.com/prod/trial/lookup?upc=${encodeURIComponent(barcode)}`;
+  const start = process.hrtime.bigint();
   try {
     const r = await fetch(url, {
       headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
       signal: AbortSignal.timeout(6000),
     });
     if (!r.ok) {
-      recordLookup("upcitemdb", "miss");
+      recordLookup("upcitemdb", "miss", elapsedMs(start));
       return null;
     }
     const data = await r.json();
     const item = Array.isArray(data?.items) ? data.items[0] : null;
     if (!item) {
-      recordLookup("upcitemdb", "miss");
+      recordLookup("upcitemdb", "miss", elapsedMs(start));
       return null;
     }
 
     const name = item.title || null;
     if (!name) {
-      recordLookup("upcitemdb", "miss");
+      recordLookup("upcitemdb", "miss", elapsedMs(start));
       return null;
     }
 
     const brand = item.brand || null;
 
-    recordLookup("upcitemdb", "hit");
+    recordLookup("upcitemdb", "hit", elapsedMs(start));
     return {
       name,
       brand,
@@ -237,7 +256,11 @@ async function lookupUPCitemdb(barcode) {
       partial: true, // no nutrition data — frontend should prompt user to fill in macros
     };
   } catch (e) {
-    recordLookup("upcitemdb", "error");
+    recordLookup(
+      "upcitemdb",
+      e?.name === "TimeoutError" ? "timeout" : "error",
+      elapsedMs(start),
+    );
     throw e;
   }
 }

--- a/server/api/lib/rateLimit.js
+++ b/server/api/lib/rateLimit.js
@@ -1,3 +1,13 @@
+import { rateLimitHitsTotal } from "../../obs/metrics.js";
+
+function recordRateLimit(key, outcome) {
+  try {
+    rateLimitHitsTotal.inc({ key, outcome });
+  } catch {
+    /* metrics must never break a request */
+  }
+}
+
 export function getIp(req) {
   const xf = req?.headers?.["x-forwarded-for"];
   if (typeof xf === "string" && xf.trim()) return xf.split(",")[0].trim();
@@ -35,9 +45,11 @@ export function checkRateLimit(req, { key, limit, windowMs }) {
   const cur = buckets.get(k);
   if (!cur || now - cur.startMs >= windowMs) {
     buckets.set(k, { startMs: now, count: 1 });
+    recordRateLimit(key, "allowed");
     return { ok: true, remaining: limit - 1, resetMs: windowMs };
   }
   if (cur.count >= limit) {
+    recordRateLimit(key, "blocked");
     return {
       ok: false,
       remaining: 0,
@@ -45,6 +57,7 @@ export function checkRateLimit(req, { key, limit, windowMs }) {
     };
   }
   cur.count += 1;
+  recordRateLimit(key, "allowed");
   return {
     ok: true,
     remaining: Math.max(0, limit - cur.count),

--- a/server/api/mono.js
+++ b/server/api/mono.js
@@ -1,11 +1,17 @@
 import { setCorsHeaders } from "./lib/cors.js";
 import { setRequestModule } from "../obs/requestContext.js";
 import { logger } from "../obs/logger.js";
-import { externalHttpRequestsTotal } from "../obs/metrics.js";
+import {
+  externalHttpDurationMs,
+  externalHttpRequestsTotal,
+} from "../obs/metrics.js";
 
-function recordMono(outcome) {
+function recordMono(outcome, ms) {
   try {
     externalHttpRequestsTotal.inc({ upstream: "monobank", outcome });
+    if (ms != null) {
+      externalHttpDurationMs.observe({ upstream: "monobank", outcome }, ms);
+    }
   } catch {
     /* ignore */
   }
@@ -42,13 +48,15 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Недозволений API шлях" });
   }
 
+  const start = process.hrtime.bigint();
   try {
     const response = await fetch(`https://api.monobank.ua${path}`, {
       headers: { "X-Token": String(token) },
     });
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
 
     if (!response.ok) {
-      recordMono(response.status === 429 ? "rate_limited" : "error");
+      recordMono(response.status === 429 ? "rate_limited" : "error", ms);
       const errorText = await response.text();
       return res.status(response.status).json({
         error: response.status === 429 ? "Занадто багато запитів" : errorText,
@@ -56,10 +64,11 @@ export default async function handler(req, res) {
     }
 
     const data = await response.json();
-    recordMono("ok");
+    recordMono("ok", ms);
     res.status(200).json(data);
   } catch (e) {
-    recordMono("error");
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    recordMono("error", ms);
     logger.error({
       msg: "mono_proxy_failed",
       err: { message: e?.message || String(e), code: e?.code },

--- a/server/api/nutrition/analyze-photo.js
+++ b/server/api/nutrition/analyze-photo.js
@@ -90,6 +90,7 @@ export default async function handler(req, res) {
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 20000,
+      endpoint: "analyze-photo",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/day-hint.js
+++ b/server/api/nutrition/day-hint.js
@@ -89,6 +89,7 @@ ${contextNote}${sourcesNote}Факт за день: ккал ${m.kcal ?? "—"},
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 20000,
+      endpoint: "day-hint",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/day-plan.js
+++ b/server/api/nutrition/day-plan.js
@@ -192,6 +192,7 @@ ${regenStr}`;
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 30000,
+      endpoint: "day-plan",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/lib/anthropicFetch.js
+++ b/server/api/nutrition/lib/anthropicFetch.js
@@ -1,15 +1,37 @@
 import {
+  aiRequestDurationMs,
+  aiRequestsTotal,
   aiTokensTotal,
+  externalHttpDurationMs,
   externalHttpRequestsTotal,
 } from "../../../obs/metrics.js";
 
 const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
 
-function recordOutcome(outcome) {
+function recordOutcome(outcome, { model, endpoint, ms }) {
   try {
     externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome });
+    if (ms != null) {
+      externalHttpDurationMs.observe({ upstream: "anthropic", outcome }, ms);
+    }
+    aiRequestsTotal.inc({
+      provider: "anthropic",
+      model: model || "unknown",
+      endpoint: endpoint || "unknown",
+      outcome,
+    });
+    if (ms != null) {
+      aiRequestDurationMs.observe(
+        {
+          provider: "anthropic",
+          model: model || "unknown",
+          endpoint: endpoint || "unknown",
+        },
+        ms,
+      );
+    }
   } catch {
-    /* ignore */
+    /* metrics must never break a request */
   }
 }
 
@@ -37,10 +59,12 @@ function recordUsage(model, data) {
 export async function anthropicMessages(
   apiKey,
   payload,
-  { timeoutMs = 20000 } = {},
+  { timeoutMs = 20000, endpoint = "unknown" } = {},
 ) {
   const maxAttempts = 3;
   const retryDelayMs = [0, 250, 750];
+  const model = payload?.model || "unknown";
+  const overallStart = process.hrtime.bigint();
 
   /** @type {Response|null} */
   let lastResponse = null;
@@ -73,17 +97,27 @@ export async function anthropicMessages(
       // Ретраїмо тільки тимчасові/перевантажені стани.
       if (shouldRetryStatus(response.status) && attempt < maxAttempts) continue;
 
+      const ms = Number(process.hrtime.bigint() - overallStart) / 1e6;
       if (response.ok) {
-        recordOutcome("ok");
-        recordUsage(payload?.model || "unknown", data);
+        recordOutcome("ok", { model, endpoint, ms });
+        recordUsage(model, data);
       } else {
-        recordOutcome(response.status === 429 ? "rate_limited" : "error");
+        recordOutcome(response.status === 429 ? "rate_limited" : "error", {
+          model,
+          endpoint,
+          ms,
+        });
       }
       return { response, data };
     } catch (e) {
       // На явний timeout (AbortError) краще не "допалювати" запити.
       if (isAbortError(e) || attempt >= maxAttempts) {
-        recordOutcome(isAbortError(e) ? "timeout" : "error");
+        const ms = Number(process.hrtime.bigint() - overallStart) / 1e6;
+        recordOutcome(isAbortError(e) ? "timeout" : "error", {
+          model,
+          endpoint,
+          ms,
+        });
         throw e;
       }
       continue;

--- a/server/api/nutrition/parse-pantry.js
+++ b/server/api/nutrition/parse-pantry.js
@@ -85,6 +85,7 @@ export default async function handler(req, res) {
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 20000,
+      endpoint: "parse-pantry",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/recommend-recipes.js
+++ b/server/api/nutrition/recommend-recipes.js
@@ -120,6 +120,7 @@ export default async function handler(req, res) {
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 45000,
+      endpoint: "recommend-recipes",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/refine-photo.js
+++ b/server/api/nutrition/refine-photo.js
@@ -114,6 +114,7 @@ export default async function handler(req, res) {
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 20000,
+      endpoint: "refine-photo",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/shopping-list.js
+++ b/server/api/nutrition/shopping-list.js
@@ -133,6 +133,7 @@ ${ingredientsList}
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 25000,
+      endpoint: "shopping-list",
     });
     if (!response.ok) {
       return res

--- a/server/api/nutrition/week-plan.js
+++ b/server/api/nutrition/week-plan.js
@@ -111,6 +111,7 @@ export default async function handler(req, res) {
 
     const { response, data } = await anthropicMessages(apiKey, payload, {
       timeoutMs: 35000,
+      endpoint: "week-plan",
     });
     if (!response.ok) {
       return res

--- a/server/api/privat.js
+++ b/server/api/privat.js
@@ -1,7 +1,21 @@
 import { setCorsHeaders } from "./lib/cors.js";
 import { setRequestModule } from "../obs/requestContext.js";
 import { logger } from "../obs/logger.js";
-import { externalHttpRequestsTotal } from "../obs/metrics.js";
+import {
+  externalHttpDurationMs,
+  externalHttpRequestsTotal,
+} from "../obs/metrics.js";
+
+function recordPrivat(outcome, ms) {
+  try {
+    externalHttpRequestsTotal.inc({ upstream: "privatbank", outcome });
+    if (ms != null) {
+      externalHttpDurationMs.observe({ upstream: "privatbank", outcome }, ms);
+    }
+  } catch {
+    /* ignore */
+  }
+}
 
 export default async function handler(req, res) {
   setRequestModule("finyk");
@@ -55,6 +69,7 @@ export default async function handler(req, res) {
   queryParams.delete("path");
   const queryString = queryParams.toString();
 
+  const start = process.hrtime.bigint();
   try {
     const url = `https://acp.privatbank.ua/api${path}${queryString ? "?" + queryString : ""}`;
     const response = await fetch(url, {
@@ -64,16 +79,10 @@ export default async function handler(req, res) {
         "Content-Type": "application/json;charset=utf-8",
       },
     });
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
 
     if (!response.ok) {
-      try {
-        externalHttpRequestsTotal.inc({
-          upstream: "privatbank",
-          outcome: response.status === 429 ? "rate_limited" : "error",
-        });
-      } catch {
-        /* ignore */
-      }
+      recordPrivat(response.status === 429 ? "rate_limited" : "error", ms);
       let errorText = "";
       try {
         errorText = await response.text();
@@ -88,22 +97,12 @@ export default async function handler(req, res) {
       });
     }
 
-    try {
-      externalHttpRequestsTotal.inc({ upstream: "privatbank", outcome: "ok" });
-    } catch {
-      /* ignore */
-    }
+    recordPrivat("ok", ms);
     const data = await response.json();
     res.status(200).json(data);
   } catch (e) {
-    try {
-      externalHttpRequestsTotal.inc({
-        upstream: "privatbank",
-        outcome: "error",
-      });
-    } catch {
-      /* ignore */
-    }
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    recordPrivat("error", ms);
     logger.error({
       msg: "privat_proxy_failed",
       err: { message: e?.message || String(e), code: e?.code },

--- a/server/api/sync.js
+++ b/server/api/sync.js
@@ -1,7 +1,12 @@
 import pool from "../db.js";
 import { getSessionUser } from "../auth.js";
 import { setRequestModule } from "../obs/requestContext.js";
-import { syncConflictsTotal } from "../obs/metrics.js";
+import {
+  syncConflictsTotal,
+  syncDurationMs,
+  syncOperationsTotal,
+  syncPayloadBytes,
+} from "../obs/metrics.js";
 
 function recordConflict(module) {
   try {
@@ -11,173 +16,243 @@ function recordConflict(module) {
   }
 }
 
+function recordSync(op, module, outcome, { ms, bytes } = {}) {
+  try {
+    syncOperationsTotal.inc({ op, module, outcome });
+    if (ms != null) syncDurationMs.observe({ op, module }, ms);
+    if (bytes != null) syncPayloadBytes.observe({ op, module }, bytes);
+  } catch {
+    /* metrics must never break a request */
+  }
+}
+
+function elapsedMs(start) {
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
 const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
 const MAX_BLOB_SIZE = 5 * 1024 * 1024;
 
 export async function syncPush(req, res) {
   setRequestModule("sync");
+  const start = process.hrtime.bigint();
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
   const user = await getSessionUser(req);
   if (!user) {
+    recordSync("push", "unknown", "unauthorized", { ms: elapsedMs(start) });
     return res.status(401).json({ error: "Unauthorized" });
   }
 
   const { module, data, clientUpdatedAt } = req.body || {};
 
   if (!module || !VALID_MODULES.has(module)) {
+    recordSync("push", module || "unknown", "invalid", {
+      ms: elapsedMs(start),
+    });
     return res.status(400).json({ error: "Invalid module" });
   }
 
   if (data === undefined || data === null) {
+    recordSync("push", module, "invalid", { ms: elapsedMs(start) });
     return res.status(400).json({ error: "Missing data" });
   }
 
   const blob = JSON.stringify(data);
   if (blob.length > MAX_BLOB_SIZE) {
+    recordSync("push", module, "too_large", {
+      ms: elapsedMs(start),
+      bytes: blob.length,
+    });
     return res.status(413).json({ error: "Data too large" });
   }
 
   const clientTs = clientUpdatedAt ? new Date(clientUpdatedAt) : new Date();
 
-  const result = await pool.query(
-    `INSERT INTO module_data (user_id, module, data, client_updated_at, version)
-     VALUES ($1, $2, $3, $4, 1)
-     ON CONFLICT (user_id, module) DO UPDATE
-       SET data = $3, client_updated_at = $4, server_updated_at = NOW(),
-           version = module_data.version + 1
-     WHERE module_data.client_updated_at <= $4
-     RETURNING server_updated_at, version`,
-    [user.id, module, blob, clientTs],
-  );
-
-  if (result.rows.length === 0) {
-    recordConflict(module);
-    const existing = await pool.query(
-      `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
-      [user.id, module],
+  try {
+    const result = await pool.query(
+      `INSERT INTO module_data (user_id, module, data, client_updated_at, version)
+       VALUES ($1, $2, $3, $4, 1)
+       ON CONFLICT (user_id, module) DO UPDATE
+         SET data = $3, client_updated_at = $4, server_updated_at = NOW(),
+             version = module_data.version + 1
+       WHERE module_data.client_updated_at <= $4
+       RETURNING server_updated_at, version`,
+      [user.id, module, blob, clientTs],
     );
+
+    if (result.rows.length === 0) {
+      recordConflict(module);
+      recordSync("push", module, "conflict", {
+        ms: elapsedMs(start),
+        bytes: blob.length,
+      });
+      const existing = await pool.query(
+        `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
+        [user.id, module],
+      );
+      return res.json({
+        ok: true,
+        module,
+        conflict: true,
+        serverUpdatedAt: existing.rows[0]?.server_updated_at,
+        version: existing.rows[0]?.version ?? 0,
+      });
+    }
+
+    recordSync("push", module, "ok", {
+      ms: elapsedMs(start),
+      bytes: blob.length,
+    });
     return res.json({
       ok: true,
       module,
-      conflict: true,
-      serverUpdatedAt: existing.rows[0]?.server_updated_at,
-      version: existing.rows[0]?.version ?? 0,
+      serverUpdatedAt: result.rows[0].server_updated_at,
+      version: result.rows[0].version,
     });
+  } catch (e) {
+    recordSync("push", module, "error", {
+      ms: elapsedMs(start),
+      bytes: blob.length,
+    });
+    throw e;
   }
-
-  return res.json({
-    ok: true,
-    module,
-    serverUpdatedAt: result.rows[0].server_updated_at,
-    version: result.rows[0].version,
-  });
 }
 
 export async function syncPull(req, res) {
   setRequestModule("sync");
+  const start = process.hrtime.bigint();
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
   const user = await getSessionUser(req);
   if (!user) {
+    recordSync("pull", "unknown", "unauthorized", { ms: elapsedMs(start) });
     return res.status(401).json({ error: "Unauthorized" });
   }
 
   const { module } = req.body || {};
 
   if (!module || !VALID_MODULES.has(module)) {
+    recordSync("pull", module || "unknown", "invalid", {
+      ms: elapsedMs(start),
+    });
     return res.status(400).json({ error: "Invalid module" });
   }
 
-  const result = await pool.query(
-    `SELECT data, client_updated_at, server_updated_at, version
-     FROM module_data
-     WHERE user_id = $1 AND module = $2`,
-    [user.id, module],
-  );
-
-  if (result.rows.length === 0) {
-    return res.json({
-      ok: true,
-      module,
-      data: null,
-      serverUpdatedAt: null,
-      version: 0,
-    });
-  }
-
-  const row = result.rows[0];
-  let data;
   try {
-    data = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
-  } catch {
-    data = row.data;
-  }
+    const result = await pool.query(
+      `SELECT data, client_updated_at, server_updated_at, version
+       FROM module_data
+       WHERE user_id = $1 AND module = $2`,
+      [user.id, module],
+    );
 
-  return res.json({
-    ok: true,
-    module,
-    data,
-    clientUpdatedAt: row.client_updated_at,
-    serverUpdatedAt: row.server_updated_at,
-    version: row.version,
-  });
-}
+    if (result.rows.length === 0) {
+      recordSync("pull", module, "empty", { ms: elapsedMs(start) });
+      return res.json({
+        ok: true,
+        module,
+        data: null,
+        serverUpdatedAt: null,
+        version: 0,
+      });
+    }
 
-export async function syncPullAll(req, res) {
-  setRequestModule("sync");
-  if (req.method !== "POST" && req.method !== "GET") {
-    return res.status(405).json({ error: "Method not allowed" });
-  }
-
-  const user = await getSessionUser(req);
-  if (!user) {
-    return res.status(401).json({ error: "Unauthorized" });
-  }
-
-  const result = await pool.query(
-    `SELECT module, data, client_updated_at, server_updated_at, version
-     FROM module_data
-     WHERE user_id = $1`,
-    [user.id],
-  );
-
-  const modules = {};
-  for (const row of result.rows) {
+    const row = result.rows[0];
     let data;
     try {
       data = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
     } catch {
       data = row.data;
     }
-    modules[row.module] = {
+
+    const bytes =
+      typeof row.data === "string"
+        ? row.data.length
+        : row.data != null
+          ? JSON.stringify(row.data).length
+          : 0;
+    recordSync("pull", module, "ok", { ms: elapsedMs(start), bytes });
+
+    return res.json({
+      ok: true,
+      module,
       data,
       clientUpdatedAt: row.client_updated_at,
       serverUpdatedAt: row.server_updated_at,
       version: row.version,
-    };
+    });
+  } catch (e) {
+    recordSync("pull", module, "error", { ms: elapsedMs(start) });
+    throw e;
+  }
+}
+
+export async function syncPullAll(req, res) {
+  setRequestModule("sync");
+  const start = process.hrtime.bigint();
+  if (req.method !== "POST" && req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
 
-  return res.json({ ok: true, modules });
+  const user = await getSessionUser(req);
+  if (!user) {
+    recordSync("pull_all", "all", "unauthorized", { ms: elapsedMs(start) });
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const result = await pool.query(
+      `SELECT module, data, client_updated_at, server_updated_at, version
+       FROM module_data
+       WHERE user_id = $1`,
+      [user.id],
+    );
+
+    const modules = {};
+    for (const row of result.rows) {
+      let data;
+      try {
+        data = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
+      } catch {
+        data = row.data;
+      }
+      modules[row.module] = {
+        data,
+        clientUpdatedAt: row.client_updated_at,
+        serverUpdatedAt: row.server_updated_at,
+        version: row.version,
+      };
+    }
+
+    recordSync("pull_all", "all", "ok", { ms: elapsedMs(start) });
+    return res.json({ ok: true, modules });
+  } catch (e) {
+    recordSync("pull_all", "all", "error", { ms: elapsedMs(start) });
+    throw e;
+  }
 }
 
 export async function syncPushAll(req, res) {
   setRequestModule("sync");
+  const start = process.hrtime.bigint();
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
   const user = await getSessionUser(req);
   if (!user) {
+    recordSync("push_all", "all", "unauthorized", { ms: elapsedMs(start) });
     return res.status(401).json({ error: "Unauthorized" });
   }
 
   const { modules } = req.body || {};
   if (!modules || typeof modules !== "object") {
+    recordSync("push_all", "all", "invalid", { ms: elapsedMs(start) });
     return res.status(400).json({ error: "Missing modules object" });
   }
 
@@ -191,6 +266,7 @@ export async function syncPushAll(req, res) {
       if (data === undefined || data === null) continue;
       const blob = JSON.stringify(data);
       if (blob.length > MAX_BLOB_SIZE) {
+        recordSync("push", mod, "too_large", { bytes: blob.length });
         results[mod] = { ok: false, error: "Too large" };
         continue;
       }
@@ -207,6 +283,7 @@ export async function syncPushAll(req, res) {
       );
       if (r.rows.length === 0) {
         recordConflict(mod);
+        recordSync("push", mod, "conflict", { bytes: blob.length });
         const existing = await client.query(
           `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
           [user.id, mod],
@@ -218,6 +295,7 @@ export async function syncPushAll(req, res) {
           version: existing.rows[0]?.version ?? 0,
         };
       } else {
+        recordSync("push", mod, "ok", { bytes: blob.length });
         results[mod] = {
           ok: true,
           serverUpdatedAt: r.rows[0].server_updated_at,
@@ -228,10 +306,12 @@ export async function syncPushAll(req, res) {
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK");
+    recordSync("push_all", "all", "error", { ms: elapsedMs(start) });
     throw err;
   } finally {
     client.release();
   }
 
+  recordSync("push_all", "all", "ok", { ms: elapsedMs(start) });
   return res.json({ ok: true, results });
 }

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,5 +1,9 @@
 import { betterAuth } from "better-auth";
 import pool from "./db.js";
+import {
+  authAttemptsTotal,
+  authSessionLookupDurationMs,
+} from "./obs/metrics.js";
 
 function getBaseURL() {
   if (process.env.BETTER_AUTH_URL) return process.env.BETTER_AUTH_URL;
@@ -81,24 +85,40 @@ function getTrustedOrigins() {
 }
 
 export async function getSessionUser(req) {
-  const session = await auth.api.getSession({
-    headers: new Headers(req.headers),
-  });
-  const user = session?.user ?? null;
-  if (user?.id) {
-    // Ліниво прив'язуємо сесію до request-context і Sentry-scope. Завдяки
-    // цьому будь-який log/Sentry-івент далі в ланцюжку знає, хто саме
-    // виконує запит. Безпечно без сесії — просто no-op.
+  const start = process.hrtime.bigint();
+  let outcome = "miss";
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers(req.headers),
+    });
+    const user = session?.user ?? null;
+    if (user?.id) {
+      outcome = "hit";
+      // Ліниво прив'язуємо сесію до request-context і Sentry-scope. Завдяки
+      // цьому будь-який log/Sentry-івент далі в ланцюжку знає, хто саме
+      // виконує запит. Безпечно без сесії — просто no-op.
+      try {
+        const [{ setUserId }, Sentry] = await Promise.all([
+          import("./obs/requestContext.js"),
+          import("@sentry/node"),
+        ]);
+        setUserId(user.id);
+        Sentry.getCurrentScope?.().setUser({ id: user.id });
+      } catch {
+        /* ignore — observability не має блокувати auth */
+      }
+    }
+    return user;
+  } catch (e) {
+    outcome = "error";
+    throw e;
+  } finally {
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
     try {
-      const [{ setUserId }, Sentry] = await Promise.all([
-        import("./obs/requestContext.js"),
-        import("@sentry/node"),
-      ]);
-      setUserId(user.id);
-      Sentry.getCurrentScope?.().setUser({ id: user.id });
+      authSessionLookupDurationMs.observe({ outcome }, ms);
+      authAttemptsTotal.inc({ op: "session_check", outcome });
     } catch {
-      /* ignore — observability не має блокувати auth */
+      /* metrics must never break a request */
     }
   }
-  return user;
 }

--- a/server/httpCommon.mjs
+++ b/server/httpCommon.mjs
@@ -1,12 +1,15 @@
 import { randomUUID } from "crypto";
 import helmet from "helmet";
 import { rateLimitExpress } from "./api/lib/rateLimit.js";
-import { logger } from "./obs/logger.js";
-import { withRequestContext } from "./obs/requestContext.js";
+import { logger, serializeError } from "./obs/logger.js";
+import { als, withRequestContext } from "./obs/requestContext.js";
 import {
+  appErrorsTotal,
+  authAttemptsTotal,
   httpInFlight,
   httpRequestDurationMs,
   httpRequestsTotal,
+  statusClass,
 } from "./obs/metrics.js";
 import { isOperationalError } from "./obs/errors.js";
 
@@ -48,11 +51,13 @@ export function requestLogMiddleware(req, res, next) {
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
     const routePath = req.route?.path;
     const basePath = typeof req.baseUrl === "string" ? req.baseUrl : "";
-    const path =
-      routePath != null ? `${basePath}${routePath}` : url.split("?")[0];
+    // Fallback на `unknown` (не сирий URL) щоб не роздувати cardinality Prometheus
+    // сканерами /wp-admin і подібним.
+    const path = routePath != null ? `${basePath}${routePath}` : "unknown";
     const status = res.statusCode;
     const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
     const bytesOut = Number(res.getHeader("content-length")) || 0;
+    const mod = als.getStore()?.module || "unknown";
 
     logger[level]({
       msg: "http",
@@ -66,8 +71,16 @@ export function requestLogMiddleware(req, res, next) {
     });
 
     try {
-      httpRequestsTotal.inc({ method: req.method, path, status });
-      httpRequestDurationMs.observe({ method: req.method, path }, ms);
+      httpRequestsTotal.inc({
+        method: req.method,
+        path,
+        status,
+        module: mod,
+      });
+      httpRequestDurationMs.observe(
+        { method: req.method, path, status_class: statusClass(status) },
+        ms,
+      );
     } catch {
       /* metrics must never break a request */
     }
@@ -152,6 +165,44 @@ export function authSensitiveRateLimit(req, res, next) {
 }
 
 /**
+ * Класифікує auth-ендпоінти better-auth і після відповіді інкрементує
+ * `authAttemptsTotal{op,outcome}`. Ставити ПІСЛЯ `authSensitiveRateLimit`,
+ * ДО `toNodeHandler(auth)` — щоб 429 від ліміту теж ловилися.
+ */
+export function authMetricsMiddleware(req, res, next) {
+  if (req.method !== "POST") return next();
+  const url = req.originalUrl || "";
+  const op =
+    (url.includes("/sign-in") && "sign_in") ||
+    (url.includes("/sign-up") && "sign_up") ||
+    (url.includes("forget-password") && "forget_password") ||
+    (url.includes("reset-password") && "reset_password") ||
+    (url.includes("/sign-out") && "signout") ||
+    null;
+  if (!op) return next();
+
+  res.on("finish", () => {
+    const s = res.statusCode;
+    const outcome =
+      s === 429
+        ? "rate_limited"
+        : s === 401 || s === 403
+          ? "bad_credentials"
+          : s >= 500
+            ? "error"
+            : s >= 400
+              ? "invalid"
+              : "ok";
+    try {
+      authAttemptsTotal.inc({ op, outcome });
+    } catch {
+      /* ignore */
+    }
+  });
+  next();
+}
+
+/**
  * @deprecated Використовуй `livezHandler` + `readyzHandler`. Лишено для
  * зворотної сумісності зі старими health-probe в інфраструктурі.
  */
@@ -200,6 +251,18 @@ export function errorHandler(err, req, res, _next) {
   const code =
     (typeof err?.code === "string" && err.code) ||
     (status === 429 ? "RATE_LIMIT" : operational ? "BAD_REQUEST" : "INTERNAL");
+  const mod = als.getStore()?.module || "unknown";
+
+  try {
+    appErrorsTotal.inc({
+      kind: operational ? "operational" : "programmer",
+      status: String(status),
+      code,
+      module: mod,
+    });
+  } catch {
+    /* metrics must never break error handling */
+  }
 
   const level = status >= 500 ? "error" : "warn";
   logger[level]({
@@ -208,12 +271,8 @@ export function errorHandler(err, req, res, _next) {
     path: req.route?.path || req.originalUrl,
     status,
     code,
-    err: {
-      name: err?.name,
-      message: err?.message || String(err),
-      stack: status >= 500 ? err?.stack : undefined,
-      cause: err?.cause?.message,
-    },
+    module: mod,
+    err: serializeError(err, { includeStack: status >= 500 }),
   });
 
   if (res.headersSent) return;

--- a/server/obs/logger.js
+++ b/server/obs/logger.js
@@ -69,3 +69,32 @@ export const logger = pino({
 export function childLogger(bindings) {
   return logger.child(bindings);
 }
+
+/**
+ * Розгортає `err.cause` ланцюжком у plain об'єкт, безпечний для JSON/pino.
+ * Корисно в `errorHandler` і process-level hooks, щоб у Loki/Grafana причину
+ * бачити без розгортання stack.
+ *
+ * @param {unknown} err
+ * @param {{ includeStack?: boolean, depth?: number }} [opts]
+ */
+export function serializeError(err, { includeStack = false, depth = 4 } = {}) {
+  if (err == null || depth < 0) return undefined;
+  if (typeof err !== "object") {
+    return { message: String(err) };
+  }
+  const out = {
+    name: err.name,
+    message: err.message || String(err),
+  };
+  if (err.code !== undefined) out.code = err.code;
+  if (err.status !== undefined) out.status = err.status;
+  if (includeStack && err.stack) out.stack = err.stack;
+  if (err.cause) {
+    out.cause = serializeError(err.cause, {
+      includeStack,
+      depth: depth - 1,
+    });
+  }
+  return out;
+}

--- a/server/obs/metrics.js
+++ b/server/obs/metrics.js
@@ -12,14 +12,14 @@ client.collectDefaultMetrics({ register });
 export const httpRequestsTotal = new client.Counter({
   name: "http_requests_total",
   help: "Total HTTP requests",
-  labelNames: ["method", "path", "status"],
+  labelNames: ["method", "path", "status", "module"],
   registers: [register],
 });
 
 export const httpRequestDurationMs = new client.Histogram({
   name: "http_request_duration_ms",
   help: "HTTP request duration in ms",
-  labelNames: ["method", "path"],
+  labelNames: ["method", "path", "status_class"],
   buckets: [5, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
   registers: [register],
 });
@@ -121,6 +121,167 @@ export const externalHttpRequestsTotal = new client.Counter({
   labelNames: ["upstream", "outcome"], // upstream=monobank|privat|anthropic|off|usda|upcitemdb...
   registers: [register],
 });
+
+export const externalHttpDurationMs = new client.Histogram({
+  name: "external_http_duration_ms",
+  help: "Outbound HTTP call duration by upstream",
+  labelNames: ["upstream", "outcome"], // outcome=ok|rate_limited|error|timeout|miss|hit
+  buckets: [25, 100, 250, 500, 1000, 2500, 5000, 10000, 20000],
+  registers: [register],
+});
+
+// ───────────────────────── Auth ───────────────────────────────
+export const authAttemptsTotal = new client.Counter({
+  name: "auth_attempts_total",
+  help: "Auth attempts by operation and outcome",
+  // op=sign_in|sign_up|forget_password|reset_password|session_check|signout
+  // outcome=ok|bad_credentials|rate_limited|invalid|error|hit|miss
+  labelNames: ["op", "outcome"],
+  registers: [register],
+});
+
+export const authSessionLookupDurationMs = new client.Histogram({
+  name: "auth_session_lookup_duration_ms",
+  help: "Duration of better-auth session resolution in ms",
+  labelNames: ["outcome"], // hit|miss|error
+  buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000],
+  registers: [register],
+});
+
+// ───────────────────────── Rate limit ─────────────────────────
+export const rateLimitHitsTotal = new client.Counter({
+  name: "rate_limit_hits_total",
+  help: "Rate limit decisions by key and outcome",
+  labelNames: ["key", "outcome"], // outcome=allowed|blocked
+  registers: [register],
+});
+
+// ───────────────────────── Sync ───────────────────────────────
+export const syncOperationsTotal = new client.Counter({
+  name: "sync_operations_total",
+  help: "Sync push/pull operations by module and outcome",
+  // op=push|pull|push_all|pull_all; outcome=ok|conflict|unauthorized|invalid|too_large|error|empty
+  labelNames: ["op", "module", "outcome"],
+  registers: [register],
+});
+
+export const syncDurationMs = new client.Histogram({
+  name: "sync_duration_ms",
+  help: "Sync operation duration in ms",
+  labelNames: ["op", "module"],
+  buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+  registers: [register],
+});
+
+export const syncPayloadBytes = new client.Histogram({
+  name: "sync_payload_bytes",
+  help: "Sync blob size in bytes",
+  labelNames: ["op", "module"],
+  // 1KB..5MB — MAX_BLOB_SIZE = 5MB
+  buckets: [1024, 8192, 65536, 262144, 1048576, 3145728, 5242880],
+  registers: [register],
+});
+
+// ───────────────────────── Application errors ─────────────────
+export const appErrorsTotal = new client.Counter({
+  name: "app_errors_total",
+  help: "Application errors surfaced by errorHandler",
+  // kind=operational|programmer; status=400..599; code=VALIDATION|UNAUTHORIZED|...
+  labelNames: ["kind", "status", "code", "module"],
+  registers: [register],
+});
+
+export const unhandledRejectionsTotal = new client.Counter({
+  name: "unhandled_rejections_total",
+  help: "Process-level unhandled promise rejections",
+  registers: [register],
+});
+
+export const uncaughtExceptionsTotal = new client.Counter({
+  name: "uncaught_exceptions_total",
+  help: "Process-level uncaught exceptions",
+  registers: [register],
+});
+
+// ───────────────────────── AI ─────────────────────────────────
+export const aiRequestsTotal = new client.Counter({
+  name: "ai_requests_total",
+  help: "AI requests by provider/model/endpoint/outcome",
+  // endpoint=analyze-photo|refine-photo|chat|coach|day-plan|...
+  // outcome=ok|rate_limited|timeout|error|bad_response
+  labelNames: ["provider", "model", "endpoint", "outcome"],
+  registers: [register],
+});
+
+export const aiRequestDurationMs = new client.Histogram({
+  name: "ai_request_duration_ms",
+  help: "AI request duration in ms",
+  labelNames: ["provider", "model", "endpoint"],
+  buckets: [100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 60000],
+  registers: [register],
+});
+
+// ───────────────────────── Helpers ────────────────────────────
+/** Класифікує HTTP-статус у одне з 4 відер для SLO / latency-дашбордів. */
+export function statusClass(status) {
+  const s = Number(status) || 0;
+  if (s >= 500) return "5xx";
+  if (s >= 400) return "4xx";
+  if (s >= 300) return "3xx";
+  if (s >= 200) return "2xx";
+  return "other";
+}
+
+/**
+ * Обгортка, що міряє тривалість async-операції в мс і пише в histogram
+ * разом з outcome counter (опційно).
+ *
+ * @template T
+ * @param {{
+ *   histogram: import("prom-client").Histogram<string>,
+ *   labels: Record<string, string>,
+ *   counter?: import("prom-client").Counter<string>,
+ *   counterLabels?: (outcome: string) => Record<string, string>,
+ *   classify?: (result: T) => string,
+ * }} opts
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function observeAsync(opts, fn) {
+  const start = process.hrtime.bigint();
+  let outcome = "ok";
+  try {
+    const result = await fn();
+    if (typeof opts.classify === "function") {
+      try {
+        outcome = opts.classify(result) || "ok";
+      } catch {
+        /* ignore */
+      }
+    }
+    return result;
+  } catch (e) {
+    outcome = e?.name === "AbortError" ? "timeout" : "error";
+    throw e;
+  } finally {
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    try {
+      opts.histogram.observe(opts.labels, ms);
+    } catch {
+      /* metrics must never break a request */
+    }
+    if (opts.counter) {
+      try {
+        const labels = opts.counterLabels
+          ? opts.counterLabels(outcome)
+          : { ...opts.labels, outcome };
+        opts.counter.inc(labels);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
 
 /**
  * Sample pg pool gauges periodically. Call once at boot.

--- a/server/railway.mjs
+++ b/server/railway.mjs
@@ -16,6 +16,7 @@ import { auth } from "./auth.js";
 import { ensureSchema, pool } from "./db.js";
 import {
   apiHelmetMiddleware,
+  authMetricsMiddleware,
   authSensitiveRateLimit,
   createReadyzHandler,
   errorHandler,
@@ -24,8 +25,13 @@ import {
   requestLogMiddleware,
   withRequestContext,
 } from "./httpCommon.mjs";
-import { logger } from "./obs/logger.js";
-import { metricsHandler, startPoolSampler } from "./obs/metrics.js";
+import { logger, serializeError } from "./obs/logger.js";
+import {
+  metricsHandler,
+  startPoolSampler,
+  uncaughtExceptionsTotal,
+  unhandledRejectionsTotal,
+} from "./obs/metrics.js";
 import chatHandler from "./api/chat.js";
 import monoHandler from "./api/mono.js";
 import privatHandler from "./api/privat.js";
@@ -87,6 +93,7 @@ app.get("/health", createReadyzHandler(pool));
 app.get("/metrics", metricsHandler);
 
 app.use("/api/auth", authSensitiveRateLimit);
+app.use("/api/auth", authMetricsMiddleware);
 app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(
@@ -169,6 +176,35 @@ attachSentryErrorHandler(app);
 app.use(errorHandler);
 
 startPoolSampler(pool);
+
+// Process-level error tracking: ловимо все, що не впіймали вище.
+// Sentry вже інструментує це окремо, а ми додаємо counter+структурний лог
+// щоб у Grafana було видно спайки незалежно від Sentry retention.
+process.on("unhandledRejection", (reason) => {
+  try {
+    unhandledRejectionsTotal.inc();
+  } catch {
+    /* ignore */
+  }
+  logger.error({
+    msg: "unhandled_rejection",
+    err: serializeError(reason, { includeStack: true }),
+  });
+});
+
+process.on("uncaughtException", (err) => {
+  try {
+    uncaughtExceptionsTotal.inc();
+  } catch {
+    /* ignore */
+  }
+  logger.fatal({
+    msg: "uncaught_exception",
+    err: serializeError(err, { includeStack: true }),
+  });
+  // Не вбиваємо процес тут: Railway рестартує за health-probe, а Sentry вже
+  // зловив stacktrace. Жорсткий exit(1) призвв би до обриву активних запитів.
+});
 
 ensureSchema()
   .then(() => {

--- a/server/replit.mjs
+++ b/server/replit.mjs
@@ -12,6 +12,7 @@ import { auth } from "./auth.js";
 import { ensureSchema, pool } from "./db.js";
 import {
   apiHelmetMiddleware,
+  authMetricsMiddleware,
   authSensitiveRateLimit,
   createReadyzHandler,
   errorHandler,
@@ -20,8 +21,13 @@ import {
   requestLogMiddleware,
   withRequestContext,
 } from "./httpCommon.mjs";
-import { logger } from "./obs/logger.js";
-import { metricsHandler, startPoolSampler } from "./obs/metrics.js";
+import { logger, serializeError } from "./obs/logger.js";
+import {
+  metricsHandler,
+  startPoolSampler,
+  uncaughtExceptionsTotal,
+  unhandledRejectionsTotal,
+} from "./obs/metrics.js";
 import chatHandler from "./api/chat.js";
 import monoHandler from "./api/mono.js";
 import privatHandler from "./api/privat.js";
@@ -80,6 +86,7 @@ app.get("/health", createReadyzHandler(pool));
 app.get("/metrics", metricsHandler);
 
 app.use("/api/auth", authSensitiveRateLimit);
+app.use("/api/auth", authMetricsMiddleware);
 app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(
@@ -169,6 +176,30 @@ if (existsSync(DIST)) {
 app.use(errorHandler);
 
 startPoolSampler(pool);
+
+process.on("unhandledRejection", (reason) => {
+  try {
+    unhandledRejectionsTotal.inc();
+  } catch {
+    /* ignore */
+  }
+  logger.error({
+    msg: "unhandled_rejection",
+    err: serializeError(reason, { includeStack: true }),
+  });
+});
+
+process.on("uncaughtException", (err) => {
+  try {
+    uncaughtExceptionsTotal.inc();
+  } catch {
+    /* ignore */
+  }
+  logger.fatal({
+    msg: "uncaught_exception",
+    err: serializeError(err, { includeStack: true }),
+  });
+});
 
 ensureSchema()
   .then(() => {


### PR DESCRIPTION
## Summary

Comprehensive observability upgrade: domain metrics for sync/auth/errors, structured error tracking with cause chain, and latency histograms for HTTP + external upstreams + AI.

### New metrics
- **Auth**: `auth_attempts_total{op,outcome}`, `auth_session_lookup_duration_ms{outcome}` — wired into `getSessionUser` and `/api/auth/*` via new `authMetricsMiddleware`.
- **Sync**: `sync_operations_total{op,module,outcome}`, `sync_duration_ms{op,module}`, `sync_payload_bytes{op,module}` on every exit path in `syncPush/Pull/PullAll/PushAll` (outcomes: `ok|unauthorized|invalid|too_large|conflict|error|empty`).
- **Errors**: `app_errors_total{kind,status,code,module}` emitted from `errorHandler`; `unhandled_rejections_total`, `uncaught_exceptions_total` on process-level hooks; error logs now use `serializeError()` that walks `err.cause` recursively.
- **Latency**: `external_http_duration_ms{upstream,outcome}` for Monobank, PrivatBank, OFF/USDA/UPCitemdb, Anthropic; `ai_requests_total{provider,model,endpoint,outcome}` + `ai_request_duration_ms{provider,model,endpoint}` passed via new `endpoint` param from all nutrition callers.
- **Rate limiting**: `rate_limit_hits_total{key,outcome}` (`allowed|blocked`) emitted from `checkRateLimit`.

### HTTP label changes
- `http_request_duration_ms` now has a `status_class` label (`2xx/3xx/4xx/5xx/other`) instead of duplicating path cardinality.
- `http_requests_total` gains a `module` label from ALS context (falls back to `"unknown"`).
- `requestLogMiddleware` uses `path="unknown"` for unmatched routes to contain Prometheus cardinality from scanner spam (`/wp-admin`, etc.).

### Process-level
- `unhandledRejection` and `uncaughtException` hooks in both `railway.mjs` and `replit.mjs` emit counters and structured fatal/error logs with full cause chain. Process is not killed; Sentry already captures the stack and Railway's health-probe handles restart.
- `authMetricsMiddleware` and `startPoolSampler(pool)` now wired in both entrypoints.

### Design principles followed
- All metric emissions wrapped in `try/catch` — observability never breaks a request.
- `process.hrtime.bigint()` for ns-precision timing.
- Outcome classification: `ok|error|timeout|rate_limited` + domain-specific values (e.g. `hit|miss|invalid|too_large|conflict`).
- Labels bounded (`module`/`endpoint` fall back to `"unknown"`; path collapsed for unmatched routes).

## Review & Testing Checklist for Human

- [ ] Hit `/metrics` after deploy and confirm new series show up under `auth_*`, `sync_*`, `app_errors_total`, `external_http_duration_ms`, `ai_request_*`, `rate_limit_hits_total`.
- [ ] Verify cardinality of `http_requests_total` stays bounded — if you see a burst of distinct `module` values or stray paths, adjust the ALS `setRequestModule` coverage.
- [ ] Spot-check auth flows (sign-in, sign-up, rate-limited): `auth_attempts_total{op,outcome}` should increment with expected outcomes (`ok/bad_credentials/rate_limited/invalid/error`).
- [ ] Force a sync conflict (push with stale `lastPulledAt`) and verify `sync_operations_total{outcome="conflict"}` + `sync_conflicts_total` both increment.
- [ ] Confirm `errorHandler` logs include `err.cause` for wrapped errors (e.g. DB error re-thrown as `AppError`).

### Notes

- No behaviour changes to request handling, auth logic, or sync semantics — purely additive instrumentation + log enrichment.
- Plan file `observability-plan.md` (on /home/ubuntu, not committed) captured the full breakdown that drove this PR.
- `chat.js`, `coach.js`, `weekly-digest.js` still use inline `fetch` to Anthropic with older counter-only instrumentation; intentionally out of scope here to keep the diff reviewable — follow-up PR can unify them through `anthropicMessages()` to pick up `ai_request_duration_ms` automatically.

Link to Devin session: https://app.devin.ai/sessions/3e3ba8f945324c828f28ff14ed18d7ec
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
