### PR TITLE
UX quick-wins: FTUX / onboarding friction reducers

### DIFF
--- a/src/core/App.jsx
+++ b/src/core/App.jsx
@@ -254,8 +254,11 @@ function AppInner() {
         />
 
         {/* Primary quick-add surface for the hub. AI chat moved to the
-            header — see `HubHeader` / `HubHeaderWithProps` (`onOpenChat`). */}
-        <HubFloatingActions />
+            header — see `HubHeader` / `HubHeaderWithProps` (`onOpenChat`).
+            Hidden during the FTUX session so the only add-surface in view is
+            the `FirstActionHeroCard` → `PresetSheet` one-tap path; the FAB
+            returns the moment the first real entry lands. */}
+        <HubFloatingActions hidden={inFtuxSession} />
 
         <HubModals
           chatOpen={ui.chatOpen}

--- a/src/core/HubDashboard.jsx
+++ b/src/core/HubDashboard.jsx
@@ -266,10 +266,13 @@ function DateHeader() {
 // module's color shows only as a 1px leading accent, so four rows read as a
 // single list rather than four competing heroes.
 // ═══════════════════════════════════════════════════════════════════════════
-function ModuleRow({ config, onClick, dragProps, isDragging }) {
+function ModuleRow({ config, onClick, dragProps, isDragging, isDemo }) {
   const preview = config.getPreview();
   const showProgress =
     config.hasGoal && preview.progress !== undefined && preview.progress > 0;
+  // Show the pill only when the module has a real preview number to label —
+  // an empty row's "tracking…" copy is self-evidently not demo data.
+  const showDemoPill = isDemo && Boolean(preview.main);
 
   return (
     <button
@@ -306,6 +309,14 @@ function ModuleRow({ config, onClick, dragProps, isDragging }) {
       </span>
 
       <div className="ml-auto flex items-center gap-2 min-w-0">
+        {showDemoPill && (
+          <span
+            className="shrink-0 px-1.5 py-0.5 rounded-md text-[10px] font-semibold uppercase tracking-wider text-brand-600 bg-brand-500/10 border border-brand-500/20"
+            title="Це приклад — заміниться на твої дані після першого запису"
+          >
+            Демо
+          </span>
+        )}
         {showProgress && (
           <div
             className="w-12 sm:w-16 h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden shrink-0"
@@ -343,7 +354,7 @@ function ModuleRow({ config, onClick, dragProps, isDragging }) {
 // ═══════════════════════════════════════════════════════════════════════════
 // SORTABLE CARD WRAPPER
 // ═══════════════════════════════════════════════════════════════════════════
-function SortableCard({ id, onOpenModule }) {
+function SortableCard({ id, onOpenModule, isDemo }) {
   const {
     attributes,
     listeners,
@@ -367,6 +378,7 @@ function SortableCard({ id, onOpenModule }) {
         config={cfg}
         onClick={() => onOpenModule(id)}
         isDragging={isDragging}
+        isDemo={isDemo}
         dragProps={{ ...attributes, ...listeners }}
       />
     </div>
@@ -467,6 +479,12 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   const showDemoBanner =
     !hasRealEntry && !demoBannerDismissed && wasDemoSeeded();
 
+  // The banner is one-shot dismissible, but the underlying fact that the
+  // numbers in "Сьогодні" are seeded demo data persists until the first real
+  // entry. A per-row "Демо" pill stays visible after the banner is closed so
+  // the user never mistakes the preview for their own data.
+  const modulePreviewsAreDemo = !hasRealEntry && wasDemoSeeded();
+
   const { focus, rest, dismiss } = useDashboardFocus();
 
   const sensors = useSensors(
@@ -538,7 +556,12 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
           <SortableContext items={order} strategy={verticalListSortingStrategy}>
             <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
               {order.map((id) => (
-                <SortableCard key={id} id={id} onOpenModule={onOpenModule} />
+                <SortableCard
+                  key={id}
+                  id={id}
+                  onOpenModule={onOpenModule}
+                  isDemo={modulePreviewsAreDemo}
+                />
               ))}
             </div>
           </SortableContext>

--- a/src/core/OnboardingWizard.jsx
+++ b/src/core/OnboardingWizard.jsx
@@ -177,6 +177,9 @@ function VibeChipRow({ picks, togglePick }) {
 // module is picked; all four default to active so the lazy path is
 // "tap → done".
 function SplashStep({ picks, togglePick, onContinue }) {
+  // Zero-picks used to disable the CTA. That gate punished users who deselected
+  // every chip to see what happens — `finish()` already falls back to
+  // ALL_MODULES, so we let the tap through and surface a gentle hint instead.
   const hasPicks = picks.length > 0;
   return (
     <div className="flex flex-col items-center text-center space-y-5">
@@ -200,13 +203,14 @@ function SplashStep({ picks, togglePick, onContinue }) {
           variant="primary"
           size="lg"
           className="w-full"
-          disabled={!hasPicks}
         >
           Заповни мій хаб
           <Icon name="chevron-right" size={16} />
         </Button>
         {!hasPicks && (
-          <p className="text-[11px] text-muted">Обери хоч один модуль.</p>
+          <p className="text-[11px] text-muted">
+            Без вибору — всі 4 модулі. Налаштуєш потім.
+          </p>
         )}
       </div>
       <p className="text-[11px] text-subtle leading-relaxed">

--- a/src/core/app/HubFloatingActions.jsx
+++ b/src/core/app/HubFloatingActions.jsx
@@ -40,9 +40,23 @@ const ACTIONS = [
   },
 ];
 
-export function HubFloatingActions() {
+/**
+ * @param {object} props
+ * @param {boolean} [props.hidden=false] - When true the FAB is not rendered
+ *   at all. Used during the FTUX session so the only add-surface in view is
+ *   `FirstActionHeroCard` → `PresetSheet` (the one-tap "real entry" path).
+ *   The generic FAB would otherwise bypass that flow and drop the user into
+ *   a full manual AddSheet, defeating the 30-second promise.
+ */
+export function HubFloatingActions({ hidden = false }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef(null);
+
+  // Collapse the speed-dial the moment we're hidden so reopening after FTUX
+  // doesn't flash a stale open state.
+  useEffect(() => {
+    if (hidden) setOpen(false);
+  }, [hidden]);
 
   // Click-outside + Escape close. Matches the ambient dismissal pattern
   // used by the rest of the hub's popovers.
@@ -70,6 +84,8 @@ export function HubFloatingActions() {
     setOpen(false);
     action.run();
   };
+
+  if (hidden) return null;
 
   return (
     <div

--- a/src/core/app/HubMainContent.jsx
+++ b/src/core/app/HubMainContent.jsx
@@ -97,7 +97,7 @@ export function HubMainContent({
                 Встановити додаток
               </p>
               <p className="text-xs text-muted">
-                Працює офлайн, як рідний додаток
+                Офлайн · пуш-нагадування · ярлик на екрані
               </p>
             </div>
             <button

--- a/src/core/app/WelcomeScreen.jsx
+++ b/src/core/app/WelcomeScreen.jsx
@@ -118,16 +118,24 @@ export function WelcomeScreen({ onDone, onOpenAuth }) {
       <div className="relative min-h-dvh flex items-end sm:items-center justify-center p-4 pb-safe">
         <div className="w-full max-w-sm space-y-3">
           <OnboardingWizard onDone={onDone} variant="fullPage" />
+          {/* Returning-user entry. The previous text-xs muted underline was
+              almost invisible on a fresh device — users who already had an
+              account were dropped into onboarding. Promoted to a secondary
+              button so the "у мене є акаунт" path is visible without
+              competing with the primary splash CTA. */}
           <button
             type="button"
             onClick={onOpenAuth}
             className={cn(
-              "w-full text-center text-xs font-medium text-muted",
-              "hover:text-text underline-offset-2 hover:underline",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-md py-1",
+              "w-full flex items-center justify-center gap-2",
+              "h-11 min-h-[44px] rounded-2xl border border-line bg-panel/60",
+              "text-sm font-semibold text-text",
+              "hover:bg-panelHi hover:border-brand-500/40 transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
             )}
           >
-            У мене вже є акаунт
+            <Icon name="user" size={16} strokeWidth={2} aria-hidden />
+            <span>У мене вже є акаунт</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

First batch from the UX audit — friction reducers on the onboarding / FTUX path. Small, low-risk edits that unblock obvious paper-cuts found across `WelcomeScreen` → `OnboardingWizard` → FTUX dashboard → `FirstActionHeroCard`.

**Changes**

1. **`OnboardingWizard` — remove zero-picks CTA gate.** `finish()` already defaults to `ALL_MODULES` when `picks` is empty (`OnboardingWizard.jsx:252`). Disabling the button when a user deselected every vibe chip was a dead-end state with a cryptic 11px error. Now the tap goes through and we show a gentle "Без вибору — всі 4 модулі. Налаштуєш потім." hint instead.

2. **`WelcomeScreen` — returning-user entry is visible.** The "У мене вже є акаунт" link was `text-xs text-muted` with a hover-underline, practically invisible on the splash. Promoted to an `h-11` secondary-ghost button with an icon so returning users on a fresh device don't get forced through onboarding.

3. **`HubFloatingActions` — hide FAB during FTUX.** The speed-dial `+` was active from the first second on the dashboard and its actions dropped the user into a full manual `AddSheet` — bypassing `FirstActionHeroCard` → `PresetSheet`, which is the one-tap "real entry in 30 seconds" path. The FAB now renders `null` while `inFtuxSession` is true and returns the moment the first real entry lands.

4. **`HubDashboard` / `ModuleRow` — persistent "Демо" pill.** `DemoModeBanner` is one-shot dismissible, but the numbers in "Сьогодні" stay seeded until the first real entry. Today, after dismiss the dashboard is visually identical to one full of real data — easy to mistake. Each `ModuleRow` now shows a subtle `Демо` chip (next to the preview number) while `!hasRealEntry && wasDemoSeeded()`. Pill disappears automatically after the first real entry.

5. **PWA install banner copy.** Subtitle changed from "Працює офлайн, як рідний додаток" (generic, doesn't answer "why bother") to "Офлайн · пуш-нагадування · ярлик на екрані" — three concrete benefits in one line.

**Not in this PR** (deferred to follow-ups):
- Add-flow quick-wins (meal time-of-day default, expense "не сьогодні" chip, name-autofill lock, segmented recurrence, emoji picker) — next PR.
- High-impact items (A–H from the audit: dashboard rebalance, 10-second expense, uni-input meal, 1-screen habit, contextual FAB, reactive previews, magic-link, demo contract) — larger, each is a day+ of its own.

## Review & Testing Checklist for Human

*Risk: green — purely visual / gating changes, no data or API surface touched.*

- [ ] Open `/welcome` on a fresh device (clear `localStorage`). Confirm:
  - splash CTA is active even with 0 vibe chips selected (fallback hint visible);
  - tapping CTA with 0 picks seeds all 4 modules (same behavior as before — just the button is no longer disabled);
  - "У мене вже є акаунт" is clearly a button with icon, not a tiny underline.
- [ ] Finish onboarding → land on hub. Confirm the FAB `+` is **not** rendered while `FirstActionHeroCard` is visible. Tap a preset to log a real entry, confirm FAB returns.
- [ ] Confirm each `ModuleRow` that has a preview number shows a `Демо` pill next to it **before** first real entry (both before and after dismissing `DemoModeBanner`). Log a real entry in any module — pill should disappear from all rows after `detectFirstRealEntry()` flips.
- [ ] Trigger a PWA install prompt (Chrome desktop → menu → Install, or wait for `beforeinstallprompt`). Confirm the banner subtitle reads the new three-benefit line.

### Notes

- `npm run lint` ✅, `npm test` ✅ (72 files / 674 tests).
- `npm run typecheck` surfaces one pre-existing error in `src/core/authClient.ts:21` (`forgetPassword` not on the Better Auth client type) — unrelated to this PR, confirmed reproduces on `main` via stash.
- No change to analytics, storage, or feature flags. All gates read existing selectors (`isFirstActionPending`, `detectFirstRealEntry`, `wasDemoSeeded`, `isDemoBannerDismissed`).

Link to Devin session: https://app.devin.ai/sessions/d98217fcc75048689eda57d880f4e540
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
