### PR TITLE
feat(recs): finyk rules with pwaAction=add_expense (over-budget, no-tx-recent, daily-vs-weekly-pace)

### DIFF
--- a/src/core/lib/recommendations/finance/budgetLimits.ts
+++ b/src/core/lib/recommendations/finance/budgetLimits.ts
@@ -50,6 +50,10 @@ export const budgetLimitsRule: Rule<FinanceContext> = {
           title: `Бюджет "${catLabel}" перевищено на ${Math.round((pct - 1) * 100)}%`,
           body: `Витрачено ${Math.round(spent).toLocaleString("uk-UA")} ₴ з ${Math.round(limit.limit).toLocaleString("uk-UA")} ₴`,
           action: "finyk",
+          // Ліміт уже пробито — часто це означає, що є ще незафіксовані
+          // витрати, які б затягнули картину ще гірше. Одним тапом відкриваємо
+          // sheet, щоб дописати їх, поки деталі свіжі в пам'яті.
+          pwaAction: "add_expense" as const,
         });
       } else if (pct >= 0.9) {
         recs.push({

--- a/src/core/lib/recommendations/finance/dailyVsWeeklyPace.ts
+++ b/src/core/lib/recommendations/finance/dailyVsWeeklyPace.ts
@@ -1,0 +1,77 @@
+// Rule: сьогоднішні витрати проти 7-денної середньої за день. Коли темп
+// різко вищий, нагадуємо зафіксувати поточні витрати, поки памʼятаємо —
+// найбільший fail-mode трекінгу в тому, що юзер «потім внесу» і забуває.
+//
+// Тригер:
+//   • локальний час ≥ 14:00 (до обіду мало даних, зашумить);
+//   • за попередні 7 повних днів сумарно ≥ 700 ₴ — інакше ratio нестабільне;
+//   • сьогодні витрачено ≥ 200 ₴ — noise floor для дрібниць;
+//   • today / avg_daily_prev7 ≥ 1.5.
+//
+// CTA: `pwaAction: "add_expense"` — шлях до manual-sheet одним тапом.
+
+import type { Rule } from "../types";
+import { txTimestamp, type FinanceContext } from "../financeContext";
+
+const MIN_PREV7_SUM = 700;
+const MIN_TODAY_SUM = 200;
+const PACE_RATIO = 1.5;
+const MIN_HOUR = 14;
+
+export const dailyVsWeeklyPaceRule: Rule<FinanceContext> = {
+  id: "finyk.daily_vs_weekly_pace",
+  module: "finyk",
+  evaluate(ctx) {
+    const now = ctx.now;
+    if (now.getHours() < MIN_HOUR) return [];
+
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+    const weekAgoStart = new Date(todayStart);
+    weekAgoStart.setDate(weekAgoStart.getDate() - 7);
+
+    const todayMs = todayStart.getTime();
+    const weekAgoMs = weekAgoStart.getTime();
+
+    let todaySpend = 0;
+    let prev7Spend = 0;
+    const add = (ts: number, amt: number) => {
+      if (!Number.isFinite(ts)) return;
+      const abs = Math.abs(amt);
+      if (ts >= todayMs) todaySpend += abs;
+      else if (ts >= weekAgoMs) prev7Spend += abs;
+    };
+
+    for (const tx of ctx.transactions) {
+      if (ctx.hiddenTxIds.has(tx.id) || ctx.transferIds.has(tx.id)) continue;
+      if ((tx.amount ?? 0) >= 0) continue;
+      add(txTimestamp(tx), tx.amount / 100);
+    }
+    for (const me of ctx.manualExpenses) {
+      const ts = new Date(me.date).getTime();
+      add(ts, Number(me.amount) || 0);
+    }
+
+    if (prev7Spend < MIN_PREV7_SUM) return [];
+    if (todaySpend < MIN_TODAY_SUM) return [];
+
+    const avgDaily = prev7Spend / 7;
+    if (avgDaily <= 0) return [];
+    const ratio = todaySpend / avgDaily;
+    if (ratio < PACE_RATIO) return [];
+
+    const pctMore = Math.round((ratio - 1) * 100);
+    return [
+      {
+        id: "finyk_daily_vs_weekly_pace",
+        module: "finyk" as const,
+        priority: 72,
+        icon: "⏱️",
+        title: `Сьогодні ${Math.round(todaySpend).toLocaleString("uk-UA")} ₴ — на ${pctMore}% вище середнього`,
+        body: `7-денна середня: ${Math.round(avgDaily).toLocaleString("uk-UA")} ₴/день. Зафіксуй поточні витрати, поки памʼятаєш.`,
+        action: "finyk",
+        pwaAction: "add_expense",
+      },
+    ];
+  },
+};

--- a/src/core/lib/recommendations/finance/finance.test.js
+++ b/src/core/lib/recommendations/finance/finance.test.js
@@ -4,6 +4,8 @@ import { describe, it, expect } from "vitest";
 import { budgetLimitsRule } from "./budgetLimits.ts";
 import { frequentNoBudgetRule } from "./frequentNoBudget.ts";
 import { goalProgressRule } from "./goalProgress.ts";
+import { noTxRecentRule } from "./noTxRecent.ts";
+import { dailyVsWeeklyPaceRule } from "./dailyVsWeeklyPace.ts";
 
 function baseCtx(overrides = {}) {
   return {
@@ -34,6 +36,18 @@ describe("budgetLimitsRule", () => {
     const recs = budgetLimitsRule.evaluate(ctx);
     expect(recs[0]?.id).toBe("budget_over_food");
     expect(recs[0]?.priority).toBeGreaterThanOrEqual(80);
+    // Over-budget тягне pwaAction, щоб одним тапом дописати ще свіжі витрати.
+    expect(recs[0]?.pwaAction).toBe("add_expense");
+  });
+
+  it("warn-стадія НЕ тягне pwaAction (review-only)", () => {
+    const ctx = baseCtx({
+      limits: [{ id: "b", type: "limit", categoryId: "cafe", limit: 100 }],
+      categorySpend: { cafe: 95 },
+    });
+    const recs = budgetLimitsRule.evaluate(ctx);
+    expect(recs[0]?.id).toBe("budget_warn_cafe");
+    expect(recs[0]?.pwaAction).toBeUndefined();
   });
 
   it("генерує warn при 90..139%", () => {
@@ -132,5 +146,210 @@ describe("goalProgressRule", () => {
       ],
     });
     expect(goalProgressRule.evaluate(ctx)).toEqual([]);
+  });
+});
+
+describe("noTxRecentRule", () => {
+  // Допоміжні хелпери: tx (amount у копійках, time у секундах), manual expense.
+  const DAY = 86_400_000;
+  const now = new Date("2025-06-15T12:00:00Z");
+  const mkTx = (id, daysAgo) => ({
+    id,
+    amount: -10000, // 100 ₴ expense
+    time: Math.floor((now.getTime() - daysAgo * DAY) / 1000),
+  });
+  const mkManual = (daysAgo) => ({
+    date: new Date(now.getTime() - daysAgo * DAY).toISOString(),
+    amount: 120,
+  });
+
+  it("тригериться, якщо ≥5 записів і останній ≥3 дні тому", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("t1", 10),
+        mkTx("t2", 9),
+        mkTx("t3", 8),
+        mkTx("t4", 7),
+        mkTx("t5", 5),
+      ],
+    });
+    const recs = noTxRecentRule.evaluate(ctx);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].id).toBe("finyk_no_tx_recent");
+    expect(recs[0].pwaAction).toBe("add_expense");
+    expect(recs[0].title).toMatch(/5 дні/);
+  });
+
+  it("не тригериться, якщо активність була сьогодні", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("t1", 10),
+        mkTx("t2", 9),
+        mkTx("t3", 8),
+        mkTx("t4", 7),
+        mkTx("t5", 0),
+      ],
+    });
+    expect(noTxRecentRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("не тригериться на новачків (<5 записів)", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [mkTx("t1", 10), mkTx("t2", 9)],
+    });
+    expect(noTxRecentRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("рахує manualExpenses як активність", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("t1", 10),
+        mkTx("t2", 9),
+        mkTx("t3", 8),
+        mkTx("t4", 7),
+      ],
+      // Разом 5 записів, але найсвіжіший — сьогодні → не тригеримось.
+      manualExpenses: [mkManual(0)],
+    });
+    expect(noTxRecentRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("ігнорує hidden/transfer-tx у підрахунку", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("t1", 10),
+        mkTx("t2", 9),
+        mkTx("t3", 8),
+        mkTx("t4", 7),
+        mkTx("h", 0), // найсвіжіший, але hidden — не має рятувати від тригеру
+      ],
+      hiddenTxIds: new Set(["h"]),
+    });
+    // 4 expense-tx видимі → <5, правило мовчить.
+    expect(noTxRecentRule.evaluate(ctx)).toEqual([]);
+  });
+});
+
+describe("dailyVsWeeklyPaceRule", () => {
+  const DAY = 86_400_000;
+  // 16:00 локального часу, щоб пройти MIN_HOUR=14.
+  const now = new Date("2025-06-15T16:00:00");
+  const mkTx = (id, daysAgo, uah) => ({
+    id,
+    amount: -Math.round(uah * 100),
+    time: Math.floor((now.getTime() - daysAgo * DAY) / 1000),
+  });
+
+  it("тригериться коли сьогодні > 1.5× середньої за 7 днів", () => {
+    // prev7 = 7 × 200 = 1400 ₴ (avg=200); today = 500 ₴ → ratio=2.5.
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("p1", 1, 200),
+        mkTx("p2", 2, 200),
+        mkTx("p3", 3, 200),
+        mkTx("p4", 4, 200),
+        mkTx("p5", 5, 200),
+        mkTx("p6", 6, 200),
+        mkTx("p7", 7, 200),
+        mkTx("t1", 0, 500),
+      ],
+    });
+    const recs = dailyVsWeeklyPaceRule.evaluate(ctx);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].id).toBe("finyk_daily_vs_weekly_pace");
+    expect(recs[0].pwaAction).toBe("add_expense");
+    expect(recs[0].title).toMatch(/500.*₴/);
+  });
+
+  it("мовчить до 14:00", () => {
+    const early = new Date("2025-06-15T10:00:00");
+    const ctx = baseCtx({
+      now: early,
+      transactions: [
+        {
+          id: "p1",
+          amount: -140000,
+          time: Math.floor((early.getTime() - DAY) / 1000),
+        },
+        { id: "t1", amount: -50000, time: Math.floor(early.getTime() / 1000) },
+      ],
+    });
+    expect(dailyVsWeeklyPaceRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("мовчить під noise floor", () => {
+    // prev7 = 600 (<700) — занадто мало історії.
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("p1", 1, 100),
+        mkTx("p2", 2, 100),
+        mkTx("p3", 3, 100),
+        mkTx("p4", 4, 100),
+        mkTx("p5", 5, 100),
+        mkTx("p6", 6, 100),
+        mkTx("t1", 0, 500),
+      ],
+    });
+    expect(dailyVsWeeklyPaceRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("мовчить коли сьогодні < noise floor 200₴", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("p1", 1, 200),
+        mkTx("p2", 2, 200),
+        mkTx("p3", 3, 200),
+        mkTx("p4", 4, 200),
+        mkTx("p5", 5, 200),
+        mkTx("p6", 6, 200),
+        mkTx("p7", 7, 200),
+        mkTx("t1", 0, 150), // < 200
+      ],
+    });
+    expect(dailyVsWeeklyPaceRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("мовчить коли ratio < 1.5", () => {
+    // today = 250, avg = 200 → ratio=1.25.
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("p1", 1, 200),
+        mkTx("p2", 2, 200),
+        mkTx("p3", 3, 200),
+        mkTx("p4", 4, 200),
+        mkTx("p5", 5, 200),
+        mkTx("p6", 6, 200),
+        mkTx("p7", 7, 200),
+        mkTx("t1", 0, 250),
+      ],
+    });
+    expect(dailyVsWeeklyPaceRule.evaluate(ctx)).toEqual([]);
+  });
+
+  it("ігнорує hidden/transfer tx", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("p1", 1, 200),
+        mkTx("p2", 2, 200),
+        mkTx("p3", 3, 200),
+        mkTx("p4", 4, 200),
+        mkTx("p5", 5, 200),
+        mkTx("p6", 6, 200),
+        mkTx("p7", 7, 200),
+        mkTx("h", 0, 5000), // hidden — не має тригерити
+      ],
+      hiddenTxIds: new Set(["h"]),
+    });
+    expect(dailyVsWeeklyPaceRule.evaluate(ctx)).toEqual([]);
   });
 });

