### PR TITLE
docs(obs): SLO definitions + Prometheus recording rules + multi-burn-rate alerts

### DIFF
--- a/docs/observability/SLO.md
+++ b/docs/observability/SLO.md
@@ -1,0 +1,180 @@
+# Service Level Objectives & Burn-Rate Alerts
+
+> Автор: obs-team. Огляд щокварталу, або коли міняється архітектура.
+
+Цей документ визначає **SLI/SLO** для Sergeant і прив'язує до них **multi-window
+multi-burn-rate** алерти (Google SRE Workbook, Ch. 5). Формули SLI зібрані у
+[`prometheus/recording_rules.yml`](./prometheus/recording_rules.yml), алерти —
+у [`prometheus/alert_rules.yml`](./prometheus/alert_rules.yml). Порядок дій під
+час алерту — у [`runbook.md`](./runbook.md).
+
+## TL;DR
+
+| Домен          | SLI (availability)                                                          | Ціль   | Latency SLO (p95)          |
+| -------------- | --------------------------------------------------------------------------- | ------ | -------------------------- |
+| HTTP API       | non-5xx / total                                                             | 99.0 % | `/api/*` без AI — `< 1s`   |
+| Sync           | non-`error` + non-`too_large` + non-`unauthorized` (ok/conflict/empty рах.) | 99.5 % | `< 2.5s`                   |
+| Auth           | outcome ∉ {`error`} (bad_credentials/rate_limited — не відмова сервісу)     | 99.0 % | session lookup `< 100ms`   |
+| AI (Anthropic) | outcome = `ok` / total                                                      | 97.0 % | non-stream request `< 30s` |
+| External HTTP  | outcome ∈ {`ok`,`hit`,`miss`} / total (per-upstream)                        | 95.0 % | —                          |
+
+**Вікно**: 30 діб rolling. **Error budget** = `1 - SLO`. Наприклад для HTTP API
+1 % бюджету ≈ 7h12m downtime / місяць.
+
+---
+
+## 1. HTTP API availability (SLO 99.0 %)
+
+**SLI**
+
+```
+sum(rate(http_requests_total{status=~"5.."}[w]))
+/
+sum(rate(http_requests_total[w]))
+```
+
+**Чому 99 %**: це персональний PWA, не SaaS із SLA. 99 % (≈7h/міс budget)
+пускає трохи повітря для майже-безкоштовного хостингу Railway і рідких
+Anthropic outage-ів, які ми проксіюємо.
+
+**Виключення**: 4xx помилки не рахуються як відмови сервісу (це валідація /
+auth). Вони моніторяться окремо через `rate_limit_hits_total{outcome="blocked"}`
+та `app_errors_total{status=~"4.."}`.
+
+**Burn-rate алерти**:
+
+- **Page (fast)** — 1h+5m long/short window, поріг 14.4×(1-SLO) = 14.4 %. Спрацьовує,
+  коли за останню годину вигорає ≈2 % місячного бюджету.
+- **Ticket (slow)** — 6h+30m window, поріг 6×(1-SLO) = 6 %. Повільніший burn
+  для тривалих деградацій, які не тригерять fast.
+
+## 2. HTTP latency (SLO p95 < 1s, non-AI)
+
+**SLI**
+
+```
+histogram_quantile(
+  0.95,
+  sum(rate(http_request_duration_ms_bucket{path!~"/api/(chat|coach|weekly-digest|nutrition/.*)"}[w])) by (le)
+)
+```
+
+AI endpoint-и виключаємо — у них власний latency SLO в секції 4.
+
+**Алерт**: просто threshold `> 1000` стабільно 15m. Burn-rate на latency не
+рахуємо — latency SLO легше обсервити на дашборді, ніж через error-budget.
+
+## 3. Sync (SLO 99.5 %)
+
+**SLI (доступність)**
+
+```
+sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[w]))
+/
+sum(rate(sync_operations_total[w]))
+```
+
+`conflict` і `empty` — очікувані бізнес-стани (не відмова), тому не у чисельнику.
+
+**Чому 99.5 %**: sync — критичний шлях (без нього клієнт не бачить оновлень
+з інших девайсів), тому жорсткіший бюджет ніж у HTTP.
+
+**Latency SLO**: `histogram_quantile(0.95, sum(rate(sync_duration_ms_bucket[w])) by (le)) < 2500`
+
+## 4. Auth (SLO 99.0 %)
+
+**SLI**
+
+```
+sum(rate(auth_attempts_total{outcome="error"}[w]))
+/
+sum(rate(auth_attempts_total[w]))
+```
+
+`bad_credentials`, `rate_limited`, `invalid` — це поведінка користувача, не
+відмова сервісу, тому вилучені з чисельника.
+
+**Session lookup latency SLO**: `histogram_quantile(0.95, sum(rate(auth_session_lookup_duration_ms_bucket[w])) by (le)) < 100` — кожен запит до API проходить через
+session-check; якщо цей p95 > 100ms → падає p95 всього API.
+
+## 5. AI (Anthropic) (SLO 97.0 %)
+
+**SLI**
+
+```
+sum(rate(ai_requests_total{outcome!="ok"}[w]))
+/
+sum(rate(ai_requests_total[w]))
+```
+
+**Чому 97 %**: LLM-бекенди самі по собі шумні (rate-limit, model overload),
+і rate-limit на Anthropic ми наразі не обходимо. 97 % = 21h6m budget / міс.
+
+**Latency SLO**: `histogram_quantile(0.95, sum(rate(ai_request_duration_ms_bucket[w])) by (le, endpoint)) < 30000` — per-endpoint, щоб швидкі
+(coach-insight, ~3s) не ховали повільні (weekly-digest, ~30s).
+
+## 6. External HTTP per-upstream (SLO 95.0 %)
+
+**SLI**
+
+```
+sum(rate(external_http_requests_total{upstream="X",outcome=~"error|timeout"}[w]))
+/
+sum(rate(external_http_requests_total{upstream="X"}[w]))
+```
+
+Для Monobank/Privat/OFF/USDA/UPCitemdb. Поріг м'якший бо ми не контролюємо
+їхню доступність. Алерт — тільки ticket-рівня (не page).
+
+## 7. Process-рівня (не SLO, hard alerts)
+
+Жорсткі алерти без burn-rate логіки — будь-який інцидент = page:
+
+- `unhandled_rejections_total` має інкремент за 5m.
+- `uncaught_exceptions_total` має інкремент за 5m.
+- `db_pool_waiting > 0` протягом 10m — вичерпано pool, запити черги.
+- `app_errors_total{kind="programmer"}` має інкремент за 5m — це завжди баг.
+
+---
+
+## Burn-rate математика (коротко)
+
+Для SLO з бюджетом `B = 1 - SLO` (напр. B=0.01 для 99 %):
+
+- **Page (2h threshold / 1h window)**: burn rate ≥ `14.4`, тобто `error_ratio_1h ≥ 14.4·B` **І** `error_ratio_5m ≥ 14.4·B`.
+  За такого темпу весь місячний бюджет згорить за 2h.
+- **Ticket (5h threshold / 6h window)**: burn rate ≥ `6`, тобто `error_ratio_6h ≥ 6·B` **І** `error_ratio_30m ≥ 6·B`.
+  Бюджет згорить за 5 діб.
+
+Дві умови AND (long-window + short-window) захищають від false-positive, коли
+ratio пульсує.
+
+Деталі: https://sre.google/workbook/alerting-on-slos/ розділ "Multiwindow, Multi-Burn-Rate Alerts".
+
+---
+
+## Як підключити
+
+Prometheus `scrape_config` має тягти `GET /metrics` з Railway/Replit
+entrypoint-у з `Authorization: Bearer $METRICS_TOKEN`. Приклад:
+
+```yaml
+scrape_configs:
+  - job_name: sergeant
+    metrics_path: /metrics
+    authorization:
+      credentials: "${METRICS_TOKEN}"
+    static_configs:
+      - targets: ["sergeant.railway.app"]
+```
+
+Потім у Prometheus конфіг додати rule_files:
+
+```yaml
+rule_files:
+  - "docs/observability/prometheus/recording_rules.yml"
+  - "docs/observability/prometheus/alert_rules.yml"
+```
+
+Alertmanager роутить `severity=page` → PagerDuty/telegram, `severity=ticket` →
+email/Sentry issue.

