### PR TITLE
refactor(server): unify zod validation + centralize error handling (PR A)

### DIFF
--- a/server/http/schemas.js
+++ b/server/http/schemas.js
@@ -48,9 +48,26 @@ export const AnalyzePhotoSchema = z.object({
 
 /** /api/nutrition/refine-photo */
 export const RefinePhotoSchema = z.object({
-  previous: z.unknown(),
-  answers: z.record(z.string().max(200), z.string().max(500)).optional(),
-  note: z.string().max(2000).optional(),
+  image_base64: z
+    .string()
+    .min(100, "Порожнє зображення")
+    .max(7_000_000, "Зображення завелике"),
+  mime_type: z
+    .string()
+    .regex(/^image\/[a-z+.-]+$/i)
+    .max(64)
+    .optional(),
+  prior_result: z.unknown().optional(),
+  portion_grams: z.number().finite().positive().optional().nullable(),
+  qna: z
+    .array(
+      z.object({
+        question: z.string().max(500).optional(),
+        answer: z.string().max(500).optional(),
+      }),
+    )
+    .max(8)
+    .optional(),
   locale: Locale,
 });
 
@@ -64,22 +81,42 @@ export const ParsePantrySchema = z.object({
   locale: Locale,
 });
 
+/** /api/nutrition/backup-upload */
+export const BackupUploadSchema = z.object({
+  // Зашифровано на клієнті; сервер не заглядає всередину структуру. Обмежуємо
+  // лише тип і загальний розмір (останнє — у handler-і, бо z.object не
+  // міряє JSON.stringify-байти).
+  blob: z.record(z.string(), z.unknown()),
+});
+
+/** Спільний формат елемента комори для nutrition-ендпойнтів. */
+const PantryItem = z.union([
+  z.string().max(200),
+  z.object({
+    name: z.string().max(120).optional(),
+    qty: z
+      .union([z.number().finite(), z.string().max(32)])
+      .optional()
+      .nullable(),
+    unit: z.string().max(32).optional().nullable(),
+    notes: z.string().max(200).optional().nullable(),
+  }),
+]);
+
 /** /api/nutrition/recommend-recipes */
 export const RecommendRecipesSchema = z.object({
-  pantry: z
-    .array(
-      z.object({
-        name: z.string().max(120),
-        qty: z.number().finite().optional().nullable(),
-        unit: z.string().max(16).optional().nullable(),
-        notes: z.string().max(200).optional().nullable(),
-      }),
-    )
-    .max(200)
+  pantry: z.array(PantryItem).max(200).optional(),
+  preferences: z
+    .object({
+      goal: z.string().max(40).optional(),
+      servings: z.number().finite().positive().optional(),
+      timeMinutes: z.number().finite().positive().optional(),
+      exclude: z.string().max(500).optional(),
+      locale: Locale,
+    })
+    .partial()
     .optional(),
-  preferences: z.string().max(1000).optional(),
-  exclude: z.array(z.string().max(120)).max(50).optional(),
-  count: z.number().int().min(1).max(10).optional(),
+  count: z.number().finite().int().positive().max(10).optional(),
   locale: Locale,
 });
 
@@ -91,32 +128,87 @@ const Macros = z.object({
   carbs_g: z.number().finite().nonnegative().nullable().optional(),
 });
 
+/**
+ * Цілі КБЖВ у форматі, який реально шле клієнт у day-hint:
+ * `dailyTargetKcal`, `dailyTargetProtein_g`, ... Приймаємо і короткі
+ * `kcal/protein_g/...` (як у day-plan), і довгі — тому `passthrough()`.
+ */
+const NutritionTargets = z
+  .object({
+    kcal: z.number().finite().nonnegative().nullable().optional(),
+    protein_g: z.number().finite().nonnegative().nullable().optional(),
+    fat_g: z.number().finite().nonnegative().nullable().optional(),
+    carbs_g: z.number().finite().nonnegative().nullable().optional(),
+    dailyTargetKcal: z.number().finite().nonnegative().nullable().optional(),
+    dailyTargetProtein_g: z
+      .number()
+      .finite()
+      .nonnegative()
+      .nullable()
+      .optional(),
+    dailyTargetFat_g: z.number().finite().nonnegative().nullable().optional(),
+    dailyTargetCarbs_g: z.number().finite().nonnegative().nullable().optional(),
+  })
+  .passthrough();
+
 export const DayHintSchema = z.object({
   macros: Macros.optional(),
-  targets: Macros.optional(),
+  targets: NutritionTargets.optional(),
   hasMeals: z.boolean().optional(),
   hasAnyMacros: z.boolean().optional(),
-  macroSources: z.array(z.string().max(50)).max(20).optional(),
+  macroSources: z
+    .union([
+      z.record(z.string().max(50), z.number().finite()),
+      z.array(z.string().max(50)).max(20),
+    ])
+    .optional(),
   locale: Locale,
 });
 
 export const DayPlanSchema = z.object({
-  targets: Macros.optional(),
-  preferences: z.string().max(1000).optional(),
-  exclude: z.array(z.string().max(120)).max(50).optional(),
+  pantry: z.array(PantryItem).max(200).optional(),
+  targets: NutritionTargets.optional(),
+  regenerateMealType: z
+    .enum(["breakfast", "lunch", "dinner", "snack"])
+    .optional(),
   locale: Locale,
 });
 
 export const WeekPlanSchema = z.object({
-  targets: Macros.optional(),
-  preferences: z.string().max(1000).optional(),
-  exclude: z.array(z.string().max(120)).max(50).optional(),
+  pantry: z.array(PantryItem).max(200).optional(),
+  preferences: z
+    .object({
+      goal: z.string().max(40).optional(),
+    })
+    .partial()
+    .optional(),
   locale: Locale,
 });
 
+/** Рецепт для shopping-list — довільна форма з клієнта, обмежуємо розміри. */
+const ShoppingListRecipe = z.object({
+  title: z.string().max(200).optional(),
+  ingredients: z.array(z.string().max(200)).max(50).optional(),
+});
+
+const ShoppingListWeekPlan = z
+  .object({
+    days: z
+      .array(
+        z.object({
+          label: z.string().max(80).optional(),
+          meals: z.array(z.string().max(500)).max(10).optional(),
+        }),
+      )
+      .max(7)
+      .optional(),
+  })
+  .partial();
+
 export const ShoppingListSchema = z.object({
-  plan: z.unknown().optional(),
-  pantry: z.array(z.unknown()).max(300).optional(),
+  recipes: z.array(ShoppingListRecipe).max(20).optional(),
+  weekPlan: ShoppingListWeekPlan.optional(),
+  pantryItems: z.array(PantryItem).max(300).optional(),
   locale: Locale,
 });
 
@@ -229,6 +321,57 @@ export const CoachMemoryPostSchema = z.object({
     })
     .optional(),
 });
+
+// ────────────────────── Sync ──────────────────────
+// Повторюємо константу `VALID_MODULES` з `server/modules/sync.js` у zod-enum:
+// єдина SSOT — той Set; тут лише back-compat перелік для 400 з деталями поля.
+const SyncModuleEnum = z.enum(["finyk", "fizruk", "routine", "nutrition"]);
+
+export const SyncPushSchema = z.object({
+  module: SyncModuleEnum,
+  // Клієнт може слати будь-який JSON всередині `data` (зашифрований blob),
+  // тому глибоко не валідуємо — розмір обмежується у handler-і (5 MB).
+  data: z.unknown().refine((v) => v !== undefined && v !== null, {
+    message: "Missing data",
+  }),
+  clientUpdatedAt: z.union([z.string(), z.number(), z.date()]).optional(),
+});
+
+export const SyncPullSchema = z.object({
+  module: SyncModuleEnum,
+});
+
+export const SyncPushAllSchema = z.object({
+  modules: z.record(
+    z.string(),
+    z.object({
+      data: z.unknown(),
+      clientUpdatedAt: z.union([z.string(), z.number(), z.date()]).optional(),
+    }),
+  ),
+});
+
+// ────────────────────── Bank proxies (query validation) ──────────────────────
+// `path` перевіряється ще raw-regex-ом в handler-ах (whitelist), тут тільки
+// формат: починається з `/`, без CRLF і розумна довжина.
+const BankApiPath = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .regex(/^\/[A-Za-z0-9\-_/]+$/, "Некоректний шлях API");
+
+export const MonoQuerySchema = z
+  .object({
+    path: BankApiPath.optional(),
+  })
+  .passthrough();
+
+export const PrivatQuerySchema = z
+  .object({
+    path: BankApiPath.optional(),
+  })
+  .passthrough();
 
 // ────────────────────── Web-push ──────────────────────
 // PushSubscription.endpoint — URL, але браузери видають доволі довгі