--- a/src/core/lib/recommendations/finance/index.ts
+++ b/src/core/lib/recommendations/finance/index.ts
@@ -8,10 +8,14 @@ import { budgetLimitsRule } from "./budgetLimits";
 import { spendingVelocityRule } from "./spendingVelocity";
 import { frequentNoBudgetRule } from "./frequentNoBudget";
 import { goalProgressRule } from "./goalProgress";
+import { noTxRecentRule } from "./noTxRecent";
+import { dailyVsWeeklyPaceRule } from "./dailyVsWeeklyPace";
 
 export const FINANCE_RULES: readonly Rule<FinanceContext>[] = [
   budgetLimitsRule,
   spendingVelocityRule,
   frequentNoBudgetRule,
   goalProgressRule,
+  noTxRecentRule,
+  dailyVsWeeklyPaceRule,
 ];

--- a/src/core/lib/recommendations/finance/noTxRecent.ts
+++ b/src/core/lib/recommendations/finance/noTxRecent.ts
@@ -1,0 +1,51 @@
+// Rule: користувач має історію витрат, але давно нічого не логав. Треба
+// нагадати зафіксувати свіжі витрати, щоб картина місяця не рвалась.
+//
+// Тригер:
+//   • ≥5 записів expense за весь час (tx + manual) — щоб не шуміти у нових
+//     юзерів, для яких є свої onboarding-правила;
+//   • від останнього запису минуло ≥3 дні.
+//
+// CTA: `pwaAction: "add_expense"` — відкриває manual-expense-sheet у
+// Фініку, не просто модуль.
+
+import type { Rule } from "../types";
+import { txTimestamp, type FinanceContext } from "../financeContext";
+
+const MIN_HISTORY = 5;
+const MIN_DAYS_SILENT = 3;
+
+export const noTxRecentRule: Rule<FinanceContext> = {
+  id: "finyk.no_tx_recent",
+  module: "finyk",
+  evaluate(ctx) {
+    const times: number[] = [];
+    for (const tx of ctx.transactions) {
+      if (ctx.hiddenTxIds.has(tx.id) || ctx.transferIds.has(tx.id)) continue;
+      if ((tx.amount ?? 0) >= 0) continue;
+      times.push(txTimestamp(tx));
+    }
+    for (const me of ctx.manualExpenses) {
+      const t = new Date(me.date).getTime();
+      if (Number.isFinite(t)) times.push(t);
+    }
+    if (times.length < MIN_HISTORY) return [];
+
+    const latest = Math.max(...times);
+    const days = Math.floor((ctx.now.getTime() - latest) / 86_400_000);
+    if (days < MIN_DAYS_SILENT) return [];
+
+    return [
+      {
+        id: "finyk_no_tx_recent",
+        module: "finyk" as const,
+        priority: 68,
+        icon: "📝",
+        title: `${days} дні без запису витрат`,
+        body: "Зафіксуй найсвіжіші витрати — картина місяця буде точнішою.",
+        action: "finyk",
+        pwaAction: "add_expense",
+      },
+    ];
+  },
+};


