### PR TITLE
feat(obs): unify Anthropic callers + fix auth metrics middleware ordering

### DIFF
--- a/server/api/chat.js
+++ b/server/api/chat.js
@@ -3,39 +3,11 @@ import { setCorsHeaders } from "./lib/cors.js";
 import { validateBody } from "./lib/validate.js";
 import { ChatRequestSchema } from "./lib/schemas.js";
 import { setRequestModule } from "../obs/requestContext.js";
-import { aiTokensTotal, externalHttpRequestsTotal } from "../obs/metrics.js";
-
-const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
-
-/** Облік токенів з Anthropic-відповіді (usage.input_tokens / output_tokens). */
-function recordAnthropicUsage(model, data) {
-  try {
-    const usage = data?.usage;
-    if (!usage) return;
-    if (Number.isFinite(usage.input_tokens)) {
-      aiTokensTotal.inc(
-        { provider: "anthropic", model, kind: "prompt" },
-        usage.input_tokens,
-      );
-    }
-    if (Number.isFinite(usage.output_tokens)) {
-      aiTokensTotal.inc(
-        { provider: "anthropic", model, kind: "completion" },
-        usage.output_tokens,
-      );
-    }
-  } catch {
-    /* ignore */
-  }
-}
-
-function recordAnthropicOutcome(outcome) {
-  try {
-    externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome });
-  } catch {
-    /* ignore */
-  }
-}
+import {
+  anthropicMessages,
+  anthropicMessagesStream,
+  extractAnthropicText,
+} from "./nutrition/lib/anthropicFetch.js";
 
 const TOOLS = [
   {
@@ -306,37 +278,22 @@ export default async function handler(req, res) {
       };
 
       if (stream) {
-        await streamAnthropicToSse(res, apiKey, payload);
+        await streamAnthropicToSse(res, apiKey, payload, "chat-tool-result");
         return;
       }
 
-      const response = await fetch(ANTHROPIC_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-        },
-        body: JSON.stringify(payload),
+      const { response, data } = await anthropicMessages(apiKey, payload, {
+        timeoutMs: 30000,
+        endpoint: "chat-tool-result",
       });
 
-      const data = await response.json();
-      if (!response.ok) {
-        recordAnthropicOutcome(
-          response.status === 429 ? "rate_limited" : "error",
-        );
+      if (!response?.ok) {
         return res
-          .status(response.status)
+          .status(response?.status || 500)
           .json({ error: data?.error?.message || "AI error" });
       }
 
-      recordAnthropicOutcome("ok");
-      recordAnthropicUsage(payload.model, data);
-
-      const text = (data?.content || [])
-        .filter((b) => b.type === "text")
-        .map((b) => b.text)
-        .join("\n");
+      const text = extractAnthropicText(data);
       return res.status(200).json({ text: text || "Готово." });
     }
 
@@ -346,34 +303,23 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: "Немає повідомлень" });
     }
 
-    const response = await fetch(ANTHROPIC_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
+    const { response, data } = await anthropicMessages(
+      apiKey,
+      {
         model: "claude-sonnet-4-6",
         max_tokens: 600,
         system: SYSTEM_PREFIX + context,
         tools: TOOLS,
         messages: cleaned,
-      }),
-    });
+      },
+      { timeoutMs: 30000, endpoint: "chat" },
+    );
 