--- a/server/modules/chat.js
+++ b/server/modules/chat.js
@@ -686,86 +686,55 @@ export default async function handler(req, res) {
   const parsed = validateBody(ChatRequestSchema, req, res);
   if (!parsed.ok) return;
 
-  try {
-    const {
-      context = "",
-      messages = [],
-      tool_results,
-      tool_calls_raw,
-      stream,
-    } = parsed.data;
+  const {
+    context = "",
+    messages = [],
+    tool_results,
+    tool_calls_raw,
+    stream,
+  } = parsed.data;
 
-    // Другий крок: клієнт виконав tool calls і повертає результати
-    if (tool_results && tool_calls_raw) {
-      const toolResultMessages = tool_results.map((r) => ({
-        type: "tool_result",
-        tool_use_id: r.tool_use_id,
-        content: String(r.content || "ok"),
-      }));
+  // Другий крок: клієнт виконав tool calls і повертає результати
+  if (tool_results && tool_calls_raw) {
+    const toolResultMessages = tool_results.map((r) => ({
+      type: "tool_result",
+      tool_use_id: r.tool_use_id,
+      content: String(r.content || "ok"),
+    }));
 
-      // Беремо лише останнє user-повідомлення (питання що спричинило tool call)
-      const lastUserMsg = [...(Array.isArray(messages) ? messages : [])]
-        .reverse()
-        .find(
-          (m) =>
-            m?.role === "user" &&
-            typeof m?.content === "string" &&
-            m.content.trim(),
-        );
+    // Беремо лише останнє user-повідомлення (питання що спричинило tool call)
+    const lastUserMsg = [...(Array.isArray(messages) ? messages : [])]
+      .reverse()
+      .find(
+        (m) =>
+          m?.role === "user" &&
+          typeof m?.content === "string" &&
+          m.content.trim(),
+      );
 
-      const fullMessages = [
-        ...(lastUserMsg
-          ? [{ role: "user", content: lastUserMsg.content }]
-          : []),
-        { role: "assistant", content: tool_calls_raw },
-        { role: "user", content: toolResultMessages },
-      ];
+    const fullMessages = [
+      ...(lastUserMsg ? [{ role: "user", content: lastUserMsg.content }] : []),
+      { role: "assistant", content: tool_calls_raw },
+      { role: "user", content: toolResultMessages },
+    ];
 
-      const payload = {
-        model: "claude-sonnet-4-6",
-        max_tokens: 400,
-        system: SYSTEM_PREFIX + context,
-        tools: TOOLS,
-        messages: fullMessages,
-      };
+    const payload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 400,
+      system: SYSTEM_PREFIX + context,
+      tools: TOOLS,
+      messages: fullMessages,
+    };
 
-      if (stream) {
-        await streamAnthropicToSse(res, apiKey, payload, "chat-tool-result");
-        return;
-      }
-
-      const { response, data } = await anthropicMessages(apiKey, payload, {
-        timeoutMs: 30000,
-        endpoint: "chat-tool-result",
-      });
-
-      if (!response?.ok) {
-        return res
-          .status(response?.status || 500)
-          .json({ error: data?.error?.message || "AI error" });
-      }
-
-      const text = extractAnthropicText(data);
-      return res.status(200).json({ text: text || "Готово." });
+    if (stream) {
+      await streamAnthropicToSse(res, apiKey, payload, "chat-tool-result");
+      return;
     }
 
-    // Перший запит — може повернути tool_use або текст
-    const cleaned = sanitizeMessages(messages);
-    if (cleaned.length === 0) {
-      return res.status(400).json({ error: "Немає повідомлень" });
-    }
-
-    const { response, data } = await anthropicMessages(
-      apiKey,
-      {
-        model: "claude-sonnet-4-6",
-        max_tokens: 600,
-        system: SYSTEM_PREFIX + context,
-        tools: TOOLS,
-        messages: cleaned,
-      },
-      { timeoutMs: 30000, endpoint: "chat" },
-    );
+    const { response, data } = await anthropicMessages(apiKey, payload, {
+      timeoutMs: 30000,
+      endpoint: "chat-tool-result",
+    });
 
     if (!response?.ok) {
       return res
@@ -773,31 +742,54 @@ export default async function handler(req, res) {
         .json({ error: data?.error?.message || "AI error" });
     }
 
-    const content = data?.content || [];
-    const toolUses = content.filter((b) => b.type === "tool_use");
-    const textParts = content
-      .filter((b) => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
-
-    if (toolUses.length > 0) {
-      return res.status(200).json({
-        text: textParts || null,
-        tool_calls: toolUses.map((t) => ({
-          id: t.id,
-          name: t.name,
-          input: t.input,
-        })),
-        tool_calls_raw: content,
-      });
-    }
-
-    return res
-      .status(200)
-      .json({ text: textParts || "Немає відповіді від AI." });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
+    const text = extractAnthropicText(data);
+    return res.status(200).json({ text: text || "Готово." });
   }
+
+  // Перший запит — може повернути tool_use або текст
+  const cleaned = sanitizeMessages(messages);
+  if (cleaned.length === 0) {
+    return res.status(400).json({ error: "Немає повідомлень" });
+  }
+
+  const { response, data } = await anthropicMessages(
+    apiKey,
+    {
+      model: "claude-sonnet-4-6",
+      max_tokens: 600,
+      system: SYSTEM_PREFIX + context,
+      tools: TOOLS,
+      messages: cleaned,
+    },
+    { timeoutMs: 30000, endpoint: "chat" },
+  );
+
+  if (!response?.ok) {
+    return res
+      .status(response?.status || 500)
+      .json({ error: data?.error?.message || "AI error" });
+  }
+
+  const content = data?.content || [];
+  const toolUses = content.filter((b) => b.type === "tool_use");
+  const textParts = content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+
+  if (toolUses.length > 0) {
+    return res.status(200).json({
+      text: textParts || null,
+      tool_calls: toolUses.map((t) => ({
+        id: t.id,
+        name: t.name,
+        input: t.input,
+      })),
+      tool_calls_raw: content,
+    });
+  }
+
+  return res.status(200).json({ text: textParts || "Немає відповіді від AI." });
 }
 
 /**

--- a/server/modules/mono.js
+++ b/server/modules/mono.js
@@ -1,28 +1,32 @@
 import { logger } from "../obs/logger.js";
 import { recordExternalHttp } from "../lib/externalHttp.js";
+import { validateQuery } from "../http/validate.js";
+import { MonoQuerySchema } from "../http/schemas.js";
+import { ExternalServiceError } from "../obs/errors.js";
 
 /**
  * `/api/mono` — проксі до Monobank personal API. CORS/rate-limit/module-tag
  * зроблені middleware-ами роутера; тут тільки upstream credentials,
  * path-валідація та HTTP-виклик.
+ *
+ * Формат `path` (whitelist-regex) валідується через `validateQuery` + zod;
+ * allowlist конкретних upstream шляхів — нижче (не чистий shape-check,
+ * тому тримаємо тут).
  */
+const ALLOWED_PATHS = ["/personal/client-info", "/personal/statement"];
+
 export default async function handler(req, res) {
   const token = req.headers["x-token"];
-  const rawPath = req.query.path || "/personal/client-info";
 
   if (!token) {
     return res.status(401).json({ error: "Токен відсутній" });
   }
 
-  // Валідація шляху API: лише безпечні символи, без CRLF, ?, #, ..
-  // і точна відповідність дозволеному префіксу (рівний шлях або префікс+"/…").
-  const path = String(rawPath);
-  if (!/^\/[A-Za-z0-9\-_/]+$/.test(path) || path.includes("..")) {
-    return res.status(400).json({ error: "Недозволений API шлях" });
-  }
+  const parsedQ = validateQuery(MonoQuerySchema, req, res);
+  if (!parsedQ.ok) return;
+  const path = String(parsedQ.data.path || "/personal/client-info");
 
-  const allowedPaths = ["/personal/client-info", "/personal/statement"];
-  const pathAllowed = allowedPaths.some(
+  const pathAllowed = ALLOWED_PATHS.some(
     (allowed) => path === allowed || path.startsWith(allowed + "/"),
   );
   if (!pathAllowed) {
@@ -30,27 +34,11 @@ export default async function handler(req, res) {
   }
 
   const start = process.hrtime.bigint();
+  let response;
   try {
-    const response = await fetch(`https://api.monobank.ua${path}`, {
+    response = await fetch(`https://api.monobank.ua${path}`, {
       headers: { "X-Token": String(token) },
     });
-    const ms = Number(process.hrtime.bigint() - start) / 1e6;
-
-    if (!response.ok) {
-      recordExternalHttp(
-        "monobank",
-        response.status === 429 ? "rate_limited" : "error",
-        ms,
-      );
-      const errorText = await response.text();
-      return res.status(response.status).json({
-        error: response.status === 429 ? "Занадто багато запитів" : errorText,
-      });
-    }
-
-    const data = await response.json();
-    recordExternalHttp("monobank", "ok", ms);
-    res.status(200).json(data);
   } catch (e) {
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
     recordExternalHttp("monobank", "error", ms);
@@ -58,6 +46,26 @@ export default async function handler(req, res) {
       msg: "mono_proxy_failed",
       err: { message: e?.message || String(e), code: e?.code },
     });
-    res.status(500).json({ error: "Помилка сервера" });
+    throw new ExternalServiceError("Помилка сервера", {
+      code: "MONOBANK_FETCH_FAILED",
+      cause: e,
+    });
   }
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+
+  if (!response.ok) {
+    recordExternalHttp(
+      "monobank",
+      response.status === 429 ? "rate_limited" : "error",
+      ms,
+    );
+    const errorText = await response.text();
+    return res.status(response.status).json({
+      error: response.status === 429 ? "Занадто багато запитів" : errorText,
+    });
+  }
+
+  const data = await response.json();
+  recordExternalHttp("monobank", "ok", ms);
+  res.status(200).json(data);
 }

--- a/server/modules/nutrition/analyze-photo.js
+++ b/server/modules/nutrition/analyze-photo.js
@@ -1,6 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { AnalyzePhotoSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -26,57 +27,59 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
 /**
  * POST /api/nutrition/analyze-photo — розпізнати страву з фото і повернути
  * оцінені КБЖВ. CORS / token / quota / rate-limit виставляє роутер.
+ *
+ * Широкий `try/catch` свідомо не використовуємо: всі очікувані помилки
+ * (bad input) ловить zod + central errorHandler; непередбачені (таймаут
+ * Anthropic, мережа) — теж піднімаємо наверх, щоб Sentry/логи отримали
+ * повноцінний контекст, а не замаскований `{ error: e.message }`.
  */
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
   const parsed = validateBody(AnalyzePhotoSchema, req, res);
   if (!parsed.ok) return;
+  const { image_base64, mime_type, locale } = parsed.data;
 
-  try {
-    const { image_base64, mime_type, locale } = parsed.data;
-    const b64 = image_base64.trim();
-    const mediaType = mime_type || "image/jpeg";
+  const b64 = image_base64.trim();
+  const mediaType = mime_type || "image/jpeg";
 
-    const userText = `Мова: ${locale || "uk-UA"}.
+  const userText = `Мова: ${locale || "uk-UA"}.
 Опиши, що на фото і порахуй приблизне КБЖВ. Якщо треба — задай уточнення.`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 700,
-      temperature: 0.2,
-      system: SYSTEM,
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "image",
-              source: { type: "base64", media_type: mediaType, data: b64 },
-            },
-            { type: "text", text: userText },
-          ],
-        },
-      ],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 700,
+    temperature: 0.2,
+    system: SYSTEM,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data: b64 },
+          },
+          { type: "text", text: userText },
+        ],
+      },
+    ],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 20000,
-      endpoint: "analyze-photo",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 20000,
+    endpoint: "analyze-photo",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const text = extractAnthropicText(data);
-
-    const parsed = extractJsonFromText(text);
-    const result = normalizePhotoResult(parsed);
-
-    return res.status(200).json({ result, rawText: text || null });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const text = extractAnthropicText(data);
+
+  const jsonParsed = extractJsonFromText(text);
+  const result = normalizePhotoResult(jsonParsed);
+
+  return res.status(200).json({ result, rawText: text || null });
 }

--- a/server/modules/nutrition/backup-download.js
+++ b/server/modules/nutrition/backup-download.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { NotFoundError } from "../../obs/errors.js";
 
 function safeKeyFromToken(req) {
   const tok = req?.headers?.["x-token"];
@@ -15,16 +16,25 @@ function safeKeyFromToken(req) {
 /**
  * POST /api/nutrition/backup-download — відновити збережений бекап.
  * CORS / token / rate-limit виставляє роутер.
+ *
+ * Вузький catch тільки на очікувану ситуацію "файл відсутній" (ENOENT).
+ * Пошкоджений JSON і файлові помилки летять наверх в errorHandler.
  */
 export default async function handler(req, res) {
+  const dir = path.join(process.cwd(), ".data");
+  const key = safeKeyFromToken(req);
+  const file = path.join(dir, `nutrition-backup-${key}.json`);
+
+  let raw;
   try {
-    const dir = path.join(process.cwd(), ".data");
-    const key = safeKeyFromToken(req);
-    const file = path.join(dir, `nutrition-backup-${key}.json`);
-    const raw = await fs.readFile(file, "utf8");
-    const blob = JSON.parse(raw);
-    return res.status(200).json({ ok: true, blob });
-  } catch {
-    return res.status(404).json({ error: "Бекап не знайдено" });
+    raw = await fs.readFile(file, "utf8");
+  } catch (e) {
+    if (e?.code === "ENOENT") {
+      throw new NotFoundError("Бекап не знайдено");
+    }
+    throw e;
   }
+
+  const blob = JSON.parse(raw);
+  return res.status(200).json({ ok: true, blob });
 }

--- a/server/modules/nutrition/backup-upload.js
+++ b/server/modules/nutrition/backup-upload.js
@@ -1,5 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { validateBody } from "../../http/validate.js";
+import { BackupUploadSchema } from "../../http/schemas.js";
+import { AppError } from "../../obs/errors.js";
 
 function safeKeyFromToken(req) {
   const tok = req?.headers?.["x-token"];
@@ -18,14 +21,19 @@ function safeKeyFromToken(req) {
  * CORS / token / rate-limit виставляє роутер.
  */
 export default async function handler(req, res) {
-  const blob = req.body?.blob;
-  if (!blob || typeof blob !== "object" || Array.isArray(blob))
-    return res.status(400).json({ error: "Некоректний blob" });
+  const parsed = validateBody(BackupUploadSchema, req, res);
+  if (!parsed.ok) return;
+  const { blob } = parsed.data;
 
-  // Keep it small-ish; this is encrypted client-side anyway.
+  // Keep it small-ish; this is encrypted client-side anyway. `z.object`
+  // не міряє JSON.stringify-байти, тому розмір перевіряємо тут.
   const raw = JSON.stringify(blob);
-  if (raw.length > 2_500_000)
-    return res.status(413).json({ error: "Бекап завеликий" });
+  if (raw.length > 2_500_000) {
+    throw new AppError("Бекап завеликий", {
+      status: 413,
+      code: "PAYLOAD_TOO_LARGE",
+    });
+  }
 
   const dir = path.join(process.cwd(), ".data");
   await fs.mkdir(dir, { recursive: true });

--- a/server/modules/nutrition/day-hint.js
+++ b/server/modules/nutrition/day-hint.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { DayHintSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -21,67 +24,63 @@ function normalizeHint(text) {
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const { macros, targets, locale, hasMeals, hasAnyMacros, macroSources } =
-      req.body || {};
-    const mRaw = macros && typeof macros === "object" ? macros : {};
-    const m = {
-      kcal: safeNonNegOrNull(mRaw.kcal),
-      protein_g: safeNonNegOrNull(mRaw.protein_g),
-      fat_g: safeNonNegOrNull(mRaw.fat_g),
-      carbs_g: safeNonNegOrNull(mRaw.carbs_g),
-    };
-    const t = targets && typeof targets === "object" ? targets : {};
-    const loc = String(locale || "uk-UA");
+  const parsed = validateBody(DayHintSchema, req, res);
+  if (!parsed.ok) return;
+  const { macros, targets, locale, hasMeals, hasAnyMacros, macroSources } =
+    parsed.data;
 
-    const contextNote =
-      hasMeals && !hasAnyMacros
-        ? "У журналі є прийоми їжі, але без КБЖВ (макроси не задані). Дай пораду, як краще заповнювати/оцінювати КБЖВ, не звинувачуючи.\n"
-        : "";
+  const mRaw = macros || {};
+  const m = {
+    kcal: safeNonNegOrNull(mRaw.kcal),
+    protein_g: safeNonNegOrNull(mRaw.protein_g),
+    fat_g: safeNonNegOrNull(mRaw.fat_g),
+    carbs_g: safeNonNegOrNull(mRaw.carbs_g),
+  };
+  const t = targets || {};
+  const loc = String(locale || "uk-UA");
 
-    const sourcesNote =
-      macroSources && typeof macroSources === "object"
-        ? `Походження КБЖВ (кількість прийомів): ${JSON.stringify(macroSources)}.\nЯкщо багато AI — обережно формулюй висновки, можеш порадити уточнити вагу/порцію.\n`
-        : "";
+  const contextNote =
+    hasMeals && !hasAnyMacros
+      ? "У журналі є прийоми їжі, але без КБЖВ (макроси не задані). Дай пораду, як краще заповнювати/оцінювати КБЖВ, не звинувачуючи.\n"
+      : "";
 
-    const prompt = `Мова: ${loc}.
+  const sourcesNote =
+    macroSources && typeof macroSources === "object"
+      ? `Походження КБЖВ (кількість прийомів): ${JSON.stringify(macroSources)}.\nЯкщо багато AI — обережно формулюй висновки, можеш порадити уточнити вагу/порцію.\n`
+      : "";
+
+  const prompt = `Мова: ${loc}.
 ${contextNote}${sourcesNote}Факт за день: ккал ${m.kcal ?? "—"}, білки ${m.protein_g ?? "—"} г, жири ${m.fat_g ?? "—"} г, вуглеводи ${m.carbs_g ?? "—"} г.
 Цілі (якщо є): ккал ${t.dailyTargetKcal ?? "—"}, білки ${t.dailyTargetProtein_g ?? "—"}, жири ${t.dailyTargetFat_g ?? "—"}, вуглеводи ${t.dailyTargetCarbs_g ?? "—"}.
 
 Дай 2–4 речення: коротко порівняй з цілями (якщо цілі задані), що добре / що звернути увагу завтра. Без моралізаторства. Відповідь ТІЛЬКИ JSON: {"hint":"..."}`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 400,
-      temperature: 0.3,
-      messages: [{ role: "user", content: prompt }],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 400,
+    temperature: 0.3,
+    messages: [{ role: "user", content: prompt }],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 20000,
-      endpoint: "day-hint",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 20000,
+    endpoint: "day-hint",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-    let hint = "";
-    try {
-      const parsed = extractJsonFromText(out);
-      hint = normalizeHint(parsed?.hint);
-    } catch {
-      try {
-        hint = normalizeHint(out);
-      } catch {
-        hint = "";
-      }
-    }
-    if (!hint) hint = "Не вдалося сформувати підказку.";
-    return res.status(200).json({ hint });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+  let hint = "";
+  try {
+    const jsonParsed = extractJsonFromText(out);
+    hint = normalizeHint(jsonParsed?.hint);
+  } catch {
+    hint = normalizeHint(out);
+  }
+  if (!hint) hint = "Не вдалося сформувати підказку.";
+  return res.status(200).json({ hint });
 }

--- a/server/modules/nutrition/day-plan.js
+++ b/server/modules/nutrition/day-plan.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { DayPlanSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -109,44 +112,45 @@ function normalizeDayPlan(parsed) {
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const { items, targets, regenerateMealType, locale } = req.body || {};
-    const arr = Array.isArray(items) ? items : [];
-    const loc = String(locale || "uk-UA");
+  const parsed = validateBody(DayPlanSchema, req, res);
+  if (!parsed.ok) return;
+  const { pantry: pantryIn, targets, regenerateMealType, locale } = parsed.data;
+  const arr = Array.isArray(pantryIn) ? pantryIn : [];
+  const loc = String(locale || "uk-UA");
 
-    const tgt = targets && typeof targets === "object" ? targets : {};
-    const kcal = tgt.kcal != null ? Number(tgt.kcal) : null;
-    const protein = tgt.protein_g != null ? Number(tgt.protein_g) : null;
-    const fat = tgt.fat_g != null ? Number(tgt.fat_g) : null;
-    const carbs = tgt.carbs_g != null ? Number(tgt.carbs_g) : null;
+  const tgt = targets || {};
+  const kcal = tgt.kcal != null ? Number(tgt.kcal) : null;
+  const protein = tgt.protein_g != null ? Number(tgt.protein_g) : null;
+  const fat = tgt.fat_g != null ? Number(tgt.fat_g) : null;
+  const carbs = tgt.carbs_g != null ? Number(tgt.carbs_g) : null;
 
-    const pantryStr =
-      arr.length > 0
-        ? arr
-            .map((x) => {
-              if (typeof x === "string") return x;
-              const name = x?.name ? String(x.name) : "";
-              const qty = x?.qty != null ? String(x.qty) : "";
-              const unit = x?.unit ? String(x.unit) : "";
-              return [name, qty && unit ? `${qty} ${unit}` : qty || unit]
-                .filter(Boolean)
-                .join(" — ");
-            })
-            .filter(Boolean)
-            .slice(0, 50)
-            .join("\n- ")
-        : "продукти не вказані";
+  const pantryStr =
+    arr.length > 0
+      ? arr
+          .map((x) => {
+            if (typeof x === "string") return x;
+            const name = x?.name ? String(x.name) : "";
+            const qty = x?.qty != null ? String(x.qty) : "";
+            const unit = x?.unit ? String(x.unit) : "";
+            return [name, qty && unit ? `${qty} ${unit}` : qty || unit]
+              .filter(Boolean)
+              .join(" — ");
+          })
+          .filter(Boolean)
+          .slice(0, 50)
+          .join("\n- ")
+      : "продукти не вказані";
 
-    const targetsStr =
-      kcal != null
-        ? `Ціль ккал: ${kcal}. Білки: ${protein ?? "не задано"} г. Жири: ${fat ?? "не задано"} г. Вуглеводи: ${carbs ?? "не задано"} г.`
-        : "Цілі не задані — запропонуй збалансоване харчування.";
+  const targetsStr =
+    kcal != null
+      ? `Ціль ккал: ${kcal}. Білки: ${protein ?? "не задано"} г. Жири: ${fat ?? "не задано"} г. Вуглеводи: ${carbs ?? "не задано"} г.`
+      : "Цілі не задані — запропонуй збалансоване харчування.";
 
-    const regenStr = regenerateMealType
-      ? `Потрібно перегенерувати ТІЛЬКИ прийом їжі типу: "${regenerateMealType}". Решту не включай.`
-      : "Згенеруй повний план на день: сніданок, обід, вечеря, 1-2 перекуси.";
+  const regenStr = regenerateMealType
+    ? `Потрібно перегенерувати ТІЛЬКИ прийом їжі типу: "${regenerateMealType}". Решту не включай.`
+    : "Згенеруй повний план на день: сніданок, обід, вечеря, 1-2 перекуси.";
 
-    const prompt = `Мова: ${loc}.
+  const prompt = `Мова: ${loc}.
 ${targetsStr}
 
 Наявні продукти (намагайся використовувати їх):
@@ -154,33 +158,31 @@ ${targetsStr}
 
 ${regenStr}`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 1500,
-      temperature: 0.3,
-      system: SYSTEM,
-      messages: [{ role: "user", content: prompt }],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 1500,
+    temperature: 0.3,
+    system: SYSTEM,
+    messages: [{ role: "user", content: prompt }],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 30000,
-      endpoint: "day-plan",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 30000,
+    endpoint: "day-plan",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-    const parsed = extractJsonFromText(out);
-    const plan = normalizeDayPlan(parsed);
-
-    return res.status(200).json({
-      plan,
-      rawText: plan.meals.length === 0 ? out || null : null,
-    });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+  const jsonParsed = extractJsonFromText(out);
+  const plan = normalizeDayPlan(jsonParsed);
+
+  return res.status(200).json({
+    plan,
+    rawText: plan.meals.length === 0 ? out || null : null,
+  });
 }

--- a/server/modules/nutrition/parse-pantry.js
+++ b/server/modules/nutrition/parse-pantry.js
@@ -1,6 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { ParsePantrySchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -38,39 +39,35 @@ export default async function handler(req, res) {
 
   const parsed = validateBody(ParsePantrySchema, req, res);
   if (!parsed.ok) return;
+  const { text: raw, locale } = parsed.data;
 
-  try {
-    const { text: raw, locale } = parsed.data;
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 500,
+    temperature: 0.2,
+    system: SYSTEM,
+    messages: [
+      {
+        role: "user",
+        content: `Мова: ${locale || "uk-UA"}.\nОсь список продуктів:\n${raw}`,
+      },
+    ],
+  };
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 500,
-      temperature: 0.2,
-      system: SYSTEM,
-      messages: [
-        {
-          role: "user",
-          content: `Мова: ${locale || "uk-UA"}.\nОсь список продуктів:\n${raw}`,
-        },
-      ],
-    };
-
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 20000,
-      endpoint: "parse-pantry",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 20000,
+    endpoint: "parse-pantry",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-
-    const parsed = extractJsonFromText(out);
-    const items = normalizePantryItems(parsed);
-    return res.status(200).json({ items, rawText: out || null });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+
+  const jsonParsed = extractJsonFromText(out);
+  const items = normalizePantryItems(jsonParsed);
+  return res.status(200).json({ items, rawText: out || null });
 }

--- a/server/modules/nutrition/recommend-recipes.js
+++ b/server/modules/nutrition/recommend-recipes.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { RecommendRecipesSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -35,38 +38,34 @@ const SYSTEM = `Ти шеф-кухар і нутріціолог. Відпові
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const { items, preferences } = req.body || {};
-    const arr = Array.isArray(items) ? items : [];
-    if (arr.length === 0)
-      return res.status(400).json({ error: "items is required" });
-    if (arr.length > 60)
-      return res.status(413).json({ error: "Too many items" });
+  const parsed = validateBody(RecommendRecipesSchema, req, res);
+  if (!parsed.ok) return;
+  const { pantry: pantryIn, preferences } = parsed.data;
+  const arr = Array.isArray(pantryIn) ? pantryIn : [];
 
-    const prefs =
-      preferences && typeof preferences === "object" ? preferences : {};
-    const goal = String(prefs.goal || "balanced");
-    const servings = Number(prefs.servings || 1);
-    const timeMinutes = Number(prefs.timeMinutes || 25);
-    const exclude = String(prefs.exclude || "");
-    const locale = String(prefs.locale || "uk-UA");
+  const prefs = preferences || {};
+  const goal = String(prefs.goal || "balanced");
+  const servings = Number(prefs.servings || 1);
+  const timeMinutes = Number(prefs.timeMinutes || 25);
+  const exclude = String(prefs.exclude || "");
+  const locale = String(prefs.locale || "uk-UA");
 
-    const pantry = arr
-      .map((x) => {
-        if (typeof x === "string") return x;
-        const name = x?.name ? String(x.name) : "";
-        const qty = x?.qty != null && x.qty !== "" ? String(x.qty) : "";
-        const unit = x?.unit ? String(x.unit) : "";
-        const notes = x?.notes ? String(x.notes) : "";
-        return [name, qty && unit ? `${qty} ${unit}` : qty || unit, notes]
-          .filter(Boolean)
-          .join(" — ");
-      })
-      .filter(Boolean)
-      .slice(0, 60)
-      .join("\n- ");
+  const pantry = arr
+    .map((x) => {
+      if (typeof x === "string") return x;
+      const name = x?.name ? String(x.name) : "";
+      const qty = x?.qty != null && x.qty !== "" ? String(x.qty) : "";
+      const unit = x?.unit ? String(x.unit) : "";
+      const notes = x?.notes ? String(x.notes) : "";
+      return [name, qty && unit ? `${qty} ${unit}` : qty || unit, notes]
+        .filter(Boolean)
+        .join(" — ");
+    })
+    .filter(Boolean)
+    .slice(0, 60)
+    .join("\n- ");
 
-    const prompt = `Мова: ${locale}.
+  const prompt = `Мова: ${locale}.
 Ціль: ${goal}.
 Порції: ${Number.isFinite(servings) && servings > 0 ? servings : 1}.
 Час: ${Number.isFinite(timeMinutes) && timeMinutes > 0 ? timeMinutes : 25} хв.
@@ -82,33 +81,31 @@ export default async function handler(req, res) {
 - ingredients: тільки ключові позиції
 Якщо продуктів мало — все одно поверни 2 прості рецепти.`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 2800,
-      temperature: 0.2,
-      system: SYSTEM,
-      messages: [{ role: "user", content: prompt }],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 2800,
+    temperature: 0.2,
+    system: SYSTEM,
+    messages: [{ role: "user", content: prompt }],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 45000,
-      endpoint: "recommend-recipes",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 45000,
+    endpoint: "recommend-recipes",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-
-    const parsed = extractJsonFromText(out);
-    const recipes = normalizeRecipes(parsed);
-    return res.status(200).json({
-      recipes,
-      rawText: recipes.length === 0 ? out || null : null,
-    });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+
+  const jsonParsed = extractJsonFromText(out);
+  const recipes = normalizeRecipes(jsonParsed);
+  return res.status(200).json({
+    recipes,
+    rawText: recipes.length === 0 ? out || null : null,
+  });
 }

--- a/server/modules/nutrition/refine-photo.js
+++ b/server/modules/nutrition/refine-photo.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { RefinePhotoSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -28,35 +31,17 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const {
-      image_base64,
-      mime_type,
-      prior_result,
-      portion_grams,
-      qna,
-      locale,
-    } = req.body || {};
+  const parsed = validateBody(RefinePhotoSchema, req, res);
+  if (!parsed.ok) return;
+  const { image_base64, mime_type, prior_result, portion_grams, qna, locale } =
+    parsed.data;
 
-    const b64 = typeof image_base64 === "string" ? image_base64.trim() : "";
-    const mediaType =
-      typeof mime_type === "string" && mime_type ? mime_type : "image/jpeg";
-    if (!b64)
-      return res.status(400).json({ error: "image_base64 is required" });
-    if (b64.length > 7_000_000)
-      return res
-        .status(413)
-        .json({ error: "Image too large (base64 payload)" });
+  const b64 = image_base64.trim();
+  const mediaType = mime_type || "image/jpeg";
+  const grams = typeof portion_grams === "number" ? portion_grams : null;
+  const qa = Array.isArray(qna) ? qna.slice(0, 8) : [];
 
-    const grams =
-      typeof portion_grams === "number" &&
-      Number.isFinite(portion_grams) &&
-      portion_grams > 0
-        ? portion_grams
-        : null;
-    const qa = Array.isArray(qna) ? qna.slice(0, 8) : [];
-
-    const userText = `Мова: ${locale || "uk-UA"}.
+  const userText = `Мова: ${locale || "uk-UA"}.
 Ось попередній результат (може бути приблизний): ${safeJson(prior_result)}
 
 Уточнення користувача:
@@ -65,44 +50,42 @@ export default async function handler(req, res) {
 
 Перерахуй і поверни JSON.`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 650,
-      temperature: 0.2,
-      system: SYSTEM,
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "image",
-              source: { type: "base64", media_type: mediaType, data: b64 },
-            },
-            { type: "text", text: userText },
-          ],
-        },
-      ],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 650,
+    temperature: 0.2,
+    system: SYSTEM,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data: b64 },
+          },
+          { type: "text", text: userText },
+        ],
+      },
+    ],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 20000,
-      endpoint: "refine-photo",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 20000,
+    endpoint: "refine-photo",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const text = extractAnthropicText(data);
-
-    const parsed = extractJsonFromText(text);
-    const result = normalizePhotoResult(parsed, { fallbackGrams: grams });
-
-    return res.status(200).json({ result, rawText: text || null });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const text = extractAnthropicText(data);
+
+  const jsonParsed = extractJsonFromText(text);
+  const result = normalizePhotoResult(jsonParsed, { fallbackGrams: grams });
+
+  return res.status(200).json({ result, rawText: text || null });
 }
 
 function safeJson(v) {

--- a/server/modules/nutrition/shopping-list.js
+++ b/server/modules/nutrition/shopping-list.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { ShoppingListSchema } from "../../http/schemas.js";
+import { ValidationError, ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -42,50 +45,49 @@ const SYSTEM = `Ти помічник з планування покупок і 
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const { recipes, weekPlan, pantryItems, locale } = req.body || {};
-    const loc = String(locale || "uk-UA");
+  const parsed = validateBody(ShoppingListSchema, req, res);
+  if (!parsed.ok) return;
+  const { recipes, weekPlan, pantryItems, locale } = parsed.data;
+  const loc = String(locale || "uk-UA");
 
-    const pantryArr = Array.isArray(pantryItems) ? pantryItems : [];
-    const pantryStr =
-      pantryArr.length > 0
-        ? pantryArr
-            .map((x) =>
-              typeof x === "string" ? x : x?.name ? String(x.name) : "",
-            )
-            .filter(Boolean)
-            .join(", ")
-        : "нічого";
+  const pantryArr = Array.isArray(pantryItems) ? pantryItems : [];
+  const pantryStr =
+    pantryArr.length > 0
+      ? pantryArr
+          .map((x) =>
+            typeof x === "string" ? x : x?.name ? String(x.name) : "",
+          )
+          .filter(Boolean)
+          .join(", ")
+      : "нічого";
 
-    let ingredientsList = "";
+  let ingredientsList = "";
 
-    if (Array.isArray(recipes) && recipes.length > 0) {
-      ingredientsList = recipes
-        .map((r) => {
-          const title = r?.title || "Рецепт";
-          const ings = Array.isArray(r?.ingredients)
-            ? r.ingredients.join(", ")
-            : "";
-          return `• ${title}: ${ings || "без деталей"}`;
-        })
-        .join("\n");
-    } else if (weekPlan?.days?.length > 0) {
-      ingredientsList = weekPlan.days
-        .map((d) => {
-          const day = d?.label || "День";
-          const meals = Array.isArray(d?.meals) ? d.meals.join("; ") : "";
-          return `• ${day}: ${meals}`;
-        })
-        .join("\n");
-    }
+  if (Array.isArray(recipes) && recipes.length > 0) {
+    ingredientsList = recipes
+      .map((r) => {
+        const title = r?.title || "Рецепт";
+        const ings = Array.isArray(r?.ingredients)
+          ? r.ingredients.join(", ")
+          : "";
+        return `• ${title}: ${ings || "без деталей"}`;
+      })
+      .join("\n");
+  } else if (weekPlan?.days?.length > 0) {
+    ingredientsList = weekPlan.days
+      .map((d) => {
+        const day = d?.label || "День";
+        const meals = Array.isArray(d?.meals) ? d.meals.join("; ") : "";
+        return `• ${day}: ${meals}`;
+      })
+      .join("\n");
+  }
 
-    if (!ingredientsList) {
-      return res
-        .status(400)
-        .json({ error: "Потрібно передати рецепти або тижневий план." });
-    }
+  if (!ingredientsList) {
+    throw new ValidationError("Потрібно передати рецепти або тижневий план.");
+  }
 
-    const prompt = `Мова: ${loc}.
+  const prompt = `Мова: ${loc}.
 
 Що вже є в коморі (НЕ додавай до списку покупок):
 ${pantryStr}
@@ -95,70 +97,68 @@ ${ingredientsList}
 
 Склади список покупок, виключи все що вже є в коморі, згрупуй за категоріями.`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 1200,
-      temperature: 0.15,
-      system: SYSTEM,
-      messages: [{ role: "user", content: prompt }],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 1200,
+    temperature: 0.15,
+    system: SYSTEM,
+    messages: [{ role: "user", content: prompt }],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 25000,
-      endpoint: "shopping-list",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 25000,
+    endpoint: "shopping-list",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-    const parsed = extractJsonFromText(out);
-
-    const obj =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? parsed
-        : {};
-
-    const seenNames = new Set();
-    const normalize = (s) => s.toLowerCase().replace(/\s+/g, " ").trim();
-
-    const categories = Array.isArray(obj.categories)
-      ? obj.categories
-          .map((cat) => {
-            if (!cat || typeof cat !== "object") return null;
-            const name = String(cat.name || "Інше").trim();
-            const items = Array.isArray(cat.items)
-              ? cat.items
-                  .map((item) => {
-                    if (!item || typeof item !== "object") return null;
-                    const itemName = String(item.name || "").trim();
-                    if (!itemName) return null;
-                    const key = normalize(itemName);
-                    if (seenNames.has(key)) return null;
-                    seenNames.add(key);
-                    return {
-                      id: `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-                      name: itemName,
-                      quantity: String(item.quantity || "").trim(),
-                      note: String(item.note || "").trim(),
-                      checked: false,
-                    };
-                  })
-                  .filter(Boolean)
-              : [];
-            if (items.length === 0) return null;
-            return { name, items };
-          })
-          .filter(Boolean)
-      : [];
-
-    return res.status(200).json({
-      categories,
-      rawText: categories.length === 0 ? out || null : null,
-    });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+  const jsonParsed = extractJsonFromText(out);
+
+  const obj =
+    jsonParsed && typeof jsonParsed === "object" && !Array.isArray(jsonParsed)
+      ? jsonParsed
+      : {};
+
+  const seenNames = new Set();
+  const normalize = (s) => s.toLowerCase().replace(/\s+/g, " ").trim();
+
+  const categories = Array.isArray(obj.categories)
+    ? obj.categories
+        .map((cat) => {
+          if (!cat || typeof cat !== "object") return null;
+          const name = String(cat.name || "Інше").trim();
+          const items = Array.isArray(cat.items)
+            ? cat.items
+                .map((item) => {
+                  if (!item || typeof item !== "object") return null;
+                  const itemName = String(item.name || "").trim();
+                  if (!itemName) return null;
+                  const key = normalize(itemName);
+                  if (seenNames.has(key)) return null;
+                  seenNames.add(key);
+                  return {
+                    id: `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+                    name: itemName,
+                    quantity: String(item.quantity || "").trim(),
+                    note: String(item.note || "").trim(),
+                    checked: false,
+                  };
+                })
+                .filter(Boolean)
+            : [];
+          if (items.length === 0) return null;
+          return { name, items };
+        })
+        .filter(Boolean)
+    : [];
+
+  return res.status(200).json({
+    categories,
+    rawText: categories.length === 0 ? out || null : null,
+  });
 }

--- a/server/modules/nutrition/week-plan.js
+++ b/server/modules/nutrition/week-plan.js
@@ -1,4 +1,7 @@
 import { extractJsonFromText } from "../../http/jsonSafe.js";
+import { validateBody } from "../../http/validate.js";
+import { WeekPlanSchema } from "../../http/schemas.js";
+import { ExternalServiceError } from "../../obs/errors.js";
 import {
   anthropicMessages,
   extractAnthropicText,
@@ -50,59 +53,55 @@ const SYSTEM = `Ти шеф-кухар і планувальник харчув�
 export default async function handler(req, res) {
   const apiKey = req.anthropicKey;
 
-  try {
-    const { items, preferences, locale } = req.body || {};
-    const arr = Array.isArray(items) ? items : [];
-    if (arr.length === 0)
-      return res.status(400).json({ error: "items is required" });
+  const parsed = validateBody(WeekPlanSchema, req, res);
+  if (!parsed.ok) return;
+  const { pantry: pantryIn, preferences, locale } = parsed.data;
+  const arr = Array.isArray(pantryIn) ? pantryIn : [];
 
-    const prefs =
-      preferences && typeof preferences === "object" ? preferences : {};
-    const goal = String(prefs.goal || "balanced");
-    const loc = String(locale || "uk-UA");
+  const prefs = preferences || {};
+  const goal = String(prefs.goal || "balanced");
+  const loc = String(locale || "uk-UA");
 
-    const pantry = arr
-      .map((x) => (typeof x === "string" ? x : x?.name ? String(x.name) : ""))
-      .filter(Boolean)
-      .slice(0, 50)
-      .join("\n- ");
+  const pantry = arr
+    .map((x) => (typeof x === "string" ? x : x?.name ? String(x.name) : ""))
+    .filter(Boolean)
+    .slice(0, 50)
+    .join("\n- ");
 
-    const prompt = `Мова: ${loc}. Ціль: ${goal}.
+  const prompt = `Мова: ${loc}. Ціль: ${goal}.
 Продукти вдома:
 - ${pantry}
 
 Запропонуй приблизний план харчування на 7 днів і список покупок того, чого бракує (коротко, реалістично).`;
 
-    const payload = {
-      model: "claude-sonnet-4-6",
-      max_tokens: 2000,
-      temperature: 0.25,
-      system: SYSTEM,
-      messages: [{ role: "user", content: prompt }],
-    };
+  const payload = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 2000,
+    temperature: 0.25,
+    system: SYSTEM,
+    messages: [{ role: "user", content: prompt }],
+  };
 
-    const { response, data } = await anthropicMessages(apiKey, payload, {
-      timeoutMs: 35000,
-      endpoint: "week-plan",
+  const { response, data } = await anthropicMessages(apiKey, payload, {
+    timeoutMs: 35000,
+    endpoint: "week-plan",
+  });
+  if (!response.ok) {
+    throw new ExternalServiceError(data?.error?.message || "AI error", {
+      status: response.status,
+      code: "ANTHROPIC_ERROR",
     });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ error: data?.error?.message || "AI error" });
-    }
-
-    const out = extractAnthropicText(data);
-    let plan = { days: [], shoppingList: [] };
-    try {
-      const parsed = extractJsonFromText(out);
-      plan = normalizeWeekPlan(parsed);
-    } catch {
-      plan = { days: [], shoppingList: [] };
-    }
-    return res
-      .status(200)
-      .json({ plan, rawText: plan.days.length === 0 ? out : null });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка AI сервера" });
   }
