### PR TITLE
docs(obs): follow-up fixes on SLO runbook + sync_conflict SLI

### DIFF
--- a/docs/observability/prometheus/recording_rules.yml
+++ b/docs/observability/prometheus/recording_rules.yml
@@ -78,7 +78,7 @@ groups:
 
       - record: sli:sync_conflict:ratio_rate1h
         expr: |
-          sum(rate(sync_operations_total{outcome="conflict"}[1h]))
+          sum(rate(sync_operations_total{op=~"push|push_all",outcome="conflict"}[1h]))
           /
           clamp_min(sum(rate(sync_operations_total{op=~"push|push_all"}[1h])), 1)
 

--- a/docs/observability/runbook.md
+++ b/docs/observability/runbook.md
@@ -6,7 +6,7 @@
 
 Загальне:
 
-- Прод entry point — `server/railway.mjs`. Заборгована реплікація — Railway.
+- Прод entry point — `server/railway.mjs`. Хостинг — Railway.
 - Метрики за bearer-токен: `GET /metrics` з `Authorization: Bearer $METRICS_TOKEN`.
 - Логи — Pino JSON у stdout, з ALS-контекстом `{requestId, userId, module}`.
 - Sentry ловить fatal/error (включно з `err.cause` чейном).
@@ -51,10 +51,10 @@
 2. `too_large` → хтось б'ється у `MAX_BLOB_SIZE`. Знайди user у логах
    (`path=/api/sync, module=sync`) і проінформуй / обріж.
 3. `unauthorized` підскочив → перевір `auth_attempts_total` — можливо
-   глобальна auth-пробл'ема відбивається на sync.
+   глобальна auth-проблема відбивається на sync.
 4. `error` підскочив → Pino-логи + Sentry issues. Найчастіше це DB
    timeout на `sync_push`.
-5. Перевір `sync_payload_bytes` — raptor payload-и можуть зʼїдати pool.
+5. Перевір `sync_payload_bytes` — великі payload-и можуть зʼїдати pool.
 6. При повному пробої — тимчасово пропиши `rate_limit` жорсткіше, щоб
    клієнти не добивали бекенд ретраями.
 


### PR DESCRIPTION
## Summary

Follow-up to #193. Self-review of the merged SLO artefacts surfaced two real issues.

### 1. `runbook.md` autocorrect/typo cleanup

- `Заборгована реплікація — Railway` → `Хостинг — Railway`. The previous phrasing was autocorrect nonsense ("overdue replication" makes no sense as a description of the hosting provider).
- `auth-пробл'ема` → `auth-проблема`.
- `raptor payload-и` → `великі payload-и`.

### 2. `sli:sync_conflict:ratio_rate1h` numerator/denominator mismatch

The recording rule looked like this:

```promql
sum(rate(sync_operations_total{outcome="conflict"}[1h]))                       # numerator
/
clamp_min(sum(rate(sync_operations_total{op=~"push|push_all"}[1h])), 1)        # denominator
```

The denominator correctly scopes to `op=~"push|push_all"` (conflicts only make sense on pushes), but the numerator summed `conflict` across **all** ops. Today we only emit `outcome="conflict"` from push paths, so in practice the numerator and denominator are equal-domain — but the rule is fragile: if we ever add a non-push op that emits `conflict` (or a label regression leaks it), the ratio silently inflates and `SyncConflictSpike` starts firing on data that isn't from the alert's intended domain.

Added the same `op=~"push|push_all"` filter to the numerator:

```promql
sum(rate(sync_operations_total{op=~"push|push_all",outcome="conflict"}[1h]))
/
clamp_min(sum(rate(sync_operations_total{op=~"push|push_all"}[1h])), 1)
```

## Review & Testing Checklist for Human

- [ ] Sanity-check that you're happy with the "great, we've emitted `outcome=conflict` for push-only" assumption — if you plan to emit conflict on pull/push_all differently in the future, revisit the SLI definition.
- [ ] Skim the runbook typo fixes; the Ukrainian copy is yours.

### Notes

- Pure docs/config PR — no runtime code touched.
- Validated locally with `promtool check rules` — 25 recording + 19 alert rules, 0 errors.
- The Devin Review UI on #193 was stuck on "Generating..." so I couldn't see the 4 "additional findings" it alluded to; these are findings I surfaced on my own re-read of the merged files. Happy to pull in more once that UI unsticks.

Link to Devin session: https://app.devin.ai/sessions/3e3ba8f945324c828f28ff14ed18d7ec
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
