### PR TITLE
refactor(ui): follow-up polish — typography fixes + Button/Card/focus-ring unification

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -219,7 +219,7 @@ function AppInner() {
           <button
             type="button"
             onClick={goToHub}
-            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-2xl bg-panel/90 backdrop-blur-md border border-line/80 text-muted hover:text-text shadow-card transition-colors"
+            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-2xl bg-panel/90 backdrop-blur-md border border-line text-muted hover:text-text shadow-card transition-colors"
             title="До вибору модуля"
             aria-label="До вибору модуля"
           >

--- a/src/core/AuthPage.jsx
+++ b/src/core/AuthPage.jsx
@@ -101,7 +101,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
                 <button
                   type="button"
                   onClick={() => setShowForgot((v) => !v)}
-                  className="text-xs text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40 rounded"
+                  className="text-xs text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
                 >
                   Забули пароль?
                 </button>
@@ -167,7 +167,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
           <button
             type="button"
             onClick={switchMode}
-            className="text-sm text-brand-600 dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40"
+            className="text-sm text-brand-600 dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
           >
             {mode === "login"
               ? "Немає акаунту? Зареєструватися"

--- a/src/core/HubBackupPanel.jsx
+++ b/src/core/HubBackupPanel.jsx
@@ -38,7 +38,7 @@ export function HubBackupPanel({ className }) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-line/60 bg-panelHi/40 px-3 py-2.5 flex flex-col gap-3 text-xs text-subtle",
+        "rounded-2xl border border-line bg-panelHi/40 px-3 py-2.5 flex flex-col gap-3 text-xs text-subtle",
         className,
       )}
     >

