### PR TITLE
feat(ftux): Ship 3 — PresetSheet + time-to-value analytics + TTV-in-toast

### DIFF
--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -6,6 +6,7 @@ import { trackEvent, ANALYTICS_EVENTS } from "./analytics";
 import {
   ALL_MODULES,
   markFirstActionPending,
+  markFirstActionStartedAt,
   saveVibePicks,
 } from "./onboarding/vibePicks.js";
 import { seedDemoForModules } from "./onboarding/demoSeeds.js";
@@ -262,6 +263,7 @@ export function OnboardingWizard({ onDone, variant = "modal" }) {
       intent: "vibe_demo",
       picksCount: chosen.length,
     });
+    markFirstActionStartedAt();
     markFirstActionPending();
     markOnboardingDone();
     // Stay on the hub dashboard so the user's "aha" is the whole populated

--- a/src/core/analytics.js
+++ b/src/core/analytics.js
@@ -37,7 +37,13 @@ export const ANALYTICS_EVENTS = Object.freeze({
   ONBOARDING_DEMO_RENDERED: "onboarding_demo_rendered",
   ONBOARDING_FIRST_ACTION_SHOWN: "onboarding_first_action_shown",
   ONBOARDING_FIRST_ACTION_PICKED: "onboarding_first_action_picked",
+  FTUX_PRESET_SHEET_SHOWN: "ftux_preset_sheet_shown",
+  FTUX_PRESET_PICKED: "ftux_preset_picked",
+  FTUX_PRESET_CUSTOM: "ftux_preset_custom",
   FIRST_REAL_ENTRY: "first_real_entry",
+  // Headline metric: milliseconds from splash CTA tap to first real
+  // (non-demo) entry anywhere in the app. Target p50 < 20_000.
+  FTUX_TIME_TO_VALUE: "ftux_time_to_value",
   AUTH_PROMPT_SHOWN: "auth_prompt_shown",
   AUTH_PROMPT_DISMISSED: "auth_prompt_dismissed",
   AUTH_AFTER_VALUE: "auth_after_value",

--- a/src/core/onboarding/FirstActionSheet.jsx
+++ b/src/core/onboarding/FirstActionSheet.jsx
@@ -1,15 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
-import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
+import { PresetSheet, getPresetModule } from "./PresetSheet.jsx";
 
 /**
- * Per-module "one tap to your first real entry" definitions. Each action
- * routes into its module with a PWA action (the same handler PWA
- * shortcuts use), so a single tap lands the user on an already-open
- * input sheet.
+ * Per-module "one tap to your first real entry" copy. Tapping a row
+ * opens `PresetSheet` for that module instead of routing into the
+ * module's full input wizard — the preset sheet's tiles write a real
+ * entry directly to storage, which is materially faster than any
+ * module's stock flow and the shortest path to the 30-second promise.
+ * If the user wants the full input, the preset sheet has a
+ * «Власний варіант» fallback that still deep-links via
+ * `openHubModuleWithAction`.
  */
 const ACTIONS = {
   routine: {
@@ -17,28 +21,24 @@ const ACTIONS = {
     title: "Створи першу звичку",
     desc: "30 секунд. Стрік почнеться сьогодні.",
     accent: "text-routine bg-routine-soft",
-    run: () => openHubModuleWithAction("routine", "add_habit"),
   },
   finyk: {
     icon: "credit-card",
     title: "Додай першу витрату",
     desc: "5 секунд, будь-яка сума.",
     accent: "text-finyk bg-finyk-soft",
-    run: () => openHubModuleWithAction("finyk", "add_expense"),
   },
   nutrition: {
     icon: "utensils",
     title: "Запиши перший прийом їжі",
     desc: "Калорії порахую я.",
     accent: "text-nutrition bg-nutrition-soft",
-    run: () => openHubModuleWithAction("nutrition", "add_meal"),
   },
   fizruk: {
     icon: "dumbbell",
     title: "Увімкни розминку",
     desc: "10 хв, таймер сам.",
     accent: "text-fizruk bg-fizruk-soft",
-    run: () => openHubModuleWithAction("fizruk", "start_workout"),
   },
 };
 
@@ -74,7 +74,10 @@ export function FirstActionHeroCard({ onDismiss }) {
     return raw.length > 0 ? raw : Object.keys(ACTIONS);
   }, []);
 
-  const primaryId = useMemo(() => pickPrimary(picks), [picks]);
+  // `pickPrimary` returns a primitive string from a trivial scan of a
+  // 4-element constant; wrapping it in `useMemo` wouldn't prevent any
+  // work and the dependency compare costs more than the scan.
+  const primaryId = pickPrimary(picks);
   const primary = ACTIONS[primaryId];
   const others = useMemo(
     () => picks.filter((id) => id !== primaryId && ACTIONS[id]),
@@ -82,6 +85,11 @@ export function FirstActionHeroCard({ onDismiss }) {
   );
 
   const [expanded, setExpanded] = useState(false);
+  // Module id whose PresetSheet is currently open, or `null` if closed.
+  // Keeping the hero card mounted while the sheet is open means the
+  // user can dismiss the sheet and try another module without losing
+  // their FTUX context.
+  const [activePresetId, setActivePresetId] = useState(null);
 
   useEffect(() => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_SHOWN, {
@@ -95,142 +103,158 @@ export function FirstActionHeroCard({ onDismiss }) {
     onDismiss?.();
   };
 
-  const run = (id) => {
+  const openPreset = (id) => {
+    if (!getPresetModule(id)) return;
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_FIRST_ACTION_PICKED, {
       module: id,
       primary: primaryId,
       via: id === primaryId ? "primary" : "expand",
     });
+    setActivePresetId(id);
+  };
+
+  const handlePresetPick = () => {
+    // The preset writer already persisted the entry; dismiss the hero
+    // card so the next dashboard render surfaces the celebration toast
+    // (from `useFirstEntryCelebration`) against a clean layout.
     clearFirstActionPending();
+    setActivePresetId(null);
     onDismiss?.();
-    ACTIONS[id]?.run();
   };
 
   if (!primary) return null;
 
   return (
-    <section
-      className="relative bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
-      aria-label="Перша дія"
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
-            Старт
-          </div>
-          <h2 className="text-base font-bold text-text mt-0.5">
-            Зроби одну річ — і хаб твій
-          </h2>
-          <p className="text-xs text-muted mt-0.5 leading-snug">
-            Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={dismiss}
-          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text p-1.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
-          aria-label="Сховати"
-        >
-          <Icon name="close" size={16} />
-        </button>
-      </div>
-
-      <button
-        type="button"
-        onClick={() => run(primaryId)}
-        className={cn(
-          "w-full text-left px-4 py-3 rounded-xl border-2 border-brand-500/50 bg-brand-500/5",
-          "hover:border-brand-500 hover:bg-brand-500/10 transition-all",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
-        )}
+    <>
+      <section
+        className="relative bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
+        aria-label="Перша дія"
       >
-        <div className="flex items-center gap-3">
-          <div
-            className={cn(
-              "w-11 h-11 shrink-0 rounded-xl flex items-center justify-center",
-              primary.accent,
-            )}
-          >
-            <Icon name={primary.icon} size={22} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-bold text-text">{primary.title}</div>
-            <div className="text-xs text-muted mt-0.5 truncate">
-              {primary.desc}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
+              Старт
             </div>
+            <h2 className="text-base font-bold text-text mt-0.5">
+              Зроби одну річ — і хаб твій
+            </h2>
+            <p className="text-xs text-muted mt-0.5 leading-snug">
+              Цифри нижче — приклад. Твої з&apos;являться, щойно щось додаси.
+            </p>
           </div>
-          <Icon name="chevron-right" size={18} className="text-brand-600" />
-        </div>
-      </button>
-
-      {others.length > 0 && (
-        <>
           <button
             type="button"
-            onClick={() => setExpanded((v) => !v)}
-            aria-expanded={expanded}
-            className={cn(
-              "w-full text-xs font-medium text-muted hover:text-text",
-              "flex items-center justify-center gap-1 py-1",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-md",
-            )}
+            onClick={dismiss}
+            className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text p-1.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+            aria-label="Сховати"
           >
-            <span>{expanded ? "Сховати" : "Інший модуль"}</span>
-            <Icon
-              name="chevron-right"
-              size={12}
-              className={cn(
-                "transition-transform",
-                expanded ? "rotate-90" : "rotate-0",
-              )}
-            />
+            <Icon name="close" size={16} />
           </button>
+        </div>
 
-          {expanded && (
-            <div className="space-y-2">
-              {others.map((id) => {
-                const a = ACTIONS[id];
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => run(id)}
-                    className={cn(
-                      "w-full text-left px-3 py-2 rounded-xl border border-line bg-panelHi",
-                      "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
-                      "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
-                    )}
-                  >
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={cn(
-                          "w-9 h-9 shrink-0 rounded-xl flex items-center justify-center",
-                          a.accent,
-                        )}
-                      >
-                        <Icon name={a.icon} size={18} />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="text-sm font-semibold text-text">
-                          {a.title}
-                        </div>
-                        <div className="text-xs text-muted mt-0.5 truncate">
-                          {a.desc}
-                        </div>
-                      </div>
-                      <Icon
-                        name="chevron-right"
-                        size={14}
-                        className="text-muted"
-                      />
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+        <button
+          type="button"
+          onClick={() => openPreset(primaryId)}
+          className={cn(
+            "w-full text-left px-4 py-3 rounded-xl border-2 border-brand-500/50 bg-brand-500/5",
+            "hover:border-brand-500 hover:bg-brand-500/10 transition-all",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
           )}
-        </>
-      )}
-    </section>
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                "w-11 h-11 shrink-0 rounded-xl flex items-center justify-center",
+                primary.accent,
+              )}
+            >
+              <Icon name={primary.icon} size={22} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-bold text-text">{primary.title}</div>
+              <div className="text-xs text-muted mt-0.5 truncate">
+                {primary.desc}
+              </div>
+            </div>
+            <Icon name="chevron-right" size={18} className="text-brand-600" />
+          </div>
+        </button>
+
+        {others.length > 0 && (
+          <>
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+              className={cn(
+                "w-full text-xs font-medium text-muted hover:text-text",
+                "flex items-center justify-center gap-1 py-1",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-md",
+              )}
+            >
+              <span>{expanded ? "Сховати" : "Інший модуль"}</span>
+              <Icon
+                name="chevron-right"
+                size={12}
+                className={cn(
+                  "transition-transform",
+                  expanded ? "rotate-90" : "rotate-0",
+                )}
+              />
+            </button>
+
+            {expanded && (
+              <div className="space-y-2">
+                {others.map((id) => {
+                  const a = ACTIONS[id];
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => openPreset(id)}
+                      className={cn(
+                        "w-full text-left px-3 py-2 rounded-xl border border-line bg-panelHi",
+                        "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
+                        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div
+                          className={cn(
+                            "w-9 h-9 shrink-0 rounded-xl flex items-center justify-center",
+                            a.accent,
+                          )}
+                        >
+                          <Icon name={a.icon} size={18} />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm font-semibold text-text">
+                            {a.title}
+                          </div>
+                          <div className="text-xs text-muted mt-0.5 truncate">
+                            {a.desc}
+                          </div>
+                        </div>
+                        <Icon
+                          name="chevron-right"
+                          size={14}
+                          className="text-muted"
+                        />
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </section>
+      <PresetSheet
+        open={activePresetId != null}
+        moduleId={activePresetId}
+        onClose={() => setActivePresetId(null)}
+        onPick={handlePresetPick}
+      />
+    </>
   );
 }

--- a/src/core/onboarding/PresetSheet.jsx
+++ b/src/core/onboarding/PresetSheet.jsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Sheet } from "@shared/components/ui/Sheet";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { applyPreset } from "./presetApply.js";
+
+/**
+ * Per-module "tap-to-log" presets. Each entry is deliberately narrow —
+ * 3 presets is the sweet spot where the list feels opinionated (not
+ * overwhelming) but still has enough spread that a real person sees
+ * themselves in at least one option.
+ *
+ * Presets are the single lowest-friction path to a real (non-demo)
+ * entry: tapping one writes straight to the module's storage, no form,
+ * no wizard. The custom-entry row at the bottom of the sheet keeps the
+ * escape hatch for users whose first instinct doesn't fit the list.
+ */
+const PRESETS = {
+  routine: {
+    title: "Яку звичку почнемо?",
+    desc: "Одне натискання — і вона у твоєму списку сьогодні.",
+    accent: "text-routine bg-routine-soft",
+    moduleIcon: "check",
+    fallback: { action: "add_habit", label: "Своя звичка", icon: "plus" },
+    items: [
+      {
+        id: "water",
+        emoji: "💧",
+        title: "Випити воду",
+        desc: "Щодня, будь-коли",
+        data: { name: "Випити воду", emoji: "💧" },
+      },
+      {
+        id: "walk",
+        emoji: "🚶",
+        title: "Пройти 10 хв",
+        desc: "Короткий вихід після обіду",
+        data: { name: "Пройти 10 хв", emoji: "🚶" },
+      },
+      {
+        id: "read",
+        emoji: "📖",
+        title: "Прочитати 10 сторінок",
+        desc: "Вечірня звичка",
+        data: { name: "Прочитати 10 сторінок", emoji: "📖" },
+      },
+    ],
+  },
+  finyk: {
+    title: "На що витратив?",
+    desc: "Занотую миттєво. Суму можна змінити потім.",
+    accent: "text-finyk bg-finyk-soft",
+    moduleIcon: "credit-card",
+    fallback: { action: "add_expense", label: "Інша сума", icon: "plus" },
+    items: [
+      {
+        id: "coffee",
+        emoji: "☕",
+        title: "Кава",
+        desc: "95 ₴ · їжа",
+        data: { description: "Кава", amount: 95, category: "їжа" },
+      },
+      {
+        id: "ride",
+        emoji: "🚕",
+        title: "Таксі",
+        desc: "180 ₴ · транспорт",
+        data: { description: "Таксі", amount: 180, category: "транспорт" },
+      },
+      {
+        id: "lunch",
+        emoji: "🥗",
+        title: "Обід",
+        desc: "220 ₴ · їжа",
+        data: { description: "Обід", amount: 220, category: "їжа" },
+      },
+    ],
+  },
+  nutrition: {
+    title: "Що з'їв зараз?",
+    desc: "Калорії й макро — вже прораховано.",
+    accent: "text-nutrition bg-nutrition-soft",
+    moduleIcon: "utensils",
+    fallback: { action: "add_meal", label: "Інша страва", icon: "plus" },
+    items: [
+      {
+        id: "omelette",
+        emoji: "🍳",
+        title: "Омлет з авокадо",
+        desc: "~420 ккал · сніданок",
+        data: { name: "Омлет з авокадо", kcal: 420, mealType: "breakfast" },
+      },
+      {
+        id: "salad",
+        emoji: "🥗",
+        title: "Салат з куркою",
+        desc: "~380 ккал · обід",
+        data: { name: "Салат з куркою", kcal: 380, mealType: "lunch" },
+      },
+      {
+        id: "snack",
+        emoji: "🍎",
+        title: "Яблуко + горіхи",
+        desc: "~220 ккал · перекус",
+        data: { name: "Яблуко + горіхи", kcal: 220, mealType: "snack" },
+      },
+    ],
+  },
+  fizruk: {
+    title: "Швидкий старт",
+    desc: "Залогую як завершене тренування. Деталі — потім.",
+    accent: "text-fizruk bg-fizruk-soft",
+    moduleIcon: "dumbbell",
+    fallback: {
+      action: "start_workout",
+      label: "Повне тренування",
+      icon: "plus",
+    },
+    items: [
+      {
+        id: "warmup",
+        emoji: "🤸",
+        title: "Розминка",
+        desc: "10 хв · легко",
+        data: { name: "Розминка", durationMin: 10 },
+      },
+      {
+        id: "walk",
+        emoji: "🚶",
+        title: "Прогулянка",
+        desc: "25 хв · кардіо",
+        data: { name: "Прогулянка", durationMin: 25 },
+      },
+      {
+        id: "quick",
+        emoji: "⚡",
+        title: "Швидке HIIT",
+        desc: "15 хв · інтенсив",
+        data: { name: "Швидке HIIT", durationMin: 15 },
+      },
+    ],
+  },
+};
+
+export function getPresetModule(moduleId) {
+  return PRESETS[moduleId] || null;
+}
+
+/**
+ * Bottom-sheet list of "one-tap" presets for a single module. Tapping a
+ * preset writes a real entry straight into the module's storage, fires
+ * `FIRST_REAL_ENTRY` on the next hub render, and closes the sheet —
+ * that is the 30-second FTUX success moment in one interaction.
+ *
+ * The "custom" fallback row deep-links into the module's full input
+ * flow (same PWA action the old FirstActionRow used) for users whose
+ * first entry isn't in the preset list.
+ */
+export function PresetSheet({ open, moduleId, onClose, onPick }) {
+  const config = useMemo(() => PRESETS[moduleId] || null, [moduleId]);
+
+  useEffect(() => {
+    if (!open || !config) return;
+    trackEvent(ANALYTICS_EVENTS.FTUX_PRESET_SHEET_SHOWN, {
+      module: moduleId,
+      presetCount: config.items.length,
+    });
+  }, [open, config, moduleId]);
+
+  if (!config) return null;
+
+  const handlePick = (item) => {
+    trackEvent(ANALYTICS_EVENTS.FTUX_PRESET_PICKED, {
+      module: moduleId,
+      presetId: item.id,
+    });
+    applyPreset(moduleId, item.data);
+    onPick?.({ moduleId, presetId: item.id });
+    onClose?.();
+  };
+
+  const handleCustom = () => {
+    trackEvent(ANALYTICS_EVENTS.FTUX_PRESET_CUSTOM, {
+      module: moduleId,
+      via: "fallback",
+    });
+    onPick?.({ moduleId, presetId: null, custom: true });
+    onClose?.();
+    openHubModuleWithAction(moduleId, config.fallback.action);
+  };
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={config.title}
+      description={config.desc}
+    >
+      <div className="px-5 pb-5 space-y-2">
+        {config.items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => handlePick(item)}
+            className={cn(
+              "w-full text-left px-3 py-3 rounded-2xl border border-line bg-panelHi",
+              "hover:border-brand-500/50 hover:bg-brand-500/5 transition-all",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+            )}
+          >
+            <div className="flex items-center gap-3">
+              <div
+                className={cn(
+                  "w-11 h-11 shrink-0 rounded-xl flex items-center justify-center text-xl",
+                  config.accent,
+                )}
+                aria-hidden
+              >
+                <span>{item.emoji}</span>
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-bold text-text truncate">
+                  {item.title}
+                </div>
+                <div className="text-xs text-muted mt-0.5 truncate">
+                  {item.desc}
+                </div>
+              </div>
+              <Icon
+                name="chevron-right"
+                size={16}
+                className="text-muted shrink-0"
+              />
+            </div>
+          </button>
+        ))}
+
+        <button
+          type="button"
+          onClick={handleCustom}
+          className={cn(
+            "w-full text-center px-3 py-3 rounded-2xl border border-dashed border-line",
+            "text-sm font-semibold text-muted hover:text-text hover:border-brand-500/50",
+            "transition-all",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+          )}
+        >
+          <div className="flex items-center justify-center gap-1.5">
+            <Icon name={config.fallback.icon} size={14} />
+            <span>{config.fallback.label}</span>
+          </div>
+        </button>
+      </div>
+    </Sheet>
+  );
+}

--- a/src/core/onboarding/firstRealEntry.js
+++ b/src/core/onboarding/firstRealEntry.js
@@ -9,7 +9,12 @@
 // We re-check on each render and fire the first-entry event once.
 
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
-import { isFirstRealEntryDone, markFirstRealEntryDone } from "./vibePicks.js";
+import {
+  getFirstActionStartedAt,
+  isFirstRealEntryDone,
+  markFirstRealEntryDone,
+  saveTimeToValueMs,
+} from "./vibePicks.js";
 
 function safeReadJSON(key) {
   try {
@@ -82,5 +87,18 @@ export function detectFirstRealEntry() {
   if (!hasAnyRealEntry()) return false;
   markFirstRealEntryDone();
   trackEvent(ANALYTICS_EVENTS.FIRST_REAL_ENTRY);
+  // Headline 30-second metric: how long did it actually take? The
+  // start stamp is captured when the user taps «Заповни мій хаб» on
+  // the splash. Missing stamp = returning user from a pre-Ship-3
+  // install; we still fire `first_real_entry` but skip the TTV event.
+  const startedAt = getFirstActionStartedAt();
+  if (startedAt) {
+    const durationMs = Math.max(0, Date.now() - startedAt);
+    saveTimeToValueMs(durationMs);
+    trackEvent(ANALYTICS_EVENTS.FTUX_TIME_TO_VALUE, {
+      durationMs,
+      durationSec: Math.round(durationMs / 1000),
+    });
+  }
   return true;
 }

--- a/src/core/onboarding/presetApply.js
+++ b/src/core/onboarding/presetApply.js
@@ -1,0 +1,234 @@
+// Writes a single preset entry directly into the matching module's
+// localStorage key. This is how the FTUX PresetSheet turns "tap a tile"
+// into a real (non-demo) entry without forcing the user into a module's
+// full input wizard first.
+//
+// The writers here intentionally skip the modules' public
+// `save*`/`createHabit` APIs and poke localStorage directly for one
+// reason: those APIs are debounced (see `createModuleStorage`) and the
+// FTUX celebration needs the entry to be visible on the very next
+// render of the Hub dashboard. A 200 ms debounce window is invisible in
+// normal use but long enough to break the 30-second promise headline.
+//
+// Each writer:
+//   - fans out the same storage-change event the module listens to, so
+//     the Hub dashboard re-renders synchronously;
+//   - writes an entry with `demo: false` (explicit) so
+//     `detectFirstRealEntry` picks it up immediately;
+//   - is idempotent w.r.t. the preset itself — two rapid taps of the
+//     same preset create two entries, which mirrors normal module
+//     behavior (users can log the same habit / expense / meal twice).
+
+const FINYK_MANUAL_EXPENSES_KEY = "finyk_manual_expenses_v1";
+const FINYK_MANUAL_ONLY_KEY = "finyk_manual_only_v1";
+const ROUTINE_STATE_KEY = "hub_routine_v1";
+const ROUTINE_EVENT = "hub-routine-storage";
+const FIZRUK_WORKOUTS_KEY = "fizruk_workouts_v1";
+const NUTRITION_LOG_KEY = "nutrition_log_v1";
+const NUTRITION_LOG_EVENT = "nutrition-log-storage";
+
+function safeReadJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return parsed == null ? fallback : parsed;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeWriteJSON(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function dispatch(eventName) {
+  try {
+    window.dispatchEvent(new CustomEvent(eventName));
+  } catch {
+    /* noop */
+  }
+}
+
+function uid(prefix) {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function toLocalISODate(d = new Date()) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// ─── Finyk ───────────────────────────────────────────────────────────────
+
+function applyFinykPreset(preset) {
+  const existing = safeReadJSON(FINYK_MANUAL_EXPENSES_KEY, []);
+  const list = Array.isArray(existing) ? existing : [];
+  const entry = {
+    id: uid("tx"),
+    demo: false,
+    date: new Date().toISOString(),
+    description: preset.description,
+    amount: preset.amount,
+    category: preset.category,
+  };
+  safeWriteJSON(FINYK_MANUAL_EXPENSES_KEY, [entry, ...list]);
+  // Keep the user out of the Monobank login gate — mirrors what
+  // `seedFinykDemoData()` does after demo seeding.
+  try {
+    localStorage.setItem(FINYK_MANUAL_ONLY_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}
+
+// ─── Routine ─────────────────────────────────────────────────────────────
+
+function applyRoutinePreset(preset) {
+  const state = safeReadJSON(ROUTINE_STATE_KEY, null);
+  const today = toLocalISODate();
+  const habit = {
+    id: uid("hab"),
+    // Explicit false — `hasNonDemoItem` flags anything without `demo:true`
+    // as real, but being explicit keeps `routineBackup` round-trips safe.
+    demo: false,
+    name: preset.name,
+    emoji: preset.emoji || "✓",
+    tagIds: [],
+    categoryId: null,
+    createdAt: new Date().toISOString(),
+    archived: false,
+    recurrence: "daily",
+    startDate: today,
+    endDate: null,
+    timeOfDay: "",
+    reminderTimes: [],
+    weekdays: [0, 1, 2, 3, 4, 5, 6],
+  };
+
+  const base =
+    state && typeof state === "object" && !Array.isArray(state) ? state : {};
+  const nextHabits = Array.isArray(base.habits)
+    ? [...base.habits, habit]
+    : [habit];
+  const nextOrder = Array.isArray(base.habitOrder)
+    ? [...base.habitOrder, habit.id]
+    : [habit.id];
+
+  safeWriteJSON(ROUTINE_STATE_KEY, {
+    schemaVersion: 3,
+    prefs: base.prefs || {
+      showFizrukInCalendar: true,
+      showFinykSubscriptionsInCalendar: true,
+      routineRemindersEnabled: false,
+    },
+    tags: Array.isArray(base.tags) ? base.tags : [],
+    categories: Array.isArray(base.categories) ? base.categories : [],
+    habits: nextHabits,
+    completions: base.completions || {},
+    pushupsByDate: base.pushupsByDate || {},
+    habitOrder: nextOrder,
+    completionNotes: base.completionNotes || {},
+  });
+  dispatch(ROUTINE_EVENT);
+}
+
+// ─── Fizruk ──────────────────────────────────────────────────────────────
+
+function applyFizrukPreset(preset) {
+  const existing = safeReadJSON(FIZRUK_WORKOUTS_KEY, null);
+  const existingList = Array.isArray(existing)
+    ? existing
+    : existing && Array.isArray(existing.workouts)
+      ? existing.workouts
+      : [];
+  const now = new Date();
+  const startedAt = new Date(now.getTime() - preset.durationMin * 60000);
+  const workout = {
+    id: uid("wo"),
+    demo: false,
+    name: preset.name,
+    startedAt: startedAt.toISOString(),
+    finishedAt: now.toISOString(),
+    durationSec: preset.durationMin * 60,
+    exercises: [],
+  };
+  safeWriteJSON(FIZRUK_WORKOUTS_KEY, {
+    schemaVersion: 1,
+    workouts: [workout, ...existingList],
+  });
+}
+
+// ─── Nutrition ───────────────────────────────────────────────────────────
+
+function applyNutritionPreset(preset) {
+  const existing = safeReadJSON(NUTRITION_LOG_KEY, null);
+  const base =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...existing }
+      : {};
+  const today = toLocalISODate();
+  const day =
+    base[today] && typeof base[today] === "object"
+      ? { ...base[today] }
+      : { meals: [] };
+  const meals = Array.isArray(day.meals) ? [...day.meals] : [];
+  const kcal = preset.kcal;
+  meals.push({
+    id: uid("meal"),
+    demo: false,
+    name: preset.name,
+    time: new Date().toTimeString().slice(0, 5),
+    mealType: preset.mealType || "snack",
+    label: preset.name,
+    macros: {
+      kcal,
+      protein_g: Math.round((kcal * 0.22) / 4),
+      fat_g: Math.round((kcal * 0.28) / 9),
+      carbs_g: Math.round((kcal * 0.5) / 4),
+    },
+    source: "manual",
+    macroSource: "manual",
+    amount_g: null,
+    foodId: null,
+  });
+  day.meals = meals;
+  base[today] = day;
+  safeWriteJSON(NUTRITION_LOG_KEY, base);
+  dispatch(NUTRITION_LOG_EVENT);
+}
+
+/**
+ * Apply a preset to the matching module storage. The module id decides
+ * which writer runs — the caller passes only preset fields relevant to
+ * its module.
+ *
+ * @param {"routine" | "finyk" | "nutrition" | "fizruk"} moduleId
+ * @param {object} preset
+ */
+export function applyPreset(moduleId, preset) {
+  switch (moduleId) {
+    case "routine":
+      applyRoutinePreset(preset);
+      return;
+    case "finyk":
+      applyFinykPreset(preset);
+      return;
+    case "nutrition":
+      applyNutritionPreset(preset);
+      return;
+    case "fizruk":
+      applyFizrukPreset(preset);
+      return;
+    default:
+      /* noop */
+      return;
+  }
+}

--- a/src/core/onboarding/useFirstEntryCelebration.js
+++ b/src/core/onboarding/useFirstEntryCelebration.js
@@ -13,6 +13,23 @@
 
 import { useEffect, useRef } from "react";
 import { useToast } from "@shared/hooks/useToast";
+import { getTimeToValueMs } from "./vibePicks.js";
+
+/**
+ * Compose the success-moment toast. If we measured a time-to-value
+ * within the 30-second window we lead with the number so the user sees
+ * the promise literally kept. Outside the window (or for returning
+ * users with no stamp) we fall back to the generic copy.
+ *
+ * @param {number | null} ttvMs
+ * @returns {string}
+ */
+function buildToastCopy(ttvMs) {
+  if (ttvMs == null) return "Готово. Це вже твої дані.";
+  const sec = Math.max(1, Math.round(ttvMs / 1000));
+  if (sec > 60) return "Готово. Це вже твої дані.";
+  return `Готово за ${sec} с. Це вже твої дані.`;
+}
 
 export function useFirstEntryCelebration(hasRealEntry) {
   // Narrow to the stable `success` callback rather than the whole
@@ -36,6 +53,10 @@ export function useFirstEntryCelebration(hasRealEntry) {
     }
     if (!hasRealEntry) return;
     firedRef.current = true;
-    success("Готово. Це вже твої дані.", 4000);
+    // `detectFirstRealEntry` ran before this effect (the dashboard
+    // calls it synchronously in render), so the TTV value is already
+    // persisted by the time we read it here.
+    const ttv = getTimeToValueMs();
+    success(buildToastCopy(ttv), 4500);
   }, [hasRealEntry, success]);
 }

--- a/src/core/onboarding/vibePicks.js
+++ b/src/core/onboarding/vibePicks.js
@@ -7,6 +7,12 @@ const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
 const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
 const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
 const DEMO_BANNER_DISMISSED_KEY = "hub_demo_banner_dismissed_v1";
+// Millisecond epoch stamp captured the moment the user taps «Заповни
+// мій хаб» on the splash. Used by `firstRealEntry.js` to compute the
+// `ftux_time_to_value` duration — the single headline metric for the
+// 30-second promise.
+const FIRST_ACTION_STARTED_AT_KEY = "hub_first_action_started_at_v1";
+const TTV_MS_KEY = "hub_ftux_ttv_ms_v1";
 
 /** @typedef {"finyk" | "fizruk" | "routine" | "nutrition"} HubModuleId */
 
@@ -123,5 +129,67 @@ export function dismissSoftAuth() {
     localStorage.setItem(SOFT_AUTH_DISMISSED_KEY, "1");
   } catch {
     /* noop */
+  }
+}
+
+/**
+ * Start the 30-second FTUX clock. Called the moment the splash CTA is
+ * tapped so `getTimeToValueMs()` (computed on first real entry) has a
+ * deterministic origin regardless of routing/navigation timing.
+ *
+ * Idempotent: does nothing if a timestamp is already recorded — a user
+ * who bounces in and out of /welcome shouldn't reset the clock.
+ */
+export function markFirstActionStartedAt() {
+  try {
+    if (localStorage.getItem(FIRST_ACTION_STARTED_AT_KEY)) return;
+    localStorage.setItem(FIRST_ACTION_STARTED_AT_KEY, String(Date.now()));
+  } catch {
+    /* noop */
+  }
+}
+
+/**
+ * @returns {number | null} epoch ms, or `null` if the stamp is missing
+ *   (returning users / anyone who completed onboarding before this ship).
+ */
+export function getFirstActionStartedAt() {
+  try {
+    const v = localStorage.getItem(FIRST_ACTION_STARTED_AT_KEY);
+    if (!v) return null;
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the final time-to-value (ms from splash CTA tap to first
+ * real entry). The celebration toast reads this so the number is
+ * stable across re-renders even though the source timestamp is cleared.
+ *
+ * @param {number} ms
+ */
+export function saveTimeToValueMs(ms) {
+  try {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    localStorage.setItem(TTV_MS_KEY, String(Math.round(ms)));
+  } catch {
+    /* noop */
+  }
+}
+
+/**
+ * @returns {number | null} ms, or `null` if not yet measured.
+ */
+export function getTimeToValueMs() {
+  try {
+    const v = localStorage.getItem(TTV_MS_KEY);
+    if (!v) return null;
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 0 ? n : null;
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Ship 3 of the **FTUX 30s redesign** (Ship 1 → #221, Ship 2 → #225, design doc in the session). This is the final-seconds ship — the one that turns the post-splash row into a measurable, celebrated first real entry.

### 1. `PresetSheet` — one tap to a real entry
Tapping a row in `FirstActionHeroCard` used to deep-link into the module's full input wizard (habit form / expense sheet / add-meal dialog / workout builder). Each of those is a real input surface — fine for daily use, but an unnecessary ~10–15 s of friction on the very first entry.

`PresetSheet` replaces that with a per-module bottom sheet containing **3 opinionated one-tap presets**:

| Module | Presets |
| --- | --- |
| Рутина | 💧 Випити воду · 🚶 Пройти 10 хв · 📖 Прочитати 10 сторінок |
| Фінік | ☕ Кава (95 ₴) · 🚕 Таксі (180 ₴) · 🥗 Обід (220 ₴) |
| Харч | 🍳 Омлет з авокадо · 🥗 Салат з куркою · 🍎 Яблуко + горіхи |
| Фізрук | 🤸 Розминка (10 хв) · 🚶 Прогулянка (25 хв) · ⚡ Швидке HIIT (15 хв) |

Each preset tile writes straight into the module's storage (`finyk_manual_expenses_v1`, `hub_routine_v1`, `nutrition_log_v1`, `fizruk_workouts_v1`) with `demo: false`, so `detectFirstRealEntry` picks it up on the next render. A «Власний варіант» fallback row preserves the old `openHubModuleWithAction` deep-link for anyone whose first entry isn't in the list.

### 2. `ftux_time_to_value` — the headline metric
A start timestamp is written to localStorage (`hub_first_action_started_at_v1`) the moment the user taps «Заповни мій хаб» on the splash. When `detectFirstRealEntry` flips, we compute the delta and fire a new analytics event:

```js
trackEvent(ANALYTICS_EVENTS.FTUX_TIME_TO_VALUE, {
  durationMs, // e.g. 14_320
  durationSec, // e.g. 14
})
```

Supporting events (`ftux_preset_sheet_shown`, `ftux_preset_picked`, `ftux_preset_custom`) let us attribute the metric to sheet vs custom-fallback paths in dashboards. Target p50 < 20 000 ms for the cohort that reaches the sheet at least once.

### 3. TTV-in-toast success moment
`useFirstEntryCelebration` now reads the persisted duration and leads with it:

> **Готово за 14 с. Це вже твої дані.**

Falls back to the old generic copy for (a) returning users with no start stamp (pre-Ship-3 installs) and (b) outliers > 60 s, where surfacing the number would be anti-motivational.

### 4. Inline fix for #225 Devin Review nit
Dropped `useMemo` around `pickPrimary(picks)` in `FirstActionHeroCard` — it wraps a primitive result and `picks` is itself memoized with `[]` deps, so the compare was pure overhead. Kept the one around `others` (array, non-primitive, real equality implication).

### Files
- `src/core/onboarding/PresetSheet.jsx` — **new**. Bottom-sheet UI, preset tiles, custom fallback row.
- `src/core/onboarding/presetApply.js` — **new**. Per-module storage writers. Writes straight to `finyk_manual_expenses_v1`, `hub_routine_v1`, `fizruk_workouts_v1`, `nutrition_log_v1`; fans out `hub-routine-storage` / `nutrition-log-storage` events so the dashboard re-renders synchronously.
- `src/core/onboarding/FirstActionSheet.jsx` — rows now open PresetSheet; dropped per-action `run` closures; addressed #225 nit.
- `src/core/onboarding/useFirstEntryCelebration.js` — TTV-aware toast copy.
- `src/core/onboarding/firstRealEntry.js` — emit `FTUX_TIME_TO_VALUE` with `durationMs`/`durationSec`.
- `src/core/onboarding/vibePicks.js` — `markFirstActionStartedAt`/`getFirstActionStartedAt`/`saveTimeToValueMs`/`getTimeToValueMs`.
- `src/core/OnboardingWizard.jsx` — stamps start-of-FTUX clock right before `markFirstActionPending`.
- `src/core/analytics.js` — `FTUX_TIME_TO_VALUE`, `FTUX_PRESET_SHEET_SHOWN`, `FTUX_PRESET_PICKED`, `FTUX_PRESET_CUSTOM`.

## Review & Testing Checklist for Human

🟡 — three structural additions + one cross-module storage writer; touches FTUX hot-path but all writes are additive and gated on explicit user taps.

- [ ] **Preset → real entry (happy path)**: clear localStorage, complete splash, on the hub tap the primary CTA. PresetSheet opens. Tap any tile — sheet closes, hero card disappears, a toast appears saying **«Готово за N с. Це вже твої дані.»** (N = actual seconds). Reload — the logged entry is still in the matching module (open Рутина / Фінік / Харч / Фізрук to verify).
- [ ] **Custom fallback still works**: same flow, but instead of a tile tap «Власний варіант» at the bottom of the sheet. Should deep-link into the module's stock input (e.g. habit form for routine, expense sheet for finyk) — no entry is written by Ship 3 code; the celebration only fires if the user then completes that stock input.
- [ ] **Expand → other module preset**: expand «Інший модуль» in the hero, tap a non-primary row — PresetSheet for *that* module opens (check the title changes to match, e.g. «На що витратив?» for Фінік).
- [ ] **TTV extremes**: (a) take > 60 s before picking a preset — toast should be generic «Готово. Це вже твої дані.» (not «Готово за 72 с.»). (b) open DevTools → Application → localStorage — confirm `hub_ftux_ttv_ms_v1` is set after celebration.
- [ ] **Returning user (no regression)**: localStorage already has `hub_onboarding_done_v1=1` and `hub_first_real_entry_done_v1=1` — hero card should not render at all; no preset sheet; no extra toast on dashboard load.
- [ ] **Analytics**: with DevTools → Network filtered to `/api/analytics` (or whatever the trackEvent sink is), verify these fire in order during one happy-path run: `onboarding_first_action_shown` → `ftux_preset_sheet_shown` → `ftux_preset_picked` → `first_real_entry` → `ftux_time_to_value`.

### Notes
- Preset writers intentionally skip the modules' debounced `save*` APIs and poke localStorage directly, so the celebration toast doesn't race the dashboard's re-render. Same pattern `demoSeeds.js` already uses.
- TTV start stamp is idempotent (`markFirstActionStartedAt` early-returns if a stamp already exists). A user who bounces between `/welcome` and `/` won't reset the clock.
- Ship 4 after this (empty states, soft auth copy, A/B polish) — not in scope here.

Link to Devin session: https://app.devin.ai/sessions/8070829be3fb4627b47160f18a7ef215
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
