### PR TITLE
feat(db): extract migrations to scripts/migrate.mjs; remove from boot path

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,6 +7,8 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 
 COPY server ./server
+# Потрібен для `npm run db:migrate` (release-stage міграції).
+COPY scripts ./scripts
 
 ENV NODE_ENV=production
 CMD ["node", "server/index.js"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
+    "db:migrate": "node scripts/migrate.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Standalone database migration runner.
+ *
+ * Історія. Раніше `ensureSchema()` викликався з `server/index.js` при кожному
+ * старті web-процесу. На rolling deploy з двома і більше реплік це давало:
+ *   - race при `INSERT schema_migrations` (один інстанс програє й упаде),
+ *   - або напіврозкочану міграцію, якщо вона довга і другий інстанс приходить
+ *     під час виконання,
+ *   - затримку readiness-проба пропорційну часу міграції.
+ *
+ * Правильна модель — Release-stage: цей скрипт запускається окремим job-ом
+ * (на Railway це pre-deploy command, на Replit — вручну), перед тим як нові
+ * інстанси server-а почнуть приймати трафік. Web-процес на старті більше
+ * НЕ виконує міграції.
+ *
+ * Вихідні коди: 0 — все ок, 1 — будь-яка помилка (DATABASE_URL відсутній,
+ * міграція впала, pg недоступний тощо).
+ */
+import { ensureSchema, pool } from "../server/db.js";
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "migrate_database_url_missing",
+      }),
+    );
+    process.exit(1);
+  }
+
+  const startedAt = Date.now();
+  try {
+    await ensureSchema();
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "migrate_ok",
+        durationMs: Date.now() - startedAt,
+      }),
+    );
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "migrate_failed",
+        durationMs: Date.now() - startedAt,
+        err: {
+          message: err?.message || String(err),
+          code: err?.code,
+        },
+      }),
+    );
+    process.exitCode = 1;
+  } finally {
+    // `pool.end()` обов'язковий: без нього процес Node триматиме pg-з'єднання
+    // відкритим і не вийде, а release-job зависне по timeout-у.
+    try {
+      await pool.end();
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(
+    JSON.stringify({
+      level: "error",
+      msg: "migrate_unhandled",
+      err: { message: err?.message || String(err) },
+    }),
+  );
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ import "./sentry.js";
 
 import { createApp } from "./app.js";
 import { config } from "./config.js";
-import { ensureSchema, pool } from "./db.js";
+import { pool } from "./db.js";
 import { logger, serializeError } from "./obs/logger.js";
 import {
   startPoolSampler,
@@ -178,17 +178,10 @@ for (const sig of ["SIGTERM", "SIGINT"]) {
   });
 }
 
-ensureSchema()
-  .then(() => {
-    logger.info({ msg: "db_schema_verified" });
-  })
-  .catch((err) => {
-    logger.error({
-      msg: "db_schema_check_failed",
-      err: { message: err?.message || String(err), code: err?.code },
-    });
-  });
-
+// Міграції свідомо НЕ запускаються з web-процесу — це задача release-stage
+// (див. `scripts/migrate.mjs` / `npm run db:migrate`). При rolling deploy з 2+
+// реплік race на `INSERT schema_migrations` раніше валив один із процесів,
+// плюс readiness-проб затримувався часом виконання міграцій.
 httpServer = app.listen(config.port, "0.0.0.0", () => {
   logger.info({
     msg: "server_listening",


### PR DESCRIPTION
## Summary

Третя пачка з короткого тех-боргу — винести міграції з web-процесу в release-stage.

**Що було.** `server/index.js` викликав `ensureSchema()` на старті кожного web-процесу. Це давало:

- race при `INSERT schema_migrations` на rolling deploy з 2+ реплік (один інстанс програє unique-конфлікт і впаде),
- напіврозкочану міграцію, якщо вона довга і другий інстанс приходить поки перший у процесі BEGIN…COMMIT,
- затримку readiness-проба пропорційну часу виконання міграції → health-check flap-и і передчасні рестарти.

**Що стало.**

1. **`scripts/migrate.mjs`** — окремий CLI. Запускається як release-job **до** того, як нові web-інстанси отримають трафік:
   - перевіряє `DATABASE_URL`, виходить з кодом 1 при відсутності,
   - викликає `ensureSchema()` (той самий код, що й раніше, тільки не з web-процесу),
   - логує JSON (`migrate_ok` / `migrate_failed` / `migrate_database_url_missing`) з `durationMs`,
   - завжди `pool.end()` у `finally`, інакше процес Node висів би поки release-job таймаутиться.
2. **`npm run db:migrate`** — npm-script для зручності.
3. **`server/index.js`** — прибрав `ensureSchema()` з boot-path. Коментар пояснює чому.
4. **`Dockerfile.api`** — додає `COPY scripts ./scripts`, щоб Railway release-stage міг виконати `npm run db:migrate` всередині того самого образу, що й web.

## Review & Testing Checklist for Human

- [ ] **Важливо:** у Railway проекті додати `db:migrate` як **pre-deploy / release command** до того, як цей PR зіллється в main. Інакше після деплою нова схема не застосується (зараз boot-шлях вже не робить це сам). Railway UI: Settings → Deploy → Pre-Deploy Command = `npm run db:migrate`.
- [ ] Локально: `DATABASE_URL=postgres://... npm run db:migrate` має надрукувати `migrate_ok` і коректно завершитись (exit 0, процес не висить).
- [ ] Без `DATABASE_URL` скрипт виходить з кодом 1 і логом `migrate_database_url_missing` — перевірити що Railway зловить це як fail release і **не** буде rollout нових web-інстансів.
- [ ] Перший деплой після merge → `migrate_ok`, нові інстанси бачать актуальну схему, `db_schema_verified` більше не з'являється в логах web-процесу (і це ок).

### Notes

Це завершує пачку коротких PR-ів:
1. `#270` — sync-coach уніфікація ✅ merged
2. `#271` — graceful shutdown + exit on uncaughtException
3. Цей PR — міграції в CLI

CI на `typecheck` може впасти через pre-existing помилку в `src/modules/nutrition/lib/nutritionStats.test.ts` (прилетіла з #269, не з цього PR — відтворюється на чистому main). Окремий маленький fix-PR для цього поряд.

Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
