### PR TITLE
fix(sync): filter syncPullAll by VALID_MODULES; enforce blob limit for coach memory

### DIFF
--- a/server/modules/coach.js
+++ b/server/modules/coach.js
@@ -1,5 +1,6 @@
 import pool from "../db.js";
 import { anthropicMessages, extractAnthropicText } from "../lib/anthropic.js";
+import { MAX_BLOB_SIZE } from "./sync.js";
 
 async function getMemory(userId) {
   const result = await pool.query(
@@ -15,8 +16,23 @@ async function getMemory(userId) {
   }
 }
 
+// Власний тип помилки, щоб handler міг відрізнити overflow від інших DB-фейлів
+// і повернути 413 замість 500.
+export class CoachMemoryTooLargeError extends Error {
+  constructor(bytes) {
+    super(`coach memory blob too large: ${bytes} bytes`);
+    this.name = "CoachMemoryTooLargeError";
+    this.bytes = bytes;
+  }
+}
+
 async function saveMemory(userId, memory) {
   const blob = JSON.stringify(memory);
+  // Ділимо той самий `MAX_BLOB_SIZE`, що й sync: це один стовпчик `module_data.data`
+  // і той самий пейлоад-транспорт, тож будь-яке різне ліміти-рішення буде сюрпризом.
+  if (blob.length > MAX_BLOB_SIZE) {
+    throw new CoachMemoryTooLargeError(blob.length);
+  }
   await pool.query(
     `INSERT INTO module_data (user_id, module, data, client_updated_at, version)
      VALUES ($1, 'coach', $2, NOW(), 1)
@@ -140,7 +156,14 @@ export async function coachMemoryPost(req, res) {
   const incoming = req.body || {};
   const existing = await getMemory(req.user.id);
   const merged = mergeMemory(existing, incoming);
-  await saveMemory(req.user.id, merged);
+  try {
+    await saveMemory(req.user.id, merged);
+  } catch (err) {
+    if (err instanceof CoachMemoryTooLargeError) {
+      return res.status(413).json({ error: "Coach memory blob too large" });
+    }
+    throw err;
+  }
   return res.json({ ok: true });
 }
 

--- a/server/modules/coach.test.js
+++ b/server/modules/coach.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../db.js", () => {
+  const pool = { query: vi.fn() };
+  return { default: pool, pool };
+});
+
+vi.mock("../lib/anthropic.js", () => ({
+  anthropicMessages: vi.fn(),
+  extractAnthropicText: vi.fn(),
+}));
+
+import pool from "../db.js";
+import { coachMemoryPost } from "./coach.js";
+import { MAX_BLOB_SIZE } from "./sync.js";
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("coachMemoryPost blob-size guard", () => {
+  it("повертає 413 коли merged-blob перевищує MAX_BLOB_SIZE і не робить INSERT", async () => {
+    // getMemory: існуюча пам'ять з одним digest, котрий зараз у межах.
+    pool.query.mockResolvedValueOnce({
+      rows: [{ data: JSON.stringify({ weeklyDigests: [] }) }],
+    });
+
+    // Вхідний digest з великим полем, який після merge дасть blob > MAX_BLOB_SIZE.
+    const huge = "x".repeat(MAX_BLOB_SIZE + 1);
+    const req = {
+      user: { id: "user_1" },
+      body: {
+        weeklyDigest: {
+          weekKey: "2026-W01",
+          weekRange: huge,
+        },
+      },
+    };
+    const res = makeRes();
+
+    await coachMemoryPost(req, res);
+
+    expect(res.statusCode).toBe(413);
+    expect(res.body).toEqual({ error: "Coach memory blob too large" });
+    // Рівно один query (getMemory). INSERT не виконувався.
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("нормальний розмір: робить INSERT і повертає ok", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [] }) // getMemory → немає існуючої
+      .mockResolvedValueOnce({ rows: [] }); // INSERT
+
+    const req = {
+      user: { id: "user_1" },
+      body: {
+        weeklyDigest: {
+          weekKey: "2026-W01",
+          weekRange: "1–7 Jan",
+          finyk: { summary: "усе ок" },
+        },
+      },
+    };
+    const res = makeRes();
+
+    await coachMemoryPost(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const insertCall = pool.query.mock.calls[1];
+    expect(insertCall[0]).toMatch(/INSERT INTO module_data/);
+    expect(insertCall[1][0]).toBe("user_1");
+  });
+});

--- a/server/modules/sync.js
+++ b/server/modules/sync.js
@@ -63,8 +63,13 @@ function elapsedMs(start) {
   return Number(process.hrtime.bigint() - start) / 1e6;
 }
 
-const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
-const MAX_BLOB_SIZE = 5 * 1024 * 1024;
+export const VALID_MODULES = new Set([
+  "finyk",
+  "fizruk",
+  "routine",
+  "nutrition",
+]);
+export const MAX_BLOB_SIZE = 5 * 1024 * 1024;
 
 export async function syncPush(req, res) {
   const start = process.hrtime.bigint();
@@ -217,11 +222,15 @@ export async function syncPullAll(req, res) {
   const user = req.user;
 
   try {
+    // Явно фільтруємо по `VALID_MODULES`. У `module_data` можуть лежати і
+    // не-sync записи (напр. `coach` memory, яка пишеться через окремий
+    // endpoint), і витягати їх сюди — це і зайві bytes на pull-all, і
+    // ламання інкапсуляції (клієнт sync-шару не повинен знати про coach).
     const result = await pool.query(
       `SELECT module, data, client_updated_at, server_updated_at, version
        FROM module_data
-       WHERE user_id = $1`,
-      [user.id],
+       WHERE user_id = $1 AND module = ANY($2::text[])`,
+      [user.id, Array.from(VALID_MODULES)],
     );
 
     const modules = {};

--- a/server/modules/sync.test.js
+++ b/server/modules/sync.test.js
@@ -38,7 +38,7 @@ import { getSessionUser } from "../auth.js";
 import pool from "../db.js";
 import { logger } from "../obs/logger.js";
 import { syncConflictsTotal, syncOperationsTotal } from "../obs/metrics.js";
-import { syncPushAll } from "./sync.js";
+import { syncPushAll, syncPullAll, VALID_MODULES } from "./sync.js";
 
 function makeRes() {
   return {
@@ -220,6 +220,23 @@ describe("syncPushAll metric correctness around transaction boundary", () => {
     expect(syncConflictsTotal.inc).toHaveBeenCalledWith({
       module: "nutrition",
     });
+  });
+});
+
+describe("syncPullAll module filtering", () => {
+  it("фільтрує по VALID_MODULES — 'coach' та інші не-sync рядки не потрапляють у відповідь", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = makeRes();
+    await syncPullAll(makeReq({}), res);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/module = ANY\(\$2::text\[\]\)/);
+    expect(params[0]).toBe("user_1");
+    // Параметр $2 має бути рівно множиною VALID_MODULES (без coach).
+    expect(new Set(params[1])).toEqual(VALID_MODULES);
+    expect(params[1]).not.toContain("coach");
   });
 });
 


