### PR TITLE
test: add unit tests for date, storageQuota, storageManager, nutritionStats

### DIFF
--- a/src/modules/nutrition/lib/nutritionStats.test.ts
+++ b/src/modules/nutrition/lib/nutritionStats.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeRows,
+  avgFromSummary,
+  topMeals,
+  mealTypeBreakdown,
+  getRowsForRange,
+  type RowsSummary,
+} from "./nutritionStats";
+import type { DaySummary } from "./nutritionStorage";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeDay(overrides: Partial<DaySummary> = {}): DaySummary {
+  return {
+    date: "2026-01-01",
+    kcal: 0,
+    protein_g: 0,
+    fat_g: 0,
+    carbs_g: 0,
+    mealCount: 0,
+    hasMeals: false,
+    hasAnyMacros: false,
+    ...overrides,
+  };
+}
+
+// ─── summarizeRows ────────────────────────────────────────────────────────────
+
+describe("nutrition/summarizeRows", () => {
+  it("returns zero totals for an empty array", () => {
+    const r = summarizeRows([]);
+    expect(r.days).toBe(0);
+    expect(r.kcal).toBe(0);
+    expect(r.daysWithMeals).toBe(0);
+    expect(r.daysWithAnyMacros).toBe(0);
+    expect(r.nonEmptyDays).toBe(0);
+  });
+
+  it("sums macros across days", () => {
+    const rows = [
+      makeDay({
+        kcal: 2000,
+        protein_g: 150,
+        fat_g: 70,
+        carbs_g: 220,
+        hasAnyMacros: true,
+        hasMeals: true,
+        mealCount: 3,
+      }),
+      makeDay({
+        kcal: 1800,
+        protein_g: 130,
+        fat_g: 60,
+        carbs_g: 200,
+        hasAnyMacros: true,
+        hasMeals: true,
+        mealCount: 2,
+      }),
+    ];
+    const r = summarizeRows(rows);
+    expect(r.days).toBe(2);
+    expect(r.kcal).toBe(3800);
+    expect(r.protein_g).toBe(280);
+    expect(r.fat_g).toBe(130);
+    expect(r.carbs_g).toBe(420);
+  });
+
+  it("counts daysWithMeals via hasMeals flag", () => {
+    const rows = [
+      makeDay({ hasMeals: true, mealCount: 2 }),
+      makeDay({ hasMeals: false, mealCount: 0 }),
+      makeDay({ hasMeals: true, mealCount: 1 }),
+    ];
+    const r = summarizeRows(rows);
+    expect(r.daysWithMeals).toBe(2);
+    expect(r.nonEmptyDays).toBe(2); // alias
+  });
+
+  it("counts daysWithMeals via mealCount even when hasMeals is false", () => {
+    // Edge case: hasMeals=false but mealCount > 0 (defensive fallback in code)
+    const rows = [makeDay({ hasMeals: false, mealCount: 3 })];
+    const r = summarizeRows(rows);
+    expect(r.daysWithMeals).toBe(1);
+  });
+
+  it("counts daysWithAnyMacros independently from daysWithMeals", () => {
+    const rows = [
+      makeDay({ hasMeals: true, mealCount: 1, hasAnyMacros: false }),
+      makeDay({ hasMeals: true, mealCount: 2, hasAnyMacros: true }),
+    ];
+    const r = summarizeRows(rows);
+    expect(r.daysWithMeals).toBe(2);
+    expect(r.daysWithAnyMacros).toBe(1);
+  });
+
+  it("coerces non-numeric macro values to 0 instead of NaN", () => {
+    const rows = [
+      makeDay({
+        kcal: undefined as unknown as number,
+        protein_g: null as unknown as number,
+      }),
+    ];
+    const r = summarizeRows(rows);
+    expect(r.kcal).toBe(0);
+    expect(r.protein_g).toBe(0);
+  });
+});
+
+// ─── avgFromSummary ───────────────────────────────────────────────────────────
+
+describe("nutrition/avgFromSummary", () => {
+  it("divides totals by daysWithAnyMacros", () => {
+    const sum: RowsSummary = {
+      days: 3,
+      kcal: 6000,
+      protein_g: 300,
+      fat_g: 210,
+      carbs_g: 600,
+      daysWithMeals: 3,
+      daysWithAnyMacros: 3,
+      nonEmptyDays: 3,
+    };
+    const avg = avgFromSummary(sum);
+    expect(avg.kcal).toBeCloseTo(2000);
+    expect(avg.protein_g).toBeCloseTo(100);
+    expect(avg.denom).toBe(3);
+  });
+
+  it("uses denom=1 when daysWithAnyMacros is 0 to avoid division by zero", () => {
+    const sum: RowsSummary = {
+      days: 5,
+      kcal: 0,
+      protein_g: 0,
+      fat_g: 0,
+      carbs_g: 0,
+      daysWithMeals: 0,
+      daysWithAnyMacros: 0,
+      nonEmptyDays: 0,
+    };
+    const avg = avgFromSummary(sum);
+    expect(avg.denom).toBe(1);
+    expect(avg.kcal).toBe(0);
+  });
+
+  it("ignores empty days without macros in the average", () => {
+    // 2 days with macros, 3 empty days → average must not be diluted by the 3 empty
+    const sum: RowsSummary = {
+      days: 5,
+      kcal: 4000,
+      protein_g: 200,
+      fat_g: 140,
+      carbs_g: 400,
+      daysWithMeals: 2,
+      daysWithAnyMacros: 2,
+      nonEmptyDays: 2,
+    };
+    const avg = avgFromSummary(sum);
+    expect(avg.kcal).toBeCloseTo(2000);
+    expect(avg.denom).toBe(2);
+  });
+});
+
+// ─── topMeals ─────────────────────────────────────────────────────────────────
+
+describe("nutrition/topMeals", () => {
+  const log = {
+    "2026-01-10": {
+      meals: [
+        { name: "Гречка", macros: { kcal: 300 } },
+        { name: "Яєчня", macros: { kcal: 250 } },
+      ],
+    },
+    "2026-01-09": {
+      meals: [
+        { name: "Гречка", macros: { kcal: 300 } },
+        { name: "Овочевий суп", macros: { kcal: 180 } },
+      ],
+    },
+    "2026-01-08": {
+      meals: [{ name: "Гречка", macros: { kcal: 300 } }],
+    },
+  };
+
+  it("returns meals sorted by frequency desc", () => {
+    const result = topMeals(log, "2026-01-10", 3);
+    expect(result[0].name).toBe("Гречка");
+    expect(result[0].count).toBe(3);
+  });
+
+  it("accumulates kcal for repeated meals", () => {
+    const result = topMeals(log, "2026-01-10", 3);
+    const buckwheat = result.find((m) => m.name === "Гречка")!;
+    expect(buckwheat.kcal).toBe(900);
+  });
+
+  it("respects the dayCount window — excludes days before start", () => {
+    // Only last 2 days → Гречка appears 2 times, not 3
+    const result = topMeals(log, "2026-01-10", 2);
+    const buckwheat = result.find((m) => m.name === "Гречка")!;
+    expect(buckwheat.count).toBe(2);
+  });
+
+  it("returns empty array for null / empty log", () => {
+    expect(topMeals(null, "2026-01-10", 7)).toEqual([]);
+    expect(topMeals({}, "2026-01-10", 7)).toEqual([]);
+  });
+
+  it("omits meals with empty names", () => {
+    const logWithEmpty = {
+      "2026-01-10": { meals: [{ name: "" }, { name: "  " }, { name: "Рис" }] },
+    };
+    const result = topMeals(logWithEmpty, "2026-01-10", 1);
+    expect(result.every((m) => m.name.trim().length > 0)).toBe(true);
+  });
+
+  it("respects the limit parameter", () => {
+    const manyMeals = Object.fromEntries(
+      Array.from({ length: 20 }, (_, i) => [
+        `2026-01-${String(i + 1).padStart(2, "0")}`,
+        { meals: [{ name: `Страва${i}`, macros: { kcal: 100 } }] },
+      ]),
+    );
+    const result = topMeals(manyMeals, "2026-01-20", 20, 5);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ─── mealTypeBreakdown ────────────────────────────────────────────────────────
+
+describe("nutrition/mealTypeBreakdown", () => {
+  const log = {
+    "2026-01-10": {
+      meals: [
+        { mealType: "breakfast", macros: { kcal: 400 } },
+        { mealType: "lunch", macros: { kcal: 600 } },
+        { mealType: "lunch", macros: { kcal: 550 } },
+      ],
+    },
+  };
+
+  it("groups meals by mealType with count and kcal", () => {
+    const result = mealTypeBreakdown(log, "2026-01-10", 1);
+    expect(result.breakfast).toEqual({ count: 1, kcal: 400 });
+    expect(result.lunch).toEqual({ count: 2, kcal: 1150 });
+  });
+
+  it("returns empty object for null log", () => {
+    expect(mealTypeBreakdown(null, "2026-01-10", 7)).toEqual({});
+  });
+
+  it("excludes days outside the date range", () => {
+    const result = mealTypeBreakdown(log, "2026-01-09", 1);
+    // 2026-01-10 is outside the 1-day window ending 2026-01-09
+    expect(Object.keys(result).length).toBe(0);
+  });
+});
+
+// ─── getRowsForRange ──────────────────────────────────────────────────────────
+
+describe("nutrition/getRowsForRange", () => {
+  it("returns dayCount rows in chronological order", () => {
+    const log = {
+      "2026-01-08": { meals: [{ name: "Сніданок", macros: { kcal: 400 } }] },
+      "2026-01-09": { meals: [{ name: "Обід", macros: { kcal: 600 } }] },
+      "2026-01-10": { meals: [{ name: "Вечеря", macros: { kcal: 500 } }] },
+    };
+    const rows = getRowsForRange(log as never, "2026-01-10", 3);
+    expect(rows.length).toBe(3);
+    expect(rows[0].date).toBe("2026-01-08");
+    expect(rows[2].date).toBe("2026-01-10");
+  });
+
+  it("returns empty-day placeholders for missing dates", () => {
+    const rows = getRowsForRange({} as never, "2026-01-10", 2);
+    expect(rows.length).toBe(2);
+    expect(rows.every((r) => r.kcal === 0)).toBe(true);
+  });
+});

--- a/src/shared/lib/date.test.ts
+++ b/src/shared/lib/date.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { toLocalISODate } from "./date";
+
+describe("shared/lib/date – toLocalISODate", () => {
+  it("formats a Date object with zero-padded month and day", () => {
+    expect(toLocalISODate(new Date(2026, 0, 5))).toBe("2026-01-05");
+    expect(toLocalISODate(new Date(2026, 8, 9))).toBe("2026-09-09");
+    expect(toLocalISODate(new Date(2026, 11, 31))).toBe("2026-12-31");
+  });
+
+  it("formats a numeric timestamp (milliseconds)", () => {
+    const ms = new Date(2026, 3, 19).getTime();
+    expect(toLocalISODate(ms)).toBe("2026-04-19");
+  });
+
+  it("formats an ISO date string (local timezone interpretation)", () => {
+    // Construct from known local Date to avoid timezone divergence
+    const d = new Date(2025, 6, 4); // 4 Jul 2025 local
+    const iso = toLocalISODate(d.toISOString());
+    // Result depends on UTC offset but must be a valid ISO date
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns 1970-01-01 for an invalid date string", () => {
+    expect(toLocalISODate("not-a-date")).toBe("1970-01-01");
+    expect(toLocalISODate("")).toBe("1970-01-01");
+  });
+
+  it("returns 1970-01-01 for NaN timestamp", () => {
+    expect(toLocalISODate(NaN)).toBe("1970-01-01");
+  });
+
+  it("uses current date when called with no argument", () => {
+    const before = toLocalISODate(new Date());
+    const result = toLocalISODate();
+    const after = toLocalISODate(new Date());
+    // result must be within the same day as before/after
+    expect(result >= before && result <= after).toBe(true);
+  });
+
+  it("handles year boundaries correctly", () => {
+    expect(toLocalISODate(new Date(2024, 11, 31))).toBe("2024-12-31");
+    expect(toLocalISODate(new Date(2025, 0, 1))).toBe("2025-01-01");
+  });
+});

--- a/src/shared/lib/storageManager.test.ts
+++ b/src/shared/lib/storageManager.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { storageManager } from "./storageManager";
+
+// Minimal localStorage polyfill — vitest runs in node by default.
+beforeAll(() => {
+  if (typeof globalThis.localStorage === "undefined") {
+    const store = new Map<string, string>();
+    globalThis.localStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => store.set(k, String(v)),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  }
+});
+
+// Reset the "already ran" record before every test so migrations can re-run.
+beforeEach(() => {
+  storageManager.resetAll();
+  localStorage.clear();
+});
+
+// ─── register() validation ────────────────────────────────────────────────────
+
+describe("storageManager.register()", () => {
+  it("throws when migration.id is empty", () => {
+    expect(() =>
+      storageManager.register({ id: "", description: "x", up: () => {} }),
+    ).toThrow();
+  });
+
+  it("throws when migration.id is whitespace-only", () => {
+    expect(() =>
+      storageManager.register({ id: "   ", description: "x", up: () => {} }),
+    ).toThrow();
+  });
+
+  it("throws when migration.up is not a function", () => {
+    expect(() =>
+      storageManager.register({
+        id: "test_reg_invalid_up",
+        description: "x",
+        up: null as unknown as () => void,
+      }),
+    ).toThrow();
+  });
+
+  it("does not throw for a valid migration", () => {
+    expect(() =>
+      storageManager.register({
+        id: "test_reg_valid_001",
+        description: "Valid",
+        up: () => {},
+      }),
+    ).not.toThrow();
+  });
+
+  it("silently ignores duplicate registration (same id)", () => {
+    // test_reg_valid_001 was already registered in a previous test call on this
+    // module — or we register it fresh here. Either way it must not throw.
+    expect(() =>
+      storageManager.register({
+        id: "test_reg_valid_001",
+        description: "Duplicate",
+        up: () => {},
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ─── runAll() ─────────────────────────────────────────────────────────────────
+
+describe("storageManager.runAll()", () => {
+  it("runs a newly registered migration and reports it in result.ran", () => {
+    let executed = false;
+    storageManager.register({
+      id: "test_run_001_basic",
+      description: "Basic run test",
+      up() {
+        executed = true;
+      },
+    });
+
+    const result = storageManager.runAll();
+    expect(executed).toBe(true);
+    expect(result.ran).toContain("test_run_001_basic");
+  });
+
+  it("skips migration on second runAll() call (already ran)", () => {
+    let count = 0;
+    storageManager.register({
+      id: "test_run_002_skip",
+      description: "Skip on second call",
+      up() {
+        count++;
+      },
+    });
+
+    storageManager.runAll(); // first run — records it
+    const countAfterFirst = count;
+    const r2 = storageManager.runAll(); // second run — should skip
+
+    expect(count).toBe(countAfterFirst); // not incremented
+    expect(r2.skipped).toContain("test_run_002_skip");
+  });
+
+  it("reports migration errors in result.errors without throwing", () => {
+    storageManager.register({
+      id: "test_run_003_error",
+      description: "Migration that throws",
+      up() {
+        throw new Error("intentional failure");
+      },
+    });
+
+    const result = storageManager.runAll();
+    const err = result.errors.find((e) => e.id === "test_run_003_error");
+    expect(err).toBeDefined();
+    expect(err!.error).toBeInstanceOf(Error);
+    // A failed migration must NOT be recorded as ran
+    expect(result.ran).not.toContain("test_run_003_error");
+  });
+
+  it("continues running subsequent migrations after one fails", () => {
+    let secondRan = false;
+    storageManager.register({
+      id: "test_run_004_fail_first",
+      description: "Fails",
+      up() {
+        throw new Error("boom");
+      },
+    });
+    storageManager.register({
+      id: "test_run_004_second",
+      description: "Runs after failure",
+      up() {
+        secondRan = true;
+      },
+    });
+
+    storageManager.runAll();
+    expect(secondRan).toBe(true);
+  });
+});
+
+// ─── resetMigration() ─────────────────────────────────────────────────────────
+
+describe("storageManager.resetMigration()", () => {
+  it("allows a migration to re-run after reset", () => {
+    let count = 0;
+    storageManager.register({
+      id: "test_reset_001",
+      description: "Re-run after reset",
+      up() {
+        count++;
+      },
+    });
+
+    storageManager.runAll();
+    expect(count).toBe(1);
+
+    storageManager.resetMigration("test_reset_001");
+    storageManager.runAll();
+    expect(count).toBe(2);
+  });
+
+  it("does not affect other migrations when resetting one", () => {
+    let countA = 0;
+    let countB = 0;
+    storageManager.register({
+      id: "test_reset_002a",
+      description: "Migration A",
+      up() {
+        countA++;
+      },
+    });
+    storageManager.register({
+      id: "test_reset_002b",
+      description: "Migration B",
+      up() {
+        countB++;
+      },
+    });
+
+    storageManager.runAll();
+    const aAfterFirst = countA;
+    const bAfterFirst = countB;
+
+    storageManager.resetMigration("test_reset_002a");
+    storageManager.runAll();
+
+    expect(countA).toBe(aAfterFirst + 1); // re-ran
+    expect(countB).toBe(bAfterFirst); // did not re-run
+  });
+});
+
+// ─── resetAll() ───────────────────────────────────────────────────────────────
+
+describe("storageManager.resetAll()", () => {
+  it("causes all registered migrations to re-run on next runAll()", () => {
+    let count = 0;
+    storageManager.register({
+      id: "test_resetall_001",
+      description: "Reset all test",
+      up() {
+        count++;
+      },
+    });
+
+    storageManager.runAll();
+    const countAfterFirst = count;
+    storageManager.resetAll();
+    storageManager.runAll();
+
+    expect(count).toBeGreaterThan(countAfterFirst);
+  });
+});

--- a/src/shared/lib/storageQuota.test.ts
+++ b/src/shared/lib/storageQuota.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  estimateUtf8Bytes,
+  safeSetItem,
+  safeJsonSet,
+  DEFAULT_MAX_BYTES,
+} from "./storageQuota";
+
+// Minimal localStorage polyfill — vitest runs in node by default.
+beforeAll(() => {
+  if (typeof globalThis.localStorage === "undefined") {
+    const store = new Map<string, string>();
+    globalThis.localStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => store.set(k, String(v)),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  }
+});
+
+beforeEach(() => localStorage.clear());
+
+// ─── estimateUtf8Bytes ────────────────────────────────────────────────────────
+
+describe("estimateUtf8Bytes", () => {
+  it("returns byte count for ASCII", () => {
+    expect(estimateUtf8Bytes("hello")).toBe(5);
+    expect(estimateUtf8Bytes("")).toBe(0);
+  });
+
+  it("returns more bytes than chars for multi-byte UTF-8 (Cyrillic)", () => {
+    // "Привіт" = 6 chars, 11 bytes in UTF-8
+    const bytes = estimateUtf8Bytes("Привіт");
+    expect(bytes).toBeGreaterThan(6);
+  });
+
+  it("coerces null / undefined to empty string → 0 bytes", () => {
+    expect(estimateUtf8Bytes(null)).toBe(0);
+    expect(estimateUtf8Bytes(undefined)).toBe(0);
+  });
+
+  it("coerces non-string values via String()", () => {
+    expect(estimateUtf8Bytes(42)).toBe(2); // "42"
+    expect(estimateUtf8Bytes(true)).toBe(4); // "true"
+  });
+});
+
+// ─── safeSetItem ──────────────────────────────────────────────────────────────
+
+describe("safeSetItem", () => {
+  it("stores a value and returns ok: true with byte count", () => {
+    const result = safeSetItem("k", "hello");
+    expect(result.ok).toBe(true);
+    expect(typeof result.bytes).toBe("number");
+    expect(localStorage.getItem("k")).toBe("hello");
+  });
+
+  it("returns { ok: false, reason: 'too_large' } when value exceeds maxBytes", () => {
+    const big = "x".repeat(50);
+    const result = safeSetItem("big", big, { maxBytes: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("too_large");
+    expect(result.bytes).toBeGreaterThan(10);
+    expect(result.maxBytes).toBe(10);
+    // Must not have written anything
+    expect(localStorage.getItem("big")).toBeNull();
+  });
+
+  it("does not reject when value is exactly at maxBytes boundary", () => {
+    // 5 ASCII chars = 5 bytes; maxBytes = 5 → should pass
+    const result = safeSetItem("edge", "abcde", { maxBytes: 5 });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns { ok: false, reason: 'exception' } on storage errors", () => {
+    const origSetItem = localStorage.setItem.bind(localStorage);
+    vi.spyOn(localStorage, "setItem").mockImplementationOnce(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+    const result = safeSetItem("err", "x");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("exception");
+    expect(result.error).toBeDefined();
+    vi.restoreAllMocks();
+    // Restore is called automatically, but keep explicit for clarity
+    void origSetItem;
+  });
+
+  it("uses DEFAULT_MAX_BYTES when no options provided", () => {
+    expect(DEFAULT_MAX_BYTES).toBeGreaterThan(0);
+    // A small value should always pass the default limit
+    const result = safeSetItem("small", "x");
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ─── safeJsonSet ─────────────────────────────────────────────────────────────
+
+describe("safeJsonSet", () => {
+  it("stringifies an object and stores it", () => {
+    const result = safeJsonSet("obj", { a: 1, b: [2, 3] });
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(localStorage.getItem("obj")!)).toEqual({
+      a: 1,
+      b: [2, 3],
+    });
+  });
+
+  it("stores null as the JSON string 'null'", () => {
+    const result = safeJsonSet("n", null);
+    expect(result.ok).toBe(true);
+    expect(localStorage.getItem("n")).toBe("null");
+  });
+
+  it("rejects oversized objects", () => {
+    const big = { data: "x".repeat(200) };
+    const result = safeJsonSet("bigobj", big, { maxBytes: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("too_large");
+    expect(localStorage.getItem("bigobj")).toBeNull();
+  });
+
+  it("stores arrays correctly", () => {
+    safeJsonSet("arr", [1, 2, 3]);
+    expect(JSON.parse(localStorage.getItem("arr")!)).toEqual([1, 2, 3]);
+  });
+
+  it("returns exception when JSON.stringify throws", () => {
+    // Circular reference causes JSON.stringify to throw
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const result = safeJsonSet("circ", circular);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("exception");
+  });
+});


### PR DESCRIPTION
Covers previously untested utility modules:
- shared/lib/date.ts — toLocalISODate edge cases (invalid input, NaN, boundaries)
- shared/lib/storageQuota.ts — estimateUtf8Bytes, safeSetItem (size limit,
  exceptions), safeJsonSet (circular ref, null, oversized)
- shared/lib/storageManager.ts — register validation, runAll lifecycle
  (run/skip/error/continue), resetMigration, resetAll
- nutrition/lib/nutritionStats.ts — summarizeRows, avgFromSummary (zero-division
  guard, empty-day dilution), topMeals (frequency, kcal, limit, range window),
  mealTypeBreakdown, getRowsForRange

All 749 tests pass.

https://claude.ai/code/session_012uead681JW64dHUztCbaGX
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
