### PR TITLE
feat(tokens): semantic color/motion design-tokens + focus-ring utility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,29 @@
 
     /* Brand accent for focus states */
     --c-accent: 16 185 129; /* emerald-500 */
+
+    /* Semantic aliases (design-token contract) — map 1:1 to existing vars.
+       Prefer these names in new code: surface / surface-muted / fg / fg-muted.
+       Existing bg / panel / text / muted remain valid for back-compat. */
+    --c-surface: var(--c-panel);
+    --c-surface-muted: var(--c-panel-hi);
+    --c-fg: var(--c-text);
+    --c-fg-muted: var(--c-muted);
+
+    /* Status semantic tokens (kept in sync with tailwind `statusColors`). */
+    --c-success: 16 185 129; /* emerald-500 */
+    --c-warning: 245 158 11; /* amber-500 */
+    --c-danger: 239 68 68; /* red-500 */
+    --c-info: 59 130 246; /* blue-500 */
+
+    /* Motion tokens — single source of truth for duration/easing. */
+    --motion-duration-fast: 150ms;
+    --motion-duration: 200ms;
+    --motion-duration-slow: 300ms;
+    --motion-duration-slower: 400ms;
+    --motion-ease-smooth: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    --motion-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --motion-ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 
   /* ═══════════════════════════════════════════════════════════════════════
@@ -135,6 +158,17 @@
 }
 
 @layer components {
+  /* ═══════════════════════════════════════════════════════════════════════
+     FOCUS RING — consistent keyboard a11y affordance across the app.
+     Apply to any interactive element that doesn't already define its own
+     focus-visible ring (Button already does). Uses the `accent` semantic
+     token so light & dark themes stay in sync automatically.
+     ═══════════════════════════════════════════════════════════════════════ */
+  .focus-ring {
+    @apply outline-none focus-visible:ring-2 focus-visible:ring-accent/60
+           focus-visible:ring-offset-2 focus-visible:ring-offset-surface;
+  }
+
   /* ═══════════════════════════════════════════════════════════════════════
      PANELS & CARDS — Core UI surfaces
      ═══════════════════════════════════════════════════════════════════════ */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,15 @@ export default {
         subtle: "rgb(var(--c-subtle) / <alpha-value>)",
         primary: "rgb(var(--c-primary) / <alpha-value>)",
 
+        // ─── Semantic aliases (preferred in new code) ──────────────────────
+        // Map 1:1 to the existing tokens above; dark mode "just works" because
+        // they resolve through the same CSS variables.
+        surface: "rgb(var(--c-panel) / <alpha-value>)",
+        "surface-muted": "rgb(var(--c-panel-hi) / <alpha-value>)",
+        fg: "rgb(var(--c-text) / <alpha-value>)",
+        "fg-muted": "rgb(var(--c-muted) / <alpha-value>)",
+        accent: "rgb(var(--c-accent) / <alpha-value>)",
+
         // ═══════════════════════════════════════════════════════════════════
         // BRAND COLORS — Soft & Organic palette with Emerald/Teal accent
         // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

PR 1 / 4 of the design-engineering series (tokens + dark theme).

Introduces **semantic design-token aliases** on top of the existing
`bg` / `panel` / `panelHi` / `line` / `text` / `muted` / `subtle` / `primary`
tokens so new code can read naturally as `surface` / `fg` / `accent`:

| Alias          | Maps to       | Dark-mode source |
|----------------|---------------|------------------|
| `surface`      | `--c-panel`   | auto (CSS var)   |
| `surface-muted`| `--c-panel-hi`| auto             |
| `fg`           | `--c-text`    | auto             |
| `fg-muted`     | `--c-muted`   | auto             |
| `accent`       | `--c-accent`  | auto             |

- Adds status tokens (`--c-success`, `--c-warning`, `--c-danger`, `--c-info`) in `:root`. They mirror the `statusColors` already exported from `chartPalette.js` and create a single source of truth for semantic status usage.
- Adds motion tokens (`--motion-duration-fast|-|-slow|-slower` and `--motion-ease-smooth|-bounce|-spring`) in `:root`, mirroring the values in `tailwind.config.js → transitionDuration / transitionTimingFunction`. This unifies duration/easing across CSS and Tailwind. `prefers-reduced-motion` is already respected globally (see `src/index.css`).
- Introduces a reusable `.focus-ring` utility (`@layer components`) that applies `focus-visible:ring-2 ring-accent/60 ring-offset-2 ring-offset-surface`. Drop-in keyboard-a11y affordance for any interactive element that doesn't already style focus (the shared `Button` component already has its own focus-visible treatment).

All changes are **additive aliases** — no existing class name or behavior is modified, so there is no visual diff to capture. Visual before/after screenshots will land alongside the follow-up PRs where components actually adopt the new tokens.

## Why

The repo already has excellent dark-mode coverage via CSS variables (verified
across `HubDashboard`, `HubChat`, `HubSettingsPage` and all module pages —
there are **zero** hard-coded `text-gray-*` / `bg-slate-*` etc. in `src/`).
What was missing was a **token contract** with stable, semantic names that
new components and contributors can code against without having to know the
legacy `panel` / `panelHi` vocabulary.

## Scope of this PR

- `tailwind.config.js` — 5 new color aliases in `theme.extend.colors`.
- `src/index.css` — new CSS vars in `:root`, `.focus-ring` component class.

No component code is touched in this PR. Adoption of the new tokens
(Hub, HubChat, HubSettings, module pages) will happen incrementally in
PRs 2–4 so diffs stay reviewable.

## Review & Testing Checklist for Human

- [ ] Spot-check that **no visual regression** is visible in the Hub (light + dark), HubChat (light + dark), and one module page of your choice. Because the PR only adds aliases, everything should render exactly as before.
- [ ] Confirm `npm run lint && npm run typecheck && npm run test && npm run build` pass locally (they pass on this branch).
- [ ] Review the alias names (`surface` / `fg` / `accent` / `fg-muted` / `surface-muted`) — these are the public API we'll use going forward; easy to rename now, harder once components adopt them.

### Notes

- PR series plan:
  1. **this PR** — token contract (palette, spacing, radii, shadows, font-size, semantic, motion, focus).
  2. UI-kit (`Modal`, `Badge`, `Tabs` additions + migration of representative raw `<button>` usages to `<Button>`).
  3. States (`SkeletonCard`, `ErrorState`; wire skeleton / empty / error into each module's main page).
  4. Icons + typography/a11y cleanup (inline-SVG dedupe via shared `Icon`, magic `tracking-*`/`leading-*` audit, `.focus-ring` adoption).
- `tailwind.config.js` already covered palette, spacing, radii, shadows, font-size (`3xs→5xl` scale with per-step `lineHeight`), animation, transition duration & easing, backdrop-blur and z-index — the audit found nothing missing there, so this PR's diff is intentionally small.


Link to Devin session: https://app.devin.ai/sessions/8f905382ff464c89a3a64ad3e1b86c38
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
