### PR TITLE
feat(server): observability hardening — explicit Sentry capture, PII/secret redaction, CORS regex logging

### DIFF
--- a/server/http/cors.js
+++ b/server/http/cors.js
@@ -38,7 +38,9 @@ export function getAllowedOrigins() {
 }
 
 // Кешуємо скомпільований regex, щоб не пересправляти його на кожен запит.
-// Якщо regex невалідний — логуємо один раз і ігноруємо (fail-closed).
+// Якщо regex невалідний — логуємо один раз (одне повідомлення на значення env)
+// і ігноруємо (fail-closed). Для test-оточення логування придушене, щоб не
+// спамити тестовий stdout — у тестах помилка перевіряється через `isOriginAllowed`.
 let cachedRegexSrc = null;
 let cachedRegex = null;
 function getAllowedOriginRegex() {
@@ -51,8 +53,18 @@ function getAllowedOriginRegex() {
   }
   try {
     cachedRegex = new RegExp(src);
-  } catch {
+  } catch (err) {
     cachedRegex = null;
+    if (process.env.NODE_ENV !== "test") {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        JSON.stringify({
+          level: "error",
+          msg: "cors_invalid_allowed_origin_regex",
+          err: { message },
+        }),
+      );
+    }
   }
   return cachedRegex;
 }

--- a/server/http/errorHandler.js
+++ b/server/http/errorHandler.js
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import { logger, serializeError } from "../obs/logger.js";
 import { als } from "../obs/requestContext.js";
 import { appErrorsTotal } from "../obs/metrics.js";
@@ -41,6 +42,19 @@ export function errorHandler(err, req, res, _next) {
     module: mod,
     err: serializeError(err, { includeStack: status >= 500 }),
   });
+
+  // Явний виклик `Sentry.captureException` на справжні помилки (5xx /
+  // не-operational). `setupExpressErrorHandler` з `server/sentry.js` теж це
+  // ловить, але дубль-safe: якщо порядок middleware колись зміниться і
+  // Sentry-хендлер не спрацює, ми все одно отримаємо подію. Sentry сам дедупає
+  // однакові events, тому подвійних подій у проді не буде.
+  if (status >= 500 && !operational) {
+    try {
+      Sentry.captureException(err);
+    } catch {
+      /* Sentry must never break error handling */
+    }
+  }
 
   if (res.headersSent) return;
 

