### PR TITLE
refactor(cloudSync): split orchestrator hook into useEngineArgs + useInitialSyncOnUser (PR 2/2)

### DIFF
--- a/src/core/cloudSync/hook/useCloudSync.ts
+++ b/src/core/cloudSync/hook/useCloudSync.ts
@@ -1,72 +1,52 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { initialSync } from "../engine/initialSync";
-import { pullAll, type PullArgs } from "../engine/pull";
+import { pullAll } from "../engine/pull";
 import { pushAll, pushDirty } from "../engine/push";
 import { uploadLocalData } from "../engine/upload";
 import { markMigrationDone } from "../state/migration";
-import { clearSyncManagedData } from "../state/moduleData";
-import { rawRemoveItem } from "../storagePatch";
 import type { CurrentUser } from "../types";
-import { useSyncCallbacks } from "./useSyncCallbacks";
+import { useEngineArgs } from "./useEngineArgs";
+import { useInitialSyncOnUser } from "./useInitialSyncOnUser";
 import { useSyncRetry } from "./useSyncRetry";
 
 /**
  * React hook that orchestrates the cloud-sync engine. Owns React state
- * (`syncing`, `lastSync`, `syncError`, `migrationPending`) and timer-based
- * retry policy (online listener, 5s debounce on SYNC_EVENT, 2min periodic).
+ * (`syncing`, `lastSync`, `syncError`, `migrationPending`) and wires the
+ * engine to retry triggers (online listener, 5s debounce on SYNC_EVENT,
+ * 2-min periodic) and the initial-sync-on-user effect.
  */
 export function useCloudSync(user: CurrentUser | null | undefined) {
   const [migrationPending, setMigrationPending] = useState(false);
-  const {
-    syncing,
-    lastSync,
-    syncError,
-    onStart,
-    onSuccess,
-    onError,
-    onSettled,
-    runExclusive,
-    claimBusy,
-  } = useSyncCallbacks();
+  const { engineArgs, lifecycle } = useEngineArgs(user);
+  const { syncing, lastSync, syncError, runExclusive, claimBusy } = lifecycle;
 
-  const doPushDirty = useCallback(async () => {
-    await runExclusive(
-      () =>
-        pushDirty({
-          user,
-          onStart,
-          onSuccess,
-          onError,
-          onSettled,
-        }),
-      undefined,
-    );
-  }, [user, onStart, onSuccess, onError, onSettled, runExclusive]);
+  const doPushDirty = useCallback(
+    () => runExclusive(() => pushDirty(engineArgs), undefined),
+    [engineArgs, runExclusive],
+  );
 
-  const doPushAll = useCallback(async () => {
-    await runExclusive(
-      () =>
-        pushAll({
-          user,
-          onStart,
-          onSuccess,
-          onError,
-          onSettled,
-        }),
-      undefined,
-    );
-  }, [user, onStart, onSuccess, onError, onSettled, runExclusive]);
+  const doPushAll = useCallback(
+    () => runExclusive(() => pushAll(engineArgs), undefined),
+    [engineArgs, runExclusive],
+  );
 
-  const doPullAll = useCallback(async () => {
-    const pullArgs: PullArgs = {
-      user,
-      onStart,
-      onSuccess,
-      onError,
-      onSettled,
-    };
-    return runExclusive(() => pullAll(pullArgs), false);
-  }, [user, onStart, onSuccess, onError, onSettled, runExclusive]);
+  const doPullAll = useCallback(
+    () => runExclusive(() => pullAll(engineArgs), false),
+    [engineArgs, runExclusive],
+  );
+
+  const doInitialSync = useCallback(
+    (): Promise<boolean> =>
+      runExclusive(
+        () =>
+          initialSync({
+            ...engineArgs,
+            onNeedMigration: () => setMigrationPending(true),
+          }),
+        false,
+      ),
+    [engineArgs, runExclusive],
+  );
 
   const doUploadLocalData = useCallback(async () => {
     if (!user?.id) return;
@@ -75,29 +55,10 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     // is mid-flight.
     claimBusy();
     await uploadLocalData({
-      user,
-      onStart,
-      onSuccess,
-      onError,
+      ...engineArgs,
       onMigrated: () => setMigrationPending(false),
-      onSettled,
     });
-  }, [user, onStart, onSuccess, onError, onSettled, claimBusy]);
-
-  const doInitialSync = useCallback(async (): Promise<boolean> => {
-    return runExclusive(
-      () =>
-        initialSync({
-          user,
-          onStart,
-          onSuccess,
-          onError,
-          onNeedMigration: () => setMigrationPending(true),
-          onSettled,
-        }),
-      false,
-    );
-  }, [user, onStart, onSuccess, onError, onSettled, runExclusive]);
+  }, [user, engineArgs, claimBusy]);
 
   const skipMigration = useCallback(() => {
     if (!user?.id) return;
@@ -105,37 +66,11 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     setMigrationPending(false);
   }, [user]);
 
