### PR TITLE
obs(logs): structured sync_event and auth_event for triage

### DIFF
--- a/server/api/sync.js
+++ b/server/api/sync.js
@@ -1,5 +1,6 @@
 import pool from "../db.js";
 import { getSessionUser } from "../auth.js";
+import { logger } from "../obs/logger.js";
 import { setRequestModule } from "../obs/requestContext.js";
 import {
   syncConflictsTotal,
@@ -16,13 +17,47 @@ function recordConflict(module) {
   }
 }
 
-function recordSync(op, module, outcome, { ms, bytes } = {}) {
+/**
+ * Спільно: метрика + structured `sync_event` лог. Карта outcome→level:
+ *   ok | empty                         → info
+ *   conflict | invalid | too_large | unauthorized → warn
+ *   error                              → error
+ *
+ * `extra` — довільні JSON-поля для тріажу (версії, timestamp-и). requestId,
+ * userId, module підтягуються з ALS у Pino `mixin()` автоматично — не дублюй.
+ *
+ * Query pattern (Loki/Railway):
+ *   {service="sergeant-api"} | json | msg="sync_event" | outcome="conflict" | module="routine"
+ */
+function recordSync(op, module, outcome, { ms, bytes, extra } = {}) {
   try {
     syncOperationsTotal.inc({ op, module, outcome });
     if (ms != null) syncDurationMs.observe({ op, module }, ms);
     if (bytes != null) syncPayloadBytes.observe({ op, module }, bytes);
   } catch {
     /* metrics must never break a request */
+  }
+  const level =
+    outcome === "error"
+      ? "error"
+      : outcome === "conflict" ||
+          outcome === "invalid" ||
+          outcome === "too_large" ||
+          outcome === "unauthorized"
+        ? "warn"
+        : "info";
+  try {
+    logger[level]({
+      msg: "sync_event",
+      op,
+      module,
+      outcome,
+      ms: ms != null ? Math.round(ms) : undefined,
+      bytes,
+      ...(extra || {}),
+    });
+  } catch {
+    /* logging must never break a request */
   }
 }
 
@@ -84,15 +119,20 @@ export async function syncPush(req, res) {
     );
 
     if (result.rows.length === 0) {
-      recordConflict(module);
-      recordSync("push", module, "conflict", {
-        ms: elapsedMs(start),
-        bytes: blob.length,
-      });
       const existing = await pool.query(
         `SELECT server_updated_at, version FROM module_data WHERE user_id = $1 AND module = $2`,
         [user.id, module],
       );
+      recordConflict(module);
+      recordSync("push", module, "conflict", {
+        ms: elapsedMs(start),
+        bytes: blob.length,
+        extra: {
+          clientUpdatedAt: clientTs.toISOString(),
+          serverUpdatedAt: existing.rows[0]?.server_updated_at,
+          serverVersion: existing.rows[0]?.version ?? 0,
+        },
+      });
       return res.json({
         ok: true,
         module,

--- a/server/api/sync.test.js
+++ b/server/api/sync.test.js
@@ -20,8 +20,23 @@ vi.mock("../obs/metrics.js", () => ({
   syncPayloadBytes: { observe: vi.fn() },
 }));
 
+vi.mock("../obs/logger.js", async () => {
+  const actual = await vi.importActual("../obs/logger.js");
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
 import { getSessionUser } from "../auth.js";
 import pool from "../db.js";
+import { logger } from "../obs/logger.js";
 import { syncConflictsTotal, syncOperationsTotal } from "../obs/metrics.js";
 import { syncPushAll } from "./sync.js";
 
@@ -203,5 +218,100 @@ describe("syncPushAll metric correctness around transaction boundary", () => {
     expect(syncConflictsTotal.inc).toHaveBeenCalledWith({
       module: "nutrition",
     });
+  });
+});
+
+describe("sync_event structured log", () => {
+  it("емітить sync_event на кожен recordSync — level по outcome", async () => {
+    const client = { query: vi.fn(), release: vi.fn() };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:00Z", version: 2 }],
+      }) // finyk ok
+      .mockResolvedValueOnce({}); // COMMIT
+    pool.connect.mockResolvedValue(client);
+
+    const res = makeRes();
+    await syncPushAll(
+      makeReq({
+        modules: {
+          finyk: { data: { x: 1 }, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+        },
+      }),
+      res,
+    );
+
+    // ok-outcome → info; push + push_all по одному info-виклику
+    const infos = logger.info.mock.calls.map(([arg]) => arg);
+    expect(infos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          msg: "sync_event",
+          op: "push",
+          module: "finyk",
+          outcome: "ok",
+        }),
+        expect.objectContaining({
+          msg: "sync_event",
+          op: "push_all",
+          module: "all",
+          outcome: "ok",
+        }),
+      ]),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("error outcome пише через logger.error (ROLLBACK path reclassifies pending)", async () => {
+    const client = { query: vi.fn(), release: vi.fn() };
+    client.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [{ server_updated_at: "2026-01-01T00:00:00Z", version: 2 }],
+      }) // finyk «ок» у транзакції → потрапляє в pending
+      .mockRejectedValueOnce(
+        Object.assign(new Error("deadlock"), { code: "40P01" }),
+      ) // routine кидає → catch
+      .mockResolvedValueOnce({}); // ROLLBACK
+    pool.connect.mockResolvedValue(client);
+
+    await expect(
+      syncPushAll(
+        makeReq({
+          modules: {
+            finyk: { data: { x: 1 }, clientUpdatedAt: "2026-01-01T00:00:00Z" },
+            routine: {
+              data: { y: 2 },
+              clientUpdatedAt: "2026-01-01T00:00:00Z",
+            },
+          },
+        }),
+        makeRes(),
+      ),
+    ).rejects.toThrow(/deadlock/);
+
+    const errors = logger.error.mock.calls.map(([arg]) => arg);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          msg: "sync_event",
+          op: "push",
+          module: "finyk",
+          outcome: "error",
+        }),
+        expect.objectContaining({
+          msg: "sync_event",
+          op: "push_all",
+          module: "all",
+          outcome: "error",
+        }),
+      ]),
+    );
+    // ok-лог НЕ має існувати, хоча finyk «пройшов» INSERT: транзакція впала.
+    const okLogs = logger.info.mock.calls.filter(
+      ([arg]) => arg.msg === "sync_event" && arg.outcome === "ok",
+    );
+    expect(okLogs).toHaveLength(0);
   });
 });

