### PR TITLE
feat(server): graceful shutdown on SIGTERM/SIGINT; exit on uncaughtException

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,7 @@ import {
   uncaughtExceptionsTotal,
   unhandledRejectionsTotal,
 } from "./obs/metrics.js";
+import { Sentry } from "./sentry.js";
 
 const app = createApp({
   servesFrontend: config.servesFrontend,
@@ -33,6 +34,109 @@ const app = createApp({
 });
 
 startPoolSampler(pool);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Graceful shutdown
+//
+// Railway і Replit надсилають SIGTERM при deploy/restart з grace-period ~30с.
+// Без власного обробника Node просто обриває event loop — усі in-flight
+// запити отримують ECONNRESET, а клієнт — 502 від проксі. Правильна
+// послідовність:
+//
+//   1. Залогувати причину зупинки.
+//   2. `server.close()` — перестаємо приймати нові з'єднання, але вже
+//      прийняті запити допрацьовують свій цикл.
+//   3. Дочекатись до `SHUTDOWN_GRACE_MS` на завершення in-flight.
+//   4. `pool.end()` — коректно закрити pg-з'єднання.
+//   5. `Sentry.flush()` — до виходу допостити події, бо transport асинхронний.
+//   6. `process.exit(code)`.
+//
+// `uncaughtException` свідомо теж веде сюди з exit=1: після некерованого
+// throw-у стан процесу невідомий (leaked timers, dirty pool, partial TX),
+// ресайкл — єдиний безпечний шлях. Railway health-probe піднімає нову
+// інстанцію. Стара поведінка ("лишаємо процес жити щоб не обривати
+// запити") ризикованіша за 502 від рестарту: наступні відповіді можуть
+// бути з пошкодженого state-у.
+// ──────────────────────────────────────────────────────────────────────────────
+
+const SHUTDOWN_GRACE_MS = Number(process.env.SHUTDOWN_GRACE_MS) || 15_000;
+const SHUTDOWN_HARD_TIMEOUT_MS =
+  Number(process.env.SHUTDOWN_HARD_TIMEOUT_MS) || 25_000;
+
+let httpServer = null;
+let shuttingDown = false;
+
+async function shutdown(reason, exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  logger.info({ msg: "shutdown_begin", reason, exitCode });
+
+  // Hard timeout: якщо щось зависне (дропнутий `await`, довгий AI-стрім
+  // без heartbeat-а, pg-connection у підвішеному стані), гарантовано
+  // виходимо. Без цього процес може зависнути у "terminating" назавжди.
+  const hardTimer = setTimeout(() => {
+    logger.error({
+      msg: "shutdown_hard_timeout",
+      reason,
+      timeoutMs: SHUTDOWN_HARD_TIMEOUT_MS,
+    });
+    process.exit(exitCode || 1);
+  }, SHUTDOWN_HARD_TIMEOUT_MS);
+  hardTimer.unref();
+
+  try {
+    if (httpServer) {
+      await new Promise((resolve) => {
+        // `server.close` чекає, поки всі активні з'єднання завершаться. Якщо
+        // у нас довгі SSE-стріми (AI chat), grace-період обмежує це зверху.
+        const graceTimer = setTimeout(() => {
+          logger.warn({
+            msg: "shutdown_grace_expired_closing_idle",
+            graceMs: SHUTDOWN_GRACE_MS,
+          });
+          resolve();
+        }, SHUTDOWN_GRACE_MS);
+        graceTimer.unref();
+
+        httpServer.close((err) => {
+          clearTimeout(graceTimer);
+          if (err) {
+            logger.warn({
+              msg: "http_server_close_error",
+              err: serializeError(err, { includeStack: false }),
+            });
+          } else {
+            logger.info({ msg: "http_server_closed" });
+          }
+          resolve();
+        });
+      });
+    }
+
+    try {
+      await pool.end();
+      logger.info({ msg: "pg_pool_ended" });
+    } catch (err) {
+      logger.warn({
+        msg: "pg_pool_end_error",
+        err: serializeError(err, { includeStack: false }),
+      });
+    }
+
+    try {
+      // 2с на flush — Sentry transport батчує події, синхронно скинути
+      // неможливо. Довше чекати сенсу немає: перевищимо hard-timeout.
+      await Sentry.flush(2000);
+    } catch {
+      /* sentry flush не має блокувати shutdown */
+    }
+  } finally {
+    clearTimeout(hardTimer);
+    logger.info({ msg: "shutdown_complete", exitCode });
+    process.exit(exitCode);
+  }
+}
 
 // Process-level error tracking: catches anything that escapes express's
 // error-handling pipeline. Sentry instruments this on its own too, but we
@@ -48,6 +152,10 @@ process.on("unhandledRejection", (reason) => {
     msg: "unhandled_rejection",
     err: serializeError(reason, { includeStack: true }),
   });
+  // Свідомо НЕ виходимо: unhandledRejection — це зазвичай баг у
+  // конкретному хендлері, не corruption state-у процесу. Sentry капчить
+  // стек, Grafana видно спайк. Якщо переведемо на exit — кожен поганий
+  // AI-респонс = рестарт процесу. uncaughtException — інша історія.
 });
 
 process.on("uncaughtException", (err) => {
@@ -60,10 +168,15 @@ process.on("uncaughtException", (err) => {
     msg: "uncaught_exception",
     err: serializeError(err, { includeStack: true }),
   });
-  // Intentionally do not `process.exit(1)` here: Railway/Replit restart the
-  // process on failing health-probes and Sentry has already captured the
-  // stack. A hard exit would abort in-flight requests.
+  shutdown("uncaughtException", 1).catch(() => process.exit(1));
 });
