### PR TITLE
refactor(server): extract per-domain routers into server/routes/ (PR 3/5)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,66 +1,17 @@
 import express from "express";
-import { existsSync } from "fs";
-import { join } from "path";
 
-import { toNodeHandler } from "better-auth/node";
-import { auth } from "./auth.js";
 import { pool } from "./db.js";
 import {
+  apiCorsMiddleware,
   apiHelmetMiddleware,
-  authMetricsMiddleware,
-  authSensitiveRateLimit,
-  createReadyzHandler,
   errorHandler,
-  livezHandler,
   requestIdMiddleware,
   requestLogMiddleware,
   withRequestContext,
 } from "./http/index.js";
-import { metricsHandler } from "./obs/metrics.js";
-import chatHandler from "./modules/chat.js";
-import monoHandler from "./modules/mono.js";
-import privatHandler from "./modules/privat.js";
-import {
-  syncPull,
-  syncPullAll,
-  syncPush,
-  syncPushAll,
-} from "./modules/sync.js";
-import barcodeHandler from "./modules/barcode.js";
-import analyzePhoto from "./modules/nutrition/analyze-photo.js";
-import parsePantry from "./modules/nutrition/parse-pantry.js";
-import refinePhoto from "./modules/nutrition/refine-photo.js";
-import recommendRecipes from "./modules/nutrition/recommend-recipes.js";
-import dayHint from "./modules/nutrition/day-hint.js";
-import weekPlan from "./modules/nutrition/week-plan.js";
-import backupUpload from "./modules/nutrition/backup-upload.js";
-import backupDownload from "./modules/nutrition/backup-download.js";
-import dayPlan from "./modules/nutrition/day-plan.js";
-import shoppingList from "./modules/nutrition/shopping-list.js";
-import weeklyDigest from "./modules/weekly-digest.js";
-import coachHandler from "./modules/coach.js";
-import {
-  sendPush,
-  subscribe as pushSubscribe,
-  unsubscribe as pushUnsubscribe,
-  vapidPublic,
-} from "./modules/push.js";
-import foodSearchHandler from "./modules/food-search.js";
-import webVitalsHandler from "./modules/web-vitals.js";
-import { setCorsHeaders } from "./http/cors.js";
-import { rateLimitExpress } from "./http/rateLimit.js";
+import { registerRoutes } from "./routes/index.js";
+import { createFrontendMiddleware } from "./routes/frontend.js";
 import { attachSentryErrorHandler } from "./sentry.js";