--- a/server/http/authMiddleware.js
+++ b/server/http/authMiddleware.js
@@ -1,4 +1,6 @@
+import { createHash } from "crypto";
 import { rateLimitExpress } from "../api/lib/rateLimit.js";
+import { logger } from "../obs/logger.js";
 import { authAttemptsTotal } from "../obs/metrics.js";
 
 /** Жорсткіший ліміт на sign-in / sign-up / reset (POST). */
@@ -19,11 +21,27 @@ export function authSensitiveRateLimit(req, res, next) {
 }
 
 /**
+ * Лишаємо тільки перші 12 hex-символів SHA-256(lower(email)) — достатньо
+ * щоб корелювати спроби за одним юзером (brute-force / credential-stuffing)
+ * і **не є PII**: не reversible без offline brute-force по словнику.
+ * У Prometheus цей лейбл НЕ йде (cardinality), тільки у Pino-лог.
+ */
+function emailFingerprint(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return undefined;
+  return createHash("sha256")
+    .update(raw.toLowerCase())
+    .digest("hex")
+    .slice(0, 12);
+}
+
+/**
  * Класифікує auth-ендпоінти better-auth і після відповіді інкрементує
- * `authAttemptsTotal{op,outcome}`. Ставити ПЕРЕД `authSensitiveRateLimit`
- * (і ДО `toNodeHandler(auth)`): `res.on("finish")` спрацьовує, навіть
- * коли rate-limiter короткозамикає пайплайн без `next()`, тому реєстрація
- * listener-а мусить відбутись раніше за сам limiter, щоб 429 ловились.
+ * `authAttemptsTotal{op,outcome}` + пише structured `auth_event` лог
+ * з `emailHash` / `ip` для brute-force тріажу. Ставити ПЕРЕД
+ * `authSensitiveRateLimit` (і ДО `toNodeHandler(auth)`): `res.on("finish")`
+ * спрацьовує, навіть коли rate-limiter короткозамикає пайплайн без
+ * `next()`, тому реєстрація listener-а мусить відбутись раніше за сам
+ * limiter, щоб 429 ловились.
  */
 export function authMetricsMiddleware(req, res, next) {
   if (req.method !== "POST") return next();
@@ -36,6 +54,15 @@ export function authMetricsMiddleware(req, res, next) {
     (url.includes("/sign-out") && "signout") ||
     null;
   if (!op) return next();
+
+  // Читаємо body ДО `res.on("finish")`: better-auth toNodeHandler може
+  // консьюмити stream і замінити/зачистити `req.body` до моменту емісії.
+  // express.json() у app.js парсить лімітом 12mb, тож на /sign-in
+  // це завжди object або undefined.
+  const emailHash =
+    op === "sign_in" || op === "sign_up" || op === "forget_password"
+      ? emailFingerprint(req.body?.email)
+      : undefined;
 
   res.on("finish", () => {
     const s = res.statusCode;
@@ -53,6 +80,30 @@ export function authMetricsMiddleware(req, res, next) {
       authAttemptsTotal.inc({ op, outcome });
     } catch {
       /* ignore */
+    }
+    // Structured log у ДОПОВНЕННЯ до HTTP-лога: той не має `op` і
+    // `emailHash`, через які робимо brute-force тріаж.
+    //   {service="sergeant-api"} | json | msg="auth_event" | outcome="bad_credentials" | emailHash="abc123..."
+    try {
+      const level =
+        outcome === "error"
+          ? "error"
+          : outcome === "bad_credentials" ||
+              outcome === "rate_limited" ||
+              outcome === "invalid"
+            ? "warn"
+            : "info";
+      logger[level]({
+        msg: "auth_event",
+        op,
+        outcome,
+        status: s,
+        emailHash,
+        ip: req.ip,
+        ua: req.get("user-agent") || undefined,
+      });
+    } catch {
+      /* logging must never break a response */
     }
   });
   next();

--- a/server/http/authMiddleware.test.js
+++ b/server/http/authMiddleware.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "crypto";
+
+// Мокаємо logger ДО імпорту модуля, щоб зафіксувати виклики.
+vi.mock("../obs/logger.js", async () => {
+  const actual = await vi.importActual("../obs/logger.js");
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../obs/metrics.js", async () => {
+  const actual = await vi.importActual("../obs/metrics.js");
+  return {
+    ...actual,
+    authAttemptsTotal: { inc: vi.fn() },
+  };
+});
+
+import { logger } from "../obs/logger.js";
+import { authAttemptsTotal } from "../obs/metrics.js";
+import { authMetricsMiddleware } from "./authMiddleware.js";
+
+describe("authMetricsMiddleware structured auth_event log", () => {
+  function makeReqRes({
+    url = "/api/auth/sign-in/email",
+    body = {},
+    ip = "1.2.3.4",
+    ua = "vitest/1.0",
+  } = {}) {
+    const listeners = {};
+    const req = {
+      method: "POST",
+      originalUrl: url,
+      body,
+      ip,
+      get: (h) => (h.toLowerCase() === "user-agent" ? ua : undefined),
+    };
+    const res = {
+      statusCode: 200,
+      on(event, handler) {
+        listeners[event] = handler;
+        return this;
+      },
+      _finish(status) {
+        this.statusCode = status;
+        listeners.finish?.();
+      },
+    };
+    return { req, res };
+  }
+
+  function expectedEmailHash(email) {
+    return createHash("sha256")
+      .update(email.toLowerCase())
+      .digest("hex")
+      .slice(0, 12);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits warn-level auth_event with emailHash on bad_credentials (401)", () => {
+    const { req, res } = makeReqRes({ body: { email: "User@Example.com" } });
+    authMetricsMiddleware(req, res, () => {});
+    res._finish(401);
+
+    expect(authAttemptsTotal.inc).toHaveBeenCalledWith({
+      op: "sign_in",
+      outcome: "bad_credentials",
+    });
+    expect(logger.warn).toHaveBeenCalledWith({
+      msg: "auth_event",
+      op: "sign_in",
+      outcome: "bad_credentials",
+      status: 401,
+      emailHash: expectedEmailHash("user@example.com"),
+      ip: "1.2.3.4",
+      ua: "vitest/1.0",
+    });
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("emits info-level auth_event on success (200) without throwing when email absent", () => {
+    const { req, res } = makeReqRes({
+      url: "/api/auth/sign-out",
+      body: undefined,
+    });
+    authMetricsMiddleware(req, res, () => {});
+    res._finish(200);
+
+    expect(authAttemptsTotal.inc).toHaveBeenCalledWith({
+      op: "signout",
+      outcome: "ok",
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: "auth_event",
+        op: "signout",
+        outcome: "ok",
+        status: 200,
+        emailHash: undefined,
+      }),
+    );
+  });
+
+  it("maps 429 → rate_limited (warn), 5xx → error; NEVER logs plaintext email", () => {
+    const { req, res } = makeReqRes({ body: { email: "victim@example.com" } });
+    authMetricsMiddleware(req, res, () => {});
+    res._finish(429);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "rate_limited", status: 429 }),
+    );
+    // Прискіпливий захист: плейн-текст email НЕ має протекти в жоден лог-виклик.
+    const allCalls = [
+      ...logger.debug.mock.calls,
+      ...logger.info.mock.calls,
+      ...logger.warn.mock.calls,
+      ...logger.error.mock.calls,
+      ...logger.fatal.mock.calls,
+    ];
+    for (const [arg] of allCalls) {
+      const s = JSON.stringify(arg);
+      expect(s).not.toContain("victim@example.com");
+      expect(s).not.toContain("VICTIM@EXAMPLE.COM");
+    }
+
+    // І окремий кейс 5xx.
+    const { req: r2, res: rs2 } = makeReqRes();
+    authMetricsMiddleware(r2, rs2, () => {});
+    rs2._finish(503);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "error", status: 503 }),
+    );
+  });
+
+  it("skips (no op match) for non-auth URLs and GET requests", () => {
+    const next = vi.fn();
+    const { req, res } = makeReqRes({ url: "/api/health" });
+    authMetricsMiddleware(req, res, next);
+    res._finish(200);
+    expect(next).toHaveBeenCalled();
+    expect(authAttemptsTotal.inc).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    const getReq = { ...req, method: "GET", originalUrl: "/api/auth/sign-in" };
+    authMetricsMiddleware(getReq, res, next);
+    expect(authAttemptsTotal.inc).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

PR #3 з observability-аудиту. Метрики (RED/USE) відповідають на "*скільки* помилок / *як довго*", але не відповідають на "**хто** саме зараз конфліктує в `routine`" або "**під чию** пошту йде brute-force із IP X". Додано два JSON-повідомлення у Pino — `requestId` / `userId` / `module` чіпляються автоматично через AsyncLocalStorage `mixin()`, не дублюються.

### `sync_event` — <ref_file file="/home/ubuntu/Sergeant/server/api/sync.js" />

- Емітиться в уніфікованому `recordSync()` разом із `syncOperationsTotal` — тобто **будь-яка** метрика sync тепер має парний лог-рядок. Рівень залежить від outcome (`ok/empty`→info, `conflict/invalid/too_large/unauthorized`→warn, `error`→error).
- На `conflict` додано `extra` з `clientUpdatedAt`, `serverUpdatedAt`, `serverVersion`. Це робить post-mortem "хто чий запис переписав" можливим без додаткового DB-запиту — той `SELECT existing` уже був у коді, я просто переставив його перед `recordConflict`.

Приклади Loki-запитів:
```logql
# Всі конфлікти routine за юзером
{service="sergeant-api"} | json | msg="sync_event" | outcome="conflict" | module="routine" | userId="u_123"

# Скільки push-помилок по модулях за годину
sum by (module) (count_over_time({service="sergeant-api"} | json | msg="sync_event" | op="push" | outcome="error" [1h]))
```

### `auth_event` — <ref_file file="/home/ubuntu/Sergeant/server/httpCommon.mjs" />

- У `authMetricsMiddleware`, поруч із `authAttemptsTotal`.
- `emailHash = sha256(lower(email))[:12]` (12 hex) — достатньо корелювати спроби по одному юзеру (brute-force, credential-stuffing), але не reversible без offline dict-attack. У Prometheus цей лейбл **не** йде (cardinality); тільки у лог.
- Email зчитується з `req.body` **синхронно перед** `res.on("finish")` — `toNodeHandler(auth)` може консьюмити body stream, і до моменту емісії `req.body.email` вже не буде.
- `status`, `ip`, `ua` додано для гео-кластеризації атак і пошуку "тупих" UA.

```logql
# Топ-10 emailHash під атакою за 15 хв
topk(10, count by (emailHash) (
  count_over_time({service="sergeant-api"} | json | msg="auth_event" | outcome="bad_credentials" [15m])
))

# IP-джерела brute-force
sum by (ip) (count_over_time({service="sergeant-api"} | json | msg="auth_event" | outcome="bad_credentials" | op="sign_in" [1h]))
```

### Tests

- <ref_file file="/home/ubuntu/Sergeant/server/api/sync.test.js" /> — 2 нових кейси: рівень лога по outcome (`ok`→info для `push` + `push_all`); ROLLBACK-path пише `logger.error` і **не пише** `info.outcome=ok`, навіть якщо INSERT "пройшов" у транзакції (узгоджено з метриковою семантикою PR #1).
- <ref_file file="/home/ubuntu/Sergeant/server/httpCommon.test.js" /> — 4 нові кейси: `bad_credentials`→warn з правильним emailHash; `signout`+порожній body→info з `emailHash: undefined`; `rate_limited`/5xx маппінг + **explicit scan**, що плейн-текст `victim@example.com` **не** попадає у жоден виклик logger'а; skip для GET / non-auth.

Локально: `npm run lint ✓`, `npx vitest run ✓` (71 файл / 675 тестів).

## Review & Testing Checklist for Human

- [ ] Потвердити, що `emailHash` (12 hex chars SHA-256) задовольняє ваш privacy / GDPR-поріг. Якщо ні — збільшити/зменшити prefix або додати salt (`process.env.AUTH_HASH_SALT`).
- [ ] Переконатися, що ваш log-sink (Railway logs / Loki / Datadog) парсить Pino JSON і вміє фільтрувати по `msg` + `outcome`. Pino-редактор уже редактить `password`/`token` — `emailHash` не PII і не потребує redact.

### Notes

- Жодних змін у HTTP-API: відповіді, статус-коди, таймінги такі ж. Нові логи — просто додаткові stdout-строки.
- Розмір лога виріс: кожен sync/auth-виклик додає ~200 байт JSON. На пік 100 RPS ≈ 20 KB/s, Railway-план витримає. Якщо не витримує — можна підняти Pino-level до `warn` у проді (`LOG_LEVEL=warn`), тоді ok/info-рядки мовчать, лишаються тільки аномалії.
- Наступний PR — за вашим вибором: #2 (`sync/push/aiQuota` через `db.js:query()`), #4 (нові метрики), #5 (`pg_stat_statements`), #7 (клієнтські Sentry breadcrumbs).

Link to Devin session: https://app.devin.ai/sessions/872bc66744e945e682bc554d94a14595
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
