### PR TITLE
fix(finyk): show correct category percentages in analytics pie chart

### DIFF
--- a/src/modules/finyk/components/analytics/CategoryPieChart.jsx
+++ b/src/modules/finyk/components/analytics/CategoryPieChart.jsx
@@ -112,9 +112,19 @@ function CategoryPieChartComponent({ data = [], size = 160, className }) {
               <span className="text-text truncate flex-1 min-w-0 text-xs">
                 {arc.label}
               </span>
-              <span className="text-muted tabular-nums text-xs shrink-0">
-                {arc.pct < 1 ? "<1" : Math.round(arc.pct * 100)}%
-              </span>
+              {(() => {
+                // `arc.pct` is the fraction of `total` (0..1), not a
+                // percentage. The old guard `arc.pct < 1` was effectively
+                // always true and showed "<1%" on every slice. Round to the
+                // integer percentage first, then keep the "<1" hint for
+                // segments that round to zero but are still > 0.
+                const pctInt = Math.round(arc.pct * 100);
+                return (
+                  <span className="text-muted tabular-nums text-xs shrink-0">
+                    {pctInt < 1 ? "<1" : pctInt}%
+                  </span>
+                );
+              })()}
               <span className="text-text tabular-nums text-xs font-medium shrink-0">
                 {arc.spent.toLocaleString("uk-UA")} ₴
               </span>


### PR DESCRIPTION
## Summary

Every slice in Finyk → Аналітика → Категорії was rendering `<1%`, regardless of its actual share of spending. On the user's screenshot, "Борги та кредити" at 12 804 ₴ out of a 56 271 ₴ total was shown as `<1%` — the real share is ~23%.

Root cause: an off-by-`×100` bug in `CategoryPieChart`. The chart math stores each slice's share as a fraction `arc.pct ∈ [0..1]`:

```jsx
const pct = seg.spent / total;   // fraction, e.g. 0.228
```

…and the rendering did:

```jsx
{arc.pct < 1 ? "<1" : Math.round(arc.pct * 100)}%
```

The guard `arc.pct < 1` is true for every multi-slice pie (the only way it's ≥ 1 is a single-slice pie that gets 100% of the total), so the `"<1"` branch always fired and the correct `Math.round(arc.pct * 100)` branch was dead code.

The fix: round to the integer percentage first, then apply the `"<1"` hint only to slices that round to zero but are still > 0:

```jsx
const pctInt = Math.round(arc.pct * 100);
// ...
{pctInt < 1 ? "<1" : pctInt}%
```

So the screenshot's six slices will now render as `23%`, `18%`, `17%`, `8%`, `8%`, `26%` (sum = 100%) instead of six `<1%`.

## Review & Testing Checklist for Human

- [ ] Open Finyk → Аналітика in prod after deploy, eyeball at least three slices and confirm percentages sum to ~100% (rounding may leave 99 or 101; that's expected with `Math.round`).
- [ ] Confirm a very small slice (< 0.5% of total) still renders as `<1%` and not `0%`.

### Notes

- Searched the codebase for other `pct < 1` comparisons against fractions; this was the only occurrence (`rg 'pct\s*<\s*1'`), so no sibling charts are affected.
- Pure presentational change inside `CategoryPieChart.jsx` — the ring, total, legend layout and colors are all untouched.


Link to Devin session: https://app.devin.ai/sessions/bf9d5e04802a4c7aac728402a639aa23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