--- a/docs/observability/SLO.md
+++ b/docs/observability/SLO.md
@@ -128,12 +128,17 @@ sum(rate(external_http_requests_total{upstream="X"}[w]))
 
 ## 7. Process-рівня (не SLO, hard alerts)
 
-Жорсткі алерти без burn-rate логіки — будь-який інцидент = page:
+Жорсткі алерти без burn-rate логіки. `page` — для симптомів, що ламають
+увесь процес або фронтують реальних користувачів:
 
-- `unhandled_rejections_total` має інкремент за 5m.
-- `uncaught_exceptions_total` має інкремент за 5m.
-- `db_pool_waiting > 0` протягом 10m — вичерпано pool, запити черги.
-- `app_errors_total{kind="programmer"}` має інкремент за 5m — це завжди баг.
+- `unhandled_rejections_total` має інкремент за 5m → **page** (request hung/double-response).
+- `uncaught_exceptions_total` має інкремент за 5m → **page** (process стан inconsistent).
+- `db_pool_waiting > 0` протягом 10m → **page** (усі запити stalled).
+
+`ticket` — для сигналів "завжди баг, але не обов'язково прод-аварія":
+
+- `app_errors_total{kind="programmer"}` має інкремент за 5m → **ticket** + Sentry issue.
+  Одноразовий throw на краю валідації не варто будити on-call о 3-й ночі.
 
 ---
 
@@ -141,10 +146,12 @@ sum(rate(external_http_requests_total{upstream="X"}[w]))
 
 Для SLO з бюджетом `B = 1 - SLO` (напр. B=0.01 для 99 %):
 
-- **Page (2h threshold / 1h window)**: burn rate ≥ `14.4`, тобто `error_ratio_1h ≥ 14.4·B` **І** `error_ratio_5m ≥ 14.4·B`.
-  За такого темпу весь місячний бюджет згорить за 2h.
-- **Ticket (5h threshold / 6h window)**: burn rate ≥ `6`, тобто `error_ratio_6h ≥ 6·B` **І** `error_ratio_30m ≥ 6·B`.
-  Бюджет згорить за 5 діб.
+- **Page (1h+5m window)**: burn rate ≥ `14.4`, тобто `error_ratio_1h ≥ 14.4·B` **І** `error_ratio_5m ≥ 14.4·B`.
+  За такого темпу весь 30-day бюджет згорить за `30d / 14.4 ≈ 2d` (50h). За 1h
+  при цьому спалюється `14.4 / (30·24) ≈ 2 %` місячного бюджету — звідси
+  короткий trigger-window і page-severity.
+- **Ticket (6h+30m window)**: burn rate ≥ `6`, тобто `error_ratio_6h ≥ 6·B` **І** `error_ratio_30m ≥ 6·B`.
+  Бюджет згорить за `30d / 6 = 5d`.
 
 Дві умови AND (long-window + short-window) захищають від false-positive, коли
 ratio пульсує.

