### PR TITLE
feat(ftux): Ship 2 — /welcome route, FirstActionRow, FTUX banner budget

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -21,6 +21,9 @@ import { HubTabs } from "./app/HubTabs.jsx";
 import { HubMainContent } from "./app/HubMainContent.jsx";
 import { HubFloatingActions } from "./app/HubFloatingActions.jsx";
 import { HubModals } from "./app/HubModals.jsx";
+import { WelcomeScreen } from "./app/WelcomeScreen.jsx";
+import { shouldShowOnboarding } from "./OnboardingWizard.jsx";
+import { isFirstRealEntryDone } from "./onboarding/vibePicks.js";
 import { useHubNavigation } from "./hooks/useHubNavigation.js";
 import { useHubUIState } from "./hooks/useHubUIState.js";
 import { usePwaActions } from "./hooks/usePwaActions.js";
@@ -52,15 +55,21 @@ export default function App() {
 // a named route also lets us link straight to sign-in from emails,
 // push-notification landing pages, etc.
 const SIGN_IN_PATH = "/sign-in";
+// URL-addressable cold-start splash. Having a real route (not just a
+// modal overlay on `/`) means the splash can be deep-linked, shows the
+// right title in history/back navigation, and — crucially — renders the
+// populated-hub peek behind itself instead of hovering over an empty
+// dashboard.
+const WELCOME_PATH = "/welcome";
 
 // Tiny effect-only component so the redirect is a declarative render,
 // not a `navigate()` call in the middle of AppInner — keeps the render
 // phase free of side effects and avoids the React warning.
-function RedirectHome() {
+function RedirectTo({ to }) {
   const navigate = useNavigate();
   useEffect(() => {
-    navigate("/", { replace: true });
-  }, [navigate]);
+    navigate(to, { replace: true });
+  }, [navigate, to]);
   return <PageLoader />;
 }
 
