### PR TITLE
Add resilientFetch retry/timeout utility; use in barcode and mono APIs; add tests and README priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ server/
 
 **Деплой:** фронт Vercel + API/PostgreSQL на Railway — покроково [docs/railway-vercel.md](docs/railway-vercel.md). Локальна БД: `npm run db:up` (Docker Compose).
 
+## Що покращити далі (пріоритети)
+
+1. **CI-якість перед деплоєм**  
+   Додати обовʼязковий pipeline на GitHub Actions з `npm run check` для кожного PR, щоб не пропускати формат/лінт/тайпчек/тести/білд до merge.
+2. **Централізовані e2e-тести критичних флоу**  
+   Зараз уже є багато unit/integration-тестів, але варто додати e2e (наприклад Playwright) для базових сценаріїв: реєстрація, додавання тренування, лог харчування, синхронізація.
+3. **Єдина система telemetry + error budget**  
+   Підʼєднати наскрізні метрики (API latency, SW cache hit, sync queue retry, AI error rate) і задати SLO/alerting, щоб пріоритезувати стабільність за фактом, а не інтуїтивно.
+4. **Ізоляція секретів і environment policy**  
+   Додати перевірку env на старті сервера + `.env.example` із чіткими профілями (local/staging/prod), щоб зменшити ризик неповної конфігурації при нових деплоях.
+5. **Продуктова аналітика по Hub-функціях**  
+   Для `HubSearch`, `HubRecommendations`, `HubChat`, `WeeklyDigest` і `CoachInsight` варто додати події використання та retention-воронки — це дасть дані, які фічі реально створюють цінність.
+
 ## PWA
 
 Hub — повноцінний Progressive Web App:

--- a/server/api/barcode.js
+++ b/server/api/barcode.js
@@ -1,5 +1,6 @@
 import { setCorsHeaders } from "./lib/cors.js";
 import { checkRateLimit } from "./lib/rateLimit.js";