--- a/docs/observability/prometheus/alert_rules.yml
+++ b/docs/observability/prometheus/alert_rules.yml
@@ -1,0 +1,303 @@
+# Alert rules, прив'язані до SLO в ../SLO.md.
+#
+# Пари вікон (за Google SRE Workbook Ch. 5):
+#   fast  — 1h long / 5m short / burn-rate 14.4 → page (≈2h до вичерпання бюджету)
+#   slow  — 6h long / 30m short / burn-rate 6   → ticket (≈5d до вичерпання)
+#
+# Поріг burn-rate (напр. 14.4) помножений на error-budget `(1 - SLO)`
+# дає кінцеву межу error-ratio. Для 99% SLO (B=0.01) fast threshold = 0.144.
+#
+# `severity=page` → PagerDuty/Telegram; `severity=ticket` → email/Sentry issue.
+
+groups:
+  # ──────────────────────────── HTTP API (SLO 99.0%) ─────────────
+  - name: slo_http
+    rules:
+      - alert: HttpErrorBudgetBurnFast
+        expr: |
+          sli:http_error:ratio_rate1h > (14.4 * 0.01)
+          and
+          sli:http_error:ratio_rate5m > (14.4 * 0.01)
+        for: 2m
+        labels:
+          severity: page
+          slo: http_availability
+        annotations:
+          summary: "HTTP API burning error budget fast (>14.4× / 2h to exhaust)"
+          description: |
+            5xx ratio >14.4% over both 1h and 5m windows. At this rate the
+            30-day error budget (1%) will be gone in ~2h.
+            Current 1h 5xx ratio: {{ $value | humanizePercentage }}.
+          runbook: "docs/observability/runbook.md#httperrorbudgetburn"
+
+      - alert: HttpErrorBudgetBurnSlow
+        expr: |
+          sli:http_error:ratio_rate6h > (6 * 0.01)
+          and
+          sli:http_error:ratio_rate30m > (6 * 0.01)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: http_availability
+        annotations:
+          summary: "HTTP API burning error budget slowly (>6× / 5d to exhaust)"
+          description: |
+            5xx ratio >6% over both 6h and 30m windows. At this rate the
+            30-day budget will be gone in ~5d.
+            Current 6h 5xx ratio: {{ $value | humanizePercentage }}.
+          runbook: "docs/observability/runbook.md#httperrorbudgetburn"
+
+      - alert: HttpLatencyP95High
+        expr: sli:http_latency_p95_ms:rate5m > 1000
+        for: 15m
+        labels:
+          severity: ticket
+          slo: http_latency
+        annotations:
+          summary: "HTTP p95 latency >1s over 15m (non-AI endpoints)"
+          description: |
+            Current p95: {{ $value }} ms. Check `db_pool_waiting`,
+            `db_query_duration_ms`, and N+1 query patterns.
+          runbook: "docs/observability/runbook.md#httplatencyp95high"
+
+  # ──────────────────────────── Sync (SLO 99.5%) ────────────────
+  - name: slo_sync
+    rules:
+      - alert: SyncErrorBudgetBurnFast
+        expr: |
+          sli:sync_error:ratio_rate1h > (14.4 * 0.005)
+          and
+          sli:sync_error:ratio_rate5m > (14.4 * 0.005)
+        for: 2m
+        labels:
+          severity: page
+          slo: sync_availability
+        annotations:
+          summary: "Sync burning error budget fast"
+          description: |
+            Sync error/too_large/unauthorized ratio >7.2% over 1h and 5m.
+            30-day budget (0.5%) gone in ~2h at this rate.
+            Clients may be silently losing data. Investigate Postgres and
+            `sync_operations_total{outcome=~"error|too_large"}` breakdown
+            by {op, module}.
+          runbook: "docs/observability/runbook.md#syncerrorbudgetburn"
+
+      - alert: SyncErrorBudgetBurnSlow
+        expr: |
+          sli:sync_error:ratio_rate6h > (6 * 0.005)
+          and
+          sli:sync_error:ratio_rate30m > (6 * 0.005)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: sync_availability
+        annotations:
+          summary: "Sync burning error budget slowly"
+          description: "6h ratio >3%. Current: {{ $value | humanizePercentage }}."
+          runbook: "docs/observability/runbook.md#syncerrorbudgetburn"
+
+      - alert: SyncLatencyP95High
+        expr: sli:sync_latency_p95_ms:rate5m > 2500
+        for: 15m
+        labels:
+          severity: ticket
+          slo: sync_latency
+        annotations:
+          summary: "Sync p95 duration >2.5s"
+          description: |
+            Current: {{ $value }} ms. Check payload sizes
+            (`sync_payload_bytes`) and DB pool waiting.
+          runbook: "docs/observability/runbook.md#synclatencyp95high"
+
+      - alert: SyncConflictSpike
+        expr: sli:sync_conflict:ratio_rate1h > 0.10
+        for: 30m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Sync push conflict ratio >10% over 1h"
+          description: |
+            Conflict ratio on push/push_all is {{ $value | humanizePercentage }}.
+            Either clients are fighting over the same state, or lastPulledAt
+            semantics regressed. Not an SLO violation, but worth attention.
+          runbook: "docs/observability/runbook.md#syncconflictspike"
+
+  # ──────────────────────────── Auth (SLO 99.0%) ────────────────
+  - name: slo_auth
+    rules:
+      - alert: AuthErrorBudgetBurnFast
+        expr: |
+          sli:auth_error:ratio_rate1h > (14.4 * 0.01)
+          and
+          sli:auth_error:ratio_rate5m > (14.4 * 0.01)
+        for: 2m
+        labels:
+          severity: page
+          slo: auth_availability
+        annotations:
+          summary: "Auth burning error budget fast"
+          description: |
+            Auth outcome=error ratio >14.4% over 1h and 5m. Users cannot
+            sign in / sign up. Check better-auth logs and DB.
+          runbook: "docs/observability/runbook.md#autherrorbudgetburn"
+
+      - alert: AuthErrorBudgetBurnSlow
+        expr: |
+          sli:auth_error:ratio_rate6h > (6 * 0.01)
+          and
+          sli:auth_error:ratio_rate30m > (6 * 0.01)
+        for: 15m
+        labels:
+          severity: ticket
+          slo: auth_availability
+        annotations:
+          summary: "Auth burning error budget slowly"
+          description: "6h error ratio: {{ $value | humanizePercentage }}."
+          runbook: "docs/observability/runbook.md#autherrorbudgetburn"
+
+      - alert: AuthSessionLookupSlow
+        expr: sli:auth_session_lookup_p95_ms:rate5m > 100
+        for: 15m
+        labels:
+          severity: ticket
+          slo: auth_latency
+        annotations:
+          summary: "Session lookup p95 >100ms"
+          description: |
+            Session lookup is on every authenticated API hit, so high p95
+            here directly drags the whole API latency. Current: {{ $value }} ms.
+            Likely causes: DB pool saturation, cold Postgres connection,
+            sessions table bloat.
+          runbook: "docs/observability/runbook.md#authsessionlookupslow"
+
+      - alert: AuthRateLimitSpike
+        expr: sli:auth_rate_limited:ratio_rate5m > 0.30
+        for: 10m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Auth rate-limit ratio >30% over 10m (possible brute-force)"
+          description: |
+            >30% of auth attempts are getting 429. Either a real abuse
+            attempt or misbehaving client. Investigate `rate_limit_hits_total{key="api:auth:sensitive",outcome="blocked"}`
+            and correlate with IPs via access logs.
+          runbook: "docs/observability/runbook.md#authratelimitspike"
+
+  # ──────────────────────────── AI (SLO 97.0%) ──────────────────
+  - name: slo_ai
+    rules:
+      - alert: AiErrorBudgetBurnFast
+        expr: |
+          sli:ai_error:ratio_rate1h > (14.4 * 0.03)
+          and
+          sli:ai_error:ratio_rate5m > (14.4 * 0.03)
+        for: 5m
+        labels:
+          severity: page
+          slo: ai_availability
+        annotations:
+          summary: "AI (Anthropic) burning error budget fast"
+          description: |
+            Non-ok AI outcome ratio >43% over 1h and 5m. Likely Anthropic
+            outage or credential/quota issue. Check `ai_requests_total`
+            by outcome and `ai_quota_blocks_total`.
+          runbook: "docs/observability/runbook.md#aierrorbudgetburn"
+
+      - alert: AiErrorBudgetBurnSlow
+        expr: |
+          sli:ai_error:ratio_rate6h > (6 * 0.03)
+          and
+          sli:ai_error:ratio_rate30m > (6 * 0.03)
+        for: 30m
+        labels:
+          severity: ticket
+          slo: ai_availability
+        annotations:
+          summary: "AI burning error budget slowly"
+          description: "6h non-ok ratio: {{ $value | humanizePercentage }}."
+          runbook: "docs/observability/runbook.md#aierrorbudgetburn"
+
+      - alert: AiLatencyP95High
+        expr: sli:ai_latency_p95_ms:rate5m > 30000
+        for: 30m
+        labels:
+          severity: ticket
+          slo: ai_latency
+        annotations:
+          summary: "AI p95 duration >30s (endpoint={{ $labels.endpoint }})"
+          description: |
+            AI endpoint `{{ $labels.endpoint }}` p95: {{ $value }} ms.
+            Likely Anthropic-side degradation. Check status.anthropic.com.
+          runbook: "docs/observability/runbook.md#ailatencyp95high"
+
+  # ──────────────────────────── External HTTP (SLO 95.0% per-upstream) ─
+  - name: slo_external_http
+    rules:
+      - alert: ExternalHttpErrorBudgetBurnSlow
+        expr: sli:external_http_error:ratio_rate6h > (6 * 0.05)
+        for: 30m
+        labels:
+          severity: ticket
+          slo: external_http_availability
+        annotations:
+          summary: "Upstream {{ $labels.upstream }} error ratio >30% over 6h"
+          description: |
+            `{{ $labels.upstream }}` outcome=error|timeout ratio over 6h:
+            {{ $value | humanizePercentage }}. We don't own this service,
+            but if it stays degraded — degrade features that depend on it.
+          runbook: "docs/observability/runbook.md#externalhttperrorbudgetburn"
+
+  # ──────────────────────────── Process-рівня (hard alerts) ─────
+  - name: process_errors
+    rules:
+      - alert: UnhandledRejectionObserved
+        expr: increase(unhandled_rejections_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: page
+        annotations:
+          summary: "Unhandled promise rejection observed"
+          description: |
+            A promise was rejected without a .catch(). Always a bug — the
+            request likely hung or double-responded. Correlate by timestamp
+            with Pino `level=fatal` logs carrying `err.cause` chain.
+          runbook: "docs/observability/runbook.md#unhandledrejection"
+
+      - alert: UncaughtExceptionObserved
+        expr: increase(uncaught_exceptions_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: page
+        annotations:
+          summary: "Uncaught exception observed"
+          description: |
+            Synchronous exception escaped to process root. Process isn't
+            killed (Sentry captures + Railway restarts on health failure),
+            but state may be inconsistent. Investigate immediately.
+          runbook: "docs/observability/runbook.md#uncaughtexception"
+
+      - alert: DbPoolSaturated
+        expr: db_pool_waiting > 0
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: "Postgres pool saturated ({{ $value }} waiting) for >10m"
+          description: |
+            Clients queuing for DB connections. Either pool size too small
+            or a leaky query / long-running transaction. Check
+            `db_query_duration_ms` and `db_slow_queries_total`.
+          runbook: "docs/observability/runbook.md#dbpoolsaturated"
+
+      - alert: ProgrammerErrorsIncreasing
+        expr: increase(app_errors_total{kind="programmer"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Programmer-class error observed (module={{ $labels.module }})"
+          description: |
+            `kind=programmer` means the error wasn't declared as operational
+            via `AppError`, i.e. unexpected crash path. Usually a bug —
+            open a Sentry issue and link the ticket.
+          runbook: "docs/observability/runbook.md#programmererrors"

--- a/docs/observability/prometheus/alert_rules.yml
+++ b/docs/observability/prometheus/alert_rules.yml
@@ -1,7 +1,7 @@
 # Alert rules, прив'язані до SLO в ../SLO.md.
 #
 # Пари вікон (за Google SRE Workbook Ch. 5):
-#   fast  — 1h long / 5m short / burn-rate 14.4 → page (≈2h до вичерпання бюджету)
+#   fast  — 1h long / 5m short / burn-rate 14.4 → page (≈2d до вичерпання 30-day бюджету)
 #   slow  — 6h long / 30m short / burn-rate 6   → ticket (≈5d до вичерпання)
 #
 # Поріг burn-rate (напр. 14.4) помножений на error-budget `(1 - SLO)`
@@ -23,10 +23,10 @@ groups:
           severity: page
           slo: http_availability
         annotations:
-          summary: "HTTP API burning error budget fast (>14.4× / 2h to exhaust)"
+          summary: "HTTP API burning error budget fast (>14.4× / ~2d to exhaust)"
           description: |
             5xx ratio >14.4% over both 1h and 5m windows. At this rate the
-            30-day error budget (1%) will be gone in ~2h.
+            30-day error budget (1%) will be gone in ~2d (30d / 14.4 ≈ 50h).
             Current 1h 5xx ratio: {{ $value | humanizePercentage }}.
           runbook: "docs/observability/runbook.md#httperrorbudgetburn"
 
@@ -76,7 +76,7 @@ groups:
           summary: "Sync burning error budget fast"
           description: |
             Sync error/too_large/unauthorized ratio >7.2% over 1h and 5m.
-            30-day budget (0.5%) gone in ~2h at this rate.
+            30-day budget (0.5%) gone in ~2d at this rate (30d / 14.4 ≈ 50h).
             Clients may be silently losing data. Investigate Postgres and
             `sync_operations_total{outcome=~"error|too_large"}` breakdown
             by {op, module}.
@@ -234,7 +234,10 @@ groups:
   - name: slo_external_http
     rules:
       - alert: ExternalHttpErrorBudgetBurnSlow
-        expr: sli:external_http_error:ratio_rate6h > (6 * 0.05)
+        expr: |
+          sli:external_http_error:ratio_rate6h > (6 * 0.05)
+          and
+          sli:external_http_error:ratio_rate30m > (6 * 0.05)
         for: 30m
         labels:
           severity: ticket

--- a/docs/observability/prometheus/recording_rules.yml
+++ b/docs/observability/prometheus/recording_rules.yml
@@ -1,0 +1,168 @@
+# Recording rules для SLO burn-rate алертів.
+#
+# Іменування: `sli:<domain>_<sli>:ratio_rate<window>` (за Google SRE Workbook).
+# Ці rules попередньо обчислюють error-ratio по різних вікнах, щоб alert-
+# rules не робили важкий `sum(rate(...))` щосекунди.
+#
+# Валідовано `promtool check rules`.
+
+groups:
+  # ──────────────────────────── HTTP API ────────────────────────
+  - name: sli_http
+    interval: 30s
+    rules:
+      - record: sli:http_error:ratio_rate5m
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(http_requests_total[5m])), 1)
+      - record: sli:http_error:ratio_rate30m
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[30m]))
+          /
+          clamp_min(sum(rate(http_requests_total[30m])), 1)
+      - record: sli:http_error:ratio_rate1h
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[1h]))
+          /
+          clamp_min(sum(rate(http_requests_total[1h])), 1)
+      - record: sli:http_error:ratio_rate6h
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[6h]))
+          /
+          clamp_min(sum(rate(http_requests_total[6h])), 1)
+      - record: sli:http_error:ratio_rate3d
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[3d]))
+          /
+          clamp_min(sum(rate(http_requests_total[3d])), 1)
+
+      - record: sli:http_latency_p95_ms:rate5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_ms_bucket{path!~"/api/(chat|coach|weekly-digest|nutrition/.*)"}[5m])) by (le)
+          )
+
+  # ──────────────────────────── Sync ────────────────────────────
+  - name: sli_sync
+    interval: 30s
+    rules:
+      - record: sli:sync_error:ratio_rate5m
+        expr: |
+          sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[5m]))
+          /
+          clamp_min(sum(rate(sync_operations_total[5m])), 1)
+      - record: sli:sync_error:ratio_rate30m
+        expr: |
+          sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[30m]))
+          /
+          clamp_min(sum(rate(sync_operations_total[30m])), 1)
+      - record: sli:sync_error:ratio_rate1h
+        expr: |
+          sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[1h]))
+          /
+          clamp_min(sum(rate(sync_operations_total[1h])), 1)
+      - record: sli:sync_error:ratio_rate6h
+        expr: |
+          sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[6h]))
+          /
+          clamp_min(sum(rate(sync_operations_total[6h])), 1)
+
+      - record: sli:sync_latency_p95_ms:rate5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(sync_duration_ms_bucket[5m])) by (le)
+          )
+
+      - record: sli:sync_conflict:ratio_rate1h
+        expr: |
+          sum(rate(sync_operations_total{outcome="conflict"}[1h]))
+          /
+          clamp_min(sum(rate(sync_operations_total{op=~"push|push_all"}[1h])), 1)
+
+  # ──────────────────────────── Auth ────────────────────────────
+  - name: sli_auth
+    interval: 30s
+    rules:
+      - record: sli:auth_error:ratio_rate5m
+        expr: |
+          sum(rate(auth_attempts_total{outcome="error"}[5m]))
+          /
+          clamp_min(sum(rate(auth_attempts_total[5m])), 1)
+      - record: sli:auth_error:ratio_rate30m
+        expr: |
+          sum(rate(auth_attempts_total{outcome="error"}[30m]))
+          /
+          clamp_min(sum(rate(auth_attempts_total[30m])), 1)
+      - record: sli:auth_error:ratio_rate1h
+        expr: |
+          sum(rate(auth_attempts_total{outcome="error"}[1h]))
+          /
+          clamp_min(sum(rate(auth_attempts_total[1h])), 1)
+      - record: sli:auth_error:ratio_rate6h
+        expr: |
+          sum(rate(auth_attempts_total{outcome="error"}[6h]))
+          /
+          clamp_min(sum(rate(auth_attempts_total[6h])), 1)
+
+      - record: sli:auth_session_lookup_p95_ms:rate5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(auth_session_lookup_duration_ms_bucket[5m])) by (le)
+          )
+
+      - record: sli:auth_rate_limited:ratio_rate5m
+        expr: |
+          sum(rate(auth_attempts_total{outcome="rate_limited"}[5m]))
+          /
+          clamp_min(sum(rate(auth_attempts_total[5m])), 1)
+
+  # ──────────────────────────── AI ──────────────────────────────
+  - name: sli_ai
+    interval: 30s
+    rules:
+      - record: sli:ai_error:ratio_rate5m
+        expr: |
+          sum(rate(ai_requests_total{outcome!="ok"}[5m]))
+          /
+          clamp_min(sum(rate(ai_requests_total[5m])), 1)
+      - record: sli:ai_error:ratio_rate30m
+        expr: |
+          sum(rate(ai_requests_total{outcome!="ok"}[30m]))
+          /
+          clamp_min(sum(rate(ai_requests_total[30m])), 1)
+      - record: sli:ai_error:ratio_rate1h
+        expr: |
+          sum(rate(ai_requests_total{outcome!="ok"}[1h]))
+          /
+          clamp_min(sum(rate(ai_requests_total[1h])), 1)
+      - record: sli:ai_error:ratio_rate6h
+        expr: |
+          sum(rate(ai_requests_total{outcome!="ok"}[6h]))
+          /
+          clamp_min(sum(rate(ai_requests_total[6h])), 1)
+
+      - record: sli:ai_latency_p95_ms:rate5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(ai_request_duration_ms_bucket[5m])) by (le, endpoint)
+          )
+
+  # ──────────────────────────── External HTTP ───────────────────
+  - name: sli_external_http
+    interval: 30s
+    rules:
+      - record: sli:external_http_error:ratio_rate30m
+        expr: |
+          sum by (upstream) (rate(external_http_requests_total{outcome=~"error|timeout"}[30m]))
+          /
+          clamp_min(sum by (upstream) (rate(external_http_requests_total[30m])), 1)
+      - record: sli:external_http_error:ratio_rate6h
+        expr: |
+          sum by (upstream) (rate(external_http_requests_total{outcome=~"error|timeout"}[6h]))
+          /
+          clamp_min(sum by (upstream) (rate(external_http_requests_total[6h])), 1)

