### PR TITLE
chore(http): remove deprecated middleware.js shim and createHealthHandler alias

### DIFF
--- a/server/http/health.js
+++ b/server/http/health.js
@@ -25,11 +25,3 @@ export function createReadyzHandler(pool) {
     else res.status(503).type("text/plain").send("unhealthy");
   };
 }
-
-/**
- * @deprecated Використовуй `livezHandler` + `createReadyzHandler`. Лишено для
- * зворотної сумісності зі старими health-probe в інфраструктурі.
- */
-export function createHealthHandler(pool) {
-  return createReadyzHandler(pool);
-}

--- a/server/http/index.js
+++ b/server/http/index.js
@@ -15,11 +15,7 @@ export {
   authMetricsMiddleware,
 } from "./authMiddleware.js";
 
-export {
-  livezHandler,
-  createReadyzHandler,
-  createHealthHandler,
-} from "./health.js";
+export { livezHandler, createReadyzHandler } from "./health.js";
 
 export { errorHandler } from "./errorHandler.js";
 

--- a/server/http/middleware.js
+++ b/server/http/middleware.js
@@ -1,8 +1,0 @@
-/**
- * DEPRECATED: вміст розбито по `requestId.js` і `requestLog.js`. Залишено
- * re-export як compatibility-shim; імпорти поступово мігрують у наступних
- * рефактор-хвилях, після чого файл буде видалено.
- */
-export { withRequestContext } from "../obs/requestContext.js";
-export { requestIdMiddleware } from "./requestId.js";
-export { requestLogMiddleware } from "./requestLog.js";


### PR DESCRIPTION
## Summary

Removes two pieces of backend dead weight that were marked deprecated and left pending a "future cleanup wave":

**1. `server/http/middleware.js` — deleted.** Was a compatibility shim that re-exported `withRequestContext`, `requestIdMiddleware`, `requestLogMiddleware` from their real locations. Every caller in the repo has since been migrated to import from `server/http/index.js` directly. Grep confirms zero remaining imports of `./middleware.js` or `http/middleware`.

**2. `createHealthHandler` — deleted.** Was an `@deprecated` alias that did nothing except `return createReadyzHandler(pool)`. Its only reference was the re-export in `server/http/index.js`; no route, test, or probe calls it. The comment claimed "for backward-compat with old health probes" — those probes point at `/livez` and `/readyz` (the direct handlers), not at anything that went through this alias.

Net: −12 lines, −1 file. Zero runtime behavior change.

## Review & Testing Checklist for Human

- [ ] Sanity-check that Railway/Vercel/any external uptime monitor still has health-probe URLs pointing at `/livez` (liveness) or `/readyz` (readiness) — the only two real handlers. If something was misconfigured to hit `/health` (there's no such route anyway), it was already broken before this PR.

### Notes

- Part of the backend-tech-debt batch following #270–#277.
- This concludes the short-PR batch from the audit backlog. Remaining audit items are larger (chat.js split, Redis rate-limit, schema validation design, cleanup crons) and warrant separate planning.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