### PR DESCRIPTION
## Summary

Перша пачка з короткого тех-боргу — уніфікація `sync` ↔ `coach` у спільній таблиці `module_data`.

**Проблема.** `server/modules/coach.js` зберігає свою memory у тій самій таблиці `module_data`, що і sync-шар, але обходить його guard-и:

- `syncPullAll` робить `SELECT … WHERE user_id = $1` без фільтра по `module`, тож рядки `module = 'coach'` витягаються разом із finyk/fizruk/routine/nutrition і повертаються клієнту — зайві bytes і ламання інкапсуляції sync-шару.
- `coach.saveMemory` не перевіряє розмір blob-а, хоча sync має `MAX_BLOB_SIZE = 5 MB`. При розрісанні `weeklyDigests` можливий тихий OOM на pg-boundary або сюрпризна 500-ка.

**Фікс.**
- `VALID_MODULES` і `MAX_BLOB_SIZE` експортуються з `server/modules/sync.js` як джерело правди.
- `syncPullAll` явно фільтрує `WHERE user_id = $1 AND module = ANY($2::text[])` з `Array.from(VALID_MODULES)`.
- `coach.saveMemory` вимірює `JSON.stringify(memory).length` і кидає `CoachMemoryTooLargeError`, який handler перетворює на `413` замість `500`.

Сюди свідомо **НЕ входить** додавання coach у `VALID_MODULES` (це окрема розмова про API-поверхню sync), тільки фільтр на стороні pull-all.

## Review & Testing Checklist for Human

- [ ] Переконатись, що після деплою клієнт далі отримує finyk/fizruk/routine/nutrition через `/api/sync/pull-all` (smoke на проді або staging).
- [ ] Якщо є юзер із дуже великою coach-memory (нагромаджені `weeklyDigests`) — `/api/coach/memory` POST тепер віддасть `413`; клієнт має це адекватно обробити (не повторювати нескінченно).
- [ ] Перевірити метрики `db_query_duration_ms` на pull-all — має бути трохи швидше на юзерах, у яких був coach-row.

### Notes

Подальші PR у цій серії:
2. graceful shutdown + коректний вихід на uncaughtException
3. міграції в окремий CLI-скрипт (щоб не бігли з web-процесу на boot)

Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
