### PR TITLE
a11y(dialog): restore focus to trigger after modal close

### DIFF
--- a/src/core/HubChat.tsx
+++ b/src/core/HubChat.tsx
@@ -5,6 +5,7 @@ import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
+import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { hubKeys } from "@shared/lib/queryKeys";
 import { useFinykHubPreview } from "./hub/useFinykHubPreview";
 
@@ -169,41 +170,10 @@ function HubChat({ onClose, initialMessage }) {
       chatRef.current.scrollTop = chatRef.current.scrollHeight;
   }, [messages, loading]);
 
-  // Focus trap
-  useEffect(() => {
-    const panel = panelRef.current;
-    if (!panel) return;
-    const getFocusable = () =>
-      Array.from(
-        panel.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])',
-        ),
-      ).filter((el) => !el.hasAttribute("disabled"));
-
-    const onKeyDown = (e) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const nodes = getFocusable();
-      if (nodes.length === 0) return;
-      const first = nodes[0];
-      const last = nodes[nodes.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else if (document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  // Focus trap + Escape + restore focus to trigger on close. Shared
+  // with Sheet / ConfirmDialog / InputDialog so every modal surface
+  // gets the same WCAG 2.4.3 focus-order guarantees in one place.
+  useDialogFocusTrap(true, panelRef, { onEscape: onClose });
 
   // TTS speaking state poll
   useEffect(() => {

--- a/src/shared/hooks/useDialogFocusTrap.test.ts
+++ b/src/shared/hooks/useDialogFocusTrap.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { useDialogFocusTrap } from "./useDialogFocusTrap.js";
+
+/**
+ * Spec: restoring focus to the dialog trigger on close is a WCAG 2.4.3
+ * requirement. These tests lock the behavior in so future refactors
+ * don't silently regress to dropping focus on <body>.
+ */
+describe("useDialogFocusTrap — focus restoration", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns focus to the previously-focused element when the trap closes", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const panel = document.createElement("div");
+    const inner = document.createElement("button");
+    inner.textContent = "Inside";
+    panel.appendChild(inner);
+    document.body.appendChild(panel);
+
+    const ref = createRef<HTMLDivElement>();
+    Object.defineProperty(ref, "current", { value: panel, writable: true });
+
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useDialogFocusTrap(open, ref),
+      { initialProps: { open: true } },
+    );
+
+    // Simulate the app moving focus into the dialog while it is open.
+    inner.focus();
+    expect(document.activeElement).toBe(inner);
+
+    rerender({ open: false });
+
+    expect(document.activeElement).toBe(trigger);
+    unmount();
+  });
+
+  it("does not throw when the trigger has unmounted before close", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const panel = document.createElement("div");
+    document.body.appendChild(panel);
+
+    const ref = createRef<HTMLDivElement>();
+    Object.defineProperty(ref, "current", { value: panel, writable: true });
+
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useDialogFocusTrap(open, ref),
+      { initialProps: { open: true } },
+    );
+
+    // Trigger disappears while dialog is open.
+    trigger.remove();
+
+    expect(() => rerender({ open: false })).not.toThrow();
+    unmount();
+  });
+
+  it("does not attempt to restore focus to <body>", () => {
+    document.body.focus();
+    expect(document.activeElement).toBe(document.body);
+
+    const panel = document.createElement("div");
+    document.body.appendChild(panel);
+    const ref = createRef<HTMLDivElement>();
+    Object.defineProperty(ref, "current", { value: panel, writable: true });
+
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useDialogFocusTrap(open, ref),
+      { initialProps: { open: true } },
+    );
+
+    const inner = document.createElement("input");
+    panel.appendChild(inner);
+    inner.focus();
+    expect(document.activeElement).toBe(inner);
+
+    rerender({ open: false });
+
+    // No recorded trigger → focus is not yanked back to body-level;
+    // whatever was focused at close time (here: nothing meaningful)
+    // is left alone.
+    expect(document.activeElement).not.toBe(document.body);
+    unmount();
+  });
+});

