### PR TITLE
refactor(finyk): unify formInp constants to &lt;Input&gt; from DS

### DIFF
--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useId, useMemo } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech } from "../../../core/lib/speechParsers.js";
@@ -81,9 +82,6 @@ function mergeAmountSuggestions(frequentMerchants) {
   }
   return merged.slice(0, 6);
 }
-
-const formInp =
-  "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
 
 // Сортує доступні підписи категорій за персональною частотою, зберігаючи
 // стабільний порядок для категорій без статистики.
@@ -262,9 +260,8 @@ export function ManualExpenseSheet({
                 · необов&apos;язково
               </span>
             </label>
-            <input
+            <Input
               id={descId}
-              className={formInp}
               placeholder="Кава, продукти, таксі..."
               value={form.description}
               onChange={(e) =>
@@ -353,9 +350,8 @@ export function ManualExpenseSheet({
               ))}
             </div>
           )}
-          <input
+          <Input
             id={amountId}
-            className={formInp}
             type="number"
             inputMode="decimal"
             placeholder="0"
@@ -401,9 +397,8 @@ export function ManualExpenseSheet({
           >
             Дата
           </label>
-          <input
+          <Input
             id={dateId}
-            className={formInp}
             type="date"
             value={form.date}
             onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}

--- a/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/GoalBudgetCard.jsx
@@ -1,9 +1,7 @@
 import { memo } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
-
-const formInp =
-  "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
+import { Input } from "@shared/components/ui/Input";
 
 // Картка цілі накопичення — детерміновані пропси, memo дозволяє не
 // перераховувати розмітку при перерендерах сторінки Budgets.
@@ -23,8 +21,8 @@ function GoalBudgetCardComponent({
     <Card radius="lg" padding="lg">
       {isEditing ? (
         <div className="space-y-2">
-          <input
-            className={formInp}
+          <Input
+            size="sm"
             type="number"
             placeholder="Відкладено ₴"
             value={budget.savedAmount || ""}

--- a/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
+++ b/src/modules/finyk/components/budgets/LimitBudgetCard.jsx
@@ -3,9 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { cn } from "@shared/lib/cn";
 import { Card } from "@shared/components/ui/Card";
-
-const formInp =
-  "w-full h-10 rounded-xl border border-line bg-bg px-3 text-sm text-text outline-none focus:border-primary";
+import { Input } from "@shared/components/ui/Input";
 
 // Презентаційна картка ліміту бюджету. Усі дані приходять готовими пропсами,
 // тому memo потрібен, щоб картка не перемальовувалась при змінах сусідніх
@@ -33,8 +31,8 @@ function LimitBudgetCardComponent({
     <Card radius="lg" padding="lg">
       {isEditing ? (
         <div className="space-y-2">
-          <input
-            className={formInp}
+          <Input
+            size="sm"
             type="number"
             placeholder="Ліміт ₴"
             value={budget.limit}

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -4,6 +4,7 @@ import { SubCard } from "../components/SubCard";
 import { RecurringSuggestions } from "../components/RecurringSuggestions";
 import { TxRow } from "../components/TxRow";
 import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
 import {
   getAccountLabel,
   getMonoDebt,
@@ -39,9 +40,6 @@ function SectionBar({ title, summary, open, onToggle }) {
     </button>
   );
 }
-
-const formInp =
-  "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
 
 export function Assets({
   mono,
@@ -471,24 +469,21 @@ export function Assets({
             ))}
             {showSubForm ? (
               <div className="bg-panel border border-line rounded-xl p-4 space-y-3 mt-2">
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Назва"
                   value={newSub.name}
                   onChange={(e) =>
                     setNewSub((a) => ({ ...a, name: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Ключове слово з транзакції"
                   value={newSub.keyword}
                   onChange={(e) =>
                     setNewSub((a) => ({ ...a, keyword: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   placeholder="День списання (1-31)"
                   type="number"
                   min="1"
@@ -608,16 +603,14 @@ export function Assets({
             ))}
             {showRecvForm ? (
               <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Ім'я або назва"
                   value={newRecv.name}
                   onChange={(e) =>
                     setNewRecv((a) => ({ ...a, name: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Сума ₴"
                   type="number"
                   value={newRecv.amount}
@@ -625,16 +618,14 @@ export function Assets({
                     setNewRecv((a) => ({ ...a, amount: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Нотатка (необов'язково)"
                   value={newRecv.note}
                   onChange={(e) =>
                     setNewRecv((a) => ({ ...a, note: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   type="date"
                   value={newRecv.dueDate}
                   onChange={(e) =>
@@ -725,16 +716,14 @@ export function Assets({
             ))}
             {showAssetForm ? (
               <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Назва"
                   value={newAsset.name}
                   onChange={(e) =>
                     setNewAsset((a) => ({ ...a, name: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Сума"
                   type="number"
                   value={newAsset.amount}
@@ -743,7 +732,7 @@ export function Assets({
                   }
                 />
                 <select
-                  className={formInp}
+                  className="w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors"
                   value={newAsset.currency}
                   onChange={(e) =>
                     setNewAsset((a) => ({ ...a, currency: e.target.value }))
@@ -844,8 +833,8 @@ export function Assets({
             {showDebtForm ? (
               <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
                 <div className="flex gap-2">
-                  <input
-                    className={cn(formInp, "flex-1")}
+                  <Input
+                    className="flex-1"
                     placeholder="Назва пасиву (кредит, борг...)"
                     value={newDebt.name}
                     onChange={(e) =>
@@ -869,8 +858,7 @@ export function Assets({
                     }}
                   />
                 </div>
-                <input
-                  className={formInp}
+                <Input
                   placeholder="Загальна сума ₴"
                   type="number"
                   value={newDebt.totalAmount}
@@ -878,8 +866,7 @@ export function Assets({
                     setNewDebt((a) => ({ ...a, totalAmount: e.target.value }))
                   }
                 />
-                <input
-                  className={formInp}
+                <Input
                   type="date"
                   value={newDebt.dueDate}
                   onChange={(e) =>


### PR DESCRIPTION
## Summary

Дрібна, локальна уніфікація полів у Фініку — прибираю 4 дублюючі `formInp` константи, переводжу всі `<input className={formInp}>` на `<Input>` з DS.

До PR у Фініку жило **дві різні форми**:
- `h-11 rounded-2xl bg-panelHi px-4 text-text` (Assets, ManualExpenseSheet) — збігається з DS `<Input size="md">`
- `h-10 rounded-xl bg-bg px-3 text-sm` (Goal/LimitBudgetCard) — близько до DS `<Input size="sm">` (h-9)

Після PR — одна форма, яка приходить з DS (`size="md"` для основних полів, `size="sm"` для компактних полів у бюджетних картках). Додатковий бонус: focus-ring (`ring-brand-100`) замість простого `border-muted` — краща видимість клавіатурного фокусу.

Файли:
- `finyk/pages/Assets.jsx` — 11 `<input>` → `<Input>`, 1 `<select>` лишив із інлайн-класами (DS ще не має спільного Select)
- `finyk/components/ManualExpenseSheet.jsx` — 3 `<input>` → `<Input>`
- `finyk/components/budgets/GoalBudgetCard.jsx` — 1 `<input>` → `<Input size="sm">`
- `finyk/components/budgets/LimitBudgetCard.jsx` — 1 `<input>` → `<Input size="sm">`

**Net:** −21 LOC. Лінт/тайпчек/білд — зелені локально.

## Review & Testing Checklist for Human

- [ ] **Бюджети** (`Фінік → Бюджети → ✏️ на картці`) — форма edit стала ледь вища (h-10 → h-9 поріг DS, але насправді h-9 proper) і з focus-ring; перевірити що редагування `savedAmount` і `limit` працює (number input)
- [ ] **Пасиви/Борги/Підписки/Активи** (`Фінік → Активи → «+» на кожній секції`) — форми мають типову h-11 DS, поля name / amount / keyword / date / сurrency зберігаються коректно
- [ ] **Ручна витрата** (`Фінік → + витрата вручну`) — поля «Назва», «Сума», «Дата» працюють, VoiceMicButton поруч не зламаний (я не чіпав `flex gap-2` контейнер у Assets pasyv-form)
- [ ] Дата-поля — нативний date picker відкривається нормально на iOS/Chrome

### Notes

- `<Input>` з DS обгортає `<input>` у `<div className="relative">` — це може теоретично вплинути на layout, якщо батько покладається на inline-flow інпута. У переглянутих випадках усі батьки — `space-y-3` / `flex gap-2 + className="flex-1"`, тому все ок.
- Один `<select>` у Assets (currency picker) лишився з inline-класами, бо DS не має Select компонента. Якщо/коли з'явиться — цей файл треба буде повернути і переписати.
- 4 `formInp` константи прибрані повністю.


Link to Devin session: https://app.devin.ai/sessions/bdf76d95774a4a598095569619d8c3ed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
