### PR TITLE
refactor(hub): route Finyk preview через React Query замість CustomEvent bus

### DIFF
--- a/src/core/HubChat.tsx
+++ b/src/core/HubChat.tsx
@@ -1,12 +1,14 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { chatApi, isApiError } from "@shared/api";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
+import { hubKeys } from "@shared/lib/queryKeys";
+import { useFinykHubPreview } from "./hub/useFinykHubPreview";
 
 import {
-  HUB_FINYK_CACHE_EVENT,
   CONTEXT_TTL_MS,
   CHAT_HISTORY_WRITE_DEBOUNCE_MS,
   friendlyApiError,
@@ -16,7 +18,6 @@ import {
   makeAssistantMsg,
   makeUserMsg,
   normalizeStoredMessages,
-  checkHasMonoData,
   requestIdle,
   cancelIdle,
 } from "./lib/hubChatUtils.js";
@@ -101,7 +102,9 @@ function HubChat({ onClose, initialMessage }) {
     }
   }, [initialMessage]);
 
-  const [hasData, setHasData] = useState(() => checkHasMonoData());
+  const queryClient = useQueryClient();
+  const finykPreview = useFinykHubPreview();
+  const hasData = finykPreview.data?.hasMonoData ?? false;
   const online = useOnlineStatus();
 
   // Context cache
@@ -136,34 +139,25 @@ function HubChat({ onClose, initialMessage }) {
   }, []);
 
   useEffect(() => {
-    const refresh = () => setHasData(checkHasMonoData());
-    window.addEventListener("storage", refresh);
-    window.addEventListener(HUB_FINYK_CACHE_EVENT, refresh);
-    window.addEventListener("focus", refresh);
-    const onVis = () => {
-      if (document.visibilityState === "visible") refresh();
-    };
-    document.addEventListener("visibilitychange", onVis);
-    return () => {
-      window.removeEventListener("storage", refresh);
-      window.removeEventListener(HUB_FINYK_CACHE_EVENT, refresh);
-      window.removeEventListener("focus", refresh);
-      document.removeEventListener("visibilitychange", onVis);
-    };
-  }, []);
-
-  useEffect(() => {
     scheduleContextBuild("mount", true);
     return () => {
       if (idleJobRef.current) cancelIdle(idleJobRef.current);
     };
   }, [scheduleContextBuild]);
 
