### PR TITLE
obs(alerts): add AiQuotaStoreDown and leading DbPoolWaitingSustained

### DIFF
--- a/docs/observability/prometheus/alert_rules.yml
+++ b/docs/observability/prometheus/alert_rules.yml
@@ -230,6 +230,25 @@ groups:
             Likely Anthropic-side degradation. Check status.anthropic.com.
           runbook: "docs/observability/runbook.md#ailatencyp95high"
 
+      # Квота зберігається в Postgres; якщо сховище впало — `assertAiQuota`
+      # fail-open пропускає запити, тобто ми тимчасово НЕ стримуємо юзерів
+      # від перевитрати Anthropic-бюджету. Це не поломка бекенду в сенсі 5xx
+      # (response = ok), але реальна фінансова ризик-подія, тому ticket.
+      - alert: AiQuotaStoreDown
+        expr: increase(ai_quota_fail_open_total[10m]) > 0
+        for: 5m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "AI quota store unavailable → fail-open (users can exceed limits)"
+          description: |
+            `ai_quota_fail_open_total` інкрементується, коли assertAiQuota
+            не може записати у `ai_usage_daily` (DB down / DATABASE_URL
+            missing / table dropped). Запити пропускаються → юзери можуть
+            вийти за денний ліміт, і ми заплатимо за Anthropic.
+            Reason label: {{ $labels.reason }}.
+          runbook: "docs/observability/runbook.md#aiquotastoredown"
+
   # ──────────────────────────── External HTTP (SLO 95.0% per-upstream) ─
   - name: slo_external_http
     rules:
@@ -278,6 +297,25 @@ groups:
             killed (Sentry captures + Railway restarts on health failure),
             but state may be inconsistent. Investigate immediately.
           runbook: "docs/observability/runbook.md#uncaughtexception"
+
+      # Leading indicator. `DbPoolSaturated` (нижче) page-ить аж через 10m —
+      # до того моменту p95 API вже просів, бо кожен session-check чекає
+      # вільний слот. Ticket на 5m дає команді час почати дослідження до
+      # того, як SLO починає гриміти.
+      - alert: DbPoolWaitingSustained
+        expr: db_pool_waiting > 0
+        for: 5m
+        labels:
+          severity: ticket
+        annotations:
+          summary: "Postgres pool has waiting clients for >5m (leading indicator)"
+          description: |
+            `db_pool_waiting` > 0 вже 5 хвилин. p95 API починає деградувати
+            через чергування session-check-ів. Якщо не розсмокчеться — за
+            ще 5m трігернеться page `DbPoolSaturated`. Перевір
+            `db_query_duration_ms{op}` і `db_slow_queries_total{op}` ЗАРАЗ,
+            знайди нового винуватця (недавній deploy / зміна схеми).
+          runbook: "docs/observability/runbook.md#dbpoolwaitingsustained"
 
       - alert: DbPoolSaturated
         expr: db_pool_waiting > 0

--- a/docs/observability/runbook.md
+++ b/docs/observability/runbook.md
@@ -140,6 +140,21 @@
 3. Patch гіпотетично в наступному релізі; temporary — тримай за алерт.
 4. `unhandledRejectionsTotal` не має бути >0 у нормі, навіть не короткочасно.
 
+## DbPoolWaitingSustained
+
+Leading indicator. `db_pool_waiting > 0` 5m → ticket. Пейдж
+`DbPoolSaturated` ще не впав, але p95 уже просідає, бо кожен
+session-check чекає слот.
+
+1. `sum by (op) (rate(db_query_duration_ms_count[5m]))` — хто раптом
+   почав робити багато запитів? Новий endpoint? N+1?
+2. `histogram_quantile(0.95, sum by (le, op) (rate(db_query_duration_ms_bucket[5m])))`
+   — який op п'є pool.
+3. Сверь із git-log: недавній deploy (< 1h) з новою heavy query —
+   найчастіший винуватець. Якщо так — розкати або патчі запит.
+4. Якщо `db_pool_waiting` падає до 0 за кілька хвилин — резолв.
+   Якщо росте далі — чекай `DbPoolSaturated` і дій за ним.
+
 ## DbPoolSaturated
 
 `db_pool_waiting > 0` 10m → connection contention.
@@ -149,6 +164,27 @@
 3. Знайди потенційні long-running transactions у логах
    (`level=info` з `module=db, msg="slow query"`).
 4. Перевір, чи не відбувся нещодавно deploy, що додав новий heavy read-path.
