### PR TITLE
feat(app): tighten global JSON body limit to 128kb; loosen per-route

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -56,7 +56,33 @@ export function createApp({
   app.use(withRequestContext);
   app.use(requestLogMiddleware);
   app.use(apiHelmetMiddleware({ servesFrontend }));
-  app.use(express.json({ limit: "12mb" }));
+
+  // Body-size policy: tight default, explicit loosening on routes that
+  // legitimately carry large payloads.
+  //
+  // Контекст. Раніше глобально стояв `express.json({ limit: "12mb" })`, що
+  // робило будь-який POST-ендпоінт потенційним каналом для 12MB сміття
+  // (OOM-amplifier, повільний парс, зайва RSS на Railway-інстансі з
+  // скромним лімітом пам'яті). 99% наших ендпоінтів обмінюються пейлоадами
+  // <4KB — дефолт 128KB дає комфортний запас навіть під великий textarea
+  // і одразу закриває 413 до того, як handler/zod навіть побачать тіло.
+  //
+  // Порядок важливий. Mount-и на конкретні шляхи мусять іти ПЕРЕД
+  // глобальним мініатюрним, інакше 128KB-парсер спрацює першим і вб'є
+  // великий legit-payload. `express.json()` no-op-ить, якщо body вже
+  // розпарсене, тож другий виклик на тому самому request-і безпечний.
+  //
+  // Ліміти підібрані: schema-level max + невеликий запас під JSON-оверхед:
+  //   analyze-photo / refine-photo : 10mb (schema допускає base64 до ~7MB)
+  //   backup-upload                : 4mb  (internal cap 2.5MB post-stringify)
+  //   sync push/pull               : 6mb  (MAX_BLOB_SIZE = 5MB)
+  //   coach memory                 : 6mb  (той самий MAX_BLOB_SIZE)
+  app.use("/api/nutrition/analyze-photo", express.json({ limit: "10mb" }));
+  app.use("/api/nutrition/refine-photo", express.json({ limit: "10mb" }));
+  app.use("/api/nutrition/backup-upload", express.json({ limit: "4mb" }));
+  app.use("/api/sync", express.json({ limit: "6mb" }));
+  app.use("/api/coach/memory", express.json({ limit: "6mb" }));
+  app.use(express.json({ limit: "128kb" }));
 
   // Global CORS for the whole /api surface. Individual handlers may re-set
   // headers (e.g. to widen allow-headers) — `setCorsHeaders` is idempotent.

--- a/server/http/authMiddleware.js
+++ b/server/http/authMiddleware.js
@@ -57,8 +57,8 @@ export function authMetricsMiddleware(req, res, next) {
 
   // Читаємо body ДО `res.on("finish")`: better-auth toNodeHandler може
   // консьюмити stream і замінити/зачистити `req.body` до моменту емісії.
-  // express.json() у app.js парсить лімітом 12mb, тож на /sign-in
-  // це завжди object або undefined.
+  // express.json() у app.js парсить auth-роути глобальним дефолтом (128kb),
+  // тож на /sign-in `req.body` — це завжди object або undefined.
   const emailHash =
     op === "sign_in" || op === "sign_up" || op === "forget_password"
       ? emailFingerprint(req.body?.email)


### PR DESCRIPTION
## Summary

Replaces the single global `express.json({ limit: "12mb" })` in `server/app.js` with a tight **128 KB** default and per-route opt-in overrides for endpoints that legitimately carry large payloads.

**Problem.** Every POST route was accepting up to 12 MB of JSON. 99% of endpoints trade <4 KB payloads (chat messages, sync deltas, auth forms, bank-proxy queries, metrics). The global 12 MB ceiling gave an attacker — or a buggy client — a free amplifier: they could send 12 MB of garbage and force the server to fully parse it before the handler/zod ever saw the body. On Railway's modest memory footprint this is a straightforward RSS-spike / OOM vector, and wastes CPU on every abusive request.

**Fix.** Mount path-specific `express.json` parsers first (each tuned to the schema/internal cap of that route), then a 128 KB global as the catch-all. Order matters — specific mounts run before the catch-all, and body-parser's second invocation on the same request is a no-op once `req._body` is set, so there is no double-parse cost.

Per-route caps:

| Route | Limit | Rationale |
|---|---|---|
| `/api/nutrition/analyze-photo` | 10 MB | `AnalyzePhotoSchema` allows base64 image ≈7 MB |
| `/api/nutrition/refine-photo` | 10 MB | same |
| `/api/nutrition/backup-upload` | 4 MB | handler enforces 2.5 MB post-stringify cap |
| `/api/sync` | 6 MB | `MAX_BLOB_SIZE = 5 MB` from `server/modules/sync.js` |
| `/api/coach/memory` | 6 MB | shares `MAX_BLOB_SIZE` with sync |
| everything else | **128 KB** | generous headroom even for long textareas |

The per-route limits are intentionally a thin margin above the schema/internal cap so body-parser returns 413 before the handler is ever invoked — meaning no CPU for zod, no DB round-trip, no rate-limit-token burn for over-sized junk.

Also updated a stale comment in `server/http/authMiddleware.js` that referenced the old 12 MB limit.

## Review & Testing Checklist for Human

- [ ] Confirm the 5 path-specific mounts are exhaustive: grep `server/routes/` for any other POST/PUT endpoint that could legitimately exceed 128 KB (e.g. a future bulk-import). If you find one, add it to `app.js` with its own limit.
- [ ] Verify that `/api/chat`, `/api/nutrition/parse-pantry`, `/api/nutrition/recommend-recipes`, `/api/nutrition/day-plan`, `/api/nutrition/week-plan`, `/api/nutrition/shopping-list`, `/api/nutrition/day-hint`, `/api/coach/insight`, `/api/weekly-digest`, `/api/push/subscribe`, `/api/push/unsubscribe` realistically fit under 128 KB — these are all prompt / config / token payloads that should comfortably fit, but worth a sanity check against production logs if you have body-size metrics.
- [ ] Smoke-test one analyze-photo call against a deployed preview with a ~3 MB image to confirm the path-specific 10 MB mount actually kicks in. If Railway's deploy rate-limit blocks the preview, a local `curl` against `npm run server:dev` is equivalent.

### Notes

- Part of the backend-tech-debt batch following #270–#275.
- The order of `app.use` calls in `createApp` is load-bearing: the path-specific parsers MUST precede the catch-all. The comment above them explains why — please don't reorder alphabetically or by path length.
- Next in the batch: `PG_POOL_MAX` env, remove dead HTTP shims, replace `console.log` in migrations.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