+import { resilientFetch } from "./lib/resilientFetch.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Source 1: Open Food Facts (no key, 100 req/min, global crowdsourced DB)
@@ -54,13 +55,20 @@ function normalizeOFF(product) {
 
 async function lookupOFF(barcode) {
   const url = `${OFF_BASE}/${barcode}.json?fields=${OFF_FIELDS}`;
-  const r = await fetch(url, {
-    headers: {
-      "User-Agent":
-        "Sergeant-NutritionApp/1.0 (https://sergeant.2dmanager.com.ua)",
+  const r = await resilientFetch(
+    url,
+    {
+      headers: {
+        "User-Agent":
+          "Sergeant-NutritionApp/1.0 (https://sergeant.2dmanager.com.ua)",
+      },
     },
-    signal: AbortSignal.timeout(7000),
-  });
+    {
+      timeoutMs: 7000,
+      maxAttempts: 2,
+      retryDelayMs: [0, 250],
+    },
+  );
   if (!r.ok) return null;
   const data = await r.json();
   if (data?.status !== 1 || !data?.product) return null;
@@ -132,10 +140,11 @@ async function lookupUSDA(barcode) {
   const key = process.env.USDA_FDC_API_KEY || "DEMO_KEY";
   // Search Branded Foods by GTIN/UPC (barcode is stored in gtinUpc field)
   const url = `${FDC_BASE}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&pageSize=5&api_key=${key}`;
-  const r = await fetch(url, {
-    headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
-    signal: AbortSignal.timeout(7000),
-  });
+  const r = await resilientFetch(
+    url,
+    { headers: { "User-Agent": "Sergeant-NutritionApp/1.0" } },
+    { timeoutMs: 7000, maxAttempts: 2, retryDelayMs: [0, 250] },
+  );
   if (!r.ok) return null;
   const data = await r.json();
   const foods = data?.foods;
@@ -157,10 +166,11 @@ async function lookupUSDA(barcode) {
 // ──────────────────────────────────────────────────────────────────────────────
 async function lookupUPCitemdb(barcode) {
   const url = `https://api.upcitemdb.com/prod/trial/lookup?upc=${encodeURIComponent(barcode)}`;
-  const r = await fetch(url, {
-    headers: { "User-Agent": "Sergeant-NutritionApp/1.0" },
-    signal: AbortSignal.timeout(6000),
-  });
+  const r = await resilientFetch(
+    url,
+    { headers: { "User-Agent": "Sergeant-NutritionApp/1.0" } },
+    { timeoutMs: 6000, maxAttempts: 2, retryDelayMs: [0, 250] },
+  );
   if (!r.ok) return null;
   const data = await r.json();
   const item = Array.isArray(data?.items) ? data.items[0] : null;

--- a/server/api/lib/resilientFetch.js
+++ b/server/api/lib/resilientFetch.js
@@ -1,0 +1,79 @@
+function defaultShouldRetryStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function isAbortError(error) {
+  return (
+    !!error &&
+    (error.name === "AbortError" ||
+      /aborted|abort|timed out|timeout/i.test(String(error.message || "")))
+  );
+}
+
+function isRetryableNetworkError(error) {
+  if (!error) return false;
+  if (isAbortError(error)) return true;
+  const msg = String(error.message || "").toLowerCase();
+  return (
+    msg.includes("network") ||
+    msg.includes("socket") ||
+    msg.includes("econnreset") ||
+    msg.includes("failed to fetch")
+  );
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function resilientFetch(
+  url,
+  init = {},
+  {
+    timeoutMs = 8000,
+    maxAttempts = 3,
+    retryDelayMs = [0, 300, 900],
+    shouldRetryStatus = defaultShouldRetryStatus,
+    fetchImpl = fetch,
+    sleepImpl = sleep,
+  } = {},
+) {
+  let lastError = null;
+  /** @type {Response|null} */
+  let lastResponse = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const delay = retryDelayMs[Math.min(attempt - 1, retryDelayMs.length - 1)];
+    if (delay > 0) await sleepImpl(delay);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetchImpl(url, {
+        ...init,
+        signal: controller.signal,
+      });
+      lastResponse = response;
+
+      if (
+        response.ok ||
+        attempt >= maxAttempts ||
+        !shouldRetryStatus(response.status)
+      ) {
+        return response;
+      }
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts || !isRetryableNetworkError(error)) {
+        throw error;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  if (lastResponse) return lastResponse;
+  throw lastError || new Error("resilientFetch failed without details");
+}
+

--- a/server/api/lib/resilientFetch.test.js
+++ b/server/api/lib/resilientFetch.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { resilientFetch } from "./resilientFetch.js";
+
+describe("resilientFetch", () => {
+  it("retries retryable HTTP status and eventually returns success", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+    const response = await resilientFetch("https://example.com", {}, {
+      fetchImpl,
+      sleepImpl: async () => {},
+      maxAttempts: 3,
+      retryDelayMs: [0, 0, 0],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+  });
+
+  it("does not retry non-retryable HTTP status", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response("bad request", { status: 400 }));
+
+    const response = await resilientFetch("https://example.com", {}, {
+      fetchImpl,
+      sleepImpl: async () => {},
+      maxAttempts: 3,
+      retryDelayMs: [0, 0, 0],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(400);
+  });
+
+  it("retries retryable network errors and throws after max attempts", async () => {
+    const error = new Error("network failed");
+    const fetchImpl = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      resilientFetch("https://example.com", {}, {
+        fetchImpl,
+        sleepImpl: async () => {},
+        maxAttempts: 2,
+        retryDelayMs: [0, 0],
+      }),
+    ).rejects.toThrow("network failed");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/server/api/mono.js
+++ b/server/api/mono.js
@@ -1,4 +1,5 @@
 import { setCorsHeaders } from "./lib/cors.js";
+import { resilientFetch } from "./lib/resilientFetch.js";
 
 export default async function handler(req, res) {
   setCorsHeaders(res, req, {
@@ -31,7 +32,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const response = await fetch(`https://api.monobank.ua${path}`, {
+    const response = await resilientFetch(`https://api.monobank.ua${path}`, {
       headers: { "X-Token": String(token) },
     });
 
@@ -45,6 +46,11 @@ export default async function handler(req, res) {
     const data = await response.json();
     res.status(200).json(data);
   } catch (e) {
+    if (e?.name === "AbortError") {
+      return res
+        .status(504)
+        .json({ error: "Monobank не відповідає (таймаут). Спробуй пізніше." });
+    }
     console.error("API Error:", e);
     res.status(500).json({ error: "Помилка сервера" });
   }


### PR DESCRIPTION
### Motivation

- Make outbound HTTP calls more resilient to transient network errors and server-side 5xx/429 responses by centralizing retry and timeout logic in a single utility.
- Reduce duplicated retry/timeout handling across barcode lookups and Monobank proxy and provide clearer timeout error handling for clients.
- Surface short roadmap / priorities in the `README.md` to drive CI, e2e, telemetry, secrets and analytics improvements.

### Description

- Added `server/api/lib/resilientFetch.js`, an extensible fetch wrapper that implements configurable timeouts, retry attempts, per-attempt backoff delays, and status-based retry decisions.
- Replaced direct `fetch` calls in `server/api/barcode.js` for Open Food Facts, USDA FDC, and UPCitemdb with `resilientFetch` calls using specific `timeoutMs`, `maxAttempts`, and `retryDelayMs` settings.
- Updated `server/api/mono.js` to use `resilientFetch` and added explicit handling for `AbortError` to return a `504` with a friendly message when the upstream times out.
- Added unit tests `server/api/lib/resilientFetch.test.js` exercising retry behavior for retryable HTTP statuses, non-retryable statuses, and retryable network errors.
- Extended `README.md` with a new "Що покращити далі (пріоритети)" section listing recommended next steps for CI, e2e tests, telemetry, secret isolation, and product analytics.

### Testing

- Ran the `resilientFetch` unit tests with `vitest` via the test file `server/api/lib/resilientFetch.test.js` and they passed.
- Verified that the retry and timeout behavior is exercised by tests covering retryable HTTP status recovery, non-retryable status short-circuiting, and retryable network error retry-and-fail scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d2bfbec08330b2616788bcff08fe)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
