### PR TITLE
feat(hub): turn dashboard into an action-driven decision screen

### DIFF
--- a/src/core/HubDashboard.tsx
+++ b/src/core/HubDashboard.tsx
@@ -3,10 +3,13 @@ import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
+import { openHubModuleWithAction } from "@shared/lib/hubNav";
+import { getModulePrimaryAction } from "@shared/lib/moduleQuickActions";
 import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard.jsx";
 import { HubInsightsPanel } from "./HubInsightsPanel.jsx";
 import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
+import { useCoachInsight } from "./useCoachInsight.js";
 import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
 import { DemoModeBanner } from "./onboarding/DemoModeBanner.jsx";
 import { FirstActionHeroCard } from "./onboarding/FirstActionSheet.jsx";
@@ -238,123 +241,108 @@ const MODULE_CONFIGS = {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════
-// DATE HEADER — replaces the decorative hero with a dense info line
+// STATUS ROW — «тихий» рядок модуля в секції «Статус»
 // ═══════════════════════════════════════════════════════════════════════════
-function DateHeader() {
-  const text = useMemo(() => {
-    try {
-      return new Date().toLocaleDateString("uk-UA", {
-        weekday: "short",
-        day: "numeric",
-        month: "long",
-      });
-    } catch {
-      return "";
-    }
-  }, []);
-
-  return (
-    <p className="px-0.5 text-xs font-medium text-muted uppercase tracking-wider">
-      {text}
-    </p>
-  );
-}
-
+// Раніше це був ModuleRow із chevron-ом, завжди-видимим progress-баром і
+// per-row Demo-піллю. Стало: без chevron-а (весь рядок клікабельний), без
+// progress-бару (крім випадків коли модуль справді має ціль і прогрес), без
+// «Демо» пілюлі (єдиний strip над секцією статус). Рядок, що відповідає
+// модулю з активним сигналом (focus/rest), отримує inline-кнопку `+`, що
+// dispatchає primary-дію без додаткового тапа «відкрити модуль».
 // ═══════════════════════════════════════════════════════════════════════════
-// MODULE ROW — compact "Today at a glance" list item
-// One icon + label, one number, one thin progress bar. Neutral text; the
-// module's color shows only as a 1px leading accent, so four rows read as a
-// single list rather than four competing heroes.
-// ═══════════════════════════════════════════════════════════════════════════
-function ModuleRow({ config, onClick, dragProps, isDragging, isDemo }) {
+function StatusRow({ config, onClick, onQuickAdd, dragProps, isDragging }) {
   const preview = config.getPreview();
   const showProgress =
     config.hasGoal && preview.progress !== undefined && preview.progress > 0;
-  // Show the pill only when the module has a real preview number to label —
-  // an empty row's "tracking…" copy is self-evidently not demo data.
-  const showDemoPill = isDemo && Boolean(preview.main);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div
       className={cn(
-        "group relative w-full text-left",
-        "flex items-center gap-3 px-3 py-2.5",
+        "group relative flex items-center",
         "bg-panel hover:bg-panelHi transition-colors",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-inset",
         isDragging && "opacity-70 shadow-float z-50 cursor-grabbing",
       )}
-      {...dragProps}
     >
-      <div
+      <button
+        type="button"
+        onClick={onClick}
         className={cn(
-          "absolute left-0 top-2 bottom-2 w-0.5 rounded-r-full",
-          config.accentClass,
+          "flex items-center gap-3 px-3 py-2.5 flex-1 min-w-0 text-left",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-inset",
         )}
-        aria-hidden
-      />
-
-      <div
-        className={cn(
-          "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
-          config.iconClass,
-        )}
+        {...dragProps}
       >
-        {config.icon}
-      </div>
-
-      <span className="text-xs font-semibold text-text truncate">
-        {config.label}
-      </span>
-
-      <div className="ml-auto flex items-center gap-2 min-w-0">
-        {showDemoPill && (
-          <span
-            className="shrink-0 px-1.5 py-0.5 rounded-md text-[10px] font-semibold uppercase tracking-wider text-brand-600 bg-brand-500/10 border border-brand-500/20"
-            title="Це приклад — заміниться на твої дані після першого запису"
-          >
-            Демо
-          </span>
-        )}
-        {showProgress && (
-          <div
-            className="w-12 sm:w-16 h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden shrink-0"
-            aria-hidden
-          >
-            <div
-              className={cn(
-                "h-full rounded-full transition-all duration-700 ease-out",
-                config.accentClass,
-              )}
-              style={{ width: `${Math.min(preview.progress, 100)}%` }}
-            />
-          </div>
-        )}
-        {preview.main ? (
-          <span className="text-sm font-semibold text-text tabular-nums truncate">
-            {preview.main}
-          </span>
-        ) : (
-          <span className="text-xs text-muted truncate">
-            {preview.sub || config.description}
-          </span>
-        )}
-        <Icon
-          name="chevron-right"
-          size={14}
-          strokeWidth={2.5}
-          className="text-muted shrink-0"
+        <div
+          className={cn(
+            "absolute left-0 top-2 bottom-2 w-0.5 rounded-r-full",
+            config.accentClass,
+          )}
+          aria-hidden
         />
-      </div>
-    </button>
+
+        <div
+          className={cn(
+            "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
+            config.iconClass,
+          )}
+        >
+          {config.icon}
+        </div>
+
+        <span className="text-xs font-semibold text-text truncate">
+          {config.label}
+        </span>
+
+        <div className="ml-auto flex items-center gap-2 min-w-0">
+          {showProgress && (
+            <div
+              className="w-12 sm:w-16 h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden shrink-0"
+              aria-hidden
+            >
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all duration-700 ease-out",
+                  config.accentClass,
+                )}
+                style={{ width: `${Math.min(preview.progress, 100)}%` }}
+              />
+            </div>
+          )}
+          {preview.main ? (
+            <span className="text-sm font-semibold text-text tabular-nums truncate">
+              {preview.main}
+            </span>
+          ) : (
+            <span className="text-xs text-muted truncate">
+              {preview.sub || config.description}
+            </span>
+          )}
+        </div>
+      </button>
+
+      {onQuickAdd && (
+        <button
+          type="button"
+          onClick={onQuickAdd.run}
+          aria-label={onQuickAdd.label}
+          title={onQuickAdd.label}
+          className={cn(
+            "shrink-0 mr-2 w-7 h-7 rounded-lg flex items-center justify-center",
+            "text-text bg-panelHi hover:bg-primary hover:text-bg",
+            "transition-colors",
+          )}
+        >
+          <Icon name="plus" size={14} strokeWidth={2.5} />
+        </button>
+      )}
+    </div>
   );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
 // SORTABLE CARD WRAPPER
 // ═══════════════════════════════════════════════════════════════════════════
