### PR TITLE
fix(sheet): drop rounded-xl from module focus-visible rules

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -221,22 +221,22 @@
      ═══════════════════════════════════════════════════════════════════════ */
   .fizruk-sheet button:focus-visible,
   .fizruk-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-teal-500/45 ring-offset-2 ring-offset-panel rounded-xl;
+    @apply outline-none ring-2 ring-teal-500/45 ring-offset-2 ring-offset-panel;
   }
 
   .routine-sheet button:focus-visible,
   .routine-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-coral-500/45 ring-offset-2 ring-offset-panel rounded-xl;
+    @apply outline-none ring-2 ring-coral-500/45 ring-offset-2 ring-offset-panel;
   }
 
   .nutrition-sheet button:focus-visible,
   .nutrition-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-lime-500/45 ring-offset-2 ring-offset-panel rounded-xl;
+    @apply outline-none ring-2 ring-lime-500/45 ring-offset-2 ring-offset-panel;
   }
 
   .finyk-sheet button:focus-visible,
   .finyk-sheet a:focus-visible {
-    @apply outline-none ring-2 ring-brand-500/45 ring-offset-2 ring-offset-panel rounded-xl;
+    @apply outline-none ring-2 ring-brand-500/45 ring-offset-2 ring-offset-panel;
   }
 
   /* ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Follow-up до #252. Devin Review знайшов реальний регрес: після того, як `panelClassName="<module>-sheet"` був прив'язаний до всіх `<Sheet>`, модульні CSS-правила `.fizruk-sheet button:focus-visible { … rounded-xl }` (і аналоги для routine/nutrition/finyk у `src/index.css:222-240`) почали матчити close-кнопку Sheet'а. У цих правил specificity (0,2,1) вища за Tailwind-утиліту `rounded-full` (0,1,0) на кнопці — тому під клавіатурним фокусом кругла close-кнопка (`src/shared/components/ui/Sheet.tsx:146`) перетворювалась на закруглений прямокутник.

Фікс — прибрати `rounded-xl` із усіх 4 правил. Це був rudiment: фокус-кільце малюється через `box-shadow` (Tailwind `ring-*`) і на його форму `rounded-*` не впливає. Форма самого елемента має задаватися на рівні елемента (`rounded-full` на close-кнопці, `rounded-xl` на інпутах тощо) — і саме так це і зроблено у компонентах.

Ніяких інших змін.

## Review & Testing Checklist for Human

- [ ] Keyboard-focus (Tab) close-кнопки всередині будь-якого модульного Sheet'а — має залишатися ідеально круглою, з модульним кольоровим кільцем (teal/coral/lime/emerald).
- [ ] Focus-кільце на інпутах/селектах всередині Sheet'а не змінило свою поведінку (вони самі мають `rounded-xl`/`rounded-lg` на елементі).

### Notes

Мінімальний 4-рядковий CSS-фікс. `npm run lint` + `npm run typecheck` проходять.

Link to Devin session: https://app.devin.ai/sessions/145a2c230f4e40fda472610e891ea893
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
