### PR TITLE
fix(server): address PR #241 review findings (CORS scope, push auth)

### DIFF
--- a/server/http/apiCors.js
+++ b/server/http/apiCors.js
@@ -5,16 +5,16 @@ import { setCorsHeaders } from "./cors.js";
  * `server/app.js` і дублювалось у кожному handler-і через `setCorsHeaders` +
  * OPTIONS-guard; PR 4 зробив це єдиним source of truth.
  *
- * `allowHeaders` — union усіх custom-хедерів, які очікують різні домени:
+ * `allowHeaders` містить тільки ті хедери, що МАЮТЬ приходити з браузера:
  *   - `X-Token` — nutrition/monobank (proxy)
  *   - `X-Privat-Id`, `X-Privat-Token` — privatbank (proxy)
- *   - `X-Api-Secret` — internal cron/worker endpoint-и (push/send)
  *   - `Content-Type` — для POST/JSON
- * Для preflight CORS різниці немає: браузеру байдуже, що deduped union
- * ширший за те, що конкретний endpoint реально читає, — це advisory-список.
+ *
+ * `X-Api-Secret` свідомо НЕ в цьому списку: `/api/push/send` — внутрішній
+ * cron/worker endpoint, браузер не має могти preflight-нути його навіть з
+ * allowed origin (defense-in-depth проти XSS / протечки секрета в logs).
  */
-const ALLOW_HEADERS =
-  "Content-Type, X-Token, X-Privat-Id, X-Privat-Token, X-Api-Secret";
+const ALLOW_HEADERS = "Content-Type, X-Token, X-Privat-Id, X-Privat-Token";
 
 export function apiCorsMiddleware() {
   return (req, res, next) => {

--- a/server/http/index.js
+++ b/server/http/index.js
@@ -36,7 +36,7 @@ export * as schemas from "./schemas.js";
 // використовувати їх замість per-handler boilerplate).
 export { asyncHandler } from "./asyncHandler.js";
 export { setModule } from "./setModule.js";
-export { requireSession } from "./requireSession.js";
+export { requireSession, requireSessionSoft } from "./requireSession.js";
 export { requireApiSecret } from "./requireApiSecret.js";
 export { requireAnthropicKey } from "./requireAnthropicKey.js";
 export { requireAiQuota } from "./requireAiQuota.js";

--- a/server/http/requireSession.js
+++ b/server/http/requireSession.js
@@ -2,10 +2,14 @@ import { getSessionUser } from "../auth.js";
 
 /**
  * Router-level auth-middleware. Резолвить Better Auth сесію, кладе юзера в
- * `req.user` і кличе `next()`. Якщо сесії немає або lookup впав — 401.
+ * `req.user` і кличе `next()`. Якщо сесії немає — 401; якщо lookup впав
+ * (наприклад, тимчасовий недоступ БД) — передаємо помилку далі у error-
+ * handler (500), бо для звичайних endpoint-ів фронту важливо відрізняти
+ * "ти не залогінений" від "у нас щас все горить".
  *
- * Handler-у не треба більше власноруч кликати `getSessionUser` + перевіряти
- * null + віддавати 401 — він просто читає `req.user`.
+ * Для endpoint-ів, де фронт історично трактує будь-яку невдачу auth як
+ * "не залогінений" (push subscribe/unsubscribe — сервіс-воркер не має
+ * падати у 500 при тимчасовому збої), використовуй `requireSessionSoft()`.
  *
  * @returns {import("express").RequestHandler}
  */
@@ -23,5 +27,32 @@ export function requireSession() {
     } catch (err) {
       next(err);
     }
+  };
+}
+
+/**
+ * Як `requireSession()`, але ковтає будь-яку exception з `getSessionUser`
+ * і мапить її у 401 замість 500. Потрібно для endpoint-ів, де фронт
+ * обробляє "не залогінений" значно коректніше за "server error" —
+ * насамперед push subscribe/unsubscribe, які смикає сервіс-воркер і де
+ * історично був явний try/catch-to-401 у handler-і (pre-PR-4).
+ *
+ * @returns {import("express").RequestHandler}
+ */
+export function requireSessionSoft() {
+  return async (req, res, next) => {
+    let user = null;
+    try {
+      user = await getSessionUser(req);
+    } catch {
+      // swallow — transient auth/DB failure treated as "not logged in".
+    }
+    if (!user) {
+      return res
+        .status(401)
+        .json({ error: "Потрібна автентифікація", code: "UNAUTHORIZED" });
+    }
+    req.user = user;
+    next();
   };
 }

