### PR TITLE
feat(ui): shared &lt;ModuleBottomNav&gt; — unify 4 per-module bottom navs

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -199,7 +199,7 @@
   }
 
   .fizruk-above-tabbar {
-    bottom: calc(58px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(60px + env(safe-area-inset-bottom, 0px));
   }
 
   /* ═══════════════════════════════════════════════════════════════════════

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -683,7 +683,7 @@ export default function App({
             setEditingManualExpenseId(null);
             setShowExpenseSheet(true);
           }}
-          className="fixed bottom-[calc(58px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
           aria-label="Додати витрату"
         >
           +

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -10,6 +10,7 @@ import {
 import { PAGES } from "./constants";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
+import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
@@ -747,44 +748,16 @@ export default function App({
       />
 
       {/* Bottom navigation */}
-      <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line relative z-30 safe-area-pb">
-        <div className="flex h-[58px]">
-          {NAV_ITEMS.map((item) => {
-            const active = page === item.id;
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => navigate(item.id)}
-                aria-current={active ? "page" : undefined}
-                aria-label={item.label}
-                className={cn(
-                  "relative flex-1 flex flex-col items-center justify-center gap-0.5 transition-all duration-200 ease-smooth min-h-[48px] active:scale-95 focus:outline-none",
-                  active ? "text-emerald-600" : "text-muted hover:text-text",
-                )}
-              >
-                {active && (
-                  <span
-                    className="absolute top-0 left-1/2 -translate-x-1/2 w-10 h-0.5 rounded-full bg-emerald-500 motion-safe:animate-scale-in"
-                    aria-hidden
-                  />
-                )}
-                <span
-                  className={cn(
-                    "flex items-center justify-center w-8 h-6 rounded-lg transition-all duration-200 ease-smooth",
-                    active && "bg-emerald-500/12 motion-safe:animate-scale-in",
-                  )}
-                >
-                  {NAV_ICONS[item.id]}
-                </span>
-                <span className="text-2xs leading-none font-semibold">
-                  {item.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      </nav>
+      <ModuleBottomNav
+        items={NAV_ITEMS.map((item) => ({
+          id: item.id,
+          label: item.label,
+          icon: NAV_ICONS[item.id],
+        }))}
+        activeId={page}
+        onChange={navigate}
+        module="finyk"
+      />
     </div>
   );
 }

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -668,7 +668,7 @@ export function Transactions({
       {/* Batch action toolbar */}
       {selectMode && (
         <div className="fixed bottom-0 left-0 right-0 z-[60] safe-area-pb">
-          <div className="max-w-4xl mx-auto px-4 pb-[calc(58px+env(safe-area-inset-bottom,0px)+0.5rem)] pt-3">
+          <div className="max-w-4xl mx-auto px-4 pb-[calc(60px+env(safe-area-inset-bottom,0px)+0.5rem)] pt-3">
             <div className="bg-panel border border-line rounded-2xl shadow-float px-4 py-3 flex items-center justify-between gap-3">
               <span className="text-sm font-semibold text-text">
                 {selectedIds.size > 0

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -18,6 +18,7 @@ import { useExerciseCatalog } from "./hooks/useExerciseCatalog";
 import { ACTIVE_WORKOUT_KEY } from "./lib/workoutUi";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 
 const NAV = [
   {
@@ -452,50 +453,15 @@ export default function FizrukApp({
       </div>
 
       {!isAtlas && !isExercise && (
-        <nav className="shrink-0 bg-panel/95 backdrop-blur-md border-t border-line relative z-30 safe-area-pb">
-          <div className="flex h-[58px]">
-            {NAV.map((item) => {
-              const active = page === item.id;
-              const hasDot =
-                item.id === "programs" && activeProgram && todaySession;
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => setHash(item.id)}
-                  className={cn(
-                    "relative flex-1 flex flex-col items-center justify-center gap-1 transition-all min-h-[48px]",
-                    active ? "text-text" : "text-muted",
-                  )}
-                >
-                  {active && (
-                    <span
-                      className="absolute top-0 left-1/2 -translate-x-1/2 w-9 h-0.5 rounded-full bg-success"
-                      aria-hidden
-                    />
-                  )}
-                  <span className={cn("relative", active && "text-success")}>
-                    {item.icon}
-                    {hasDot && !active && (
-                      <span
-                        className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-fizruk border border-panel"
-                        aria-hidden
-                      />
-                    )}
-                  </span>
-                  <span
-                    className={cn(
-                      "text-2xs leading-none font-semibold",
-                      active ? "text-text" : "text-muted",
-                    )}
-                  >
-                    {item.label}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </nav>
+        <ModuleBottomNav
+          items={NAV.map((item) => ({
+            ...item,
+            badge: item.id === "programs" && !!activeProgram && !!todaySession,
+          }))}
+          activeId={page}
+          onChange={setHash}
+          module="fizruk"
+        />
       )}
     </div>
   );

--- a/src/modules/nutrition/components/NutritionBottomNav.jsx
+++ b/src/modules/nutrition/components/NutritionBottomNav.jsx
@@ -1,4 +1,4 @@
-import { cn } from "@shared/lib/cn";
+import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 
 const NAV = [
   {
@@ -94,64 +94,11 @@ const NAV = [
 
 export function NutritionBottomNav({ activePage, setActivePage }) {
   return (
-    <nav
-      className={cn(
-        "shrink-0 relative z-30 safe-area-pb",
-        "bg-panel/95 backdrop-blur-xl",
-        "border-t border-line",
-      )}
-    >
-      <div className="flex h-[60px]">
-        {NAV.map((item) => {
-          const active = activePage === item.id;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => setActivePage(item.id)}
-              className={cn(
-                "relative flex-1 flex flex-col items-center justify-center gap-1",
-                "transition-all duration-200 min-h-[48px]",
-                "active:scale-95",
-                active ? "text-text" : "text-muted hover:text-text/70",
-              )}
-            >
-              {/* Active indicator pill */}
-              {active && (
-                <span
-                  className={cn(
-                    "absolute top-0 left-1/2 -translate-x-1/2",
-                    "w-8 h-1 rounded-full",
-                    "bg-gradient-to-r from-lime-400 to-lime-500",
-                    "shadow-sm",
-                  )}
-                  aria-hidden
-                />
-              )}
-
-              {/* Icon */}
-              <span
-                className={cn(
-                  "scale-90 transition-all duration-200",
-                  active && "text-nutrition",
-                  active && "drop-shadow-[0_0_8px_rgba(132,204,22,0.3)]",
-                )}
-              >
-                {item.icon}
-              </span>
-
-              <span
-                className={cn(
-                  "text-2xs leading-none font-semibold transition-colors",
-                  active ? "text-text" : "text-muted",
-                )}
-              >
-                {item.label}
-              </span>
-            </button>
-          );
-        })}
-      </div>
-    </nav>
+    <ModuleBottomNav
+      items={NAV}
+      activeId={activePage}
+      onChange={setActivePage}
+      module="nutrition"
+    />
   );
 }

--- a/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/src/modules/routine/components/RoutineBottomNav.tsx
@@ -1,17 +1,17 @@
 import type { ReactNode } from "react";
-import { cn } from "@shared/lib/cn";
-import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
+import {
+  ModuleBottomNav,
+  type ModuleBottomNavItem,
+} from "@shared/components/ui/ModuleBottomNav";
 
 export type RoutineMainTab = "calendar" | "stats" | "settings";
 
-interface NavItem {
+interface RoutineNavItem extends ModuleBottomNavItem {
   id: RoutineMainTab;
-  label: string;
-  panelId: string;
   icon: ReactNode;
 }
 
-const NAV: readonly NavItem[] = [
+const NAV: readonly RoutineNavItem[] = [
   {
     id: "calendar",
     label: "Календар",
@@ -90,71 +90,13 @@ export function RoutineBottomNav({
   onSelectTab,
 }: RoutineBottomNavProps) {
   return (
-    <nav
-      className={cn(
-        "shrink-0 relative z-30 safe-area-pb",
-        "bg-panel/95 backdrop-blur-xl",
-        "border-t border-line",
-      )}
-      aria-label="Розділи Рутини"
-    >
-      <div className="flex h-[60px]" role="tablist">
-        {NAV.map((item) => {
-          const active = mainTab === item.id;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              role="tab"
-              id={`routine-tab-${item.id}`}
-              aria-selected={active}
-              aria-controls={item.panelId}
-              tabIndex={active ? 0 : -1}
-              onClick={() => onSelectTab(item.id)}
-              className={cn(
-                "relative flex-1 flex flex-col items-center justify-center gap-1.5",
-                "transition-all duration-200 min-h-[48px]",
-                "active:scale-95",
-                active ? "text-text" : "text-muted hover:text-text/70",
-              )}
-            >
-              {/* Active indicator pill */}
-              {active && (
-                <span
-                  className={cn(
-                    "absolute top-0 left-1/2 -translate-x-1/2",
-                    "w-10 h-1 rounded-full",
-                    "bg-gradient-to-r from-coral-400 to-coral-500",
-                    "shadow-sm",
-                  )}
-                  aria-hidden
-                />
-              )}
-
-              {/* Icon with glow effect when active */}
-              <span
-                className={cn(
-                  "transition-all duration-200",
-                  active && C.navActive,
-                  active && "drop-shadow-[0_0_8px_rgba(249,112,102,0.3)]",
-                )}
-                aria-hidden
-              >
-                {item.icon}
-              </span>
-
-              <span
-                className={cn(
-                  "text-xs leading-none font-semibold transition-colors",
-                  active ? "text-text" : "text-muted",
-                )}
-              >
-                {item.label}
-              </span>
-            </button>
-          );
-        })}
-      </div>
-    </nav>
+    <ModuleBottomNav
+      items={NAV}
+      activeId={mainTab}
+      onChange={(id) => onSelectTab(id as RoutineMainTab)}
+      module="routine"
+      role="tablist"
+      ariaLabel="Розділи Рутини"
+    />
   );
 }

--- a/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/src/shared/components/ui/ModuleBottomNav.tsx
@@ -1,0 +1,174 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+/**
+ * Sergeant Design System — ModuleBottomNav
+ *
+ * Single shared bottom-navigation shell for Фінік / Фізрук / Рутина /
+ * Харчування. Replaces 4 near-identical per-module implementations that
+ * had drifted on height (58 vs 60 px), blur (md vs xl), label size,
+ * active-indicator treatment and color tokens.
+ *
+ * Canonical shape:
+ * - height 60 px
+ * - bg-panel/95 backdrop-blur-xl border-t border-line
+ * - 4 tabs, each min-h-[48px], gap-1, active:scale-95
+ * - active indicator: w-10 h-1 rounded-full at the top, module color
+ * - icon uses module-colored glow when active
+ * - label: text-2xs font-semibold
+ *
+ * Accessibility:
+ * - Default role is <nav> with <button aria-current="page">.
+ * - Pass `role="tablist"` to render as tabs (role="tab", aria-selected,
+ *   tabIndex, aria-controls via `panelId`). Matches routine settings
+ *   tabs semantics.
+ */
+
+export type ModuleNavColor = "finyk" | "fizruk" | "routine" | "nutrition";
+
+export interface ModuleBottomNavItem {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  /** Show a small unread/attention dot on the icon. */
+  badge?: boolean;
+  /** aria-controls target id (only used when role="tablist"). */
+  panelId?: string;
+}
+
+export interface ModuleBottomNavProps {
+  items: readonly ModuleBottomNavItem[];
+  activeId: string;
+  onChange: (id: string) => void;
+  module: ModuleNavColor;
+  ariaLabel?: string;
+  /** "navigation" (default) renders buttons as nav links with aria-current;
+   *  "tablist" renders role=tab with aria-selected. */
+  role?: "navigation" | "tablist";
+  className?: string;
+}
+
+type ColorTokens = {
+  text: string;
+  pill: string;
+  glow: string;
+  badge: string;
+};
+
+const COLORS: Record<ModuleNavColor, ColorTokens> = {
+  finyk: {
+    text: "text-finyk",
+    pill: "bg-gradient-to-r from-brand-400 to-brand-500",
+    glow: "drop-shadow-[0_0_8px_rgba(16,185,129,0.3)]",
+    badge: "bg-finyk",
+  },
+  fizruk: {
+    text: "text-fizruk",
+    pill: "bg-gradient-to-r from-teal-400 to-teal-500",
+    glow: "drop-shadow-[0_0_8px_rgba(20,184,166,0.3)]",
+    badge: "bg-fizruk",
+  },
+  routine: {
+    text: "text-routine",
+    pill: "bg-gradient-to-r from-coral-400 to-coral-500",
+    glow: "drop-shadow-[0_0_8px_rgba(249,112,102,0.3)]",
+    badge: "bg-routine",
+  },
+  nutrition: {
+    text: "text-nutrition",
+    pill: "bg-gradient-to-r from-lime-400 to-lime-500",
+    glow: "drop-shadow-[0_0_8px_rgba(132,204,22,0.3)]",
+    badge: "bg-nutrition",
+  },
+};
+
+export function ModuleBottomNav({
+  items,
+  activeId,
+  onChange,
+  module,
+  ariaLabel,
+  role = "navigation",
+  className,
+}: ModuleBottomNavProps) {
+  const tokens = COLORS[module];
+  const isTablist = role === "tablist";
+
+  return (
+    <nav
+      className={cn(
+        "shrink-0 relative z-30 safe-area-pb",
+        "bg-panel/95 backdrop-blur-xl",
+        "border-t border-line",
+        className,
+      )}
+      aria-label={ariaLabel}
+    >
+      <div className="flex h-[60px]" role={isTablist ? "tablist" : undefined}>
+        {items.map((item) => {
+          const active = activeId === item.id;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              role={isTablist ? "tab" : undefined}
+              id={isTablist ? `${module}-tab-${item.id}` : undefined}
+              aria-selected={isTablist ? active : undefined}
+              aria-current={
+                !isTablist ? (active ? "page" : undefined) : undefined
+              }
+              aria-controls={isTablist ? item.panelId : undefined}
+              tabIndex={isTablist ? (active ? 0 : -1) : undefined}
+              aria-label={item.label}
+              onClick={() => onChange(item.id)}
+              className={cn(
+                "relative flex-1 flex flex-col items-center justify-center gap-1",
+                "transition-all duration-200 min-h-[48px] active:scale-95",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+                active ? "text-text" : "text-muted hover:text-text/70",
+              )}
+            >
+              {active && (
+                <span
+                  className={cn(
+                    "absolute top-0 left-1/2 -translate-x-1/2",
+                    "w-10 h-1 rounded-full shadow-sm",
+                    tokens.pill,
+                  )}
+                  aria-hidden
+                />
+              )}
+              <span
+                className={cn(
+                  "relative transition-all duration-200",
+                  active && tokens.text,
+                  active && tokens.glow,
+                )}
+                aria-hidden
+              >
+                {item.icon}
+                {item.badge && !active && (
+                  <span
+                    className={cn(
+                      "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full border border-panel",
+                      tokens.badge,
+                    )}
+                    aria-hidden
+                  />
+                )}
+              </span>
+              <span
+                className={cn(
+                  "text-2xs leading-none font-semibold transition-colors",
+                  active ? "text-text" : "text-muted",
+                )}
+              >
+                {item.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

PR #1/9 із серії unification quick-fixes після UI-аудиту — уніфікую нижню навігацію.

До цього кожен модуль (Фінік, Фізрук, Рутина, Харчування) мав **власну реалізацію одного й того самого UI**, які встигли розсинхронізуватися:

| Що                 | Фінік           | Фізрук          | Рутина            | Харчування        |
| ------------------ | --------------- | --------------- | ----------------- | ----------------- |
| Висота             | 58 px           | 58 px           | **60 px**         | **60 px**         |
| backdrop-blur      | `md`            | `md`            | **`xl`**          | **`xl`**          |
| Активна «пілюля»   | `h-0.5`         | `h-0.5 bg-success` | `h-1` gradient | `h-1` gradient    |
| Активний колір     | `text-emerald-600` + фон-pill | `text-success` | `C.navActive` + glow | `text-nutrition` + glow |
| Label size         | `text-2xs`      | `text-2xs`      | **`text-xs`**     | `text-2xs`        |

Додаю один `<ModuleBottomNav>` у `src/shared/components/ui/ModuleBottomNav.tsx`; він тримає **канонічну форму** (60 px, blur-xl, gradient-pill, module-glow, `text-2xs` label, 44 px tap-target, focus-visible ring) і параметризується кольором модуля (`finyk` | `fizruk` | `routine` | `nutrition`) + режимом `navigation` / `tablist`.

Чотири оригінальні нав-и стали тонкими обгортками (або inline-викликами) — поведінка збережена:

- `RoutineBottomNav.tsx` — залишив як wrapper із `role="tablist"`, `aria-label="Розділи Рутини"`, `panelId` на кожній вкладці. Існуючий `RoutineBottomNav.test.tsx` (перевіряє tablist + зміну табів) проходить без змін.
- `NutritionBottomNav.jsx` — тонкий wrapper.
- Inline nav у `FizrukApp.tsx` — замінено на `<ModuleBottomNav module="fizruk">`, перенесено dot-badge як `badge` проп.
- Inline nav у `FinykApp.jsx` — замінено на `<ModuleBottomNav module="finyk">`.

Результат: `+216 / −214` рядків, -1 копія коду, 4 модулі гарантовано однакові візуально й поведінково.

## Review & Testing Checklist for Human

- [ ] Відкрити кожен із 4 модулів (Фінік, Фізрук, Рутина, Харчування) й візуально пройти по нижній навігації — активний стан, перемикання, лейбли не зрізані, нічого не «стрибнуло» після мерджа.
- [ ] Перевірити на Фізруку: коли `activeProgram && todaySession`, дот-бейдж має з'явитися на `programs` табі (але `programs` не входить у nav — це існуюча dead-code поведінка, збережена 1:1).
- [ ] На Рутині перевірити, що клавіатурна навігація (Tab, стрілки) по табам працює як раніше — `role="tablist"` + `tabIndex` логіка збережені.
- [ ] iOS Safari / safe-area: нижній відступ `safe-area-pb` — перевірити на пристрої з notch, щоб вкладки не наїхали на home-indicator.

CI checks passing is necessary but *insufficient* — візуальна перевірка на пристрої важлива.

### Notes

Це PR #1 із серії 9 PR після UI-аудиту. Далі піде:
- #2 SubCard.jsx → `<Card>` + `<Button>` (showcase)
- #3 `<Sheet>` shell (фіксить 32→44 px close-кнопки)
- #4 `<FormField>` + `<Label>` + `<Select>` + заміна `<input>` у Фініку
- #5 `<PageHeader>` + `<SectionHeading>`
- #6 empty-states migration
- #7 `Icon.tsx` expansion + inline SVG migration
- #8 color-token cleanup (`bg-emerald-*` → `bg-finyk-*` у Фініку)
- #9 ESLint-rule «no raw `<button>`/`<input>` outside shared/components/ui»

Повний аудит-звіт у сесії.

Link to Devin session: https://app.devin.ai/sessions/42d8559209714faba6d1f3739924ad2d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
