### PR TITLE
refactor(ui): migrate 6 more hand-rolled sheets to shared &lt;Sheet&gt;

### DIFF
--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -7,6 +7,7 @@ import { mergeExpenseCategoryDefinitions } from "../constants";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { Icon } from "@shared/components/ui/Icon";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useToast } from "@shared/hooks/useToast";
@@ -708,46 +709,28 @@ export function Transactions({
       )}
 
       {/* Batch category picker */}
-      {batchCatPicker && (
-        <div className="fixed inset-0 z-[70] flex items-end">
-          <div
-            className="absolute inset-0 bg-text/40 backdrop-blur-sm"
-            onClick={() => setBatchCatPicker(false)}
-            aria-hidden
-          />
-          <div className="relative z-10 w-full max-w-lg mx-auto bg-panel rounded-t-3xl border-t border-line shadow-soft max-h-[70vh] flex flex-col safe-area-pb">
-            <div className="flex justify-center pt-3 pb-1 shrink-0">
-              <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
-            </div>
-            <div className="px-5 pb-3 shrink-0">
-              <div className="text-base font-bold text-text">
-                Вибрати категорію
-              </div>
-              <div className="text-xs text-subtle mt-0.5">
-                Застосується до {selectedIds.size} транзакц
-                {selectedIds.size === 1 ? "ії" : "ій"}
-              </div>
-            </div>
-            <div className="overflow-y-auto px-4 pb-6 flex flex-col gap-1">
-              {mergeExpenseCategoryDefinitions(customCategories)
-                .filter((c) => c.id !== "income")
-                .map((cat) => (
-                  <button
-                    key={cat.id}
-                    type="button"
-                    onClick={() => applyBatchCategory(cat.id)}
-                    className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-2xl hover:bg-panelHi transition-colors min-h-[48px]"
-                  >
-                    <span className="text-lg">{cat.emoji}</span>
-                    <span className="text-sm font-medium text-text">
-                      {cat.label}
-                    </span>
-                  </button>
-                ))}
-            </div>
-          </div>
-        </div>
-      )}
+      <Sheet
+        open={batchCatPicker}
+        onClose={() => setBatchCatPicker(false)}
+        title="Вибрати категорію"
+        description={`Застосується до ${selectedIds.size} транзакц${selectedIds.size === 1 ? "ії" : "ій"}`}
+        zIndex={70}
+        bodyClassName="px-4 pb-6 flex flex-col gap-1"
+      >
+        {mergeExpenseCategoryDefinitions(customCategories)
+          .filter((c) => c.id !== "income")
+          .map((cat) => (
+            <button
+              key={cat.id}
+              type="button"
+              onClick={() => applyBatchCategory(cat.id)}
+              className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-2xl hover:bg-panelHi transition-colors min-h-[48px]"
+            >
+              <span className="text-lg">{cat.emoji}</span>
+              <span className="text-sm font-medium text-text">{cat.label}</span>
+            </button>
+          ))}
+      </Sheet>
     </div>
   );
 }

