### PR TITLE
ux(fizruk/dashboard): contextual one-tap hero CTA (action-driven dashboard · step 1/4)

### DIFF
--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -246,6 +246,78 @@ export function Dashboard({
     startWorkoutFromPlan(picks, templateId);
   };
 
+  const primaryAction = useMemo(() => {
+    if (activeProgram && todaySession) {
+      const session = activeProgram.sessions?.[todaySession.sessionKey];
+      if (session) {
+        return {
+          kind: "program" as const,
+          label: todaySession.name,
+          hint: activeProgram.name,
+          exerciseCount: (session.exerciseIds || []).length,
+          sessionKey: todaySession.sessionKey,
+        };
+      }
+    }
+    const fallbackTemplateId =
+      monthlyPlan.todayTemplateId ||
+      recentlyUsed[0]?.id ||
+      templates[0]?.id ||
+      null;
+    if (fallbackTemplateId) {
+      const tpl = templates.find((t) => t.id === fallbackTemplateId);
+      if (tpl) {
+        const picks = (tpl.exerciseIds || [])
+          .map((id) => exercises.find((e) => e.id === id))
+          .filter(Boolean);
+        if (picks.length > 0) {
+          let hint: string | null = null;
+          if (monthlyPlan.todayTemplateId === tpl.id) {
+            hint = "З місячного плану";
+          } else if (recentlyUsed[0]?.id === tpl.id) {
+            hint = "Останнє тренування";
+          }
+          return {
+            kind: "template" as const,
+            label: tpl.name,
+            hint,
+            exerciseCount: picks.length,
+            templateId: tpl.id,
+            picks,
+          };
+        }
+      }
+    }
+    return null;
+  }, [
+    activeProgram,
+    todaySession,
+    monthlyPlan.todayTemplateId,
+    recentlyUsed,
+    templates,
+    exercises,
+  ]);
+
+  const estimatedDurationMin = useMemo(() => {
+    if (!primaryAction?.exerciseCount) return null;
+    if (avgDurationSec > 300) {
+      return Math.max(10, Math.round(avgDurationSec / 60 / 5) * 5);
+    }
+    return Math.max(10, primaryAction.exerciseCount * 8);
+  }, [primaryAction, avgDurationSec]);
+
+  const handleStartPrimary = () => {
+    if (!primaryAction) return;
+    if (primaryAction.kind === "program") {
+      const session = activeProgram?.sessions?.[primaryAction.sessionKey];
+      if (session && onStartProgramWorkout) {
+        onStartProgramWorkout(session, activeProgram);
+      }
+      return;
+    }
+    tryStartPlan(primaryAction.picks, primaryAction.templateId);
+  };
+
   const kpi = [
     {
       id: "total",
@@ -327,19 +399,57 @@ export function Dashboard({
             </div>
           </div>
           <div className="mt-5 flex flex-col gap-3">
-            <button
-              type="button"
-              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white transition-all active:scale-[0.98]"
-              onClick={() => {
-                try {
-                  sessionStorage.setItem("fizruk_workouts_mode", "log");
-                } catch {}
-                window.location.hash = "#workouts";
-              }}
-              aria-label="Почати тренування"
-            >
-              Почати тренування
-            </button>
+            {primaryAction ? (
+              <button
+                type="button"
+                className="w-full py-4 px-5 rounded-2xl bg-fizruk text-white transition-all active:scale-[0.98] flex items-center gap-3 text-left"
+                onClick={handleStartPrimary}
+                aria-label={`Почати: ${primaryAction.label}`}
+              >
+                <span
+                  className="shrink-0 w-11 h-11 rounded-full bg-white/15 flex items-center justify-center"
+                  aria-hidden
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-2xs font-bold uppercase tracking-widest text-white/70">
+                    Почати
+                  </span>
+                  <span className="block text-base font-black truncate leading-tight">
+                    {primaryAction.label}
+                  </span>
+                  <span className="block text-2xs text-white/70 mt-0.5 truncate">
+                    {primaryAction.exerciseCount} вправ
+                    {estimatedDurationMin
+                      ? ` · ~${estimatedDurationMin} хв`
+                      : ""}
+                    {primaryAction.hint ? ` · ${primaryAction.hint}` : ""}
+                  </span>
+                </span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white transition-all active:scale-[0.98]"
+                onClick={() => {
+                  try {
+                    sessionStorage.setItem("fizruk_workouts_mode", "templates");
+                  } catch {}
+                  window.location.hash = "#workouts";
+                }}
+                aria-label="Створити перший шаблон"
+              >
+                Створити перший шаблон
+              </button>
+            )}
             <button
               type="button"
               className="w-full py-4 rounded-full font-semibold text-base text-white border border-white/25 transition-colors active:bg-white/10"


### PR DESCRIPTION
## Summary

First of four staged PRs turning the Fizruk Dashboard from a "shelf of data" into an **action-driven decision screen**. (Full product-design proposal lives in the session.)

**Before:** hero shows a generic `Почати тренування` pill that just navigates to `#workouts` — it tells the user nothing about *what* they're about to start and still requires 2–3 clicks (pick template → start) to actually begin.

**After:** hero becomes a one-tap contextual starter that answers "what / how much / how long" *before* the tap:

```
[▶]  ПОЧАТИ
     Push — Груди, плечі, трицепс
     6 вправ · ~55 хв · Push / Pull / Legs
```

### Resolution order for today's workout
1. Active program + session scheduled for today → starts it via `onStartProgramWorkout`
2. Template assigned to today in the monthly plan → starts it via `tryStartPlan`
3. Most recently used template
4. First available template
5. No templates → fallback CTA `Створити перший шаблон` (routes to templates mode)

### Duration estimate
- If the user has >5 min of average past-workout history → round avg to nearest 5 min
- Otherwise → rough heuristic of `N × 8 min` per exercise
- If nothing is available → hidden

### What this PR does NOT change (intentionally)
- Mini-stats strip in hero (Тиждень / Серія / Сер.час / Місяць) — removed in step 2
- KPI 4-card block — moved to `/profile/stats` in step 2
- Recovery block expanded layout — collapsed to 1-line in step 3
- `План на сьогодні` + `Швидкий старт` merge into "Інший варіант" sheet — step 4
- Existing `Розпочати за програмою` in the program card stays for now (duplication removed in step 4)

Reuses the existing `tryStartPlan` / `onStartProgramWorkout` paths, so recovery-conflict warnings (`planConfirmOpen` sheet) keep working identically.

Risk: 🟡 yellow — behavioral change on the most-used CTA of the Fizruk module; no API or storage changes; falls back to safe onboarding CTA when no templates exist.

## Review & Testing Checklist for Human

- [ ] On a fresh account with **no templates and no active program** → hero shows `Створити перший шаблон` (not a broken empty state)
- [ ] With **active program** whose `schedule` includes today → hero label reads the program session name + correct exercise count; tapping starts the program workout (goes through `onStartProgramWorkout`)
- [ ] With **monthlyPlan.todayTemplateId** set but no active program → hero picks that template; hint reads "З місячного плану"
- [ ] With only `recentlyUsed` → hero picks `recentlyUsed[0]`; hint reads "Останнє тренування"
- [ ] With a template containing exercises whose primary muscles are still **recovering (red/yellow)** → tapping the hero still triggers the `planConfirmOpen` warning sheet (recovery guardrail preserved)
- [ ] Long session names (e.g. `Push — Груди, плечі, трицепс`) truncate cleanly on 360px-wide mobile; metadata line also truncates

### Notes
- Pre-existing typecheck failure on `src/core/authClient.ts:21` (`forgetPassword` prop) is present on `main` and unrelated to this PR — verified by `git stash && npm run typecheck` on clean main.
- This is step 1/4 in the "Dashboard → керуючий" redesign. Remaining steps: (2) remove hero mini-stats + KPI block, (3) collapse recovery to 1-line summary, (4) merge Швидкий старт + План into one "Інший варіант" sheet.

Link to Devin session: https://app.devin.ai/sessions/68e85770e862425f9b11eefee1aaa2de
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
