### PR TITLE
chore(routine): migrate components/settings + routineConstants to TypeScript

### DIFF
--- a/src/modules/routine/components/settings/ActiveHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ActiveHabitsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { sortHabitsByOrder } from "../../lib/habitOrder.js";
@@ -8,6 +8,22 @@ import {
   setHabitOrder,
 } from "../../lib/routineStorage.js";
 import { HabitListItem } from "./HabitListItem.jsx";
+import type {
+  Habit,
+  PendingHabitDeletion,
+  RoutineState,
+} from "../../lib/types";
+
+export interface ActiveHabitsSectionProps {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  editingId: string | null;
+  onEdit: (habit: Habit) => void;
+  onCancelEditIf: (id: string) => void;
+  onOpenDetails: (id: string) => void;
+  onOpenCalendar?: () => void;
+  onRequestDelete: (pending: PendingHabitDeletion) => void;
+}
 
 export function ActiveHabitsSection({
   routine,
@@ -18,8 +34,8 @@ export function ActiveHabitsSection({
   onOpenDetails,
   onOpenCalendar,
   onRequestDelete,
-}) {
-  const [dragId, setDragId] = useState(null);
+}: ActiveHabitsSectionProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
   const [habitListQuery, setHabitListQuery] = useState("");
 
   const q = habitListQuery.trim().toLowerCase();

--- a/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
@@ -1,11 +1,19 @@
+import type { Dispatch, SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { setHabitArchived } from "../../lib/routineStorage.js";
+import type { PendingHabitDeletion, RoutineState } from "../../lib/types";
+
+export interface ArchivedHabitsSectionProps {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  onRequestDelete: (pending: PendingHabitDeletion) => void;
+}
 
 export function ArchivedHabitsSection({
   routine,
   setRoutine,
   onRequestDelete,
-}) {
+}: ArchivedHabitsSectionProps) {
   const archived = routine.habits.filter((h) => h.archived);
   if (archived.length === 0) return null;
 

--- a/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -8,15 +8,28 @@ import {
   updateCategory,
   deleteCategory,
 } from "../../lib/routineStorage.js";
+import type {
+  CategoryDraft,
+  PendingCategoryDeletion,
+  RoutineState,
+} from "../../lib/types";
+
+export interface CategoriesSectionProps {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  catDraft: CategoryDraft;
+  setCatDraft: Dispatch<SetStateAction<CategoryDraft>>;
+}
 
 export function CategoriesSection({
   routine,
   setRoutine,
   catDraft,
   setCatDraft,
-}) {
-  const [editingCatId, setEditingCatId] = useState(null);
-  const [deleteCatPending, setDeleteCatPending] = useState(null);
+}: CategoriesSectionProps) {
+  const [editingCatId, setEditingCatId] = useState<string | null>(null);
+  const [deleteCatPending, setDeleteCatPending] =
+    useState<PendingCategoryDeletion | null>(null);
 
   return (
     <>

--- a/src/modules/routine/components/settings/HabitForm.tsx
+++ b/src/modules/routine/components/settings/HabitForm.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useId, useRef, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -8,6 +15,24 @@ import {
 } from "../../lib/routineConstants.js";
 import { ReminderPresets } from "./ReminderPresets.jsx";
 import { WeekdayPicker } from "./WeekdayPicker.jsx";
+import type { HabitDraft, RoutineState } from "../../lib/types";
+
+export interface HabitFormProps {
+  routine: RoutineState;
+  habitDraft: HabitDraft;
+  setHabitDraft: Dispatch<SetStateAction<HabitDraft>>;
+  editingId: string | null;
+  onSave: () => void;
+  onCancel: () => void;
+  /**
+   * Monotonic tick bumped by the parent (`RoutineApp`) when the
+   * `add_habit` PWA action or the FTUX first-action sheet wants us to
+   * scroll into view and focus the name input. A tick — not a bool —
+   * so repeated triggers keep re-firing without the parent having to
+   * reset anything.
+   */
+  focusTick?: number;
+}
 
 export function HabitForm({
   routine,
@@ -16,19 +41,14 @@ export function HabitForm({
   editingId,
   onSave,
   onCancel,
-  // Monotonic tick bumped by the parent (`RoutineApp`) when the
-  // `add_habit` PWA action or the FTUX first-action sheet wants us to
-  // scroll into view and focus the name input. A tick — not a bool —
-  // so repeated triggers keep re-firing without the parent having to
-  // reset anything.
   focusTick,
-}) {
+}: HabitFormProps) {
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
   const endId = `${fieldIds}-end`;
   const advancedId = `${fieldIds}-advanced`;
-  const sectionRef = useRef(null);
-  const nameRef = useRef(null);
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const nameRef = useRef<HTMLInputElement | null>(null);
   // Minimal-first UX: emoji + name + regularity are visible on first
   // render. Dates, reminders, tags and categories live behind a
   // "Більше опцій" disclosure. When editing an existing habit we open

--- a/src/modules/routine/components/settings/HabitListItem.tsx
+++ b/src/modules/routine/components/settings/HabitListItem.tsx
@@ -1,7 +1,24 @@
-import { memo } from "react";
+import { memo, type DragEventHandler } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { RECURRENCE_OPTIONS } from "../../lib/routineConstants.js";
+import type { Habit } from "../../lib/types";
+
+export interface HabitListItemProps {
+  habit: Habit;
+  editing: boolean;
+  dragging: boolean;
+  onDragStart: DragEventHandler<HTMLLIElement>;
+  onDragEnd: DragEventHandler<HTMLLIElement>;
+  onDragOver: DragEventHandler<HTMLLIElement>;
+  onDrop: DragEventHandler<HTMLLIElement>;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onOpenDetails: () => void;
+  onStartEdit: () => void;
+  onArchive: () => void;
+  onRequestDelete: () => void;
+}
 
 /**
  * Єдиний рядок у списку активних звичок: перетягування, кнопки ↑↓,
@@ -22,7 +39,7 @@ export const HabitListItem = memo(function HabitListItem({
   onStartEdit,
   onArchive,
   onRequestDelete,
-}) {
+}: HabitListItemProps) {
   const recLabel =
     RECURRENCE_OPTIONS.find((o) => o.value === (h.recurrence || "daily"))
       ?.label || "";

--- a/src/modules/routine/components/settings/ReminderPresets.tsx
+++ b/src/modules/routine/components/settings/ReminderPresets.tsx
@@ -1,9 +1,19 @@
+import type { Dispatch, SetStateAction } from "react";
 import { cn } from "@shared/lib/cn";
 import { Input } from "@shared/components/ui/Input";
 import { ROUTINE_THEME as C } from "../../lib/routineConstants.js";
 import { REMINDER_PRESETS } from "../../lib/routineDraftUtils.js";
+import type { HabitDraft } from "../../lib/types";
 
-export function ReminderPresets({ habitDraft, setHabitDraft }) {
+export interface ReminderPresetsProps {
+  habitDraft: HabitDraft;
+  setHabitDraft: Dispatch<SetStateAction<HabitDraft>>;
+}
+
+export function ReminderPresets({
+  habitDraft,
+  setHabitDraft,
+}: ReminderPresetsProps) {
   const times = habitDraft.reminderTimes || [];
   return (
     <div className="space-y-2">

--- a/src/modules/routine/components/settings/TagsSection.tsx
+++ b/src/modules/routine/components/settings/TagsSection.tsx
@@ -1,14 +1,27 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { createTag, deleteTag, updateTag } from "../../lib/routineStorage.js";
+import type { RoutineState } from "../../lib/types";
 
-export function TagsSection({ routine, setRoutine, tagDraft, setTagDraft }) {
-  const [editingTagId, setEditingTagId] = useState(null);
+export interface TagsSectionProps {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  tagDraft: string;
+  setTagDraft: Dispatch<SetStateAction<string>>;
+}
+
+export function TagsSection({
+  routine,
+  setRoutine,
+  tagDraft,
+  setTagDraft,
+}: TagsSectionProps) {
+  const [editingTagId, setEditingTagId] = useState<string | null>(null);
   const [editingTagName, setEditingTagName] = useState("");
   const tagSavedRef = useRef(false);
 
-  const commitEdit = (id) => {
+  const commitEdit = (id: string) => {
     if (!tagSavedRef.current && editingTagName.trim()) {
       tagSavedRef.current = true;
       setRoutine((s) => updateTag(s, id, editingTagName));

--- a/src/modules/routine/components/settings/WeekdayPicker.tsx
+++ b/src/modules/routine/components/settings/WeekdayPicker.tsx
@@ -5,10 +5,15 @@ import {
   WEEKDAY_LABELS,
 } from "../../lib/routineConstants.js";
 
+export interface WeekdayPickerProps {
+  weekdays: number[] | null | undefined;
+  onChange: (next: number[]) => void;
+}
+
 export const WeekdayPicker = memo(function WeekdayPicker({
   weekdays,
   onChange,
-}) {
+}: WeekdayPickerProps) {
   const active = weekdays || [];
   return (
     <div>

--- a/src/modules/routine/lib/routineConstants.ts
+++ b/src/modules/routine/lib/routineConstants.ts
@@ -76,7 +76,12 @@ export const ROUTINE_THEME = {
 };
 
 // Time mode options
-export const ROUTINE_TIME_MODES = [
+export type RoutineTimeModeId = "today" | "tomorrow" | "week" | "month";
+export interface RoutineTimeMode {
+  id: RoutineTimeModeId;
+  label: string;
+}
+export const ROUTINE_TIME_MODES: readonly RoutineTimeMode[] = [
   { id: "today", label: "Сьогодні" },
   { id: "tomorrow", label: "Завтра" },
   { id: "week", label: "Тиждень" },
@@ -84,7 +89,11 @@ export const ROUTINE_TIME_MODES = [
 ];
 
 // Recurrence patterns
-export const RECURRENCE_OPTIONS = [
+export interface RecurrenceOption {
+  value: "daily" | "weekdays" | "weekly" | "monthly" | "once";
+  label: string;
+}
+export const RECURRENCE_OPTIONS: readonly RecurrenceOption[] = [
   { value: "daily", label: "Щодня" },
   { value: "weekdays", label: "Будні (пн-пт)" },
   { value: "weekly", label: "Обрані дні тижня" },
@@ -93,13 +102,23 @@ export const RECURRENCE_OPTIONS = [
 ];
 
 // Weekday labels (Ukrainian, Monday first)
-export const WEEKDAY_LABELS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
+export const WEEKDAY_LABELS: readonly string[] = [
+  "Пн",
+  "Вт",
+  "Ср",
+  "Чт",
+  "Пт",
+  "Сб",
+  "Нд",
+];
 
 // Gamification streak thresholds
-export const STREAK_MILESTONES = [3, 7, 14, 21, 30, 60, 90, 180, 365];
+export const STREAK_MILESTONES: readonly number[] = [
+  3, 7, 14, 21, 30, 60, 90, 180, 365,
+];
 
 // Get milestone message based on streak count
-export function getStreakMessage(streak) {
+export function getStreakMessage(streak: number): string | null {
   if (streak >= 365) return "Неймовірно! Рік послідовності!";
   if (streak >= 180) return "Півроку! Ти - легенда!";
   if (streak >= 90) return "3 місяці! Це вже стиль життя!";

--- a/src/modules/routine/lib/routineDraftUtils.ts
+++ b/src/modules/routine/lib/routineDraftUtils.ts
@@ -1,12 +1,18 @@
 import { dateKeyFromDate } from "./hubCalendarAggregate.js";
+import type {
+  Habit,
+  HabitDraft,
+  HabitDraftPatch,
+  ReminderPreset,
+} from "./types";
 
-export function routineTodayDate() {
+export function routineTodayDate(): Date {
   const d = new Date();
   d.setHours(12, 0, 0, 0);
   return d;
 }
 
-export const REMINDER_PRESETS = [
+export const REMINDER_PRESETS: readonly ReminderPreset[] = [
   { id: "morning", label: "Ранок", times: ["08:00"] },
   { id: "afternoon", label: "День", times: ["13:00"] },
   { id: "evening", label: "Вечір", times: ["20:00"] },
@@ -18,7 +24,9 @@ export const REMINDER_PRESETS = [
   },
 ];
 
-export function normalizeReminderTimes(habit) {
+export function normalizeReminderTimes(
+  habit: Pick<Habit, "reminderTimes" | "timeOfDay">,
+): string[] {
   if (Array.isArray(habit.reminderTimes) && habit.reminderTimes.length > 0) {
     return habit.reminderTimes.filter(
       (t) => typeof t === "string" && /^\d{2}:\d{2}$/.test(t),
@@ -29,7 +37,7 @@ export function normalizeReminderTimes(habit) {
   return [];
 }
 
-export function emptyHabitDraft() {
+export function emptyHabitDraft(): HabitDraft {
   const t = routineTodayDate();
   return {
     name: "",
@@ -45,7 +53,7 @@ export function emptyHabitDraft() {
   };
 }
 
-export function habitDraftToPatch(draft) {
+export function habitDraftToPatch(draft: HabitDraft): HabitDraftPatch {
   const tagIds = draft.tagIds || [];
   const reminderTimes = (draft.reminderTimes || [])
     .map((t) =>

--- a/src/modules/routine/lib/types.ts
+++ b/src/modules/routine/lib/types.ts
@@ -64,6 +64,46 @@ export interface HabitDraftPatch {
   weekdays?: number[];
 }
 
+/**
+ * Full habit draft used by HabitForm. All fields are defined (possibly
+ * empty strings / empty arrays) so inputs are always controlled.
+ */
+export interface HabitDraft {
+  name: string;
+  emoji: string;
+  tagIds: string[];
+  categoryId: string | null;
+  recurrence: Recurrence | string;
+  startDate: string;
+  endDate: string;
+  timeOfDay: string;
+  reminderTimes: string[];
+  weekdays: number[];
+}
+
+export interface ReminderPreset {
+  id: string;
+  label: string;
+  times: string[];
+}
+
+export interface CategoryDraft {
+  name: string;
+  emoji: string;
+}
+
+export interface PendingHabitDeletion {
+  id: string;
+  name: string;
+  archived: boolean;
+}
+
+export interface PendingCategoryDeletion {
+  id: string;
+  name: string;
+  habitCount: number;
+}
+
 export interface CreateHabitOptions extends HabitDraftPatch {
   name: string;
 }


### PR DESCRIPTION
## Summary

PR #3 з TS-міграції модуля «Рутина».

**`routine/lib`** — підбираю хвости з PR #1:

- `routineConstants.js` → `.ts`: додав типи для `ROUTINE_TIME_MODES`, `RECURRENCE_OPTIONS`, `WEEKDAY_LABELS`, `STREAK_MILESTONES` і сигнатуру `getStreakMessage(streak: number): string | null`. (Файл пропустили в PR #1; без нього компоненти налаштувань не мали джерела типів.)
- `routineDraftUtils.ts`: типізував `REMINDER_PRESETS`, `normalizeReminderTimes`, `emptyHabitDraft`, `habitDraftToPatch` через уже наявні `Habit` / `HabitDraftPatch`.
- `types.ts`: додав `HabitDraft`, `ReminderPreset`, `CategoryDraft`, `PendingHabitDeletion`, `PendingCategoryDeletion`.

**`routine/components/settings/*`** — 8 `.jsx` → `.tsx`, у кожному експортований `*Props` інтерфейс:

- `HabitForm` — `HabitFormProps` з `HabitDraft`, `editingId: string | null`, `focusTick?: number` (тік-лічильник зі сторони `RoutineApp`).
- `HabitListItem` — `HabitListItemProps` з `Habit`, drag-хендлерами `DragEventHandler<HTMLLIElement>`.
- `ActiveHabitsSection`, `ArchivedHabitsSection` — сигнатури з `RoutineState`, `PendingHabitDeletion`.
- `CategoriesSection` — `CategoryDraft` для чернетки і `PendingCategoryDeletion` для діалогу.
- `TagsSection` — `string`-чернетка + типізовані setState.
- `ReminderPresets`, `WeekdayPicker` — дрібні контролери форми.

Без змін поведінки: 604 тести зелені, `typecheck`/`lint`/`format:check`/`build` локально чисті.

## Review & Testing Checklist for Human

- [ ] «Налаштування» Рутини → додавання/редагування звички: емодзі, назва, регулярність, пресет нагадувань, дні тижня — зберегти.
- [ ] Архівувати й повернути звичку з архіву; видалити через діалог.
- [ ] Створити/відредагувати/видалити категорію з емодзі (діалог коректно показує кількість прив'язаних звичок).
- [ ] Теги — створити, перейменувати inline, видалити.
- [ ] PWA-action `add_habit` (`focusTick`) все ще скроллить форму у кадр і фокусує поле назви.

### Notes

Наступні кроки серії:

4. `routine/components/*` (RoutineCalendarPanel, RoutineStatsPanel, RoutineSettingsSection, HabitDetailSheet, DayReportSheet, HabitHeatmap + leaf-компоненти)
5. `RoutineApp.jsx → .tsx` (заодно — точний контракт `data/actions` у `RoutineCalendarContext`)
6. `nutrition/lib` + домен
7. `nutrition/components|pages`
8. Добити `finyk`
9. `core/app`, `core/onboarding`, `core/components`
10. `server/`
11. Поетапно `strict` / `noImplicitAny` / `checkJs`

Link to Devin session: https://app.devin.ai/sessions/1a8b262d0aba4d34bedf5a757fce56da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
