### PR TITLE
feat(db): support MIGRATE_DATABASE_URL override in scripts/migrate.mjs

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -14,22 +14,41 @@
  * інстанси server-а почнуть приймати трафік. Web-процес на старті більше
  * НЕ виконує міграції.
  *
- * Вихідні коди: 0 — все ок, 1 — будь-яка помилка (DATABASE_URL відсутній,
- * міграція впала, pg недоступний тощо).
+ * Вибір URL-а:
+ *   `MIGRATE_DATABASE_URL` (якщо виставлений) має пріоритет над `DATABASE_URL`.
+ *   Сенс: на Railway internal DNS `postgres.railway.internal` не резолвиться
+ *   у Pre-Deploy контейнері (він ще не в runtime-мережі), тому runtime-значення
+ *   `DATABASE_URL` там непридатне. Виставляєш `MIGRATE_DATABASE_URL` на
+ *   публічний proxy-URL Postgres (`${{ Postgres.DATABASE_PUBLIC_URL }}`), а
+ *   web-процес продовжує ходити в БД через швидший internal DNS. На Replit,
+ *   docker-compose, CI/local — достатньо одного `DATABASE_URL`.
+ *
+ * Вихідні коди: 0 — все ок, 1 — будь-яка помилка (URL відсутній, міграція
+ * впала, pg недоступний тощо).
  */
-import { ensureSchema, pool } from "../server/db.js";
+
+// Нормалізація URL-ів ДО того, як імпортується `server/db.js`: pg-pool
+// створюється на етапі eval модуля з `process.env.DATABASE_URL`, тому
+// override має відпрацювати раніше за імпорт.
+const migrateUrl = process.env.MIGRATE_DATABASE_URL;
+if (migrateUrl) {
+  process.env.DATABASE_URL = migrateUrl;
+}
+
+if (!process.env.DATABASE_URL) {
+  console.error(
+    JSON.stringify({
+      level: "error",
+      msg: "migrate_database_url_missing",
+      hint: "Set MIGRATE_DATABASE_URL (preferred for Railway pre-deploy, points to Postgres public URL) or DATABASE_URL.",
+    }),
+  );
+  process.exit(1);
+}
+
+const { ensureSchema, pool } = await import("../server/db.js");
 
 async function main() {
-  if (!process.env.DATABASE_URL) {
-    console.error(
-      JSON.stringify({
-        level: "error",
-        msg: "migrate_database_url_missing",
-      }),
-    );
-    process.exit(1);
-  }
-
   const startedAt = Date.now();
   try {
     await ensureSchema();
@@ -38,6 +57,7 @@ async function main() {
         level: "info",
         msg: "migrate_ok",
         durationMs: Date.now() - startedAt,
+        source: migrateUrl ? "MIGRATE_DATABASE_URL" : "DATABASE_URL",
       }),
     );
   } catch (err) {
@@ -46,6 +66,7 @@ async function main() {
         level: "error",
         msg: "migrate_failed",
         durationMs: Date.now() - startedAt,
+        source: migrateUrl ? "MIGRATE_DATABASE_URL" : "DATABASE_URL",
         err: {
           message: err?.message || String(err),
           code: err?.code,


### PR DESCRIPTION
## Summary

Фікс для Railway Pre-Deploy: зараз `npm run db:migrate` падає з `ENOTFOUND postgres.railway.internal`, бо Pre-Deploy контейнер на Railway **ще не в runtime-мережі проекту** і internal DNS там не резолвиться. Репорт від @Skords-01 з прод-логів:

```json
{"msg": "migrate_failed", "err": {"code": "ENOTFOUND",
  "message": "getaddrinfo ENOTFOUND postgres.railway.internal"}}
```

**Рішення.** Скрипт тепер приймає окремий `MIGRATE_DATABASE_URL`, що має пріоритет над `DATABASE_URL`. На Railway виставляється як `${{ Postgres.DATABASE_PUBLIC_URL }}` — публічний proxy (`*.proxy.rlwy.net`), доступний і з Pre-Deploy, і з runtime. Web-процес продовжує використовувати швидший internal DNS через `DATABASE_URL`.

На Replit / docker-compose / CI / локально нічого не змінюється — `MIGRATE_DATABASE_URL` просто не виставлений, використовується `DATABASE_URL`.

Додатково: лог `migrate_database_url_missing` тепер включає `hint` з порадою, щоб зменшити час до діагнозу.

## Review & Testing Checklist for Human

- [ ] **Railway:** у API-сервісі додати змінну `MIGRATE_DATABASE_URL = ${{ Postgres.DATABASE_PUBLIC_URL }}` (саме `DATABASE_PUBLIC_URL`, не `DATABASE_URL`).
- [ ] Перезапустити деплой — у логах Pre-Deploy очікувати `{"msg":"migrate_ok","source":"MIGRATE_DATABASE_URL"}`. Якщо бачиш `"source":"DATABASE_URL"` — значить `MIGRATE_DATABASE_URL` не пропагувався, перевір змінну на рівні API-сервісу.
- [ ] Перевірити, що runtime web-процес далі логує `db_query_duration_ms` у норму (тобто internal DNS для `DATABASE_URL` все ще працює і не постраждав).
- [ ] Локально без змін: `DATABASE_URL=postgres://... npm run db:migrate` → `migrate_ok`, `"source":"DATABASE_URL"`.

### Notes

Override читається ДО імпорту `server/db.js`, бо pg-pool створюється на eval-і модуля з `process.env.DATABASE_URL`. Тому в скрипті використано top-level `await import(...)` замість звичайного `import`.

Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
