### PR TITLE
design-system: wire chartTheme.ts into real charts

### DIFF
--- a/src/modules/finyk/components/NetworthChart.jsx
+++ b/src/modules/finyk/components/NetworthChart.jsx
@@ -1,5 +1,10 @@
 import { memo } from "react";
-import { THEME_HEX } from "@shared/lib/themeHex.js";
+import {
+  chartAxis,
+  chartGrid,
+  chartTick,
+  statusColors,
+} from "@shared/charts/chartTheme";
 
 // SVG-графік нетворсу повністю детермінований вхідним `data`.
 // `memo` запобігає перерендеру при незв'язаних оновленнях стану Overview.
@@ -28,7 +33,7 @@ function NetworthChartComponent({ data }) {
   ].join(" ");
 
   const isPositive = values[values.length - 1] >= values[0];
-  const color = isPositive ? THEME_HEX.success : THEME_HEX.danger;
+  const color = isPositive ? statusColors.success : statusColors.danger;
 
   const fmt = (v) => {
     if (Math.abs(v) >= 1000) return `${Math.round(v / 1000)}к`;
@@ -59,7 +64,7 @@ function NetworthChartComponent({ data }) {
       <svg viewBox={`0 0 ${W} ${H}`} className="w-full overflow-visible">
         <defs>
           <linearGradient id="nwGrad" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor={color} stopOpacity="0.15" />
+            <stop offset="0%" stopColor={color} stopOpacity="0.28" />
             <stop offset="100%" stopColor={color} stopOpacity="0" />
           </linearGradient>
         </defs>
@@ -71,10 +76,9 @@ function NetworthChartComponent({ data }) {
             y1={py(0)}
             x2={W - PAD.right}
             y2={py(0)}
-            stroke="currentColor"
-            strokeOpacity="0.15"
-            strokeWidth="1"
-            strokeDasharray="3 3"
+            className={chartGrid.horizontal.className}
+            strokeDasharray={chartGrid.horizontal.strokeDasharray}
+            strokeWidth={chartGrid.horizontal.strokeWidth}
           />
         )}
 
@@ -99,10 +103,9 @@ function NetworthChartComponent({ data }) {
             <text
               x={px(i)}
               y={H - 4}
-              textAnchor="middle"
+              textAnchor={chartTick.textAnchor}
               fontSize="8"
-              fill="currentColor"
-              opacity="0.5"
+              className={chartTick.className}
             >
               {monthLabel(d.month)}
             </text>
@@ -115,6 +118,7 @@ function NetworthChartComponent({ data }) {
                 fontSize="8"
                 fill={color}
                 fontWeight="600"
+                className={chartAxis.label.className}
               >
                 {fmt(d.networth)}₴
               </text>

--- a/src/modules/fizruk/components/WeeklyVolumeChart.tsx
+++ b/src/modules/fizruk/components/WeeklyVolumeChart.tsx
@@ -1,9 +1,15 @@
 import { cn } from "@shared/lib/cn";
 import { EmptyState } from "@shared/components/ui/EmptyState";
+import {
+  chartGradients,
+  chartGrid,
+  chartSeries,
+  chartTick,
+} from "@shared/charts/chartTheme";
 
 const LABELS_UK = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
 
-/** Легкий area-chart без залежностей; акцент — success з tailwind. */
+/** Легкий area-chart без залежностей; акцент — module accent (fizruk/teal). */
 interface WeeklyVolumeChartProps {
   volumeKg?: number[];
   className?: string;
@@ -30,7 +36,10 @@ export function WeeklyVolumeChart({
             className="text-2xs text-subtle flex items-center gap-1.5"
             aria-hidden
           >
-            <span className="inline-block w-2 h-2 rounded-full bg-success" />
+            <span
+              className="inline-block w-2 h-2 rounded-full"
+              style={{ backgroundColor: chartSeries.fizruk.primary }}
+            />
             кг×повт
           </span>
         </div>
@@ -80,7 +89,10 @@ export function WeeklyVolumeChart({
           className="text-2xs text-subtle flex items-center gap-1.5"
           aria-hidden
         >
-          <span className="inline-block w-2 h-2 rounded-full bg-success" />
+          <span
+            className="inline-block w-2 h-2 rounded-full"
+            style={{ backgroundColor: chartSeries.fizruk.primary }}
+          />
           кг×повт
         </span>
       </div>
@@ -92,8 +104,9 @@ export function WeeklyVolumeChart({
       >
         <defs>
           <linearGradient id="wvFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="rgb(22 163 74)" stopOpacity="0.28" />
-            <stop offset="100%" stopColor="rgb(22 163 74)" stopOpacity="0" />
+            {chartGradients.fizruk.map((stop, i) => (
+              <stop key={i} {...stop} />
+            ))}
           </linearGradient>
         </defs>
         {yTicks.map((t, i) => (
@@ -103,15 +116,14 @@ export function WeeklyVolumeChart({
               x2={w - padR}
               y1={t.y}
               y2={t.y}
-              stroke="currentColor"
-              className="text-line/80"
-              strokeWidth="1"
-              strokeDasharray="3 4"
+              className={chartGrid.horizontal.className}
+              strokeWidth={chartGrid.horizontal.strokeWidth}
+              strokeDasharray={chartGrid.horizontal.strokeDasharray}
             />
             <text
               x={4}
               y={t.y + 4}
-              className="fill-subtle text-3xs font-medium"
+              className={cn(chartTick.className, "font-medium")}
             >
               {t.lab}
             </text>
@@ -121,7 +133,7 @@ export function WeeklyVolumeChart({
         <path
           d={lineD}
           fill="none"
-          stroke="rgb(22 163 74)"
+          stroke={chartSeries.fizruk.primary}
           strokeWidth="2.25"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -132,7 +144,8 @@ export function WeeklyVolumeChart({
             cx={p.x}
             cy={p.y}
             r="3.5"
-            className="fill-success stroke-white"
+            fill={chartSeries.fizruk.primary}
+            stroke="white"
             strokeWidth="2"
           />
         ))}
@@ -155,7 +168,7 @@ export function WeeklyVolumeChart({
   );
 }
 
-function formatYAxis(kg) {
+function formatYAxis(kg: number) {
   const n = Number(kg) || 0;
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
   return String(Math.round(n));

--- a/src/modules/routine/components/HabitHeatmap.tsx
+++ b/src/modules/routine/components/HabitHeatmap.tsx
@@ -2,11 +2,13 @@ import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@shared/lib/cn";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
+import { chartHeatmap } from "@shared/charts/chartTheme";
 import type { Habit, RoutineState } from "../lib/types";
 
 const WEEKS = 53;
 const DAYS = 7;
 const DAY_LABELS = ["Пн", "", "Ср", "", "Пт", "", "Нд"];
+const HEATMAP = chartHeatmap.routine;
 
 interface HeatmapCell {
   key: string;
@@ -28,11 +30,11 @@ function localDateKey(d: Date): string {
 }
 
 function cellBg(ratio: number, isFuture: boolean): string {
-  if (isFuture) return "bg-line/15 dark:bg-line/10";
-  if (ratio === 0) return "bg-panelHi dark:bg-line/25";
-  if (ratio < 0.34) return "bg-orange-200/80 dark:bg-orange-900/55";
-  if (ratio < 0.67) return "bg-orange-400/75 dark:bg-orange-600/70";
-  return "bg-orange-500/90 dark:bg-orange-500/80";
+  if (isFuture) return HEATMAP.future;
+  if (ratio === 0) return HEATMAP.levels[0];
+  if (ratio < 0.34) return HEATMAP.levels[1];
+  if (ratio < 0.67) return HEATMAP.levels[2];
+  return HEATMAP.levels[3];
 }
 
 export interface HabitHeatmapProps {
@@ -186,10 +188,10 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
                     aria-label={`${cell.key}: ${cell.cnt} з ${cell.total} звичок`}
                     aria-pressed={cell.key === selected}
                     className={cn(
-                      "rounded-sm transition-opacity focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400",
+                      "rounded-sm transition-opacity focus-visible:outline focus-visible:outline-2",
+                      HEATMAP.outline,
                       cellBg(cell.ratio, cell.isFuture),
-                      cell.isToday &&
-                        "ring-1 ring-orange-400/80 dark:ring-orange-300/70",
+                      cell.isToday && cn("ring-1", HEATMAP.ring),
                       cell.key === selected && "opacity-60",
                     )}
                     style={{ width: 12, height: 12, flexShrink: 0 }}
@@ -222,12 +224,7 @@ export function HabitHeatmap({ habits, completions }: HabitHeatmapProps) {
       ) : (
         <div className="mt-3 flex items-center gap-2 text-3xs text-subtle/70 select-none">
           <span>менше</span>
-          {[
-            "bg-panelHi dark:bg-line/25",
-            "bg-orange-200/80 dark:bg-orange-900/55",
-            "bg-orange-400/75 dark:bg-orange-600/70",
-            "bg-orange-500/90 dark:bg-orange-500/80",
-          ].map((c, i) => (
+          {HEATMAP.levels.map((c, i) => (
             <span
               key={i}
               className={cn("rounded-sm inline-block flex-shrink-0", c)}

--- a/src/shared/charts/chartTheme.ts
+++ b/src/shared/charts/chartTheme.ts
@@ -110,6 +110,29 @@ export const chartTooltip = {
 } as const;
 
 /**
+ * Heatmap cell tokens — four monotonic steps per module plus a neutral
+ * "empty" and a disabled "future" shade. Values are Tailwind className
+ * strings so dark mode resolves through the same CSS variables.
+ *
+ * Level scale (0 → 3):
+ *   0 = no activity, 1 < 34 %, 2 < 67 %, 3 ≥ 67 %
+ */
+export const chartHeatmap = {
+  routine: {
+    empty: "bg-panelHi dark:bg-line/25",
+    future: "bg-line/15 dark:bg-line/10",
+    levels: [
+      "bg-panelHi dark:bg-line/25",
+      "bg-coral-200/80 dark:bg-coral-900/55",
+      "bg-coral-400/75 dark:bg-coral-600/70",
+      "bg-coral-500/90 dark:bg-coral-500/80",
+    ] as const,
+    ring: "ring-coral-400/80 dark:ring-coral-300/70",
+    outline: "outline-coral-400",
+  },
+} as const;
+
+/**
  * Gradient stops used by area/fill series, keyed by module. Consumers can
  * embed these as `<linearGradient>` stops without re-picking hex codes.
  */


### PR DESCRIPTION
## Summary

Перший крок по пріоритету №1 з handoff-у: підключити `src/shared/charts/chartTheme.ts` (створено в PR #293, але неюзано) у реальні чарти, щоб прибрати хардкодні кольори/класи й щоб лінії, ґрід, тики й легенди в усіх модулях приїжджали з одного дизайн-токена.

### Зміни

- **`src/shared/charts/chartTheme.ts`** — додав `chartHeatmap.routine` (Tailwind classNames для 4 рівнів заповнення + `future`/`empty`/`ring`/`outline`). Дарк-мод «просто працює», бо колірні токени йдуть через CSS-vars.
- **`NetworthChart.jsx`** (Finyk) — замість `THEME_HEX` тепер `statusColors.success/danger` для позитивного/негативного тренду нетворсу. Нульова лінія + тики підписів місяця/значень рендеряться через `chartGrid.horizontal`, `chartTick`, `chartAxis.label`.
- **`WeeklyVolumeChart.tsx`** (Fizruk) — пішов hardcoded `rgb(22 163 74)` з лінії/точок/легенди; лінія та точки тепер на `chartSeries.fizruk.primary` (teal), area-градієнт — `chartGradients.fizruk`, горизонтальні тик-лінії + підписи — `chartGrid.horizontal` + `chartTick`.
- **`HabitHeatmap.tsx`** (Routine) — комірки + легенда + today-ring + focus-outline тепер з `chartHeatmap.routine` (coral scale, консистентно з module-accent'ом рутини). Масив-літерал у легенді замінено на `HEATMAP.levels.map(...)`.

### Що НЕ зачіпав

- Інші чарти/спарклайни з pie-/bar-подібних VolumeCard, рецепт-макро-барів, body-atlas тощо — залишаю для наступного PR цього ж пріоритету, якщо треба.
- `THEME_HEX` досі використовується в `BodyAtlas.tsx`, `Overview.jsx`, `FlowRow.jsx`, `debtEngine.ts` — міграція туди окремо (там логіка not про чарти, а про індикатори).

### CI / локально

- `npm run lint` — ✅
- `npm run typecheck` — ✅
- `npm test` — 835 passed / 87 files
- prettier / lint-staged на commit — ✅

## Review & Testing Checklist for Human

Ризик: 🟡 жовтий — візуальна зміна (Fizruk WeeklyVolume змінює колір з green → teal; Routine heatmap змінює з orange → coral). Це навмисна уніфікація під module-accent, але варто побачити «живцем».

- [ ] Відкрити Finyk Overview → переконатись, що networth-графік малюється, зелений/червоний по знаку тренду, лейбли місяців і значення видимі в обидвох темах.
- [ ] Відкрити Fizruk → Progress → секція «Тижневий обʼєм»: лінія + точки — teal (#14b8a6), area-градієнт teal→прозорий, grid-лінії видимі, порожній стан (без тренувань) показує teal dot у легенді.
- [ ] Відкрити Routine → Stats → Heatmap за рік: рівні заповнення — корал-шкала, today-cell має корал-ring, клавіатурний фокус — корал-outline, легенда «менше ↔ більше» — corresponding 4 коралових кроків.
- [ ] Перевірити дарк-мод усіх трьох.
- [ ] Переконатись, що `grep "THEME_HEX" src/modules/finyk/components/NetworthChart.jsx` тепер порожній (тобто імпорт прибрано).

### Notes

- Свідомо НЕ чіпав `THEME_HEX` повністю — його ще використовують не-чартові місця; це окрема міграція.
- `chartHeatmap` винесено на рівень модуля-рутини бо зараз heatmap єдиний у модулі-рутини; коли/якщо з'явиться fizruk/nutrition heatmap — просто додається ще один ключ.
- Прибрав лінт-попередження з WeeklyVolumeChart: в `formatYAxis(kg)` параметр тепер типізований.

Link to Devin session: https://app.devin.ai/sessions/be64ee66b3e74e829999608ec00ffda6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
