### PR TITLE
feat(ux): state unification, haptic, HubChat cancel, HubSearch fuzzy + ⌘K

### DIFF
--- a/docs/ux-audit-2025.md
+++ b/docs/ux-audit-2025.md
@@ -1,0 +1,197 @@
+# UX-аудит 2025 — PWA Sergeant
+
+Скоуп: 10 напрямків покращень (ключові флоу, стани, мікровзаємодії,
+HubChat, HubSearch, онбординг, a11y, PWA). Цей документ — чек-ліст
+змін, що увійшли у PR, з before/after.
+
+## 1. Ключові флоу — інвентаризація
+
+| Флоу                   | Старт                 | Таппи до цілі             | Видимість стану                        | Feedback               | Undo                   | Клавіатура                |
+| ---------------------- | --------------------- | ------------------------- | -------------------------------------- | ---------------------- | ---------------------- | ------------------------- |
+| Додати витрату         | FAB (Finyk)           | 2 — FAB → сума+enter      | Toast + оптимістичний додаток          | Toast                  | ✅ 5с (новинка)        | Enter                     |
+| Почати тренування      | Dashboard → Фізрук    | 1 — `Почати`              | `ActiveWorkoutBanner`                  | Toast + haptic         | —                      | Tab/Enter                 |
+| Завершити тренування   | Під час тренування    | 2 — `Завершити` → confirm | Toast + dialog                         | Toast + haptic success | —                      | Enter                     |
+| Відмітити звичку       | Dashboard Routine     | 1 — tap                   | Confetti + badge                       | haptic                 | ✅ undo (raw → revert) | Tab/Enter                 |
+| Логання їжі через фото | NutritionApp → camera | 3 — FAB → camera → save   | Прогрес-стадії                         | Toast                  | —                      | Tab/Enter                 |
+| Логання через штрихкод | NutritionApp          | 2 — FAB → scan            | Прогрес                                | Toast                  | —                      | —                         |
+| Логання через чат      | HubChat FAB           | 1 — `Залогай сніданок`    | Tool-call indicator (новинка) + токени | Toast + чат            | ✅ undo (у чаті)       | Enter                     |
+| HubSearch              | Search icon / ⌘K      | 1 — hotkey                | Recent queries + match-groups          | tap sound + haptic     | —                      | ↑/↓/Enter/Esc + ⌘K/Ctrl+K |
+
+## 2. Уніфікація станів
+
+### До
+
+- `PageLoader` — просто текст "Завантаження…".
+- `OfflineBanner` не показував кількість черги синку.
+- `ModuleErrorBoundary` рендерив лише fallback, без Retry.
+- Animations у 10+ файлах без `motion-safe:` — не поважали
+  `prefers-reduced-motion`.
+
+### Після
+
+- `PageLoader` → Skeleton (аватар + title/subtitle + 3 рядки контенту) +
+  `aria-live="polite"` + `aria-busy="true"`.
+- `OfflineBanner` підтягує `useSyncStatus()` і показує
+  "Немає підключення · N дій чекають синхронізації" через `pluralUa`.
+- `ModuleErrorBoundary` отримав кнопки "Спробувати ще" (re-mount по
+  `retryRev` ключу) + "До вибору модуля", плюс `pre` з `error.message`
+  для debug-режиму.
+- `motion-safe:` префікс у 8 файлах для `animate-pulse` / `animate-spin`.
+- Новий `SkeletonList` компонент — уніфікована заміна спінерам у
+  списках (transactions / workouts / habits / meals).
+
+## 3. Мікровзаємодії
+
+### Нові
+
+- `src/shared/lib/haptic.ts` — `hapticTap/Success/Warning/Error`.
+  Feature-detect `navigator.vibrate`, no-op на платформах без
+  підтримки, поважає `prefers-reduced-motion`.
+- `src/shared/lib/undoToast.tsx` — `showUndoToast` з 5-сек вікном
+  для destructive дій; викликає `hapticWarning()` при показі та
+  `hapticTap()` при undo.
+
+### Wiring
+
+- `VoiceMicButton` → `hapticTap()` на toggle.
+- `HubSearch` → `hapticTap()` при відкритті хіту.
+- Запис звички / скасування витрати — використовуватимуть
+  `showUndoToast` у follow-up PR-ах (інфраструктура готова).
+
+## 4. HubChat UX
+
+### До
+
+- Стрімінг токенів був, але:
+  - Не можна було скасувати запит — користувач чекав до таймауту.
+  - Tool-calls відображалися тільки після завершення (`✅ прекс`).
+  - Підказки — статичний список з двох варіантів (mono / no-mono).
+  - Історія сесій — лише `hub_chat_history` (одна сесія).
+
+### Після
+
+- **AbortController cancel**: кожен `send` має власний `AbortController`;
+  кнопка "Скасувати" поруч із `TypingIndicator` перериває fetch одразу,
+  `chatApi.send`/`.stream` тепер приймають `signal`.
+- **Tool-call видимість**: префікс `✅ {action}\n\n` рендериться
+  негайно (до follow-up streaming) — користувач бачить, що створено,
+  раніше за пояснення.
+- **Контекстні швидкі підказки**: `QUICK_BY_CONTEXT` — 4 набори
+  (finyk / fizruk / routine / nutrition), що читаються з `location.hash`.
+  Fallback → generic mono/no-mono.
+- **Abort cleanup on unmount**: `useEffect` у HubChat abortить живий
+  запит при unmount (закриття чату) — інакше fetch продовжує
+  "ганяти" токени у фоні.
+- **Друге повідомлення "⏹ Запит скасовано"** замість generic error, коли
+  причина — aborted.
+
+## 5. HubSearch — fuzzy + keyboard + recent
+
+### До
+
+- `includes()` case-sensitive fallback, без token-based scoring.
+- Нема keyboard-nav (↑/↓/Enter) — тільки Escape.
+- Нема recent queries.
+- Нема глобального shortcut.
+
+### Після
+
+- `src/core/hubSearchEngine.ts`:
+  - `normalize(s)` — lowercase + NFD + diacritic strip + apostrophe
+    normalization (ʼ → ').
+  - `tokenize(q)` — split by whitespace.
+  - `scoreMatch(item, tokens)` — AND-logic; prefix > substring,
+    title > subtitle; повертає -1 коли не всі токени знайдені.
+  - `scoreAndSort(items, query, limit)` — filter + rank + stable sort.
+  - `getRecentQueries / pushRecentQuery / clearRecentQueries` —
+    localStorage cap-5, оновлюється при `Enter` або кліку на хіт.
+- `src/core/HubSearch.tsx` (переписано):
+  - Показує recent-queries chips коли input порожній.
+  - Highlighted row (`aria-selected`, `ring-1 ring-brand-500/25`) +
+    `data-hit-idx` для keyboard-nav scroll.
+  - `aria-combobox/listbox/option` ARIA-патерн.
+  - Hint у порожньому стані згадує ⌘K / Ctrl+K залежно від платформи.
+- **Глобальний shortcut** в `src/core/App.tsx`:
+  - `keydown` handler на `window`, `metaKey || ctrlKey` + `k`.
+  - Ігнорується, якщо фокус у `<input>`, `<textarea>`, або
+    `isContentEditable` — інакше ⌘K блокував би editing.
+
+## 6. Онбординг + PermissionsPrompt
+
+План — додати `PermissionsPrompt.tsx` у onboarding flow (push / speech
+/ camera) з поясненням "навіщо" + кнопка skip. Скоуп великий —
+перенесено у follow-up PR; інфраструктура haptic і a11y вже на місці.
+
+## 7. Доступність (a11y)
+
+### Зроблено
+
+- `motion-safe:` префікс у всіх `animate-pulse` / `animate-spin`
+  (8 файлів: Skeleton, Button, VoiceMicButton, ChatInput × 2,
+  UserMenuButton × 2, WeeklyDigestCard, Transactions,
+  SyncStatusBadge, FoodPickerSection, PageLoader).
+- `aria-hidden="true"` на `Skeleton` (декоративний — не зчитувати
+  AT-ями).
+- `PageLoader` → `aria-live="polite"` + `aria-busy="true"` +
+  `aria-label="Завантаження сторінки"`.
+- `HubSearch` → `role="dialog"`/`aria-modal`, `role="combobox"` з
+  `aria-expanded`/`aria-controls`/`aria-activedescendant`, `role="listbox"`
+  для результатів, `role="option"` + `aria-selected` для рядків.
+- `focus-visible:ring-2 focus-visible:ring-brand-500/45` у нових
+  інтерактивних елементах (замість `focus:ring-*`, яке показується
+  і для mouse).
+
+### Ще
+
+- Audit focus rings у застарілих компонентах (`h-11 rounded-xl` tokens)
+  для follow-up.
+
+## 8. PWA
+
+- `OfflineBanner` з queued-count — зрозуміла іконка офлайн-стану
+  ("Немає підключення · N дій чекають").
+- `IOSInstallBanner` / `usePwaInstall` — перевірено, не змінено
+  (існуюча поведінка коректна).
+- `manifest.json` shortcuts — не чіпали, валідні.
+
+## 9. Файли в PR
+
+### Нові
+
+- `src/shared/lib/haptic.ts`
+- `src/shared/lib/undoToast.tsx`
+- `src/shared/components/ui/SkeletonList.tsx`
+- `src/core/hubSearchEngine.ts`
+- `docs/ux-audit-2025.md`
+
+### Змінені (основні)
+
+- `src/core/App.tsx` — ⌘K/Ctrl+K handler.
+- `src/core/HubChat.tsx` — AbortController cancel, context-aware
+  prompts, unmount-abort cleanup.
+- `src/core/HubSearch.tsx` — перевстановлено з fuzzy engine +
+  keyboard-nav + recent queries + ARIA.
+- `src/core/ModuleErrorBoundary.tsx` — Retry button + remount key.
+- `src/core/app/PageLoader.tsx` — Skeleton замість тексту.
+- `src/core/app/OfflineBanner.tsx` — queued-count через useSyncStatus.
+- `src/shared/api/endpoints/chat.ts` — accept `signal`.
+
+### Змінені (a11y `motion-safe:`)
+
+- `src/shared/components/ui/Skeleton.tsx`
+- `src/shared/components/ui/Button.tsx`
+- `src/shared/components/ui/VoiceMicButton.tsx`
+- `src/core/components/ChatInput.jsx`
+- `src/core/app/UserMenuButton.tsx`
+- `src/core/WeeklyDigestCard.tsx`
+- `src/modules/finyk/pages/Transactions.jsx`
+- `src/modules/finyk/components/SyncStatusBadge.jsx`
+- `src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx`
+
+## 10. Не увійшло (follow-up)
+
+- `PermissionsPrompt` у онбординг (push / speech / camera).
+- Масштабне перенесення `showUndoToast` у всі destructive actions.
+- Drawer з історією сесій HubChat (наразі одна активна сесія у
+  `hub_chat_history`).
+- A11y audit legacy focus rings.

--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -165,6 +165,28 @@ function AppInner() {
     return () => window.removeEventListener(HUB_OPEN_MODULE_EVENT, onHubOpen);
   }, [openModule, setPwaAction, validActions]);
 
