### PR TITLE
feat(ui): shared &lt;Sheet&gt; shell — fix 32-px close, migrate 2 sheets

### DIFF
--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useId, useMemo } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech } from "../../../core/lib/speechParsers.js";
 import { useVisualKeyboardInset } from "@shared/hooks/useVisualKeyboardInset";
@@ -232,192 +233,14 @@ export function ManualExpenseSheet({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm motion-safe:animate-fade-in">
-      <div
-        className="w-full max-w-lg bg-panel rounded-t-3xl p-5 pb-safe-area-bottom space-y-4 animate-slide-up"
-        style={{ marginBottom: kbInsetPx }}
-      >
-        <div className="flex items-center justify-between mb-1">
-          <h2 className="text-base font-bold text-text">
-            {isEditing ? "Редагувати витрату" : "Додати витрату"}
-          </h2>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 rounded-full bg-panelHi flex items-center justify-center text-muted hover:text-text transition-colors"
-            aria-label="Закрити"
-          >
-            ✕
-          </button>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex gap-2 items-center">
-            <div className="flex-1">
-              <label
-                htmlFor={descId}
-                className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-              >
-                Назва{" "}
-                <span className="text-subtle normal-case">
-                  · необов&apos;язково
-                </span>
-              </label>
-              <input
-                id={descId}
-                className={formInp}
-                placeholder="Кава, продукти, таксі..."
-                value={form.description}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, description: e.target.value }))
-                }
-              />
-            </div>
-            <div className="mt-5">
-              <VoiceMicButton
-                size="md"
-                label="Голосовий ввід"
-                onResult={(transcript) => {
-                  const parsed = parseExpenseSpeech(transcript);
-                  if (!parsed) return;
-                  setForm((f) => ({
-                    ...f,
-                    description: parsed.name || f.description,
-                    amount:
-                      parsed.amount != null
-                        ? String(Math.round(parsed.amount))
-                        : f.amount,
-                  }));
-                }}
-              />
-            </div>
-          </div>
-
-          {merchantSuggestions.length > 0 && (
-            <div
-              className="flex flex-wrap gap-1.5 -mt-1"
-              role="group"
-              aria-label="Нещодавні мерчанти"
-            >
-              <span className="text-2xs text-subtle uppercase tracking-wide font-semibold w-full">
-                Нещодавнє
-              </span>
-              {merchantSuggestions.map((m) => (
-                <button
-                  key={m.key}
-                  type="button"
-                  onClick={() =>
-                    setForm((f) => {
-                      const next = { ...f, description: m.name };
-                      // Якщо є впевнений підпис manual-категорії для цього
-                      // мерчанта — підставляємо його, щоб економити тапи.
-                      const suggested =
-                        m.suggestedManualCategory &&
-                        CATEGORIES.includes(m.suggestedManualCategory)
-                          ? m.suggestedManualCategory
-                          : null;
-                      if (suggested) next.category = suggested;
-                      return next;
-                    })
-                  }
-                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
-                  title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
-                >
-                  {m.name}
-                </button>
-              ))}
-            </div>
-          )}
-
-          <div>
-            <label
-              htmlFor={amountId}
-              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-            >
-              Сума ₴
-            </label>
-            {amountSuggestions.length > 0 && (
-              <div
-                className="flex flex-wrap gap-1.5 mb-2"
-                role="group"
-                aria-label="Швидкі суми"
-              >
-                {amountSuggestions.map((v) => (
-                  <button
-                    key={v}
-                    type="button"
-                    onClick={() =>
-                      setForm((f) => ({ ...f, amount: String(v) }))
-                    }
-                    className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
-                  >
-                    {v.toLocaleString("uk-UA")} ₴
-                  </button>
-                ))}
-              </div>
-            )}
-            <input
-              id={amountId}
-              className={formInp}
-              type="number"
-              inputMode="decimal"
-              placeholder="0"
-              min="0"
-              step="0.01"
-              value={form.amount}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, amount: e.target.value }))
-              }
-            />
-          </div>
-
-          <div>
-            <div
-              id={catLabelId}
-              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-            >
-              Категорія
-            </div>
-            <div
-              className="flex flex-wrap gap-2"
-              role="group"
-              aria-labelledby={catLabelId}
-            >
-              {sortedCategories.map((cat) => (
-                <button
-                  key={cat}
-                  onClick={() => setForm((f) => ({ ...f, category: cat }))}
-                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 ease-smooth active:scale-95 ${
-                    form.category === cat
-                      ? "bg-emerald-500 text-white border-emerald-500 shadow-sm"
-                      : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
-                  }`}
-                >
-                  {cat}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <label
-              htmlFor={dateId}
-              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-            >
-              Дата
-            </label>
-            <input
-              id={dateId}
-              className={formInp}
-              type="date"
-              value={form.date}
-              onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
-            />
-          </div>
-
-          {error && <p className="text-xs text-red-500">{error}</p>}
-        </div>
-
-        <div className="flex gap-3 pt-1">
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={isEditing ? "Редагувати витрату" : "Додати витрату"}
+      kbInsetPx={kbInsetPx}
+      bodyClassName="space-y-4"
+      footer={
+        <div className="flex gap-3">
           <Button variant="ghost" className="flex-1" onClick={onClose}>
             Скасувати
           </Button>
@@ -425,7 +248,170 @@ export function ManualExpenseSheet({
             {isEditing ? "Зберегти" : "Додати"}
           </Button>
         </div>
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex gap-2 items-center">
+          <div className="flex-1">
+            <label
+              htmlFor={descId}
+              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+            >
+              Назва{" "}
+              <span className="text-subtle normal-case">
+                · необов&apos;язково
+              </span>
+            </label>
+            <input
+              id={descId}
+              className={formInp}
+              placeholder="Кава, продукти, таксі..."
+              value={form.description}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, description: e.target.value }))
+              }
+            />
+          </div>
+          <div className="mt-5">
+            <VoiceMicButton
+              size="md"
+              label="Голосовий ввід"
+              onResult={(transcript) => {
+                const parsed = parseExpenseSpeech(transcript);
+                if (!parsed) return;
+                setForm((f) => ({
+                  ...f,
+                  description: parsed.name || f.description,
+                  amount:
+                    parsed.amount != null
+                      ? String(Math.round(parsed.amount))
+                      : f.amount,
+                }));
+              }}
+            />
+          </div>
+        </div>
+
+        {merchantSuggestions.length > 0 && (
+          <div
+            className="flex flex-wrap gap-1.5 -mt-1"
+            role="group"
+            aria-label="Нещодавні мерчанти"
+          >
+            <span className="text-2xs text-subtle uppercase tracking-wide font-semibold w-full">
+              Нещодавнє
+            </span>
+            {merchantSuggestions.map((m) => (
+              <button
+                key={m.key}
+                type="button"
+                onClick={() =>
+                  setForm((f) => {
+                    const next = { ...f, description: m.name };
+                    // Якщо є впевнений підпис manual-категорії для цього
+                    // мерчанта — підставляємо його, щоб економити тапи.
+                    const suggested =
+                      m.suggestedManualCategory &&
+                      CATEGORIES.includes(m.suggestedManualCategory)
+                        ? m.suggestedManualCategory
+                        : null;
+                    if (suggested) next.category = suggested;
+                    return next;
+                  })
+                }
+                className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
+                title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
+              >
+                {m.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div>
+          <label
+            htmlFor={amountId}
+            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+          >
+            Сума ₴
+          </label>
+          {amountSuggestions.length > 0 && (
+            <div
+              className="flex flex-wrap gap-1.5 mb-2"
+              role="group"
+              aria-label="Швидкі суми"
+            >
+              {amountSuggestions.map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setForm((f) => ({ ...f, amount: String(v) }))}
+                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                >
+                  {v.toLocaleString("uk-UA")} ₴
+                </button>
+              ))}
+            </div>
+          )}
+          <input
+            id={amountId}
+            className={formInp}
+            type="number"
+            inputMode="decimal"
+            placeholder="0"
+            min="0"
+            step="0.01"
+            value={form.amount}
+            onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+          />
+        </div>
+
+        <div>
+          <div
+            id={catLabelId}
+            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+          >
+            Категорія
+          </div>
+          <div
+            className="flex flex-wrap gap-2"
+            role="group"
+            aria-labelledby={catLabelId}
+          >
+            {sortedCategories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setForm((f) => ({ ...f, category: cat }))}
+                className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 ease-smooth active:scale-95 ${
+                  form.category === cat
+                    ? "bg-emerald-500 text-white border-emerald-500 shadow-sm"
+                    : "bg-panelHi text-muted border-line hover:border-muted/50 hover:bg-panelHi/80"
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor={dateId}
+            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+          >
+            Дата
+          </label>
+          <input
+            id={dateId}
+            className={formInp}
+            type="date"
+            value={form.date}
+            onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
+          />
+        </div>
+
+        {error && <p className="text-xs text-red-500">{error}</p>}
       </div>
-    </div>
+    </Sheet>
   );
 }

--- a/src/modules/nutrition/components/ConfirmDeleteSheet.jsx
+++ b/src/modules/nutrition/components/ConfirmDeleteSheet.jsx
@@ -1,7 +1,5 @@
-import { useRef } from "react";
 import { Button } from "@shared/components/ui/Button";
-import { cn } from "@shared/lib/cn";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { Sheet } from "@shared/components/ui/Sheet";
 
 export function ConfirmDeleteSheet({
   open,
@@ -10,73 +8,46 @@ export function ConfirmDeleteSheet({
   activePantryId: _activePantryId,
   onConfirm,
 }) {
-  const ref = useRef(null);
-  useDialogFocusTrap(open, ref, { onEscape: onClose });
-
   if (!open) return null;
 
   const arr = Array.isArray(pantries) ? pantries : [];
 
   return (
-    <div className={cn("fixed inset-0 flex items-end", "z-[110]")}>
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      <div
-        ref={ref}
-        className={cn(
-          "relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft",
-          "fizruk-sheet-pad",
-        )}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="nutrition-delete-title"
-      >
-        <div className="flex justify-center pt-3 pb-1">
-          <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
-        </div>
-        <div className="px-5 pb-6">
-          <div
-            id="nutrition-delete-title"
-            className="text-lg font-extrabold text-text leading-tight"
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="Видалити склад?"
+      description="Це прибере всі продукти в ньому. Дію не можна відмінити."
+      zIndex={110}
+      footer={
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-12 min-h-[44px]"
+            onClick={onClose}
           >
-            Видалити склад?
-          </div>
-          <div className="text-xs text-subtle mt-1">
-            Це прибере всі продукти в ньому. Дію не можна відмінити.
-          </div>
-          {arr.length <= 1 ? (
-            <div className="mt-4 rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm text-warning">
-              Не можна видалити останній склад.
-            </div>
-          ) : null}
-          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              className="h-12 min-h-[44px]"
-              onClick={onClose}
-            >
-              Скасувати
-            </Button>
-            <Button
-              type="button"
-              variant="danger"
-              className="h-12 min-h-[44px]"
-              onClick={() => {
-                if (arr.length <= 1) return;
-                onConfirm();
-              }}
-            >
-              Видалити
-            </Button>
-          </div>
+            Скасувати
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            className="h-12 min-h-[44px]"
+            onClick={() => {
+              if (arr.length <= 1) return;
+              onConfirm();
+            }}
+          >
+            Видалити
+          </Button>
         </div>
-      </div>
-    </div>
+      }
+    >
+      {arr.length <= 1 ? (
+        <div className="rounded-2xl border border-warning/40 bg-warning/10 p-4 text-sm text-warning">
+          Не можна видалити останній склад.
+        </div>
+      ) : null}
+    </Sheet>
   );
 }

--- a/src/shared/components/ui/Sheet.tsx
+++ b/src/shared/components/ui/Sheet.tsx
@@ -1,0 +1,171 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { cn } from "../../lib/cn";
+import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
+
+/**
+ * Sergeant Design System — Sheet (bottom sheet / modal)
+ *
+ * Canonical bottom-sheet shell used across Фінік / Фізрук / Рутина /
+ * Харчування. Replaces ≥ 6 hand-rolled sheet shells that drifted on:
+ *   - overlay opacity/blur
+ *   - close button size (32×32 in Finyk vs 44×44 in Fizruk — a11y bug)
+ *   - focus-trap wiring
+ *   - keyboard inset handling
+ *   - header markup & labelling
+ *
+ * What this enforces for every caller:
+ *   - role="dialog" + aria-modal + aria-labelledby auto-wired
+ *   - 44×44 close button (WCAG tap target) with <Button variant="ghost" iconOnly>
+ *   - focus trap + Escape via useDialogFocusTrap
+ *   - overlay-click dismiss
+ *   - animated slide-up with safe-area padding (safe-area-pb)
+ *   - keyboard-inset-aware margin if kbInsetPx is supplied
+ *
+ * Callers are still responsible for their own form state, validation,
+ * and action footer — Sheet only owns the shell.
+ */
+
+export interface SheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** Dialog title — rendered in the header and used for aria-labelledby. */
+  title: ReactNode;
+  /** Optional subtitle rendered under the title. */
+  description?: ReactNode;
+  /** Main sheet body. */
+  children?: ReactNode;
+  /** Sticky footer (e.g. action buttons). Rendered inside the panel, outside the scroll area. */
+  footer?: ReactNode;
+  /** Slot rendered in the header row to the left of the close button (e.g. extra action). */
+  headerRight?: ReactNode;
+  /** Hide the drag-handle pill. */
+  hideHandle?: boolean;
+  /** Keyboard (visual viewport) inset in px — shifts panel up when an on-screen keyboard is visible. */
+  kbInsetPx?: number;
+  /** Sheet z-index. Defaults to 50 — raise for nested sheets. */
+  zIndex?: number;
+  /** Accessible label for the close button. */
+  closeLabel?: string;
+  /** Optional className on the panel (for per-module accents). */
+  panelClassName?: string;
+  /** Optional className on the scroll region. */
+  bodyClassName?: string;
+}
+
+export function Sheet({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  headerRight,
+  hideHandle = false,
+  kbInsetPx,
+  zIndex = 50,
+  closeLabel = "Закрити",
+  panelClassName,
+  bodyClassName,
+}: SheetProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  useDialogFocusTrap(open, panelRef, { onEscape: onClose });
+
+  // Lock body scroll while sheet is open. Matches the ad-hoc patterns
+  // several existing sheets already implemented inconsistently.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const panelStyle: CSSProperties | undefined =
+    kbInsetPx && kbInsetPx > 0 ? { marginBottom: kbInsetPx } : undefined;
+
+  return (
+    <div
+      className="fixed inset-0 flex items-end justify-center motion-safe:animate-fade-in"
+      style={{ zIndex }}
+    >
+      {/* Scrim. A real <button> makes the dismiss discoverable to AT. */}
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={closeLabel}
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        style={panelStyle}
+        onPointerDown={(e) => e.stopPropagation()}
+        className={cn(
+          "relative w-full max-w-lg bg-panel border-t border-line rounded-t-3xl shadow-soft",
+          "flex flex-col max-h-[90vh] safe-area-pb",
+          "animate-slide-up",
+          panelClassName,
+        )}
+      >
+        {!hideHandle && (
+          <div className="flex justify-center pt-3 pb-1 shrink-0">
+            <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
+          </div>
+        )}
+        <div className="flex items-start justify-between gap-3 px-5 pt-1 pb-3 shrink-0">
+          <div className="min-w-0 flex-1">
+            <div
+              id={titleId}
+              className="text-lg font-extrabold text-text leading-tight"
+            >
+              {title}
+            </div>
+            {description && (
+              <div className="text-xs text-subtle mt-1">{description}</div>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {headerRight}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={closeLabel}
+              className={cn(
+                "flex items-center justify-center w-11 h-11 min-w-[44px] min-h-[44px] rounded-full",
+                "bg-panelHi text-muted hover:text-text text-lg transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+              )}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+        <div
+          className={cn(
+            "flex-1 min-h-0 overflow-y-auto px-5 pb-4",
+            bodyClassName,
+          )}
+        >
+          {children}
+        </div>
+        {footer && (
+          <div className="shrink-0 px-5 pt-3 pb-4 border-t border-line bg-panel">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR #3/9 із серії unification після UI-аудиту — канонічний bottom-sheet.

До цього кожен module-sheet (≥ 6 шт.) мав свій оболонковий bojlerplate: fixed-inset overlay, backdrop-blur, panel з drag-handle, header, close button, focus-trap. Вони встигли розійтися, найбільш а11y-критично — **розмір close-кнопки**:

| Де                                                           | Розмір close |
| ------------------------------------------------------------ | ------------ |
| `finyk/ManualExpenseSheet.jsx`                               | **32×32**    |
| `finyk/components/SubCard.jsx` (inline «скасувати»)          | текст-only   |
| `fizruk/components/workouts/AddExerciseSheet.tsx`            | 44×44        |
| `nutrition/components/ConfirmDeleteSheet.jsx`                | через `<Button variant="ghost">` (≥ 44) |
| `routine/components/HabitDetailSheet.tsx`                    | 44×44        |

32×32 не проходить WCAG 2.5.5 (24 CSS-px мінімум) і явно промахується у порівнянні з 44-px tap-target-ами інших модулів.

Додано `src/shared/components/ui/Sheet.tsx` з канонічним контрактом — кожен виклик отримує гарантовано:

- `role="dialog"` + `aria-modal` + `aria-labelledby` (auto-wired через `useId`).
- 44×44 close-кнопка (`min-w/h 44`), focus-visible ring.
- `useDialogFocusTrap` — Tab циклічно і Escape = close.
- Overlay-клік дисмісс через справжній `<button>` (discoverable AT).
- `safe-area-pb`, `kbInsetPx` (visual-viewport keyboard), sticky `footer` slot, drag-handle, scrollable body з `max-h-[90vh]`.
- Lock `body { overflow: hidden }` на час відкриття.

Мігрував два sheet-и як showcase (мінімальна поверхня ризику):

- `modules/finyk/components/ManualExpenseSheet.jsx` — прибрав 32×32 close, дубль overlay-markup; форма й логіка збережені 1:1. `footer` тепер фіксований знизу, прокрутка тепер у body, тобто «Додати / Скасувати» не зʼїжджає за keyboard.
- `modules/nutrition/components/ConfirmDeleteSheet.jsx` — 80→53 рядки, делегував focus-trap і markup.

Решта 4–5 sheet-ів (`AddMealSheet`, `AddExerciseSheet`, `HabitDetailSheet` тощо) переїдуть окремим PR (мають специфіку: scrollable pickers, sticky keyboards, nested sheets) — щоб цей PR лишився маленьким і легко перевірявся візуально.

## Review & Testing Checklist for Human

- [ ] Відкрити Фінік → «Додати витрату» (`+` FAB). Перевірити: close ✕ у правому верхньому куті **44×44** (не 32×32), не обрізаний, не злипається з іншими контролами. Tab цикл працює, Escape закриває, iOS-клавіатура підіймає панель (`kbInsetPx`).
- [ ] Відкрити Харчування → Pantry manager → «Видалити склад» коли складів > 1 — Скасувати / Видалити, різні кольори, висота 48+ px.
- [ ] Keyboard trap: всередині sheet-ів Tab не випадає на фон, Shift-Tab теж циклічний.
- [ ] Body scroll: під час відкритого sheet-у сторінка за ним не скролиться (lock працює).

## Notes

Наступні кроки серії:
- #4 `<FormField>` + `<Label>` + `<Select>` + заміна 31 `<input>` у Фініку
- #5 `<PageHeader>` / `<SectionHeading>`
- #6 empty-states migration
- #7 `Icon.tsx` expansion
- #8 color-token cleanup (`bg-emerald-*` → `bg-finyk-*`)
- #9 ESLint-rule «no raw `<button>`/`<input>` outside shared/components/ui»

Link to Devin session: https://app.devin.ai/sessions/42d8559209714faba6d1f3739924ad2d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
