### PR TITLE
feat(ui): &lt;SectionHeading&gt; + &lt;Stat&gt; primitives — showcase на Fizruk Progress

### DIFF
--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -17,6 +17,8 @@ import {
 } from "../lib/fizrukStorage";
 import { epley1rm, weeklyVolumeSeriesNow } from "../lib/workoutStats";
 import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Stat } from "@shared/components/ui/Stat";
 
 function weekStartMs(d) {
   const x = new Date(d);
@@ -404,67 +406,67 @@ export function Progress() {
         {/* Weight + fat cards */}
         <div className="grid grid-cols-2 gap-3">
           <Card radius="lg">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-              Вага
-            </div>
-            <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
-              {meas.latest?.weightKg != null
-                ? `${meas.latest.weightKg} кг`
-                : "—"}
-            </div>
-            <div className="text-xs text-subtle mt-1">
-              {meas.delta("weightKg") == null ? (
-                "Немає порівняння"
-              ) : (
-                <span
-                  className={cn(
-                    "font-semibold",
-                    meas.delta("weightKg") > 0
-                      ? "text-warning"
-                      : "text-success",
-                  )}
-                >
-                  {meas.delta("weightKg") > 0 ? "+" : ""}
-                  {meas.delta("weightKg").toFixed(1)} кг
-                </span>
-              )}
-            </div>
+            <Stat
+              label="Вага"
+              value={
+                meas.latest?.weightKg != null
+                  ? `${meas.latest.weightKg} кг`
+                  : "—"
+              }
+              sublabel={
+                meas.delta("weightKg") == null ? (
+                  "Немає порівняння"
+                ) : (
+                  <span
+                    className={cn(
+                      "font-semibold",
+                      meas.delta("weightKg") > 0
+                        ? "text-warning"
+                        : "text-success",
+                    )}
+                  >
+                    {meas.delta("weightKg") > 0 ? "+" : ""}
+                    {meas.delta("weightKg").toFixed(1)} кг
+                  </span>
+                )
+              }
+            />
           </Card>
           <Card radius="lg">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-              % жиру
-            </div>
-            <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
-              {meas.latest?.bodyFatPct != null
-                ? `${meas.latest.bodyFatPct}%`
-                : "—"}
-            </div>
-            <div className="text-xs text-subtle mt-1">
-              {meas.delta("bodyFatPct") == null ? (
-                "—"
-              ) : (
-                <span
-                  className={cn(
-                    "font-semibold",
-                    meas.delta("bodyFatPct") > 0
-                      ? "text-warning"
-                      : "text-success",
-                  )}
-                >
-                  {meas.delta("bodyFatPct") > 0 ? "+" : ""}
-                  {meas.delta("bodyFatPct").toFixed(1)}%
-                </span>
-              )}
-            </div>
+            <Stat
+              label="% жиру"
+              value={
+                meas.latest?.bodyFatPct != null
+                  ? `${meas.latest.bodyFatPct}%`
+                  : "—"
+              }
+              sublabel={
+                meas.delta("bodyFatPct") == null ? (
+                  "—"
+                ) : (
+                  <span
+                    className={cn(
+                      "font-semibold",
+                      meas.delta("bodyFatPct") > 0
+                        ? "text-warning"
+                        : "text-success",
+                    )}
+                  >
+                    {meas.delta("bodyFatPct") > 0 ? "+" : ""}
+                    {meas.delta("bodyFatPct").toFixed(1)}%
+                  </span>
+                )
+              }
+            />
           </Card>
         </div>
 
         {/* Weight trend chart */}
         {weightTrend.filter((d) => d.value != null).length >= 2 && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading size="sm" className="mb-3">
               Тренд ваги
-            </div>
+            </SectionHeading>
             <MiniLineChart
               data={weightTrend}
               unit="кг"
@@ -477,9 +479,9 @@ export function Progress() {
         {/* Body fat trend chart */}
         {fatTrend.filter((d) => d.value != null).length >= 2 && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading size="sm" className="mb-3">
               Тренд % жиру
-            </div>
+            </SectionHeading>
             <MiniLineChart
               data={fatTrend}
               unit="%"
@@ -492,18 +494,18 @@ export function Progress() {
         {/* Wellbeing chart */}
         {wellbeingData.length >= 2 && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading size="sm" className="mb-3">
               Самопочуття
-            </div>
+            </SectionHeading>
             <WellbeingChart data={wellbeingData} />
           </Card>
         )}
 
         {/* Muscle volume bars */}
         <Card radius="lg" padding="lg">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+          <SectionHeading size="sm" className="mb-3">
             Обʼєм по мʼязах
-          </div>
+          </SectionHeading>
           {weeklyByMuscle.top.length === 0 ? (
             <EmptyState
               compact

--- a/src/shared/components/ui/SectionHeading.tsx
+++ b/src/shared/components/ui/SectionHeading.tsx
@@ -1,0 +1,60 @@
+import { type ElementType, type HTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+/**
+ * Sergeant Design System — SectionHeading
+ *
+ * Consolidates the 80+ "eyebrow"-style section titles scattered across
+ * modules. Current de-facto drift:
+ *   - text-2xs font-bold text-subtle uppercase tracking-widest  (53 matches)
+ *   - text-xs  font-bold text-subtle uppercase tracking-widest  (majority of Fizruk)
+ *   - text-xs  text-muted uppercase tracking-wide font-semibold (Finyk)
+ *
+ * The canonical sizes are xs (for in-card titles) and xl (for section
+ * headers above a group of cards). Semantics default to <h3> — callers
+ * can override via `as`.
+ */
+
+export type SectionHeadingSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+const sizes: Record<SectionHeadingSize, string> = {
+  xs: "text-2xs font-bold text-subtle uppercase tracking-widest",
+  sm: "text-xs font-bold text-subtle uppercase tracking-widest",
+  md: "text-sm font-semibold text-text",
+  lg: "text-lg font-extrabold text-text leading-tight",
+  xl: "text-xl font-extrabold text-text leading-tight",
+};
+
+export interface SectionHeadingProps extends HTMLAttributes<HTMLElement> {
+  size?: SectionHeadingSize;
+  as?: ElementType;
+  /** Optional right-aligned slot for actions/links. */
+  action?: ReactNode;
+  children?: ReactNode;
+}
+
+export function SectionHeading({
+  className,
+  size = "xs",
+  as: Component = "h3",
+  action,
+  children,
+  ...props
+}: SectionHeadingProps) {
+  if (action) {
+    return (
+      <div className={cn("flex items-center justify-between gap-3", className)}>
+        <Component className={sizes[size]} {...props}>
+          {children}
+        </Component>
+        <div className="shrink-0">{action}</div>
+      </div>
+    );
+  }
+
+  return (
+    <Component className={cn(sizes[size], className)} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/src/shared/components/ui/Stat.tsx
+++ b/src/shared/components/ui/Stat.tsx
@@ -1,0 +1,100 @@
+import { type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+/**
+ * Sergeant Design System — Stat
+ *
+ * The canonical "eyebrow + big number + sublabel" triple that repeats
+ * dozens of times across Fizruk dashboards and Finyk summaries:
+ *
+ *   <div className="text-2xs font-bold text-subtle uppercase tracking-widest">Вага</div>
+ *   <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">82 кг</div>
+ *   <div className="text-xs text-subtle mt-1">+0.4 кг</div>
+ *
+ * Tones tint the value: default (text-text), success, warning, danger,
+ * and each module's brand token (finyk/fizruk/routine/nutrition) for the
+ * rare branded metric readouts.
+ */
+
+export type StatTone =
+  | "default"
+  | "success"
+  | "warning"
+  | "danger"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type StatSize = "sm" | "md" | "lg";
+
+const toneClass: Record<StatTone, string> = {
+  default: "text-text",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-coral-500",
+  nutrition: "text-lime-600",
+};
+
+const valueSize: Record<StatSize, string> = {
+  sm: "text-lg font-extrabold tabular-nums",
+  md: "text-2xl font-extrabold tabular-nums",
+  lg: "text-3xl font-black tabular-nums",
+};
+
+export interface StatProps {
+  label: ReactNode;
+  value: ReactNode;
+  sublabel?: ReactNode;
+  tone?: StatTone;
+  size?: StatSize;
+  /** Optional leading icon / emoji rendered left of the value. */
+  icon?: ReactNode;
+  /** Align contents. Defaults to left. */
+  align?: "left" | "center" | "right";
+  className?: string;
+}
+
+export function Stat({
+  label,
+  value,
+  sublabel,
+  tone = "default",
+  size = "md",
+  icon,
+  align = "left",
+  className,
+}: StatProps) {
+  const alignClass =
+    align === "center"
+      ? "text-center"
+      : align === "right"
+        ? "text-right"
+        : "text-left";
+
+  return (
+    <div className={cn(alignClass, className)}>
+      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+        {label}
+      </div>
+      <div
+        className={cn(
+          "mt-1 flex items-baseline gap-1.5",
+          align === "center" && "justify-center",
+          align === "right" && "justify-end",
+          valueSize[size],
+          toneClass[tone],
+        )}
+      >
+        {icon && (
+          <span className="text-base font-normal leading-none">{icon}</span>
+        )}
+        <span>{value}</span>
+      </div>
+      {sublabel && <div className="text-xs text-subtle mt-1">{sublabel}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR #5/9 — уніфікація типографії в картках.

**Що мігрує:**

- **`<SectionHeading>`** — 80+ «eyebrow»-титлів у картках/секціях. Де-факто дрейф:
  - `text-2xs font-bold text-subtle uppercase tracking-widest` — 53 появи
  - `text-xs font-bold text-subtle uppercase tracking-widest` — десятки в Fizruk
  - `text-xs text-muted uppercase tracking-wide font-semibold` — Finyk pages  
  → канон: `xs` (у картках) / `sm` (в картках лейбли чартів) / `md` / `lg` / `xl` для page-h1. Опційний правий `action` slot.

- **`<Stat>`** — «label + big tabular-nums value + sublabel» триплет, що повторюється в `Progress.tsx`, `Dashboard.tsx`, `Exercise.tsx`, `MonthPulseCard.jsx`, `Assets.jsx` десятки разів. Підтримує тони (`default / success / warning / danger / finyk / fizruk / routine / nutrition`) і розміри (`sm / md / lg`).

**Мігрував як showcase (`Fizruk Progress.tsx`):**

- Картки «Вага» і «% жиру» → `<Stat label value sublabel>`. Кольорна логіка дельти (↑/↓ → warning/success) збережена 1:1 через ReactNode у `sublabel`.
- 4 внутрішні лейбли чартів («Тренд ваги / Тренд % жиру / Самопочуття / Об'єм по м'язах») → `<SectionHeading size="sm" className="mb-3">`.

Інші екземпляри (`Dashboard.tsx`, `Exercise.tsx`, `MonthPulseCard.jsx`, тощо) тягну одним follow-up PR разом з ESLint-правилом у #9, щоб новий дрейф не просочився назад.

## Review & Testing Checklist for Human

- [ ] Fizruk → Прогрес: картки «Вага» і «% жиру» — лейбл (uppercase XS), число (2xl extrabold tabular-nums), підпис (XS із правильним кольором ↑/↓). Рендер ідентичний до merge.
- [ ] Fizruk → Прогрес: розділи «Тренд ваги», «Тренд % жиру», «Самопочуття», «Об'єм по м'язах» — заголовки однакові за шрифтом/відступом.
- [ ] Темна тема — `text-subtle` усе ще читається, tabular-nums вирівняні.

### Notes

Маленький, низькоризиковий PR (+100/−60). Додам решту call-sites + розширення `Stat` на нові тони, коли доберемось до PR #9 і зайдемо під ESLint.

Далі:
- #6 empty-states migration
- #7 Icon.tsx expansion
- #8 color-token cleanup
- #9 ESLint rule + final cleanup

p.s. у Devin Review на мердженому #226 зафіксував один реальний regression (`ManualExpenseSheet` тепер закривається по кліку на скрім і губить форму) — це виправлю окремим маленьким follow-up PR (додати `dismissOnBackdropClick=false` опцію в `<Sheet>` і передати з `ManualExpenseSheet`).

Link to Devin session: https://app.devin.ai/sessions/42d8559209714faba6d1f3739924ad2d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