+  // Глобальний shortcut ⌘K / Ctrl+K → відкрити HubSearch. Ставимо
+  // `preventDefault`, щоб не спрацював нативний focus-address-bar у
+  // браузера. Не реагуємо, якщо пошук вже відкритий або фокус у
+  // input/textarea — тоді ⌘K не має перехоплювати typing.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod || (e.key !== "k" && e.key !== "K")) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const inEditable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        (target && target.isContentEditable);
+      if (inEditable) return;
+      e.preventDefault();
+      ui.setSearchOpen(true);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [ui]);
+
   if (sync.migrationPending) {
     return (
       <MigrationPrompt

--- a/src/core/HubChat.tsx
+++ b/src/core/HubChat.tsx
@@ -43,6 +43,36 @@ const QUICK_NO_MONO = [
   "Порадь щось",
 ];
 
+// Контекстні підказки, що залежать від модуля, з якого користувач
+// відкрив чат (якщо знаємо). Робимо підказки більш actionable, щоб
+// перший тап одразу вів до дії, а не до generic small-talk.
+const QUICK_BY_CONTEXT: Record<string, string[]> = {
+  finyk: [
+    "Додай витрату 120 грн на каву",
+    "Скільки витратив за тиждень?",
+    "Які мої активні підписки?",
+    "Склади короткий звіт по тижню",
+  ],
+  fizruk: [
+    "Почни тренування ноги",
+    "Порадь розминку перед залом",
+    "Скільки я тренувався цього тижня?",
+    "Додай сет присідання 5 повторів 40 кг",
+  ],
+  routine: [
+    "Познач звичку «вода» на сьогодні",
+    "Яка моя серія за цей тиждень?",
+    "Додай звичку читати 20 хв щодня",
+    "Що я пропустив цього тижня?",
+  ],
+  nutrition: [
+    "Залогай сніданок: вівсянка 100г + яблуко",
+    "Скільки ккал я з'їв сьогодні?",
+    "Порадь високобілкову вечерю",
+    "Склади короткий звіт по калоріях",
+  ],
+};
+
 function HubChat({ onClose, initialMessage }) {
   const [messages, setMessages] = useState(() => {
     try {
@@ -94,6 +124,11 @@ function HubChat({ onClose, initialMessage }) {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [speaking, setSpeaking] = useState(false);
+  // AbortController для скасування активного запиту (кнопка "Скасувати").
+  // Живе у ref, бо не впливає на рендер — лише даємо можливість
+  // натисненням перервати `chatApi.send`/`.stream`, і цим одразу
+  // повернути UI у стан готовності (loading=false).
+  const abortRef = useRef<AbortController | null>(null);
   const chatRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const lastWasVoice = useRef(false);
@@ -161,10 +196,26 @@ function HubChat({ onClose, initialMessage }) {
     scheduleContextBuild("finyk-cache", true);
   }, [finykPreviewUpdatedAt, scheduleContextBuild]);
 
-  const quickPrompts = useMemo(
-    () => (hasData ? QUICK_WITH_MONO : QUICK_NO_MONO),
-    [hasData],
-  );
+  // Якщо чат відкрився з-під модуля (через URL hash або подію), беремо
+  // контекстні підказки; інакше — генеричні mono/no-mono.
+  const activeModule = (() => {
+    try {
+      const hash = (window.location.hash || "")
+        .replace(/^#\/?/, "")
+        .toLowerCase();
+      const first = hash.split(/[/?#]/)[0];
+      if (["finyk", "fizruk", "routine", "nutrition"].includes(first))
+        return first;
+    } catch {
+      /* noop */
+    }
+    return null;
+  })();
+  const quickPrompts = useMemo(() => {
+    if (activeModule && QUICK_BY_CONTEXT[activeModule])
+      return QUICK_BY_CONTEXT[activeModule];
+    return hasData ? QUICK_WITH_MONO : QUICK_NO_MONO;
+  }, [hasData, activeModule]);
 
   useEffect(() => {
     if (chatRef.current)
@@ -229,6 +280,14 @@ function HubChat({ onClose, initialMessage }) {
       .slice(-10)
       .map((m) => ({ role: m.role, content: m.text }));
 
+    // Створюємо новий AbortController для цієї відправки. Якщо раптом
+    // попередній ще живий (не мало б бути — send гардить `loading`), то
+    // акуратно abort-имо його. Signal пробрасуємо у chatApi.send/stream.
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    const signal = ac.signal;
+
     try {
       const context = contextRef.current.text || buildContextMeasured();
       if (!contextRef.current.text) {
@@ -238,7 +297,7 @@ function HubChat({ onClose, initialMessage }) {
 
       let data;
       try {
-        data = await chatApi.send({ context, messages: history });
+        data = await chatApi.send({ context, messages: history }, { signal });
       } catch (err) {
         // Переписуємо `message` на юзер-френдлі, але лишаємося в межах
         // `ApiError` — щоб зовнішній `friendlyChatError` бачив ту саму
@@ -286,13 +345,16 @@ function HubChat({ onClose, initialMessage }) {
 
         let followUpText = "";
         try {
-          const res2 = await chatApi.stream({
-            context: contextRef.current.text || context,
-            messages: history,
-            tool_results: toolResults,
-            tool_calls_raw: data.tool_calls_raw,
-            stream: true,
-          });
+          const res2 = await chatApi.stream(
+            {
+              context: contextRef.current.text || context,
+              messages: history,
+              tool_results: toolResults,
+              tool_calls_raw: data.tool_calls_raw,
+              stream: true,
+            },
+            { signal },
+          );
 
           const ct = res2.headers.get("content-type") || "";
           if (res2.ok && ct.includes("text/event-stream")) {
@@ -358,11 +420,33 @@ function HubChat({ onClose, initialMessage }) {
         if (shouldSpeak) maybeSpeak(reply);
       }
     } catch (e) {
-      setMessages((m) => [...m, makeAssistantMsg(friendlyChatError(e))]);
+      // Явне скасування (кнопка "Скасувати" або закриття чату) не
+      // показуємо як помилку — додаємо тихий маркер.
+      if (isApiError(e) && e.kind === "aborted") {
+        setMessages((m) => [...m, makeAssistantMsg("⏹ Запит скасовано.")]);
+      } else if ((e as { name?: string } | null)?.name === "AbortError") {
+        setMessages((m) => [...m, makeAssistantMsg("⏹ Запит скасовано.")]);
+      } else {
+        setMessages((m) => [...m, makeAssistantMsg(friendlyChatError(e))]);
+      }
     } finally {
+      if (abortRef.current === ac) abortRef.current = null;
       setLoading(false);
     }
   };
+
+  const cancelInFlight = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  // Скасовуємо живий запит, якщо чат закривають прямо під час стріму —
+  // інакше fetch продовжує "ганяти" токени у фоні і finally-хендлер
+  // спрацьовує вже після unmount (лог у консоль + потенційна race).
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
   sendRef.current = send;
 
   const clearChat = () => {
@@ -496,7 +580,21 @@ function HubChat({ onClose, initialMessage }) {
               onSpeak={() => setSpeaking(true)}
             />
           ))}
-          {loading && <TypingIndicator />}
+          {loading && (
+            <div className="flex items-center gap-2">
+              <TypingIndicator />
+              <button
+                type="button"
+                onClick={cancelInFlight}
+                className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full bg-panelHi hover:bg-line/40 text-muted hover:text-text text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+                aria-label="Скасувати поточний запит"
+                title="Скасувати (Esc)"
+              >
+                <Icon name="close" size={12} />
+                Скасувати
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Quick prompts */}

--- a/src/core/HubSearch.tsx
+++ b/src/core/HubSearch.tsx
@@ -1,7 +1,15 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
+import { hapticTap } from "@shared/lib/haptic";
+import {
+  scoreMatch,
+  tokenize,
+  getRecentQueries,
+  pushRecentQuery,
+  clearRecentQueries,
+} from "./hubSearchEngine";
 
 function safeParseLS(key, fallback) {
   try {
@@ -19,7 +27,9 @@ function parseFizrukWorkouts(raw) {
     const p = JSON.parse(raw);
     if (Array.isArray(p)) return p;
     if (p && Array.isArray(p.workouts)) return p.workouts;
-  } catch {}
+  } catch {
+    /* ignore bad JSON — treat as empty */
+  }
   return [];
 }
 
@@ -29,7 +39,9 @@ function parseFizrukCustomExercises(raw) {
     const p = JSON.parse(raw);
     if (Array.isArray(p)) return p;
     if (p && Array.isArray(p.exercises)) return p.exercises;
-  } catch {}
+  } catch {
+    /* ignore bad JSON — treat as empty */
+  }
   return [];
 }
 
@@ -37,30 +49,52 @@ function localDateKey(d = new Date()) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-function searchFinyk(query) {
-  const q = query.toLowerCase();
-  const results = [];
+type Hit = {
+  id: string;
+  module: "finyk" | "fizruk" | "routine" | "nutrition";
+  moduleLabel: string;
+  title: string;
+  subtitle: string;
+  icon: string;
+  _score: number;
+};
+
+function pushScored(
+  acc: Hit[],
+  base: Omit<Hit, "_score">,
+  tokens: string[],
+  limit: number,
+) {
+  const s = scoreMatch(base, tokens);
+  if (s < 0) return acc.length >= limit;
+  acc.push({ ...base, _score: s });
+  return acc.length >= limit;
+}
+
+function searchFinyk(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
 
   const txList = safeParseLS("finyk_tx_cache", []);
   if (Array.isArray(txList)) {
     for (const tx of txList) {
       if (!tx || typeof tx !== "object") continue;
-      const desc = (tx.description || tx.comment || "").toLowerCase();
-      const mcc = String(tx.mcc || "");
-      if (desc.includes(q) || mcc.includes(q)) {
-        const amtRaw = Number(tx.amount);
-        const amount = (Number.isFinite(amtRaw) ? amtRaw : 0) / 100;
-        const sign = amount < 0 ? "−" : "+";
-        results.push({
+      const amtRaw = Number(tx.amount);
+      const amount = (Number.isFinite(amtRaw) ? amtRaw : 0) / 100;
+      const sign = amount < 0 ? "−" : "+";
+      const stop = pushScored(
+        results,
+        {
           id: `finyk_tx_${tx.id || tx.time}`,
           module: "finyk",
           moduleLabel: "Фінік",
           title: tx.description || tx.comment || "Транзакція",
           subtitle: `${sign}${Math.abs(amount).toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ₴ · ${tx.time > 1e10 ? localDateKey(new Date(tx.time)) : localDateKey(new Date(tx.time * 1000))}`,
           icon: "💳",
-        });
-        if (results.length >= 20) break;
-      }
+        },
+        tokens,
+        20,
+      );
+      if (stop) break;
     }
   }
 
@@ -68,61 +102,66 @@ function searchFinyk(query) {
   if (Array.isArray(subs)) {
     for (const s of subs) {
       if (!s || typeof s !== "object") continue;
-      if ((s.name || "").toLowerCase().includes(q)) {
-        const amtRaw = Number(s.amount);
-        const amt = Number.isFinite(amtRaw) && amtRaw > 0 ? amtRaw : 0;
-        results.push({
+      const amtRaw = Number(s.amount);
+      const amt = Number.isFinite(amtRaw) && amtRaw > 0 ? amtRaw : 0;
+      pushScored(
+        results,
+        {
           id: `finyk_sub_${s.id}`,
           module: "finyk",
           moduleLabel: "Фінік",
-          title: s.name,
+          title: s.name || "Підписка",
           subtitle: `Підписка · ${amt ? (amt / 100).toFixed(0) + " ₴" : ""}`,
           icon: "🔄",
-        });
-      }
+        },
+        tokens,
+        25,
+      );
     }
   }
 
-  return results.slice(0, 10);
+  return results.sort((a, b) => b._score - a._score).slice(0, 10);
 }
 
-function searchFizruk(query) {
-  const q = query.toLowerCase();
-  const results = [];
+function searchFizruk(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
 
   const workouts = parseFizrukWorkouts(
     localStorage.getItem("fizruk_workouts_v1"),
   );
-  if (workouts.length > 0) {
-    for (const w of workouts) {
-      if (!w || typeof w !== "object") continue;
-      const note = (w.note || "").toLowerCase();
-      const itemsRaw = Array.isArray(w.items) ? w.items : [];
-      const exercises = itemsRaw.map((i) =>
-        ((i && (i.exerciseName || i.name)) || "").toLowerCase(),
-      );
-      const matchNote = note.includes(q);
-      const matchExercise = exercises.some((e) => e.includes(q));
-      if (matchNote || matchExercise) {
-        const dateLabel = w.startedAt
-          ? localDateKey(new Date(w.startedAt))
-          : "";
-        const exNames = itemsRaw
-          .slice(0, 2)
-          .map((i) => (i && (i.exerciseName || i.name)) || "")
-          .filter(Boolean);
-        results.push({
-          id: `fizruk_w_${w.id}`,
-          module: "fizruk",
-          moduleLabel: "Фізрук",
-          title: w.note || exNames.join(", ") || "Тренування",
-          subtitle:
-            dateLabel + (itemsRaw.length ? ` · ${itemsRaw.length} вправ` : ""),
-          icon: "🏋️",
-        });
-      }
-      if (results.length >= 10) break;
-    }
+  for (const w of workouts) {
+    if (!w || typeof w !== "object") continue;
+    const itemsRaw = Array.isArray(w.items) ? w.items : [];
+    const exNames = itemsRaw
+      .slice(0, 2)
+      .map((i) => (i && (i.exerciseName || i.name)) || "")
+      .filter(Boolean);
+    const dateLabel = w.startedAt ? localDateKey(new Date(w.startedAt)) : "";
+    const combinedTitle = w.note || exNames.join(", ") || "Тренування";
+    // subtitle додатково "розширює" текст усіма вправами, щоб токен
+    // типу "присідання" знайшовся навіть коли він не в `note`.
+    const fullTokensText = itemsRaw
+      .map((i) => (i && (i.exerciseName || i.name)) || "")
+      .filter(Boolean)
+      .join(" ");
+    const stop = pushScored(
+      results,
+      {
+        id: `fizruk_w_${w.id}`,
+        module: "fizruk",
+        moduleLabel: "Фізрук",
+        title: combinedTitle,
+        subtitle:
+          dateLabel +
+          (itemsRaw.length
+            ? ` · ${itemsRaw.length} вправ · ${fullTokensText}`
+            : ""),
+        icon: "🏋️",
+      },
+      tokens,
+      10,
+    );
+    if (stop) break;
   }
 
   const exercises = parseFizrukCustomExercises(
@@ -130,14 +169,9 @@ function searchFizruk(query) {
   );
   for (const e of exercises) {
     if (!e || typeof e !== "object") continue;
-    if (
-      (e.name || "").toLowerCase().includes(q) ||
-      (Array.isArray(e.muscles) ? e.muscles : [])
-        .join(" ")
-        .toLowerCase()
-        .includes(q)
-    ) {
-      results.push({
+    const stop = pushScored(
+      results,
+      {
         id: `fizruk_ex_${e.id}`,
         module: "fizruk",
         moduleLabel: "Фізрук",
@@ -146,105 +180,106 @@ function searchFizruk(query) {
           (Array.isArray(e.muscles) ? e.muscles : []).join(", ") ||
           "Власна вправа",
         icon: "💪",
-      });
-      if (results.length >= 15) break;
-    }
+      },
+      tokens,
+      15,
+    );
+    if (stop) break;
   }
 
-  return results.slice(0, 10);
+  return results.sort((a, b) => b._score - a._score).slice(0, 10);
 }
 
-function searchRoutine(query) {
-  const q = query.toLowerCase();
-  const results = [];
-
+function searchRoutine(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
   const state = safeParseLS("hub_routine_v1", null);
   if (!state) return results;
 
   const habits = Array.isArray(state.habits) ? state.habits : [];
   for (const h of habits) {
     if (!h || typeof h !== "object") continue;
-    if (
-      (h.name || "").toLowerCase().includes(q) ||
-      (h.note || "").toLowerCase().includes(q) ||
-      (h.emoji || "").includes(q)
-    ) {
-      results.push({
+    const title = `${h.emoji || ""} ${h.name || "Звичка"}`.trim();
+    const stop = pushScored(
+      results,
+      {
         id: `routine_h_${h.id}`,
         module: "routine",
         moduleLabel: "Рутина",
-        title: `${h.emoji || ""} ${h.name || "Звичка"}`.trim(),
+        title,
         subtitle: h.archived ? "Архівовано" : h.recurrence || "daily",
         icon: "✅",
-      });
-    }
-    if (results.length >= 10) break;
+      },
+      tokens,
+      10,
+    );
+    if (stop) break;
   }
-
-  return results;
+  return results.sort((a, b) => b._score - a._score).slice(0, 10);
 }
 
-function searchNutrition(query) {
-  const q = query.toLowerCase();
-  const results = [];
-  const seen = new Set();
-
+function searchNutrition(tokens: string[]): Hit[] {
+  const results: Hit[] = [];
+  const seen = new Set<string>();
   const log = safeParseLS("nutrition_log_v1", {});
   const dates = Object.keys(log).sort().reverse();
 
   for (const date of dates) {
     const meals = Array.isArray(log[date]?.meals) ? log[date].meals : [];
     for (const m of meals) {
-      const name = (m.name || "").toLowerCase();
-      if (name.includes(q)) {
-        const key = m.name;
-        if (!seen.has(key)) {
-          seen.add(key);
-          results.push({
-            id: `nutrition_m_${m.id || date}`,
-            module: "nutrition",
-            moduleLabel: "Харчування",
-            title: m.name || "Прийом їжі",
-            subtitle: `${date} · ${m.macros?.kcal ?? 0} ккал`,
-            icon: "🥗",
-          });
-        }
-        if (results.length >= 10) break;
-      }
+      if (!m || typeof m !== "object") continue;
+      const key = m.name || `${date}_${m.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const stop = pushScored(
+        results,
+        {
+          id: `nutrition_m_${m.id || date}`,
+          module: "nutrition",
+          moduleLabel: "Харчування",
+          title: m.name || "Прийом їжі",
+          subtitle: `${date} · ${m.macros?.kcal ?? 0} ккал`,
+          icon: "🥗",
+        },
+        tokens,
+        10,
+      );
+      if (stop) break;
     }
     if (results.length >= 10) break;
   }
-
-  return results;
+  return results.sort((a, b) => b._score - a._score).slice(0, 10);
 }
 
-function performSearch(query) {
-  if (!query.trim() || query.trim().length < 2) return [];
-
-  const finykResults = searchFinyk(query);
-  const fizrukResults = searchFizruk(query);
-  const routineResults = searchRoutine(query);
-  const nutritionResults = searchNutrition(query);
-
+function performSearch(query: string): Hit[] {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
   return [
-    ...finykResults,
-    ...fizrukResults,
-    ...routineResults,
-    ...nutritionResults,
+    ...searchFinyk(tokens),
+    ...searchFizruk(tokens),
+    ...searchRoutine(tokens),
+    ...searchNutrition(tokens),
   ];
 }
 
-const MODULE_COLORS = {
+const MODULE_COLORS: Record<string, string> = {
   finyk: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
   fizruk: "bg-sky-500/10 text-sky-700 dark:text-sky-400",
   routine: "bg-orange-500/10 text-orange-700 dark:text-orange-400",
   nutrition: "bg-lime-500/10 text-lime-700 dark:text-lime-500",
 };
 
-export function HubSearch({ onClose, onOpenModule }) {
+interface HubSearchProps {
+  onClose: () => void;
+  onOpenModule: (moduleId: string) => void;
+}
+
+export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
-  const inputRef = useRef(null);
+  const [results, setResults] = useState<Hit[]>([]);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [recents, setRecents] = useState<string[]>(() => getRecentQueries());
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -253,32 +288,96 @@ export function HubSearch({ onClose, onOpenModule }) {
   useEffect(() => {
     if (query.trim().length < 2) {
       setResults([]);
+      setActiveIdx(0);
       return;
     }
     const timer = setTimeout(() => {
-      setResults(performSearch(query));
-    }, 150);
+      const next = performSearch(query);
+      setResults(next);
+      setActiveIdx(0);
+    }, 120);
     return () => clearTimeout(timer);
   }, [query]);
 
+  // Готуємо плоский список для keyboard-nav (↑/↓/Enter працюють по
+  // порядку рендеру, а не по groups-first).
+  const flat = useMemo(() => {
+    const order = ["finyk", "fizruk", "routine", "nutrition"];
+    return order.map((m) => results.filter((r) => r.module === m)).flat();
+  }, [results]);
+
+  const commitQuery = (q: string) => {
+    if (!q.trim()) return;
+    const next = pushRecentQuery(q);
+    setRecents(next);
+  };
+
+  const openHit = (hit: Hit) => {
+    hapticTap();
+    commitQuery(query);
+    onOpenModule(hit.module);
+    onClose();
+  };
+
   useEffect(() => {
-    function handleKeyDown(e) {
-      if (e.key === "Escape") onClose();
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.min(i + 1, Math.max(flat.length - 1, 0)));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter") {
+        const hit = flat[activeIdx];
+        if (hit) {
+          e.preventDefault();
+          openHit(hit);
+        } else if (query.trim()) {
+          commitQuery(query);
+        }
+      }
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flat, activeIdx, onClose, query]);
+
+  // Автоскрол до активного рядка при навігації клавіатурою.
+  useEffect(() => {
+    const root = listRef.current;
+    if (!root) return;
+    const el = root.querySelector<HTMLElement>(`[data-hit-idx="${activeIdx}"]`);
+    if (el) el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [activeIdx]);
 
   const grouped = results.reduce<
-    Record<string, { label: string; items: typeof results }>
+    Record<string, { label: string; items: Hit[] }>
   >((acc, r) => {
     if (!acc[r.module]) acc[r.module] = { label: r.moduleLabel, items: [] };
     acc[r.module].items.push(r);
     return acc;
   }, {});
 
+  const showRecents = query.trim().length < 2 && recents.length > 0;
+
+  let runningIdx = -1;
+
   return (
-    <div className="fixed inset-0 z-[200] flex flex-col bg-bg safe-area-pt-pb page-enter">
+    <div
+      className="fixed inset-0 z-[200] flex flex-col bg-bg safe-area-pt-pb page-enter"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Глобальний пошук"
+    >
       <div className="px-4 pt-4 pb-2 flex items-center gap-3 border-b border-line">
         <div className="flex-1 relative">
           <Icon
@@ -289,22 +388,34 @@ export function HubSearch({ onClose, onOpenModule }) {
           <input
             ref={inputRef}
             type="search"
-            placeholder="Пошук по всіх модулях..."
+            placeholder="Пошук по всіх модулях…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full h-11 pl-10 pr-4 rounded-2xl bg-panelHi border border-line text-text placeholder:text-muted text-sm focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+            role="combobox"
+            aria-expanded={flat.length > 0}
+            aria-controls="hub-search-results"
+            aria-activedescendant={
+              flat[activeIdx] ? `hub-hit-${flat[activeIdx].id}` : undefined
+            }
+            aria-autocomplete="list"
+            className="w-full h-11 pl-10 pr-4 rounded-2xl bg-panelHi border border-line text-text placeholder:text-muted text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
           />
         </div>
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 text-sm text-muted hover:text-text transition-colors"
+          className="shrink-0 text-sm text-muted hover:text-text transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-lg px-2 py-1"
         >
           Скасувати
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+      <div
+        ref={listRef}
+        id="hub-search-results"
+        className="flex-1 overflow-y-auto px-4 py-3 space-y-4"
+        role="listbox"
+      >
         {query.trim().length >= 2 && results.length === 0 && (
           <EmptyState
             icon={<Icon name="search" size={22} strokeWidth={1.6} />}
@@ -313,11 +424,66 @@ export function HubSearch({ onClose, onOpenModule }) {
           />
         )}
 
-        {query.trim().length < 2 && (
+        {showRecents && (
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <p className="text-xs font-semibold text-muted uppercase tracking-wider">
+                Недавні запити
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  clearRecentQueries();
+                  setRecents([]);
+                }}
+                className="text-xs text-muted hover:text-text transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded-lg px-1.5 py-0.5"
+              >
+                Очистити
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {recents.map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => {
+                    setQuery(r);
+                    inputRef.current?.focus();
+                  }}
+                  className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full bg-panelHi border border-line text-sm text-text hover:bg-line/40 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="text-muted"
+                    aria-hidden
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <polyline points="12 6 12 12 16 14" />
+                  </svg>
+                  {r}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!showRecents && query.trim().length < 2 && (
           <EmptyState
             icon={<Icon name="search" size={22} strokeWidth={1.6} />}
             title="Глобальний пошук"
-            description="Транзакції, тренування, звички, їжа — все в одному місці."
+            description={
+              typeof navigator !== "undefined" &&
+              /Mac|iPhone|iPad/.test(navigator.platform)
+                ? "Транзакції, тренування, звички, їжа — все в одному місці. ⌘K, щоб відкрити звідусіль."
+                : "Транзакції, тренування, звички, їжа — все в одному місці. Ctrl+K, щоб відкрити звідусіль."
+            }
           />
         )}
 
@@ -327,46 +493,58 @@ export function HubSearch({ onClose, onOpenModule }) {
               {group.label}
             </p>
             <div className="space-y-1">
-              {group.items.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => {
-                    onOpenModule(moduleId);
-                    onClose();
-                  }}
-                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-panelHi active:bg-panelHi transition-colors text-left"
-                >
-                  <span
+              {group.items.map((item) => {
+                runningIdx += 1;
+                const isActive = runningIdx === activeIdx;
+                return (
+                  <button
+                    key={item.id}
+                    id={`hub-hit-${item.id}`}
+                    data-hit-idx={runningIdx}
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    onClick={() => openHit(item)}
+                    onMouseEnter={() => setActiveIdx(runningIdx)}
                     className={cn(
-                      "w-8 h-8 rounded-xl flex items-center justify-center text-sm shrink-0",
-                      MODULE_COLORS[moduleId],
+                      "w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+                      isActive
+                        ? "bg-panelHi ring-1 ring-brand-500/25"
+                        : "hover:bg-panelHi active:bg-panelHi",
                     )}
                   >
-                    {item.icon}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm text-text truncate">{item.title}</p>
-                    <p className="text-xs text-muted truncate">
-                      {item.subtitle}
-                    </p>
-                  </div>
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="text-muted/40 shrink-0"
-                    aria-hidden
-                  >
-                    <path d="M9 18l6-6-6-6" />
-                  </svg>
-                </button>
-              ))}
+                    <span
+                      className={cn(
+                        "w-8 h-8 rounded-xl flex items-center justify-center text-sm shrink-0",
+                        MODULE_COLORS[moduleId],
+                      )}
+                      aria-hidden
+                    >
+                      {item.icon}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm text-text truncate">{item.title}</p>
+                      <p className="text-xs text-muted truncate">
+                        {item.subtitle}
+                      </p>
+                    </div>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="text-muted/40 shrink-0"
+                      aria-hidden
+                    >
+                      <path d="M9 18l6-6-6-6" />
+                    </svg>
+                  </button>
+                );
+              })}
             </div>
           </div>
         ))}

--- a/src/core/ModuleErrorBoundary.tsx
+++ b/src/core/ModuleErrorBoundary.tsx
@@ -7,10 +7,21 @@ interface ModuleErrorBoundaryProps {
 
 interface ModuleErrorBoundaryState {
   error: Error | null;
+  /** Rev-лічильник, який використовуємо як React `key`, щоб під час
+   *  ретраю піддерево ремонтувалось чисто — простий `setState({error:null})`
+   *  не завжди цього робить, якщо помилка була кинута у `useEffect`
+   *  (той самий effect може повторно кинути). */
+  retryRev: number;
 }
 
 /**
- * Ловить помилки рендеру всередині lazy-модуля; дозволяє повернутися до хаба без перезавантаження вкладки.
+ * Ловить помилки рендеру всередині lazy-модуля; дозволяє повернутися до хаба
+ * без перезавантаження вкладки.
+ *
+ * Дві дії:
+ *  - "Спробувати ще" — скидає `error` і через зміну `retryRev` як
+ *    React-ключа примусово перемонтовує модульне піддерево;
+ *  - "До вибору модуля" — повертає у хаб (логіка делегується parent-у).
  */
 export default class ModuleErrorBoundary extends Component<
   ModuleErrorBoundaryProps,
@@ -18,37 +29,75 @@ export default class ModuleErrorBoundary extends Component<
 > {
   constructor(props: ModuleErrorBoundaryProps) {
     super(props);
-    this.state = { error: null };
+    this.state = { error: null, retryRev: 0 };
   }
 
   static getDerivedStateFromError(error: Error) {
     return { error };
   }
 
+  private handleRetry = () => {
+    this.setState((s) => ({ error: null, retryRev: s.retryRev + 1 }));
+  };
+
+  private handleBack = () => {
+    this.setState({ error: null });
+    this.props.onBackToHub();
+  };
+
   render() {
     if (this.state.error) {
-      const { onBackToHub } = this.props;
       return (
         <div className="min-h-dvh bg-bg flex flex-col items-center justify-center p-6 text-text safe-area-pt-pb">
+          <div className="w-12 h-12 rounded-2xl bg-danger/10 text-danger flex items-center justify-center mb-3">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+          </div>
           <p className="text-sm text-muted mb-2 text-center">
             Помилка в модулі
           </p>
           <pre className="text-xs text-danger mb-6 max-w-lg w-full overflow-auto whitespace-pre-wrap break-words">
             {this.state.error.message}
           </pre>
-          <button
-            type="button"
-            onClick={() => {
-              this.setState({ error: null });
-              onBackToHub();
-            }}
-            className="px-5 py-2.5 rounded-2xl bg-panel border border-line text-text text-sm font-medium shadow-card hover:shadow-float transition-shadow"
-          >
-            До вибору модуля
-          </button>
+          <div className="flex flex-col sm:flex-row gap-2 w-full max-w-xs">
+            <button
+              type="button"
+              onClick={this.handleRetry}
+              className="flex-1 px-5 py-2.5 rounded-2xl bg-primary text-bg text-sm font-semibold shadow-card hover:brightness-110 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              aria-label="Спробувати ще раз"
+            >
+              Спробувати ще
+            </button>
+            <button
+              type="button"
+              onClick={this.handleBack}
+              className="flex-1 px-5 py-2.5 rounded-2xl bg-panel border border-line text-text text-sm font-medium shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+            >
+              До вибору модуля
+            </button>
+          </div>
         </div>
       );
     }
-    return this.props.children;
+    // Зміна `retryRev` примусово ремонтує дерево — без цього useEffect
+    // всередині модуля може повторно кинути ту ж саму помилку.
+    return (
+      <div key={this.state.retryRev} className="contents">
+        {this.props.children}
+      </div>
+    );
   }
 }

--- a/src/core/WeeklyDigestCard.tsx
+++ b/src/core/WeeklyDigestCard.tsx
@@ -150,7 +150,7 @@ function LoadingSpinner() {
   return (
     <div className="flex items-center justify-center gap-2 py-6">
       <svg
-        className="animate-spin w-4 h-4 text-primary"
+        className="motion-safe:animate-spin w-4 h-4 text-primary"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"

--- a/src/core/app/OfflineBanner.tsx
+++ b/src/core/app/OfflineBanner.tsx
@@ -1,14 +1,36 @@
 import { Icon } from "@shared/components/ui/Icon";
+import { useSyncStatus } from "../useCloudSync.js";
+import { pluralUa } from "@shared/lib/ukrainianPlural";
 
+/**
+ * Офлайн-банер у шапці. Раніше показував лише статичне "Немає
+ * підключення до інтернету". Тепер підтягує `useSyncStatus`, щоб
+ * користувач одразу бачив, скільки дій стоїть у черзі — це закриває
+ * головну тривогу ("чи збережеться витрата, якщо я без мережі?").
+ *
+ * Шрифт/кольори не змінюємо, щоб не зміщувати layout у залежності від
+ * кількості елементів у черзі (висота банера константна).
+ */
 export function OfflineBanner() {
+  const { queuedCount, dirtyCount } = useSyncStatus();
+  const pending = Math.max(queuedCount, dirtyCount);
+  const label =
+    pending > 0
+      ? `Немає підключення · ${pending} ${pluralUa(pending, {
+          one: "дія чекає",
+          few: "дії чекають",
+          many: "дій чекають",
+        })} синхронізації`
+      : "Немає підключення до інтернету";
+
   return (
     <div
       role="status"
       aria-live="polite"
       className="fixed top-0 left-0 right-0 z-[300] flex items-center justify-center gap-2 px-4 py-2 bg-warning text-white text-xs font-semibold safe-area-pt shadow-soft"
     >
-      <Icon name="wifi-off" size={14} strokeWidth={2.5} />
-      Немає підключення до інтернету
+      <Icon name="wifi-off" size={14} strokeWidth={2.5} aria-hidden />
+      <span className="truncate max-w-[min(92vw,40rem)]">{label}</span>
     </div>
   );
 }

--- a/src/core/app/PageLoader.tsx
+++ b/src/core/app/PageLoader.tsx
@@ -1,7 +1,34 @@
+import { Skeleton } from "@shared/components/ui/Skeleton";
+
+/**
+ * Skeleton-плейсхолдер, який використовується як Suspense fallback для
+ * lazy-модулів. Замінив текстовий "Завантаження…" на скелетон, що
+ * імітує реальну структуру хабу: шапка + 3 картки. Це різко скорочує
+ * перцептивне очікування (немає порожнього екрану) й усуває CLS у
+ * момент, коли модуль фактично приїжджає.
+ *
+ * motion-safe: `animate-pulse` вимикається при `prefers-reduced-motion`.
+ */
 export function PageLoader() {
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="text-subtle text-sm animate-pulse">Завантаження...</div>
+    <div
+      className="flex-1 flex flex-col px-4 py-4 gap-3 safe-area-pt-pb"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Завантаження сторінки"
+    >
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-2xl motion-safe:animate-pulse" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-3.5 w-1/2 motion-safe:animate-pulse" />
+          <Skeleton className="h-3 w-1/3 motion-safe:animate-pulse" />
+        </div>
+      </div>
+      <Skeleton className="h-28 w-full motion-safe:animate-pulse" />
+      <Skeleton className="h-20 w-full motion-safe:animate-pulse" />
+      <Skeleton className="h-20 w-full motion-safe:animate-pulse" />
+      <span className="sr-only">Завантаження…</span>
     </div>
   );
 }

--- a/src/core/app/UserMenuButton.tsx
+++ b/src/core/app/UserMenuButton.tsx
@@ -15,7 +15,7 @@ function SyncBadge({ user, syncing }) {
   if (!tone) return null;
   const toneCls =
     tone === "syncing"
-      ? "bg-primary animate-pulse"
+      ? "bg-primary motion-safe:animate-pulse"
       : tone === "offline"
         ? "bg-muted"
         : "bg-warning";
@@ -66,7 +66,7 @@ export function UserMenuButton({
           "relative w-11 h-11 flex items-center justify-center rounded-2xl text-sm font-bold transition-colors",
           "bg-brand-500/15 text-brand-600 dark:text-brand-400 hover:bg-brand-500/25",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-          syncing && "animate-pulse",
+          syncing && "motion-safe:animate-pulse",
         )}
       >
         {initial}

--- a/src/core/components/ChatInput.jsx
+++ b/src/core/components/ChatInput.jsx
@@ -59,7 +59,7 @@ export function ChatInput({
             stopSpeaking();
             setSpeaking(false);
           }}
-          className="w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-all border bg-warning/15 border-warning text-warning animate-pulse"
+          className="w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-all border bg-warning/15 border-warning text-warning motion-safe:animate-pulse"
           title="Зупинити озвучення"
           aria-label="Зупинити озвучення"
         >
@@ -80,7 +80,7 @@ export function ChatInput({
           className={cn(
             "w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-all border",
             listening
-              ? "bg-danger text-white border-danger animate-pulse"
+              ? "bg-danger text-white border-danger motion-safe:animate-pulse"
               : "bg-panel border-line text-muted hover:text-text hover:border-muted",
           )}
           title={listening ? "Зупинити запис" : "Голосовий ввід"}

--- a/src/core/hubSearchEngine.ts
+++ b/src/core/hubSearchEngine.ts
@@ -1,0 +1,118 @@
+/**
+ * Матчінг рядків для глобального пошуку. Колись жив інлайном у
+ * `HubSearch.tsx` і зводився до `String.includes`. Тепер:
+ *
+ *  1) Нормалізуємо (lowercase + NFD + видалення діакритики + заміна
+ *     апострофів — щоб "їдальня" знаходилась за "ідальня" / "idalnya"
+ *     не претендуємо, але "м'ясо" ↔ "мясо" ↔ "м`ясо" матчиться).
+ *  2) Токенуємо запит по пробілах і вимагаємо, щоб кожен токен
+ *     з'являвся у title/subtitle як підрядок (AND між токенами).
+ *     Це fuzzy-ish без ваги Levenshtein — дешево й стабільно на
+ *     десятках тисяч транзакцій.
+ *  3) Рахуємо простий skor (prefix match > substring, match у title >
+ *     match у subtitle) щоб сортувати результати в межах групи.
+ */
+
+export function normalize(s: string): string {
+  if (!s) return "";
+  try {
+    return s
+      .toLowerCase()
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[\u2018\u2019\u02bc'`´]/g, "");
+  } catch {
+    return s.toLowerCase();
+  }
+}
+
+export function tokenize(q: string): string[] {
+  return normalize(q)
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+export interface Scorable {
+  title?: string;
+  subtitle?: string;
+}
+
+/**
+ * Повертає score >= 0 якщо збіг, або -1 якщо не збіг. Усі токени
+ * запиту мають зустрітися у title/subtitle.
+ */
+export function scoreMatch(item: Scorable, tokens: string[]): number {
+  if (tokens.length === 0) return 0;
+  const title = normalize(item.title || "");
+  const subtitle = normalize(item.subtitle || "");
+  const hay = `${title} ${subtitle}`;
+
+  let score = 0;
+  for (const t of tokens) {
+    if (!hay.includes(t)) return -1;
+    // Prefix у title — топ; просто subtitle — менше.
+    if (title.startsWith(t)) score += 12;
+    else if (title.includes(t)) score += 6;
+    else if (subtitle.includes(t)) score += 2;
+    // Бонус за довгий збіг (щоб "хліб" бив над "хлібом" без префіксу).
+    score += Math.min(4, t.length);
+  }
+  return score;
+}
+
+/** Фільтр + сортування за score. Зберігає стабільний порядок для рівних scores. */
+export function scoreAndSort<T extends Scorable>(
+  items: T[],
+  query: string,
+  limit = 10,
+): T[] {
+  const tokens = tokenize(query);
+  if (!tokens.length) return items.slice(0, limit);
+  const scored: Array<{ item: T; score: number; idx: number }> = [];
+  items.forEach((item, idx) => {
+    const s = scoreMatch(item, tokens);
+    if (s >= 0) scored.push({ item, score: s, idx });
+  });
+  scored.sort((a, b) => b.score - a.score || a.idx - b.idx);
+  return scored.slice(0, limit).map((e) => e.item);
+}
+
+/** Локальне сховище для недавніх запитів. Кап на 5 — щоб UI лишався легким. */
+const RECENTS_KEY = "hub_search_recents_v1";
+const RECENTS_CAP = 5;
+
+export function getRecentQueries(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENTS_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    return arr.filter((v) => typeof v === "string").slice(0, RECENTS_CAP);
+  } catch {
+    return [];
+  }
+}
+
+export function pushRecentQuery(q: string): string[] {
+  const norm = q.trim();
+  if (!norm) return getRecentQueries();
+  try {
+    const current = getRecentQueries();
+    const next = [norm, ...current.filter((v) => v !== norm)].slice(
+      0,
+      RECENTS_CAP,
+    );
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+    return next;
+  } catch {
+    return getRecentQueries();
+  }
+}
+
+export function clearRecentQueries(): void {
+  try {
+    localStorage.removeItem(RECENTS_KEY);
+  } catch {
+    /* noop */
+  }
+}

--- a/src/core/lib/hubChatActions.test.ts
+++ b/src/core/lib/hubChatActions.test.ts
@@ -130,6 +130,7 @@ describe("log_set", () => {
 
     const saved = readLS<{
       workouts: Array<{
+        id: string;
         endedAt: string | null;
         items: Array<{
           nameUk: string;

--- a/src/modules/finyk/components/SyncStatusBadge.jsx
+++ b/src/modules/finyk/components/SyncStatusBadge.jsx
@@ -26,7 +26,7 @@ function SyncStatusBadgeComponent({
   const isSuccess = status === "success";
 
   const dotClass = isLoading
-    ? "bg-amber-400 animate-pulse"
+    ? "bg-amber-400 motion-safe:animate-pulse"
     : isError
       ? "bg-danger"
       : isPartial

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -472,7 +472,7 @@ export function Transactions({
                     strokeWidth="2.2"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className={activeLoading ? "animate-spin" : ""}
+                    className={activeLoading ? "motion-safe:animate-spin" : ""}
                     aria-hidden
                   >
                     <polyline points="23 4 23 10 17 10" />

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -57,7 +57,7 @@ export function FoodPickerSection({
         </SectionHeading>
         {(foodBusy || offBusy) && (
           <span className="text-2xs text-subtle flex items-center gap-1.5">
-            <span className="inline-block w-3 h-3 border border-nutrition/40 border-t-nutrition rounded-full animate-spin" />
+            <span className="inline-block w-3 h-3 border border-nutrition/40 border-t-nutrition rounded-full motion-safe:animate-spin" />
             пошук…
           </span>
         )}

--- a/src/shared/api/endpoints/chat.ts
+++ b/src/shared/api/endpoints/chat.ts
@@ -20,14 +20,24 @@ export interface ChatResponse {
   error?: string;
 }
 
+export interface ChatCallOpts {
+  /** Скасувати активний запит (AbortController у HubChat). */
+  signal?: AbortSignal;
+}
+
 export const chatApi = {
   /** Звичайний non-streaming JSON-запит. */
-  send: (payload: ChatRequestPayload) =>
-    http.post<ChatResponse>("/api/chat", payload),
+  send: (payload: ChatRequestPayload, opts: ChatCallOpts = {}) =>
+    http.post<ChatResponse>("/api/chat", payload, { signal: opts.signal }),
   /**
    * SSE-стрім. Повертає сирий `Response`, щоб викликач сам керував
-   * `ReadableStream` (напр. через `consumeHubChatSse`).
+   * `ReadableStream` (напр. через `consumeHubChatSse`). `signal` прокидуємо
+   * у fetch, щоб скасування з UI перериває read loop.
    */
-  stream: (payload: ChatRequestPayload) =>
-    http.raw("/api/chat", { method: "POST", body: payload }),
+  stream: (payload: ChatRequestPayload, opts: ChatCallOpts = {}) =>
+    http.raw("/api/chat", {
+      method: "POST",
+      body: payload,
+      signal: opts.signal,
+    }),
 };

--- a/src/shared/components/ui/Button.tsx
+++ b/src/shared/components/ui/Button.tsx
@@ -138,7 +138,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {loading ? (
           <>
-            <LoadingSpinner className="animate-spin" />
+            <LoadingSpinner className="motion-safe:animate-spin" />
             {!iconOnly && (
               <span className="opacity-0" aria-hidden="true">
                 {children}

--- a/src/shared/components/ui/Skeleton.tsx
+++ b/src/shared/components/ui/Skeleton.tsx
@@ -4,14 +4,29 @@ export interface SkeletonProps {
   className?: string;
 }
 
+// `motion-safe:animate-pulse` замість безумовного `animate-pulse`:
+// користувачі з `prefers-reduced-motion: reduce` отримають статичну
+// панель замість миготіння (вимога WCAG 2.3.3 + Apple HIG reduced motion).
 export function Skeleton({ className }: SkeletonProps) {
   return (
-    <div className={cn("animate-pulse bg-panelHi rounded-2xl", className)} />
+    <div
+      className={cn(
+        "motion-safe:animate-pulse bg-panelHi rounded-2xl",
+        className,
+      )}
+      aria-hidden="true"
+    />
   );
 }
 
 export function SkeletonText({ className }: SkeletonProps) {
   return (
-    <div className={cn("animate-pulse bg-panelHi rounded-lg h-3", className)} />
+    <div
+      className={cn(
+        "motion-safe:animate-pulse bg-panelHi rounded-lg h-3",
+        className,
+      )}
+      aria-hidden="true"
+    />
   );
 }

--- a/src/shared/components/ui/SkeletonList.tsx
+++ b/src/shared/components/ui/SkeletonList.tsx
@@ -1,0 +1,61 @@
+import { cn } from "../../lib/cn";
+import { Skeleton } from "./Skeleton";
+
+export interface SkeletonListProps {
+  /** Скільки рядків намалювати (за замовчуванням 5). */
+  rows?: number;
+  /** Висота кожного рядка. */
+  rowClassName?: string;
+  /** Відстань між рядками. */
+  className?: string;
+  /** Відрендерити "аватар"-квадрат ліворуч (корисно для списків транзакцій / вправ). */
+  avatar?: boolean;
+  /** Показати 2 лінії тексту (title + subtitle) замість однієї. */
+  twoLine?: boolean;
+}
+
+/**
+ * Уніфікований skeleton для списків (транзакції, тренування, звички,
+ * прийоми їжі). Замінює спінер `animate-pulse` текст "Завантаження…",
+ * що давав CLS і повне порожнє поле. Motion-safe: `animate-pulse` на
+ * дочірніх `Skeleton` сам респектує `prefers-reduced-motion` через
+ * Tailwind.
+ */
+export function SkeletonList({
+  rows = 5,
+  rowClassName,
+  className,
+  avatar = false,
+  twoLine = false,
+}: SkeletonListProps) {
+  return (
+    <div
+      className={cn("space-y-2", className)}
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Завантаження списку"
+    >
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          className={cn(
+            "flex items-center gap-3 bg-panel border border-line rounded-2xl px-3 py-3",
+            rowClassName,
+          )}
+        >
+          {avatar && (
+            <Skeleton className="w-10 h-10 rounded-xl shrink-0 motion-safe:animate-pulse" />
+          )}
+          <div className="flex-1 min-w-0 space-y-2">
+            <Skeleton className="h-3.5 w-2/3 motion-safe:animate-pulse" />
+            {twoLine && (
+              <Skeleton className="h-3 w-1/3 motion-safe:animate-pulse" />
+            )}
+          </div>
+          <Skeleton className="h-3 w-12 shrink-0 motion-safe:animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/shared/components/ui/VoiceMicButton.tsx
+++ b/src/shared/components/ui/VoiceMicButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
+import { hapticTap } from "@shared/lib/haptic";
 
 type SpeechRecognitionLike = {
   lang: string;
@@ -171,10 +172,15 @@ export function VoiceMicButton({
   };
   const iconSize = size === "sm" ? 14 : size === "lg" ? 20 : 16;
 
+  const handleClick = () => {
+    hapticTap();
+    toggle();
+  };
+
   return (
     <button
       type="button"
-      onClick={toggle}
+      onClick={handleClick}
       disabled={disabled}
       aria-label={listening ? "Зупинити запис" : label || "Голосовий ввід"}
       title={listening ? "Зупинити запис" : label || "Голосовий ввід"}
@@ -182,7 +188,7 @@ export function VoiceMicButton({
         "relative flex items-center justify-center rounded-2xl shrink-0 transition-all",
         sizeMap[size] || sizeMap.md,
         listening
-          ? "bg-error/15 text-error border border-error/30 animate-pulse"
+          ? "bg-error/15 text-error border border-error/30 motion-safe:animate-pulse"
           : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line",
         disabled && "opacity-40 pointer-events-none",
         className,

--- a/src/shared/lib/haptic.ts
+++ b/src/shared/lib/haptic.ts
@@ -1,0 +1,70 @@
+/**
+ * Тонкий шар над `navigator.vibrate`, який:
+ *  1) вимикається, коли користувач ввімкнув `prefers-reduced-motion`;
+ *  2) тихо робить no-op на платформах без підтримки (iOS Safari, настільні);
+ *  3) ловить винятки, бо деякі мобільні Chrome кидають `NotAllowedError`,
+ *     якщо викликати `vibrate` поза user-gesture.
+ *
+ * Патерни вибрані так, щоб співпасти з фізичним очікуванням від дії:
+ *  - `tap`      — легкий тап (10 мс), primary CTA, toggle, tab change;
+ *  - `success`  — подвійний короткий (12/40/18), успішне збереження;
+ *  - `warning`  — 30 мс, destructive confirm;
+ *  - `error`    — 60/60/60, помилка мережі / валідації.
+ *
+ * Використовуй `hapticPattern` напряму для особливих сценаріїв (наприклад,
+ * фінішер тренування вже вібрує [200, 100, 200] у Fizruk — цей модуль
+ * не знижує його "силу").
+ */
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+function canVibrate(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return typeof navigator.vibrate === "function";
+}
+
+export function hapticPattern(pattern: number | number[]): void {
+  if (!canVibrate() || prefersReducedMotion()) return;
+  try {
+    navigator.vibrate(pattern);
+  } catch {
+    /* noop — NotAllowedError / throttled by browser */
+  }
+}
+
+/** Легкий tap — головні CTAs, toggles, tab switch. */
+export function hapticTap(): void {
+  hapticPattern(10);
+}
+
+/** Успішне збереження / завершення дії. */
+export function hapticSuccess(): void {
+  hapticPattern([12, 40, 18]);
+}
+
+/** Попередження / destructive confirm. */
+export function hapticWarning(): void {
+  hapticPattern(30);
+}
+
+/** Помилка (мережа, валідація, немає доступу). */
+export function hapticError(): void {
+  hapticPattern([60, 60, 60]);
+}
+
+/** Скасовує поточну вібрацію (наприклад, під час довгого натискання). */
+export function hapticCancel(): void {
+  if (!canVibrate()) return;
+  try {
+    navigator.vibrate(0);
+  } catch {
+    /* noop */
+  }
+}

--- a/src/shared/lib/undoToast.tsx
+++ b/src/shared/lib/undoToast.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import type { ToastApi } from "@shared/hooks/useToast";
+import { hapticTap, hapticWarning } from "./haptic";
+
+export interface UndoToastOptions {
+  /** Текст, який бачить користувач ("Видалено звичку «Вода»"). */
+  msg: ReactNode;
+  /** Скільки мс тримати toast відкритим (default 5000, як і просив продакт-бриф). */
+  duration?: number;
+  /** Лейбл для кнопки undo ("Повернути"). */
+  undoLabel?: string;
+  /** Викликається, коли юзер натиснув undo — ти відновлюєш локальний state / БД. */
+  onUndo: () => void;
+}
+
+/**
+ * Обгортка над `useToast().show`, що стандартизує patern для
+ * деструктивних дій (видалення звички / транзакції / сета) під єдиний
+ * 5-секундний таймер із undo-кнопкою.
+ *
+ * Виклик:
+ * ```tsx
+ * const toast = useToast();
+ * showUndoToast(toast, {
+ *   msg: "Видалено звичку «Вода»",
+ *   onUndo: () => restoreHabit(habit),
+ * });
+ * ```
+ *
+ * Haptic: викликається `hapticWarning()` на появу toast, і `hapticTap()`
+ * на натискання undo — щоб користувач фізично відчув і небезпечну дію,
+ * і виправлення.
+ */
+export function showUndoToast(
+  toast: ToastApi,
+  { msg, duration = 5000, undoLabel = "Повернути", onUndo }: UndoToastOptions,
+): number {
+  hapticWarning();
+  return toast.show(msg, "info", duration, {
+    label: undoLabel,
+    onClick: () => {
+      hapticTap();
+      try {
+        onUndo();
+      } catch {
+        /* caller повинен сам лапати помилки — undo ідемпотентне */
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Комплексний UX-аудит і покращення 10 напрямків: ключові флоу, стани, мікровзаємодії, HubChat, HubSearch, a11y, PWA. Повний чек-ліст у `docs/ux-audit-2025.md`.

**Стани** (було → стало)
- `PageLoader` "Завантаження…" текст → структурований skeleton (avatar + title/subtitle + 3 рядки) з `aria-live` / `aria-busy`
- `OfflineBanner` без контексту → підтягує `useSyncStatus()` і показує "Немає підключення · N дій чекають синхронізації" (через `pluralUa`)
- `ModuleErrorBoundary` тільки fallback → кнопки **Спробувати ще** (remount по `retryRev`) + **До вибору модуля** + `error.message` для debug
- Уніфікований `SkeletonList` компонент для transactions/workouts/habits/meals

**Мікровзаємодії** (новий infrastructure)
- `src/shared/lib/haptic.ts` — `hapticTap/Success/Warning/Error`. Feature-detect `navigator.vibrate`, поважає `prefers-reduced-motion`, catch `NotAllowedError`. Wired у VoiceMicButton + HubSearch.
- `src/shared/lib/undoToast.tsx` — 5-сек undo з `hapticWarning` при показі і `hapticTap` при undo.

**HubChat** (було → стало)
- **Cancel**: `chatApi.send/.stream` тепер приймають `signal`; `HubChat` створює AbortController на send; кнопка "Скасувати" поруч із `TypingIndicator`; unmount-effect abortить fetch, щоб не "ганяти" токени у фоні.
- **Контекстні prompts**: `QUICK_BY_CONTEXT` (finyk/fizruk/routine/nutrition) — 4 набори actionable підказок на основі `location.hash`. Fallback → generic mono/no-mono.
- **Aborted UX**: "⏹ Запит скасовано" замість generic error, коли причина — `AbortError` / `ApiError{kind:"aborted"}`.

**HubSearch** (переписано)
- `src/core/hubSearchEngine.ts`:
  - `normalize(s)` — lowercase + NFD + diacritic strip + ʼ → '
  - `tokenize(q)` — whitespace-split
  - `scoreMatch(item, tokens)` — AND-logic, prefix > substring, title > subtitle
  - `scoreAndSort(items, query, limit)` — filter + rank (stable)
  - `getRecentQueries / pushRecentQuery / clearRecentQueries` — localStorage cap-5
- Keyboard: **↑/↓/Enter/Esc** у списку, `aria-combobox/listbox/option` патерн, `data-hit-idx` для scroll-into-view, hover синхронізується з active-idx.
- Recent-queries chips у порожньому стані + кнопка "Очистити".
- **Глобальний ⌘K / Ctrl+K** у `src/core/App.tsx` — ігноруємо, коли фокус у input/textarea/contentEditable.

**A11y**
- `motion-safe:` префікс для `animate-pulse` / `animate-spin` у 10+ файлах (Skeleton, Button, VoiceMicButton, ChatInput, UserMenuButton, WeeklyDigestCard, Transactions, SyncStatusBadge, FoodPickerSection, PageLoader).
- `aria-hidden="true"` на decorative Skeleton.
- `focus-visible:ring-2 focus-visible:ring-brand-500/45` у нових інтерактивних елементах (не показується для mouse).
- `PageLoader` → `aria-live="polite"`, `aria-busy="true"`, `aria-label="Завантаження сторінки"`.

**Не увійшло у цей PR (follow-up)**
- `PermissionsPrompt` у онбординг (push / speech / camera) — окремий PR, скоуп значний.
- Масове перенесення `showUndoToast` у всі destructive actions (інфраструктура готова, але потребує audit).
- Drawer з історією сесій HubChat (зараз — одна активна сесія `hub_chat_history`).

## Review & Testing Checklist for Human

- [ ] Відкрити HubSearch через ⌘K / Ctrl+K у різних браузерах — не має блокувати, коли фокус у чаті / textarea.
- [ ] HubChat: розпочати довгий запит → натиснути "Скасувати" → переконатись, що стрім зупиняється і з'являється "⏹ Запит скасовано".
- [ ] HubSearch: зайти з типовою помилкою типу "присід" / "вівсянк" (без закінчення) — fuzzy token-based match має працювати, prefix-scoring ранжує краще.
- [ ] Перевірити `OfflineBanner` з декількома pending операціями у `useCloudSync` — має показувати "N дій чекають синхронізації" з коректною множиною.
- [ ] Увімкнути `prefers-reduced-motion` в OS і перевірити, що skeletons/loading spinners не анімуються.

### Notes

- `src/core/lib/hubChatActions.test.ts`: додав `id: string` у inline тип саме тому, що раніше typecheck падав на master через відсутнє це поле — фіксую разом.
- `PageLoader` тепер повертає більший DOM — CLS має покращитися (менше layout shift при повному завантаженні модуля).
- HubChat abort-on-unmount може впливати на поведінку, коли користувач закриває чат посеред стріму: раніше токени продовжували приходити у background; тепер fetch перериває чисто.
- `chatApi.stream(..., { signal })` використовує існуючий `http.raw` signal-прокидання через `RequestOptions` — 0 breaking changes для інших викликів.

Детальний чек-ліст усіх змін — `docs/ux-audit-2025.md`.


Link to Devin session: https://app.devin.ai/sessions/8d2523d0fe3c49549c8892a696adc970
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
