### PR TITLE
fix(sync): defer push-all metric emits until after COMMIT

### DIFF
--- a/server/api/sync.js
+++ b/server/api/sync.js
@@ -257,6 +257,13 @@ export async function syncPushAll(req, res) {
   }
 
   const results = {};
+  // Per-module метрики `push` накопичуємо тут і емітимо ЛИШЕ після COMMIT.
+  // Якщо один із модулів посеред транзакції кине — `ROLLBACK` відкотить
+  // уже «успішні» INSERT-и, але лічильник `sync_operations_total{outcome="ok"}`
+  // уже був би інкрементований → SLI бреше, `SyncErrorBudgetBurn` пропускає
+  // реальні збої. `too_large` — виняток: це per-item reject ДО будь-якого
+  // DML, тому rollback його не зачіпає, фіксуємо одразу.
+  const pending = [];
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
@@ -282,12 +289,11 @@ export async function syncPushAll(req, res) {
         [user.id, mod, blob, clientTs],
       );
       if (r.rows.length === 0) {
-        recordConflict(mod);
-        recordSync("push", mod, "conflict", { bytes: blob.length });
         const existing = await client.query(
           `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
           [user.id, mod],
         );
+        pending.push({ module: mod, outcome: "conflict", bytes: blob.length });
         results[mod] = {
           ok: true,
           conflict: true,
@@ -295,7 +301,7 @@ export async function syncPushAll(req, res) {
           version: existing.rows[0]?.version ?? 0,
         };
       } else {
-        recordSync("push", mod, "ok", { bytes: blob.length });
+        pending.push({ module: mod, outcome: "ok", bytes: blob.length });
         results[mod] = {
           ok: true,
           serverUpdatedAt: r.rows[0].server_updated_at,
@@ -305,13 +311,26 @@ export async function syncPushAll(req, res) {
     }
     await client.query("COMMIT");
   } catch (err) {
-    await client.query("ROLLBACK");
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore secondary rollback failure — original error matters more */
+    }
+    // Все, що «встигло» в pending — насправді відкотилося. Перекласифікуй
+    // як error, щоб метрики відображали реальний стан БД.
+    for (const p of pending) {
+      recordSync("push", p.module, "error", { bytes: p.bytes });
+    }
     recordSync("push_all", "all", "error", { ms: elapsedMs(start) });
     throw err;
   } finally {
     client.release();
   }
 
+  for (const p of pending) {
+    if (p.outcome === "conflict") recordConflict(p.module);
+    recordSync("push", p.module, p.outcome, { bytes: p.bytes });
+  }
   recordSync("push_all", "all", "ok", { ms: elapsedMs(start) });
   return res.json({ ok: true, results });
 }

--- a/server/api/sync.test.js
+++ b/server/api/sync.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../auth.js", () => ({
+  getSessionUser: vi.fn(),
+}));
+
+vi.mock("../db.js", () => {
+  const pool = { connect: vi.fn(), query: vi.fn() };
+  return { default: pool, pool };
+});
+
+vi.mock("../obs/requestContext.js", () => ({
+  setRequestModule: vi.fn(),
+}));
+
+vi.mock("../obs/metrics.js", () => ({
+  syncConflictsTotal: { inc: vi.fn() },
+  syncDurationMs: { observe: vi.fn() },
+  syncOperationsTotal: { inc: vi.fn() },
+  syncPayloadBytes: { observe: vi.fn() },
+}));
+
+import { getSessionUser } from "../auth.js";
+import pool from "../db.js";
+import { syncConflictsTotal, syncOperationsTotal } from "../obs/metrics.js";
+import { syncPushAll } from "./sync.js";
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function makeReq(body) {
+  return { method: "POST", body };
+}
+
+/** Збирає всі виклики `.inc(labels)` у масив для зручних assert-ів. */
+function outcomesFor(op) {
+  return syncOperationsTotal.inc.mock.calls
+    .map(([labels]) => labels)
+    .filter((l) => l.op === op);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionUser.mockResolvedValue({ id: "user_1" });
+});
+
+describe("syncPushAll metric correctness around transaction boundary", () => {
+  it("emits per-module outcomes only after COMMIT succeeds", async () => {
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      // finyk — ok
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:00Z", version: 2 }],
+      })
+      // routine — ok
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:01Z", version: 5 }],
+      })
+      .mockResolvedValueOnce({}); // COMMIT
+    pool.connect.mockResolvedValue(client);
+
+    const res = makeRes();
+    await syncPushAll(
+      makeReq({
+        modules: {
+          finyk: { data: { x: 1 }, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+          routine: { data: { y: 2 }, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+        },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    const pushOutcomes = outcomesFor("push");
+    expect(pushOutcomes).toHaveLength(2);
+    expect(pushOutcomes.map((o) => [o.module, o.outcome])).toEqual(
+      expect.arrayContaining([
+        ["finyk", "ok"],
+        ["routine", "ok"],
+      ]),
+    );
+    expect(outcomesFor("push_all")).toEqual([
+      { op: "push_all", module: "all", outcome: "ok" },
+    ]);
+  });
+
+  it("reclassifies in-flight records as error when COMMIT fails → ROLLBACK", async () => {
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      // finyk — «успішний» INSERT у межах транзакції
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:00Z", version: 2 }],
+      })
+      // routine — INSERT кидає (наприклад, deadlock)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("deadlock detected"), { code: "40P01" }),
+      )
+      .mockResolvedValueOnce({}); // ROLLBACK
+    pool.connect.mockResolvedValue(client);
+
+    const res = makeRes();
+    await expect(
+      syncPushAll(
+        makeReq({
+          modules: {
+            finyk: { data: { x: 1 }, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+            routine: {
+              data: { y: 2 },
+              clientUpdatedAt: "2026-01-01T00:00:00Z",
+            },
+          },
+        }),
+        res,
+      ),
+    ).rejects.toThrow(/deadlock/);
+
+    // Ключова гарантія: finyk, який «пройшов» INSERT у try-блоці, ПІСЛЯ
+    // ROLLBACK-у враховується як error, а не як ok.
+    const pushOutcomes = outcomesFor("push");
+    expect(pushOutcomes).toEqual([
+      expect.objectContaining({
+        op: "push",
+        module: "finyk",
+        outcome: "error",
+      }),
+    ]);
+    expect(outcomesFor("push_all")).toEqual([
+      { op: "push_all", module: "all", outcome: "error" },
+    ]);
+    // Conflict counter НЕ має рухатись при error-гілці.
+    expect(syncConflictsTotal.inc).not.toHaveBeenCalled();
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it("emits too_large immediately (pre-DML reject), but defers ok/conflict until COMMIT", async () => {
+    const big = "x".repeat(6 * 1024 * 1024); // > 5 MB MAX_BLOB_SIZE
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      // nutrition — conflict (INSERT returns 0 rows → SELECT existing)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:00Z", version: 7 }],
+      })
+      .mockResolvedValueOnce({}); // COMMIT
+    pool.connect.mockResolvedValue(client);
+
+    const res = makeRes();
+    await syncPushAll(
+      makeReq({
+        modules: {
+          // too_large — reject до DML, метрика емітиться одразу в циклі.
+          finyk: { data: big, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+          nutrition: {
+            data: { z: 3 },
+            clientUpdatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results.finyk).toEqual({ ok: false, error: "Too large" });
+    expect(res.body.results.nutrition).toMatchObject({
+      ok: true,
+      conflict: true,
+      version: 7,
+    });
+
+    const pushOutcomes = outcomesFor("push");
+    expect(pushOutcomes.map((o) => [o.module, o.outcome])).toEqual(
+      expect.arrayContaining([
+        ["finyk", "too_large"],
+        ["nutrition", "conflict"],
+      ]),
+    );
+    expect(syncConflictsTotal.inc).toHaveBeenCalledWith({
+      module: "nutrition",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`syncPushAll` інкрементував `sync_operations_total{outcome=ok|conflict}` **всередині** транзакційного циклу — ще до `COMMIT`. Якщо один із модулів кидав посеред (deadlock, serialization failure, DB-disconnect) → `ROLLBACK` відкочував INSERT-и, але лічильники вже було збільшено.

Наслідок: SLI `sync_availability` (`sum(rate(sync_operations_total{outcome=~"error|too_large|unauthorized"}[w])) / sum(rate(sync_operations_total[w]))`) **занижував error-ratio**, і алерт `SyncErrorBudgetBurn` пропускав частину реальних збоїв push-all — клієнти ретраїли, але дашборд показував «все добре».

### Що змінено у `server/api/sync.js:syncPushAll`

- `ok` / `conflict` per-module outcomes акумулюються у `pending` масив і емітяться `recordSync(...)` **лише після успішного `COMMIT`**.
- На `catch` → `ROLLBACK` усі записи з `pending` перекласифіковуються у `outcome="error"` (реальний стан БД).
- `too_large` залишено прямим `recordSync(...)` всередині циклу: це per-item reject **до** будь-якого DML, rollback його не зачіпає.
- `recordConflict(module)` (окремий `sync_conflicts_total`) так само відкладено до COMMIT.
- Захистив секундарний `ROLLBACK` у `catch` try/catch-ом, щоб не маскувати оригінальну помилку.

### Тести (`server/api/sync.test.js`, новий файл)

3 кейси, усі проходять локально (`npm test -- server/api/sync.test.js`):

1. **Happy path:** 2 модулі → `COMMIT` → `sync_operations_total{op=push}` має рівно 2 emit-и з `outcome=ok`.
2. **Rollback path:** finyk успішний INSERT, routine кидає deadlock → `ROLLBACK` → finyk має `outcome=error`, а не `ok`. `syncConflictsTotal` не зачіплений.
3. **too_large mix:** великий blob (>5MB) для finyk + conflict для nutrition → `too_large` емітиться одразу, `conflict` — тільки після `COMMIT`.

Також пройдено локально:
- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm test` → **669/669 passed**

## Review & Testing Checklist for Human

- [ ] Перевір, що `SyncErrorBudgetBurn` алерт після деплою може спрацювати на реальному rollback-у (можна штучно спровокувати — наприклад, тимчасово кинути з `client.query` у dev).
- [ ] Якщо маєте існуючий дашборд `sync_operations_total` — перевір, що ratio `outcome=error` стане **не меншим** (чекаємо корекцію вгору, якщо rollback-и були в історії).
- [ ] Підтвердити, що поведінка відповіді клієнту **не змінена** (`results[mod]` будується в тому ж місці, тільки метрики відкладені).

### Notes

Це PR #1 із 7 у observability-аудиті. Наступні (після твого підтвердження):
- #2 маршрутизація `sync.js`/`push.js`/`aiQuota.js` через `db.js:query()` з `op`-лейблами
- #3 structured `sync_event` / `auth_event` логи
- #4 `auth_cookie_cache_total`, `db_connection_acquire_ms`, `ai_tokens_total{endpoint}`
- #5 `pg_stat_statements` + admin endpoint
- #6 alerts (`AiQuotaStoreDown`, leading `DbPoolWaiting`)
- #7 client-side offline queue breadcrumbs → Sentry

Link to Devin session: https://app.devin.ai/sessions/872bc66744e945e682bc554d94a14595
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
