### PR TITLE
refactor(nutrition): invalidate coach/digest caches on nutrition log changes

### DIFF
--- a/src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx
+++ b/src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx
@@ -51,12 +51,13 @@ export function SaveAsFood({
             setFoodErr(res.error || "Не вдалося зберегти продукт.");
             return;
           }
-          // Bust the local food-search cache so the next search (including
-          // the refetch triggered by `setFoodQuery(name)` below) sees the
-          // freshly saved product instead of 5 min of stale IndexedDB
-          // results.
+          // Bust the food-search cache so the next search (including the
+          // refetch triggered by `setFoodQuery(name)` below) sees the
+          // freshly saved product instead of 5 min of stale results.
+          // The `foodSearch` prefix matches both local (IndexedDB) and
+          // OFF (OpenFoodFacts) sub-queries.
           queryClient.invalidateQueries({
-            queryKey: [...nutritionKeys.foodSearch, "local"],
+            queryKey: nutritionKeys.foodSearch,
           });
           setPickedFood(res.product);
           setPickedGrams("100");

--- a/src/modules/nutrition/hooks/useNutritionLog.js
+++ b/src/modules/nutrition/hooks/useNutritionLog.js
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { coachKeys, digestKeys } from "@shared/lib/queryKeys.js";
 import {
   NUTRITION_LOG_KEY,
   loadNutritionLog,
@@ -87,6 +89,7 @@ function collectMealIds(log) {
  * }}
  */
 export function useNutritionLog() {
+  const queryClient = useQueryClient();
   const [nutritionLog, setNutritionLog] = useState(() =>
     loadNutritionLog(NUTRITION_LOG_KEY),
   );
@@ -97,6 +100,7 @@ export function useNutritionLog() {
   const [addMealPhotoResult, setAddMealPhotoResult] = useState(null);
   const [storageErr, setStorageErr] = useState("");
   const pendingThumbDeletesRef = useRef(new Map());
+  const didMountRef = useRef(false);
 
   useEffect(() => {
     const ok = persistNutritionLog(nutritionLog, NUTRITION_LOG_KEY);
@@ -106,6 +110,20 @@ export function useNutritionLog() {
         : "Не вдалося зберегти журнал (переповнення сховища або приватний режим).",
     );
   }, [nutritionLog]);
+
+  // Coach insight and weekly digest both derive from the nutrition log.
+  // Invalidate them whenever the log changes so the next mount / user
+  // refresh regenerates with the latest context. `staleTime: Infinity`
+  // on those queries means invalidation only marks them stale — it does
+  // not trigger unsolicited AI calls.
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    queryClient.invalidateQueries({ queryKey: coachKeys.all });
+    queryClient.invalidateQueries({ queryKey: digestKeys.all });
+  }, [nutritionLog, queryClient]);
 
   /**
    * Add a meal to the currently selected date and close the add-meal sheet.

--- a/src/modules/nutrition/hooks/useNutritionLog.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionLog.test.jsx
@@ -1,8 +1,20 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useNutritionLog } from "./useNutritionLog.js";
 import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
 
 describe("useNutritionLog – defensive imports", () => {
   let errorSpy;
@@ -17,7 +29,9 @@ describe("useNutritionLog – defensive imports", () => {
   });
 
   it("replaceLogFromJsonText returns false and does not throw on malformed JSON", () => {
-    const { result } = renderHook(() => useNutritionLog());
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
     let ok;
     act(() => {
       ok = result.current.replaceLogFromJsonText("{not: valid json");
@@ -49,7 +63,9 @@ describe("useNutritionLog – defensive imports", () => {
     };
     localStorage.setItem(NUTRITION_LOG_KEY, JSON.stringify(seeded));
 
-    const { result } = renderHook(() => useNutritionLog());
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
     await waitFor(() =>
       expect(result.current.nutritionLog["2025-01-01"]?.meals?.length).toBe(1),
     );
@@ -64,7 +80,9 @@ describe("useNutritionLog – defensive imports", () => {
   });
 
   it("replaceLogFromJsonText returns true on valid JSON and applies normalized log", async () => {
-    const { result } = renderHook(() => useNutritionLog());
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
     const payload = {
       "2025-02-03": {
         meals: [
@@ -92,7 +110,9 @@ describe("useNutritionLog – defensive imports", () => {
   });
 
   it("replaceLogFromJsonText ignores non-object JSON (array / null) without throwing", () => {
-    const { result } = renderHook(() => useNutritionLog());
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
     let ok1;
     act(() => {
       ok1 = result.current.replaceLogFromJsonText("null");


### PR DESCRIPTION
## Summary

Після міграції 4 nutrition-хуків на React Query (#184) і типізації endpoint-обгорток (#189) залишилась дірка в cache-coherence: `coachKeys.all` (AI-інсайт на день) і `digestKeys.all` (тижневий digest) беруть дані з nutrition log, але ніхто їх не інвалідовує при зміні лога.

Цей PR закриває цю дірку.

### Що зроблено

**`useNutritionLog`** (`src/modules/nutrition/hooks/useNutritionLog.js`)
- Підписався на `useQueryClient`.
- Додав `useEffect` з ref-guard на перший mount, що на кожну зміну `nutritionLog` викликає `invalidateQueries({ coachKeys.all })` + `invalidateQueries({ digestKeys.all })`.
- Покриває усі 8 мутуючих шляхів: `handleAddMeal`, `handleEditMeal`, `handleRemoveMeal`, `handleRestoreMeal`, `duplicateYesterday`, `replaceLogFromJsonText`, `mergeLogFromJsonText`, `trimLogToLastDays` — без дублювання коду в кожній функції.
- **Безпечно по AI-квотах**: обидва запити мають `staleTime: Infinity` (див. `useCoachInsight.js:231`, `useWeeklyDigest.js:357–379`), тож інвалідація лише ставить stale-мітку. Регенерація — досі user-initiated (`refresh()` або re-mount). Якщо коучпанель розмонтована — виклик не відбувається взагалі (RQ не refetch-ить unmounted queries).

**`SaveAsFood.jsx`** (`src/modules/nutrition/components/meal-sheet/SaveAsFood.jsx`)
- Замінив інлайн `[...nutritionKeys.foodSearch, "local"]` на сам префікс `nutritionKeys.foodSearch`. Тепер інвалідація після збереження продукту коректно бʼє і local (IndexedDB), і off (Open Food Facts) под-запити, не лише local.

**Тести** (`useNutritionLog.test.jsx`)
- Обернув 4 існуючих `renderHook` у `QueryClientProvider` wrapper (інакше б падало на `useQueryClient()` без provider).

### Чого свідомо НЕ зроблено

У попередньому повідомленні я помилково пропонував інвалідувати `nutritionKeys.foodSearch` після `parsePantry` і `hubKeys.preview("nutrition")` після `recommend/dayPlan/weekPlan`. Перевірив — обидва напрями хибні:

- **`parsePantry` не пише у foodDb.** Client `parsePantry` просто мерджить items у in-memory pantry (+localStorage). `upsertFood` викликається тільки з `SaveAsFood.jsx` і `foodDb.js::seed` — той шлях вже правильно інвалідовує `foodSearch`.
- **`hubKeys.preview("nutrition")` не має споживачів.** Key визначений у `queryKeys.ts:80`, але `grep -r "hubKeys\.preview" src/` повертає 0 результатів. Інвалідація була б no-op.

### CI локально

- `npm run lint` → 0 помилок
- `npm run typecheck` → 0 помилок (3 tsconfig: main/server/sw)
- `npm test` → 604/604 passed (включно з оновленими `useNutritionLog` тестами)

## Review & Testing Checklist for Human

Risk: **green** (обмежене по scope: один хук + один componet, логіка інвалідації ідемпотентна та не тригерить мережеві виклики).

- [ ] Sanity check: після додавання/редагування/видалення meal — при наступному відкритті CoachInsightCard (якщо він був розмонтований) або натисканні "Оновити" на інсайті — він регенерується з новим контекстом лога.
- [ ] Sanity check: після зміни лога — weekly digest (той самий тиждень) перемальовується наступного разу, коли користувач відкриває digest-вкладку.
- [ ] Edge case: відкрий HubInsightsPanel, додай meal; переконайся, що AI-виклик НЕ тригериться одразу (`staleTime: Infinity` — має чекати manual refresh).

### Notes

- Інвалідація через один `useEffect` дає мʼякший code-footprint і не додає boilerplate у кожен меал-хендлер. Мінус: mount-invalidate skip реалізований через `didMountRef` (StrictMode-safe, бо ref-guard стабільний між double-invokes).
- `useQueryClient` тепер required-dependency у `useNutritionLog` → тестам потрібен `QueryClientProvider`. Це типовий цінник за RQ-інтеграцію; додав wrapper один раз замість того, щоб мокати модуль.

Link to Devin session: https://app.devin.ai/sessions/e3a4d57196374ee5b3bc3dec3b9f9f2e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
