### PR TITLE
hub: UX audit batch — onboarding splash, FAB, habit form, expense order

### DIFF
--- a/src/core/HubDashboard.tsx
+++ b/src/core/HubDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
@@ -16,6 +16,8 @@ import {
   isDemoBannerDismissed,
   dismissDemoBanner,
   isFirstActionPending,
+  recordSessionDay,
+  getSessionDays,
 } from "./onboarding/vibePicks.js";
 import { wasDemoSeeded } from "./onboarding/demoSeeds.js";
 import { useFirstEntryCelebration } from "./onboarding/useFirstEntryCelebration.js";
@@ -457,18 +459,32 @@ export function HubDashboard({ onOpenModule, onOpenChat, user, onShowAuth }) {
     isFirstActionPending(),
   );
 
-  // Soft auth prompt appears only once the user has typed in real data and
-  // has no account yet — an "offer to save", never a toll gate.
+  // Soft auth prompt — an "offer to save", never a toll gate. Two triggers:
+  //   1. user has entered real data (the moment the local data becomes
+  //      worth losing), or
+  //   2. user has been opening the hub for N+ distinct days without ever
+  //      creating an account — catches the browse-only cohort that would
+  //      otherwise silently lose everything on a device swap. N is small
+  //      enough that a regular user hits it within their first week.
   const hasRealEntry = detectFirstRealEntry();
   useFirstEntryCelebration(hasRealEntry);
+  // Record today's session on mount so the proactive nudge actually
+  // accumulates days; scoped to once-per-mount via ref to avoid
+  // double-counting if the component re-renders.
+  const sessionDaysRef = useRef<number>(0);
+  if (sessionDaysRef.current === 0) {
+    sessionDaysRef.current = recordSessionDay() || getSessionDays();
+  }
+  const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
   const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
     isSoftAuthDismissed(),
   );
   const showSoftAuth =
     !user &&
-    hasRealEntry &&
     !softAuthDismissed &&
-    typeof onShowAuth === "function";
+    typeof onShowAuth === "function" &&
+    (hasRealEntry ||
+      sessionDaysRef.current >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
 
   // Demo banner: only while we're still showing seeded FTUX data and the
   // user hasn't contributed anything of their own yet. Dismissible; once

--- a/src/core/OnboardingWizard.tsx
+++ b/src/core/OnboardingWizard.tsx
@@ -65,77 +65,40 @@ function markOnboardingDone() {
   }
 }
 
