### PR TITLE
refactor(api): retry для network/parse, дедуп friendlyApiError + тести

### DIFF
--- a/src/core/lib/hubChatUtils.ts
+++ b/src/core/lib/hubChatUtils.ts
@@ -1,5 +1,7 @@
 // Utility functions shared across HubChat modules
 
+import { friendlyApiError as baseFriendlyApiError } from "@shared/lib/friendlyApiError";
+
 export const CONTEXT_TTL_MS = 15_000;
 export const CHAT_HISTORY_WRITE_DEBOUNCE_MS = 600;
 
@@ -13,19 +15,22 @@ export interface ChatMessage {
   [key: string]: unknown;
 }
 
+/**
+ * HubChat-специфічний `friendlyApiError`. Додає два кейси поверх
+ * загального мапера в `@shared/lib/friendlyApiError`:
+ *  - 500 без ключа AI → окремий текст про чат;
+ *  - 429 з маркером AI_QUOTA / «ліміт AI» → явне повідомлення про
+ *    денний ліміт (замість загального «Забагато запитів»).
+ */
 export function friendlyApiError(status: number, message?: string): string {
   const m = message || "";
   if (status === 500 && /ANTHROPIC|not set|key/i.test(m)) {
     return "Чат на сервері не налаштовано (немає ключа AI).";
   }
-  if (status === 429) {
-    if (/ліміт AI|AI_QUOTA|квот/i.test(m)) {
-      return "Денний ліміт AI вичерпано. Спробуй завтра або зменш навантаження.";
-    }
-    return "Забагато запитів. Спробуй через хвилину.";
+  if (status === 429 && /ліміт AI|AI_QUOTA|квот/i.test(m)) {
+    return "Денний ліміт AI вичерпано. Спробуй завтра або зменш навантаження.";
   }
-  if (status === 401 || status === 403) return "Доступ заборонено.";
-  return m || `Помилка ${status}`;
+  return baseFriendlyApiError(status, message);
 }
 
 export function friendlyChatError(e: unknown): string {

--- a/src/core/useWeeklyDigest.ts
+++ b/src/core/useWeeklyDigest.ts
@@ -397,25 +397,17 @@ async function generateWeeklyDigest(weekKey: string): Promise<{
   const nutrition = aggregateNutrition(weekKey);
   const routine = aggregateRoutine(weekKey);
 
-  let json: { report: unknown; generatedAt: string };
-  try {
-    json = (await weeklyDigestApi.generate({
-      weekRange: currentWeekRange,
-      finyk,
-      fizruk,
-      nutrition,
-      routine,
-    })) as { report: unknown; generatedAt: string };
-  } catch (e) {
-    if (isApiError(e) && e.kind === "http") {
-      const err = Object.assign(
-        new Error(e.serverMessage || "Помилка генерації звіту"),
-        { status: e.status },
-      );
-      throw err;
-    }
-    throw e;
-  }
+  // Не огортаємо `ApiError` у plain `Error` — це ламало retry-логіку
+  // React Query (`isRetriableError` читає `.status`) і приховувало `kind`
+  // від UI-селекторів. Консьюмери тепер читають `.serverMessage` через
+  // `isApiError(query.error)`.
+  const json = (await weeklyDigestApi.generate({
+    weekRange: currentWeekRange,
+    finyk,
+    fizruk,
+    nutrition,
+    routine,
+  })) as { report: unknown; generatedAt: string };
 
   return {
     report: json.report,
@@ -508,7 +500,9 @@ export function useWeeklyDigest(selectedWeekKey?: string) {
     digest: query.data ?? null,
     loading: mutation.isPending,
     error: mutation.error
-      ? (mutation.error as Error).message || "Помилка мережі"
+      ? isApiError(mutation.error) && mutation.error.kind === "http"
+        ? mutation.error.serverMessage || "Помилка генерації звіту"
+        : (mutation.error as Error).message || "Помилка мережі"
       : null,
     weekKey,
     weekRange,

--- a/src/modules/nutrition/lib/nutritionApi.test.ts
+++ b/src/modules/nutrition/lib/nutritionApi.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ApiError, isApiError } from "@shared/api";
+import { postJson } from "./nutritionApi";
+
+// Мокаємо централізований `nutritionApi` з `@shared/api`: під час
+// імпорту `./nutritionApi` адаптер підтягує саме цей мок. Використовуємо
+// `vi.hoisted` для мок-функції, бо `vi.mock` піднімається вище імпортів.
+const { postJsonMock } = vi.hoisted(() => ({ postJsonMock: vi.fn() }));
+vi.mock("@shared/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@shared/api")>();
+  return {
+    ...actual,
+    nutritionApi: {
+      postJson: (url: string, body: unknown) => postJsonMock(url, body),
+    },
+  };
+});
+
+const URL = "/api/nutrition/day-plan";
+
+describe("nutritionApi adapter postJson", () => {
+  beforeEach(() => {
+    postJsonMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("пробрасує успішний response", async () => {
+    const payload = { plan: "ok" };
+    postJsonMock.mockResolvedValueOnce(payload);
+    await expect(postJson(URL, { weekKey: "2025-01-01" })).resolves.toEqual(
+      payload,
+    );
+    expect(postJsonMock).toHaveBeenCalledWith(URL, { weekKey: "2025-01-01" });
+  });
+
+  it("HTTP 500 → ApiError (kind=http) з юзер-френдлі повідомленням і збереженим status/body", async () => {
+    const src = new ApiError({
+      kind: "http",
+      message: "HTTP 500",
+      status: 500,
+      body: { error: "server exploded" },
+      bodyText: '{"error":"server exploded"}',
+      url: URL,
+    });
+    postJsonMock.mockRejectedValueOnce(src);
+
+    const err = await postJson(URL, {}).catch((e: unknown) => e);
+    expect(isApiError(err)).toBe(true);
+    const apiErr = err as ApiError;
+    expect(apiErr.kind).toBe("http");
+    expect(apiErr.status).toBe(500);
+    expect(apiErr.message).toBe("server exploded");
+    expect(apiErr.body).toEqual({ error: "server exploded" });
+    expect(apiErr.serverMessage).toBe("server exploded");
+    expect(apiErr.url).toBe(URL);
+    expect(apiErr.cause).toBe(src);
+  });
+
+  it("HTTP 500 без ключа AI → nutrition-специфічний текст", async () => {
+    postJsonMock.mockRejectedValueOnce(
+      new ApiError({
+        kind: "http",
+        message: "HTTP 500",
+        status: 500,
+        body: { error: "ANTHROPIC_API_KEY not set" },
+        url: URL,
+      }),
+    );
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(err.message).toBe(
+      "Сервер харчування не налаштовано (немає ключа AI).",
+    );
+    expect(err.status).toBe(500);
+    expect(err.kind).toBe("http");
+  });
+
+  it("HTTP 413 → nutrition-специфічний текст про фото", async () => {
+    postJsonMock.mockRejectedValueOnce(
+      new ApiError({
+        kind: "http",
+        message: "HTTP 413",
+        status: 413,
+        body: { error: "Payload Too Large" },
+        url: URL,
+      }),
+    );
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(err.message).toBe(
+      "Занадто велике фото. Стисни/обріж і спробуй ще раз.",
+    );
+    expect(err.status).toBe(413);
+  });
+
+  it("kind=network + navigator.onLine=false → офлайн-текст, kind зберігається", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+    postJsonMock.mockRejectedValueOnce(
+      new ApiError({
+        kind: "network",
+        message: "Failed to fetch",
+        url: URL,
+      }),
+    );
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(err.kind).toBe("network");
+    expect(err.status).toBe(0);
+    expect(err.message).toBe(
+      "Немає підключення до інтернету. Спробуй пізніше.",
+    );
+  });
+
+  it("kind=parse + HTML body → текст про rewrite; bodyText зберігається", async () => {
+    postJsonMock.mockRejectedValueOnce(
+      new ApiError({
+        kind: "parse",
+        message: "Unexpected token <",
+        bodyText: "<!doctype html><html>...</html>",
+        url: URL,
+      }),
+    );
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(err.kind).toBe("parse");
+    expect(err.message).toBe(
+      "API повернув HTML замість JSON (ймовірно, rewrite перехоплює /api/*).",
+    );
+    expect(err.bodyText).toBe("<!doctype html><html>...</html>");
+  });
+
+  it("не-ApiError (plain Error) → огортається в ApiError(kind=network) з .cause", async () => {
+    const raw = new Error("unexpected explosion");
+    postJsonMock.mockRejectedValueOnce(raw);
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(isApiError(err)).toBe(true);
+    expect(err.kind).toBe("network");
+    expect(err.message).toBe("unexpected explosion");
+    expect(err.url).toBe(URL);
+    expect(err.cause).toBe(raw);
+  });
+
+  it("HTTP 429 → загальний текст про rate-limit", async () => {
+    postJsonMock.mockRejectedValueOnce(
+      new ApiError({
+        kind: "http",
+        message: "HTTP 429",
+        status: 429,
+        body: { error: "Too Many Requests" },
+        url: URL,
+      }),
+    );
+    const err = (await postJson(URL, {}).catch((e: unknown) => e)) as ApiError;
+    expect(err.status).toBe(429);
+    expect(err.message).toBe("Забагато запитів. Спробуй через хвилину.");
+  });
+});

--- a/src/modules/nutrition/lib/nutritionErrors.ts
+++ b/src/modules/nutrition/lib/nutritionErrors.ts
@@ -1,3 +1,14 @@
+import { friendlyApiError as baseFriendlyApiError } from "@shared/lib/friendlyApiError";
+
+/**
+ * Nutrition-специфічний варіант `friendlyApiError`. Додає дві речі,
+ * яких немає у загальному мапері:
+ *  - 500 без ключа AI → окремий текст про «сервер харчування»;
+ *  - 413 для завеликого фото → конкретна інструкція.
+ *
+ * Усе інше делегуємо у `@shared/lib/friendlyApiError` — щоб
+ * 401/403/429/дефолт поводились однаково по всьому застосунку.
+ */
 export function friendlyApiError(
   status: number,
   message?: string | null,
@@ -6,9 +17,8 @@ export function friendlyApiError(
   if (status === 500 && /ANTHROPIC|not set|key/i.test(m)) {
     return "Сервер харчування не налаштовано (немає ключа AI).";
   }
-  if (status === 413)
+  if (status === 413) {
     return "Занадто велике фото. Стисни/обріж і спробуй ще раз.";
-  if (status === 429) return "Забагато запитів. Спробуй через хвилину.";
-  if (status === 401 || status === 403) return "Доступ заборонено.";
-  return m || `Помилка ${status}`;
+  }
+  return baseFriendlyApiError(status, message);
 }

--- a/src/shared/lib/friendlyApiError.test.ts
+++ b/src/shared/lib/friendlyApiError.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { friendlyApiError } from "./friendlyApiError";
+
+describe("friendlyApiError (shared)", () => {
+  it("повертає фіксований текст для 429", () => {
+    expect(friendlyApiError(429)).toBe(
+      "Забагато запитів. Спробуй через хвилину.",
+    );
+    expect(friendlyApiError(429, "rate limit")).toBe(
+      "Забагато запитів. Спробуй через хвилину.",
+    );
+  });
+
+  it("повертає фіксований текст для 401/403", () => {
+    expect(friendlyApiError(401)).toBe("Доступ заборонено.");
+    expect(friendlyApiError(403, "Forbidden")).toBe("Доступ заборонено.");
+  });
+
+  it("віддає серверне повідомлення, якщо воно є", () => {
+    expect(friendlyApiError(500, "boom")).toBe("boom");
+    expect(friendlyApiError(502, "upstream down")).toBe("upstream down");
+  });
+
+  it("фолбек `Помилка {status}`, коли повідомлення порожнє", () => {
+    expect(friendlyApiError(500)).toBe("Помилка 500");
+    expect(friendlyApiError(418, "")).toBe("Помилка 418");
+    expect(friendlyApiError(418, null)).toBe("Помилка 418");
+  });
+});

--- a/src/shared/lib/friendlyApiError.ts
+++ b/src/shared/lib/friendlyApiError.ts
@@ -1,0 +1,19 @@
+/**
+ * Спільний мапер HTTP-статусу у юзер-френдлі українське повідомлення.
+ *
+ * Обробляє ті кейси, що ідентичні в усіх доменах (auth / rate-limit /
+ * дефолт). Доменно-специфічні рядки (nutrition photo 413, AI_QUOTA у
+ * чаті, різний текст для 500-без-ключа) живуть у відповідних обгортках
+ * (див. `src/modules/nutrition/lib/nutritionErrors.ts` і
+ * `src/core/lib/hubChatUtils.ts`), які викликають `friendlyApiError`
+ * як fallback.
+ */
+export function friendlyApiError(
+  status: number,
+  message?: string | null,
+): string {
+  const m = message || "";
+  if (status === 429) return "Забагато запитів. Спробуй через хвилину.";
+  if (status === 401 || status === 403) return "Доступ заборонено.";
+  return m || `Помилка ${status}`;
+}

--- a/src/shared/lib/queryClient.test.ts
+++ b/src/shared/lib/queryClient.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "@shared/api";
+import { isRetriableError } from "./queryClient";
+
+describe("isRetriableError", () => {
+  const mk = (
+    kind: "http" | "network" | "parse" | "aborted",
+    status = 0,
+  ): ApiError => new ApiError({ kind, message: "x", status, url: "/api/x" });
+
+  it("ретраїть network / parse ApiError", () => {
+    expect(isRetriableError(mk("network"))).toBe(true);
+    expect(isRetriableError(mk("parse"))).toBe(true);
+  });
+
+  it("не ретраїть aborted ApiError (користувач пішов)", () => {
+    expect(isRetriableError(mk("aborted"))).toBe(false);
+  });
+
+  it("ретраїть HTTP 408 / 429 / 5xx, не ретраїть інші 4xx", () => {
+    expect(isRetriableError(mk("http", 408))).toBe(true);
+    expect(isRetriableError(mk("http", 429))).toBe(true);
+    expect(isRetriableError(mk("http", 500))).toBe(true);
+    expect(isRetriableError(mk("http", 502))).toBe(true);
+    expect(isRetriableError(mk("http", 599))).toBe(true);
+
+    expect(isRetriableError(mk("http", 400))).toBe(false);
+    expect(isRetriableError(mk("http", 401))).toBe(false);
+    expect(isRetriableError(mk("http", 403))).toBe(false);
+    expect(isRetriableError(mk("http", 404))).toBe(false);
+    expect(isRetriableError(mk("http", 422))).toBe(false);
+  });
+
+  it("legacy-фолбек: читає .status / .response.status", () => {
+    expect(isRetriableError({ status: 500 })).toBe(true);
+    expect(isRetriableError({ status: 408 })).toBe(true);
+    expect(isRetriableError({ response: { status: 429 } })).toBe(true);
+    expect(isRetriableError({ status: 400 })).toBe(false);
+    expect(isRetriableError({ response: { status: 404 } })).toBe(false);
+  });
+
+  it("невідома форма помилки → ретрай (оптимістично)", () => {
+    expect(isRetriableError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isRetriableError("string")).toBe(true);
+  });
+
+  it("falsy → не ретраїть", () => {
+    expect(isRetriableError(null)).toBe(false);
+    expect(isRetriableError(undefined)).toBe(false);
+    expect(isRetriableError(0)).toBe(false);
+    expect(isRetriableError("")).toBe(false);
+  });
+});

--- a/src/shared/lib/queryClient.ts
+++ b/src/shared/lib/queryClient.ts
@@ -21,21 +21,36 @@
  */
 
 import { QueryClient } from "@tanstack/react-query";
+import { isApiError } from "@shared/api";
 
 interface MaybeHttpError {
   status?: number;
   response?: { status?: number };
 }
 
-function isRetriableError(error: unknown): boolean {
+export function isRetriableError(error: unknown): boolean {
   if (!error) return false;
+
+  // Канонічний шлях: помилки з `@shared/api` — це завжди `ApiError`.
+  // Ретраємо лише те, що має шанс пройти з другої спроби.
+  if (isApiError(error)) {
+    if (error.kind === "aborted") return false; // користувач пішов — не повторюємо
+    if (error.kind === "network" || error.kind === "parse") return true;
+    // kind === "http"
+    return (
+      error.status === 408 ||
+      error.status === 429 ||
+      (error.status >= 500 && error.status <= 599)
+    );
+  }
+
+  // Fallback для можливих легасі-помилок, які ще не пройшли через ApiError.
   const e = error as MaybeHttpError;
   const status = e?.status ?? e?.response?.status;
   if (typeof status === "number") {
-    // 408 Request Timeout, 429 Too Many Requests, 5xx
     return status === 408 || status === 429 || status >= 500;
   }
-  // Мережеві помилки (TypeError: Failed to fetch, AbortError і т.ін.)
+  // Невідома форма (TypeError: Failed to fetch тощо) — спробуємо ще раз.
   return true;
 }
 


### PR DESCRIPTION
## Summary

Продовження #263. Чотири речі в одному PR — усі малі й незалежні, але пов'язані однією темою «уніфікований error-шлях».

### 1. Fix: retry для мережевих/парсингових помилок (`queryClient.isRetriableError`)
До цього `ApiError` з `kind: "network" | "parse" | "aborted"` мали `status: 0`, отже старий чек `status === 408 || status === 429 || status >= 500` повертав `false` і React Query **не ретраїв** ці запити — навіть попри те, що README явно обіцяє ретрай мережевих збоїв.

Тепер:
- `kind: "network" | "parse"` → `true` (тимчасові збої, варто спробувати ще раз)
- `kind: "aborted"` → `false` (користувач пішов зі сторінки — не повторюємо)
- `kind: "http"` → retry лише на `408 / 429 / 5xx` (як і раніше)

Legacy-фолбек (`error.status ?? error.response?.status`) збережений — щоб нічого, що ще не перенесено через `@shared/api`, не зламалось.

### 2. Fix: ще одна `ApiError → Error` конверсія (`useWeeklyDigest`)
Я пропустив її у #263. Було `Object.assign(new Error(e.serverMessage), { status: e.status })`, ставиться на тій самій проблемі — губився `kind`, ламався `isApiError` нижче по стеку. Тепер `ApiError` проходить наскрізь, а UI-селектор у хуці читає `.serverMessage` через `isApiError(mutation.error)`.

### 3. Refactor: дедуп `friendlyApiError`
Дві майже ідентичні копії (`src/core/lib/hubChatUtils.ts` і `src/modules/nutrition/lib/nutritionErrors.ts`) винесені у спільну базу — `@shared/lib/friendlyApiError`. Базовий мапер покриває те, що однакове скрізь: `401/403 → "Доступ заборонено"`, `429 → "Забагато запитів..."`, дефолт `message || "Помилка {status}"`.

Nutrition / HubChat лишають **тонкі обгортки** зі своїми специфіками:
- **Nutrition**: `500` без ключа AI → «сервер харчування не налаштовано»; `413` → інструкція про розмір фото.
- **HubChat**: `500` без ключа AI → «чат не налаштовано»; `429` з маркером `AI_QUOTA`/«ліміт AI» → окремий текст про денний ліміт.

Обидві обгортки делегують у `baseFriendlyApiError` для всього іншого — зміни поведінки немає.

### 4. Tests: 18 нових unit-тестів
- `src/shared/lib/friendlyApiError.test.ts` — базовий мапер (429/401/403/дефолт/фолбек).
- `src/shared/lib/queryClient.test.ts` — `isRetriableError` по всіх `kind` × статусах + legacy-фолбек + falsy.
- `src/modules/nutrition/lib/nutritionApi.test.ts` — адаптер `postJson`:
  - успішний payload пробрасується;
  - HTTP 500 → `ApiError` з юзер-френдлі `.message` і збереженими `kind/status/body/serverMessage/url/cause`;
  - HTTP 500 + `ANTHROPIC_API_KEY not set` → nutrition-специфічний текст;
  - HTTP 413 → текст про фото;
  - `kind=network` + `navigator.onLine=false` → офлайн-текст, `kind` зберігається;
  - `kind=parse` + HTML body → текст про rewrite;
  - не-`ApiError` → огортається в `ApiError(kind=network)` з `.cause`;
  - HTTP 429 → спільний «Забагато запитів».

Юніт-тести вперше явно фіксують контракт «адаптер переписує `.message`, але не ламає `ApiError`-форму» — тож регрес типу #263 злапається одразу.

## Review & Testing Checklist for Human

- [ ] **Подивитись, чи retry-поведінка тепер відповідає очікуванням.** Якщо сервер раптом віддає невалідний JSON або пропадає мережа — React Query тепер зробить 1 додаткову спробу (і для queries, і для mutations із `retry: N > 0`). На дорогих AI-мутаціях у nutrition/chat уже стоїть `retry: false`, тож їх це не стосується.
- [ ] Пройтись по тих місцях, що залежать від текстів помилок (nutrition day-plan 500/429/413, chat 429 з `AI_QUOTA`, coach insight 500, weekly digest 500) — рядки у UI не повинні змінитись.

### Notes

- Публічні контракти `friendlyApiError(...)` у `hubChatUtils.ts` і `nutritionErrors.ts` збережені (той самий signature, той самий результат на всіх вхідних кейсах, що зустрічалися раніше). Це перевірено руками по кожній гілці + покрито тестами.
- Не чіпав: `webVitals.ts` (sendBeacon-вийняток), `authClient.ts` (better-auth vendor), `(as Error)` fallback-касти у `usePushNotifications.ts` / `useCoachInsight.ts` — вони захищають шлях «якщо помилка не ApiError», тож свідомо лишаю їх як є.
- Локально: `npm run check` (format + lint + typecheck + test + build) — зелено. Тести: 714 passed (було 696 у #263 + 18 нових).

Link to Devin session: https://app.devin.ai/sessions/8ca6c15d73b44131afe54a65e0e4fdf2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