-  const didInitialSync = useRef(false);
-  const lastUserId = useRef<string | null>(null);
-  useEffect(() => {
-    const uid = user?.id ?? null;
-    if (uid !== lastUserId.current) {
-      if (lastUserId.current !== null) {
-        clearSyncManagedData(rawRemoveItem);
-      }
-      didInitialSync.current = false;
-      lastUserId.current = uid;
-      setMigrationPending(false);
-    }
-    if (!user || didInitialSync.current) return;
-    // Reserve the slot before awaiting so concurrent renders don't fire a
-    // second initialSync for the same user. If the run fails (network,
-    // 5xx, ApiError), release the slot so the next render — or a
-    // subsequent user-change effect — can retry. Without this, a transient
-    // failure on the very first sign-in would leave the app in a
-    // permanently "initial-synced" state with no cloud reconciliation
-    // until the page is reloaded.
-    didInitialSync.current = true;
-    const uidAtStart = user.id;
-    doInitialSync().then((ok) => {
-      if (ok) return;
-      // Only clear the flag if the user is still the same — a user change
-      // will reset it anyway and we must not race that reset.
-      if (lastUserId.current === uidAtStart) {
-        didInitialSync.current = false;
-      }
-    });
-  }, [user, doInitialSync]);
+  const clearMigrationPending = useCallback(
+    () => setMigrationPending(false),
+    [],
+  );
+  useInitialSyncOnUser(user, doInitialSync, clearMigrationPending);
 
   useSyncRetry(!!user, doPushDirty);
 

--- a/src/core/cloudSync/hook/useEngineArgs.ts
+++ b/src/core/cloudSync/hook/useEngineArgs.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import type { CurrentUser, EngineArgs } from "../types";
+import { useSyncCallbacks, type SyncLifecycle } from "./useSyncCallbacks";
+
+export interface UseEngineArgsResult {
+  /**
+   * The 5-field bag every engine entry point accepts
+   * (`user` + `onStart` + `onSuccess` + `onError` + `onSettled`).
+   * Spread into engine args to add extra callbacks like `onNeedMigration`.
+   */
+  engineArgs: EngineArgs;
+  /**
+   * React state (`syncing`, `lastSync`, `syncError`) plus the in-flight
+   * concurrency guard (`runExclusive`, `claimBusy`). Exposed separately
+   * from `engineArgs` because the orchestrator wires the guard around
+   * engine calls rather than passing it to engines.
+   */
+  lifecycle: SyncLifecycle;
+}
+
+/**
+ * Builds the engine argument bag and lifecycle handle used by the cloud-sync
+ * orchestrator. Owns `useSyncCallbacks` so consumers don't juggle four
+ * individual callbacks next to `user` — they read a single `engineArgs`
+ * reference whose identity is stable across renders.
+ */
+export function useEngineArgs(
+  user: CurrentUser | null | undefined,
+): UseEngineArgsResult {
+  const lifecycle = useSyncCallbacks();
+  const { onStart, onSuccess, onError, onSettled } = lifecycle;
+  const engineArgs: EngineArgs = useMemo(
+    () => ({ user, onStart, onSuccess, onError, onSettled }),
+    [user, onStart, onSuccess, onError, onSettled],
+  );
+  return { engineArgs, lifecycle };
+}

--- a/src/core/cloudSync/hook/useInitialSyncOnUser.ts
+++ b/src/core/cloudSync/hook/useInitialSyncOnUser.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { clearSyncManagedData } from "../state/moduleData";
+import { rawRemoveItem } from "../storagePatch";
+import type { CurrentUser } from "../types";
+
+/**
+ * Runs `runInitialSync` exactly once per signed-in user. On user change,
+ * wipes the previous user's sync-managed localStorage slice and calls
+ * `onUserChanged` (used to reset migration-pending UI state).
+ *
+ * Reserves the "already synced" slot before awaiting so concurrent renders
+ * don't fire a second initialSync for the same user. If the run fails
+ * (network, 5xx, `ApiError`), releases the slot so the next render — or a
+ * subsequent user-change effect — can retry. Without this, a transient
+ * failure on the very first sign-in would leave the app in a permanently
+ * "initial-synced" state with no cloud reconciliation until page reload.
+ */
+export function useInitialSyncOnUser(
+  user: CurrentUser | null | undefined,
+  runInitialSync: () => Promise<boolean>,
+  onUserChanged: () => void,
+): void {
+  const didInitialSync = useRef(false);
+  const lastUserId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const uid = user?.id ?? null;
+    if (uid !== lastUserId.current) {
+      if (lastUserId.current !== null) {
+        clearSyncManagedData(rawRemoveItem);
+      }
+      didInitialSync.current = false;
+      lastUserId.current = uid;
+      onUserChanged();
+    }
+    if (!user || didInitialSync.current) return;
+
+    didInitialSync.current = true;
+    const uidAtStart = user.id;
+    runInitialSync().then((ok) => {
+      if (ok) return;
+      // Only clear the flag if the user is still the same — a user change
+      // will reset it anyway and we must not race that reset.
+      if (lastUserId.current === uidAtStart) {
+        didInitialSync.current = false;
+      }
+    });
+  }, [user, runInitialSync, onUserChanged]);
+}


