### PR TITLE
refactor(cloudSync): unify engine types, extract payload builder, flatten initialSync (PR 1/2)

### DIFF
--- a/src/core/cloudSync/engine/buildPayload.ts
+++ b/src/core/cloudSync/engine/buildPayload.ts
@@ -1,0 +1,29 @@
+import { collectModuleData } from "../state/moduleData";
+import type { ModulePayload } from "../types";
+
+/**
+ * Build the `{ module → payload }` map pushed to the server. For each
+ * requested module, reads its localStorage slice via `collectModuleData`
+ * and stamps `clientUpdatedAt` from the dirty-tracking `modifiedTimes`
+ * snapshot (falling back to "now" for modules without a tracked modify).
+ *
+ * Modules with no local data are omitted so we never send empty objects.
+ * Extracted from the inline blocks that previously lived in `push.ts`,
+ * `upload.ts`, and `initialSync.ts` (merge branch).
+ */
+export function buildModulesPayload(
+  modNames: Iterable<string>,
+  modifiedTimes: Record<string, string>,
+): Record<string, ModulePayload> {
+  const modules: Record<string, ModulePayload> = {};
+  for (const mod of modNames) {
+    const data = collectModuleData(mod);
+    if (data && Object.keys(data).length > 0) {
+      modules[mod] = {
+        data,
+        clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
+      };
+    }
+  }
+  return modules;
+}

--- a/src/core/cloudSync/engine/initialSync.ts
+++ b/src/core/cloudSync/engine/initialSync.ts
@@ -7,27 +7,59 @@ import {
   getModuleModifiedTimes,
 } from "../state/dirtyModules";
 import { isMigrationDone, markMigrationDone } from "../state/migration";
-import {
-  applyModuleData,
-  collectModuleData,
-  hasLocalData,
-} from "../state/moduleData";
+import { applyModuleData, hasLocalData } from "../state/moduleData";
 import { getModuleVersion, setModuleVersion } from "../state/versions";
-import type {
-  CurrentUser,
-  ModulePayload,
-  PullAllModuleBody,
-  PullAllResponse,
-} from "../types";
+import type { EngineArgs, PullAllModuleBody, PullAllResponse } from "../types";
+import { buildModulesPayload } from "./buildPayload";
 import { replayOfflineQueue } from "./replay";
 
