### PR TITLE
refactor(ui): snap text-[11/15px] to scale + extend Card to &lt;section&gt; wrappers

### DIFF
--- a/src/core/AuthPage.jsx
+++ b/src/core/AuthPage.jsx
@@ -177,7 +177,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
 
         {typeof onContinueWithoutAccount === "function" && (
           <>
-            <div className="my-6 flex items-center gap-3 text-[11px] text-muted uppercase tracking-wider">
+            <div className="my-6 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
               <span className="flex-1 h-px bg-line" />
               або
               <span className="flex-1 h-px bg-line" />
@@ -191,7 +191,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
             >
               Продовжити без акаунту
             </Button>
-            <p className="mt-2 text-center text-[11px] text-subtle leading-relaxed">
+            <p className="mt-2 text-center text-xs text-subtle leading-relaxed">
               Все працює локально. Акаунт потрібен лише для синхронізації між
               пристроями.
             </p>

--- a/src/core/HubBackupPanel.jsx
+++ b/src/core/HubBackupPanel.jsx
@@ -45,7 +45,7 @@ export function HubBackupPanel({ className }) {
       <p className="font-semibold text-text leading-snug">
         Резервна копія всього Hub (Фінік, Фізрук, Рутина, останній модуль).
       </p>
-      <p className="leading-relaxed text-[11px]">
+      <p className="leading-relaxed text-xs">
         Токен Monobank і кеш транзакцій не входять у файл — після імпорту
         підключи рахунок знову в Фініку.
       </p>

--- a/src/core/HubChat.jsx
+++ b/src/core/HubChat.jsx
@@ -519,7 +519,7 @@ function HubChat({ onClose, initialMessage }) {
         {!online && (
           <div
             role="status"
-            className="mx-4 mb-2 mt-1 px-3 py-2 bg-warning/10 border border-warning/30 rounded-xl text-[11px] text-warning text-center shrink-0"
+            className="mx-4 mb-2 mt-1 px-3 py-2 bg-warning/10 border border-warning/30 rounded-xl text-xs text-warning text-center shrink-0"
           >
             Асистент недоступний без інтернету. Дані модулів видно офлайн, але
             AI-відповіді потребують підключення.

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -519,7 +519,7 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
 
       {/* Today at a glance — compact module list (replaces the 2×2 grid) */}
       <section className="space-y-2">
-        <h2 className="px-0.5 text-[11px] font-semibold text-muted uppercase tracking-wider">
+        <h2 className="px-0.5 text-xs font-semibold text-muted uppercase tracking-wider">
           Сьогодні
         </h2>
 

--- a/src/core/HubInsightsPanel.jsx
+++ b/src/core/HubInsightsPanel.jsx
@@ -69,7 +69,7 @@ function RecRow({ rec, onAction, onDismiss }) {
           <button
             type="button"
             onClick={() => onAction(rec.action)}
-            className="mt-1.5 inline-flex items-center gap-1 text-[11px] font-semibold text-text hover:text-primary transition-colors"
+            className="mt-1.5 inline-flex items-center gap-1 text-xs font-semibold text-text hover:text-primary transition-colors"
           >
             Відкрити
             <Icon name="chevron-right" size={12} strokeWidth={2.5} />
@@ -137,7 +137,7 @@ function CoachRow({ insight, loading, error, onDiscuss, onRefresh }) {
           <button
             type="button"
             onClick={onDiscuss}
-            className="mt-1.5 inline-flex items-center gap-1 text-[11px] font-semibold text-text hover:text-primary transition-colors"
+            className="mt-1.5 inline-flex items-center gap-1 text-xs font-semibold text-text hover:text-primary transition-colors"
           >
             Обговорити
             <Icon name="chevron-right" size={12} strokeWidth={2.5} />

--- a/src/core/HubSearch.jsx
+++ b/src/core/HubSearch.jsx
@@ -321,7 +321,7 @@ export function HubSearch({ onClose, onOpenModule }) {
 
         {Object.entries(grouped).map(([moduleId, group]) => (
           <div key={moduleId}>
-            <p className="text-[11px] font-semibold text-muted uppercase tracking-wider mb-1.5">
+            <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-1.5">
               {group.label}
             </p>
             <div className="space-y-1">

--- a/src/core/WeeklyDigestCard.jsx
+++ b/src/core/WeeklyDigestCard.jsx
@@ -91,7 +91,7 @@ function ModuleBlock({ moduleKey, data }) {
       >
         <div
           className={cn(
-            "w-6 h-6 rounded-lg flex items-center justify-center text-[11px] shrink-0",
+            "w-6 h-6 rounded-lg flex items-center justify-center text-xs shrink-0",
             cfg.bgClass,
           )}
         >
@@ -100,9 +100,7 @@ function ModuleBlock({ moduleKey, data }) {
         <div className="flex-1 min-w-0 text-left">
           <span className="text-xs font-semibold text-text">{cfg.label}</span>
           {data.summary && (
-            <p className="text-[11px] text-muted truncate mt-0.5">
-              {data.summary}
-            </p>
+            <p className="text-xs text-muted truncate mt-0.5">{data.summary}</p>
           )}
         </div>
         <ChevronIcon expanded={open} />
@@ -134,7 +132,7 @@ function ModuleBlock({ moduleKey, data }) {
                       >
                         →
                       </span>
-                      <span className="text-[11px] text-text leading-snug">
+                      <span className="text-xs text-text leading-snug">
                         {rec}
                       </span>
                     </div>
@@ -277,7 +275,7 @@ function DigestContent({
                       <span className="text-2xs font-bold text-primary mt-0.5 shrink-0">
                         ★
                       </span>
-                      <span className="text-[11px] text-text leading-snug">
+                      <span className="text-xs text-text leading-snug">
                         {rec}
                       </span>
                     </div>
@@ -374,7 +372,7 @@ export function WeeklyDigestCard() {
         </div>
         <div className="flex-1 min-w-0">
           <div className="text-sm font-bold text-text">Звіт тижня</div>
-          <div className="text-[11px] text-muted mt-0.5">{weekRange}</div>
+          <div className="text-xs text-muted mt-0.5">{weekRange}</div>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           {digest?.generatedAt && (
@@ -430,7 +428,7 @@ export function WeeklyDigestCard() {
                   setShowHistory(false);
                 }}
                 className={cn(
-                  "px-2.5 py-1 rounded-lg text-[11px] font-semibold transition-colors",
+                  "px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors",
                   selectedWeekKey === h.weekKey
                     ? "bg-primary/15 text-primary"
                     : "bg-panelHi text-muted hover:text-text",
@@ -451,7 +449,7 @@ export function WeeklyDigestCard() {
           <button
             type="button"
             onClick={() => setSelectedWeekKey(currentWeekKey)}
-            className="text-[11px] text-primary hover:underline"
+            className="text-xs text-primary hover:underline"
           >
             ← Поточний тиждень
           </button>

--- a/src/core/WeeklyDigestStories.jsx
+++ b/src/core/WeeklyDigestStories.jsx
@@ -163,7 +163,7 @@ function IntroSlide({ slide }) {
         <h2 className="text-[40px] leading-[1.05] font-black mb-4">
           Твій тиждень
         </h2>
-        <p className="text-[15px] text-white/85 leading-relaxed max-w-[22rem]">
+        <p className="text-base text-white/85 leading-relaxed max-w-[22rem]">
           Коротке зведення по всіх модулях. Тапай праворуч, щоб гортати далі,
           ліворуч — назад. Утримуй, щоб зупинити.
         </p>
@@ -202,7 +202,7 @@ function FinykSlide({ slide }) {
 
       {topCats.length > 0 && (
         <div className="mb-6 space-y-2">
-          <p className="text-[11px] uppercase tracking-wider text-white/75 font-bold">
+          <p className="text-xs uppercase tracking-wider text-white/75 font-bold">
             Куди пішли гроші
           </p>
           {topCats.map((c) => {
@@ -265,7 +265,7 @@ function FizrukSlide({ slide }) {
 
       <div className="grid grid-cols-2 gap-3 mb-6">
         <div className="rounded-2xl bg-white/15 border border-white/20 px-4 py-3">
-          <div className="text-[11px] uppercase tracking-wider text-white/75 font-bold">
+          <div className="text-xs uppercase tracking-wider text-white/75 font-bold">
             Тренувань
           </div>
           <div className="text-[36px] leading-none font-black tabular-nums mt-1">
@@ -273,7 +273,7 @@ function FizrukSlide({ slide }) {
           </div>
         </div>
         <div className="rounded-2xl bg-white/15 border border-white/20 px-4 py-3">
-          <div className="text-[11px] uppercase tracking-wider text-white/75 font-bold">
+          <div className="text-xs uppercase tracking-wider text-white/75 font-bold">
             Обсяг, кг
           </div>
           <div className="text-[36px] leading-none font-black tabular-nums mt-1">
@@ -284,7 +284,7 @@ function FizrukSlide({ slide }) {
 
       {topEx.length > 0 && (
         <div className="mb-4">
-          <p className="text-[11px] uppercase tracking-wider text-white/75 font-bold mb-2">
+          <p className="text-xs uppercase tracking-wider text-white/75 font-bold mb-2">
             Головні вправи
           </p>
           <div className="space-y-1">
@@ -353,7 +353,7 @@ function NutritionSlide({ slide }) {
             style={{ width: `${Math.min(100, kcalPct)}%` }}
           />
         </div>
-        <div className="text-[11px] text-white/75 mt-1">
+        <div className="text-xs text-white/75 mt-1">
           {kcalPct}% від цілі · залоговано {agg?.daysLogged ?? 0} / 7 днів
         </div>
       </div>
@@ -455,7 +455,7 @@ function RoutineSlide({ slide }) {
 
       {top.length > 0 && (
         <div className="mb-4 space-y-2">
-          <p className="text-[11px] uppercase tracking-wider text-white/75 font-bold">
+          <p className="text-xs uppercase tracking-wider text-white/75 font-bold">
             Топ-звички
           </p>
           {top.map((h) => (

--- a/src/core/components/ChatMessage.jsx
+++ b/src/core/components/ChatMessage.jsx
@@ -32,7 +32,7 @@ export function ChatMessage({ message, onSpeak }) {
               speak(text);
               onSpeak?.();
             }}
-            className="mt-1.5 flex items-center gap-1 text-[11px] text-subtle hover:text-text transition-colors"
+            className="mt-1.5 flex items-center gap-1 text-xs text-subtle hover:text-text transition-colors"
             title="Озвучити"
             aria-label="Озвучити відповідь"
           >

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -84,7 +84,7 @@ export function FirstActionHeroCard({ onDismiss }) {
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle">
+          <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
             Старт
           </div>
           <h2 className="text-base font-bold text-text mt-0.5">

--- a/src/core/settings/AIDigestSection.tsx
+++ b/src/core/settings/AIDigestSection.tsx
@@ -30,14 +30,14 @@ export function AIDigestSection() {
   return (
     <SettingsGroup title="AI Звіт тижня" emoji="📋">
       <div className="space-y-3">
-        <p className="text-[11px] text-subtle leading-snug">
+        <p className="text-xs text-subtle leading-snug">
           Тижневий AI-аналіз прогресу по всіх модулях: фінанси, тренування,
           харчування та звички. Звіт доступний на дашборді щопонеділка або за
           запитом.
         </p>
         <div className="p-3 rounded-xl bg-bg border border-line">
           <p className="text-xs font-semibold text-text">Поточний тиждень</p>
-          <p className="text-[11px] text-muted mt-0.5">{weekRange}</p>
+          <p className="text-xs text-muted mt-0.5">{weekRange}</p>
           {generatedAt && (
             <p className="text-2xs text-subtle mt-1">
               Згенеровано: {generatedAt}

--- a/src/core/settings/ExperimentalSection.tsx
+++ b/src/core/settings/ExperimentalSection.tsx
@@ -13,7 +13,7 @@ export function ExperimentalSection() {
 
   return (
     <SettingsGroup title="Експериментальне" emoji="🧪">
-      <p className="text-[11px] text-subtle leading-snug">
+      <p className="text-xs text-subtle leading-snug">
         Ці можливості ще тестуються. Вмикайте на свій ризик — поведінка може
         змінитись у наступних версіях.
       </p>

--- a/src/core/settings/FinykSection.tsx
+++ b/src/core/settings/FinykSection.tsx
@@ -225,7 +225,7 @@ export function FinykSection() {
       />
 
       <SettingsSubGroup title="Власні категорії витрат">
-        <p className="text-[11px] text-subtle leading-snug">
+        <p className="text-xs text-subtle leading-snug">
           Додаються до списку категорій у транзакціях, сплітах і лімітах (можна
           вказати емодзі на початку назви).
         </p>
@@ -280,7 +280,7 @@ export function FinykSection() {
 
       {uahAccounts.length > 0 && (
         <SettingsSubGroup title="Рахунки">
-          <p className="text-[11px] text-subtle leading-snug">
+          <p className="text-xs text-subtle leading-snug">
             Сховані рахунки не враховуються у балансі та нетворсі.
           </p>
           <div className="space-y-0 -mx-4">
@@ -354,7 +354,7 @@ export function FinykSection() {
       )}
 
       <SettingsSubGroup title="Сервіс">
-        <p className="text-[11px] text-subtle leading-snug">
+        <p className="text-xs text-subtle leading-snug">
           Якщо список операцій виглядає некоректно — очисти кеш і синхронізуй
           знову.
         </p>
@@ -414,7 +414,7 @@ export function FinykSection() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-[11px] text-subtle leading-snug">
+              <p className="text-xs text-subtle leading-snug">
                 API Приват24 для підприємців. Merchant ID та токен знаходяться у
                 Приват24 Бізнес → Налаштування → API.
               </p>

--- a/src/core/settings/FizrukSection.tsx
+++ b/src/core/settings/FizrukSection.tsx
@@ -15,7 +15,7 @@ export function FizrukSection() {
   return (
     <SettingsGroup title="Фізрук" emoji="🏋️">
       <SettingsSubGroup title="Таймер відпочинку">
-        <p className="text-[11px] text-subtle leading-snug">
+        <p className="text-xs text-subtle leading-snug">
           Рекомендований час відпочинку підбирається автоматично за типом
           вправи. Ці значення з&apos;являться як кнопка за замовчуванням у
           кожній вправі.

--- a/src/core/settings/GeneralSection.tsx
+++ b/src/core/settings/GeneralSection.tsx
@@ -31,7 +31,7 @@ function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
         const isLast = index === order.length - 1;
         return (
           <li key={id} className="flex items-center gap-2 px-3 py-2 bg-panel">
-            <span className="text-[11px] font-semibold text-muted tabular-nums w-4">
+            <span className="text-xs font-semibold text-muted tabular-nums w-4">
               {index + 1}
             </span>
             <span className="flex-1 text-sm text-text truncate">
@@ -123,7 +123,7 @@ export function GeneralSection({
         />
       </SettingsSubGroup>
       <SettingsSubGroup title="Упорядкувати модулі">
-        <p className="text-[11px] text-subtle leading-snug">
+        <p className="text-xs text-subtle leading-snug">
           Порядок модулів у списку «Сьогодні» на дашборді.
         </p>
         <ModuleReorderList order={order} onMove={handleMove} />

--- a/src/core/settings/NotificationsSection.tsx
+++ b/src/core/settings/NotificationsSection.tsx
@@ -147,7 +147,7 @@ export function NotificationsSection() {
           </Button>
         )}
         {permStatus === "denied" && (
-          <p className="text-[11px] text-subtle">
+          <p className="text-xs text-subtle">
             Відкрий налаштування браузера, щоб дозволити
           </p>
         )}

--- a/src/core/settings/SettingsPrimitives.tsx
+++ b/src/core/settings/SettingsPrimitives.tsx
@@ -117,7 +117,7 @@ export function ToggleRow({
       <div className="flex-1 min-w-0">
         <span className="text-sm text-text">{label}</span>
         {description && (
-          <p className="text-[11px] text-subtle mt-0.5 leading-snug">
+          <p className="text-xs text-subtle mt-0.5 leading-snug">
             {description}
           </p>
         )}

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -457,12 +457,12 @@ export default function App({
             >
               Почати без банку
             </Button>
-            <p className="mt-2 text-center text-[11px] text-subtle">
+            <p className="mt-2 text-center text-xs text-subtle">
               Ручні витрати, бюджети та аналітика — без API-токена. Monobank
               можна підключити пізніше.
             </p>
 
-            <div className="my-4 flex items-center gap-3 text-[11px] text-muted uppercase tracking-wider">
+            <div className="my-4 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
               <span className="flex-1 h-px bg-line" />
               або через API
               <span className="flex-1 h-px bg-line" />

--- a/src/modules/finyk/components/CategoryManager.jsx
+++ b/src/modules/finyk/components/CategoryManager.jsx
@@ -201,7 +201,7 @@ export function CategoryManager({
 
   return (
     <div>
-      <div className="text-[11px] font-bold text-subtle uppercase tracking-widest mb-3">
+      <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
         Власні категорії
       </div>
 

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -319,7 +319,7 @@ export function ManualExpenseSheet({
                       return next;
                     })
                   }
-                  className="px-2.5 py-1 rounded-full text-[11px] font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
+                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
                   title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
                 >
                   {m.name}
@@ -348,7 +348,7 @@ export function ManualExpenseSheet({
                     onClick={() =>
                       setForm((f) => ({ ...f, amount: String(v) }))
                     }
-                    className="px-2.5 py-1 rounded-full text-[11px] font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                    className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
                   >
                     {v.toLocaleString("uk-UA")} ₴
                   </button>

--- a/src/modules/finyk/components/RetroComparison.jsx
+++ b/src/modules/finyk/components/RetroComparison.jsx
@@ -109,10 +109,10 @@ export const RetroComparison = memo(function RetroComparison({
     >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-[11px] font-bold text-subtle uppercase tracking-widest">
+          <div className="text-xs font-bold text-subtle uppercase tracking-widest">
             Порівняння з попереднім місяцем
           </div>
-          <p className="text-[11px] text-subtle/80 mt-1 capitalize">
+          <p className="text-xs text-subtle/80 mt-1 capitalize">
             vs {formatMonthKeyLabel(comparison.previousMonth)}
           </p>
         </div>
@@ -120,7 +120,7 @@ export const RetroComparison = memo(function RetroComparison({
 
       <div className="grid grid-cols-2 gap-3 mt-4">
         <div>
-          <div className="text-[11px] text-subtle mb-1">Цього місяця</div>
+          <div className="text-xs text-subtle mb-1">Цього місяця</div>
           <div className="text-lg font-semibold tabular-nums text-text">
             {showBalance
               ? `${comparison.currentSpent.toLocaleString("uk-UA")} ₴`
@@ -128,7 +128,7 @@ export const RetroComparison = memo(function RetroComparison({
           </div>
         </div>
         <div>
-          <div className="text-[11px] text-subtle mb-1">Різниця</div>
+          <div className="text-xs text-subtle mb-1">Різниця</div>
           <div
             className={cn(
               "text-lg font-semibold tabular-nums flex items-baseline gap-2",

--- a/src/modules/finyk/components/SubCard.jsx
+++ b/src/modules/finyk/components/SubCard.jsx
@@ -164,7 +164,7 @@ function SubCardComponent({
           · {sub.billingDay}-го
         </div>
         {sub.linkedTxId && lastTx && (
-          <div className="text-[11px] text-emerald-600 dark:text-emerald-400 mt-0.5">
+          <div className="text-xs text-emerald-600 dark:text-emerald-400 mt-0.5">
             Привʼязано до транзакції · оновлює суму та дату
           </div>
         )}

--- a/src/modules/finyk/components/analytics/MerchantList.jsx
+++ b/src/modules/finyk/components/analytics/MerchantList.jsx
@@ -14,7 +14,7 @@ function MerchantListComponent({ merchants = [], className }) {
         const barPct = Math.round((m.total / maxTotal) * 100);
         return (
           <div key={m.name} className="flex items-center gap-3">
-            <span className="text-[11px] text-subtle w-4 shrink-0 text-right tabular-nums">
+            <span className="text-xs text-subtle w-4 shrink-0 text-right tabular-nums">
               {i + 1}
             </span>
             <div className="flex-1 min-w-0">

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -37,7 +37,7 @@ const Section = memo(function Section({ title, children, className }) {
         className,
       )}
     >
-      <div className="text-[11px] font-bold text-subtle uppercase tracking-widest mb-4">
+      <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-4">
         {title}
       </div>
       {children}

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -442,7 +442,7 @@ export function Assets({
               <button
                 type="button"
                 onClick={() => openHubModule("routine", "")}
-                className="w-full text-[11px] text-muted hover:text-text transition-colors pb-2 flex items-center justify-center gap-1.5"
+                className="w-full text-xs text-muted hover:text-text transition-colors pb-2 flex items-center justify-center gap-1.5"
               >
                 <span aria-hidden>📅</span>
                 <span>Побачити у календарі Рутини</span>
@@ -555,7 +555,7 @@ export function Assets({
         />
         {open.assets && (
           <div className="mb-3 space-y-2">
-            <div className="text-[11px] font-bold text-subtle uppercase tracking-widest pt-1">
+            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
               💳 Картки Monobank
             </div>
             {accounts
@@ -586,7 +586,7 @@ export function Assets({
                 </div>
               ))}
 
-            <div className="text-[11px] font-bold text-subtle uppercase tracking-widest pt-2">
+            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-2">
               💰 Мені винні
             </div>
             {receivables.map((r) => (
@@ -688,7 +688,7 @@ export function Assets({
               </button>
             )}
 
-            <div className="text-[11px] font-bold text-subtle uppercase tracking-widest pt-2">
+            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-2">
               🏦 Інші активи
             </div>
             {manualAssets.map((a, i) => (

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -384,7 +384,7 @@ export function Budgets({ mono, storage }) {
             isOver ? "border-danger/40" : "border-line",
           )}
         >
-          <div className="text-[11px] font-bold text-subtle uppercase tracking-widest mb-3">
+          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Фінплан на місяць
           </div>
           <div className="space-y-2">
@@ -471,7 +471,7 @@ export function Budgets({ mono, storage }) {
               {/* Progress bar */}
               {planExpense > 0 && (
                 <>
-                  <div className="flex justify-between text-[11px] text-subtle">
+                  <div className="flex justify-between text-xs text-subtle">
                     <span>{pctExpense}% від плану</span>
                     <span>план {planExpense.toLocaleString("uk-UA")} ₴</span>
                   </div>
@@ -506,7 +506,7 @@ export function Budgets({ mono, storage }) {
                   <span className="font-semibold">
                     {safePerDay.toLocaleString("uk-UA")} ₴/день
                   </span>
-                  <span className="text-[11px] ml-1 opacity-75">
+                  <span className="text-xs ml-1 opacity-75">
                     · безпечно витрачати ({daysLeft2} дн.)
                   </span>
                 </div>
@@ -516,7 +516,7 @@ export function Budgets({ mono, storage }) {
         </div>
 
         {/* Limits */}
-        <div className="text-[11px] font-bold text-subtle uppercase tracking-widest">
+        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
           Ліміти · {monthStart.toLocaleDateString("uk-UA", { month: "long" })}
         </div>
         {limitBudgets.length === 0 && (
@@ -589,7 +589,7 @@ export function Budgets({ mono, storage }) {
         {/* Forecast — shown whenever there are limit budgets to avoid layout shifts */}
         {limitBudgets.length > 0 && (
           <>
-            <div className="text-[11px] font-bold text-subtle uppercase tracking-widest pt-1">
+            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
               Прогноз · кінець місяця
             </div>
             {loadingTx && forecasts.length === 0 ? (
@@ -700,7 +700,7 @@ export function Budgets({ mono, storage }) {
         )}
 
         {/* Goals */}
-        <div className="text-[11px] font-bold text-subtle uppercase tracking-widest pt-1">
+        <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
           Цілі накопичення
         </div>
         {goalBudgets.length === 0 && (

--- a/src/modules/finyk/pages/Overview.jsx
+++ b/src/modules/finyk/pages/Overview.jsx
@@ -425,7 +425,7 @@ export function Overview({
           showBalance={showBalance}
         />
 
-        <p className="text-[11px] text-subtle px-1 -mt-1 leading-relaxed">
+        <p className="text-xs text-subtle px-1 -mt-1 leading-relaxed">
           Огляд, категорії та бюджети на цій сторінці — у гривні (UAH). Інші
           валюти рахунків у загальному балансі не конвертуються автоматично.
         </p>

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -625,7 +625,7 @@ export function Transactions({
               increaseViewportBy={{ top: 400, bottom: 400 }}
               groupContent={(groupIndex) => (
                 <div
-                  className="px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-[11px] font-semibold text-subtle tracking-wide"
+                  className="px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-xs font-semibold text-subtle tracking-wide"
                   role="presentation"
                 >
                   {formatStickyDayLabel(groupedByDate[groupIndex].key)}

--- a/src/modules/finyk/pages/overview/FlowRow.jsx
+++ b/src/modules/finyk/pages/overview/FlowRow.jsx
@@ -11,14 +11,14 @@ export const FlowRow = memo(function FlowRow({ flow, showAmount = true }) {
   return (
     <div className="flex justify-between items-center py-3 border-b border-line last:border-0">
       <div className="min-w-0 mr-3">
-        <div className="text-[15px] font-medium leading-snug truncate">
+        <div className="text-base font-medium leading-snug truncate">
           {flow.title}
         </div>
         <div className="text-xs text-subtle mt-0.5">{flow.hint}</div>
       </div>
       <div
         className={cn(
-          "text-[15px] font-bold tabular-nums shrink-0",
+          "text-base font-bold tabular-nums shrink-0",
           isGreen ? "text-success" : "text-danger",
         )}
       >

--- a/src/modules/finyk/pages/overview/HeroCard.jsx
+++ b/src/modules/finyk/pages/overview/HeroCard.jsx
@@ -19,7 +19,7 @@ export function HeroCard({
       <div className="flex items-start justify-between gap-2">
         <div>
           <p className="text-emerald-100/90 text-sm">Загальний нетворс</p>
-          <p className="text-[11px] text-emerald-200/70 mt-0.5">
+          <p className="text-xs text-emerald-200/70 mt-0.5">
             {firstName} · {dateLabel}
           </p>
         </div>
@@ -65,9 +65,7 @@ export function HeroCard({
       </div>
       <div className="flex flex-wrap gap-x-4 gap-y-2 mt-4 pt-4 border-t border-white/20 text-sm">
         <div>
-          <div className="text-[11px] text-emerald-200/80 mb-0.5">
-            На картках
-          </div>
+          <div className="text-xs text-emerald-200/80 mb-0.5">На картках</div>
           <div className="font-semibold tabular-nums text-emerald-50">
             {showBalance
               ? `+${monoTotal.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
@@ -76,7 +74,7 @@ export function HeroCard({
         </div>
         <div className="w-px bg-white/25 hidden sm:block self-stretch min-h-[2.5rem]" />
         <div>
-          <div className="text-[11px] text-emerald-200/80 mb-0.5">Борги</div>
+          <div className="text-xs text-emerald-200/80 mb-0.5">Борги</div>
           <div className="font-semibold tabular-nums text-emerald-50">
             {showBalance
               ? `−${totalDebt.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`

--- a/src/modules/finyk/pages/overview/MonthPulseCard.jsx
+++ b/src/modules/finyk/pages/overview/MonthPulseCard.jsx
@@ -44,11 +44,11 @@ export function MonthPulseCard({
       <div className="flex items-start justify-between gap-3 mb-4">
         <div>
           <div className="text-xs font-medium text-subtle">Місяць</div>
-          <p className="text-[11px] text-subtle/80 mt-0.5 capitalize">
+          <p className="text-xs text-subtle/80 mt-0.5 capitalize">
             {dateLabel}
           </p>
         </div>
-        <span className="text-[11px] text-subtle/60 shrink-0 text-right tabular-nums">
+        <span className="text-xs text-subtle/60 shrink-0 text-right tabular-nums">
           {Math.max(0, daysInMonth - daysPassed)} дн. залишилось
         </span>
       </div>
@@ -86,7 +86,7 @@ export function MonthPulseCard({
       </div>
 
       <div className="mt-4 space-y-1.5">
-        <div className="flex justify-between text-[11px] text-subtle/70">
+        <div className="flex justify-between text-xs text-subtle/70">
           <span>Витрати від доходу</span>
           <span>{showBalance ? `${Math.round(spendPct)}%` : "—"}</span>
         </div>
@@ -99,7 +99,7 @@ export function MonthPulseCard({
             style={{ width: showBalance ? `${spendPct}%` : "0%" }}
           />
         </div>
-        <div className="flex justify-between text-[11px] text-subtle/70">
+        <div className="flex justify-between text-xs text-subtle/70">
           <span>
             {showBalance
               ? `Залишок: ${monthBalance >= 0 ? "+" : "−"}${Math.abs(monthBalance).toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
@@ -120,7 +120,7 @@ export function MonthPulseCard({
           <div className="text-xs font-medium text-subtle">
             Факт і прогноз витрат
           </div>
-          <p className="text-[11px] text-subtle/80 leading-snug">
+          <p className="text-xs text-subtle/80 leading-snug">
             За {daysPassed}{" "}
             {daysPassed === 1 ? "день" : daysPassed < 5 ? "дні" : "дн."} · факт{" "}
             <span className="font-semibold text-text tabular-nums">
@@ -143,7 +143,7 @@ export function MonthPulseCard({
               style={{ width: `${forecastTrendPct}%` }}
             />
           </div>
-          <div className="flex justify-between text-[11px] text-subtle/70">
+          <div className="flex justify-between text-xs text-subtle/70">
             <span>{forecastTrendPct}% від прогнозу за темпом</span>
           </div>
         </div>
@@ -152,7 +152,7 @@ export function MonthPulseCard({
       <div className="mt-4 pt-4 border-t border-line">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-medium text-subtle">Фінпульс</span>
-          <span className="text-[11px] text-subtle/60">
+          <span className="text-xs text-subtle/60">
             цільова витрата на день
           </span>
         </div>
@@ -179,7 +179,7 @@ export function MonthPulseCard({
         <div className={cn("text-sm mt-0.5", color)}>{statusText}</div>
         {(recurringOutThisMonth > 0 || recurringInThisMonth > 0) &&
           showBalance && (
-            <div className="text-[11px] text-subtle/70 mt-2 leading-relaxed">
+            <div className="text-xs text-subtle/70 mt-2 leading-relaxed">
               Враховано планових: −
               {recurringOutThisMonth.toLocaleString("uk-UA", {
                 maximumFractionDigits: 0,

--- a/src/modules/finyk/pages/overview/PlanFactCard.jsx
+++ b/src/modules/finyk/pages/overview/PlanFactCard.jsx
@@ -21,7 +21,7 @@ export function PlanFactCard({
       <div className="text-xs font-medium text-subtle mb-3">План / Факт</div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">
-          <div className="text-[11px] text-subtle/60 mb-1">План</div>
+          <div className="text-xs text-subtle/60 mb-1">План</div>
           <div className="text-sm text-muted tabular-nums">
             +{planIncome.toLocaleString("uk-UA")} ₴
           </div>
@@ -33,7 +33,7 @@ export function PlanFactCard({
           </div>
         </div>
         <div className="space-y-1.5">
-          <div className="text-[11px] text-subtle/60 mb-1">Факт</div>
+          <div className="text-xs text-subtle/60 mb-1">Факт</div>
           <div className="text-sm text-success tabular-nums">
             +{income.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
           </div>

--- a/src/modules/finyk/pages/overview/QuickAddCard.jsx
+++ b/src/modules/finyk/pages/overview/QuickAddCard.jsx
@@ -18,7 +18,7 @@ export function QuickAddCard({
     <Card radius="lg" padding="lg" className="space-y-3">
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle">
+          <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
             Швидке додавання
           </div>
           <div className="text-sm text-muted mt-0.5">
@@ -50,7 +50,7 @@ export function QuickAddCard({
                 <span className="text-sm font-medium text-text truncate">
                   {c.label || manualLabel}
                 </span>
-                <span className="text-[11px] text-subtle tabular-nums shrink-0">
+                <span className="text-xs text-subtle tabular-nums shrink-0">
                   ×{c.count}
                 </span>
               </button>
@@ -60,7 +60,7 @@ export function QuickAddCard({
       )}
       {frequentMerchants.length > 0 && (
         <div className="pt-2 border-t border-line">
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-subtle mb-2">
+          <div className="text-xs font-semibold uppercase tracking-wide text-subtle mb-2">
             Нещодавнє
           </div>
           <div className="flex flex-wrap gap-1.5">
@@ -69,7 +69,7 @@ export function QuickAddCard({
                 key={m.key}
                 type="button"
                 onClick={() => onQuickAdd?.(m.suggestedManualCategory || null)}
-                className="px-2.5 py-1 rounded-full text-[11px] font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
+                className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
                 title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
               >
                 {m.name}

--- a/src/modules/fizruk/components/PhotoProgress.tsx
+++ b/src/modules/fizruk/components/PhotoProgress.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
 import { useBodyPhotos } from "../hooks/useBodyPhotos";
 
@@ -257,11 +258,11 @@ export function PhotoProgress() {
 
   if (!ready) {
     return (
-      <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+      <Card as="section" radius="lg" padding="md">
         <div className="text-xs text-subtle text-center py-4">
           Завантаження…
         </div>
-      </section>
+      </Card>
     );
   }
 

--- a/src/modules/fizruk/components/WellbeingChart.tsx
+++ b/src/modules/fizruk/components/WellbeingChart.tsx
@@ -45,7 +45,7 @@ export function WellbeingChart({ data }) {
   return (
     <div className="w-full">
       {/* Legend */}
-      <div className="flex items-center gap-4 mb-2 text-[11px] text-subtle">
+      <div className="flex items-center gap-4 mb-2 text-xs text-subtle">
         <span className="flex items-center gap-1.5">
           <span
             className="inline-block w-2.5 h-2.5 rounded-sm"

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -192,7 +192,7 @@ export function WorkoutTemplatesSection({
               {orderIds.length >= 2 && !groupSelectMode && (
                 <button
                   type="button"
-                  className="text-[11px] px-2 py-1 rounded-lg border border-line text-subtle hover:text-text hover:bg-panelHi transition-colors"
+                  className="text-xs px-2 py-1 rounded-lg border border-line text-subtle hover:text-text hover:bg-panelHi transition-colors"
                   onClick={() => {
                     setGroupSelectMode(true);
                     setGroupSelected(new Set());
@@ -205,7 +205,7 @@ export function WorkoutTemplatesSection({
                 <div className="flex gap-1">
                   <button
                     type="button"
-                    className="text-[11px] px-2 py-1 rounded-lg border border-success/40 text-success disabled:opacity-40"
+                    className="text-xs px-2 py-1 rounded-lg border border-success/40 text-success disabled:opacity-40"
                     disabled={groupSelected.size < 2 || groupSelected.size > 3}
                     onClick={() => handleCreateGroup("superset")}
                     title="Виберіть 2-3 вправи"
@@ -214,7 +214,7 @@ export function WorkoutTemplatesSection({
                   </button>
                   <button
                     type="button"
-                    className="text-[11px] px-2 py-1 rounded-lg border border-fizruk/40 text-fizruk disabled:opacity-40"
+                    className="text-xs px-2 py-1 rounded-lg border border-fizruk/40 text-fizruk disabled:opacity-40"
                     disabled={groupSelected.size < 2 || groupSelected.size > 3}
                     onClick={() => handleCreateGroup("circuit")}
                     title="Виберіть 2-3 вправи"
@@ -223,7 +223,7 @@ export function WorkoutTemplatesSection({
                   </button>
                   <button
                     type="button"
-                    className="text-[11px] px-2 py-1 rounded-lg border border-line text-subtle"
+                    className="text-xs px-2 py-1 rounded-lg border border-line text-subtle"
                     onClick={() => {
                       setGroupSelectMode(false);
                       setGroupSelected(new Set());

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -263,7 +263,7 @@ export function ActiveWorkoutPanel({
           className={`border rounded-2xl p-3 bg-bg transition-colors ${groupSelectMode && isSelected ? "border-success bg-success/5" : "border-line"}`}
         >
           {it.exerciseId && lastByExerciseId[it.exerciseId] && (
-            <div className="text-[11px] text-subtle/70 mb-1">
+            <div className="text-xs text-subtle/70 mb-1">
               Минулого разу{" "}
               {lastByExerciseId[it.exerciseId]._startedAt
                 ? `(${new Date(lastByExerciseId[it.exerciseId]._startedAt).toLocaleDateString("uk-UA", { month: "short", day: "numeric" })})`
@@ -343,7 +343,7 @@ export function ActiveWorkoutPanel({
                 const redL = cf.red.map((x) => x.label).join(", ");
                 const yelL = cf.yellow.map((x) => x.label).join(", ");
                 return (
-                  <div className="text-[11px] mt-1.5 rounded-xl border border-warning/40 bg-warning/10 px-2 py-1.5 text-warning leading-snug">
+                  <div className="text-xs mt-1.5 rounded-xl border border-warning/40 bg-warning/10 px-2 py-1.5 text-warning leading-snug">
                     {cf.red.length ? (
                       <>
                         Рано навантажувати:{" "}
@@ -869,7 +869,7 @@ export function ActiveWorkoutPanel({
             {!groupSelectMode ? (
               <button
                 type="button"
-                className="text-[11px] px-3 py-1.5 rounded-lg border border-line text-subtle hover:text-text hover:bg-panelHi transition-colors"
+                className="text-xs px-3 py-1.5 rounded-lg border border-line text-subtle hover:text-text hover:bg-panelHi transition-colors"
                 onClick={() => {
                   setGroupSelectMode(true);
                   setGroupSelected(new Set());
@@ -881,7 +881,7 @@ export function ActiveWorkoutPanel({
               <>
                 <button
                   type="button"
-                  className="text-[11px] px-3 py-1.5 rounded-lg border border-success/40 text-success bg-success/10 hover:bg-success/20 transition-colors disabled:opacity-40"
+                  className="text-xs px-3 py-1.5 rounded-lg border border-success/40 text-success bg-success/10 hover:bg-success/20 transition-colors disabled:opacity-40"
                   disabled={groupSelected.size < 2 || groupSelected.size > 3}
                   onClick={() => handleCreateSuperset("superset")}
                   title="Виберіть 2-3 вправи"
@@ -890,7 +890,7 @@ export function ActiveWorkoutPanel({
                 </button>
                 <button
                   type="button"
-                  className="text-[11px] px-3 py-1.5 rounded-lg border border-fizruk/40 text-fizruk bg-fizruk/10 hover:bg-fizruk/20 transition-colors disabled:opacity-40"
+                  className="text-xs px-3 py-1.5 rounded-lg border border-fizruk/40 text-fizruk bg-fizruk/10 hover:bg-fizruk/20 transition-colors disabled:opacity-40"
                   disabled={groupSelected.size < 2 || groupSelected.size > 3}
                   onClick={() => handleCreateSuperset("circuit")}
                   title="Виберіть 2-3 вправи"
@@ -899,7 +899,7 @@ export function ActiveWorkoutPanel({
                 </button>
                 <button
                   type="button"
-                  className="text-[11px] px-3 py-1.5 rounded-lg border border-line text-subtle hover:text-text transition-colors"
+                  className="text-xs px-3 py-1.5 rounded-lg border border-line text-subtle hover:text-text transition-colors"
                   onClick={() => {
                     setGroupSelectMode(false);
                     setGroupSelected(new Set());

--- a/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -157,7 +157,7 @@ export function WorkoutFinishSheets({
             <div className="fizruk-summary-header">
               <div className="flex items-start justify-between gap-2">
                 <div>
-                  <div className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
+                  <div className="text-xs font-bold tracking-widest uppercase text-fizruk">
                     Завершено
                   </div>
                   <div className="text-lg font-black text-white mt-1 leading-tight">
@@ -240,7 +240,7 @@ export function WorkoutFinishSheets({
                 </Button>
                 <button
                   type="button"
-                  className="fizruk-cta-accent flex-1 py-3 rounded-full text-[15px]"
+                  className="fizruk-cta-accent flex-1 py-3 rounded-full text-base"
                   onClick={() => setFinishFlash(null)}
                 >
                   Готово

--- a/src/modules/fizruk/pages/Atlas.tsx
+++ b/src/modules/fizruk/pages/Atlas.tsx
@@ -53,7 +53,7 @@ export function Atlas() {
           className="rounded-3xl p-5 border border-line/20 bg-hero-teal"
           aria-label="Атлас мʼязів"
         >
-          <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
+          <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
             Атлас мʼязів
           </p>
           <h1 className="text-hero font-black text-white mt-2 leading-tight">

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -415,7 +415,7 @@ export function Body({ onOpenMeasurements }) {
                   className="flex items-start gap-3 rounded-xl border border-line bg-bg p-3"
                 >
                   <div className="min-w-0 flex-1">
-                    <div className="text-[11px] text-subtle mb-1">
+                    <div className="text-xs text-subtle mb-1">
                       {new Date(entry.at).toLocaleDateString("uk-UA", {
                         weekday: "short",
                         day: "numeric",

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -286,7 +286,7 @@ export function Dashboard({
           className="rounded-3xl p-6 overflow-hidden bg-hero-teal"
           aria-label="Привітання"
         >
-          <p className="text-[11px] font-bold tracking-widest uppercase text-fizruk">
+          <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
             {greeting} · {today}
           </p>
           <h1 className="text-hero font-black text-white mt-3 leading-tight">
@@ -331,7 +331,7 @@ export function Dashboard({
           <div className="mt-5 flex flex-col gap-3">
             <button
               type="button"
-              className="w-full py-4 rounded-full font-bold text-[15px] bg-fizruk text-white transition-all active:scale-[0.98]"
+              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white transition-all active:scale-[0.98]"
               onClick={() => {
                 try {
                   sessionStorage.setItem("fizruk_workouts_mode", "log");
@@ -344,7 +344,7 @@ export function Dashboard({
             </button>
             <button
               type="button"
-              className="w-full py-4 rounded-full font-semibold text-[15px] text-white border border-white/25 transition-colors active:bg-white/10"
+              className="w-full py-4 rounded-full font-semibold text-base text-white border border-white/25 transition-colors active:bg-white/10"
               onClick={() => {
                 try {
                   sessionStorage.setItem("fizruk_workouts_mode", "templates");
@@ -407,7 +407,7 @@ export function Dashboard({
                           <div className="text-sm font-semibold text-text truncate">
                             {tpl.name}
                           </div>
-                          <div className="text-[11px] text-subtle mt-0.5">
+                          <div className="text-xs text-subtle mt-0.5">
                             {picks.length > 0
                               ? `${picks.length} вправ`
                               : "Немає вправ у каталозі"}
@@ -443,7 +443,7 @@ export function Dashboard({
               </div>
               <button
                 type="button"
-                className="text-[11px] font-semibold text-success hover:underline shrink-0"
+                className="text-xs font-semibold text-success hover:underline shrink-0"
                 onClick={() => onOpenPrograms?.()}
               >
                 Програми →
@@ -482,7 +482,7 @@ export function Dashboard({
                 <h2 className="text-base font-semibold text-text">
                   Відновлення й фокус
                 </h2>
-                <p className="text-[11px] text-subtle mt-1 leading-snug">
+                <p className="text-xs text-subtle mt-1 leading-snug">
                   Колір на силуеті — готовність груп; чіпи — пріоритет після
                   відпочинку.
                 </p>
@@ -525,7 +525,7 @@ export function Dashboard({
                   <span className="text-base shrink-0" aria-hidden>
                     😴
                   </span>
-                  <p className="text-[11px] text-warning leading-snug">
+                  <p className="text-xs text-warning leading-snug">
                     {rec.wellbeingMult >= 1.3
                       ? "Поганий сон або дуже низька енергія — відновлення значно сповільнене."
                       : "Недостатній сон або низька енергія — відновлення сповільнене."}{" "}
@@ -674,7 +674,7 @@ export function Dashboard({
             </div>
             <button
               type="button"
-              className="text-[11px] font-semibold text-primary hover:underline shrink-0"
+              className="text-xs font-semibold text-primary hover:underline shrink-0"
               onClick={() => {
                 window.location.hash = "#plan";
               }}
@@ -683,7 +683,7 @@ export function Dashboard({
             </button>
           </div>
           {monthlyPlan.todayTemplateId && (
-            <p className="text-[11px] text-success/90 mb-2">
+            <p className="text-xs text-success/90 mb-2">
               Шаблон з місячного плану на сьогодні.
             </p>
           )}

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -623,7 +623,7 @@ export function Exercise({ exerciseId }) {
           <div className="mt-3">
             <button
               type="button"
-              className="w-full py-4 rounded-full font-bold text-[15px] bg-fizruk text-white"
+              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white"
               onClick={() => (window.location.hash = "#workouts")}
             >
               Перейти до журналу

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -131,7 +131,7 @@ export function Measurements() {
           <div className="mt-3">
             <button
               type="button"
-              className="w-full py-4 rounded-full font-bold text-[15px] bg-fizruk text-white transition-all active:scale-[0.98]"
+              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white transition-all active:scale-[0.98]"
               onClick={() => {
                 const payload = {};
                 for (const f of MEASURE_FIELDS) {

--- a/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
@@ -119,7 +120,7 @@ export function PlanCalendar() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
-        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+        <Card as="section" radius="lg" padding="md">
           <div className="flex items-center justify-between gap-2 mb-4">
             <button
               type="button"
@@ -201,13 +202,13 @@ export function PlanCalendar() {
           <p className="text-2xs text-subtle mt-3">
             Натисни день, щоб призначити або зняти шаблон.
           </p>
-        </section>
+        </Card>
 
-        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+        <Card as="section" radius="lg" padding="md">
           <h2 className="text-sm font-semibold text-text mb-1">
             Повне відновлення м’язів (прогноз)
           </h2>
-          <p className="text-[11px] text-subtle mb-3 leading-snug">
+          <p className="text-xs text-subtle mb-3 leading-snug">
             Орієнтовна дата, коли навантаження спаде до «зеленого» стану (модель
             як у блоці відновлення).
           </p>
@@ -237,7 +238,7 @@ export function PlanCalendar() {
               ))}
             </ul>
           )}
-        </section>
+        </Card>
       </div>
 
       {sheet && (
@@ -289,7 +290,7 @@ export function PlanCalendar() {
                           {w.note || "Тренування"}
                         </div>
                         {w.items?.length > 0 && (
-                          <div className="text-[11px] text-subtle mt-0.5">
+                          <div className="text-xs text-subtle mt-0.5">
                             {w.items
                               .map((it) => it.nameUk || it.name)
                               .filter(Boolean)

--- a/src/modules/fizruk/pages/Programs.tsx
+++ b/src/modules/fizruk/pages/Programs.tsx
@@ -210,7 +210,7 @@ function ProgramDetails({ prog, exercises }) {
                 {exList.map((ex) => (
                   <span
                     key={ex.id}
-                    className="text-[11px] px-2 py-0.5 rounded-full bg-panelHi border border-line text-subtle"
+                    className="text-xs px-2 py-0.5 rounded-full bg-panelHi border border-line text-subtle"
                   >
                     {ex.name?.uk || ex.name?.en || ex.id}
                   </span>

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -367,7 +367,7 @@ export function Progress() {
                 <div className="text-sm font-semibold text-text">
                   Відтискання
                 </div>
-                <div className="text-[11px] text-subtle">
+                <div className="text-xs text-subtle">
                   за даними щоденних звичок
                 </div>
               </div>
@@ -551,7 +551,7 @@ export function Progress() {
                   Рекорди (PR) · {prs.length}
                 </div>
                 {filtered.length !== prs.length && (
-                  <div className="text-[11px] text-subtle">
+                  <div className="text-xs text-subtle">
                     {filtered.length} показано
                   </div>
                 )}
@@ -564,7 +564,7 @@ export function Progress() {
                     type="button"
                     onClick={() => setPrFilter("all")}
                     className={cn(
-                      "shrink-0 px-3 h-7 rounded-full text-[11px] font-semibold transition-colors border",
+                      "shrink-0 px-3 h-7 rounded-full text-xs font-semibold transition-colors border",
                       prFilter === "all"
                         ? "bg-fizruk text-white border-fizruk"
                         : "bg-panel border-line text-subtle hover:text-text",
@@ -578,7 +578,7 @@ export function Progress() {
                       type="button"
                       onClick={() => setPrFilter(g === prFilter ? "all" : g)}
                       className={cn(
-                        "shrink-0 px-3 h-7 rounded-full text-[11px] font-semibold transition-colors border whitespace-nowrap",
+                        "shrink-0 px-3 h-7 rounded-full text-xs font-semibold transition-colors border whitespace-nowrap",
                         prFilter === g
                           ? "bg-fizruk text-white border-fizruk"
                           : "bg-panel border-line text-subtle hover:text-text",
@@ -641,7 +641,7 @@ export function Progress() {
                             {p.weightKg ?? 0} кг × {p.reps ?? 0}
                           </span>
                           {p.at && (
-                            <span className="text-[11px] text-muted">
+                            <span className="text-xs text-muted">
                               ·{" "}
                               {new Date(p.at).toLocaleDateString("uk-UA", {
                                 month: "short",
@@ -671,7 +671,7 @@ export function Progress() {
           </div>
           <button
             type="button"
-            className="w-full py-4 rounded-full font-bold text-[15px] bg-fizruk text-white mb-2 transition-all active:scale-[0.98]"
+            className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white mb-2 transition-all active:scale-[0.98]"
             onClick={exportJson}
           >
             Експорт (backup)
@@ -712,7 +712,7 @@ export function Progress() {
               Скинути всі дані
             </Button>
           </div>
-          <div className="text-[11px] text-subtle/70 mt-2">
+          <div className="text-xs text-subtle/70 mt-2">
             Порада: роби експорт перед великими змінами/оновленнями.
           </div>
         </Card>

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -302,7 +302,7 @@ export function AddMealSheet({
                 setScannerOpen={setScannerOpen}
               />
 
-              <div className="mt-5 flex items-center gap-3 text-[11px] text-muted uppercase tracking-wider">
+              <div className="mt-5 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
                 <span className="flex-1 h-px bg-line" />
                 або
                 <span className="flex-1 h-px bg-line" />

--- a/src/modules/nutrition/components/BarcodeScanner.jsx
+++ b/src/modules/nutrition/components/BarcodeScanner.jsx
@@ -235,9 +235,9 @@ export function BarcodeScanner({ onDetected, onClose }) {
             </div>
           </div>
           {status ? (
-            <p className="text-[11px] text-danger">{status}</p>
+            <p className="text-xs text-danger">{status}</p>
           ) : (
-            <p className="text-[11px] text-subtle text-center">
+            <p className="text-xs text-subtle text-center">
               Наведи камеру на штрих-код. Якщо не зчитує — введи код вручну.
             </p>
           )}

--- a/src/modules/nutrition/components/DailyPlanCard.jsx
+++ b/src/modules/nutrition/components/DailyPlanCard.jsx
@@ -114,7 +114,7 @@ function MacroBadge({ label, value, unit = "г", color }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 text-[11px] rounded-lg px-2 py-0.5",
+        "inline-flex items-center gap-1 text-xs rounded-lg px-2 py-0.5",
         color || "bg-bg border border-line text-subtle",
       )}
     >
@@ -136,7 +136,7 @@ function MealRow({ meal, onAddToLog, onRegen, busy }) {
             <span className="text-base leading-none" aria-hidden>
               {MEAL_TYPE_ICONS[meal.type] || "🍴"}
             </span>
-            <span className="text-[11px] font-bold text-nutrition/80 uppercase tracking-widest">
+            <span className="text-xs font-bold text-nutrition/80 uppercase tracking-widest">
               {MEAL_TYPE_LABELS[meal.type] || meal.label}
             </span>
           </div>
@@ -186,7 +186,7 @@ function MealRow({ meal, onAddToLog, onRegen, busy }) {
       {meal.ingredients?.length > 0 && (
         <button
           type="button"
-          className="mt-2 text-[11px] text-nutrition/70 hover:text-nutrition transition-colors"
+          className="mt-2 text-xs text-nutrition/70 hover:text-nutrition transition-colors"
           onClick={() => setExpanded((v) => !v)}
         >
           {expanded ? "▲ Сховати інгредієнти" : "▼ Інгредієнти"}
@@ -253,9 +253,7 @@ export function DailyPlanCard({
 
       <div className="mt-4 space-y-4">
         <div>
-          <div className="text-[11px] text-subtle mb-2">
-            Пресет або ручні цілі
-          </div>
+          <div className="text-xs text-subtle mb-2">Пресет або ручні цілі</div>
           <div className="flex gap-2 flex-wrap">
             {PRESETS.map((preset) => (
               <button
@@ -322,7 +320,7 @@ export function DailyPlanCard({
                 <div key={key}>
                   <div
                     className={cn(
-                      "text-[11px] mb-1 font-semibold",
+                      "text-xs mb-1 font-semibold",
                       color ?? "text-subtle",
                     )}
                   >
@@ -377,28 +375,28 @@ export function DailyPlanCard({
           {hasTargets && (
             <div className="mt-2 flex flex-wrap gap-1 items-center">
               {prefs.dailyTargetKcal != null && (
-                <span className="text-[11px] bg-nutrition/10 text-nutrition border border-nutrition/20 rounded-lg px-2 py-0.5">
+                <span className="text-xs bg-nutrition/10 text-nutrition border border-nutrition/20 rounded-lg px-2 py-0.5">
                   {prefs.dailyTargetKcal} ккал
                 </span>
               )}
               {prefs.dailyTargetProtein_g != null && (
-                <span className="text-[11px] bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
+                <span className="text-xs bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
                   Б: {prefs.dailyTargetProtein_g}г
                 </span>
               )}
               {prefs.dailyTargetFat_g != null && (
-                <span className="text-[11px] bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
+                <span className="text-xs bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
                   Ж: {prefs.dailyTargetFat_g}г
                 </span>
               )}
               {prefs.dailyTargetCarbs_g != null && (
-                <span className="text-[11px] bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
+                <span className="text-xs bg-bg border border-line rounded-lg px-2 py-0.5 text-subtle">
                   В: {prefs.dailyTargetCarbs_g}г
                 </span>
               )}
               <button
                 type="button"
-                className="text-[11px] text-muted hover:text-danger transition-colors px-1 ml-auto"
+                className="text-xs text-muted hover:text-danger transition-colors px-1 ml-auto"
                 onClick={() =>
                   setPrefs((p) => ({
                     ...p,
@@ -448,7 +446,7 @@ export function DailyPlanCard({
 
             {dayPlan?.totalKcal != null && prefs.dailyTargetKcal != null && (
               <div className="rounded-xl bg-panel border border-line px-3 py-2">
-                <div className="flex justify-between text-[11px] text-subtle mb-1">
+                <div className="flex justify-between text-xs text-subtle mb-1">
                   <span>Прогрес до цілі</span>
                   <span>
                     {Math.round(dayPlan.totalKcal)} / {prefs.dailyTargetKcal}{" "}

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -172,7 +172,7 @@ export function LogCard({
             <span className="font-extrabold text-text text-base">
               {formatDate(selectedDate)}
             </span>
-            <span className="text-[11px] text-subtle">{selectedDate}</span>
+            <span className="text-xs text-subtle">{selectedDate}</span>
           </div>
           <button
             type="button"
@@ -296,7 +296,7 @@ export function LogCard({
         {weekOpen && (
           <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3">
             <div className="overflow-x-auto">
-              <table className="w-full text-[11px] text-left">
+              <table className="w-full text-xs text-left">
                 <thead>
                   <tr className="text-subtle">
                     <th className="py-1 pr-2">Дата</th>
@@ -336,7 +336,7 @@ export function LogCard({
                   type="button"
                   onClick={() => setStatsRange(d)}
                   className={cn(
-                    "px-2 py-1 rounded-lg text-[11px] font-semibold border",
+                    "px-2 py-1 rounded-lg text-xs font-semibold border",
                     statsRange === d
                       ? "border-nutrition/60 text-nutrition bg-nutrition/10"
                       : "border-line text-subtle bg-panelHi",
@@ -412,7 +412,7 @@ export function LogCard({
                       <span className="text-xs text-text truncate">
                         {x.name}
                       </span>
-                      <span className="text-[11px] text-subtle shrink-0">
+                      <span className="text-xs text-subtle shrink-0">
                         {x.count}× · {Math.round(x.kcal)} ккал
                       </span>
                     </li>
@@ -437,7 +437,7 @@ export function LogCard({
                         <span className="text-xs text-text">
                           {MEAL_META[t]?.emoji} {MEAL_META[t]?.label || t}
                         </span>
-                        <span className="text-[11px] text-subtle shrink-0">
+                        <span className="text-xs text-subtle shrink-0">
                           {statsMealTypes[t].count}× ·{" "}
                           {Math.round(statsMealTypes[t].kcal)} ккал
                         </span>
@@ -604,9 +604,7 @@ function MealRow({ meal, onRemove, onEdit }) {
             {meal.name}
           </span>
           {meal.time && (
-            <span className="text-[11px] text-subtle shrink-0">
-              {meal.time}
-            </span>
+            <span className="text-xs text-subtle shrink-0">{meal.time}</span>
           )}
           {sourceLabel && (
             <span
@@ -619,22 +617,22 @@ function MealRow({ meal, onRemove, onEdit }) {
         </div>
         <div className="flex gap-2 mt-0.5 flex-wrap">
           {mac.kcal != null && (
-            <span className="text-[11px] text-nutrition font-bold">
+            <span className="text-xs text-nutrition font-bold">
               {Math.round(mac.kcal)} ккал
             </span>
           )}
           {mac.protein_g != null && (
-            <span className="text-[11px] text-subtle">
+            <span className="text-xs text-subtle">
               Б {Math.round(mac.protein_g)}г
             </span>
           )}
           {mac.fat_g != null && (
-            <span className="text-[11px] text-subtle">
+            <span className="text-xs text-subtle">
               Ж {Math.round(mac.fat_g)}г
             </span>
           )}
           {mac.carbs_g != null && (
-            <span className="text-[11px] text-subtle">
+            <span className="text-xs text-subtle">
               В {Math.round(mac.carbs_g)}г
             </span>
           )}

--- a/src/modules/nutrition/components/NutritionDashboard.jsx
+++ b/src/modules/nutrition/components/NutritionDashboard.jsx
@@ -184,7 +184,7 @@ export function NutritionDashboard({
                   <div className="relative">
                     {ring(p, m.color)}
                     <div className="absolute inset-0 flex items-center justify-center">
-                      <span className="text-[11px] font-bold text-text leading-none">
+                      <span className="text-xs font-bold text-text leading-none">
                         {cur}
                       </span>
                     </div>

--- a/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
+++ b/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
@@ -172,7 +172,7 @@ export function PhotoAnalyzeCard({
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <div className="text-[11px] text-subtle mb-1">
+                    <div className="text-xs text-subtle mb-1">
                       Порція (г), якщо знаєш
                     </div>
                     <Input
@@ -200,7 +200,7 @@ export function PhotoAnalyzeCard({
 
                 {photoResult.questions.slice(0, 6).map((q) => (
                   <div key={q}>
-                    <div className="text-[11px] text-subtle mb-1">{q}</div>
+                    <div className="text-xs text-subtle mb-1">{q}</div>
                     <Input
                       value={answers[q] || ""}
                       onChange={(e) =>

--- a/src/modules/nutrition/components/RecipesCard.jsx
+++ b/src/modules/nutrition/components/RecipesCard.jsx
@@ -144,11 +144,11 @@ export function RecipesCard({
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-text">Мої рецепти</span>
             {!savedBusy && saved.length > 0 && (
-              <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-nutrition/15 text-nutrition">
+              <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-nutrition/15 text-nutrition">
                 {saved.length}
               </span>
             )}
-            {savedBusy && <span className="text-[11px] text-subtle">…</span>}
+            {savedBusy && <span className="text-xs text-subtle">…</span>}
           </div>
           <ChevronIcon open={savedOpen} />
         </button>
@@ -185,7 +185,7 @@ export function RecipesCard({
                             <span className="block text-sm font-semibold text-text break-words">
                               {r.title}
                             </span>
-                            <span className="block text-[11px] text-subtle mt-0.5">
+                            <span className="block text-xs text-subtle mt-0.5">
                               {r.timeMinutes ? `${r.timeMinutes} хв` : "—"} ·{" "}
                               {r.servings ? `${r.servings} порц.` : "—"}
                               {r.macros?.kcal != null
@@ -214,7 +214,7 @@ export function RecipesCard({
                         </div>
                       </div>
                       <div className="mt-2 flex items-center gap-2">
-                        <span className="text-[11px] text-subtle">
+                        <span className="text-xs text-subtle">
                           Порції (множник):
                         </span>
                         <Input
@@ -228,7 +228,7 @@ export function RecipesCard({
                           inputMode="decimal"
                           className="w-20"
                         />
-                        <span className="text-[11px] text-subtle">
+                        <span className="text-xs text-subtle">
                           × макроси рецепту
                         </span>
                       </div>
@@ -272,7 +272,7 @@ export function RecipesCard({
                             (r.macros.protein_g != null ||
                               r.macros.fat_g != null ||
                               r.macros.carbs_g != null) && (
-                              <div className="text-[11px] text-subtle">
+                              <div className="text-xs text-subtle">
                                 Б: {fmtMacro(r.macros.protein_g)} г · Ж:{" "}
                                 {fmtMacro(r.macros.fat_g)} г · В:{" "}
                                 {fmtMacro(r.macros.carbs_g)} г
@@ -290,7 +290,7 @@ export function RecipesCard({
                   );
                 })}
                 {saved.length > 8 && (
-                  <div className="text-[11px] text-subtle">
+                  <div className="text-xs text-subtle">
                     Показано 8 з {saved.length}.
                   </div>
                 )}
@@ -318,7 +318,7 @@ export function RecipesCard({
         <div className="mt-3 grid gap-3">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <div className="text-[11px] text-subtle mb-1">Ціль</div>
+              <div className="text-xs text-subtle mb-1">Ціль</div>
               <select
                 value={prefs.goal}
                 onChange={(e) =>
@@ -334,7 +334,7 @@ export function RecipesCard({
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <div className="text-[11px] text-subtle mb-1">Порції</div>
+                <div className="text-xs text-subtle mb-1">Порції</div>
                 <Input
                   value={String(prefs.servings)}
                   onChange={(e) =>
@@ -345,7 +345,7 @@ export function RecipesCard({
                 />
               </div>
               <div>
-                <div className="text-[11px] text-subtle mb-1">Хвилин</div>
+                <div className="text-xs text-subtle mb-1">Хвилин</div>
                 <Input
                   value={String(prefs.timeMinutes)}
                   onChange={(e) =>
@@ -359,7 +359,7 @@ export function RecipesCard({
           </div>
 
           <div>
-            <div className="text-[11px] text-subtle mb-1">
+            <div className="text-xs text-subtle mb-1">
               Не використовувати / алергени
             </div>
             <Input
@@ -438,7 +438,7 @@ export function RecipesCard({
               <summary className="cursor-pointer text-xs text-muted">
                 Діагностика плану (raw)
               </summary>
-              <pre className="mt-2 whitespace-pre-wrap text-[11px] text-subtle max-h-48 overflow-auto">
+              <pre className="mt-2 whitespace-pre-wrap text-xs text-subtle max-h-48 overflow-auto">
                 {weekPlanRaw}
               </pre>
             </details>
@@ -540,7 +540,7 @@ export function RecipesCard({
                   <summary className="cursor-pointer text-xs text-muted hover:text-text">
                     Показати діагностику (raw відповідь AI)
                   </summary>
-                  <pre className="mt-2 whitespace-pre-wrap text-[11px] leading-snug text-subtle bg-bg border border-line rounded-xl p-3 max-h-64 overflow-auto">
+                  <pre className="mt-2 whitespace-pre-wrap text-xs leading-snug text-subtle bg-bg border border-line rounded-xl p-3 max-h-64 overflow-auto">
                     {recipesRaw}
                   </pre>
                 </details>

--- a/src/modules/nutrition/components/ShoppingListCard.jsx
+++ b/src/modules/nutrition/components/ShoppingListCard.jsx
@@ -58,7 +58,7 @@ export function ShoppingListCard({
 
       <div className="mt-4 space-y-3">
         <div>
-          <div className="text-[11px] text-subtle mb-2">Джерело для списку</div>
+          <div className="text-xs text-subtle mb-2">Джерело для списку</div>
           <div className="flex gap-2">
             <button
               type="button"
@@ -176,7 +176,7 @@ export function ShoppingListCard({
                       <span className="text-xs font-semibold text-text">
                         {cat.name}
                       </span>
-                      <span className="text-[11px] text-muted ml-auto">
+                      <span className="text-xs text-muted ml-auto">
                         {cat.items.filter((i) => i.checked).length}/
                         {cat.items.length}
                       </span>
@@ -230,12 +230,12 @@ export function ShoppingListCard({
                             {item.name}
                           </span>
                           {item.quantity && (
-                            <span className="ml-1.5 text-[11px] text-subtle">
+                            <span className="ml-1.5 text-xs text-subtle">
                               {item.quantity}
                             </span>
                           )}
                           {item.note && (
-                            <div className="text-[11px] text-muted mt-0.5">
+                            <div className="text-xs text-muted mt-0.5">
                               {item.note}
                             </div>
                           )}
@@ -258,7 +258,7 @@ export function ShoppingListCard({
         <button
           type="button"
           onClick={() => openHubModule("finyk", "/analytics")}
-          className="w-full text-[11px] text-muted hover:text-text transition-colors pt-1 flex items-center justify-center gap-1.5"
+          className="w-full text-xs text-muted hover:text-text transition-colors pt-1 flex items-center justify-center gap-1.5"
         >
           <span aria-hidden>💸</span>
           <span>Скільки витратив на їжу цього місяця?</span>

--- a/src/modules/nutrition/components/WaterTrackerCard.jsx
+++ b/src/modules/nutrition/components/WaterTrackerCard.jsx
@@ -39,7 +39,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
             <div className="text-sm font-semibold text-text leading-none">
               Вода
             </div>
-            <div className="text-[11px] text-subtle mt-0.5">
+            <div className="text-xs text-subtle mt-0.5">
               {fmt(todayMl)}
               {goalMl > 0 && ` / ${fmt(goalMl)}`}
               {done && <span aria-hidden="true"> ✓</span>}
@@ -70,7 +70,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
                 }, 2500);
               }
             }}
-            className="text-[11px] text-subtle hover:text-danger transition-colors px-2 py-1 rounded-lg"
+            className="text-xs text-subtle hover:text-danger transition-colors px-2 py-1 rounded-lg"
             aria-label={
               resetPending
                 ? "Підтвердити скидання води за сьогодні"

--- a/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
@@ -56,7 +56,7 @@ export function BarcodeSection({
         </Button>
       </div>
       {barcodeStatus && (
-        <div className="text-[11px] text-subtle mt-1">{barcodeStatus}</div>
+        <div className="text-xs text-subtle mt-1">{barcodeStatus}</div>
       )}
     </div>
   );

--- a/src/modules/nutrition/components/meal-sheet/FoodHitRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodHitRow.jsx
@@ -17,7 +17,7 @@ export function FoodHitRow({ p, badge, onPick }) {
             {Math.round(p.per100?.kcal || 0)} ккал
           </div>
         </div>
-        <div className="text-[11px] text-subtle mt-0.5">
+        <div className="text-xs text-subtle mt-0.5">
           Б {Math.round(p.per100?.protein_g || 0)}г · Ж{" "}
           {Math.round(p.per100?.fat_g || 0)}г · В{" "}
           {Math.round(p.per100?.carbs_g || 0)}г{" "}

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -71,7 +71,7 @@ export function FoodPickerSection({
             placeholder="Курка, Activia, вівсянка, Lays…"
             aria-label="Пошук продукту"
           />
-          {foodErr && <div className="text-[11px] text-muted">{foodErr}</div>}
+          {foodErr && <div className="text-xs text-muted">{foodErr}</div>}
           {(foodHits.length > 0 || offHits.length > 0) && (
             <div className="max-h-56 overflow-y-auto rounded-2xl border border-line bg-bg shadow-sm">
               <ul className="divide-y divide-line/20">
@@ -127,7 +127,7 @@ export function FoodPickerSection({
                   <span className="ml-1 text-2xs text-subtle">🌍</span>
                 )}
               </div>
-              <div className="text-[11px] text-subtle mt-0.5">
+              <div className="text-xs text-subtle mt-0.5">
                 {Math.round(pickedFood.per100?.kcal || 0)} ккал · Б{" "}
                 {Math.round(pickedFood.per100?.protein_g || 0)}г · Ж{" "}
                 {Math.round(pickedFood.per100?.fat_g || 0)}г · В{" "}
@@ -178,7 +178,7 @@ export function FoodPickerSection({
                   aria-label="Грами"
                   className="w-[76px] text-center bg-panel border border-line rounded-xl px-2 py-2 text-sm font-bold text-text outline-none focus:border-nutrition/60 transition-colors [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 />
-                <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-subtle pointer-events-none">
+                <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-subtle pointer-events-none">
                   г
                 </span>
               </div>
@@ -202,7 +202,7 @@ export function FoodPickerSection({
                   type="button"
                   onClick={() => setPickedGrams(String(g))}
                   className={cn(
-                    "px-2 py-0.5 rounded-lg text-[11px] font-semibold border transition-all",
+                    "px-2 py-0.5 rounded-lg text-xs font-semibold border transition-all",
                     Number(pickedGrams) === g
                       ? "bg-nutrition text-white border-nutrition"
                       : "bg-panelHi text-subtle border-line hover:border-nutrition/40",

--- a/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
@@ -55,7 +55,7 @@ export function MacrosEditor({
                 err: "",
               }))
             }
-            className="text-[11px] text-nutrition font-semibold hover:underline"
+            className="text-xs text-nutrition font-semibold hover:underline"
           >
             ← З результату фото
           </button>
@@ -84,13 +84,13 @@ export function MacrosEditor({
       </div>
       {pickedFood && !pendingUnlink && (
         <div className="mt-1.5 flex items-center justify-between gap-2">
-          <span className="text-[11px] text-subtle">
+          <span className="text-xs text-subtle">
             Щоб змінити вручну — відʼєднайте продукт
           </span>
           <button
             type="button"
             onClick={() => setPendingUnlink({ key: null, value: null })}
-            className="text-[11px] font-semibold text-nutrition hover:underline shrink-0"
+            className="text-xs font-semibold text-nutrition hover:underline shrink-0"
           >
             Відʼєднати
           </button>

--- a/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/src/modules/routine/components/HabitDetailSheet.tsx
@@ -236,7 +236,7 @@ export function HabitDetailSheet({
           </button>
         </div>
 
-        <div className="text-[11px] text-subtle space-y-0.5 mb-5">
+        <div className="text-xs text-subtle space-y-0.5 mb-5">
           <p>
             {recLabel}
             {habit.timeOfDay ? ` · ${habit.timeOfDay}` : ""}
@@ -282,7 +282,7 @@ export function HabitDetailSheet({
                   </span>
                 )}
                 {pct30 !== null && (
-                  <span className="text-[11px] text-muted tabular-nums">
+                  <span className="text-xs text-muted tabular-nums">
                     {pct30}%
                   </span>
                 )}
@@ -346,7 +346,7 @@ export function HabitDetailSheet({
                 <div
                   key={dk}
                   className={cn(
-                    "aspect-square flex items-center justify-center rounded-lg text-[11px] font-medium transition-colors",
+                    "aspect-square flex items-center justify-center rounded-lg text-xs font-medium transition-colors",
                     done
                       ? "bg-routine-surface2 dark:bg-routine/15 text-routine-done dark:text-routine border border-routine-ring/40 dark:border-routine/30 font-bold"
                       : scheduled

--- a/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/src/modules/routine/components/RoutineBackupSection.tsx
@@ -1,5 +1,6 @@
 import { useRef, type ChangeEvent } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
 import { buildRoutineBackupPayload } from "../lib/routineStorage.js";
 
@@ -25,7 +26,7 @@ export function RoutineBackupSection({
   const backupRef = useRef<HTMLInputElement | null>(null);
 
   return (
-    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
+    <Card as="section" radius="lg" padding="md" className="space-y-3">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Резервна копія
       </h2>
@@ -81,6 +82,6 @@ export function RoutineBackupSection({
           }}
         />
       </div>
-    </section>
+    </Card>
   );
 }

--- a/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/src/modules/routine/components/RoutineBottomNav.tsx
@@ -145,7 +145,7 @@ export function RoutineBottomNav({
 
               <span
                 className={cn(
-                  "text-[11px] leading-none font-semibold transition-colors",
+                  "text-xs leading-none font-semibold transition-colors",
                   active ? "text-text" : "text-muted",
                 )}
               >

--- a/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -126,7 +126,7 @@ export function RoutineCalendarPanel({
       >
         <p
           className={cn(
-            "text-[11px] font-bold tracking-widest uppercase",
+            "text-xs font-bold tracking-widest uppercase",
             C.heroKicker,
           )}
         >
@@ -256,7 +256,7 @@ export function RoutineCalendarPanel({
           type="button"
           onClick={() => setTagFilter(null)}
           className={cn(
-            "px-2.5 py-1.5 rounded-full text-[11px] font-medium border",
+            "px-2.5 py-1.5 rounded-full text-xs font-medium border",
             tagFilter === null ? C.chipOn : C.chipOff,
           )}
         >
@@ -269,7 +269,7 @@ export function RoutineCalendarPanel({
               setTagFilter((f) => (f === "__fizruk" ? null : "__fizruk"))
             }
             className={cn(
-              "px-2.5 py-1.5 rounded-full text-[11px] font-medium border",
+              "px-2.5 py-1.5 rounded-full text-xs font-medium border",
               tagFilter === "__fizruk"
                 ? "border-sky-400/50 bg-sky-500/10 text-text"
                 : C.chipOff,
@@ -285,7 +285,7 @@ export function RoutineCalendarPanel({
               setTagFilter((f) => (f === "__finyk_sub" ? null : "__finyk_sub"))
             }
             className={cn(
-              "px-2.5 py-1.5 rounded-full text-[11px] font-medium border max-w-[200px] truncate",
+              "px-2.5 py-1.5 rounded-full text-xs font-medium border max-w-[200px] truncate",
               tagFilter === "__finyk_sub"
                 ? "border-emerald-500/40 bg-emerald-500/10 text-text"
                 : C.chipOff,
@@ -300,7 +300,7 @@ export function RoutineCalendarPanel({
             type="button"
             onClick={() => setTagFilter((f) => (f === name ? null : name))}
             className={cn(
-              "px-2.5 py-1.5 rounded-full text-[11px] font-medium border max-w-[160px] truncate",
+              "px-2.5 py-1.5 rounded-full text-xs font-medium border max-w-[160px] truncate",
               tagFilter === name ? C.chipOn : C.chipOff,
             )}
           >
@@ -346,7 +346,7 @@ export function RoutineCalendarPanel({
       )}
 
       {timeMode === "month" && (
-        <section className="bg-panel border border-line rounded-2xl p-4 shadow-card">
+        <Card as="section" radius="lg" padding="md">
           <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
             {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"].map((d) => (
               <div key={d}>{d}</div>
@@ -408,7 +408,7 @@ export function RoutineCalendarPanel({
               month: "long",
             })}
           </p>
-        </section>
+        </Card>
       )}
 
       <section className="space-y-4 pb-2">
@@ -538,10 +538,10 @@ export function RoutineCalendarPanel({
                             e.habitId ? `Деталі: ${e.title}` : undefined
                           }
                         >
-                          <p className="font-semibold text-text text-[15px] leading-snug">
+                          <p className="font-semibold text-text text-base leading-snug">
                             {e.title}
                           </p>
-                          <p className="text-[11px] text-subtle mt-0.5">
+                          <p className="text-xs text-subtle mt-0.5">
                             {parseDateKey(e.date).toLocaleDateString("uk-UA", {
                               weekday: "short",
                               day: "numeric",

--- a/src/modules/routine/components/WeekDayStrip.tsx
+++ b/src/modules/routine/components/WeekDayStrip.tsx
@@ -50,7 +50,7 @@ export function WeekDayStrip({
               type="button"
               onClick={() => onSelectDay(k)}
               className={cn(
-                "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-[11px]",
+                "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-xs",
                 isSel
                   ? "border-routine-ring dark:border-routine/40 bg-routine-surface2 dark:bg-routine/15 text-text shadow-sm ring-1 ring-routine-line/50 dark:ring-routine/30"
                   : "border-transparent bg-panelHi/50 text-muted hover:bg-panelHi hover:text-text",

--- a/src/modules/routine/components/settings/ActiveHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ActiveHabitsSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { sortHabitsByOrder } from "../../lib/habitOrder.js";
 import {
@@ -53,7 +54,7 @@ export function ActiveHabitsSection({
   const hasActive = routine.habits.some((h) => !h.archived);
 
   return (
-    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-2">
+    <Card as="section" radius="lg" padding="md" className="space-y-2">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Активні звички
       </h2>
@@ -147,6 +148,6 @@ export function ActiveHabitsSection({
           />
         ))}
       </ul>
-    </section>
+    </Card>
   );
 }

--- a/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { setHabitArchived } from "../../lib/routineStorage.js";
 import type { PendingHabitDeletion, RoutineState } from "../../lib/types";
 
@@ -18,7 +19,12 @@ export function ArchivedHabitsSection({
   if (archived.length === 0) return null;
 
   return (
-    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-2 opacity-95">
+    <Card
+      as="section"
+      radius="lg"
+      padding="md"
+      className="space-y-2 opacity-95"
+    >
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Архів
       </h2>
@@ -61,6 +67,6 @@ export function ArchivedHabitsSection({
           </li>
         ))}
       </ul>
-    </section>
+    </Card>
   );
 }

--- a/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -1,6 +1,7 @@
 import { useState, type Dispatch, type SetStateAction } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import {
@@ -33,7 +34,7 @@ export function CategoriesSection({
 
   return (
     <>
-      <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
+      <Card as="section" radius="lg" padding="md" className="space-y-3">
         <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
           {editingCatId ? "Редагувати категорію" : "Категорії"}
         </h2>
@@ -162,7 +163,7 @@ export function CategoriesSection({
             })}
           </ul>
         )}
-      </section>
+      </Card>
 
       <ConfirmDialog
         open={!!deleteCatPending}

--- a/src/modules/routine/components/settings/HabitForm.tsx
+++ b/src/modules/routine/components/settings/HabitForm.tsx
@@ -186,7 +186,7 @@ export function HabitForm({
 
           {(habitDraft.recurrence === "once" ||
             habitDraft.recurrence === "monthly") && (
-            <p className="text-[11px] text-subtle leading-snug">
+            <p className="text-xs text-subtle leading-snug">
               {habitDraft.recurrence === "once"
                 ? "Подія зʼявиться лише в день «Початок». Кінець можна залишити порожнім."
                 : "Орієнтир — день місяця з «Початок». У коротких місяцях (наприклад 31 → лютий) — останній день місяця."}

--- a/src/modules/routine/components/settings/ReminderPresets.tsx
+++ b/src/modules/routine/components/settings/ReminderPresets.tsx
@@ -24,7 +24,7 @@ export function ReminderPresets({
             key={preset.id}
             type="button"
             className={cn(
-              "text-[11px] px-2.5 py-1.5 rounded-lg border font-medium transition-colors min-h-[32px]",
+              "text-xs px-2.5 py-1.5 rounded-lg border font-medium transition-colors min-h-[32px]",
               JSON.stringify(times.slice().sort()) ===
                 JSON.stringify(preset.times.slice().sort())
                 ? C.chipOn
@@ -44,7 +44,7 @@ export function ReminderPresets({
         <button
           type="button"
           className={cn(
-            "text-[11px] px-2.5 py-1.5 rounded-lg border font-medium transition-colors min-h-[32px]",
+            "text-xs px-2.5 py-1.5 rounded-lg border font-medium transition-colors min-h-[32px]",
             times.length === 0 ? C.chipOn : C.chipOff,
           )}
           onClick={() =>
@@ -98,7 +98,7 @@ export function ReminderPresets({
       {times.length < 5 && times.length > 0 && (
         <button
           type="button"
-          className="text-[11px] text-routine font-semibold hover:underline"
+          className="text-xs text-routine font-semibold hover:underline"
           onClick={() =>
             setHabitDraft((d) => ({
               ...d,

--- a/src/modules/routine/components/settings/TagsSection.tsx
+++ b/src/modules/routine/components/settings/TagsSection.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { createTag, deleteTag, updateTag } from "../../lib/routineStorage.js";
 import type { RoutineState } from "../../lib/types";
@@ -31,7 +32,7 @@ export function TagsSection({
   };
 
   return (
-    <section className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3">
+    <Card as="section" radius="lg" padding="md" className="space-y-3">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         Теги
       </h2>
@@ -110,6 +111,6 @@ export function TagsSection({
           </li>
         ))}
       </ul>
-    </section>
+    </Card>
   );
 }

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -39,7 +39,7 @@ export function EmptyState({
       <p
         className={cn(
           "font-semibold text-text",
-          compact ? "text-sm" : "text-[15px]",
+          compact ? "text-sm" : "text-base",
         )}
       >
         {title}

--- a/src/shared/components/ui/SectionErrorBoundary.tsx
+++ b/src/shared/components/ui/SectionErrorBoundary.tsx
@@ -40,7 +40,7 @@ export class SectionErrorBoundary extends Component<
           <div className="text-xs text-subtle mt-1">
             Ця секція впала, але інші частини модуля працюють.
           </div>
-          <pre className="mt-2 text-[11px] text-danger whitespace-pre-wrap break-words max-h-40 overflow-auto">
+          <pre className="mt-2 text-xs text-danger whitespace-pre-wrap break-words max-h-40 overflow-auto">
             {String(error?.message || error)}
           </pre>
           <div className="mt-3 flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary

Combined batch of the remaining UI-audit follow-ups. Polish only — no layout / structure / color changes beyond the typography snaps noted below.

### Typography — arbitrary sizes snapped to the scale (189 sites, 66 files)
- `text-[11px]` → `text-xs` (12px) — **178 sites**. Mostly micro-labels, eyebrows, and annotations. +1px polish toward the Tailwind scale; removes the last bulk source of `text-[Npx]`.
- `text-[15px]` → `text-base` (16px) — **11 sites**. Hand-rolled primary CTAs (`Dashboard`, `Exercise`, `Measurements`, `Progress`, `WorkoutFinishSheets`), a calendar day row, and a digest story paragraph. +1px toward the 16px CTA baseline.

### Card primitive — `<section>` second pass (9 sites, 8 files)
Extends the PR #192 Card migration to `<section>`-wrapped containers that followed the same canonical `bg-panel border border-line rounded-2xl p-4 shadow-card[ extras]` pattern. Each becomes `<Card as="section" radius="lg" padding="md">`, with any `space-y-*` / `opacity-*` tail preserved via `className`.

Migrated:
- `ActiveHabitsSection`, `CategoriesSection`, `ArchivedHabitsSection`, `TagsSection`, `RoutineBackupSection`
- `RoutineCalendarPanel` (month grid)
- `PhotoProgress` (loading state)
- `PlanCalendar` (2 sites)

### Intentionally deferred (with rationale in the commit)
- **Icon button sizes** (`w-8 / w-9 / w-10 / w-11` variants) — too many bespoke hover / border / transition tweaks to blanket-migrate to `<Button iconOnly>` without visual regressions; best as a per-module pass.
- **Shadows** (`shadow-sm / md / lg / xl` → `shadow-card / float / soft`) — Tailwind `shadow-sm` and Sergeant `--shadow-card` are structurally different (subtle 2px vs warm 16–40px blur + inset highlight). A blanket replacement would change the visual weight of many small elements. Needs site-by-site design judgement.
- **Eyebrow outliers** — the remaining eyebrow variants form two coherent secondary patterns (hub-level `font-semibold text-muted tracking-wider`, and stat sub-labels `tracking-wide text-white/60`). They are not real outliers — leaving them preserves intentional hierarchy distinction vs the main `font-bold text-subtle tracking-widest` eyebrow.

## Review & Testing Checklist for Human

- [ ] Spot-check micro-labels (eyebrows, annotations, badges) across **Fizruk Dashboard / Progress / Workouts / Exercise / Body**, **Finyk Overview / Budgets / Transactions**, **Nutrition LogCard / DailyPlanCard / RecipesCard**, **Routine Calendar / HabitDetailSheet / Settings** — confirm 11→12px is visually neutral (no chip overflow, no awkward line wraps).
- [ ] Spot-check the primary CTAs that used `text-[15px]`: **Dashboard ("Продовжити тренування"/"Завершити"), Exercise, Measurements, Progress, WorkoutFinishSheets** — confirm 15→16px feels right for a primary CTA.
- [ ] Scroll **Routine → Settings** (active / archived habits, categories, tags, backup) and **Routine → Calendar (month view)** — confirm the `<section>` → `<Card>` migration renders identically (radius, padding, shadow, spacing).
- [ ] Open **Fizruk → Body → PhotoProgress** loading state and **Fizruk → PlanCalendar** — confirm the two cards look unchanged.

### Notes

Local checks all green:
- `npm run lint` (eslint + import check)
- `npm run typecheck` (3 tsconfigs)
- `npm test` — 604 / 604
- `npm run build` (Vite + PWA manifest)
- `npm run format:check`

No `text-[11px]` / `text-[15px]` remain in `src/`. Remaining `text-[Npx]` uses are now only in `WeeklyDigestStories` (editorial story layout with tuned sizes) and two iOS-zoom-prevention `text-[16px] md:text-sm` inputs — both intentional and out of scope for this PR.

Link to Devin session: https://app.devin.ai/sessions/5b1aebe8911c40058c2847104209824e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