-
-/**
- * Adapts `(req, res) => Promise<void>` handlers to Express 4's error-handling
- * contract by routing any thrown/rejected error into `next(err)` so that
- * `errorHandler` can produce a uniform 4xx/5xx response.
- */
-function wrap(handler) {
-  return (req, res, next) => {
-    Promise.resolve(handler(req, res)).catch(next);
-  };
-}
 
 /**
  * @typedef {Object} CreateAppOptions
@@ -84,9 +35,8 @@ function wrap(handler) {
  * listener. Keeping `createApp` pure makes it trivial to smoke-test routes in
  * Vitest without spinning up a real server.
  *
- * Route registration order mirrors what the legacy `railway.mjs` did — the
- * previous `replit.mjs` had the same set minus `/api/push/*` (which was a
- * silent divergence bug). Unifying entrypoints fixes that automatically.
+ * Routing itself is delegated to `server/routes/` — per-domain routers are
+ * mounted through `registerRoutes`. The order matters and is preserved there.
  *
  * @param {CreateAppOptions} [opts]
  * @returns {import("express").Express}
@@ -110,129 +60,18 @@ export function createApp({
 
   // Global CORS for the whole /api surface. Individual handlers may re-set
   // headers (e.g. to widen allow-headers) — `setCorsHeaders` is idempotent.
-  app.use("/api", (req, res, next) => {
-    setCorsHeaders(res, req, {
-      allowHeaders: "X-Token, Content-Type",
-      methods: "GET, POST, OPTIONS",
-    });
-    if (req.method === "OPTIONS") return res.status(200).end();
-    next();
-  });
+  app.use("/api", apiCorsMiddleware());
 
-  app.get("/livez", livezHandler);
-  app.get("/readyz", createReadyzHandler(pool));
-  // `/health` stays as an alias of `/readyz` for legacy platform probes.
-  app.get("/health", createReadyzHandler(pool));
-  app.get("/metrics", metricsHandler);
-
-  // `authMetricsMiddleware` must be registered BEFORE the rate-limiter — it
-  // only attaches a `res.on("finish")` listener and calls `next()`, so even
-  // when the limiter short-circuits with 429, the listener still fires on
-  // response completion and the counter is incremented correctly.
-  app.use("/api/auth", authMetricsMiddleware);
-  app.use("/api/auth", authSensitiveRateLimit);
-  app.all("/api/auth/*", toNodeHandler(auth));
-
-  app.use(
-    "/api/sync",
-    rateLimitExpress({ key: "api:sync", limit: 30, windowMs: 60_000 }),
-  );
-  app.all("/api/sync/push", wrap(syncPush));
-  app.all("/api/sync/pull", wrap(syncPull));
-  app.all("/api/sync/pull-all", wrap(syncPullAll));
-  app.all("/api/sync/push-all", wrap(syncPushAll));
-
-  app.all(
-    "/api/chat",
-    rateLimitExpress({ key: "api:chat", limit: 30, windowMs: 60_000 }),
-    wrap(chatHandler),
-  );
-  app.all(
-    "/api/mono",
-    rateLimitExpress({ key: "api:mono", limit: 60, windowMs: 60_000 }),
-    wrap(monoHandler),
-  );
-  app.all(
-    "/api/privat",
-    rateLimitExpress({ key: "api:privat", limit: 30, windowMs: 60_000 }),
-    wrap(privatHandler),
-  );
-
-  app.get("/api/barcode", wrap(barcodeHandler));
-
-  // Broad best-effort limiter for nutrition endpoints (detailed limits exist inside handlers too).
-  app.use(
-    "/api/nutrition",
-    rateLimitExpress({ key: "api:nutrition", limit: 120, windowMs: 60_000 }),
-  );
-  app.all("/api/nutrition/analyze-photo", wrap(analyzePhoto));
-  app.all("/api/nutrition/parse-pantry", wrap(parsePantry));
-  app.all("/api/nutrition/refine-photo", wrap(refinePhoto));
-  app.all("/api/nutrition/recommend-recipes", wrap(recommendRecipes));
-  app.all("/api/nutrition/day-hint", wrap(dayHint));
-  app.all("/api/nutrition/week-plan", wrap(weekPlan));
-  app.all("/api/nutrition/backup-upload", wrap(backupUpload));
-  app.all("/api/nutrition/backup-download", wrap(backupDownload));
-  app.all("/api/nutrition/day-plan", wrap(dayPlan));
-  app.all("/api/nutrition/shopping-list", wrap(shoppingList));
-
-  app.all(
-    "/api/weekly-digest",
-    rateLimitExpress({
-      key: "api:weekly-digest",
-      limit: 10,
-      windowMs: 60 * 60_000,
-    }),
-    wrap(weeklyDigest),
-  );
-
-  app.use(
-    "/api/coach",
-    rateLimitExpress({ key: "api:coach", limit: 20, windowMs: 60 * 60_000 }),
-  );
-  app.all("/api/coach/memory", wrap(coachHandler));
-  app.all("/api/coach/insight", wrap(coachHandler));
-
-  app.get(
-    "/api/food-search",
-    rateLimitExpress({ key: "api:food-search", limit: 40, windowMs: 60_000 }),
-    wrap(foodSearchHandler),
-  );
-
-  app.post(
-    "/api/metrics/web-vitals",
-    rateLimitExpress({ key: "api:web-vitals", limit: 60, windowMs: 60_000 }),
-    wrap(webVitalsHandler),
-  );
-
-  app.get("/api/push/vapid-public", wrap(vapidPublic));
-  app.use(
-    "/api/push",
-    rateLimitExpress({ key: "api:push", limit: 30, windowMs: 60_000 }),
-  );
-  app.post("/api/push/subscribe", wrap(pushSubscribe));
-  app.delete("/api/push/subscribe", wrap(pushUnsubscribe));
-  app.post("/api/push/send", wrap(sendPush));
+  registerRoutes(app, { pool });
 
   if (servesFrontend && distPath) {
-    if (existsSync(distPath)) {
-      app.use(
-        "/assets",
-        express.static(join(distPath, "assets"), {
-          maxAge: "1y",
-          immutable: true,
-        }),
-      );
-      app.use(express.static(distPath, { maxAge: 0 }));
-      app.get("*", (_req, res) => {
-        res.sendFile(join(distPath, "index.html"));
-      });
+    const fe = createFrontendMiddleware({ distPath });
+    if (typeof fe === "function") {
+      app.get("*", fe);
     } else {
-      app.get("*", (_req, res) => {
-        res
-          .status(503)
-          .send("Frontend not built. Run <code>npm run build</code> first.");
-      });
+      app.use("/assets", fe.assetsStatic);
+      app.use(fe.rootStatic);
+      app.get("*", fe.sendIndex);
     }
   }
 

--- a/server/http/apiCors.js
+++ b/server/http/apiCors.js
@@ -1,0 +1,23 @@
+import { setCorsHeaders } from "./cors.js";
+
+/**
+ * Global CORS middleware для всього /api. Залишилось один-в-один те, що
+ * раніше жило inline у `server/app.js`:
+ *   - ставимо стандартні CORS-хедери (idempotent → handler-и можуть
+ *     перевизначити allow-headers якщо треба ширший список);
+ *   - на OPTIONS одразу 200, щоб preflight не проходив далі по middleware
+ *     chain (rate-limit, auth).
+ *
+ * Ця middleware зараз дублюється в handler-ах (per-handler виклики
+ * setCorsHeaders + OPTIONS-guard) — PR 4 видалить дублікати.
+ */
+export function apiCorsMiddleware() {
+  return (req, res, next) => {
+    setCorsHeaders(res, req, {
+      allowHeaders: "X-Token, Content-Type",
+      methods: "GET, POST, OPTIONS",
+    });
+    if (req.method === "OPTIONS") return res.status(200).end();
+    next();
+  };
+}

