### PR TITLE
chore: remove unused exports (round 2)

### DIFF
--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -48,8 +48,6 @@ export const DASHBOARD_MODULE_LABELS = {
   nutrition: "Харчування",
 };
 
-export const DASHBOARD_DEFAULT_ORDER = DEFAULT_ORDER;
-
 export function loadDashboardOrder() {
   const saved = safeReadLS(DASHBOARD_ORDER_KEY, null);
   if (

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -10,7 +10,7 @@ import {
 } from "./onboarding/vibePicks.js";
 import { seedDemoForModules } from "./onboarding/demoSeeds.js";
 
-export const ONBOARDING_DONE_KEY = "hub_onboarding_done_v1";
+const ONBOARDING_DONE_KEY = "hub_onboarding_done_v1";
 
 function hasExistingData() {
   try {

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -44,43 +44,6 @@ export const ANALYTICS_EVENTS = Object.freeze({
 });
 
 /**
- * @typedef {{
- *   name: string,
- *   track: (event: AnalyticsEvent) => void,
- * }} AnalyticsProvider
- */
-
-/** @type {AnalyticsProvider[]} */
-const providers = [];
-
-/**
- * Register a transport (e.g. PostHog / Amplitude wrapper). Providers must
- * be resilient — any thrown error is swallowed so analytics can never
- * break the UI.
- * @param {AnalyticsProvider} provider
- */
-export function registerAnalyticsProvider(provider) {
-  if (!provider || typeof provider.track !== "function") return;
-  providers.push(provider);
-}
-
-/** Clear all registered providers. Primarily useful in tests. */
-export function resetAnalyticsProviders() {
-  providers.length = 0;
-}
-
-function safeDispatch(event) {
-  for (const p of providers) {
-    try {
-      p.track(event);
-    } catch (err) {
-      // Never let a misbehaving provider impact the UI.
-      console.warn(`[analytics] provider "${p.name}" failed`, err);
-    }
-  }
-}
-
-/**
  * Record a product event. Fire-and-forget — safe to call from any UI
  * handler without awaiting.
  *
@@ -95,9 +58,6 @@ export function trackEvent(eventName, payload = {}) {
     timestamp: new Date().toISOString(),
   };
   try {
-    // Stage 1: just log. Real transports will be registered via
-    // `registerAnalyticsProvider` once we pick a vendor.
     console.log("[analytics]", event);
   } catch {}
-  safeDispatch(event);
 }

--- a/src/core/authClient.js
+++ b/src/core/authClient.js
@@ -9,7 +9,7 @@ function getAuthBaseURL() {
   return window.location.origin;
 }
 
-export const authClient = createAuthClient({
+const authClient = createAuthClient({
   baseURL: getAuthBaseURL(),
 });
 

--- a/src/core/cloudSync/state/versions.ts
+++ b/src/core/cloudSync/state/versions.ts
@@ -3,7 +3,7 @@ import { SYNC_VERSION_KEY } from "../config";
 
 type VersionMap = Record<string, Record<string, number>>;
 
-export function getModuleVersions(): VersionMap {
+function getModuleVersions(): VersionMap {
   return safeReadLS<VersionMap>(SYNC_VERSION_KEY, {}) || {};
 }
 

--- a/src/core/lib/hubChatContext.ts
+++ b/src/core/lib/hubChatContext.ts
@@ -209,7 +209,7 @@ function readAllData(): AllData {
   };
 }
 
-export function buildContext(): string {
+function buildContext(): string {
   const d = readAllData();
   const lines: string[] = [];
 

--- a/src/core/lib/hubChatSpeech.ts
+++ b/src/core/lib/hubChatSpeech.ts
@@ -1,6 +1,6 @@
 export const VOICE_KEYWORDS = /голосом|вголос|скажи|озвуч|прочитай/i;
 
-export function cleanTextForSpeech(text: string): string {
+function cleanTextForSpeech(text: string): string {
   return text
     .replace(/✅/g, "")
     .replace(/\[.*?\]/g, "")

--- a/src/core/onboarding/demoSeeds.js
+++ b/src/core/onboarding/demoSeeds.js
@@ -15,7 +15,7 @@ import {
   enableFinykManualOnly,
 } from "../../modules/finyk/lib/demoData.js";
 
-export const DEMO_SEEDED_FLAG_KEY = "hub_demo_seeded_v1";
+const DEMO_SEEDED_FLAG_KEY = "hub_demo_seeded_v1";
 
 const FIZRUK_WORKOUTS_KEY = "fizruk_workouts_v1";
 const ROUTINE_STATE_KEY = "hub_routine_v1";

--- a/src/core/onboarding/firstRealEntry.js
+++ b/src/core/onboarding/firstRealEntry.js
@@ -30,7 +30,7 @@ function hasNonDemoItem(list) {
  * Returns true if the user has at least one non-demo entry anywhere.
  * Called on every dashboard render; O(modules) and cheap (no reserialize).
  */
-export function hasAnyRealEntry() {
+function hasAnyRealEntry() {
   // Finyk — manual expenses.
   const manual = safeReadJSON("finyk_manual_expenses_v1");
   if (hasNonDemoItem(manual)) return true;

--- a/src/core/onboarding/vibePicks.js
+++ b/src/core/onboarding/vibePicks.js
@@ -2,11 +2,11 @@
 // Everything here is synchronous localStorage access — the wizard runs
 // before React Query / cloud sync, so we keep it dependency-free.
 
-export const VIBE_PICKS_KEY = "hub_onboarding_vibes_v1";
-export const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
-export const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
-export const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
-export const DEMO_BANNER_DISMISSED_KEY = "hub_demo_banner_dismissed_v1";
+const VIBE_PICKS_KEY = "hub_onboarding_vibes_v1";
+const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
+const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
+const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
+const DEMO_BANNER_DISMISSED_KEY = "hub_demo_banner_dismissed_v1";
 
 /** @typedef {"finyk" | "fizruk" | "routine" | "nutrition"} HubModuleId */
 

--- a/src/core/settings/SettingsPrimitives.tsx
+++ b/src/core/settings/SettingsPrimitives.tsx
@@ -3,11 +3,11 @@ import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Card } from "@shared/components/ui/Card";
 
-export interface ChevronIconProps {
+interface ChevronIconProps {
   expanded: boolean;
 }
 
-export function ChevronIcon({ expanded }: ChevronIconProps) {
+function ChevronIcon({ expanded }: ChevronIconProps) {
   return (
     <Icon
       name="chevron-right"

--- a/src/core/settings/hubPrefs.ts
+++ b/src/core/settings/hubPrefs.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 
-export const HUB_PREFS_KEY = STORAGE_KEYS.HUB_PREFS;
+const HUB_PREFS_KEY = STORAGE_KEYS.HUB_PREFS;
 
-export type HubPrefs = Record<string, unknown>;
+type HubPrefs = Record<string, unknown>;
 
-export function loadHubPrefs(): HubPrefs {
+function loadHubPrefs(): HubPrefs {
   try {
     const raw = localStorage.getItem(HUB_PREFS_KEY);
     if (!raw) return {};
@@ -16,7 +16,7 @@ export function loadHubPrefs(): HubPrefs {
   }
 }
 
-export function saveHubPref(key: string, value: unknown): void {
+function saveHubPref(key: string, value: unknown): void {
   try {
     const prefs = loadHubPrefs();
     localStorage.setItem(

--- a/src/core/useCoachInsight.js
+++ b/src/core/useCoachInsight.js
@@ -202,7 +202,7 @@ async function fetchCoachInsight() {
 // React Query key factory — re-exported from the centralized queryKeys
 // module so other callers (e.g. the weekly digest mutation) can invalidate
 // the insight when the underlying data signature changes.
-export const coachInsightQueryKey = (todayKey = localDateKey()) =>
+const coachInsightQueryKey = (todayKey = localDateKey()) =>
   coachKeys.insight(todayKey);
 
 // Seed the query from localStorage only when the cached date matches the

--- a/src/core/useWeeklyDigest.js
+++ b/src/core/useWeeklyDigest.js
@@ -40,7 +40,7 @@ export function getWeekKey(d = new Date()) {
   return localDateKey(monday);
 }
 
-export function getWeekRange(d = new Date()) {
+function getWeekRange(d = new Date()) {
   const monday = new Date(d);
   monday.setDate(d.getDate() - ((d.getDay() + 6) % 7));
   const sunday = new Date(monday);
@@ -54,7 +54,7 @@ export function loadDigest(weekKey) {
   return safeReadLS(`${DIGEST_PREFIX}${weekKey}`, null);
 }
 
-export function listDigestHistory() {
+function listDigestHistory() {
   const results = [];
   try {
     for (let i = 0; i < localStorage.length; i++) {
@@ -333,8 +333,8 @@ async function generateWeeklyDigest(weekKey) {
 // Re-exported from the centralized queryKeys module — consumers may import
 // these names directly for historical reasons, but new code should import
 // `digestKeys` and `coachKeys` from "@shared/lib/queryKeys.js".
-export const weeklyDigestQueryKey = (weekKey) => digestKeys.byWeek(weekKey);
-export const weeklyDigestHistoryQueryKey = digestKeys.history;
+const weeklyDigestQueryKey = (weekKey) => digestKeys.byWeek(weekKey);
+const weeklyDigestHistoryQueryKey = digestKeys.history;
 
 export function useDigestHistory() {
   return useQuery({

--- a/src/modules/finyk/domain/budget.ts
+++ b/src/modules/finyk/domain/budget.ts
@@ -5,8 +5,6 @@
 import { getTxStatAmount, calcMonthlyNeeded } from "../utils";
 import type {
   Budget,
-  MonthBudgetSummary,
-  MonthlyPlan,
   RemainingBudget,
   Transaction,
   TxSplitsMap,
@@ -250,47 +248,6 @@ export function getMonthlyPlanUsage(
     isOver,
     safePerDay,
     daysLeft,
-  };
-}
-
-export interface MonthBudgetOptions {
-  excludedTxIds?: Set<string> | Iterable<string>;
-  txSplits?: TxSplitsMap;
-  monthlyPlan?: MonthlyPlan;
-}
-
-export function getMonthBudgetSummary(
-  transactions: readonly Transaction[] | null | undefined,
-  {
-    excludedTxIds = new Set<string>(),
-    txSplits = {},
-    monthlyPlan = {},
-  }: MonthBudgetOptions = {},
-): MonthBudgetSummary {
-  const excluded =
-    excludedTxIds instanceof Set
-      ? excludedTxIds
-      : new Set<string>(excludedTxIds || []);
-  const statTx = Array.isArray(transactions)
-    ? transactions.filter((t) => t && !excluded.has(t.id))
-    : [];
-  const totalFact = calculateTotalExpenseFact(statTx, txSplits);
-  const usage = getMonthlyPlanUsage(
-    {
-      planIncome: Number(monthlyPlan?.income || 0),
-      planExpense: Number(monthlyPlan?.expense || 0),
-      totalFact,
-    },
-    new Date(),
-  );
-  return {
-    totalPlan: usage.planExpense,
-    planIncome: usage.planIncome,
-    totalFact: usage.totalFact,
-    totalRemaining: usage.remaining,
-    safePerDay: usage.safePerDay,
-    isOverall: usage.isOver,
-    daysLeft: usage.daysLeft,
   };
 }
 

--- a/src/modules/finyk/domain/personalization.ts
+++ b/src/modules/finyk/domain/personalization.ts
@@ -71,7 +71,7 @@ export interface PersonalizationOptions {
 // Мапа manual-підписів (як у ManualExpenseSheet) на canonical id з MCC_CATEGORIES.
 // Якщо користувач вводить щось інше (custom manual-категорія) — зберігаємо
 // «як є» і використовуємо сам підпис як id.
-export const MANUAL_CATEGORY_ID_MAP: Record<string, string> = {
+const MANUAL_CATEGORY_ID_MAP: Record<string, string> = {
   їжа: "food",
   продукти: "food",
   "кафе та ресторани": "restaurant",
@@ -401,15 +401,4 @@ export function getFrequentMerchants(
   // Ховаємо випадкові одноразові мерчанти — персоналізація має сенс від 2-го
   // використання; limit лишаємо прозорим — виклик може взяти менше.
   return arr.filter((m) => m.count >= 2).slice(0, limit);
-}
-
-// Reuse: з customCategories робимо {id → label} для UI-сортування.
-export function buildCategoryLabelIndex(
-  customCategories: Category[] = [],
-): Record<string, string> {
-  const idx: Record<string, string> = {};
-  for (const c of customCategories) {
-    if (c && c.id) idx[c.id] = c.label;
-  }
-  return idx;
 }

--- a/src/modules/finyk/domain/subscriptionUtils.js
+++ b/src/modules/finyk/domain/subscriptionUtils.js
@@ -30,9 +30,3 @@ export function getSubscriptionAmountMeta(sub, transactions) {
   const currency = lastTx.currencyCode === CURRENCY.USD ? "$" : "₴";
   return { amount, currency, lastTx };
 }
-
-/** День місяця з unix-часу транзакції Monobank (секунди). */
-export function billingDayFromTxTime(timeSec) {
-  if (!timeSec) return null;
-  return new Date(timeSec * 1000).getDate();
-}


### PR DESCRIPTION
## Summary

Follow-up to #188 — a second, low-risk pass over the dead-code audit's Category A targets. Every change is either:

1. **Strip `export`** from a symbol that has **zero external importers** but is still used internally (preserves behavior, shrinks the module's API surface), or
2. **Delete** a definition with **zero references anywhere** (truly dead).

**No behavior changes.** Lint, typecheck, and all 604 tests pass locally.

### `export` stripped (symbol kept, no longer public)

| Symbol | File |
|---|---|
| `VIBE_PICKS_KEY`, `FIRST_ACTION_PENDING_KEY`, `FIRST_REAL_ENTRY_KEY`, `SOFT_AUTH_DISMISSED_KEY`, `DEMO_BANNER_DISMISSED_KEY` | `src/core/onboarding/vibePicks.js` |
| `ONBOARDING_DONE_KEY` | `src/core/OnboardingWizard.jsx` |
| `DEMO_SEEDED_FLAG_KEY` | `src/core/onboarding/demoSeeds.js` |
| `hasAnyRealEntry` | `src/core/onboarding/firstRealEntry.js` |
| `authClient` | `src/core/authClient.js` |
| `getModuleVersions` | `src/core/cloudSync/state/versions.ts` |
| `buildContext` | `src/core/lib/hubChatContext.ts` |
| `cleanTextForSpeech` | `src/core/lib/hubChatSpeech.ts` |
| `HUB_PREFS_KEY`, `HubPrefs`, `loadHubPrefs`, `saveHubPref` | `src/core/settings/hubPrefs.ts` (public `useHubPref` kept) |
| `ChevronIcon`, `ChevronIconProps` | `src/core/settings/SettingsPrimitives.tsx` |
| `coachInsightQueryKey` | `src/core/useCoachInsight.js` |
| `getWeekRange`, `listDigestHistory`, `weeklyDigestQueryKey`, `weeklyDigestHistoryQueryKey` | `src/core/useWeeklyDigest.js` |
| `MANUAL_CATEGORY_ID_MAP` | `src/modules/finyk/domain/personalization.ts` |

### Fully removed (zero references, truly dead)

| Symbol | File |
|---|---|
| `registerAnalyticsProvider`, `resetAnalyticsProviders` + the now-orphaned `providers` array & `safeDispatch` helper | `src/core/analytics.js` |
| `DASHBOARD_DEFAULT_ORDER` | `src/core/HubDashboard.jsx` |
| `getMonthBudgetSummary` + `MonthBudgetOptions` interface | `src/modules/finyk/domain/budget.ts` |
| `buildCategoryLabelIndex` | `src/modules/finyk/domain/personalization.ts` |
| `billingDayFromTxTime` | `src/modules/finyk/domain/subscriptionUtils.js` |

### Intentionally skipped (from the audit list)

- **`SYNC_EVENT` / `SYNC_STATUS_EVENT`** — used in `useCloudSync.behavior.test.js`. Knip marked them unused from a production-import perspective, but they are live test contract.
- **`calcCategorySpent` / `getCategory` / `getIncomeCategory` / `resolveExpenseCategoryMeta`** re-exports in `src/modules/finyk/domain/categories.js` — documented intentional facade (see the file header comment); deferred to a separate policy decision.

## Review & Testing Checklist for Human

- [ ] Sanity-check the `src/core/analytics.js` cleanup — the analytics module still logs via `console.log` (stage 1 behavior unchanged), but the never-populated provider fan-out is gone.
- [ ] Confirm none of the stripped-`export` symbols are consumed by out-of-tree code (e.g. other repos / server worker).
- [ ] Smoke-test onboarding (wizard → demo seed → first real entry) and the Hub dashboard — all of those touched files still exercise the same storage keys, just as private constants.

### Notes

- `diff --stat`: **17 files, +24 / −126**.
- Full round-1 + round-2 running total: **8 files deleted, 140+ dead exports/aliases trimmed**, zero functional regressions.

Link to Devin session: https://app.devin.ai/sessions/ae709e1989f949e4a5a5e55bb86cb322
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