-// Static preview of what a "full" Sergeant hub looks like: four concrete
-// metrics rendered at once in a compact 2×2 grid. Replaces the earlier
-// auto-cycling ticker — a full rotation took ~9 s, which burnt a third of
-// the 30-second FTUX promise before the user could even tap the CTA.
-const SPLASH_PREVIEW_ITEMS = [
-  {
-    icon: "credit-card",
-    accent: "text-finyk bg-finyk-soft",
-    metric: "−320 грн",
-    label: "на каву цього тижня",
-  },
-  {
-    icon: "dumbbell",
-    accent: "text-fizruk bg-fizruk-soft",
-    metric: "5 трен.",
-    label: "за 14 днів",
-  },
-  {
-    icon: "check",
-    accent: "text-routine bg-routine-soft",
-    metric: "7 днів",
-    label: "стрік — «вода»",
-  },
-  {
-    icon: "utensils",
-    accent: "text-nutrition bg-nutrition-soft",
-    metric: "420 ккал",
-    label: "сніданок",
-  },
-];
-
-function SplashPreviewGrid() {
-  return (
-    <div className="grid grid-cols-2 gap-2 w-full">
-      {SPLASH_PREVIEW_ITEMS.map((item) => (
-        <div
-          key={item.icon}
-          className={cn(
-            "rounded-xl border border-line bg-surface",
-            "px-3 py-2.5 flex items-center gap-2.5 text-left",
-          )}
-        >
-          <div
-            className={cn(
-              "shrink-0 w-9 h-9 rounded-lg flex items-center justify-center",
-              item.accent,
-            )}
-          >
-            <Icon name={item.icon} size={18} strokeWidth={2} aria-hidden />
-          </div>
-          <div className="min-w-0">
-            <div className="text-sm font-semibold text-text leading-tight truncate">
-              {item.metric}
-            </div>
-            <div className="text-[11px] text-muted leading-tight truncate">
-              {item.label}
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Short per-module chips shown inline on the splash. Keys match
-// `ALL_MODULES` so picks feed straight into `saveVibePicks`.
+// Module chips shown inline on the splash — the single source of truth
+// for module taxonomy on this screen. Previously accompanied by a
+// separate 2×2 preview grid that duplicated the four modules with
+// different labels ("Гроші" chip vs "−320 грн" preview tile), so new
+// users saw two competing taxonomies on one screen. We now fold a
+// small aspirational metric into each chip instead, so the chip is
+// both the selector and the teaser — one object, one label.
+//
+// Keys match `ALL_MODULES` so picks feed straight into `saveVibePicks`.
 const VIBE_CHIPS = [
-  { id: "finyk", icon: "credit-card", label: "Гроші" },
-  { id: "fizruk", icon: "dumbbell", label: "Тіло" },
-  { id: "routine", icon: "check", label: "Рутина" },
-  { id: "nutrition", icon: "utensils", label: "Їжа" },
+  {
+    id: "finyk",
+    icon: "credit-card",
+    label: "Гроші",
+    teaser: "−320₴ / тиждень",
+  },
+  {
+    id: "fizruk",
+    icon: "dumbbell",
+    label: "Тіло",
+    teaser: "5 трен. за 14 днів",
+  },
+  {
+    id: "routine",
+    icon: "check",
+    label: "Рутина",
+    teaser: "стрік «вода» 7 днів",
+  },
+  {
+    id: "nutrition",
+    icon: "utensils",
+    label: "Їжа",
+    teaser: "сніданок · 420 ккал",
+  },
 ];
 
 function VibeChipRow({ picks, togglePick }) {
@@ -144,7 +107,7 @@ function VibeChipRow({ picks, togglePick }) {
       <p className="text-[11px] text-muted text-center">
         Зніми зайве — решту легко додати потім.
       </p>
-      <div className="flex flex-wrap gap-2 justify-center">
+      <div className="grid grid-cols-2 gap-2">
         {VIBE_CHIPS.map((chip) => {
           const active = picks.includes(chip.id);
           return (
@@ -154,15 +117,30 @@ function VibeChipRow({ picks, togglePick }) {
               onClick={() => togglePick(chip.id)}
               aria-pressed={active}
               className={cn(
-                "inline-flex items-center gap-1.5 h-9 px-3 rounded-full border transition-all",
+                "flex items-center gap-2.5 px-3 py-2.5 rounded-xl border text-left transition-all",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
                 active
-                  ? "border-brand-500/60 bg-brand-500/10 text-text"
-                  : "border-line bg-panelHi text-muted hover:border-brand-500/40",
+                  ? "border-brand-500/60 bg-brand-500/10 text-text shadow-card"
+                  : "border-line bg-panel text-muted hover:border-brand-500/40",
               )}
             >
-              <Icon name={chip.icon} size={14} strokeWidth={2} aria-hidden />
-              <span className="text-xs font-medium">{chip.label}</span>
+              <span
+                className={cn(
+                  "shrink-0 w-8 h-8 rounded-lg flex items-center justify-center",
+                  active ? "bg-brand-500/15 text-brand-600" : "bg-panelHi",
+                )}
+                aria-hidden
+              >
+                <Icon name={chip.icon} size={16} strokeWidth={2} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-semibold text-text leading-tight truncate">
+                  {chip.label}
+                </span>
+                <span className="block text-[11px] text-muted leading-tight truncate">
+                  {chip.teaser}
+                </span>
+              </span>
             </button>
           );
         })}
@@ -191,10 +169,9 @@ function SplashStep({ picks, togglePick, onContinue }) {
           Твоє життя — один екран.
         </h2>
         <p className="text-sm text-muted mt-2 leading-relaxed">
-          Гроші, тіло, звички, їжа. Офлайн. 30 секунд до першого запису.
+          Гроші, тіло, звички, їжа. Офлайн. ~5 секунд на перший запис.
         </p>
       </div>
-      <SplashPreviewGrid />
       <VibeChipRow picks={picks} togglePick={togglePick} />
       <div className="w-full space-y-2">
         <Button

--- a/src/core/app/HubFloatingActions.tsx
+++ b/src/core/app/HubFloatingActions.tsx
@@ -124,19 +124,34 @@ export function HubFloatingActions({ hidden = false }) {
         </div>
       )}
 
+      {/* S5 / S14: extended FAB pill — shows an always-visible "Додати"
+          label on first paint so the primary action isn't just a blue
+          circle users have to guess at (especially on touch, where the
+          `title` tooltip never appears). Collapses to an icon-only
+          rotated × when the speed-dial is open. */}
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label={open ? "Закрити меню додавання" : "Додати"}
-        title="Додати"
+        title={open ? "Закрити" : "Додати"}
         className={cn(
-          "pointer-events-auto w-14 h-14 flex items-center justify-center rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-          open && "rotate-45",
+          "pointer-events-auto h-14 flex items-center justify-center gap-2 rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          open ? "w-14" : "pl-4 pr-5",
         )}
       >
-        <Icon name="plus" size={26} strokeWidth={2.5} />
+        <Icon
+          name="plus"
+          size={26}
+          strokeWidth={2.5}
+          className={cn("transition-transform", open && "rotate-45")}
+        />
+        {!open && (
+          <span className="text-sm font-semibold whitespace-nowrap">
+            Додати
+          </span>
+        )}
       </button>
     </div>
   );

--- a/src/core/onboarding/FirstActionSheet.tsx
+++ b/src/core/onboarding/FirstActionSheet.tsx
@@ -19,13 +19,13 @@ const ACTIONS = {
   routine: {
     icon: "check",
     title: "Створи першу звичку",
-    desc: "30 секунд. Стрік почнеться сьогодні.",
+    desc: "~5 секунд. Стрік почнеться сьогодні.",
     accent: "text-routine bg-routine-soft",
   },
   finyk: {
     icon: "credit-card",
     title: "Додай першу витрату",
-    desc: "5 секунд, будь-яка сума.",
+    desc: "~5 секунд, будь-яка сума.",
     accent: "text-finyk bg-finyk-soft",
   },
   nutrition: {

--- a/src/core/onboarding/vibePicks.ts
+++ b/src/core/onboarding/vibePicks.ts
@@ -7,6 +7,13 @@ const FIRST_ACTION_PENDING_KEY = "hub_first_action_pending_v1";
 const FIRST_REAL_ENTRY_KEY = "hub_first_real_entry_done_v1";
 const SOFT_AUTH_DISMISSED_KEY = "hub_soft_auth_dismissed_v1";
 const DEMO_BANNER_DISMISSED_KEY = "hub_demo_banner_dismissed_v1";
+// Rolling count of distinct calendar days the user has opened the hub.
+// Used by the proactive soft-auth nudge so users who never make a
+// "real entry" (e.g. they open the app, browse, close) still get
+// offered cloud sync after a few days instead of being silently locked
+// out of their data if they switch devices.
+const SESSION_DAYS_KEY = "hub_session_days_v1";
+const LAST_SESSION_DAY_KEY = "hub_last_session_day_v1";
 // Millisecond epoch stamp captured the moment the user taps «Заповни
 // мій хаб» on the splash. Used by `firstRealEntry.js` to compute the
 // `ftux_time_to_value` duration — the single headline metric for the
@@ -191,5 +198,48 @@ export function getTimeToValueMs() {
     return Number.isFinite(n) && n >= 0 ? n : null;
   } catch {
     return null;
+  }
+}
+
+function todayKey(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Record a hub session for today. If the current calendar day has
+ * already been counted, this is a no-op, so repeat navigations within
+ * the same day don't inflate the counter. Returns the (possibly
+ * incremented) session-day count so callers can render conditional UI
+ * without a second read.
+ */
+export function recordSessionDay(): number {
+  try {
+    const key = todayKey();
+    const last = localStorage.getItem(LAST_SESSION_DAY_KEY);
+    const current = Number(localStorage.getItem(SESSION_DAYS_KEY) || "0") || 0;
+    if (last === key) return current;
+    const next = current + 1;
+    localStorage.setItem(LAST_SESSION_DAY_KEY, key);
+    localStorage.setItem(SESSION_DAYS_KEY, String(next));
+    return next;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * @returns Total number of distinct calendar days the user has opened
+ *   the hub (0 if never recorded / localStorage disabled).
+ */
+export function getSessionDays(): number {
+  try {
+    const n = Number(localStorage.getItem(SESSION_DAYS_KEY) || "0");
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch {
+    return 0;
   }
 }

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -63,24 +63,26 @@ function stripEmoji(label) {
 }
 
 // Amount suggestion pills. Defaults give a first-run user sane round
-// values; once the user has spending history we merge in the top-3
-// distinct recent amounts (see `mergeAmountSuggestions`).
+// values; once the user has spending history we show personalised
+// «Часте» amounts (from top merchants’ average spend) separately
+// from the «Швидко» round-number defaults, so the user can tell
+// which suggestion is based on their own history and which is a
+// generic shortcut.
 const DEFAULT_AMOUNTS = [50, 100, 200, 500];
 
-function mergeAmountSuggestions(frequentMerchants) {
-  const fromMerchants = [];
+function buildAmountSuggestions(frequentMerchants) {
+  const frequent = [];
   for (const m of frequentMerchants || []) {
     if (!m || typeof m.total !== "number" || !m.count) continue;
     const avg = Math.round(m.total / m.count);
-    if (avg > 0 && !fromMerchants.includes(avg)) fromMerchants.push(avg);
-    if (fromMerchants.length >= 3) break;
+    if (avg > 0 && !frequent.includes(avg)) frequent.push(avg);
+    if (frequent.length >= 3) break;
   }
-  const merged = [...fromMerchants];
-  for (const v of DEFAULT_AMOUNTS) {
-    if (!merged.includes(v)) merged.push(v);
-    if (merged.length >= 6) break;
-  }
-  return merged.slice(0, 6);
+  const quick = DEFAULT_AMOUNTS.filter((v) => !frequent.includes(v)).slice(
+    0,
+    4,
+  );
+  return { frequent, quick };
 }
 
 // Сортує доступні підписи категорій за персональною частотою, зберігаючи
@@ -187,8 +189,8 @@ export function ManualExpenseSheet({
     [frequentCategories],
   );
 
-  const amountSuggestions = useMemo(
-    () => mergeAmountSuggestions(frequentMerchants),
+  const { frequent: frequentAmounts, quick: quickAmounts } = useMemo(
+    () => buildAmountSuggestions(frequentMerchants),
     [frequentMerchants],
   );
   // Ховаємо зі списку пропозицій мерчанта, якого вже введено у полі description.
@@ -249,23 +251,80 @@ export function ManualExpenseSheet({
       }
     >
       <div className="space-y-3">
-        <div className="flex gap-2 items-center">
+        {/* S15: amount is the only «must-fill» field — it used to live
+            under the name input, so new users had to scroll past an
+            optional field before they could do the single thing that
+            makes an expense valid. Amount is now the first block on the
+            sheet; the mic stays near it because dictation typically
+            produces both the amount and the description in one shot. */}
+        <div className="flex gap-2 items-end">
           <div className="flex-1">
             <label
-              htmlFor={descId}
+              htmlFor={amountId}
               className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
             >
-              Назва{" "}
-              <span className="text-subtle normal-case">
-                · необов&apos;язково
-              </span>
+              Сума ₴
             </label>
+            {(frequentAmounts.length > 0 || quickAmounts.length > 0) && (
+              <div className="space-y-1.5 mb-2">
+                {frequentAmounts.length > 0 && (
+                  <div
+                    className="flex flex-wrap items-center gap-1.5"
+                    role="group"
+                    aria-label="Часті суми"
+                  >
+                    <span className="text-2xs text-subtle uppercase tracking-wide font-semibold">
+                      Часте
+                    </span>
+                    {frequentAmounts.map((v) => (
+                      <button
+                        key={`f-${v}`}
+                        type="button"
+                        onClick={() =>
+                          setForm((f) => ({ ...f, amount: String(v) }))
+                        }
+                        className="px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
+                      >
+                        {v.toLocaleString("uk-UA")} ₴
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {quickAmounts.length > 0 && (
+                  <div
+                    className="flex flex-wrap items-center gap-1.5"
+                    role="group"
+                    aria-label="Швидкі суми"
+                  >
+                    <span className="text-2xs text-subtle uppercase tracking-wide font-semibold">
+                      Швидко
+                    </span>
+                    {quickAmounts.map((v) => (
+                      <button
+                        key={`q-${v}`}
+                        type="button"
+                        onClick={() =>
+                          setForm((f) => ({ ...f, amount: String(v) }))
+                        }
+                        className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                      >
+                        {v.toLocaleString("uk-UA")} ₴
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
             <Input
-              id={descId}
-              placeholder="Кава, продукти, таксі..."
-              value={form.description}
+              id={amountId}
+              type="number"
+              inputMode="decimal"
+              placeholder="0"
+              min="0"
+              step="0.01"
+              value={form.amount}
               onChange={(e) =>
-                setForm((f) => ({ ...f, description: e.target.value }))
+                setForm((f) => ({ ...f, amount: e.target.value }))
               }
             />
           </div>
@@ -277,7 +336,7 @@ export function ManualExpenseSheet({
               that case via `hidden:*`-style absent fallback (the button
               returns null and the flex container collapses to the input
               alone). */}
-          <div className="mt-5 flex flex-col items-center gap-0.5">
+          <div className="flex flex-col items-center gap-0.5 pb-1">
             <VoiceMicButton
               size="md"
               label="Сказати голосом"
@@ -298,6 +357,26 @@ export function ManualExpenseSheet({
               Сказати
             </span>
           </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor={descId}
+            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+          >
+            Назва{" "}
+            <span className="text-subtle normal-case">
+              · необов&apos;язково
+            </span>
+          </label>
+          <Input
+            id={descId}
+            placeholder="Кава, продукти, таксі..."
+            value={form.description}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, description: e.target.value }))
+            }
+          />
         </div>
 
         {/* Date is "today" 95%+ of the time — the always-visible picker
@@ -365,43 +444,6 @@ export function ManualExpenseSheet({
             ))}
           </div>
         )}
-
-        <div>
-          <label
-            htmlFor={amountId}
-            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-          >
-            Сума ₴
-          </label>
-          {amountSuggestions.length > 0 && (
-            <div
-              className="flex flex-wrap gap-1.5 mb-2"
-              role="group"
-              aria-label="Швидкі суми"
-            >
-              {amountSuggestions.map((v) => (
-                <button
-                  key={v}
-                  type="button"
-                  onClick={() => setForm((f) => ({ ...f, amount: String(v) }))}
-                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
-                >
-                  {v.toLocaleString("uk-UA")} ₴
-                </button>
-              ))}
-            </div>
-          )}
-          <Input
-            id={amountId}
-            type="number"
-            inputMode="decimal"
-            placeholder="0"
-            min="0"
-            step="0.01"
-            value={form.amount}
-            onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
-          />
-        </div>
 
         <div>
           <div

--- a/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -7,7 +7,7 @@ import {
   emptyHabitDraft,
   habitDraftToPatch,
 } from "../lib/routineDraftUtils.js";
-import { HabitForm } from "./settings/HabitForm";
+import { HabitForm, type HabitFormErrors } from "./settings/HabitForm";
 import type { HabitDraft, RoutineState } from "../lib/types";
 import type { Dispatch, SetStateAction } from "react";
 
@@ -47,6 +47,7 @@ export function HabitQuickCreateDialog({
   const toast = useToast();
   const [draft, setDraft] = useState<HabitDraft>(() => emptyHabitDraft());
   const [internalFocusTick, setInternalFocusTick] = useState(0);
+  const [errors, setErrors] = useState<HabitFormErrors>({});
 
   // Reset the draft and re-fire the focus tick each time the dialog
   // opens. Keeps reopens feeling like a fresh entry point instead of
@@ -54,24 +55,46 @@ export function HabitQuickCreateDialog({
   useEffect(() => {
     if (!open) return;
     setDraft(emptyHabitDraft());
+    setErrors({});
     setInternalFocusTick((t) => t + 1);
   }, [open, focusTick]);
+
+  // Clear field errors as soon as the user touches the relevant field
+  // so the red border doesn't linger once they start fixing the input.
+  useEffect(() => {
+    if (errors.name && draft.name.trim()) {
+      setErrors((e) => ({ ...e, name: undefined }));
+    }
+  }, [draft.name, errors.name]);
+  useEffect(() => {
+    if (
+      errors.weekdays &&
+      Array.isArray(draft.weekdays) &&
+      draft.weekdays.length > 0
+    ) {
+      setErrors((e) => ({ ...e, weekdays: undefined }));
+    }
+  }, [draft.weekdays, errors.weekdays]);
 
   if (!open) return null;
 
   const handleSave = () => {
     const patch = habitDraftToPatch(draft);
+    const nextErrors: HabitFormErrors = {};
     if (!patch.name) {
-      toast.warning("Додай назву звички.");
-      return;
+      nextErrors.name = "Додай назву звички.";
     }
     if (
       patch.recurrence === "weekly" &&
       (!patch.weekdays || patch.weekdays.length === 0)
     ) {
-      toast.warning("Обери хоча б один день тижня.");
+      nextErrors.weekdays = "Обери хоча б один день тижня.";
+    }
+    if (nextErrors.name || nextErrors.weekdays) {
+      setErrors(nextErrors);
       return;
     }
+    setErrors({});
     setRoutine((s) => createHabit(s, patch));
     toast.success("Звичку створено.");
     onClose();
@@ -136,6 +159,8 @@ export function HabitQuickCreateDialog({
             onSave={handleSave}
             onCancel={onClose}
             focusTick={internalFocusTick}
+            hideHeading
+            errors={errors}
           />
         </div>
       </div>

--- a/src/modules/routine/components/settings/HabitForm.tsx
+++ b/src/modules/routine/components/settings/HabitForm.tsx
@@ -19,6 +19,11 @@ import { ReminderPresets } from "./ReminderPresets.jsx";
 import { WeekdayPicker } from "./WeekdayPicker.jsx";
 import type { HabitDraft, RoutineState } from "../../lib/types";
 
+export interface HabitFormErrors {
+  name?: string;
+  weekdays?: string;
+}
+
 export interface HabitFormProps {
   routine: RoutineState;
   habitDraft: HabitDraft;
@@ -34,7 +39,39 @@ export interface HabitFormProps {
    * reset anything.
    */
   focusTick?: number;
+  /**
+   * When true, suppress the internal "Нова звичка / Редагувати звичку"
+   * heading. The dialog host already renders a bolder title so we skip
+   * the duplicate for a cleaner one-title-per-screen look.
+   */
+  hideHeading?: boolean;
+  /**
+   * Inline error messages for individual fields, rendered next to the
+   * offending field (red border + message). Replaces the old toast-only
+   * validation pattern so users can see what to fix without scrolling
+   * back up.
+   */
+  errors?: HabitFormErrors;
 }
+
+const EMOJI_SUGGESTIONS: readonly string[] = [
+  "✓",
+  "💧",
+  "🚶",
+  "🏃",
+  "💪",
+  "🧘",
+  "📖",
+  "✍️",
+  "🧠",
+  "💊",
+  "🥗",
+  "😴",
+  "☕",
+  "🎯",
+  "⏰",
+  "🌙",
+];
 
 export function HabitForm({
   routine,
@@ -44,13 +81,43 @@ export function HabitForm({
   onSave,
   onCancel,
   focusTick,
+  hideHeading = false,
+  errors,
 }: HabitFormProps) {
   const fieldIds = useId();
   const startId = `${fieldIds}-start`;
   const endId = `${fieldIds}-end`;
   const advancedId = `${fieldIds}-advanced`;
+  const nameErrId = `${fieldIds}-name-err`;
+  const weekdaysErrId = `${fieldIds}-weekdays-err`;
   const sectionRef = useRef<HTMLElement | null>(null);
   const nameRef = useRef<HTMLInputElement | null>(null);
+  const weekdaysRef = useRef<HTMLDivElement | null>(null);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const emojiWrapRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!showEmojiPicker) return;
+    const handleOutside = (e: MouseEvent) => {
+      if (
+        emojiWrapRef.current &&
+        !emojiWrapRef.current.contains(e.target as Node)
+      ) {
+        setShowEmojiPicker(false);
+      }
+    };
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, [showEmojiPicker]);
+  // Scroll the weekday picker into view when the parent surfaces a
+  // weekdays error (e.g. user picked «По тижню» but no days). Without
+  // this the inline error can sit off-screen on small viewports.
+  useEffect(() => {
+    if (!errors?.weekdays) return;
+    const el = weekdaysRef.current;
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [errors?.weekdays]);
   // Minimal-first UX: emoji + name + regularity are visible on first
   // render. Dates, reminders, tags and categories live behind a
   // "Більше опцій" disclosure. When editing an existing habit we open
@@ -83,31 +150,79 @@ export function HabitForm({
 
   return (
     <Card as="section" ref={sectionRef} radius="lg" className="space-y-3">
-      <SectionHeading as="h2" size="sm">
-        {editingId ? "Редагувати звичку" : "Нова звичка"}
-      </SectionHeading>
+      {!hideHeading && (
+        <SectionHeading as="h2" size="sm">
+          {editingId ? "Редагувати звичку" : "Нова звичка"}
+        </SectionHeading>
+      )}
 
-      <div className="flex gap-2 items-stretch">
-        <Input
-          className="routine-touch-field w-16 shrink-0 text-center"
-          value={habitDraft.emoji}
-          onChange={(e) =>
-            setHabitDraft((d) => ({
-              ...d,
-              emoji: e.target.value.slice(0, 4),
-            }))
-          }
-          aria-label="Емодзі"
-        />
-        <Input
-          ref={nameRef}
-          className="routine-touch-field min-w-0 flex-1"
-          placeholder="Назва"
-          value={habitDraft.name}
-          onChange={(e) =>
-            setHabitDraft((d) => ({ ...d, name: e.target.value }))
-          }
-        />
+      <div>
+        <div className="flex gap-2 items-stretch">
+          <div className="relative" ref={emojiWrapRef}>
+            <button
+              type="button"
+              onClick={() => setShowEmojiPicker((v) => !v)}
+              aria-label="Обрати емодзі"
+              aria-expanded={showEmojiPicker}
+              className={cn(
+                "routine-touch-field w-16 h-full shrink-0 flex items-center justify-center",
+                "rounded-2xl border border-line bg-panel text-xl",
+                "hover:bg-panelHi transition-colors",
+              )}
+            >
+              <span aria-hidden>{habitDraft.emoji || "✓"}</span>
+            </button>
+            {showEmojiPicker && (
+              <div
+                role="dialog"
+                aria-label="Обрати емодзі"
+                className={cn(
+                  "absolute z-30 mt-2 left-0",
+                  "rounded-2xl border border-line bg-panel shadow-float p-2",
+                  "grid grid-cols-4 gap-1",
+                )}
+              >
+                {EMOJI_SUGGESTIONS.map((e) => (
+                  <button
+                    key={e}
+                    type="button"
+                    onClick={() => {
+                      setHabitDraft((d) => ({ ...d, emoji: e }));
+                      setShowEmojiPicker(false);
+                    }}
+                    className={cn(
+                      "w-9 h-9 rounded-lg text-lg",
+                      "hover:bg-panelHi transition-colors",
+                      habitDraft.emoji === e && "bg-panelHi ring-1 ring-line",
+                    )}
+                    aria-label={`Емодзі ${e}`}
+                  >
+                    <span aria-hidden>{e}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <Input
+            ref={nameRef}
+            className={cn(
+              "routine-touch-field min-w-0 flex-1",
+              errors?.name && "border-danger",
+            )}
+            placeholder="Назва"
+            aria-invalid={errors?.name ? true : undefined}
+            aria-describedby={errors?.name ? nameErrId : undefined}
+            value={habitDraft.name}
+            onChange={(e) =>
+              setHabitDraft((d) => ({ ...d, name: e.target.value }))
+            }
+          />
+        </div>
+        {errors?.name && (
+          <p id={nameErrId} className="text-xs text-danger mt-1">
+            {errors.name}
+          </p>
+        )}
       </div>
 
       {/* Segmented chips — a native <select> sits right on top of the
@@ -147,6 +262,36 @@ export function HabitForm({
           })}
         </div>
       </div>
+
+      {/* When user picks «По тижню», surface the weekday selector inline
+          — previously buried under «Більше опцій», which meant the user
+          had to pick a recurrence, then Save, then hunt for the hidden
+          disclosure when the toast complained. S3 / S10. */}
+      {habitDraft.recurrence === "weekly" && (
+        <div
+          ref={weekdaysRef}
+          className={cn(
+            "rounded-2xl border p-3 transition-colors",
+            errors?.weekdays
+              ? "border-danger bg-danger/5"
+              : "border-line bg-panel/40",
+          )}
+          aria-invalid={errors?.weekdays ? true : undefined}
+          aria-describedby={errors?.weekdays ? weekdaysErrId : undefined}
+        >
+          <WeekdayPicker
+            weekdays={habitDraft.weekdays}
+            onChange={(next) =>
+              setHabitDraft((d) => ({ ...d, weekdays: next }))
+            }
+          />
+          {errors?.weekdays && (
+            <p id={weekdaysErrId} className="text-xs text-danger mt-2">
+              {errors.weekdays}
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Reminder presets — previously hidden under "Більше опцій". Push
           notifications are the single highest-value habit feature, so the
@@ -197,15 +342,6 @@ export function HabitForm({
               />
             </label>
           </div>
-
-          {habitDraft.recurrence === "weekly" && (
-            <WeekdayPicker
-              weekdays={habitDraft.weekdays}
-              onChange={(next) =>
-                setHabitDraft((d) => ({ ...d, weekdays: next }))
-              }
-            />
-          )}
 
           {(habitDraft.recurrence === "once" ||
             habitDraft.recurrence === "monthly") && (


### PR DESCRIPTION
## Summary

First-pass implementation of the UX audit. Ships the low-risk, high-visibility quick wins and one higher-impact fix (proactive soft auth). Deliberately defers the larger refactors (demo-seeding removal, meal-sheet merge, unified quick-add sheet) to a follow-up PR so this can land and be reviewed in isolation.

### Onboarding splash (`OnboardingWizard.tsx`) — **S1, S12**
- Removed the 2×2 `SplashPreviewGrid` that duplicated the vibe chips with different labels (e.g. «Гроші» chip vs «−320 грн» preview tile). The splash now has a single taxonomy: the vibe chips themselves, each enriched with a small aspirational teaser («Гроші · −320₴ / тиждень»).
- Unified the time-to-value promise: splash now says `~5 секунд на перший запис` (was `30 секунд`) and the `routine` + `finyk` FTUX rows in `FirstActionSheet` now both say `~5 секунд` (was mixed `30 секунд` / `5 секунд`).

### Primary FAB (`HubFloatingActions.tsx`) — **S5, S14**
- Extended FAB: the closed state is now an icon-pill with a visible `Додати` label (was an icon-only blue circle). On touch devices the `title` tooltip never surfaces, so a discoverability gap is closed. When the speed-dial is open the button collapses back to a square-ish × for menu-close affordance.

### Habit form (`HabitForm.tsx`, `HabitQuickCreateDialog.tsx`) — **S3, S6, S7, S10**
- **S3** Weekly weekday picker is now rendered inline on the primary form as soon as `recurrence === "weekly"`, wrapped in a dedicated outlined block. Previously it was hidden under «Більше опцій», so a user who picked «По тижню» + Save would get a toast telling them to pick days that lived behind a collapsed disclosure.
- **S6** Emoji is now a proper popover picker (grid of 16 curated habit emojis with outside-click dismissal, aria-expanded, highlight for the current selection). Previously a bare `Input` that accepted any 4-char string.
- **S7** Removed the duplicate «Нова звичка / Редагувати звичку» `SectionHeading` inside `HabitForm` when it is rendered from the quick-create dialog — the dialog already owns the title, so we now render a single H2 per screen. Done via a new `hideHeading` prop so the route-level settings screen keeps its heading.
- **S10** Validation moved from toast-only to inline errors: new `errors` prop on `HabitForm` + `errors` state in `HabitQuickCreateDialog`. Empty name → red border + message next to the name input. Empty weekdays on weekly → red-bordered block + message, auto-scrolled into view. Errors clear the moment the user fixes the field.

### Manual expense sheet (`ManualExpenseSheet.jsx`) — **S9, S15**
- **S15** Reordered: `Сума` is now the first block (above `Назва`). Amount is the only required field; new users used to scroll past an optional free-text field before they could do the thing that makes the expense valid.
- **S9** Amount suggestion pills split into two labeled groups: **«Часте»** (personalised — top-3 avg amounts from frequent merchants, rendered as filled emerald chips) and **«Швидко»** (round-number defaults, rendered as muted outline chips). Previously a single row mixed both so users couldn't tell which was their history and which was a generic shortcut.

### Proactive soft-auth (`HubDashboard.tsx`, `vibePicks.ts`) — **H5**
- Added session-day tracking (`recordSessionDay` / `getSessionDays` in `vibePicks.ts`) — counts distinct calendar days the hub was opened, not re-entrant within a day.
- `SoftAuthPromptCard` now shows when the user has **either** made a real entry **or** opened the hub for ≥3 distinct days without an account. Previously it only ever appeared after a real entry, so the browse-only cohort silently risked losing data on a device swap.

---

### Deferred to follow-up

Not in scope of this PR — flagged for a dedicated, larger PR:

- **H1** Remove `demoSeeds` entirely + replace with per-module empty-state CTAs (touches every module preview; want to land this surgically).
- **H2** Merge `AddMealSheet` source + fill steps into a single screen (cross-cutting refactor; auto-route logic for search/barcode/pantry is non-trivial).
- **H3** Unified cross-module Quick Add Sheet (conflicts with the S-level surgical changes shipped here).
- **H4** Inline habit creation from dashboard (separate UX decision: route vs sheet).
- **H6** Actionable TodayFocusCard (data-flow changes across modules).
- **H7** Global voice entry in header (cross-module Web Speech integration).
- **S2** mealType auto from current time — **already shipped** (`mealFormUtils.js` → `mealTypeByNow()`).
- **S4** Default category = null — audit re-read suggests current `DEFAULT_CATEGORY = "інше"` is the less-bad default (explicit «інше» clearer than empty state); deferred pending user confirmation.
- **S8** Default `startDate = today` — **already shipped** (`routineDraftUtils.ts` sets `dateKeyFromDate(routineTodayDate())`).
- **S11** Voice mic in `AddMealSheet` + `HabitForm` — deferred (meal sheet is due for H2 refactor; habit form already dense).
- **S13** Photo-button row in `AddMealSheet` source-step — deferred (requires cross-screen wiring to `PhotoAnalyzeCard`; H2 will subsume).

---

## Review & Testing Checklist for Human

This touches FTUX and validation states, so a little manual poke-around is worth it.

- [ ] Open `/welcome` (or reset onboarding) and verify the splash shows 2×2 chip tiles only (no separate preview grid) and that the subtitle says `~5 секунд на перший запис`.
- [ ] Tap the primary «+» FAB on the hub and verify it reads `Додати` at rest, and that tapping opens the speed-dial.
- [ ] In the routine module, open the quick-create habit dialog. Pick «По тижню» — the weekday picker should appear inline immediately. Tap Save with no days selected: the picker should get a red border + inline error (no toast).
- [ ] In the same dialog, tap the emoji square: a 4×4 grid popover of habit emojis should open; picking one should update the emoji and close the popover.
- [ ] Open `ManualExpenseSheet` (finyk → «Додати витрату»). Verify `Сума` is the first field, and that — after you have some history — amount pills split into a green «Часте» row and a grey «Швидко» row.
- [ ] On a fresh install, open the hub on three different days (or bump `hub_session_days_v1` in localStorage to `3`) without creating an entry, and confirm the soft-auth nudge appears.

### Notes

- `npm run lint`, `npm run typecheck`, `npm run test` (678 tests), and `npm run build` all pass locally.
- No new dependencies.
- No changes to public analytics event names.

Link to Devin session: https://app.devin.ai/sessions/6fb5972d97c449959ba292dbe20009c6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
