### PR TITLE
fix(recs): correct Ukrainian plural in finyk no_tx_recent title

### DIFF
--- a/src/core/lib/recommendations/finance/finance.test.js
+++ b/src/core/lib/recommendations/finance/finance.test.js
@@ -163,7 +163,7 @@ describe("noTxRecentRule", () => {
     amount: 120,
   });
 
-  it("тригериться, якщо ≥5 записів і останній ≥3 дні тому", () => {
+  it("тригериться, якщо ≥5 записів і останній ≥3 дні тому (5 днів → many)", () => {
     const ctx = baseCtx({
       now,
       transactions: [
@@ -179,6 +179,21 @@ describe("noTxRecentRule", () => {
     expect(recs[0].id).toBe("finyk_no_tx_recent");
     expect(recs[0].pwaAction).toBe("add_expense");
     expect(recs[0].title).toMatch(/5 днів/);
+  });
+
+  it("плюралізація: 3 дні (few), а не «3 днів»", () => {
+    const ctx = baseCtx({
+      now,
+      transactions: [
+        mkTx("t1", 10),
+        mkTx("t2", 9),
+        mkTx("t3", 8),
+        mkTx("t4", 7),
+        mkTx("t5", 3),
+      ],
+    });
+    const recs = noTxRecentRule.evaluate(ctx);
+    expect(recs[0].title).toMatch(/^3 дні /);
   });
 
   it("не тригериться, якщо активність була сьогодні", () => {

--- a/src/core/lib/recommendations/finance/finance.test.js
+++ b/src/core/lib/recommendations/finance/finance.test.js
@@ -178,7 +178,7 @@ describe("noTxRecentRule", () => {
     expect(recs).toHaveLength(1);
     expect(recs[0].id).toBe("finyk_no_tx_recent");
     expect(recs[0].pwaAction).toBe("add_expense");
-    expect(recs[0].title).toMatch(/5 дні/);
+    expect(recs[0].title).toMatch(/5 днів/);
   });
 
   it("не тригериться, якщо активність була сьогодні", () => {

--- a/src/core/lib/recommendations/finance/noTxRecent.ts
+++ b/src/core/lib/recommendations/finance/noTxRecent.ts
@@ -11,6 +11,7 @@
 
 import type { Rule } from "../types";
 import { txTimestamp, type FinanceContext } from "../financeContext";
+import { pluralDays } from "@shared/lib/ukrainianPlural";
 
 const MIN_HISTORY = 5;
 const MIN_DAYS_SILENT = 3;
@@ -41,7 +42,7 @@ export const noTxRecentRule: Rule<FinanceContext> = {
         module: "finyk" as const,
         priority: 68,
         icon: "📝",
-        title: `${days} днів без запису витрат`,
+        title: `${days} ${pluralDays(days)} без запису витрат`,
         body: "Зафіксуй найсвіжіші витрати — картина місяця буде точнішою.",
         action: "finyk",
         pwaAction: "add_expense",

--- a/src/core/lib/recommendations/finance/noTxRecent.ts
+++ b/src/core/lib/recommendations/finance/noTxRecent.ts
@@ -41,7 +41,7 @@ export const noTxRecentRule: Rule<FinanceContext> = {
         module: "finyk" as const,
         priority: 68,
         icon: "📝",
-        title: `${days} дні без запису витрат`,
+        title: `${days} днів без запису витрат`,
         body: "Зафіксуй найсвіжіші витрати — картина місяця буде точнішою.",
         action: "finyk",
         pwaAction: "add_expense",

--- a/src/shared/lib/ukrainianPlural.test.ts
+++ b/src/shared/lib/ukrainianPlural.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { pluralDays, pluralUa } from "./ukrainianPlural";
+
+describe("pluralDays", () => {
+  it("one: 1, 21, 31, 101", () => {
+    expect(pluralDays(1)).toBe("день");
+    expect(pluralDays(21)).toBe("день");
+    expect(pluralDays(31)).toBe("день");
+    expect(pluralDays(101)).toBe("день");
+  });
+
+  it("few: 2-4, 22-24, 32-34", () => {
+    expect(pluralDays(2)).toBe("дні");
+    expect(pluralDays(3)).toBe("дні");
+    expect(pluralDays(4)).toBe("дні");
+    expect(pluralDays(22)).toBe("дні");
+    expect(pluralDays(34)).toBe("дні");
+  });
+
+  it("many: 5-20, 25-30, 100, 111-114", () => {
+    expect(pluralDays(0)).toBe("днів");
+    expect(pluralDays(5)).toBe("днів");
+    expect(pluralDays(10)).toBe("днів");
+    expect(pluralDays(11)).toBe("днів");
+    expect(pluralDays(12)).toBe("днів");
+    expect(pluralDays(13)).toBe("днів");
+    expect(pluralDays(14)).toBe("днів");
+    expect(pluralDays(20)).toBe("днів");
+    expect(pluralDays(25)).toBe("днів");
+    expect(pluralDays(100)).toBe("днів");
+    expect(pluralDays(111)).toBe("днів");
+    expect(pluralDays(114)).toBe("днів");
+  });
+
+  it("симетрично для негативних значень", () => {
+    expect(pluralDays(-1)).toBe("день");
+    expect(pluralDays(-3)).toBe("дні");
+    expect(pluralDays(-11)).toBe("днів");
+  });
+
+  it("працює як загальний helper на інших формах", () => {
+    const forms = { one: "година", few: "години", many: "годин" };
+    expect(pluralUa(1, forms)).toBe("година");
+    expect(pluralUa(3, forms)).toBe("години");
+    expect(pluralUa(7, forms)).toBe("годин");
+    expect(pluralUa(12, forms)).toBe("годин");
+  });
+});

--- a/src/shared/lib/ukrainianPlural.ts
+++ b/src/shared/lib/ukrainianPlural.ts
@@ -1,0 +1,31 @@
+// Українська плюралізація — три форми за правилами CLDR.
+//
+// Приклад: день/дні/днів, година/години/годин.
+//   one (n mod 10 == 1, n mod 100 != 11) → "день"
+//   few (n mod 10 in 2..4, n mod 100 not in 12..14) → "дні"
+//   many (все інше, вкл. 0) → "днів"
+//
+// Перенесено з intl-плаг: залежностей не додаємо, бо потрібні лише лічильники
+// без локалей, а intl.PluralRules не дасть саму форму слова.
+
+export type UaPluralForms = {
+  one: string;
+  few: string;
+  many: string;
+};
+
+export function pluralUa(n: number, forms: UaPluralForms): string {
+  const abs = Math.abs(Math.trunc(n));
+  const mod100 = abs % 100;
+  if (mod100 >= 11 && mod100 <= 14) return forms.many;
+  const mod10 = abs % 10;
+  if (mod10 === 1) return forms.one;
+  if (mod10 >= 2 && mod10 <= 4) return forms.few;
+  return forms.many;
+}
+
+const DAYS_FORMS: UaPluralForms = { one: "день", few: "дні", many: "днів" };
+
+export function pluralDays(n: number): string {
+  return pluralUa(n, DAYS_FORMS);
+}


### PR DESCRIPTION
## Summary

Follow-up до PR #258 — Devin Review [спіймав](https://github.com/Skords-01/Sergeant/pull/258#discussion_r3107009586) i18n-баг у `finyk.no_tx_recent`:

`${days} дні` граматично коректне тільки для 2–4. Оскільки `MIN_DAYS_SILENT = 3`, `days` починається з 3 і зазвичай ≥5 (користувач бачить карточку через тиждень тиші, не рівно на 3-й день), а там потрібне "днів". Міняю на "днів", як вже зроблено в решті кодбейсу (`recommendationEngine.ts:181` для fizruk, `:266, :294` для routine-streak).

Тест `finance.test.js:181` також оновив (`/5 дні/` → `/5 днів/`).

Локально: lint ✓, 22/22 finyk-тестів ✓.

## Review & Testing Checklist for Human

- [ ] Підтвердити, що "днів" ок як універсальне рішення. Якщо хочеш повну plural-коректність (3/4 → "дні", 5+ → "днів", 21 → "день") — це окремий helper, краще робити системно для всього кодбейсу разом (fizruk/routine мають такий самий технічний борг).

### Notes

- `daily_vs_weekly_pace` не має згадок «днів» у тексті — там лише валюта. Без змін.
- Не чіпаю існуючі "днів" у `recommendationEngine.ts` — це scope PR suit лише до мого нового правила.

Link to Devin session: https://app.devin.ai/sessions/2057a8e2266047ebba88c015403c19d0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
