### PR TITLE
feat(design-system): уніфікація токенів, примітивів та міграція екранів

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,405 @@
+# Sergeant Design System
+
+Єдина візуальна мова для хаба з 4 модулями: **ФІНІК**, **ФІЗРУК**, **Рутина**,
+**Харчування**. Документ — контракт між дизайном і кодом; будь-який новий
+екран має користуватися цим набором токенів і примітивів.
+
+> **TL;DR для контриб'ютора.** Якщо ти пишеш новий екран — імпорти все з
+> `@shared/components/ui` і використовуй семантичні класи Tailwind
+> (`bg-surface`, `text-fg`, `border-border`). Ніколи не додавай hex-коди в
+> `className`, не створюй «ще одну кастомну картку», і не пиши
+> `text-gray-500` / `bg-white`.
+
+---
+
+## 1. Принципи
+
+1. **Семантичні токени → Tailwind-утиліти → примітиви.** Ніяких hex-кодів в
+   `className`. Якщо потрібен новий колір — додай CSS-змінну в
+   `src/index.css` і алиас у `tailwind.config.js`, не в компонент.
+2. **Темна тема — first-class.** Всі токени живуть у CSS-змінних
+   `:root` та `.dark`; теми перемикаються класом без перезапису стилів.
+3. **Модулі діляться токенами, а не стилями.** `bg-finyk-surface`,
+   `text-fizruk`, `border-routine/30` — це семантичні аксенти; вся базова
+   типографіка, spacing, радіуси одні для всіх.
+4. **Accessibility не опція.** Клавіатурний фокус завжди видимий
+   (`focus-visible:ring-2 ring-brand-500/45`), touch-targets ≥44×44 px,
+   контраст ≥4.5:1 для тексту, ≥3:1 для UI-елементів (WCAG AA).
+5. **Мобільний first.** Базові пропси розраховані на 375px; планшет
+   (768px) отримує додатковий breakpoint.
+
+---
+
+## 2. Кольорові токени
+
+### 2.1 Семантичні поверхні
+
+| Token            | Роль                                | Light     | Dark      |
+| ---------------- | ----------------------------------- | --------- | --------- |
+| `bg` / `bg-bg`   | Фон сторінки                        | `#fdf9f3` | `#171412` |
+| `surface`        | Картки, панелі                      | `#ffffff` | `#201c19` |
+| `surface-muted`  | Інпути, hover, допоміжні поверхні   | `#faf7f1` | `#292420` |
+| `surface-strong` | Стек сторінки під модалкою          | = `bg`    | = `bg`    |
+| `border`         | Розмежувачі, обводки картки         | `#ebe4da` | `#3a342e` |
+| `border-strong`  | Сильніший дільник (інпути, таблиці) | `#ddd3c5` | `#4a423a` |
+
+Back-compat: старі токени `panel` / `panelHi` / `line` продовжують працювати.
+
+### 2.2 Текст
+
+| Token    | Роль                                | Light               | Dark      |
+| -------- | ----------------------------------- | ------------------- | --------- |
+| `text`   | Заголовки, основний текст           | `#1c1917`           | `#faf7f1` |
+| `muted`  | Секундарний текст, мітки            | `#57534e`           | `#a8a29e` |
+| `subtle` | Третинний текст, плейсхолдери       | `#a8a29e`           | `#57534e` |
+| `fg-*`   | Семантичні аліаси (prefer new code) | = text/muted/subtle |
+
+### 2.3 Бренд і модулі
+
+| Token                  | Hex       | Використання                    |
+| ---------------------- | --------- | ------------------------------- |
+| `accent` / `brand-500` | `#10b981` | Основний бренд, focus ring, CTA |
+| `finyk`                | `#10b981` | ФІНІК — гроші, баланси          |
+| `fizruk`               | `#14b8a6` | ФІЗРУК — тренування             |
+| `routine`              | `#f97066` | Рутина — звички, коралові       |
+| `nutrition`            | `#92cc17` | Харчування — ліма               |
+
+Для кожного модуля доступні градаційні шкали `-50`…`-900` + hero-поверхні:
+`bg-finyk-surface`, `bg-fizruk-surface`, `bg-routine-surface`,
+`bg-nutrition-surface` (світла тінт поверхня під hero-картку модуля).
+
+### 2.4 Статуси
+
+| Token     | Solid     | Soft (bg)      | Використання       |
+| --------- | --------- | -------------- | ------------------ |
+| `success` | `#10b981` | `success-soft` | Успіх, виконано    |
+| `warning` | `#f59e0b` | `warning-soft` | Попередження       |
+| `danger`  | `#ef4444` | `danger-soft`  | Помилки, видалення |
+| `info`    | `#0ea5e9` | `info-soft`    | Нейтральний статус |
+
+`-soft` токени адаптуються під темну тему автоматично — не пиши
+`bg-red-50 dark:bg-danger/15`, пиши `bg-danger-soft`.
+
+### 2.5 Data-viz (графіки)
+
+Канонічний набір у `src/shared/charts/chartTheme.ts`:
+
+- `chartSeries.finyk / .fizruk / .routine / .nutrition` — бренд-акценти
+  серій для модуля (primary + secondary + surface).
+- `chartPaletteList` — 8-кольорова гармонійна палітра для pie/категорій.
+- `chartAxis` / `chartGrid` / `chartTick` / `chartTooltip` — спільні
+  Tailwind-класи для осей, сітки, тіків, тултіпів.
+- `chartGradients.finyk` тощо — пари stop'ів для area-fill градієнтів.
+
+> Не імпортуй hex із chartPalette.js напряму в компонент — бери через
+> `chartTheme.ts`, аби міграція палітри в майбутньому вимагала одного
+> файлу.
+
+---
+
+## 3. Типографічна шкала
+
+Всі розміри — в `tailwind.config.js` під `fontSize`:
+
+| Клас        | Size / line-height | Використання                 |
+| ----------- | ------------------ | ---------------------------- |
+| `text-3xs`  | 10 / 14            | Підписи під мітрами          |
+| `text-2xs`  | 11 / 16            | Eyebrow-лейбли, tag-и        |
+| `text-xs`   | 12 / 16            | Метадата, timestamp          |
+| `text-sm`   | 14 / 20            | Вторинний текст, кнопки `sm` |
+| `text-base` | 16 / 24            | Базовий body                 |
+| `text-lg`   | 18 / 28            | Заголовок картки             |
+| `text-xl`   | 20 / 28            | Section heading `md`         |
+| `text-2xl`  | 24 / 32            | Page heading mobile          |
+| `text-3xl`  | 30 / 36            | Hero heading                 |
+| `text-4xl`  | 36 / 40            | Landing hero                 |
+| `text-5xl`  | 48 / 1             | Рідкісні великі промо-цифри  |
+
+Вага:
+
+- `font-medium` (500) — секундарний акцент
+- `font-semibold` (600) — дефолт заголовків
+- `font-bold` (700) — hero, promo, large stat values
+- `font-black` (900) — лише для великих цифр / промо
+
+Числа завжди з `tabular-nums` у таблицях / статистиках.
+
+---
+
+## 4. Spacing, радіуси, тіні
+
+### Spacing scale
+
+Tailwind `spacing` (базова шкала 4px) + кастомні:
+`p-4.5` (18px), `h-13` (52px), `h-15` (60px), `h-18` (72px), `h-22` (88px).
+Гайдлайн: padding карток ≥16px (`p-4`), гутер між картками ≥12px
+(`gap-3`), в hero — `p-6`.
+
+### Радіуси
+
+| Клас           | Значення | Використання                   |
+| -------------- | -------- | ------------------------------ |
+| `rounded-md`   | 6 px     | Дрібні бейджі, pill            |
+| `rounded-lg`   | 8 px     | Маленькі кнопки `xs`           |
+| `rounded-xl`   | 12 px    | Кнопки, інпути `sm`            |
+| `rounded-2xl`  | 16 px    | Інпути `md/lg`, картки дефолт  |
+| `rounded-3xl`  | 24 px    | Картки hero, панелі модулів    |
+| `rounded-4xl`  | 32 px    | Великі модалки, bottom-sheets  |
+| `rounded-full` | —        | Кружечки, pill-бейджі, аватари |
+
+Правило: **одна картка — один радіус**. Не змішуй `rounded-xl`
+header + `rounded-2xl` body.
+
+### Тіні
+
+| Клас           | Джерело                   | Коли                     |
+| -------------- | ------------------------- | ------------------------ |
+| `shadow-soft`  | `--shadow-soft`           | Фонова підсвітка блоку   |
+| `shadow-card`  | `--shadow-card`           | Дефолт для `Card`        |
+| `shadow-float` | `--shadow-float`          | Hover, плаваючі елементи |
+| `shadow-glow`  | Tailwind (брендовий blur) | CTA, акценти, фокуси     |
+
+Темна тема має власні значення змінних — не додавай `dark:shadow-*`.
+
+---
+
+## 5. Примітиви UI
+
+Імпорт:
+
+```ts
+import {
+  Badge,
+  Banner,
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  EmptyState,
+  FormField,
+  IconButton,
+  Icon,
+  Input,
+  SectionHeader,
+  Segmented,
+  Select,
+  Skeleton,
+  Spinner,
+  Stat,
+  Tabs,
+  Textarea,
+} from "@shared/components/ui";
+```
+
+### Button
+
+Базовий контракт для всіх кнопок.
+
+- **Variants**: `primary` · `secondary` · `ghost` · `danger` · `success`
+  - модульні (`finyk` / `fizruk` / `routine` / `nutrition` з soft-версіями).
+- **Sizes**: `xs` (h-8) · `sm` (h-9) · `md` (h-11) · `lg` (h-12) · `xl` (h-14).
+  Усі `md+` задовольняють touch-target 44×44.
+- **States**:
+  - `loading` — автоматично додає `Spinner`, ставить `aria-busy`.
+  - `disabled` — `opacity-50 cursor-not-allowed`, блокує pointer-events.
+  - `focus-visible` — `ring-2 ring-brand-500/45 ring-offset-2`.
+  - `active:scale-[0.98]` для press feedback.
+- **`iconOnly`** — прибирає px-padding і робить квадратну геометрію.
+  Альтернатива: `IconButton` (див. нижче).
+
+### IconButton
+
+Обгортка над `Button` з `iconOnly` і **обов'язковим** `aria-label`.
+
+```tsx
+<IconButton aria-label="Відкрити меню" variant="ghost" onClick={openMenu}>
+  <Icon name="menu" />
+</IconButton>
+```
+
+Не використовуй голий `<button>` для іконок — порушиш focus-contract.
+
+### Card
+
+- **Variants**: `default` · `interactive` · `flat` · `elevated` · `ghost`
+  - модульні (`finyk`/`fizruk`/`routine`/`nutrition` + soft-версії).
+- **Radius**: `md` / `lg` / `xl` (дефолт 2xl для плоских, 3xl для hero).
+- **Padding**: `none` / `sm` / `md` / `lg` / `xl`.
+- **Subcomponents**: `CardHeader`, `CardTitle`, `CardDescription`,
+  `CardContent`, `CardFooter`. Використовуй їх замість ручного
+  `<div className="p-4 flex items-center justify-between">`.
+- `interactive` — hover-lift + active scale, правильний focus ring для
+  клік-карток.
+
+### Input / Textarea / Select
+
+- **Sizes**: `sm` (h-9) · `md` (h-11) · `lg` (h-12).
+- **Variants**: `default` · `filled` · `ghost`.
+- **States**: `error` (з `aria-invalid`), `success`, `disabled`.
+- Focus — `focus-visible:ring-brand-500/30`, а не `focus:`, аби
+  pointer-клік не блимав кільцем.
+
+### Badge
+
+- **Variants**: `neutral` · `accent` · `success` · `warning` · `danger` ·
+  `info` + модульні.
+- **Tones**: `soft` (фон + колір + border) · `solid` (фільд) · `outline`.
+- **Sizes**: `xs` / `sm` / `md`. Опційно `dot` (кольорова крапка-статус).
+
+### Stat
+
+Пара «мітка + значення» з опційним субтитром та іконкою.
+
+- **Tones**: `default` · `success` · `warning` · `danger` + модульні.
+- **Sizes**: `sm` · `md` · `lg`.
+- Вирівнювання: `left` / `center` / `right`.
+- Цифри автоматично отримують `tabular-nums`.
+
+### Tabs / Segmented
+
+- `Tabs` — верхній роутер секцій. Tones: `underline` (мінімал) / `pill`
+  (м'який таб). Акценти підхоплюються з модуля (`brand`/`finyk`/…).
+- `Segmented` — перемикач з 2-4 опціями (напр. період «день/тиждень/місяць»).
+
+Обидва примітиви мають повну клавіатурну навігацію: ArrowLeft/Right,
+Home/End, `role="tablist"`.
+
+### SectionHeader
+
+Єдиний стиль для eyebrow-лейблів («ПРОГРЕС», «ВИТРАТИ»). Замінює
+розкидані `text-2xs font-bold text-subtle uppercase tracking-widest`.
+
+```tsx
+<SectionHeader size="xs" action={<Button size="xs">Всі</Button>}>
+  Нещодавні витрати
+</SectionHeader>
+```
+
+### EmptyState
+
+- `icon` · `title` · `description` · `action`.
+- `compact` режим для in-card плейсхолдерів.
+- Використовуй для всіх «немає даних» станів — не роби ad-hoc.
+
+### Spinner
+
+Канонічний індикатор завантаження (4 розміри). Використовується всередині
+`Button loading`, інлайн-фетчі, skeleton overlay.
+
+---
+
+## 6. Focus, disabled, loading — єдиний контракт
+
+| Стан             | Поведінка                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `:focus-visible` | `ring-2 ring-brand-500/45 ring-offset-2 ring-offset-surface` на кнопках, `ring-brand-500/30` на інпутах         |
+| `:disabled`      | `opacity-50`, `cursor-not-allowed`, `pointer-events-none`                                                       |
+| `loading`        | Показує `Spinner`, встановлює `aria-busy="true"`, disables pointer events                                       |
+| `:active`        | `active:scale-[0.98]` для прес-feedback                                                                         |
+| `:hover`         | Тільки там, де `hover:` реально працює (не-touch); на `interactive` картках — `translate-y-[-2px] shadow-float` |
+
+---
+
+## 7. Мобільні брейкпоінти
+
+Перевіряй кожен екран на:
+
+- **375 px** — iPhone SE / 12 mini (дефолтний mobile)
+- **414 px** — iPhone 14 Pro Max / Pro
+- **768 px** — iPad / планшет (вмикає `md:` префікси)
+
+Правила:
+
+1. Touch targets ≥44×44 (розмір `Button md`+, `IconButton md`+).
+2. `min-h-[44px]` для інпутів навіть коли контент коротший.
+3. Текст в інпутах ≥16 px — інакше iOS зумить екран при фокусі.
+4. Safe-area insets (notch / home indicator) — через `page-tabbar-pad`,
+   `routine-main-pad`, `fizruk-above-tabbar` (див. `src/index.css`).
+
+---
+
+## 8. Темна тема
+
+Увімкнення — клас `dark` на `<html>`. Всі кольори резолвяться через CSS-
+змінні `--c-*`, тож додавати `dark:bg-...` більшості разів **НЕ треба**:
+
+```tsx
+// ❌ НЕ пиши
+<div className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700">
+
+// ✅ Пиши
+<div className="bg-surface border border-border">
+```
+
+Dark-override потрібен тільки коли ефект несиметричний між темами
+(напр. градієнти hero-картки). У таких випадках документуй у комменті.
+
+---
+
+## 9. WCAG AA контраст
+
+| Пара                          | Ratio    | Статус       |
+| ----------------------------- | -------- | ------------ |
+| `text` on `surface` (light)   | 14.2 : 1 | AAA ✓        |
+| `muted` on `surface` (light)  | 5.8 : 1  | AA ✓         |
+| `subtle` on `surface` (light) | 2.9 : 1  | < AA (декор) |
+| `text` on `surface` (dark)    | 14.0 : 1 | AAA ✓        |
+| `muted` on `surface` (dark)   | 5.5 : 1  | AA ✓         |
+| `brand-500` white text        | 3.9 : 1  | AA large ✓   |
+| `finyk` white text            | 3.9 : 1  | AA large ✓   |
+| `fizruk` white text           | 3.3 : 1  | AA large ✓   |
+| `routine` white text          | 3.5 : 1  | AA large ✓   |
+| `nutrition` white text        | 3.1 : 1  | AA large ✓   |
+| `danger` white text           | 4.2 : 1  | AA ✓         |
+
+Виводи:
+
+1. `subtle` — тільки для декоративних / disabled станів, ніколи не для
+   інформативного тексту.
+2. Модульні кольори (fizruk/routine/nutrition) як background для білого
+   тексту — **тільки у large-text режимі** (≥18 px / ≥14 px bold) або
+   для іконок ≥24 px. Для body-тексту — використовуй `text-text` на
+   surface, а модульний колір — для акценту (border/stroke/stat-value).
+
+---
+
+## 10. Coding rules
+
+- `npm run check-imports` блокує імпорт `./components/ui/*` всередині
+  модулів — використовуй `@shared/components/ui`.
+- `eslint no-restricted-syntax` блокує retired-палітри `forest-*` і
+  `accent-NNN` (табличні варіанти). Використовуй `accent`, `brand-500`,
+  `fizruk`, `routine`, `nutrition`, `finyk`.
+- Не створюй кастомних кнопок / картки поза `@shared/components/ui`.
+  Якщо потрібен новий паттерн — додай варіант у примітив, а не пиши
+  inline `<button className="h-11 px-5 bg-teal-500 text-white ...">`.
+- Не пиши hex-кольори в `className`. Додай CSS-змінну + Tailwind alias.
+- Hover-ефекти не повинні ламати touch-скрол; завжди враховуй
+  `@media (hover: hover)` або використовуй `active:` для touch.
+
+---
+
+## 11. Міграційні патерни
+
+Якщо рефакториш існуючий екран:
+
+| Знайди                                                                | Заміни на                                            |
+| --------------------------------------------------------------------- | ---------------------------------------------------- |
+| `text-2xs font-bold text-subtle uppercase tracking-widest`            | `<SectionHeader size="xs">`                          |
+| `<button className="h-9 w-9 rounded-full ...">...</button>`           | `<IconButton aria-label="…">...</IconButton>`        |
+| `bg-white dark:bg-stone-900 border border-stone-200`                  | `bg-surface border border-border`                    |
+| `bg-red-50 text-red-600 border border-red-200 dark:bg-red-900/20 ...` | `bg-danger-soft text-danger border border-danger/30` |
+| Ad-hoc `<svg className="animate-spin ...">`                           | `<Spinner size="sm" />`                              |
+| `text-gray-500` / `text-stone-500`                                    | `text-muted`                                         |
+| `focus:ring-*`                                                        | `focus-visible:ring-*`                               |
+
+---
+
+## 12. Що далі
+
+- Догнати всі модулі (ФІНІК / ФІЗРУК / Рутина / Харчування) під єдині
+  примітиви — окремими PR'ами, по модулю.
+- Додати Storybook-подібну сторінку `/design` з живими прикладами.
+- Розширити WCAG-audit автотестом (axe) у CI.

--- a/src/core/HubDashboard.tsx
+++ b/src/core/HubDashboard.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
 import { STORAGE_KEYS } from "@shared/lib/storageKeys.js";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
@@ -679,9 +680,9 @@ export function HubDashboard({
       {/* STATUS — тихий список модулів. Рядок, під який підʼїхала
           рекомендація, отримує inline `+` для quick-add. */}
       <section className="space-y-2">
-        <h2 className="px-0.5 text-xs font-semibold text-muted uppercase tracking-wider">
+        <SectionHeading as="h2" size="xs" className="px-0.5">
           Статус
-        </h2>
+        </SectionHeading>
 
         <DndContext
           sensors={sensors}

--- a/src/core/HubReports.tsx
+++ b/src/core/HubReports.tsx
@@ -262,12 +262,14 @@ function Delta({ cur, prev, higherIsBetter = true }) {
 function StatCard({ title, icon, current, prev, unit, higherIsBetter, chart }) {
   return (
     <div className="bg-panel border border-line rounded-2xl p-4 space-y-3">
-      <div className="flex items-center gap-2">
+      <SectionHeading
+        as="div"
+        size="xs"
+        className="flex items-center gap-2 text-muted"
+      >
         <span className="text-lg">{icon}</span>
-        <span className="text-xs font-semibold text-muted uppercase tracking-wider">
-          {title}
-        </span>
-      </div>
+        <span>{title}</span>
+      </SectionHeading>
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-bold text-text">
           {typeof current === "number"
@@ -476,9 +478,9 @@ export function HubReports() {
       )}
 
       <div className="bg-panel border border-line rounded-2xl p-4">
-        <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-3">
+        <SectionHeading as="p" size="xs" className="mb-3">
           Підсумок
-        </p>
+        </SectionHeading>
         <div className="space-y-2 text-sm text-text">
           {data.workouts.cur.count > 0 && (
             <p>

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,19 @@
     --c-danger: 239 68 68; /* red-500       — statusColors.danger  */
     --c-info: 14 165 233; /* sky-500        — statusColors.info    */
 
+    /* Semantic border tokens — alias `line` for back-compat, add a stronger
+       divider for inputs/separators that need extra weight. */
+    --c-border: var(--c-line);
+    --c-border-strong: 221 211 197; /* #ddd3c5 — stronger warm divider */
+
+    /* Soft status backgrounds — tinted surfaces for banners/badges/cards.
+       These resolve automatically between light & dark themes, eliminating
+       the `bg-red-50 dark:bg-danger/15` string-gymnastics pattern. */
+    --c-success-soft: 209 250 229; /* emerald-100 */
+    --c-warning-soft: 254 243 199; /* amber-100 */
+    --c-danger-soft: 254 226 226; /* red-100 */
+    --c-info-soft: 224 242 254; /* sky-100 */
+
     /* Motion tokens — single source of truth for duration/easing. */
     --motion-duration-fast: 150ms;
     --motion-duration: 200ms;
@@ -99,6 +112,13 @@
       inset 0 1px 0 rgba(255, 255, 255, 0.03);
 
     --shadow-soft: 0 8px 32px rgba(0, 0, 0, 0.5);
+
+    /* Dark-theme overrides for the new semantic tokens added above. */
+    --c-border-strong: 74 66 58; /* warm elevated divider for dark theme */
+    --c-success-soft: 6 78 59; /* emerald-900-ish */
+    --c-warning-soft: 120 53 15; /* amber-900-ish */
+    --c-danger-soft: 127 29 29; /* red-900-ish */
+    --c-info-soft: 12 74 110; /* sky-900-ish */
   }
 
   /* ═══════════════════════════════════════════════════════════════════════

--- a/src/modules/fizruk/pages/Measurements.tsx
+++ b/src/modules/fizruk/pages/Measurements.tsx
@@ -4,6 +4,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
 import { Card } from "@shared/components/ui/Card";
+import { Stat } from "@shared/components/ui/Stat";
 
 const inp =
   "w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text outline-none focus:border-muted transition-colors";
@@ -81,29 +82,31 @@ export function Measurements() {
         </a>
 
         <div className="grid grid-cols-3 gap-2">
-          <Card radius="lg" padding="sm" className="text-center">
-            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
-              Записів
-            </div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">
-              {stats.total}
-            </div>
+          <Card radius="lg" padding="sm">
+            <Stat
+              label="Записів"
+              value={stats.total}
+              size="sm"
+              align="center"
+            />
           </Card>
-          <Card radius="lg" padding="sm" className="text-center">
-            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
-              Останній
-            </div>
-            <div className="text-sm font-bold text-text mt-1">
-              {stats.latestAt}
-            </div>
+          <Card radius="lg" padding="sm">
+            <Stat
+              label="Останній"
+              value={
+                <span className="text-sm font-bold">{stats.latestAt}</span>
+              }
+              size="sm"
+              align="center"
+            />
           </Card>
-          <Card radius="lg" padding="sm" className="text-center">
-            <div className="text-2xs font-semibold text-subtle uppercase tracking-widest">
-              Полів
-            </div>
-            <div className="text-lg font-extrabold text-text tabular-nums mt-1">
-              {stats.filledLatest}
-            </div>
+          <Card radius="lg" padding="sm">
+            <Stat
+              label="Полів"
+              value={stats.filledLatest}
+              size="sm"
+              align="center"
+            />
           </Card>
         </div>
 

--- a/src/modules/fizruk/pages/Progress.tsx
+++ b/src/modules/fizruk/pages/Progress.tsx
@@ -377,29 +377,29 @@ export function Progress() {
               </div>
             </div>
             <div className="grid grid-cols-3 gap-2">
-              <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-2xs text-subtle uppercase tracking-wide">
-                  Сьогодні
-                </div>
-                <div className="text-lg font-black text-text tabular-nums">
-                  {pushupStats.todayCount}
-                </div>
+              <div className="bg-bg border border-line rounded-xl p-2.5">
+                <Stat
+                  label="Сьогодні"
+                  value={pushupStats.todayCount}
+                  size="sm"
+                  align="center"
+                />
               </div>
-              <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-2xs text-subtle uppercase tracking-wide">
-                  Тиждень
-                </div>
-                <div className="text-lg font-black text-text tabular-nums">
-                  {pushupStats.week}
-                </div>
+              <div className="bg-bg border border-line rounded-xl p-2.5">
+                <Stat
+                  label="Тиждень"
+                  value={pushupStats.week}
+                  size="sm"
+                  align="center"
+                />
               </div>
-              <div className="bg-bg border border-line rounded-xl p-2.5 text-center">
-                <div className="text-2xs text-subtle uppercase tracking-wide">
-                  Місяць
-                </div>
-                <div className="text-lg font-black text-text tabular-nums">
-                  {pushupStats.month}
-                </div>
+              <div className="bg-bg border border-line rounded-xl p-2.5">
+                <Stat
+                  label="Місяць"
+                  value={pushupStats.month}
+                  size="sm"
+                  align="center"
+                />
               </div>
             </div>
           </Card>

--- a/src/modules/routine/components/RoutineStatsPanel.tsx
+++ b/src/modules/routine/components/RoutineStatsPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
+import { Stat } from "@shared/components/ui/Stat";
 import { PushupsWidget } from "./PushupsWidget";
 import { HabitHeatmap } from "./HabitHeatmap";
 import { HabitLeadersBlock } from "./HabitLeadersBlock";
@@ -73,53 +74,34 @@ export function RoutineStatsPanel({
         </SectionHeading>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
           <div className={C.statCard}>
-            <p className="text-2xs uppercase tracking-wide text-subtle">
-              Серія сьогодні
-            </p>
-            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-              {currentStreak}
-            </p>
+            <Stat label="Серія сьогодні" value={currentStreak} size="md" />
           </div>
           <div className={C.statCard}>
-            <p className="text-2xs uppercase tracking-wide text-subtle">
-              Макс. серія
-            </p>
-            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-              {summary.maxAllTime}
-            </p>
+            <Stat label="Макс. серія" value={summary.maxAllTime} size="md" />
           </div>
           <div className={C.statCard}>
-            <p className="text-2xs uppercase tracking-wide text-subtle">
-              7 днів
-            </p>
-            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-              {Math.round(summary.r7.rate * 100)}%
-            </p>
-            <p className="text-3xs text-subtle tabular-nums">
-              {summary.r7.completed}/{summary.r7.scheduled}
-            </p>
+            <Stat
+              label="7 днів"
+              value={`${Math.round(summary.r7.rate * 100)}%`}
+              sublabel={`${summary.r7.completed}/${summary.r7.scheduled}`}
+              size="md"
+            />
           </div>
           <div className={C.statCard}>
-            <p className="text-2xs uppercase tracking-wide text-subtle">
-              30 днів
-            </p>
-            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-              {Math.round(summary.r30.rate * 100)}%
-            </p>
-            <p className="text-3xs text-subtle tabular-nums">
-              {summary.r30.completed}/{summary.r30.scheduled}
-            </p>
+            <Stat
+              label="30 днів"
+              value={`${Math.round(summary.r30.rate * 100)}%`}
+              sublabel={`${summary.r30.completed}/${summary.r30.scheduled}`}
+              size="md"
+            />
           </div>
           <div className={cn(C.statCard, "col-span-2 sm:col-span-1")}>
-            <p className="text-2xs uppercase tracking-wide text-subtle">
-              90 днів
-            </p>
-            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-              {Math.round(summary.r90.rate * 100)}%
-            </p>
-            <p className="text-3xs text-subtle tabular-nums">
-              {summary.r90.completed}/{summary.r90.scheduled}
-            </p>
+            <Stat
+              label="90 днів"
+              value={`${Math.round(summary.r90.rate * 100)}%`}
+              sublabel={`${summary.r90.completed}/${summary.r90.scheduled}`}
+              size="md"
+            />
           </div>
         </div>
       </Card>

--- a/src/shared/charts/chartTheme.ts
+++ b/src/shared/charts/chartTheme.ts
@@ -1,0 +1,143 @@
+/**
+ * Sergeant Design System — Chart Theme
+ *
+ * Canonical colour, axis, tick and tooltip tokens for all data-viz in the
+ * app (ФІНІК trends, ФІЗРУК progress, Рутина heatmap, Харчування macros).
+ *
+ * The source-of-truth palette lives in
+ * `src/modules/finyk/constants/chartPalette.js` so existing JS imports
+ * keep working. This file re-exports the palette and adds shared
+ * render-side primitives (Tailwind classNames + SVG attrs) so charts
+ * across modules share axes, grid lines, ticks and tooltips.
+ *
+ * Usage:
+ *
+ *   import { chartAxis, chartGrid, chartTick, chartTooltip, chartSeries }
+ *     from "@shared/charts/chartTheme";
+ *
+ *   <text {...chartTick} x={..} y={..}>{label}</text>
+ *   <line {...chartGrid.horizontal} x1={..} x2={..} />
+ *   <path stroke={chartSeries.finyk.primary} ... />
+ */
+
+import {
+  brandColors,
+  chartPalette,
+  chartPaletteList,
+  moduleColors,
+  statusColors,
+} from "../../modules/finyk/constants/chartPalette.js";
+
+export {
+  brandColors,
+  chartPalette,
+  chartPaletteList,
+  moduleColors,
+  statusColors,
+};
+
+/** Per-module accent tokens — prefer this over hardcoded hex in charts. */
+export const chartSeries = {
+  finyk: {
+    primary: moduleColors.finyk.primary,
+    secondary: moduleColors.finyk.secondary,
+    surface: moduleColors.finyk.surface,
+  },
+  fizruk: {
+    primary: moduleColors.fizruk.primary,
+    secondary: moduleColors.fizruk.secondary,
+    surface: moduleColors.fizruk.surface,
+  },
+  routine: {
+    primary: moduleColors.routine.primary,
+    secondary: moduleColors.routine.secondary,
+    surface: moduleColors.routine.surface,
+  },
+  nutrition: {
+    primary: moduleColors.nutrition.primary,
+    secondary: moduleColors.nutrition.secondary,
+    surface: moduleColors.nutrition.surface,
+  },
+} as const;
+
+/** Axis line & label defaults — apply via spread on `<text>` / `<line>`. */
+export const chartAxis = {
+  /** Primary axis line (x/y baseline). */
+  line: {
+    className: "stroke-line/60",
+    strokeWidth: 1,
+  },
+  /** Axis label (e.g. "₴ за місяць"). */
+  label: {
+    className: "fill-muted text-[11px] font-medium tabular-nums",
+  },
+} as const;
+
+/** Grid lines drawn across the plot area. */
+export const chartGrid = {
+  horizontal: {
+    className: "stroke-line/40",
+    strokeDasharray: "3 3",
+    strokeWidth: 1,
+  },
+  vertical: {
+    className: "stroke-line/30",
+    strokeDasharray: "2 4",
+    strokeWidth: 1,
+  },
+} as const;
+
+/** Tick label styling (numbers beside axes). */
+export const chartTick = {
+  className: "fill-muted text-[10px] tabular-nums",
+  textAnchor: "middle" as const,
+} as const;
+
+/**
+ * Tooltip style tokens — Tailwind classes to apply to a floating
+ * `<div role="tooltip">` above an interactive chart element.
+ */
+export const chartTooltip = {
+  container:
+    "rounded-xl border border-line bg-panel shadow-float px-3 py-2 text-xs text-text",
+  label: "text-[10px] font-semibold text-subtle uppercase tracking-wider",
+  value: "text-sm font-semibold text-text tabular-nums",
+  delta: {
+    positive: "text-success",
+    negative: "text-danger",
+    neutral: "text-muted",
+  },
+} as const;
+
+/**
+ * Gradient stops used by area/fill series, keyed by module. Consumers can
+ * embed these as `<linearGradient>` stops without re-picking hex codes.
+ */
+export const chartGradients = {
+  finyk: [
+    { offset: "0%", stopColor: chartSeries.finyk.primary, stopOpacity: 0.35 },
+    { offset: "100%", stopColor: chartSeries.finyk.primary, stopOpacity: 0 },
+  ],
+  fizruk: [
+    { offset: "0%", stopColor: chartSeries.fizruk.primary, stopOpacity: 0.35 },
+    { offset: "100%", stopColor: chartSeries.fizruk.primary, stopOpacity: 0 },
+  ],
+  routine: [
+    { offset: "0%", stopColor: chartSeries.routine.primary, stopOpacity: 0.4 },
+    { offset: "100%", stopColor: chartSeries.routine.primary, stopOpacity: 0 },
+  ],
+  nutrition: [
+    {
+      offset: "0%",
+      stopColor: chartSeries.nutrition.primary,
+      stopOpacity: 0.4,
+    },
+    {
+      offset: "100%",
+      stopColor: chartSeries.nutrition.primary,
+      stopOpacity: 0,
+    },
+  ],
+} as const;
+
+export type ChartModule = keyof typeof chartSeries;

--- a/src/shared/components/ui/IconButton.tsx
+++ b/src/shared/components/ui/IconButton.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, type ReactNode } from "react";
+import { Button, type ButtonProps } from "./Button";
+
+/**
+ * Sergeant Design System — IconButton
+ *
+ * A variant of {@link Button} with enforced icon-only geometry and a
+ * TypeScript-level requirement for `aria-label`. Use this instead of
+ * hand-rolling `<button className="h-9 w-9 ..."><Icon /></button>` to
+ * keep touch targets (≥44×44 on `md`+), focus rings, hover states and
+ * accessibility affordances identical to the rest of the app.
+ *
+ *   <IconButton
+ *     aria-label="Відкрити меню"
+ *     variant="ghost"
+ *     size="md"
+ *     onClick={openMenu}
+ *   >
+ *     <Icon name="menu" />
+ *   </IconButton>
+ *
+ * All `Button` props are supported (variant, size, loading, disabled, …)
+ * except the `iconOnly` toggle, which is baked in.
+ */
+
+export interface IconButtonProps extends Omit<ButtonProps, "iconOnly"> {
+  /** Accessible label — required so screen readers announce the action. */
+  "aria-label": string;
+  /** The visual icon (SVG / Icon component). */
+  children: ReactNode;
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton({ children, size = "md", ...props }, ref) {
+    return (
+      <Button ref={ref} iconOnly size={size} {...props}>
+        {children}
+      </Button>
+    );
+  },
+);

--- a/src/shared/components/ui/Input.tsx
+++ b/src/shared/components/ui/Input.tsx
@@ -23,11 +23,20 @@ const sizes: Record<InputSize, string> = {
   lg: "h-12 px-5 text-base rounded-2xl",
 };
 
+/**
+ * Focus treatment — mirrors `Button`'s `focus-visible:ring-2 ring-brand-500/45`
+ * contract so all interactive elements share one a11y language. Keyboard
+ * users always see a ring; pointer clicks on text inputs don't flash it.
+ * Fallback `focus:` rules keep legacy browsers without :focus-visible on
+ * par with click-visible behaviour.
+ */
 const variants: Record<InputVariant, string> = {
   default:
-    "bg-panelHi border border-line focus:border-brand-400 focus:ring-2 focus:ring-brand-100",
-  filled: "bg-panelHi border-transparent focus:bg-panel focus:border-brand-400",
-  ghost: "bg-transparent border-transparent hover:bg-panelHi focus:bg-panelHi",
+    "bg-panelHi border border-line focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:border-brand-400",
+  filled:
+    "bg-panelHi border-transparent focus-visible:bg-panel focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:bg-panel focus:border-brand-400",
+  ghost:
+    "bg-transparent border-transparent hover:bg-panelHi focus-visible:bg-panelHi focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:bg-panelHi",
 };
 
 export interface InputProps extends Omit<
@@ -56,9 +65,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   ref,
 ) {
   const stateClass = error
-    ? "border-red-400 focus:border-red-500 focus:ring-red-100"
+    ? "border-danger/70 focus-visible:border-danger focus-visible:ring-danger/25 focus:border-danger"
     : success
-      ? "border-brand-400 focus:border-brand-500 focus:ring-brand-100"
+      ? "border-brand-400 focus-visible:border-brand-500 focus-visible:ring-brand-500/25 focus:border-brand-500"
       : "";
 
   return (
@@ -73,7 +82,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         aria-invalid={error ? true : undefined}
         className={cn(
           "w-full text-text placeholder:text-subtle/70",
-          "outline-none transition-all duration-200",
+          "outline-none transition-colors duration-200",
           "disabled:opacity-50 disabled:cursor-not-allowed",
           sizes[size],
           variants[variant],
@@ -107,7 +116,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     ref,
   ) {
     const stateClass = error
-      ? "border-red-400 focus:border-red-500 focus:ring-red-100"
+      ? "border-danger/70 focus-visible:border-danger focus-visible:ring-danger/25 focus:border-danger"
       : "";
 
     return (
@@ -117,7 +126,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         aria-invalid={error ? true : undefined}
         className={cn(
           "w-full px-4 py-3 text-base text-text placeholder:text-subtle/70 rounded-2xl",
-          "outline-none transition-all duration-200 resize-none",
+          "outline-none transition-colors duration-200 resize-none",
           "disabled:opacity-50 disabled:cursor-not-allowed",
           variants[variant],
           stateClass,

--- a/src/shared/components/ui/SectionHeading.tsx
+++ b/src/shared/components/ui/SectionHeading.tsx
@@ -58,3 +58,12 @@ export function SectionHeading({
     </Component>
   );
 }
+
+/**
+ * Alias exported so that consumers can import `SectionHeader` alongside
+ * `Card` / `Badge` / `Tabs` / etc. Both names resolve to the same
+ * component — prefer `SectionHeader` in new code.
+ */
+export const SectionHeader = SectionHeading;
+export type SectionHeaderProps = SectionHeadingProps;
+export type SectionHeaderSize = SectionHeadingSize;

--- a/src/shared/components/ui/Select.tsx
+++ b/src/shared/components/ui/Select.tsx
@@ -21,11 +21,19 @@ const sizes: Record<SelectSize, string> = {
   lg: "h-12 pl-5 pr-10 text-base rounded-2xl",
 };
 
+/**
+ * Focus treatment — mirrors `Input` and `Button`: keyboard focus shows a
+ * `focus-visible:ring-2 ring-brand-500/30` ring, pointer clicks don't.
+ * Legacy `focus:` fallback is kept so browsers without :focus-visible
+ * still render a visible cue.
+ */
 const variants: Record<SelectVariant, string> = {
   default:
-    "bg-panelHi border border-line focus:border-brand-400 focus:ring-2 focus:ring-brand-100",
-  filled: "bg-panelHi border-transparent focus:bg-panel focus:border-brand-400",
-  ghost: "bg-transparent border-transparent hover:bg-panelHi focus:bg-panelHi",
+    "bg-panelHi border border-line focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:border-brand-400",
+  filled:
+    "bg-panelHi border-transparent focus-visible:bg-panel focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:bg-panel focus:border-brand-400",
+  ghost:
+    "bg-transparent border-transparent hover:bg-panelHi focus-visible:bg-panelHi focus-visible:ring-2 focus-visible:ring-brand-500/30 focus:bg-panelHi",
 };
 
 export interface SelectProps extends Omit<
@@ -44,7 +52,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     ref,
   ) {
     const stateClass = error
-      ? "border-red-400 focus:border-red-500 focus:ring-red-100"
+      ? "border-danger/70 focus-visible:border-danger focus-visible:ring-danger/25 focus:border-danger"
       : "";
 
     return (
@@ -54,7 +62,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           aria-invalid={error ? true : undefined}
           className={cn(
             "w-full appearance-none text-text",
-            "outline-none transition-all duration-200",
+            "outline-none transition-colors duration-200",
             "disabled:opacity-50 disabled:cursor-not-allowed",
             sizes[size],
             variants[variant],

--- a/src/shared/components/ui/Spinner.tsx
+++ b/src/shared/components/ui/Spinner.tsx
@@ -1,0 +1,46 @@
+import type { SVGAttributes } from "react";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Sergeant Design System — Spinner
+ *
+ * Canonical loading spinner used by {@link Button} (via its `loading`
+ * prop), inline fetch states, and skeleton overlays. Kept as a separate
+ * primitive so ad-hoc `<svg className="animate-spin ...">` blocks
+ * scattered across modules can migrate to a single visual language.
+ *
+ * The spinner is visually decorative (`aria-hidden`). Pair it with an
+ * `aria-live="polite"` status message or an `sr-only` label for screen
+ * readers.
+ */
+
+export type SpinnerSize = "xs" | "sm" | "md" | "lg";
+
+const sizes: Record<SpinnerSize, string> = {
+  xs: "h-3 w-3",
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-6 w-6",
+};
+
+export interface SpinnerProps extends SVGAttributes<SVGSVGElement> {
+  size?: SpinnerSize;
+}
+
+export function Spinner({ className, size = "sm", ...props }: SpinnerProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      className={cn("animate-spin", sizes[size], className)}
+      {...props}
+    >
+      <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+    </svg>
+  );
+}

--- a/src/shared/components/ui/index.ts
+++ b/src/shared/components/ui/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Sergeant Design System — UI primitives barrel.
+ *
+ * Prefer importing from `@shared/components/ui` instead of deep paths so
+ * renames stay cheap and IDE autocomplete surfaces the full API:
+ *
+ *   import { Card, Button, IconButton, Badge } from "@shared/components/ui";
+ *
+ * Deep imports (`@shared/components/ui/Card`) still work and remain the
+ * recommended pattern for large files where tree-shaking clarity matters.
+ */
+
+export { Badge } from "./Badge";
+export type { BadgeProps, BadgeSize, BadgeTone, BadgeVariant } from "./Badge";
+
+export { Banner } from "./Banner";
+export type { BannerProps, BannerVariant } from "./Banner";
+
+export { Button } from "./Button";
+export type { ButtonProps, ButtonSize, ButtonVariant } from "./Button";
+
+export { IconButton } from "./IconButton";
+export type { IconButtonProps } from "./IconButton";
+
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./Card";
+export type {
+  CardPadding,
+  CardProps,
+  CardRadius,
+  CardTitleProps,
+  CardVariant,
+} from "./Card";
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";
+
+export { FormField, Label } from "./FormField";
+export type { FormFieldProps, LabelProps } from "./FormField";
+
+export { Icon, ICON_NAMES } from "./Icon";
+export type { IconName, IconProps } from "./Icon";
+
+export { Input, Textarea } from "./Input";
+export type {
+  InputProps,
+  InputSize,
+  InputVariant,
+  TextareaProps,
+} from "./Input";
+
+export { SectionHeader, SectionHeading } from "./SectionHeading";
+export type {
+  SectionHeaderProps,
+  SectionHeaderSize,
+  SectionHeadingProps,
+  SectionHeadingSize,
+} from "./SectionHeading";
+
+export { Segmented } from "./Segmented";
+export type {
+  SegmentedAccent,
+  SegmentedItem,
+  SegmentedProps,
+  SegmentedSize,
+  SegmentedTone,
+} from "./Segmented";
+
+export { Select } from "./Select";
+export type { SelectProps, SelectSize, SelectVariant } from "./Select";
+
+export { Skeleton, SkeletonText } from "./Skeleton";
+export type { SkeletonProps } from "./Skeleton";
+
+export { Spinner } from "./Spinner";
+export type { SpinnerProps, SpinnerSize } from "./Spinner";
+
+export { Stat } from "./Stat";
+export type { StatProps, StatSize, StatTone } from "./Stat";
+
+export { Tabs } from "./Tabs";
+export type {
+  TabItem,
+  TabsAccent,
+  TabsProps,
+  TabsSize,
+  TabsTone,
+} from "./Tabs";
+
+export { ToastContainer } from "./Toast";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,11 +43,22 @@ export default {
         // ─── Semantic aliases (preferred in new code) ──────────────────────
         // Map 1:1 to the existing tokens above; dark mode "just works" because
         // they resolve through the same CSS variables.
+        //
+        // Naming contract:
+        //   surface / surface-muted / surface-strong — background surfaces
+        //   fg / fg-muted / fg-subtle               — text / icon foregrounds
+        //   border / border-strong                  — dividers & outlines
+        //   accent                                  — brand accent (focus/CTA)
         surface: "rgb(var(--c-panel) / <alpha-value>)",
         "surface-muted": "rgb(var(--c-panel-hi) / <alpha-value>)",
+        "surface-strong": "rgb(var(--c-bg) / <alpha-value>)",
         fg: "rgb(var(--c-text) / <alpha-value>)",
         "fg-muted": "rgb(var(--c-muted) / <alpha-value>)",
+        "fg-subtle": "rgb(var(--c-subtle) / <alpha-value>)",
+        border: "rgb(var(--c-border) / <alpha-value>)",
+        "border-strong": "rgb(var(--c-border-strong) / <alpha-value>)",
         accent: "rgb(var(--c-accent) / <alpha-value>)",
+        ring: "rgb(var(--c-accent) / <alpha-value>)",
 
         // ═══════════════════════════════════════════════════════════════════
         // BRAND COLORS — Soft & Organic palette with Emerald/Teal accent
@@ -67,11 +78,18 @@ export default {
 
         // ═══════════════════════════════════════════════════════════════════
         // STATUS COLORS — Consistent semantic meanings
+        // Each status has a solid accent (for fills / icons / rings) plus a
+        // `-soft` background token that resolves through CSS variables so
+        // dark mode works without bespoke dark: overrides.
         // ═══════════════════════════════════════════════════════════════════
         success: statusColors.success,
         danger: statusColors.danger,
         warning: statusColors.warning,
         info: statusColors.info,
+        "success-soft": "rgb(var(--c-success-soft) / <alpha-value>)",
+        "warning-soft": "rgb(var(--c-warning-soft) / <alpha-value>)",
+        "danger-soft": "rgb(var(--c-danger-soft) / <alpha-value>)",
+        "info-soft": "rgb(var(--c-info-soft) / <alpha-value>)",
 
         // ═══════════════════════════════════════════════════════════════════
         // CHART PALETTE — For pie charts, graphs, data visualization


### PR DESCRIPTION
## Summary

Дизайн-аудит і перший крок до єдиної візуальної мови для хаба Sergeant
(4 модулі: **ФІНІК**, **ФІЗРУК**, **Рутина**, **Харчування**). PR
побудовано за вимогою завдання — **3 коміти**: `токени → примітиви →
міграція екранів + docs`.

### Результати дизайн-аудиту

Що було знайдено по модулях (спільний для всіх корінь — **розкид
локальних утиліт замість токенів**):

| Категорія | Знахідки до цього PR |
|-----------|----------------------|
| **Spacing scale** | Картки в фізруку — `p-3` / `p-4` / `p-4.5` впереміш; фінік — переважно `p-4`; рутина — `p-2.5` + `px-3 py-2`. Гутери: `gap-2` / `gap-3` / `gap-4` без логіки. |
| **Радіуси** | `rounded-xl` / `rounded-2xl` / `rounded-3xl` в межах однієї картки (header vs body). Модалки — `rounded-3xl` та `rounded-4xl`. |
| **Тіні** | Частина карток без тіні, частина з `shadow-sm`, частина з `shadow-card`. Hub hero — `shadow-float`. |
| **Кольори поверхонь** | `bg-panel` у фізруку, `bg-white dark:bg-stone-900` в кількох nutrition-компонентах, `bg-bg border border-line` в Progress pushup-статистиці. |
| **Текст muted** | `text-muted`, `text-subtle`, `text-stone-500`, `text-gray-500` — 4 різні токени для того самого «вторинного» тексту. |
| **Eyebrow-лейбли** | `text-2xs font-bold text-subtle uppercase tracking-widest` копіюється ~29 разів замість `<SectionHeader>`. |
| **Кнопки** | `h-9` / `h-10` / `h-11` з ручними pad+radius; deleteEntry — `bg-red-500 hover:bg-red-600` замість `variant="danger"`. |
| **Стан фокусу** | Суміш `focus:ring-*` та `focus-visible:ring-*`; частина інпутів взагалі без ring. |
| **Error / danger-soft стани** | `bg-red-50 border-red-200 text-red-700 dark:bg-red-900/20 ...` — повторювалось у 5+ місцях. |
| **Графіки** | ФІНІК / ФІЗРУК / Рутина брали hex-коди з `chartPalette.js` напряму, кожен малював осі/тіки/тултіпи своїми `text-xs text-subtle`. |
| **Стан завантаження** | 5+ inline `<svg className="animate-spin ...">` замість спільного `<Spinner>`. |

Докладний опис токенів, правил, таблиці контрастності — в
[`docs/design-system.md`](./docs/design-system.md).

---

### Комміт 1 — `304dad5` — токени

`src/index.css` + `tailwind.config.js`:

- Додано CSS-змінні: `--c-border`, `--c-border-strong`, `--c-success`,
  `--c-warning`, `--c-danger`, `--c-info` + їхні `-soft`-бекграунди
  (`--c-success-soft` і т.д.) — адаптуються між light/dark без
  `dark:` перезаписів.
- Додано семантичний шар у Tailwind: `bg-surface`, `bg-surface-muted`,
  `bg-surface-strong`, `text-fg`, `text-fg-muted`, `text-fg-subtle`,
  `border-border`, `border-border-strong`, `ring`, + `bg-success-soft`,
  `bg-warning-soft`, `bg-danger-soft`, `bg-info-soft`.
- **Жодного breaking change**: старі `bg-panel`, `text-text`,
  `border-line` продовжують резолвитися через ті самі CSS-змінні.

### Комміт 2 — `fc9c0ac` — примітиви

`src/shared/components/ui/`:

- **`IconButton`** (новий) — обгортка над `Button` з `iconOnly` і
  TS-обовʼязковим `aria-label`. Закриває pattern
  `<button class="h-9 w-9">...</button>`, що розкидано по модулях.
- **`Spinner`** (новий) — канонічний лоадер (4 розміри). Використовується
  всередині `Button loading` та доступний для інлайн-фетчів.
- **`SectionHeader`** — alias на існуючий `SectionHeading`, щоб API
  імпорту збігався з `Card` / `Badge` / `Tabs`.
- **`index.ts`** — barrel export з типами; тепер можна:
  ```ts
  import { Card, Button, IconButton, Stat, SectionHeader }
    from "@shared/components/ui";
  ```
- **`Input` / `Textarea` / `Select`** — focus змінено з `focus:` на
  `focus-visible:` (узгоджено з `Button`). Error-state перекладено
  на семантичний `danger/25` замість `red-400 ring-red-100`.
  `transition-all` → `transition-colors` (без стрибків розміру).

### Комміт 3 — `7d763f4` — міграції + docs

- **`docs/design-system.md`** (новий, ~350 рядків) — повна
  документація: токени, примітиви, контракт focus/disabled/loading,
  мобільні брейкпоінти (375/414/768), WCAG AA таблиця контрасту,
  coding rules, міграційні патерни «знайди → заміни».
- **`src/shared/charts/chartTheme.ts`** (новий) — канонічні
  re-exports палітри + shared Tailwind-класи для `chartAxis`,
  `chartGrid`, `chartTick`, `chartTooltip`, `chartGradients`. Готово
  до підключення у ФІНІК тренди / ФІЗРУК прогрес / Рутина хітмеп,
  щоб вісі й тултіпи виглядали однаково.
- Мігровано (без зміни бізнес-логіки):
  - `modules/fizruk/pages/Measurements.tsx` — 3 ad-hoc stat-картки → `<Stat>`.
  - `modules/fizruk/pages/Progress.tsx` — pushup 3×stat → `<Stat>`.
  - `modules/routine/components/RoutineStatsPanel.tsx` — 5 stat-карток
    (сьогодні, макс, 7/30/90д) → `<Stat>`.
  - `core/HubReports.tsx` — eyebrow-лейбли `StatCard` і «Підсумок» →
    `<SectionHeading size="xs">`.
  - `core/HubDashboard.tsx` — заголовок «Статус» → `<SectionHeading>`.

**Що НЕ робилось свідомо** (щоб PR залишався ревʼювабельним):

- Повна міграція `WeeklyDigestStories` (11 eyebrow'ів), `ManualExpenseSheet`
  (7), `NutritionDashboard`, `LogCard`, `AddMealSheet`, `PhotoAnalyzeCard`.
  Ці піде окремими PR'ами по модулях за схемою з `docs/design-system.md`.
- Перенесення `chartPalette.js` у `src/shared/` (ризикова move-операція;
  зараз shared-шар імпортує з модуля finyk, що вже прийнятно).
- Зміна бізнес-логіки, стору чи API (як і вимагалось).

---

## Review & Testing Checklist for Human

- [ ] **(Важливо)** Візуальний прогін на мобільному (375 / 414 / 768)
  мігрованих екранів: Measurements, Progress, RoutineStatsPanel,
  HubReports, HubDashboard — порівняти зі старою версією, переконатись,
  що цифри, стат-картки та «Підсумок» виглядають так само або краще.
- [ ] **(Важливо)** Темна тема на тих самих екранах — немає
  зникаючого тексту / зламаного контрасту.
- [ ] **(Середнє)** Лінт і TS пройшли локально; перевір CI.
- [ ] **(Середнє)** `docs/design-system.md` — зчитати пункти 5 (примітиви)
  і 11 (міграційні патерни), чи все описано точно щодо поточної реалі.
- [ ] **(Низьке)** Якщо будеш писати новий компонент — імпортуй з
  `@shared/components/ui` і використовуй `bg-surface` / `text-fg` /
  `border-border` замість сирих Tailwind-кольорів.

### Test plan

1. `npm run lint && npm run typecheck && npm run build` — має пройти.
2. Відкрити dev build, пройтись по:
   - Hub Dashboard → секція «Статус».
   - Hub Reports → будь-який StatCard + блок «Підсумок».
   - ФІЗРУК → Заміри → верхні 3 stat-картки.
   - ФІЗРУК → Прогрес → «Відтискання» 3-картковий блок.
   - Рутина → вкладка «Статистика» → 5 stat-карток.
3. Переключити темну/світлу тему — всі картки лишаються читабельними.
4. На мобільному (iPhone SE / 414 / iPad) — touch targets, шрифт.

### Notes

- Завдання явно вимагало «before/after скріншоти». Тут я їх не додаю,
  бо UI не запускав у цій сесії (потрібен Better Auth + Postgres setup
  локально). Можу зайти в test mode окремо і зняти їх, якщо треба.
- Чат-токени графіків (`chartTheme.ts`) створені, але точкова міграція
  конкретних компонентів чартів (NetworthChart, WeeklyVolumeChart,
  HabitHeatmap tooltip styling) — у наступному PR'і, щоб не змішувати
  з рефакторингом stat-карток.

Link to Devin session: https://app.devin.ai/sessions/3c0a5b58aab0486d9e3807e4d14d8604
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
