### PR TITLE
test(nutrition): add unit tests for 4 RQ mutation hooks + regression tests for #189 fixes

### DIFF
--- a/src/modules/nutrition/hooks/useNutritionCloudBackup.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionCloudBackup.test.jsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../lib/nutritionApi.js", () => ({
+  backupUpload: vi.fn(),
+  backupDownload: vi.fn(),
+}));
+vi.mock("../domain/nutritionBackup.js", () => ({
+  buildNutritionBackupPayload: vi.fn(() => ({
+    version: 1,
+    log: { "2025-01-01": { meals: [] } },
+  })),
+  applyNutritionBackupPayload: vi.fn(),
+}));
+vi.mock("../lib/nutritionCloudBackup.js", () => ({
+  encryptJsonToBlob: vi.fn(() => Promise.resolve("ENC_BLOB")),
+  decryptBlobToJson: vi.fn(() => Promise.resolve({ version: 1, log: {} })),
+}));
+
+import { useNutritionCloudBackup } from "./useNutritionCloudBackup.js";
+import {
+  backupUpload as apiBackupUpload,
+  backupDownload as apiBackupDownload,
+} from "../lib/nutritionApi.js";
+import {
+  encryptJsonToBlob,
+  decryptBlobToJson,
+} from "../lib/nutritionCloudBackup.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function renderHarness(initial = {}) {
+  const toast = { success: vi.fn(), error: vi.fn() };
+  const setErr = vi.fn();
+  const setCloudBackupBusy = vi.fn();
+  const setBackupPasswordDialog = vi.fn();
+  const setRestoreConfirm = vi.fn();
+  const { result } = renderHook(
+    () =>
+      useNutritionCloudBackup({
+        toast,
+        setErr,
+        cloudBackupBusy: initial.cloudBackupBusy ?? false,
+        setCloudBackupBusy,
+        backupPasswordDialog: initial.backupPasswordDialog ?? null,
+        setBackupPasswordDialog,
+        setRestoreConfirm,
+      }),
+    { wrapper: makeWrapper() },
+  );
+  return {
+    result,
+    toast,
+    setErr,
+    setCloudBackupBusy,
+    setBackupPasswordDialog,
+    setRestoreConfirm,
+  };
+}
+
+describe("useNutritionCloudBackup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("dialog openers", () => {
+    it("uploadCloudBackup opens password dialog in 'upload' mode", () => {
+      const { result, setBackupPasswordDialog } = renderHarness();
+      act(() => {
+        result.current.uploadCloudBackup();
+      });
+      expect(setBackupPasswordDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "upload" }),
+      );
+    });
+
+    it("downloadCloudBackup opens password dialog in 'download' mode", () => {
+      const { result, setBackupPasswordDialog } = renderHarness();
+      act(() => {
+        result.current.downloadCloudBackup();
+      });
+      expect(setBackupPasswordDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "download" }),
+      );
+    });
+
+    it("does not open dialog while a backup is in flight", () => {
+      const { result, setBackupPasswordDialog } = renderHarness({
+        cloudBackupBusy: true,
+      });
+      act(() => {
+        result.current.uploadCloudBackup();
+        result.current.downloadCloudBackup();
+      });
+      expect(setBackupPasswordDialog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleBackupPasswordConfirm — upload", () => {
+    it("encrypts payload, posts to backup-upload, shows success toast", async () => {
+      apiBackupUpload.mockResolvedValueOnce({ ok: true });
+      const { result, toast, setBackupPasswordDialog } = renderHarness({
+        backupPasswordDialog: { mode: "upload" },
+      });
+
+      act(() => {
+        result.current.handleBackupPasswordConfirm("s3cret");
+      });
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("Бекап завантажено.");
+      });
+      expect(encryptJsonToBlob).toHaveBeenCalledWith(
+        expect.objectContaining({ version: 1 }),
+        "s3cret",
+      );
+      expect(apiBackupUpload).toHaveBeenCalledWith({ blob: "ENC_BLOB" });
+      // Dialog closed before mutation runs.
+      expect(setBackupPasswordDialog).toHaveBeenCalledWith(null);
+    });
+
+    it("surfaces upload error via setErr", async () => {
+      apiBackupUpload.mockRejectedValueOnce(new Error("Upload 500"));
+      const { result, setErr } = renderHarness({
+        backupPasswordDialog: { mode: "upload" },
+      });
+      act(() => {
+        result.current.handleBackupPasswordConfirm("s3cret");
+      });
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith("Upload 500");
+      });
+    });
+
+    it("no-op if pass is empty", () => {
+      const { result } = renderHarness({
+        backupPasswordDialog: { mode: "upload" },
+      });
+      act(() => {
+        result.current.handleBackupPasswordConfirm("");
+      });
+      expect(apiBackupUpload).not.toHaveBeenCalled();
+      expect(encryptJsonToBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleBackupPasswordConfirm — download", () => {
+    it("fetches blob, decrypts, and stashes payload in restoreConfirm", async () => {
+      apiBackupDownload.mockResolvedValueOnce({ blob: "REMOTE_BLOB" });
+      const { result, setRestoreConfirm } = renderHarness({
+        backupPasswordDialog: { mode: "download" },
+      });
+
+      act(() => {
+        result.current.handleBackupPasswordConfirm("s3cret");
+      });
+
+      await waitFor(() => {
+        expect(setRestoreConfirm).toHaveBeenCalledWith({
+          payload: { version: 1, log: {} },
+        });
+      });
+      expect(decryptBlobToJson).toHaveBeenCalledWith("REMOTE_BLOB", "s3cret");
+    });
+
+    it("surfaces download error via setErr", async () => {
+      apiBackupDownload.mockRejectedValueOnce(new Error("Download 404"));
+      const { result, setErr } = renderHarness({
+        backupPasswordDialog: { mode: "download" },
+      });
+      act(() => {
+        result.current.handleBackupPasswordConfirm("s3cret");
+      });
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith("Download 404");
+      });
+    });
+  });
+});