### PR DESCRIPTION
## Summary

PR 2 з двох у плані «знизити складність `useCloudSync` без зміни
поведінки/API». Продовження #264 — там почистили engine/types; тут
скорочуємо React-орhestrator.

### Що зроблено

- **Новий хук `hook/useEngineArgs.ts`** — володіє `useSyncCallbacks` і
  повертає memoized `engineArgs` (`{ user, onStart, onSuccess, onError,
  onSettled }`) + повний `lifecycle` (`syncing`/`lastSync`/`syncError` +
  `runExclusive`/`claimBusy`). Забирає з оркестратора повторення
  5-полевого спреду біля кожного engine-виклику.
- **Новий хук `hook/useInitialSyncOnUser.ts`** — ефект першого sync при
  зміні користувача: чистить сині дані попереднього юзера через
  `clearSyncManagedData(rawRemoveItem)`, викликає `onUserChanged`
  (скидання `migrationPending`), «бронює» слот `didInitialSync` ДО
  `await` і звільняє лише якщо юзер не змінився — щоб транзієнтний
  фейл не лишив стан `initial-synced` без реконсиляції.
- **`hook/useCloudSync.ts` скорочено зі 152 до ~87 рядків**: чотири
  `doX`-коллбеки тепер ділять один deps-список
  `[engineArgs, runExclusive]` і спредять `engineArgs` замість
  перелічення 5 полів.

### Що саме НЕ змінено

- Публічний контракт хука: повертаємо ті ж поля (`syncing`, `lastSync`,
  `syncError`, `pushAll`, `pullAll`, `migrationPending`,
  `uploadLocalData`, `skipMigration`).
- Ретраї: `useSyncRetry(!!user, doPushDirty)` — 5 с debounce на
  `SYNC_EVENT`, 2-хв period, `online` listener — без змін.
- `doUploadLocalData` і далі викликає `claimBusy()` до awaitʼу і
  навмисно оминає in-flight guard (користувач підтверджує міграцію).
- `skipMigration` → `markMigrationDone(user.id)` + скидання
  `migrationPending`.
- Порядок side-effects: `clearSyncManagedData` викликається лише коли
  `lastUserId.current !== null` (тобто не чистимо на першому mount).
- Залежності `doPushDirty` у новому коді — `[engineArgs, runExclusive]`,
  що еквівалентно старим `[user, onStart, onSuccess, onError,
  onSettled, runExclusive]` (всі 5 полів входять у memoized
  `engineArgs`). Отже `useSyncRetry` реагує на зміну юзера так само.
- Жоден тест-файл не редагувався.

### Перевірки локально

- `npm run typecheck` — ok
- `npm test` — 696/696 passed
- `npm run lint` — ok
- `npm run format:check` — ok

## Review & Testing Checklist for Human

- [ ] `src/core/cloudSync/hook/useInitialSyncOnUser.ts`: перевірити, що логіка з `didInitialSync` / `lastUserId` / на-failure-release ідентична попередньому вбудованому ефекту. Особливо — що `clearSyncManagedData(rawRemoveItem)` не викликається на першому mount (коли `lastUserId.current === null`).
- [ ] `src/core/cloudSync/hook/useCloudSync.ts`: `doUploadLocalData` має викликати `claimBusy()` ДО awaitʼу і оминати `runExclusive` — це спеціально (міграція з модалки не повинна блокуватись фоновим ретраєм).
- [ ] Вручну: логін/логаут, перемикання між юзерами, режим офлайн → онлайн, міграція (якщо акаунт має локальні дані без хмарних).

### Notes

Це завершує план рефакторингу `useCloudSync`. Структура така:

```
src/core/cloudSync/
├── hook/
│   ├── useCloudSync.ts         # тонкий оркестратор (~87 рядків)
│   ├── useEngineArgs.ts        # NEW: engineArgs + lifecycle
│   ├── useInitialSyncOnUser.ts # NEW: first-run ефект
│   ├── useSyncCallbacks.ts
│   ├── useSyncRetry.ts
│   └── useSyncStatus.ts
├── engine/ ...
├── state/ ...
└── ...
```

Link to Devin session: https://app.devin.ai/sessions/54ac5b54df424b6e9bca621384cfedb4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
