### PR TITLE
feat(design-system): міграція finyk + nutrition екранів на Label / SectionHeading + фікс Spinner

### DIFF
--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useId, useMemo } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
+import { Label } from "@shared/components/ui/FormField";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech } from "../../../core/lib/speechParsers.js";
@@ -260,12 +261,7 @@ export function ManualExpenseSheet({
             produces both the amount and the description in one shot. */}
         <div className="flex gap-2 items-end">
           <div className="flex-1">
-            <label
-              htmlFor={amountId}
-              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-            >
-              Сума ₴
-            </label>
+            <Label htmlFor={amountId}>Сума ₴</Label>
             {(frequentAmounts.length > 0 || quickAmounts.length > 0) && (
               <div className="space-y-1.5 mb-2">
                 {frequentAmounts.length > 0 && (
@@ -361,15 +357,9 @@ export function ManualExpenseSheet({
         </div>
 
         <div>
-          <label
-            htmlFor={descId}
-            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-          >
-            Назва{" "}
-            <span className="text-subtle normal-case">
-              · необов&apos;язково
-            </span>
-          </label>
+          <Label htmlFor={descId} optional>
+            Назва
+          </Label>
           <Input
             id={descId}
             placeholder="Кава, продукти, таксі..."
@@ -387,12 +377,7 @@ export function ManualExpenseSheet({
             entry where the date is already not today. */}
         {form.date !== toLocalISODate() || form.showDateField ? (
           <div>
-            <label
-              htmlFor={dateId}
-              className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
-            >
-              Дата
-            </label>
+            <Label htmlFor={dateId}>Дата</Label>
             <Input
               id={dateId}
               type="date"
@@ -449,7 +434,7 @@ export function ManualExpenseSheet({
         <div>
           <div
             id={catLabelId}
-            className="text-xs text-muted uppercase tracking-wide font-semibold mb-1 block"
+            className="block text-xs text-muted uppercase tracking-wide font-semibold mb-1"
           >
             Категорія
           </div>

--- a/src/modules/finyk/pages/overview/QuickAddCard.jsx
+++ b/src/modules/finyk/pages/overview/QuickAddCard.jsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { CANONICAL_TO_MANUAL_LABEL } from "../../domain/personalization";
 import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 
 /**
  * Квікадд-картка: топ-категорії + «нещодавнє». Показуємо лише коли
@@ -19,9 +20,9 @@ const QuickAddCardImpl = function QuickAddCard({
     <Card radius="lg" padding="lg" className="space-y-3">
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
+          <SectionHeading as="div" size="xs">
             Швидке додавання
-          </div>
+          </SectionHeading>
           <div className="text-sm text-muted mt-0.5">
             Ваші найчастіші категорії
           </div>
@@ -61,9 +62,9 @@ const QuickAddCardImpl = function QuickAddCard({
       )}
       {frequentMerchants.length > 0 && (
         <div className="pt-2 border-t border-line">
-          <div className="text-xs font-semibold uppercase tracking-wide text-subtle mb-2">
+          <SectionHeading as="div" size="xs" className="mb-2">
             Нещодавнє
-          </div>
+          </SectionHeading>
           <div className="flex flex-wrap gap-1.5">
             {frequentMerchants.slice(0, 4).map((m) => (
               <button

--- a/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
+++ b/src/modules/nutrition/components/PhotoAnalyzeCard.jsx
@@ -1,5 +1,6 @@
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
 
 export function PhotoAnalyzeCard({
@@ -166,9 +167,9 @@ export function PhotoAnalyzeCard({
           {Array.isArray(photoResult.questions) &&
             photoResult.questions.length > 0 && (
               <div className="rounded-2xl border border-line bg-panelHi p-3 grid gap-3">
-                <div className="text-xs font-semibold text-subtle uppercase tracking-widest">
+                <SectionHeading as="div" size="xs">
                   Уточнення порції
-                </div>
+                </SectionHeading>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>

--- a/src/shared/components/ui/Spinner.tsx
+++ b/src/shared/components/ui/Spinner.tsx
@@ -28,19 +28,27 @@ export interface SpinnerProps extends SVGAttributes<SVGSVGElement> {
 }
 
 export function Spinner({ className, size = "sm", ...props }: SpinnerProps) {
+  // Wrap the <svg> in a <div> that carries `animate-spin`: CSS animations on
+  // SVG elements are often not hardware-accelerated in Chromium/WebKit, so
+  // animating the wrapper keeps the transform on the compositor thread.
+  // See `.agents/skills/vercel-react-best-practices/AGENTS.md` §6.1.
   return (
-    <svg
+    <div
       aria-hidden="true"
-      focusable="false"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      className={cn("animate-spin", sizes[size], className)}
-      {...props}
+      className={cn("inline-block animate-spin", sizes[size], className)}
     >
-      <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
-    </svg>
+      <svg
+        focusable="false"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        className="h-full w-full"
+        {...props}
+      >
+        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+      </svg>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Продовження уніфікації дизайн-системи після мерджу #293
(токени → примітиви → міграція екранів). Цей PR робить дві речі:

### 1. Fix Devin Review findings з PR #293

`src/shared/components/ui/Spinner.tsx` — `animate-spin` перенесено з
`<svg>` на `<div>`-обгортку відповідно до правила 6.1 у
`.agents/skills/vercel-react-best-practices/AGENTS.md` (на SVG у
Chromium/WebKit CSS-анімація часто не йде на compositor-потік; на
обгортці — йде). `aria-hidden` і `inline-block` переїхали на
обгортку; SVG лише заповнює (`h-full w-full`).

### 2. Міграція finyk + nutrition eyebrow-лейблів

**`finyk/components/ManualExpenseSheet.jsx`** (7 → 3):
- 3× inline `<label className="text-xs text-muted uppercase tracking-wide
  font-semibold mb-1 block">` → `<Label>` (з нового примітиву
  `@shared/components/ui/FormField`).
- Опцію "`Назва · необов'язково`" тепер рендерить сам `Label` через
  `optional={true}` prop.
- 3 eyebrow-chip спани (Часте / Швидко / Нещодавнє) — це не форм-лейбли,
  а шапки груп кнопок; збережено як `span` зі сталим класом.
- 1× `<div id={catLabelId}>` (labelled container) — нормалізовано
  клас до канонічного `block text-xs text-muted uppercase tracking-wide
  font-semibold mb-1`.

**`finyk/pages/overview/QuickAddCard.jsx`** (2 → 0):
- "Швидке додавання" + "Нещодавнє" → `<SectionHeading size="xs">`.

**`nutrition/components/PhotoAnalyzeCard.jsx`** (1 → 0):
- "Уточнення порції" → `<SectionHeading size="xs">`.

### Що свідомо НЕ чіпали

- **`nutrition/NutritionDashboard.jsx`** і **`PhotoAnalyzeCard.jsx`** (macro-
  картки Білки/Жири/Вугл.) + **`nutrition/DailyPlanCard.jsx`** (meal-type
  лейбл) — використовують `text-nutrition/70 font-bold uppercase
  tracking-wide` як фірмовий акцент модуля. `SectionHeading` жорстко
  прив'язаний до `text-muted`; створювати colored-variant — окремий PR
  за власним обговоренням.
- **`core/WeeklyDigestStories.tsx`** (11 `text-white/75` eyebrow'ів) — це
  overlay-стиль stories-карток на кольорових градієнтах, не загальний
  паттерн. Лишаємо.
- **`LogCard.jsx`** pill-badge `text-subtle font-bold uppercase tracking-wider`
  — компактний inline-бейдж (1.5px padding), не eyebrow-лейбл.
- **`AddMealSheet.jsx`** / **`FinykApp.jsx`** — декоративні роздільники з
  `uppercase tracking-wider` (АБО). Не форми й не eyebrow-header'и;
  залишено.

### Метрики `uppercase tracking-wide*` патерну в `src/`

- До цієї серії PR'ів (main до #293): **65 збігів**.
- Після #293: **60 збігів**.
- Після цього PR: **53 збіги**.

Жодних змін у сторах / бізнес-логіці / API.

## Review & Testing Checklist for Human

- [ ] **(Важливо)** Відкрити ФІНІК → швидке додавання «ручна витрата»:
  поле `Сума ₴` / `Назва` / `Дата` лейбли виглядають так само; плейсхолдер
  «необов'язково» на «Назві» є і відокремлений нижнім регістром.
- [ ] **(Важливо)** ФІНІК оверв'ю → `QuickAddCard` (з'являється за наявності
  історії витрат) — заголовки «Швидке додавання» і «Нещодавнє» виглядають
  узгоджено з іншими секціями.
- [ ] **(Середнє)** Харчування → `PhotoAnalyzeCard` → після аналізу фото
  з'являється блок «Уточнення порції» з новим `SectionHeading`.
- [ ] **(Низьке)** Кнопка з `loading` prop (або будь-який компонент, що
  показує `<Spinner>`) крутиться плавно в обох темах.

### Test plan

1. `npm run lint && npm run typecheck && npm run build` — пройшло локально.
2. Ручна перевірка на мобільному 375/414 у двох темах:
   - ФІНІК: манульний sheet витрати (лейбли + категорії).
   - ФІНІК: overview → QuickAddCard (потребує хоч одну витрату в історії).
   - Харчування: Photo → Analyze (завантажити будь-яку фотографію).
3. Спостерігати обертання `Spinner` на будь-якому `Button loading`
   (наприклад, під час збереження форми).

### Notes

- Перший коміт закриває інлайн-коментар Devin Review на PR #293.
- Наступний крок по дизайн-системі (окремий PR): підключення
  `chartTheme.ts` у `NetworthChart`, `WeeklyVolumeChart`,
  `HabitHeatmap` — щоб вісі/тултіпи стали спільними.

Link to Devin session: https://app.devin.ai/sessions/3c0a5b58aab0486d9e3807e4d14d8604
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
