### PR TITLE
fix(core/auth): restore forgetPassword/resetPassword destructure types

### DIFF
--- a/src/core/authClient.ts
+++ b/src/core/authClient.ts
@@ -13,6 +13,30 @@ const authClient = createAuthClient({
   baseURL: getAuthBaseURL(),
 });
 
+type PasswordResetResult = {
+  data?: unknown;
+  error: {
+    message?: string;
+    status?: number;
+    statusText?: string;
+  } | null;
+};
+
+// The React auth-client's static TypeScript surface doesn't advertise
+// `forgetPassword` / `resetPassword` — Better Auth resolves them at runtime via
+// a Proxy over the email/password plugin endpoints. We extend the type here so
+// consumers can keep destructuring them; runtime behaviour is unchanged.
+const typedAuthClient = authClient as typeof authClient & {
+  forgetPassword: (args: {
+    email: string;
+    redirectTo?: string;
+  }) => Promise<PasswordResetResult>;
+  resetPassword: (args: {
+    newPassword: string;
+    token?: string;
+  }) => Promise<PasswordResetResult>;
+};
+
 export const {
   useSession,
   signIn,
@@ -20,4 +44,4 @@ export const {
   signOut,
   forgetPassword,
   resetPassword,
-} = authClient;
+} = typedAuthClient;


### PR DESCRIPTION
## Summary

Unblocks CI `typecheck` on `main`. Tiny, scoped fix.

PR #231 destructured `forgetPassword` and `resetPassword` from the Better Auth React client at the module top level:

```ts
export const { useSession, signIn, signUp, signOut, forgetPassword, resetPassword } = authClient;
```

Those two methods **do work at runtime** — Better Auth resolves arbitrary method names via a Proxy over the email/password plugin endpoints — but they are **not** advertised on the static TypeScript surface returned by `createAuthClient`. So `tsc -p tsconfig.json --noEmit` has been failing on every PR since #231 was merged:

```
src/core/authClient.ts(21,3): error TS2339:
  Property 'forgetPassword' does not exist on type '{ signIn: ... }'
```

Reproduction: `git stash && npm run typecheck` on clean `main` also fails with this error.

### Fix

Narrow the auth-client's type locally so the destructure typechecks again. Runtime behaviour is unchanged. Callsites (`src/core/AuthContext.jsx`, `src/core/ResetPasswordPage.jsx`) stay exactly the same.

```ts
const typedAuthClient = authClient as typeof authClient & {
  forgetPassword: (args: { email: string; redirectTo?: string }) => Promise<PasswordResetResult>;
  resetPassword:  (args: { newPassword: string; token?: string })  => Promise<PasswordResetResult>;
};

export const {
  useSession, signIn, signUp, signOut,
  forgetPassword, resetPassword,
} = typedAuthClient;
```

The `PasswordResetResult` type mirrors the shape the consumers already read (`result?.error?.message`).

## Review & Testing Checklist for Human

- [ ] `npm run typecheck` passes locally (`tsc -p tsconfig.json --noEmit`) — it was failing on `main` before this PR
- [ ] Login still works (no functional change — the narrow only affects the type surface)
- [ ] "Forgot password" flow in `AuthPage.jsx → AuthContext.requestPasswordReset → forgetPassword({ email, redirectTo })` still sends the reset email
- [ ] Reset-password flow on `/reset-password?token=…` still works

### Notes

- Risk: 🟢 green — type-only change; zero runtime delta.
- Blocks/unblocks: once merged, CI typecheck will go green on all open PRs rebased on top of this (including the follow-ups to #244).
- If Better Auth ships a future version that exports these methods natively, the `typedAuthClient` cast becomes a no-op and can be deleted.

Link to Devin session: https://app.devin.ai/sessions/68e85770e862425f9b11eefee1aaa2de
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
