### PR TITLE
chore(routine): migrate sheets/panels to TypeScript (PR #4b)

### DIFF
--- a/src/modules/routine/components/DayReportSheet.tsx
+++ b/src/modules/routine/components/DayReportSheet.tsx
@@ -2,6 +2,20 @@ import { useRef } from "react";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { cn } from "@shared/lib/cn";
 import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
+import type { Habit } from "../lib/types";
+
+export interface ScheduledHabitForReport extends Habit {
+  completed: boolean;
+}
+
+export interface DayReportSheetProps {
+  open: boolean;
+  onClose: () => void;
+  dayLabel: string;
+  scheduledHabits: ScheduledHabitForReport[];
+  onToggleHabit: (habitId: string, dateKey: string) => void;
+  dateKey: string;
+}
 
 export function DayReportSheet({
   open,
@@ -10,8 +24,8 @@ export function DayReportSheet({
   scheduledHabits,
   onToggleHabit,
   dateKey,
-}) {
-  const ref = useRef(null);
+}: DayReportSheetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
   useDialogFocusTrap(open, ref, { onEscape: onClose });
 
   if (!open) return null;

--- a/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/src/modules/routine/components/HabitDetailSheet.tsx
@@ -13,24 +13,29 @@ import {
   RECURRENCE_OPTIONS,
   WEEKDAY_LABELS,
 } from "../lib/routineConstants.js";
+import type { Habit, RoutineState } from "../lib/types";
 
-function todayKey() {
+function todayKey(): string {
   const d = new Date();
   d.setHours(12, 0, 0, 0);
   return dateKeyFromDate(d);
 }
 
-function monthGrid(y, m) {
+function monthGrid(y: number, m: number): Array<number | null> {
   const last = new Date(y, m + 1, 0).getDate();
   const firstWd = (new Date(y, m, 1).getDay() + 6) % 7;
-  const cells = [];
+  const cells: Array<number | null> = [];
   for (let i = 0; i < firstWd; i++) cells.push(null);
   for (let d = 1; d <= last; d++) cells.push(d);
   while (cells.length % 7 !== 0) cells.push(null);
   return cells;
 }
 
-function completionPct(habit, completions, days) {
+function completionPct(
+  habit: Habit,
+  completions: string[],
+  days: number,
+): number | null {
   const tk = todayKey();
   let scheduled = 0;
   let done = 0;
@@ -48,8 +53,28 @@ function completionPct(habit, completions, days) {
   return Math.round((done / scheduled) * 100);
 }
 
-export function HabitDetailSheet({ habitId, routine, onClose }) {
-  const ref = useRef(null);
+export interface HabitDetailSheetProps {
+  habitId: string;
+  routine: RoutineState;
+  onClose: () => void;
+}
+
+interface MonthCursor {
+  y: number;
+  m: number;
+}
+
+interface NoteEntry {
+  date: string;
+  text: string;
+}
+
+export function HabitDetailSheet({
+  habitId,
+  routine,
+  onClose,
+}: HabitDetailSheetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
   useDialogFocusTrap(true, ref, { onEscape: onClose });
 
   const habit = routine.habits.find((h) => h.id === habitId);
@@ -60,17 +85,17 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
   const tk = todayKey();
 
   const now = new Date();
-  const [calMonth, setCalMonth] = useState({
+  const [calMonth, setCalMonth] = useState<MonthCursor>({
     y: now.getFullYear(),
     m: now.getMonth(),
   });
 
-  const tag = useMemo(() => {
+  const tag = useMemo<string[]>(() => {
     if (!habit) return [];
     const ids = habit.tagIds || [];
     return ids
       .map((id) => routine.tags.find((t) => t.id === id)?.name)
-      .filter(Boolean);
+      .filter((n): n is string => Boolean(n));
   }, [habit, routine.tags]);
 
   const category = useMemo(() => {
@@ -122,7 +147,7 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
     },
   );
 
-  const goCalMonth = (delta) => {
+  const goCalMonth = (delta: number) => {
     setCalMonth((c) => {
       let m = c.m + delta;
       let y = c.y;
@@ -138,9 +163,9 @@ export function HabitDetailSheet({ habitId, routine, onClose }) {
     });
   };
 
-  const notes = useMemo(() => {
+  const notes = useMemo<NoteEntry[]>(() => {
     const notesObj = routine.completionNotes || {};
-    const items = [];
+    const items: NoteEntry[] = [];
     const sorted = [...completions].sort().reverse();
     for (const dk of sorted) {
       const k = completionNoteKey(habitId, dk);

--- a/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
-import { WeekDayStrip } from "./WeekDayStrip.jsx";
-import { HabitDetailSheet } from "./HabitDetailSheet.jsx";
+import { WeekDayStrip } from "./WeekDayStrip";
+import { HabitDetailSheet } from "./HabitDetailSheet";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { completionNoteKey } from "../lib/completionNoteKey.js";
-import { DayProgressRing } from "./DayProgressRing.jsx";
-import { DayReportSheet } from "./DayReportSheet.jsx";
+import { DayProgressRing } from "./DayProgressRing";
+import { DayReportSheet } from "./DayReportSheet";
 import {
   FIZRUK_GROUP_LABEL,
   parseDateKey,
@@ -23,9 +23,20 @@ import { setCompletionNote } from "../lib/routineStorage.js";
 import {
   useRoutineCalendarActions,
   useRoutineCalendarData,
-} from "../context/RoutineCalendarContext.jsx";
+} from "../context/RoutineCalendarContext";
+import type { HubCalendarEvent } from "../lib/types";
 
-export function RoutineCalendarPanel({ hidden: panelHidden }) {
+type GroupedListItem =
+  | { kind: "header"; label: string }
+  | { kind: "event"; e: HubCalendarEvent };
+
+export interface RoutineCalendarPanelProps {
+  hidden?: boolean;
+}
+
+export function RoutineCalendarPanel({
+  hidden: panelHidden,
+}: RoutineCalendarPanelProps) {
   const {
     rangeLabel,
     headlineDate,
@@ -75,10 +86,10 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
     return () => clearTimeout(id);
   }, [listQueryDraft, setListQuery]);
   const [dayReportOpen, setDayReportOpen] = useState(false);
-  const [detailHabitId, setDetailHabitId] = useState(null);
+  const [detailHabitId, setDetailHabitId] = useState<string | null>(null);
 
-  const flatGroupedItems = useMemo(() => {
-    const items = [];
+  const flatGroupedItems = useMemo<GroupedListItem[]>(() => {
+    const items: GroupedListItem[] = [];
     for (const [label, rows] of grouped || []) {
       items.push({ kind: "header", label });
       for (const e of rows || []) items.push({ kind: "event", e });
@@ -231,7 +242,9 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
         className="routine-touch-field w-full max-w-md"
         placeholder="Пошук у стрічці…"
         value={listQueryDraft}
-        onChange={(e) => setListQueryDraft(e.target.value)}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setListQueryDraft(e.target.value)
+        }
         aria-label="Пошук подій"
       />
 
@@ -456,9 +469,9 @@ export function RoutineCalendarPanel({ hidden: panelHidden }) {
           </div>
         )}
         {flatGroupedItems.length > 0 && (
-          <Virtuoso
+          <Virtuoso<GroupedListItem>
             data={flatGroupedItems}
-            itemKey={(_, item) =>
+            computeItemKey={(_, item) =>
               item.kind === "header" ? `h_${item.label}` : `e_${item.e?.id}`
             }
             itemContent={(_, item) => {

--- a/src/modules/routine/components/RoutineSettingsSection.tsx
+++ b/src/modules/routine/components/RoutineSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
 import {
@@ -16,13 +16,38 @@ import {
   routineTodayDate,
   normalizeReminderTimes,
 } from "../lib/routineDraftUtils.js";
-import { HabitDetailSheet } from "./HabitDetailSheet.jsx";
-import { RoutineBackupSection } from "./RoutineBackupSection.jsx";
-import { HabitForm } from "./settings/HabitForm.jsx";
-import { TagsSection } from "./settings/TagsSection.jsx";
-import { CategoriesSection } from "./settings/CategoriesSection.jsx";
-import { ActiveHabitsSection } from "./settings/ActiveHabitsSection.jsx";
-import { ArchivedHabitsSection } from "./settings/ArchivedHabitsSection.jsx";
+import { HabitDetailSheet } from "./HabitDetailSheet";
+import { RoutineBackupSection } from "./RoutineBackupSection";
+import { HabitForm } from "./settings/HabitForm";
+import { TagsSection } from "./settings/TagsSection";
+import { CategoriesSection } from "./settings/CategoriesSection";
+import { ActiveHabitsSection } from "./settings/ActiveHabitsSection";
+import { ArchivedHabitsSection } from "./settings/ArchivedHabitsSection";
+import type {
+  CategoryDraft,
+  Habit,
+  HabitDraft,
+  PendingHabitDeletion,
+  RoutineState,
+} from "../lib/types";
+
+interface ImportConfirmState {
+  parsed: unknown;
+}
+
+export interface RoutineSettingsSectionProps {
+  routine: RoutineState;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  habitDraft: HabitDraft;
+  setHabitDraft: Dispatch<SetStateAction<HabitDraft>>;
+  tagDraft: string;
+  setTagDraft: Dispatch<SetStateAction<string>>;
+  catDraft: CategoryDraft;
+  setCatDraft: Dispatch<SetStateAction<CategoryDraft>>;
+  onOpenCalendar?: () => void;
+  habitFormFocusTick?: number;
+  hidden?: boolean;
+}
 
 export function RoutineSettingsSection({
   routine,
@@ -36,14 +61,17 @@ export function RoutineSettingsSection({
   onOpenCalendar,
   habitFormFocusTick,
   hidden: panelHidden,
-}) {
+}: RoutineSettingsSectionProps) {
   const toast = useToast();
-  const [editingId, setEditingId] = useState(null);
-  const [detailHabitId, setDetailHabitId] = useState(null);
-  const [deleteHabitPending, setDeleteHabitPending] = useState(null);
-  const [importConfirm, setImportConfirm] = useState(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [detailHabitId, setDetailHabitId] = useState<string | null>(null);
+  const [deleteHabitPending, setDeleteHabitPending] =
+    useState<PendingHabitDeletion | null>(null);
+  const [importConfirm, setImportConfirm] = useState<ImportConfirmState | null>(
+    null,
+  );
 
-  const loadHabitIntoDraft = (h) => {
+  const loadHabitIntoDraft = (h: Habit) => {
     const times = normalizeReminderTimes(h);
     setHabitDraft({
       name: h.name || "",

--- a/src/modules/routine/components/RoutineStatsPanel.tsx
+++ b/src/modules/routine/components/RoutineStatsPanel.tsx
@@ -1,26 +1,37 @@
 import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
-import { PushupsWidget } from "./PushupsWidget.jsx";
-import { HabitHeatmap } from "./HabitHeatmap.jsx";
-import { HabitLeadersBlock } from "./HabitLeadersBlock.jsx";
+import { PushupsWidget } from "./PushupsWidget";
+import { HabitHeatmap } from "./HabitHeatmap";
+import { HabitLeadersBlock } from "./HabitLeadersBlock";
 import { completionRateForRange, maxStreakAllTime } from "../lib/streaks.js";
 import { dateKeyFromDate, parseDateKey } from "../lib/hubCalendarAggregate.js";
 import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
+import type { RoutineState } from "../lib/types";
 
-function dateKeyMinusDays(baseKey, daysBack) {
+function dateKeyMinusDays(baseKey: string, daysBack: number): string {
   const d = parseDateKey(baseKey);
   d.setDate(d.getDate() - daysBack);
   d.setHours(12, 0, 0, 0);
   return dateKeyFromDate(d);
 }
 
-export function RoutineStatsPanel({ routine, currentStreak, hidden }) {
+export interface RoutineStatsPanelProps {
+  routine: RoutineState;
+  currentStreak: number;
+  hidden?: boolean;
+}
+
+export function RoutineStatsPanel({
+  routine,
+  currentStreak,
+  hidden,
+}: RoutineStatsPanelProps) {
   const todayKey = dateKeyFromDate(new Date());
 
   const summary = useMemo(() => {
     const habits = routine.habits || [];
     const completions = routine.completions || {};
-    const maxAllTime = habits.reduce((acc, h) => {
+    const maxAllTime = habits.reduce((acc: number, h) => {
       if (h.archived) return acc;
       const m = maxStreakAllTime(h, completions[h.id] || []);
       return m > acc ? m : acc;

--- a/src/modules/routine/context/RoutineCalendarContext.tsx
+++ b/src/modules/routine/context/RoutineCalendarContext.tsx
@@ -1,7 +1,70 @@
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
+import type { HubCalendarEvent, RoutineState } from "../lib/types";
 
-export type RoutineCalendarData = Record<string, unknown>;
-export type RoutineCalendarActions = Record<string, unknown>;
+export interface RoutineCompletionRate {
+  completed: number;
+  scheduled: number;
+  rate: number;
+}
+
+export interface RoutineDayProgress {
+  completed: number;
+  scheduled: number;
+}
+
+export interface RoutineMonthCursor {
+  y: number;
+  m: number;
+}
+
+export type RoutineTimeMode = "day" | "week" | "month" | string;
+
+export interface RoutineCalendarData {
+  rangeLabel: string;
+  headlineDate: string;
+  filtered: HubCalendarEvent[];
+  routine: RoutineState;
+  currentStreak: number;
+  completionRate: RoutineCompletionRate;
+  dayProgress: RoutineDayProgress;
+  timeMode: RoutineTimeMode;
+  selectedDay: string;
+  todayKey: string;
+  shiftWeekStrip: (delta: number) => void;
+  setSelectedDay: Dispatch<SetStateAction<string>>;
+  setTimeMode: Dispatch<SetStateAction<RoutineTimeMode>>;
+  listQuery: string;
+  setListQuery: Dispatch<SetStateAction<string>>;
+  tagFilter: string | null;
+  setTagFilter: Dispatch<SetStateAction<string | null>>;
+  tagChips: string[];
+  monthCursor: RoutineMonthCursor;
+  monthTitle: string;
+  goMonth: (delta: number) => void;
+  goToToday: () => void;
+  cells: Array<number | null>;
+  dayCounts: Map<string, number>;
+  listIsEmpty: boolean;
+  hasListFilter: boolean;
+  hasNoHabits: boolean;
+  grouped: Map<string, HubCalendarEvent[]>;
+  canBulkMark: boolean;
+}
+
+export interface RoutineCalendarActions {
+  applyTimeMode: (mode: RoutineTimeMode) => void;
+  onToggleHabit: (habitId: string, dateKey: string) => void;
+  setRoutine: Dispatch<SetStateAction<RoutineState>>;
+  setMainTab: (tab: string) => void;
+  onOpenModule?: (moduleId: string, opts?: { hash?: string }) => void;
+  onBulkMarkDay: () => void;
+}
 
 const RoutineCalendarDataContext = createContext<RoutineCalendarData | null>(
   null,


### PR DESCRIPTION
## Summary

Continues the phased TypeScript migration of the `routine` module. After PR #4a migrated leaf components, this PR migrates the five remaining `src/modules/routine/components/*` files — the larger panels and sheets:

- `DayReportSheet.jsx → .tsx` — added `DayReportSheetProps` and `ScheduledHabitForReport extends Habit { completed: boolean }`.
- `HabitDetailSheet.jsx → .tsx` — added `HabitDetailSheetProps`, internal `MonthCursor` / `NoteEntry`, and typed the month-grid / completion-% helpers.
- `RoutineCalendarPanel.jsx → .tsx` — added `RoutineCalendarPanelProps`, typed the virtualized list items via a `GroupedListItem` union and narrowed the search input handler.
- `RoutineStatsPanel.jsx → .tsx` — added `RoutineStatsPanelProps` and typed the `dateKeyMinusDays` helper.
- `RoutineSettingsSection.jsx → .tsx` — added `RoutineSettingsSectionProps`, typed all local state (`editingId`, `detailHabitId`, `deleteHabitPending`, `importConfirm`), and typed the `loadHabitIntoDraft` parameter.

To unblock `RoutineCalendarPanel`, the `RoutineCalendarContext` data/actions contract is tightened — replacing the temporary `Record<string, unknown>` placeholders from PR #2 with concrete interfaces (`RoutineCalendarData`, `RoutineCalendarActions`, `RoutineCompletionRate`, `RoutineDayProgress`, `RoutineMonthCursor`, `RoutineTimeMode`). `RoutineApp.jsx` is still untyped JS, so it continues to pass through unchecked under `allowJs`/`checkJs: false`.

One incidental fix during migration: `RoutineCalendarPanel` passed `itemKey` to `<Virtuoso>`, but `react-virtuoso`'s props only declare `computeItemKey` — the old prop was silently ignored. Renamed to the correct API so keys actually drive reconciliation.

No runtime behavior changes beyond that `computeItemKey` rename. `strict`, `noImplicitAny`, and `checkJs` remain off; that's planned for a later PR.

Local verification:
- `npm run typecheck` — passed all three tsconfigs
- `npm test` — 604 tests passed (61 files)
- `npm run lint` — eslint + import check passed
- `npm run format:check` — passed
- `npm run build` — passed (client + SW)

After this PR, `src/modules/routine/components/` is 100% TypeScript. Next up: PR #5 — `RoutineApp.jsx → .tsx`.

## Review & Testing Checklist for Human

- [ ] Open the Routine calendar tab and confirm the Virtuoso list still renders correctly (this PR changed `itemKey` → `computeItemKey` on `<Virtuoso>`; list items should still render and scroll).
- [ ] Open the day-report sheet from the progress ring and toggle a habit — confirm it marks/unmarks as before.
- [ ] Open Habit details from a calendar row — confirm stats, month grid, and notes render identically.
- [ ] Import a routine backup JSON from Settings — confirm the confirm-dialog flow and toast behavior are unchanged.

### Notes

- The `RoutineCalendarData` / `RoutineCalendarActions` contract is intentionally typed from the consumer (`RoutineCalendarPanel`) side. If/when `RoutineApp` becomes TS in PR #5, TS will now actually enforce the shape the provider produces.

Link to Devin session: https://app.devin.ai/sessions/1a8b262d0aba4d34bedf5a757fce56da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
