### PR TITLE
feat(hubchat): expand tool-use to 19 new tools across all 4 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,45 @@ server/
 
 **Деплой:** фронт Vercel + API/PostgreSQL на Railway — покроково [docs/railway-vercel.md](docs/railway-vercel.md). Локальна БД: `npm run db:up` (Docker Compose).
 
+## HubChat (AI-чат)
+
+**Архітектура:** клієнт `src/core/HubChat.tsx` + `src/core/lib/hubChatActions.ts` (виконавець tool-calls) ↔ сервер `server/modules/chat.js` (Anthropic tool-use, Claude Sonnet 4.6). Користувач керує всіма 4 модулями голосом або текстом без переходу в UI.
+
+**Інструменти (32):**
+
+| Модуль     | Tools                                                                                                                                                                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Фінік      | `create_transaction`, `delete_transaction`, `change_category`, `hide_transaction`, `create_debt`, `mark_debt_paid`, `create_receivable`, `set_budget_limit`, `update_budget`, `set_monthly_plan`, `add_asset`, `import_monobank_range` |
+| Фізрук     | `plan_workout`, `start_workout`, `finish_workout`, `log_set`, `add_program_day`, `log_measurement`, `log_wellbeing`                                                                                                                    |
+| Рутина     | `create_habit`, `mark_habit_done`, `complete_habit_for_date`, `create_reminder`, `archive_habit`, `add_calendar_event`                                                                                                                 |
+| Харчування | `log_meal`, `log_water`, `add_recipe`, `add_to_shopping_list`, `consume_from_pantry`, `set_daily_plan`, `log_weight`                                                                                                                   |
+
+**Приклади промптів:**
+
+- "Видали транзакцію m_abc123" → `delete_transaction`
+- "Постав ліміт на кафе 3000 грн" → `update_budget { scope:'limit', ... }`
+- "Створи ціль 'Відпустка' на 30 000 грн, вже зібрано 5000" → `update_budget { scope:'goal', ... }`
+- "Закрий борг оренди" → `mark_debt_paid`
+- "Додай актив депозит Приват 100 000 грн" → `add_asset`
+- "Оновити монобанк з 1 травня до сьогодні" → `import_monobank_range`
+- "Почни тренування" / "Заверши тренування" → `start_workout` / `finish_workout`
+- "Запиши заміри: вага 78.5, талія 82" → `log_measurement`
+- "В понеділок груди/трицепс: жим 4×8 80 кг, розводка 3×12" → `add_program_day`
+- "Самопочуття: вага 78, сон 7.5 год, енергія 4/5" → `log_wellbeing`
+- "Нагадай про розминку о 8:00" → `create_reminder`
+- "Познач 'Пити воду' виконаною на 10 червня" → `complete_habit_for_date`
+- "Заархівуй звичку ..." → `archive_habit`
+- "Додай у календар 'Лікар' 1 липня о 9:30" → `add_calendar_event`
+- "Збережи рецепт 'Овочевий суп', інгредієнти ..." → `add_recipe`
+- "Додай у список покупок молоко 2 л" → `add_to_shopping_list`
+- "Використав яйця з комори" → `consume_from_pantry`
+- "Постав щоденний план: 2200 ккал, білок 150 г, вода 2.5 л" → `set_daily_plan`
+- "Запиши вагу 77.3" → `log_weight`
+
+**Квоти:** кожен виклик `/api/chat` (перший крок та tool-result-продовження) інкрементує `aiQuota` через `requireAiQuota()`-middleware. Ліміти — `AI_DAILY_USER_LIMIT` / `AI_DAILY_ANON_LIMIT`.
+
+**Тести:** `src/core/lib/hubChatActions.test.ts` + `hubChatActionsExtended.test.ts` (клієнтські обробники, localStorage mutations), `server/modules/chat.test.js` (tool-parsing з мок-Anthropic).
+
 ## PWA
 
 Hub — повноцінний Progressive Web App:

--- a/server/modules/chat.js
+++ b/server/modules/chat.js
@@ -299,6 +299,364 @@ const TOOLS = [
       required: ["name", "kcal"],
     },
   },
+  // ── Фінік (розширені) ─────────────────────────────────────────────
+  {
+    name: "delete_transaction",
+    description:
+      "Видалити ручну транзакцію з Фініка. Приймає id ручної транзакції (починається з 'm_') — такий, як у блоці [Останні операції]. Монобанк-транзакції видалити не можна — для них використовуй hide_transaction. Ідемпотентно: якщо транзакції немає — повертає відповідне повідомлення.",
+    input_schema: {
+      type: "object",
+      properties: {
+        tx_id: {
+          type: "string",
+          description:
+            "ID ручної транзакції (формат 'm_...'). Напр. 'm_abc123'",
+        },
+      },
+      required: ["tx_id"],
+    },
+  },
+  {
+    name: "update_budget",
+    description:
+      "Оновити або створити бюджет: або ліміт на категорію (scope='limit'), або ціль заощаджень (scope='goal'). Для ліміту потрібні category_id + limit. Для цілі — name + target_amount, опціонально saved_amount. Ідемпотентно (upsert).",
+    input_schema: {
+      type: "object",
+      properties: {
+        scope: {
+          type: "string",
+          description:
+            "'limit' — ліміт витрат на категорію; 'goal' — ціль заощаджень",
+        },
+        category_id: {
+          type: "string",
+          description: "Для scope='limit': id категорії з блоку [Категорії]",
+        },
+        limit: {
+          type: "number",
+          description: "Для scope='limit': сума ліміту грн/міс",
+        },
+        name: {
+          type: "string",
+          description: "Для scope='goal': назва цілі (напр. 'Відпустка')",
+        },
+        target_amount: {
+          type: "number",
+          description: "Для scope='goal': цільова сума грн",
+        },
+        saved_amount: {
+          type: "number",
+          description: "Для scope='goal': вже накопичена сума грн (опційно)",
+        },
+      },
+      required: ["scope"],
+    },
+  },
+  {
+    name: "mark_debt_paid",
+    description:
+      "Відмітити борг як (частково чи повністю) сплачений. Створює ручну витрату-погашення на вказану суму (якщо не задано — на суму боргу) і лінкує її до боргу (linkedTxIds). Якщо повна сума покрита — борг вважається закритим. ID боргу беріть з блоку [Борги].",
+    input_schema: {
+      type: "object",
+      properties: {
+        debt_id: { type: "string", description: "ID боргу (формат 'd_...')" },
+        amount: {
+          type: "number",
+          description:
+            "Сума погашення грн (опційно; за замовчуванням — повна сума боргу)",
+        },
+        note: {
+          type: "string",
+          description: "Короткий опис транзакції (опційно)",
+        },
+      },
+      required: ["debt_id"],
+    },
+  },
+  {
+    name: "add_asset",
+    description:
+      "Додати актив (вклад, готівка, нерухомість, авто тощо) у розділ Фінік/Активи.",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Назва активу" },
+        amount: { type: "number", description: "Сума грн (або в currency)" },
+        currency: {
+          type: "string",
+          description: "Валюта 3 літери (опційно, default 'UAH')",
+        },
+      },
+      required: ["name", "amount"],
+    },
+  },
+  {
+    name: "import_monobank_range",
+    description:
+      "Попросити Фінік перезавантажити транзакції з Монобанку за період YYYY-MM-DD..YYYY-MM-DD. Очищує кеш відповідних місяців і диспатчить подію, на яку реагує модуль Фінік. Сам імпорт виконується коли користувач відкриє Фінік (потрібен токен).",
+    input_schema: {
+      type: "object",
+      properties: {
+        from: { type: "string", description: "Початкова дата YYYY-MM-DD" },
+        to: { type: "string", description: "Кінцева дата YYYY-MM-DD" },
+      },
+      required: ["from", "to"],
+    },
+  },
+  // ── Фізрук (розширені) ────────────────────────────────────────────
+  {
+    name: "start_workout",
+    description:
+      "Розпочати нове тренування зараз (або з вказаного часу). Зберігає як активне у Фізруку, щоб наступні log_set підходи записувались у нього. Якщо вже є активне — лише повідомляє про нього (ідемпотентно).",
+    input_schema: {
+      type: "object",
+      properties: {
+        note: { type: "string", description: "Коротка нотатка / назва" },
+        date: {
+          type: "string",
+          description: "Дата YYYY-MM-DD (опційно, default — сьогодні)",
+        },
+        time: {
+          type: "string",
+          description: "Час початку HH:MM (опційно, default — зараз)",
+        },
+      },
+    },
+  },
+  {
+    name: "finish_workout",
+    description:
+      "Завершити поточне активне тренування (виставити endedAt=now) і прибрати активний статус. Якщо передано workout_id — завершує саме його. Ідемпотентно.",
+    input_schema: {
+      type: "object",
+      properties: {
+        workout_id: {
+          type: "string",
+          description:
+            "ID тренування (опційно; default — поточне активне або останнє незавершене)",
+        },
+      },
+    },
+  },
+  {
+    name: "log_measurement",
+    description:
+      "Записати антропометрію у Фізрук/Заміри. Можна передавати лише ті поля, які виміряні. Додає новий запис у журнал замірів (не перезаписує попередні).",
+    input_schema: {
+      type: "object",
+      properties: {
+        weight_kg: { type: "number", description: "Вага кг" },
+        body_fat_pct: { type: "number", description: "% жиру" },
+        neck_cm: { type: "number", description: "Шия см" },
+        chest_cm: { type: "number", description: "Груди см" },
+        waist_cm: { type: "number", description: "Талія см" },
+        hips_cm: { type: "number", description: "Стегна (обхват) см" },
+        bicep_l_cm: { type: "number", description: "Біцепс лівий см" },
+        bicep_r_cm: { type: "number", description: "Біцепс правий см" },
+        thigh_l_cm: { type: "number", description: "Стегно лівий см" },
+        thigh_r_cm: { type: "number", description: "Стегно правий см" },
+        calf_l_cm: { type: "number", description: "Литка лівий см" },
+        calf_r_cm: { type: "number", description: "Литка правий см" },
+      },
+    },
+  },
+  {
+    name: "add_program_day",
+    description:
+      "Додати/оновити день тижневого шаблону програми тренувань (fizruk_plan_template_v1). weekday: 0=неділя..6=субота. Ідемпотентно: перезаписує день за weekday.",
+    input_schema: {
+      type: "object",
+      properties: {
+        weekday: {
+          type: "number",
+          description: "День тижня 0-6 (0=нд, 1=пн, ..., 6=сб)",
+        },
+        name: { type: "string", description: "Назва тренування дня" },
+        exercises: {
+          type: "array",
+          description: "Список вправ для дня",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Назва вправи" },
+              sets: { type: "number", description: "Кількість підходів" },
+              reps: { type: "number", description: "Повторень" },
+              weight: { type: "number", description: "Вага кг" },
+            },
+            required: ["name"],
+          },
+        },
+      },
+      required: ["weekday", "name"],
+    },
+  },
+  {
+    name: "log_wellbeing",
+    description:
+      "Записати самопочуття у щоденний журнал Фізрука: сон, енергія 1-5, настрій 1-5, вага, нотатка. Можна передавати лише частину полів.",
+    input_schema: {
+      type: "object",
+      properties: {
+        weight_kg: { type: "number", description: "Вага кг" },
+        sleep_hours: { type: "number", description: "Годин сну" },
+        energy_level: { type: "number", description: "Енергія 1-5" },
+        mood_score: { type: "number", description: "Настрій 1-5" },
+        note: { type: "string", description: "Нотатка (опційно)" },
+      },
+    },
+  },
+  // ── Рутина (розширені) ────────────────────────────────────────────
+  {
+    name: "create_reminder",
+    description:
+      "Додати час нагадування HH:MM до звички у Рутині. ID звички — з блоку [Рутина сьогодні]. Ідемпотентно: якщо такий час вже є — не дублюється.",
+    input_schema: {
+      type: "object",
+      properties: {
+        habit_id: { type: "string", description: "ID звички" },
+        time: { type: "string", description: "Час HH:MM (напр. '08:00')" },
+      },
+      required: ["habit_id", "time"],
+    },
+  },
+  {
+    name: "complete_habit_for_date",
+    description:
+      "Позначити або зняти позначку виконання звички на конкретну дату YYYY-MM-DD. Якщо completed=false — знімає позначку; default=true.",
+    input_schema: {
+      type: "object",
+      properties: {
+        habit_id: { type: "string", description: "ID звички" },
+        date: { type: "string", description: "Дата YYYY-MM-DD" },
+        completed: {
+          type: "boolean",
+          description: "true=позначити, false=зняти (default true)",
+        },
+      },
+      required: ["habit_id", "date"],
+    },
+  },
+  {
+    name: "archive_habit",
+    description:
+      "Заархівувати звичку (прибрати зі списку активних) або повернути з архіву. Ідемпотентно.",
+    input_schema: {
+      type: "object",
+      properties: {
+        habit_id: { type: "string", description: "ID звички" },
+        archived: {
+          type: "boolean",
+          description: "true=заархівувати (default), false=повернути з архіву",
+        },
+      },
+      required: ["habit_id"],
+    },
+  },
+  {
+    name: "add_calendar_event",
+    description:
+      "Додати разову подію в календар Рутини (реалізовано як звичка recurrence='once' на одну дату). Корисно для нагадувань про зустріч, деньнародження тощо.",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Назва події" },
+        date: { type: "string", description: "Дата YYYY-MM-DD" },
+        time: { type: "string", description: "Час HH:MM (опційно)" },
+        emoji: { type: "string", description: "Емодзі (опційно)" },
+      },
+      required: ["name", "date"],
+    },
+  },
+  // ── Харчування (розширені) ────────────────────────────────────────
+  {
+    name: "add_recipe",
+    description:
+      "Зберегти рецепт у книгу рецептів (IndexedDB). Напр. коли користувач каже 'збережи рецепт омлету з ...'. Збереження асинхронне, повідомлення повертається одразу.",
+    input_schema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Назва рецепту" },
+        ingredients: {
+          type: "array",
+          description: "Список інгредієнтів (рядки)",
+          items: { type: "string" },
+        },
+        steps: {
+          type: "array",
+          description: "Кроки приготування (рядки)",
+          items: { type: "string" },
+        },
+        servings: { type: "number", description: "Порцій" },
+        time_minutes: { type: "number", description: "Час готування хв" },
+        kcal: { type: "number", description: "Ккал на порцію (опційно)" },
+        protein_g: { type: "number", description: "Білок г (опційно)" },
+        fat_g: { type: "number", description: "Жири г (опційно)" },
+        carbs_g: { type: "number", description: "Вуглеводи г (опційно)" },
+      },
+      required: ["title"],
+    },
+  },
+  {
+    name: "add_to_shopping_list",
+    description:
+      "Додати продукт у список покупок. Якщо такий вже є у відповідній категорії — оновлює кількість/нотатку (ідемпотентно по імені).",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Назва продукту" },
+        quantity: {
+          type: "string",
+          description: "Кількість (напр. '500 г', '2 шт')",
+        },
+        note: { type: "string", description: "Нотатка (опційно)" },
+        category: {
+          type: "string",
+          description: "Категорія списку (опційно, default 'Інше')",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "consume_from_pantry",
+    description:
+      "Видалити / спожити продукт з активної комори (pantry). Ідемпотентно: якщо продукту немає — повертає відповідне повідомлення.",
+    input_schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Назва продукту" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "set_daily_plan",
+    description:
+      "Задати/оновити щоденні цілі Харчування: ккал, білок, жири, вуглеводи, ціль по воді (мл). Можна передавати лише ті поля, які змінюються.",
+    input_schema: {
+      type: "object",
+      properties: {
+        kcal: { type: "number", description: "Ціль ккал/день" },
+        protein_g: { type: "number", description: "Ціль білка г/день" },
+        fat_g: { type: "number", description: "Ціль жирів г/день" },
+        carbs_g: { type: "number", description: "Ціль вуглеводів г/день" },
+        water_ml: { type: "number", description: "Ціль води мл/день" },
+      },
+    },
+  },
+  {
+    name: "log_weight",
+    description:
+      "Записати поточну вагу (кг) у щоденний журнал Фізрука. Аналог log_wellbeing, але лише з вагою — швидкий шлях для прокидання ваги.",
+    input_schema: {
+      type: "object",
+      properties: {
+        weight_kg: { type: "number", description: "Вага кг" },
+        note: { type: "string", description: "Нотатка (опційно)" },
+      },
+      required: ["weight_kg"],
+    },
+  },
 ];
 
 const SYSTEM_PREFIX = `Ти персональний асистент додатку "Мій простір". Ти маєш доступ до 4 модулів: Фінік (фінанси), Фізрук (тренування), Рутина (щоденні звички) та Харчування (нутрієнти й калорії). Відповідай ТІЛЬКИ українською, стисло (2-4 речення).
@@ -307,10 +665,10 @@ const SYSTEM_PREFIX = `Ти персональний асистент додат
 - Усі числа бери з блоку ДАНІ нижче.
 - Якщо потрібно порахувати (середня/день, прогноз, залишок ліміту, відсоток виконання) — рахуй на основі наданих чисел.
 - Якщо користувач просить змінити або записати дані — використай відповідний tool.
