### PR TITLE
fix(nutrition): close 16:00 gap in mealTypeByHour

### DIFF
--- a/src/modules/nutrition/lib/mealTypes.test.ts
+++ b/src/modules/nutrition/lib/mealTypes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { mealTypeByHour } from "./mealTypes.js";
+
+describe("mealTypeByHour", () => {
+  it("maps 5–10 to breakfast", () => {
+    for (let h = 5; h <= 10; h++) expect(mealTypeByHour(h)).toBe("breakfast");
+  });
+
+  it("maps 11–15 to lunch", () => {
+    for (let h = 11; h <= 15; h++) expect(mealTypeByHour(h)).toBe("lunch");
+  });
+
+  it("maps 16–21 to dinner (including the 16:00 boundary)", () => {
+    // Regression: the original split used 17–21 for dinner and 11–15 for
+    // lunch, which left hour 16 falling through to "snack". 4 PM is a
+    // common meal time and should not collapse to Перекус.
+    for (let h = 16; h <= 21; h++) expect(mealTypeByHour(h)).toBe("dinner");
+  });
+
+  it("maps late-night and pre-dawn hours to snack", () => {
+    for (const h of [22, 23, 0, 1, 2, 3, 4]) {
+      expect(mealTypeByHour(h)).toBe("snack");
+    }
+  });
+});

--- a/src/modules/nutrition/lib/mealTypes.ts
+++ b/src/modules/nutrition/lib/mealTypes.ts
@@ -50,14 +50,18 @@ export function labelForMealType(id: MealTypeId | string): string {
 
 /**
  * Time-of-day → most likely meal type. Used to seed the "Додати прийом їжі"
- * form so the default doesn't say "Сніданок" at 9 PM. Bands are wide on
- * purpose — we'd rather be a bit sloppy than make the user tap the picker
- * just to flip the obvious option.
+ * form so the default doesn't say "Сніданок" at 9 PM. Bands are wide and
+ * contiguous between 5:00–22:00 on purpose — we'd rather pick an obvious-
+ * enough option than force the user to tap the picker just to flip it.
+ *
+ * Bands: 5–10 breakfast · 11–15 lunch · 16–21 dinner · else snack. Dinner
+ * intentionally covers 16:00 so the picker doesn't collapse to "Перекус" at
+ * 4 PM (that was a gap in the original 11–15 / 17–21 split).
  */
 export function mealTypeByHour(hour: number): MealTypeId {
   if (hour >= 5 && hour < 11) return "breakfast";
   if (hour >= 11 && hour < 16) return "lunch";
-  if (hour >= 17 && hour < 22) return "dinner";
+  if (hour >= 16 && hour < 22) return "dinner";
   return "snack";
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #248. Devin Review flagged that `mealTypeByHour` had a gap at hour 16: lunch ended at `< 16` and dinner started at `>= 17`, so adding a meal at 4 PM defaulted to "Перекус" instead of lunch or dinner — exactly the picker-tap the helper was meant to eliminate.

Widens dinner to `16 <= hour < 22` so the bands are now contiguous between 5:00–22:00:

| hours | meal |
| --- | --- |
| 5–10 | breakfast |
| 11–15 | lunch |
| 16–21 | dinner |
| else | snack |

Also adds `mealTypes.test.ts` — a regression test covering every hour band, including the 16:00 boundary that used to fall through.

Local checks:

```
npm run lint        ok
npm run typecheck   ok (main is now clean after #249)
npm run test        mealTypes.test.ts → 4/4 pass
```

## Review & Testing Checklist for Human

Risk: **green** — one-line band shift + added test; no persistence shape or UI changes.

- [ ] Open "Додати прийом їжі" at 16:00–16:59 on your machine clock — the type picker defaults to "Вечеря" (not "Перекус").
- [ ] Spot-check another hour (e.g. 09:00 → Сніданок, 13:00 → Обід, 23:00 → Перекус) to confirm no other band moved.

### Notes

- No UI copy / persistence changes; editing an existing meal still keeps its saved `mealType`.
- Not addressing the 4 additional findings Devin Review mentioned in aggregate — the review web page is currently throwing an asset-preload error and no further inline comments were posted, so I can't see their contents. Happy to follow up once they're visible.


Link to Devin session: https://app.devin.ai/sessions/d98217fcc75048689eda57d880f4e540
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
