### PR TITLE
feat(chat): SSE heartbeat to prevent proxy idle-timeout during slow AI responses

### DIFF
--- a/server/modules/chat.js
+++ b/server/modules/chat.js
@@ -336,6 +336,20 @@ export default async function handler(req, res) {
 }
 
 /**
+ * Як часто слати SSE-коментар ": ping\n\n", коли upstream мовчить.
+ *
+ * Контекст: Vercel/Railway/Cloudflare закривають idle HTTP-з'єднання приблизно
+ * через 30-60с. Якщо Anthropic довго генерує першу токен-дельту (reasoning,
+ * великий prompt, rate-limit backoff), проксі обірве SSE-сокет раніше, ніж
+ * ми встигнемо щось записати — клієнт побачить "зависло" замість відповіді.
+ * Heartbeat тримає сокет активним, не засмічуючи потік видимими даними
+ * (коментарі `:` EventSource мовчки ігнорує).
+ *
+ * Env-override `SSE_HEARTBEAT_MS` — для тестів і тюнінгу під конкретний proxy.
+ */
+const SSE_HEARTBEAT_MS = Number(process.env.SSE_HEARTBEAT_MS) || 15_000;
+
+/**
  * Anthropic Messages API stream → SSE для клієнта (data: {"t":"фрагмент"}).
  */
 async function streamAnthropicToSse(res, apiKey, payload, endpoint = "chat") {
@@ -373,6 +387,13 @@ async function streamAnthropicToSse(res, apiKey, payload, endpoint = "chat") {
     return;
   }
 
+  // Heartbeat: чистий SSE-коментар кожні N мс, поки живе з'єднання.
+  // `res.writableEnded` — щоб не писати у вже закритий потік (клієнт відвалився).
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded) res.write(": ping\n\n");
+  }, SSE_HEARTBEAT_MS);
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
+
   const decoder = new TextDecoder();
   let lineBuf = "";
   try {
@@ -407,6 +428,7 @@ async function streamAnthropicToSse(res, apiKey, payload, endpoint = "chat") {
     streamOutcome = "error";
     res.write(`data: ${JSON.stringify({ err: String(e?.message || e) })}\n\n`);
   } finally {
+    clearInterval(heartbeat);
     recordStreamEnd(streamOutcome);
   }
   res.write("data: [DONE]\n\n");


### PR DESCRIPTION
## Summary

Adds a 15-second SSE heartbeat to `streamAnthropicToSse` in `server/modules/chat.js`.

**Problem.** Vercel/Railway/Cloudflare close idle HTTP connections after ~30–60 seconds. When Anthropic takes a while to emit the first token (long reasoning, large prompts, rate-limit backoff), the proxy severs the SSE socket before any `data:` frame is written. From the client's perspective the chat hangs silently — there is no error, just a dead stream.

**Fix.** After the response headers are sent, start a `setInterval` that writes the SSE comment line `": ping\n\n"` every `SSE_HEARTBEAT_MS` (default 15_000). `EventSource` on the client silently ignores comment lines, so the user sees no behavior change while the TCP socket stays active. The interval is cleared in the existing `finally` block, guaranteeing cleanup on success, error, and client disconnect paths alike. `res.writableEnded` guards against writing to a socket the client already closed. `heartbeat.unref()` is called so the interval never keeps the event loop alive on its own.

**Env knob.** `SSE_HEARTBEAT_MS` overrides the default. Useful if a specific proxy (e.g. Cloudflare free-tier at ~100s) needs tuning without a code change; default of 15s is conservative enough for every managed proxy I'm aware of.

No other logic is touched — the decoder loop, DONE frame, and `recordStreamEnd` accounting behave exactly as before.

## Review & Testing Checklist for Human

- [ ] Skim `server/modules/chat.js` diff — confirm `clearInterval(heartbeat)` is in the `finally` (so an early `throw` or client-abort never leaks a timer).
- [ ] Confirm `: ping\n\n` is treated as an SSE comment (`:` prefix, no `data:` field) and that the existing client `EventSource` in `src/` does not have a custom parser that would choke on it — a grep for `EventSource` / `onmessage` in the frontend is sufficient.
- [ ] Verify no new test is added here (the function has no existing unit test coverage and adding one properly requires mocking `anthropicMessagesStream` + a ReadableStream, which is out of scope for this minimal fix — happy to split that into a follow-up if you want it).

### Notes

- This is part of the backend-tech-debt batch following #270–#274.
- Default 15s picked to be safely below the most aggressive common proxy idle (Vercel ~30s for serverless, Cloudflare Free ~100s, Railway ~60s).
- Next in the batch: tighten body-limits, `PG_POOL_MAX` env, remove dead HTTP shims, replace `console.log` in migrations.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
