### PR TITLE
fix(hub): розблокувати модалку при краші й стабілізувати ErrorBoundary fallback

### DIFF
--- a/src/core/app/HubMainContent.tsx
+++ b/src/core/app/HubMainContent.tsx
@@ -153,10 +153,7 @@ export function HubMainContent({
 
       <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
         {hubView === "dashboard" && (
-          <ErrorBoundary
-            key="dashboard"
-            fallback={(props) => <HubSectionFallback {...props} />}
-          >
+          <ErrorBoundary key="dashboard" fallback={HubSectionFallback}>
             <div className="flex flex-col gap-5 pt-2">
               <HubDashboard
                 onOpenModule={onOpenModule}
@@ -169,10 +166,7 @@ export function HubMainContent({
         )}
 
         {hubView === "reports" && (
-          <ErrorBoundary
-            key="reports"
-            fallback={(props) => <HubSectionFallback {...props} />}
-          >
+          <ErrorBoundary key="reports" fallback={HubSectionFallback}>
             <div className="pt-2">
               <HubReports />
             </div>
@@ -180,10 +174,7 @@ export function HubMainContent({
         )}
 
         {hubView === "settings" && (
-          <ErrorBoundary
-            key="settings"
-            fallback={(props) => <HubSectionFallback {...props} />}
-          >
+          <ErrorBoundary key="settings" fallback={HubSectionFallback}>
             <HubSettingsPage
               dark={dark}
               onToggleDark={onToggleDark}

--- a/src/core/app/HubModals.tsx
+++ b/src/core/app/HubModals.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { ErrorBoundary } from "../ErrorBoundary";
 
 const HubSearch = lazy(() =>
@@ -6,11 +6,25 @@ const HubSearch = lazy(() =>
 );
 const HubChat = lazy(() => import("../HubChat"));
 
-// Модалки огортаємо в ErrorBoundary, щоб непередбачений збій у HubChat
-// або HubSearch не ламав увесь хаб — просто закриваємо модалку, а хаб
-// залишається робочим. `fallback={null}` = тихий no-op: користувач
-// ще має closeChat/closeSearch через зовнішні хендлери, а Sentry
-// отримає exception через lazy-forward у `captureException`.
+// Коли модалка крешиться, `ErrorBoundary` рендерить `null`, але стан
+// `chatOpen` / `searchOpen` у `useHubUIState` лишається `true` — усі
+// хендлери закриття (Esc, click-outside, X) живуть усередині самої
+// модалки і після збою вже не рендеряться. Без явного виклику
+// `onClose` користувач опиняється у "невидимій" модалці, яку не
+// можна ні закрити, ні перевідкрити (React ігнорує `setChatOpen(true)`,
+// бо значення вже `true`).
+//
+// `CloseOnError` — крихітний side-effect-only компонент: після mount
+// кличе `onClose`, що очищує стан у батьківському хуку. Рендер
+// `null` зберігає попередню поведінку (користувач не бачить
+// поламаної модалки), але тепер без "залиплого" стану.
+function CloseOnError({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    onClose();
+  }, [onClose]);
+  return null;
+}
+
 export function HubModals({
   chatOpen,
   onCloseChat,
@@ -22,7 +36,7 @@ export function HubModals({
   return (
     <>
       {chatOpen && (
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<CloseOnError onClose={onCloseChat} />}>
           <Suspense fallback={null}>
             <HubChat
               onClose={onCloseChat}
@@ -33,7 +47,7 @@ export function HubModals({
       )}
 
       {searchOpen && (
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<CloseOnError onClose={onCloseSearch} />}>
           <Suspense fallback={null}>
             <HubSearch onClose={onCloseSearch} onOpenModule={onOpenModule} />
           </Suspense>


### PR DESCRIPTION
## Summary

Follow-up до [#284](https://github.com/Skords-01/Sergeant/pull/284) по двох знахідках Devin Review.

### 1. `HubModals.tsx` — `fallback={null}` робив модалку uncloseable

Коли `HubChat` або `HubSearch` крешились, `ErrorBoundary` рендерив `null` → модалка ставала невидимою, але стан `chatOpen` / `searchOpen` у `useHubUIState` лишався `true`. Усі закривачі (Esc listener, backdrop click, X-кнопка) живуть **усередині** крешнутої модалки → їх більше не існує. Натискання кнопки «Чат» у шапці знов викликало `setChatOpen(true)`, але React ігнорував апдейт, бо значення вже `true`. Користувач застрягав у невидимій модалці без способу вийти (окрім перезавантаження вкладки).

Фікс: fallback тепер `<CloseOnError onClose={onClose} />` — крихітний side-effect-only компонент, що на mount викликає parent-ний `onClose`, очищаючи стан у `useHubUIState`, і нічого не рендерить. UX той самий («невидимий» збій), але без «залиплого» стану.

### 2. `HubMainContent.tsx` — inline arrow fallback створював новий компонент на кожен render

`fallback={(props) => <HubSectionFallback {...props} />}` — нова стрілка на кожен render `HubMainContent` → `ErrorBoundary` рендерить її як `<Fallback .../>`, React бачить новий component type і unmount-ить попередній fallback (стирає його DOM). Це якраз випадок з AGENTS.md rule 5.4 («Don't Define Components Inside Components»).

`HubSectionFallback` уже відповідає сигнатурі `FallbackProps`, тому передаємо стабільний референс напряму: `fallback={HubSectionFallback}`.

## Review & Testing Checklist for Human

- [ ] HubChat / HubSearch: імітувати throw всередині модалки → стан `chatOpen` / `searchOpen` автоматично скидається, можна знов відкрити модалку.
- [ ] Hub section fallback: якщо секція справді впала і користувач тисне «Спробувати ще раз», dashboard / reports / settings перемонтовується без зайвого unmount-remount циклу на кожен рендер батька.

### Notes

- Жодних змін у `server/`, дизайн-токенах чи API-контрактах.
- `npm run lint`, `npm run typecheck`, `npm run test` (773 тести) — локально зелені.


Link to Devin session: https://app.devin.ai/sessions/2ce309361ad34bc2b8446ac6e5e9e575
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
