### PR TITLE
unify sheets: module panelClassName + 44px close buttons (UI-audit PR #1)

### DIFF
--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -236,6 +236,7 @@ export function ManualExpenseSheet({
       onClose={onClose}
       title={isEditing ? "Редагувати витрату" : "Додати витрату"}
       kbInsetPx={kbInsetPx}
+      panelClassName="finyk-sheet"
       bodyClassName="space-y-4"
       footer={
         <div className="flex gap-3">

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -714,6 +714,7 @@ export function Transactions({
         onClose={() => setBatchCatPicker(false)}
         title="Вибрати категорію"
         description={`Застосується до ${selectedIds.size} транзакц${selectedIds.size === 1 ? "ії" : "ій"}`}
+        panelClassName="finyk-sheet"
         zIndex={70}
         bodyClassName="px-4 pb-6 flex flex-col gap-1"
       >

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -409,7 +409,7 @@ export default function FizrukApp({
               <button
                 type="button"
                 onClick={() => setSettingsOpen(false)}
-                className="w-10 h-10 min-w-[40px] min-h-[40px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+                className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
                 aria-label="Закрити"
               >
                 <Icon name="close" size={22} />

--- a/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -59,6 +59,7 @@ export function AddExerciseSheet({
       description="Збережеться локально на цьому пристрої"
       closeLabel="Закрити форму"
       kbInsetPx={kbInsetPx}
+      panelClassName="fizruk-sheet"
       zIndex={100}
     >
       <div className="space-y-3">

--- a/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -46,6 +46,7 @@ export function ExerciseDetailSheet({
       onClose={onClose}
       title={selected?.name?.uk || selected?.name?.en}
       description={description}
+      panelClassName="fizruk-sheet"
       zIndex={100}
     >
       {cf?.hasWarning && (

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -683,7 +683,7 @@ export function Dashboard({
         open={planConfirmOpen}
         onClose={closePlanConfirm}
         title="Увага"
-        panelClassName="max-w-4xl"
+        panelClassName="fizruk-sheet max-w-4xl"
         zIndex={100}
         footer={
           <div className="flex gap-2">

--- a/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -251,7 +251,7 @@ export function PlanCalendar() {
               })
             : ""
         }
-        panelClassName="max-w-md"
+        panelClassName="fizruk-sheet max-w-md"
         zIndex={100}
         footer={
           <Button

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -226,6 +226,7 @@ export function AddMealSheet({
         open={open}
         onClose={onClose}
         title={title}
+        panelClassName="nutrition-sheet"
         zIndex={120}
         kbInsetPx={kbInsetPx}
       >

--- a/src/modules/nutrition/components/ConfirmDeleteSheet.jsx
+++ b/src/modules/nutrition/components/ConfirmDeleteSheet.jsx
@@ -18,6 +18,7 @@ export function ConfirmDeleteSheet({
       onClose={onClose}
       title="Видалити склад?"
       description="Це прибере всі продукти в ньому. Дію не можна відмінити."
+      panelClassName="nutrition-sheet"
       zIndex={110}
       footer={
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/src/modules/nutrition/components/ItemEditSheet.jsx
+++ b/src/modules/nutrition/components/ItemEditSheet.jsx
@@ -11,6 +11,7 @@ export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
       onClose={onClose}
       title={itemEdit.name}
       description="Кількість і одиниці (порожньо — прибрати)"
+      panelClassName="nutrition-sheet"
       zIndex={120}
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/modules/nutrition/components/PantryManagerSheet.jsx
+++ b/src/modules/nutrition/components/PantryManagerSheet.jsx
@@ -24,6 +24,7 @@ export function PantryManagerSheet({
       onClose={onClose}
       title="Склади продуктів"
       description="Створи окремо для Дім / Робота або по дієті"
+      panelClassName="nutrition-sheet"
       zIndex={100}
     >
       <div className="rounded-2xl border border-line bg-bg overflow-hidden mb-4">

--- a/src/modules/routine/components/DayReportSheet.tsx
+++ b/src/modules/routine/components/DayReportSheet.tsx
@@ -34,6 +34,7 @@ export function DayReportSheet({
       onClose={onClose}
       title="Денний звіт"
       description={dayLabel}
+      panelClassName="routine-sheet"
       zIndex={200}
     >
       {scheduledHabits.length === 0 && (

--- a/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/src/modules/routine/components/HabitDetailSheet.tsx
@@ -206,7 +206,7 @@ export function HabitDetailSheet({
         </span>
       }
       description={chips}
-      panelClassName="max-w-4xl"
+      panelClassName="routine-sheet max-w-4xl"
       zIndex={200}
     >
       <div className="text-xs text-subtle space-y-0.5 mb-5">

--- a/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -109,7 +109,7 @@ export function HabitQuickCreateDialog({
           <button
             type="button"
             onClick={onClose}
-            className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
             aria-label="Закрити"
           >
             <svg

--- a/src/modules/routine/components/PushupsWidget.tsx
+++ b/src/modules/routine/components/PushupsWidget.tsx
@@ -103,6 +103,7 @@ export function PushupsWidget() {
         onClose={() => setOpen(false)}
         title="Додати відтискання"
         kbInsetPx={keyboardInset}
+        panelClassName="routine-sheet"
         zIndex={200}
       >
         <div className="mb-4 grid grid-cols-5 gap-1.5 sm:gap-2">


### PR DESCRIPTION
## Summary

Перший PR з плану UI-аудиту. Виправляє дві категорії дрейфу, які видно неозброєним оком і якими легко зашкодити a11y:

1. **Оживляє 4 мертві CSS-правила модульних фокус-кілець** (`.finyk-sheet`, `.fizruk-sheet`, `.routine-sheet`, `.nutrition-sheet` у `src/index.css:222-240`). Правила вже були написані, але `panelClassName` ніде не прокидувався у `<Sheet>` виклики — тому фокус-кільце всередині модульних шторок завжди було brand-emerald, а не модульним. Тепер 13 `<Sheet>` викликів отримали відповідний `panelClassName="<module>-sheet"` (зберігши існуючі `max-w-4xl`/`max-w-md`-обмеження).

2. **Усуває 2 WCAG-баги на розмір тапа** (рекомендовано ≥44×44):
   - `HabitQuickCreateDialog` close-кнопка: `w-9 h-9` (36×36) → `w-11 h-11 min-*[44px]`.
   - `FizrukApp` settings drawer close-кнопка: 40×40 → 44×44.

Це частина ширшої уніфікації — див. план у `ui-audit.md` (6 PR-ів, цей №1). Решта чекає на окремі PR-и.

Жодного нового компонента, жодного нового CSS — лише пропси + 2 класи. `npm run lint` і `npm run typecheck` проходять локально.

## Review & Testing Checklist for Human

- [ ] Відкрити `<Sheet>` кожного модуля й перевірити, що фокус-кільце на елементах всередині шторки тепер модульне (emerald у Фініка / teal у Фізрука / coral у Рутини / lime у Харчуванні). Раніше завжди було emerald-brand.
- [ ] Перевірити, що max-width поведінка у `HabitDetailSheet` (max-w-4xl), `Dashboard` (max-w-4xl), `PlanCalendar` (max-w-md) не зламалась — я доклеїв модульний клас перед існуючим (`panelClassName="fizruk-sheet max-w-4xl"`), `cn()` має це коректно з'єднати.
- [ ] Перевірити close-кнопки у «Нова звичка» (HabitQuickCreateDialog) та у drawer налаштувань Фізрука — розмір тапа має стати 44×44, візуально ікони по центру.

### Notes

Це "низько-ризиковий" PR з плану ui-audit. Наступні PR (drift-лейбли, міграція `<input>`/`<select>` на shared-компоненти, `<Segmented>`-компонент, міграція HabitQuickCreateDialog + Fizruk settings drawer на `<Sheet>`, `<PageHeader>`) — окремо.

Link to Devin session: https://app.devin.ai/sessions/145a2c230f4e40fda472610e891ea893
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
