### PR TITLE
chore(db): env-driven pool.max via PG_POOL_MAX; structured migration log

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -11,9 +11,18 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Максимум активних клієнтів у пулі. На Railway Hobby-інстансі з ~512MB
+ * пам'яті та одним vCPU 10 — розумний baseline, але під пікове навантаження
+ * або після bump-у плану хочеться підняти без релізу коду. Ставиться через
+ * `PG_POOL_MAX`; Postgres-сторона (`max_connections`) лишається єдиним
+ * жорстким лімітом — значення вище за неї просто призведе до conn-помилок.
+ */
+const PG_POOL_MAX = Number(process.env.PG_POOL_MAX) || 10;
+
 const pool = new pg.Pool({
   connectionString: process.env.DATABASE_URL,
-  max: 10,
+  max: PG_POOL_MAX,
   idleTimeoutMillis: 30_000,
 });
 
@@ -129,7 +138,7 @@ async function runPendingSqlMigrations(client) {
         file,
       ]);
       await client.query("COMMIT");
-      console.log(`[db] Migration applied: ${file}`);
+      logger.info({ msg: "migration_applied", file });
     } catch (e) {
       await client.query("ROLLBACK");
       throw e;


### PR DESCRIPTION
## Summary

Two tiny, independent cleanups in `server/db.js`, bundled because both are one-line changes to the same file.

**1. `PG_POOL_MAX` env knob.** Pool size was hardcoded `max: 10`. Fine as a baseline on Railway Hobby, but moving to a paid tier or hitting a traffic spike means you have to ship a code change to raise it. Now read from `PG_POOL_MAX` with `10` as the fallback — behavior on every existing deploy is unchanged.

Caveat: Postgres's `max_connections` is still the upstream hard ceiling. Setting `PG_POOL_MAX` above it just surfaces `too many clients already` instead of silently working, which is the correct failure mode — we want to notice.

**2. `console.log` → `logger.info` for applied migrations.** The rest of `db.js` uses the Pino `logger` (`db_slow`, `db_error`, `db_pool_error`). The migration-applied line was the lone `console.log("[db] Migration applied: …")` left over. Replaced with a structured `logger.info({ msg: "migration_applied", file })` so the pre-deploy log stream is fully JSON and parseable (matches how Railway aggregates logs, and how `scripts/migrate.mjs` emits `migrate_ok` / `migrate_failed`).

No behavior change for healthy runs. Pool sizing, migration ordering, transaction semantics, error paths — all identical.

## Review & Testing Checklist for Human

- [ ] Confirm the log-line format change in pre-deploy logs — next deploy that runs a new migration should emit `{"msg":"migration_applied","file":"NNN_...sql", ...}` instead of `[db] Migration applied: …`. If you have a logs-based alert on the old string, update it.
- [ ] Decide whether to bump `PG_POOL_MAX` in Railway right now — not required for this PR (default is `10`, same as before). If/when you do, set it on the Sergeant service → Variables, no restart-other-side needed.

### Notes

- Part of the backend-tech-debt batch following #270–#276.
- Remaining in the batch: remove dead HTTP shims (`server/http/middleware.js`, legacy `createHealthHandler`).


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