--- a/server/http/index.js
+++ b/server/http/index.js
@@ -26,6 +26,7 @@ export { errorHandler } from "./errorHandler.js";
 // CORS / rate-limit / validation / schemas / json-extract — перенесено сюди
 // з історичної `server/api/lib/` у PR 1 (#236); реекспортимо з одного місця.
 export { setCorsHeaders, getAllowedOrigins } from "./cors.js";
+export { apiCorsMiddleware } from "./apiCors.js";
 export { checkRateLimit, getIp, rateLimitExpress } from "./rateLimit.js";
 export { validateBody, validateQuery } from "./validate.js";
 export { extractJsonFromText } from "./jsonSafe.js";

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "../auth.js";
+import {
+  authMetricsMiddleware,
+  authSensitiveRateLimit,
+} from "../http/index.js";
+
+/**
+ * `/api/auth/*` — Better Auth mount.
+ *
+ * Router навмисно мапить повний шлях (`/api/auth/*`) і мoнтується до app
+ * через `app.use(router)` (без префіксу). Це зберігає `req.url` у вигляді
+ * `/api/auth/sign-in`, як очікує Better Auth handler.
+ *
+ * `authMetricsMiddleware` МАЄ йти перед rate-limiter-ом: він тільки вішає
+ * `res.on("finish")` і кличе `next()`, тож навіть якщо лімітер відстрілить
+ * 429, finish-listener все одно спрацює і метрика інкрементнеться коректно.
+ */
+export function createAuthRouter() {
+  const r = Router();
+  r.use("/api/auth", authMetricsMiddleware);
+  r.use("/api/auth", authSensitiveRateLimit);
+  r.all("/api/auth/*", toNodeHandler(auth));
+  return r;
+}

--- a/server/routes/banks.js
+++ b/server/routes/banks.js
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import monoHandler from "../modules/mono.js";
+import privatHandler from "../modules/privat.js";
+
+/**
+ * Bank-proxy endpoints: Monobank та Privatbank. Обидва просто проксують до
+ * API банку (з кешуванням/rate-limit-ом), тому логічно в одному routerі.
+ */
+export function createBanksRouter() {
+  const r = Router();
+  r.all(
+    "/api/mono",
+    rateLimitExpress({ key: "api:mono", limit: 60, windowMs: 60_000 }),
+    asyncHandler(monoHandler),
+  );
+  r.all(
+    "/api/privat",
+    rateLimitExpress({ key: "api:privat", limit: 30, windowMs: 60_000 }),
+    asyncHandler(privatHandler),
+  );
+  return r;
+}

--- a/server/routes/barcode.js
+++ b/server/routes/barcode.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { asyncHandler } from "../http/index.js";
+import barcodeHandler from "../modules/barcode.js";
+
+export function createBarcodeRouter() {
+  const r = Router();
+  r.get("/api/barcode", asyncHandler(barcodeHandler));
+  return r;
+}

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import chatHandler from "../modules/chat.js";
+
+export function createChatRouter() {
+  const r = Router();
+  r.all(
+    "/api/chat",
+    rateLimitExpress({ key: "api:chat", limit: 30, windowMs: 60_000 }),
+    asyncHandler(chatHandler),
+  );
+  return r;
+}

