### PR TITLE
ui: unify modules — destructive button, toast/ConfirmDialog, SectionHeading rollout

### DIFF
--- a/src/core/HubBackupPanel.jsx
+++ b/src/core/HubBackupPanel.jsx
@@ -1,10 +1,12 @@
 import { useRef } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
 import { applyHubBackupPayload, buildHubBackupPayload } from "./hubBackup.js";
 
 export function HubBackupPanel({ className }) {
   const fileRef = useRef(null);
+  const toast = useToast();
 
   const exportJson = () => {
     const payload = buildHubBackupPayload({ includeChat: false });
@@ -28,7 +30,7 @@ export function HubBackupPanel({ className }) {
         applyHubBackupPayload(data);
         window.location.reload();
       } catch (err) {
-        alert(err?.message || "Не вдалось імпортувати файл");
+        toast.error(err?.message || "Не вдалось імпортувати файл");
       }
       e.target.value = "";
     };

--- a/src/core/HubReports.jsx
+++ b/src/core/HubReports.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
 import { generateInsights } from "./lib/insightsEngine";
 import {
@@ -446,9 +447,9 @@ export function HubReports() {
 
       {insights.length >= 2 ? (
         <div className="space-y-3">
-          <p className="text-xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="p" size="sm">
             Інсайти
-          </p>
+          </SectionHeading>
           {insights.map((ins) => (
             <InsightCard key={ins.id} {...ins} />
           ))}

--- a/src/modules/finyk/components/CategoryManager.jsx
+++ b/src/modules/finyk/components/CategoryManager.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
@@ -201,9 +202,9 @@ export function CategoryManager({
 
   return (
     <div>
-      <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+      <SectionHeading as="div" size="sm" className="mb-3">
         Власні категорії
-      </div>
+      </SectionHeading>
 
       {customCategories.length === 0 && !showForm && (
         <p className="text-sm text-muted mb-3">Власних категорій ще немає</p>

--- a/src/modules/finyk/components/RetroComparison.jsx
+++ b/src/modules/finyk/components/RetroComparison.jsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
 import {
   formatComparisonSummary,
@@ -109,9 +110,9 @@ export const RetroComparison = memo(function RetroComparison({
     >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="sm">
             Порівняння з попереднім місяцем
-          </div>
+          </SectionHeading>
           <p className="text-xs text-subtle/80 mt-1 capitalize">
             vs {formatMonthKeyLabel(comparison.previousMonth)}
           </p>

--- a/src/modules/finyk/components/budgets/MonthlyPlanCard.jsx
+++ b/src/modules/finyk/components/budgets/MonthlyPlanCard.jsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 
 // Merged monthly-plan block: income/expense/savings inputs + fact summary +
@@ -24,9 +25,9 @@ function MonthlyPlanCardComponent({
         isOver ? "border-danger/40" : "border-line",
       )}
     >
-      <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+      <SectionHeading as="div" size="sm" className="mb-3">
         Фінплан на місяць
-      </div>
+      </SectionHeading>
       <div className="space-y-2">
         <Input
           type="number"

--- a/src/modules/finyk/pages/Analytics.jsx
+++ b/src/modules/finyk/pages/Analytics.jsx
@@ -7,6 +7,7 @@ import {
   useRef,
   Suspense,
 } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
@@ -37,9 +38,9 @@ const Section = memo(function Section({ title, children, className }) {
         className,
       )}
     >
-      <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-4">
+      <SectionHeading as="div" size="sm" className="mb-4">
         {title}
-      </div>
+      </SectionHeading>
       {children}
     </div>
   );

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -3,6 +3,7 @@ import { DebtCard } from "../components/DebtCard";
 import { SubCard } from "../components/SubCard";
 import { RecurringSuggestions } from "../components/RecurringSuggestions";
 import { TxRow } from "../components/TxRow";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -551,9 +552,9 @@ export function Assets({
         />
         {open.assets && (
           <div className="mb-3 space-y-2">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
+            <SectionHeading as="div" size="sm" className="pt-1">
               💳 Картки Monobank
-            </div>
+            </SectionHeading>
             {accounts
               .filter((a) => !hiddenAccounts.includes(a.id))
               .map((a, i) => (
@@ -582,9 +583,9 @@ export function Assets({
                 </div>
               ))}
 
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-2">
+            <SectionHeading as="div" size="sm" className="pt-2">
               💰 Мені винні
-            </div>
+            </SectionHeading>
             {receivables.map((r) => (
               <DebtCard
                 key={r.id}
@@ -680,9 +681,9 @@ export function Assets({
               </button>
             )}
 
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-2">
+            <SectionHeading as="div" size="sm" className="pt-2">
               🏦 Інші активи
-            </div>
+            </SectionHeading>
             {manualAssets.map((a, i) => (
               <div
                 key={i}

--- a/src/modules/finyk/pages/Budgets.jsx
+++ b/src/modules/finyk/pages/Budgets.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback } from "react";
 import { useMutation, useQueries } from "@tanstack/react-query";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { calcCategorySpent, resolveExpenseCategoryMeta } from "../utils";
@@ -385,9 +386,9 @@ export function Budgets({ mono, storage }) {
         />
 
         {/* Limits */}
-        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="sm">
           Ліміти · {monthStart.toLocaleDateString("uk-UA", { month: "long" })}
-        </div>
+        </SectionHeading>
         {limitBudgets.length === 0 && (
           <EmptyState
             compact
@@ -458,9 +459,9 @@ export function Budgets({ mono, storage }) {
         {/* Forecast — shown whenever there are limit budgets to avoid layout shifts */}
         {limitBudgets.length > 0 && (
           <>
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
+            <SectionHeading as="div" size="sm" className="pt-1">
               Прогноз · кінець місяця
-            </div>
+            </SectionHeading>
             {loadingTx && forecasts.length === 0 ? (
               limitBudgets.map((b) => (
                 <Skeleton key={b.id} className="h-64 rounded-2xl" />
@@ -499,9 +500,9 @@ export function Budgets({ mono, storage }) {
         )}
 
         {/* Goals */}
-        <div className="text-xs font-bold text-subtle uppercase tracking-widest pt-1">
+        <SectionHeading as="div" size="sm" className="pt-1">
           Цілі накопичення
-        </div>
+        </SectionHeading>
         {goalBudgets.length === 0 && (
           <EmptyState
             compact

--- a/src/modules/fizruk/components/PhotoProgress.tsx
+++ b/src/modules/fizruk/components/PhotoProgress.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
 import { useBodyPhotos } from "../hooks/useBodyPhotos";
@@ -272,9 +273,9 @@ export function PhotoProgress() {
       aria-label="Фото-прогрес"
     >
       <div className="flex items-center justify-between gap-3 mb-3">
-        <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="h2" size="sm">
           Фото-прогрес
-        </h2>
+        </SectionHeading>
         {photos.length >= 2 && (
           <button
             type="button"

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
+import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 
 function uid(prefix = "g") {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -23,6 +25,7 @@ export function WorkoutTemplatesSection({
   const [groups, setGroups] = useState([]);
   const [groupSelectMode, setGroupSelectMode] = useState(false);
   const [groupSelected, setGroupSelected] = useState(new Set());
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
   const pickList = useMemo(() => search(q).slice(0, 40), [search, q]);
 
@@ -156,9 +159,9 @@ export function WorkoutTemplatesSection({
             aria-label="Назва шаблону"
           />
           <div>
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+            <SectionHeading as="div" size="xs" className="mb-2">
               Додати вправу з каталогу
-            </div>
+            </SectionHeading>
             <Input
               placeholder="Пошук…"
               value={q}
@@ -186,9 +189,9 @@ export function WorkoutTemplatesSection({
 
           <div>
             <div className="flex items-center justify-between mb-2">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+              <SectionHeading as="div" size="xs">
                 Порядок ({orderIds.length})
-              </div>
+              </SectionHeading>
               {orderIds.length >= 2 && !groupSelectMode && (
                 <button
                   type="button"
@@ -357,9 +360,9 @@ export function WorkoutTemplatesSection({
 
       <Card radius="lg" padding="none" className="overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="sm">
             Збережені шаблони
-          </div>
+          </SectionHeading>
         </div>
         {(templates || []).length === 0 ? (
           <div className="p-6 text-center text-sm text-subtle">
@@ -408,9 +411,7 @@ export function WorkoutTemplatesSection({
                   size="sm"
                   variant="danger"
                   className="h-10 min-w-[44px] px-3"
-                  onClick={() => {
-                    if (confirm("Видалити шаблон?")) removeTemplate(t.id);
-                  }}
+                  onClick={() => setConfirmDeleteId(t.id)}
                 >
                   ✕
                 </Button>
@@ -419,6 +420,19 @@ export function WorkoutTemplatesSection({
           ))
         )}
       </Card>
+      <ConfirmDialog
+        open={confirmDeleteId != null}
+        title="Видалити шаблон?"
+        description="Цю дію неможливо відмінити."
+        confirmLabel="Видалити"
+        cancelLabel="Скасувати"
+        danger
+        onConfirm={() => {
+          if (confirmDeleteId != null) removeTemplate(confirmDeleteId);
+          setConfirmDeleteId(null);
+        }}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </div>
   );
 }

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useId, useMemo, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { recoveryConflictsForWorkoutItem } from "../../lib/recoveryConflict";
 import {
@@ -374,9 +375,9 @@ export function ActiveWorkoutPanel({
 
           <div className="mt-2">
             <div className="rounded-2xl border border-line bg-panelHi px-3">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
+              <SectionHeading as="div" size="xs" className="pt-2">
                 Тип
-              </div>
+              </SectionHeading>
               <select
                 className="w-full h-10 bg-transparent text-sm text-text outline-none disabled:opacity-70"
                 value={it.type || "strength"}
@@ -519,9 +520,9 @@ export function ActiveWorkoutPanel({
               {!activeWorkout.endedAt && !group && (
                 <div className="flex flex-wrap items-center gap-2 mt-2 pt-2 border-t border-line">
                   <div className="flex items-center justify-between w-full gap-1">
-                    <span className="text-2xs font-bold text-subtle uppercase tracking-widest">
+                    <SectionHeading as="span" size="xs">
                       Таймер відпочинку
-                    </span>
+                    </SectionHeading>
                     <span className="text-3xs text-muted">
                       {catLabel} · реком. {defSec}с
                     </span>
@@ -705,9 +706,9 @@ export function ActiveWorkoutPanel({
           {groupItems.map((gIt) => renderItem(gIt))}
           {!activeWorkout?.endedAt && (
             <div className="flex flex-wrap items-center gap-2 px-1 pt-1 border-t border-success/20">
-              <span className="text-2xs font-bold text-subtle uppercase tracking-widest w-full">
+              <SectionHeading as="span" size="xs" className="w-full">
                 Спільний таймер відпочинку між колами
-              </span>
+              </SectionHeading>
               <button
                 type="button"
                 className="min-h-[40px] px-3 rounded-xl border-2 border-success bg-success/10 text-sm font-semibold text-success hover:bg-success/20 transition-colors"

--- a/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
@@ -69,9 +70,9 @@ export function AddExerciseSheet({
         />
 
         <div className="rounded-2xl border border-line bg-panelHi px-3">
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
+          <SectionHeading as="div" size="xs" className="pt-2">
             Основна група
-          </div>
+          </SectionHeading>
           <select
             className="w-full min-h-[44px] bg-transparent text-sm text-text outline-none py-2"
             value={form.primaryGroup}
@@ -94,9 +95,9 @@ export function AddExerciseSheet({
         </div>
 
         <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="xs">
             Обладнання
-          </div>
+          </SectionHeading>
           <div className="py-2 flex flex-wrap gap-2">
             {EQUIPMENT_OPTIONS.map((o) => {
               const active = (form.equipment || []).includes(o.id);
@@ -126,9 +127,9 @@ export function AddExerciseSheet({
         </div>
 
         <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="xs">
             Основні мʼязи
-          </div>
+          </SectionHeading>
           <div className="flex flex-wrap gap-1.5 mt-2">
             {suggestedMuscles.map((id) => (
               <button
@@ -154,9 +155,9 @@ export function AddExerciseSheet({
         </div>
 
         <div className="rounded-2xl border border-line bg-panelHi px-3 py-2">
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="xs">
             Супутні мʼязи
-          </div>
+          </SectionHeading>
           <div className="flex flex-wrap gap-1.5 mt-2">
             {suggestedMuscles.map((id) => (
               <button

--- a/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
@@ -90,9 +91,9 @@ export function ExerciseDetailSheet({
       )}
 
       <div className="space-y-2">
-        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="sm">
           Мʼязи
-        </div>
+        </SectionHeading>
         <div className="flex flex-wrap gap-1.5">
           {(selected?.muscles?.primary || []).map((m) => (
             <span
@@ -114,9 +115,9 @@ export function ExerciseDetailSheet({
       </div>
 
       <div className="mt-4 space-y-2">
-        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="sm">
           Обладнання
-        </div>
+        </SectionHeading>
         <div className="flex flex-wrap gap-1.5">
           {(selected.equipmentUk || selected.equipment || []).map((eq) => (
             <span
@@ -131,9 +132,9 @@ export function ExerciseDetailSheet({
 
       {selected.tips?.length ? (
         <div className="mt-4">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-2">
+          <SectionHeading as="div" size="sm" className="mb-2">
             Підказки
-          </div>
+          </SectionHeading>
           <ul className="space-y-1.5">
             {selected.tips.map((t, i) => (
               <li key={i} className="text-sm text-text leading-relaxed">

--- a/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
+++ b/src/modules/fizruk/components/workouts/RestTimerOverlay.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { formatRestClock } from "../../lib/workoutUi";
 
@@ -47,9 +48,9 @@ export function RestTimerOverlay({ restTimer, onCancel }) {
             </svg>
           </div>
           <div>
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="xs">
               Відпочинок
-            </div>
+            </SectionHeading>
             <div
               className={
                 "text-3xl font-extrabold tabular-nums leading-tight " +

--- a/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
@@ -1,5 +1,7 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
 import {
   applyFizrukBackupPayload,
@@ -9,6 +11,8 @@ import {
 export function WorkoutBackupBar({ className }) {
   const fileRef = useRef(null);
   const fileReplaceRef = useRef(null);
+  const toast = useToast();
+  const [confirmReplace, setConfirmReplace] = useState(false);
 
   const exportJson = () => {
     const payload = buildFizrukBackupPayload();
@@ -32,7 +36,7 @@ export function WorkoutBackupBar({ className }) {
         applyFizrukBackupPayload(data, { replace });
         window.location.reload();
       } catch (err) {
-        alert((err as Error)?.message || "Не вдалось імпортувати файл");
+        toast.error((err as Error)?.message || "Не вдалось імпортувати файл");
       }
       e.target.value = "";
     };
@@ -73,14 +77,7 @@ export function WorkoutBackupBar({ className }) {
           size="sm"
           className="h-9 min-h-[44px] text-warning"
           type="button"
-          onClick={() => {
-            if (
-              confirm(
-                "Замінити всі тренування та власні вправи даними з файлу?",
-              )
-            )
-              fileReplaceRef.current?.click();
-          }}
+          onClick={() => setConfirmReplace(true)}
         >
           Імпорт (замінити)
         </Button>
@@ -98,6 +95,19 @@ export function WorkoutBackupBar({ className }) {
         accept="application/json,.json"
         className="hidden"
         onChange={(e) => runImport(e, true)}
+      />
+      <ConfirmDialog
+        open={confirmReplace}
+        title="Замінити всі дані Фізрука?"
+        description="Поточні тренування та власні вправи буде замінено даними з файлу. Цю дію неможливо відмінити."
+        confirmLabel="Замінити"
+        cancelLabel="Скасувати"
+        danger
+        onConfirm={() => {
+          setConfirmReplace(false);
+          fileReplaceRef.current?.click();
+        }}
+        onCancel={() => setConfirmReplace(false)}
       />
     </div>
   );

--- a/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
@@ -43,9 +44,9 @@ export function WorkoutFinishSheets({
               Оціни по шкалі 1–5 (можна пропустити).
             </p>
             <div>
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="div" size="xs" className="mb-2">
                 Енергія
-              </div>
+              </SectionHeading>
               <div className="flex flex-wrap gap-2">
                 {[1, 2, 3, 4, 5].map((n) => (
                   <button
@@ -68,9 +69,9 @@ export function WorkoutFinishSheets({
               </div>
             </div>
             <div>
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="div" size="xs" className="mb-2">
                 Настрій
-              </div>
+              </SectionHeading>
               <div className="flex flex-wrap gap-2">
                 {[1, 2, 3, 4, 5].map((n) => (
                   <button

--- a/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { Virtuoso } from "react-virtuoso";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { compactToolbarButtonClass } from "@shared/components/ui/buttonPresets";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -194,9 +195,9 @@ export function WorkoutJournalSection({
 
       <Card radius="lg" padding="none" className="overflow-hidden">
         <div className="px-4 py-3 bg-panelHi/60 border-b border-line flex items-center justify-between gap-2">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="sm">
             Останні тренування
-          </div>
+          </SectionHeading>
           <button
             type="button"
             onClick={() => setRetroOpen((o) => !o)}
@@ -219,9 +220,9 @@ export function WorkoutJournalSection({
             </p>
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+                <SectionHeading as="div" size="xs" className="mb-1">
                   Дата
-                </div>
+                </SectionHeading>
                 <input
                   type="date"
                   className="w-full h-11 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"
@@ -230,9 +231,9 @@ export function WorkoutJournalSection({
                 />
               </div>
               <div>
-                <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+                <SectionHeading as="div" size="xs" className="mb-1">
                   Час початку
-                </div>
+                </SectionHeading>
                 <input
                   type="time"
                   className="w-full h-11 rounded-xl border border-line bg-panelHi px-3 text-sm text-text outline-none"

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
@@ -195,9 +196,9 @@ export function Body({ onOpenMeasurements }) {
         </div>
 
         <Card as="section" radius="lg" aria-label="Записати показники">
-          <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+          <SectionHeading as="h2" size="sm" className="mb-3">
             Записати сьогодні
-          </h2>
+          </SectionHeading>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-2 gap-3">
               <div>
@@ -247,9 +248,9 @@ export function Body({ onOpenMeasurements }) {
             </div>
 
             <div>
-              <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="p" size="xs" className="mb-2">
                 Рівень енергії
-              </p>
+              </SectionHeading>
               <div
                 className="flex gap-1.5"
                 role="group"
@@ -273,9 +274,9 @@ export function Body({ onOpenMeasurements }) {
             </div>
 
             <div>
-              <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="p" size="xs" className="mb-2">
                 Настрій
-              </p>
+              </SectionHeading>
               <div className="flex gap-1.5" role="group" aria-label="Настрій">
                 {[1, 2, 3, 4, 5].map((v) => (
                   <ScoreButton
@@ -330,9 +331,9 @@ export function Body({ onOpenMeasurements }) {
 
         {weightData.length >= 2 && (
           <Card as="section" radius="lg" aria-label="Динаміка ваги">
-            <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="h2" size="sm" className="mb-3">
               Динаміка ваги
-            </h2>
+            </SectionHeading>
             <MiniLineChart
               data={weightData}
               unit="кг"
@@ -344,9 +345,9 @@ export function Body({ onOpenMeasurements }) {
 
         {sleepData.length >= 2 && (
           <Card as="section" radius="lg" aria-label="Динаміка сну">
-            <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="h2" size="sm" className="mb-3">
               Сон
-            </h2>
+            </SectionHeading>
             <MiniLineChart
               data={sleepData}
               unit="год"
@@ -358,9 +359,9 @@ export function Body({ onOpenMeasurements }) {
 
         {energyData.length >= 2 && (
           <Card as="section" radius="lg" aria-label="Динаміка енергії">
-            <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="h2" size="sm" className="mb-3">
               Рівень енергії
-            </h2>
+            </SectionHeading>
             <MiniLineChart
               data={energyData}
               unit="/5"
@@ -372,9 +373,9 @@ export function Body({ onOpenMeasurements }) {
 
         {moodData.length >= 2 && (
           <Card as="section" radius="lg" aria-label="Динаміка настрою">
-            <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="h2" size="sm" className="mb-3">
               Настрій
-            </h2>
+            </SectionHeading>
             <MiniLineChart
               data={moodData}
               unit="/5"
@@ -388,9 +389,9 @@ export function Body({ onOpenMeasurements }) {
 
         {entries.length > 0 && (
           <Card as="section" radius="lg" aria-label="Журнал записів">
-            <h2 className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="h2" size="sm" className="mb-3">
               Журнал
-            </h2>
+            </SectionHeading>
             <div className="space-y-2">
               {entries.slice(0, 15).map((entry) => (
                 <div

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { useEffect, useMemo, useState } from "react";
@@ -363,9 +364,9 @@ export function Dashboard({
             return (
               <Card as="section" radius="lg" aria-label="Швидкий старт">
                 <div className="flex items-center justify-between gap-2 mb-3">
-                  <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+                  <SectionHeading as="h2" size="sm">
                     Швидкий старт
-                  </h2>
+                  </SectionHeading>
                   <span className="text-2xs text-muted">
                     {recentlyUsed.length > 0
                       ? "Нещодавно використані"
@@ -420,9 +421,9 @@ export function Dashboard({
           <Card as="section" radius="lg" aria-label="Програма сьогодні">
             <div className="flex items-center justify-between gap-2 mb-3">
               <div>
-                <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+                <SectionHeading as="h2" size="sm">
                   Програма: {activeProgram.name}
-                </h2>
+                </SectionHeading>
                 {todaySession ? (
                   <p className="text-sm font-semibold text-text mt-0.5">
                     {todaySession.name}
@@ -535,9 +536,9 @@ export function Dashboard({
               />
 
               <div className="mt-4 pt-3 border-t border-line">
-                <p className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+                <SectionHeading as="p" size="xs" className="mb-2">
                   Пріоритет після відпочинку
-                </p>
+                </SectionHeading>
                 <div className="flex flex-wrap gap-2">
                   {(plan.focus || []).map((m) => (
                     <span
@@ -682,9 +683,9 @@ export function Dashboard({
             </p>
           )}
           <div className="rounded-2xl border border-line bg-panelHi px-3">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest pt-2">
+            <SectionHeading as="div" size="xs" className="pt-2">
               Мій шаблон
-            </div>
+            </SectionHeading>
             <select
               className="w-full min-h-[44px] bg-transparent text-sm text-text outline-none"
               value={selectedTemplateId}

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useWorkouts } from "../hooks/useWorkouts";
@@ -47,9 +48,9 @@ function LoadCalculator({ oneRM }) {
   return (
     <Card radius="lg">
       <div className="flex items-baseline justify-between gap-2 mb-3">
-        <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="sm">
           Калькулятор навантаження
-        </div>
+        </SectionHeading>
         <div className="text-2xs text-subtle">1RM = {fmt(oneRM, 0)} кг</div>
       </div>
       <div className="space-y-3">
@@ -441,9 +442,9 @@ export function Exercise({ exerciseId }) {
 
         <div className="grid grid-cols-2 gap-3">
           <Card radius="lg">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="xs">
               Особистий рекорд
-            </div>
+            </SectionHeading>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
               {best.best1rm ? `${fmt(best.best1rm, 0)} кг` : "—"}
             </div>
@@ -463,9 +464,9 @@ export function Exercise({ exerciseId }) {
             )}
           </Card>
           <Card radius="lg">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="xs">
               Наступного разу
-            </div>
+            </SectionHeading>
             <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">
               {suggestedNext ? `${fmt(suggestedNext.weightKg, 1)} кг` : "—"}
             </div>
@@ -489,9 +490,9 @@ export function Exercise({ exerciseId }) {
 
         {hasStrength && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="div" size="sm" className="mb-3">
               Прогресія 1RM (за тижнями)
-            </div>
+            </SectionHeading>
             <ProgressChart
               points={progressData.rmPoints}
               label="1RM"
@@ -503,9 +504,9 @@ export function Exercise({ exerciseId }) {
 
         {hasStrength && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="div" size="sm" className="mb-3">
               Обʼєм тренування (кг × повтори, за тижнями)
-            </div>
+            </SectionHeading>
             <ProgressChart
               points={progressData.volPoints}
               label="Обсяг"
@@ -517,9 +518,9 @@ export function Exercise({ exerciseId }) {
 
         {hasCardio && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="div" size="sm" className="mb-3">
               Темп (хв/км) — кардіо
-            </div>
+            </SectionHeading>
             <ProgressChart
               points={cardioData.pacePoints}
               label="Темп"
@@ -534,9 +535,9 @@ export function Exercise({ exerciseId }) {
 
         {hasCardio && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="div" size="sm" className="mb-3">
               Дистанція (км) — кардіо
-            </div>
+            </SectionHeading>
             <ProgressChart
               points={cardioData.distPoints}
               label="Дистанція"
@@ -549,9 +550,9 @@ export function Exercise({ exerciseId }) {
         {best.best1rm > 0 && <LoadCalculator oneRM={best.best1rm} />}
 
         <Card radius="lg" padding="lg">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+          <SectionHeading as="div" size="sm" className="mb-3">
             Історія сетів
-          </div>
+          </SectionHeading>
           {history.length === 0 ? (
             <EmptyState
               compact

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
 import { Card } from "@shared/components/ui/Card";
@@ -70,9 +71,9 @@ export function Measurements() {
             </svg>
           </div>
           <div className="min-w-0">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="sm">
               Мануал
-            </div>
+            </SectionHeading>
             <div className="text-sm font-semibold text-success mt-0.5">
               Як правильно робити заміри →
             </div>
@@ -107,15 +108,15 @@ export function Measurements() {
         </div>
 
         <Card radius="lg">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+          <SectionHeading as="div" size="sm" className="mb-3">
             Додати замір
-          </div>
+          </SectionHeading>
           <div className="grid grid-cols-2 gap-2">
             {MEASURE_FIELDS.map((f) => (
               <div key={f.id} className="space-y-1">
-                <div className="text-2xs font-bold text-subtle uppercase tracking-widest px-1">
+                <SectionHeading as="div" size="xs" className="px-1">
                   {f.label} · {f.unit}
-                </div>
+                </SectionHeading>
                 <input
                   className={inp}
                   inputMode="decimal"
@@ -153,12 +154,12 @@ export function Measurements() {
           <Card radius="lg">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+                <SectionHeading as="div" size="sm">
                   Останній замір{" "}
                   <span className="ml-1 normal-case tracking-normal font-medium text-subtle">
                     · {stats.latestAt}
                   </span>
-                </div>
+                </SectionHeading>
               </div>
               <div className="text-xs text-subtle">
                 {Object.keys(deltas).length ? "Δ від попереднього" : ""}
@@ -170,9 +171,9 @@ export function Measurements() {
                   key={f.id}
                   className="bg-bg border border-line rounded-2xl p-3"
                 >
-                  <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+                  <SectionHeading as="div" size="xs">
                     {f.label}
-                  </div>
+                  </SectionHeading>
                   <div className="text-lg font-extrabold tabular-nums text-text mt-1">
                     {Number.isFinite(Number(latest[f.id]))
                       ? Number(latest[f.id]).toLocaleString("uk-UA")
@@ -198,9 +199,9 @@ export function Measurements() {
 
         <Card radius="lg" padding="none" className="overflow-hidden">
           <div className="px-4 py-3 bg-panelHi/60 border-b border-line">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="sm">
               Історія
-            </div>
+            </SectionHeading>
           </div>
           {(entries || []).map((e) => (
             <div

--- a/src/modules/fizruk/pages/Programs.tsx
+++ b/src/modules/fizruk/pages/Programs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
@@ -169,9 +170,9 @@ export function Programs({
 function ProgramDetails({ prog, exercises }) {
   return (
     <div className="border-t border-line px-4 pb-4 pt-3 space-y-3 bg-bg/50">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="div" size="xs">
         Розклад та вправи
-      </div>
+      </SectionHeading>
       {prog.schedule.map((schedEntry) => {
         const session = prog.sessions[schedEntry.sessionKey];
         if (!session) return null;

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { EmptyState } from "@shared/components/ui/EmptyState";
+import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useMeasurements } from "../hooks/useMeasurements";
@@ -29,6 +30,7 @@ function weekStartMs(d) {
 }
 
 export function Progress() {
+  const toast = useToast();
   const { workouts } = useWorkouts();
   const { entries } = useMeasurements();
   const { exercises, musclesUk } = useExerciseCatalog();
@@ -358,9 +360,9 @@ export function Progress() {
         {/* Cross-module activity */}
         {hasPushupData && (
           <Card radius="lg">
-            <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+            <SectionHeading as="div" size="sm" className="mb-3">
               Активність з інших модулів
-            </div>
+            </SectionHeading>
             <div className="flex items-center gap-3 mb-3">
               <div className="w-9 h-9 rounded-xl bg-fizruk/10 flex items-center justify-center shrink-0 text-base">
                 💪
@@ -549,9 +551,9 @@ export function Progress() {
           return (
             <Card radius="lg" padding="lg">
               <div className="flex items-center justify-between gap-2 mb-3">
-                <div className="text-xs font-bold text-subtle uppercase tracking-widest">
+                <SectionHeading as="div" size="sm">
                   Рекорди (PR) · {prs.length}
-                </div>
+                </SectionHeading>
                 {filtered.length !== prs.length && (
                   <div className="text-xs text-subtle">
                     {filtered.length} показано
@@ -668,9 +670,9 @@ export function Progress() {
 
         {/* Data management */}
         <Card radius="lg" padding="lg">
-          <div className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+          <SectionHeading as="div" size="sm" className="mb-3">
             Дані
-          </div>
+          </SectionHeading>
           <button
             type="button"
             className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white mb-2 transition-all active:scale-[0.98]"
@@ -702,7 +704,9 @@ export function Progress() {
             onChange={(e) => {
               const f = e.target.files?.[0];
               if (!f) return;
-              importJson(f).catch(() => alert("Не вдалося імпортувати файл"));
+              importJson(f).catch(() =>
+                toast.error("Не вдалося імпортувати файл"),
+              );
             }}
           />
           <div className="mt-3">

--- a/src/modules/nutrition/components/DailyPlanCard.jsx
+++ b/src/modules/nutrition/components/DailyPlanCard.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -62,9 +63,9 @@ function MacroRatioBar({ prefs }) {
 
   return (
     <div className="mt-3 space-y-1.5">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="div" size="xs">
         Відсоткове співвідношення макро
-      </div>
+      </SectionHeading>
       <div className="flex rounded-lg overflow-hidden h-5">
         {pctP > 0 && (
           <div

--- a/src/modules/nutrition/components/ItemEditSheet.jsx
+++ b/src/modules/nutrition/components/ItemEditSheet.jsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
@@ -14,9 +15,9 @@ export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+          <SectionHeading as="div" size="xs" className="mb-1">
             Кількість
-          </div>
+          </SectionHeading>
           <Input
             value={itemEdit.qty}
             onChange={(e) =>
@@ -28,9 +29,9 @@ export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
           />
         </div>
         <div>
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+          <SectionHeading as="div" size="xs" className="mb-1">
             Одиниця
-          </div>
+          </SectionHeading>
           <Input
             value={itemEdit.unit}
             onChange={(e) =>

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
@@ -191,9 +192,9 @@ export function LogCard({
         </div>
 
         <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-2">
-          <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="div" size="xs">
             Пошук по журналу
-          </div>
+          </SectionHeading>
           <Input
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -326,9 +327,9 @@ export function LogCard({
 
         <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3 space-y-3">
           <div className="flex items-center justify-between gap-2">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="div" size="xs">
               Аналітика (тренди)
-            </div>
+            </SectionHeading>
             <div className="flex gap-2">
               {[30, 90].map((d) => (
                 <button
@@ -368,9 +369,9 @@ export function LogCard({
           </div>
 
           <div className="bg-panelHi rounded-2xl px-3 py-3">
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+            <SectionHeading as="div" size="xs" className="mb-2">
               Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
-            </div>
+            </SectionHeading>
             {statsRows.length === 0 ? (
               <div className="text-xs text-muted">Поки що порожньо</div>
             ) : (
@@ -397,9 +398,9 @@ export function LogCard({
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="div" size="xs" className="mb-2">
                 Топ страв
-              </div>
+              </SectionHeading>
               {statsTop.length === 0 ? (
                 <div className="text-xs text-muted">Поки що порожньо</div>
               ) : (
@@ -421,9 +422,9 @@ export function LogCard({
               )}
             </div>
             <div className="bg-panelHi rounded-2xl px-3 py-3">
-              <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+              <SectionHeading as="div" size="xs" className="mb-2">
                 Розподіл прийомів
-              </div>
+              </SectionHeading>
               {Object.keys(statsMealTypes).length === 0 ? (
                 <div className="text-xs text-muted">Поки що порожньо</div>
               ) : (
@@ -545,9 +546,9 @@ function VirtualMealList({
           return (
             <div className="flex items-center gap-2 pt-2 pb-1">
               <span className="text-base">{meta.emoji}</span>
-              <span className="text-xs font-bold text-subtle uppercase tracking-widest">
+              <SectionHeading as="span" size="sm">
                 {meta.label}
-              </span>
+              </SectionHeading>
             </div>
           );
         }

--- a/src/modules/nutrition/components/PantryManagerSheet.jsx
+++ b/src/modules/nutrition/components/PantryManagerSheet.jsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
@@ -73,9 +74,9 @@ export function PantryManagerSheet({
       </div>
 
       <div className="rounded-2xl border border-line bg-panelHi p-4">
-        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="xs">
           {pantryForm.mode === "rename" ? "Нова назва" : "Назва складу"}
-        </div>
+        </SectionHeading>
         <div className="mt-2">
           <Input
             value={pantryForm.name}

--- a/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/BarcodeSection.jsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 
@@ -12,9 +13,9 @@ export function BarcodeSection({
 }) {
   return (
     <div className="mb-4 rounded-2xl border border-line bg-panel/40 px-3 py-3">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+      <SectionHeading as="div" size="xs" className="mb-2">
         Штрихкод
-      </div>
+      </SectionHeading>
       <div className="flex flex-wrap gap-2 items-center">
         <Input
           value={barcode}

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
 import { FoodHitRow } from "./FoodHitRow.jsx";
@@ -51,9 +52,9 @@ export function FoodPickerSection({
   return (
     <div className="mb-4 space-y-2">
       <div className="flex items-center justify-between gap-2">
-        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="xs">
           Продукт
-        </div>
+        </SectionHeading>
         {(foodBusy || offBusy) && (
           <span className="text-2xs text-subtle flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 border border-nutrition/40 border-t-nutrition rounded-full animate-spin" />

--- a/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FromPantryRow.jsx
@@ -1,4 +1,5 @@
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 
 export function FromPantryRow({
   pantryItems,
@@ -10,14 +11,14 @@ export function FromPantryRow({
   if (!pantryItems || pantryItems.length === 0) return null;
   return (
     <div className="mb-4 rounded-2xl border border-line bg-panel/40 px-3 py-3">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+      <SectionHeading as="div" size="xs" className="mb-2">
         Зі складу
         {fromPantryItem && (
           <span className="ml-2 text-nutrition font-semibold normal-case tracking-normal">
             · {fromPantryItem}
           </span>
         )}
-      </div>
+      </SectionHeading>
       <div className="flex flex-wrap gap-1.5">
         {pantryItems.slice(0, 20).map((item) => {
           const isActive = fromPantryItem === item.name;

--- a/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MacrosEditor.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { emptyForm } from "./mealFormUtils.js";
@@ -39,9 +40,9 @@ export function MacrosEditor({
   return (
     <div className="mb-1">
       <div className="flex items-center justify-between mb-2">
-        <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="div" size="xs">
           {pickedFood ? "КБЖВ (редагувати вручну)" : "КБЖВ"}
-        </div>
+        </SectionHeading>
         {hasPhotoMacros && (
           <button
             type="button"
@@ -69,9 +70,9 @@ export function MacrosEditor({
           { key: "carbs_g", label: "Вуглев. г", placeholder: "60" },
         ].map(({ key, label, placeholder }) => (
           <div key={key}>
-            <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+            <SectionHeading as="div" size="xs" className="mb-1">
               {label}
-            </div>
+            </SectionHeading>
             <Input
               value={form[key]}
               onChange={handleMacroChange(key)}

--- a/src/modules/nutrition/components/meal-sheet/MealTemplatesRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MealTemplatesRow.jsx
@@ -1,10 +1,12 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+
 export function MealTemplatesRow({ mealTemplates, setForm, onSelected }) {
   if (!Array.isArray(mealTemplates) || mealTemplates.length === 0) return null;
   return (
     <div className="mb-4">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+      <SectionHeading as="div" size="xs" className="mb-2">
         Шаблони
-      </div>
+      </SectionHeading>
       <div className="flex flex-wrap gap-2">
         {mealTemplates.map((t) => (
           <button

--- a/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MealTypePicker.jsx
@@ -1,12 +1,13 @@
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { MEAL_TYPES } from "../../lib/mealTypes.js";
 
 export function MealTypePicker({ mealType, setForm }) {
   return (
     <div className="mb-4">
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-2">
+      <SectionHeading as="div" size="xs" className="mb-2">
         Прийом їжі
-      </div>
+      </SectionHeading>
       <div className="flex gap-2 flex-wrap">
         {MEAL_TYPES.map((mt) => (
           <button

--- a/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseMealSpeech } from "../../../../core/lib/speechParsers.js";
@@ -25,7 +26,11 @@ export function NameTimeRow({ form, field, setForm }) {
   return (
     <div className="grid grid-cols-[1fr_auto] gap-3 mb-4">
       <div>
-        <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1 flex items-center gap-2">
+        <SectionHeading
+          as="div"
+          size="xs"
+          className="mb-1 flex items-center gap-2"
+        >
           Назва страви
           <VoiceMicButton
             size="sm"
@@ -33,7 +38,7 @@ export function NameTimeRow({ form, field, setForm }) {
             onError={(e) => setForm((s) => ({ ...s, err: e }))}
             label="Голосовий ввід страви"
           />
-        </div>
+        </SectionHeading>
         <Input
           value={form.name}
           onChange={(e) => field("name")(e.target.value)}
@@ -42,9 +47,9 @@ export function NameTimeRow({ form, field, setForm }) {
         />
       </div>
       <div>
-        <div className="text-2xs font-bold text-subtle uppercase tracking-widest mb-1">
+        <SectionHeading as="div" size="xs" className="mb-1">
           Час
-        </div>
+        </SectionHeading>
         <Input
           type="time"
           value={form.time}

--- a/src/modules/routine/components/DayReportSheet.tsx
+++ b/src/modules/routine/components/DayReportSheet.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
 import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
@@ -43,9 +44,9 @@ export function DayReportSheet({
 
       {done.length > 0 && (
         <div className="mb-4">
-          <p className="text-2xs font-bold uppercase tracking-widest text-subtle mb-2">
+          <SectionHeading as="p" size="xs" className="mb-2">
             Виконано ({done.length})
-          </p>
+          </SectionHeading>
           <ul className="space-y-1.5">
             {done.map((h) => (
               <li
@@ -74,9 +75,9 @@ export function DayReportSheet({
 
       {missed.length > 0 && (
         <div>
-          <p className="text-2xs font-bold uppercase tracking-widest text-subtle mb-2">
+          <SectionHeading as="p" size="xs" className="mb-2">
             Пропущено ({missed.length})
-          </p>
+          </SectionHeading>
           <ul className="space-y-1.5">
             {missed.map((h) => (
               <li

--- a/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/src/modules/routine/components/HabitDetailSheet.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import {
   dateKeyFromDate,
@@ -224,9 +225,9 @@ export function HabitDetailSheet({
       </div>
 
       <section className="mb-5" aria-label="Статистика">
-        <h3 className="text-xs font-bold text-subtle uppercase tracking-widest mb-2">
+        <SectionHeading as="h3" size="sm" className="mb-2">
           Статистика
-        </h3>
+        </SectionHeading>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <div className={C.statCard}>
             <p className="text-2xl font-black text-text tabular-nums">
@@ -274,9 +275,9 @@ export function HabitDetailSheet({
 
       <section className="mb-5" aria-label="Календар виконань">
         <div className="flex items-center justify-between mb-2">
-          <h3 className="text-xs font-bold text-subtle uppercase tracking-widest">
+          <SectionHeading as="h3" size="sm">
             Календар
-          </h3>
+          </SectionHeading>
           <div className="flex items-center gap-2">
             <button
               type="button"
@@ -353,9 +354,9 @@ export function HabitDetailSheet({
 
       {notes.length > 0 && (
         <section className="mb-2" aria-label="Нотатки">
-          <h3 className="text-xs font-bold text-subtle uppercase tracking-widest mb-2">
+          <SectionHeading as="h3" size="sm" className="mb-2">
             Останні нотатки
-          </h3>
+          </SectionHeading>
           <ul className="space-y-1.5">
             {notes.map((n) => (
               <li

--- a/src/modules/routine/components/HabitHeatmap.tsx
+++ b/src/modules/routine/components/HabitHeatmap.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import type { Habit, RoutineState } from "../lib/types";
 
@@ -134,9 +135,9 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
 
   return (
     <Card ref={rootRef} radius="lg">
-      <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+      <SectionHeading as="p" size="sm" className="mb-3">
         Активність за рік
-      </p>
+      </SectionHeading>
 
       <div className="overflow-x-auto -mx-1 px-1 pb-1">
         <div style={{ display: "flex", gap: 0, alignItems: "flex-start" }}>

--- a/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { habitCompletionRate } from "../lib/streaks.js";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import type { Habit, RoutineState } from "../lib/types";
 
@@ -38,9 +39,9 @@ export function HabitLeadersBlock({
 
   return (
     <Card radius="lg">
-      <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+      <SectionHeading as="p" size="sm" className="mb-3">
         Лідери та аутсайдери (30 днів)
-      </p>
+      </SectionHeading>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div className="rounded-xl border border-routine-line/40 dark:border-routine/20 bg-routine-surface/30 dark:bg-routine/8 p-3">
           <p className="text-2xs uppercase tracking-wide text-subtle mb-1">

--- a/src/modules/routine/components/PushupsWidget.tsx
+++ b/src/modules/routine/components/PushupsWidget.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect, type ChangeEvent } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { Card } from "@shared/components/ui/Card";
 import { useRoutinePushups } from "../hooks/useRoutinePushups.js";
@@ -30,9 +31,9 @@ export function PushupsWidget() {
       <Card as="section" radius="lg" aria-label="Відтискання">
         <div className="flex items-center justify-between gap-2">
           <div>
-            <p className="text-xs font-bold text-subtle uppercase tracking-widest">
+            <SectionHeading as="p" size="sm">
               Відтискання сьогодні
-            </p>
+            </SectionHeading>
             <p className="text-4xl font-black text-text tabular-nums mt-1">
               {todayCount}
             </p>

--- a/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/src/modules/routine/components/RoutineBackupSection.tsx
@@ -1,4 +1,5 @@
 import { useRef, type ChangeEvent } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
@@ -27,9 +28,9 @@ export function RoutineBackupSection({
 
   return (
     <Card as="section" radius="lg" padding="md" className="space-y-3">
-      <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="h2" size="sm">
         Резервна копія
-      </h2>
+      </SectionHeading>
       <p className="text-xs text-subtle">
         Експорт/імпорт JSON для переносу даних між пристроями.
       </p>

--- a/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -249,9 +250,9 @@ export function RoutineCalendarPanel({
       />
 
       <div className="flex flex-wrap gap-1.5 items-center">
-        <span className="text-2xs font-bold text-subtle uppercase tracking-widest w-full sm:w-auto">
+        <SectionHeading as="span" size="xs" className="w-full sm:w-auto">
           Теги
-        </span>
+        </SectionHeading>
         <button
           type="button"
           onClick={() => setTagFilter(null)}
@@ -477,9 +478,9 @@ export function RoutineCalendarPanel({
             itemContent={(_, item) => {
               if (item.kind === "header") {
                 return (
-                  <h3 className="text-xs font-bold text-subtle uppercase tracking-widest mb-2 mt-3">
+                  <SectionHeading as="h3" size="sm" className="mb-2 mt-3">
                     {item.label}
-                  </h3>
+                  </SectionHeading>
                 );
               }
               const e = item.e;

--- a/src/modules/routine/components/RoutineStatsPanel.tsx
+++ b/src/modules/routine/components/RoutineStatsPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import { PushupsWidget } from "./PushupsWidget";
 import { HabitHeatmap } from "./HabitHeatmap";
@@ -67,9 +68,9 @@ export function RoutineStatsPanel({
       className="space-y-4"
     >
       <Card as="section" radius="lg" aria-label="Зведена статистика">
-        <p className="text-xs font-bold text-subtle uppercase tracking-widest mb-3">
+        <SectionHeading as="p" size="sm" className="mb-3">
           Зведення
-        </p>
+        </SectionHeading>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
           <div className={C.statCard}>
             <p className="text-2xs uppercase tracking-wide text-subtle">

--- a/src/modules/routine/components/settings/ActiveHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ActiveHabitsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -55,9 +56,9 @@ export function ActiveHabitsSection({
 
   return (
     <Card as="section" radius="lg" padding="md" className="space-y-2">
-      <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="h2" size="sm">
         Активні звички
-      </h2>
+      </SectionHeading>
       <p className="text-2xs text-subtle leading-snug">
         Порядок у списку = порядок у календарі. На десктопі можна перетягнути;
         на телефоні — кнопки ↑↓. Для клавіатури та скрінрідерів зручніші кнопки

--- a/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
+++ b/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
@@ -1,4 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { setHabitArchived } from "../../lib/routineStorage.js";
@@ -25,9 +26,9 @@ export function ArchivedHabitsSection({
       padding="md"
       className="space-y-2 opacity-95"
     >
-      <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="h2" size="sm">
         Архів
-      </h2>
+      </SectionHeading>
       <p className="text-2xs text-subtle">
         Не показуються в календарі; відмітки збережені.
       </p>

--- a/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -1,5 +1,6 @@
 import { useState, type Dispatch, type SetStateAction } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -35,9 +36,9 @@ export function CategoriesSection({
   return (
     <>
       <Card as="section" radius="lg" padding="md" className="space-y-3">
-        <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+        <SectionHeading as="h2" size="sm">
           {editingCatId ? "Редагувати категорію" : "Категорії"}
-        </h2>
+        </SectionHeading>
         <div className="flex flex-wrap gap-2 items-stretch">
           <Input
             className="routine-touch-field w-16 shrink-0"

--- a/src/modules/routine/components/settings/HabitForm.tsx
+++ b/src/modules/routine/components/settings/HabitForm.tsx
@@ -7,6 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -82,9 +83,9 @@ export function HabitForm({
 
   return (
     <Card as="section" ref={sectionRef} radius="lg" className="space-y-3">
-      <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="h2" size="sm">
         {editingId ? "Редагувати звичку" : "Нова звичка"}
-      </h2>
+      </SectionHeading>
 
       <div className="flex gap-2 items-stretch">
         <Input

--- a/src/modules/routine/components/settings/TagsSection.tsx
+++ b/src/modules/routine/components/settings/TagsSection.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -33,9 +34,9 @@ export function TagsSection({
 
   return (
     <Card as="section" radius="lg" padding="md" className="space-y-3">
-      <h2 className="text-xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="h2" size="sm">
         Теги
-      </h2>
+      </SectionHeading>
       <div className="flex gap-2 items-stretch">
         <Input
           className="routine-touch-field min-w-0 flex-1"

--- a/src/shared/components/ui/Button.tsx
+++ b/src/shared/components/ui/Button.tsx
@@ -8,7 +8,8 @@ import { cn } from "../../lib/cn";
  * - primary: Main CTA, emerald brand color
  * - secondary: Secondary actions, outlined
  * - ghost: Minimal, text-only actions
- * - danger: Destructive actions
+ * - danger: Soft destructive affordance (red-tinted, for inline "Delete" chips)
+ * - destructive: Solid destructive CTA (use for confirmation dialogs / primary delete buttons)
  * - success: Confirmation actions
  *
  * Module-specific variants:
@@ -23,6 +24,7 @@ export type ButtonVariant =
   | "secondary"
   | "ghost"
   | "danger"
+  | "destructive"
   | "success"
   | "finyk"
   | "fizruk"
@@ -45,6 +47,8 @@ const variants: Record<ButtonVariant, string> = {
     "bg-transparent text-muted hover:bg-panelHi hover:text-text active:bg-line/50",
   danger:
     "bg-red-50 text-red-600 border border-red-200/50 hover:bg-red-100 hover:border-red-300 active:scale-[0.98]",
+  destructive:
+    "bg-danger text-white shadow-sm hover:bg-red-600 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 active:scale-[0.98]",
 

--- a/src/shared/components/ui/Card.tsx
+++ b/src/shared/components/ui/Card.tsx
@@ -13,11 +13,24 @@ import { cn } from "../../lib/cn";
  * - default: Standard panel card
  * - interactive: Hover lift effect for clickable cards
  * - flat: No shadow, minimal border
+ * - elevated: Soft float shadow for hero/preview surfaces
+ * - ghost: Transparent (use only when nesting in a coloured wrapper)
  *
  * Plus module-branded variants (finyk, fizruk, routine, nutrition) and
- * their soft counterparts.
+ * their soft counterparts (`*-soft`).
  *
  * Padding: none | sm | md (default) | lg | xl.
+ *
+ * Radius hierarchy (canonical):
+ *   - md  → rounded-xl  (16px) — inline / list cards & chips
+ *   - lg  → rounded-2xl (24px) — section/panel cards (DEFAULT for content
+ *                                blocks inside a page)
+ *   - xl  → rounded-3xl (32px) — hero & module-branded cards (the four
+ *                                module variants bake this in already)
+ *
+ * The default `radius="xl"` matches the largest hero treatment so that
+ * branded cards and `<Card variant="default" radius="xl">` wrappers feel
+ * consistent. Use `radius="lg"` for the typical settings/list panel.
  */
 
 export type CardVariant =

--- a/src/shared/components/ui/ConfirmDialog.tsx
+++ b/src/shared/components/ui/ConfirmDialog.tsx
@@ -69,11 +69,8 @@ export function ConfirmDialog({
         )}
         <div className="flex flex-col gap-2">
           <Button
-            variant={danger ? "danger" : "primary"}
-            className={cn(
-              "w-full h-12",
-              danger && "!bg-danger !text-white border-0",
-            )}
+            variant={danger ? "destructive" : "primary"}
+            className="w-full h-12"
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/src/shared/components/ui/Stat.tsx
+++ b/src/shared/components/ui/Stat.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "../../lib/cn";
 
 /**
@@ -7,7 +8,7 @@ import { cn } from "../../lib/cn";
  * The canonical "eyebrow + big number + sublabel" triple that repeats
  * dozens of times across Fizruk dashboards and Finyk summaries:
  *
- *   <div className="text-2xs font-bold text-subtle uppercase tracking-widest">Вага</div>
+ *   <SectionHeading as="div" size="xs">Вага</SectionHeading>
  *   <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">82 кг</div>
  *   <div className="text-xs text-subtle mt-1">+0.4 кг</div>
  *
@@ -77,9 +78,9 @@ export function Stat({
 
   return (
     <div className={cn(alignClass, className)}>
-      <div className="text-2xs font-bold text-subtle uppercase tracking-widest">
+      <SectionHeading as="div" size="xs">
         {label}
-      </div>
+      </SectionHeading>
       <div
         className={cn(
           "mt-1 flex items-baseline gap-1.5",


### PR DESCRIPTION
## Summary

Phase 1 of the UI/UX unification audit ([report attached in conversation thread](https://app.devin.ai/sessions/68ff8d9e87564418a2ff58a2220ba243)).
The goal: make all four modules (Фінік, Фізрук, Рутина, Харчування) feel like one product by adopting the existing design-system primitives that were sitting underused.

### Changes by phase

**Phase 1a — `Button` design-system fix** (2 files)
- New `variant="destructive"` for solid red destructive CTAs (vs the existing soft `"danger"` chip).
- `ConfirmDialog` now uses `destructive`, removing the `!important` override hack.

**Phase 1b — `window.alert` → `toast.error`** (3 files)
- `fizruk/pages/Progress.tsx`, `fizruk/components/workouts/WorkoutBackupBar.tsx`, `core/HubBackupPanel.jsx`.
- All three were JSON-import error fallbacks; now they go through the in-app toast surface for consistent styling.

**Phase 1c — `window.confirm` → `<ConfirmDialog>`** (2 files)
- `WorkoutTemplatesSection` (delete template) and `WorkoutBackupBar` (replace-from-backup) now use the design-system modal with the new `destructive` variant — no more native browser dialogs in the middle of a Sergeant flow.

**Phase 1d — eyebrow headings → `<SectionHeading>`** (46 files, 99 instances)
- Replaced inline `text-xs/2xs font-bold text-subtle uppercase tracking-widest` patterns with the existing `<SectionHeading size="xs|sm" as=…>` primitive.
- Done via a one-shot codemod (`/tmp/codemod-eyebrow.mjs`, run twice — opening + matching close tag) so semantics are preserved (`h2`/`h3`/`p`/`div`/`span` map to `as=…`).
- Imports auto-added; codemod artefacts not committed.

**Phase 4a — `<Card>` JSDoc**
- Documented the canonical radius hierarchy (`md=16px` / `lg=24px` / `xl=32px`) plus a note on when each is appropriate. No runtime change.

### Deferred to follow-up PRs
The audit also flagged the items below; they are bigger / riskier and were intentionally left out so this PR stays reviewable:
- Phase 2a: migrate ~23 inline `<select>`s to `<Select>`.
- Phase 2b: wrap fields with inline error text in `<FormField>`.
- Phase 2c: collapse the parallel `nutrition/components/ConfirmDeleteSheet.jsx` into `<ConfirmDialog>`.
- Phase 2d: make `<Input>`/`<Select>` focus-ring module-aware (requires per-module CSS theme classes that don't exist yet).
- Phase 3: migrate the top-10 inline-card files to `<Card>`.
- Phase 4b: remove stray `shadow-sm/md/lg` uses in modules.

## Review & Testing Checklist for Human

Risk: **yellow** — large file count but each diff is mechanical. The visual surface area is wide.

- [ ] Spot-check one screen per module to confirm eyebrows still render correctly (size/colour identical):
  - **Фінік**: Аналітика, Активи, Бюджети
  - **Фізрук**: Дашборд, Тренування → шаблон, Фізичні параметри, Прогрес
  - **Рутина**: Налаштування звичок, Календар, Деталі звички
  - **Харчування**: Лог дня, Редагувати продукт, Шаблон страви
- [ ] Trigger destructive flows: delete workout template, "Імпорт (замінити)" in Фізрук backup. Confirm the new `<ConfirmDialog>` appears (not native `confirm()`) and the confirm button is solid red.
- [ ] Trigger an import error (drop a non-JSON file into Фізрук progress import / Hub backup import). Confirm a red toast appears instead of `window.alert`.
- [ ] Verify `npm run check` is green locally if you have time — `lint` and the 674-test suite are green here. (Pre-existing typecheck failure in `src/core/authClient.ts` is unrelated and present on `main`.)

### Notes
- No design tokens were changed; only adoption of existing primitives.
- The codemod is reproducible — see commit `ui: migrate eyebrow headings to <SectionHeading>` for the full file list.
- Will follow up with screenshots after entering visual test mode.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
