### PR TITLE
perf(core): lazy-load RoutineApp + ErrorBoundary навколо Hub секцій та модалок

### DIFF
--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -34,7 +34,6 @@ import { useHubNavigation } from "./hooks/useHubNavigation.js";
 import { useHubUIState } from "./hooks/useHubUIState.js";
 import { usePwaActions, type PwaAction } from "./hooks/usePwaActions.js";
 
-import RoutineApp from "../modules/routine/RoutineApp.jsx";
 const AuthPage = lazy(() =>
   import("./AuthPage.jsx").then((m) => ({ default: m.AuthPage })),
 );
@@ -56,6 +55,13 @@ const FinykApp = lazy(
 const FizrukApp = lazy(() => import("../modules/fizruk/FizrukApp"));
 const NutritionApp = lazy(
   () => import("../modules/nutrition/NutritionApp"),
+) as unknown as ComponentType<ModuleAppProps>;
+// Routine раніше імпортувалось синхронно — це зобов'язувало тягнути
+// весь модуль у main chunk навіть для користувачів, що сидять у Фінікові.
+// Ліниве завантаження збігається з іншими модулями (Suspense fallback
+// та ModuleErrorBoundary уже огортають цей слот).
+const RoutineApp = lazy(
+  () => import("../modules/routine/RoutineApp"),
 ) as unknown as ComponentType<ModuleAppProps>;
 
 export default function App() {

--- a/src/core/app/HubMainContent.tsx
+++ b/src/core/app/HubMainContent.tsx
@@ -1,10 +1,30 @@
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
+import { ErrorBoundary } from "../ErrorBoundary";
 import { HubDashboard } from "../HubDashboard.jsx";
 import { HubReports } from "../HubReports.jsx";
 import { HubSettingsPage } from "../HubSettingsPage.jsx";
 import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
+
+// Дешевий inline-fallback для секцій хаба: повідомляємо про збій і
+// даємо кнопку `reset`, щоб спробувати перемонтувати секцію без
+// перезавантаження вкладки. Шапка/таби лишаються робочими, бо
+// ErrorBoundary стоїть навколо окремого view, а не навколо `<main>`.
+function HubSectionFallback({ resetError }) {
+  return (
+    <div className="px-1 py-6 text-center">
+      <p className="text-sm text-muted mb-3">Щось пішло не так у цій секції.</p>
+      <button
+        type="button"
+        onClick={resetError}
+        className="px-4 py-2 rounded-xl bg-panel border border-line text-text text-sm font-medium hover:bg-panelHi transition-colors"
+      >
+        Спробувати ще раз
+      </button>
+    </div>
+  );
+}
 
 export function HubMainContent({
   updateAvailable,
@@ -133,31 +153,46 @@ export function HubMainContent({
 
       <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
         {hubView === "dashboard" && (
-          <div className="flex flex-col gap-5 pt-2">
-            <HubDashboard
-              onOpenModule={onOpenModule}
-              onOpenChat={onOpenChat}
-              user={user}
-              onShowAuth={onShowAuth}
-            />
-          </div>
+          <ErrorBoundary
+            key="dashboard"
+            fallback={(props) => <HubSectionFallback {...props} />}
+          >
+            <div className="flex flex-col gap-5 pt-2">
+              <HubDashboard
+                onOpenModule={onOpenModule}
+                onOpenChat={onOpenChat}
+                user={user}
+                onShowAuth={onShowAuth}
+              />
+            </div>
+          </ErrorBoundary>
         )}
 
         {hubView === "reports" && (
-          <div className="pt-2">
-            <HubReports />
-          </div>
+          <ErrorBoundary
+            key="reports"
+            fallback={(props) => <HubSectionFallback {...props} />}
+          >
+            <div className="pt-2">
+              <HubReports />
+            </div>
+          </ErrorBoundary>
         )}
 
         {hubView === "settings" && (
-          <HubSettingsPage
-            dark={dark}
-            onToggleDark={onToggleDark}
-            syncing={syncing}
-            onSync={onSync}
-            onPull={onPull}
-            user={user}
-          />
+          <ErrorBoundary
+            key="settings"
+            fallback={(props) => <HubSectionFallback {...props} />}
+          >
+            <HubSettingsPage
+              dark={dark}
+              onToggleDark={onToggleDark}
+              syncing={syncing}
+              onSync={onSync}
+              onPull={onPull}
+              user={user}
+            />
+          </ErrorBoundary>
         )}
       </main>
     </>

--- a/src/core/app/HubModals.tsx
+++ b/src/core/app/HubModals.tsx
@@ -1,10 +1,16 @@
 import { lazy, Suspense } from "react";
+import { ErrorBoundary } from "../ErrorBoundary";
 
 const HubSearch = lazy(() =>
   import("../HubSearch.jsx").then((m) => ({ default: m.HubSearch })),
 );
 const HubChat = lazy(() => import("../HubChat"));
 
+// Модалки огортаємо в ErrorBoundary, щоб непередбачений збій у HubChat
+// або HubSearch не ламав увесь хаб — просто закриваємо модалку, а хаб
+// залишається робочим. `fallback={null}` = тихий no-op: користувач
+// ще має closeChat/closeSearch через зовнішні хендлери, а Sentry
+// отримає exception через lazy-forward у `captureException`.
 export function HubModals({
   chatOpen,
   onCloseChat,
@@ -16,15 +22,22 @@ export function HubModals({
   return (
     <>
       {chatOpen && (
-        <Suspense fallback={null}>
-          <HubChat onClose={onCloseChat} initialMessage={chatInitialMessage} />
-        </Suspense>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <HubChat
+              onClose={onCloseChat}
+              initialMessage={chatInitialMessage}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
 
       {searchOpen && (
-        <Suspense fallback={null}>
-          <HubSearch onClose={onCloseSearch} onOpenModule={onOpenModule} />
-        </Suspense>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <HubSearch onClose={onCloseSearch} onOpenModule={onOpenModule} />
+          </Suspense>
+        </ErrorBoundary>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Code-splitting + надійність хаба. Два пов'язані покращення:

**1. `RoutineApp` за `React.lazy`.** Раніше модуль Routine імпортувався синхронно в `src/core/App.tsx` — це тягнуло ~80 kB у main `index.js` навіть для користувачів, що сидять у Фінікові/Харчах. Тепер він лежить у власному chunk, як і решта модулів (Suspense fallback і `ModuleErrorBoundary` вже стоять у коробці).

**2. ErrorBoundary покриття для HubDashboard / HubReports / HubSettings / HubChat / HubSearch.** Падіння в одному з цих view більше не ламає шапку+таби і не вимагає перезавантаження вкладки — секція показує inline-fallback з кнопкою "Спробувати ще раз", а модалки тихо закриваються (fallback=null). `captureException` у `ErrorBoundary.componentDidCatch` уже пересилає exception у Sentry через lazy-forward.

### Bundle before → after

| chunk | before | after | Δ |
| --- | --- | --- | --- |
| `index-*.js` (main) | 376.17 kB / 111.16 kB gz | 287.22 kB / 86.72 kB gz | **−88.95 kB / −24.44 kB gz** |
| `RoutineApp-*.js` | *(в main)* | 79.64 kB / 22.87 kB gz | новий split chunk |

Фінальні цифри (після build) — всі інші модулі (`FinykApp`, `FizrukApp`, `NutritionApp`) вже лежали за `React.lazy`, тому цей діфф лише вирівнює Routine із ними.

## Review & Testing Checklist for Human

- [ ] Відкрити хаб → відкрити Routine: перевірити що з'являється fallback під час лінивого завантаження і потім нормально рендериться модуль.
- [ ] Перевірити решту модулів (Finyk/Fizruk/Nutrition) — вони не мали змінитись, але ще раз переконатись що Suspense fallback не зіпсувався.
- [ ] Відкрити HubChat і HubSearch — нормальний flow. Збій у чаті більше не ламає хаб, а просто закриває модалку.

### Notes

- Жодних змін у `server/`, дизайн-токенах чи API-контрактах.
- `npm run lint`, `npm run typecheck`, `npm run test` (770 тестів) і `npm run build` — локально зелені.
- Це перший із серії PR-ів на аудит фронтенду (дивись також майбутні PR по ре-рендерам, react-query та dead-imports).


Link to Devin session: https://app.devin.ai/sessions/2ce309361ad34bc2b8446ac6e5e9e575
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
