### PR TITLE
ux(mobile): HubChat keyboard inset, overscroll-contain, persistent active-workout CTA

### DIFF
--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -27,6 +27,7 @@ import { HubTabs } from "./app/HubTabs.jsx";
 import { HubMainContent } from "./app/HubMainContent.jsx";
 import { HubFloatingActions } from "./app/HubFloatingActions.jsx";
 import { HubModals } from "./app/HubModals.jsx";
+import { ActiveWorkoutBanner } from "./app/ActiveWorkoutBanner.jsx";
 import { WelcomeScreen } from "./app/WelcomeScreen.jsx";
 import { shouldShowOnboarding } from "./OnboardingWizard.jsx";
 import { isFirstRealEntryDone } from "./onboarding/vibePicks.js";
@@ -283,6 +284,12 @@ function AppInner() {
             returns the moment the first real entry lands. */}
         <HubFloatingActions hidden={inFtuxSession} />
 
+        {/* Persistent shortcut back to an in-progress Fizruk workout.
+            Hidden during FTUX so the splash stays single-CTA; otherwise
+            visible whenever `fizruk_active_workout_id_v1` is set, so the
+            user never loses the thread after jumping to another tab. */}
+        <ActiveWorkoutBanner hidden={inFtuxSession} />
+
         <HubModals
           chatOpen={ui.chatOpen}
           onCloseChat={ui.closeChat}