--- a/server/routes/coach.js
+++ b/server/routes/coach.js
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import coachHandler from "../modules/coach.js";
+
+/**
+ * `/api/coach/*` — поки той самий handler обробляє і `/memory`, і `/insight`,
+ * розрізняючи по URL-суфіксу всередині. PR 5 розіб'є на два файли, а поки що
+ * просто мапимо обидва шляхи на той самий export.
+ */
+export function createCoachRouter() {
+  const r = Router();
+  r.use(
+    "/api/coach",
+    rateLimitExpress({ key: "api:coach", limit: 20, windowMs: 60 * 60_000 }),
+  );
+  r.all("/api/coach/memory", asyncHandler(coachHandler));
+  r.all("/api/coach/insight", asyncHandler(coachHandler));
+  return r;
+}

--- a/server/routes/food-search.js
+++ b/server/routes/food-search.js
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import foodSearchHandler from "../modules/food-search.js";
+
+export function createFoodSearchRouter() {
+  const r = Router();
+  r.get(
+    "/api/food-search",
+    rateLimitExpress({ key: "api:food-search", limit: 40, windowMs: 60_000 }),
+    asyncHandler(foodSearchHandler),
+  );
+  return r;
+}

--- a/server/routes/frontend.js
+++ b/server/routes/frontend.js
@@ -1,0 +1,31 @@
+import express from "express";
+import { existsSync } from "fs";
+import { join } from "path";
+
+/**
+ * SPA-serving для Replit-режиму (той самий процес хостить і API, і фронт).
+ * Повертає middleware-функцію, яку `app.js` просто прикладає наприкінці.
+ *
+ * Якщо `distPath` не існує — віддаємо 503 з підказкою, щоб не збити з пантелику
+ * розробника, який запустив сервер без попереднього `npm run build`.
+ *
+ * @param {{ distPath: string }} opts
+ */
+export function createFrontendMiddleware({ distPath }) {
+  if (!existsSync(distPath)) {
+    return (_req, res) => {
+      res
+        .status(503)
+        .send("Frontend not built. Run <code>npm run build</code> first.");
+    };
+  }
+  const assetsStatic = express.static(join(distPath, "assets"), {
+    maxAge: "1y",
+    immutable: true,
+  });
+  const rootStatic = express.static(distPath, { maxAge: 0 });
+  const sendIndex = (_req, res) => {
+    res.sendFile(join(distPath, "index.html"));
+  };
+  return { assetsStatic, rootStatic, sendIndex };
+}

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { createReadyzHandler, livezHandler } from "../http/index.js";
+import { metricsHandler } from "../obs/metrics.js";
+
+/**
+ * Health / readiness / metrics endpoints.
+ *
+ * `/health` лишається аліасом для `/readyz` через історичні platform-probe-и
+ * (Railway, старі Replit-пайплайни). Не видаляти без координації з деплоєм.
+ *
+ * @param {{ pool: import("pg").Pool }} deps
+ */
+export function createHealthRouter({ pool }) {
+  const r = Router();
+  r.get("/livez", livezHandler);
+  r.get("/readyz", createReadyzHandler(pool));
+  r.get("/health", createReadyzHandler(pool));
+  r.get("/metrics", metricsHandler);
+  return r;
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,40 @@
+import { createAuthRouter } from "./auth.js";
+import { createBanksRouter } from "./banks.js";
+import { createBarcodeRouter } from "./barcode.js";
+import { createChatRouter } from "./chat.js";
+import { createCoachRouter } from "./coach.js";
+import { createFoodSearchRouter } from "./food-search.js";
+import { createHealthRouter } from "./health.js";
+import { createNutritionRouter } from "./nutrition.js";
+import { createPushRouter } from "./push.js";
+import { createSyncRouter } from "./sync.js";
+import { createWebVitalsRouter } from "./web-vitals.js";
+import { createWeeklyDigestRouter } from "./weekly-digest.js";
+
+/**
+ * Реєструє всі доменні роутери на переданому Express-додатку. Кожен роутер
+ * мапить повний шлях (`/api/...`) і мoнтується без префіксу, щоб `req.url`
+ * лишався ідентичним тому, що бачили handler-и до рефактору — це гарантує
+ * нуль поведінкових змін.
+ *
+ * Порядок реєстрації відповідає тому, що був inline у `server/app.js`: спочатку
+ * health/metrics, потім auth (перед глобальним CORS на /api — див. коментар у
+ * `app.js`), потім решта доменних роутерів.
+ *
+ * @param {import("express").Express} app
+ * @param {{ pool: import("pg").Pool }} deps
+ */
+export function registerRoutes(app, { pool }) {
+  app.use(createHealthRouter({ pool }));
+  app.use(createAuthRouter());
+  app.use(createSyncRouter());
+  app.use(createChatRouter());
+  app.use(createBanksRouter());
+  app.use(createBarcodeRouter());
+  app.use(createNutritionRouter());
+  app.use(createWeeklyDigestRouter());
+  app.use(createCoachRouter());
+  app.use(createFoodSearchRouter());
+  app.use(createWebVitalsRouter());
+  app.use(createPushRouter());
+}

--- a/server/routes/nutrition.js
+++ b/server/routes/nutrition.js
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import analyzePhoto from "../modules/nutrition/analyze-photo.js";
+import parsePantry from "../modules/nutrition/parse-pantry.js";
+import refinePhoto from "../modules/nutrition/refine-photo.js";
+import recommendRecipes from "../modules/nutrition/recommend-recipes.js";
+import dayHint from "../modules/nutrition/day-hint.js";
+import weekPlan from "../modules/nutrition/week-plan.js";
+import backupUpload from "../modules/nutrition/backup-upload.js";
+import backupDownload from "../modules/nutrition/backup-download.js";
+import dayPlan from "../modules/nutrition/day-plan.js";
+import shoppingList from "../modules/nutrition/shopping-list.js";
+
+/**
+ * Broad best-effort лімітер для всіх nutrition-endpoint-ів; детальні per-key
+ * ліміти лишаються всередині окремих handler-ів (буде підчищено у PR 4).
+ */
+export function createNutritionRouter() {
+  const r = Router();
+  r.use(
+    "/api/nutrition",
+    rateLimitExpress({ key: "api:nutrition", limit: 120, windowMs: 60_000 }),
+  );
+  r.all("/api/nutrition/analyze-photo", asyncHandler(analyzePhoto));
+  r.all("/api/nutrition/parse-pantry", asyncHandler(parsePantry));
+  r.all("/api/nutrition/refine-photo", asyncHandler(refinePhoto));
+  r.all("/api/nutrition/recommend-recipes", asyncHandler(recommendRecipes));
+  r.all("/api/nutrition/day-hint", asyncHandler(dayHint));
+  r.all("/api/nutrition/week-plan", asyncHandler(weekPlan));
+  r.all("/api/nutrition/backup-upload", asyncHandler(backupUpload));
+  r.all("/api/nutrition/backup-download", asyncHandler(backupDownload));
+  r.all("/api/nutrition/day-plan", asyncHandler(dayPlan));
+  r.all("/api/nutrition/shopping-list", asyncHandler(shoppingList));
+  return r;
+}

--- a/server/routes/push.js
+++ b/server/routes/push.js
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import {
+  sendPush,
+  subscribe as pushSubscribe,
+  unsubscribe as pushUnsubscribe,
+  vapidPublic,
+} from "../modules/push.js";
+
+/**
+ * `/api/push/vapid-public` свідомо поза rate-limiter-ом: його смикає фронт
+ * під час регіс трації сервіс-воркера і він має бути швидким/дешевим. Решта
+ * endpoint-ів (subscribe/unsubscribe/send) лімітуються.
+ */
+export function createPushRouter() {
+  const r = Router();
+  r.get("/api/push/vapid-public", asyncHandler(vapidPublic));
+  r.use(
+    "/api/push",
+    rateLimitExpress({ key: "api:push", limit: 30, windowMs: 60_000 }),
+  );
+  r.post("/api/push/subscribe", asyncHandler(pushSubscribe));
+  r.delete("/api/push/subscribe", asyncHandler(pushUnsubscribe));
+  r.post("/api/push/send", asyncHandler(sendPush));
+  return r;
+}

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import {
+  syncPull,
+  syncPullAll,
+  syncPush,
+  syncPushAll,
+} from "../modules/sync.js";
+
+export function createSyncRouter() {
+  const r = Router();
+  r.use(
+    "/api/sync",
+    rateLimitExpress({ key: "api:sync", limit: 30, windowMs: 60_000 }),
+  );
+  r.all("/api/sync/push", asyncHandler(syncPush));
+  r.all("/api/sync/pull", asyncHandler(syncPull));
+  r.all("/api/sync/pull-all", asyncHandler(syncPullAll));
+  r.all("/api/sync/push-all", asyncHandler(syncPushAll));
+  return r;
+}

--- a/server/routes/web-vitals.js
+++ b/server/routes/web-vitals.js
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import webVitalsHandler from "../modules/web-vitals.js";
+
+export function createWebVitalsRouter() {
+  const r = Router();
+  r.post(
+    "/api/metrics/web-vitals",
+    rateLimitExpress({ key: "api:web-vitals", limit: 60, windowMs: 60_000 }),
+    asyncHandler(webVitalsHandler),
+  );
+  return r;
+}

--- a/server/routes/weekly-digest.js
+++ b/server/routes/weekly-digest.js
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { asyncHandler, rateLimitExpress } from "../http/index.js";
+import weeklyDigest from "../modules/weekly-digest.js";
+
+export function createWeeklyDigestRouter() {
+  const r = Router();
+  r.all(
+    "/api/weekly-digest",
+    rateLimitExpress({
+      key: "api:weekly-digest",
+      limit: 10,
+      windowMs: 60 * 60_000,
+    }),
+    asyncHandler(weeklyDigest),
+  );
+  return r;
+}


### PR DESCRIPTION
## Summary

**PR 3 з серії 1–5.** `server/app.js` перестає бути route-table-ом — стискається з **246 → 85 рядків**. Кожен домен отримує власний `Router()` у `server/routes/`.

> Stacked поверх #237 (PR 2). Після мерджу PR 1 і PR 2 base автоматично переналаштується на main.

### Що зроблено
- **13 доменних роутерів** у `server/routes/`:
  `auth.js`, `banks.js` (mono+privat), `barcode.js`, `chat.js`, `coach.js`, `food-search.js`, `health.js`, `nutrition.js`, `push.js`, `sync.js`, `weekly-digest.js`, `web-vitals.js`, `frontend.js`
- `server/routes/index.js` → `registerRoutes(app, { pool })` мoнтує всі роутери у правильному порядку
- `server/http/apiCors.js` → винесено `/api` CORS-middleware з `app.js`
- `wrap()` видалено; handler-и тепер обгортаються через `asyncHandler` з `server/http/` (доданий у PR 1)

### Ключовий момент архітектури
Усі роутери **декларують повні шляхи** (`/api/sync/push`, а не `/push`) і монтуються у `app.js` через `app.use(router)` **без префіксу**. Це гарантує що `req.url` залишається ідентичним до рефактору — критично для:
- `toNodeHandler(auth)` від Better Auth (читає повний URL для матчу ендпоінтів)
- `requestLogMiddleware` (логує route-pattern)
- будь-яких handler-ів, що читають `req.url` напряму

### Що НЕ робить цей PR
- Handler-и не чіпано (тільки імпорти в роутерах)
- `setRequestModule`, CORS-виклики, method-guard, token-guard всередині handler-ів — на місці. Це PR 4.
- `coach.js` і `push.js` все ще multi-handler файли. Це PR 5.

### Числа
```
server/app.js     246 → 85 lines  (-161)
server/routes/*   + ~290 lines across 13 files
```

## Review & Testing Checklist for Human

Ризик: **yellow** — routing-зміни, хоч і з принципом "zero behavior change". 669 тестів зелені, lint+typecheck чисті.

- [ ] **Критично:** `/api/auth/*` має працювати (Better Auth чутливий до URL — тому роутер мапить повний шлях, без префіксу).
- [ ] Перевірити один endpoint з різних роутерів: `/api/sync/pull`, `/api/nutrition/day-hint`, `/api/push/vapid-public`, `/livez` — мають відповідати як і раніше.
- [ ] Replit-mode (якщо є препрев): SPA-serving лишається працювати (`createFrontendMiddleware` сервить `dist/`).

### Notes

Після мерджу далі:
- **PR 4** — debolerplate 17 handler-ів: router-middleware з PR 1 замінять per-handler boilerplate (`setRequestModule` ×25, `setCorsHeaders` ×20, OPTIONS-guard ×17, token-guard ×21, quota ×11 і т.д.)
- **PR 5** — split `coach.js` (роутить по URL-суфіксу) і `push.js` (4 handler-и в одному файлі)

Link to Devin session: https://app.devin.ai/sessions/84e53f5360944a6fb5051721c711ea65
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
