### PR TITLE
refactor(api): унифікація помилок — ApiError замість plain Error у 4 місцях

### DIFF
--- a/src/core/HubChat.tsx
+++ b/src/core/HubChat.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { chatApi, isApiError } from "@shared/api";
+import { ApiError, chatApi, isApiError } from "@shared/api";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { perfMark, perfEnd } from "@shared/lib/perf";
@@ -268,11 +268,30 @@ function HubChat({ onClose, initialMessage }) {
       try {
         data = await chatApi.send({ context, messages: history });
       } catch (err) {
+        // Переписуємо `message` на юзер-френдлі, але лишаємося в межах
+        // `ApiError` — щоб зовнішній `friendlyChatError` бачив ту саму
+        // форму помилки, що й решта викликів, і щоб `isApiError` тут
+        // продовжував працювати вгору по стеку.
         if (isApiError(err) && err.kind === "http") {
-          throw new Error(friendlyApiError(err.status, err.serverMessage));
+          throw new ApiError({
+            kind: "http",
+            message: friendlyApiError(err.status, err.serverMessage),
+            status: err.status,
+            body: err.body,
+            bodyText: err.bodyText,
+            url: err.url,
+            cause: err,
+          });
         }
         if (isApiError(err) && err.kind === "parse") {
-          throw new Error("Некоректна відповідь сервера");
+          throw new ApiError({
+            kind: "parse",
+            message: "Некоректна відповідь сервера",
+            body: err.body,
+            bodyText: err.bodyText,
+            url: err.url,
+            cause: err,
+          });
         }
         throw err;
       }
@@ -325,7 +344,14 @@ function HubChat({ onClose, initialMessage }) {
             }
             const parsed = data2 as { error?: string; text?: string };
             if (!res2.ok)
-              throw new Error(friendlyApiError(res2.status, parsed?.error));
+              throw new ApiError({
+                kind: "http",
+                message: friendlyApiError(res2.status, parsed?.error),
+                status: res2.status,
+                body: data2,
+                bodyText: raw2,
+                url: res2.url,
+              });
             followUpText = parsed.text || "";
             setMessages((m) =>
               m.map((x) =>

--- a/src/core/useCoachInsight.ts
+++ b/src/core/useCoachInsight.ts
@@ -258,19 +258,8 @@ async function fetchCoachInsight(): Promise<string | null> {
 
   const snapshot = aggregateCurrentSnapshot();
 
-  try {
-    const insightJson = await coachApi.postInsight({ snapshot, memory });
-    return (insightJson as { insight?: string }).insight ?? null;
-  } catch (e) {
-    if (isApiError(e) && e.kind === "http") {
-      const error = Object.assign(
-        new Error(e.serverMessage || "Помилка генерації інсайту"),
-        { status: e.status },
-      );
-      throw error;
-    }
-    throw e;
-  }
+  const insightJson = await coachApi.postInsight({ snapshot, memory });
+  return (insightJson as { insight?: string }).insight ?? null;
 }
 
 const coachInsightQueryKey = (todayKey = localDateKey()) =>
@@ -344,7 +333,9 @@ export function useCoachInsight(): UseCoachInsightResult {
     insight: query.data ?? null,
     loading: query.isPending || query.isFetching,
     error: query.error
-      ? (query.error as Error).message || "Помилка завантаження"
+      ? isApiError(query.error) && query.error.kind === "http"
+        ? query.error.serverMessage || "Помилка генерації інсайту"
+        : (query.error as Error).message || "Помилка завантаження"
       : null,
     refresh,
   };

--- a/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
+++ b/src/modules/nutrition/components/meal-sheet/useFoodSearch.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { foodSearchApi, isApiError } from "@shared/api";
+import { foodSearchApi } from "@shared/api";
 import { nutritionKeys } from "@shared/lib/queryKeys.js";
 import { searchFoods } from "../../lib/foodDb/foodDb.js";
 
@@ -13,18 +13,14 @@ const OFF_MIN_LEN = 2;
 // retype), requests for stale queries are auto-cancelled via `signal`, and
 // the built-in retry policy from the shared QueryClient handles flaky
 // mobile networks without the component having to know.
+//
+// Помилки від `foodSearchApi` — це вже `ApiError` з коректним `.status`,
+// так що `isRetriableError` у `queryClient` сам вирішить, чи варто ретраїти.
+// Раніше тут була конверсія у plain `Error` — лишали лише `.status` і
+// втрачали `kind`/`serverMessage`/`isOffline`. React Query таке не любить.
 async function fetchOpenFoodFacts(query, signal) {
-  try {
-    const data = await foodSearchApi.search(query, { signal });
-    return Array.isArray(data?.products) ? data.products : [];
-  } catch (e) {
-    if (isApiError(e) && e.kind === "http") {
-      const err = new Error(`food-search failed with ${e.status}`);
-      err.status = e.status;
-      throw err;
-    }
-    throw e;
-  }
+  const data = await foodSearchApi.search(query, { signal });
+  return Array.isArray(data?.products) ? data.products : [];
 }
 
 // Debounce user input separately from the queries themselves. We don't want

--- a/src/modules/nutrition/lib/nutritionApi.ts
+++ b/src/modules/nutrition/lib/nutritionApi.ts
@@ -1,6 +1,7 @@
 import {
   nutritionApi,
   isApiError,
+  ApiError,
   type NutritionPhotoResponse,
   type NutritionRecipesResponse,
   type NutritionWeekPlanResponse,
@@ -14,9 +15,12 @@ import {
 import { friendlyApiError } from "./nutritionErrors.js";
 
 /**
- * Тонкий адаптер над централізованим `nutritionApi`. Переводить
- * `ApiError` з `@shared/api` у юзер-френдлі `new Error(message)` —
- * старий контракт, якого очікують nutrition-хуки.
+ * Тонкий адаптер над централізованим `nutritionApi`. Переписує `message`
+ * у `ApiError` на юзер-френдлі текст (той, що очікують nutrition-хуки
+ * і показують у банері помилки), але зберігає `kind` / `status` / `body`
+ * — щоб React Query міг коректно ретраїти (`isRetriableError` читає
+ * `.status`) і щоб консьюмери могли розрізняти `isOffline` / `isAuth`
+ * через `isApiError`.
  *
  * Generic-параметр `T` пробрасує типізовану відповідь із
  * `@shared/api/endpoints/nutrition` у споживача (наприклад,
@@ -24,6 +28,24 @@ import { friendlyApiError } from "./nutritionErrors.js";
  * Типізовані helper-и нижче (`recommendRecipes`, `parsePantry`, …)
  * роблять це автоматично — вони кращий вибір для нового коду.
  */
+function friendlyNutritionMessage(err: ApiError): string {
+  if (err.kind === "network") {
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      return "Немає підключення до інтернету. Спробуй пізніше.";
+    }
+    return err.message || "Не вдалося зʼєднатися із сервером.";
+  }
+  if (err.kind === "parse") {
+    // Частий кейс на Vercel: /api/* перехоплено rewrite і повернувся index.html
+    if (/<!doctype html/i.test(err.bodyText || "")) {
+      return "API повернув HTML замість JSON (ймовірно, rewrite перехоплює /api/*).";
+    }
+    return err.bodyText || "Некоректна відповідь сервера";
+  }
+  // kind === "http" або "aborted"
+  return friendlyApiError(err.status, err.serverMessage);
+}
+
 export async function postJson<T = unknown>(
   url: string,
   body: unknown,
@@ -36,25 +58,24 @@ export async function postJson<T = unknown>(
         err instanceof Error && err.message
           ? err.message
           : "Не вдалося зʼєднатися із сервером.";
-      throw new Error(message);
+      // Обгортаємо невідому помилку у ApiError(kind:"network"), щоб
+      // подальший onError не мусив розрізняти "шар API" і "все інше".
+      throw new ApiError({
+        kind: "network",
+        message,
+        url,
+        cause: err,
+      });
     }
-    if (err.kind === "network") {
-      if (typeof navigator !== "undefined" && navigator.onLine === false) {
-        throw new Error("Немає підключення до інтернету. Спробуй пізніше.");
-      }
-      throw new Error(err.message || "Не вдалося зʼєднатися із сервером.");
-    }
-    if (err.kind === "parse") {
-      // Частий кейс на Vercel: /api/* перехоплено rewrite і повернувся index.html
-      if (/<!doctype html/i.test(err.bodyText || "")) {
-        throw new Error(
-          "API повернув HTML замість JSON (ймовірно, rewrite перехоплює /api/*).",
-        );
-      }
-      throw new Error(err.bodyText || "Некоректна відповідь сервера");
-    }
-    // kind === "http" або "aborted"
-    throw new Error(friendlyApiError(err.status, err.serverMessage));
+    throw new ApiError({
+      kind: err.kind,
+      message: friendlyNutritionMessage(err),
+      status: err.status,
+      body: err.body,
+      bodyText: err.bodyText,
+      url: err.url,
+      cause: err,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Завершує уніфікацію API-шару: прибирає 4 місця, де `ApiError` з `@shared/api` сайленс-конвертувався у `new Error(message)`, з втратою `.status`/`.kind`/`.serverMessage`/`.body`.

**Контекст.** `src/shared/api/README.md` прямо вимагає (рядки 210-213): ендпоінти/адаптери мають кидати `ApiError`, бо React Query `isRetriableError` читає саме `.status` — плейн-Error змушує ретрай-логіку працювати невірно.

**Аудит прямих `fetch()` у клієнтському коді:**
- `src/shared/api/httpClient.ts` — єдине легітимне місце (сам клієнт).
- `src/core/webVitals.ts` — документований виняток (`sendBeacon` + `keepalive fetch` на unload; потрібен `credentials: "omit"`).
- `src/core/authClient.ts` — вендорний транспорт better-auth.
- Решта клієнта — чисто; усі запити йдуть через `http.*` з `@shared/api`.

**Реальна проблема — конверсії ApiError → Error у 4 файлах:**

| Файл | Було | Стало |
|---|---|---|
| `src/modules/nutrition/lib/nutritionApi.ts` | `throw new Error(friendlyMsg)` — втрата `.status`/`.kind`/`.body`. Зачіпає всі nutrition-мутації (photo, recipes, week/day plan, day hint, pantry, cloud backup). | `throw new ApiError({ kind, status, body, bodyText, url, message: friendlyMsg, cause })` — зберігає всі поля; UI і далі читає `.message`. |
| `src/core/useCoachInsight.ts` | `Object.assign(new Error(serverMessage), { status })` — зберігало `.status`, але втрачало `.kind`. | Просто пробрасує `ApiError` далі; `friendlyMessage` застосовується в UI-селекторі (`hook.error`). |
| `src/modules/nutrition/components/meal-sheet/useFoodSearch.js` | `new Error(\`food-search failed with ${status}\`)` — діагностичний текст, втрата `.kind`. | Прибрано конверсію. `foodSearchApi` уже кидає `ApiError` з правильним `.status`; `queryClient.isRetriableError` спрацьовує як належить. |
| `src/core/HubChat.tsx` (2 сайти) | `new Error(friendlyApiError(status, msg))` після `chatApi.send` і після `res2.text()`. | `new ApiError({ kind: "http"/"parse", message, status, body, bodyText, url, cause })`. `friendlyChatError` нижче по стеку читає `.message` — поведінка UI не змінюється. |

**Контракт після PR:**
- Один http client (`@shared/api/httpClient`), `credentials: "include"` за замовчуванням.
- Усі помилки на клієнтському шляху — `ApiError` з `kind: "http" | "network" | "parse" | "aborted"`.
- React Query `isRetriableError` тепер бачить реальний `.status` на всіх мутаціях / query — коректно ретраїть 5xx/408/429 і не ретраїть 4xx.
- Консьюмери UI продовжують читати `.message` як раніше (ApiError extends Error).

## Review & Testing Checklist for Human

- [ ] Прогнати сценарії, які залежать від повідомлень помилок: nutrition photo analyze → 500/429/413; day plan → 500; food search (OpenFoodFacts) → offline; chat (`HubChat`) → 429/500. Перевірити, що юзер-фейсінг текст не змінився.
- [ ] Перевірити Coach Insight: коли сервер відповідає 500 з `serverMessage`, банер показує той серверний текст; коли `serverMessage` порожній — fallback "Помилка генерації інсайту".
- [ ] Переконатися, що тестовий набір nutrition-хуків (`useNutritionRemoteActions.test.jsx`, `usePhotoAnalysis.test.jsx`, `useNutritionPantries.test.jsx`, `useNutritionCloudBackup.test.jsx`) у CI зелений — ці тести мокають `postJson` і опосередковано перевіряють контракт onError.

### Notes

Свідомо не чіпав:
- `src/core/webVitals.ts` / `src/core/authClient.ts` — документовані / вендорні винятки.
- Дубль `friendlyApiError` у `src/core/lib/hubChatUtils.ts` і `src/modules/nutrition/lib/nutritionErrors.ts` — ідентичний, але виносити в `@shared/lib` варто окремим PR (щоб не розмивати діф).
- `ApiError.status ?? 0` для `kind: "network"/"parse"/"aborted"` + поточна логіка `isRetriableError` → мережеві помилки фактично не ретраяться, хоча README натякає на retry. Пре-існуюче, поза скоупом.

Локально: `npm run lint`, `npm run typecheck`, `npm test` (696 passed), `npm run build` — усі зелені.

Link to Devin session: https://app.devin.ai/sessions/8ca6c15d73b44131afe54a65e0e4fdf2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
