### PR TITLE
chore(routine): migrate leaf components to TypeScript (PR #4a)

### DIFF
--- a/src/modules/routine/components/DayProgressRing.tsx
+++ b/src/modules/routine/components/DayProgressRing.tsx
@@ -3,7 +3,17 @@ const STROKE = 7;
 const RADIUS = (SIZE - STROKE) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
-export function DayProgressRing({ completed, scheduled, onClick }) {
+export interface DayProgressRingProps {
+  completed: number;
+  scheduled: number;
+  onClick?: () => void;
+}
+
+export function DayProgressRing({
+  completed,
+  scheduled,
+  onClick,
+}: DayProgressRingProps) {
   const ratio = scheduled > 0 ? completed / scheduled : 0;
   const offset = CIRCUMFERENCE * (1 - ratio);
 

--- a/src/modules/routine/components/HabitHeatmap.tsx
+++ b/src/modules/routine/components/HabitHeatmap.tsx
@@ -1,15 +1,31 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@shared/lib/cn";
+import type { Habit, RoutineState } from "../lib/types";
 
 const WEEKS = 53;
 const DAYS = 7;
 const DAY_LABELS = ["Пн", "", "Ср", "", "Пт", "", "Нд"];
 
-function localDateKey(d) {
+interface HeatmapCell {
+  key: string;
+  dt: Date;
+  isFuture: boolean;
+  isToday: boolean;
+  cnt: number;
+  total: number;
+  ratio: number;
+}
+
+interface MonthMarker {
+  weekIdx: number;
+  label: string;
+}
+
+function localDateKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-function cellBg(ratio, isFuture) {
+function cellBg(ratio: number, isFuture: boolean): string {
   if (isFuture) return "bg-line/15 dark:bg-line/10";
   if (ratio === 0) return "bg-panelHi dark:bg-line/25";
   if (ratio < 0.34) return "bg-orange-200/80 dark:bg-orange-900/55";
@@ -17,14 +33,23 @@ function cellBg(ratio, isFuture) {
   return "bg-orange-500/90 dark:bg-orange-500/80";
 }
 
-export function HabitHeatmap({ habits, completions }) {
-  const [selected, setSelected] = useState(null);
-  const rootRef = useRef(null);
+export interface HabitHeatmapProps {
+  habits: Habit[] | null | undefined;
+  completions: RoutineState["completions"] | null | undefined;
+}
+
+export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!selected) return;
-    function onPointerDown(e) {
-      if (rootRef.current && !rootRef.current.contains(e.target)) {
+    function onPointerDown(e: PointerEvent) {
+      if (
+        rootRef.current &&
+        e.target instanceof Node &&
+        !rootRef.current.contains(e.target)
+      ) {
         setSelected(null);
       }
     }
@@ -52,19 +77,19 @@ export function HabitHeatmap({ habits, completions }) {
     const startDate = new Date(mondayThisWeek);
     startDate.setDate(mondayThisWeek.getDate() - (WEEKS - 1) * 7);
 
-    const cntByDay = {};
+    const cntByDay: Record<string, number> = {};
     for (const h of activeHabits) {
       for (const dk of completions?.[h.id] || []) {
         cntByDay[dk] = (cntByDay[dk] || 0) + 1;
       }
     }
 
-    const weeks = [];
-    const seenMonths = new Set();
-    const monthMarkers = [];
+    const weeks: HeatmapCell[][] = [];
+    const seenMonths = new Set<string>();
+    const monthMarkers: MonthMarker[] = [];
 
     for (let w = 0; w < WEEKS; w++) {
-      const week = [];
+      const week: HeatmapCell[] = [];
       for (let d = 0; d < DAYS; d++) {
         const dt = new Date(startDate);
         dt.setDate(startDate.getDate() + w * 7 + d);
@@ -92,7 +117,7 @@ export function HabitHeatmap({ habits, completions }) {
     return { weeks, monthMarkers };
   }, [activeHabits, completions]);
 
-  const handleClick = useCallback((key) => {
+  const handleClick = useCallback((key: string) => {
     setSelected((prev) => (prev === key ? null : key));
   }, []);
 

--- a/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -1,8 +1,17 @@
 import { useMemo } from "react";
 import { habitCompletionRate } from "../lib/streaks.js";
 import { Card } from "@shared/components/ui/Card";
+import type { Habit, RoutineState } from "../lib/types";
 
-export function HabitLeadersBlock({ habits, completions }) {
+export interface HabitLeadersBlockProps {
+  habits: Habit[];
+  completions: RoutineState["completions"];
+}
+
+export function HabitLeadersBlock({
+  habits,
+  completions,
+}: HabitLeadersBlockProps) {
   const { best, worst } = useMemo(() => {
     const active = habits.filter((h) => !h.archived);
     if (active.length === 0) return { best: null, worst: null };

--- a/src/modules/routine/components/PushupsWidget.tsx
+++ b/src/modules/routine/components/PushupsWidget.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, type ChangeEvent } from "react";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useRoutinePushups } from "../hooks/useRoutinePushups.js";
@@ -15,8 +15,8 @@ export function PushupsWidget() {
   const { todayCount, addReps, recentHistory } = useRoutinePushups();
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
-  const ref = useRef(null);
-  const inputRef = useRef(null);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const keyboardInset = useVisualKeyboardInset(open);
   useDialogFocusTrap(open, ref, { onEscape: () => setOpen(false) });
 
@@ -163,7 +163,9 @@ export function PushupsWidget() {
                 min="1"
                 max="999"
                 value={input}
-                onChange={(e) => setInput(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setInput(e.target.value)
+                }
                 placeholder="Скільки?"
                 className="routine-touch-field min-h-[48px] min-w-0 flex-1 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-routine [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 onKeyDown={(e) => {

--- a/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/src/modules/routine/components/RoutineBackupSection.tsx
@@ -1,10 +1,28 @@
-import { useRef } from "react";
+import { useRef, type ChangeEvent } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
 import { buildRoutineBackupPayload } from "../lib/routineStorage.js";
 
-export function RoutineBackupSection({ theme, toast, onImportParsed }) {
-  const backupRef = useRef(null);
+export interface RoutineBackupTheme {
+  primary?: string;
+}
+
+export interface RoutineBackupToast {
+  warning?: (message: string) => void;
+}
+
+export interface RoutineBackupSectionProps {
+  theme?: RoutineBackupTheme;
+  toast?: RoutineBackupToast;
+  onImportParsed?: (parsed: unknown) => void;
+}
+
+export function RoutineBackupSection({
+  theme,
+  toast,
+  onImportParsed,
+}: RoutineBackupSectionProps) {
+  const backupRef = useRef<HTMLInputElement | null>(null);
 
   return (
     <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
@@ -45,15 +63,19 @@ export function RoutineBackupSection({ theme, toast, onImportParsed }) {
           type="file"
           accept="application/json,.json"
           className="hidden"
-          onChange={async (e) => {
+          onChange={async (e: ChangeEvent<HTMLInputElement>) => {
             const f = e.target.files?.[0];
             if (!f) return;
             try {
               const text = await f.text();
-              const parsed = JSON.parse(text);
+              const parsed: unknown = JSON.parse(text);
               onImportParsed?.(parsed);
             } catch (err) {
-              toast?.warning?.(err?.message || "Не вдалося імпортувати файл.");
+              const msg =
+                err instanceof Error
+                  ? err.message
+                  : "Не вдалося імпортувати файл.";
+              toast?.warning?.(msg);
             }
             e.target.value = "";
           }}

--- a/src/modules/routine/components/RoutineBottomNav.test.tsx
+++ b/src/modules/routine/components/RoutineBottomNav.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { RoutineBottomNav } from "./RoutineBottomNav.jsx";
+import { RoutineBottomNav } from "./RoutineBottomNav";
 
 describe("RoutineBottomNav", () => {
   it("renders tablist and switches tab", () => {

--- a/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/src/modules/routine/components/RoutineBottomNav.tsx
@@ -1,7 +1,17 @@
+import type { ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
 
-const NAV = [
+export type RoutineMainTab = "calendar" | "stats" | "settings";
+
+interface NavItem {
+  id: RoutineMainTab;
+  label: string;
+  panelId: string;
+  icon: ReactNode;
+}
+
+const NAV: readonly NavItem[] = [
   {
     id: "calendar",
     label: "Календар",
@@ -70,7 +80,15 @@ const NAV = [
   },
 ];
 
-export function RoutineBottomNav({ mainTab, onSelectTab }) {
+export interface RoutineBottomNavProps {
+  mainTab: RoutineMainTab;
+  onSelectTab: (tab: RoutineMainTab) => void;
+}
+
+export function RoutineBottomNav({
+  mainTab,
+  onSelectTab,
+}: RoutineBottomNavProps) {
   return (
     <nav
       className={cn(

--- a/src/modules/routine/components/WeekDayStrip.tsx
+++ b/src/modules/routine/components/WeekDayStrip.tsx
@@ -6,9 +6,17 @@ import {
   startOfIsoWeek,
 } from "../lib/weekUtils.js";
 
-function weekKeysFromAnchor(anchorKey) {
+function weekKeysFromAnchor(anchorKey: string): string[] {
   const s = startOfIsoWeek(parseDateKey(anchorKey));
   return Array.from({ length: 7 }, (_, i) => dateKeyFromDate(addDays(s, i)));
+}
+
+export interface WeekDayStripProps {
+  anchorKey: string;
+  selectedDay: string;
+  todayKey: string;
+  onSelectDay: (dateKey: string) => void;
+  onShiftWeek: (delta: number) => void;
 }
 
 export function WeekDayStrip({
@@ -17,7 +25,7 @@ export function WeekDayStrip({
   todayKey,
   onSelectDay,
   onShiftWeek,
-}) {
+}: WeekDayStripProps) {
   const keys = weekKeysFromAnchor(anchorKey);
   const short = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
 


### PR DESCRIPTION
## Summary

PR #4a серії TS-міграції модуля «Рутина» — прості/leaf-компоненти з `routine/components/*` (7 файлів + тест).

Мігровано `.jsx → .tsx`, додано `*Props` інтерфейси, без змін поведінки:

- **`DayProgressRing`** — `DayProgressRingProps` (`completed`, `scheduled`, `onClick?`).
- **`WeekDayStrip`** — `WeekDayStripProps` (`anchorKey`, `selectedDay`, `todayKey`, `onSelectDay`, `onShiftWeek`); внутрішня `weekKeysFromAnchor(string): string[]`.
- **`HabitLeadersBlock`** — `habits: Habit[]`, `completions: RoutineState["completions"]`.
- **`PushupsWidget`** — типізовані `useRef<HTMLDivElement>`, `useRef<HTMLInputElement>` і `ChangeEvent<HTMLInputElement>`.
- **`HabitHeatmap`** — `HabitHeatmapProps` + внутрішні `HeatmapCell` / `MonthMarker`; типізовано `cellBg`, `localDateKey`, `handleClick`, `onPointerDown` (замість `e: any`).
- **`RoutineBottomNav`** — експортовано `RoutineMainTab = "calendar" | "stats" | "settings"`, `NavItem` з `ReactNode`-іконкою, `RoutineBottomNavProps`.
- **`RoutineBackupSection`** — `RoutineBackupSectionProps` (`theme?`, `toast?`, `onImportParsed?: (parsed: unknown) => void`); типізовано `file`-input `ChangeEvent` і безпечний `err instanceof Error` гілку в `catch`.

Також перейменовано `RoutineBottomNav.test.jsx → .test.tsx` (сам тест без змін, крім імпорту без `.jsx`).

Локально: `typecheck` / `lint` / `format:check` / `build` чисті, 604 тести зелені.

## Review & Testing Checklist for Human

- [ ] Нижня навігація Рутини — перемикання між `Календар` / `Статистика` / `Налаштування` все ще шле правильний `tab` в `onSelectTab`.
- [ ] Віджет «Відтискання» — +5/+10/+15/+20/+25, ручне введення + Enter; історія 7 днів малюється.
- [ ] Річна хітмапа на екрані «Статистика»: вибір дня показує підсумок, клік поза межами скидає виділення.

### Notes

Далі йде **PR #4b** — великі sheets/panels: `HabitDetailSheet`, `DayReportSheet`, `RoutineCalendarPanel` (625 LOC), `RoutineStatsPanel`, `RoutineSettingsSection`. Потім PR #5 — `RoutineApp.jsx → .tsx`.

Link to Devin session: https://app.devin.ai/sessions/1a8b262d0aba4d34bedf5a757fce56da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
