### PR TITLE
perf(hub): memo StatusRow/SortableCard + стабільний quickAdd у dnd-списку

### DIFF
--- a/src/core/HubDashboard.tsx
+++ b/src/core/HubDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
@@ -248,7 +248,14 @@ const MODULE_CONFIGS = {
 // модулю з активним сигналом (focus/rest), отримує inline-кнопку `+`, що
 // dispatchає primary-дію без додаткового тапа «відкрити модуль».
 // ═══════════════════════════════════════════════════════════════════════════
-function StatusRow({ config, onClick, onQuickAdd, dragProps, isDragging }) {
+// Мемоізуємо рядок — перерендериться тільки якщо реально змінився його
+// config/quickAdd/isDragging. Без memo кожна зміна state на дашборді
+// (FTUX-герой, м'яка авторизація, digest-експанд) перераховувала всі
+// чотири модульні рядки, включно з `preview = config.getPreview()`,
+// що читає localStorage.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const StatusRow = memo(function StatusRow(props: any) {
+  const { config, onClick, onQuickAdd, dragProps, isDragging } = props;
   const preview = config.getPreview();
   const showProgress =
     config.hasGoal && preview.progress !== undefined && preview.progress > 0;
@@ -335,12 +342,17 @@ function StatusRow({ config, onClick, onQuickAdd, dragProps, isDragging }) {
       )}
     </div>
   );
-}
+});
 
 // ═══════════════════════════════════════════════════════════════════════════
 // SORTABLE CARD WRAPPER
 // ═══════════════════════════════════════════════════════════════════════════
-function SortableCard({ id, onOpenModule, quickAdd }) {
+// `memo` + локальний `useCallback` для onClick — коли `onOpenModule` і
+// `quickAdd` стабільні (див. `HubDashboard`), перерендер всього списку
+// стає no-op для рядків, які не тягнуть у dnd-kit.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SortableCard = memo(function SortableCard(props: any) {
+  const { id, onOpenModule, quickAdd } = props;
   const {
     attributes,
     listeners,
@@ -350,10 +362,20 @@ function SortableCard({ id, onOpenModule, quickAdd }) {
     isDragging,
   } = useSortable({ id });
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
+  const style = useMemo(
+    () => ({
+      transform: CSS.Transform.toString(transform),
+      transition,
+    }),
+    [transform, transition],
+  );
+
+  const dragProps = useMemo(
+    () => ({ ...attributes, ...listeners }),
+    [attributes, listeners],
+  );
+
+  const handleClick = useCallback(() => onOpenModule(id), [onOpenModule, id]);
 
   const cfg = MODULE_CONFIGS[id];
   if (!cfg) return null;
@@ -362,14 +384,14 @@ function SortableCard({ id, onOpenModule, quickAdd }) {
     <div ref={setNodeRef} style={style}>
       <StatusRow
         config={cfg}
-        onClick={() => onOpenModule(id)}
+        onClick={handleClick}
         onQuickAdd={quickAdd}
         isDragging={isDragging}
-        dragProps={{ ...attributes, ...listeners }}
+        dragProps={dragProps}
       />
     </div>
   );
-}
+});
 
 // ═══════════════════════════════════════════════════════════════════════════
 // MONDAY AUTO DIGEST HOOK
@@ -572,6 +594,28 @@ export function HubDashboard({
     }),
   );
 
+  // Стабільна мапа quickAdd-дій по модулю — раніше обчислювалась inline у
+  // `.map()` і створювала новий об'єкт з новою closure `run` кожного рендеру,
+  // що пробивало `memo(SortableCard)`. Тепер набір перераховується лише
+  // коли реально змінюється набір модулів з сигналом.
+  const quickAddByModule = useMemo(() => {
+    const map: Record<string, { label: string; run: () => void } | undefined> =
+      {};
+    for (const id of modulesWithSignal) {
+      const quick = getModulePrimaryAction(id);
+      if (!quick) continue;
+      map[id] = {
+        label: quick.label,
+        run: () =>
+          openHubModuleWithAction(
+            id as Parameters<typeof openHubModuleWithAction>[0],
+            quick.action,
+          ),
+      };
+    }
+    return map;
+  }, [modulesWithSignal]);
+
   const handleDragEnd = useCallback((event) => {
     const { active, over } = event;
     if (active && over && active.id !== over.id) {
@@ -646,29 +690,14 @@ export function HubDashboard({
         >
           <SortableContext items={order} strategy={verticalListSortingStrategy}>
             <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
-              {order.map((id) => {
-                const hasSignal = modulesWithSignal.has(id);
-                const quick = getModulePrimaryAction(id);
-                const quickAdd =
-                  hasSignal && quick
-                    ? {
-                        label: quick.label,
-                        run: () =>
-                          openHubModuleWithAction(
-                            id as Parameters<typeof openHubModuleWithAction>[0],
-                            quick.action,
-                          ),
-                      }
-                    : null;
-                return (
-                  <SortableCard
-                    key={id}
-                    id={id}
-                    onOpenModule={onOpenModule}
-                    quickAdd={quickAdd}
-                  />
-                );
-              })}
+              {order.map((id) => (
+                <SortableCard
+                  key={id}
+                  id={id}
+                  onOpenModule={onOpenModule}
+                  quickAdd={quickAddByModule[id] || null}
+                />
+              ))}
             </div>
           </SortableContext>
         </DndContext>


### PR DESCRIPTION
## Summary

Фікс зайвих ре-рендерів у `HubDashboard`, секція «Статус» (dnd-kit список модулів).

До змін кожен render дашборду створював нові inline-об'єкти для кожного рядка:

- `quickAdd = { label, run: () => openHubModuleWithAction(...) }` — нова closure в `.map()` на кожен render.
- `onClick={() => onOpenModule(id)}` і `dragProps={{ ...attributes, ...listeners }}` — теж inline усередині `SortableCard`.

Через це будь-яка зміна стану на дашборді (FTUX-герой, м'яка авторизація, `digestExpanded`, coach insight) викликала повторний render усіх 4 статус-рядків, включно з читанням `localStorage` через `config.getPreview()`.

Що зроблено:

- `StatusRow` і `SortableCard` огорнуті в `React.memo`.
- `quickAddByModule` — `useMemo` із залежністю `modulesWithSignal`; у `.map()` вже беремо готовий стабільний об'єкт.
- `style`, `dragProps` і `onClick` усередині `SortableCard` — `useMemo` / `useCallback`.

Поведінка не змінюється: drag-and-drop, inline-`+`, preview, кольори акценту — все той самий UX, просто без зайвих рендерів.

## Review & Testing Checklist for Human

- [ ] Відкрити хаб, дашборд: перевірити що рядки модулів відображаються, прев'ю правильні.
- [ ] Перевірити drag-and-drop — rows реагують на pointer/touch, `PointerSensor` (delay=0, distance=8) і `TouchSensor` (delay=250, tolerance=5) працюють як раніше.
- [ ] Якщо для модуля є активна рекомендація (focus/rest з `useDashboardFocus`), поряд з'являється `+` quickAdd, тап викликає `openHubModuleWithAction` з правильним action.

### Notes

- Жодних змін у `server/`, дизайн-токенах чи API-контрактах.
- `npm run lint`, `npm run typecheck`, `npm run test` (770 тестів) — локально зелені.
- Це другий PR із серії аудиту фронтенду (див. merged [#284](https://github.com/Skords-01/Sergeant/pull/284) для code-split; далі будуть react-query та dead-imports).


Link to Devin session: https://app.devin.ai/sessions/2ce309361ad34bc2b8446ac6e5e9e575
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