--- a/server/routes/push.js
+++ b/server/routes/push.js
@@ -3,7 +3,7 @@ import {
   asyncHandler,
   rateLimitExpress,
   requireApiSecret,
-  requireSession,
+  requireSessionSoft,
   setModule,
 } from "../http/index.js";
 import {
@@ -18,8 +18,12 @@ import {
  * під час реєстрації сервіс-воркера і він має бути швидким/дешевим. Решта
  * endpoint-ів (subscribe/unsubscribe/send) лімітуються.
  *
- * subscribe/unsubscribe вимагають сесії; send — внутрішній API для
- * cron/worker-ів, захищений `X-Api-Secret`.
+ * subscribe/unsubscribe використовують `requireSessionSoft`, а не
+ * `requireSession`: service worker смикає ці endpoint-и у фоні, і
+ * історично handler трактував будь-яку невдачу `getSessionUser` як 401
+ * (а не 500), щоб тимчасовий збій БД не перетворювався на notification
+ * "server error" на фронті. `send` — внутрішній API cron/worker-ів,
+ * захищений `X-Api-Secret`.
  */
 export function createPushRouter() {
   const r = Router();
@@ -29,10 +33,14 @@ export function createPushRouter() {
     "/api/push",
     rateLimitExpress({ key: "api:push", limit: 30, windowMs: 60_000 }),
   );
-  r.post("/api/push/subscribe", requireSession(), asyncHandler(pushSubscribe));
+  r.post(
+    "/api/push/subscribe",
+    requireSessionSoft(),
+    asyncHandler(pushSubscribe),
+  );
   r.delete(
     "/api/push/subscribe",
-    requireSession(),
+    requireSessionSoft(),
     asyncHandler(pushUnsubscribe),
   );
   r.post(


### PR DESCRIPTION
## Summary

Follow-up на вже змерджений **#241** — фіксить 2 легітимні знахідки з Devin Review, обидві стосуються неявних регресій поведінки, які переїхали разом з boilerplate-очисткою.

Stacked поверх гілки #236 (`devin/1776601881-backend-pr1-http-infra`), бо PR-и 1–4 ще не у `main`. Після мерджу ланцюжка base автоматично стане `main`.

### 1. `X-Api-Secret` виведений з глобального CORS allow-headers

До PR 4 глобальний CORS дозволяв лише `X-Token, Content-Type`. PR 4 зібрав **union** custom-хедерів з усіх доменів у `apiCorsMiddleware` — зокрема туди потрапив `X-Api-Secret`, який використовується тільки internal cron/worker-endpoint-ом `/api/push/send`.

Чому це регресія defense-in-depth:
- `requireApiSecret` у `server/http/requireApiSecret.js` — перша і основна лінія оборони, вона **не** ламається.
- Але якщо секрет колись протече (logs / client-side bundle / XSS на allowed origin), старий CORS preflight додатково відфільтровував би браузерні виклики з `X-Api-Secret` ще до серверної перевірки. Новий — пропускає preflight успішно.

Фікс — забрати `X-Api-Secret` зі глобального ALLOW_HEADERS. Сам endpoint продовжує працювати для cron/worker викликів (не-браузерних, CORS preflight не йде), `requireApiSecret` як і раніше забороняє виклики без правильного секрета.

### 2. `requireSessionSoft()` для `/api/push/subscribe` (POST+DELETE)

До PR 4 push-handler мав явний `getSession` wrapper, який `catch`-ив **будь-яку** exception з `getSessionUser` і повертав `null` → 401. Коментар у коді прямо казав, що це навмисне: _"push-ендпоінти історично трактують будь-яку невдачу better-auth як 'не залогінений' і повертають 401, а не 500"_. Причина: service worker фронту смикає subscribe/unsubscribe у фоні, і "server error" notification від тимчасового збою БД псує UX сильніше за мовчазний 401.

PR 4 замінив це на generic `requireSession()`, який пропускає виняток через `next(err)` → глобальний error-handler віддає 500. Це регресія.

Рішення — окрема variant-middleware `requireSessionSoft()` у `server/http/requireSession.js`, що ковтає exception з `getSessionUser` і мапить її у 401 (звичайний `requireSession()` лишається strict). Використовую її тільки на push-subscribe/unsubscribe, бо тільки там стара поведінка була задокументовано навмисною.

### Що НЕ змінено
- HTTP-контракти endpoint-ів не змінилися: на happy-path і на "явно не залогінений" обидва роути віддають те саме, що до PR 4.
- `requireSession()` усюди інде лишається strict (sync / coach / nutrition) — там фронт правильно обробляє 500 як tmp-збій і має знати про нього.

### Числа
```
4 files changed, 55 insertions(+), 12 deletions(-)
```
Тести — 674 passed (без нових — обидва фікси це відновлення попередньої поведінки, що покрита інтеграційним smoke-ом).

## Review & Testing Checklist for Human

Ризик: **yellow** — два малі фокусні фікси, але обидва стосуються auth/CORS boundary, який CI не ганяє end-to-end.

- [ ] `/api/push/send` з браузера (XHR/fetch з `X-Api-Secret`) тепер **має** впасти на preflight (як і до PR 4). cron/worker з Node-клієнта (де немає CORS) — **має** продовжити працювати.
- [ ] Симулювати тимчасовий збій БД під час `POST /api/push/subscribe` (наприклад, `pg_terminate_backend` усіх коннекшенів або `DROP TABLE user` в dev-БД) — endpoint має віддати **401**, а не 500; service worker фронту — не вибивати "server error" notification.
- [ ] Smoke: happy-path `POST /api/push/subscribe` (з валідною сесією) і `POST /api/push/send` (з `X-Api-Secret`) продовжують працювати ідентично.

### Notes

Після цього PR серія 1–4 закриває всі знайдені регресії. Опційний PR 5 (split `coach.js` / `push.js` на окремі файли) — чисто cosmetic, можна робити або пропускати.

Link to Devin session: https://app.devin.ai/sessions/84e53f5360944a6fb5051721c711ea65
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