--- a/src/modules/nutrition/hooks/useNutritionPantries.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionPantries.test.jsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../lib/nutritionApi.js", () => ({
+  parsePantry: vi.fn(),
+}));
+
+import { useNutritionPantries } from "./useNutritionPantries.js";
+import { parsePantry as apiParsePantry } from "../lib/nutritionApi.js";
+import {
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_ACTIVE_PANTRY_KEY,
+} from "../lib/nutritionStorage.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function seedPantries(pantries, activeId) {
+  localStorage.setItem(NUTRITION_PANTRIES_KEY, JSON.stringify(pantries));
+  localStorage.setItem(NUTRITION_ACTIVE_PANTRY_KEY, String(activeId));
+}
+
+function renderHarness() {
+  const setBusy = vi.fn();
+  const setErr = vi.fn();
+  const setStatusText = vi.fn();
+  const { result } = renderHook(
+    () => useNutritionPantries({ setBusy, setErr, setStatusText }),
+    { wrapper: makeWrapper() },
+  );
+  return { result, setBusy, setErr, setStatusText };
+}
+
+describe("useNutritionPantries", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe("parsePantry validation", () => {
+    it("surfaces validation error when pantryText is empty", async () => {
+      seedPantries([{ id: "home", name: "Дім", items: [], text: "" }], "home");
+      const { result, setErr } = renderHarness();
+      act(() => {
+        result.current.parsePantry();
+      });
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith("Надиктуй/впиши список продуктів.");
+      });
+      expect(apiParsePantry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parsePantry happy path", () => {
+    it("posts text, merges parsed items into active pantry", async () => {
+      seedPantries(
+        [{ id: "home", name: "Дім", items: [], text: "молоко, яйця" }],
+        "home",
+      );
+      apiParsePantry.mockResolvedValueOnce({
+        items: [
+          { name: "молоко", qty: 1, unit: "л" },
+          { name: "яйця", qty: 10, unit: "шт" },
+        ],
+      });
+      const { result } = renderHarness();
+
+      act(() => {
+        result.current.parsePantry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.pantryItems.length).toBe(2);
+      });
+      expect(result.current.pantryItems.map((x) => x.name)).toEqual([
+        "молоко",
+        "яйця",
+      ]);
+      // text cleared after successful parse
+      expect(result.current.pantryText).toBe("");
+      expect(apiParsePantry).toHaveBeenCalledWith({
+        text: "молоко, яйця",
+        locale: "uk-UA",
+      });
+    });
+  });
+
+  describe("regression: pantryId captured at mutate-time (issue #189)", () => {
+    it("merges parsed items into the ORIGINAL pantry even if user switches active pantry mid-flight", async () => {
+      seedPantries(
+        [
+          { id: "home", name: "Дім", items: [], text: "молоко" },
+          { id: "work", name: "Робота", items: [], text: "" },
+        ],
+        "home",
+      );
+
+      // Deferred promise — we resolve after the user switches pantries.
+      let resolveParse;
+      apiParsePantry.mockImplementationOnce(
+        () =>
+          new Promise((res) => {
+            resolveParse = res;
+          }),
+      );
+
+      const { result } = renderHarness();
+      expect(result.current.activePantryId).toBe("home");
+
+      // Kick off parse — captures pantryId = "home" at mutate-time.
+      act(() => {
+        result.current.parsePantry();
+      });
+      // Wait for mutationFn to actually invoke the mock (resolveParse set).
+      await waitFor(() => expect(apiParsePantry).toHaveBeenCalled());
+
+      // User switches to "work" while API is still in flight.
+      act(() => {
+        result.current.setActivePantryId("work");
+      });
+      expect(result.current.activePantryId).toBe("work");
+
+      // Now resolve — items must still go to "home", not "work".
+      await act(async () => {
+        resolveParse({ items: [{ name: "молоко", qty: 1, unit: "л" }] });
+      });
+
+      await waitFor(() => {
+        const home = result.current.pantries.find((p) => p.id === "home");
+        expect(home?.items?.length).toBe(1);
+      });
+
+      const home = result.current.pantries.find((p) => p.id === "home");
+      const work = result.current.pantries.find((p) => p.id === "work");
+      expect(home.items[0].name).toBe("молоко");
+      expect(work.items).toEqual([]);
+      // Active remained "work" (user's choice).
+      expect(result.current.activePantryId).toBe("work");
+    });
+  });
+});

