### PR TITLE
refactor(ui): unify hero h1 typography via text-hero token

### DIFF
--- a/src/modules/finyk/pages/overview/MonthPulseCard.jsx
+++ b/src/modules/finyk/pages/overview/MonthPulseCard.jsx
@@ -56,7 +56,7 @@ export function MonthPulseCard({
       <div className="flex justify-between items-start gap-4">
         <div>
           <div className="text-xs text-subtle font-medium">Витрати</div>
-          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight">
+          <div className="text-hero font-bold tabular-nums mt-1 leading-tight">
             {showBalance
               ? spent.toLocaleString("uk-UA", { maximumFractionDigits: 0 })
               : "••••"}
@@ -67,7 +67,7 @@ export function MonthPulseCard({
         </div>
         <div className="text-right">
           <div className="text-xs text-subtle font-medium">Дохід</div>
-          <div className="text-[26px] font-bold tabular-nums mt-1 leading-tight text-success">
+          <div className="text-hero font-bold tabular-nums mt-1 leading-tight text-success">
             {showBalance ? (
               <>
                 +

--- a/src/modules/fizruk/pages/Atlas.tsx
+++ b/src/modules/fizruk/pages/Atlas.tsx
@@ -56,7 +56,7 @@ export function Atlas() {
           <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
             Атлас мʼязів
           </p>
-          <h1 className="text-2xl font-black text-white mt-2 leading-tight">
+          <h1 className="text-hero font-black text-white mt-2 leading-tight">
             Стан відновлення
           </h1>
           <div className="flex gap-4 mt-3">

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -289,7 +289,7 @@ export function Dashboard({
           <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
             {greeting} · {today}
           </p>
-          <h1 className="text-[26px] font-black text-white mt-3 leading-tight">
+          <h1 className="text-hero font-black text-white mt-3 leading-tight">
             Твій прогрес
             <br />
             зібраний в одному місці

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -206,6 +206,9 @@ export default {
         lg: ["18px", { lineHeight: "28px" }],
         xl: ["20px", { lineHeight: "28px" }],
         "2xl": ["24px", { lineHeight: "32px" }],
+        // `hero`: hero-section H1s and hero stat numbers (slightly larger
+        // than 2xl for the page-greeting / headline-stat slot).
+        hero: ["26px", { lineHeight: "32px" }],
         "3xl": ["30px", { lineHeight: "36px" }],
         "4xl": ["36px", { lineHeight: "40px" }],
         "5xl": ["48px", { lineHeight: "1" }],


### PR DESCRIPTION
## Summary

Page-title normalization follow-up from the UI audit. The fizruk hero `h1`s used two different sizes — Atlas at `text-2xl` (24px) and Dashboard at the arbitrary `text-[26px]` — for the same role (page-greeting headline on a colored hero surface). MonthPulseCard's hero stat numbers also used the same arbitrary `text-[26px]`.

Adds a named token `text-hero` = `26px / 32px` and migrates all four sites onto it.

**Changes:**
- `tailwind.config.js:209-211` — new `hero` entry in the `fontSize` scale, with a comment explaining the intended slot.
- `src/modules/fizruk/pages/Dashboard.tsx:292` — hero h1 `text-[26px]` → `text-hero` (no visual change; same 26px).
- `src/modules/finyk/pages/overview/MonthPulseCard.jsx:59,70` — spent / income hero numbers `text-[26px]` → `text-hero` (no visual change).
- `src/modules/fizruk/pages/Atlas.tsx:59` — hero h1 `text-2xl` → `text-hero` (visible polish: 24px → 26px to match the Dashboard greeting; layout has plenty of room).

**What is left untouched (intentionally):**
- The 5 non-hero fizruk page titles (`Progress`, `Exercise`, `Workouts`, `Body`, `Programs`) already follow the canonical `text-xl font-bold text-text` pattern.
- `FinykApp.jsx:304` (`text-2xl font-bold` "ФІНІК") is on the unauthenticated splash, not a page title — kept as-is.
- `HubHeader.jsx:29` and `AuthPage.jsx:44` (`text-3xl font-bold tracking-tight`) are app-shell / landing-screen titles — kept as-is.

After this PR there are no remaining `text-[26px]` arbitrary-size sites in `src/`.

## Review & Testing Checklist for Human

- [ ] Open Fizruk **Atlas** page and confirm the "Стан відновлення" hero heading reads slightly larger but stays on a single line in the hero card.
- [ ] Open Fizruk **Dashboard** and confirm the "Твій прогрес / зібраний в одному місці" hero h1 looks unchanged.
- [ ] Open Finyk **Overview → MonthPulseCard** and confirm the spent/income numbers look unchanged (light + dark).

### Notes

All local checks green: `npm run lint`, `npm run typecheck`, `npm test` (604 / 604), `npm run build`, `npm run format:check`. No layout / structure / color changes — only typography token consolidation.

Link to Devin session: https://app.devin.ai/sessions/5b1aebe8911c40058c2847104209824e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
