### PR TITLE
refactor(ui): migrate hand-rolled cards to &lt;Card&gt; from DS

### DIFF
--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -4,6 +4,7 @@ import { SubCard } from "../components/SubCard";
 import { RecurringSuggestions } from "../components/RecurringSuggestions";
 import { TxRow } from "../components/TxRow";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import {
   getAccountLabel,
@@ -152,7 +153,7 @@ export function Assets({
           </div>
           <div className="flex-1 overflow-y-auto">
             <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-              <div className="bg-panel border border-line rounded-xl p-4 mb-3">
+              <Card variant="flat" radius="md" className="mb-3">
                 <div className="text-xs text-subtle mb-1">{label}</div>
                 <div className="text-2xl font-extrabold text-danger">
                   −
@@ -176,7 +177,7 @@ export function Assets({
                     }}
                   />
                 </div>
-              </div>
+              </Card>
               <p className="text-xs text-subtle mb-3 px-1">
                 Тапни транзакцію щоб прив&apos;язати як погашення. Виділені
                 зеленим — автоматично виявлені поповнення картки.
@@ -245,7 +246,7 @@ export function Assets({
           </div>
           <div className="flex-1 overflow-y-auto">
             <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-              <div className="bg-panel border border-line rounded-xl p-4 mb-4">
+              <Card variant="flat" radius="md" className="mb-4">
                 <p className="text-xs text-subtle leading-relaxed">
                   Обери списання (наприклад через Apple/Google). День місяця з
                   транзакції підставиться в «день списання»; сума піде в огляд і
@@ -263,7 +264,7 @@ export function Assets({
                     </button>
                   )}
                 </p>
-              </div>
+              </Card>
               {expenses.map((t, i) => {
                 const isLinked = linkedId === t.id;
                 return (
@@ -327,7 +328,7 @@ export function Assets({
         </div>
         <div className="flex-1 overflow-y-auto">
           <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-            <div className="bg-panel border border-line rounded-xl p-4 mb-4">
+            <Card variant="flat" radius="md" className="mb-4">
               <div className="text-xs text-subtle">
                 {item?.emoji} {item?.name}
               </div>
@@ -344,7 +345,7 @@ export function Assets({
                 Сплачено: {paid.toLocaleString("uk-UA")} з{" "}
                 {total?.toLocaleString("uk-UA")} ₴
               </div>
-            </div>
+            </Card>
             {transactions.map((t, i) => {
               const isLinked = linked.includes(t.id);
               const role = isLinked ? getTxRole(t) : null;
@@ -468,7 +469,7 @@ export function Assets({
               />
             ))}
             {showSubForm ? (
-              <div className="bg-panel border border-line rounded-xl p-4 space-y-3 mt-2">
+              <Card variant="flat" radius="md" className="space-y-3 mt-2">
                 <Input
                   placeholder="Назва"
                   value={newSub.name}
@@ -529,7 +530,7 @@ export function Assets({
                     Скасувати
                   </Button>
                 </div>
-              </div>
+              </Card>
             ) : (
               <button
                 onClick={() => setShowSubForm(true)}
@@ -602,7 +603,7 @@ export function Assets({
               />
             ))}
             {showRecvForm ? (
-              <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
+              <Card variant="flat" radius="md" className="space-y-3">
                 <Input
                   placeholder="Ім'я або назва"
                   value={newRecv.name}
@@ -669,7 +670,7 @@ export function Assets({
                     Скасувати
                   </Button>
                 </div>
-              </div>
+              </Card>
             ) : (
               <button
                 onClick={() => setShowRecvForm(true)}
@@ -715,7 +716,7 @@ export function Assets({
               </div>
             ))}
             {showAssetForm ? (
-              <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
+              <Card variant="flat" radius="md" className="space-y-3">
                 <Input
                   placeholder="Назва"
                   value={newAsset.name}
@@ -771,7 +772,7 @@ export function Assets({
                     Скасувати
                   </Button>
                 </div>
-              </div>
+              </Card>
             ) : (
               <button
                 onClick={() => setShowAssetForm(true)}
@@ -831,7 +832,7 @@ export function Assets({
               />
             ))}
             {showDebtForm ? (
-              <div className="bg-panel border border-line rounded-xl p-4 space-y-3">
+              <Card variant="flat" radius="md" className="space-y-3">
                 <div className="flex gap-2">
                   <Input
                     className="flex-1"
@@ -909,7 +910,7 @@ export function Assets({
                     Скасувати
                   </Button>
                 </div>
-              </div>
+              </Card>
             ) : (
               <button
                 onClick={() => setShowDebtForm(true)}

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -101,7 +101,7 @@ export function WorkoutJournalSection({
   return (
     <div className="space-y-3">
       {!activeWorkout && (
-        <div className="bg-panel border border-line rounded-2xl p-5 shadow-card text-center">
+        <Card radius="lg" padding="lg" className="text-center">
           <div className="text-sm font-semibold text-text">
             Немає активного тренування
           </div>
@@ -127,7 +127,7 @@ export function WorkoutJournalSection({
               Шаблони
             </Button>
           </div>
-        </div>
+        </Card>
       )}
 
       {activeWorkout && (

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
+import { Card } from "@shared/components/ui/Card";
 import { MiniLineChart } from "../components/MiniLineChart";
 import { PhotoProgress } from "../components/PhotoProgress";
 
@@ -193,10 +194,7 @@ export function Body({ onOpenMeasurements }) {
           </div>
         </div>
 
-        <section
-          className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-          aria-label="Записати показники"
-        >
+        <Card as="section" radius="lg" aria-label="Записати показники">
           <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
             Записати сьогодні
           </h2>
@@ -328,13 +326,10 @@ export function Body({ onOpenMeasurements }) {
               {submitSuccess ? "Записано ✓" : "Записати"}
             </button>
           </form>
-        </section>
+        </Card>
 
         {weightData.length >= 2 && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Динаміка ваги"
-          >
+          <Card as="section" radius="lg" aria-label="Динаміка ваги">
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Динаміка ваги
             </h2>
@@ -344,14 +339,11 @@ export function Body({ onOpenMeasurements }) {
               color="rgb(22 163 74)"
               metricLabel="вагу"
             />
-          </section>
+          </Card>
         )}
 
         {sleepData.length >= 2 && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Динаміка сну"
-          >
+          <Card as="section" radius="lg" aria-label="Динаміка сну">
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Сон
             </h2>
@@ -361,14 +353,11 @@ export function Body({ onOpenMeasurements }) {
               color="rgb(99 102 241)"
               metricLabel="сон"
             />
-          </section>
+          </Card>
         )}
 
         {energyData.length >= 2 && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Динаміка енергії"
-          >
+          <Card as="section" radius="lg" aria-label="Динаміка енергії">
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Рівень енергії
             </h2>
@@ -378,14 +367,11 @@ export function Body({ onOpenMeasurements }) {
               color="rgb(245 158 11)"
               metricLabel="рівень енергії"
             />
-          </section>
+          </Card>
         )}
 
         {moodData.length >= 2 && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Динаміка настрою"
-          >
+          <Card as="section" radius="lg" aria-label="Динаміка настрою">
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Настрій
             </h2>
@@ -395,16 +381,13 @@ export function Body({ onOpenMeasurements }) {
               color="rgb(236 72 153)"
               metricLabel="настрій"
             />
-          </section>
+          </Card>
         )}
 
         <PhotoProgress />
 
         {entries.length > 0 && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Журнал записів"
-          >
+          <Card as="section" radius="lg" aria-label="Журнал записів">
             <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
               Журнал
             </h2>
@@ -484,7 +467,7 @@ export function Body({ onOpenMeasurements }) {
                 </div>
               ))}
             </div>
-          </section>
+          </Card>
         )}
       </div>
     </div>

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -361,10 +361,7 @@ export function Dashboard({
             const quickTemplates =
               recentlyUsed.length > 0 ? recentlyUsed : templates.slice(0, 3);
             return (
-              <section
-                className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-                aria-label="Швидкий старт"
-              >
+              <Card as="section" radius="lg" aria-label="Швидкий старт">
                 <div className="flex items-center justify-between gap-2 mb-3">
                   <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
                     Швидкий старт
@@ -415,15 +412,12 @@ export function Dashboard({
                     );
                   })}
                 </div>
-              </section>
+              </Card>
             );
           })()}
 
         {activeProgram && (
-          <section
-            className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-            aria-label="Програма сьогодні"
-          >
+          <Card as="section" radius="lg" aria-label="Програма сьогодні">
             <div className="flex items-center justify-between gap-2 mb-3">
               <div>
                 <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
@@ -462,11 +456,12 @@ export function Dashboard({
                 Розпочати тренування за програмою
               </button>
             )}
-          </section>
+          </Card>
         )}
 
-        <section
-          className="bg-panel border border-line rounded-2xl p-4 shadow-card"
+        <Card
+          as="section"
+          radius="lg"
           aria-label="Відновлення та фокус тренування"
         >
           <div className="flex items-start justify-between gap-2">
@@ -570,7 +565,7 @@ export function Dashboard({
               </div>
             </>
           )}
-        </section>
+        </Card>
 
         <div
           className="grid grid-cols-2 lg:grid-cols-4 gap-3"
@@ -578,10 +573,11 @@ export function Dashboard({
           aria-label="Ключові показники"
         >
           {kpi.map((card) => (
-            <div
+            <Card
               key={card.id}
               role="listitem"
-              className="bg-panel border border-line rounded-2xl p-4 shadow-card min-h-[100px]"
+              radius="lg"
+              className="min-h-[100px]"
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
@@ -661,7 +657,7 @@ export function Dashboard({
                   )}
                 </div>
               </div>
-            </div>
+            </Card>
           ))}
         </div>
 

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -390,9 +390,9 @@ export function Exercise({ exerciseId }) {
     return (
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-          <div className="bg-panel border border-line rounded-2xl p-5 shadow-card text-sm text-subtle">
+          <Card radius="lg" padding="lg" className="text-sm text-subtle">
             Невірний ID вправи
-          </div>
+          </Card>
         </div>
       </div>
     );

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -80,30 +80,30 @@ export function Measurements() {
         </a>
 
         <div className="grid grid-cols-3 gap-2">
-          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
+          <Card radius="lg" padding="sm" className="text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Записів
             </div>
             <div className="text-lg font-extrabold text-text tabular-nums mt-1">
               {stats.total}
             </div>
-          </div>
-          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
+          </Card>
+          <Card radius="lg" padding="sm" className="text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Останній
             </div>
             <div className="text-sm font-bold text-text mt-1">
               {stats.latestAt}
             </div>
-          </div>
-          <div className="bg-panel border border-line rounded-2xl p-3 shadow-card text-center">
+          </Card>
+          <Card radius="lg" padding="sm" className="text-center">
             <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
               Полів
             </div>
             <div className="text-lg font-extrabold text-text tabular-nums mt-1">
               {stats.filledLatest}
             </div>
-          </div>
+          </Card>
         </div>
 
         <Card radius="lg">

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -337,7 +337,7 @@ export function Progress() {
         </div>
 
         {!hasAny && (
-          <Card radius="lg" padding="xl" className="text-center">
+          <Card radius="lg" padding="xl" className="p-8 text-center">
             <div className="text-3xl mb-3">📈</div>
             <div className="text-sm font-medium text-text mb-1">
               Даних ще немає

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -337,7 +337,7 @@ export function Progress() {
         </div>
 
         {!hasAny && (
-          <div className="bg-panel border border-line rounded-2xl p-8 shadow-card text-center">
+          <Card radius="lg" padding="xl" className="text-center">
             <div className="text-3xl mb-3">📈</div>
             <div className="text-sm font-medium text-text mb-1">
               Даних ще немає
@@ -345,7 +345,7 @@ export function Progress() {
             <div className="text-xs text-subtle">
               Додай тренування або заміри — і тут зʼявиться аналітика
             </div>
-          </div>
+          </Card>
         )}
 
         {/* Weekly volume chart */}

--- a/src/modules/routine/components/HabitHeatmap.tsx
+++ b/src/modules/routine/components/HabitHeatmap.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 import type { Habit, RoutineState } from "../lib/types";
 
 const WEEKS = 53;
@@ -132,10 +133,7 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
   }, [selected, weeks]);
 
   return (
-    <div
-      ref={rootRef}
-      className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-    >
+    <Card ref={rootRef} radius="lg">
       <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
         Активність за рік
       </p>
@@ -238,6 +236,6 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
           <span>більше</span>
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/modules/routine/components/PushupsWidget.tsx
+++ b/src/modules/routine/components/PushupsWidget.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect, type ChangeEvent } from "react";
 import { cn } from "@shared/lib/cn";
 import { Sheet } from "@shared/components/ui/Sheet";
+import { Card } from "@shared/components/ui/Card";
 import { useRoutinePushups } from "../hooks/useRoutinePushups.js";
 import { useVisualKeyboardInset } from "../hooks/useVisualKeyboardInset.js";
 import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
@@ -26,10 +27,7 @@ export function PushupsWidget() {
 
   return (
     <>
-      <section
-        className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-        aria-label="Відтискання"
-      >
+      <Card as="section" radius="lg" aria-label="Відтискання">
         <div className="flex items-center justify-between gap-2">
           <div>
             <p className="text-xs font-bold text-subtle uppercase tracking-widest">
@@ -97,7 +95,7 @@ export function PushupsWidget() {
             </div>
           </div>
         )}
-      </section>
+      </Card>
 
       <Sheet
         open={open}

--- a/src/modules/routine/components/RoutineStatsPanel.tsx
+++ b/src/modules/routine/components/RoutineStatsPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
 import { PushupsWidget } from "./PushupsWidget";
 import { HabitHeatmap } from "./HabitHeatmap";
 import { HabitLeadersBlock } from "./HabitLeadersBlock";
@@ -65,10 +66,7 @@ export function RoutineStatsPanel({
       hidden={hidden}
       className="space-y-4"
     >
-      <section
-        className="bg-panel border border-line rounded-2xl p-4 shadow-card"
-        aria-label="Зведена статистика"
-      >
+      <Card as="section" radius="lg" aria-label="Зведена статистика">
         <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
           Зведення
         </p>
@@ -123,7 +121,7 @@ export function RoutineStatsPanel({
             </p>
           </div>
         </div>
-      </section>
+      </Card>
 
       <PushupsWidget />
 

--- a/src/modules/routine/components/settings/HabitForm.tsx
+++ b/src/modules/routine/components/settings/HabitForm.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import {
   ROUTINE_THEME as C,
@@ -80,10 +81,7 @@ export function HabitForm({
   }, [focusTick]);
 
   return (
-    <section
-      ref={sectionRef}
-      className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
-    >
+    <Card as="section" ref={sectionRef} radius="lg" className="space-y-3">
       <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
         {editingId ? "Редагувати звичку" : "Нова звичка"}
       </h2>
@@ -263,6 +261,6 @@ export function HabitForm({
           </Button>
         )}
       </div>
-    </section>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary

Косметична фаза уніфікації: ~27 хендроллених «дів-карток» у 11 файлах перекладено на DS `<Card>`. Усе інлайнове `bg-panel border border-line rounded-(xl|2xl) p-(3|4|5|8) [shadow-card]` замінено на пропси компонента.

**Мапінг інлайн-класів → пропси Card:**
- `rounded-xl` → `radius="md"`
- `rounded-2xl` → `radius="lg"` (найпоширеніший)
- `p-3` → `padding="sm"`, `p-4` → `padding="md"` (default), `p-5` → `padding="lg"`, `p-8` → `padding="xl"`
- `shadow-card` — тепер дефолт `variant="default"`, з інлайну прибрано
- Форми без тіні (`rounded-xl p-4` без `shadow-card`) → `variant="flat"`
- Оригінальний тег (`<section>` з `aria-label`) збережено через `as="section"`; `forwardRef` Card підтримує `ref` безпосередньо

**Файли (11):**
- **routine** (4): `PushupsWidget.tsx`, `HabitHeatmap.tsx`, `RoutineStatsPanel.tsx`, `settings/HabitForm.tsx`
- **fizruk** (6): `pages/Measurements.tsx` (3 stat-cards), `pages/Body.tsx` (6 sections), `pages/Dashboard.tsx` (3 sections + KPI-grid з 4 карток у мапі), `pages/Progress.tsx` (empty-state), `pages/Exercise.tsx` (error-card), `components/workouts/WorkoutJournalSection.tsx` (empty-state)
- **finyk** (1): `pages/Assets.jsx` — 3 info-картки (mono-debt/sub/item-debt pickers) + 4 форми (Subscription/Receivable/Asset/Debt)

**Навмисно не чіпав:**
- `<a>`-cards (наприклад посилання на wikiHow у `Measurements.tsx`) — `Card` розширює `HTMLAttributes<HTMLElement>` і не приймає `href`. Лишив як є.
- Hero-картки з модульними варіантами (`variant="finyk"` / `fizruk"` etc.) — вони вже на DS у `shared/components/ui/Cards.tsx`.
- Решту ~35 файлів з патерном — це окремий PR, щоб діфф лишився оглядним.

**Net:** −28 LOC (−92 / +64), жодної поведінкової зміни — лише перехід з інлайн-класів на пропси.

## Review & Testing Checklist for Human

- [ ] Відкрити `Рутина → Статистика` — переконатись що `PushupsWidget`, heat-map, статисичний блок і `HabitForm` виглядають ідентично (бордер/тінь/радіус/паддинг).
- [ ] `Фізрук → Тіло` — форма «Записати сьогодні» + 4 графіки (вага/сон/енергія/настрій) + «Журнал» → картки виглядають так само, `aria-label` на місці.
- [ ] `Фізрук → Dashboard` — «Швидкий старт», «Програма сьогодні», «Відновлення і фокус», 4 KPI-картки з `role="list" / role="listitem"` — візуально однакові.
- [ ] `Фінік → Активи` — відкрити по черзі форми «+ Додати підписку / актив / мені-винні / пасив» — усередині відображаються так само (`rounded-xl`, `p-4`, без тіні).

### Notes

- CardProps не включає `href`, тому anchor-картки (ex. `Measurements.tsx` wikiHow-посилання) лишилися на голих `<a className="bg-panel …">`. Якщо хочеш — можна розширити `CardProps` до `AnchorHTMLAttributes` як окремий маленький PR.
- Лінт, тайпчек, білд — зелені локально.

Link to Devin session: https://app.devin.ai/sessions/bdf76d95774a4a598095569619d8c3ed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