@@ -69,6 +78,7 @@ function AppInner() {
   const location = useLocation();
   const navigate = useNavigate();
   const onSignInRoute = location.pathname === SIGN_IN_PATH;
+  const onWelcomeRoute = location.pathname === WELCOME_PATH;
 
   const openAuth = useCallback(() => {
     navigate(SIGN_IN_PATH);
@@ -76,6 +86,10 @@ function AppInner() {
 
   const leaveAuth = useCallback(() => {
     navigate("/");
+  }, [navigate]);
+
+  const leaveWelcome = useCallback(() => {
+    navigate("/", { replace: true });
   }, [navigate]);
 
   const { activeModule, openModule, goToHub, moduleAnimClass } =
@@ -139,7 +153,7 @@ function AppInner() {
   // the form before `user` hydrates.
   if (onSignInRoute) {
     if (!authLoading && user) {
-      return <RedirectHome />;
+      return <RedirectTo to="/" />;
     }
     return (
       <Suspense fallback={<PageLoader />}>
@@ -150,7 +164,31 @@ function AppInner() {
     );
   }
 
+  // `/welcome` is the cold-start surface. A returning user who somehow
+  // lands here (stale link, auto-complete, shared URL) bounces back to
+  // the dashboard instead of being asked to re-onboard.
+  if (onWelcomeRoute) {
+    if (!shouldShowOnboarding()) {
+      return <RedirectTo to="/" />;
+    }
+    return <WelcomeScreen onDone={leaveWelcome} onOpenAuth={openAuth} />;
+  }
+
+  // First-time visitors at `/` get redirected to `/welcome` so the
+  // splash is a real route (back button, deep links, peek-of-product
+  // backdrop) rather than a modal over an empty dashboard.
+  if (!activeModule && shouldShowOnboarding()) {
+    return <RedirectTo to={WELCOME_PATH} />;
+  }
+
   if (!activeModule) {
+    // FTUX session = the window between the splash and the user's first
+    // real (non-demo) entry. During this window we intentionally
+    // suppress PWA install / iOS install / SW update banners and the
+    // "Sign in" header button so the one signal on screen is the
+    // FirstActionRow. The update banner comes back the moment a real
+    // entry is logged.
+    const inFtuxSession = !user && !isFirstRealEntryDone();
     return (
       <div className="min-h-dvh bg-bg flex flex-col safe-area-pt-pb page-enter">
         {!online && <OfflineBanner />}
@@ -169,6 +207,7 @@ function AppInner() {
           onShowAuth={openAuth}
           dark={dark}
           onToggleDark={toggleDark}
+          hideAuthButton={inFtuxSession}
         />
 
         <HubTabs hubView={ui.hubView} onChange={ui.setHubView} />
@@ -179,8 +218,6 @@ function AppInner() {
           canInstall={canInstall}
           onInstall={install}
           onDismissInstall={dismiss}
-          onboarding={ui.onboarding}
-          setOnboarding={ui.setOnboarding}
           onOpenModule={openModule}
           iosVisible={iosVisible}
           onDismissIos={iosDismiss}
@@ -193,6 +230,7 @@ function AppInner() {
           onPull={sync.pullAll}
           user={user}
           onShowAuth={openAuth}
+          inFtuxSession={inFtuxSession}
         />
 
         {/* Primary quick-add surface for the hub. AI chat moved to the

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -215,7 +215,21 @@ function SplashStep({ picks, togglePick, onContinue }) {
   );
 }
 
-export function OnboardingWizard({ onDone }) {
+/**
+ * Onboarding splash. Renders the same single-step content either as a
+ * modal overlay (default, for legacy callers) or inline inside a larger
+ * layout when a parent already owns the page chrome.
+ *
+ * The `fullPage` variant is used by the `/welcome` route so the splash
+ * becomes a URL-addressable cold-start surface with the populated hub
+ * peeking through behind it, instead of a dialog that hovers over an
+ * empty page.
+ *
+ * @param {object} props
+ * @param {(startModuleId: string | null, opts?: { intent: string, picks: string[] }) => void} props.onDone
+ * @param {"modal" | "fullPage"} [props.variant="modal"]
+ */
+export function OnboardingWizard({ onDone, variant = "modal" }) {
   // Single-step flow: default to "all four modules active" so the lazy
   // path is one tap. The vibe picker is still a real choice — motivated
   // users can deselect what they don't want before tapping the primary
@@ -256,6 +270,24 @@ export function OnboardingWizard({ onDone }) {
     onDone(null, { intent: "vibe_demo", picks: chosen });
   };
 
+  const content = (
+    <SplashStep picks={picks} togglePick={togglePick} onContinue={finish} />
+  );
+
+  if (variant === "fullPage") {
+    // Parent (`WelcomeScreen`) owns the full-page frame + peek backdrop.
+    // We render just the card so the splash can share the same viewport
+    // with a blurred hub preview without a modal dialog wrapper.
+    return (
+      <div
+        className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-5 animate-onboarding-enter"
+        aria-label="Вітальний екран"
+      >
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div
       className="fixed inset-0 z-[500] flex items-end sm:items-center justify-center p-4 pb-safe"
@@ -265,7 +297,7 @@ export function OnboardingWizard({ onDone }) {
     >
       <div className="absolute inset-0 bg-bg/80 backdrop-blur-md" />
       <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-5 animate-onboarding-enter">
-        <SplashStep picks={picks} togglePick={togglePick} onContinue={finish} />
+        {content}
       </div>
     </div>
   );

--- a/src/core/app/HubHeader.jsx
+++ b/src/core/app/HubHeader.jsx
@@ -19,6 +19,7 @@ export function HubHeader({
   onShowAuth,
   dark,
   onToggleDark,
+  hideAuthButton = false,
 }) {
   return (
     <header
@@ -73,7 +74,7 @@ export function HubHeader({
         ) : (
           <>
             <DarkModeToggle dark={dark} onToggle={onToggleDark} />
-            {!authLoading && (
+            {!authLoading && !hideAuthButton && (
               <button
                 type="button"
                 onClick={onShowAuth}

--- a/src/core/app/HubMainContent.jsx
+++ b/src/core/app/HubMainContent.jsx
@@ -2,7 +2,6 @@ import { Icon } from "@shared/components/ui/Icon";
 import { HubDashboard } from "../HubDashboard.jsx";
 import { HubReports } from "../HubReports.jsx";
 import { HubSettingsPage } from "../HubSettingsPage.jsx";
-import { OnboardingWizard } from "../OnboardingWizard.jsx";
 import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
 
 export function HubMainContent({
@@ -11,8 +10,6 @@ export function HubMainContent({
   canInstall,
   onInstall,
   onDismissInstall,
-  onboarding,
-  setOnboarding,
   onOpenModule,
   iosVisible,
   onDismissIos,
@@ -25,19 +22,21 @@ export function HubMainContent({
   onPull,
   user,
   onShowAuth,
+  inFtuxSession = false,
 }) {
-  // Post-wizard FTUX is now a non-blocking hero card rendered inline on
-  // the dashboard (see `FirstActionHeroCard`), not a third stacked modal.
-  // The wizard just flips the `first_action_pending` flag and lands the
-  // user on the populated hub.
-  //
   // Banner budget: at most one chrome banner above the hub content.
-  // Priority: update > install (PWA) > iOS install. This prevents a cold
-  // start where update + install + iOS stack three banners before any
-  // real data is visible.
-  const showUpdate = !!updateAvailable;
-  const showInstall = !showUpdate && !!canInstall;
-  const showIos = !showUpdate && !showInstall && iosVisible;
+  // Priority: update > install (PWA) > iOS install.
+  //
+  // During the FTUX session — between the splash and the user's first
+  // real (non-demo) entry — we suppress all three so the dashboard
+  // delivers one signal: the FirstActionRow. Otherwise a first-time
+  // install would see update + install + iOS stack three chrome rows
+  // before any data is visible, which contradicts the 30-second
+  // promise. Banners rehydrate the moment the user logs their first
+  // real entry (see `isFirstRealEntryDone`).
+  const showUpdate = !inFtuxSession && !!updateAvailable;
+  const showInstall = !inFtuxSession && !showUpdate && !!canInstall;
+  const showIos = !inFtuxSession && !showUpdate && !showInstall && iosVisible;
 
   return (
     <>
@@ -116,20 +115,6 @@ export function HubMainContent({
             </button>
           </div>
         </div>
-      )}
-
-      {onboarding && (
-        <OnboardingWizard
-          onDone={(startModuleId, opts = {}) => {
-            setOnboarding(false);
-            if (opts.intent !== "vibe_demo" && startModuleId) {
-              // Legacy paths / external callers: if a module id is
-              // explicitly passed, open it immediately. vibe_demo lands
-              // on the dashboard where the inline hero card picks up.
-              onOpenModule(startModuleId);
-            }
-          }}
-        />
       )}
 
       {showIos && <IOSInstallBanner onDismiss={onDismissIos} />}

--- a/src/core/app/WelcomeScreen.jsx
+++ b/src/core/app/WelcomeScreen.jsx
@@ -1,0 +1,136 @@
+import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+import { OnboardingWizard } from "../OnboardingWizard.jsx";
+
+// Static preview of the populated hub that sits behind the splash card on
+// `/welcome`. We intentionally don't render the real `HubDashboard` here
+// — the module rows show numbers that haven't been seeded yet, so a real
+// render would display zero-state copy and break the "look, this is your
+// hub about to happen" illusion. Instead we hand-roll four rows matching
+// `ModuleRow`'s visual rhythm.
+const PEEK_ROWS = [
+  {
+    id: "finyk",
+    label: "Фінік",
+    accent: "text-finyk bg-finyk-soft",
+    icon: "credit-card",
+    metric: "−320 грн",
+    sub: "тиждень",
+  },
+  {
+    id: "fizruk",
+    label: "Фізрук",
+    accent: "text-fizruk bg-fizruk-soft",
+    icon: "dumbbell",
+    metric: "5 трен.",
+    sub: "14 днів",
+  },
+  {
+    id: "routine",
+    label: "Рутина",
+    accent: "text-routine bg-routine-soft",
+    icon: "check",
+    metric: "7 днів",
+    sub: "стрік «вода»",
+  },
+  {
+    id: "nutrition",
+    label: "Харчування",
+    accent: "text-nutrition bg-nutrition-soft",
+    icon: "utensils",
+    metric: "420 ккал",
+    sub: "сніданок",
+  },
+];
+
+function PeekBackdrop() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      <div
+        className={cn(
+          "absolute inset-0",
+          // Soft brand wash so the backdrop never looks empty on cold load.
+          "bg-gradient-to-b from-brand-500/5 via-transparent to-transparent",
+        )}
+      />
+      {/* Faux hub rendered under a blur so the user perceives the shape
+          and accent colors of their about-to-be-populated dashboard, but
+          can't read individual numbers well enough to be distracted from
+          the splash copy. */}
+      <div
+        className="absolute inset-x-0 top-0 pt-[max(2.5rem,env(safe-area-inset-top))] px-5 max-w-lg mx-auto w-full opacity-40 blur-[6px]"
+        style={{ filter: "blur(6px) saturate(0.85)" }}
+      >
+        <div className="space-y-3">
+          <div>
+            <div className="h-6 w-32 rounded-md bg-panelHi" />
+            <div className="h-3 w-24 rounded-md bg-panelHi mt-2" />
+          </div>
+          <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
+            {PEEK_ROWS.map((row) => (
+              <div
+                key={row.id}
+                className="flex items-center gap-3 px-4 py-3 bg-panel"
+              >
+                <div
+                  className={cn(
+                    "w-8 h-8 rounded-xl flex items-center justify-center shrink-0",
+                    row.accent,
+                  )}
+                >
+                  <Icon name={row.icon} size={16} strokeWidth={2} aria-hidden />
+                </div>
+                <span className="text-xs font-semibold text-text truncate">
+                  {row.label}
+                </span>
+                <div className="ml-auto flex items-center gap-2">
+                  <span className="text-sm font-semibold text-text tabular-nums">
+                    {row.metric}
+                  </span>
+                  <span className="text-[11px] text-muted">{row.sub}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-page cold-start at `/welcome`. Owns the page chrome + peek
+ * backdrop and delegates the splash card to `OnboardingWizard` in
+ * `fullPage` mode.
+ *
+ * @param {object} props
+ * @param {(startModuleId: string | null, opts?: { intent: string, picks: string[] }) => void} props.onDone
+ * @param {() => void} props.onOpenAuth - Navigate to the sign-in route for
+ *   users who already have an account.
+ */
+export function WelcomeScreen({ onDone, onOpenAuth }) {
+  return (
+    <div className="relative min-h-dvh bg-bg text-text overflow-hidden page-enter">
+      <PeekBackdrop />
+      <div className="relative min-h-dvh flex items-end sm:items-center justify-center p-4 pb-safe">
+        <div className="w-full max-w-sm space-y-3">
+          <OnboardingWizard onDone={onDone} variant="fullPage" />
+          <button
+            type="button"
+            onClick={onOpenAuth}
+            className={cn(
+              "w-full text-center text-xs font-medium text-muted",
+              "hover:text-text underline-offset-2 hover:underline",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-md py-1",
+            )}
+          >
+            У мене вже є акаунт
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/core/hooks/useHubUIState.ts
+++ b/src/core/hooks/useHubUIState.ts
@@ -1,16 +1,16 @@
 import { useCallback, useState } from "react";
-import { shouldShowOnboarding } from "../OnboardingWizard.jsx";
 
 export type HubView = "dashboard" | "reports" | "recommendations";
 
+// Onboarding is now a URL-addressable route (`/welcome`) owned by
+// `AppInner`; it no longer lives in hub UI state. The router handles
+// gating and redirects, so this hook only tracks chat/search/hub-view.
 export interface HubUIState {
   chatOpen: boolean;
   chatInitialMessage: string | null;
   searchOpen: boolean;
   hubView: HubView;
-  onboarding: boolean;
   setHubView: (view: HubView) => void;
-  setOnboarding: (value: boolean) => void;
   setSearchOpen: (value: boolean) => void;
   openChat: (message?: string | null) => void;
   closeChat: () => void;
@@ -24,9 +24,6 @@ export function useHubUIState(): HubUIState {
   );
   const [searchOpen, setSearchOpen] = useState(false);
   const [hubView, setHubView] = useState<HubView>("dashboard");
-  const [onboarding, setOnboarding] = useState<boolean>(() =>
-    shouldShowOnboarding(),
-  );
 
   const openChat = useCallback((message: string | null = null) => {
     setChatInitialMessage(message || null);
@@ -45,9 +42,7 @@ export function useHubUIState(): HubUIState {
     chatInitialMessage,
     searchOpen,
     hubView,
-    onboarding,
     setHubView,
-    setOnboarding,
     setSearchOpen,
     openChat,
     closeChat,

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
@@ -6,46 +6,67 @@ import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
 
 /**
- * Per-module "one tap to your first real entry" tiles. Each option routes
- * into its module with a PWA action (the same handler PWA shortcuts use),
- * so a single tap lands the user on an already-open input.
+ * Per-module "one tap to your first real entry" definitions. Each action
+ * routes into its module with a PWA action (the same handler PWA
+ * shortcuts use), so a single tap lands the user on an already-open
+ * input sheet.
  */
 const ACTIONS = {
+  routine: {
+    icon: "check",
+    title: "Створи першу звичку",
+    desc: "30 секунд. Стрік почнеться сьогодні.",
+    accent: "text-routine bg-routine-soft",
+    run: () => openHubModuleWithAction("routine", "add_habit"),
+  },
   finyk: {
     icon: "credit-card",
-    title: "Додай витрату",
-    desc: "5 секунд, будь-яка сума",
+    title: "Додай першу витрату",
+    desc: "5 секунд, будь-яка сума.",
     accent: "text-finyk bg-finyk-soft",
     run: () => openHubModuleWithAction("finyk", "add_expense"),
+  },
+  nutrition: {
+    icon: "utensils",
+    title: "Запиши перший прийом їжі",
+    desc: "Калорії порахую я.",
+    accent: "text-nutrition bg-nutrition-soft",
+    run: () => openHubModuleWithAction("nutrition", "add_meal"),
   },
   fizruk: {
     icon: "dumbbell",
     title: "Увімкни розминку",
-    desc: "10 хв, таймер сам",
+    desc: "10 хв, таймер сам.",
     accent: "text-fizruk bg-fizruk-soft",
     run: () => openHubModuleWithAction("fizruk", "start_workout"),
   },
-  nutrition: {
-    icon: "utensils",
-    title: "Сфоткай обід",
-    desc: "Калорії порахую я",
-    accent: "text-nutrition bg-nutrition-soft",
-    run: () => openHubModuleWithAction("nutrition", "add_meal"),
-  },
-  routine: {
-    icon: "check",
-    title: "Створити звичку",
-    desc: "Почни стрік сьогодні",
-    accent: "text-routine bg-routine-soft",
-    run: () => openHubModuleWithAction("routine", "add_habit"),
-  },
 };
 
+// Priority order when more than one vibe is picked. Routine comes first
+// because "create a habit" has the lowest friction (no numbers, no
+// camera, no bank auth) and the highest emotional payoff (7-day streak
+// preview). Fizruk requires an in-module wizard to produce a real entry,
+// so it goes last.
+const PRIORITY = ["routine", "finyk", "nutrition", "fizruk"];
+
+function pickPrimary(picks) {
+  for (const id of PRIORITY) {
+    if (picks.includes(id)) return id;
+  }
+  return "routine";
+}
+
 /**
- * Inline FTUX hero card rendered on the Hub dashboard when a first action
- * is pending. Replaces the old blocking `FirstActionSheet` modal so the
- * user sees their populated hub plus the quick-win CTAs in the same view
- * (no dialog to dismiss before touching their data).
+ * Inline FTUX row rendered at the top of the Hub dashboard when a first
+ * action is pending. Replaces the earlier 4-tile `FirstActionHeroCard`
+ * with one opinionated primary CTA plus an inline expand.
+ *
+ * Rationale: the old layout asked the user to *choose* a module before
+ * they knew what any of them did, even though they had just selected
+ * module chips on the splash one screen earlier. Forcing a second
+ * explicit selection cost ~6 s and a visible beat of indecision. The
+ * row now makes the default choice for them (highest-priority pick) and
+ * only reveals the alternatives if they tap "Інший модуль".
  */
 export function FirstActionHeroCard({ onDismiss }) {
   const picks = useMemo(() => {
@@ -53,29 +74,39 @@ export function FirstActionHeroCard({ onDismiss }) {
     return raw.length > 0 ? raw : Object.keys(ACTIONS);
   }, []);
 
+  const primaryId = useMemo(() => pickPrimary(picks), [picks]);
+  const primary = ACTIONS[primaryId];
+  const others = useMemo(
+    () => picks.filter((id) => id !== primaryId && ACTIONS[id]),
+    [picks, primaryId],
+  );
+
+  const [expanded, setExpanded] = useState(false);
+
   useEffect(() => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_SHOWN, {
       picks,
+      primary: primaryId,
     });
-  }, [picks]);
+  }, [picks, primaryId]);
 
   const dismiss = () => {
     clearFirstActionPending();
     onDismiss?.();
   };
 
-  const pick = (id) => {
+  const run = (id) => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
       module: id,
+      primary: primaryId,
+      via: id === primaryId ? "primary" : "expand",
     });
     clearFirstActionPending();
     onDismiss?.();
-    const action = ACTIONS[id];
-    if (action) action.run();
+    ACTIONS[id]?.run();
   };
 
-  const visible = picks.filter((id) => ACTIONS[id]);
-  if (visible.length === 0) return null;
+  if (!primary) return null;
 
   return (
     <section
@@ -88,7 +119,7 @@ export function FirstActionHeroCard({ onDismiss }) {
             Старт
           </div>
           <h2 className="text-base font-bold text-text mt-0.5">
-            Одна дія — і хаб твій
+            Зроби одну річ — і хаб твій
           </h2>
           <p className="text-xs text-muted mt-0.5 leading-snug">
             Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
@@ -103,43 +134,103 @@ export function FirstActionHeroCard({ onDismiss }) {
           <Icon name="close" size={16} />
         </button>
       </div>
-      <div className="space-y-2">
-        {visible.map((id) => {
-          const a = ACTIONS[id];
-          return (
-            <button
-              key={id}
-              type="button"
-              onClick={() => pick(id)}
+
+      <button
+        type="button"
+        onClick={() => run(primaryId)}
+        className={cn(
+          "w-full text-left px-4 py-3 rounded-xl border-2 border-brand-500/50 bg-brand-500/5",
+          "hover:border-brand-500 hover:bg-brand-500/10 transition-all",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              "w-11 h-11 shrink-0 rounded-xl flex items-center justify-center",
+              primary.accent,
+            )}
+          >
+            <Icon name={primary.icon} size={22} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-bold text-text">{primary.title}</div>
+            <div className="text-xs text-muted mt-0.5 truncate">
+              {primary.desc}
+            </div>
+          </div>
+          <Icon name="chevron-right" size={18} className="text-brand-600" />
+        </div>
+      </button>
+
+      {others.length > 0 && (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            className={cn(
+              "w-full text-xs font-medium text-muted hover:text-text",
+              "flex items-center justify-center gap-1 py-1",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-md",
+            )}
+          >
+            <span>{expanded ? "Сховати" : "Інший модуль"}</span>
+            <Icon
+              name="chevron-right"
+              size={12}
               className={cn(
-                "w-full text-left px-3 py-2.5 rounded-xl border border-line bg-panelHi",
-                "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+                "transition-transform",
+                expanded ? "rotate-90" : "rotate-0",
               )}
-            >
-              <div className="flex items-center gap-3">
-                <div
-                  className={cn(
-                    "w-9 h-9 shrink-0 rounded-xl flex items-center justify-center",
-                    a.accent,
-                  )}
-                >
-                  <Icon name={a.icon} size={18} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-semibold text-text">
-                    {a.title}
-                  </div>
-                  <div className="text-xs text-muted mt-0.5 truncate">
-                    {a.desc}
-                  </div>
-                </div>
-                <Icon name="chevron-right" size={16} className="text-muted" />
-              </div>
-            </button>
-          );
-        })}
-      </div>
+            />
+          </button>
+
+          {expanded && (
+            <div className="space-y-2">
+              {others.map((id) => {
+                const a = ACTIONS[id];
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => run(id)}
+                    className={cn(
+                      "w-full text-left px-3 py-2 rounded-xl border border-line bg-panelHi",
+                      "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
+                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+                    )}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={cn(
+                          "w-9 h-9 shrink-0 rounded-xl flex items-center justify-center",
+                          a.accent,
+                        )}
+                      >
+                        <Icon name={a.icon} size={18} />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-semibold text-text">
+                          {a.title}
+                        </div>
+                        <div className="text-xs text-muted mt-0.5 truncate">
+                          {a.desc}
+                        </div>
+                      </div>
+                      <Icon
+                        name="chevron-right"
+                        size={14}
+                        className="text-muted"
+                      />
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Ship 2 of the **FTUX 30s redesign** (see Ship 1 in #221 and the design doc). Three structural changes aimed at the second half of the 30-second promise — getting the user to their first real entry quickly after the splash.

### 1. `/welcome` — URL-addressable cold-start
The splash is no longer a modal hovering over an empty hub. It now lives at `/welcome` with a blurred populated-hub peek behind the card, so the user can *see* the shape of their about-to-be-filled dashboard while they read the splash copy.

- First-time visitors at `/` → redirect to `/welcome`.
- Returning users who land on `/welcome` (stale link, shared URL) → redirect back to `/`.
- `OnboardingWizard` gains a `fullPage` variant used by the new `WelcomeScreen`; the legacy modal variant is kept for any code path that still instantiates it directly.
- New "У мене вже є акаунт" link under the CTA for returning users — routes straight to `/sign-in`.

### 2. `FirstActionHeroCard` → single primary CTA with expand
The post-splash hero card used to list all 4 modules as equally-weighted tiles, which re-asked the user to choose a module one screen after they'd already picked chips on the splash. Now it makes the choice for them:

- Priority order: **routine > finyk > nutrition > fizruk** (lowest-friction-to-first-entry first).
- Primary CTA is the highest-priority pick from the user's vibes, visually weighted (2px brand border, 44×44 icon, bold title).
- "Інший модуль" toggle reveals the other picks inline if the user disagrees.
- New analytics on the picked event: `primary` (the suggested module) and `via` (`primary` | `expand`), so we can see how often users override the default.

### 3. FTUX banner budget
A first-time visitor who hadn't installed the PWA yet could see **update + PWA install + iOS install** banners stacked above the dashboard before any real data appeared. During the FTUX session (no user + no real entry yet) all three are now suppressed, along with the header "Sign in" icon. The one signal on the hub is the FirstActionRow. Banners rehydrate the moment the user logs their first real entry (`isFirstRealEntryDone`).

### Files
- `src/core/App.jsx` — `/welcome` route, redirect logic, `inFtuxSession` wiring.
- `src/core/app/WelcomeScreen.jsx` — new; peek backdrop + full-page splash.
- `src/core/OnboardingWizard.jsx` — `fullPage` variant.
- `src/core/onboarding/FirstActionSheet.jsx` — primary-CTA-with-expand layout.
- `src/core/app/HubMainContent.jsx` — banner suppression during FTUX; removed the in-content wizard render (route owns it now).
- `src/core/app/HubHeader.jsx` — `hideAuthButton` prop.
- `src/core/hooks/useHubUIState.ts` — dropped `onboarding` state (route-driven now).

## Review & Testing Checklist for Human

- [ ] **Cold-start path**: clear localStorage, load `/` — expect redirect to `/welcome`, splash card with peek-of-hub visible behind, "У мене вже є акаунт" link under CTA.
- [ ] **First-action row**: after tapping "Заповни мій хаб", land on `/` with a single primary CTA (should be "Створи першу звичку" when all chips are picked). Tap "Інший модуль" — expands to show the other 3.
- [ ] **Banner suppression**: on the same first session, verify none of update/install/iOS banners render and the sign-in icon is hidden in the header. After creating a real (non-demo) entry anywhere, reload — banners + sign-in icon reappear.
- [ ] **Returning user**: localStorage already has `hub_onboarding_done_v1=1` — `/welcome` should redirect to `/`, and `/` should show the normal dashboard with no hero row.
- [ ] **Partial picks**: deselect "Рутина" before CTA — first-action row's primary becomes "Додай першу витрату" (finyk next in priority). Deselect all then reselect one module — priority should still respect the ordering.
- [ ] **Sign-in route still works**: `/sign-in` opens the auth page; after auth, lands back on `/`.

### Notes
- `useHubUIState`'s `onboarding`/`setOnboarding` were unused outside `HubMainContent`; dropping them is a safe cleanup.
- `detectFirstRealEntry` is intentionally not called at the App level — it fires an analytics event on first-real-entry and would fire too early if hoisted. `App.jsx` uses the non-side-effecting `isFirstRealEntryDone()` instead; the actual event still fires from the dashboard on render.
- Ship 3 follows (PresetSheet + success-moment strengthening + `ftux_time_to_value` analytics event). Ship 4 after that (empty states, soft auth copy, A/B polish).


Link to Devin session: https://app.devin.ai/sessions/8070829be3fb4627b47160f18a7ef215
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