--- a/src/modules/nutrition/hooks/useNutritionRemoteActions.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionRemoteActions.test.jsx
@@ -1,0 +1,409 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../lib/nutritionApi.js", () => ({
+  recommendRecipes: vi.fn(),
+  fetchWeekPlan: vi.fn(),
+  fetchDayHint: vi.fn(),
+  fetchDayPlan: vi.fn(),
+  fetchShoppingList: vi.fn(),
+}));
+vi.mock("../lib/recipeCache.js", () => ({
+  writeRecipeCache: vi.fn(),
+}));
+
+import { useNutritionRemoteActions } from "./useNutritionRemoteActions.js";
+import {
+  recommendRecipes as apiRecommendRecipes,
+  fetchWeekPlan as apiFetchWeekPlan,
+  fetchDayHint as apiFetchDayHint,
+  fetchDayPlan as apiFetchDayPlan,
+  fetchShoppingList as apiFetchShoppingList,
+} from "../lib/nutritionApi.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function makeHarness(overrides = {}) {
+  const setBusy = vi.fn();
+  const setErr = vi.fn();
+  const setStatusText = vi.fn();
+  const setRecipes = vi.fn();
+  const setRecipesRaw = vi.fn();
+  const setRecipesTried = vi.fn();
+  const setWeekPlan = vi.fn();
+  const setWeekPlanRaw = vi.fn();
+  const setWeekPlanBusy = vi.fn();
+  const setDayPlan = vi.fn();
+  const setDayPlanBusy = vi.fn();
+  const setDayHintBusy = vi.fn();
+  const setDayHintText = vi.fn();
+  const setShoppingBusy = vi.fn();
+  const setGeneratedList = vi.fn();
+
+  const base = {
+    setBusy,
+    setErr,
+    setStatusText,
+    pantry: { effectiveItems: [{ name: "яйця", qty: 10, unit: "шт" }] },
+    prefs: {
+      goal: "balanced",
+      servings: 2,
+      timeMinutes: 30,
+      exclude: "",
+      dailyTargetKcal: 2000,
+      dailyTargetProtein_g: 120,
+      dailyTargetFat_g: 70,
+      dailyTargetCarbs_g: 200,
+    },
+    recipes: [],
+    setRecipes,
+    setRecipesRaw,
+    setRecipesTried,
+    recipeCacheKey: "k",
+    weekPlan: null,
+    setWeekPlan,
+    setWeekPlanRaw,
+    setWeekPlanBusy,
+    setDayPlan,
+    setDayPlanBusy,
+    setDayHintBusy,
+    setDayHintText,
+    log: {
+      nutritionLog: {},
+      selectedDate: "2025-01-01",
+      handleAddMeal: vi.fn(),
+    },
+    shopping: { setGeneratedList },
+    setShoppingBusy,
+    ...overrides,
+  };
+
+  const { result, rerender } = renderHook((p) => useNutritionRemoteActions(p), {
+    wrapper: makeWrapper(),
+    initialProps: base,
+  });
+  return {
+    result,
+    rerender,
+    base,
+    spies: {
+      setBusy,
+      setErr,
+      setStatusText,
+      setRecipes,
+      setRecipesRaw,
+      setRecipesTried,
+      setWeekPlan,
+      setWeekPlanRaw,
+      setWeekPlanBusy,
+      setDayPlan,
+      setDayPlanBusy,
+      setDayHintBusy,
+      setDayHintText,
+      setShoppingBusy,
+      setGeneratedList,
+    },
+  };
+}
+
+describe("useNutritionRemoteActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("recommendRecipes", () => {
+    it("posts items + preferences and feeds result through setters", async () => {
+      apiRecommendRecipes.mockResolvedValueOnce({
+        recipes: [
+          { id: "r1", name: "Омлет", kcal: 300 },
+          { name: "Яєчня" /* no id — derive */ },
+        ],
+        rawText: "raw blob",
+      });
+      const { result, spies } = makeHarness();
+
+      act(() => {
+        result.current.recommendRecipes();
+      });
+
+      await waitFor(() => expect(spies.setRecipes).toHaveBeenCalled());
+      const pushed = spies.setRecipes.mock.calls.at(-1)[0];
+      expect(pushed).toHaveLength(2);
+      expect(pushed[0].id).toBe("r1");
+      expect(pushed[1].id).toBeTruthy(); // derived id
+      expect(spies.setRecipesRaw).toHaveBeenCalledWith("raw blob");
+      expect(spies.setRecipesTried).toHaveBeenCalledWith(true);
+      expect(apiRecommendRecipes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: expect.any(Array),
+          preferences: expect.objectContaining({
+            goal: "balanced",
+            locale: "uk-UA",
+          }),
+        }),
+      );
+    });
+
+    it("throws validation error when pantry is empty", async () => {
+      const { result, spies } = makeHarness({ pantry: { effectiveItems: [] } });
+      act(() => {
+        result.current.recommendRecipes();
+      });
+      await waitFor(() => {
+        expect(spies.setErr).toHaveBeenCalledWith(
+          "Дай хоча б 2–3 продукти для рецептів.",
+        );
+      });
+      expect(apiRecommendRecipes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchWeekPlan", () => {
+    it("sets week plan + raw text on success", async () => {
+      apiFetchWeekPlan.mockResolvedValueOnce({
+        plan: { days: [{ day: 1 }] },
+        rawText: "wk-raw",
+      });
+      const { result, spies } = makeHarness();
+      act(() => {
+        result.current.fetchWeekPlan();
+      });
+      await waitFor(() =>
+        expect(spies.setWeekPlan).toHaveBeenCalledWith({ days: [{ day: 1 }] }),
+      );
+      expect(spies.setWeekPlanRaw).toHaveBeenCalledWith("wk-raw");
+    });
+
+    it("throws when pantry is empty", async () => {
+      const { result, spies } = makeHarness({ pantry: { effectiveItems: [] } });
+      act(() => {
+        result.current.fetchWeekPlan();
+      });
+      await waitFor(() =>
+        expect(spies.setErr).toHaveBeenCalledWith("Додай продукти на склад."),
+      );
+      expect(apiFetchWeekPlan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchDayHint", () => {
+    it("skips network and emits synthetic hint when day has no meals", async () => {
+      const { result, spies } = makeHarness();
+      act(() => {
+        result.current.fetchDayHint();
+      });
+      await waitFor(() =>
+        expect(spies.setDayHintText).toHaveBeenCalledWith(
+          "День порожній. Додай прийом їжі — і я зможу дати підказку.",
+        ),
+      );
+      expect(apiFetchDayHint).not.toHaveBeenCalled();
+    });
+
+    it("calls API when day has meals and feeds hint to setter", async () => {
+      apiFetchDayHint.mockResolvedValueOnce({ hint: "Додай білка" });
+      const { result, spies } = makeHarness({
+        log: {
+          nutritionLog: {
+            "2025-01-01": {
+              meals: [
+                {
+                  id: "m1",
+                  mealType: "breakfast",
+                  macros: { kcal: 300, protein_g: 20, fat_g: 10, carbs_g: 30 },
+                  macroSource: "manual",
+                },
+              ],
+            },
+          },
+          selectedDate: "2025-01-01",
+          handleAddMeal: vi.fn(),
+        },
+      });
+      act(() => {
+        result.current.fetchDayHint();
+      });
+      await waitFor(() =>
+        expect(spies.setDayHintText).toHaveBeenCalledWith("Додай білка"),
+      );
+      expect(apiFetchDayHint).toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchDayPlan", () => {
+    it("sets the returned plan on success (no regenerate)", async () => {
+      const plan = {
+        meals: [
+          { type: "breakfast", name: "Омлет", kcal: 300 },
+          { type: "lunch", name: "Борщ", kcal: 500 },
+        ],
+        totalKcal: 800,
+      };
+      apiFetchDayPlan.mockResolvedValueOnce({ plan });
+      const { result, spies } = makeHarness();
+
+      act(() => {
+        result.current.fetchDayPlan();
+      });
+      await waitFor(() => expect(spies.setDayPlan).toHaveBeenCalled());
+
+      // Functional setState — call the updater with null prev to see the
+      // "plain replace" branch.
+      const updater = spies.setDayPlan.mock.calls.at(-1)[0];
+      expect(typeof updater).toBe("function");
+      expect(updater(null)).toEqual(plan);
+    });
+
+    it("throws when server returns empty plan", async () => {
+      apiFetchDayPlan.mockResolvedValueOnce({ plan: null });
+      const { result, spies } = makeHarness();
+      act(() => {
+        result.current.fetchDayPlan();
+      });
+      await waitFor(() =>
+        expect(spies.setErr).toHaveBeenCalledWith(
+          "Не вдалося отримати план харчування",
+        ),
+      );
+    });
+  });
+
+  describe("regression: fetchDayPlan regenerateMealType (issue #189)", () => {
+    it("uses functional setDayPlan so merge happens against LATEST state, not stale closure", async () => {
+      // Simulates regenerating only the `lunch` meal while breakfast/dinner
+      // already exist in the prior plan. The merge must preserve breakfast
+      // and dinner from `prev`, replace lunch, and recompute totals.
+      apiFetchDayPlan.mockResolvedValueOnce({
+        plan: {
+          meals: [
+            {
+              type: "lunch",
+              name: "Новий суп",
+              kcal: 400,
+              protein_g: 30,
+              fat_g: 10,
+              carbs_g: 40,
+            },
+          ],
+        },
+      });
+      const { result, spies } = makeHarness();
+
+      act(() => {
+        result.current.fetchDayPlan("lunch");
+      });
+      await waitFor(() => expect(spies.setDayPlan).toHaveBeenCalled());
+
+      const updater = spies.setDayPlan.mock.calls.at(-1)[0];
+      expect(typeof updater).toBe("function");
+
+      // Simulate "latest committed state" — stale closure would have missed
+      // these recent edits entirely.
+      const latestPrev = {
+        meals: [
+          {
+            type: "breakfast",
+            name: "Омлет",
+            kcal: 300,
+            protein_g: 20,
+            fat_g: 15,
+            carbs_g: 10,
+          },
+          {
+            type: "lunch",
+            name: "СТАРИЙ",
+            kcal: 999,
+            protein_g: 1,
+            fat_g: 1,
+            carbs_g: 1,
+          },
+          {
+            type: "dinner",
+            name: "Риба",
+            kcal: 500,
+            protein_g: 40,
+            fat_g: 20,
+            carbs_g: 10,
+          },
+        ],
+        totalKcal: 1799,
+      };
+
+      const merged = updater(latestPrev);
+      const byType = Object.fromEntries(merged.meals.map((m) => [m.type, m]));
+
+      // Breakfast + dinner preserved from prev.
+      expect(byType.breakfast.name).toBe("Омлет");
+      expect(byType.dinner.name).toBe("Риба");
+      // Lunch replaced by regenerated meal.
+      expect(byType.lunch.name).toBe("Новий суп");
+      // Totals recomputed off merged meals, not prev's stale totalKcal.
+      expect(merged.totalKcal).toBe(300 + 400 + 500);
+      expect(merged.totalProtein_g).toBe(20 + 30 + 40);
+      expect(merged.totalFat_g).toBe(15 + 10 + 20);
+      expect(merged.totalCarbs_g).toBe(10 + 40 + 10);
+    });
+
+    it("falls back to plain replace when prev has no meals (first-time generate)", async () => {
+      const plan = {
+        meals: [{ type: "breakfast", name: "Only meal", kcal: 100 }],
+        totalKcal: 100,
+      };
+      apiFetchDayPlan.mockResolvedValueOnce({ plan });
+      const { result, spies } = makeHarness();
+
+      act(() => {
+        // Even though regenerate is requested, prev has no meals → replace.
+        result.current.fetchDayPlan("breakfast");
+      });
+      await waitFor(() => expect(spies.setDayPlan).toHaveBeenCalled());
+
+      const updater = spies.setDayPlan.mock.calls.at(-1)[0];
+      expect(updater({ meals: [] })).toEqual(plan);
+      expect(updater(null)).toEqual(plan);
+    });
+  });
+
+  describe("generateShoppingList", () => {
+    it("throws if neither recipes nor weekPlan available", async () => {
+      const { result, spies } = makeHarness();
+      act(() => {
+        result.current.generateShoppingList("weekplan");
+      });
+      await waitFor(() =>
+        expect(spies.setErr).toHaveBeenCalledWith(
+          "Немає рецептів чи тижневого плану для генерації.",
+        ),
+      );
+      expect(apiFetchShoppingList).not.toHaveBeenCalled();
+    });
+
+    it("posts recipes when source fallback and feeds categories to shopping", async () => {
+      apiFetchShoppingList.mockResolvedValueOnce({
+        categories: [{ name: "Овочі", items: [] }],
+      });
+      const { result, spies } = makeHarness({
+        recipes: [{ id: "r1", name: "Омлет" }],
+      });
+      act(() => {
+        result.current.generateShoppingList("recipes");
+      });
+      await waitFor(() =>
+        expect(spies.setGeneratedList).toHaveBeenCalledWith([
+          { name: "Овочі", items: [] },
+        ]),
+      );
+    });
+  });
+});

--- a/src/modules/nutrition/hooks/usePhotoAnalysis.test.jsx
+++ b/src/modules/nutrition/hooks/usePhotoAnalysis.test.jsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../lib/nutritionApi.js", () => ({
+  analyzePhoto: vi.fn(),
+  refinePhoto: vi.fn(),
+}));
+vi.mock("../lib/fileToBase64.js", () => ({
+  fileToBase64: vi.fn(() => Promise.resolve("BASE64")),
+}));
+
+import { usePhotoAnalysis } from "./usePhotoAnalysis.js";
+import {
+  analyzePhoto as apiAnalyzePhoto,
+  refinePhoto as apiRefinePhoto,
+} from "../lib/nutritionApi.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function renderUsePhotoAnalysis() {
+  const setBusy = vi.fn();
+  const setErr = vi.fn();
+  const setStatusText = vi.fn();
+  const { result } = renderHook(
+    () => usePhotoAnalysis({ setBusy, setErr, setStatusText }),
+    { wrapper: makeWrapper() },
+  );
+  return { result, setBusy, setErr, setStatusText };
+}
+
+// Stub fileRef.current so analyzeMutation reads file.
+function attachFile(result, file) {
+  // fileRef is a ref object; hook returns it directly.
+  result.current.fileRef.current = { files: [file] };
+}
+
+function fakeImageFile() {
+  // jsdom File is fine
+  return new File([new Uint8Array([1, 2, 3])], "meal.jpg", {
+    type: "image/jpeg",
+  });
+}
+
+describe("usePhotoAnalysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("analyzePhoto", () => {
+    it("posts image payload and stores photoResult on success", async () => {
+      apiAnalyzePhoto.mockResolvedValueOnce({
+        result: { name: "Борщ", kcal: 300 },
+      });
+      const { result, setBusy, setErr } = renderUsePhotoAnalysis();
+      attachFile(result, fakeImageFile());
+
+      act(() => {
+        result.current.analyzePhoto();
+      });
+
+      await waitFor(() => {
+        expect(result.current.photoResult).toEqual({
+          name: "Борщ",
+          kcal: 300,
+        });
+      });
+
+      expect(apiAnalyzePhoto).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image_base64: "BASE64",
+          mime_type: "image/jpeg",
+          locale: "uk-UA",
+        }),
+      );
+      expect(result.current.lastPhotoPayload).toEqual(
+        expect.objectContaining({ image_base64: "BASE64" }),
+      );
+      // Lifecycle flags toggled.
+      expect(setBusy).toHaveBeenCalledWith(true);
+      expect(setBusy).toHaveBeenLastCalledWith(false);
+      expect(setErr).toHaveBeenCalledWith("");
+    });
+
+    it("surfaces error when no file is selected", async () => {
+      const { result, setErr } = renderUsePhotoAnalysis();
+      // no file attached
+      act(() => {
+        result.current.analyzePhoto();
+      });
+
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith("Спочатку обери фото.");
+      });
+      expect(apiAnalyzePhoto).not.toHaveBeenCalled();
+    });
+
+    it("surfaces API error message via setErr", async () => {
+      apiAnalyzePhoto.mockRejectedValueOnce(new Error("Сервер AI впав"));
+      const { result, setErr } = renderUsePhotoAnalysis();
+      attachFile(result, fakeImageFile());
+
+      act(() => {
+        result.current.analyzePhoto();
+      });
+
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith("Сервер AI впав");
+      });
+      expect(result.current.photoResult).toBeNull();
+    });
+  });
+
+  describe("refinePhoto", () => {
+    it("throws before any analyze has run (no lastPhotoPayload)", async () => {
+      const { result, setErr } = renderUsePhotoAnalysis();
+      act(() => {
+        result.current.refinePhoto();
+      });
+      await waitFor(() => {
+        expect(setErr).toHaveBeenCalledWith(
+          "Немає вихідного фото. Спочатку зроби аналіз.",
+        );
+      });
+      expect(apiRefinePhoto).not.toHaveBeenCalled();
+    });
+
+    it("reuses lastPhotoPayload and updates photoResult", async () => {
+      apiAnalyzePhoto.mockResolvedValueOnce({
+        result: { name: "v1", questions: ["Яка порція?"] },
+      });
+      apiRefinePhoto.mockResolvedValueOnce({
+        result: { name: "v2", kcal: 420 },
+      });
+      const { result } = renderUsePhotoAnalysis();
+      attachFile(result, fakeImageFile());
+
+      act(() => {
+        result.current.analyzePhoto();
+      });
+      await waitFor(() => expect(result.current.photoResult?.name).toBe("v1"));
+
+      act(() => {
+        result.current.setPortionGrams("250");
+        result.current.setAnswers((a) => ({ ...a, "Яка порція?": "звичайна" }));
+      });
+
+      act(() => {
+        result.current.refinePhoto();
+      });
+      await waitFor(() => expect(result.current.photoResult?.name).toBe("v2"));
+
+      expect(apiRefinePhoto).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image_base64: "BASE64",
+          portion_grams: 250,
+          qna: [{ question: "Яка порція?", answer: "звичайна" }],
+          locale: "uk-UA",
+        }),
+      );
+    });
+  });
+
+  describe("onPickPhoto", () => {
+    it("rejects non-image files", async () => {
+      const { result, setErr } = renderUsePhotoAnalysis();
+      const txt = new File(["hello"], "note.txt", { type: "text/plain" });
+      await act(async () => {
+        await result.current.onPickPhoto(txt);
+      });
+      expect(setErr).toHaveBeenCalledWith(
+        "Обери файл зображення (jpg/png/heic).",
+      );
+    });
+
+    it("rejects oversized files", async () => {
+      const { result, setErr } = renderUsePhotoAnalysis();
+      // 5 MB image — above 4.5 MB cap
+      const big = new File([new Uint8Array(5 * 1024 * 1024)], "big.jpg", {
+        type: "image/jpeg",
+      });
+      await act(async () => {
+        await result.current.onPickPhoto(big);
+      });
+      expect(setErr).toHaveBeenCalledWith(
+        "Фото завелике для швидкого аналізу. Обріж або стисни (≈ до 4 МБ).",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the 4 nutrition hooks migrated to React Query `useMutation` in #184 and tightened in #189. Total: **30 new tests** (604 → 634). No production code changed.

| Hook | Tests | Coverage |
|---|---:|---|
| `usePhotoAnalysis` | 7 | `analyze`/`refine` happy paths, file validation (non-image, oversize), "no file"/"no prior analyze" guards, lifecycle flags |
| `useNutritionCloudBackup` | 8 | Upload/download encrypt flow, dialog openers, busy-guard, empty-password no-op, error surfacing |
| `useNutritionPantries` | 3 | `parsePantry` validation + happy path + **pantry-race regression** |
| `useNutritionRemoteActions` | 12 | `recommendRecipes` / `fetchWeekPlan` / `fetchDayHint` / `fetchDayPlan` / `generateShoppingList` — happy paths, validation throws, synthetic-hint path, + **dayPlan-regenerate regression** |

### Regression coverage for #189 closure-capture bugs

1. **`parsePantry` pantry-race** — test kicks off `parsePantry()` with `active = "home"`, switches `activePantryId` to `"work"` mid-flight, then resolves the deferred API. Verifies items merged into **"home"** (the pantry the user was looking at when they pressed the button), not the current `"work"` pantry. Pantryid must be captured at mutate-time via `mutate({ pantryId, text })`, not read from closure in `onSuccess`.

2. **`fetchDayPlan` regenerate-race** — test asserts `setDayPlan` is called with a **function** (not object), then invokes that updater against a simulated "latest committed state" to verify the merge preserves breakfast/dinner from `prev`, replaces lunch with the regenerated meal, and recomputes totals off the merged meals (not `prev.totalKcal`). Functional `setState` ensures the merge happens against the latest committed state even if rapid sequential regenerates race.

## Review & Testing Checklist for Human

- [ ] Skim the two regression tests (`useNutritionPantries.test.jsx` "issue #189" block and `useNutritionRemoteActions.test.jsx` "regression: fetchDayPlan regenerateMealType") and confirm they actually exercise the bug shape that was fixed — i.e. that they would fail if someone reverted the fix.
- [ ] Confirm `npm test` runs 634 tests green locally.

### Notes

- Test pattern follows <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/hooks/useNutritionLog.test.jsx" />: `@vitest-environment jsdom`, shared `makeWrapper()` that provides `QueryClientProvider`, `vi.mock("../lib/nutritionApi.js", ...)` for deterministic API responses, deferred-promise pattern for mid-flight race tests.
- No production code touched — hooks' external APIs weren't changed.
- Remaining known follow-up: mono/privat sync-engine migration to RQ (needs design first; not in scope here).


Link to Devin session: https://app.devin.ai/sessions/e3a4d57196374ee5b3bc3dec3b9f9f2e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
