### PR TITLE
fix(digest): portal Stories modal to body; widen safe-area padding

### DIFF
--- a/src/core/WeeklyDigestStories.tsx
+++ b/src/core/WeeklyDigestStories.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import {
@@ -137,12 +138,23 @@ function buildSlides(digest, weekKey, weekRange) {
 }
 
 function StoryShell({ slide, children }) {
+  // Top padding has to clear the progress bars + header row + the iOS safe
+  // area (~47px on notch devices). Bottom padding clears the home-indicator.
+  // Without `env(safe-area-inset-*)` the first card's label rendered *behind*
+  // the chrome on iPhone, leaving only the big number visible — see the bug
+  // that triggered this file's last refactor.
   return (
     <div
       className={cn("absolute inset-0 bg-gradient-to-br text-white", slide.bg)}
     >
       <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_at_top,rgba(255,255,255,0.25),transparent_60%)]" />
-      <div className="relative h-full w-full flex flex-col px-6 pt-24 pb-16 overflow-y-auto">
+      <div
+        className="relative h-full w-full flex flex-col px-6 overflow-y-auto"
+        style={{
+          paddingTop: "calc(env(safe-area-inset-top, 0px) + 5.5rem)",
+          paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 2.5rem)",
+        }}
+      >
         {children}
       </div>
     </div>
@@ -721,7 +733,18 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   if (!slides.length) return null;
   const slide = slides[clampedIndex];
 
-  return (
+  // Portal to <body> so the modal escapes every ancestor stacking context.
+  // Without this, the `page-enter` animation on the hub root (which keeps
+  // `transform: translateY(0)` via `animation-fill-mode: both`) and the
+  // `overflow-hidden` + shadow wrapper on `WeeklyDigestCard` both promote
+  // themselves to independent stacking contexts — and the primary FAB
+  // (`HubFloatingActions`, z-40) ends up painted *above* this overlay
+  // (z-[600]) because the 600 is scoped to a context whose parent
+  // z-index is lower than the FAB's. Rendering into `document.body`
+  // short-circuits all of that and makes z-index globally meaningful again.
+  if (typeof document === "undefined") return null;
+
+  const overlay = (
     <div
       className="fixed inset-0 z-[600] select-none"
       role="dialog"
@@ -818,6 +841,7 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
         {/* Invisible nav hints on sides for clarity on first view. */}
         <div
           className="pointer-events-none absolute inset-y-0 left-0 w-1/3 bg-gradient-to-r from-black/10 to-transparent"
+          data-nav-hint="prev"
           aria-hidden
         />
         <div
@@ -827,4 +851,6 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
       </div>
     </div>
   );
+
+  return createPortal(overlay, document.body);
 }


### PR DESCRIPTION
## Summary

The weekly-digest Stories overlay was rendering correctly in DOM but the primary `+ Додати` FAB (`HubFloatingActions`, z-40) was painting on top of it, and the top label of each stat card was clipped behind the chrome. Two separate CSS bugs with the same symptom (broken Stories view).

### Bug #1 — FAB leaks through the overlay

`WeeklyDigestStories` returned `<div className="fixed inset-0 z-[600] ...">` directly from inside `WeeklyDigestCard`. The modal was mounted deep under the hub tree, which on the hub root carries `page-enter` from `src/index.css`:

```css
@keyframes page-enter { from { transform: translateY(8px); } to { transform: translateY(0); } }
.page-enter { animation: page-enter 0.22s ease-out both; }
```

With `animation-fill-mode: both` the `transform: translateY(0)` persists forever, and any non-`none` transform creates a stacking context. On top of that `WeeklyDigestCard` itself has `overflow-hidden` + `shadow-card` + `transition-all` — another candidate for a nested context. Result: the modal's `z-[600]` was scoped to a nested context whose parent's effective z-index was below the sibling FAB's `z-40`, so the FAB painted over the overlay.

Standard fix: render the overlay through `createPortal` into `document.body`. That escapes every ancestor stacking context and makes the z-index globally meaningful again, so `z-[600]` now wins over the FAB without touching either number.

### Bug #2 — Stat card labels clipped on notched iPhones

`StoryShell` used `pt-24 pb-16` (hardcoded 96px / 64px). The top chrome (progress bars + header row) plus the iOS safe-area inset (~47px on Dynamic Island devices) can reach ~106px — more than the 96px the shell reserved. The result on the user's screenshot: the "Тренувань" / "Обсяг, кг" labels were rendered behind the chrome; only the big `1` / `0` numbers were visible.

Fix: switch the shell to `paddingTop: calc(env(safe-area-inset-top, 0px) + 5.5rem)` and a matching bottom inset. This keeps the layout compact on short Android screens while preserving enough room on notched iOS devices, and the body still gets the full gradient under the chrome.

### Not in this PR

- No changes to slide content, gesture handling, auto-advance, or analytics. Purely layout/stacking.
- Didn't touch the `mt-auto` layout pattern inside individual slides — big whitespace on sparse weeks (1 workout, 0 kg) is by design for Stories pacing. If it looks off after this fix I'll do a separate pass.

## Review & Testing Checklist for Human

- [ ] Open a week with a Stories-ready digest on iPhone (notch / Dynamic Island), play Stories, confirm the primary `+ Додати` FAB is no longer visible on top of the overlay.
- [ ] On the Fizruk slide (the one in the screenshot that triggered this), confirm both `Тренувань` and `Обсяг, кг` labels are fully readable above their numbers.
- [ ] Tap the close `×` button and swipe-down-to-close — both paths should still close the overlay and restore body scroll (`document.body.style.overflow` is reset in the existing `useEffect`, portal doesn't change that).
- [ ] Android / desktop Chrome: overlay still fullscreen, no visual regression.

### Notes

- Related prior session that landed the Stories feature: #270-274 sequencing.
- If the FAB still shows on top after this deploys, it means there's another FAB instance outside `HubFloatingActions` — ping me and I'll grep for strays.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
