### PR TITLE
unify drift labels: Label/SectionHeading across modules (UI-audit PR #2)

### DIFF
--- a/src/modules/fizruk/components/PhotoProgress.tsx
+++ b/src/modules/fizruk/components/PhotoProgress.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Label } from "@shared/components/ui/FormField";
 import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
 import { useBodyPhotos } from "../hooks/useBodyPhotos";
@@ -296,12 +297,7 @@ export function PhotoProgress() {
         <div className="mb-4 space-y-3">
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <label
-                htmlFor={compareBeforeId}
-                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-              >
-                До
-              </label>
+              <Label htmlFor={compareBeforeId}>До</Label>
               <select
                 id={compareBeforeId}
                 value={beforeId}
@@ -318,12 +314,7 @@ export function PhotoProgress() {
               </select>
             </div>
             <div>
-              <label
-                htmlFor={compareAfterId}
-                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-              >
-                Після
-              </label>
+              <Label htmlFor={compareAfterId}>Після</Label>
               <select
                 id={compareAfterId}
                 value={afterId}
@@ -369,12 +360,7 @@ export function PhotoProgress() {
           />
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <label
-                htmlFor={addDateId}
-                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-              >
-                Дата
-              </label>
+              <Label htmlFor={addDateId}>Дата</Label>
               <input
                 id={addDateId}
                 type="date"
@@ -384,12 +370,7 @@ export function PhotoProgress() {
               />
             </div>
             <div>
-              <label
-                htmlFor={addNoteId}
-                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-              >
-                Нотатка
-              </label>
+              <Label htmlFor={addNoteId}>Нотатка</Label>
               <input
                 id={addNoteId}
                 type="text"

--- a/src/modules/fizruk/pages/Body.tsx
+++ b/src/modules/fizruk/pages/Body.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Label } from "@shared/components/ui/FormField";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
@@ -202,12 +203,7 @@ export function Body({ onOpenMeasurements }) {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label
-                  htmlFor="body-weight"
-                  className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-                >
-                  Вага (кг)
-                </label>
+                <Label htmlFor="body-weight">Вага (кг)</Label>
                 <input
                   id="body-weight"
                   type="number"
@@ -224,12 +220,7 @@ export function Body({ onOpenMeasurements }) {
                 />
               </div>
               <div>
-                <label
-                  htmlFor="body-sleep"
-                  className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-                >
-                  Сон (год)
-                </label>
+                <Label htmlFor="body-sleep">Сон (год)</Label>
                 <input
                   id="body-sleep"
                   type="number"
@@ -296,12 +287,9 @@ export function Body({ onOpenMeasurements }) {
             </div>
 
             <div>
-              <label
-                htmlFor="body-note"
-                className="text-2xs font-bold text-subtle uppercase tracking-widest block mb-1"
-              >
-                Нотатка (необов&apos;язково)
-              </label>
+              <Label htmlFor="body-note" optional>
+                Нотатка
+              </Label>
               <input
                 id="body-note"
                 type="text"

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -295,9 +295,13 @@ export function Dashboard({
                   </svg>
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="block text-2xs font-bold uppercase tracking-widest text-white/70">
+                  <SectionHeading
+                    as="span"
+                    size="xs"
+                    className="block text-white/70"
+                  >
                     Почати
-                  </span>
+                  </SectionHeading>
                   <span className="block text-base font-black truncate leading-tight">
                     {primaryAction.label}
                   </span>

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -277,10 +277,12 @@ export function LogCard({
           </div>
         )}
 
-        <button
+        <SectionHeading
+          as="button"
+          size="xs"
           type="button"
           onClick={() => setWeekOpen((v) => !v)}
-          className="flex items-center gap-2 text-2xs font-bold text-subtle uppercase tracking-widest w-full text-left py-1"
+          className="flex items-center gap-2 w-full text-left py-1"
         >
           <Icon
             name="chevron-right"
@@ -292,7 +294,7 @@ export function LogCard({
             )}
           />
           Журнал за тиждень
-        </button>
+        </SectionHeading>
 
         {weekOpen && (
           <div className="rounded-2xl border border-line bg-panel/40 px-3 py-3">

--- a/src/modules/nutrition/components/NutritionPantrySelector.jsx
+++ b/src/modules/nutrition/components/NutritionPantrySelector.jsx
@@ -1,11 +1,13 @@
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+
 export function NutritionPantrySelector({ pantry, busy }) {
   const pantries = Array.isArray(pantry.pantries) ? pantry.pantries : [];
   return (
     <div className="rounded-2xl bg-nutrition/10 border border-nutrition/20 px-4 py-3 mb-4 flex items-center gap-3">
       <div className="min-w-0 flex-1">
-        <div className="text-2xs font-bold text-nutrition/70 uppercase tracking-widest mb-0.5">
+        <SectionHeading as="div" size="xs" className="text-nutrition/70 mb-0.5">
           Активний склад
-        </div>
+        </SectionHeading>
         <div className="text-base font-extrabold text-text leading-tight">
           {pantry.activePantry?.name || "Склад"}
         </div>

--- a/src/modules/nutrition/components/meal-sheet/MacroChip.jsx
+++ b/src/modules/nutrition/components/meal-sheet/MacroChip.jsx
@@ -1,11 +1,12 @@
 import { cn } from "@shared/lib/cn";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 
 export function MacroChip({ label, value, unit = "г", color }) {
   return (
     <div className={cn("flex flex-col items-center px-3 py-2 min-w-0", color)}>
-      <span className="text-2xs font-bold uppercase tracking-widest opacity-70">
+      <SectionHeading as="span" size="xs" className="text-inherit opacity-70">
         {label}
-      </span>
+      </SectionHeading>
       <span className="text-base font-extrabold leading-tight">
         {value != null ? Math.round(value) : "—"}
       </span>

--- a/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -218,9 +218,9 @@ export function RoutineCalendarPanel({
       </div>
 
       <div className="rounded-2xl border border-line bg-panel/80 p-3 shadow-card">
-        <p className="mb-2 text-2xs font-bold uppercase tracking-widest text-subtle">
+        <SectionHeading as="p" size="xs" className="mb-2">
           Тиждень
-        </p>
+        </SectionHeading>
         <WeekDayStrip
           anchorKey={selectedDay}
           selectedDay={selectedDay}


### PR DESCRIPTION
## Summary

Другий PR з плану UI-аудиту. Виносить 11 інлайн drift-лейблів (`text-2xs font-bold text-subtle uppercase tracking-widest` і варіації) на існуючі shared-примітиви — `<Label>` з `FormField` і `<SectionHeading>`. Жодної нової логіки, жодних нових CSS-класів — лише заміна рядкової стилізації на компонент, який інкапсулює канонічний токен.

### Що саме змінено

**Form-лейбли → `<Label htmlFor=...>` (canonical eyebrow: `text-xs text-muted uppercase tracking-wide font-semibold`):**
- `fizruk/pages/Body.tsx` ×3 (Вага, Сон, Нотатка — останній з `optional` проп замість вручну приписаного `(необов'язково)`)
- `fizruk/components/PhotoProgress.tsx` ×4 (До, Після, Дата, Нотатка)

**Section eyebrow-лейбли → `<SectionHeading size="xs">` (drift-токен тепер живе в одному місці):**
- `routine/components/RoutineCalendarPanel.tsx` — "Тиждень"
- `nutrition/components/LogCard.jsx` — toggle "Журнал за тиждень" (`as="button"`, структурні класи збережено)
- `nutrition/components/meal-sheet/MacroChip.jsx` — макро-лейбл (`text-inherit opacity-70` щоб не перекрити акцентний колір чіпа)
- `nutrition/components/NutritionPantrySelector.jsx` — "Активний склад" (`text-nutrition/70` збережено)
- `fizruk/pages/Dashboard.tsx` — "Почати" всередині hero-CTA (`text-white/70` збережено)

### Візуальна різниця

- Form-лейбли (7 штук у Fizruk) стають канонічним eyebrow — `text-xs / text-muted / tracking-wide / font-semibold` замість `text-2xs / text-subtle / tracking-widest / font-bold`. Це **навмисна** зміна, щоб Fizruk-форми виглядали як Finyk-форми (Finyk уже використовує канонічний стиль у `ManualExpenseSheet`, тому після цього PR дві найбільші форми додатку стають візуально ідентичними по типографіці).
- Section-eyebrow (5 штук) — візуально ідентично, бо `SectionHeading size="xs"` має точно той самий токен. Це чисто API-уніфікація.

Після PR у `src/` не залишається жодного live-usage drift-рядка (решта 3 матчі у grep — це строки-документації всередині `FormField.tsx`/`SectionHeading.tsx`).

`npm run lint` і `npm run typecheck` проходять.

## Review & Testing Checklist for Human

- [ ] Fizruk → Тіло → «Записати сьогодні»: лейбли "Вага", "Сон", "Нотатка" тепер трохи тонші й світліші (text-muted/font-semibold замість text-subtle/font-bold). Спосіб тапа не змінився.
- [ ] Fizruk → Тіло → Прогрес-фото → "До/Після" режим: лейбли "До"/"Після"/"Дата"/"Нотатка" стали такими ж, як у Fizruk → "Записати сьогодні" вище.
- [ ] Routine → Calendar: блок "Тиждень" має виглядати 1-в-1 як до PR.
- [ ] Nutrition → Журнал → toggle "Журнал за тиждень": клікабельність, хрестик-іконка, поворот на open — все працює; шрифт такий самий.
- [ ] Nutrition → Meal Sheet → макро-чіпи (Б/Ж/В): лейбл всередині чіпа успадковує колір акценту чіпа (не сірий).
- [ ] Nutrition → шапка "Активний склад": текст "АКТИВНИЙ СКЛАД" зеленуватий (nutrition/70), не сірий.
- [ ] Fizruk → Dashboard → primary-CTA "Почати / {вправа}": "ПОЧАТИ" бачимо напівпрозорим білим, не сірим.

### Notes

Це PR #2 із 6-PR плану UI-аудиту. Наступні (PR #3 — міграція голих `<input>`/`<select>` на shared `<Input>`/`<Select>`; PR #4 — `<Segmented>` shared + Workouts/RoutineCalendar; PR #5 — міграція HabitQuickCreateDialog + Fizruk settings drawer на `<Sheet>`; PR #6 — `<PageHeader>`) — окремими PR-ами.

Link to Devin session: https://app.devin.ai/sessions/145a2c230f4e40fda472610e891ea893
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