--- a/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -1,10 +1,9 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useVisualKeyboardInset } from "@shared/hooks/useVisualKeyboardInset";
-import { FIZRUK_SHEET_PAD_CLASS, SHEET_Z } from "../../lib/workoutUi";
 
 const EQUIPMENT_OPTIONS = [
   { id: "bodyweight", label: "Власна вага" },
@@ -43,8 +42,6 @@ export function AddExerciseSheet({
   musclesByPrimaryGroup,
   addExercise,
 }) {
-  const sheetRef = useRef(null);
-  useDialogFocusTrap(open, sheetRef, { onEscape: onClose });
   const kbInsetPx = useVisualKeyboardInset(open);
 
   const suggestedMuscles = useMemo(() => {
@@ -53,239 +50,189 @@ export function AddExerciseSheet({
     return ids.filter((id) => musclesUk?.[id]);
   }, [form.primaryGroup, musclesByPrimaryGroup, musclesUk]);
 
-  if (!open) return null;
-
   return (
-    <div
-      className={cn("fixed inset-0 flex items-end fizruk-sheet", SHEET_Z)}
-      role="presentation"
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="Додати вправу"
+      description="Збережеться локально на цьому пристрої"
+      closeLabel="Закрити форму"
+      kbInsetPx={kbInsetPx}
+      zIndex={100}
     >
-      <div className="absolute inset-0" role="presentation" />
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      <div
-        ref={sheetRef}
-        className={cn(
-          "relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft max-h-[92dvh] flex flex-col",
-          FIZRUK_SHEET_PAD_CLASS,
-        )}
-        style={{ marginBottom: kbInsetPx }}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-ex-title"
-      >
-        <div className="flex justify-center pt-3 pb-1 shrink-0">
-          <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
-        </div>
-        <div className="px-4 sm:px-5 pb-6 overflow-y-auto flex-1 min-h-0">
-          <div className="flex items-start justify-between gap-3 mb-3">
-            <div className="min-w-0">
-              <div
-                id="add-ex-title"
-                className="text-lg font-extrabold text-text leading-tight"
-              >
-                Додати вправу
-              </div>
-              <div className="text-xs text-subtle mt-1">
-                Збережеться локально на цьому пристрої
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text text-lg transition-colors"
-              aria-label="Закрити форму"
-            >
-              ✕
-            </button>
+      <div className="space-y-3">
+        <Input
+          placeholder="Назва (укр) *"
+          value={form.nameUk}
+          onChange={(e) => setForm((f) => ({ ...f, nameUk: e.target.value }))}
+          aria-label="Назва вправи українською"
+        />
+
+        <div className="rounded-2xl border border-line bg-panelHi px-3">
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
+            Основна група
           </div>
+          <select
+            className="w-full min-h-[44px] bg-transparent text-sm text-text outline-none py-2"
+            value={form.primaryGroup}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                primaryGroup: e.target.value,
+                musclesPrimary: [],
+                musclesSecondary: [],
+              }))
+            }
+            aria-label="Основна група м'язів"
+          >
+            {Object.keys(primaryGroupsUk).map((id) => (
+              <option key={id} value={id}>
+                {primaryGroupsUk[id]}
+              </option>
+            ))}
+          </select>
+        </div>
 
-          <div className="space-y-3">
-            <Input
-              placeholder="Назва (укр) *"
-              value={form.nameUk}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, nameUk: e.target.value }))
-              }
-              aria-label="Назва вправи українською"
-            />
+        <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            Обладнання
+          </div>
+          <div className="py-2 flex flex-wrap gap-2">
+            {EQUIPMENT_OPTIONS.map((o) => {
+              const active = (form.equipment || []).includes(o.id);
+              return (
+                <button
+                  key={o.id}
+                  type="button"
+                  onClick={() =>
+                    setForm((f) => ({
+                      ...f,
+                      equipment: toggleArr(f.equipment, o.id),
+                    }))
+                  }
+                  className={cn(
+                    "text-xs px-3 py-2.5 min-h-[44px] rounded-full border transition-colors",
+                    active
+                      ? "bg-text text-white border-text"
+                      : "border-line bg-bg text-muted hover:border-muted hover:text-text",
+                  )}
+                  aria-pressed={active}
+                >
+                  {o.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
-            <div className="rounded-2xl border border-line bg-panelHi px-3">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
-                Основна група
-              </div>
-              <select
-                className="w-full min-h-[44px] bg-transparent text-sm text-text outline-none py-2"
-                value={form.primaryGroup}
-                onChange={(e) =>
+        <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            Основні мʼязи
+          </div>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {suggestedMuscles.map((id) => (
+              <button
+                key={id}
+                type="button"
+                className={cn(
+                  "text-xs px-3 py-2 min-h-[44px] rounded-full border transition-colors",
+                  (form.musclesPrimary || []).includes(id)
+                    ? "bg-primary border-primary text-white"
+                    : "border-line bg-bg text-muted hover:border-muted hover:text-text",
+                )}
+                onClick={() =>
                   setForm((f) => ({
                     ...f,
-                    primaryGroup: e.target.value,
-                    musclesPrimary: [],
-                    musclesSecondary: [],
+                    musclesPrimary: toggleArr(f.musclesPrimary, id),
                   }))
                 }
-                aria-label="Основна група м'язів"
               >
-                {Object.keys(primaryGroupsUk).map((id) => (
-                  <option key={id} value={id}>
-                    {primaryGroupsUk[id]}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-                Обладнання
-              </div>
-              <div className="py-2 flex flex-wrap gap-2">
-                {EQUIPMENT_OPTIONS.map((o) => {
-                  const active = (form.equipment || []).includes(o.id);
-                  return (
-                    <button
-                      key={o.id}
-                      type="button"
-                      onClick={() =>
-                        setForm((f) => ({
-                          ...f,
-                          equipment: toggleArr(f.equipment, o.id),
-                        }))
-                      }
-                      className={cn(
-                        "text-xs px-3 py-2.5 min-h-[44px] rounded-full border transition-colors",
-                        active
-                          ? "bg-text text-white border-text"
-                          : "border-line bg-bg text-muted hover:border-muted hover:text-text",
-                      )}
-                      aria-pressed={active}
-                    >
-                      {o.label}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-                Основні мʼязи
-              </div>
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {suggestedMuscles.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    className={cn(
-                      "text-xs px-3 py-2 min-h-[44px] rounded-full border transition-colors",
-                      (form.musclesPrimary || []).includes(id)
-                        ? "bg-primary border-primary text-white"
-                        : "border-line bg-bg text-muted hover:border-muted hover:text-text",
-                    )}
-                    onClick={() =>
-                      setForm((f) => ({
-                        ...f,
-                        musclesPrimary: toggleArr(f.musclesPrimary, id),
-                      }))
-                    }
-                  >
-                    {musclesUk[id] || id}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-                Супутні мʼязи
-              </div>
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {suggestedMuscles.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    className={cn(
-                      "text-xs px-3 py-2 min-h-[44px] rounded-full border transition-colors",
-                      (form.musclesSecondary || []).includes(id)
-                        ? "bg-text/80 border-text/80 text-white"
-                        : "border-line bg-bg text-muted hover:border-muted hover:text-text",
-                    )}
-                    onClick={() =>
-                      setForm((f) => ({
-                        ...f,
-                        musclesSecondary: toggleArr(f.musclesSecondary, id),
-                      }))
-                    }
-                  >
-                    {musclesUk[id] || id}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <Input
-              placeholder="Опис"
-              value={form.description}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, description: e.target.value }))
-              }
-            />
-          </div>
-
-          <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <Button
-              className="h-12 min-h-[44px]"
-              onClick={() => {
-                const nameUk = (form.nameUk || "").trim();
-                if (!nameUk) return;
-                const id = `custom_${slugify(nameUk) || Date.now()}`;
-                addExercise({
-                  id,
-                  name: { uk: nameUk, en: nameUk },
-                  primaryGroup: form.primaryGroup,
-                  primaryGroupUk:
-                    primaryGroupsUk[form.primaryGroup] || form.primaryGroup,
-                  muscles: {
-                    primary: form.musclesPrimary || [],
-                    secondary: form.musclesSecondary || [],
-                    stabilizers: [],
-                  },
-                  equipment: form.equipment || [],
-                  equipmentUk: (form.equipment || []).map(
-                    (eid) =>
-                      EQUIPMENT_OPTIONS.find((x) => x.id === eid)?.label || eid,
-                  ),
-                  description: (form.description || "").trim(),
-                  source: "manual",
-                });
-                onClose();
-                setForm({
-                  nameUk: "",
-                  primaryGroup: "chest",
-                  musclesPrimary: [],
-                  musclesSecondary: [],
-                  equipment: ["bodyweight"],
-                  description: "",
-                });
-              }}
-            >
-              Зберегти
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-12 min-h-[44px]"
-              onClick={onClose}
-            >
-              Скасувати
-            </Button>
+                {musclesUk[id] || id}
+              </button>
+            ))}
           </div>
         </div>
+
+        <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            Супутні мʼязи
+          </div>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {suggestedMuscles.map((id) => (
+              <button
+                key={id}
+                type="button"
+                className={cn(
+                  "text-xs px-3 py-2 min-h-[44px] rounded-full border transition-colors",
+                  (form.musclesSecondary || []).includes(id)
+                    ? "bg-text/80 border-text/80 text-white"
+                    : "border-line bg-bg text-muted hover:border-muted hover:text-text",
+                )}
+                onClick={() =>
+                  setForm((f) => ({
+                    ...f,
+                    musclesSecondary: toggleArr(f.musclesSecondary, id),
+                  }))
+                }
+              >
+                {musclesUk[id] || id}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <Input
+          placeholder="Опис"
+          value={form.description}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, description: e.target.value }))
+          }
+        />
       </div>
-    </div>
+
+      <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <Button
+          className="h-12 min-h-[44px]"
+          onClick={() => {
+            const nameUk = (form.nameUk || "").trim();
+            if (!nameUk) return;
+            const id = `custom_${slugify(nameUk) || Date.now()}`;
+            addExercise({
+              id,
+              name: { uk: nameUk, en: nameUk },
+              primaryGroup: form.primaryGroup,
+              primaryGroupUk:
+                primaryGroupsUk[form.primaryGroup] || form.primaryGroup,
+              muscles: {
+                primary: form.musclesPrimary || [],
+                secondary: form.musclesSecondary || [],
+                stabilizers: [],
+              },
+              equipment: form.equipment || [],
+              equipmentUk: (form.equipment || []).map(
+                (eid) =>
+                  EQUIPMENT_OPTIONS.find((x) => x.id === eid)?.label || eid,
+              ),
+              description: (form.description || "").trim(),
+              source: "manual",
+            });
+            onClose();
+            setForm({
+              nameUk: "",
+              primaryGroup: "chest",
+              musclesPrimary: [],
+              musclesSecondary: [],
+              equipment: ["bodyweight"],
+              description: "",
+            });
+          }}
+        >
+          Зберегти
+        </Button>
+        <Button variant="ghost" className="h-12 min-h-[44px]" onClick={onClose}>
+          Скасувати
+        </Button>
+      </div>
+    </Sheet>
   );
 }

--- a/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -1,8 +1,6 @@
-import { useRef } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
-import { FIZRUK_SHEET_PAD_CLASS, SHEET_Z } from "../../lib/workoutUi";
 
 export function ExerciseDetailSheet({
   selected,
@@ -17,9 +15,6 @@ export function ExerciseDetailSheet({
   onDeleteRequest,
   toast,
 }) {
-  const sheetRef = useRef(null);
-  useDialogFocusTrap(!!selected, sheetRef, { onEscape: onClose });
-
   if (!selected) return null;
 
   const cf = recoveryConflictsForExercise(selected, rec?.by);
@@ -28,212 +23,179 @@ export function ExerciseDetailSheet({
     selected.source === "manual" ||
     String(selected.id || "").startsWith("custom_");
 
+  const description = (
+    <>
+      Основна група:{" "}
+      <span className="font-semibold text-muted">
+        {selected.primaryGroupUk || selected.primaryGroup}
+      </span>
+      {selected.level ? (
+        <>
+          {" "}
+          · рівень:{" "}
+          <span className="font-semibold text-muted">{selected.level}</span>
+        </>
+      ) : null}
+    </>
+  );
+
   return (
-    <div className={cn("fixed inset-0 flex items-end fizruk-sheet", SHEET_Z)}>
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      <div
-        ref={sheetRef}
-        className={cn(
-          "relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft",
-          FIZRUK_SHEET_PAD_CLASS,
-        )}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="fizruk-ex-details-title"
-      >
-        <div className="flex justify-center pt-3 pb-1">
-          <div className="w-10 h-1 bg-line rounded-full" />
-        </div>
-        <div className="px-5 pb-6">
-          <div className="flex items-start justify-between gap-3 mb-3">
-            <div className="min-w-0">
-              <div
-                id="fizruk-ex-details-title"
-                className="text-lg font-extrabold text-text leading-tight"
-              >
-                {selected?.name?.uk || selected?.name?.en}
-              </div>
-              <div className="text-xs text-subtle mt-1">
-                Основна група:{" "}
-                <span className="font-semibold text-muted">
-                  {selected.primaryGroupUk || selected.primaryGroup}
-                </span>
-                {selected.level ? (
-                  <>
-                    {" "}
-                    · рівень:{" "}
-                    <span className="font-semibold text-muted">
-                      {selected.level}
-                    </span>
-                  </>
-                ) : null}
-              </div>
-            </div>
-            <button
-              onClick={onClose}
-              className="w-8 h-8 flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text text-lg transition-colors"
-            >
-              ✕
-            </button>
-          </div>
-
-          {cf?.hasWarning && (
-            <div className="mb-4 rounded-2xl border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning leading-snug">
-              {cf.red?.length ? (
-                <div>
-                  <span className="font-semibold">Рано:</span>{" "}
-                  {cf.red.map((x) => x.label).join(", ")}
-                </div>
-              ) : null}
-              {cf.yellow?.length ? (
-                <div className="mt-1">
-                  <span className="font-semibold">Краще почекати:</span>{" "}
-                  {cf.yellow.map((x) => x.label).join(", ")}
-                </div>
-              ) : null}
-            </div>
-          )}
-
-          {(selected.images || []).filter(Boolean).length > 0 && (
-            <div className="mb-4 -mx-5 px-5 overflow-x-auto no-scrollbar">
-              <div className="flex gap-3">
-                {selected.images.slice(0, 8).map((src) => (
-                  <img
-                    key={src}
-                    src={src}
-                    alt={selected?.name?.uk || selected?.name?.en || "exercise"}
-                    loading="lazy"
-                    decoding="async"
-                    width="160"
-                    height="160"
-                    className="h-40 w-40 rounded-2xl object-cover border border-line bg-bg"
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {selected.description && (
-            <div className="text-sm text-text leading-relaxed mb-4">
-              {selected.description}
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest">
-              Мʼязи
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {(selected?.muscles?.primary || []).map((m) => (
-                <span
-                  key={m}
-                  className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-muted font-semibold"
-                >
-                  {musclesUk?.[m] || m} · основний
-                </span>
-              ))}
-              {(selected?.muscles?.secondary || []).map((m) => (
-                <span
-                  key={m}
-                  className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-subtle font-semibold"
-                >
-                  {musclesUk?.[m] || m}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <div className="mt-4 space-y-2">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest">
-              Обладнання
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {(selected.equipmentUk || selected.equipment || []).map((eq) => (
-                <span
-                  key={eq}
-                  className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-muted font-semibold"
-                >
-                  {eq}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          {selected.tips?.length ? (
-            <div className="mt-4">
-              <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-2">
-                Підказки
-              </div>
-              <ul className="space-y-1.5">
-                {selected.tips.map((t, i) => (
-                  <li key={i} className="text-sm text-text leading-relaxed">
-                    <span className="text-muted font-bold mr-2">•</span>
-                    {t}
-                  </li>
-                ))}
-              </ul>
+    <Sheet
+      open={!!selected}
+      onClose={onClose}
+      title={selected?.name?.uk || selected?.name?.en}
+      description={description}
+      zIndex={100}
+    >
+      {cf?.hasWarning && (
+        <div className="mb-4 rounded-2xl border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning leading-snug">
+          {cf.red?.length ? (
+            <div>
+              <span className="font-semibold">Рано:</span>{" "}
+              {cf.red.map((x) => x.label).join(", ")}
             </div>
           ) : null}
-
-          {isCustom && (
-            <div className="mt-4">
-              <Button
-                variant="danger"
-                className="w-full h-12"
-                onClick={onDeleteRequest}
-              >
-                Видалити з каталогу
-              </Button>
+          {cf.yellow?.length ? (
+            <div className="mt-1">
+              <span className="font-semibold">Краще почекати:</span>{" "}
+              {cf.yellow.map((x) => x.label).join(", ")}
             </div>
-          )}
+          ) : null}
+        </div>
+      )}
 
-          {mode === "log" && (
-            <Button
-              type="button"
-              className="w-full h-12 mt-5 bg-fizruk text-white border-fizruk hover:bg-fizruk/90"
-              onClick={() => {
-                if (!activeWorkoutId) {
-                  toast?.warning("Спочатку натисни «+ Нове» у блоці вище.");
-                  return;
-                }
-                if (activeWorkout?.endedAt) {
-                  toast?.warning(
-                    "Це тренування вже завершено. Обери чернетку або створи нове.",
-                  );
-                  return;
-                }
-                addExerciseToActive(selected);
-                onClose();
-              }}
-            >
-              + Додати в активне тренування
-            </Button>
-          )}
-
-          <div className="mt-5 grid grid-cols-2 gap-2">
-            <Button className="h-12" onClick={onClose}>
-              Закрити
-            </Button>
-            <Button
-              variant="ghost"
-              className={cn("h-12")}
-              onClick={() => {
-                navigator.clipboard
-                  ?.writeText(selected?.name?.uk || selected?.name?.en || "")
-                  .catch(() => {});
-              }}
-            >
-              📋 Копіювати назву
-            </Button>
+      {(selected.images || []).filter(Boolean).length > 0 && (
+        <div className="mb-4 -mx-5 px-5 overflow-x-auto no-scrollbar">
+          <div className="flex gap-3">
+            {selected.images.slice(0, 8).map((src) => (
+              <img
+                key={src}
+                src={src}
+                alt={selected?.name?.uk || selected?.name?.en || "exercise"}
+                loading="lazy"
+                decoding="async"
+                width="160"
+                height="160"
+                className="h-40 w-40 rounded-2xl object-cover border border-line bg-bg"
+              />
+            ))}
           </div>
         </div>
+      )}
+
+      {selected.description && (
+        <div className="text-sm text-text leading-relaxed mb-4">
+          {selected.description}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+          Мʼязи
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {(selected?.muscles?.primary || []).map((m) => (
+            <span
+              key={m}
+              className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-muted font-semibold"
+            >
+              {musclesUk?.[m] || m} · основний
+            </span>
+          ))}
+          {(selected?.muscles?.secondary || []).map((m) => (
+            <span
+              key={m}
+              className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-subtle font-semibold"
+            >
+              {musclesUk?.[m] || m}
+            </span>
+          ))}
+        </div>
       </div>
-    </div>
+
+      <div className="mt-4 space-y-2">
+        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+          Обладнання
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {(selected.equipmentUk || selected.equipment || []).map((eq) => (
+            <span
+              key={eq}
+              className="text-xs px-3 py-1.5 rounded-full border border-line bg-bg text-muted font-semibold"
+            >
+              {eq}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {selected.tips?.length ? (
+        <div className="mt-4">
+          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-2">
+            Підказки
+          </div>
+          <ul className="space-y-1.5">
+            {selected.tips.map((t, i) => (
+              <li key={i} className="text-sm text-text leading-relaxed">
+                <span className="text-muted font-bold mr-2">•</span>
+                {t}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {isCustom && (
+        <div className="mt-4">
+          <Button
+            variant="danger"
+            className="w-full h-12"
+            onClick={onDeleteRequest}
+          >
+            Видалити з каталогу
+          </Button>
+        </div>
+      )}
+
+      {mode === "log" && (
+        <Button
+          type="button"
+          className="w-full h-12 mt-5 bg-fizruk text-white border-fizruk hover:bg-fizruk/90"
+          onClick={() => {
+            if (!activeWorkoutId) {
+              toast?.warning("Спочатку натисни «+ Нове» у блоці вище.");
+              return;
+            }
+            if (activeWorkout?.endedAt) {
+              toast?.warning(
+                "Це тренування вже завершено. Обери чернетку або створи нове.",
+              );
+              return;
+            }
+            addExerciseToActive(selected);
+            onClose();
+          }}
+        >
+          + Додати в активне тренування
+        </Button>
+      )}
+
+      <div className="mt-5 grid grid-cols-2 gap-2">
+        <Button className="h-12" onClick={onClose}>
+          Закрити
+        </Button>
+        <Button
+          variant="ghost"
+          className={cn("h-12")}
+          onClick={() => {
+            navigator.clipboard
+              ?.writeText(selected?.name?.uk || selected?.name?.en || "")
+              .catch(() => {});
+          }}
+        >
+          📋 Копіювати назву
+        </Button>
+      </div>
+    </Sheet>
   );
 }

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { useVisualKeyboardInset } from "@shared/hooks/useVisualKeyboardInset";
 import { MEAL_TYPES } from "../lib/mealTypes.js";
 import { ensureSeedFoods } from "../lib/foodDb/foodDb.js";
@@ -29,7 +29,6 @@ export function AddMealSheet({
   pantryItems = [],
   onConsumePantryItem,
 }) {
-  const ref = useRef(null);
   const kbInsetPx = useVisualKeyboardInset(open);
   const [form, setForm] = useState(() => emptyForm(null));
   const [foodQuery, setFoodQuery] = useState("");
@@ -60,8 +59,6 @@ export function AddMealSheet({
     setPickedGrams,
     setForm,
   });
-
-  useDialogFocusTrap(open, ref, { onEscape: onClose });
 
   useEffect(() => {
     if (open) {
@@ -176,17 +173,35 @@ export function AddMealSheet({
     photoResult?.macros &&
     Object.values(photoResult.macros).some((v) => v != null && v !== 0);
 
-  if (!open) return null;
+  const showBack = step === "fill" && !initialMeal?.id && !photoResult;
+  const title = (
+    <div className="flex items-center gap-2 min-w-0">
+      {showBack && (
+        <button
+          type="button"
+          onClick={() => {
+            // Also clear any picked source, otherwise the auto-advance
+            // effect immediately pushes us back to "fill" as soon as we
+            // return to "source".
+            setPickedFood(null);
+            setFromPantryItem(null);
+            setStep("source");
+          }}
+          className="w-9 h-9 flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text transition-colors"
+          aria-label="Назад до вибору джерела"
+        >
+          ←
+        </button>
+      )}
+      <span className="truncate">
+        {step === "source" ? "Звідки страва?" : "Додати прийом їжі"}
+      </span>
+    </div>
+  );
 
   return (
-    <div className="fixed inset-0 flex items-end z-[120]">
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      {scannerOpen && (
+    <>
+      {open && scannerOpen && (
         <BarcodeScanner
           onDetected={async (raw) => {
             setScannerOpen(false);
@@ -196,184 +211,135 @@ export function AddMealSheet({
           onClose={() => setScannerOpen(false)}
         />
       )}
-      <div
-        ref={ref}
-        className="relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft max-h-[90dvh] overflow-y-auto"
-        style={{ marginBottom: kbInsetPx }}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-meal-sheet-title"
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title={title}
+        zIndex={120}
+        kbInsetPx={kbInsetPx}
       >
-        <div className="flex justify-center pt-3 pb-1 sticky top-0 bg-panel z-10">
-          <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
-        </div>
+        {step === "source" ? (
+          <>
+            <p className="text-xs text-muted mb-3">
+              Оберіть джерело — або заповніть вручну. Макроси, назву й час
+              відредагуєте на наступному кроці.
+            </p>
 
-        <div className="px-5 pb-8 pt-2">
-          {/* Header */}
-          <div className="flex items-center justify-between gap-3 mb-4">
-            <div className="flex items-center gap-2 min-w-0">
-              {step === "fill" && !initialMeal?.id && !photoResult && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    // Also clear any picked source, otherwise the
-                    // auto-advance effect immediately pushes us back to
-                    // "fill" as soon as we return to "source".
-                    setPickedFood(null);
-                    setFromPantryItem(null);
-                    setStep("source");
-                  }}
-                  className="w-9 h-9 flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text transition-colors"
-                  aria-label="Назад до вибору джерела"
-                >
-                  ←
-                </button>
-              )}
-              <div
-                id="add-meal-sheet-title"
-                className="text-lg font-extrabold text-text truncate"
-              >
-                {step === "source" ? "Звідки страва?" : "Додати прийом їжі"}
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text text-lg transition-colors"
-              aria-label="Закрити"
-            >
-              ✕
-            </button>
-          </div>
-
-          {step === "source" ? (
-            <>
-              <p className="text-xs text-muted mb-3">
-                Оберіть джерело — або заповніть вручну. Макроси, назву й час
-                відредагуєте на наступному кроці.
-              </p>
-
-              {/* Templates / pantry rows disappear when empty so a
+            {/* Templates / pantry rows disappear when empty so a
                   first-time user sees search + barcode as the whole step
                   (no half-broken UI). They come back automatically once
                   the user saves a template or stocks the pantry. */}
-              {mealTemplates.length > 0 && (
-                <MealTemplatesRow
-                  mealTemplates={mealTemplates}
-                  setForm={setForm}
-                  onSelected={() => setStep("fill")}
-                />
-              )}
+            {mealTemplates.length > 0 && (
+              <MealTemplatesRow
+                mealTemplates={mealTemplates}
+                setForm={setForm}
+                onSelected={() => setStep("fill")}
+              />
+            )}
 
-              {pantryItems.length > 0 && (
-                <FromPantryRow
-                  pantryItems={pantryItems}
-                  fromPantryItem={fromPantryItem}
-                  setFromPantryItem={setFromPantryItem}
-                  setForm={setForm}
-                  setFoodQuery={setFoodQuery}
-                />
-              )}
+            {pantryItems.length > 0 && (
+              <FromPantryRow
+                pantryItems={pantryItems}
+                fromPantryItem={fromPantryItem}
+                setFromPantryItem={setFromPantryItem}
+                setForm={setForm}
+                setFoodQuery={setFoodQuery}
+              />
+            )}
 
-              <FoodPickerSection
+            <FoodPickerSection
+              form={form}
+              setForm={setForm}
+              foodQuery={foodQuery}
+              setFoodQuery={setFoodQuery}
+              foodHits={foodHits}
+              offHits={offHits}
+              foodBusy={foodBusy}
+              offBusy={offBusy}
+              foodErr={foodErr}
+              pickedFood={pickedFood}
+              setPickedFood={setPickedFood}
+              pickedGrams={pickedGrams}
+              setPickedGrams={setPickedGrams}
+            />
+
+            <BarcodeSection
+              barcode={barcode}
+              setBarcode={setBarcode}
+              barcodeStatus={barcodeStatus}
+              setBarcodeStatus={setBarcodeStatus}
+              handleBarcodeLookup={handleBarcodeLookup}
+              handleBarcodeBind={handleBarcodeBind}
+              setScannerOpen={setScannerOpen}
+            />
+
+            <div className="mt-5 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
+              <span className="flex-1 h-px bg-line" />
+              або
+              <span className="flex-1 h-px bg-line" />
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              className="mt-3 w-full h-12 min-h-[44px]"
+              onClick={() => setStep("fill")}
+            >
+              Ввести вручну
+            </Button>
+          </>
+        ) : (
+          <>
+            <MealTypePicker mealType={form.mealType} setForm={setForm} />
+
+            <NameTimeRow form={form} field={field} setForm={setForm} />
+
+            <MacrosEditor
+              form={form}
+              field={field}
+              setForm={setForm}
+              pickedFood={pickedFood}
+              setPickedFood={setPickedFood}
+              photoResult={photoResult}
+              hasPhotoMacros={hasPhotoMacros}
+            />
+
+            {!pickedFood && (
+              <SaveAsFood
                 form={form}
                 setForm={setForm}
-                foodQuery={foodQuery}
-                setFoodQuery={setFoodQuery}
-                foodHits={foodHits}
-                offHits={offHits}
-                foodBusy={foodBusy}
-                offBusy={offBusy}
-                foodErr={foodErr}
-                pickedFood={pickedFood}
                 setPickedFood={setPickedFood}
-                pickedGrams={pickedGrams}
                 setPickedGrams={setPickedGrams}
+                setFoodQuery={setFoodQuery}
+                setFoodErr={setFoodErr}
               />
+            )}
 
-              <BarcodeSection
-                barcode={barcode}
-                setBarcode={setBarcode}
-                barcodeStatus={barcodeStatus}
-                setBarcodeStatus={setBarcodeStatus}
-                handleBarcodeLookup={handleBarcodeLookup}
-                handleBarcodeBind={handleBarcodeBind}
-                setScannerOpen={setScannerOpen}
-              />
+            {form.err && (
+              <div className="text-xs text-danger mt-2">{form.err}</div>
+            )}
 
-              <div className="mt-5 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
-                <span className="flex-1 h-px bg-line" />
-                або
-                <span className="flex-1 h-px bg-line" />
-              </div>
+            <SaveAsTemplate form={form} setForm={setForm} setPrefs={setPrefs} />
+
+            <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
               <Button
                 type="button"
-                variant="secondary"
-                className="mt-3 w-full h-12 min-h-[44px]"
-                onClick={() => setStep("fill")}
+                className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
+                onClick={handleSave}
               >
-                Ввести вручну
+                Зберегти
               </Button>
-            </>
-          ) : (
-            <>
-              <MealTypePicker mealType={form.mealType} setForm={setForm} />
-
-              <NameTimeRow form={form} field={field} setForm={setForm} />
-
-              <MacrosEditor
-                form={form}
-                field={field}
-                setForm={setForm}
-                pickedFood={pickedFood}
-                setPickedFood={setPickedFood}
-                photoResult={photoResult}
-                hasPhotoMacros={hasPhotoMacros}
-              />
-
-              {!pickedFood && (
-                <SaveAsFood
-                  form={form}
-                  setForm={setForm}
-                  setPickedFood={setPickedFood}
-                  setPickedGrams={setPickedGrams}
-                  setFoodQuery={setFoodQuery}
-                  setFoodErr={setFoodErr}
-                />
-              )}
-
-              {form.err && (
-                <div className="text-xs text-danger mt-2">{form.err}</div>
-              )}
-
-              <SaveAsTemplate
-                form={form}
-                setForm={setForm}
-                setPrefs={setPrefs}
-              />
-
-              <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
-                <Button
-                  type="button"
-                  className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
-                  onClick={handleSave}
-                >
-                  Зберегти
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-12 min-h-[44px]"
-                  onClick={onClose}
-                >
-                  Скасувати
-                </Button>
-              </div>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-12 min-h-[44px]"
+                onClick={onClose}
+              >
+                Скасувати
+              </Button>
+            </div>
+          </>
+        )}
+      </Sheet>
+    </>
   );
 }

--- a/src/modules/nutrition/components/ItemEditSheet.jsx
+++ b/src/modules/nutrition/components/ItemEditSheet.jsx
@@ -1,125 +1,78 @@
-import { useRef } from "react";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
-import { cn } from "@shared/lib/cn";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { normalizeUnit } from "../lib/pantryTextParser.js";
 
 export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
-  const ref = useRef(null);
-  useDialogFocusTrap(itemEdit.open, ref, { onEscape: onClose });
-
-  if (!itemEdit.open) return null;
-
   return (
-    <div className={cn("fixed inset-0 flex items-end", "z-[120]")}>
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      <div
-        ref={ref}
-        className={cn(
-          "relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft",
-          "fizruk-sheet-pad",
-        )}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="nutrition-item-edit-title"
-      >
-        <div className="flex justify-center pt-3 pb-1">
-          <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
+    <Sheet
+      open={!!itemEdit.open}
+      onClose={onClose}
+      title={itemEdit.name}
+      description="Кількість і одиниці (порожньо — прибрати)"
+      zIndex={120}
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+            Кількість
+          </div>
+          <Input
+            value={itemEdit.qty}
+            onChange={(e) =>
+              setItemEdit((s) => ({ ...s, qty: e.target.value, err: "" }))
+            }
+            inputMode="decimal"
+            placeholder="напр. 2.5"
+            aria-label="Кількість"
+          />
         </div>
-        <div className="px-5 pb-6">
-          <div className="flex items-start justify-between gap-3 mb-3">
-            <div className="min-w-0">
-              <div
-                id="nutrition-item-edit-title"
-                className="text-lg font-extrabold text-text leading-tight truncate"
-              >
-                {itemEdit.name}
-              </div>
-              <div className="text-xs text-subtle mt-1">
-                Кількість і одиниці (порожньо — прибрати)
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text text-lg transition-colors"
-              aria-label="Закрити"
-            >
-              ✕
-            </button>
+        <div>
+          <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+            Одиниця
           </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
-                Кількість
-              </div>
-              <Input
-                value={itemEdit.qty}
-                onChange={(e) =>
-                  setItemEdit((s) => ({ ...s, qty: e.target.value, err: "" }))
-                }
-                inputMode="decimal"
-                placeholder="напр. 2.5"
-                aria-label="Кількість"
-              />
-            </div>
-            <div>
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
-                Одиниця
-              </div>
-              <Input
-                value={itemEdit.unit}
-                onChange={(e) =>
-                  setItemEdit((s) => ({ ...s, unit: e.target.value, err: "" }))
-                }
-                placeholder="г / кг / мл / л / шт"
-                aria-label="Одиниця"
-              />
-            </div>
-          </div>
-
-          {itemEdit.err ? (
-            <div className="text-xs text-danger mt-2">{itemEdit.err}</div>
-          ) : null}
-
-          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <Button
-              type="button"
-              className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
-              onClick={() => {
-                const qtyStr = String(itemEdit.qty || "").trim();
-                const unitStr = String(itemEdit.unit || "").trim();
-                const qty =
-                  qtyStr === "" ? null : Number(qtyStr.replace(",", "."));
-                if (qtyStr !== "" && !Number.isFinite(qty)) {
-                  setItemEdit((s) => ({ ...s, err: "Некоректна кількість." }));
-                  return;
-                }
-                const unit = unitStr === "" ? null : normalizeUnit(unitStr);
-                onSave(itemEdit.idx, Number.isFinite(qty) ? qty : null, unit);
-              }}
-            >
-              Зберегти
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="h-12 min-h-[44px]"
-              onClick={onClose}
-            >
-              Скасувати
-            </Button>
-          </div>
+          <Input
+            value={itemEdit.unit}
+            onChange={(e) =>
+              setItemEdit((s) => ({ ...s, unit: e.target.value, err: "" }))
+            }
+            placeholder="г / кг / мл / л / шт"
+            aria-label="Одиниця"
+          />
         </div>
       </div>
-    </div>
+
+      {itemEdit.err ? (
+        <div className="text-xs text-danger mt-2">{itemEdit.err}</div>
+      ) : null}
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <Button
+          type="button"
+          className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
+          onClick={() => {
+            const qtyStr = String(itemEdit.qty || "").trim();
+            const unitStr = String(itemEdit.unit || "").trim();
+            const qty = qtyStr === "" ? null : Number(qtyStr.replace(",", "."));
+            if (qtyStr !== "" && !Number.isFinite(qty)) {
+              setItemEdit((s) => ({ ...s, err: "Некоректна кількість." }));
+              return;
+            }
+            const unit = unitStr === "" ? null : normalizeUnit(unitStr);
+            onSave(itemEdit.idx, Number.isFinite(qty) ? qty : null, unit);
+          }}
+        >
+          Зберегти
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-12 min-h-[44px]"
+          onClick={onClose}
+        >
+          Скасувати
+        </Button>
+      </div>
+    </Sheet>
   );
 }

--- a/src/modules/nutrition/components/NutritionOverlays.jsx
+++ b/src/modules/nutrition/components/NutritionOverlays.jsx
@@ -58,12 +58,10 @@ export function NutritionOverlays({
       />
 
       {pantryScannerOpen && (
-        <div className="fixed inset-0 z-[120]">
-          <BarcodeScanner
-            onDetected={handlePantryBarcodeDetected}
-            onClose={() => setPantryScannerOpen(false)}
-          />
-        </div>
+        <BarcodeScanner
+          onDetected={handlePantryBarcodeDetected}
+          onClose={() => setPantryScannerOpen(false)}
+        />
       )}
 
       <AddMealSheet

--- a/src/modules/nutrition/components/PantryManagerSheet.jsx
+++ b/src/modules/nutrition/components/PantryManagerSheet.jsx
@@ -1,8 +1,7 @@
-import { useRef } from "react";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
+import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 
 export function PantryManagerSheet({
   open,
@@ -18,152 +17,108 @@ export function PantryManagerSheet({
   onBeginRename,
   onBeginDelete,
 }) {
-  const ref = useRef(null);
-  useDialogFocusTrap(open, ref, { onEscape: onClose });
-
-  if (!open) return null;
-
   return (
-    <div className={cn("fixed inset-0 flex items-end", "z-[100]")}>
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        aria-label="Закрити"
-        onClick={onClose}
-      />
-      <div
-        ref={ref}
-        className={cn(
-          "relative w-full bg-panel border-t border-line rounded-t-3xl shadow-soft max-h-[92dvh] flex flex-col",
-          "fizruk-sheet-pad",
-        )}
-        onPointerDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="nutrition-pantries-title"
-      >
-        <div className="flex justify-center pt-3 pb-1 shrink-0">
-          <div className="w-10 h-1 bg-line rounded-full" aria-hidden />
-        </div>
-        <div className="px-4 sm:px-5 pb-6 overflow-y-auto flex-1 min-h-0">
-          <div className="flex items-start justify-between gap-3 mb-3">
-            <div className="min-w-0">
-              <div
-                id="nutrition-pantries-title"
-                className="text-lg font-extrabold text-text leading-tight"
-              >
-                Склади продуктів
-              </div>
-              <div className="text-xs text-subtle mt-1">
-                Створи окремо для Дім / Робота або по дієті
-              </div>
-            </div>
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="Склади продуктів"
+      description="Створи окремо для Дім / Робота або по дієті"
+      zIndex={100}
+    >
+      <div className="rounded-2xl border border-line bg-bg overflow-hidden mb-4">
+        {(Array.isArray(pantries) ? pantries : []).map((p) => {
+          const active = p.id === activePantryId;
+          return (
             <button
+              key={p.id}
               type="button"
-              onClick={onClose}
-              className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text text-lg transition-colors"
-              aria-label="Закрити"
+              onClick={() => setActivePantryId(p.id)}
+              className={cn(
+                "w-full text-left px-4 py-3 border-b border-line last:border-0 hover:bg-panelHi transition-colors",
+                active && "bg-nutrition/10",
+              )}
+              aria-pressed={active}
             >
-              ✕
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-semibold text-text truncate">
+                  {p.name || "Склад"}
+                </div>
+                {active ? (
+                  <span className="text-2xs px-2 py-0.5 rounded-full bg-nutrition/15 text-nutrition border border-nutrition/25">
+                    Активний
+                  </span>
+                ) : null}
+              </div>
             </button>
-          </div>
+          );
+        })}
+      </div>
 
-          <div className="rounded-2xl border border-line bg-bg overflow-hidden mb-4">
-            {(Array.isArray(pantries) ? pantries : []).map((p) => {
-              const active = p.id === activePantryId;
-              return (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => setActivePantryId(p.id)}
-                  className={cn(
-                    "w-full text-left px-4 py-3 border-b border-line last:border-0 hover:bg-panelHi transition-colors",
-                    active && "bg-nutrition/10",
-                  )}
-                  aria-pressed={active}
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="text-sm font-semibold text-text truncate">
-                      {p.name || "Склад"}
-                    </div>
-                    {active ? (
-                      <span className="text-2xs px-2 py-0.5 rounded-full bg-nutrition/15 text-nutrition border border-nutrition/25">
-                        Активний
-                      </span>
-                    ) : null}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
+        <Button
+          type="button"
+          className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
+          onClick={onBeginCreate}
+        >
+          + Новий склад
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-12 min-h-[44px]"
+          onClick={onBeginRename}
+        >
+          Перейменувати активний
+        </Button>
+      </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
-            <Button
-              type="button"
-              className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
-              onClick={onBeginCreate}
-            >
-              + Новий склад
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="h-12 min-h-[44px]"
-              onClick={onBeginRename}
-            >
-              Перейменувати активний
-            </Button>
-          </div>
-
-          <div className="rounded-2xl border border-line bg-panelHi p-4">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
-              {pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"}
-            </div>
-            <div className="mt-2">
-              <Input
-                value={pantryForm.name}
-                onChange={(e) =>
-                  setPantryForm((f) => ({
-                    ...f,
-                    name: e.target.value,
-                    err: "",
-                  }))
-                }
-                placeholder="напр. Дім"
-                disabled={busy}
-                aria-label="Назва складу"
-              />
-              {pantryForm.err ? (
-                <div className="text-xs text-danger mt-2">{pantryForm.err}</div>
-              ) : null}
-            </div>
-            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <Button
-                type="button"
-                className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
-                onClick={() => {
-                  const name = String(pantryForm.name || "").trim();
-                  if (!name) {
-                    setPantryForm((f) => ({ ...f, err: "Вкажи назву." }));
-                    return;
-                  }
-                  onSavePantryForm(name, pantryForm.mode);
-                }}
-              >
-                Зберегти
-              </Button>
-              <Button
-                type="button"
-                variant="danger"
-                className="h-12 min-h-[44px]"
-                onClick={onBeginDelete}
-              >
-                Видалити активний
-              </Button>
-            </div>
-          </div>
+      <div className="rounded-2xl border border-line bg-panelHi p-4">
+        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+          {pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"}
+        </div>
+        <div className="mt-2">
+          <Input
+            value={pantryForm.name}
+            onChange={(e) =>
+              setPantryForm((f) => ({
+                ...f,
+                name: e.target.value,
+                err: "",
+              }))
+            }
+            placeholder="напр. Дім"
+            disabled={busy}
+            aria-label="Назва складу"
+          />
+          {pantryForm.err ? (
+            <div className="text-xs text-danger mt-2">{pantryForm.err}</div>
+          ) : null}
+        </div>
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <Button
+            type="button"
+            className="h-12 min-h-[44px] bg-nutrition text-white hover:bg-nutrition-hover"
+            onClick={() => {
+              const name = String(pantryForm.name || "").trim();
+              if (!name) {
+                setPantryForm((f) => ({ ...f, err: "Вкажи назву." }));
+                return;
+              }
+              onSavePantryForm(name, pantryForm.mode);
+            }}
+          >
+            Зберегти
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            className="h-12 min-h-[44px]"
+            onClick={onBeginDelete}
+          >
+            Видалити активний
+          </Button>
         </div>
       </div>
-    </div>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Summary

Частина 2 Sheet-міграції (продовження #235). Ще 6 хендроллених шітів → `<Sheet>`:

**nutrition**
- `ItemEditSheet` (z-120)
- `PantryManagerSheet` (z-100)
- `AddMealSheet` (z-120, має `kbInsetPx` + вкладений `BarcodeScanner` як sibling)
- `NutritionOverlays` — прибрав зайвий `fixed inset-0 z-[120]` wrapper навколо `BarcodeScanner` (у нього вже свій `z-[130]`)

**fizruk**
- `ExerciseDetailSheet` (z-100, `SHEET_Z` більше не потрібен)
- `AddExerciseSheet` (z-100, з `kbInsetPx`)

**finyk**
- `Transactions` batch-category picker (z-70)

Всюди явно проставив `zIndex` щоб не впасти в ту ж пастку з z-50 default, що була в #235.

Що **не** рухалось:
- `BarcodeScanner` — камера-оверлей, не bottom-sheet
- `FizrukApp` settings — side-panel, не bottom-sheet (окремий ришонтент)

**Net:** −236 LOC (+807 / −1043, більша частина — rewrite через форматер). Уся боїлерплейта (useRef / useDialogFocusTrap / fixed inset-0 / overlay-button / drag-handle / 32×32 vs 44×44 close) прибрана, `Sheet` тепер у 11/13 bottom-sheet сайтів.

Лінт/тайпчек/білд — зелені локально.

## Review & Testing Checklist for Human

- [ ] **AddMealSheet** (`Харчування → + страва`) — найризикованіший файл. Перевірити:
  - two-step flow: step="source" → вибір з пошуку/штрих-коду/шаблона → step="fill" з назвою/макро
  - кнопка «←» назад в step="fill" (не з'являється при редагуванні існуючої страви)
  - штрих-код: BarcodeScanner відкривається **поверх** Sheet (він рендериться як sibling, має власний z-130)
  - клавіатурний inset при фокусі в полі «Назва» / «Час» — `kbInsetPx` все ще живий
- [ ] **PantryManagerSheet** (`Харчування → керування складами`) — скрол довгого списку складів, форма rename/create, кнопка «Видалити активний» тригерить `ConfirmDeleteSheet` поверх
- [ ] **ExerciseDetailSheet** + **AddExerciseSheet** (`Фізрук → вправа → деталі / + Додати вправу`) — overlay/Esc/close, у AddExercise перевірити kbInset при фокусі в полі назви
- [ ] **Transactions batch-category** (`Фінік → Транзакції → обрати кілька → «Категорія»`) — z-70 нижче інших фінік-оверлеїв, шіт має відкриватись ПОВЕРХ списку але ПІД toast/confirm
- [ ] **ItemEditSheet** (`Харчування → склад → картка товару → edit`) — zIndex=120 достатній щоб сидіти над PantryManagerSheet (z-100)

### Notes

- У `Transactions.jsx` batch-picker був з overlay `bg-text/40` замість стандартного `bg-black/40` — міграція уніфікує це до DS default; візуально майже не відрізнити, але на світлій темі overlay тепер чорний, не фоновий.
- `AddMealSheet` тепер повертає `<>…</>` фрагмент, бо `BarcodeScanner` рендериться як sibling, а не дитина Sheet (інакше Sheet перекриває камеру).


Link to Devin session: https://app.devin.ai/sessions/bdf76d95774a4a598095569619d8c3ed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