+
+for (const sig of ["SIGTERM", "SIGINT"]) {
+  process.on(sig, () => {
+    logger.info({ msg: "signal_received", signal: sig });
+    shutdown(sig, 0).catch(() => process.exit(1));
+  });
+}
 
 ensureSchema()
   .then(() => {
@@ -76,7 +189,7 @@ ensureSchema()
     });
   });
 
-app.listen(config.port, "0.0.0.0", () => {
+httpServer = app.listen(config.port, "0.0.0.0", () => {
   logger.info({
     msg: "server_listening",
     role: config.role,


### PR DESCRIPTION
## Summary

Друга пачка з короткого тех-боргу — коректне завершення процесу.

**Що було.** У `server/index.js` не було обробників SIGTERM/SIGINT, тож при Railway-deploy або restart процес просто обривав event loop: усі in-flight запити отримували `ECONNRESET`, а клієнт — `502` від edge-проксі. Додатково `uncaughtException` **свідомо** не виходив з процесу, щоб "не обірвати in-flight" — але це антипатерн: після некерованого throw-у стан процесу невідомий (leaked timers, dirty pg-connection, partial TX), і наступні відповіді можуть бути з пошкодженого state-у.

**Що стало.**

1. Централізований `shutdown(reason, exitCode)` з idempotency-guard і hard-timeout:
   - `server.close()` → чекає in-flight до `SHUTDOWN_GRACE_MS` (default **15с**)
   - `pool.end()` для pg
   - `Sentry.flush(2000)` щоб асинхронний transport допостив події
   - `process.exit(exitCode)`
   - Hard-timeout `SHUTDOWN_HARD_TIMEOUT_MS` (default **25с**) як страховка від зависання в terminating-стані (довгі SSE-стріми, pg-commit, що не повертається, etc.).
2. SIGTERM/SIGINT → `shutdown(sig, 0)`.
3. `uncaughtException` → `shutdown("uncaughtException", 1)`. Railway health-probe підніме нову інстанцію.
4. `unhandledRejection` свідомо лишається без exit — зазвичай це баг одного хендлера, не corruption процесу; Sentry і Pino-метрика вже капчать.

Конфігурується через env:
- `SHUTDOWN_GRACE_MS` (default 15000)
- `SHUTDOWN_HARD_TIMEOUT_MS` (default 25000)

Railway default grace — ~30с, тому 25с hard-timeout лишається в межах.

## Review & Testing Checklist for Human

- [ ] Staging-деплой: під час redeploy в Railway переконатися, що в логах з'являються `shutdown_begin` → `http_server_closed` → `pg_pool_ended` → `shutdown_complete`, і **не** з'являється `shutdown_hard_timeout`.
- [ ] Клієнт під час redeploy не має отримувати 502 на короткий звичайний запит (sync pull, chat-request без стріму). Для довгих SSE-стрімів (chat streaming) 15с grace може обірвати; якщо бачимо це у проді — підняти `SHUTDOWN_GRACE_MS`.
- [ ] Симулювати `uncaughtException` (наприклад, тимчасово кинути з handler-а) у staging — перевірити що процес виходить з exit=1 і Sentry отримав подію.

### Notes

Подальший PR у серії:
3. міграції в окремий CLI-скрипт (щоб не бігли з web-процесу на boot і не рейсили при rolling deploy).

Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
