### PR TITLE
a11y(dialog): stop focus trap from firing on onEscape identity change

### DIFF
--- a/src/shared/hooks/useDialogFocusTrap.test.ts
+++ b/src/shared/hooks/useDialogFocusTrap.test.ts
@@ -68,6 +68,66 @@ describe("useDialogFocusTrap — focus restoration", () => {
     unmount();
   });
 
+  it("does not yank focus out of the dialog when onEscape identity changes while open", () => {
+    // Regression: putting `onEscape` in the effect deps caused every
+    // parent re-render (which creates a new inline arrow) to tear down
+    // the trap and run the focus-restore cleanup, stealing focus from
+    // inside the open dialog back to the trigger.
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const panel = document.createElement("div");
+    const inner = document.createElement("button");
+    inner.textContent = "Inside";
+    panel.appendChild(inner);
+    document.body.appendChild(panel);
+
+    const ref = createRef<HTMLDivElement>();
+    Object.defineProperty(ref, "current", { value: panel, writable: true });
+
+    const { rerender, unmount } = renderHook(
+      ({ onEscape }: { onEscape: () => void }) =>
+        useDialogFocusTrap(true, ref, { onEscape }),
+      { initialProps: { onEscape: () => {} } },
+    );
+
+    // User has tabbed into the dialog.
+    inner.focus();
+    expect(document.activeElement).toBe(inner);
+
+    // Parent re-renders with a new inline arrow — dialog is still open.
+    rerender({ onEscape: () => {} });
+
+    // Focus must NOT have been yanked out to the trigger.
+    expect(document.activeElement).toBe(inner);
+    unmount();
+  });
+
+  it("uses the latest onEscape callback when Escape is pressed", () => {
+    const panel = document.createElement("div");
+    document.body.appendChild(panel);
+    const ref = createRef<HTMLDivElement>();
+    Object.defineProperty(ref, "current", { value: panel, writable: true });
+
+    const first = { called: 0 };
+    const second = { called: 0 };
+
+    const { rerender, unmount } = renderHook(
+      ({ onEscape }: { onEscape: () => void }) =>
+        useDialogFocusTrap(true, ref, { onEscape }),
+      { initialProps: { onEscape: () => first.called++ } },
+    );
+
+    rerender({ onEscape: () => second.called++ });
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(first.called).toBe(0);
+    expect(second.called).toBe(1);
+    unmount();
+  });
+
   it("does not attempt to restore focus to <body>", () => {
     document.body.focus();
     expect(document.activeElement).toBe(document.body);

--- a/src/shared/hooks/useDialogFocusTrap.ts
+++ b/src/shared/hooks/useDialogFocusTrap.ts
@@ -16,6 +16,15 @@ export interface DialogFocusTrapOptions {
  * If the previously focused element is no longer in the DOM when the
  * dialog closes (e.g. a sheet that unmounts its own trigger), we quietly
  * skip the restore instead of throwing.
+ *
+ * `onEscape` is intentionally NOT in the effect dependency array. It is
+ * stored in a ref and read on each keydown. Most callers pass an inline
+ * arrow (`onEscape: () => setOpen(false)`) whose identity changes on
+ * every parent render — if we depended on it, every parent re-render
+ * while the dialog was open would tear down the effect and run the
+ * focus-restore cleanup, yanking focus out of the open dialog back to
+ * the trigger element. This is the "Store Event Handlers in Refs" rule
+ * from AGENTS.md §8.3.
  */
 export function useDialogFocusTrap(
   open: boolean,
@@ -23,7 +32,13 @@ export function useDialogFocusTrap(
   options: DialogFocusTrapOptions = {},
 ): void {
   const { onEscape } = options;
+  const onEscapeRef = useRef(onEscape);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Keep the latest onEscape callable without re-running the trap effect.
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
 
   useEffect(() => {
     if (!open) return;
@@ -49,10 +64,13 @@ export function useDialogFocusTrap(
       );
 
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && onEscape) {
-        e.preventDefault();
-        onEscape();
-        return;
+      if (e.key === "Escape") {
+        const cb = onEscapeRef.current;
+        if (cb) {
+          e.preventDefault();
+          cb();
+          return;
+        }
       }
       if (e.key !== "Tab") return;
       const nodes = getFocusable();
@@ -86,5 +104,6 @@ export function useDialogFocusTrap(
         /* ignore — element became non-focusable */
       }
     };
-  }, [open, onEscape, containerRef]);
+    // onEscape is read via a ref — see block comment above.
+  }, [open, containerRef]);
 }


### PR DESCRIPTION
## Summary

Devin Review found a regression on #282: the focus-restore cleanup was firing on every parent re-render that passed a new inline arrow as `onEscape`, yanking focus out of the open dialog back to the trigger.

Concrete callsites that pass an inline arrow and would have been affected:
- `src/modules/fizruk/FizrukApp.tsx:169` — `onEscape: () => setSettingsOpen(false)`
- `src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx:16` — `onEscape: () => setFinishFlash(null)`

Any parent re-render while the dialog was open would create a new arrow, the trap effect would tear down, the cleanup would fire, and focus would jump from wherever the user was inside the dialog back to the opener.

### Fix
- `onEscape` is now stored in a ref updated in a tiny effect (per AGENTS.md §8.3 "Store Event Handlers in Refs").
- The trap effect's deps are now `[open, containerRef]` only — no callback identity in there.
- Keydown handler reads `onEscapeRef.current` so the latest `onEscape` is still called when Escape is pressed.
- Two new unit tests lock the behavior: (1) identity change on `onEscape` while open must not move focus; (2) the *latest* `onEscape` must run on Escape.

No public API change. No visual change. Behavior for mouse/touch users unchanged.

## Review & Testing Checklist for Human

- [ ] Open a Fizruk workout-finish sheet with keyboard, tab to an inner control, then trigger a parent re-render (e.g. React DevTools "force render" or any state change upstream). Focus must stay where you put it, not jump back to the FAB that opened the sheet.
- [ ] Press Escape inside any sheet — the sheet must still close (i.e. `onEscape` still wired).
- [ ] Close the sheet normally — focus returns to the trigger (PR #282 behavior still intact).

### Notes

This is a targeted follow-up to #282 (PR 1/4 of the UX/a11y/PWA batch). PR 2 (mobile layout / safe-area) builds on this.


Link to Devin session: https://app.devin.ai/sessions/4bbfa8999dd3498aa335370caed48215
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