-export interface InitialSyncArgs {
-  user: CurrentUser | null | undefined;
-  onStart(): void;
-  onSuccess(when: Date): void;
-  onError(message: string): void;
+export type InitialSyncArgs = EngineArgs & {
   onNeedMigration(): void;
-  onSettled(): void;
+};
+
+type UserId = string | undefined;
+
+function ensureMigrationDone(userId: UserId): void {
+  if (!isMigrationDone(userId)) markMigrationDone(userId);
+}
+
+function applyAdoptCloud(
+  applyModules: Array<{
+    mod: string;
+    data: Record<string, unknown>;
+    version?: number;
+  }>,
+  userId: UserId,
+): void {
+  for (const { mod, data, version } of applyModules) {
+    applyModuleData(mod, data);
+    if (userId && version) setModuleVersion(userId, mod, version);
+  }
+}
+
+async function applyMerge(
+  plan: {
+    applyModules: Array<{ mod: string; data: Record<string, unknown> }>;
+    setVersions: Array<{ mod: string; version: number }>;
+    dirtyMods: string[];
+  },
+  userId: UserId,
+): Promise<void> {
+  for (const { mod, data } of plan.applyModules) applyModuleData(mod, data);
+  if (userId) {
+    for (const { mod, version } of plan.setVersions) {
+      setModuleVersion(userId, mod, version);
+    }
+  }
+  if (plan.dirtyMods.length === 0) return;
+  const modules = buildModulesPayload(plan.dirtyMods, getModuleModifiedTimes());
+  if (Object.keys(modules).length === 0) return;
+  // Let ApiError propagate to the caller's catch so onError fires and
+  // markMigrationDone is skipped — matches pre-refactor behavior where
+  // `if (pushRes.ok) clearAllDirty()` combined with the syncApi-throwing
+  // transport meant a push failure aborted the whole initialSync.
+  await syncApi.pushAll(modules);
+  clearAllDirty();
 }
 
 /**
@@ -63,60 +95,22 @@ export async function initialSync(args: InitialSyncArgs): Promise<boolean> {
       dirtyModules: getDirtyModules(),
     });
 
-    switch (plan.kind) {
-      case "adoptCloud": {
-        for (const { mod, data, version } of plan.applyModules) {
-          applyModuleData(mod, data);
-          if (user?.id && version) {
-            setModuleVersion(user.id, mod, version);
-          }
-        }
-        if (!isMigrationDone(user?.id)) markMigrationDone(user?.id);
-        break;
-      }
-      case "needMigration": {
-        onNeedMigration();
-        return true;
-      }
-      case "merge": {
-        for (const { mod, data } of plan.applyModules) {
-          applyModuleData(mod, data);
-        }
-        if (user?.id) {
-          for (const { mod, version } of plan.setVersions) {
-            setModuleVersion(user.id, mod, version);
-          }
-        }
-        if (plan.dirtyMods.length > 0) {
-          const modifiedTimes = getModuleModifiedTimes();
-          const modules: Record<string, ModulePayload> = {};
-          for (const mod of plan.dirtyMods) {
-            const data = collectModuleData(mod);
-            if (data && Object.keys(data).length > 0) {
-              modules[mod] = {
-                data,
-                clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
-              };
-            }
-          }
-          if (Object.keys(modules).length > 0) {
-            // Let ApiError propagate to the outer catch so onError fires and
-            // markMigrationDone is skipped — matches pre-refactor behavior
-            // where `if (pushRes.ok) clearAllDirty()` combined with the
-            // syncApi-throwing transport meant a push failure aborted the
-            // whole initialSync.
-            await syncApi.pushAll(modules);
-            clearAllDirty();
-          }
-        }
-        if (!isMigrationDone(user?.id)) markMigrationDone(user?.id);
-        break;
-      }
-      case "noop": {
-        if (!isMigrationDone(user?.id)) markMigrationDone(user?.id);
-        break;
-      }
+    if (plan.kind === "needMigration") {
+      onNeedMigration();
+      return true;
     }
+
+    switch (plan.kind) {
+      case "adoptCloud":
+        applyAdoptCloud(plan.applyModules, user?.id);
+        break;
+      case "merge":
+        await applyMerge(plan, user?.id);
+        break;
+      case "noop":
+        break;
+    }
+    ensureMigrationDone(user?.id);
 
     onSuccess(new Date());
     return true;

--- a/src/core/cloudSync/engine/pull.ts
+++ b/src/core/cloudSync/engine/pull.ts
@@ -1,15 +1,9 @@
 import { syncApi } from "@shared/api";
 import { applyModuleData } from "../state/moduleData";
 import { setModuleVersion } from "../state/versions";
-import type { CurrentUser, PullAllResponse } from "../types";
+import type { EngineArgs, PullAllResponse } from "../types";
 
-export interface PullArgs {
-  user: CurrentUser | null | undefined;
-  onStart(): void;
-  onSuccess(when: Date): void;
-  onError(message: string): void;
-  onSettled(): void;
-}
+export type PullArgs = EngineArgs;
 
 export async function pullAll(args: PullArgs): Promise<boolean> {
   const { user, onStart, onSuccess, onError, onSettled } = args;

--- a/src/core/cloudSync/engine/push.ts
+++ b/src/core/cloudSync/engine/push.ts
@@ -8,18 +8,12 @@ import {
   getDirtyModules,
   getModuleModifiedTimes,
 } from "../state/dirtyModules";
-import { collectModuleData } from "../state/moduleData";
 import { setModuleVersion } from "../state/versions";
-import type { CurrentUser, ModulePayload, PushAllResponse } from "../types";
+import type { EngineArgs, PushAllResponse } from "../types";
+import { buildModulesPayload } from "./buildPayload";
 import { replayOfflineQueue } from "./replay";
 
-export interface PushArgs {
-  user: CurrentUser | null | undefined;
-  onStart(): void;
-  onSuccess(when: Date): void;
-  onError(message: string): void;
-  onSettled(): void;
-}
+export type PushArgs = EngineArgs;
 
 /**
  * Push all currently-dirty modules. Behavior matches the original
@@ -41,16 +35,7 @@ export async function pushDirty(args: PushArgs): Promise<void> {
   // only clear a module's dirty flag if its modifiedAt hasn't advanced —
   // otherwise a change that happened mid-request would be silently dropped.
   const modifiedSnapshot = getModuleModifiedTimes();
-  const modules: Record<string, ModulePayload> = {};
-  for (const mod of dirtyMods) {
-    const data = collectModuleData(mod);
-    if (data && Object.keys(data).length > 0) {
-      modules[mod] = {
-        data,
-        clientUpdatedAt: modifiedSnapshot[mod] || new Date().toISOString(),
-      };
-    }
-  }
+  const modules = buildModulesPayload(dirtyMods, modifiedSnapshot);
   try {
     if (Object.keys(modules).length === 0) {
       clearAllDirty();
@@ -100,17 +85,10 @@ export async function pushAll(args: PushArgs): Promise<void> {
   const { user, onStart, onSuccess, onError, onSettled } = args;
   onStart();
   try {
-    const modifiedTimes = getModuleModifiedTimes();
-    const modules: Record<string, ModulePayload> = {};
-    for (const mod of Object.keys(SYNC_MODULES)) {
-      const data = collectModuleData(mod);
-      if (data && Object.keys(data).length > 0) {
-        modules[mod] = {
-          data,
-          clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
-        };
-      }
-    }
+    const modules = buildModulesPayload(
+      Object.keys(SYNC_MODULES),
+      getModuleModifiedTimes(),
+    );
     if (Object.keys(modules).length === 0) return;
 
     if (!navigator.onLine) {

--- a/src/core/cloudSync/engine/upload.ts
+++ b/src/core/cloudSync/engine/upload.ts
@@ -2,17 +2,12 @@ import { syncApi } from "@shared/api";
 import { SYNC_MODULES } from "../config";
 import { clearAllDirty, getModuleModifiedTimes } from "../state/dirtyModules";
 import { markMigrationDone } from "../state/migration";
-import { collectModuleData } from "../state/moduleData";
-import type { CurrentUser, ModulePayload } from "../types";
+import type { EngineArgs } from "../types";
+import { buildModulesPayload } from "./buildPayload";
 
-export interface UploadArgs {
-  user: CurrentUser | null | undefined;
-  onStart(): void;
-  onSuccess(when: Date): void;
-  onError(message: string): void;
+export type UploadArgs = EngineArgs & {
   onMigrated(): void;
-  onSettled(): void;
-}
+};
 
 /**
  * Upload all local data to the cloud and mark the migration as done for this
@@ -23,17 +18,10 @@ export async function uploadLocalData(args: UploadArgs): Promise<void> {
   if (!user?.id) return;
   onStart();
   try {
-    const modifiedTimes = getModuleModifiedTimes();
-    const modules: Record<string, ModulePayload> = {};
-    for (const mod of Object.keys(SYNC_MODULES)) {
-      const data = collectModuleData(mod);
-      if (data && Object.keys(data).length > 0) {
-        modules[mod] = {
-          data,
-          clientUpdatedAt: modifiedTimes[mod] || new Date().toISOString(),
-        };
-      }
-    }
+    const modules = buildModulesPayload(
+      Object.keys(SYNC_MODULES),
+      getModuleModifiedTimes(),
+    );
     if (Object.keys(modules).length > 0) {
       await syncApi.pushAll(modules);
     }

--- a/src/core/cloudSync/hook/useSyncCallbacks.ts
+++ b/src/core/cloudSync/hook/useSyncCallbacks.ts
@@ -1,16 +1,7 @@
 import { useCallback, useRef, useState } from "react";
+import type { SyncCallbacks } from "../types";
 
-/**
- * The four callbacks every engine entry point (pushDirty, pushAll, pullAll,
- * initialSync, uploadLocalData) accepts. Kept as a named shape so the
- * orchestrator can spread them into engine args without enumerating.
- */
-export interface SyncCallbacks {
-  onStart(): void;
-  onSuccess(when: Date): void;
-  onError(message: string): void;
-  onSettled(): void;
-}
+export type { SyncCallbacks };
 
 export interface SyncLifecycle extends SyncCallbacks {
   syncing: boolean;

--- a/src/core/cloudSync/storagePatch.ts
+++ b/src/core/cloudSync/storagePatch.ts
@@ -1,8 +1,10 @@
+// Side-effect import: ensure the dirty-modules module is evaluated before
+// we install the localStorage patch below, so `markModuleDirty` can run
+// against an initialized module graph.
+import "./state/dirtyModules";
+
 import { ALL_TRACKED_KEYS, keyToModule } from "./config";
-import {
-  markModuleDirty,
-  getDirtyModules as _unused_getDirty, // keep import so the module graph pulls in state before patching
-} from "./state/dirtyModules";
+import { markModuleDirty } from "./state/dirtyModules";
 import { emitSyncEvent } from "./state/events";
 
 // Capture raw references BEFORE installing the patch so `clearSyncManagedData`
@@ -11,11 +13,6 @@ const origSetItem = localStorage.setItem.bind(localStorage);
 const origRemoveItem = localStorage.removeItem.bind(localStorage);
 
 export const rawRemoveItem: (key: string) => void = origRemoveItem;
-
-// Reference to satisfy the import (we only want the side-effect of loading
-// state/dirtyModules before our patch runs). Prefix with underscore to
-// appease no-unused-vars lint rules.
-void _unused_getDirty;
 
 declare global {
   interface Window {

--- a/src/core/cloudSync/types.ts
+++ b/src/core/cloudSync/types.ts
@@ -1,5 +1,25 @@
 import type { ModuleName } from "./config";
 
+/**
+ * Lifecycle callbacks every engine entry point (pushDirty, pushAll,
+ * pullAll, initialSync, uploadLocalData) accepts. The React hook owns
+ * the implementations via `useSyncCallbacks`; engines only invoke them.
+ */
+export interface SyncCallbacks {
+  onStart(): void;
+  onSuccess(when: Date): void;
+  onError(message: string): void;
+  onSettled(): void;
+}
+
+/**
+ * Base args bag passed into engine entry points. Engines that need extra
+ * callbacks (e.g. `onNeedMigration`, `onMigrated`) intersect with this.
+ */
+export interface EngineArgs extends SyncCallbacks {
+  user: CurrentUser | null | undefined;
+}
+
 export interface ModulePayload {
   data: Record<string, unknown>;
   clientUpdatedAt: string;


### PR DESCRIPTION
## Summary

PR 1 з двох у плані «знизити складність `useCloudSync` без зміни поведінки/API».
Тут — engine/types-рівень. PR 2 буде про поділ самого хука.

Публічне API barrelʼу (`useCloudSync`, `useSyncStatus`, `getDirtyModules`,
`getOfflineQueue`, `notifySyncDirty`, `SYNC_EVENT`, `SYNC_STATUS_EVENT`,
`__internal_*`) і поведінка — без змін.

### Що зроблено

- **Уніфіковано engine callback-контракт** у `cloudSync/types.ts`:
  додано `SyncCallbacks` і `EngineArgs`. `PushArgs`/`PullArgs` стали
  аліасами; `UploadArgs` та `InitialSyncArgs` — інтерсекціями з
  додатковими колбеками (`onMigrated`, `onNeedMigration`).
  `useSyncCallbacks` реекспортує `SyncCallbacks` з `types.ts`, щоб не
  мати двох джерел істини.
- **Винесено `engine/buildPayload.ts`** — спільний `buildModulesPayload(modNames, modifiedTimes)`.
  Використовується у `pushDirty`, `pushAll`, `uploadLocalData`,
  `initialSync` (гілка `merge`). Видалено 3 майже однакові блоки «collect →
  stamp `clientUpdatedAt` → skip empty».
- **Сплюснуто `initialSync` switch**: `needMigration` — ранній return;
  `adoptCloud` / `merge` / `noop` ділять спільний хвіст
  `ensureMigrationDone(user?.id)` після switchʼу. Тіла гілок винесено в
  маленькі helper-функції (`applyAdoptCloud`, `applyMerge`,
  `ensureMigrationDone`) у тому ж файлі.
- **Мікрочистка `storagePatch.ts`**: замінено трюк з
  `_unused_getDirty` на чистий side-effect імпорт
  `import "./state/dirtyModules";`.

### Що НЕ змінено

- Порядок ітерацій `Object.keys(SYNC_MODULES)`.
- Семантика clear-dirty у `pushDirty` (snapshot-based) і `pushAll`
  (`clearAllDirty`).
- Поведінка `initialSync` при фейлі `syncApi.pushAll` у `merge` —
  `ApiError` так само летить у зовнішній catch, `markMigrationDone` не
  викликається.
- Re-queue payloadʼу при failure push і offline/online-семантика.
- Seed-порядок side-effects у `cloudSync/index.ts`.
- Жоден тест-файл не редагувався.

### Перевірки локально

- `npm run typecheck` — ok
- `npm test` — 696/696 passed
- `npm run lint` — ok
- `npm run format:check` — ok

## Review & Testing Checklist for Human

- [ ] Переглянути `src/core/cloudSync/engine/initialSync.ts`: переконатись, що `ensureMigrationDone` викликається лише на успішних гілках (`adoptCloud`/`merge`/`noop`), а `needMigration` і всі `catch` — оминають його (як і до рефакторингу).
- [ ] Переглянути `src/core/cloudSync/engine/buildPayload.ts` і три місця-виклики: мапа `modifiedTimes → clientUpdatedAt` / пропуск порожніх модулів має точно відповідати старій логіці.
- [ ] Прогнати наявний набір тестів cloud-sync: `useCloudSync.behavior.test.js`, `useCloudSync.hardening.test.js`, `cloudSync/__tests__/resolver.test.ts`, `engine/initialSync.test.ts`, `hook/useSyncCallbacks.test.ts`.

### Notes

PR 2 (наступний) зачепить тільки `cloudSync/hook/*` — поділ оркестратора
на `useEngineArgs` + `useInitialSyncOnUser` + тонкий `useCloudSync`.

Link to Devin session: https://app.devin.ai/sessions/54ac5b54df424b6e9bca621384cfedb4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