-  - Фінанси: create_transaction (записати витрату/дохід), change_category, create_debt, create_receivable, hide_transaction, set_budget_limit, set_monthly_plan
-  - Фізрук: plan_workout (запланувати тренування на дату; можна одразу зі списком вправ), log_set (додати підхід у активне або нове тренування)
-  - Рутина: create_habit (додати нову звичку), mark_habit_done (id звички з [Рутина сьогодні])
-  - Харчування: log_meal (назва + ккал; білок/жири/вуглеводи опційно), log_water (мл води)
+  - Фінанси: create_transaction, delete_transaction (лише ручні m_...), change_category, hide_transaction, create_debt, mark_debt_paid, create_receivable, set_budget_limit, update_budget (ліміт або ціль), set_monthly_plan, add_asset, import_monobank_range
+  - Фізрук: start_workout / finish_workout, log_set, plan_workout, add_program_day, log_measurement, log_wellbeing
+  - Рутина: create_habit, mark_habit_done, complete_habit_for_date, create_reminder, archive_habit, add_calendar_event
+  - Харчування: log_meal, log_water, add_recipe, add_to_shopping_list, consume_from_pantry, set_daily_plan, log_weight
 - Транзакції мають id і дату — використовуй для tool calls.
 - Категорії та їх id перелічені в [Категорії].
 - Відповідай на питання по всіх 4 модулях.