--- a/server/http/errorHandler.test.js
+++ b/server/http/errorHandler.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@sentry/node", () => {
+  return {
+    captureException: vi.fn(),
+  };
+});
+
+import * as Sentry from "@sentry/node";
+import { errorHandler } from "./errorHandler.js";
+import { AppError } from "../obs/errors.js";
+
+function makeReqRes() {
+  const headers = {};
+  return {
+    req: {
+      method: "POST",
+      originalUrl: "/api/x",
+      requestId: "req_1",
+    },
+    res: {
+      statusCode: 200,
+      body: undefined,
+      headersSent: false,
+      setHeader(name, value) {
+        headers[name] = value;
+      },
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.body = payload;
+        return this;
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("errorHandler → Sentry.captureException", () => {
+  it("капсулує неочікувану помилку (500) у Sentry.captureException", () => {
+    const { req, res } = makeReqRes();
+    const err = new Error("boom");
+    errorHandler(err, req, res, () => {});
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual(
+      expect.objectContaining({ code: "INTERNAL", requestId: "req_1" }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(err);
+  });
+
+  it("operational AppError (4xx) НЕ йде в Sentry.captureException", () => {
+    const { req, res } = makeReqRes();
+    const err = new AppError("bad input", { status: 400, code: "BAD_INPUT" });
+    errorHandler(err, req, res, () => {});
+    expect(res.statusCode).toBe(400);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("429 rate-limit теж НЕ йде у Sentry (це operational)", () => {
+    const { req, res } = makeReqRes();
+    const err = new AppError("rate limited", {
+      status: 429,
+      code: "RATE_LIMIT",
+    });
+    errorHandler(err, req, res, () => {});
+    expect(res.statusCode).toBe(429);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/server/http/schemas.js
+++ b/server/http/schemas.js
@@ -247,10 +247,12 @@ export const PushUnsubscribeSchema = z.object({
   endpoint: z.string().url().max(2048),
 });
 
+// `.nullable()` на необов'язкових полях — для back-compat із воркерами, які
+// історично слали `null` замість відсутнього поля.
 export const PushSendSchema = z.object({
   userId: z.string().min(1).max(200),
   title: z.string().min(1).max(200),
-  body: z.string().max(2000).optional(),
+  body: z.string().max(2000).optional().nullable(),
   module: z.string().max(40).optional().nullable(),
   tag: z.string().max(120).optional().nullable(),
 });

--- a/server/obs/logger.js
+++ b/server/obs/logger.js
@@ -15,17 +15,35 @@ import { als } from "./requestContext.js";
 const isDev = process.env.NODE_ENV !== "production";
 const level = process.env.LOG_LEVEL || (isDev ? "debug" : "info");
 
+// Список шляхів, які pino маскуватиме на `[redacted]`, щоб PII та секрети
+// ніколи не просочувались у JSON-логи. Розширюємо консервативно: email і phone
+// — навіть у вкладених user-об'єктах; усі типові варіанти токенів і secret.
+// Якщо треба додати новий шлях — додавай тут, а НЕ робиш `logger.info({...})`
+// з плейнтекстовим email, обходячи редакцію.
 const redactPaths = [
   "req.headers.authorization",
   "req.headers.cookie",
   'req.headers["x-api-key"]',
   'req.headers["x-token"]',
   "password",
+  "newPassword",
+  "currentPassword",
   "token",
   "accessToken",
   "refreshToken",
   "idToken",
   "apiKey",
+  "secret",
+  "clientSecret",
+  // PII — емейл/телефон в корені і всередині `user`/`body`.
+  "email",
+  "phone",
+  "*.email",
+  "*.phone",
+  "user.email",
+  "user.phone",
+  "body.email",
+  "body.phone",
 ];
 
 const usePretty = process.env.LOG_PRETTY === "1";


### PR DESCRIPTION
## Summary

Hardening PR #2 of 4 — observability. Без архітектурних змін, лише точкові правки.

**Sentry.** У `server/http/errorHandler.js` додав явний `Sentry.captureException(err)` для 5xx/не-operational помилок:
- `setupExpressErrorHandler` із `server/sentry.js` уже ловить винятки, але дубль-safe: якщо колись хтось зробить `app.use(errorHandler)` поза sentry-хендлером, ми все одно отримаємо подію. Sentry дедупає однакові events за fingerprint, тож подвійних інцидентів у проді не буде.
- Новий тест `server/http/errorHandler.test.js` ізолює виклик: 500 → `captureException` викликано; 400/429 (`AppError`/`RateLimitError`) — ні.

**Pino redact.** Розширив `redactPaths` у `server/obs/logger.js`:
- PII: `email`, `phone`, плюс глобальні `*.email`/`*.phone` і вкладені `user.email|phone`, `body.email|phone`. Це страховка на випадок, якщо хтось зробить `logger.info({ user })` з `email` у user-об'єкті.
- Секрети: додав `newPassword`, `currentPassword`, `secret`, `clientSecret`.
- `authMiddleware` і так логує лише `emailHash` (SHA-256, перші 12 символів) — цього не чіпав.

**CORS.** У `server/http/cors.js`: якщо `ALLOWED_ORIGIN_REGEX` не компілюється, тепер пишемо структурований JSON-error у `console.error` (pino ще не готовий — модуль bootstrap-рівня), а не тихо ковтаємо. Поведінка лишилась fail-closed. Для `NODE_ENV=test` лог придушено, щоб не спамити тестовий stdout. Фікс за Devin Review коментарем на PR #285.

**Push.** У `server/http/schemas.js` поле `PushSendSchema.body` зробив `.optional().nullable()` для back-compat із воркерами, що історично слали `null`. Фікс за Devin Review коментарем на PR #285. Handler у `push.js` уже підготовлений до обох варіантів (`body || ""`).

**AI duration histogram.** Уже існує в `server/obs/metrics.js` як `aiRequestDurationMs{provider,model,endpoint}` і фактично спостерігається у `lib/anthropic.js` — для всіх AI-проксі (`chat`, `coach-insight`, `weekly-digest`, і всі `nutrition/*`). Змін не потрібно.

## Review & Testing Checklist for Human

- [ ] У staging прогнати сценарій з навмисно битим `ALLOWED_ORIGIN_REGEX` (напр. `"["`) і перевірити, що у Railway logs з'являється рядок `cors_invalid_allowed_origin_regex` (level=error) — а CORS default-список працює без змін.
- [ ] Переконатись, що у Sentry після штучного 500 (напр. `throw new Error("x")` у чутливому роуті) тепер з'являється подія з `requestId` у тегах — і тільки одна (а не дві, якщо dedupe не спрацює).
- [ ] Перевірити, що жоден існуючий код не робив `logger.info({ email: "..." })` — це тепер `[redacted]`. Grep по `logger\.(info|warn|error).*email` — нічого не повернув; перевірив вручну.
- [ ] Перевірити на реальному payload-і воркера, що `POST /api/push/send` з `body: null` повертає 200, а не 400.

### Notes

- Жодних нових залежностей.
- Наступні PR-и (окремо): (3) auth hardening, (4) db/індекси.

Link to Devin session: https://app.devin.ai/sessions/cf79616ad74648af862c8d60cd8e7e61
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