### PR DESCRIPTION
## Summary

До цього PR жодне finyk-правило не несло `pwaAction`, тож `NextCard` на дашборді падав на fallback CTA «Відкрити Фінік». Цей PR дає три сигнали, що ведуть одним тапом в `ManualExpenseSheet`:

1. **`budget_over_*`** (existing rule, updated) — при 140%+ перевищенні ліміту додаємо `pwaAction: "add_expense"`. Логіка: якщо бюджет уже пробито, найчастіше ще є незафіксовані витрати — пропонуємо одразу їх додати, щоб картина була точною. `budget_warn_*` (90–139%) лишається review-only.
2. **`finyk.no_tx_recent`** (new) — 3+ днів без жодного запису при ≥5 записів у історії. Оминає новачків (щоб не конфліктувати з onboarding-правилами) і користувачів, які вже логали сьогодні.
3. **`finyk.daily_vs_weekly_pace`** (new) — сьогодні > 1.5× від 7-денної середньої за день, після 14:00 (до обіду мало даних), з noise floor (prev7 ≥ 700 ₴, today ≥ 200 ₴), щоб ratio був стабільний.

Всі три тягнуть `pwaAction: "add_expense"`, тож `TodayFocusCard` показує CTA «Додати витрату» і клік диспетчить PWA-intent (`App.tsx:144-159` → `FinykApp.jsx:208-216` → `setShowExpenseSheet(true)`). Пайплайн той самий, що ми пруфнули на nutrition у PR #253 T2.