--- a/docs/observability/runbook.md
+++ b/docs/observability/runbook.md
@@ -1,0 +1,161 @@
+# Observability Runbook
+
+Інструкції "що робити, коли спрацював алерт" для правил з
+[`prometheus/alert_rules.yml`](./prometheus/alert_rules.yml). Тримай коротко:
+перший крок завжди `/metrics` + логи Pino за той же інтервал.
+
+Загальне:
+
+- Прод entry point — `server/railway.mjs`. Заборгована реплікація — Railway.
+- Метрики за bearer-токен: `GET /metrics` з `Authorization: Bearer $METRICS_TOKEN`.
+- Логи — Pino JSON у stdout, з ALS-контекстом `{requestId, userId, module}`.
+- Sentry ловить fatal/error (включно з `err.cause` чейном).
+
+---
+
+## HttpErrorBudgetBurn
+
+**Що горить**: `http_requests_total{status=~"5.."}` рахунок стрибнув.
+
+1. Перевір розподіл 5xx по path+module:
+   ```promql
+   sum by (path, module) (rate(http_requests_total{status=~"5.."}[5m]))
+   ```
+2. Подивись `app_errors_total{kind,status,code,module}` за той же інтервал —
+   видно чи це operational (AppError) чи programmer.
+3. Знайди логи Pino `level>=error` за period, особливо ті що несуть
+   `err.cause.message` і `err.cause.stack`.
+4. Частий суспект №1 — DB saturated: перевір `db_pool_waiting` і
+   `db_query_duration_ms` одночасно.
+5. Якщо це AI endpoint (chat/coach/nutrition) — `ai_requests_total{outcome}`
+   підкаже, чи це Anthropic-outage замаскований під 500.
+6. Якщо root cause = вичерпана пам'ять / OOM на Railway — збільш план або
+   знайди leak у `process_resident_memory_bytes`.
+
+## HttpLatencyP95High
+
+1. `sum by (path) (histogram_quantile(0.95, sum by (le, path) (rate(http_request_duration_ms_bucket[5m]))))` — знайти гарячі path-и.
+2. Частий суспект — `auth_session_lookup_duration_ms` через кожен запит
+   (див. `AuthSessionLookupSlow` алерт нижче).
+3. Перевір `db_query_duration_ms` + `db_pool_waiting > 0` як симптом saturate-у.
+4. Якщо гарячий path — `/api/sync` чи AI endpoint — застосуй специфічний runbook.
+
+## SyncErrorBudgetBurn
+
+**Ризик**: клієнти втрачають дані або бачать застарілий стан.
+
+1. Розкрий outcome-breakdown:
+   ```promql
+   sum by (op, module, outcome) (rate(sync_operations_total[5m]))
+   ```
+2. `too_large` → хтось б'ється у `MAX_BLOB_SIZE`. Знайди user у логах
+   (`path=/api/sync, module=sync`) і проінформуй / обріж.
+3. `unauthorized` підскочив → перевір `auth_attempts_total` — можливо
+   глобальна auth-пробл'ема відбивається на sync.
+4. `error` підскочив → Pino-логи + Sentry issues. Найчастіше це DB
+   timeout на `sync_push`.
+5. Перевір `sync_payload_bytes` — raptor payload-и можуть зʼїдати pool.
+6. При повному пробої — тимчасово пропиши `rate_limit` жорсткіше, щоб
+   клієнти не добивали бекенд ретраями.
+
+## SyncLatencyP95High
+
+1. `histogram_quantile(0.95, sum by (le, op, module) (rate(sync_duration_ms_bucket[5m])))` — який саме op+module тягне p95.
+2. Перевір `db_query_duration_ms` і `db_pool_waiting` — sync IO-важкий.
+3. Якщо `sync_payload_bytes` p95 стрибнув — хтось шле великі сторінки.
+
+## SyncConflictSpike
+
+Не SLO-порушення, але варто дивитись.
+
+1. `sum by (module) (rate(sync_conflicts_total[1h]))` — хто конфліктить.
+2. Типово: два девайси одного user-а пишуть незалежно, `lastPulledAt`
+   старий. Якщо вибух на одному module — регресія в логіці merge-у.
+3. Подивись чи не було недавнього деплою `server/api/sync.js`.
+
+## AuthErrorBudgetBurn
+
+1. Breakdown:
+   ```promql
+   sum by (op, outcome) (rate(auth_attempts_total[5m]))
+   ```
+2. `outcome=error` означає internal error (5xx) а не bad-credentials.
+3. Перший підозрюваний — better-auth адаптер / DB. Глянь
+   `app_errors_total{module="auth"}` і Pino logs.
+4. Якщо тільки `sign_in/sign_up` падає, а `session_check` здоровий —
+   проблема у верифікації пароля/email (bcrypt / SMTP).
+
+## AuthSessionLookupSlow
+
+Критично — session lookup на кожному authenticated API.
+
+1. `histogram_quantile(0.95, sum by (le) (rate(auth_session_lookup_duration_ms_bucket[5m])))` підтверджує.
+2. Перевір `db_pool_waiting > 0` — pool saturate є найчастіший root cause.
+3. Перевір розмір `sessions` таблиці й індекси (`EXPLAIN ANALYZE` на query).
+4. Як тимчасовий фікс — більший pool (`DATABASE_POOL_MAX`).
+
+## AuthRateLimitSpike
+
+> 30% auth-атак попадає на limiter → або brute-force, або баг у клієнті.
+
+1. `rate(rate_limit_hits_total{key="api:auth:sensitive",outcome="blocked"}[5m])` — обсяг.
+2. Подивись Pino logs з `module=auth` — корелюй `req.ip`. Якщо
+   однакова IP — бан через Cloudflare або `RATE_LIMIT_BAN_IPS`.
+3. Якщо це клієнт-реагує на 401 ретраями без backoff — зафіксуй issue.
+
+## AiErrorBudgetBurn
+
+1. Breakdown:
+   ```promql
+   sum by (endpoint, outcome) (rate(ai_requests_total[5m]))
+   ```
+2. `outcome=rate_limited` від Anthropic → включи тимчасово m'якший `assertAiQuota` або проси кредит.
+3. `outcome=timeout` → див. `ai_request_duration_ms` p95 + Anthropic status page.
+4. `outcome=bad_response` (якщо є) → regression у парсингу. Відкат.
+5. `ai_quota_blocks_total{reason="limit"}` стрибнув → ми самі блокуємо користувачів (не помилка бекенду).
+
+## AiLatencyP95High
+
+1. `histogram_quantile(0.95, sum by (le, endpoint) (rate(ai_request_duration_ms_bucket[5m])))` — який endpoint тормозить.
+2. Глянь status.anthropic.com. Якщо там incident — deduplicate.
+3. Якщо лише weekly-digest тормозить, інші здорові — ймовірно зростає
+   розмір prompt-у (надто багато контексту). Підріж.
+
+## ExternalHttpErrorBudgetBurn
+
+Стороння залежність деградує — ми не контролюємо.
+
+1. `sum by (upstream, outcome) (rate(external_http_requests_total[5m]))`.
+2. Для Monobank/Privat → перевір їхні статус-сторінки.
+3. Якщо barcode upstream (off/usda/upcitemdb) недоступний — client-side
+   fallback має вже грати, просто трекай.
+4. Якщо це не одноразовий сплеск — деградуй UI-фічу (hide CTA, no retries).
+
+## UnhandledRejection / UncaughtException
+
+Завжди баг. Stack-trace — у Pino `level=fatal` з повним `err.cause` chain.
+
+1. Відкрий Sentry issue (має бути автоматично створений).
+2. Correlate за `requestId` у лозі з HTTP-access логом.
+3. Patch гіпотетично в наступному релізі; temporary — тримай за алерт.
+4. `unhandledRejectionsTotal` не має бути >0 у нормі, навіть не короткочасно.
+
+## DbPoolSaturated
+
+`db_pool_waiting > 0` 10m → connection contention.
+
+1. Миттєво: збільш `DATABASE_POOL_MAX` (Railway env).
+2. Дослідь: `db_slow_queries_total{op}` — які operations довше `DB_SLOW_MS`.
+3. Знайди потенційні long-running transactions у логах
+   (`level=info` з `module=db, msg="slow query"`).
+4. Перевір, чи не відбувся нещодавно deploy, що додав новий heavy read-path.
+
+## ProgrammerErrors
+
+`kind=programmer` → виняток без `AppError`-обгортки, код не очікував.
+
+1. Перший suspect — недавній deploy. Перевір Sentry issues за останню годину.
+2. Correlate `module` з кодовою базою. `module="unknown"` → десь
+   `setRequestModule()` не викликався (або код поза request context).
+3. Fix: огорни у `AppError({ kind: "operational" })` де доречно,
+   або виправ root cause.