--- a/src/shared/hooks/useDialogFocusTrap.ts
+++ b/src/shared/hooks/useDialogFocusTrap.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 
 export interface DialogFocusTrapOptions {
   onEscape?: () => void;
@@ -6,6 +6,16 @@ export interface DialogFocusTrapOptions {
 
 /**
  * Tab циклічно лишається в межах контейнера; Escape викликає onEscape.
+ *
+ * Additionally, the element that was focused when the dialog opened is
+ * remembered and receives focus back after the dialog closes. This is a
+ * WCAG 2.4.3 (Focus Order) requirement — otherwise a keyboard user who
+ * triggers a modal and dismisses it is dropped on `<body>` and has to
+ * re-traverse the whole page to get back to where they were.
+ *
+ * If the previously focused element is no longer in the DOM when the
+ * dialog closes (e.g. a sheet that unmounts its own trigger), we quietly
+ * skip the restore instead of throwing.
  */
 export function useDialogFocusTrap(
   open: boolean,
@@ -13,11 +23,19 @@ export function useDialogFocusTrap(
   options: DialogFocusTrapOptions = {},
 ): void {
   const { onEscape } = options;
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
     const panel = containerRef.current;
     if (!panel) return;
+
+    // Snapshot the currently-focused element so we can restore focus
+    // after the dialog closes. Skip body itself — restoring focus to
+    // <body> is identical to losing focus entirely.
+    const active = document.activeElement;
+    previouslyFocusedRef.current =
+      active instanceof HTMLElement && active !== document.body ? active : null;
 
     const getFocusable = (): HTMLElement[] =>
       Array.from(
@@ -53,6 +71,20 @@ export function useDialogFocusTrap(
     };
 
     document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      const el = previouslyFocusedRef.current;
+      previouslyFocusedRef.current = null;
+      if (!el) return;
+      // The trigger may have unmounted while the dialog was open
+      // (e.g. tapping a card button that is re-rendered into a new
+      // position). Guard against focusing an orphaned node.
+      if (!el.isConnected) return;
+      try {
+        el.focus({ preventScroll: true });
+      } catch {
+        /* ignore — element became non-focusable */
+      }
+    };
   }, [open, onEscape, containerRef]);
 }


### PR DESCRIPTION
## Summary

Every modal surface (Sheet, ConfirmDialog, InputDialog, HabitQuickCreateDialog, Fizruk finish sheets, HubChat) routes through `useDialogFocusTrap`. The hook trapped Tab and handled Escape, but did not restore focus to the element that opened the dialog. A keyboard user who dismissed a sheet was silently dropped on `<body>` and had to re-traverse the whole page to get back — a WCAG 2.4.3 (Focus Order) regression.

- `useDialogFocusTrap` now snapshots `document.activeElement` on open and calls `.focus({ preventScroll: true })` on cleanup.
- Guards for the trigger having unmounted mid-dialog, for activeElement being `<body>` itself (which would just yank focus nowhere), and for the element becoming non-focusable.
- `HubChat` had a duplicated hand-rolled focus-trap. Swapped it for the shared hook so the fix applies uniformly and the trap logic lives in one place.
- Three new unit tests lock the restoration behavior in: happy-path restoration, unmounted-trigger safety, body-as-previous-focus.

No visual changes. No behavioral changes for mouse/touch users.

Scope: only `src/shared/hooks/useDialogFocusTrap.ts`, its new test file, and `src/core/HubChat.tsx` (migration to shared hook). Backend logic untouched per task brief.

## Review & Testing Checklist for Human

- [ ] Open any sheet (e.g. `+` FAB in Finyk to add a manual expense, or a workout set editor in Fizruk) with keyboard (Tab → Enter), close with Escape, confirm focus returns to the trigger button (visible focus ring).
- [ ] Open the Hub assistant (🤖 button), close with Escape, confirm focus returns to the 🤖 button.
- [ ] Tab cycling inside a sheet is still clamped (last → first, first ← last with Shift+Tab).

### Notes

- This is PR 1/4 of the UX/a11y/PWA batch. Subsequent PRs: mobile layout + safe-area, PWA SW strategies + quiet hours, optimistic updates.
- No changes to backend logic — per task brief.


Link to Devin session: https://app.devin.ai/sessions/4bbfa8999dd3498aa335370caed48215
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