**Test coverage:** 12 нових per-rule тестів покривають: тригер, історичний поріг, noise floor, фільтрацію hidden/transfer, time-of-day gate. `budget_over` тест тепер перевіряє `pwaAction`, окремий case підтверджує, що `budget_warn` його НЕ має.

Локально: `npm run lint` ✓, `npm run typecheck` ✓, `npm test` ✓ 690/690 (було 678; +12).

## Review & Testing Checklist for Human

- [ ] Перевірте, що перебіг ≥140% бюджету і клік CTA «Додати витрату» на NextCard дійсно відкриває Manual-sheet у Фініку (а не просто навігацію). Посіяти: 1 ліміт `food: 500` + `categorySpend.food=800` у `finyk_tx_cache`/`finyk_budgets`.
- [ ] Перевірте, що `no_tx_recent` не світиться у свіжопоставленого користувача (<5 expense записів) — це було свідоме обмеження, щоб не конкурувати з onboarding-CTA.
- [ ] Перевірте локальний timezone на `daily_vs_weekly_pace` — `now.getHours() < 14` використовує локальну годину, що для прод-білду ОК, але якщо у вас якесь server-side передрендерення — воно може давати UTC.

### Notes

- `budget_warn_*` лишено без `pwaAction` свідомо: на стадії «майже вичерпано» юзеру треба *побачити* картину, а не додавати ще витрат — fallback «Відкрити Фінік» підходить краще.
- Нові правила не зачіпають `HubModuleAction` union (лише переіспользовують наявну `"add_expense"`).
- Не чіпав `FinykApp.jsx` — handler уже готовий (підтверджено ручним тестом PR #253 T2).

Link to Devin session: https://app.devin.ai/sessions/2057a8e2266047ebba88c015403c19d0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