-    const data = await response.json();
-    if (!response.ok) {
-      recordAnthropicOutcome(
-        response.status === 429 ? "rate_limited" : "error",
-      );
+    if (!response?.ok) {
       return res
-        .status(response.status)
+        .status(response?.status || 500)
         .json({ error: data?.error?.message || "AI error" });
     }
-
-    recordAnthropicOutcome("ok");
-    recordAnthropicUsage("claude-sonnet-4-6", data);
 
     const content = data?.content || [];
     const toolUses = content.filter((b) => b.type === "tool_use");
@@ -405,16 +351,12 @@ export default async function handler(req, res) {
 /**
  * Anthropic Messages API stream → SSE для клієнта (data: {"t":"фрагмент"}).
  */
-async function streamAnthropicToSse(res, apiKey, payload) {
-  const response = await fetch(ANTHROPIC_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({ ...payload, stream: true }),
-  });
+async function streamAnthropicToSse(res, apiKey, payload, endpoint = "chat") {
+  const { response, recordStreamEnd } = await anthropicMessagesStream(
+    apiKey,
+    payload,
+    { endpoint, timeoutMs: 60000 },
+  );
 
   if (!response.ok) {
     let errMsg = "AI error";
@@ -433,6 +375,7 @@ async function streamAnthropicToSse(res, apiKey, payload) {
   }
 
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  let streamOutcome = "ok";
   res.setHeader("Cache-Control", "no-cache, no-transform");
   res.setHeader("X-Accel-Buffering", "no");
 
@@ -473,7 +416,10 @@ async function streamAnthropicToSse(res, apiKey, payload) {
       }
     }
   } catch (e) {
+    streamOutcome = "error";
     res.write(`data: ${JSON.stringify({ err: String(e?.message || e) })}\n\n`);
+  } finally {
+    recordStreamEnd(streamOutcome);
   }
   res.write("data: [DONE]\n\n");
   res.end();

--- a/server/api/coach.js
+++ b/server/api/coach.js
@@ -3,9 +3,10 @@ import { getSessionUser } from "../auth.js";
 import { assertAiQuota } from "../aiQuota.js";
 import { setCorsHeaders } from "./lib/cors.js";
 import { setRequestModule } from "../obs/requestContext.js";
-import { aiTokensTotal, externalHttpRequestsTotal } from "../obs/metrics.js";
-
-const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+import {
+  anthropicMessages,
+  extractAnthropicText,
+} from "./nutrition/lib/anthropicFetch.js";
 
 async function getMemory(userId) {
   const result = await pool.query(
@@ -224,69 +225,23 @@ ${snapshotText}
 
 Відповідай ТІЛЬКИ текстом повідомлення, без вітань, без підписів, без лапок.`;
 
-    const aiRes = await fetch(ANTHROPIC_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
+    const { response: aiRes, data: aiData } = await anthropicMessages(
+      apiKey,
+      {
         model: "claude-sonnet-4-6",
         max_tokens: 300,
         messages: [{ role: "user", content: systemPrompt }],
-      }),
-    });
+      },
+      { timeoutMs: 20000, endpoint: "coach-insight" },
+    );
 
-    const aiData = await aiRes.json();
-    if (!aiRes.ok) {
-      try {
-        externalHttpRequestsTotal.inc({
-          upstream: "anthropic",
-          outcome: aiRes.status === 429 ? "rate_limited" : "error",
-        });
-      } catch {
-        /* ignore */
-      }
+    if (!aiRes?.ok) {
       return res
-        .status(aiRes.status)
+        .status(aiRes?.status || 500)
         .json({ error: aiData?.error?.message || "AI error" });
     }
 
-    try {
-      externalHttpRequestsTotal.inc({ upstream: "anthropic", outcome: "ok" });
-      const usage = aiData?.usage;
-      if (usage) {
-        if (Number.isFinite(usage.input_tokens)) {
-          aiTokensTotal.inc(
-            {
-              provider: "anthropic",
-              model: "claude-sonnet-4-6",
-              kind: "prompt",
-            },
-            usage.input_tokens,
-          );
-        }
-        if (Number.isFinite(usage.output_tokens)) {
-          aiTokensTotal.inc(
-            {
-              provider: "anthropic",
-              model: "claude-sonnet-4-6",
-              kind: "completion",
-            },
-            usage.output_tokens,
-          );
-        }
-      }
-    } catch {
-      /* ignore */
-    }
-
-    const text = (aiData?.content || [])
-      .filter((b) => b.type === "text")
-      .map((b) => b.text)
-      .join("")
-      .trim();
+    const text = extractAnthropicText(aiData);
 
     return res.json({ ok: true, insight: text });
   }

--- a/server/api/nutrition/lib/anthropicFetch.js
+++ b/server/api/nutrition/lib/anthropicFetch.js
@@ -130,6 +130,66 @@ export async function anthropicMessages(
   return { response: lastResponse, data: lastData };
 }
 
+/**
+ * Стрімова версія Anthropic Messages API. Викликає fetch з `stream: true`,
+ * інструментує outcome/latency (розмір відповіді = час до закриття з'єднання),
+ * і повертає `{ response, recordStreamEnd }`. Викликай `recordStreamEnd(outcome?)`
+ * коли боді повністю спожите (або з помилкою) щоб закрити latency-вимір.
+ */
+export async function anthropicMessagesStream(
+  apiKey,
+  payload,
+  { endpoint = "unknown", timeoutMs = 60000 } = {},
+) {
+  const model = payload?.model || "unknown";
+  const start = process.hrtime.bigint();
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(ANTHROPIC_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({ ...payload, stream: true }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const ms = Number(process.hrtime.bigint() - start) / 1e6;
+      recordOutcome(response.status === 429 ? "rate_limited" : "error", {
+        model,
+        endpoint,
+        ms,
+      });
+      return { response, recordStreamEnd: () => {} };
+    }
+
+    let settled = false;
+    const recordStreamEnd = (outcome = "ok") => {
+      if (settled) return;
+      settled = true;
+      const ms = Number(process.hrtime.bigint() - start) / 1e6;
+      recordOutcome(outcome, { model, endpoint, ms });
+    };
+
+    return { response, recordStreamEnd };
+  } catch (e) {
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    recordOutcome(isAbortError(e) ? "timeout" : "error", {
+      model,
+      endpoint,
+      ms,
+    });
+    throw e;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
 export function extractAnthropicText(data) {
   return (data?.content || [])
     .filter((b) => b.type === "text")

--- a/server/api/weekly-digest.js
+++ b/server/api/weekly-digest.js
@@ -1,6 +1,10 @@
 import { assertAiQuota } from "../aiQuota.js";
 import { setCorsHeaders } from "./lib/cors.js";
 import { setRequestModule } from "../obs/requestContext.js";
+import {
+  anthropicMessages,
+  extractAnthropicText,
+} from "./nutrition/lib/anthropicFetch.js";
 
 function extractJsonObject(raw) {
   if (typeof raw !== "string") return null;
@@ -173,32 +177,24 @@ ${habitsInfo}`);
 ДАНІ:
 ${dataContext}`;
 
-    const aiRes = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
+    const { response: aiRes, data: aiData } = await anthropicMessages(
+      apiKey,
+      {
         model: "claude-sonnet-4-6",
         max_tokens: 2500,
         system: systemPrompt,
         messages: [{ role: "user", content: userPrompt }],
-      }),
-    });
+      },
+      { timeoutMs: 45000, endpoint: "weekly-digest" },
+    );
 
-    const aiData = await aiRes.json();
-    if (!aiRes.ok) {
+    if (!aiRes?.ok) {
       return res
-        .status(aiRes.status)
+        .status(aiRes?.status || 500)
         .json({ error: aiData?.error?.message || "AI error" });
     }
 
-    const text = (aiData?.content || [])
-      .filter((b) => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
+    const text = extractAnthropicText(aiData);
 
     const report = extractJsonObject(text);
     if (!report) {

--- a/server/httpCommon.mjs
+++ b/server/httpCommon.mjs
@@ -166,8 +166,10 @@ export function authSensitiveRateLimit(req, res, next) {
 
 /**
  * Класифікує auth-ендпоінти better-auth і після відповіді інкрементує
- * `authAttemptsTotal{op,outcome}`. Ставити ПІСЛЯ `authSensitiveRateLimit`,
- * ДО `toNodeHandler(auth)` — щоб 429 від ліміту теж ловилися.
+ * `authAttemptsTotal{op,outcome}`. Ставити ПЕРЕД `authSensitiveRateLimit`
+ * (і ДО `toNodeHandler(auth)`): `res.on("finish")` спрацьовує, навіть
+ * коли rate-limiter короткозамикає пайплайн без `next()`, тому реєстрація
+ * listener-а мусить відбутись раніше за сам limiter, щоб 429 ловились.
  */
 export function authMetricsMiddleware(req, res, next) {
   if (req.method !== "POST") return next();

--- a/server/railway.mjs
+++ b/server/railway.mjs
@@ -92,8 +92,11 @@ app.get("/readyz", createReadyzHandler(pool));
 app.get("/health", createReadyzHandler(pool));
 app.get("/metrics", metricsHandler);
 
-app.use("/api/auth", authSensitiveRateLimit);
+// authMetricsMiddleware має реєструватись ПЕРЕД rate-limiter-ом — він лише
+// чіпляє `res.on("finish")` і викликає next(), а коли limiter короткозамикає
+// запит (429 без next()), listener усе одно спрацює на завершенні відповіді.
 app.use("/api/auth", authMetricsMiddleware);
+app.use("/api/auth", authSensitiveRateLimit);
 app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(

--- a/server/replit.mjs
+++ b/server/replit.mjs
@@ -85,8 +85,11 @@ app.get("/readyz", createReadyzHandler(pool));
 app.get("/health", createReadyzHandler(pool));
 app.get("/metrics", metricsHandler);
 
-app.use("/api/auth", authSensitiveRateLimit);
+// authMetricsMiddleware має реєструватись ПЕРЕД rate-limiter-ом — він лише
+// чіпляє `res.on("finish")` і викликає next(), а коли limiter короткозамикає
+// запит (429 без next()), listener усе одно спрацює на завершенні відповіді.
 app.use("/api/auth", authMetricsMiddleware);
+app.use("/api/auth", authSensitiveRateLimit);
 app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(


### PR DESCRIPTION
## Summary

Follow-up to #181. Two changes:

### 1. Unify Anthropic callers through `anthropicMessages()`
`chat.js`, `coach.js` and `weekly-digest.js` all had their own inline `fetch()` calls to `api.anthropic.com` with only counter-level instrumentation (no duration, no `ai_request_*`). They now go through the shared `anthropicMessages()` helper so they automatically pick up:
- `external_http_duration_ms{upstream="anthropic",outcome}`
- `ai_requests_total{provider,model,endpoint,outcome}`
- `ai_request_duration_ms{provider,model,endpoint}`
- `ai_tokens_total{provider,model,kind}` (prompt/completion)
- Built-in retry on transient statuses (429/5xx/529) and `AbortError`→`timeout` classification.

Added a new `anthropicMessagesStream()` helper in the same module to wrap the streaming (SSE) path in `chat.js` with the same timer + outcome emission. `recordStreamEnd()` is called in a `finally` block so interrupted streams still emit latency+outcome.

New `endpoint` labels: `chat`, `chat-tool-result`, `coach-insight`, `weekly-digest`.

### 2. Fix: `authMetricsMiddleware` was registered AFTER the rate limiter
[Devin Review](https://app.devin.ai/review/skords-01/sergeant/pull/181) caught a real functional bug in #181. `authSensitiveRateLimit` short-circuits the pipeline on 429 without calling `next()`, so `authMetricsMiddleware` never ran and its `res.on("finish")` listener was never attached — meaning rate-limited auth requests were silently dropped from `auth_attempts_total{outcome="rate_limited"}`.

Moved `authMetricsMiddleware` **before** `authSensitiveRateLimit` in both `railway.mjs` and `replit.mjs` and updated the stale JSDoc on `authMetricsMiddleware`. `res.on("finish")` still fires when the limiter ends the response directly, so 429s now get counted correctly.

## Review & Testing Checklist for Human

- [ ] Hit `/api/chat` (both streaming and non-streaming) and `/api/coach/insight` and `/api/weekly-digest`. Verify `ai_request_duration_ms{endpoint=...}` shows samples for each endpoint label.
- [ ] Trigger auth rate-limit (>20 POSTs to `/api/auth/*` in 60s) and confirm `auth_attempts_total{outcome="rate_limited"}` now increments.
- [ ] Spot-check SSE streaming still works end-to-end on `/api/chat` with `stream:true` — viewed text deltas arrive and `[DONE]` terminator fires; metric `external_http_duration_ms{upstream="anthropic"}` gets an observation on stream close.

### Notes

- No behaviour changes for successful paths — identical request payload, identical response shape.
- `coach.js` previously emitted `ai_tokens_total` manually; `anthropicMessages()` already does this via `recordUsage()`, so the manual block was removed (no double-counting, no regression).

Link to Devin session: https://app.devin.ai/sessions/3e3ba8f945324c828f28ff14ed18d7ec
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
