### PR TITLE
refactor(finyk): SubCard → &lt;Card&gt;/&lt;Button&gt;/&lt;Input&gt; + module tokens

### DIFF
--- a/src/modules/finyk/components/SubCard.jsx
+++ b/src/modules/finyk/components/SubCard.jsx
@@ -1,6 +1,9 @@
 import { memo, useState } from "react";
 import { daysUntil, fmtDate } from "../utils";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
+import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
 import {
   getLastTxForSubscription,
   getSubscriptionAmountMeta,
@@ -23,6 +26,13 @@ const EMOJI_OPTIONS = [
   "🌐",
   "📡",
 ];
+
+// Matches <Input size="md"> visual shell so the currency select sits flush
+// with the day-of-month input (proper <Select> comes in PR #4).
+const SELECT_CLASS =
+  "h-11 w-full px-4 text-base rounded-2xl text-text bg-panelHi " +
+  "border border-line outline-none transition-all duration-200 " +
+  "focus:border-brand-400 focus:ring-2 focus:ring-brand-100";
 
 // Картка підписки. Всередині тримає лише локальний стан редагування,
 // тож memo уникає перерендеру при змінах інших підписок/сторінки.
@@ -56,16 +66,20 @@ function SubCardComponent({
 
   if (editing) {
     return (
-      <div className="bg-panel border border-primary/30 rounded-xl p-4 mb-3 space-y-3">
+      <Card variant="finyk-soft" padding="md" className="mb-3 space-y-3">
         <div className="flex gap-2 flex-wrap">
           {EMOJI_OPTIONS.map((e) => (
             <button
               key={e}
+              type="button"
               onClick={() => setForm((f) => ({ ...f, emoji: e }))}
+              aria-label={`Вибрати ${e}`}
+              aria-pressed={form.emoji === e}
               className={cn(
-                "text-xl w-9 h-9 rounded-lg flex items-center justify-center transition-colors",
+                "text-xl w-9 h-9 rounded-xl flex items-center justify-center transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
                 form.emoji === e
-                  ? "bg-emerald-500/15 ring-1 ring-emerald-500/40"
+                  ? "bg-finyk-soft ring-1 ring-finyk-ring/50"
                   : "hover:bg-panelHi",
               )}
             >
@@ -73,50 +87,57 @@ function SubCardComponent({
             </button>
           ))}
         </div>
-        <input
-          className="w-full bg-bg border border-line rounded-xl px-3 py-2.5 text-sm text-text placeholder:text-subtle outline-none focus:border-primary/50"
+        <Input
           placeholder="Назва"
           value={form.name}
           onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
         />
-        <input
-          className="w-full bg-bg border border-line rounded-xl px-3 py-2.5 text-sm text-text placeholder:text-subtle outline-none focus:border-primary/50"
+        <Input
           placeholder="Ключове слово з транзакції (якщо без ручної привʼязки)"
           value={form.keyword}
           onChange={(e) => setForm((f) => ({ ...f, keyword: e.target.value }))}
         />
         <div className="flex gap-2">
-          <input
-            className="flex-1 bg-bg border border-line rounded-xl px-3 py-2.5 text-sm text-text outline-none focus:border-primary/50"
-            placeholder="День (1-31)"
-            type="number"
-            min="1"
-            max="31"
-            value={form.billingDay}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, billingDay: e.target.value }))
-            }
-          />
-          <select
-            className="flex-1 bg-bg border border-line rounded-xl px-3 py-2.5 text-sm text-text outline-none focus:border-primary/50"
-            value={form.currency}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, currency: e.target.value }))
-            }
-          >
-            <option value="UAH">₴ UAH</option>
-            <option value="USD">$ USD</option>
-            <option value="EUR">€ EUR</option>
-          </select>
+          <div className="flex-1">
+            <Input
+              placeholder="День (1-31)"
+              type="number"
+              min="1"
+              max="31"
+              value={form.billingDay}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, billingDay: e.target.value }))
+              }
+            />
+          </div>
+          <div className="flex-1">
+            <select
+              className={SELECT_CLASS}
+              value={form.currency}
+              aria-label="Валюта"
+              onChange={(e) =>
+                setForm((f) => ({ ...f, currency: e.target.value }))
+              }
+            >
+              <option value="UAH">₴ UAH</option>
+              <option value="USD">$ USD</option>
+              <option value="EUR">€ EUR</option>
+            </select>
+          </div>
         </div>
         <div className="flex gap-2">
-          <button
+          <Button
+            variant="finyk-soft"
+            size="md"
+            className="flex-1"
             onClick={saveEdit}