@@ -298,6 +305,13 @@ function AppInner() {
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       {!online && <OfflineBanner />}
+      {/* Persistent "resume workout" shortcut — rendered in Finyk,
+          Routine, Nutrition (but not inside Fizruk itself, where the
+          in-module ActiveWorkoutPanel is already the primary surface).
+          This is the "at transitions" part of the persistent-CTA
+          requirement: switching modules mid-set must not bury the
+          workout. */}
+      {activeModule !== "fizruk" && <ActiveWorkoutBanner />}
       {/* Finyk has no in-module header of its own, so we provide a
           floating back-to-hub pill here. Fizruk, Routine and Nutrition
           render their own inline "← Хаб" button inside the module header

--- a/src/core/HubChat.tsx
+++ b/src/core/HubChat.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@shared/components/ui/Icon";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { useVisualKeyboardInset } from "@shared/hooks/useVisualKeyboardInset";
 import { hubKeys } from "@shared/lib/queryKeys";
 import { useFinykHubPreview } from "./hub/useFinykHubPreview";
 
@@ -174,6 +175,13 @@ function HubChat({ onClose, initialMessage }) {
   // with Sheet / ConfirmDialog / InputDialog so every modal surface
   // gets the same WCAG 2.4.3 focus-order guarantees in one place.
   useDialogFocusTrap(true, panelRef, { onEscape: onClose });
+
+  // On-screen keyboard handling. Without this, when a mobile user taps
+  // the chat input, the browser's virtual keyboard covers the field
+  // and the send button — visualViewport API tells us the remaining
+  // viewport height so we can pad the panel up and keep the input
+  // visible. Matches the `kbInsetPx` pattern used by Sheet.
+  const kbInsetPx = useVisualKeyboardInset(true);
 
   // TTS speaking state poll
   useEffect(() => {
@@ -393,7 +401,8 @@ function HubChat({ onClose, initialMessage }) {
         aria-modal="true"
         aria-labelledby="hub-chat-title"
         aria-describedby="hub-chat-privacy"
-        className="relative mt-auto flex flex-col bg-bg border-t border-line rounded-t-3xl shadow-float max-h-[92dvh] outline-none"
+        className="relative mt-auto flex flex-col bg-bg border-t border-line rounded-t-3xl shadow-float max-h-[92dvh] outline-none transition-[margin] duration-150"
+        style={kbInsetPx > 0 ? { marginBottom: kbInsetPx } : undefined}
       >
         <div className="flex justify-center pt-3 pb-1 shrink-0">
           <div className="w-10 h-1 bg-line rounded-full" />
@@ -476,7 +485,7 @@ function HubChat({ onClose, initialMessage }) {
         {/* Messages */}
         <div
           ref={chatRef}
-          className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0"
+          className="flex-1 overflow-y-auto overscroll-contain px-4 py-3 space-y-3 min-h-0"
           aria-live="polite"
           aria-relevant="additions"
         >

--- a/src/core/app/ActiveWorkoutBanner.tsx
+++ b/src/core/app/ActiveWorkoutBanner.tsx
@@ -1,0 +1,53 @@
+import { Icon } from "@shared/components/ui/Icon";
+import { openHubModule } from "@shared/lib/hubNav";
+import { useActiveFizrukWorkout } from "@shared/hooks/useActiveFizrukWorkout";
+
+/**
+ * Persistent "return to active workout" CTA.
+ *
+ * Fizruk remembers the open workout in `fizruk_active_workout_id_v1`. If
+ * the user navigates to the Hub (or another module) mid-set, the workout
+ * is still "live" but the user has to manually open Fizruk → Workouts →
+ * find the highlighted row to get back. That's three taps for an action
+ * that should be one — and it's especially easy to lose the thread when
+ * the user jumps to Finyk to log the protein shake they just bought.
+ *
+ * This banner renders in the Hub shell (outside of any module) whenever
+ * an active workout id is persisted. One tap opens Fizruk and deep-links
+ * to the Workouts page via the existing cross-module nav bus.
+ *
+ * Returns null when there's no active workout, or when `hidden` is true
+ * (e.g. during the FTUX session where any extra CTA crowds the splash).
+ */
+export function ActiveWorkoutBanner({ hidden = false }: { hidden?: boolean }) {
+  const activeId = useActiveFizrukWorkout();
+
+  if (hidden) return null;
+  if (!activeId) return null;
+
+  return (
+    <div
+      className="fixed left-4 z-40 pointer-events-none"
+      style={{ bottom: "calc(5.25rem + env(safe-area-inset-bottom, 0px))" }}
+      aria-live="polite"
+    >
+      <button
+        type="button"
+        onClick={() => openHubModule("fizruk", "#workouts")}
+        className="pointer-events-auto flex items-center gap-2.5 h-12 pl-3 pr-4 rounded-full bg-fizruk text-white shadow-float hover:brightness-110 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        aria-label="Повернутись до активного тренування"
+      >
+        <span
+          className="relative flex w-8 h-8 items-center justify-center rounded-full bg-white/15"
+          aria-hidden
+        >
+          <Icon name="dumbbell" size={16} strokeWidth={2.25} />
+          <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-success ring-2 ring-fizruk motion-safe:animate-pulse" />
+        </span>
+        <span className="text-sm font-semibold whitespace-nowrap">
+          Тренування триває
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/shared/components/ui/Sheet.tsx
+++ b/src/shared/components/ui/Sheet.tsx
@@ -154,7 +154,11 @@ export function Sheet({
         </div>
         <div
           className={cn(
-            "flex-1 min-h-0 overflow-y-auto px-5 pb-4",
+            // `overscroll-contain` prevents rubber-band scroll from
+            // leaking out to the page under the sheet — on iOS this
+            // would otherwise scroll the body behind the modal while
+            // the sheet is open, which is disorienting.
+            "flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 pb-4",
             bodyClassName,
           )}
         >

--- a/src/shared/hooks/useActiveFizrukWorkout.ts
+++ b/src/shared/hooks/useActiveFizrukWorkout.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Shared read-only pointer to the in-progress Fizruk workout.
+ *
+ * Fizruk persists `fizruk_active_workout_id_v1` in localStorage while a
+ * workout is open. Other surfaces (Hub header, module pages, cross-module
+ * CTAs) need to see that signal so they can offer a "Повернутися до
+ * тренування" shortcut without pulling in the whole `useWorkouts` API.
+ *
+ * Listens to `storage` events so that when the user ends a workout in
+ * another tab the banner disappears immediately, not on next navigation.
+ *
+ * Also dispatches a synthetic `local-storage` event on same-tab writes
+ * if callers want cross-component reactivity (Fizruk's own
+ * setActiveWorkoutId dispatches via the effect that writes the key).
+ */
+const ACTIVE_WORKOUT_KEY = "fizruk_active_workout_id_v1";
+
+function readId(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_WORKOUT_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function useActiveFizrukWorkout(): string | null {
+  const [id, setId] = useState<string | null>(() => readId());
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      // e.key === null means storage was cleared entirely (logout, sync).
+      if (e.key === ACTIVE_WORKOUT_KEY || e.key === null) {
+        setId(readId());
+      }
+    };
+    // Poll every 1.5s as a fallback — storage events don't fire in the
+    // same tab, and Fizruk writes via localStorage.setItem in an effect.
+    // The cost (1 localStorage.getItem per 1.5s) is negligible.
+    const poll = setInterval(() => {
+      const next = readId();
+      setId((prev) => (prev === next ? prev : next));
+    }, 1500);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      clearInterval(poll);
+    };
+  }, []);
+
+  return id;
+}


### PR DESCRIPTION
## Summary

PR 2/4 of the UX/a11y/PWA batch. Three targeted mobile fixes, no backend changes.

### 1. HubChat on-screen keyboard no longer covers the input

Chat dialog now uses the existing `useVisualKeyboardInset` hook to pad the panel up by the virtual keyboard height. Matches the `kbInsetPx` pattern already used by `Sheet` — no new API, just applying the hook where the brief flagged it as missing.

- <ref_file file="/home/ubuntu/repos/Sergeant/src/core/HubChat.tsx" />

### 2. Sheet + HubChat scroll is now contained

`overscroll-behavior: contain` on the scroll regions stops rubber-band scroll from propagating to the page under an open modal. Eliminates the iOS bug where the body scrolls behind the sheet while the user scrubs a long list.

- <ref_snippet file="/home/ubuntu/repos/Sergeant/src/shared/components/ui/Sheet.tsx" lines="155-166" />
- <ref_snippet file="/home/ubuntu/repos/Sergeant/src/core/HubChat.tsx" lines="485-491" />

### 3. Persistent "resume workout" CTA

Fizruk persists `fizruk_active_workout_id_v1` in localStorage. Before this PR, jumping to another module mid-set buried the workout behind three taps. `ActiveWorkoutBanner` reads that key via the new `useActiveFizrukWorkout` hook and renders a floating CTA:

- Visible in the Hub (hidden during FTUX session so the splash stays single-CTA).
- Visible inside Finyk / Routine / Nutrition — hidden inside Fizruk itself, where the in-module `ActiveWorkoutPanel` is already the primary surface.
- Polls + listens to cross-tab `storage` events so it disappears the moment the workout ends in another tab.
- One tap deep-links via the existing `HUB_OPEN_MODULE_EVENT` bus.

- <ref_file file="/home/ubuntu/repos/Sergeant/src/core/app/ActiveWorkoutBanner.tsx" />
- <ref_file file="/home/ubuntu/repos/Sergeant/src/shared/hooks/useActiveFizrukWorkout.ts" />

`env(safe-area-inset-bottom)` was already in use for the FAB in `HubFloatingActions`; the new banner adopts the same pattern.

## Review & Testing Checklist for Human

- [ ] On a real phone, open HubChat (🤖 in header), tap the input. The input and Send button must both stay visible above the keyboard.
- [ ] Start a workout in Fizruk, press "← Хаб". A green "Тренування триває" pill appears bottom-left. Tap it — it should land you back in Fizruk → Workouts. End the workout; the pill disappears.
- [ ] Open Fizruk's finish-sheet on an iPhone, scroll past the bottom of the list: the page beneath must not scroll.
- [ ] Confirm the banner does NOT appear inside Fizruk itself.
- [ ] `npm run lint && npm run typecheck && npm run test && npm run build` still pass.

### Notes

- PR 1/4 (#282) + its follow-up (#287) shipped the focus-restore work.
- Remaining: PR 3/4 (PWA: SW strategies + quiet hours + install UX) and PR 4/4 (optimistic updates in react-query mutations).
- Vercel previews are rate-limited on the repo today; a fresh preview will roll once the daily cap resets.


Link to Devin session: https://app.devin.ai/sessions/4bbfa8999dd3498aa335370caed48215
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