+  // Rebuild the chat context whenever the Finyk preview snapshot flips
+  // (Monobank sync, clear-cache, disconnect, or a cross-tab storage event).
+  // Previously signalled via `HUB_FINYK_CACHE_EVENT`; now driven by RQ
+  // invalidation of `hubKeys.preview("finyk")`.
+  const finykPreviewUpdatedAt = finykPreview.dataUpdatedAt;
+  const mountedRef = useRef(false);
   useEffect(() => {
-    const onUpdate = () => scheduleContextBuild("finyk-cache", true);
-    window.addEventListener(HUB_FINYK_CACHE_EVENT, onUpdate);
-    return () => window.removeEventListener(HUB_FINYK_CACHE_EVENT, onUpdate);
-  }, [scheduleContextBuild]);
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    scheduleContextBuild("finyk-cache", true);
+  }, [finykPreviewUpdatedAt, scheduleContextBuild]);
 
   const quickPrompts = useMemo(
     () => (hasData ? QUICK_WITH_MONO : QUICK_NO_MONO),
@@ -350,7 +344,9 @@ function HubChat({ onClose, initialMessage }) {
           if (speakTarget) maybeSpeak(speakTarget);
         }
 
-        window.dispatchEvent(new CustomEvent(HUB_FINYK_CACHE_EVENT));
+        queryClient.invalidateQueries({
+          queryKey: hubKeys.preview("finyk"),
+        });
         scheduleContextBuild("after-tools", true);
       } else {
         const reply = data.text || "Немає відповіді.";

--- a/src/core/hub/useFinykHubPreview.ts
+++ b/src/core/hub/useFinykHubPreview.ts
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { hubKeys } from "@shared/lib/queryKeys";
+
+/**
+ * React Query-backed signal for "does Finyk have Monobank data loaded?".
+ *
+ * Replaces the legacy `window.dispatchEvent("hub-finyk-cache-updated")` fan-out
+ * used by the Hub chat and the Routine calendar. Writers (see
+ * `useMonobank.saveCache/disconnect/clearTxCache` and the Settings "Clear
+ * cache" button) invalidate `hubKeys.preview("finyk")`, and every consumer
+ * that subscribes to this hook re-renders without a manual bus.
+ *
+ * Cross-tab updates are covered by listening to the `storage` event and
+ * triggering the same invalidation — `localStorage` already broadcasts the
+ * write to other tabs, so we only need to rebuild the derived value there.
+ */
+
+const TX_CACHE_LS_KEY = "finyk_tx_cache";
+
+export interface FinykHubPreview {
+  hasMonoData: boolean;
+}
+
+function readHasMonoData(): boolean {
+  try {
+    const raw = localStorage.getItem(TX_CACHE_LS_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as { txs?: unknown[] } | null;
+    return Array.isArray(parsed?.txs) && parsed.txs.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function readPreview(): FinykHubPreview {
+  return { hasMonoData: readHasMonoData() };
+}
+
+export function useFinykHubPreview() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === null || e.key === TX_CACHE_LS_KEY) {
+        queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") });
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [queryClient]);
+
+  return useQuery({
+    queryKey: hubKeys.preview("finyk"),
+    queryFn: readPreview,
+    // The source of truth is `localStorage`; RQ is used purely as a pub/sub
+    // broadcaster for derived values. Explicit invalidations refetch.
+    staleTime: 60_000,
+    gcTime: Infinity,
+    // Returning to the tab rebuilds the preview — covers the case where a
+    // storage event was dropped (Safari occasionally does).
+    refetchOnWindowFocus: true,
+  });
+}

--- a/src/core/lib/hubChatUtils.ts
+++ b/src/core/lib/hubChatUtils.ts
@@ -1,6 +1,5 @@
 // Utility functions shared across HubChat modules
 
-export const HUB_FINYK_CACHE_EVENT = "hub-finyk-cache-updated";
 export const CONTEXT_TTL_MS = 15_000;
 export const CHAT_HISTORY_WRITE_DEBOUNCE_MS = 600;
 
@@ -136,13 +135,4 @@ export function cancelIdle(id: IdleHandle): void {
   if (typeof window === "undefined") return clearTimeout(id);
   if (window.cancelIdleCallback) return window.cancelIdleCallback(id);
   return clearTimeout(id);
-}
-
-export function checkHasMonoData(): boolean {
-  try {
-    const c = ls<{ txs?: unknown[] } | null>("finyk_tx_cache", null);
-    return !!c?.txs?.length;
-  } catch {
-    return false;
-  }
 }

--- a/src/core/settings/FinykSection.tsx
+++ b/src/core/settings/FinykSection.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { privatApi, isApiError } from "@shared/api";
 import { safeReadLS } from "@shared/lib/storage";
+import { hubKeys } from "@shared/lib/queryKeys";
 import { useStorage as useFinykStorage } from "../../modules/finyk/hooks/useStorage.js";
 import { getAccountLabel } from "../../modules/finyk/utils.js";
 import {
@@ -42,6 +44,7 @@ interface FinykStorageShape {
 }
 
 export function FinykSection() {
+  const queryClient = useQueryClient();
   const {
     hiddenAccounts,
     toggleHideAccount,
@@ -181,7 +184,7 @@ export function FinykSection() {
     try {
       localStorage.removeItem("finyk_tx_cache");
       localStorage.removeItem("finyk_tx_cache_last_good");
-      window.dispatchEvent(new CustomEvent("hub-finyk-cache-updated"));
+      queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") });
     } catch {
       /* storage may be disabled — safe to ignore */
     }

--- a/src/modules/finyk/hooks/useMonobank.ts
+++ b/src/modules/finyk/hooks/useMonobank.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { monoApi, isApiError } from "@shared/api";
-import { finykKeys, hashToken } from "@shared/lib/queryKeys";
+import { finykKeys, hubKeys, hashToken } from "@shared/lib/queryKeys";
 import { TX_CACHE_TTL, CURRENCY } from "../constants";
 import {
   readJSON,
@@ -39,12 +39,13 @@ import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
  * Current synchronisation state for the Monobank data fetch.
  */
 
-const HUB_FINYK_CACHE_EVENT = "hub-finyk-cache-updated";
-
-function notifyHubFinykCache() {
-  try {
-    window.dispatchEvent(new CustomEvent(HUB_FINYK_CACHE_EVENT));
-  } catch {}
+/**
+ * Signal every subscriber of `hubKeys.preview("finyk")` that the Monobank
+ * cache on disk changed. Replaces the legacy `window.dispatchEvent(
+ * "hub-finyk-cache-updated")` bus — see `useFinykHubPreview`.
+ */
+function notifyHubFinykPreview(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") });
 }
 
 const CACHE_KEY = "finyk_tx_cache";
@@ -74,9 +75,9 @@ function loadAnyCache() {
   return cache;
 }
 
-function saveCache(txs) {
+function saveCache(txs, queryClient: QueryClient) {
   if (writeJSON(CACHE_KEY, { txs, timestamp: Date.now() })) {
-    notifyHubFinykCache();
+    notifyHubFinykPreview(queryClient);
   }
 }
 
@@ -414,7 +415,7 @@ export function useMonobank() {
 
       if (unique.length > 0) {
         setTransactions(unique);
-        saveCache(unique);
+        saveCache(unique, queryClient);
         if (accountsOk === targetAccounts.length || unique.length >= 15) {
           saveLastGoodBackup(unique);
         }
@@ -724,7 +725,7 @@ export function useMonobank() {
     // (`useMonoClientInfo`, `useMonoStatements`) не видавали кешовані
     // дані попереднього користувача.
     queryClient.removeQueries({ queryKey: finykKeys.mono });
-    notifyHubFinykCache();
+    notifyHubFinykPreview(queryClient);
   };
 
   const clearTxCache = () => {
@@ -733,7 +734,7 @@ export function useMonobank() {
     // Очищуємо тільки statement-кеш RQ; client-info залишаємо,
     // токен не змінювався — профіль валідний.
     queryClient.removeQueries({ queryKey: finykKeys.monoStatements });
-    notifyHubFinykCache();
+    notifyHubFinykPreview(queryClient);
     setTransactions([]);
     setLastUpdated(null);
     setSyncState((s) => ({

--- a/src/modules/finyk/hubRoutineSync.js
+++ b/src/modules/finyk/hubRoutineSync.js
@@ -1,8 +1,5 @@
-/** Подія для перемальовки календаря Рутини після змін підписок/кешу Фініка. */
+/** Подія для перемальовки календаря Рутини після змін підписок Фініка. */
 export const HUB_FINYK_ROUTINE_SYNC_EVENT = "hub-finyk-routine-sync";
-
-/** Оновлення кешу транзакцій Monobank (див. useMonobank). */
-export const HUB_FINYK_TX_CACHE_EVENT = "hub-finyk-cache-updated";
 
 export function notifyFinykRoutineCalendarSync() {
   try {

--- a/src/modules/routine/RoutineApp.tsx
+++ b/src/modules/routine/RoutineApp.tsx
@@ -20,10 +20,8 @@ import {
   habitScheduledOnDate,
 } from "./lib/hubCalendarAggregate.js";
 import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar.js";
-import {
-  HUB_FINYK_ROUTINE_SYNC_EVENT,
-  HUB_FINYK_TX_CACHE_EVENT,
-} from "../finyk/hubRoutineSync.js";
+import { HUB_FINYK_ROUTINE_SYNC_EVENT } from "../finyk/hubRoutineSync.js";
+import { useFinykHubPreview } from "../../core/hub/useFinykHubPreview";
 import { ROUTINE_THEME as C } from "./lib/routineConstants.js";
 import { emptyHabitDraft } from "./lib/routineDraftUtils.js";
 import { RoutineBottomNav } from "./components/RoutineBottomNav";
@@ -163,16 +161,20 @@ export default function RoutineApp({
 }: RoutineAppProps = {}) {
   const [routine, setRoutine] = useRoutineState();
   const toast = useToast();
-  const [finykCalendarTick, setFinykCalendarTick] = useState<number>(0);
+  // Finyk calendar events depend on both the Finyk Monobank cache and the
+  // subscription calendar. The former now flows through React Query
+  // (`hubKeys.preview("finyk")`), the latter still uses a custom event
+  // because nothing else observes the subscription-only signal.
+  const finykPreview = useFinykHubPreview();
+  const [routineSyncBump, setRoutineSyncBump] = useState<number>(0);
   useEffect(() => {
-    const bump = () => setFinykCalendarTick((n) => n + 1);
+    const bump = () => setRoutineSyncBump((n) => n + 1);
     window.addEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
-    window.addEventListener(HUB_FINYK_TX_CACHE_EVENT, bump);
     return () => {
       window.removeEventListener(HUB_FINYK_ROUTINE_SYNC_EVENT, bump);
-      window.removeEventListener(HUB_FINYK_TX_CACHE_EVENT, bump);
     };
   }, []);
+  const finykCalendarTick = finykPreview.dataUpdatedAt + routineSyncBump;
 
   useEffect(() => {
     const onErr = (ev: Event) => {


### PR DESCRIPTION
## Summary

Перший крок інтеграції React Query за планом з аналізу (Phase 3 + вибіркова частина Phase 1): прибрати ручний `window`-event bus для Hub-preview сигналів Фініка й перевести його на інвалідацію RQ-кешу.

### Що змінилось

- **Новий хук `useFinykHubPreview`** (`src/core/hub/useFinykHubPreview.ts`) — `useQuery` над `hubKeys.preview("finyk")`. Читає те саме `localStorage.getItem("finyk_tx_cache")`, що й раніше, але тепер як джерело правди для підписників. Cross-tab через `storage` event триває.
- **`useMonobank`**: `notifyHubFinykCache()` + константа `HUB_FINYK_CACHE_EVENT` видалені. Замість `window.dispatchEvent` тепер `queryClient.invalidateQueries({ queryKey: hubKeys.preview("finyk") })` у `saveCache`, `disconnect`, `clearTxCache`.
- **`HubChat.tsx`**: `useState(checkHasMonoData)` + 4 event listeners (storage/focus/visibilitychange/custom-event) замінено одним `useFinykHubPreview()`. Перебудова контексту після `send()`-викликів тулзів тепер теж через `invalidateQueries`, а не `dispatchEvent`.
- **`RoutineApp.tsx`**: прибраний лістенер `HUB_FINYK_TX_CACHE_EVENT` — календар тикає через `finykPreview.dataUpdatedAt`. Окремий `HUB_FINYK_ROUTINE_SYNC_EVENT` (підписки) залишено, бо на нього більше нічого не зав'язано.
- **`FinykSection.tsx`** (settings): «Очистити кеш» тепер робить `invalidateQueries(hubKeys.preview("finyk"))` замість `dispatchEvent`.
- Мертвий `checkHasMonoData` та обидві константи `HUB_FINYK_CACHE_EVENT` / `HUB_FINYK_TX_CACHE_EVENT` видалено.

### Що **не** зачіпається

- `fetchAllTx`, `mergeTxWithPrevious`, `loadLastGoodBackup`, auth-error propagation, `fetchMonth`, per-month localStorage кеш, auto-refresh на visibility/online — залишаються як є. Повна перебудова `useMonobank` у RQ-хуки (решта Phase 1) — окремий PR, бо там ризик regression на партіальних відмовах API Monobank.
- Окремий `HUB_FINYK_ROUTINE_SYNC_EVENT` (синхронізація підписок з Routine) лишається — його семантика не збігається з Monobank cache.

## Review & Testing Checklist for Human

- [ ] **Monobank flow у Фініку:** відкрити Фінік → підключити Monobank → переконатися, що після успішного sync кнопка «Контекст» у Hub чаті стає доступною (`hasData=true`) без перезавантаження.
- [ ] **Clear cache у Settings:** натиснути «Очистити кеш транзакцій» у налаштуваннях Фініка й перевірити, що Hub чат у тій самій вкладці одразу переходить у режим `QUICK_NO_MONO`.
- [ ] **Cross-tab:** відкрити дві вкладки, у першій зробити sync/clear → у другій preview має оновитись (через `storage` event).
- [ ] **Календар Рутини:** переконатися, що після sync Monobank події календаря з групою «Monobank» оновлюються без F5.
- [ ] **Chat tool invocations:** у Hub чаті викликати інструмент, який щось пише у сховище Фініка (`add_expense`, `edit_category` тощо), й перевірити, що контекст перебудовується після відповіді.

### Notes

- Поведінка не змінюється — це чистий refactor. Усі 696 юніт-тестів зелені, `lint` і `typecheck` теж.
- Наступний очікуваний PR за планом: повний Phase 1 — мігрувати `useMonobank` sync-state-machine (transactions/syncState/loadingTx) на `useMonoStatements` + RQ-derived стан. Зроблю окремо, бо там треба пройти acceptance на кейс «Monobank повертає мало/пусто після тимчасового збою» без регресії `loadLastGoodBackup`.

Link to Devin session: https://app.devin.ai/sessions/28990661dd7642d687e7d1fa6b6808ac
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