+
+## AiQuotaStoreDown
+
+`ai_quota_fail_open_total` зростає → `assertAiQuota` не може
+записати в `ai_usage_daily` і **пропускає запити без ліку**. Юзери
+можуть вийти за денний ліміт → непередбачуваний Anthropic-білл.
+
+1. `sum by (reason) (increase(ai_quota_fail_open_total[30m]))` — зрозумій
+   категорію:
+   - `database_url_missing` → env зник/не переексопортнувся. Перевір
+     Railway service vars і deploy-логи.
+   - `db_error` → Postgres down/unreachable/table missing. Глянь
+     `db_errors_total{code}` і Pino `msg=ai_quota_store_unavailable`
+     (там є `err.code`).
+2. Поки fix не виїхав — **тимчасово заборони AI-фічі** через
+   `AI_QUOTA_DISABLED=0` і `AI_DAILY_ANON_LIMIT=0` / `AI_DAILY_USER_LIMIT=0`,
+   щоб `assertAiQuota` повертав 429 замість fail-open.
+3. Перевір міграцію `ai_usage_daily`: `SELECT to_regclass('ai_usage_daily')`.
+   Якщо null — запусти міграції.
+4. Після відновлення — дивись Anthropic-dashboard, чи не було сплеску
+   витрат за вікно fail-open.
 
 ## ProgrammerErrors
 


### PR DESCRIPTION
## Summary

Два пропущених сигнали з observability-аудиту ([попередній session](https://github.com/Skords-01/Sergeant/pull/220)). Зараз відповідні метрики (`ai_quota_fail_open_total`, `db_pool_waiting`) збираються — але алертів на них або нема, або page-сигнал приходить занадто пізно.

### 1. `AiQuotaStoreDown` — `slo_ai` group, `severity=ticket`, `for: 5m`

**Що:** `increase(ai_quota_fail_open_total[10m]) > 0` → тригер.

**Чому важливо:** якщо `assertAiQuota` не може записати в `ai_usage_daily` (DB down / `DATABASE_URL` missing / міграція не проїхала), поточна логіка — **fail-open**, тобто запит все одно пропускається. Жодного 5xx ми не віддаємо → існуючі HTTP / AI error-budget алерти **цього не ловлять**. Але юзери в цей момент можуть вийти за денний ліміт і видати нам непередбачуваний Anthropic-білл — це класичний фінансовий інцидент. Ticket-severity (не page), бо не impact-ить UX напряму.

### 2. `DbPoolWaitingSustained` — `process_errors` group, `severity=ticket`, `for: 5m`

**Що:** той самий expr, що й у існуючого `DbPoolSaturated` (`db_pool_waiting > 0`), але `for: 5m` замість `10m` і ticket замість page.

**Чому важливо:** `DbPoolSaturated` сьогодні пейдж-ить **аж через 10 хвилин**. До цього часу p95 API вже просів, бо кожен `session-check` стоїть у черзі. Leading ticket на 5m дає команді 5-хвилинне вікно для дослідження (`db_query_duration_ms{op}`, recent deploys) до повноцінного page-у. Обидва правила незалежно тріммеряться Prometheus-ом за своїми `for`, так що при тривалому incident-і спрацюють обидва (ticket → потім page).

### 3. Runbook entries

Додано `#dbpoolwaitingsustained` і `#aiquotastoredown` у [runbook.md](docs/observability/runbook.md) з PromQL для тріажу. Зокрема `AiQuotaStoreDown` runbook пропонує temporary workaround: виставити `AI_DAILY_USER_LIMIT=0` і `AI_DAILY_ANON_LIMIT=0` — тоді `assertAiQuota` повертає 429 замість fail-open, і Anthropic-витрати зупиняються, поки фіксимо DB.

## Review & Testing Checklist for Human

- [ ] Якщо ви підвантажуєте `alert_rules.yml` у Prometheus через `prometheus.yml`-конфіг — зробіть `promtool check rules docs/observability/prometheus/alert_rules.yml` після мерджу (у CI цього немає). Локально перевірив `yaml.parse()` — синтаксис ок, структура збігається з існуючими group-ами.
- [ ] Підтвердіть, що `for: 5m` на `DbPoolWaitingSustained` не буде надмірним шумом для вашого trafic-патерну (якщо є регулярні короткі піки `db_pool_waiting > 0`, підніміть на `for: 7m` або додайте поріг `> 1`).
- [ ] Переконайтеся, що канал доставки ticket-алертів (email / Slack / Sentry) налаштований — сам YAML лише експонує їх Prometheus-у.

### Notes

- Метрика `ai_quota_fail_open_total` уже є (`server/obs/metrics.js`) і інкрементується у `server/aiQuota.js:logQuotaStoreUnavailable`.
- Метрика `db_pool_waiting` уже є як gauge, оновлюється у `server/obs/metrics.js`.
- Жодних змін у коді або test suite — лише YAML + markdown. `npm run lint` ✓.
- Наступний PR з плану: #2 (sync/push/aiQuota через `db.js:query()`) або інший за вашим вибором.

Link to Devin session: https://app.devin.ai/sessions/872bc66744e945e682bc554d94a14595
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
