### PR TITLE
refactor(ui): adopt &lt;Card&gt; primitive for 42 hand-rolled panels + add radius prop

### DIFF
--- a/src/core/settings/SettingsPrimitives.tsx
+++ b/src/core/settings/SettingsPrimitives.tsx
@@ -1,6 +1,7 @@
 import { useState, type ChangeEvent, type ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { Card } from "@shared/components/ui/Card";
 
 export interface ChevronIconProps {
   expanded: boolean;
@@ -34,7 +35,7 @@ export function SettingsGroup({
 }: SettingsGroupProps) {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   return (
-    <div className="rounded-2xl border border-line bg-panel shadow-card overflow-hidden">
+    <Card radius="lg" padding="none" className="overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -56,7 +57,7 @@ export function SettingsGroup({
           <div className="border-t border-line p-4 space-y-5">{children}</div>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/src/modules/finyk/components/CategoryManager.jsx
+++ b/src/modules/finyk/components/CategoryManager.jsx
@@ -3,6 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 
 const PRESET_COLORS = [
   "#10b981",
@@ -308,7 +309,7 @@ export function CategoryManager({
       </div>
 
       {showForm ? (
-        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+        <Card radius="lg">
           <div className="text-sm font-semibold text-text mb-3">
             Нова категорія
           </div>
@@ -324,7 +325,7 @@ export function CategoryManager({
             }}
             onCancel={() => setShowForm(false)}
           />
-        </div>
+        </Card>
       ) : (
         <button
           type="button"

--- a/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
@@ -19,7 +20,7 @@ function GoalBudgetCardComponent({
   onDelete,
 }) {
   return (
-    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+    <Card radius="lg" padding="lg">
       {isEditing ? (
         <div className="space-y-2">
           <input
@@ -83,7 +84,7 @@ function GoalBudgetCardComponent({
           </div>
         </>
       )}
-    </div>
+    </Card>
   );
 }
 

--- a/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
@@ -29,7 +30,7 @@ function LimitBudgetCardComponent({
   const warnLimit = pctRaw >= 80 && !overLimit;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+    <Card radius="lg" padding="lg">
       {isEditing ? (
         <div className="space-y-2">
           <input
@@ -132,7 +133,7 @@ function LimitBudgetCardComponent({
             )}
         </>
       )}
-    </div>
+    </Card>
   );
 }
 

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -33,6 +33,7 @@ import { CategorySelector } from "../components/CategorySelector.jsx";
 import { CategoryManager } from "../components/CategoryManager.jsx";
 import { readJSON, writeJSON } from "../lib/finykStorage.js";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
+import { Card } from "@shared/components/ui/Card";
 
 const formInp =
   "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
@@ -757,7 +758,7 @@ export function Budgets({ mono, storage }) {
         })}
 
         {showForm ? (
-          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card space-y-3">
+          <Card radius="lg" padding="lg" className="space-y-3">
             <div className="flex gap-2">
               <button
                 onClick={() => {
@@ -893,7 +894,7 @@ export function Budgets({ mono, storage }) {
                 Скасувати
               </Button>
             </div>
-          </div>
+          </Card>
         ) : (
           <button
             onClick={() => setShowForm(true)}
@@ -904,7 +905,7 @@ export function Budgets({ mono, storage }) {
         )}
 
         {/* Category manager — collapsible at bottom so it never shifts other sections */}
-        <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
+        <Card radius="lg" padding="none" className="overflow-hidden">
           <button
             type="button"
             onClick={() => setShowCategories((v) => !v)}
@@ -931,7 +932,7 @@ export function Budgets({ mono, storage }) {
               />
             </div>
           )}
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/src/modules/finyk/pages/overview/CategoryChartSection.jsx
+++ b/src/modules/finyk/pages/overview/CategoryChartSection.jsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { CategoryChart } from "../../components/charts/lazy";
 import { ChartFallback } from "../../components/charts/ChartFallback";
 import { EmptyState } from "@shared/components/ui/EmptyState";
+import { Card } from "@shared/components/ui/Card";
 
 /**
  * «Витрати за категоріями». Відмальовує chart якщо є дані, або empty-state
@@ -14,7 +15,7 @@ export function CategoryChartSection({
 }) {
   if (catSpends.length > 0) {
     return (
-      <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+      <Card radius="lg" padding="lg">
         <div className="text-xs font-medium text-subtle mb-4">
           Витрати за категоріями
         </div>
@@ -31,7 +32,7 @@ export function CategoryChartSection({
             }
           />
         </Suspense>
-      </div>
+      </Card>
     );
   }
 

--- a/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
+++ b/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
@@ -1,3 +1,4 @@
+import { Card } from "@shared/components/ui/Card";
 /**
  * Пара карток «Дохід» / «Витрати» під Hero-ом. Стрілки з inline-SVG лишаємо
  * тут — це декоративні іконки конкретні для цієї секції.
@@ -5,7 +6,7 @@
 export function IncomeExpensePills({ income, spent, showBalance = true }) {
   return (
     <div className="grid grid-cols-2 gap-3">
-      <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+      <Card radius="lg">
         <div className="flex items-center gap-2 text-emerald-600">
           <svg
             width="16"
@@ -29,8 +30,8 @@ export function IncomeExpensePills({ income, spent, showBalance = true }) {
             : "••••"}{" "}
           <span className="text-base font-medium text-muted">₴</span>
         </p>
-      </div>
-      <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+      </Card>
+      <Card radius="lg">
         <div className="flex items-center gap-2 text-red-500">
           <svg
             width="16"
@@ -54,7 +55,7 @@ export function IncomeExpensePills({ income, spent, showBalance = true }) {
             : "••••"}{" "}
           <span className="text-base font-medium text-muted">₴</span>
         </p>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/modules/finyk/pages/overview/PlanFactCard.jsx
+++ b/src/modules/finyk/pages/overview/PlanFactCard.jsx
@@ -1,4 +1,5 @@
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 
 /**
  * Картка «План / Факт» — показує planIncome/planExpense/planSavings поряд з
@@ -16,7 +17,7 @@ export function PlanFactCard({
   if (!(planIncome > 0 || planExpense > 0 || planSavings > 0)) return null;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+    <Card radius="lg" padding="lg">
       <div className="text-xs font-medium text-subtle mb-3">План / Факт</div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">
@@ -52,6 +53,6 @@ export function PlanFactCard({
           </div>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/modules/finyk/pages/overview/PlannedFlowsCard.jsx
+++ b/src/modules/finyk/pages/overview/PlannedFlowsCard.jsx
@@ -1,4 +1,5 @@
 import { FlowRow } from "./FlowRow.jsx";
+import { Card } from "@shared/components/ui/Card";
 
 /**
  * Список «Найближчі платежі» (до 5 рядків). plannedFlows — вже відфільтрований
@@ -8,7 +9,7 @@ export function PlannedFlowsCard({ plannedFlows, onNavigate, showBalance }) {
   if (plannedFlows.length === 0) return null;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl overflow-hidden shadow-card">
+    <Card radius="lg" padding="none" className="overflow-hidden">
       <div className="px-5 pt-4 pb-2 flex items-center justify-between">
         <span className="text-xs font-medium text-subtle">
           Найближчі платежі
@@ -25,6 +26,6 @@ export function PlannedFlowsCard({ plannedFlows, onNavigate, showBalance }) {
           <FlowRow key={f.id} flow={f} showAmount={showBalance} />
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/modules/finyk/pages/overview/QuickAddCard.jsx
+++ b/src/modules/finyk/pages/overview/QuickAddCard.jsx
@@ -1,4 +1,5 @@
 import { CANONICAL_TO_MANUAL_LABEL } from "../../domain/personalization";
+import { Card } from "@shared/components/ui/Card";
 
 /**
  * Квікадд-картка: топ-категорії + «нещодавнє». Показуємо лише коли
@@ -14,7 +15,7 @@ export function QuickAddCard({
     return null;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-5 shadow-card space-y-3">
+    <Card radius="lg" padding="lg" className="space-y-3">
       <div className="flex items-center justify-between">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle">
@@ -77,6 +78,6 @@ export function QuickAddCard({
           </div>
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 
 function uid(prefix = "g") {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -147,7 +148,7 @@ export function WorkoutTemplatesSection({
       )}
 
       {editingId && (
-        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
+        <Card radius="lg" className="space-y-3">
           <Input
             placeholder="Назва (за замовчуванням — «Мій шаблон»)"
             value={name}
@@ -351,10 +352,10 @@ export function WorkoutTemplatesSection({
               Скасувати
             </Button>
           </div>
-        </div>
+        </Card>
       )}
 
-      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
+      <Card radius="lg" padding="none" className="overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest">
             Збережені шаблони
@@ -417,7 +418,7 @@ export function WorkoutTemplatesSection({
             </div>
           ))
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -12,6 +12,7 @@ import {
   makeDefaultWarmup,
   makeDefaultCooldown,
 } from "../../hooks/useWorkouts";
+import { Card } from "@shared/components/ui/Card";
 
 function uid(prefix = "id") {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -752,7 +753,7 @@ export function ActiveWorkoutPanel({
   if (!activeWorkout) return null;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+    <Card radius="lg">
       <div className="flex items-center justify-between gap-2">
         <div>
           <div className="text-sm font-bold text-text">
@@ -935,6 +936,6 @@ export function ActiveWorkoutPanel({
           />
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
@@ -1,6 +1,7 @@
 import { Input } from "@shared/components/ui/Input";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 
 export function WorkoutCatalogSection({
   mode,
@@ -40,7 +41,7 @@ export function WorkoutCatalogSection({
         </p>
       )}
 
-      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
+      <Card radius="lg" padding="none" className="overflow-hidden">
         {grouped.length === 0 ? (
           <EmptyState
             compact
@@ -139,7 +140,7 @@ export function WorkoutCatalogSection({
             );
           })
         )}
-      </div>
+      </Card>
     </>
   );
 }

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@shared/components/ui/EmptyState";
 import { ActiveWorkoutPanel } from "../workouts/ActiveWorkoutPanel";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
+import { Card } from "@shared/components/ui/Card";
 
 function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
   // An ended workout is always "Завершене" — even if it happens to be the
@@ -191,7 +192,7 @@ export function WorkoutJournalSection({
         </SectionErrorBoundary>
       )}
 
-      <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
+      <Card radius="lg" padding="none" className="overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line flex items-center justify-between gap-2">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest">
             Останні тренування
@@ -296,7 +297,7 @@ export function WorkoutJournalSection({
             )}
           />
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/modules/fizruk/pages/Atlas.tsx
+++ b/src/modules/fizruk/pages/Atlas.tsx
@@ -1,5 +1,6 @@
 import { BodyAtlas } from "../components/BodyAtlas";
 import { useRecovery } from "../hooks/useRecovery";
+import { Card } from "@shared/components/ui/Card";
 
 export function Atlas() {
   const rec = useRecovery();
@@ -74,13 +75,13 @@ export function Atlas() {
           </div>
         </section>
 
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+        <Card radius="lg" padding="lg">
           <BodyAtlas
             statusByMuscle={statusByMuscle}
             height={520}
             showLegend={false}
           />
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
   workoutDurationSec,
 } from "../lib/workoutStats";
 import { ACTIVE_WORKOUT_KEY } from "../lib/workoutUi";
+import { Card } from "@shared/components/ui/Card";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
 
@@ -666,7 +667,7 @@ export function Dashboard({
           ))}
         </div>
 
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+        <Card radius="lg" padding="lg">
           <div className="flex items-center justify-between gap-2 mb-3">
             <div className="text-xs font-medium text-subtle">
               План на сьогодні
@@ -790,7 +791,7 @@ export function Dashboard({
               Журнал
             </Button>
           </div>
-        </div>
+        </Card>
       </div>
 
       {planConfirmOpen && (

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -4,6 +4,7 @@ import { EmptyState } from "@shared/components/ui/EmptyState";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { epley1rm, suggestNextSet } from "../lib/workoutStats";
+import { Card } from "@shared/components/ui/Card";
 
 function fmt(n, digits = 0) {
   const x = Number(n);
@@ -44,7 +45,7 @@ const CALC_ZONES = [
 
 function LoadCalculator({ oneRM }) {
   return (
-    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+    <Card radius="lg">
       <div className="flex items-baseline justify-between gap-2 mb-3">
         <div className="text-xs font-bold text-subtle uppercase tracking-widest">
           Калькулятор навантаження
@@ -92,7 +93,7 @@ function LoadCalculator({ oneRM }) {
       <p className="text-3xs text-muted mt-2 text-center">
         Ваги округлені до найближчих 2.5 кг
       </p>
-    </div>
+    </Card>
   );
 }
 
@@ -439,7 +440,7 @@ export function Exercise({ exerciseId }) {
         )}
 
         <div className="grid grid-cols-2 gap-3">
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Особистий рекорд
             </div>
@@ -460,8 +461,8 @@ export function Exercise({ exerciseId }) {
                 })}
               </div>
             )}
-          </div>
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          </Card>
+          <Card radius="lg">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Наступного разу
             </div>
@@ -483,11 +484,11 @@ export function Exercise({ exerciseId }) {
                 {`зараз: ${best.lastTop.weightKg ?? 0} × ${best.lastTop.reps ?? 0}`}
               </div>
             )}
-          </div>
+          </Card>
         </div>
 
         {hasStrength && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Прогресія 1RM (за тижнями)
             </div>
@@ -497,11 +498,11 @@ export function Exercise({ exerciseId }) {
               unit="кг"
               color="rgb(22 163 74)"
             />
-          </div>
+          </Card>
         )}
 
         {hasStrength && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Обʼєм тренування (кг × повтори, за тижнями)
             </div>
@@ -511,11 +512,11 @@ export function Exercise({ exerciseId }) {
               unit="кг"
               color="rgb(99 102 241)"
             />
-          </div>
+          </Card>
         )}
 
         {hasCardio && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Темп (хв/км) — кардіо
             </div>
@@ -528,11 +529,11 @@ export function Exercise({ exerciseId }) {
             <div className="text-2xs text-subtle mt-1">
               Менше — краще (швидший темп)
             </div>
-          </div>
+          </Card>
         )}
 
         {hasCardio && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Дистанція (км) — кардіо
             </div>
@@ -542,12 +543,12 @@ export function Exercise({ exerciseId }) {
               unit="км"
               color="rgb(6 182 212)"
             />
-          </div>
+          </Card>
         )}
 
         {best.best1rm > 0 && <LoadCalculator oneRM={best.best1rm} />}
 
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+        <Card radius="lg" padding="lg">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Історія сетів
           </div>
@@ -628,7 +629,7 @@ export function Exercise({ exerciseId }) {
               Перейти до журналу
             </button>
           </div>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
+import { Card } from "@shared/components/ui/Card";
 
 const inp =
   "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
@@ -105,7 +106,7 @@ export function Measurements() {
           </div>
         </div>
 
-        <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+        <Card radius="lg">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Додати замір
           </div>
@@ -146,10 +147,10 @@ export function Measurements() {
               Зберегти замір
             </button>
           </div>
-        </div>
+        </Card>
 
         {latest && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="flex items-center justify-between">
               <div>
                 <div className="text-xs font-bold text-subtle uppercase tracking-widest">
@@ -192,10 +193,10 @@ export function Measurements() {
                 </div>
               ))}
             </div>
-          </div>
+          </Card>
         )}
 
-        <div className="bg-panel border border-line rounded-2xl shadow-card overflow-hidden">
+        <Card radius="lg" padding="none" className="overflow-hidden">
           <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest">
               Історія
@@ -239,7 +240,7 @@ export function Measurements() {
               description="Додай перший запис, щоб бачити динаміку показників."
             />
           )}
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -16,6 +16,7 @@ import {
   FIZRUK_RESET_KEYS,
 } from "../lib/fizrukStorage";
 import { epley1rm, weeklyVolumeSeriesNow } from "../lib/workoutStats";
+import { Card } from "@shared/components/ui/Card";
 
 function weekStartMs(d) {
   const x = new Date(d);
@@ -347,14 +348,14 @@ export function Progress() {
 
         {/* Weekly volume chart */}
         {(workouts || []).some((w) => w.endedAt) && (
-          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+          <Card radius="lg" padding="lg">
             <WeeklyVolumeChart volumeKg={weekly.volumeKg} />
-          </div>
+          </Card>
         )}
 
         {/* Cross-module activity */}
         {hasPushupData && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Активність з інших модулів
             </div>
@@ -397,12 +398,12 @@ export function Progress() {
                 </div>
               </div>
             </div>
-          </div>
+          </Card>
         )}
 
         {/* Weight + fat cards */}
         <div className="grid grid-cols-2 gap-3">
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               Вага
             </div>
@@ -428,8 +429,8 @@ export function Progress() {
                 </span>
               )}
             </div>
-          </div>
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          </Card>
+          <Card radius="lg">
             <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
               % жиру
             </div>
@@ -455,12 +456,12 @@ export function Progress() {
                 </span>
               )}
             </div>
-          </div>
+          </Card>
         </div>
 
         {/* Weight trend chart */}
         {weightTrend.filter((d) => d.value != null).length >= 2 && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Тренд ваги
             </div>
@@ -470,12 +471,12 @@ export function Progress() {
               color="rgb(22 163 74)"
               metricLabel="вагу тіла"
             />
-          </div>
+          </Card>
         )}
 
         {/* Body fat trend chart */}
         {fatTrend.filter((d) => d.value != null).length >= 2 && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Тренд % жиру
             </div>
@@ -485,21 +486,21 @@ export function Progress() {
               color="rgb(234 179 8)"
               metricLabel="відсоток жиру"
             />
-          </div>
+          </Card>
         )}
 
         {/* Wellbeing chart */}
         {wellbeingData.length >= 2 && (
-          <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+          <Card radius="lg">
             <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Самопочуття
             </div>
             <WellbeingChart data={wellbeingData} />
-          </div>
+          </Card>
         )}
 
         {/* Muscle volume bars */}
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+        <Card radius="lg" padding="lg">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Обʼєм по мʼязах
           </div>
@@ -531,7 +532,7 @@ export function Progress() {
               ))}
             </div>
           )}
-        </div>
+        </Card>
 
         {/* PR Board */}
         {(() => {
@@ -544,7 +545,7 @@ export function Progress() {
               : prs.filter((p) => p.muscleGroup === prFilter);
           const MEDALS = ["🥇", "🥈", "🥉"];
           return (
-            <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+            <Card radius="lg" padding="lg">
               <div className="flex items-center justify-between gap-2 mb-3">
                 <div className="text-xs font-bold text-subtle uppercase tracking-widest">
                   Рекорди (PR) · {prs.length}
@@ -659,12 +660,12 @@ export function Progress() {
                   })}
                 </div>
               )}
-            </div>
+            </Card>
           );
         })()}
 
         {/* Data management */}
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card">
+        <Card radius="lg" padding="lg">
           <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Дані
           </div>
@@ -714,7 +715,7 @@ export function Progress() {
           <div className="text-[11px] text-subtle/70 mt-2">
             Порада: роби експорт перед великими змінами/оновленнями.
           </div>
-        </div>
+        </Card>
       </div>
 
       <ConfirmDialog

--- a/src/modules/nutrition/components/WaterTrackerCard.jsx
+++ b/src/modules/nutrition/components/WaterTrackerCard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { useWaterTracker } from "../hooks/useWaterTracker.js";
+import { Card } from "@shared/components/ui/Card";
 
 const QUICK_ML = [200, 300, 500, 750];
 
@@ -28,7 +29,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
   }, []);
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+    <Card radius="lg">
       <div className="flex items-center justify-between gap-2 mb-3">
         <div className="flex items-center gap-2">
           <span className="text-lg leading-none" aria-hidden="true">
@@ -111,6 +112,6 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
           </button>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/modules/routine/components/HabitLeadersBlock.jsx
+++ b/src/modules/routine/components/HabitLeadersBlock.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { habitCompletionRate } from "../lib/streaks.js";
+import { Card } from "@shared/components/ui/Card";
 
 export function HabitLeadersBlock({ habits, completions }) {
   const { best, worst } = useMemo(() => {
@@ -27,7 +28,7 @@ export function HabitLeadersBlock({ habits, completions }) {
   if (!best) return null;
 
   return (
-    <div className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+    <Card radius="lg">
       <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
         Лідери та аутсайдери (30 днів)
       </p>
@@ -58,6 +59,6 @@ export function HabitLeadersBlock({ habits, completions }) {
           </div>
         )}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/shared/components/ui/Card.tsx
+++ b/src/shared/components/ui/Card.tsx
@@ -37,13 +37,23 @@ export type CardVariant =
 
 export type CardPadding = "none" | "sm" | "md" | "lg" | "xl";
 
+export type CardRadius = "md" | "lg" | "xl";
+
+const radii: Record<CardRadius, string> = {
+  md: "rounded-xl",
+  lg: "rounded-2xl",
+  xl: "rounded-3xl",
+};
+
+// Core variants omit the radius class — it's controlled by the `radius` prop.
+// Module (branded) variants bake rounded-3xl into their class string for hero surfaces.
 const variants: Record<CardVariant, string> = {
-  default: "bg-panel border border-line rounded-3xl shadow-card",
+  default: "bg-panel border border-line shadow-card",
   interactive:
-    "bg-panel border border-line rounded-3xl shadow-card transition-all duration-200 ease-smooth hover:shadow-float hover:-translate-y-0.5 active:scale-[0.99] cursor-pointer",
-  flat: "bg-panel border border-line rounded-3xl",
-  elevated: "bg-panel border border-line rounded-3xl shadow-float",
-  ghost: "bg-transparent border border-transparent rounded-3xl",
+    "bg-panel border border-line shadow-card transition-all duration-200 ease-smooth hover:shadow-float hover:-translate-y-0.5 active:scale-[0.99] cursor-pointer",
+  flat: "bg-panel border border-line",
+  elevated: "bg-panel border border-line shadow-float",
+  ghost: "bg-transparent border border-transparent",
 
   // Module hero cards — branded surface in light, subtle tinted panel in dark.
   finyk:
@@ -77,25 +87,42 @@ const paddings: Record<CardPadding, string> = {
 export interface CardProps extends HTMLAttributes<HTMLElement> {
   variant?: CardVariant;
   padding?: CardPadding;
+  radius?: CardRadius;
   as?: ElementType;
   children?: ReactNode;
 }
+
+const CORE_VARIANTS: ReadonlySet<CardVariant> = new Set([
+  "default",
+  "interactive",
+  "flat",
+  "elevated",
+  "ghost",
+]);
 
 export const Card = forwardRef<HTMLElement, CardProps>(function Card(
   {
     className,
     variant = "default",
     padding = "md",
+    radius = "xl",
     as: Component = "div",
     children,
     ...props
   },
   ref,
 ) {
+  // Module (branded) variants bake their own radius for hero treatment.
+  const radiusClass = CORE_VARIANTS.has(variant) ? radii[radius] : "";
   return (
     <Component
       ref={ref}
-      className={cn(variants[variant], paddings[padding], className)}
+      className={cn(
+        variants[variant],
+        radiusClass,
+        paddings[padding],
+        className,
+      )}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary

Follow-up to the audit PRs (#180, #185). Adopts the `<Card>` primitive for the de-facto standard `rounded-2xl` panel shape used across modules, and extends `Card` with a `radius` prop so the primitive can match the majority pattern without breaking existing hero sites.

### Primitive extension — `src/shared/components/ui/Card.tsx`

- New `CardRadius = "md" | "lg" | "xl"` → `rounded-xl | rounded-2xl | rounded-3xl`.
- Core variants (`default`, `interactive`, `flat`, `elevated`, `ghost`) no longer bake `rounded-3xl` — the radius now comes from the `radius` prop. Default stays `"xl"` so the 7 existing `<Card>` users render identically.
- Module (branded) variants (`finyk`, `fizruk`, `routine`, `nutrition`, `*-soft`) still bake their radius inline since those are hero surfaces with bespoke styling.

### Adoption — 42 sites across 21 files

Converted `<div className="bg-panel border border-line rounded-2xl p-N shadow-card …">` → `<Card radius="lg" padding="…">`. Padding map: `p-3→sm`, `p-4→md (default, omitted)`, `p-5→lg`, `p-6→xl`.

### Conservative filters (why 42, not 87)

Migrated only where:
- Element is `<div>` (not `<section>`/`<article>`/`<button>`).
- `className` is the only attribute on the opening tag (no `onClick`, no `style`, no `role`, etc.).
- className contains exactly the 5 core tokens: `bg-panel border border-line rounded-2xl shadow-card`.
- Remaining classes are on a safe allow-list: `p-N`, `overflow-hidden`, `flex`, `flex-col`, `relative`, `space-y-N`, `gap-N`, `items-*`, `justify-*`.

Skipped (deliberately left as hand-rolled):
- Conditional classNames via `cn()`/template literals (e.g. active-program highlight in `Programs.tsx:56`).
- Sites with extra `hover:`/`transition-*`/`dark:` overrides.
- `<section>` wrappers with `aria-label`.
- Sites with `min-h-[…]` or `text-*` suffixes appended to the panel div itself.
- `rounded-xl` (smaller radius) panels — those are a distinct micro-panel size.

Affected files (by count): `Progress.tsx` (10), `Exercise.tsx` (8), `Measurements.tsx` (3), `Budgets.jsx` (2), `IncomeExpensePills.jsx` (2), `WorkoutTemplatesSection.tsx` (2); 15 other files with 1 each.

## Review & Testing Checklist for Human

- [ ] Scan one full screen per module in light + dark mode for any border/shadow/radius regressions (Fizruk Progress and Exercise pages carry the most migrations).
- [ ] Confirm nested content (grids, forms, sub-panels) still lays out identically — padding class was preserved as a prop not a className override.
- [ ] Verify existing `<Card>` call sites in `nutrition/` (DailyPlanCard, RecipesCard, ShoppingListCard, etc.) still render at `rounded-3xl`.

### Notes

All local checks green: lint, typecheck, 604/604 tests, build, `format:check`. A follow-up PR can expand adoption to the `cn()`-wrapped and `<section>`-wrapped cases after a visual pass on this one.


Link to Devin session: https://app.devin.ai/sessions/5b1aebe8911c40058c2847104209824e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
