### PR TITLE
fix(app): raise body-limit for /api/chat to 1mb

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -77,11 +77,16 @@ export function createApp({
   //   backup-upload                : 4mb  (internal cap 2.5MB post-stringify)
   //   sync push/pull               : 6mb  (MAX_BLOB_SIZE = 5MB)
   //   coach memory                 : 6mb  (той самий MAX_BLOB_SIZE)
+  //   chat                         : 1mb  (ChatRequestSchema: context 40KB +
+  //                                        50 messages × 8KB + 20 tool_results ×
+  //                                        8KB + 20 tool_calls_raw ≈ до ~1MB
+  //                                        на активній сесії з tool-calling)
   app.use("/api/nutrition/analyze-photo", express.json({ limit: "10mb" }));
   app.use("/api/nutrition/refine-photo", express.json({ limit: "10mb" }));
   app.use("/api/nutrition/backup-upload", express.json({ limit: "4mb" }));
   app.use("/api/sync", express.json({ limit: "6mb" }));
   app.use("/api/coach/memory", express.json({ limit: "6mb" }));
+  app.use("/api/chat", express.json({ limit: "1mb" }));
   app.use(express.json({ limit: "128kb" }));
 
   // Global CORS for the whole /api surface. Individual handlers may re-set


### PR DESCRIPTION
## Summary

Follow-up to #276. Devin Review surfaced that `/api/chat` falls through to the new 128 KB global default, but `ChatRequestSchema` in `server/http/schemas.js` explicitly allows payloads well beyond that — so an active user with a long conversation plus module context would hit a 413 before zod or the handler ever runs. Adds a path-specific 1 MB mount for `/api/chat`.

### Why 128 KB was too tight

Worst case from `ChatRequestSchema`:

| Field | Zod cap | Size |
|---|---|---|
| `context` | max 40 000 chars | ~40 KB |
| `messages` | 50 × 8 000 chars | up to ~400 KB |
| `tool_results` | 20 × 8 000 chars | up to ~160 KB |
| `tool_calls_raw` | 20 × unbounded (Anthropic raw blocks) | realistically a few hundred KB |

Even a moderate real session (30 KB context + 20 messages × 3 KB + one tool-calling round-trip) already lands around ~90 KB and keeps growing. 1 MB matches the theoretical schema ceiling minus the unbounded `tool_calls_raw` tail (which Anthropic itself keeps reasonably bounded in practice).

### Why not raise the zod caps instead

Tempting but wrong for this PR — the caps exist for Anthropic cost-control and prompt-injection limiting, not transport sizing. They should stay where they are; only the transport ceiling needs to align with what the schema already allows.

### Why 1 MB specifically

- Above the realistic 95p of active sessions with module-context + tool-calling.
- Below anything that would make a 12 MB-style OOM amplifier meaningful.
- Body-parser still returns 413 before the handler for anything beyond — failure mode unchanged, ceiling for legit traffic raised.

No behavior change for any other route: 128 KB global stays, existing `/api/nutrition/*`, `/api/sync`, `/api/coach/memory` mounts untouched.

## Review & Testing Checklist for Human

- [ ] Quick gut-check that 1 MB is the right number — if you have production metrics on `/api/chat` body sizes, real 99p is almost certainly under 200 KB; 1 MB is deliberately a comfortable ceiling above that. Easy to lower later if telemetry says we can.
- [ ] Optional smoke test: send a chat request with ~300 KB context + long history against a deployed preview and confirm 200 instead of 413. If Vercel is rate-limited again, `curl` locally against `npm run server:dev` is equivalent.

### Notes

- Originated from a Devin Review finding on #276.
- Same load-bearing ordering rule applies: path-specific mounts precede the catch-all. Please don't reorder.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