-function SortableCard({ id, onOpenModule, isDemo }) {
+function SortableCard({ id, onOpenModule, quickAdd }) {
   const {
     attributes,
     listeners,
@@ -374,11 +362,11 @@ function SortableCard({ id, onOpenModule, isDemo }) {
 
   return (
     <div ref={setNodeRef} style={style}>
-      <ModuleRow
+      <StatusRow
         config={cfg}
         onClick={() => onOpenModule(id)}
+        onQuickAdd={quickAdd}
         isDragging={isDragging}
-        isDemo={isDemo}
         dragProps={{ ...attributes, ...listeners }}
       />
     </div>
@@ -415,9 +403,60 @@ function useMondayAutoDigest() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// WEEKLY DIGEST FOOTER — always-collapsed link on the dashboard. Renders a
-// small "fresh" dot when a live digest exists so users still notice it
-// without letting the full card hijack the primary block on Mondays.
+// DEMO STRIP — один тихий рядок над статус-списком, замість per-row «Демо»
+// пілюль на кожному модулі. Не inline-dismissable, знімається автоматично
+// після першого реального запису (див. `modulePreviewsAreDemo`).
+// ═══════════════════════════════════════════════════════════════════════════
+function DemoStrip() {
+  return (
+    <div
+      className={cn(
+        "px-3 py-1.5 text-2xs font-semibold uppercase tracking-wider",
+        "text-brand-600 bg-brand-500/10 border border-brand-500/20 rounded-lg",
+        "flex items-center justify-between gap-2",
+      )}
+      title="Це приклад — заміниться на твої дані після першого запису"
+    >
+      <span>Дані — приклад</span>
+      <span className="font-normal normal-case tracking-normal text-muted">
+        Заміниться після першого запису
+      </span>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SECONDARY CHIPS — ≤2 contextual quick-add chips, які підсвічуються тільки
+// коли є сигнал (recs з pwaAction). Стоять між NextCard і списком статусу.
+// Не дублює primary-CTA з NextCard — береться з `rest`, не з `focus`.
+// ═══════════════════════════════════════════════════════════════════════════
+function SecondaryChips({ chips }) {
+  if (!chips || chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {chips.map((chip) => (
+        <button
+          key={chip.id}
+          type="button"
+          onClick={chip.run}
+          className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+            "text-xs font-medium text-text",
+            "bg-panel border border-line hover:bg-panelHi transition-colors",
+          )}
+          title={chip.hint}
+        >
+          <span aria-hidden>{chip.icon}</span>
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WEEKLY DIGEST FOOTER — тихий лінк у нижньому ряду. Fresh-dot показується,
+// коли live-digest за цей тиждень існує.
 // ═══════════════════════════════════════════════════════════════════════════
 function WeeklyDigestFooter({ onExpand, fresh }) {
   return (
@@ -444,10 +483,22 @@ function WeeklyDigestFooter({ onExpand, fresh }) {
   );
 }
 
+const MODULE_ICON_EMOJI = {
+  finyk: "💳",
+  fizruk: "🏋️",
+  routine: "✅",
+  nutrition: "🥗",
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // MAIN HUB DASHBOARD
 // ═══════════════════════════════════════════════════════════════════════════
-export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
+export function HubDashboard({
+  onOpenModule,
+  onOpenChat: _onOpenChat,
+  user,
+  onShowAuth,
+}) {
   const [order, setOrder] = useState(loadOrder);
   useMondayAutoDigest();
 
@@ -479,13 +530,62 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
   const showDemoBanner =
     !hasRealEntry && !demoBannerDismissed && wasDemoSeeded();
 
-  // The banner is one-shot dismissible, but the underlying fact that the
-  // numbers in "Сьогодні" are seeded demo data persists until the first real
-  // entry. A per-row "Демо" pill stays visible after the banner is closed so
-  // the user never mistakes the preview for their own data.
+  // Фактичний «демо-mode» контексту залишається, поки немає жодного
+  // реального запису. Раніше це малювало «Демо»-пілюлю на КОЖНОМУ рядку
+  // статус-списку — тепер це один тихий strip над списком (див. DemoStrip).
   const modulePreviewsAreDemo = !hasRealEntry && wasDemoSeeded();
 
   const { focus, rest, dismiss } = useDashboardFocus();
+
+  // Coach insight підʼєднується на рівні дашборду і передається в NextCard
+  // як inline italic-рядок. Раніше він жив у `HubInsightsPanel` і
+  // змушував секцію авто-розкриватись — зараз інсайт стоїть поруч із
+  // фокусом, без окремого місця у списку.
+  const { insight: coachInsightText } = useCoachInsight();
+
+  // ─────────────────────────────────────────────────────────────────────
+  // «Є сигнал?» мапа — які модулі мають видиму рекомендацію. Використовується
+  // для inline-`+` у StatusRow. focus+rest охоплює всі recs, які не були
+  // dismissed.
+  // ─────────────────────────────────────────────────────────────────────
+  const modulesWithSignal = useMemo(() => {
+    const all = focus ? [focus, ...rest] : rest;
+    const set = new Set<string>();
+    for (const r of all) {
+      if (r.module && r.module !== "hub") set.add(r.module);
+    }
+    return set;
+  }, [focus, rest]);
+
+  // Secondary chips: до 2-х рекомендацій (без focus), які несуть pwaAction.
+  // Показуються тільки коли у нас >1 recs (інакше focus вистачає). Кожен
+  // chip відкриває модуль із інтентом, не просто навігуючи.
+  const secondaryChips = useMemo(() => {
+    const withAction = rest.filter((r) => r.pwaAction && r.module !== "hub");
+    // де-дублюємо за модулем — один сигнал на модуль достатньо
+    const seen = new Set<string>();
+    const picked: typeof withAction = [];
+    for (const r of withAction) {
+      if (seen.has(r.module)) continue;
+      seen.add(r.module);
+      picked.push(r);
+      if (picked.length >= 2) break;
+    }
+    return picked.map((r) => {
+      const quick = getModulePrimaryAction(r.module);
+      return {
+        id: r.id,
+        label: quick?.shortLabel || "Додати",
+        hint: r.title,
+        icon: MODULE_ICON_EMOJI[r.module] || "➕",
+        run: () =>
+          openHubModuleWithAction(
+            r.module as Parameters<typeof openHubModuleWithAction>[0],
+            r.pwaAction!,
+          ),
+      };
+    });
+  }, [rest]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -507,46 +607,71 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
     }
   }, []);
 
+  // Weekly digest: не показуємо картку автоматично. Fresh-дот у footer
+  // появляється, якщо користувач явно згенерував digest цього тижня. Сам
+  // card розкривається тільки по тапу на footer-link.
   const [digestExpanded, setDigestExpanded] = useState(false);
   const digestFresh = hasLiveWeeklyDigest();
+  // Footer-лінк видно тільки коли є свіжий digest АБО сьогодні Пн/Вт
+  // (коли має сенс нагадати про підсумок тижня). Інакше лінк ховається,
+  // щоб не створювати постійного шуму.
+  const now = new Date();
+  const isMondayOrTuesday = now.getDay() === 1 || now.getDay() === 2;
+  const showDigestFooter = digestFresh || isMondayOrTuesday;
 
-  return (
-    <div className="space-y-4">
-      <DateHeader />
-
-      {/* Today focus — the ONE primary action on the dashboard. Rendered
-          before any banner so it is always the first thing the user sees. */}
+  // ─────────────────────────────────────────────────────────────────────
+  // ONE-HERO RULE. На екрані завжди рівно одна primary-картка:
+  //   FirstAction → DemoBanner → SoftAuth → NextCard
+  // FTUX-онбординг-картки мають власні CTA, тому їх не треба дублювати з
+  // NextCard. Як тільки вони зняті, хероєм стає NextCard (focus чи empty).
+  // ─────────────────────────────────────────────────────────────────────
+  let hero: React.ReactNode;
+  if (firstActionVisible) {
+    hero = (
+      <FirstActionHeroCard onDismiss={() => setFirstActionVisible(false)} />
+    );
+  } else if (showDemoBanner) {
+    hero = (
+      <DemoModeBanner
+        onDismiss={() => {
+          dismissDemoBanner();
+          setDemoBannerDismissed(true);
+        }}
+      />
+    );
+  } else if (showSoftAuth) {
+    hero = (
+      <SoftAuthPromptCard
+        onOpenAuth={onShowAuth}
+        onDismiss={() => setSoftAuthDismissed(true)}
+      />
+    );
+  } else {
+    hero = (
       <TodayFocusCard
         focus={focus}
         onAction={onOpenModule}
         onDismiss={dismiss}
+        coachInsight={coachInsightText}
       />
+    );
+  }
 
-      {/* Banner budget: one system card at a time on the dashboard.
-          Priority: first-action hero (post-wizard FTUX) > demo banner >
-          soft-auth nudge. Prevents the cold-start where two or three
-          "meta" cards push real data below the fold. */}
-      {firstActionVisible ? (
-        <FirstActionHeroCard onDismiss={() => setFirstActionVisible(false)} />
-      ) : showDemoBanner ? (
-        <DemoModeBanner
-          onDismiss={() => {
-            dismissDemoBanner();
-            setDemoBannerDismissed(true);
-          }}
-        />
-      ) : showSoftAuth ? (
-        <SoftAuthPromptCard
-          onOpenAuth={onShowAuth}
-          onDismiss={() => setSoftAuthDismissed(true)}
-        />
-      ) : null}
+  return (
+    <div className="space-y-4">
+      {hero}
 
-      {/* Today at a glance — compact module list (replaces the 2×2 grid) */}
+      <SecondaryChips chips={secondaryChips} />
+
+      {/* STATUS — тихий список модулів. Колапсована секція з одним демо-strip
+          зверху (коли актуально). Рядок, під який підʼїхала рекомендація,
+          отримує inline `+` для quick-add. */}
       <section className="space-y-2">
         <h2 className="px-0.5 text-xs font-semibold text-muted uppercase tracking-wider">
-          Сьогодні
+          Статус
         </h2>
+
+        {modulePreviewsAreDemo && <DemoStrip />}
 
         <DndContext
           sensors={sensors}
@@ -555,38 +680,53 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
         >
           <SortableContext items={order} strategy={verticalListSortingStrategy}>
             <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
-              {order.map((id) => (
-                <SortableCard
-                  key={id}
-                  id={id}
-                  onOpenModule={onOpenModule}
-                  isDemo={modulePreviewsAreDemo}
-                />
-              ))}
+              {order.map((id) => {
+                const hasSignal = modulesWithSignal.has(id);
+                const quick = getModulePrimaryAction(id);
+                const quickAdd =
+                  hasSignal && quick
+                    ? {
+                        label: quick.label,
+                        run: () =>
+                          openHubModuleWithAction(
+                            id as Parameters<typeof openHubModuleWithAction>[0],
+                            quick.action,
+                          ),
+                      }
+                    : null;
+                return (
+                  <SortableCard
+                    key={id}
+                    id={id}
+                    onOpenModule={onOpenModule}
+                    quickAdd={quickAdd}
+                  />
+                );
+              })}
             </div>
           </SortableContext>
         </DndContext>
       </section>
 
-      {/* Unified insights — collapsed by default */}
-      <HubInsightsPanel
-        items={rest}
-        onOpenModule={onOpenModule}
-        onOpenChat={onOpenChat}
-        onDismiss={dismiss}
-      />
-
-      {/* Weekly digest — always a footer link on the dashboard; expands
-          inline on demand. Prevents Monday auto-generation from hijacking
-          the primary block. */}
-      {digestExpanded ? (
-        <WeeklyDigestCard />
-      ) : (
-        <WeeklyDigestFooter
-          fresh={digestFresh}
-          onExpand={() => setDigestExpanded(true)}
+      {/* «ще» — тихий футер-ряд з вторинними точками входу. HubInsightsPanel
+          ховає rest за колапсом; WeeklyDigest-link показується лише в Пн/Вт
+          або коли є свіжий звіт, щоб не створювати постійного шуму. */}
+      <div className="space-y-2">
+        <HubInsightsPanel
+          items={rest}
+          onOpenModule={onOpenModule}
+          onDismiss={dismiss}
         />
-      )}
+
+        {digestExpanded ? (
+          <WeeklyDigestCard />
+        ) : showDigestFooter ? (
+          <WeeklyDigestFooter
+            fresh={digestFresh}
+            onExpand={() => setDigestExpanded(true)}
+          />
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/core/HubInsightsPanel.tsx
+++ b/src/core/HubInsightsPanel.tsx
@@ -1,32 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
-import { useCoachInsight } from "./useCoachInsight.js";
-
-// localStorage flag used to auto-expand the insights panel at most once per
-// calendar day when a coach insight is present. After the first expand on a
-// given day (automatic or manual), we stamp today's date here so subsequent
-// dashboard opens keep the panel quietly collapsed.
-const AUTO_OPEN_KEY = "hub_insights_auto_opened_v1";
-
-function todayKey() {
-  const d = new Date();
-  return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
-}
-
-function wasAutoOpenedToday() {
-  try {
-    return localStorage.getItem(AUTO_OPEN_KEY) === todayKey();
-  } catch {
-    return false;
-  }
-}
-
-function markAutoOpenedToday() {
-  try {
-    localStorage.setItem(AUTO_OPEN_KEY, todayKey());
-  } catch {}
-}
 
 const MODULE_ACCENT = {
   finyk: "bg-finyk",
@@ -91,101 +65,18 @@ function RecRow({ rec, onAction, onDismiss }) {
   );
 }
 
-function CoachRow({ insight, loading, error, onDiscuss, onRefresh }) {
-  if (loading && !insight) {
-    return (
-      <div className="rounded-xl border border-line bg-bg px-3 py-2.5">
-        <p className="text-xs text-muted animate-pulse">
-          Коуч готує повідомлення…
-        </p>
-      </div>
-    );
-  }
-  if (error && !insight) {
-    return null;
-  }
-  if (!insight) return null;
-
-  return (
-    <div className="relative rounded-xl border border-line bg-bg px-3 py-2.5">
-      <div
-        className="absolute left-0 top-3 bottom-3 w-0.5 rounded-r-full bg-primary"
-        aria-hidden
-      />
-      <div className="pl-1">
-        <div className="flex items-center justify-between gap-2 mb-1">
-          <span className="text-2xs font-semibold uppercase tracking-wider text-muted">
-            Коуч
-          </span>
-          <button
-            type="button"
-            onClick={onRefresh}
-            disabled={loading}
-            aria-label="Оновити повідомлення коуча"
-            title="Оновити"
-            className={cn(
-              "w-6 h-6 rounded-md flex items-center justify-center",
-              "text-muted hover:text-text hover:bg-panelHi transition-colors",
-              loading && "opacity-40 cursor-not-allowed",
-            )}
-          >
-            <Icon name="refresh-cw" size={12} strokeWidth={2.5} />
-          </button>
-        </div>
-        <p className="text-xs text-text/90 leading-relaxed">{insight}</p>
-        {onDiscuss && (
-          <button
-            type="button"
-            onClick={onDiscuss}
-            className="mt-1.5 inline-flex items-center gap-1 text-xs font-semibold text-text hover:text-primary transition-colors"
-          >
-            Обговорити
-            <Icon name="chevron-right" size={12} strokeWidth={2.5} />
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
-
 /**
- * Unified collapsible "Insights" panel that merges recommendation nudges and
- * the daily coach insight into one compact block. Replaces three separate
- * cards (HubRecommendations, CoachInsightCard, DailyFinykSummaryCard) on the
- * dashboard.
+ * Колапсована панель вторинних інсайтів на дашборді. Показує список
+ * рекомендацій із нижчим пріоритетом, які не попали в NextCard. Coach-insight
+ * більше НЕ рендериться тут — він переїхав усередину NextCard як інлайн-рядок
+ * під body. Це знімає дубль-UI: раніше інсайт існував і в картці фокусу, і
+ * в цьому блоці окремо.
  */
-export function HubInsightsPanel({
-  items,
-  onOpenModule,
-  onOpenChat,
-  onDismiss,
-}) {
+export function HubInsightsPanel({ items, onOpenModule, onDismiss }) {
   const [open, setOpen] = useState(false);
-  const { insight, loading, error, refresh } = useCoachInsight();
 
-  const hasCoach = Boolean(insight) || Boolean(loading);
-  const coachCount = insight ? 1 : 0;
-  const total = (items?.length || 0) + coachCount;
-
-  // Auto-expand once per day when a coach insight is available so the user
-  // actually notices it — without re-opening on every subsequent dashboard
-  // visit that day.
-  useEffect(() => {
-    if (!insight) return;
-    if (wasAutoOpenedToday()) return;
-    setOpen(true);
-    markAutoOpenedToday();
-  }, [insight]);
-
+  const total = items?.length || 0;
   if (total === 0) return null;
-
-  const handleDiscuss = () => {
-    if (typeof onOpenChat !== "function") return;
-    const ctx = insight
-      ? `[Коуч-контекст]\nПерсональне повідомлення дня:\n"${insight}"\n\nЯ хочу обговорити цей інсайт або отримати більше порад.`
-      : "[Коуч-контекст]\nЯ хочу поговорити з персональним коучем.";
-    onOpenChat(ctx);
-  };
 
   return (
     <section className="space-y-2">
@@ -224,15 +115,6 @@ export function HubInsightsPanel({
       >
         <div className="overflow-hidden">
           <div className="space-y-2 pt-1">
-            {hasCoach && (
-              <CoachRow
-                insight={insight}
-                loading={loading}
-                error={error}
-                onRefresh={refresh}
-                onDiscuss={onOpenChat ? handleDiscuss : null}
-              />
-            )}
             {items?.map((rec) => (
               <RecRow
                 key={rec.id}

--- a/src/core/TodayFocusCard.tsx
+++ b/src/core/TodayFocusCard.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import {
+  openHubModuleWithAction,
+  type HubModuleAction,
+  type HubModuleId,
+} from "@shared/lib/hubNav";
+import {
+  MODULE_PRIMARY_ACTION,
+  getModulePrimaryAction,
+} from "@shared/lib/moduleQuickActions";
 import { generateRecommendations } from "./lib/recommendationEngine.js";
 
 // Reuse the same dismissed-map key HubRecommendations used so user
@@ -26,7 +35,11 @@ const MODULE_WASH = {
   hub: "bg-panelHi",
 };
 
-const MODULE_CTA = {
+// Fallback for CTA коли rec не несе свого `pwaAction`: просто відкриває
+// модуль. Імперативна дія (`add_expense`, `start_workout`, …) береться з
+// `MODULE_PRIMARY_ACTION` і dispatchається через hubNav — центральний шлях
+// квік-адду з дашборду.
+const MODULE_OPEN_CTA = {
   finyk: "Відкрити Фінік",
   fizruk: "Відкрити Фізрук",
   routine: "Відкрити Рутину",
@@ -34,7 +47,14 @@ const MODULE_CTA = {
   hub: "Подивитись",
 };
 
-function readJSON(key) {
+const MODULE_SHORT_LABEL: Record<HubModuleId, string> = {
+  finyk: "Фінік",
+  fizruk: "Фізрук",
+  routine: "Рутина",
+  nutrition: "Харчування",
+};
+
+function readJSON(key: string) {
   try {
     const raw = localStorage.getItem(key);
     return raw ? JSON.parse(raw) : null;
@@ -43,56 +63,7 @@ function readJSON(key) {
   }
 }
 
-/**
- * Derive a single "reward" line for the empty focus state from the latest
- * quick-stats each module writes to localStorage. Priority:
- *   1. longest active streak (habits > training)
- *   2. today's habit completion ratio (if any progress made)
- *   3. nutrition on-goal today
- *   4. fallback neutral message
- */
-function deriveRewardSignal() {
-  const routine = readJSON("routine_quick_stats") || {};
-  const fizruk = readJSON("fizruk_quick_stats") || {};
-  const nutrition = readJSON("nutrition_quick_stats") || {};
-
-  const streaks = [
-    { module: "routine", days: Number(routine.streak) || 0 },
-    { module: "fizruk", days: Number(fizruk.streak) || 0 },
-  ]
-    .filter((s) => s.days >= 2)
-    .sort((a, b) => b.days - a.days);
-
-  if (streaks.length > 0) {
-    const top = streaks[0];
-    return {
-      line: `Серія ${top.days} днів досі`,
-      module: top.module,
-    };
-  }
-
-  if (routine.todayTotal > 0 && routine.todayDone > 0) {
-    return {
-      line: `Звички сьогодні: ${routine.todayDone}/${routine.todayTotal}`,
-      module: "routine",
-    };
-  }
-
-  if (
-    nutrition.calGoal &&
-    nutrition.todayCal &&
-    nutrition.todayCal <= nutrition.calGoal
-  ) {
-    return {
-      line: `Уклався в ціль по калоріях: ${nutrition.todayCal}/${nutrition.calGoal} ккал`,
-      module: "nutrition",
-    };
-  }
-
-  return null;
-}
-
-function loadDismissed() {
+function loadDismissed(): Record<string, number> {
   try {
     const raw = localStorage.getItem(DISMISSED_KEY);
     return raw ? JSON.parse(raw) : {};
@@ -101,10 +72,12 @@ function loadDismissed() {
   }
 }
 
-function saveDismissed(map) {
+function saveDismissed(map: Record<string, number>) {
   try {
     localStorage.setItem(DISMISSED_KEY, JSON.stringify(map));
-  } catch {}
+  } catch {
+    /* noop */
+  }
 }
 
 /**
@@ -128,7 +101,7 @@ export function useDashboardFocus() {
     [recs, dismissed],
   );
 
-  const dismiss = useCallback((id) => {
+  const dismiss = useCallback((id: string) => {
     setDismissed((prev) => {
       const next = { ...prev, [id]: Date.now() };
       saveDismissed(next);
@@ -143,89 +116,181 @@ export function useDashboardFocus() {
   };
 }
 
-function EmptyFocus({ onOpenReports }) {
+/**
+ * Snapshot reward-сигналу для хедера Next: серія, що горить, або щойно
+ * виконана ціль. Повертається маленьким chip'ом у хедері Next, замість
+ * того щоб забирати окрему картку.
+ */
+function deriveRewardSignal(): {
+  line: string;
+  module: keyof typeof MODULE_ACCENT;
+} | null {
+  const routine = readJSON("routine_quick_stats") || {};
+  const fizruk = readJSON("fizruk_quick_stats") || {};
+
+  const streaks = [
+    { module: "routine" as const, days: Number(routine.streak) || 0 },
+    { module: "fizruk" as const, days: Number(fizruk.streak) || 0 },
+  ]
+    .filter((s) => s.days >= 2)
+    .sort((a, b) => b.days - a.days);
+
+  if (streaks.length > 0) {
+    const top = streaks[0];
+    return {
+      line: `${top.days} днів поспіль`,
+      module: top.module,
+    };
+  }
+  return null;
+}
+
+interface QuickAddChip {
+  module: HubModuleId;
+  label: string;
+  action: HubModuleAction;
+}
+
+const QUICK_ADD_CHIPS: QuickAddChip[] = (
+  ["finyk", "nutrition", "routine", "fizruk"] as HubModuleId[]
+).map((mod) => {
+  const a = MODULE_PRIMARY_ACTION[mod];
+  return { module: mod, label: a.shortLabel, action: a.action };
+});
+
+const MODULE_CHIP_CLASS: Record<HubModuleId, string> = {
+  finyk: "bg-finyk-soft text-finyk",
+  fizruk: "bg-fizruk-soft text-fizruk",
+  routine: "bg-routine-surface text-routine",
+  nutrition: "bg-nutrition-soft text-nutrition",
+};
+
+/**
+ * Empty-state Next: коли жодної рекомендації немає. Замість пасивного
+ * «Сьогодні нічого термінового» показує 4 quick-add чипи — один тап і
+ * користувач фіксує запис, не мусячи шукати «+» FAB.
+ */
+function EmptyFocus() {
   const reward = deriveRewardSignal();
-  const washClass = reward ? MODULE_WASH[reward.module] : null;
-  const accentClass = reward ? MODULE_ACCENT[reward.module] : null;
+  const washClass = reward
+    ? MODULE_WASH[reward.module]
+    : "bg-panelHi/60 dark:bg-panelHi/30";
 
   return (
     <div
       className={cn(
         "relative overflow-hidden rounded-2xl border border-line bg-panel p-4",
-        "flex items-center gap-3",
         washClass,
       )}
     >
-      {accentClass && (
-        <div
-          className={cn(
-            "absolute left-0 top-4 bottom-4 w-1 rounded-r-full",
-            accentClass,
-          )}
-          aria-hidden
-        />
-      )}
-      <div
-        className={cn(
-          "relative shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-          reward
-            ? "bg-panel/70 text-text"
-            : "bg-brand-100/70 dark:bg-brand-900/30 text-brand-600 dark:text-brand-400",
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-2xs font-semibold uppercase tracking-widest text-muted">
+          Зараз
+        </span>
+        {reward && (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 px-2 py-0.5 rounded-full",
+              "text-2xs font-semibold text-text bg-panel/80 border border-line",
+            )}
+            title="Не розривай серію"
+          >
+            <span aria-hidden>🔥</span>
+            {reward.line}
+          </span>
         )}
-      >
-        <Icon name={reward ? "sparkle" : "check"} size={18} strokeWidth={2.5} />
       </div>
-      <div className="relative flex-1 min-w-0">
-        <p className="text-sm font-semibold text-text leading-snug">
-          {reward ? "Ти в грі" : "Сьогодні нічого термінового"}
-        </p>
-        <p className="text-xs text-muted mt-0.5 leading-snug">
-          {reward
-            ? reward.line
-            : "Все зафіксовано. Переглянь тижневий прогрес або відкрий модуль."}
-        </p>
+
+      <h2 className="text-base font-bold text-text leading-snug">
+        Що зафіксуємо?
+      </h2>
+      <p className="text-xs text-muted mt-0.5 leading-relaxed">
+        Один тап — один запис. Обери модуль і продовжуй.
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {QUICK_ADD_CHIPS.map((chip) => (
+          <button
+            key={chip.module}
+            type="button"
+            onClick={() => openHubModuleWithAction(chip.module, chip.action)}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+              "text-xs font-semibold",
+              "hover:brightness-110 active:scale-[0.98] transition-all",
+              MODULE_CHIP_CLASS[chip.module],
+            )}
+          >
+            {chip.label}
+          </button>
+        ))}
       </div>
-      {onOpenReports && (
-        <button
-          type="button"
-          onClick={onOpenReports}
-          className={cn(
-            "relative shrink-0 text-xs font-semibold text-muted hover:text-text",
-            "px-2.5 py-1.5 rounded-lg hover:bg-panelHi transition-colors",
-          )}
-        >
-          Звіти →
-        </button>
-      )}
     </div>
   );
 }
 
+interface FocusRec {
+  id: string;
+  module: keyof typeof MODULE_ACCENT;
+  title: string;
+  body?: string;
+  icon?: string;
+  action: string;
+  pwaAction?: HubModuleAction;
+}
+
 /**
- * Primary hero on the dashboard: shows a single next-best-action derived from
- * the recommendation engine, or a neutral empty state. Replaces the old
- * decorative DailyProgressHero.
+ * Primary hero on the dashboard: one next-best-action derived from the
+ * recommendation engine, or an action-driven empty state when nothing is
+ * pending. CTA виконує дію (PWA-intent) інлайн, а не навігує в модуль —
+ * це ключова зміна action-driven дашборду.
  */
 export function TodayFocusCard({
   focus,
   onAction,
   onDismiss,
-  onOpenReports,
+  coachInsight,
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  focus: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onAction: (module: any) => void;
+  focus: FocusRec | null;
+  onAction: (module: string) => void;
   onDismiss: (id: string) => void;
-  onOpenReports?: () => void;
+  coachInsight?: string | null;
 }) {
   if (!focus) {
-    return <EmptyFocus onOpenReports={onOpenReports} />;
+    return <EmptyFocus />;
   }
 
   const accent = MODULE_ACCENT[focus.module] || "bg-primary";
   const wash = MODULE_WASH[focus.module] || "bg-panelHi";
-  const cta = MODULE_CTA[focus.module] || "Відкрити";
+
+  const primary = focus.pwaAction
+    ? (() => {
+        const quick = getModulePrimaryAction(focus.module);
+        return {
+          label: quick?.label || MODULE_OPEN_CTA[focus.module] || "Відкрити",
+          run: () =>
+            openHubModuleWithAction(
+              focus.module as HubModuleId,
+              focus.pwaAction as HubModuleAction,
+            ),
+        };
+      })()
+    : {
+        label: MODULE_OPEN_CTA[focus.module] || "Відкрити",
+        run: () => onAction(focus.action),
+      };
+
+  // Fallback: коли primary був імперативним, додаємо текстовий линк
+  // «Відкрити X» як secondary — для юзерів, які хочуть спершу
+  // перевірити контекст у модулі, не фіксуючи нічого.
+  const secondary =
+    focus.pwaAction && onAction
+      ? {
+          label:
+            `Відкрити ${MODULE_SHORT_LABEL[focus.module as HubModuleId] ?? ""}`.trim(),
+          run: () => onAction(focus.action),
+        }
+      : null;
 
   return (
     <div
@@ -245,24 +310,10 @@ export function TodayFocusCard({
       />
 
       <div className="pl-3">
-        <div className="flex items-start justify-between gap-3 mb-1">
+        <div className="flex items-center justify-between gap-3 mb-1">
           <span className="text-2xs font-semibold uppercase tracking-widest text-muted">
             Зараз
           </span>
-          {onDismiss && (
-            <button
-              type="button"
-              onClick={() => onDismiss(focus.id)}
-              aria-label="Відкласти"
-              title="Відкласти"
-              className={cn(
-                "shrink-0 w-7 h-7 -mr-1 -mt-1 rounded-lg flex items-center justify-center",
-                "text-muted hover:text-text hover:bg-panelHi transition-colors",
-              )}
-            >
-              <Icon name="close" size={14} />
-            </button>
-          )}
         </div>
 
         <h2 className="text-base font-bold text-text leading-snug text-balance">
@@ -280,34 +331,50 @@ export function TodayFocusCard({
           </p>
         )}
 
-        {focus.action && (
-          <div className="mt-3 flex items-center gap-2">
+        {coachInsight && (
+          <p className="text-xs text-text/85 italic mt-2 leading-relaxed border-l-2 border-primary/40 pl-2">
+            {coachInsight}
+          </p>
+        )}
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={primary.run}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
+              "bg-primary text-bg text-xs font-semibold",
+              "hover:brightness-110 active:scale-[0.98] transition-all",
+            )}
+          >
+            {primary.label}
+            <Icon name="chevron-right" size={14} strokeWidth={2.5} />
+          </button>
+          {secondary && (
             <button
               type="button"
-              onClick={() => onAction(focus.action)}
+              onClick={secondary.run}
               className={cn(
-                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg",
-                "bg-primary text-bg text-xs font-semibold",
-                "hover:brightness-110 active:scale-[0.98] transition-all",
+                "text-xs font-medium text-muted hover:text-text",
+                "px-2.5 py-1.5 rounded-lg hover:bg-panelHi transition-colors",
               )}
             >
-              {cta}
-              <Icon name="chevron-right" size={14} strokeWidth={2.5} />
+              {secondary.label}
             </button>
-            {onDismiss && (
-              <button
-                type="button"
-                onClick={() => onDismiss(focus.id)}
-                className={cn(
-                  "text-xs font-medium text-muted hover:text-text",
-                  "px-2.5 py-1.5 rounded-lg hover:bg-panelHi transition-colors",
-                )}
-              >
-                Пізніше
-              </button>
-            )}
-          </div>
-        )}
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={() => onDismiss(focus.id)}
+              className={cn(
+                "ml-auto text-xs font-medium text-muted hover:text-text",
+                "px-2.5 py-1.5 rounded-lg hover:bg-panelHi transition-colors",
+              )}
+            >
+              Пізніше
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/core/lib/recommendationEngine.ts
+++ b/src/core/lib/recommendationEngine.ts
@@ -181,6 +181,7 @@ function buildFizrukRecs(): Rec[] {
       title: `${Math.round(daysSinceWorkout)} днів без тренування`,
       body: "Пора відновити активність! Навіть легке тренування краще, ніж нічого.",
       action: "fizruk",
+      pwaAction: "start_workout",
     });
   }
 
@@ -198,6 +199,7 @@ function buildFizrukRecs(): Rec[] {
         title: `${label} не тренували ${days} днів`,
         body: "Включи вправи на ці м'язи в наступне тренування.",
         action: "fizruk",
+        pwaAction: "start_workout",
       });
     }
   }
@@ -217,6 +219,7 @@ function buildFizrukRecs(): Rec[] {
       title: "Цього тижня ще немає тренувань",
       body: "Тиждень вже в розпалі — час запланувати тренування!",
       action: "fizruk",
+      pwaAction: "start_workout",
     });
   }
 
@@ -327,6 +330,7 @@ function buildNutritionRecs(): Rec[] {
       title: "Сьогодні ще немає записів про їжу",
       body: "Зафіксуй свій прийом їжі, щоб стежити за КБЖВ.",
       action: "nutrition",
+      pwaAction: "add_meal",
     });
   } else if (meals.length > 0) {
     const pctKcal = kcal / targetKcal;
@@ -339,6 +343,7 @@ function buildNutritionRecs(): Rec[] {
         title: `Лише ${Math.round(kcal)} ккал з ${targetKcal} ккал цілі`,
         body: "Недостатнє споживання калорій може уповільнити відновлення.",
         action: "nutrition",
+        pwaAction: "add_meal",
       });
     }
 
@@ -352,6 +357,7 @@ function buildNutritionRecs(): Rec[] {
         title: `Лише ${Math.round(protein)}г білка з ${targetProtein}г`,
         body: "Додай протеїновий прийом їжі — це важливо для м'язів.",
         action: "nutrition",
+        pwaAction: "add_meal",
       });
     }
 
@@ -373,6 +379,7 @@ function buildNutritionRecs(): Rec[] {
           title: "Після тренування — час поповнити білок!",
           body: "У вас є ~30 хвилин на протеїновий прийом для кращого відновлення.",
           action: "nutrition",
+          pwaAction: "add_meal",
         });
       }
     }

--- a/src/core/lib/recommendations/types.ts
+++ b/src/core/lib/recommendations/types.ts
@@ -4,6 +4,8 @@
 // per-rule і декларативний пріоритет. Натхненно json-rules-engine, але без
 // DSL — правило це звичайна функція `evaluate(ctx)`.
 
+import type { HubModuleAction } from "@shared/lib/hubNav";
+
 export type Module = "finyk" | "fizruk" | "routine" | "nutrition" | "hub";
 
 export interface Rec {
@@ -13,7 +15,12 @@ export interface Rec {
   icon: string;
   title: string;
   body: string;
+  // Навігаційна дія (модуль або "reports"). Залишаємо як fallback — колись
+  // просто відкривала розділ. Нове поле `pwaAction` вмикає імперативний
+  // CTA ("Додати витрату", "Почати тренування"), який виконується одним
+  // тапом без додаткового кроку «Відкрити модуль».
   action: string;
+  pwaAction?: HubModuleAction;
 }
 
 export interface Rule<Ctx> {

--- a/src/shared/lib/moduleQuickActions.ts
+++ b/src/shared/lib/moduleQuickActions.ts
@@ -1,0 +1,51 @@
+/**
+ * Централізована мапа «primary quick-action» для кожного Hub-модуля.
+ *
+ * Використовується на dashboard'і (NextCard, ModuleRow, empty-state chips),
+ * щоб усі поверхні показували однакові label'и та dispatchали однакові
+ * PWA-intent-и через `openHubModuleWithAction`. Не використовуй окремі
+ * строки-CTA в UI — бери звідси.
+ */
+
+import type { HubModuleAction, HubModuleId } from "./hubNav";
+
+export interface ModulePrimaryAction {
+  /** Імперативний label для CTA: «Додати витрату», «Почати тренування», … */
+  label: string;
+  /** Короткий label для інлайн-чипа у списку модулів. */
+  shortLabel: string;
+  /** PWA-інтент, який dispatchається через `openHubModuleWithAction`. */
+  action: HubModuleAction;
+}
+
+export const MODULE_PRIMARY_ACTION: Record<HubModuleId, ModulePrimaryAction> = {
+  finyk: {
+    label: "Додати витрату",
+    shortLabel: "+ Витрата",
+    action: "add_expense",
+  },
+  fizruk: {
+    label: "Почати тренування",
+    shortLabel: "+ Тренування",
+    action: "start_workout",
+  },
+  routine: {
+    label: "Додати звичку",
+    shortLabel: "+ Звичка",
+    action: "add_habit",
+  },
+  nutrition: {
+    label: "Додати прийом їжі",
+    shortLabel: "+ Їжа",
+    action: "add_meal",
+  },
+};
+
+export function getModulePrimaryAction(
+  moduleId: string,
+): ModulePrimaryAction | null {
+  return (
+    (MODULE_PRIMARY_ACTION as Record<string, ModulePrimaryAction>)[moduleId] ||
+    null
+  );
+}


### PR DESCRIPTION
## Summary

Переводить hub-дашборд з «екрану даних» на «екран прийняття рішень». Головна дія — зафіксувати наступний запис одним тапом, а не «відкрити модуль».

**Як було:** DateHeader → TodayFocusCard → FTUX/Demo/SoftAuth banner → 4 module-рядки з chevron+progress+«Демо» на кожному → HubInsightsPanel (зі своїм coach-дублем) → WeeklyDigestFooter завжди. Кілька конкурентних «hero»-блоків, CTA-и приводили в модуль без дії.

**Як стало:**
- **Один hero-слот.** FTUX → Demo → SoftAuth → `TodayFocusCard`. Бʼєш-бюджет банерів = 0, поверх NextCard нічого не рендериться.
- **Імперативний CTA.** Recs несуть optional `pwaAction` (`add_expense`, `start_workout`, `add_meal`). NextCard dispatch-ить його через `openHubModuleWithAction`, відкриваючи модуль одразу в add-sheet замість порожнього списку. Fallback-лінк «Відкрити X» лишається для дослідницького юзкейсу.
- **Empty-state = дія.** Замість «Сьогодні нічого термінового» — «Що зафіксуємо?» з 4 quick-add chips (Витрата / Їжа / Звичка / Тренування) через ту саму intent-систему.
- **Coach inline під body NextCard.** Раніше дубль: інсайт був у картці фокусу **і** в HubInsightsPanel. Тепер тільки в NextCard як italic-рядок з accent-border.
- **Secondary chips (≤2)** між NextCard і списком статусу — показуються лише коли є сигнал на іншому модулі.
- **Status-список тихіший.** Зник chevron з кожного рядка. Progress-бар рендериться тільки коли `hasGoal && progress > 0`. Per-row «Демо» pill замінена одним `DemoStrip` над секцією. Модуль, під яким є видима рекомендація, отримує inline-кнопку `+` — quick-add одним тапом.
- **Weekly digest footer.** Видно тільки в Пн/Вт або коли є fresh digest. Fresh-дот лишається як раніше.
- **HubInsightsPanel** більше не тримає coach-row (переїхав у NextCard) і не авто-розкривається.

### Файли
- `src/core/lib/recommendations/types.ts` — додав optional `pwaAction?: HubModuleAction` на `Rec`.
- `src/core/lib/recommendationEngine.ts` — `fizruk_*` → `start_workout`, `nutrition_*` → `add_meal`.
- `src/shared/lib/moduleQuickActions.ts` *(новий)* — централізована мапа primary-дій на модуль (label + action). Споживається NextCard, StatusRow, SecondaryChips, EmptyFocus — не лишилось розкиданих строк-CTA.
- `src/core/TodayFocusCard.tsx` — refactor на action-driven: primary-CTA із pwaAction, secondary «Відкрити X», coach inline, single dismiss («Пізніше»), quick-add empty-state.
- `src/core/HubInsightsPanel.tsx` — прибрав CoachRow і auto-open, лишив тихий колапс з rest-recs.
- `src/core/HubDashboard.tsx` — one-hero rule, SecondaryChips, StatusRow із inline `+`, DemoStrip, прибраний DateHeader, digest footer конус-онлі Пн/Вт|fresh.

### Behaviour/compat notes
- Dismiss-state (`hub_recs_dismissed_v1`) зберігається — стара і нова панелі ділять один ключ, нічого не ресетнеться.
- DnD-reorder на дашборді лишився (touch delay 250ms працює як long-press; не ламає звичайний тап).
- `onOpenChat` prop на `HubDashboard` зараз не використовується — prefixed `_onOpenChat`, щоб lint не падав. Залишив у сигнатурі, бо його ще передає `HubMainContent`; прибирати окремим PR, коли chat-surface реально переживе рішення.

## Review & Testing Checklist for Human

- [ ] **Intent-dispatch працює для всіх модулів.** Тапни по primary-CTA в NextCard, secondary chip-у і inline `+` у status-списку для кожного модуля → має відкривати саме add-sheet (Finyk add expense, Fizruk start workout, Nutrition add meal, Routine add habit), а не просто модуль. Особливо перевір Routine: `add_habit` має відкрити «create habit», не головний список.
- [ ] **Empty-state і FTUX-ланцюжок.** Холодний старт (чистий localStorage) → видно FirstActionHero як hero. Після dismiss → Demo banner (коли `wasDemoSeeded`). Після dismiss + без реальних даних → NextCard з «Що зафіксуємо?» і 4 chips. Після першого реального запису → focus-рек або empty-state з chips, SoftAuth йде якщо без акаунту.
- [ ] **Coach insight не дублюється.** Якщо сьогодні є coach insight — бачиш italic-рядок у NextCard, і в HubInsightsPanel його вже немає.
- [ ] **Secondary chips.** При 2+ recs із `pwaAction` на різних модулях між hero і status-списком зʼявляються 1–2 чипи; при 0–1 recs — їх немає.
- [ ] **WeeklyDigestFooter умовний.** Відкрити дашборд у середу без fresh-digest → лінка немає. У понеділок або коли `hasLiveWeeklyDigest()` → лінк присутній. `WeeklyDigestCard` розгортається по кліку.
- [ ] **Status-список.** Chevron нема, progress-бар є тільки на Routine/Nutrition коли є прогрес, «Демо» pill зникла — зверху один `DemoStrip` доки нема реального запису. Inline `+` зʼявляється тільки на тих модулях, що мають видимий rec.

### Notes

Бекенд/intent-пайплайн (`usePwaActions`, `HUB_OPEN_MODULE_EVENT`, `PWA_ACTION_KEY`) не змінювався — використовується як було. Якщо треба чистіший «log_habit» для `routine_evening_reminder` / `routine_streak_at_risk` (щоб «+» логував звичку, не додавав нову) — окремий PR: зараз ці recs свідомо без `pwaAction`, щоб не запалити створення нової звички замість позначення існуючої.


Link to Devin session: https://app.devin.ai/sessions/2057a8e2266047ebba88c015403c19d0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