### PR DESCRIPTION
## Summary

Follow-up to #181/#187. Docs + Prometheus rule files that turn the metrics we emit into **error-budget-based alerts** (Google SRE Workbook, Ch. 5).

### What's in the diff

All under `docs/observability/` — docs/config only, no runtime code touched:

- `SLO.md` — SLO targets per domain (HTTP 99.0%, sync 99.5%, auth 99.0%, AI 97.0%, external HTTP 95.0%), PromQL for each SLI, justification for each number, and how-to-wire-up section.
- `prometheus/recording_rules.yml` — 25 pre-computed error-ratio rates (5m/30m/1h/6h/3d) + latency p95 recordings. Shortens alert-rule PromQL and keeps Prometheus query load low.
- `prometheus/alert_rules.yml` — 19 alerts:
  - Per SLO: **fast burn** (1h+5m window, 14.4× burn-rate → page) and **slow burn** (6h+30m, 6× → ticket). Two AND-ed windows guard against flapping.
  - Latency alerts (non-burn) where p95 threshold is simpler than budget math.
  - Hard process-level alerts: `unhandled_rejections_total` / `uncaught_exceptions_total` increase, `db_pool_waiting > 0 for 10m`, `app_errors_total{kind="programmer"}`.
  - Non-SLO-but-useful: `SyncConflictSpike`, `AuthRateLimitSpike` (possible brute-force signal).