-            className="flex-1 py-2.5 text-sm font-semibold bg-emerald-500/12 text-emerald-700 border border-emerald-500/25 rounded-xl hover:bg-emerald-500/20 transition-colors"
           >
             Зберегти
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            className="flex-1"
             onClick={() => {
               setForm({
                 name: sub.name,
@@ -127,24 +148,21 @@ function SubCardComponent({
               });
               setEditing(false);
             }}
-            className="flex-1 py-2.5 text-sm font-semibold text-muted border border-line rounded-xl hover:bg-panelHi transition-colors"
           >
             Скасувати
-          </button>
+          </Button>
         </div>
-      </div>
+      </Card>
     );
   }
 
   return (
-    <div
+    <Card
+      variant="default"
+      padding="md"
       className={cn(
-        "bg-panel border rounded-xl p-4 mb-3 flex items-center gap-3",
-        veryClose
-          ? "border-danger/50"
-          : soon
-            ? "border-amber-500/40"
-            : "border-line",
+        "mb-3 flex items-center gap-3",
+        veryClose ? "border-danger/50" : soon ? "border-amber-500/40" : null,
       )}
     >
       <span className="text-2xl shrink-0 leading-none">{sub.emoji}</span>
@@ -164,7 +182,7 @@ function SubCardComponent({
           · {sub.billingDay}-го
         </div>
         {sub.linkedTxId && lastTx && (
-          <div className="text-xs text-emerald-600 dark:text-emerald-400 mt-0.5">
+          <div className="text-xs text-finyk mt-0.5">
             Привʼязано до транзакції · оновлює суму та дату
           </div>
         )}
@@ -185,33 +203,40 @@ function SubCardComponent({
         )}
         <div className="flex flex-wrap justify-end gap-1.5 mt-1">
           {onLinkTransactions && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="xs"
+              className="px-1.5 h-auto py-0.5 text-xs text-primary hover:bg-transparent hover:underline hover:text-primary"
               onClick={onLinkTransactions}
-              className="text-xs font-medium text-primary hover:underline"
             >
               {sub.linkedTxId ? "Змінити транзакцію" : "Привʼязати транзакцію"}
-            </button>
+            </Button>
           )}
           {onEdit && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="xs"
+              iconOnly
+              aria-label="Редагувати підписку"
               onClick={() => setEditing(true)}
-              className="text-subtle hover:text-primary text-sm transition-colors"
+              className="text-subtle hover:text-primary"
             >
               ✏️
-            </button>
+            </Button>
           )}
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
+            iconOnly
+            aria-label="Видалити підписку"
             onClick={onDelete}
-            className="text-subtle hover:text-danger text-sm transition-colors"
+            className="text-subtle hover:text-danger"
           >
             🗑
-          </button>
+          </Button>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary

PR #2/9 із серії unification після UI-аудиту — showcase-міграція «чемпіона розсихання» з аудиту.

До цього `SubCard.jsx` у Фініку мав свою власну оболонку й кольори:

- свій радіус `rounded-xl` замість системного `rounded-2xl` / `rounded-3xl`;
- сирі `<input>` із власним класом замість `<Input>`;
- сирі `<button>` із власними класами замість `<Button>`;
- кольорові літерали `bg-emerald-500/12`, `text-emerald-700`, `border-emerald-500/25` замість модульних токенів `bg-finyk-soft`, `text-finyk`, `finyk-ring`.

Тепер компонент лежить на дизайн-системі:

- `<Card variant="default">` для view-режиму (з урахуванням dynamic-border-color через `cn` + tailwind-merge — near-due та overdue зберігають `border-amber-500/40` / `border-danger/50`).
- `<Card variant="finyk-soft">` для edit-режиму.
- `<Input size="md">` × 3 у формі редагування.
- `<Button variant="finyk-soft">` (Save) + `<Button variant="secondary">` (Cancel) + 2 `<Button variant="ghost" iconOnly>` у списку дій.
- Emoji-пікер використовує токен `bg-finyk-soft ring-finyk-ring/50` замість `bg-emerald-500/15 ring-emerald-500/40`. Додав `aria-pressed` + `focus-visible` ринг.
- `text-emerald-600 dark:text-emerald-400` замінено на модульний `text-finyk`.

`<select>` для валюти залишений як raw (з класом, що підганяє висоту `h-11` й радіус `rounded-2xl` під `<Input size="md">`), бо повний `<Select>` компонент лежить у PR #4.

Поведінка збережена 1:1 — emoji picker, save/cancel, link-to-tx, delete, hover-стани, різні стани border-кольору (near-due / overdue).

## Review & Testing Checklist for Human

- [ ] Відкрити сторінку підписок у Фініку, натиснути олівець на будь-якій картці → emoji-пікер, інпути, валютний селект та кнопки Save/Cancel мають виглядати однаково як решта Фініка (м’який зелений фон, `rounded-2xl`), без синіх/emerald-600 літералів.
- [ ] Перевірити, що overdue / near-due (днів ≤ 1 / ≤ 3) бордер все ще червоний / amber.
- [ ] Клавіатурою: Tab по emoji-кнопках, по інпутах, по валютному селекту, по Save/Cancel — focus-ring має з’являтися всюди.
- [ ] Валютний селект: перевірити висоту `h-11`, що flush із сусіднім Input day-of-month (до PR #4 це ручна стилізація).

## Notes

Будь-ласка, мерджити після PR #1 (`<ModuleBottomNav>`, #222). Дуже простий, низький ризик, 1 файл ±80 рядків.

Далі по плану:
- #3 `<Sheet>` shell (фіксить 32→44 px close-кнопки)
- #4 `<FormField>` + `<Label>` + `<Select>` + заміна `<input>` у Фініку
- #5 `<PageHeader>` + `<SectionHeading>`
- #6 empty-states migration
- #7 `Icon.tsx` expansion
- #8 color-token cleanup (`bg-emerald-*` → `bg-finyk-*`)
- #9 ESLint-rule «no raw `<button>`/`<input>` outside shared/components/ui»

Link to Devin session: https://app.devin.ai/sessions/42d8559209714faba6d1f3739924ad2d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