--- a/src/core/HubChat.jsx
+++ b/src/core/HubChat.jsx
@@ -407,7 +407,7 @@ function HubChat({ onClose, initialMessage }) {
         </div>
 
         {/* Header */}
-        <div className="flex items-center justify-between px-4 pb-3 shrink-0 border-b border-line/60">
+        <div className="flex items-center justify-between px-4 pb-3 shrink-0 border-b border-line">
           <div className="flex items-center gap-2.5 min-w-0">
             <span className="text-2xl leading-none shrink-0" aria-hidden>
               🤖

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -531,7 +531,7 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={order} strategy={verticalListSortingStrategy}>
-            <div className="rounded-2xl border border-line/60 bg-panel overflow-hidden divide-y divide-line/60">
+            <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
               {order.map((id) => (
                 <SortableCard key={id} id={id} onOpenModule={onOpenModule} />
               ))}

--- a/src/core/HubInsightsPanel.jsx
+++ b/src/core/HubInsightsPanel.jsx
@@ -41,7 +41,7 @@ function RecRow({ rec, onAction, onDismiss }) {
   return (
     <div
       className={cn(
-        "relative flex gap-3 rounded-xl border border-line/60 bg-bg px-3 py-2.5",
+        "relative flex gap-3 rounded-xl border border-line bg-bg px-3 py-2.5",
       )}
     >
       <div
@@ -94,7 +94,7 @@ function RecRow({ rec, onAction, onDismiss }) {
 function CoachRow({ insight, loading, error, onDiscuss, onRefresh }) {
   if (loading && !insight) {
     return (
-      <div className="rounded-xl border border-line/60 bg-bg px-3 py-2.5">
+      <div className="rounded-xl border border-line bg-bg px-3 py-2.5">
         <p className="text-xs text-muted animate-pulse">
           Коуч готує повідомлення…
         </p>
@@ -107,7 +107,7 @@ function CoachRow({ insight, loading, error, onDiscuss, onRefresh }) {
   if (!insight) return null;
 
   return (
-    <div className="relative rounded-xl border border-line/60 bg-bg px-3 py-2.5">
+    <div className="relative rounded-xl border border-line bg-bg px-3 py-2.5">
       <div
         className="absolute left-0 top-3 bottom-3 w-0.5 rounded-r-full bg-primary"
         aria-hidden
@@ -195,7 +195,7 @@ export function HubInsightsPanel({
         aria-expanded={open}
         className={cn(
           "w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl",
-          "border border-line/60 bg-panel",
+          "border border-line bg-panel",
           "hover:bg-panelHi transition-colors",
         )}
       >

--- a/src/core/HubReports.jsx
+++ b/src/core/HubReports.jsx
@@ -454,7 +454,7 @@ export function HubReports() {
           ))}
         </div>
       ) : (
-        <div className="bg-panel border border-line/50 rounded-2xl p-4 text-center text-xs text-muted">
+        <div className="bg-panel border border-line rounded-2xl p-4 text-center text-xs text-muted">
           Збери більше даних для інсайтів
         </div>
       )}

--- a/src/core/HubSettingsPage.jsx
+++ b/src/core/HubSettingsPage.jsx
@@ -160,7 +160,7 @@ export function HubSettingsPage({
                   onClick={() => setTab(g.id)}
                   className={cn(
                     "flex-1 min-w-[100px] min-h-[40px] px-3 py-2 rounded-xl text-sm font-semibold transition-colors whitespace-nowrap",
-                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
                     active
                       ? "bg-panel text-text shadow-sm"
                       : "text-muted hover:text-text",

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -267,7 +267,7 @@ function VibePickerStep({ picks, togglePick, onNext, onBack }) {
               aria-pressed={active}
               className={cn(
                 "w-full text-left px-4 py-3 rounded-2xl border transition-all",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
                 active
                   ? "border-brand-500/60 bg-brand-500/5 shadow-card"
                   : "border-line bg-panelHi hover:border-brand-500/40",
@@ -399,7 +399,7 @@ export function OnboardingWizard({ onDone }) {
                 markOnboardingDone();
                 onDone(null, { intent: "skipped" });
               }}
-              className="text-xs text-muted hover:text-text transition-colors px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+              className="text-xs text-muted hover:text-text transition-colors px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
             >
               Пропустити
             </button>

--- a/src/core/TodayFocusCard.jsx
+++ b/src/core/TodayFocusCard.jsx
@@ -151,7 +151,7 @@ function EmptyFocus({ onOpenReports }) {
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-2xl border border-line/60 bg-panel p-4",
+        "relative overflow-hidden rounded-2xl border border-line bg-panel p-4",
         "flex items-center gap-3",
         washClass,
       )}
@@ -218,7 +218,7 @@ export function TodayFocusCard({ focus, onAction, onDismiss, onOpenReports }) {
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-2xl border border-line/60 bg-panel",
+        "relative overflow-hidden rounded-2xl border border-line bg-panel",
         "shadow-card p-4",
         wash,
       )}

--- a/src/core/WeeklyDigestCard.jsx
+++ b/src/core/WeeklyDigestCard.jsx
@@ -115,7 +115,7 @@ function ModuleBlock({ moduleKey, data }) {
         )}
       >
         <div className="overflow-hidden">
-          <div className="px-3 pb-3 border-t border-line/60 pt-2 space-y-2">
+          <div className="px-3 pb-3 border-t border-line pt-2 space-y-2">
             {data.comment && (
               <p className="text-xs text-muted leading-relaxed">
                 {data.comment}
@@ -260,7 +260,7 @@ function DigestContent({
         )}
       >
         <div className="overflow-hidden">
-          <div className="border-t border-line/60 px-4 pt-3 pb-4 space-y-2">
+          <div className="border-t border-line px-4 pt-3 pb-4 space-y-2">
             {["finyk", "fizruk", "nutrition", "routine"].map((key) =>
               digest[key] ? (
                 <ModuleBlock key={key} moduleKey={key} data={digest[key]} />
@@ -309,7 +309,7 @@ function DigestContent({
         </div>
       )}
       {expanded && (
-        <div className="px-4 pb-3 border-t border-line/60 pt-2">
+        <div className="px-4 pb-3 border-t border-line pt-2">
           <button
             type="button"
             onClick={() => setExpanded(false)}
@@ -341,7 +341,7 @@ export function WeeklyDigestCard() {
     <div
       className={cn(
         "rounded-2xl border bg-panel shadow-card overflow-hidden",
-        "border-line/80 dark:border-line",
+        "border-line dark:border-line",
         "transition-all duration-200 hover:shadow-float",
       )}
     >
@@ -419,7 +419,7 @@ export function WeeklyDigestCard() {
       </div>
 
       {showHistory && history.length > 1 && (
-        <div className="border-t border-line/60 px-4 py-2">
+        <div className="border-t border-line px-4 py-2">
           <div className="flex flex-wrap gap-1">
             {history.map((h) => (
               <button
@@ -438,7 +438,7 @@ export function WeeklyDigestCard() {
               >
                 {h.weekRange}
                 {h.weekKey === currentWeekKey && (
-                  <span className="ml-1 text-2xs opacity-70">поточний</span>
+                  <span className="ml-1 text-3xs opacity-70">поточний</span>
                 )}
               </button>
             ))}

--- a/src/core/app/DarkModeToggle.jsx
+++ b/src/core/app/DarkModeToggle.jsx
@@ -1,7 +1,7 @@
 import { Icon } from "@shared/components/ui/Icon";
 
 const CLS =
-  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 /** Sun/Moon icon toggle for dark mode */
 export function DarkModeToggle({ dark, onToggle }) {

--- a/src/core/app/HubFloatingActions.jsx
+++ b/src/core/app/HubFloatingActions.jsx
@@ -89,7 +89,7 @@ export function HubFloatingActions() {
               type="button"
               role="menuitem"
               onClick={() => runAction(a)}
-              className="group flex items-center gap-3 pl-3 pr-2 h-11 rounded-full bg-panel border border-line shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+              className="group flex items-center gap-3 pl-3 pr-2 h-11 rounded-full bg-panel border border-line shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
             >
               <span className="text-sm font-medium text-text whitespace-nowrap">
                 {a.label}
@@ -116,7 +116,7 @@ export function HubFloatingActions() {
         aria-label={open ? "Закрити меню додавання" : "Додати"}
         title="Додати"
         className={cn(
-          "pointer-events-auto w-14 h-14 flex items-center justify-center rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          "pointer-events-auto w-14 h-14 flex items-center justify-center rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
           open && "rotate-45",
         )}
       >

--- a/src/core/app/HubHeader.jsx
+++ b/src/core/app/HubHeader.jsx
@@ -3,7 +3,7 @@ import { DarkModeToggle } from "./DarkModeToggle.jsx";
 import { UserMenuButton } from "./UserMenuButton.jsx";
 
 const ICON_BUTTON_CLS =
-  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 export function HubHeader({
   hubView,

--- a/src/core/app/HubTabs.jsx
+++ b/src/core/app/HubTabs.jsx
@@ -10,7 +10,7 @@ function TabButton({ active, onClick, children, iconName, iconBody }) {
       aria-selected={active}
       className={cn(
         "flex-1 flex items-center justify-center gap-1.5 min-h-[44px] py-2 rounded-xl text-sm font-medium transition-all",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
         active
           ? "bg-panel text-text shadow-card"
           : "text-muted hover:text-text",

--- a/src/core/app/UserMenuButton.jsx
+++ b/src/core/app/UserMenuButton.jsx
@@ -64,7 +64,7 @@ export function UserMenuButton({
         className={cn(
           "relative w-11 h-11 flex items-center justify-center rounded-2xl text-sm font-bold transition-colors",
           "bg-brand-500/15 text-brand-600 dark:text-brand-400 hover:bg-brand-500/25",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
           syncing && "animate-pulse",
         )}
       >
@@ -79,7 +79,7 @@ export function UserMenuButton({
             </p>
             <p className="text-xs text-muted truncate">{user.email}</p>
           </div>
-          <div className="border-t border-line/60 pt-2 space-y-1">
+          <div className="border-t border-line pt-2 space-y-1">
             <button
               type="button"
               onClick={() => {
@@ -111,7 +111,7 @@ export function UserMenuButton({
             )}
           </div>
           {typeof onToggleDark === "function" && (
-            <div className="border-t border-line/60 pt-2">
+            <div className="border-t border-line pt-2">
               <button
                 type="button"
                 onClick={() => {
@@ -124,7 +124,7 @@ export function UserMenuButton({
               </button>
             </div>
           )}
-          <div className="border-t border-line/60 pt-2">
+          <div className="border-t border-line pt-2">
             <button
               type="button"
               onClick={() => {

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -79,7 +79,7 @@ export function FirstActionHeroCard({ onDismiss }) {
 
   return (
     <section
-      className="relative bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3"
+      className="relative bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
       aria-label="Перша дія"
     >
       <div className="flex items-start justify-between gap-3">
@@ -97,7 +97,7 @@ export function FirstActionHeroCard({ onDismiss }) {
         <button
           type="button"
           onClick={dismiss}
-          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text p-1.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text p-1.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
           aria-label="Сховати"
         >
           <Icon name="close" size={16} />
@@ -114,7 +114,7 @@ export function FirstActionHeroCard({ onDismiss }) {
               className={cn(
                 "w-full text-left px-3 py-2.5 rounded-xl border border-line bg-panelHi",
                 "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
               )}
             >
               <div className="flex items-center gap-3">

--- a/src/core/onboarding/SoftAuthPromptCard.jsx
+++ b/src/core/onboarding/SoftAuthPromptCard.jsx
@@ -57,7 +57,7 @@ export function SoftAuthPromptCard({ onOpenAuth, onDismiss }) {
             <button
               type="button"
               onClick={handleDismiss}
-              className="text-xs text-muted hover:text-text px-3 py-2 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+              className="text-xs text-muted hover:text-text px-3 py-2 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
             >
               Пізніше
             </button>

--- a/src/core/settings/FinykSection.tsx
+++ b/src/core/settings/FinykSection.tsx
@@ -260,7 +260,7 @@ export function FinykSection() {
             {customCategories.map((c) => (
               <li
                 key={c.id}
-                className="flex items-center justify-between gap-2 px-4 py-3 border-b border-line/60 last:border-0"
+                className="flex items-center justify-between gap-2 px-4 py-3 border-b border-line last:border-0"
               >
                 <span className="text-sm font-medium truncate">{c.label}</span>
                 <button
@@ -289,7 +289,7 @@ export function FinykSection() {
               return (
                 <div
                   key={acc.id}
-                  className="flex items-center justify-between px-4 py-3 border-b border-line/60 last:border-0"
+                  className="flex items-center justify-between px-4 py-3 border-b border-line last:border-0"
                 >
                   <div>
                     <div className="text-sm font-medium">

--- a/src/core/settings/GeneralSection.tsx
+++ b/src/core/settings/GeneralSection.tsx
@@ -25,7 +25,7 @@ interface ModuleReorderListProps {
 
 function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
   return (
-    <ul className="rounded-xl border border-line/60 divide-y divide-line/60 overflow-hidden">
+    <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
       {order.map((id, index) => {
         const isFirst = index === 0;
         const isLast = index === order.length - 1;

--- a/src/core/settings/SettingsPrimitives.tsx
+++ b/src/core/settings/SettingsPrimitives.tsx
@@ -53,9 +53,7 @@ export function SettingsGroup({
         )}
       >
         <div className="overflow-hidden">
-          <div className="border-t border-line/60 p-4 space-y-5">
-            {children}
-          </div>
+          <div className="border-t border-line p-4 space-y-5">{children}</div>
         </div>
       </div>
     </div>

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -310,7 +310,7 @@ export default function App({
           <div
             className={cn(
               "bg-panel/95 backdrop-blur-xl border rounded-3xl p-6 shadow-float",
-              "border-line/80 dark:border-line",
+              "border-line dark:border-line",
             )}
           >
             <label
@@ -513,7 +513,7 @@ export default function App({
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       {/* Header */}
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line/60 z-40 relative safe-area-pt">
+      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
         <div className="flex h-14 items-center justify-between px-4 sm:px-5 gap-3">
           <div className="flex items-center gap-2.5 min-w-0">
             <div
@@ -682,7 +682,7 @@ export default function App({
             setEditingManualExpenseId(null);
             setShowExpenseSheet(true);
           }}
-          className="fixed bottom-[calc(58px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-emerald-500 text-white shadow-lg flex items-center justify-center text-2xl hover:bg-emerald-600 hover:shadow-xl hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          className="fixed bottom-[calc(58px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
           aria-label="Додати витрату"
         >
           +
@@ -747,7 +747,7 @@ export default function App({
       />
 
       {/* Bottom navigation */}
-      <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line/60 relative z-30 safe-area-pb">
+      <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line relative z-30 safe-area-pb">
         <div className="flex h-[58px]">
           {NAV_ITEMS.map((item) => {
             const active = page === item.id;

--- a/src/modules/finyk/components/CategoryManager.jsx
+++ b/src/modules/finyk/components/CategoryManager.jsx
@@ -235,7 +235,7 @@ export function CategoryManager({
           return (
             <div
               key={cat.id}
-              className="bg-panel border border-line/60 rounded-2xl px-4 py-3 flex items-center gap-3 shadow-card"
+              className="bg-panel border border-line rounded-2xl px-4 py-3 flex items-center gap-3 shadow-card"
             >
               <div
                 className="w-8 h-8 rounded-xl flex items-center justify-center text-base shrink-0"
@@ -308,7 +308,7 @@ export function CategoryManager({
       </div>
 
       {showForm ? (
-        <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
           <div className="text-sm font-semibold text-text mb-3">
             Нова категорія
           </div>

--- a/src/modules/finyk/components/RetroComparison.jsx
+++ b/src/modules/finyk/components/RetroComparison.jsx
@@ -102,7 +102,7 @@ export const RetroComparison = memo(function RetroComparison({
   return (
     <div
       className={cn(
-        "rounded-2xl border border-line/60 bg-panel p-5 shadow-card border-l-[4px]",
+        "rounded-2xl border border-line bg-panel p-5 shadow-card border-l-[4px]",
         accentBorder,
         className,
       )}

--- a/src/modules/finyk/components/SyncStatusBadge.jsx
+++ b/src/modules/finyk/components/SyncStatusBadge.jsx
@@ -55,7 +55,7 @@ function SyncStatusBadgeComponent({
           ? "bg-danger/10 border-danger/30"
           : isPartial
             ? "bg-warning/10 border-warning/30"
-            : "bg-panel border-line/60",
+            : "bg-panel border-line",
       )}
     >
       <span className={cn("w-2 h-2 rounded-full shrink-0", dotClass)} />

--- a/src/modules/finyk/components/TxRow.jsx
+++ b/src/modules/finyk/components/TxRow.jsx
@@ -132,32 +132,32 @@ function TxRowImpl({
         <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
           <span className="text-xs text-subtle">{catName}</span>
           {cat.id === INTERNAL_TRANSFER_ID && (
-            <span className="text-2xs bg-muted/15 text-muted px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-3xs bg-muted/15 text-muted px-1.5 py-0.5 rounded-full font-semibold">
               не в статистиці
             </span>
           )}
           {overrideCatId && cat.id !== INTERNAL_TRANSFER_ID && (
-            <span className="text-2xs bg-text/8 text-muted px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-3xs bg-text/8 text-muted px-1.5 py-0.5 rounded-full font-semibold">
               змін.
             </span>
           )}
           {existingSplits.length > 0 && (
-            <span className="text-2xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-3xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-full font-semibold">
               ⅔ спліт
             </span>
           )}
           {isCreditCard && (
-            <span className="text-2xs bg-danger/8 text-danger px-1.5 py-0.5 rounded-full font-semibold">
+            <span className="text-3xs bg-danger/8 text-danger px-1.5 py-0.5 rounded-full font-semibold">
               💳 {accountName}
             </span>
           )}
           {!isCreditCard && account && (
-            <span className="text-2xs text-subtle/50 px-1 py-0.5">
+            <span className="text-3xs text-subtle/50 px-1 py-0.5">
               {accountName}
             </span>
           )}
           {tx._source === "privatbank" && (
-            <span className="text-2xs bg-green-500/10 text-green-700 dark:text-green-400 px-1.5 py-0.5 rounded-full font-semibold shrink-0">
+            <span className="text-3xs bg-green-500/10 text-green-700 dark:text-green-400 px-1.5 py-0.5 rounded-full font-semibold shrink-0">
               П24
             </span>
           )}

--- a/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
@@ -19,7 +19,7 @@ function GoalBudgetCardComponent({
   onDelete,
 }) {
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
       {isEditing ? (
         <div className="space-y-2">
           <input

--- a/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
@@ -29,7 +29,7 @@ function LimitBudgetCardComponent({
   const warnLimit = pctRaw >= 80 && !overLimit;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
       {isEditing ? (
         <div className="space-y-2">
           <input

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -33,7 +33,7 @@ const Section = memo(function Section({ title, children, className }) {
   return (
     <div
       className={cn(
-        "bg-panel border border-line/60 rounded-2xl p-5 shadow-card",
+        "bg-panel border border-line rounded-2xl p-5 shadow-card",
         className,
       )}
     >

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -380,7 +380,7 @@ export function Budgets({ mono, storage }) {
         <div
           className={cn(
             "bg-panel border rounded-2xl p-5 shadow-card",
-            isOver ? "border-danger/40" : "border-line/60",
+            isOver ? "border-danger/40" : "border-line",
           )}
         >
           <div className="text-[11px] font-bold text-subtle uppercase tracking-widest mb-3">
@@ -612,7 +612,7 @@ export function Budgets({ mono, storage }) {
                   key={fc.categoryId}
                   className={cn(
                     "bg-panel border rounded-2xl p-5 shadow-card",
-                    fc.overLimit ? "border-danger/50" : "border-line/60",
+                    fc.overLimit ? "border-danger/50" : "border-line",
                   )}
                 >
                   <div className="flex justify-between items-start mb-1">
@@ -757,7 +757,7 @@ export function Budgets({ mono, storage }) {
         })}
 
         {showForm ? (
-          <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card space-y-3">
+          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card space-y-3">
             <div className="flex gap-2">
               <button
                 onClick={() => {
@@ -904,7 +904,7 @@ export function Budgets({ mono, storage }) {
         )}
 
         {/* Category manager — collapsible at bottom so it never shifts other sections */}
-        <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
+        <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
           <button
             type="button"
             onClick={() => setShowCategories((v) => !v)}

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -588,7 +588,7 @@ export function Transactions({
 
         {/* Empty */}
         {filtered.length === 0 && !activeLoading && (
-          <div className="rounded-2xl border border-dashed border-line/60 bg-panelHi/40">
+          <div className="rounded-2xl border border-dashed border-line bg-panelHi/40">
             <EmptyState
               icon={<Icon name="search" size={20} strokeWidth={1.6} />}
               title={
@@ -625,7 +625,7 @@ export function Transactions({
               increaseViewportBy={{ top: 400, bottom: 400 }}
               groupContent={(groupIndex) => (
                 <div
-                  className="px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line/50 text-[11px] font-semibold text-subtle tracking-wide"
+                  className="px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-[11px] font-semibold text-subtle tracking-wide"
                   role="presentation"
                 >
                   {formatStickyDayLabel(groupedByDate[groupIndex].key)}

--- a/src/modules/finyk/pages/overview/CategoryChartSection.jsx
+++ b/src/modules/finyk/pages/overview/CategoryChartSection.jsx
@@ -14,7 +14,7 @@ export function CategoryChartSection({
 }) {
   if (catSpends.length > 0) {
     return (
-      <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+      <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
         <div className="text-xs font-medium text-subtle mb-4">
           Витрати за категоріями
         </div>
@@ -36,7 +36,7 @@ export function CategoryChartSection({
   }
 
   return (
-    <div className="bg-panel border border-dashed border-line/60 rounded-2xl shadow-card">
+    <div className="bg-panel border border-dashed border-line rounded-2xl shadow-card">
       <EmptyState
         title="Поки немає витрат"
         description="Цього місяця витрат за категоріями ще немає."

--- a/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
+++ b/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
@@ -5,7 +5,7 @@
 export function IncomeExpensePills({ income, spent, showBalance = true }) {
   return (
     <div className="grid grid-cols-2 gap-3">
-      <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+      <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
         <div className="flex items-center gap-2 text-emerald-600">
           <svg
             width="16"
@@ -30,7 +30,7 @@ export function IncomeExpensePills({ income, spent, showBalance = true }) {
           <span className="text-base font-medium text-muted">₴</span>
         </p>
       </div>
-      <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+      <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
         <div className="flex items-center gap-2 text-red-500">
           <svg
             width="16"

--- a/src/modules/finyk/pages/overview/MonthPulseCard.jsx
+++ b/src/modules/finyk/pages/overview/MonthPulseCard.jsx
@@ -36,7 +36,7 @@ export function MonthPulseCard({
   return (
     <div
       className={cn(
-        "rounded-2xl border border-line/60 bg-panel p-5 shadow-card border-l-[4px]",
+        "rounded-2xl border border-line bg-panel p-5 shadow-card border-l-[4px]",
         accentLeft,
         bg,
       )}
@@ -56,7 +56,7 @@ export function MonthPulseCard({
       <div className="flex justify-between items-start gap-4">
         <div>
           <div className="text-xs text-subtle font-medium">Витрати</div>
-          <div className="text-2xl font-bold tabular-nums mt-1 leading-tight">
+          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight">
             {showBalance
               ? spent.toLocaleString("uk-UA", { maximumFractionDigits: 0 })
               : "••••"}
@@ -67,7 +67,7 @@ export function MonthPulseCard({
         </div>
         <div className="text-right">
           <div className="text-xs text-subtle font-medium">Дохід</div>
-          <div className="text-2xl font-bold tabular-nums mt-1 leading-tight text-success">
+          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight text-success">
             {showBalance ? (
               <>
                 +
@@ -116,7 +116,7 @@ export function MonthPulseCard({
       </div>
 
       {showMonthForecast && (
-        <div className="mt-4 pt-4 border-t border-line/50 space-y-2">
+        <div className="mt-4 pt-4 border-t border-line space-y-2">
           <div className="text-xs font-medium text-subtle">
             Факт і прогноз витрат
           </div>
@@ -149,7 +149,7 @@ export function MonthPulseCard({
         </div>
       )}
 
-      <div className="mt-4 pt-4 border-t border-line/50">
+      <div className="mt-4 pt-4 border-t border-line">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-medium text-subtle">Фінпульс</span>
           <span className="text-[11px] text-subtle/60">

--- a/src/modules/finyk/pages/overview/NetworthSection.jsx
+++ b/src/modules/finyk/pages/overview/NetworthSection.jsx
@@ -9,7 +9,7 @@ import { ChartFallback } from "../../components/charts/ChartFallback";
 export function NetworthSection({ networthHistory }) {
   if (networthHistory.length >= 2) {
     return (
-      <div className="bg-panel border border-line/60 rounded-2xl px-5 pt-4 pb-3 shadow-card">
+      <div className="bg-panel border border-line rounded-2xl px-5 pt-4 pb-3 shadow-card">
         <div className="flex items-center justify-between mb-3">
           <span className="text-xs font-medium text-subtle">
             Динаміка нетворсу
@@ -26,7 +26,7 @@ export function NetworthSection({ networthHistory }) {
   }
 
   return (
-    <div className="bg-panel border border-dashed border-line/60 rounded-2xl p-6 text-center shadow-card">
+    <div className="bg-panel border border-dashed border-line rounded-2xl p-6 text-center shadow-card">
       <p className="text-sm text-subtle">
         Ще мало знімків для графіка нетворсу — з’явиться після кількох змін
         балансу.

--- a/src/modules/finyk/pages/overview/PlanFactCard.jsx
+++ b/src/modules/finyk/pages/overview/PlanFactCard.jsx
@@ -16,7 +16,7 @@ export function PlanFactCard({
   if (!(planIncome > 0 || planExpense > 0 || planSavings > 0)) return null;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
       <div className="text-xs font-medium text-subtle mb-3">План / Факт</div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">

--- a/src/modules/finyk/pages/overview/PlannedFlowsCard.jsx
+++ b/src/modules/finyk/pages/overview/PlannedFlowsCard.jsx
@@ -8,7 +8,7 @@ export function PlannedFlowsCard({ plannedFlows, onNavigate, showBalance }) {
   if (plannedFlows.length === 0) return null;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl overflow-hidden shadow-card">
+    <div className="bg-panel border border-line rounded-2xl overflow-hidden shadow-card">
       <div className="px-5 pt-4 pb-2 flex items-center justify-between">
         <span className="text-xs font-medium text-subtle">
           Найближчі платежі

--- a/src/modules/finyk/pages/overview/QuickAddCard.jsx
+++ b/src/modules/finyk/pages/overview/QuickAddCard.jsx
@@ -14,7 +14,7 @@ export function QuickAddCard({
     return null;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card space-y-3">
+    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card space-y-3">
       <div className="flex items-center justify-between">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle">
@@ -58,7 +58,7 @@ export function QuickAddCard({
         </div>
       )}
       {frequentMerchants.length > 0 && (
-        <div className="pt-2 border-t border-line/50">
+        <div className="pt-2 border-t border-line">
           <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle mb-2">
             Нещодавнє
           </div>

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -261,7 +261,7 @@ export default function FizrukApp({
 
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line/60 z-40 relative safe-area-pt">
+      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
         <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
           {isAtlas || isExercise ? (
             <button
@@ -287,7 +287,7 @@ export default function FizrukApp({
             <button
               type="button"
               onClick={onBackToHub}
-              className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line/80 bg-panel/80"
+              className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
               aria-label="До вибору модуля"
               title="До хабу"
             >
@@ -334,7 +334,7 @@ export default function FizrukApp({
           )}
           <div className="min-w-0 flex-1">
             {!isAtlas && !isExercise && (
-              <span className="text-2xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
+              <span className="text-3xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
                 ОСОБИСТИЙ ЖУРНАЛ
               </span>
             )}
@@ -358,7 +358,7 @@ export default function FizrukApp({
           <button
             type="button"
             onClick={() => setSettingsOpen(true)}
-            className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line/80 bg-panel/80"
+            className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
             aria-label="Налаштування даних"
             title="Налаштування даних"
           >
@@ -398,7 +398,7 @@ export default function FizrukApp({
             aria-labelledby="fizruk-settings-title"
             className="relative w-full max-w-sm h-full bg-panel border-l border-line shadow-2xl flex flex-col safe-area-pt-pb"
           >
-            <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line/60">
+            <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line">
               <h2
                 id="fizruk-settings-title"
                 className="text-base font-semibold text-text"
@@ -452,7 +452,7 @@ export default function FizrukApp({
       </div>
 
       {!isAtlas && !isExercise && (
-        <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line/60 relative z-30 safe-area-pb">
+        <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line relative z-30 safe-area-pb">
           <div className="flex h-[58px]">
             {NAV.map((item) => {
               const active = page === item.id;

--- a/src/modules/fizruk/components/MiniLineChart.tsx
+++ b/src/modules/fizruk/components/MiniLineChart.tsx
@@ -9,7 +9,7 @@ export function MiniLineChart({ data, unit, color, metricLabel = "показни
     return (
       <EmptyState
         compact
-        className="rounded-2xl border border-dashed border-line/60 bg-panelHi/50"
+        className="rounded-2xl border border-dashed border-line bg-panelHi/50"
         title="Немає числових даних"
         description={`Додай записи в розділі «Заміри», щоб відстежувати ${metricLabel}.`}
       />
@@ -19,7 +19,7 @@ export function MiniLineChart({ data, unit, color, metricLabel = "показни
     return (
       <EmptyState
         compact
-        className="rounded-2xl border border-dashed border-line/60 bg-panelHi/50"
+        className="rounded-2xl border border-dashed border-line bg-panelHi/50"
         title="Замало точок для лінії"
         description={`Потрібні щонайменше два заміри з ${metricLabel}, щоб побудувати тренд.`}
       />

--- a/src/modules/fizruk/components/PhotoProgress.tsx
+++ b/src/modules/fizruk/components/PhotoProgress.tsx
@@ -257,7 +257,7 @@ export function PhotoProgress() {
 
   if (!ready) {
     return (
-      <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+      <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
         <div className="text-xs text-subtle text-center py-4">
           Завантаження…
         </div>
@@ -267,7 +267,7 @@ export function PhotoProgress() {
 
   return (
     <section
-      className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+      className="bg-panel border border-line rounded-2xl p-4 shadow-card"
       aria-label="Фото-прогрес"
     >
       <div className="flex items-center justify-between gap-3 mb-3">
@@ -347,7 +347,7 @@ export function PhotoProgress() {
           {(!beforePhoto ||
             !afterPhoto ||
             beforePhoto.id === afterPhoto.id) && (
-            <div className="rounded-xl border border-dashed border-line/60 bg-panelHi/50 py-6 text-center text-xs text-subtle">
+            <div className="rounded-xl border border-dashed border-line bg-panelHi/50 py-6 text-center text-xs text-subtle">
               Обери два різні фото для порівняння
             </div>
           )}
@@ -454,7 +454,7 @@ export function PhotoProgress() {
           </div>
 
           {photos.length === 0 ? (
-            <div className="rounded-xl border border-dashed border-line/60 bg-panelHi/50 py-8 text-center text-xs text-subtle">
+            <div className="rounded-xl border border-dashed border-line bg-panelHi/50 py-8 text-center text-xs text-subtle">
               Додай перше фото прогресу
             </div>
           ) : (
@@ -475,7 +475,7 @@ export function PhotoProgress() {
                   />
                   <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors" />
                   <div className="absolute bottom-0 left-0 right-0 px-1.5 pb-1 pt-3 bg-gradient-to-t from-black/60 to-transparent">
-                    <p className="text-2xs text-white font-semibold leading-tight">
+                    <p className="text-3xs text-white font-semibold leading-tight">
                       {p.date}
                     </p>
                     {p.note && (

--- a/src/modules/fizruk/components/WeeklyVolumeChart.tsx
+++ b/src/modules/fizruk/components/WeeklyVolumeChart.tsx
@@ -36,7 +36,7 @@ export function WeeklyVolumeChart({
         </div>
         <EmptyState
           compact
-          className="rounded-2xl border border-dashed border-line/60 bg-panelHi/50"
+          className="rounded-2xl border border-dashed border-line bg-panelHi/50"
           title="Поки без обʼєму за тиждень"
           description="Заверши тренування з силовими підходами — тут зʼявиться сумарний обʼєм (кг×повторення) по днях."
         />
@@ -111,7 +111,7 @@ export function WeeklyVolumeChart({
             <text
               x={4}
               y={t.y + 4}
-              className="fill-subtle text-2xs font-medium"
+              className="fill-subtle text-3xs font-medium"
             >
               {t.lab}
             </text>
@@ -144,7 +144,7 @@ export function WeeklyVolumeChart({
               x={x}
               y={h - 6}
               textAnchor="middle"
-              className="fill-muted text-2xs font-semibold"
+              className="fill-muted text-3xs font-semibold"
             >
               {lab}
             </text>

--- a/src/modules/fizruk/components/WellbeingChart.tsx
+++ b/src/modules/fizruk/components/WellbeingChart.tsx
@@ -6,7 +6,7 @@ export function WellbeingChart({ data }) {
     return (
       <EmptyState
         compact
-        className="rounded-2xl border border-dashed border-line/60 bg-panelHi/50"
+        className="rounded-2xl border border-dashed border-line bg-panelHi/50"
         title="Немає даних для графіка"
         description="Після кількох тренувань з оцінкою енергії та настрою тут зʼявиться діаграма."
       />
@@ -16,7 +16,7 @@ export function WellbeingChart({ data }) {
     return (
       <EmptyState
         compact
-        className="rounded-2xl border border-dashed border-line/60 bg-panelHi/50"
+        className="rounded-2xl border border-dashed border-line bg-panelHi/50"
         title="Замало точок"
         description="Потрібно щонайменше два тренування з оцінкою самопочуття, щоб порівняти динаміку."
       />

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -147,7 +147,7 @@ export function WorkoutTemplatesSection({
       )}
 
       {editingId && (
-        <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3">
+        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
           <Input
             placeholder="Назва (за замовчуванням — «Мій шаблон»)"
             value={name}
@@ -280,7 +280,7 @@ export function WorkoutTemplatesSection({
                       </span>
                       {group && (
                         <span
-                          className={`text-2xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${group.type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
+                          className={`text-3xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${group.type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
                         >
                           {group.type === "circuit" ? "Коло" : "СС"}
                         </span>
@@ -354,7 +354,7 @@ export function WorkoutTemplatesSection({
         </div>
       )}
 
-      <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
+      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest">
             Збережені шаблони

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -127,7 +127,7 @@ function WarmupCooldownChecklist({ title, items, onToggle, onInit, color }) {
 function SupersetBadge({ type }) {
   return (
     <span
-      className={`text-2xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
+      className={`text-3xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
     >
       {type === "circuit" ? "Коло" : "Суперсет"}
     </span>
@@ -516,12 +516,12 @@ export function ActiveWorkoutPanel({
                 </div>
               )}
               {!activeWorkout.endedAt && !group && (
-                <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-line/60">
+                <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-line">
                   <div className="flex items-center justify-between w-full gap-1">
                     <span className="text-2xs font-bold text-subtle uppercase tracking-widest">
                       Таймер відпочинку
                     </span>
-                    <span className="text-2xs text-muted">
+                    <span className="text-3xs text-muted">
                       {catLabel} · реком. {defSec}с
                     </span>
                   </div>
@@ -615,7 +615,7 @@ export function ActiveWorkoutPanel({
               {cardioMetrics && (
                 <div className="grid grid-cols-2 gap-2">
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
-                    <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+                    <div className="text-3xs font-bold text-subtle uppercase tracking-widest">
                       Темп
                     </div>
                     <div className="text-sm font-bold text-text tabular-nums">
@@ -623,7 +623,7 @@ export function ActiveWorkoutPanel({
                     </div>
                   </div>
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
-                    <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+                    <div className="text-3xs font-bold text-subtle uppercase tracking-widest">
                       Швидкість
                     </div>
                     <div className="text-sm font-bold text-text tabular-nums">
@@ -752,7 +752,7 @@ export function ActiveWorkoutPanel({
   if (!activeWorkout) return null;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
       <div className="flex items-center justify-between gap-2">
         <div>
           <div className="text-sm font-bold text-text">
@@ -808,7 +808,7 @@ export function ActiveWorkoutPanel({
         </div>
       </div>
 
-      <details className="mt-3 rounded-xl border border-line/60 bg-panelHi/50 px-3 py-2">
+      <details className="mt-3 rounded-xl border border-line bg-panelHi/50 px-3 py-2">
         <summary className="text-xs font-semibold text-subtle cursor-pointer select-none">
           Час тренування
         </summary>

--- a/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
@@ -42,7 +42,7 @@ export function WorkoutBackupBar({ className }) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-line/60 bg-panelHi/40 px-3 py-2.5 flex flex-col gap-3 text-xs text-subtle",
+        "rounded-2xl border border-line bg-panelHi/40 px-3 py-2.5 flex flex-col gap-3 text-xs text-subtle",
         className,
       )}
     >

--- a/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
@@ -40,7 +40,7 @@ export function WorkoutCatalogSection({
         </p>
       )}
 
-      <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
+      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
         {grouped.length === 0 ? (
           <EmptyState
             compact
@@ -112,7 +112,7 @@ export function WorkoutCatalogSection({
                           {mode === "log" && (
                             <button
                               type="button"
-                              className="shrink-0 w-12 min-h-[48px] flex items-center justify-center border-l border-line/80 text-muted hover:text-text hover:bg-panelHi transition-colors"
+                              className="shrink-0 w-12 min-h-[48px] flex items-center justify-center border-l border-line text-muted hover:text-text hover:bg-panelHi transition-colors"
                               aria-label="Опис і фото вправи"
                               onClick={() => setSelected(ex)}
                             >

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { Button } from "@shared/components/ui/Button";
+import { compactToolbarButtonClass } from "@shared/components/ui/buttonPresets";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { ActiveWorkoutPanel } from "../workouts/ActiveWorkoutPanel";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
@@ -99,7 +100,7 @@ export function WorkoutJournalSection({
   return (
     <div className="space-y-3">
       {!activeWorkout && (
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card text-center">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card text-center">
           <div className="text-sm font-semibold text-text">
             Немає активного тренування
           </div>
@@ -190,7 +191,7 @@ export function WorkoutJournalSection({
         </SectionErrorBoundary>
       )}
 
-      <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
+      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line flex items-center justify-between gap-2">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest">
             Останні тренування
@@ -198,7 +199,7 @@ export function WorkoutJournalSection({
           <button
             type="button"
             onClick={() => setRetroOpen((o) => !o)}
-            className="h-8 px-2.5 rounded-lg border border-line text-xs text-subtle hover:text-text hover:bg-panel transition-colors"
+            className={compactToolbarButtonClass}
             aria-expanded={retroOpen}
             title="Записати заднім числом"
           >

--- a/src/modules/fizruk/pages/Atlas.tsx
+++ b/src/modules/fizruk/pages/Atlas.tsx
@@ -74,7 +74,7 @@ export function Atlas() {
           </div>
         </section>
 
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
           <BodyAtlas
             statusByMuscle={statusByMuscle}
             height={520}

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
 import { MiniLineChart } from "../components/MiniLineChart";
@@ -38,7 +39,7 @@ function ScoreButton({ value, selected, onClick, label }) {
       <span className="text-base leading-none">{value}</span>
       <span
         className={cn(
-          "text-2xs leading-none truncate max-w-full px-1",
+          "text-3xs leading-none truncate max-w-full px-1",
           selected ? "text-white/80" : "text-muted",
         )}
       >
@@ -184,7 +185,7 @@ export function Body({ onOpenMeasurements }) {
               <button
                 type="button"
                 onClick={onOpenMeasurements}
-                className="h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle hover:text-text hover:bg-panelHi transition-colors"
+                className={subtleNavButtonClass}
               >
                 Виміри
               </button>
@@ -193,7 +194,7 @@ export function Body({ onOpenMeasurements }) {
         </div>
 
         <section
-          className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+          className="bg-panel border border-line rounded-2xl p-4 shadow-card"
           aria-label="Записати показники"
         >
           <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -331,7 +332,7 @@ export function Body({ onOpenMeasurements }) {
 
         {weightData.length >= 2 && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Динаміка ваги"
           >
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -348,7 +349,7 @@ export function Body({ onOpenMeasurements }) {
 
         {sleepData.length >= 2 && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Динаміка сну"
           >
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -365,7 +366,7 @@ export function Body({ onOpenMeasurements }) {
 
         {energyData.length >= 2 && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Динаміка енергії"
           >
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -382,7 +383,7 @@ export function Body({ onOpenMeasurements }) {
 
         {moodData.length >= 2 && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Динаміка настрою"
           >
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -401,7 +402,7 @@ export function Body({ onOpenMeasurements }) {
 
         {entries.length > 0 && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Журнал записів"
           >
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -288,7 +288,7 @@ export function Dashboard({
           <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
             {greeting} · {today}
           </p>
-          <h1 className="text-2xl font-black text-white mt-3 leading-tight">
+          <h1 className="text-[26px] font-black text-white mt-3 leading-tight">
             Твій прогрес
             <br />
             зібраний в одному місці
@@ -363,7 +363,7 @@ export function Dashboard({
               recentlyUsed.length > 0 ? recentlyUsed : templates.slice(0, 3);
             return (
               <section
-                className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+                className="bg-panel border border-line rounded-2xl p-4 shadow-card"
                 aria-label="Швидкий старт"
               >
                 <div className="flex items-center justify-between gap-2 mb-3">
@@ -422,7 +422,7 @@ export function Dashboard({
 
         {activeProgram && (
           <section
-            className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
             aria-label="Програма сьогодні"
           >
             <div className="flex items-center justify-between gap-2 mb-3">
@@ -467,7 +467,7 @@ export function Dashboard({
         )}
 
         <section
-          className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+          className="bg-panel border border-line rounded-2xl p-4 shadow-card"
           aria-label="Відновлення та фокус тренування"
         >
           <div className="flex items-start justify-between gap-2">
@@ -540,7 +540,7 @@ export function Dashboard({
                 showLegend={false}
               />
 
-              <div className="mt-4 pt-3 border-t border-line/60">
+              <div className="mt-4 pt-3 border-t border-line">
                 <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
                   Пріоритет після відпочинку
                 </p>
@@ -582,7 +582,7 @@ export function Dashboard({
             <div
               key={card.id}
               role="listitem"
-              className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card min-h-[100px]"
+              className="bg-panel border border-line rounded-2xl p-4 shadow-card min-h-[100px]"
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
@@ -592,7 +592,7 @@ export function Dashboard({
                   <div className="text-2xs font-semibold text-subtle uppercase tracking-wide mt-2">
                     {card.label}
                   </div>
-                  <div className="text-2xs text-muted mt-0.5 leading-snug">
+                  <div className="text-3xs text-muted mt-0.5 leading-snug">
                     {card.sub}
                   </div>
                 </div>
@@ -666,7 +666,7 @@ export function Dashboard({
           ))}
         </div>
 
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
           <div className="flex items-center justify-between gap-2 mb-3">
             <div className="text-xs font-medium text-subtle">
               План на сьогодні

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -44,7 +44,7 @@ const CALC_ZONES = [
 
 function LoadCalculator({ oneRM }) {
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
       <div className="flex items-baseline justify-between gap-2 mb-3">
         <div className="text-xs font-bold text-subtle uppercase tracking-widest">
           Калькулятор навантаження
@@ -81,7 +81,7 @@ function LoadCalculator({ oneRM }) {
                     <div className="text-sm font-bold text-text tabular-nums leading-tight">
                       {kg > 0 ? `${kg}` : "—"}
                     </div>
-                    <div className="text-2xs text-muted leading-none">кг</div>
+                    <div className="text-3xs text-muted leading-none">кг</div>
                   </div>
                 );
               })}
@@ -89,7 +89,7 @@ function LoadCalculator({ oneRM }) {
           </div>
         ))}
       </div>
-      <p className="text-2xs text-muted mt-2 text-center">
+      <p className="text-3xs text-muted mt-2 text-center">
         Ваги округлені до найближчих 2.5 кг
       </p>
     </div>
@@ -99,7 +99,7 @@ function LoadCalculator({ oneRM }) {
 function ProgressChart({ points, label, unit, color }) {
   if (!points || points.length < 2) {
     return (
-      <div className="rounded-xl border border-dashed border-line/60 bg-panelHi/50 py-6 text-center text-xs text-subtle">
+      <div className="rounded-xl border border-dashed border-line bg-panelHi/50 py-6 text-center text-xs text-subtle">
         Потрібно щонайменше 2 тренування для графіка
       </div>
     );
@@ -389,7 +389,7 @@ export function Exercise({ exerciseId }) {
     return (
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-          <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card text-sm text-subtle">
+          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card text-sm text-subtle">
             Невірний ID вправи
           </div>
         </div>
@@ -439,7 +439,7 @@ export function Exercise({ exerciseId }) {
         )}
 
         <div className="grid grid-cols-2 gap-3">
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Особистий рекорд
             </div>
@@ -461,7 +461,7 @@ export function Exercise({ exerciseId }) {
               </div>
             )}
           </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Наступного разу
             </div>
@@ -487,7 +487,7 @@ export function Exercise({ exerciseId }) {
         </div>
 
         {hasStrength && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Прогресія 1RM (за тижнями)
             </div>
@@ -501,7 +501,7 @@ export function Exercise({ exerciseId }) {
         )}
 
         {hasStrength && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Обʼєм тренування (кг × повтори, за тижнями)
             </div>
@@ -515,7 +515,7 @@ export function Exercise({ exerciseId }) {
         )}
 
         {hasCardio && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Темп (хв/км) — кардіо
             </div>
@@ -532,7 +532,7 @@ export function Exercise({ exerciseId }) {
         )}
 
         {hasCardio && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Дистанція (км) — кардіо
             </div>
@@ -547,7 +547,7 @@ export function Exercise({ exerciseId }) {
 
         {best.best1rm > 0 && <LoadCalculator oneRM={best.best1rm} />}
 
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Історія сетів
           </div>

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -51,7 +51,7 @@ export function Measurements() {
           href="https://www.wikihow.com/Take-Body-Measurements"
           target="_blank"
           rel="noreferrer"
-          className="flex items-center gap-3 bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+          className="flex items-center gap-3 bg-panel border border-line rounded-2xl p-4 shadow-card"
         >
           <div className="shrink-0 w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center text-success">
             <svg
@@ -79,7 +79,7 @@ export function Measurements() {
         </a>
 
         <div className="grid grid-cols-3 gap-2">
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Записів
             </div>
@@ -87,7 +87,7 @@ export function Measurements() {
               {stats.total}
             </div>
           </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Останній
             </div>
@@ -95,7 +95,7 @@ export function Measurements() {
               {stats.latestAt}
             </div>
           </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-3 shadow-card text-center">
+          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Полів
             </div>
@@ -105,7 +105,7 @@ export function Measurements() {
           </div>
         </div>
 
-        <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Додати замір
           </div>
@@ -149,7 +149,7 @@ export function Measurements() {
         </div>
 
         {latest && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="flex items-center justify-between">
               <div>
                 <div className="text-xs font-bold text-subtle uppercase tracking-widest">
@@ -195,7 +195,7 @@ export function Measurements() {
           </div>
         )}
 
-        <div className="bg-panel border border-line/60 rounded-2xl shadow-card overflow-hidden">
+        <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
           <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest">
               Історія

--- a/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -119,7 +119,7 @@ export function PlanCalendar() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
-        <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
           <div className="flex items-center justify-between gap-2 mb-4">
             <button
               type="button"
@@ -181,7 +181,7 @@ export function PlanCalendar() {
                 >
                   <span className="text-xs font-bold text-text">{day}</span>
                   {tpl && (
-                    <span className="text-2xs text-subtle leading-tight line-clamp-1 mt-0.5 px-0.5">
+                    <span className="text-3xs text-subtle leading-tight line-clamp-1 mt-0.5 px-0.5">
                       {tpl.name}
                     </span>
                   )}
@@ -203,7 +203,7 @@ export function PlanCalendar() {
           </p>
         </section>
 
-        <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
           <h2 className="text-sm font-semibold text-text mb-1">
             Повне відновлення м’язів (прогноз)
           </h2>

--- a/src/modules/fizruk/pages/Programs.tsx
+++ b/src/modules/fizruk/pages/Programs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { BUILTIN_PROGRAMS } from "../lib/trainingPrograms";
@@ -33,7 +34,7 @@ export function Programs({
             <button
               type="button"
               onClick={deactivateProgram}
-              className="h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle hover:text-text hover:bg-panelHi transition-colors"
+              className={subtleNavButtonClass}
             >
               Зупинити
             </button>
@@ -53,7 +54,7 @@ export function Programs({
                 key={prog.id}
                 className={cn(
                   "bg-panel border rounded-2xl shadow-card overflow-hidden transition-all",
-                  isActive ? "border-success/60" : "border-line/60",
+                  isActive ? "border-success/60" : "border-line",
                 )}
               >
                 <div className="p-4">
@@ -68,7 +69,7 @@ export function Programs({
                             Активна
                           </span>
                         )}
-                        <span className="text-2xs text-subtle border border-line/60 rounded-full px-2 py-0.5">
+                        <span className="text-2xs text-subtle border border-line rounded-full px-2 py-0.5">
                           {prog.days} дн/тиждень
                         </span>
                       </div>
@@ -88,7 +89,7 @@ export function Programs({
                         <div
                           key={i}
                           className={cn(
-                            "flex-1 text-center rounded py-1 text-2xs font-bold transition-colors",
+                            "flex-1 text-center rounded py-1 text-3xs font-bold transition-colors",
                             hasSession
                               ? isToday && isActive
                                 ? "bg-success text-white"
@@ -167,7 +168,7 @@ export function Programs({
 
 function ProgramDetails({ prog, exercises }) {
   return (
-    <div className="border-t border-line/60 px-4 pb-4 pt-3 space-y-3 bg-bg/50">
+    <div className="border-t border-line px-4 pb-4 pt-3 space-y-3 bg-bg/50">
       <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
         Розклад та вправи
       </div>
@@ -209,7 +210,7 @@ function ProgramDetails({ prog, exercises }) {
                 {exList.map((ex) => (
                   <span
                     key={ex.id}
-                    className="text-[11px] px-2 py-0.5 rounded-full bg-panelHi border border-line/60 text-subtle"
+                    className="text-[11px] px-2 py-0.5 rounded-full bg-panelHi border border-line text-subtle"
                   >
                     {ex.name?.uk || ex.name?.en || ex.id}
                   </span>

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -334,7 +334,7 @@ export function Progress() {
         </div>
 
         {!hasAny && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-8 shadow-card text-center">
+          <div className="bg-panel border border-line rounded-2xl p-8 shadow-card text-center">
             <div className="text-3xl mb-3">📈</div>
             <div className="text-sm font-medium text-text mb-1">
               Даних ще немає
@@ -347,14 +347,14 @@ export function Progress() {
 
         {/* Weekly volume chart */}
         {(workouts || []).some((w) => w.endedAt) && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
             <WeeklyVolumeChart volumeKg={weekly.volumeKg} />
           </div>
         )}
 
         {/* Cross-module activity */}
         {hasPushupData && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Активність з інших модулів
             </div>
@@ -402,7 +402,7 @@ export function Progress() {
 
         {/* Weight + fat cards */}
         <div className="grid grid-cols-2 gap-3">
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Вага
             </div>
@@ -429,7 +429,7 @@ export function Progress() {
               )}
             </div>
           </div>
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               % жиру
             </div>
@@ -460,7 +460,7 @@ export function Progress() {
 
         {/* Weight trend chart */}
         {weightTrend.filter((d) => d.value != null).length >= 2 && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Тренд ваги
             </div>
@@ -475,7 +475,7 @@ export function Progress() {
 
         {/* Body fat trend chart */}
         {fatTrend.filter((d) => d.value != null).length >= 2 && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Тренд % жиру
             </div>
@@ -490,7 +490,7 @@ export function Progress() {
 
         {/* Wellbeing chart */}
         {wellbeingData.length >= 2 && (
-          <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Самопочуття
             </div>
@@ -499,7 +499,7 @@ export function Progress() {
         )}
 
         {/* Muscle volume bars */}
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Обʼєм по мʼязах
           </div>
@@ -544,7 +544,7 @@ export function Progress() {
               : prs.filter((p) => p.muscleGroup === prFilter);
           const MEDALS = ["🥇", "🥈", "🥉"];
           return (
-            <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+            <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
               <div className="flex items-center justify-between gap-2 mb-3">
                 <div className="text-xs font-bold text-subtle uppercase tracking-widest">
                   Рекорди (PR) · {prs.length}
@@ -664,7 +664,7 @@ export function Progress() {
         })()}
 
         {/* Data management */}
-        <div className="bg-panel border border-line/60 rounded-2xl p-5 shadow-card">
+        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Дані
           </div>

--- a/src/modules/fizruk/pages/Workouts.tsx
+++ b/src/modules/fizruk/pages/Workouts.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
@@ -397,14 +398,14 @@ export function Workouts() {
           <div className="flex items-center gap-2">
             <button
               type="button"
-              className="h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle hover:text-text hover:bg-panelHi transition-colors"
+              className={subtleNavButtonClass}
               onClick={() => (window.location.hash = "#progress")}
             >
               Прогрес →
             </button>
             <button
               type="button"
-              className="h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle hover:text-text hover:bg-panelHi transition-colors"
+              className={subtleNavButtonClass}
               onClick={() => (window.location.hash = "#programs")}
             >
               Програми →

--- a/src/modules/nutrition/components/BarcodeScanner.jsx
+++ b/src/modules/nutrition/components/BarcodeScanner.jsx
@@ -222,7 +222,7 @@ export function BarcodeScanner({ onDetected, onClose }) {
           </button>
         </div>
         <div className="px-4 pb-8 space-y-3">
-          <div className="rounded-2xl overflow-hidden border border-line/50 bg-black relative">
+          <div className="rounded-2xl overflow-hidden border border-line bg-black relative">
             <video
               ref={videoRef}
               className="w-full aspect-video object-cover"

--- a/src/modules/nutrition/components/DailyPlanCard.jsx
+++ b/src/modules/nutrition/components/DailyPlanCard.jsx
@@ -68,7 +68,7 @@ function MacroRatioBar({ prefs }) {
       <div className="flex rounded-lg overflow-hidden h-5">
         {pctP > 0 && (
           <div
-            className="bg-blue-500 flex items-center justify-center text-2xs font-bold text-white"
+            className="bg-blue-500 flex items-center justify-center text-3xs font-bold text-white"
             style={{ width: `${pctP}%` }}
           >
             {pctP}%
@@ -76,7 +76,7 @@ function MacroRatioBar({ prefs }) {
         )}
         {pctF > 0 && (
           <div
-            className="bg-yellow-500 flex items-center justify-center text-2xs font-bold text-white"
+            className="bg-yellow-500 flex items-center justify-center text-3xs font-bold text-white"
             style={{ width: `${pctF}%` }}
           >
             {pctF}%
@@ -84,7 +84,7 @@ function MacroRatioBar({ prefs }) {
         )}
         {pctC > 0 && (
           <div
-            className="bg-green-500 flex items-center justify-center text-2xs font-bold text-white"
+            className="bg-green-500 flex items-center justify-center text-3xs font-bold text-white"
             style={{ width: `${pctC}%` }}
           >
             {pctC}%
@@ -129,7 +129,7 @@ function MealRow({ meal, onAddToLog, onRegen, busy }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-2xl border border-line/60 bg-bg/40 p-3">
+    <div className="rounded-2xl border border-line bg-bg/40 p-3">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 mb-0.5">
@@ -489,7 +489,7 @@ export function DailyPlanCard({
             </div>
 
             {dayPlan?.note && (
-              <div className="rounded-xl bg-panel/60 border border-line/60 px-3 py-2 text-xs text-subtle">
+              <div className="rounded-xl bg-panel/60 border border-line px-3 py-2 text-xs text-subtle">
                 {dayPlan.note}
               </div>
             )}

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -76,7 +76,7 @@ function MealThumb({ mealId }) {
       decoding="async"
       width="40"
       height="40"
-      className="w-10 h-10 rounded-lg object-cover shrink-0 border border-line/60"
+      className="w-10 h-10 rounded-lg object-cover shrink-0 border border-line"
     />
   );
 }
@@ -190,7 +190,7 @@ export function LogCard({
           </button>
         </div>
 
-        <div className="rounded-2xl border border-line/50 bg-panel/40 px-3 py-3 space-y-2">
+        <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-2">
           <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
             Пошук по журналу
           </div>
@@ -294,7 +294,7 @@ export function LogCard({
         </button>
 
         {weekOpen && (
-          <div className="rounded-2xl border border-line/50 bg-panel/40 px-3 py-3">
+          <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3">
             <div className="overflow-x-auto">
               <table className="w-full text-[11px] text-left">
                 <thead>
@@ -324,7 +324,7 @@ export function LogCard({
           </div>
         )}
 
-        <div className="rounded-2xl border border-line/50 bg-panel/40 px-3 py-3 space-y-3">
+        <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-3">
           <div className="flex items-center justify-between gap-2">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Аналітика (тренди)

--- a/src/modules/nutrition/components/NutritionBottomNav.jsx
+++ b/src/modules/nutrition/components/NutritionBottomNav.jsx
@@ -98,7 +98,7 @@ export function NutritionBottomNav({ activePage, setActivePage }) {
       className={cn(
         "shrink-0 relative z-30 safe-area-pb",
         "bg-panel/95 backdrop-blur-xl",
-        "border-t border-line/60",
+        "border-t border-line",
       )}
     >
       <div className="flex h-[60px]">

--- a/src/modules/nutrition/components/NutritionDashboard.jsx
+++ b/src/modules/nutrition/components/NutritionDashboard.jsx
@@ -108,7 +108,7 @@ function MiniBar({ rows, targetKcal }) {
             </div>
             <span
               className={cn(
-                "text-2xs leading-none",
+                "text-3xs leading-none",
                 isToday ? "text-text font-bold" : "text-muted",
               )}
             >
@@ -193,7 +193,7 @@ export function NutritionDashboard({
                     {m.label}
                   </div>
                   {target > 0 && (
-                    <div className="text-2xs text-muted leading-none">
+                    <div className="text-3xs text-muted leading-none">
                       / {target}
                       {m.unit}
                     </div>

--- a/src/modules/nutrition/components/NutritionHeader.jsx
+++ b/src/modules/nutrition/components/NutritionHeader.jsx
@@ -2,7 +2,7 @@ import { cn } from "@shared/lib/cn";
 
 export function NutritionHeader({ busy: _busy, onBackToHub }) {
   return (
-    <div className="shrink-0 bg-panel/95 backdrop-blur-xl border-b border-line/60 z-40 relative safe-area-pt">
+    <div className="shrink-0 bg-panel/95 backdrop-blur-xl border-b border-line z-40 relative safe-area-pt">
       <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
         {typeof onBackToHub === "function" ? (
           <button
@@ -12,7 +12,7 @@ export function NutritionHeader({ busy: _busy, onBackToHub }) {
               "shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] -ml-1",
               "flex items-center justify-center rounded-xl",
               "text-muted hover:text-text transition-all duration-200",
-              "border border-line/80 bg-panel/80 hover:bg-panelHi",
+              "border border-line bg-panel/80 hover:bg-panelHi",
               "active:scale-95",
             )}
             aria-label="До вибору модуля"
@@ -65,7 +65,7 @@ export function NutritionHeader({ busy: _busy, onBackToHub }) {
         )}
 
         <div className="min-w-0 flex-1">
-          <span className="text-2xs text-lime-600/80 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
+          <span className="text-3xs text-lime-600/80 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
             ХАРЧУВАННЯ
           </span>
           <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">

--- a/src/modules/nutrition/components/PantryCard.jsx
+++ b/src/modules/nutrition/components/PantryCard.jsx
@@ -207,7 +207,7 @@ export function PantryCard({
                 📷
               </button>
             )}
-            <div className="flex rounded-xl bg-panelHi border border-line/50 p-0.5">
+            <div className="flex rounded-xl bg-panelHi border border-line p-0.5">
               {INPUT_MODES.map((m) => (
                 <button
                   key={m.id}

--- a/src/modules/nutrition/components/RecipesCard.jsx
+++ b/src/modules/nutrition/components/RecipesCard.jsx
@@ -169,7 +169,7 @@ export function RecipesCard({
                   return (
                     <div
                       key={r.id}
-                      className="rounded-2xl border border-line/60 bg-bg/40 p-3 overflow-hidden"
+                      className="rounded-2xl border border-line bg-bg/40 p-3 overflow-hidden"
                     >
                       <div className="flex flex-wrap items-start justify-between gap-2">
                         <button

--- a/src/modules/nutrition/components/ShoppingListCard.jsx
+++ b/src/modules/nutrition/components/ShoppingListCard.jsx
@@ -166,7 +166,7 @@ export function ShoppingListCard({
               {shoppingList.categories.map((cat) => (
                 <div
                   key={cat.name}
-                  className="rounded-2xl border border-line/60 bg-bg/30 overflow-hidden"
+                  className="rounded-2xl border border-line bg-bg/30 overflow-hidden"
                 >
                   <div className="px-3 py-2 border-b border-line/40 bg-panel/40">
                     <div className="flex items-center gap-1.5">

--- a/src/modules/nutrition/components/SubTabs.jsx
+++ b/src/modules/nutrition/components/SubTabs.jsx
@@ -24,7 +24,7 @@ export function SubTabs({ value, onChange, tabs, className }) {
             onClick={() => onChange(t.id)}
             className={cn(
               "flex-1 min-h-[40px] px-3 py-2 rounded-xl text-sm font-semibold transition-colors",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/40",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
               active
                 ? "bg-panel text-text shadow-sm"
                 : "text-muted hover:text-text",

--- a/src/modules/nutrition/components/WaterTrackerCard.jsx
+++ b/src/modules/nutrition/components/WaterTrackerCard.jsx
@@ -28,7 +28,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
   }, []);
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
       <div className="flex items-center justify-between gap-2 mb-3">
         <div className="flex items-center gap-2">
           <span className="text-lg leading-none" aria-hidden="true">

--- a/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
@@ -11,7 +11,7 @@ export function BarcodeSection({
   setScannerOpen,
 }) {
   return (
-    <div className="mb-4 rounded-2xl border border-line/50 bg-panel/40 px-3 py-3">
+    <div className="mb-4 rounded-2xl border border-line bg-panel/40 px-3 py-3">
       <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Штрихкод
       </div>

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -73,7 +73,7 @@ export function FoodPickerSection({
           />
           {foodErr && <div className="text-[11px] text-muted">{foodErr}</div>}
           {(foodHits.length > 0 || offHits.length > 0) && (
-            <div className="max-h-56 overflow-y-auto rounded-2xl border border-line/60 bg-bg shadow-sm">
+            <div className="max-h-56 overflow-y-auto rounded-2xl border border-line bg-bg shadow-sm">
               <ul className="divide-y divide-line/20">
                 {foodHits.map((p) => (
                   <FoodHitRow

--- a/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
@@ -9,7 +9,7 @@ export function FromPantryRow({
 }) {
   if (!pantryItems || pantryItems.length === 0) return null;
   return (
-    <div className="mb-4 rounded-2xl border border-line/50 bg-panel/40 px-3 py-3">
+    <div className="mb-4 rounded-2xl border border-line bg-panel/40 px-3 py-3">
       <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
         Зі складу
         {fromPantryItem && (

--- a/src/modules/routine/RoutineApp.jsx
+++ b/src/modules/routine/RoutineApp.jsx
@@ -440,13 +440,13 @@ export default function RoutineApp({
 
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line/60 z-40 relative safe-area-pt">
+      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
         <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
           {typeof onBackToHub === "function" ? (
             <button
               type="button"
               onClick={onBackToHub}
-              className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line/80 bg-panel/80"
+              className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
               aria-label="До вибору модуля"
               title="До хабу"
             >
@@ -490,7 +490,7 @@ export default function RoutineApp({
           <div className="min-w-0 flex-1">
             <span
               className={cn(
-                "text-2xs font-bold tracking-widest uppercase block leading-none mb-0.5",
+                "text-3xs font-bold tracking-widest uppercase block leading-none mb-0.5",
                 C.eyebrow,
               )}
             >

--- a/src/modules/routine/components/DayReportSheet.jsx
+++ b/src/modules/routine/components/DayReportSheet.jsx
@@ -116,7 +116,7 @@ export function DayReportSheet({
               {missed.map((h) => (
                 <li
                   key={h.id}
-                  className="flex items-center gap-3 rounded-xl bg-panel border border-line/50 px-3 py-2.5"
+                  className="flex items-center gap-3 rounded-xl bg-panel border border-line px-3 py-2.5"
                 >
                   <button
                     type="button"
@@ -136,7 +136,7 @@ export function DayReportSheet({
         )}
 
         {scheduledHabits.length > 0 && (
-          <div className="mt-4 pt-3 border-t border-line/50 text-center">
+          <div className="mt-4 pt-3 border-t border-line text-center">
             <p className="text-xs text-subtle">
               {done.length} з {scheduledHabits.length} виконано
               {scheduledHabits.length > 0 && (

--- a/src/modules/routine/components/HabitDetailSheet.jsx
+++ b/src/modules/routine/components/HabitDetailSheet.jsx
@@ -195,7 +195,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
                 </span>
               ))}
               {category && (
-                <span className="text-2xs px-2 py-0.5 rounded-full bg-panelHi border border-line/60 text-muted font-medium">
+                <span className="text-2xs px-2 py-0.5 rounded-full bg-panelHi border border-line text-muted font-medium">
                   {category}
                 </span>
               )}
@@ -204,7 +204,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
           <button
             type="button"
             onClick={onClose}
-            className="shrink-0 w-9 h-9 rounded-xl border border-line/70 flex items-center justify-center text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="shrink-0 w-9 h-9 rounded-xl border border-line flex items-center justify-center text-muted hover:text-text hover:bg-panelHi transition-colors"
             aria-label="Закрити"
           >
             ✕
@@ -284,7 +284,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               <button
                 type="button"
                 onClick={() => goCalMonth(-1)}
-                className="w-8 h-8 rounded-lg border border-line/70 text-muted hover:text-text flex items-center justify-center text-sm"
+                className="w-8 h-8 rounded-lg border border-line text-muted hover:text-text flex items-center justify-center text-sm"
                 aria-label="Попередній місяць"
               >
                 ‹
@@ -295,7 +295,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               <button
                 type="button"
                 onClick={() => goCalMonth(1)}
-                className="w-8 h-8 rounded-lg border border-line/70 text-muted hover:text-text flex items-center justify-center text-sm"
+                className="w-8 h-8 rounded-lg border border-line text-muted hover:text-text flex items-center justify-center text-sm"
                 aria-label="Наступний місяць"
               >
                 ›
@@ -306,7 +306,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
             {WEEKDAY_LABELS.map((wd) => (
               <div
                 key={wd}
-                className="text-center text-2xs text-subtle font-medium pb-1"
+                className="text-center text-3xs text-subtle font-medium pb-1"
               >
                 {wd}
               </div>
@@ -343,7 +343,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
               );
             })}
           </div>
-          <div className="flex items-center gap-3 mt-2 text-2xs text-subtle">
+          <div className="flex items-center gap-3 mt-2 text-3xs text-subtle">
             <span className="flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded bg-routine-surface2 dark:bg-routine/15 border border-routine-ring/40 dark:border-routine/30" />
               Виконано

--- a/src/modules/routine/components/HabitHeatmap.jsx
+++ b/src/modules/routine/components/HabitHeatmap.jsx
@@ -109,7 +109,7 @@ export function HabitHeatmap({ habits, completions }) {
   return (
     <div
       ref={rootRef}
-      className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+      className="bg-panel border border-line rounded-2xl p-4 shadow-card"
     >
       <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
         Активність за рік
@@ -178,7 +178,7 @@ export function HabitHeatmap({ habits, completions }) {
       </div>
 
       {selectedCell ? (
-        <div className="mt-3 flex items-center justify-between gap-2 rounded-xl border border-line/60 bg-bg px-3 py-2 text-xs">
+        <div className="mt-3 flex items-center justify-between gap-2 rounded-xl border border-line bg-bg px-3 py-2 text-xs">
           <span className="text-subtle truncate">
             {selectedCell.dt.toLocaleDateString("uk-UA", {
               weekday: "long",
@@ -196,7 +196,7 @@ export function HabitHeatmap({ habits, completions }) {
           </span>
         </div>
       ) : (
-        <div className="mt-3 flex items-center gap-2 text-2xs text-subtle/70 select-none">
+        <div className="mt-3 flex items-center gap-2 text-3xs text-subtle/70 select-none">
           <span>менше</span>
           {[
             "bg-panelHi dark:bg-line/25",

--- a/src/modules/routine/components/HabitLeadersBlock.jsx
+++ b/src/modules/routine/components/HabitLeadersBlock.jsx
@@ -27,7 +27,7 @@ export function HabitLeadersBlock({ habits, completions }) {
   if (!best) return null;
 
   return (
-    <div className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
       <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
         Лідери та аутсайдери (30 днів)
       </p>
@@ -44,7 +44,7 @@ export function HabitLeadersBlock({ habits, completions }) {
           </p>
         </div>
         {worst && (
-          <div className="rounded-xl border border-line/50 bg-panel p-3">
+          <div className="rounded-xl border border-line bg-panel p-3">
             <p className="text-2xs uppercase tracking-wide text-subtle mb-1">
               Найслабша
             </p>

--- a/src/modules/routine/components/PushupsWidget.jsx
+++ b/src/modules/routine/components/PushupsWidget.jsx
@@ -29,7 +29,7 @@ export function PushupsWidget() {
   return (
     <>
       <section
-        className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+        className="bg-panel border border-line rounded-2xl p-4 shadow-card"
         aria-label="Відтискання"
       >
         <div className="flex items-center justify-between gap-2">
@@ -65,7 +65,7 @@ export function PushupsWidget() {
         </div>
 
         {recentHistory.some((d) => d.total > 0) && (
-          <div className="mt-4 pt-3 border-t border-line/60">
+          <div className="mt-4 pt-3 border-t border-line">
             <p className="text-2xs text-subtle mb-2">Останні 7 днів</p>
             <div className="flex items-end gap-1 h-10">
               {recentHistory.map((d) => {

--- a/src/modules/routine/components/RoutineBackupSection.jsx
+++ b/src/modules/routine/components/RoutineBackupSection.jsx
@@ -7,7 +7,7 @@ export function RoutineBackupSection({ theme, toast, onImportParsed }) {
   const backupRef = useRef(null);
 
   return (
-    <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3">
+    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Резервна копія
       </h2>
@@ -35,7 +35,7 @@ export function RoutineBackupSection({ theme, toast, onImportParsed }) {
         <Button
           type="button"
           variant="ghost"
-          className="border border-line/70"
+          className="border border-line"
           onClick={() => backupRef.current?.click()}
         >
           Імпорт

--- a/src/modules/routine/components/RoutineBottomNav.jsx
+++ b/src/modules/routine/components/RoutineBottomNav.jsx
@@ -76,7 +76,7 @@ export function RoutineBottomNav({ mainTab, onSelectTab }) {
       className={cn(
         "shrink-0 relative z-30 safe-area-pb",
         "bg-panel/95 backdrop-blur-xl",
-        "border-t border-line/60",
+        "border-t border-line",
       )}
       aria-label="Розділи Рутини"
     >

--- a/src/modules/routine/components/RoutineCalendarPanel.jsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.jsx
@@ -152,7 +152,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {Math.round(completionRate.rate * 100)}%
               </p>
-              <p className="text-2xs text-subtle tabular-nums">
+              <p className="text-3xs text-subtle tabular-nums">
                 {completionRate.completed}/{completionRate.scheduled}
               </p>
             </div>
@@ -205,7 +205,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
         ))}
       </div>
 
-      <div className="rounded-2xl border border-line/60 bg-panel/80 p-3 shadow-card">
+      <div className="rounded-2xl border border-line bg-panel/80 p-3 shadow-card">
         <p className="mb-2 text-2xs font-bold uppercase tracking-widest text-subtle">
           Тиждень
         </p>
@@ -301,7 +301,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
           <div className="flex items-center justify-between gap-2">
             <button
               type="button"
-              className="w-10 h-10 rounded-xl border border-line/80 bg-panel/90 text-muted hover:text-text shadow-sm"
+              className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
               onClick={() => goMonth(-1)}
               aria-label="Попередній місяць"
             >
@@ -312,7 +312,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
             </span>
             <button
               type="button"
-              className="w-10 h-10 rounded-xl border border-line/80 bg-panel/90 text-muted hover:text-text shadow-sm"
+              className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
               onClick={() => goMonth(1)}
               aria-label="Наступний місяць"
             >
@@ -333,7 +333,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
       )}
 
       {timeMode === "month" && (
-        <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card">
+        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
           <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
             {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"].map((d) => (
               <div key={d}>{d}</div>
@@ -377,7 +377,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
                     <span className="flex items-center gap-0.5" aria-hidden>
                       <span className={cn("w-1.5 h-1.5 rounded-full", C.dot)} />
                       {n > 1 && (
-                        <span className="text-2xs text-subtle tabular-nums">
+                        <span className="text-3xs text-subtle tabular-nums">
                           {n}
                         </span>
                       )}
@@ -387,7 +387,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
               );
             })}
           </div>
-          <p className="text-xs text-subtle mt-3 pt-3 border-t border-line/50">
+          <p className="text-xs text-subtle mt-3 pt-3 border-t border-line">
             Обрано:{" "}
             {parseDateKey(selectedDay).toLocaleDateString("uk-UA", {
               weekday: "long",
@@ -400,7 +400,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
 
       <section className="space-y-4 pb-2">
         {listIsEmpty && hasListFilter && (
-          <div className="rounded-2xl border border-line/60 bg-panel p-6 text-center shadow-card">
+          <div className="rounded-2xl border border-line bg-panel p-6 text-center shadow-card">
             <p className="text-sm text-muted">
               Нічого не знайдено за фільтром
               {hasNoHabits ? " (і звичок ще немає)" : ""}.
@@ -408,7 +408,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
             <Button
               type="button"
               variant="ghost"
-              className="mt-3 border border-line/70"
+              className="mt-3 border border-line"
               onClick={() => {
                 setTagFilter(null);
                 setListQuery("");
@@ -437,7 +437,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
           </div>
         )}
         {listIsEmpty && !hasListFilter && !hasNoHabits && (
-          <div className="rounded-2xl border border-line/60 bg-panel p-6 text-center shadow-card">
+          <div className="rounded-2xl border border-line bg-panel p-6 text-center shadow-card">
             <p className="text-sm text-muted leading-relaxed">
               У цьому періоді подій немає. Перевір регулярність звичок або{" "}
               {typeof onOpenModule === "function" ? (
@@ -490,7 +490,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
                   >
                     <div
                       className={cn(
-                        "overflow-hidden rounded-2xl border border-line/60 bg-panel pl-4 pr-4 py-3 shadow-card flex flex-col gap-2 border-l-4",
+                        "overflow-hidden rounded-2xl border border-line bg-panel pl-4 pr-4 py-3 shadow-card flex flex-col gap-2 border-l-4",
                         e.fizruk
                           ? "border-l-sky-500"
                           : e.finykSub
@@ -542,7 +542,7 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="!h-9 !px-3 !text-xs border border-line/70 bg-panelHi/80"
+                              className="!h-9 !px-3 !text-xs border border-line bg-panelHi/80"
                               type="button"
                               onClick={() =>
                                 onOpenModule("fizruk", { hash: "plan" })

--- a/src/modules/routine/components/RoutineStatsPanel.jsx
+++ b/src/modules/routine/components/RoutineStatsPanel.jsx
@@ -55,7 +55,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
       className="space-y-4"
     >
       <section
-        className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card"
+        className="bg-panel border border-line rounded-2xl p-4 shadow-card"
         aria-label="Зведена статистика"
       >
         <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
@@ -85,7 +85,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r7.rate * 100)}%
             </p>
-            <p className="text-2xs text-subtle tabular-nums">
+            <p className="text-3xs text-subtle tabular-nums">
               {summary.r7.completed}/{summary.r7.scheduled}
             </p>
           </div>
@@ -96,7 +96,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r30.rate * 100)}%
             </p>
-            <p className="text-2xs text-subtle tabular-nums">
+            <p className="text-3xs text-subtle tabular-nums">
               {summary.r30.completed}/{summary.r30.scheduled}
             </p>
           </div>
@@ -107,7 +107,7 @@ export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
               {Math.round(summary.r90.rate * 100)}%
             </p>
-            <p className="text-2xs text-subtle tabular-nums">
+            <p className="text-3xs text-subtle tabular-nums">
               {summary.r90.completed}/{summary.r90.scheduled}
             </p>
           </div>

--- a/src/modules/routine/components/WeekDayStrip.jsx
+++ b/src/modules/routine/components/WeekDayStrip.jsx
@@ -25,7 +25,7 @@ export function WeekDayStrip({
     <div className="flex items-center gap-1.5 sm:gap-2">
       <button
         type="button"
-        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line/80 bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
+        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
         onClick={() => onShiftWeek(-1)}
         aria-label="Попередній тиждень"
       >
@@ -49,7 +49,7 @@ export function WeekDayStrip({
                 isToday && !isSel && "ring-1 ring-routine/40",
               )}
             >
-              <span className="text-2xs uppercase tracking-wide text-subtle">
+              <span className="text-3xs uppercase tracking-wide text-subtle">
                 {short[i]}
               </span>
               <span className="tabular-nums text-sm text-text">{dom}</span>
@@ -59,7 +59,7 @@ export function WeekDayStrip({
       </div>
       <button
         type="button"
-        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line/80 bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
+        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
         onClick={() => onShiftWeek(1)}
         aria-label="Наступний тиждень"
       >

--- a/src/modules/routine/components/settings/ActiveHabitsSection.jsx
+++ b/src/modules/routine/components/settings/ActiveHabitsSection.jsx
@@ -37,7 +37,7 @@ export function ActiveHabitsSection({
   const hasActive = routine.habits.some((h) => !h.archived);
 
   return (
-    <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-2">
+    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-2">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Активні звички
       </h2>
@@ -57,7 +57,7 @@ export function ActiveHabitsSection({
         Порядок у списку можна змінити перетягуванням або кнопками вгору вниз.
       </p>
       {!hasActive && (
-        <div className="rounded-xl border border-dashed border-line/70 bg-panelHi/50 p-4 text-center">
+        <div className="rounded-xl border border-dashed border-line bg-panelHi/50 p-4 text-center">
           <p className="text-sm text-muted">
             Поки порожньо — додай першу звичку формою вище.
           </p>
@@ -65,7 +65,7 @@ export function ActiveHabitsSection({
             <Button
               type="button"
               variant="ghost"
-              className="mt-3 border border-line/70"
+              className="mt-3 border border-line"
               onClick={onOpenCalendar}
             >
               Перейти до календаря

--- a/src/modules/routine/components/settings/ArchivedHabitsSection.jsx
+++ b/src/modules/routine/components/settings/ArchivedHabitsSection.jsx
@@ -10,7 +10,7 @@ export function ArchivedHabitsSection({
   if (archived.length === 0) return null;
 
   return (
-    <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-2 opacity-95">
+    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-2 opacity-95">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Архів
       </h2>
@@ -31,7 +31,7 @@ export function ArchivedHabitsSection({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="!h-9 !px-3 !text-xs border border-line/70"
+                className="!h-9 !px-3 !text-xs border border-line"
                 onClick={() =>
                   setRoutine((s) => setHabitArchived(s, h.id, false))
                 }

--- a/src/modules/routine/components/settings/CategoriesSection.jsx
+++ b/src/modules/routine/components/settings/CategoriesSection.jsx
@@ -20,7 +20,7 @@ export function CategoriesSection({
 
   return (
     <>
-      <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3">
+      <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
         <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
           {editingCatId ? "Редагувати категорію" : "Категорії"}
         </h2>
@@ -46,7 +46,7 @@ export function CategoriesSection({
               <Button
                 type="button"
                 variant="ghost"
-                className="min-h-[44px] min-w-0 border border-line/70 sm:min-w-[7rem]"
+                className="min-h-[44px] min-w-0 border border-line sm:min-w-[7rem]"
                 onClick={() => {
                   setRoutine((s) =>
                     updateCategory(s, editingCatId, {
@@ -63,7 +63,7 @@ export function CategoriesSection({
               <Button
                 type="button"
                 variant="ghost"
-                className="min-h-[44px] min-w-0 border border-line/70"
+                className="min-h-[44px] min-w-0 border border-line"
                 onClick={() => {
                   setEditingCatId(null);
                   setCatDraft({ name: "", emoji: "" });
@@ -76,7 +76,7 @@ export function CategoriesSection({
             <Button
               type="button"
               variant="ghost"
-              className="min-h-[44px] w-full min-w-0 border border-line/70 sm:w-auto sm:min-w-[7rem]"
+              className="min-h-[44px] w-full min-w-0 border border-line sm:w-auto sm:min-w-[7rem]"
               onClick={() => {
                 setRoutine((s) =>
                   createCategory(s, catDraft.name, catDraft.emoji),
@@ -98,7 +98,7 @@ export function CategoriesSection({
                 <li
                   key={c.id}
                   className={cn(
-                    "flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-panelHi border border-line/50",
+                    "flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-panelHi border border-line",
                     editingCatId === c.id &&
                       "ring-2 ring-routine-ring/60 dark:ring-routine/40",
                   )}
@@ -108,7 +108,7 @@ export function CategoriesSection({
                       {c.emoji ? `${c.emoji} ` : ""}
                       {c.name}
                     </span>
-                    <span className="shrink-0 text-2xs text-subtle bg-panel border border-line/50 rounded-full px-2 py-0.5">
+                    <span className="shrink-0 text-2xs text-subtle bg-panel border border-line rounded-full px-2 py-0.5">
                       {habitCount}{" "}
                       {habitCount === 1
                         ? "звичка"

--- a/src/modules/routine/components/settings/HabitForm.jsx
+++ b/src/modules/routine/components/settings/HabitForm.jsx
@@ -62,7 +62,7 @@ export function HabitForm({
   return (
     <section
       ref={sectionRef}
-      className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3"
+      className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
     >
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         {editingId ? "Редагувати звичку" : "Нова звичка"}
@@ -236,7 +236,7 @@ export function HabitForm({
           <Button
             type="button"
             variant="ghost"
-            className="w-full border border-line/70"
+            className="w-full border border-line"
             onClick={onCancel}
           >
             Скасувати

--- a/src/modules/routine/components/settings/HabitListItem.jsx
+++ b/src/modules/routine/components/settings/HabitListItem.jsx
@@ -58,7 +58,7 @@ export const HabitListItem = memo(function HabitListItem({
           <div className="flex gap-1">
             <button
               type="button"
-              className="min-w-[32px] min-h-[36px] rounded-lg border border-line/70 text-xs text-muted hover:text-text"
+              className="min-w-[32px] min-h-[36px] rounded-lg border border-line text-xs text-muted hover:text-text"
               onClick={onMoveUp}
               aria-label="Вгору в списку"
             >
@@ -66,7 +66,7 @@ export const HabitListItem = memo(function HabitListItem({
             </button>
             <button
               type="button"
-              className="min-w-[32px] min-h-[36px] rounded-lg border border-line/70 text-xs text-muted hover:text-text"
+              className="min-w-[32px] min-h-[36px] rounded-lg border border-line text-xs text-muted hover:text-text"
               onClick={onMoveDown}
               aria-label="Вниз в списку"
             >
@@ -86,7 +86,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-line/70"
+            className="!h-9 !px-3 !text-xs border border-line"
             onClick={onStartEdit}
           >
             Змінити
@@ -95,7 +95,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-line/70"
+            className="!h-9 !px-3 !text-xs border border-line"
             onClick={onArchive}
           >
             В архів

--- a/src/modules/routine/components/settings/TagsSection.jsx
+++ b/src/modules/routine/components/settings/TagsSection.jsx
@@ -18,7 +18,7 @@ export function TagsSection({ routine, setRoutine, tagDraft, setTagDraft }) {
   };
 
   return (
-    <section className="bg-panel border border-line/60 rounded-2xl p-4 shadow-card space-y-3">
+    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Теги
       </h2>
@@ -32,7 +32,7 @@ export function TagsSection({ routine, setRoutine, tagDraft, setTagDraft }) {
         <Button
           type="button"
           variant="ghost"
-          className="min-h-[44px] shrink-0 border border-line/70 px-4"
+          className="min-h-[44px] shrink-0 border border-line px-4"
           onClick={() => {
             setRoutine((s) => createTag(s, tagDraft));
             setTagDraft("");
@@ -45,7 +45,7 @@ export function TagsSection({ routine, setRoutine, tagDraft, setTagDraft }) {
         {routine.tags.map((t) => (
           <li
             key={t.id}
-            className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-xl bg-panelHi text-xs border border-line/50 font-medium"
+            className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-xl bg-panelHi text-xs border border-line font-medium"
           >
             {editingTagId === t.id ? (
               <form

--- a/src/modules/routine/lib/routineConstants.js
+++ b/src/modules/routine/lib/routineConstants.js
@@ -40,7 +40,7 @@ export const ROUTINE_THEME = {
   chipOn:
     "border-routine-ring dark:border-routine/40 bg-routine-surface dark:bg-routine/15 text-routine shadow-sm",
   chipOff:
-    "border-line/60 bg-panel text-muted hover:text-text hover:bg-panelHi transition-colors",
+    "border-line bg-panel text-muted hover:text-text hover:bg-panelHi transition-colors",
 
   // Calendar dots
   dot: "bg-routine",

--- a/src/shared/components/ui/Button.tsx
+++ b/src/shared/components/ui/Button.tsx
@@ -122,7 +122,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           // Base styles
           "inline-flex items-center justify-center",
           "transition-all duration-200 ease-smooth",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
           "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
           // Variant
           variants[variant],

--- a/src/shared/components/ui/VoiceMicButton.tsx
+++ b/src/shared/components/ui/VoiceMicButton.tsx
@@ -183,7 +183,7 @@ export function VoiceMicButton({
         sizeMap[size] || sizeMap.md,
         listening
           ? "bg-error/15 text-error border border-error/30 animate-pulse"
-          : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line/60",
+          : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line",
         disabled && "opacity-40 pointer-events-none",
         className,
       )}

--- a/src/shared/components/ui/buttonPresets.ts
+++ b/src/shared/components/ui/buttonPresets.ts
@@ -1,0 +1,22 @@
+/**
+ * Button preset class strings — shared presets for hand-rolled <button>
+ * elements that don't fit the <Button> variants cleanly.
+ *
+ * Prefer <Button variant="…"> when possible. Use these presets only for
+ * the specific patterns below.
+ */
+
+/**
+ * Subtle nav-style secondary button. Used in page headers for "Прогрес →",
+ * "Програми →", "Виміри" navigation links.
+ *
+ * h-9, 12px text, subtle color by default, hover lifts to panelHi.
+ */
+export const subtleNavButtonClass =
+  "h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle hover:text-text hover:bg-panelHi transition-colors";
+
+/**
+ * Compact retro/toolbar button. h-8, tighter padding.
+ */
+export const compactToolbarButtonClass =
+  "h-8 px-2.5 rounded-lg border border-line text-xs text-subtle hover:text-text hover:bg-panel transition-colors";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -198,6 +198,7 @@ export default {
       // TYPOGRAPHY — Readable, friendly, clear hierarchy
       // ═══════════════════════════════════════════════════════════════════
       fontSize: {
+        "3xs": ["9px", { lineHeight: "12px" }],
         "2xs": ["10px", { lineHeight: "14px" }],
         xs: ["12px", { lineHeight: "16px" }],
         sm: ["14px", { lineHeight: "20px" }],


### PR DESCRIPTION
## Summary

Comprehensive UI consistency follow-up from the audit, plus regression fixes from #180.

**Regression fixes from #180**
- Add `text-3xs` = `9px / 12px` token in `tailwind.config.js:201`.
- Revert 38 originally-`text-[9px]` sites from `text-2xs` (10px) → `text-3xs` (9px). The 9px→10px shift in #180 was incorrect; these are intentional micro-labels. Affected files incl. `src/modules/finyk/components/TxRow.jsx:135-160`, `src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx:130,524,618,626`, `src/modules/routine/components/RoutineStatsPanel.jsx:88,99,110`, etc.
- Revert 3 hero-number sites back to custom `text-[26px]`: `src/modules/finyk/pages/overview/MonthPulseCard.jsx:59,70` (spent/income), `src/modules/fizruk/pages/Dashboard.tsx:291` (h1). These are intentional overrides outside the Tailwind scale; `text-2xl` (24px) shrinks them noticeably.

**Audit follow-ups**
- **Focus-ring opacity unify on `/45`.** 17 sites across `/40`, `/50`, `/20` normalized. Matches the primitive's default in `src/shared/components/ui/Button.tsx:125`.
- **Button dedup.** New `src/shared/components/ui/buttonPresets.ts` exports `subtleNavButtonClass` + `compactToolbarButtonClass`. Replaces the duplicated `h-9 px-3 rounded-xl border border-line text-xs font-semibold text-subtle …` string at 4 call sites: `Workouts.tsx:401,408`, `Body.tsx:188`, `Programs.tsx:37`, `WorkoutJournalSection.tsx:202`.
- **FAB tokenization.** `src/modules/finyk/FinykApp.jsx:685` — replaced raw `bg-emerald-500 / hover:bg-emerald-600 / shadow-lg / shadow-xl` with module tokens (`bg-finyk / hover:bg-finyk-hover / shadow-float / hover:shadow-glow / ring-finyk/45`). No visual change but now consistent with `<Button variant="finyk">`.
- **Card border opacity normalize.** 193 sites across 92 files — `border-line/{50,60,70,80,90}` → solid `border-line`. (The one `border-line/50` left in `src/index.css:153` is the intentional `.panel-soft` utility — low-alpha "soft" surface.)

**Deferred to a later PR** (documented in audit):
- `<Card>` primitive adoption (83 hand-rolled panels). Risk is medium-high due to padding/radius variance; worth a separate visual-review PR.
- `text-[11px]` / `text-[15px]` unification.

## Review & Testing Checklist for Human

- [ ] Spot-check 2-3 screens per module in both light and dark mode for any border/ring visual regressions after the opacity normalize.
- [ ] Verify Fizruk Dashboard greeting `h1` still reads at hero size (26px) and MonthPulseCard spent/income numbers match across currencies.
- [ ] Confirm the Finyk FAB (+) still stands out on the Dashboard/Transactions/Budgets screens — same emerald, now via tokens.
- [ ] Tap through navigational secondary buttons (Workouts "Прогрес →", "Програми →"; Body "Виміри"; Programs "Зупинити"; WorkoutJournal "•••") to confirm they render identically.

### Notes

All local checks green: lint, typecheck, 604/604 tests, build, `format:check`. Vercel preview will surface visual regressions; comment if anything looks off and I'll iterate.


Link to Devin session: https://app.devin.ai/sessions/5b1aebe8911c40058c2847104209824e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