--- a/server/modules/chat.test.js
+++ b/server/modules/chat.test.js
@@ -1,0 +1,233 @@
+/**
+ * Unit tests для server/modules/chat.js — tool-parsing з моканим Anthropic.
+ *
+ * Покриття:
+ * - Перший крок: повертає tool_calls коли Anthropic присилає tool_use-блоки.
+ * - Другий крок (tool_results + tool_calls_raw): повертає summary-текст.
+ * - Перший крок без tool_use: повертає text напряму.
+ * - Всі нові tools присутні у TOOLS з валідними input_schema.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../lib/anthropic.js", () => ({
+  anthropicMessages: vi.fn(),
+  anthropicMessagesStream: vi.fn(),
+  extractAnthropicText: vi.fn((d) =>
+    (d?.content || [])
+      .filter((b) => b.type === "text")
+      .map((b) => b.text)
+      .join("\n"),
+  ),
+}));
+
+import { anthropicMessages } from "../lib/anthropic.js";
+import handler from "./chat.js";
+
+function makeReq(body) {
+  return { anthropicKey: "sk-test", body };
+}
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("chat handler — tool_use parsing", () => {
+  it("повертає tool_calls коли Anthropic присилає tool_use-блоки", async () => {
+    const toolUseBlock = {
+      type: "tool_use",
+      id: "toolu_01ABC",
+      name: "delete_transaction",
+      input: { tx_id: "m_abc123" },
+    };
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Видаляю..." }, toolUseBlock] },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Видали транзакцію m_abc123" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      text: "Видаляю...",
+      tool_calls: [
+        {
+          id: "toolu_01ABC",
+          name: "delete_transaction",
+          input: { tx_id: "m_abc123" },
+        },
+      ],
+    });
+    expect(res.body.tool_calls_raw).toHaveLength(2);
+    // Перевіряємо, що TOOLS передалися
+    const callArg = anthropicMessages.mock.calls[0][1];
+    expect(Array.isArray(callArg.tools)).toBe(true);
+    expect(callArg.tools.length).toBeGreaterThan(20);
+  });
+
+  it("повертає text напряму коли немає tool_use", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Привіт!" }] },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Привіт" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ text: "Привіт!" });
+  });
+
+  it("другий крок з tool_results → повертає summary-text", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: {
+        content: [{ type: "text", text: "Готово, транзакцію видалено." }],
+      },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Видали m_abc" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "delete_transaction",
+          input: { tx_id: "m_abc" },
+        },
+      ],
+      tool_results: [
+        { tool_use_id: "toolu_1", content: "Транзакцію m_abc видалено" },
+      ],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.text).toContain("видалено");
+
+    // Перевіряємо формат повідомлень до Anthropic на другому кроці
+    const payload = anthropicMessages.mock.calls[0][1];
+    expect(payload.messages).toHaveLength(3);
+    expect(payload.messages[0]).toMatchObject({ role: "user" });
+    expect(payload.messages[1]).toMatchObject({ role: "assistant" });
+    expect(payload.messages[2].role).toBe("user");
+    expect(payload.messages[2].content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "toolu_1",
+    });
+  });
+
+  it("400 коли немає повідомлень", async () => {
+    const req = makeReq({ messages: [] });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Немає повідомлень" });
+    expect(anthropicMessages).not.toHaveBeenCalled();
+  });
+
+  it("поширює помилку коли Anthropic повертає !ok", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: false, status: 429 },
+      data: { error: { message: "rate limit" } },
+    });
+    const req = makeReq({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(429);
+    expect(res.body).toEqual({ error: "rate limit" });
+  });
+});
+
+describe("TOOLS registry — структура нових tools", () => {
+  const expected = [
+    // Фінік
+    "delete_transaction",
+    "update_budget",
+    "mark_debt_paid",
+    "add_asset",
+    "import_monobank_range",
+    // Фізрук
+    "start_workout",
+    "finish_workout",
+    "log_measurement",
+    "add_program_day",
+    "log_wellbeing",
+    // Рутина
+    "create_reminder",
+    "complete_habit_for_date",
+    "archive_habit",
+    "add_calendar_event",
+    // Харчування
+    "add_recipe",
+    "add_to_shopping_list",
+    "consume_from_pantry",
+    "set_daily_plan",
+    "log_weight",
+  ];
+
+  it("всі 19 нових tools передаються в Anthropic з валідним input_schema", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "ok" }] },
+    });
+    const req = makeReq({
+      messages: [{ role: "user", content: "ping" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    const tools = anthropicMessages.mock.calls[0][1].tools;
+    const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+    for (const name of expected) {
+      expect(
+        byName[name],
+        `tool "${name}" має бути зареєстрований`,
+      ).toBeTruthy();
+      expect(byName[name].description).toBeTypeOf("string");
+      expect(byName[name].input_schema.type).toBe("object");
+      expect(byName[name].input_schema.properties).toBeTypeOf("object");
+    }
+
+    // Обов'язкові required-поля для критичних tools
+    expect(byName.delete_transaction.input_schema.required).toEqual(["tx_id"]);
+    expect(byName.update_budget.input_schema.required).toEqual(["scope"]);
+    expect(byName.mark_debt_paid.input_schema.required).toEqual(["debt_id"]);
+    expect(byName.log_weight.input_schema.required).toEqual(["weight_kg"]);
+    expect(byName.import_monobank_range.input_schema.required).toEqual([
+      "from",
+      "to",
+    ]);
+    expect(byName.create_reminder.input_schema.required).toEqual([
+      "habit_id",
+      "time",
+    ]);
+    expect(byName.add_calendar_event.input_schema.required).toEqual([
+      "name",
+      "date",
+    ]);
+  });
+});

--- a/src/core/lib/hubChatActions.test.ts
+++ b/src/core/lib/hubChatActions.test.ts
@@ -130,6 +130,7 @@ describe("log_set", () => {
 
     const saved = readLS<{
       workouts: Array<{
+        id: string;
         endedAt: string | null;
         items: Array<{
           nameUk: string;

--- a/src/core/lib/hubChatActions.ts
+++ b/src/core/lib/hubChatActions.ts
@@ -3,6 +3,7 @@ import {
   createHabit as routineCreateHabit,
   loadRoutineState,
 } from "../../modules/routine/lib/routineStorage";
+import { saveRecipeToBook } from "../../modules/nutrition/lib/recipeBook";
 import { ls, lsSet } from "./hubChatUtils.js";
 
 interface ChangeCategoryAction {
@@ -115,6 +116,152 @@ interface LogWaterAction {
   };
 }
 
+interface DeleteTransactionAction {
+  name: "delete_transaction";
+  input: { tx_id: string };
+}
+
+interface UpdateBudgetAction {
+  name: "update_budget";
+  input: {
+    scope: "limit" | "goal";
+    category_id?: string;
+    limit?: number | string;
+    name?: string;
+    target_amount?: number | string;
+    saved_amount?: number | string;
+  };
+}
+
+interface MarkDebtPaidAction {
+  name: "mark_debt_paid";
+  input: {
+    debt_id: string;
+    amount?: number | string;
+    note?: string;
+  };
+}
+
+interface AddAssetAction {
+  name: "add_asset";
+  input: {
+    name: string;
+    amount: number | string;
+    currency?: string;
+  };
+}
+
+interface ImportMonobankRangeAction {
+  name: "import_monobank_range";
+  input: { from: string; to: string };
+}
+
+interface StartWorkoutAction {
+  name: "start_workout";
+  input: { note?: string; date?: string; time?: string };
+}
+
+interface FinishWorkoutAction {
+  name: "finish_workout";
+  input: { workout_id?: string };
+}
+
+interface LogMeasurementAction {
+  name: "log_measurement";
+  input: Record<string, number | string | undefined>;
+}
+
+interface AddProgramDayAction {
+  name: "add_program_day";
+  input: {
+    weekday: number | string;
+    name: string;
+    exercises?: Array<{
+      name: string;
+      sets?: number | string;
+      reps?: number | string;
+      weight?: number | string;
+    }>;
+  };
+}
+
+interface LogWellbeingAction {
+  name: "log_wellbeing";
+  input: {
+    weight_kg?: number | string;
+    sleep_hours?: number | string;
+    energy_level?: number | string;
+    mood_score?: number | string;
+    note?: string;
+  };
+}
+
+interface CreateReminderAction {
+  name: "create_reminder";
+  input: { habit_id: string; time: string };
+}
+
+interface CompleteHabitForDateAction {
+  name: "complete_habit_for_date";
+  input: { habit_id: string; date: string; completed?: boolean };
+}
+
+interface ArchiveHabitAction {
+  name: "archive_habit";
+  input: { habit_id: string; archived?: boolean };
+}
+
+interface AddCalendarEventAction {
+  name: "add_calendar_event";
+  input: { name: string; date: string; time?: string; emoji?: string };
+}
+
+interface AddRecipeAction {
+  name: "add_recipe";
+  input: {
+    title: string;
+    ingredients?: string[];
+    steps?: string[];
+    servings?: number | string;
+    time_minutes?: number | string;
+    kcal?: number | string;
+    protein_g?: number | string;
+    fat_g?: number | string;
+    carbs_g?: number | string;
+  };
+}
+
+interface AddToShoppingListAction {
+  name: "add_to_shopping_list";
+  input: {
+    name: string;
+    quantity?: string;
+    note?: string;
+    category?: string;
+  };
+}
+
+interface ConsumeFromPantryAction {
+  name: "consume_from_pantry";
+  input: { name: string };
+}
+
+interface SetDailyPlanAction {
+  name: "set_daily_plan";
+  input: {
+    kcal?: number | string;
+    protein_g?: number | string;
+    fat_g?: number | string;
+    carbs_g?: number | string;
+    water_ml?: number | string;
+  };
+}
+
+interface LogWeightAction {
+  name: "log_weight";
+  input: { weight_kg: number | string; note?: string };
+}
+
 export type ChatAction =
   | ChangeCategoryAction
   | CreateDebtAction
@@ -129,6 +276,25 @@ export type ChatAction =
   | CreateTransactionAction
   | LogSetAction
   | LogWaterAction
+  | DeleteTransactionAction
+  | UpdateBudgetAction
+  | MarkDebtPaidAction
+  | AddAssetAction
+  | ImportMonobankRangeAction
+  | StartWorkoutAction
+  | FinishWorkoutAction
+  | LogMeasurementAction
+  | AddProgramDayAction
+  | LogWellbeingAction
+  | CreateReminderAction
+  | CompleteHabitForDateAction
+  | ArchiveHabitAction
+  | AddCalendarEventAction
+  | AddRecipeAction
+  | AddToShoppingListAction
+  | ConsumeFromPantryAction
+  | SetDailyPlanAction
+  | LogWeightAction
   | { name: string; input: Record<string, unknown> };
 
 interface BudgetLimit {
@@ -658,6 +824,703 @@ export function executeAction(action: ChatAction): string {
         log[dateKey] = prev + ml;
         lsSet("nutrition_water_v1", log);
         return `Додано ${ml} мл води (разом за ${dateKey}: ${log[dateKey]} мл)`;
+      }
+      case "delete_transaction": {
+        const { tx_id } = (action as DeleteTransactionAction).input;
+        const id = String(tx_id || "").trim();
+        if (!id) return "Потрібен tx_id для видалення.";
+        if (!id.startsWith("m_")) {
+          return `Транзакцію ${id} не видалено: можна видаляти лише ручні (m_...). Для монобанк-транзакцій використайте hide_transaction.`;
+        }
+        const list = ls<Array<{ id: string }>>("finyk_manual_expenses_v1", []);
+        const idx = list.findIndex((t) => t.id === id);
+        if (idx < 0) return `Транзакцію ${id} не знайдено (вже видалена).`;
+        const next = list.slice();
+        next.splice(idx, 1);
+        lsSet("finyk_manual_expenses_v1", next);
+        return `Транзакцію ${id} видалено`;
+      }
+      case "update_budget": {
+        const input = (action as UpdateBudgetAction).input;
+        const scope = input.scope;
+        const budgets = ls<Budget[]>("finyk_budgets", []);
+        if (scope === "limit") {
+          const categoryId = String(input.category_id || "").trim();
+          const limitN = Number(input.limit);
+          if (!categoryId) return "Для scope='limit' потрібен category_id.";
+          if (!Number.isFinite(limitN) || limitN <= 0)
+            return "Для scope='limit' потрібен додатний limit.";
+          const idx = budgets.findIndex(
+            (b) => b.type === "limit" && b.categoryId === categoryId,
+          );
+          if (idx >= 0) {
+            (budgets[idx] as BudgetLimit).limit = limitN;
+          } else {
+            budgets.push({
+              id: `b_${Date.now()}`,
+              type: "limit",
+              categoryId,
+              limit: limitN,
+            });
+          }
+          lsSet("finyk_budgets", budgets);
+          const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
+          const cat = resolveExpenseCategoryMeta(categoryId, customC);
+          return `Ліміт ${cat?.label || categoryId} оновлено: ${limitN} грн`;
+        }
+        if (scope === "goal") {
+          const goalName = String(input.name || "").trim();
+          const target = Number(input.target_amount);
+          if (!goalName) return "Для scope='goal' потрібне name.";
+          if (!Number.isFinite(target) || target <= 0)
+            return "Для scope='goal' потрібен додатний target_amount.";
+          const saved =
+            input.saved_amount != null &&
+            Number.isFinite(Number(input.saved_amount))
+              ? Number(input.saved_amount)
+              : 0;
+          const idx = budgets.findIndex(
+            (b) =>
+              b.type === "goal" &&
+              (b as BudgetGoal).name.trim().toLowerCase() ===
+                goalName.toLowerCase(),
+          );
+          if (idx >= 0) {
+            const g = budgets[idx] as BudgetGoal;
+            g.targetAmount = target;
+            g.savedAmount = saved;
+            g.name = goalName;
+          } else {
+            budgets.push({
+              id: `b_${Date.now()}`,
+              type: "goal",
+              name: goalName,
+              targetAmount: target,
+              savedAmount: saved,
+            });
+          }
+          lsSet("finyk_budgets", budgets);
+          return `Ціль "${goalName}" оновлено: ${saved}/${target} грн`;
+        }
+        return "Невідомий scope для update_budget (очікую 'limit' або 'goal').";
+      }
+      case "mark_debt_paid": {
+        const { debt_id, amount, note } = (action as MarkDebtPaidAction).input;
+        const id = String(debt_id || "").trim();
+        if (!id) return "Потрібен debt_id.";
+        const debts = ls<Debt[]>("finyk_debts", []);
+        const idx = debts.findIndex((d) => d.id === id);
+        if (idx < 0) return `Борг ${id} не знайдено.`;
+        const debt = { ...debts[idx] };
+        const payAmount =
+          amount != null && Number.isFinite(Number(amount))
+            ? Math.abs(Number(amount))
+            : Number(debt.totalAmount) || 0;
+        if (payAmount <= 0) return "Сума погашення має бути додатною.";
+        const txId = `m_${Date.now().toString(36)}_${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        const manualExpenses = ls<
+          Array<{
+            id: string;
+            date: string;
+            description?: string;
+            amount: number;
+            category?: string;
+            type?: string;
+          }>
+        >("finyk_manual_expenses_v1", []);
+        manualExpenses.unshift({
+          id: txId,
+          date: new Date().toISOString(),
+          description:
+            (note && String(note).trim()) || `Погашення: ${debt.name}`,
+          amount: payAmount,
+          category: "",
+          type: "expense",
+        });
+        lsSet("finyk_manual_expenses_v1", manualExpenses);
+        debt.linkedTxIds = [...(debt.linkedTxIds || []), txId];
+        const totalPaid = payAmount;
+        const closed = totalPaid >= Number(debt.totalAmount);
+        if (closed) {
+          debts.splice(idx, 1);
+        } else {
+          debts[idx] = debt;
+        }
+        lsSet("finyk_debts", debts);
+        return `Погашено ${payAmount} грн з "${debt.name}"${closed ? " — борг закрито" : ""} (tx:${txId})`;
+      }
+      case "add_asset": {
+        const { name, amount, currency } = (action as AddAssetAction).input;
+        const trimmed = (name || "").trim();
+        const amt = Number(amount);
+        if (!trimmed) return "Потрібна назва активу.";
+        if (!Number.isFinite(amt) || amt <= 0)
+          return "Сума активу має бути додатною.";
+        const cur =
+          (currency && String(currency).trim().slice(0, 3).toUpperCase()) ||
+          "UAH";
+        const assets = ls<
+          Array<{ name: string; amount: number | string; currency?: string }>
+        >("finyk_assets", []);
+        assets.push({ name: trimmed, amount: amt, currency: cur });
+        lsSet("finyk_assets", assets);
+        return `Актив "${trimmed}" додано: ${amt} ${cur}`;
+      }
+      case "import_monobank_range": {
+        const { from, to } = (action as ImportMonobankRangeAction).input;
+        const fromStr = String(from || "").trim();
+        const toStr = String(to || "").trim();
+        const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+        if (!dateRe.test(fromStr) || !dateRe.test(toStr))
+          return "Дати мають бути у форматі YYYY-MM-DD.";
+        const fromD = new Date(`${fromStr}T00:00:00`);
+        const toD = new Date(`${toStr}T00:00:00`);
+        if (
+          !Number.isFinite(fromD.getTime()) ||
+          !Number.isFinite(toD.getTime()) ||
+          fromD > toD
+        ) {
+          return "Некоректний діапазон дат.";
+        }
+        const clearedMonths: string[] = [];
+        const cur = new Date(fromD.getFullYear(), fromD.getMonth(), 1);
+        const end = new Date(toD.getFullYear(), toD.getMonth(), 1);
+        while (cur <= end) {
+          const y = cur.getFullYear();
+          const m0 = cur.getMonth();
+          try {
+            localStorage.removeItem(`finyk_tx_cache_${y}_${m0}`);
+          } catch {}
+          clearedMonths.push(`${y}-${String(m0 + 1).padStart(2, "0")}`);
+          cur.setMonth(cur.getMonth() + 1);
+        }
+        try {
+          if (
+            typeof window !== "undefined" &&
+            typeof CustomEvent === "function"
+          ) {
+            window.dispatchEvent(
+              new CustomEvent("hub:finyk-mono-import-range", {
+                detail: { from: fromStr, to: toStr },
+              }),
+            );
+          }
+        } catch {}
+        return `Запит на оновлення Монобанку з ${fromStr} до ${toStr} прийнято. Очищено кеш за ${clearedMonths.length} міс. (${clearedMonths.join(", ")}). Оновиться при відкритті Фініка.`;
+      }
+      case "start_workout": {
+        const { note, date, time } = (action as StartWorkoutAction).input || {};
+        const now = new Date();
+        const today = [
+          now.getFullYear(),
+          String(now.getMonth() + 1).padStart(2, "0"),
+          String(now.getDate()).padStart(2, "0"),
+        ].join("-");
+        const targetDate =
+          date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : today;
+        const timeStr =
+          time && /^\d{1,2}:\d{2}$/.test(String(time).trim())
+            ? String(time).trim().padStart(5, "0")
+            : `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+        const startedAt = new Date(`${targetDate}T${timeStr}:00`).toISOString();
+        const existingActiveId = ls<string | null>(
+          "fizruk_active_workout_id_v1",
+          null,
+        );
+        const wRaw = localStorage.getItem("fizruk_workouts_v1");
+        let workouts: Workout[] = [];
+        try {
+          const parsed = wRaw ? JSON.parse(wRaw) : null;
+          if (Array.isArray(parsed)) workouts = parsed as Workout[];
+          else if (parsed && Array.isArray(parsed.workouts))
+            workouts = parsed.workouts as Workout[];
+        } catch {}
+        if (
+          existingActiveId &&
+          workouts.some((w) => w.id === existingActiveId && !w.endedAt)
+        ) {
+          return `Вже є активне тренування (id:${existingActiveId}). Спочатку заверши його (finish_workout).`;
+        }
+        const wid = `w_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+        const newW: Workout = {
+          id: wid,
+          startedAt,
+          endedAt: null,
+          items: [],
+          groups: [],
+          warmup: null,
+          cooldown: null,
+          note: note ? String(note).trim() : "",
+          planned: false,
+        };
+        lsSet("fizruk_workouts_v1", {
+          schemaVersion: 1,
+          workouts: [newW, ...workouts],
+        });
+        lsSet("fizruk_active_workout_id_v1", wid);
+        return `Тренування розпочато о ${timeStr}${note ? ` ("${String(note).trim()}")` : ""} (id:${wid})`;
+      }
+      case "finish_workout": {
+        const { workout_id } = (action as FinishWorkoutAction).input || {};
+        const activeId = ls<string | null>("fizruk_active_workout_id_v1", null);
+        const wRaw = localStorage.getItem("fizruk_workouts_v1");
+        let workouts: Workout[] = [];
+        try {
+          const parsed = wRaw ? JSON.parse(wRaw) : null;
+          if (Array.isArray(parsed)) workouts = parsed as Workout[];
+          else if (parsed && Array.isArray(parsed.workouts))
+            workouts = parsed.workouts as Workout[];
+        } catch {}
+        const targetId =
+          (workout_id && String(workout_id).trim()) ||
+          activeId ||
+          workouts.find((w) => !w.endedAt)?.id ||
+          "";
+        if (!targetId) return "Немає активного тренування для завершення.";
+        const idx = workouts.findIndex((w) => w.id === targetId);
+        if (idx < 0) return `Тренування ${targetId} не знайдено.`;
+        if (workouts[idx].endedAt) {
+          if (activeId === targetId) lsSet("fizruk_active_workout_id_v1", null);
+          return `Тренування ${targetId} вже завершено.`;
+        }
+        workouts[idx] = {
+          ...workouts[idx],
+          endedAt: new Date().toISOString(),
+        };
+        lsSet("fizruk_workouts_v1", { schemaVersion: 1, workouts });
+        if (activeId === targetId) lsSet("fizruk_active_workout_id_v1", null);
+        const setsCount = workouts[idx].items.reduce(
+          (acc, it) => acc + (Array.isArray(it.sets) ? it.sets.length : 0),
+          0,
+        );
+        return `Тренування завершено (id:${targetId}), підходів: ${setsCount}`;
+      }
+      case "log_measurement": {
+        const input = (action as LogMeasurementAction).input || {};
+        const keyMap: Record<string, string> = {
+          weight_kg: "weightKg",
+          body_fat_pct: "bodyFatPct",
+          neck_cm: "neckCm",
+          chest_cm: "chestCm",
+          waist_cm: "waistCm",
+          hips_cm: "hipsCm",
+          bicep_l_cm: "bicepLCm",
+          bicep_r_cm: "bicepRCm",
+          forearm_l_cm: "forearmLCm",
+          forearm_r_cm: "forearmRCm",
+          thigh_l_cm: "thighLCm",
+          thigh_r_cm: "thighRCm",
+          calf_l_cm: "calfLCm",
+          calf_r_cm: "calfRCm",
+        };
+        const entry: Record<string, number | string> = {
+          id: `m_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+          at: new Date().toISOString(),
+        };
+        const changed: string[] = [];
+        for (const [src, dst] of Object.entries(keyMap)) {
+          const v = input[src];
+          if (v != null && v !== "") {
+            const n = Number(v);
+            if (Number.isFinite(n) && n > 0) {
+              entry[dst] = n;
+              changed.push(`${dst}=${n}`);
+            }
+          }
+        }
+        if (changed.length === 0)
+          return "Немає жодного валідного поля для заміру.";
+        const existing = ls<Array<Record<string, unknown>>>(
+          "fizruk_measurements_v1",
+          [],
+        );
+        lsSet("fizruk_measurements_v1", [entry, ...existing]);
+        return `Заміри записано: ${changed.join(", ")}`;
+      }
+      case "add_program_day": {
+        const { weekday, name, exercises } = (action as AddProgramDayAction)
+          .input;
+        const wd = Number(weekday);
+        if (!Number.isInteger(wd) || wd < 0 || wd > 6)
+          return "weekday має бути цілим 0..6.";
+        const dayName = (name || "").trim();
+        if (!dayName) return "Потрібна назва тренування.";
+        const exList: Array<{
+          name: string;
+          sets?: number;
+          reps?: number;
+          weight?: number;
+        }> = [];
+        if (Array.isArray(exercises)) {
+          for (const ex of exercises) {
+            if (!ex || typeof ex !== "object") continue;
+            const exName = String(ex.name || "").trim();
+            if (!exName) continue;
+            const setsN = Number(ex.sets);
+            const repsN = Number(ex.reps);
+            const weightN = Number(ex.weight);
+            exList.push({
+              name: exName,
+              sets: Number.isFinite(setsN) && setsN > 0 ? setsN : undefined,
+              reps: Number.isFinite(repsN) && repsN > 0 ? repsN : undefined,
+              weight:
+                Number.isFinite(weightN) && weightN >= 0 ? weightN : undefined,
+            });
+          }
+        }
+        const tpl = ls<{
+          schemaVersion?: number;
+          days?: Record<string, { name: string; exercises: unknown[] }>;
+        }>("fizruk_plan_template_v1", {});
+        const days = { ...(tpl.days || {}) };
+        days[String(wd)] = { name: dayName, exercises: exList };
+        lsSet("fizruk_plan_template_v1", { schemaVersion: 1, days });
+        const weekdayLabels = ["нд", "пн", "вт", "ср", "чт", "пт", "сб"];
+        return `День "${dayName}" (${weekdayLabels[wd]}) збережено: ${exList.length} вправ.`;
+      }
+      case "log_wellbeing": {
+        const input = (action as LogWellbeingAction).input || {};
+        const entry: Record<string, number | string | null> = {
+          id: `dl_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+          at: new Date().toISOString(),
+          weightKg: null,
+          sleepHours: null,
+          energyLevel: null,
+          moodScore: null,
+          note: "",
+        };
+        const parts: string[] = [];
+        const weight = Number(input.weight_kg);
+        if (Number.isFinite(weight) && weight > 0) {
+          entry.weightKg = weight;
+          parts.push(`вага ${weight} кг`);
+        }
+        const sleep = Number(input.sleep_hours);
+        if (Number.isFinite(sleep) && sleep >= 0 && sleep <= 24) {
+          entry.sleepHours = sleep;
+          parts.push(`сон ${sleep} год`);
+        }
+        const energy = Number(input.energy_level);
+        if (Number.isFinite(energy) && energy >= 1 && energy <= 5) {
+          entry.energyLevel = Math.round(energy);
+          parts.push(`енергія ${Math.round(energy)}/5`);
+        }
+        const mood = Number(input.mood_score);
+        if (Number.isFinite(mood) && mood >= 1 && mood <= 5) {
+          entry.moodScore = Math.round(mood);
+          parts.push(`настрій ${Math.round(mood)}/5`);
+        }
+        if (input.note && String(input.note).trim()) {
+          entry.note = String(input.note).trim().slice(0, 500);
+        }
+        if (parts.length === 0 && !entry.note)
+          return "Немає жодного валідного поля для самопочуття.";
+        const existing = ls<Array<Record<string, unknown>>>(
+          "fizruk_daily_log_v1",
+          [],
+        );
+        lsSet("fizruk_daily_log_v1", [entry, ...existing]);
+        return `Самопочуття записано${parts.length ? ": " + parts.join(", ") : ""}.`;
+      }
+      case "create_reminder": {
+        const { habit_id, time } = (action as CreateReminderAction).input;
+        const id = String(habit_id || "").trim();
+        const t = String(time || "").trim();
+        if (!id) return "Потрібен habit_id.";
+        if (!/^\d{1,2}:\d{2}$/.test(t)) return "Час має бути у форматі HH:MM.";
+        const normTime = t.padStart(5, "0");
+        const state = ls<{
+          habits?: Array<{
+            id: string;
+            name?: string;
+            reminderTimes?: string[];
+          }>;
+        }>("hub_routine_v1", {});
+        const habits = Array.isArray(state.habits) ? state.habits.slice() : [];
+        const hIdx = habits.findIndex((h) => h.id === id);
+        if (hIdx < 0) return `Звичку ${id} не знайдено.`;
+        const reminders = Array.isArray(habits[hIdx].reminderTimes)
+          ? [...(habits[hIdx].reminderTimes as string[])]
+          : [];
+        if (reminders.includes(normTime)) {
+          return `Нагадування ${normTime} для "${habits[hIdx].name || id}" вже існує.`;
+        }
+        reminders.push(normTime);
+        reminders.sort();
+        habits[hIdx] = { ...habits[hIdx], reminderTimes: reminders };
+        lsSet("hub_routine_v1", { ...state, habits });
+        return `Нагадування ${normTime} додано до "${habits[hIdx].name || id}"`;
+      }
+      case "complete_habit_for_date": {
+        const { habit_id, date, completed } = (
+          action as CompleteHabitForDateAction
+        ).input;
+        const id = String(habit_id || "").trim();
+        const d = String(date || "").trim();
+        if (!id) return "Потрібен habit_id.";
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(d))
+          return "Дата має бути у форматі YYYY-MM-DD.";
+        const doComplete = completed !== false;
+        const state = ls<{
+          habits?: Array<{ id: string; name?: string }>;
+          completions?: Record<string, string[]>;
+        }>("hub_routine_v1", {});
+        const habits = Array.isArray(state.habits) ? state.habits : [];
+        const habit = habits.find((h) => h.id === id);
+        if (!habit) return `Звичку ${id} не знайдено.`;
+        const completions: Record<string, string[]> = {
+          ...(state.completions || {}),
+        };
+        const cur = Array.isArray(completions[id])
+          ? completions[id].slice()
+          : [];
+        const has = cur.includes(d);
+        if (doComplete) {
+          if (!has) cur.push(d);
+        } else {
+          const idx = cur.indexOf(d);
+          if (idx >= 0) cur.splice(idx, 1);
+        }
+        completions[id] = cur.sort();
+        lsSet("hub_routine_v1", { ...state, completions });
+        return `Звичку "${habit.name || id}" ${doComplete ? "відмічено" : "знято з позначки"} на ${d}`;
+      }
+      case "archive_habit": {
+        const { habit_id, archived } = (action as ArchiveHabitAction).input;
+        const id = String(habit_id || "").trim();
+        const doArchive = archived !== false;
+        if (!id) return "Потрібен habit_id.";
+        const state = ls<{
+          habits?: Array<{ id: string; name?: string; archived?: boolean }>;
+        }>("hub_routine_v1", {});
+        const habits = Array.isArray(state.habits) ? state.habits.slice() : [];
+        const idx = habits.findIndex((h) => h.id === id);
+        if (idx < 0) return `Звичку ${id} не знайдено.`;
+        if (!!habits[idx].archived === doArchive) {
+          return `Звичку "${habits[idx].name || id}" вже ${doArchive ? "заархівовано" : "активна"}.`;
+        }
+        habits[idx] = { ...habits[idx], archived: doArchive };
+        lsSet("hub_routine_v1", { ...state, habits });
+        return `Звичку "${habits[idx].name || id}" ${doArchive ? "заархівовано" : "повернуто з архіву"}`;
+      }
+      case "add_calendar_event": {
+        const { name, date, time, emoji } = (action as AddCalendarEventAction)
+          .input;
+        const evName = (name || "").trim();
+        const d = String(date || "").trim();
+        if (!evName) return "Потрібна назва події.";
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(d))
+          return "Дата має бути у форматі YYYY-MM-DD.";
+        const tod =
+          time && /^\d{1,2}:\d{2}$/.test(String(time).trim())
+            ? String(time).trim().padStart(5, "0")
+            : "";
+        const state = loadRoutineState();
+        const nextState = routineCreateHabit(state, {
+          name: evName,
+          emoji: emoji || "📅",
+          recurrence: "once",
+          startDate: d,
+          endDate: d,
+          timeOfDay: tod,
+        });
+        const created = nextState.habits[nextState.habits.length - 1];
+        return `Подію "${evName}" додано на ${d}${tod ? ` о ${tod}` : ""} (id:${created?.id || "?"})`;
+      }
+      case "add_recipe": {
+        const {
+          title,
+          ingredients,
+          steps,
+          servings,
+          time_minutes,
+          kcal,
+          protein_g,
+          fat_g,
+          carbs_g,
+        } = (action as AddRecipeAction).input;
+        const t = (title || "").trim();
+        if (!t) return "Потрібна назва рецепту.";
+        const payload = {
+          title: t,
+          servings:
+            servings != null && Number.isFinite(Number(servings))
+              ? Number(servings)
+              : null,
+          timeMinutes:
+            time_minutes != null && Number.isFinite(Number(time_minutes))
+              ? Number(time_minutes)
+              : null,
+          ingredients: Array.isArray(ingredients)
+            ? ingredients.map((x) => String(x)).filter(Boolean)
+            : [],
+          steps: Array.isArray(steps)
+            ? steps.map((x) => String(x)).filter(Boolean)
+            : [],
+          tips: [],
+          macros: {
+            kcal:
+              kcal != null && Number.isFinite(Number(kcal))
+                ? Number(kcal)
+                : null,
+            protein_g:
+              protein_g != null && Number.isFinite(Number(protein_g))
+                ? Number(protein_g)
+                : null,
+            fat_g:
+              fat_g != null && Number.isFinite(Number(fat_g))
+                ? Number(fat_g)
+                : null,
+            carbs_g:
+              carbs_g != null && Number.isFinite(Number(carbs_g))
+                ? Number(carbs_g)
+                : null,
+          },
+        };
+        void saveRecipeToBook(payload).catch(() => {});
+        return `Рецепт "${t}" збережено в книгу рецептів.`;
+      }
+      case "add_to_shopping_list": {
+        const { name, quantity, note, category } = (
+          action as AddToShoppingListAction
+        ).input;
+        const itemName = (name || "").trim();
+        if (!itemName) return "Потрібна назва продукту.";
+        const catName = (category && String(category).trim()) || "Інше";
+        const list = ls<{
+          categories?: Array<{
+            name: string;
+            items: Array<{
+              id: string;
+              name: string;
+              quantity?: string;
+              note?: string;
+              checked?: boolean;
+            }>;
+          }>;
+        }>("nutrition_shopping_list_v1", {});
+        const categories = Array.isArray(list.categories)
+          ? list.categories.slice()
+          : [];
+        let catIdx = categories.findIndex((c) => c.name === catName);
+        if (catIdx < 0) {
+          categories.push({ name: catName, items: [] });
+          catIdx = categories.length - 1;
+        }
+        const items = (categories[catIdx].items || []).slice();
+        const lower = itemName.toLowerCase();
+        const itemIdx = items.findIndex(
+          (it) =>
+            String(it.name || "")
+              .trim()
+              .toLowerCase() === lower,
+        );
+        const qty = (quantity && String(quantity).trim()) || "";
+        const notTxt = (note && String(note).trim()) || "";
+        let action_msg = "додано";
+        if (itemIdx >= 0) {
+          items[itemIdx] = {
+            ...items[itemIdx],
+            quantity: qty || items[itemIdx].quantity || "",
+            note: notTxt || items[itemIdx].note || "",
+          };
+          action_msg = "оновлено";
+        } else {
+          items.push({
+            id: `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            name: itemName,
+            quantity: qty,
+            note: notTxt,
+            checked: false,
+          });
+        }
+        categories[catIdx] = { ...categories[catIdx], items };
+        lsSet("nutrition_shopping_list_v1", { ...list, categories });
+        return `Продукт "${itemName}" ${action_msg} у список покупок${qty ? ` (${qty})` : ""} [${catName}]`;
+      }
+      case "consume_from_pantry": {
+        const { name } = (action as ConsumeFromPantryAction).input;
+        const rawName = (name || "").trim();
+        if (!rawName) return "Потрібна назва продукту.";
+        const activeId =
+          ls<string | null>("nutrition_active_pantry_v1", null) || "home";
+        const pantries = ls<
+          Array<{
+            id: string;
+            name: string;
+            items: Array<{ name: string }>;
+          }>
+        >("nutrition_pantries_v1", []);
+        const idx = pantries.findIndex((p) => p.id === activeId);
+        if (idx < 0) return `Активну комору (${activeId}) не знайдено.`;
+        const pantry = pantries[idx];
+        const lower = rawName.toLowerCase();
+        const items = Array.isArray(pantry.items) ? pantry.items : [];
+        const before = items.length;
+        const nextItems = items.filter(
+          (it) =>
+            String(it.name || "")
+              .trim()
+              .toLowerCase() !== lower,
+        );
+        if (nextItems.length === before) {
+          return `Продукт "${rawName}" у коморі не знайдено.`;
+        }
+        const next = [...pantries];
+        next[idx] = { ...pantry, items: nextItems };
+        lsSet("nutrition_pantries_v1", next);
+        return `Продукт "${rawName}" прибрано з комори "${pantry.name}"`;
+      }
+      case "set_daily_plan": {
+        const { kcal, protein_g, fat_g, carbs_g, water_ml } = (
+          action as SetDailyPlanAction
+        ).input;
+        const prefs = ls<Record<string, unknown>>("nutrition_prefs_v1", {});
+        const next = { ...prefs };
+        const parts: string[] = [];
+        const setField = (
+          key: string,
+          val: unknown,
+          label: string,
+          unit: string,
+        ) => {
+          const n = Number(val);
+          if (val != null && val !== "" && Number.isFinite(n) && n > 0) {
+            next[key] = n;
+            parts.push(`${label} ${n} ${unit}`);
+          }
+        };
+        setField("dailyTargetKcal", kcal, "ккал", "");
+        setField("dailyTargetProtein_g", protein_g, "білок", "г");
+        setField("dailyTargetFat_g", fat_g, "жири", "г");
+        setField("dailyTargetCarbs_g", carbs_g, "вуглеводи", "г");
+        setField("waterGoalMl", water_ml, "вода", "мл");
+        if (parts.length === 0) return "Немає полів для оновлення плану.";
+        lsSet("nutrition_prefs_v1", next);
+        return `Щоденний план оновлено: ${parts.join(", ")}`;
+      }
+      case "log_weight": {
+        const { weight_kg, note } = (action as LogWeightAction).input;
+        const n = Number(weight_kg);
+        if (!Number.isFinite(n) || n <= 0)
+          return "Вага має бути додатним числом (кг).";
+        const entry = {
+          id: `dl_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+          at: new Date().toISOString(),
+          weightKg: n,
+          sleepHours: null,
+          energyLevel: null,
+          moodScore: null,
+          note: note ? String(note).trim().slice(0, 500) : "",
+        };
+        const existing = ls<Array<Record<string, unknown>>>(
+          "fizruk_daily_log_v1",
+          [],
+        );
+        lsSet("fizruk_daily_log_v1", [entry, ...existing]);
+        return `Вагу записано: ${n} кг`;
       }
       default:
         return `Невідома дія: ${action.name}`;

--- a/src/core/lib/hubChatActionsExtended.test.ts
+++ b/src/core/lib/hubChatActionsExtended.test.ts
@@ -1,0 +1,661 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for hubChatActions executeAction — extended tools
+ * (delete_transaction, update_budget, mark_debt_paid, add_asset,
+ *  import_monobank_range, start_workout, finish_workout,
+ *  log_measurement, add_program_day, log_wellbeing,
+ *  create_reminder, complete_habit_for_date, archive_habit,
+ *  add_calendar_event, add_to_shopping_list, consume_from_pantry,
+ *  set_daily_plan, log_weight, add_recipe).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { executeAction } from "./hubChatActions";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+function readLS<T>(key: string, fallback: T): T {
+  const raw = localStorage.getItem(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+// ─── Фінік ────────────────────────────────────────────────────────────
+
+describe("delete_transaction", () => {
+  it("видаляє ручну транзакцію за id", () => {
+    localStorage.setItem(
+      "finyk_manual_expenses_v1",
+      JSON.stringify([
+        { id: "m_keep", amount: 100, type: "expense", date: "2024-06-14" },
+        { id: "m_drop", amount: 50, type: "expense", date: "2024-06-14" },
+      ]),
+    );
+    const msg = executeAction({
+      name: "delete_transaction",
+      input: { tx_id: "m_drop" },
+    });
+    expect(msg).toContain("видалено");
+    const arr = readLS<Array<{ id: string }>>("finyk_manual_expenses_v1", []);
+    expect(arr.map((t) => t.id)).toEqual(["m_keep"]);
+  });
+
+  it("відмовляє для монобанк-транзакцій (не m_)", () => {
+    const msg = executeAction({
+      name: "delete_transaction",
+      input: { tx_id: "mono_xyz" },
+    });
+    expect(msg).toContain("hide_transaction");
+  });
+
+  it("повертає повідомлення коли id не знайдено (ідемпотентність)", () => {
+    const msg = executeAction({
+      name: "delete_transaction",
+      input: { tx_id: "m_missing" },
+    });
+    expect(msg).toContain("не знайдено");
+  });
+});
+
+describe("update_budget", () => {
+  it("створює ліміт якщо немає, upsert", () => {
+    const msg = executeAction({
+      name: "update_budget",
+      input: { scope: "limit", category_id: "food", limit: 5000 },
+    });
+    expect(msg).toContain("5000");
+    const budgets = readLS<
+      Array<{ type: string; categoryId?: string; limit?: number }>
+    >("finyk_budgets", []);
+    expect(budgets).toHaveLength(1);
+    expect(budgets[0]).toMatchObject({
+      type: "limit",
+      categoryId: "food",
+      limit: 5000,
+    });
+    // Повторний виклик — upsert, не дублює
+    executeAction({
+      name: "update_budget",
+      input: { scope: "limit", category_id: "food", limit: 6000 },
+    });
+    const after = readLS<Array<{ limit?: number }>>("finyk_budgets", []);
+    expect(after).toHaveLength(1);
+    expect(after[0].limit).toBe(6000);
+  });
+
+  it("створює ціль scope='goal'", () => {
+    const msg = executeAction({
+      name: "update_budget",
+      input: {
+        scope: "goal",
+        name: "Відпустка",
+        target_amount: 30000,
+        saved_amount: 5000,
+      },
+    });
+    expect(msg).toContain("Відпустка");
+    expect(msg).toContain("5000/30000");
+    const budgets = readLS<
+      Array<{
+        type: string;
+        name?: string;
+        targetAmount?: number;
+        savedAmount?: number;
+      }>
+    >("finyk_budgets", []);
+    expect(budgets[0]).toMatchObject({
+      type: "goal",
+      name: "Відпустка",
+      targetAmount: 30000,
+      savedAmount: 5000,
+    });
+  });
+
+  it("відмовляє на невалідні вхідні дані", () => {
+    expect(
+      executeAction({
+        name: "update_budget",
+        input: { scope: "limit", limit: 500 },
+      }),
+    ).toContain("category_id");
+    expect(
+      executeAction({
+        name: "update_budget",
+        input: { scope: "goal", target_amount: 1000 },
+      }),
+    ).toContain("name");
+  });
+});
+
+describe("mark_debt_paid", () => {
+  it("створює repayment-транзакцію і закриває борг при повній сумі", () => {
+    localStorage.setItem(
+      "finyk_debts",
+      JSON.stringify([
+        {
+          id: "d_rent",
+          name: "Оренда",
+          totalAmount: 5000,
+          dueDate: "",
+          emoji: "🏠",
+          linkedTxIds: [],
+        },
+      ]),
+    );
+    const msg = executeAction({
+      name: "mark_debt_paid",
+      input: { debt_id: "d_rent" },
+    });
+    expect(msg).toContain("закрито");
+    const debts = readLS<Array<{ id: string }>>("finyk_debts", []);
+    expect(debts).toHaveLength(0);
+    const tx = readLS<Array<{ amount: number; type: string }>>(
+      "finyk_manual_expenses_v1",
+      [],
+    );
+    expect(tx).toHaveLength(1);
+    expect(tx[0].amount).toBe(5000);
+    expect(tx[0].type).toBe("expense");
+  });
+
+  it("частково гасить борг зі збереженням", () => {
+    localStorage.setItem(
+      "finyk_debts",
+      JSON.stringify([
+        {
+          id: "d_rent",
+          name: "Оренда",
+          totalAmount: 5000,
+          dueDate: "",
+          emoji: "🏠",
+          linkedTxIds: [],
+        },
+      ]),
+    );
+    const msg = executeAction({
+      name: "mark_debt_paid",
+      input: { debt_id: "d_rent", amount: 2000 },
+    });
+    expect(msg).not.toContain("закрито");
+    const debts = readLS<Array<{ id: string; linkedTxIds: string[] }>>(
+      "finyk_debts",
+      [],
+    );
+    expect(debts).toHaveLength(1);
+    expect(debts[0].linkedTxIds).toHaveLength(1);
+  });
+
+  it("повертає помилку для невідомого id", () => {
+    const msg = executeAction({
+      name: "mark_debt_paid",
+      input: { debt_id: "d_missing" },
+    });
+    expect(msg).toContain("не знайдено");
+  });
+});
+
+describe("add_asset", () => {
+  it("додає актив у finyk_assets", () => {
+    const msg = executeAction({
+      name: "add_asset",
+      input: { name: "Депозит ПриватБанк", amount: 100000 },
+    });
+    expect(msg).toContain("100000");
+    expect(msg).toContain("UAH");
+    const assets = readLS<
+      Array<{ name: string; amount: number; currency?: string }>
+    >("finyk_assets", []);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      name: "Депозит ПриватБанк",
+      amount: 100000,
+      currency: "UAH",
+    });
+  });
+
+  it("підтримує валюту", () => {
+    executeAction({
+      name: "add_asset",
+      input: { name: "Готівка", amount: 500, currency: "usd" },
+    });
+    const assets = readLS<Array<{ currency?: string }>>("finyk_assets", []);
+    expect(assets[0].currency).toBe("USD");
+  });
+
+  it("відмовляє на невалідні дані", () => {
+    expect(
+      executeAction({
+        name: "add_asset",
+        input: { name: "", amount: 100 },
+      }),
+    ).toContain("назва");
+    expect(
+      executeAction({
+        name: "add_asset",
+        input: { name: "X", amount: 0 },
+      }),
+    ).toContain("додатною");
+  });
+});
+
+describe("import_monobank_range", () => {
+  it("очищує кеш місяців у діапазоні і диспатчить подію", () => {
+    // month0: Jan=0 ... Mar=2, Apr=3, May=4, Jun=5
+    localStorage.setItem("finyk_tx_cache_2024_2", '{"stub":1}'); // березень — поза діапазоном
+    localStorage.setItem("finyk_tx_cache_2024_4", '{"stub":1}'); // травень
+    localStorage.setItem("finyk_tx_cache_2024_5", '{"stub":1}'); // червень
+    let dispatched = false;
+    const handler = () => {
+      dispatched = true;
+    };
+    window.addEventListener("hub:finyk-mono-import-range", handler);
+    const msg = executeAction({
+      name: "import_monobank_range",
+      input: { from: "2024-05-01", to: "2024-06-15" },
+    });
+    window.removeEventListener("hub:finyk-mono-import-range", handler);
+    expect(msg).toContain("2024-05-01");
+    expect(localStorage.getItem("finyk_tx_cache_2024_2")).not.toBeNull();
+    expect(localStorage.getItem("finyk_tx_cache_2024_4")).toBeNull();
+    expect(localStorage.getItem("finyk_tx_cache_2024_5")).toBeNull();
+    expect(dispatched).toBe(true);
+  });
+
+  it("відмовляє на некоректний формат дат", () => {
+    const msg = executeAction({
+      name: "import_monobank_range",
+      input: { from: "2024/05/01", to: "2024-06-01" },
+    });
+    expect(msg).toContain("YYYY-MM-DD");
+  });
+});
+
+// ─── Фізрук ──────────────────────────────────────────────────────────
+
+describe("start_workout / finish_workout", () => {
+  it("start_workout створює workout і встановлює активний id", () => {
+    const msg = executeAction({
+      name: "start_workout",
+      input: { note: "ранкова" },
+    });
+    expect(msg).toContain("Тренування розпочато");
+    const saved = readLS<{
+      workouts: Array<{ id: string; endedAt: string | null; note: string }>;
+    }>("fizruk_workouts_v1", { workouts: [] });
+    expect(saved.workouts).toHaveLength(1);
+    expect(saved.workouts[0].note).toBe("ранкова");
+    expect(saved.workouts[0].endedAt).toBeNull();
+    const activeId = readLS<string | null>("fizruk_active_workout_id_v1", null);
+    expect(activeId).toBe(saved.workouts[0].id);
+  });
+
+  it("start_workout відмовляє якщо вже є активне", () => {
+    executeAction({ name: "start_workout", input: {} });
+    const msg = executeAction({ name: "start_workout", input: {} });
+    expect(msg).toContain("Вже є активне");
+  });
+
+  it("finish_workout завершує активне і прибирає active id", () => {
+    executeAction({ name: "start_workout", input: {} });
+    const msg = executeAction({ name: "finish_workout", input: {} });
+    expect(msg).toContain("завершено");
+    const saved = readLS<{
+      workouts: Array<{ endedAt: string | null }>;
+    }>("fizruk_workouts_v1", { workouts: [] });
+    expect(saved.workouts[0].endedAt).not.toBeNull();
+    const activeId = readLS<string | null>("fizruk_active_workout_id_v1", null);
+    expect(activeId).toBeNull();
+  });
+
+  it("finish_workout повертає повідомлення якщо активного немає", () => {
+    const msg = executeAction({ name: "finish_workout", input: {} });
+    expect(msg).toContain("Немає активного");
+  });
+});
+
+describe("log_measurement", () => {
+  it("додає запис з валідними полями", () => {
+    const msg = executeAction({
+      name: "log_measurement",
+      input: { weight_kg: 78.5, waist_cm: 82, chest_cm: 100 },
+    });
+    expect(msg).toContain("weightKg=78.5");
+    const arr = readLS<Array<Record<string, unknown>>>(
+      "fizruk_measurements_v1",
+      [],
+    );
+    expect(arr).toHaveLength(1);
+    expect(arr[0].weightKg).toBe(78.5);
+    expect(arr[0].waistCm).toBe(82);
+  });
+
+  it("ігнорує порожні/невалідні поля, відмовляє якщо нічого", () => {
+    const msg = executeAction({
+      name: "log_measurement",
+      input: { weight_kg: 0, waist_cm: "" as unknown as number },
+    });
+    expect(msg).toContain("валідного");
+  });
+});
+
+describe("add_program_day", () => {
+  it("додає день з вправами у шаблон", () => {
+    const msg = executeAction({
+      name: "add_program_day",
+      input: {
+        weekday: 1,
+        name: "Груди/трицепс",
+        exercises: [
+          { name: "Жим лежачи", sets: 4, reps: 8, weight: 80 },
+          { name: "Розводка", sets: 3, reps: 12 },
+        ],
+      },
+    });
+    expect(msg).toContain("Груди/трицепс");
+    expect(msg).toContain("2 вправ");
+    const tpl = readLS<{
+      days: Record<
+        string,
+        { name: string; exercises: Array<{ name: string }> }
+      >;
+    }>("fizruk_plan_template_v1", { days: {} });
+    expect(tpl.days["1"].name).toBe("Груди/трицепс");
+    expect(tpl.days["1"].exercises).toHaveLength(2);
+  });
+
+  it("відмовляє на невалідний weekday", () => {
+    const msg = executeAction({
+      name: "add_program_day",
+      input: { weekday: 9, name: "X" },
+    });
+    expect(msg).toContain("0..6");
+  });
+});
+
+describe("log_wellbeing", () => {
+  it("записує самопочуття у fizruk_daily_log_v1", () => {
+    const msg = executeAction({
+      name: "log_wellbeing",
+      input: {
+        weight_kg: 78,
+        sleep_hours: 7.5,
+        energy_level: 4,
+        mood_score: 4,
+      },
+    });
+    expect(msg).toContain("вага 78");
+    expect(msg).toContain("сон 7.5");
+    const arr = readLS<
+      Array<{
+        weightKg: number | null;
+        sleepHours: number | null;
+        energyLevel: number | null;
+      }>
+    >("fizruk_daily_log_v1", []);
+    expect(arr).toHaveLength(1);
+    expect(arr[0].weightKg).toBe(78);
+    expect(arr[0].sleepHours).toBe(7.5);
+    expect(arr[0].energyLevel).toBe(4);
+  });
+
+  it("відмовляє якщо немає жодного поля", () => {
+    const msg = executeAction({
+      name: "log_wellbeing",
+      input: {},
+    });
+    expect(msg).toContain("валідного");
+  });
+});
+
+// ─── Рутина ──────────────────────────────────────────────────────────
+
+describe("create_reminder", () => {
+  it("додає нагадування до звички", () => {
+    executeAction({
+      name: "create_habit",
+      input: { name: "Ранкова розминка" },
+    });
+    const state0 = readLS<{
+      habits: Array<{ id: string }>;
+    }>("hub_routine_v1", { habits: [] });
+    const habitId = state0.habits[0].id;
+    const msg = executeAction({
+      name: "create_reminder",
+      input: { habit_id: habitId, time: "8:00" },
+    });
+    expect(msg).toContain("08:00");
+    const state = readLS<{
+      habits: Array<{ id: string; reminderTimes: string[] }>;
+    }>("hub_routine_v1", { habits: [] });
+    expect(state.habits[0].reminderTimes).toEqual(["08:00"]);
+  });
+
+  it("ідемпотентне — не дублює той самий час", () => {
+    executeAction({
+      name: "create_habit",
+      input: { name: "Ранкова розминка" },
+    });
+    const state0 = readLS<{
+      habits: Array<{ id: string }>;
+    }>("hub_routine_v1", { habits: [] });
+    const habitId = state0.habits[0].id;
+    executeAction({
+      name: "create_reminder",
+      input: { habit_id: habitId, time: "08:00" },
+    });
+    const msg = executeAction({
+      name: "create_reminder",
+      input: { habit_id: habitId, time: "08:00" },
+    });
+    expect(msg).toContain("вже існує");
+    const state = readLS<{
+      habits: Array<{ reminderTimes: string[] }>;
+    }>("hub_routine_v1", { habits: [] });
+    expect(state.habits[0].reminderTimes).toHaveLength(1);
+  });
+});
+
+describe("complete_habit_for_date + archive_habit", () => {
+  it("позначає/знімає виконання на вказану дату", () => {
+    executeAction({ name: "create_habit", input: { name: "Тестова" } });
+    const state0 = readLS<{ habits: Array<{ id: string }> }>("hub_routine_v1", {
+      habits: [],
+    });
+    const id = state0.habits[0].id;
+    executeAction({
+      name: "complete_habit_for_date",
+      input: { habit_id: id, date: "2024-06-10" },
+    });
+    let state = readLS<{ completions: Record<string, string[]> }>(
+      "hub_routine_v1",
+      { completions: {} },
+    );
+    expect(state.completions[id]).toEqual(["2024-06-10"]);
+    executeAction({
+      name: "complete_habit_for_date",
+      input: { habit_id: id, date: "2024-06-10", completed: false },
+    });
+    state = readLS<{ completions: Record<string, string[]> }>(
+      "hub_routine_v1",
+      {
+        completions: {},
+      },
+    );
+    expect(state.completions[id]).toEqual([]);
+  });
+
+  it("archive_habit архівує і повертає з архіву", () => {
+    executeAction({ name: "create_habit", input: { name: "Архів" } });
+    const state0 = readLS<{ habits: Array<{ id: string }> }>("hub_routine_v1", {
+      habits: [],
+    });
+    const id = state0.habits[0].id;
+    const msg = executeAction({
+      name: "archive_habit",
+      input: { habit_id: id },
+    });
+    expect(msg).toContain("заархівовано");
+    const state = readLS<{ habits: Array<{ id: string; archived: boolean }> }>(
+      "hub_routine_v1",
+      { habits: [] },
+    );
+    expect(state.habits[0].archived).toBe(true);
+    const msg2 = executeAction({
+      name: "archive_habit",
+      input: { habit_id: id, archived: false },
+    });
+    expect(msg2).toContain("повернуто");
+  });
+});
+
+describe("add_calendar_event", () => {
+  it("створює разову подію як звичку once", () => {
+    const msg = executeAction({
+      name: "add_calendar_event",
+      input: { name: "Лікар", date: "2024-07-01", time: "09:30" },
+    });
+    expect(msg).toContain("Лікар");
+    expect(msg).toContain("09:30");
+    const state = readLS<{
+      habits: Array<{
+        name: string;
+        recurrence: string;
+        startDate: string;
+        endDate: string;
+        timeOfDay: string;
+      }>;
+    }>("hub_routine_v1", { habits: [] });
+    expect(state.habits[0].recurrence).toBe("once");
+    expect(state.habits[0].startDate).toBe("2024-07-01");
+    expect(state.habits[0].endDate).toBe("2024-07-01");
+    expect(state.habits[0].timeOfDay).toBe("09:30");
+  });
+});
+
+// ─── Харчування ──────────────────────────────────────────────────────
+
+describe("add_to_shopping_list", () => {
+  it("додає продукт у список покупок (upsert)", () => {
+    executeAction({
+      name: "add_to_shopping_list",
+      input: { name: "Молоко", quantity: "1 л", category: "Молочні" },
+    });
+    let list = readLS<{
+      categories: Array<{
+        name: string;
+        items: Array<{ name: string; quantity: string; checked: boolean }>;
+      }>;
+    }>("nutrition_shopping_list_v1", { categories: [] });
+    expect(list.categories).toHaveLength(1);
+    expect(list.categories[0].items[0]).toMatchObject({
+      name: "Молоко",
+      quantity: "1 л",
+      checked: false,
+    });
+    // Upsert — не дублює
+    const msg = executeAction({
+      name: "add_to_shopping_list",
+      input: { name: "молоко", quantity: "2 л", category: "Молочні" },
+    });
+    expect(msg).toContain("оновлено");
+    list = readLS<{
+      categories: Array<{
+        name: string;
+        items: Array<{ name: string; quantity: string; checked: boolean }>;
+      }>;
+    }>("nutrition_shopping_list_v1", { categories: [] });
+    expect(list.categories[0].items).toHaveLength(1);
+    expect(list.categories[0].items[0].quantity).toBe("2 л");
+  });
+});
+
+describe("consume_from_pantry", () => {
+  it("видаляє продукт з активної комори", () => {
+    localStorage.setItem("nutrition_active_pantry_v1", '"home"');
+    localStorage.setItem(
+      "nutrition_pantries_v1",
+      JSON.stringify([
+        {
+          id: "home",
+          name: "Дім",
+          items: [{ name: "яйця" }, { name: "молоко" }],
+          text: "",
+        },
+      ]),
+    );
+    const msg = executeAction({
+      name: "consume_from_pantry",
+      input: { name: "яйця" },
+    });
+    expect(msg).toContain("прибрано");
+    const pantries = readLS<
+      Array<{ id: string; items: Array<{ name: string }> }>
+    >("nutrition_pantries_v1", []);
+    expect(pantries[0].items.map((i) => i.name)).toEqual(["молоко"]);
+  });
+
+  it("повертає повідомлення якщо продукт відсутній (ідемпотентність)", () => {
+    localStorage.setItem("nutrition_active_pantry_v1", '"home"');
+    localStorage.setItem(
+      "nutrition_pantries_v1",
+      JSON.stringify([{ id: "home", name: "Дім", items: [], text: "" }]),
+    );
+    const msg = executeAction({
+      name: "consume_from_pantry",
+      input: { name: "тофу" },
+    });
+    expect(msg).toContain("не знайдено");
+  });
+});
+
+describe("set_daily_plan", () => {
+  it("оновлює лише передані поля", () => {
+    const msg = executeAction({
+      name: "set_daily_plan",
+      input: { kcal: 2200, protein_g: 150, water_ml: 2500 },
+    });
+    expect(msg).toContain("2200");
+    const prefs = readLS<Record<string, number>>("nutrition_prefs_v1", {});
+    expect(prefs.dailyTargetKcal).toBe(2200);
+    expect(prefs.dailyTargetProtein_g).toBe(150);
+    expect(prefs.waterGoalMl).toBe(2500);
+    expect(prefs.dailyTargetFat_g).toBeUndefined();
+  });
+
+  it("відмовляє якщо немає полів", () => {
+    const msg = executeAction({ name: "set_daily_plan", input: {} });
+    expect(msg).toContain("Немає полів");
+  });
+});
+
+describe("log_weight", () => {
+  it("пише вагу у fizruk_daily_log_v1", () => {
+    const msg = executeAction({
+      name: "log_weight",
+      input: { weight_kg: 77.3 },
+    });
+    expect(msg).toContain("77.3");
+    const arr = readLS<Array<{ weightKg: number }>>("fizruk_daily_log_v1", []);
+    expect(arr).toHaveLength(1);
+    expect(arr[0].weightKg).toBe(77.3);
+  });
+
+  it("відмовляє на 0/неч.", () => {
+    const msg = executeAction({
+      name: "log_weight",
+      input: { weight_kg: 0 },
+    });
+    expect(msg).toContain("додатним");
+  });
+});


### PR DESCRIPTION
## Summary

Розширено HubChat AI-асистента з 13 до **32 tools** — Claude тепер може керувати всіма 4 модулями (ФІНІК / ФІЗРУК / Рутина / Харчування) без переходу в UI. Під капотом — server-side tool definitions + client-side handlers, що мутують localStorage і повертають короткий Ukrainian-summary для наступного кроку моделі.

### Нові tools (19)

| Модуль | Tools | Side-effect |
| --- | --- | --- |
| **Фінік** | `delete_transaction` | видаляє ручну транзакцію (`m_*`) з `finyk_manual_expenses_v1` |
|  | `update_budget` | upsert ліміту на категорію або цілі заощаджень у `finyk_budgets` |
|  | `mark_debt_paid` | створює repayment-транзакцію + закриває/зменшує борг у `finyk_debts` |
|  | `add_asset` | додає актив у `finyk_assets` |
|  | `import_monobank_range` | очищує кеш `finyk_tx_cache_*` і диспатчить `hub:finyk-mono-import-range` |
| **Фізрук** | `start_workout` | створює workout і ставить active-id |
|  | `finish_workout` | ставить `endedAt=now`, знімає active-id |
|  | `log_measurement` | append у `fizruk_measurements_v1` (вага, талія, груди, біцепс і т.д.) |
|  | `add_program_day` | upsert дня тижня у `fizruk_plan_template_v1` |
|  | `log_wellbeing` | append у `fizruk_daily_log_v1` (сон, енергія, настрій) |
| **Рутина** | `create_reminder` | додає HH:MM у `habit.reminderTimes` (idempotent) |
|  | `complete_habit_for_date` | set/unset completion на вказану дату |
|  | `archive_habit` | `habit.archived=true/false` |
|  | `add_calendar_event` | створює звичку `recurrence:"once"` з `startDate=endDate=date` |
| **Харчування** | `add_recipe` | fire-and-forget у IndexedDB-книгу рецептів через `saveRecipeToBook` |
|  | `add_to_shopping_list` | upsert у `nutrition_shopping_list_v1` (по імені всередині категорії) |
|  | `consume_from_pantry` | видаляє продукт з активної комори `nutrition_pantries_v1` |
|  | `set_daily_plan` | оновлює поля у `nutrition_prefs_v1` |
|  | `log_weight` | append у `fizruk_daily_log_v1` (лише вага) |

### Приклади викликів

- "Видали транзакцію m_abc123" → `delete_transaction { tx_id:"m_abc123" }`
- "Постав ліміт на кафе 3000 грн" → `update_budget { scope:"limit", category_id:"food", limit:3000 }`
- "Створи ціль 'Відпустка' 30 000 грн, вже 5000" → `update_budget { scope:"goal", name:"Відпустка", target_amount:30000, saved_amount:5000 }`
- "Закрий борг оренди" → `mark_debt_paid { debt_id:"d_rent" }`
- "Додай актив депозит Приват 100 000" → `add_asset { name:"Депозит Приват", amount:100000 }`
- "Оновити монобанк з 1 травня" → `import_monobank_range { from:"2024-05-01", to:"2024-06-15" }`
- "Почни / заверши тренування" → `start_workout` / `finish_workout`
- "Заміри: вага 78.5, талія 82" → `log_measurement { weight_kg:78.5, waist_cm:82 }`
- "Пн: груди/трицепс — жим 4×8 80 кг" → `add_program_day { weekday:1, name:"Груди/трицепс", exercises:[...] }`
- "Самопочуття: сон 7.5, енергія 4" → `log_wellbeing { sleep_hours:7.5, energy_level:4 }`
- "Нагадай про розминку о 8:00" → `create_reminder { habit_id:"hab_x", time:"08:00" }`
- "Познач 'Пити воду' на 10 червня" → `complete_habit_for_date { habit_id:"hab_x", date:"2024-06-10" }`
- "Заархівуй звичку 'Йога'" → `archive_habit { habit_id:"hab_y" }`
- "Календар: 'Лікар' 1 липня 9:30" → `add_calendar_event { name:"Лікар", date:"2024-07-01", time:"09:30" }`
- "Збережи рецепт овочевий суп" → `add_recipe { title:"Овочевий суп", ingredients:[...], steps:[...] }`
- "Додай молоко 2 л у список" → `add_to_shopping_list { name:"Молоко", quantity:"2 л", category:"Молочні" }`
- "Використав яйця з комори" → `consume_from_pantry { name:"яйця" }`
- "Щоденний план: 2200 ккал, білок 150" → `set_daily_plan { kcal:2200, protein_g:150 }`
- "Запиши вагу 77.3" → `log_weight { weight_kg:77.3 }`

### Принципи реалізації

- **Валідація** — ручна у стилі існуючих 13 tools (Number-parse, regex для дат/часу, min/max діапазони). zod не додавав, щоб не розширювати публічний контракт.
- **Ідемпотентність** — `delete_transaction`, `create_reminder`, `update_budget`, `archive_habit`, `consume_from_pantry`, `import_monobank_range` повертають змістовне повідомлення при повторному виклику без дублювання.
- **Повернення** — кожен handler повертає короткий Ukrainian string, який Claude використовує у summary-відповіді користувачеві.
- **AI-квоти** — не чіпав, існуючий `requireAiQuota()` middleware вже інкрементує лічильник і на першому кроці, і на tool-result continuation.
- **SYSTEM_PREFIX** — дописано перелік усіх tools per module, щоб модель знала свій інструментарій.

### Файли

- `server/modules/chat.js` — +19 tools у `TOOLS`, оновлено SYSTEM_PREFIX
- `src/core/lib/hubChatActions.ts` — +19 TS-інтерфейсів у `ChatAction` + 19 case-handlers у `executeAction`
- `server/modules/chat.test.js` — нові unit-тести (моканий Anthropic, tool-parsing, структура TOOLS)
- `src/core/lib/hubChatActionsExtended.test.ts` — нові unit-тести клієнтських обробників (localStorage mutations, ідемпотентність)
- `src/core/lib/hubChatActions.test.ts` — fix існуючого type-error у тесті (додано `id: string` у inline-type)
- `README.md` — нова секція "HubChat (AI-чат)" з повною таблицею tools та прикладами промптів

### Verification

- `npm run lint` ✓
- `npm run typecheck` ✓ (3 tsconfig: client, server, sw)
- `npm test` ✓ — **835 passed**, +42 нових
- `npm run build` ✓ — Vite + PWA SW

## Review & Testing Checklist for Human

- [ ] Швидко проглянути `SYSTEM_PREFIX` на предмет того, чи вірно модель зможе вибрати між схожими tools (`update_budget` vs `set_budget_limit`, `mark_habit_done` vs `complete_habit_for_date`, `log_weight` vs `log_wellbeing`)
- [ ] Живий smoke у чаті: голосом "Додай актив депозит 50 000" і "Заархівуй звичку X" — перевірити Ukrainian summary у відповіді
- [ ] `import_monobank_range` — перевірити, що подія `hub:finyk-mono-import-range` реально перехоплюється у Фініку (я лише диспатчу; listener має бути в модулі)
- [ ] `add_recipe` — рецепт пишеться у IndexedDB (fire-and-forget `saveRecipeToBook`), перевірити що з'являється в книзі рецептів без ручного рефрешу

### Notes

- Не створював нових сторів/ключів localStorage — всі handler'и працюють з існуючими схемами.
- Деякі tools перекриваються з вже існуючими через різні use-cases (напр. `set_budget_limit` — швидкий ліміт, `update_budget` — loop для цілей і upsert лімітів). Claude має достатньо контексту в SYSTEM_PREFIX, щоб не плутати.
- `mark_debt_paid` з `amount=totalAmount` закриває борг (видаляє з масиву) — якщо це небажана поведінка, можна додати прапор `close_debt:boolean` у майбутньому.

Link to Devin session: https://app.devin.ai/sessions/cc009273ddc346df98af1d7c77fe8cc7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
