### PR TITLE
feat(hubchat): P0 tools — create_habit, create_transaction, log_set, log_water

### DIFF
--- a/server/modules/chat.js
+++ b/server/modules/chat.js
@@ -162,6 +162,113 @@ const TOOLS = [
     },
   },
   {
+    name: "create_habit",
+    description:
+      "Створити нову звичку в модулі Рутина. Використовуй коли користувач просить додати / завести / почати нову звичку (напр. 'додай звичку пити воду', 'заведи пробіжку щопонеділка').",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Назва звички" },
+        emoji: {
+          type: "string",
+          description: "Емодзі (опційно, за замовчуванням ✓)",
+        },
+        recurrence: {
+          type: "string",
+          description:
+            "Регулярність: 'daily' (щодня), 'weekdays' (будні), 'weekly' (у конкретні дні тижня), 'monthly' (щомісяця). За замовчуванням — 'daily'.",
+        },
+        weekdays: {
+          type: "array",
+          description:
+            "Для recurrence='weekly': номери днів 0-6 (0 — неділя, 1 — понеділок, ..., 6 — субота). Опційно.",
+          items: { type: "number" },
+        },
+        time_of_day: {
+          type: "string",
+          description: "Час доби HH:MM (опційно, напр. '08:00')",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "create_transaction",
+    description:
+      "Записати ручну витрату або дохід у Фінік. Використовуй коли користувач повідомляє що витратив/отримав кошти (напр. 'я витратив 200 грн на каву', 'запиши дохід 5000 грн').",
+    input_schema: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          description:
+            "'expense' (витрата) або 'income' (дохід). Default: expense.",
+        },
+        amount: {
+          type: "number",
+          description: "Сума в грн (завжди додатнє число)",
+        },
+        category: {
+          type: "string",
+          description:
+            "Категорія: або id канонічної категорії (food, transport, restaurant, subscriptions, health тощо) з блоку [Категорії], або підпис manual-категорії (напр. 'їжа', 'транспорт'). Для доходу можна лишити порожнім.",
+        },
+        description: {
+          type: "string",
+          description: "Короткий опис / мерчант (опційно)",
+        },
+        date: {
+          type: "string",
+          description: "Дата YYYY-MM-DD (опційно, за замовчуванням — сьогодні)",
+        },
+      },
+      required: ["amount"],
+    },
+  },
+  {
+    name: "log_set",
+    description:
+      "Додати підхід (set) до тренування у Фізрук. Використовуй коли користувач каже 'я зробив X повторень Y кг жиму/присіду' тощо. Якщо зараз є активне тренування — додає підхід до відповідної вправи; інакше — створює нове тренування на сьогодні й додає туди.",
+    input_schema: {
+      type: "object",
+      properties: {
+        exercise_name: {
+          type: "string",
+          description: "Назва вправи (напр. 'Жим штанги лежачи')",
+        },
+        weight_kg: {
+          type: "number",
+          description: "Вага в кг (0 — якщо власна вага)",
+        },
+        reps: { type: "number", description: "Кількість повторень у підході" },
+        sets: {
+          type: "number",
+          description: "Скільки однакових підходів додати (опційно, default 1)",
+        },
+      },
+      required: ["exercise_name", "reps"],
+    },
+  },
+  {
+    name: "log_water",
+    description:
+      "Додати випиту воду в журнал Харчування. Використовуй коли користувач каже 'я випив X мл/склянку води'. Одна склянка ≈ 250 мл.",
+    input_schema: {
+      type: "object",
+      properties: {
+        amount_ml: {
+          type: "number",
+          description: "Кількість випитої води в мілілітрах (напр. 250, 500)",
+        },
+        date: {
+          type: "string",
+          description: "Дата YYYY-MM-DD (опційно, за замовчуванням — сьогодні)",
+        },
+      },
+      required: ["amount_ml"],
+    },
+  },
+  {
     name: "log_meal",
     description:
       "Записати прийом їжі в щоденник харчування на сьогодні. Використовуй коли користувач каже що з'їв щось і хоче записати.",
@@ -200,10 +307,10 @@ const SYSTEM_PREFIX = `Ти персональний асистент додат
 - Усі числа бери з блоку ДАНІ нижче.
 - Якщо потрібно порахувати (середня/день, прогноз, залишок ліміту, відсоток виконання) — рахуй на основі наданих чисел.
 - Якщо користувач просить змінити або записати дані — використай відповідний tool.
-  - Фінанси: change_category, create_debt, create_receivable, hide_transaction, set_budget_limit, set_monthly_plan
-  - Фізрук: plan_workout (запланувати тренування на дату; можна одразу зі списком вправ)
-  - Рутина: mark_habit_done (id звички з [Рутина сьогодні])
-  - Харчування: log_meal (назва + ккал; білок/жири/вуглеводи опційно)
+  - Фінанси: create_transaction (записати витрату/дохід), change_category, create_debt, create_receivable, hide_transaction, set_budget_limit, set_monthly_plan
+  - Фізрук: plan_workout (запланувати тренування на дату; можна одразу зі списком вправ), log_set (додати підхід у активне або нове тренування)
+  - Рутина: create_habit (додати нову звичку), mark_habit_done (id звички з [Рутина сьогодні])
+  - Харчування: log_meal (назва + ккал; білок/жири/вуглеводи опційно), log_water (мл води)
 - Транзакції мають id і дату — використовуй для tool calls.
 - Категорії та їх id перелічені в [Категорії].
 - Відповідай на питання по всіх 4 модулях.

--- a/src/core/lib/hubChatActions.test.ts
+++ b/src/core/lib/hubChatActions.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for hubChatActions executeAction — P0 tools:
+ * create_habit, create_transaction, log_set, log_water.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { executeAction } from "./hubChatActions";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+function readLS<T>(key: string, fallback: T): T {
+  const raw = localStorage.getItem(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+describe("create_habit", () => {
+  it("створює звичку з default daily і повертає id", () => {
+    const msg = executeAction({
+      name: "create_habit",
+      input: { name: "Пити воду" },
+    });
+    expect(msg).toContain("Пити воду");
+    expect(msg).toContain("щодня");
+    const state = readLS<{
+      habits: Array<{ name: string; recurrence: string }>;
+    }>("hub_routine_v1", { habits: [] });
+    expect(state.habits).toHaveLength(1);
+    expect(state.habits[0].name).toBe("Пити воду");
+    expect(state.habits[0].recurrence).toBe("daily");
+  });
+
+  it("підтримує recurrence='weekly' з weekdays", () => {
+    const msg = executeAction({
+      name: "create_habit",
+      input: { name: "Біг", recurrence: "weekly", weekdays: [1, 3, 5] },
+    });
+    expect(msg).toContain("щотижня");
+    const state = readLS<{
+      habits: Array<{ recurrence: string; weekdays: number[] }>;
+    }>("hub_routine_v1", { habits: [] });
+    expect(state.habits[0].recurrence).toBe("weekly");
+    expect(state.habits[0].weekdays).toEqual([1, 3, 5]);
+  });
+
+  it("відмовляє на порожню назву", () => {
+    const msg = executeAction({
+      name: "create_habit",
+      input: { name: "   " },
+    });
+    expect(msg).toContain("назви");
+    expect(localStorage.getItem("hub_routine_v1")).toBeNull();
+  });
+});
+
+describe("create_transaction", () => {
+  it("записує витрату в finyk_manual_expenses_v1", () => {
+    const msg = executeAction({
+      name: "create_transaction",
+      input: { amount: 150, category: "food", description: "кава" },
+    });
+    expect(msg).toContain("Витрату");
+    expect(msg).toContain("150");
+    const arr = readLS<
+      Array<{
+        amount: number;
+        category: string;
+        description: string;
+        type: string;
+      }>
+    >("finyk_manual_expenses_v1", []);
+    expect(arr).toHaveLength(1);
+    expect(arr[0].amount).toBe(150);
+    expect(arr[0].category).toBe("food");
+    expect(arr[0].type).toBe("expense");
+  });
+
+  it("записує дохід коли type='income'", () => {
+    const msg = executeAction({
+      name: "create_transaction",
+      input: { type: "income", amount: 5000 },
+    });
+    expect(msg).toContain("Дохід");
+    const arr = readLS<Array<{ type: string; amount: number }>>(
+      "finyk_manual_expenses_v1",
+      [],
+    );
+    expect(arr[0].type).toBe("income");
+    expect(arr[0].amount).toBe(5000);
+  });
+
+  it("відмовляє на 0 або від'ємну суму", () => {
+    expect(
+      executeAction({
+        name: "create_transaction",
+        input: { amount: 0 },
+      }),
+    ).toContain("Некоректна");
+    expect(
+      executeAction({
+        name: "create_transaction",
+        input: { amount: -5 },
+      }),
+    ).toContain("Некоректна");
+    expect(localStorage.getItem("finyk_manual_expenses_v1")).toBeNull();
+  });
+});
+
+describe("log_set", () => {
+  it("створює нове тренування якщо активного немає", () => {
+    const msg = executeAction({
+      name: "log_set",
+      input: { exercise_name: "Жим штанги", weight_kg: 80, reps: 8 },
+    });
+    expect(msg).toContain("Нове тренування");
+    expect(msg).toContain("80 кг");
+    expect(msg).toContain("8 повторень");
+
+    const saved = readLS<{
+      workouts: Array<{
+        endedAt: string | null;
+        items: Array<{
+          nameUk: string;
+          sets: Array<{ reps: number; weightKg: number }>;
+        }>;
+      }>;
+    }>("fizruk_workouts_v1", { workouts: [] });
+    expect(saved.workouts).toHaveLength(1);
+    expect(saved.workouts[0].endedAt).toBeNull();
+    expect(saved.workouts[0].items[0].nameUk).toBe("Жим штанги");
+    expect(saved.workouts[0].items[0].sets).toHaveLength(1);
+    expect(saved.workouts[0].items[0].sets[0]).toEqual({
+      reps: 8,
+      weightKg: 80,
+    });
+
+    const activeId = readLS<string | null>("fizruk_active_workout_id_v1", null);
+    expect(activeId).toBe(saved.workouts[0].id);
+  });
+
+  it("додає підходи до існуючої вправи у активному тренуванні", () => {
+    executeAction({
+      name: "log_set",
+      input: { exercise_name: "Присід", reps: 10, weight_kg: 60 },
+    });
+    executeAction({
+      name: "log_set",
+      input: { exercise_name: "Присід", reps: 10, weight_kg: 60, sets: 2 },
+    });
+    const saved = readLS<{
+      workouts: Array<{
+        items: Array<{ nameUk: string; sets: unknown[] }>;
+      }>;
+    }>("fizruk_workouts_v1", { workouts: [] });
+    expect(saved.workouts).toHaveLength(1);
+    expect(saved.workouts[0].items).toHaveLength(1);
+    expect(saved.workouts[0].items[0].sets).toHaveLength(3);
+  });
+
+  it("відмовляє без reps", () => {
+    expect(
+      executeAction({
+        name: "log_set",
+        input: { exercise_name: "Жим", reps: 0 },
+      }),
+    ).toContain("повторень");
+  });
+});
+
+describe("log_water", () => {
+  it("додає воду на сьогодні", () => {
+    const msg = executeAction({
+      name: "log_water",
+      input: { amount_ml: 250 },
+    });
+    expect(msg).toContain("250 мл");
+    const log = readLS<Record<string, number>>("nutrition_water_v1", {});
+    expect(log["2024-06-15"]).toBe(250);
+  });
+
+  it("акумулює послідовні записи на той самий день", () => {
+    executeAction({ name: "log_water", input: { amount_ml: 250 } });
+    executeAction({ name: "log_water", input: { amount_ml: 500 } });
+    const log = readLS<Record<string, number>>("nutrition_water_v1", {});
+    expect(log["2024-06-15"]).toBe(750);
+  });
+
+  it("підтримує кастомну дату", () => {
+    executeAction({
+      name: "log_water",
+      input: { amount_ml: 300, date: "2024-01-10" },
+    });
+    const log = readLS<Record<string, number>>("nutrition_water_v1", {});
+    expect(log["2024-01-10"]).toBe(300);
+    expect(log["2024-06-15"]).toBeUndefined();
+  });
+
+  it("відмовляє на некоректну кількість", () => {
+    expect(
+      executeAction({
+        name: "log_water",
+        input: { amount_ml: 0 },
+      }),
+    ).toContain("Некоректна");
+  });
+});

--- a/src/core/lib/hubChatActions.ts
+++ b/src/core/lib/hubChatActions.ts
@@ -1,4 +1,8 @@
 import { resolveExpenseCategoryMeta } from "../../modules/finyk/utils";
+import {
+  createHabit as routineCreateHabit,
+  loadRoutineState,
+} from "../../modules/routine/lib/routineStorage";
 import { ls, lsSet } from "./hubChatUtils.js";
 
 interface ChangeCategoryAction {
@@ -71,6 +75,46 @@ interface LogMealAction {
   };
 }
 
+interface CreateHabitAction {
+  name: "create_habit";
+  input: {
+    name: string;
+    emoji?: string;
+    recurrence?: string;
+    weekdays?: number[];
+    time_of_day?: string;
+  };
+}
+
+interface CreateTransactionAction {
+  name: "create_transaction";
+  input: {
+    type?: string;
+    amount: number | string;
+    category?: string;
+    description?: string;
+    date?: string;
+  };
+}
+
+interface LogSetAction {
+  name: "log_set";
+  input: {
+    exercise_name: string;
+    weight_kg?: number | string;
+    reps: number | string;
+    sets?: number | string;
+  };
+}
+
+interface LogWaterAction {
+  name: "log_water";
+  input: {
+    amount_ml: number | string;
+    date?: string;
+  };
+}
+
 export type ChatAction =
   | ChangeCategoryAction
   | CreateDebtAction
@@ -81,6 +125,10 @@ export type ChatAction =
   | MarkHabitDoneAction
   | PlanWorkoutAction
   | LogMealAction
+  | CreateHabitAction
+  | CreateTransactionAction
+  | LogSetAction
+  | LogWaterAction
   | { name: string; input: Record<string, unknown> };
 
 interface BudgetLimit {
@@ -391,6 +439,225 @@ export function executeAction(action: ChatAction): string {
         nutritionLog[todayKey] = { ...dayData, meals };
         lsSet("nutrition_log_v1", nutritionLog);
         return `Прийом їжі "${name || "Без назви"}" записано: ${Math.round(Number(kcal) || 0)} ккал`;
+      }
+      case "create_habit": {
+        const {
+          name,
+          emoji,
+          recurrence,
+          weekdays,
+          time_of_day: timeOfDay,
+        } = (action as CreateHabitAction).input;
+        const trimmed = (name || "").trim();
+        if (!trimmed) return "Не можу створити звичку без назви.";
+        const allowedRec = new Set([
+          "daily",
+          "weekdays",
+          "weekly",
+          "monthly",
+          "once",
+        ]);
+        const rec =
+          recurrence && allowedRec.has(recurrence) ? recurrence : "daily";
+        const wdays = Array.isArray(weekdays)
+          ? weekdays
+              .map((d) => Number(d))
+              .filter((d) => Number.isInteger(d) && d >= 0 && d <= 6)
+          : undefined;
+        const tod =
+          timeOfDay && /^\d{1,2}:\d{2}$/.test(String(timeOfDay).trim())
+            ? String(timeOfDay).trim().padStart(5, "0")
+            : "";
+        const state = loadRoutineState();
+        const nextState = routineCreateHabit(state, {
+          name: trimmed,
+          emoji: emoji || "✓",
+          recurrence: rec,
+          weekdays: wdays && wdays.length ? wdays : undefined,
+          timeOfDay: tod,
+        });
+        const created = nextState.habits[nextState.habits.length - 1];
+        const recLabelMap: Record<string, string> = {
+          daily: "щодня",
+          weekdays: "по буднях",
+          weekly: "щотижня",
+          monthly: "щомісяця",
+          once: "разово",
+        };
+        return `Звичку "${trimmed}" створено (${recLabelMap[rec] || rec}, id:${created?.id || "?"})`;
+      }
+      case "create_transaction": {
+        const { type, amount, category, description, date } = (
+          action as CreateTransactionAction
+        ).input;
+        const amt = Number(amount);
+        if (!Number.isFinite(amt) || amt <= 0) {
+          return "Некоректна сума транзакції.";
+        }
+        const txType = type === "income" ? "income" : "expense";
+        const nowIso = new Date().toISOString();
+        const isoDate =
+          date && /^\d{4}-\d{2}-\d{2}$/.test(date)
+            ? new Date(`${date}T12:00:00`).toISOString()
+            : nowIso;
+        const customC = ls<Array<{ id: string; label?: string }>>(
+          "finyk_custom_cats_v1",
+          [],
+        );
+        let categoryLabel = "";
+        if (category && category.trim()) {
+          const meta = resolveExpenseCategoryMeta(category.trim(), customC);
+          categoryLabel = meta?.label || category.trim();
+        }
+        const manualId = `m_${Date.now().toString(36)}_${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        const manualExpenses = ls<
+          Array<{
+            id: string;
+            date: string;
+            description?: string;
+            amount: number;
+            category?: string;
+            type?: string;
+          }>
+        >("finyk_manual_expenses_v1", []);
+        const entry = {
+          id: manualId,
+          date: isoDate,
+          description: description?.trim() || "",
+          amount: Math.abs(amt),
+          category: category?.trim() || "",
+          type: txType,
+        };
+        manualExpenses.unshift(entry);
+        lsSet("finyk_manual_expenses_v1", manualExpenses);
+        const label = categoryLabel ? ` (${categoryLabel})` : "";
+        const human = txType === "income" ? "Дохід" : "Витрату";
+        return `${human} ${amt} грн${description ? ` "${description.trim()}"` : ""}${label} записано (id:${manualId})`;
+      }
+      case "log_set": {
+        const { exercise_name, weight_kg, reps, sets } = (
+          action as LogSetAction
+        ).input;
+        const exName = (exercise_name || "").trim();
+        if (!exName) return "Потрібна назва вправи для підходу.";
+        const repsN = Number(reps);
+        if (!Number.isFinite(repsN) || repsN <= 0) {
+          return "Некоректна кількість повторень.";
+        }
+        const weightN = Number(weight_kg);
+        const weightKg = Number.isFinite(weightN) && weightN >= 0 ? weightN : 0;
+        const setsN = Math.max(1, Math.min(20, Number(sets) || 1));
+        const newSets: WorkoutSet[] = Array.from({ length: setsN }, () => ({
+          weightKg,
+          reps: repsN,
+        }));
+
+        const wRaw = localStorage.getItem("fizruk_workouts_v1");
+        let workouts: Workout[] = [];
+        try {
+          const parsed = wRaw ? JSON.parse(wRaw) : null;
+          if (Array.isArray(parsed)) workouts = parsed as Workout[];
+          else if (parsed && Array.isArray(parsed.workouts))
+            workouts = parsed.workouts as Workout[];
+        } catch {}
+
+        const activeId = ls<string | null>("fizruk_active_workout_id_v1", null);
+        const exerciseNameLower = exName.toLowerCase();
+
+        let targetIdx = -1;
+        if (activeId) {
+          targetIdx = workouts.findIndex((w) => w.id === activeId);
+        }
+        if (targetIdx < 0) {
+          targetIdx = workouts.findIndex((w) => !w.endedAt);
+        }
+
+        let workout: Workout;
+        let created = false;
+        if (targetIdx >= 0) {
+          workout = {
+            ...workouts[targetIdx],
+            items: [...workouts[targetIdx].items],
+          };
+        } else {
+          created = true;
+          workout = {
+            id: `w_${Date.now().toString(36)}_${Math.random()
+              .toString(36)
+              .slice(2, 8)}`,
+            startedAt: new Date().toISOString(),
+            endedAt: null,
+            items: [],
+            groups: [],
+            warmup: null,
+            cooldown: null,
+            note: "",
+            planned: false,
+          };
+        }
+
+        const itemIdx = workout.items.findIndex(
+          (it) => it.nameUk.trim().toLowerCase() === exerciseNameLower,
+        );
+        if (itemIdx >= 0) {
+          const item = { ...workout.items[itemIdx] };
+          item.sets = [...item.sets, ...newSets];
+          workout.items[itemIdx] = item;
+        } else {
+          workout.items.push({
+            id: `i_${Date.now().toString(36)}_${Math.random()
+              .toString(36)
+              .slice(2, 6)}`,
+            nameUk: exName,
+            type: "strength",
+            musclesPrimary: [],
+            musclesSecondary: [],
+            sets: newSets,
+            durationSec: 0,
+            distanceM: 0,
+          });
+        }
+
+        if (created) {
+          workouts = [workout, ...workouts];
+          lsSet("fizruk_active_workout_id_v1", workout.id);
+        } else {
+          workouts[targetIdx] = workout;
+        }
+        lsSet("fizruk_workouts_v1", {
+          schemaVersion: 1,
+          workouts,
+        });
+
+        const weightLabel = weightKg > 0 ? `${weightKg} кг × ` : "";
+        const setsLabel =
+          setsN === 1 ? "1 підхід" : `${setsN} підходи${setsN >= 5 ? "в" : ""}`;
+        const prefix = created ? "Нове тренування розпочато. " : "";
+        return `${prefix}Додано ${setsLabel} "${exName}": ${weightLabel}${repsN} повторень`;
+      }
+      case "log_water": {
+        const { amount_ml, date: waterDate } = (action as LogWaterAction).input;
+        const ml = Math.floor(Number(amount_ml));
+        if (!Number.isFinite(ml) || ml <= 0) {
+          return "Некоректна кількість води.";
+        }
+        const now = new Date();
+        const today = [
+          now.getFullYear(),
+          String(now.getMonth() + 1).padStart(2, "0"),
+          String(now.getDate()).padStart(2, "0"),
+        ].join("-");
+        const dateKey =
+          waterDate && /^\d{4}-\d{2}-\d{2}$/.test(waterDate)
+            ? waterDate
+            : today;
+        const log = ls<Record<string, number>>("nutrition_water_v1", {});
+        const prev = Number(log[dateKey]) || 0;
+        log[dateKey] = prev + ml;
+        lsSet("nutrition_water_v1", log);
+        return `Додано ${ml} мл води (разом за ${dateKey}: ${log[dateKey]} мл)`;
       }
       default:
         return `Невідома дія: ${action.name}`;


### PR DESCRIPTION
## Summary

Додає 4 P0-інструменти у tool-calling API HubChat — найбільш болючі відсутні дії. До цього чат міг **відмічати** вже існуючі звички, але не створювати нові; не міг записувати витрати/доходи; не міг логувати підходи в Фізруку чи воду в Харчуванні.

### Нові tool-и (у `server/modules/chat.js` → `TOOLS`)

| Tool | Модуль | Що робить |
|------|--------|-----------|
| `create_habit` | Рутина | Нова звичка: name (req), emoji, recurrence (daily/weekdays/weekly/monthly/once), weekdays[], time_of_day |
| `create_transaction` | Фінік | Ручна витрата/дохід: amount (req), type, category, description, date |
| `log_set` | Фізрук | Підхід: exercise_name (req), reps (req), weight_kg, sets. Додає у активне тренування або створює нове |
| `log_water` | Харчування | Воду: amount_ml (req), date |

### Архітектурні точки (без змін контракту)

- **3 точки синхронізації** для кожного тулу: `TOOLS` масив + `SYSTEM_PREFIX` у `server/modules/chat.js`, і `ChatAction` union + case у `src/core/lib/hubChatActions.ts`.
- **Все через localStorage** (як існуючі тули): `hub_routine_v1`, `finyk_manual_expenses_v1`, `fizruk_workouts_v1` + `fizruk_active_workout_id_v1`, `nutrition_water_v1`.
- **`create_habit` використовує готову `createHabit` із `routine/lib/routineStorage`** (реюз існуючої нормалізації/валідації), а не реімплементує логіку.
- **`log_set`** сам визначає активне тренування: спершу дивиться `fizruk_active_workout_id_v1`, потім fallback на перший workout без `endedAt`, інакше створює новий і позначає його активним.
- **Контракт `executeAction`** не змінюється — повертає рядок, який летить у `tool_result` назад до Claude для фіналізації відповіді.

### Тести

13 нових unit-тестів у `src/core/lib/hubChatActions.test.ts` (jsdom) — покривають happy path, валідацію та акумулятивну поведінку.

Повний прогін: **783 passed / 0 failed**, typecheck/lint/build — чисто.

## Review & Testing Checklist for Human

- [ ] Спробувати в UI: «додай звичку пити воду щодня», «я витратив 200 грн на каву», «я зробив 3 підходи по 10 жим 60 кг», «випив 500 мл води» — кожне має створити відповідний запис у модулі без перезавантаження сторінки (React Query invalidates після tool-calls у `HubChat.tsx`).
- [ ] `create_transaction` пише у `finyk_manual_expenses_v1` у форматі `ManualExpense` (`id/date/description/amount/category`). Переконатись, що нова транзакція з'являється у списку Фініка (UI читає з того ж ключа через `useStorage`).
- [ ] `log_set` з activeId → додає підхід у ту ж вправу (якщо назва збігається case-insensitive), інакше створює нову `WorkoutItem`. Без activeId — створює новий workout і проставляє його активним.

### Notes

- Це **перший із 4 PR-ів** у серії розширення HubChat. Наступні: P1 CRUD (edit/delete habit, delete/split tx, goals, workout lifecycle, pantry), P2 навігація/нагадування, P3 read/search tools.
- `SYSTEM_PREFIX` оновлено мінімально — додано згадки нових тулів у перелік «що є в яких модулях».
- Категорії у `create_transaction` резолвляться через вже існуючий `resolveExpenseCategoryMeta` — тож Claude може давати як канонічний id (`food`, `transport`), так і лейбл ("їжа", "транспорт").


Link to Devin session: https://app.devin.ai/sessions/c200b422e6ab4e7fb826262927b6a9d3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