- `runbook.md` — step-by-step triage per alert with concrete PromQL queries (`sum by (...) (rate(...))`) to drill into the breakdown fast.

Validated locally with `promtool check rules` — 25 recording + 19 alert rules, 0 errors.

### Burn-rate math recap

For SLO with budget `B = 1 - SLO` (e.g. `B=0.01` for 99%):
- **Fast page** fires when 1h-ratio **AND** 5m-ratio ≥ `14.4 · B` → 30d budget would burn in ~2h.
- **Slow ticket** fires when 6h-ratio **AND** 30m-ratio ≥ `6 · B` → 30d budget would burn in ~5d.

Two windows AND-ed together defend against a single metric spike causing a page.

### How to wire up (not in this PR)

`SLO.md` has the scrape-config snippet. Summary:
1. Add `/metrics` to your Prometheus scrape with the `METRICS_TOKEN` bearer.
2. Point `rule_files` at the two YAMLs in `docs/observability/prometheus/`.
3. Map `severity=page` to PagerDuty/Telegram and `severity=ticket` to email/Sentry in Alertmanager.

## Review & Testing Checklist for Human

- [ ] Sanity-check the SLO targets (99.0% HTTP, 99.5% sync, 97.0% AI, etc) — these are proposals based on typical personal-PWA risk tolerance. If we want jobs-critical strictness somewhere, bump the number and the alert thresholds update automatically via the `B` constant.
- [ ] Confirm the SLI exclusions are right: HTTP SLO excludes 4xx (validation/auth errors aren't service failures); sync SLO excludes `conflict` and `empty` (expected business states); auth SLO excludes `bad_credentials` and `rate_limited` (user behavior, not our failure).
- [ ] The HTTP latency SLI excludes AI endpoints via the path regex `/api/(chat|coach|weekly-digest|nutrition/.*)` — verify that matches actual route strings in the `path` label (you may have caught N+1 patterns via `setRequestModule`).

### Notes

- Pure docs/config — no runtime code touched, no package installs.
- `promtool v2.55.0` (installed ad-hoc in the session to validate YAML syntax) is not persisted to env config since it's a one-off verification tool, not part of CI.

Link to Devin session: https://app.devin.ai/sessions/3e3ba8f945324c828f28ff14ed18d7ec
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