+
+  const out = extractAnthropicText(data);
+  let plan = { days: [], shoppingList: [] };
+  try {
+    const jsonParsed = extractJsonFromText(out);
+    plan = normalizeWeekPlan(jsonParsed);
+  } catch {
+    plan = { days: [], shoppingList: [] };
+  }
+  return res
+    .status(200)
+    .json({ plan, rawText: plan.days.length === 0 ? out : null });
 }

--- a/server/modules/privat.js
+++ b/server/modules/privat.js
@@ -1,33 +1,29 @@
 import { logger } from "../obs/logger.js";
 import { recordExternalHttp } from "../lib/externalHttp.js";
+import { validateQuery } from "../http/validate.js";
+import { PrivatQuerySchema } from "../http/schemas.js";
+import { ExternalServiceError } from "../obs/errors.js";
 
 /**
  * `/api/privat` — проксі до PrivatBank merchant API. CORS/rate-limit/tag
  * зроблені middleware-ами роутера; тут тільки upstream credentials,
  * path-валідація і фільтрація заголовків від CRLF-injection.
  */
+const ALLOWED_PATHS = ["/statements/balance/final", "/statements/transactions"];
+
 export default async function handler(req, res) {
   const merchantId = req.headers["x-privat-id"];
   const merchantToken = req.headers["x-privat-token"];
-  const rawPath = req.query.path || "/statements/balance/final";
 
   if (!merchantId || !merchantToken) {
     return res.status(401).json({ error: "Credentials відсутні" });
   }
 
-  // Валідація шляху API: лише безпечні символи, без CRLF, ?, #, ..
-  // і точна відповідність дозволеному префіксу (рівний шлях або префікс+"/…").
-  const path = String(rawPath);
-  if (!/^\/[A-Za-z0-9\-_/]+$/.test(path) || path.includes("..")) {
-    return res.status(400).json({ error: "Недозволений API шлях" });
-  }
+  const parsedQ = validateQuery(PrivatQuerySchema, req, res);
+  if (!parsedQ.ok) return;
+  const path = String(parsedQ.data.path || "/statements/balance/final");
 
-  const allowedPaths = [
-    "/statements/balance/final",
-    "/statements/transactions",
-  ];
-
-  const pathAllowed = allowedPaths.some(
+  const pathAllowed = ALLOWED_PATHS.some(
     (p) => path === p || path.startsWith(p + "/"),
   );
   if (!pathAllowed) {
@@ -51,40 +47,16 @@ export default async function handler(req, res) {
   const queryString = queryParams.toString();
 
   const start = process.hrtime.bigint();
+  let response;
   try {
     const url = `https://acp.privatbank.ua/api${path}${queryString ? "?" + queryString : ""}`;
-    const response = await fetch(url, {
+    response = await fetch(url, {
       headers: {
         id: safeId,
         token: safeToken,
         "Content-Type": "application/json;charset=utf-8",
       },
     });
-    const ms = Number(process.hrtime.bigint() - start) / 1e6;
-
-    if (!response.ok) {
-      recordExternalHttp(
-        "privatbank",
-        response.status === 429 ? "rate_limited" : "error",
-        ms,
-      );
-      let errorText = "";
-      try {
-        errorText = await response.text();
-      } catch {}
-      return res.status(response.status).json({
-        error:
-          response.status === 429
-            ? "Занадто багато запитів"
-            : response.status === 401 || response.status === 403
-              ? "Невірні credentials PrivatBank"
-              : errorText || `Помилка ${response.status}`,
-      });
-    }
-
-    recordExternalHttp("privatbank", "ok", ms);
-    const data = await response.json();
-    res.status(200).json(data);
   } catch (e) {
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
     recordExternalHttp("privatbank", "error", ms);
@@ -92,6 +64,36 @@ export default async function handler(req, res) {
       msg: "privat_proxy_failed",
       err: { message: e?.message || String(e), code: e?.code },
     });
-    res.status(500).json({ error: "Помилка сервера" });
+    throw new ExternalServiceError("Помилка сервера", {
+      code: "PRIVATBANK_FETCH_FAILED",
+      cause: e,
+    });
   }
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+
+  if (!response.ok) {
+    recordExternalHttp(
+      "privatbank",
+      response.status === 429 ? "rate_limited" : "error",
+      ms,
+    );
+    let errorText = "";
+    try {
+      errorText = await response.text();
+    } catch {
+      /* response body may be unreadable — surface status text only */
+    }
+    return res.status(response.status).json({
+      error:
+        response.status === 429
+          ? "Занадто багато запитів"
+          : response.status === 401 || response.status === 403
+            ? "Невірні credentials PrivatBank"
+            : errorText || `Помилка ${response.status}`,
+    });
+  }
+
+  recordExternalHttp("privatbank", "ok", ms);
+  const data = await response.json();
+  res.status(200).json(data);
 }

--- a/server/modules/push.js
+++ b/server/modules/push.js
@@ -51,21 +51,13 @@ export async function subscribe(req, res) {
   if (!parsed.ok) return;
   const { endpoint, keys } = parsed.data;
 
-  try {
-    await pool.query(
-      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth)
+  await pool.query(
+    `INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth)
        VALUES ($1, $2, $3, $4)
        ON CONFLICT (endpoint) DO UPDATE SET p256dh = $3, auth = $4`,
-      [user.id, endpoint, keys.p256dh, keys.auth],
-    );
-    res.json({ ok: true });
-  } catch (e) {
-    logger.error({
-      msg: "push_subscribe_failed",
-      err: { message: e?.message || String(e), code: e?.code },
-    });
-    res.status(500).json({ error: "DB error" });
-  }
+    [user.id, endpoint, keys.p256dh, keys.auth],
+  );
+  res.json({ ok: true });
 }
 
 /** DELETE /api/push/subscribe — видалити підписку. Session в `req.user`. */
@@ -75,19 +67,11 @@ export async function unsubscribe(req, res) {
   if (!parsed.ok) return;
   const { endpoint } = parsed.data;
 
-  try {
-    await pool.query(
-      `DELETE FROM push_subscriptions WHERE user_id = $1 AND endpoint = $2`,
-      [user.id, endpoint],
-    );
-    res.json({ ok: true });
-  } catch (e) {
-    logger.error({
-      msg: "push_unsubscribe_failed",
-      err: { message: e?.message || String(e), code: e?.code },
-    });
-    res.status(500).json({ error: "DB error" });
-  }
+  await pool.query(
+    `DELETE FROM push_subscriptions WHERE user_id = $1 AND endpoint = $2`,
+    [user.id, endpoint],
+  );
+  res.json({ ok: true });
 }
 
 /**
@@ -105,68 +89,62 @@ export async function sendPush(req, res) {
   if (!parsed.ok) return;
   const { userId, title, body, module: mod, tag } = parsed.data;
 
-  try {
-    const { rows } = await pool.query(
-      `SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1`,
-      [userId],
-    );
-    if (rows.length === 0) return res.json({ sent: 0 });
+  const { rows } = await pool.query(
+    `SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1`,
+    [userId],
+  );
+  if (rows.length === 0) return res.json({ sent: 0 });
 
-    const payload = JSON.stringify({
-      title,
-      body: body || "",
-      module: mod || null,
-      tag: tag || null,
-    });
-    let sent = 0;
-    const stale = [];
+  const payload = JSON.stringify({
+    title,
+    body: body || "",
+    module: mod || null,
+    tag: tag || null,
+  });
+  let sent = 0;
+  const stale = [];
 
-    await Promise.all(
-      rows.map(async (row) => {
-        const sub = {
-          endpoint: row.endpoint,
-          keys: { p256dh: row.p256dh, auth: row.auth },
-        };
-        try {
-          await webpush.sendNotification(sub, payload);
-          sent++;
-          recordSend("ok");
-        } catch (e) {
-          if (e.statusCode === 404 || e.statusCode === 410) {
-            stale.push(row.endpoint);
-            recordSend("invalid_endpoint");
-          } else if (e.statusCode === 429) {
-            recordSend("rate_limited");
-            logger.warn({
-              msg: "push_rate_limited",
-              status: e.statusCode,
-              err: { message: e?.message },
-            });
-          } else {
-            recordSend("error");
-            logger.warn({
-              msg: "push_send_error",
-              status: e.statusCode,
-              err: { message: e?.message },
-            });
-          }
+  // Вузький per-subscription catch: одна невдала підписка не повинна
+  // зривати весь fan-out. Інші помилки (DB, тощо) летять наверх в errorHandler.
+  await Promise.all(
+    rows.map(async (row) => {
+      const sub = {
+        endpoint: row.endpoint,
+        keys: { p256dh: row.p256dh, auth: row.auth },
+      };
+      try {
+        await webpush.sendNotification(sub, payload);
+        sent++;
+        recordSend("ok");
+      } catch (e) {
+        if (e.statusCode === 404 || e.statusCode === 410) {
+          stale.push(row.endpoint);
+          recordSend("invalid_endpoint");
+        } else if (e.statusCode === 429) {
+          recordSend("rate_limited");
+          logger.warn({
+            msg: "push_rate_limited",
+            status: e.statusCode,
+            err: { message: e?.message },
+          });
+        } else {
+          recordSend("error");
+          logger.warn({
+            msg: "push_send_error",
+            status: e.statusCode,
+            err: { message: e?.message },
+          });
         }
-      }),
+      }
+    }),
+  );
+
+  if (stale.length > 0) {
+    await pool.query(
+      `DELETE FROM push_subscriptions WHERE endpoint = ANY($1)`,
+      [stale],
     );
-
-    if (stale.length > 0) {
-      await pool.query(
-        `DELETE FROM push_subscriptions WHERE endpoint = ANY($1)`,
-        [stale],
-      );
-    }
-
-    res.json({ sent, stale: stale.length });
-  } catch (e) {
-    logger.error({
-      msg: "push_send_failed",
-      err: { message: e?.message || String(e), code: e?.code },
-    });
-    res.status(500).json({ error: "Internal error" });
   }
+
+  res.json({ sent, stale: stale.length });
 }

--- a/server/modules/weekly-digest.js
+++ b/server/modules/weekly-digest.js
@@ -1,6 +1,7 @@
 import { anthropicMessages, extractAnthropicText } from "../lib/anthropic.js";
 import { validateBody } from "../http/validate.js";
 import { WeeklyDigestSchema } from "../http/schemas.js";
+import { ExternalServiceError, ValidationError } from "../obs/errors.js";
 
 function extractJsonObject(raw) {
   if (typeof raw !== "string") return null;
@@ -59,82 +60,80 @@ export default async function handler(req, res) {
 
   const parsed = validateBody(WeeklyDigestSchema, req, res);
   if (!parsed.ok) return;
+  const { weekRange, finyk, fizruk, nutrition, routine } = parsed.data;
 
-  try {
-    const { weekRange, finyk, fizruk, nutrition, routine } = parsed.data;
+  const sections = [];
 
-    const sections = [];
-
-    if (finyk) {
-      const budgetLine = finyk.monthlyBudget
-        ? `Місячний бюджет: ${finyk.monthlyBudget} грн`
-        : "Місячний бюджет: не встановлено";
-      const topCats =
-        Array.isArray(finyk.topCategories) && finyk.topCategories.length
-          ? finyk.topCategories
-              .map((c) => `  - ${c.name}: ${c.amount} грн`)
-              .join("\n")
-          : "  Немає даних";
-      sections.push(`[ФІНАНСИ (${weekRange || "тиждень"})]
+  if (finyk) {
+    const budgetLine = finyk.monthlyBudget
+      ? `Місячний бюджет: ${finyk.monthlyBudget} грн`
+      : "Місячний бюджет: не встановлено";
+    const topCats =
+      Array.isArray(finyk.topCategories) && finyk.topCategories.length
+        ? finyk.topCategories
+            .map((c) => `  - ${c.name}: ${c.amount} грн`)
+            .join("\n")
+        : "  Немає даних";
+    sections.push(`[ФІНАНСИ (${weekRange || "тиждень"})]
 Витрати: ${finyk.totalSpent ?? 0} грн | Надходження: ${finyk.totalIncome ?? 0} грн
 ${budgetLine}
 Топ категорії витрат:
 ${topCats}
 Транзакцій: ${finyk.txCount ?? 0}`);
-    }
+  }
 
-    if (fizruk) {
-      const exercises =
-        Array.isArray(fizruk.topExercises) && fizruk.topExercises.length
-          ? fizruk.topExercises
-              .map((e) => `  - ${e.name}: ${e.totalVolume} кг`)
-              .join("\n")
-          : "  Немає даних";
-      sections.push(`[ТРЕНУВАННЯ (${weekRange || "тиждень"})]
+  if (fizruk) {
+    const exercises =
+      Array.isArray(fizruk.topExercises) && fizruk.topExercises.length
+        ? fizruk.topExercises
+            .map((e) => `  - ${e.name}: ${e.totalVolume} кг`)
+            .join("\n")
+        : "  Немає даних";
+    sections.push(`[ТРЕНУВАННЯ (${weekRange || "тиждень"})]
 Тренувань завершено: ${fizruk.workoutsCount ?? 0}
 Загальний об'єм: ${fizruk.totalVolume ?? 0} кг
 Стан відновлення: ${fizruk.recoveryLabel ?? "Немає даних"}
 Топ вправи:
 ${exercises}`);
-    }
+  }
 
-    if (nutrition) {
-      const deficit = (nutrition.targetKcal ?? 0) - (nutrition.avgKcal ?? 0);
-      const balance =
-        deficit > 50
-          ? `дефіцит ${Math.round(deficit)} ккал`
-          : deficit < -50
-            ? `профіцит ${Math.round(Math.abs(deficit))} ккал`
-            : "баланс";
-      sections.push(`[ХАРЧУВАННЯ (${weekRange || "тиждень"})]
+  if (nutrition) {
+    const deficit = (nutrition.targetKcal ?? 0) - (nutrition.avgKcal ?? 0);
+    const balance =
+      deficit > 50
+        ? `дефіцит ${Math.round(deficit)} ккал`
+        : deficit < -50
+          ? `профіцит ${Math.round(Math.abs(deficit))} ккал`
+          : "баланс";
+    sections.push(`[ХАРЧУВАННЯ (${weekRange || "тиждень"})]
 Середньодобово: ${nutrition.avgKcal ?? 0} ккал (ціль ${nutrition.targetKcal ?? 2000} ккал, ${balance})
 Середній БЖВ: Б ${nutrition.avgProtein ?? 0}г / Ж ${nutrition.avgFat ?? 0}г / В ${nutrition.avgCarbs ?? 0}г
 Днів із записами: ${nutrition.daysLogged ?? 0} з 7`);
-    }
+  }
 
-    if (routine) {
-      const habitsInfo =
-        Array.isArray(routine.habits) && routine.habits.length
-          ? routine.habits
-              .map(
-                (h) =>
-                  `  - ${h.name}: ${h.completionRate}% (${h.done}/${h.total} днів)`,
-              )
-              .join("\n")
-          : "  Немає активних звичок";
-      sections.push(`[ЗВИЧКИ (${weekRange || "тиждень"})]
+  if (routine) {
+    const habitsInfo =
+      Array.isArray(routine.habits) && routine.habits.length
+        ? routine.habits
+            .map(
+              (h) =>
+                `  - ${h.name}: ${h.completionRate}% (${h.done}/${h.total} днів)`,
+            )
+            .join("\n")
+        : "  Немає активних звичок";
+    sections.push(`[ЗВИЧКИ (${weekRange || "тиждень"})]
 Загальний відсоток: ${routine.overallRate ?? 0}%
 Активних звичок: ${routine.habitCount ?? 0}
 По звичках:
 ${habitsInfo}`);
-    }
+  }
 
-    if (!sections.length) {
-      return res.status(400).json({ error: "Немає даних для генерації звіту" });
-    }
+  if (!sections.length) {
+    throw new ValidationError("Немає даних для генерації звіту");
+  }
 
-    const dataContext = sections.join("\n\n");
-    const userPrompt = `Проаналізуй тижневі дані юзера і поверни ТІЛЬКИ валідний JSON (без markdown-обгортки, без \`\`\`json) такого вигляду:
+  const dataContext = sections.join("\n\n");
+  const userPrompt = `Проаналізуй тижневі дані юзера і поверни ТІЛЬКИ валідний JSON (без markdown-обгортки, без \`\`\`json) такого вигляду:
 {
   "finyk": {
     "summary": "1 речення: що відбулося з фінансами",
@@ -160,43 +159,42 @@ ${habitsInfo}`);
 }
 Якщо даних по модулю немає — поверни null для цього ключа. Відповідай ВИКЛЮЧНО валідним JSON.`;
 
-    const systemPrompt = `Ти аналітик персональних даних користувача додатку "Мій простір".
+  const systemPrompt = `Ти аналітик персональних даних користувача додатку "Мій простір".
 Відповідай ВИКЛЮЧНО валідним JSON — без markdown, без коментарів, без преамбули.
 Уся аналітика — українською. Числа бери з блоку даних.
 
 ДАНІ:
 ${dataContext}`;
 
-    const { response: aiRes, data: aiData } = await anthropicMessages(
-      apiKey,
-      {
-        model: "claude-sonnet-4-6",
-        max_tokens: 2500,
-        system: systemPrompt,
-        messages: [{ role: "user", content: userPrompt }],
-      },
-      { timeoutMs: 45000, endpoint: "weekly-digest" },
-    );
+  const { response: aiRes, data: aiData } = await anthropicMessages(
+    apiKey,
+    {
+      model: "claude-sonnet-4-6",
+      max_tokens: 2500,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userPrompt }],
+    },
+    { timeoutMs: 45000, endpoint: "weekly-digest" },
+  );
 
-    if (!aiRes?.ok) {
-      return res
-        .status(aiRes?.status || 500)
-        .json({ error: aiData?.error?.message || "AI error" });
-    }
-
-    const text = extractAnthropicText(aiData);
-
-    const report = extractJsonObject(text);
-    if (!report) {
-      return res
-        .status(500)
-        .json({ error: "Не вдалося розпарсити відповідь AI", raw: text });
-    }
-
-    return res
-      .status(200)
-      .json({ report, generatedAt: new Date().toISOString() });
-  } catch (e) {
-    return res.status(500).json({ error: e?.message || "Помилка сервера" });
+  if (!aiRes?.ok) {
+    throw new ExternalServiceError(aiData?.error?.message || "AI error", {
+      status: aiRes?.status || 502,
+      code: "ANTHROPIC_ERROR",
+    });
   }
+
+  const text = extractAnthropicText(aiData);
+
+  const report = extractJsonObject(text);
+  if (!report) {
+    throw new ExternalServiceError("Не вдалося розпарсити відповідь AI", {
+      status: 502,
+      code: "ANTHROPIC_PARSE_ERROR",
+    });
+  }
+
+  return res
+    .status(200)
+    .json({ report, generatedAt: new Date().toISOString() });
 }


### PR DESCRIPTION
## Summary

PR A із серії виправлень по інвентарю техборгу (`docs/backend-tech-debt.md`, PR #296). Уніфікує валідацію запитів через zod у `server/http/schemas.js` + `server/http/validate.js` і переводить обробку помилок на центральний `errorHandler` через throw типізованих `AppError`-субкласів.

### Зміни схем (`server/http/schemas.js`)
- Виправлено `RefinePhotoSchema` — тепер відповідає реальному body хендлера (`image_base64/mime_type/prior_result/portion_grams/qna/locale`) замість фантомного `{previous, answers, note}`.
- Додано `BackupUploadSchema`, `MonoQuerySchema`, `PrivatQuerySchema`, `SyncPushSchema`, `SyncPullSchema`, `SyncPushAllSchema`.
- Витягнуто спільний `PantryItem` (union string|object) і `NutritionTargets` (passthrough для `dailyTargetKcal/...`); усі nutrition-схеми тепер дивляться на один тип.
- `RecommendRecipesSchema` / `DayPlanSchema` / `WeekPlanSchema` приймають поле `pantry` (було `items` — не збігалося з клієнтом) і всі опційні, щоб existing тести `validate.test.js` пройшли.

### Nutrition handlers
- `analyze-photo`, `refine-photo`, `day-hint`, `day-plan`, `week-plan`, `recommend-recipes`, `shopping-list`, `parse-pantry`: замість ручної валідації + broad `try/catch → 500` тепер `validateBody(Schema, req, res)` + пряме читання `parsed.data`. На upstream-помилки Anthropic — `throw new ExternalServiceError(...)` замість `res.status(...).json({...})`, далі обробляє центральний `errorHandler`.
- `backup-upload`: `validateBody(BackupUploadSchema)` + `throw new AppError(..., { status: 413 })` на занадто великий blob.
- `backup-download`: вузький `catch` тільки на `ENOENT → throw new NotFoundError("Бекап не знайдено")`. Пошкоджений JSON і інші помилки летять наверх в errorHandler замість swallow-у.

### Bank proxies
- `mono.js`, `privat.js`: path-format валідується через `validateQuery(MonoQuerySchema/PrivatQuerySchema)`. Allowlist upstream-шляхів і CRLF-захист заголовків залишено inline, бо це не чистий shape-check. Broad `catch` навколо `fetch` замінено на `throw new ExternalServiceError(..., { cause: e })` після `recordExternalHttp("...", "error", ms)`.

### Push
- `push.js::subscribe/unsubscribe/sendPush` — прибрано зовнішні `try/catch → 500 "DB error"`, помилки БД тепер летять в errorHandler. Залишено **вузький** per-subscription catch у `Promise.all`, щоб одна невдала підписка не зривала fan-out (invalid_endpoint / rate_limited / error — окремі метрики).

### Weekly digest & chat
- `weekly-digest.js`: прибрано broad `try/catch` на 140 рядків. Порожні секції → `ValidationError`. AI-помилки → `ExternalServiceError`.
- `chat.js`: прибрано зовнішній `try/catch` у POST /api/chat. Внутрішні вузькі catch-и (SSE stream reader, Anthropic error JSON/text fallback) залишені — вони навмисні і пишуть у `recordStreamEnd`/SSE потік.

### Що **не** робив у цьому PR
- Не чіпав `sync.js` — там `try/catch` не swallow: він емітить `syncOperationsTotal{outcome="error"}` метрику і `throw e`. Це свідомий pattern, міняти треба разом із рестрактуризацією metric-шару (окремий PR).
- Не додавав retry/timeout/circuit breaker для банків (PR B).
- Не чіпав `aiQuota.js` (PR C).

## Review & Testing Checklist for Human

- [ ] Перевірити, що існуючі дашборди/алерти на `push_sends_total`, `external_http_requests_total{upstream="monobank|privatbank|push"}` не зламались — метрики емітяться до `throw`, але формат тіла відповіді на банківських 5xx тепер `{ error, code, requestId }` від errorHandler, а не старий `{ error: "Помилка сервера" }`.
- [ ] Sanity-check від `/api/nutrition/recommend-recipes` / `/api/nutrition/day-plan` / `/api/nutrition/week-plan` — схема тепер очікує поле `pantry` (не `items`); переконатися, що клієнт не шле `items`.
- [ ] Прогнати smoke `/api/chat` (у т.ч. tool-result другий крок і SSE stream) — змінився тільки wrapping, логіка не чіпалась.
- [ ] Перевірити, що `backup-download` на відсутньому файлі повертає 404 (`NotFoundError`), а не 500.

### Notes
- CI на [PR #296](https://github.com/Skords-01/Sergeant/pull/296) (inventory) падав на pre-existing TS-помилці `src/core/lib/hubChatActions.test.ts:150` — фронтенд, не з цієї серії.
- Наступні кроки за inventory: PR B (банки), PR C (aiQuota), PR D (міграції), PR E (obs), PR F (тести).


Link to Devin session: https://app.devin.ai/sessions/70cebda63c50416a8ee961e2c9e946b5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
