### PR TITLE
fix(obs): keep abort timer alive during Anthropic stream consumption

### DIFF
--- a/server/api/chat.js
+++ b/server/api/chat.js
@@ -381,6 +381,7 @@ async function streamAnthropicToSse(res, apiKey, payload, endpoint = "chat") {
 
   const reader = response.body?.getReader();
   if (!reader) {
+    recordStreamEnd("error");
     res.status(500).json({ error: "No response body" });
     return;
   }

--- a/server/api/nutrition/lib/anthropicFetch.js
+++ b/server/api/nutrition/lib/anthropicFetch.js
@@ -135,6 +135,10 @@ export async function anthropicMessages(
  * інструментує outcome/latency (розмір відповіді = час до закриття з'єднання),
  * і повертає `{ response, recordStreamEnd }`. Викликай `recordStreamEnd(outcome?)`
  * коли боді повністю спожите (або з помилкою) щоб закрити latency-вимір.
+ *
+ * Таймаут (`AbortController`) навмисно НЕ гаситься у `finally`: боді SSE
+ * споживається у caller-і після повернення з цієї функції, тому abort-таймер
+ * мусить жити до виклику `recordStreamEnd`, щоб захистити stream від зависання.
  */
 export async function anthropicMessagesStream(
   apiKey,
@@ -146,8 +150,9 @@ export async function anthropicMessagesStream(
   const controller = new AbortController();
   const t = setTimeout(() => controller.abort(), timeoutMs);
 
+  let response;
   try {
-    const response = await fetch(ANTHROPIC_URL, {
+    response = await fetch(ANTHROPIC_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -157,27 +162,8 @@ export async function anthropicMessagesStream(
       body: JSON.stringify({ ...payload, stream: true }),
       signal: controller.signal,
     });
-
-    if (!response.ok) {
-      const ms = Number(process.hrtime.bigint() - start) / 1e6;
-      recordOutcome(response.status === 429 ? "rate_limited" : "error", {
-        model,
-        endpoint,
-        ms,
-      });
-      return { response, recordStreamEnd: () => {} };
-    }
-
-    let settled = false;
-    const recordStreamEnd = (outcome = "ok") => {
-      if (settled) return;
-      settled = true;
-      const ms = Number(process.hrtime.bigint() - start) / 1e6;
-      recordOutcome(outcome, { model, endpoint, ms });
-    };
-
-    return { response, recordStreamEnd };
   } catch (e) {
+    clearTimeout(t);
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
     recordOutcome(isAbortError(e) ? "timeout" : "error", {
       model,
@@ -185,9 +171,29 @@ export async function anthropicMessagesStream(
       ms,
     });
     throw e;
-  } finally {
-    clearTimeout(t);
   }
+
+  if (!response.ok) {
+    clearTimeout(t);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    recordOutcome(response.status === 429 ? "rate_limited" : "error", {
+      model,
+      endpoint,
+      ms,
+    });
+    return { response, recordStreamEnd: () => {} };
+  }
+
+  let settled = false;
+  const recordStreamEnd = (outcome = "ok") => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(t);
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    recordOutcome(outcome, { model, endpoint, ms });
+  };
+
+  return { response, recordStreamEnd };
 }
 
 export function extractAnthropicText(data) {


### PR DESCRIPTION
## Summary

Follow-up fix to #187. [Devin Review](https://app.devin.ai/review/skords-01/sergeant/pull/187) caught a real bug in `anthropicMessagesStream()`.

### The bug

```js
// before
const t = setTimeout(() => controller.abort(), timeoutMs);
try {
  const response = await fetch(...);
  // ... return { response, recordStreamEnd };
} finally {
  clearTimeout(t); // ← fires as soon as fetch() resolves
}
```

The `finally` block cleared the abort timer the moment `fetch()` resolved and the function returned. But the response body (SSE stream) is consumed _externally_ — by `streamAnthropicToSse` in `chat.js` via `reader.read()` — **after** this function returns. Since the timer was already cleared, `controller.abort()` would never fire during body consumption, so a stalled Anthropic stream could hang indefinitely despite the caller passing `timeoutMs: 60000`.

The non-streaming `anthropicMessages` is fine because `response.json()` is called _inside_ the function, so the timer covers the full consume window.

### The fix

Moved `clearTimeout(t)` to the three places that correspond to "done consuming":

1. `catch` around the initial `fetch` (fetch itself threw, e.g. abort/network).
2. The `!response.ok` early-return branch (we return without giving the caller a stream to consume).
3. Inside `recordStreamEnd()` — the callback the caller invokes after the stream is fully drained (or errored).

The `AbortController` now stays armed while the caller iterates `reader.read()`. If the Anthropic stream stalls > `timeoutMs`, the controller aborts the underlying connection and the reader unblocks with an error.

Also added a JSDoc note explicitly documenting why the timer isn't in `finally`, so this isn't "fixed" back by a future reviewer.

## Review & Testing Checklist for Human

- [ ] Force a mid-stream stall (e.g. mock Anthropic to send `data: {}` then hang) and verify the request aborts after `timeoutMs` and `external_http_duration_ms{upstream="anthropic"}` is observed. Before the fix, the request hung indefinitely.
- [ ] Normal chat streaming still works end-to-end — text deltas arrive, `[DONE]` terminator fires, metric gets one observation on stream close.
- [ ] Trigger a non-200 response from Anthropic (e.g. bad API key) and confirm the early-return path still cancels the timer (no leaked timers — can check with `process._getActiveHandles()` in dev).

### Notes

- No change to happy-path behavior. Metric observation timing is identical — `recordOutcome` still fires on success/error/stream-end.
- No change to non-streaming `anthropicMessages` — its `finally { clearTimeout }` is correct since the body is consumed synchronously inside the function.

Link to Devin session: https://app.devin.ai/sessions/3e3ba8f945324c828f28ff14ed18d7ec
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
