### PR TITLE
feat(server): bank proxy resilience — timeout, retry, circuit breaker, TTL cache

### DIFF
--- a/server/lib/bankProxy.js
+++ b/server/lib/bankProxy.js
@@ -1,0 +1,293 @@
+import crypto from "node:crypto";
+import { logger } from "../obs/logger.js";
+import { recordExternalHttp } from "./externalHttp.js";
+import { ExternalServiceError } from "../obs/errors.js";
+
+/**
+ * Спільний transport-шар для банківських upstream-проксі (Monobank, PrivatBank).
+ * Інкапсулює AbortController-таймаут, експоненційний retry з jitter для 5xx/мережевих
+ * помилок, per-upstream circuit breaker та in-memory TTL-кеш для ідентичних GET.
+ *
+ * Розподіл відповідальності: path-whitelist і sanitizing заголовків залишаються в
+ * handler-ах (`modules/mono.js`, `modules/privat.js`) — це policy, не transport.
+ *
+ * Стан (breakers, cache) — module-level. `__bankProxyTestHooks()` експортується тільки
+ * для unit-тестів (скидання стану, конфіг retry-затримок/TTL).
+ */
+
+const DEFAULTS = Object.freeze({
+  retryDelaysMs: [0, 250, 750],
+  retryJitterMs: 100,
+  timeoutMs: 15_000,
+  breakerFailThreshold: 5,
+  breakerOpenMs: 30_000,
+  cacheTtlMs: 60_000,
+  cacheMaxEntries: 500,
+});
+
+const state = {
+  retryDelaysMs: [...DEFAULTS.retryDelaysMs],
+  retryJitterMs: DEFAULTS.retryJitterMs,
+  timeoutMs: DEFAULTS.timeoutMs,
+  breakerFailThreshold: DEFAULTS.breakerFailThreshold,
+  breakerOpenMs: DEFAULTS.breakerOpenMs,
+  cacheTtlMs: DEFAULTS.cacheTtlMs,
+  cacheMaxEntries: DEFAULTS.cacheMaxEntries,
+  /** @type {Map<string, {failures:number, openUntil:number}>} */
+  breakers: new Map(),
+  /** @type {Map<string, {expires:number, status:number, body:string, contentType:string|null}>} */
+  cache: new Map(),
+};
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isRetryableStatus(s) {
+  return s >= 500 && s <= 599;
+}
+
+function isAbortError(e) {
+  return Boolean(
+    e && (e.name === "AbortError" || e.code === "ABORT_ERR" || e.code === 20),
+  );
+}
+
+function jitteredDelay(base) {
+  if (base <= 0) return 0;
+  return base + Math.floor(Math.random() * state.retryJitterMs);
+}
+
+function hashForCache(...parts) {
+  const h = crypto.createHash("sha256");
+  for (const p of parts) h.update(String(p ?? "") + "\x1f");
+  return h.digest("hex").slice(0, 16);
+}
+
+function getBreaker(upstream) {
+  let s = state.breakers.get(upstream);
+  if (!s) {
+    s = { failures: 0, openUntil: 0 };
+    state.breakers.set(upstream, s);
+  }
+  return s;
+}
+
+function onBreakerFailure(upstream) {
+  const s = getBreaker(upstream);
+  s.failures += 1;
+  if (s.failures >= state.breakerFailThreshold) {
+    s.openUntil = Date.now() + state.breakerOpenMs;
+  }
+}
+
+function onBreakerSuccess(upstream) {
+  const s = getBreaker(upstream);
+  s.failures = 0;
+  s.openUntil = 0;
+}
+
+function isBreakerOpen(upstream) {
+  const s = getBreaker(upstream);
+  if (!s.openUntil) return false;
+  if (Date.now() < s.openUntil) return true;
+  // Вікно минуло — half-open: дозволяємо один пробний запит. Якщо він fail-не,
+  // onBreakerFailure знову підніме openUntil; успіх — onBreakerSuccess обнулить.
+  s.openUntil = 0;
+  return false;
+}
+
+function cacheGet(key) {
+  const entry = state.cache.get(key);
+  if (!entry) return null;
+  if (entry.expires < Date.now()) {
+    state.cache.delete(key);
+    return null;
+  }
+  // LRU-ish: перекласти в кінець
+  state.cache.delete(key);
+  state.cache.set(key, entry);
+  return entry;
+}
+
+function cacheSet(key, entry) {
+  if (state.cache.size >= state.cacheMaxEntries) {
+    const oldest = state.cache.keys().next().value;
+    if (oldest !== undefined) state.cache.delete(oldest);
+  }
+  state.cache.set(key, entry);
+}
+
+/**
+ * @typedef {Object} BankProxyResult
+ * @property {number} status
+ * @property {string} body                — сирий текст відповіді upstream-а
+ * @property {string|null} contentType
+ * @property {boolean} fromCache
+ * @property {number} attempts            — скільки HTTP-спроб було зроблено (1..3)
+ */
+
+/**
+ * @param {Object} opts
+ * @param {string} opts.upstream          — стабільний label (monobank|privatbank|...)
+ * @param {string} opts.baseUrl           — напр. "https://api.monobank.ua"
+ * @param {string} opts.path              — уже провалідований whitelist-шлях
+ * @param {Record<string,string>} [opts.query]    — query-параметри без `path`
+ * @param {Record<string,string>} opts.headers    — sanitized outbound headers
+ * @param {string} [opts.cacheKeySecret]  — client-secret для shard-у cache-ключа (hash-ується)
+ * @param {string} [opts.method]          — default "GET". Не-GET не кешуються.
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<BankProxyResult>}
+ */
+export async function bankProxyFetch(opts) {
+  const {
+    upstream,
+    baseUrl,
+    path,
+    query,
+    headers,
+    cacheKeySecret,
+    method = "GET",
+    timeoutMs = state.timeoutMs,
+  } = opts;
+
+  const qs = query ? new URLSearchParams(query).toString() : "";
+  const url = `${baseUrl}${path}${qs ? "?" + qs : ""}`;
+
+  const cacheable = method === "GET";
+  const cacheKey = cacheable
+    ? `${upstream}|${path}|${qs}|${hashForCache(cacheKeySecret)}`
+    : null;
+
+  if (cacheKey) {
+    const hit = cacheGet(cacheKey);
+    if (hit) {
+      recordExternalHttp(upstream, "hit", 0);
+      return {
+        status: hit.status,
+        body: hit.body,
+        contentType: hit.contentType,
+        fromCache: true,
+        attempts: 0,
+      };
+    }
+  }
+
+  if (isBreakerOpen(upstream)) {
+    recordExternalHttp(upstream, "circuit_open", 0);
+    throw new ExternalServiceError(
+      "Сервіс банку тимчасово недоступний — спробуйте пізніше",
+      {
+        status: 503,
+        code: `${upstream.toUpperCase()}_CIRCUIT_OPEN`,
+      },
+    );
+  }
+
+  const maxAttempts = state.retryDelaysMs.length;
+  const start = process.hrtime.bigint();
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const delay = jitteredDelay(state.retryDelaysMs[attempt]);
+    if (delay > 0) await sleep(delay);
+
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        signal: controller.signal,
+      });
+      const body = await response.text();
+
+      // Ретраїмо тільки 5xx, і лише якщо є ще спроби.
+      if (isRetryableStatus(response.status) && attempt < maxAttempts - 1) {
+        continue;
+      }
+
+      const ms = Number(process.hrtime.bigint() - start) / 1e6;
+      if (response.ok) {
+        onBreakerSuccess(upstream);
+        recordExternalHttp(upstream, "ok", ms);
+      } else if (response.status === 429) {
+        recordExternalHttp(upstream, "rate_limited", ms);
+        // 429 — це троттлінг, не availability-issue; breaker не торкаємо.
+      } else if (response.status >= 500) {
+        onBreakerFailure(upstream);
+        recordExternalHttp(upstream, "error", ms);
+      } else {
+        // 4xx auth/validation — не availability-issue; breaker не торкаємо.
+        recordExternalHttp(upstream, "error", ms);
+      }
+
+      const contentType = response.headers.get("content-type");
+      if (cacheKey && response.ok) {
+        cacheSet(cacheKey, {
+          expires: Date.now() + state.cacheTtlMs,
+          status: response.status,
+          body,
+          contentType,
+        });
+      }
+
+      return {
+        status: response.status,
+        body,
+        contentType,
+        fromCache: false,
+        attempts: attempt + 1,
+      };
+    } catch (e) {
+      // Мережева помилка або AbortError (timeout). Ретраїмо до вичерпання.
+      if (attempt < maxAttempts - 1) {
+        continue;
+      }
+      const ms = Number(process.hrtime.bigint() - start) / 1e6;
+      onBreakerFailure(upstream);
+      recordExternalHttp(upstream, isAbortError(e) ? "timeout" : "error", ms);
+      logger.error({
+        msg: `${upstream}_proxy_failed`,
+        err: { message: e?.message || String(e), code: e?.code },
+        attempts: attempt + 1,
+      });
+      throw new ExternalServiceError("Помилка сервера", {
+        code: `${upstream.toUpperCase()}_FETCH_FAILED`,
+        cause: e,
+      });
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  // Недосяжно: цикл завжди або повертає, або кидає.
+  /* c8 ignore next */
+  throw new ExternalServiceError("Помилка сервера", {
+    code: `${upstream.toUpperCase()}_UNEXPECTED`,
+  });
+}
+
+/**
+ * Test-only hooks. Не використовуй у прод-коді.
+ */
+export function __bankProxyTestHooks() {
+  return {
+    configure(overrides) {
+      for (const [k, v] of Object.entries(overrides)) {
+        if (k in state) state[k] = v;
+      }
+    },
+    reset() {
+      state.breakers.clear();
+      state.cache.clear();
+      state.retryDelaysMs = [...DEFAULTS.retryDelaysMs];
+      state.retryJitterMs = DEFAULTS.retryJitterMs;
+      state.timeoutMs = DEFAULTS.timeoutMs;
+      state.breakerFailThreshold = DEFAULTS.breakerFailThreshold;
+      state.breakerOpenMs = DEFAULTS.breakerOpenMs;
+      state.cacheTtlMs = DEFAULTS.cacheTtlMs;
+      state.cacheMaxEntries = DEFAULTS.cacheMaxEntries;
+    },
+    state,
+  };
+}

--- a/server/modules/bankProxy.test.js
+++ b/server/modules/bankProxy.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import monoHandler from "./mono.js";
 import privatHandler from "./privat.js";
+import { bankProxyFetch, __bankProxyTestHooks } from "../lib/bankProxy.js";
 
 function mockRes() {
   const res = {
@@ -16,6 +17,10 @@ function mockRes() {
     res.body = payload;
     return res;
   };
+  res.send = (payload) => {
+    res.body = payload;
+    return res;
+  };
   res.setHeader = (name, value) => {
     res.headers[name] = value;
   };
@@ -23,10 +28,31 @@ function mockRes() {
   return res;
 }
 
+/**
+ * Фабрика mock-responses, сумісна з `bankProxyFetch` (потребує .text() і .headers).
+ * `body` — або object (серіалізуємо через JSON.stringify), або string.
+ */
+function mockFetchResponse({ status = 200, body = {}, contentType } = {}) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  const ct =
+    contentType ??
+    (typeof body === "string" ? "text/plain" : "application/json");
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => (typeof body === "string" ? body : body),
+    headers: {
+      get: (name) => (name.toLowerCase() === "content-type" ? ct : null),
+    },
+  };
+}
+
 describe("mono proxy path validation", () => {
   const origFetch = global.fetch;
 
   beforeEach(() => {
+    __bankProxyTestHooks().reset();
     global.fetch = vi.fn();
   });
 
@@ -72,14 +98,12 @@ describe("mono proxy path validation", () => {
   });
 
   it("allows exact /personal/client-info", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true }),
-    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { ok: true } }));
     const req = {
       method: "GET",
-      headers: { "x-token": "tok", origin: "http://localhost:5173" },
+      headers: { "x-token": "tok-1", origin: "http://localhost:5173" },
       query: { path: "/personal/client-info" },
     };
     const res = mockRes();
@@ -89,14 +113,12 @@ describe("mono proxy path validation", () => {
   });
 
   it("allows /personal/statement/<id>", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true }),
-    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { ok: true } }));
     const req = {
       method: "GET",
-      headers: { "x-token": "tok", origin: "http://localhost:5173" },
+      headers: { "x-token": "tok-2", origin: "http://localhost:5173" },
       query: { path: "/personal/statement/abc123" },
     };
     const res = mockRes();
@@ -110,6 +132,7 @@ describe("privat proxy path validation", () => {
   const origFetch = global.fetch;
 
   beforeEach(() => {
+    __bankProxyTestHooks().reset();
     global.fetch = vi.fn();
   });
 
@@ -151,11 +174,9 @@ describe("privat proxy path validation", () => {
   });
 
   it("allows /statements/transactions/<acc>", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true }),
-    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { ok: true } }));
     const req = {
       method: "GET",
       headers: {
@@ -169,5 +190,236 @@ describe("privat proxy path validation", () => {
     await privatHandler(req, res);
     expect(res.statusCode).toBe(200);
     expect(global.fetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("bankProxyFetch — retry + breaker + cache + timeout", () => {
+  const origFetch = global.fetch;
+
+  beforeEach(() => {
+    __bankProxyTestHooks().reset();
+    // У тестах вимикаємо delay-и, щоб не чекати 1с на 3 ретраї.
+    __bankProxyTestHooks().configure({
+      retryDelaysMs: [0, 0, 0],
+      retryJitterMs: 0,
+    });
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    __bankProxyTestHooks().reset();
+    vi.restoreAllMocks();
+  });
+
+  const baseOpts = {
+    upstream: "testbank",
+    baseUrl: "https://example.test",
+    path: "/foo",
+    headers: { "X-Key": "k" },
+    cacheKeySecret: "secret-a",
+  };
+
+  it("returns 2xx on first try — no retry", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { ok: 1 } }));
+    const r = await bankProxyFetch(baseOpts);
+    expect(r.status).toBe(200);
+    expect(r.attempts).toBe(1);
+    expect(r.fromCache).toBe(false);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry on 4xx", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 401, body: "bad" }));
+    const r = await bankProxyFetch({
+      ...baseOpts,
+      cacheKeySecret: "secret-4xx",
+    });
+    expect(r.status).toBe(401);
+    expect(r.attempts).toBe(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry on 429", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 429, body: "rate" }));
+    const r = await bankProxyFetch({
+      ...baseOpts,
+      cacheKeySecret: "secret-429",
+    });
+    expect(r.status).toBe(429);
+    expect(r.attempts).toBe(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 5xx up to 3 times", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 502, body: "bad gw" }));
+    const r = await bankProxyFetch({
+      ...baseOpts,
+      cacheKeySecret: "secret-5xx",
+    });
+    expect(r.status).toBe(502);
+    expect(r.attempts).toBe(3);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds on second attempt after transient 503", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mockFetchResponse({ status: 503 }))
+      .mockResolvedValueOnce(mockFetchResponse({ body: { ok: true } }));
+    const r = await bankProxyFetch({
+      ...baseOpts,
+      cacheKeySecret: "secret-transient",
+    });
+    expect(r.status).toBe(200);
+    expect(r.attempts).toBe(2);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries network errors and eventually throws ExternalServiceError", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+    await expect(
+      bankProxyFetch({ ...baseOpts, cacheKeySecret: "secret-net" }),
+    ).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      code: "TESTBANK_FETCH_FAILED",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("aborts on timeout and surfaces ExternalServiceError", async () => {
+    __bankProxyTestHooks().configure({ timeoutMs: 5 });
+    global.fetch = vi.fn().mockImplementation(
+      (_url, init) =>
+        new Promise((_, reject) => {
+          init.signal.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+    await expect(
+      bankProxyFetch({ ...baseOpts, cacheKeySecret: "secret-timeout" }),
+    ).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      code: "TESTBANK_FETCH_FAILED",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("caches identical GET — second request does not hit fetch", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { hello: "world" } }));
+    const r1 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "cache-a" });
+    const r2 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "cache-a" });
+    expect(r1.fromCache).toBe(false);
+    expect(r2.fromCache).toBe(true);
+    expect(r2.body).toBe(r1.body);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("different cacheKeySecret → different cache entries", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { x: 1 } }));
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "token-A" });
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "token-B" });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("cache expires after TTL", async () => {
+    __bankProxyTestHooks().configure({ cacheTtlMs: 1 });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ body: { ok: 1 } }));
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "ttl-k" });
+    await new Promise((r) => setTimeout(r, 10));
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "ttl-k" });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT cache 4xx/5xx responses", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 401, body: "no" }));
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "no-cache-err" });
+    await bankProxyFetch({ ...baseOpts, cacheKeySecret: "no-cache-err" });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens circuit after threshold consecutive 5xx failures, then fast-fails 503", async () => {
+    __bankProxyTestHooks().configure({
+      breakerFailThreshold: 2,
+      breakerOpenMs: 60_000,
+    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 500, body: "oops" }));
+
+    // Дві послідовні невдачі (кожна вичерпує 3 HTTP-спроби = 6 fetch-ів).
+    const r1 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "brk-1" });
+    expect(r1.status).toBe(500);
+    const r2 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "brk-2" });
+    expect(r2.status).toBe(500);
+    expect(global.fetch).toHaveBeenCalledTimes(6);
+
+    // Третій запит fast-fail-ить 503 без fetch.
+    await expect(
+      bankProxyFetch({ ...baseOpts, cacheKeySecret: "brk-3" }),
+    ).rejects.toMatchObject({
+      name: "ExternalServiceError",
+      status: 503,
+      code: "TESTBANK_CIRCUIT_OPEN",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("breaker closes (half-open pass) after openMs elapses", async () => {
+    __bankProxyTestHooks().configure({
+      breakerFailThreshold: 1,
+      breakerOpenMs: 5,
+    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mockFetchResponse({ status: 500 }))
+      .mockResolvedValueOnce(mockFetchResponse({ status: 500 }))
+      .mockResolvedValueOnce(mockFetchResponse({ status: 500 }))
+      .mockResolvedValue(mockFetchResponse({ body: { recovered: true } }));
+
+    const r1 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "hopen-1" });
+    expect(r1.status).toBe(500);
+
+    // Вікно breaker-а минуло.
+    await new Promise((r) => setTimeout(r, 15));
+
+    const r2 = await bankProxyFetch({ ...baseOpts, cacheKeySecret: "hopen-2" });
+    expect(r2.status).toBe(200);
+  });
+
+  it("breaker does NOT trip on 4xx/429", async () => {
+    __bankProxyTestHooks().configure({ breakerFailThreshold: 2 });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockFetchResponse({ status: 401, body: "nope" }));
+
+    for (let i = 0; i < 5; i++) {
+      const r = await bankProxyFetch({
+        ...baseOpts,
+        cacheKeySecret: `401-${i}`,
+      });
+      expect(r.status).toBe(401);
+    }
+    // Усі 5 запитів пройшли — breaker не відкрився.
+    expect(global.fetch).toHaveBeenCalledTimes(5);
   });
 });

--- a/server/modules/mono.js
+++ b/server/modules/mono.js
@@ -1,17 +1,12 @@
-import { logger } from "../obs/logger.js";
-import { recordExternalHttp } from "../lib/externalHttp.js";
+import { bankProxyFetch } from "../lib/bankProxy.js";
 import { validateQuery } from "../http/validate.js";
 import { MonoQuerySchema } from "../http/schemas.js";
-import { ExternalServiceError } from "../obs/errors.js";
 
 /**
  * `/api/mono` — проксі до Monobank personal API. CORS/rate-limit/module-tag
- * зроблені middleware-ами роутера; тут тільки upstream credentials,
- * path-валідація та HTTP-виклик.
- *
- * Формат `path` (whitelist-regex) валідується через `validateQuery` + zod;
- * allowlist конкретних upstream шляхів — нижче (не чистий shape-check,
- * тому тримаємо тут).
+ * зроблені middleware-ами роутера; тут — лише upstream credentials,
+ * path-валідація (whitelist), делегація transport-шару в `bankProxy.js`
+ * (timeout/retry/breaker/TTL-cache).
  */
 const ALLOWED_PATHS = ["/personal/client-info", "/personal/statement"];
 
@@ -33,39 +28,27 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Недозволений API шлях" });
   }
 
-  const start = process.hrtime.bigint();
-  let response;
+  const { status, body, contentType } = await bankProxyFetch({
+    upstream: "monobank",
+    baseUrl: "https://api.monobank.ua",
+    path,
+    headers: { "X-Token": String(token) },
+    cacheKeySecret: String(token),
+  });
+
+  if (status < 200 || status >= 300) {
+    return res.status(status).json({
+      error: status === 429 ? "Занадто багато запитів" : body,
+    });
+  }
+
+  let data;
   try {
-    response = await fetch(`https://api.monobank.ua${path}`, {
-      headers: { "X-Token": String(token) },
-    });
-  } catch (e) {
-    const ms = Number(process.hrtime.bigint() - start) / 1e6;
-    recordExternalHttp("monobank", "error", ms);
-    logger.error({
-      msg: "mono_proxy_failed",
-      err: { message: e?.message || String(e), code: e?.code },
-    });
-    throw new ExternalServiceError("Помилка сервера", {
-      code: "MONOBANK_FETCH_FAILED",
-      cause: e,
-    });
+    data = JSON.parse(body);
+  } catch {
+    // upstream повернув не-JSON на 2xx — віддаємо як plain text, щоб не мовчки ковтати.
+    res.setHeader("Content-Type", contentType || "text/plain; charset=utf-8");
+    return res.status(status).send(body);
   }
-  const ms = Number(process.hrtime.bigint() - start) / 1e6;
-
-  if (!response.ok) {
-    recordExternalHttp(
-      "monobank",
-      response.status === 429 ? "rate_limited" : "error",
-      ms,
-    );
-    const errorText = await response.text();
-    return res.status(response.status).json({
-      error: response.status === 429 ? "Занадто багато запитів" : errorText,
-    });
-  }
-
-  const data = await response.json();
-  recordExternalHttp("monobank", "ok", ms);
   res.status(200).json(data);
 }

--- a/server/modules/privat.js
+++ b/server/modules/privat.js
@@ -1,13 +1,12 @@
-import { logger } from "../obs/logger.js";
-import { recordExternalHttp } from "../lib/externalHttp.js";
+import { bankProxyFetch } from "../lib/bankProxy.js";
 import { validateQuery } from "../http/validate.js";
 import { PrivatQuerySchema } from "../http/schemas.js";
-import { ExternalServiceError } from "../obs/errors.js";
 
 /**
  * `/api/privat` — проксі до PrivatBank merchant API. CORS/rate-limit/tag
- * зроблені middleware-ами роутера; тут тільки upstream credentials,
- * path-валідація і фільтрація заголовків від CRLF-injection.
+ * зроблені middleware-ами роутера; тут — лише upstream credentials,
+ * path-валідація, CRLF-фільтр заголовків і делегація transport-шару в
+ * `bankProxy.js` (timeout/retry/breaker/TTL-cache).
  */
 const ALLOWED_PATHS = ["/statements/balance/final", "/statements/transactions"];
 
@@ -44,56 +43,37 @@ export default async function handler(req, res) {
 
   const queryParams = new URLSearchParams(req.query);
   queryParams.delete("path");
-  const queryString = queryParams.toString();
+  const query = Object.fromEntries(queryParams.entries());
 
-  const start = process.hrtime.bigint();
-  let response;
+  const { status, body, contentType } = await bankProxyFetch({
+    upstream: "privatbank",
+    baseUrl: "https://acp.privatbank.ua/api",
+    path,
+    query,
+    headers: {
+      id: safeId,
+      token: safeToken,
+      "Content-Type": "application/json;charset=utf-8",
+    },
+    cacheKeySecret: `${safeId}|${safeToken}`,
+  });
+
+  if (status < 200 || status >= 300) {
+    const errorMessage =
+      status === 429
+        ? "Занадто багато запитів"
+        : status === 401 || status === 403
+          ? "Невірні credentials PrivatBank"
+          : body || `Помилка ${status}`;
+    return res.status(status).json({ error: errorMessage });
+  }
+
+  let data;
   try {
-    const url = `https://acp.privatbank.ua/api${path}${queryString ? "?" + queryString : ""}`;
-    response = await fetch(url, {
-      headers: {
-        id: safeId,
-        token: safeToken,
-        "Content-Type": "application/json;charset=utf-8",
-      },
-    });
-  } catch (e) {
-    const ms = Number(process.hrtime.bigint() - start) / 1e6;
-    recordExternalHttp("privatbank", "error", ms);
-    logger.error({
-      msg: "privat_proxy_failed",
-      err: { message: e?.message || String(e), code: e?.code },
-    });
-    throw new ExternalServiceError("Помилка сервера", {
-      code: "PRIVATBANK_FETCH_FAILED",
-      cause: e,
-    });
+    data = JSON.parse(body);
+  } catch {
+    res.setHeader("Content-Type", contentType || "text/plain; charset=utf-8");
+    return res.status(status).send(body);
   }
-  const ms = Number(process.hrtime.bigint() - start) / 1e6;
-
-  if (!response.ok) {
-    recordExternalHttp(
-      "privatbank",
-      response.status === 429 ? "rate_limited" : "error",
-      ms,
-    );
-    let errorText = "";
-    try {
-      errorText = await response.text();
-    } catch {
-      /* response body may be unreadable — surface status text only */
-    }
-    return res.status(response.status).json({
-      error:
-        response.status === 429
-          ? "Занадто багато запитів"
-          : response.status === 401 || response.status === 403
-            ? "Невірні credentials PrivatBank"
-            : errorText || `Помилка ${response.status}`,
-    });
-  }
-
-  recordExternalHttp("privatbank", "ok", ms);
-  const data = await response.json();
   res.status(200).json(data);
 }


### PR DESCRIPTION
## Summary

PR B з запропонованого плану — стійкість bank-proxy до частих 5xx/таймаутів від Mono/Privat.

Винесено transport-шар у `server/lib/bankProxy.js` — Mono/Privat handler-и тепер тонкі і відповідають лише за upstream credentials, path-whitelist і CRLF-фільтр.

Нова функціональність у `bankProxyFetch`:
- **AbortController-таймаут**: 15с на кожну HTTP-спробу.
- **Exponential retry з jitter**: 3 спроби з затримками 0 / 250+jit / 750+jit мс. Ретрай **тільки** для 5xx і мережевих/timeout-помилок. 4xx (включно з 401/403/429) не ретраяться.
- **Circuit breaker per-upstream**: після ≥5 послідовних fail-ів (5xx або мережева помилка) breaker відкривається на 30с — подальші запити fast-fail-ять 503 `ExternalServiceError` без походу в upstream. Успішна відповідь обнуляє лічильник. 4xx / 429 не крутять breaker. Після вікна — half-open: наступний запит пропускається як пробний.
- **In-memory TTL-кеш** (60с) для ідентичних GET: ключ = `upstream|path|querystring|sha256(secret).slice(0,16)`. Кешуються лише 2xx. Простий LRU-eviction при досягненні `cacheMaxEntries` (500).
- Метрики `external_http_requests_total{upstream, outcome}` розширено нашими нормованими outcome-ами: `ok | error | rate_limited | timeout | hit | circuit_open`.

Handler-и `mono.js` / `privat.js` переписано як тонкі обгортки — path whitelist, `validateQuery`, CRLF-фільтр заголовків (для Privat), делегація в `bankProxyFetch`, форматування помилок українською.

Тести (`bankProxy.test.js`) розширено з 8 до 22 випадків: 8 існуючих path-валідаційних + 14 нових на transport-шар (retry, не-retry на 4xx/429, timeout, breaker open/half-open, breaker не тріпається на 4xx, кеш hit/miss/TTL-expiry/shard-by-secret, non-cache для 4xx/5xx).

### Notes

- `bankProxyFetch` експортує `__bankProxyTestHooks()` для unit-тестів — `configure()` і `reset()` стану. У прод-коді не використовувати.
- `ExternalServiceError` приймає `status: 503` для breaker-open (базовий 502 зберігається для mережевих fail-ів).
- Тіло відповіді upstream-а тепер читається як text один раз і передається далі як є — немає подвійної JSON.parse → JSON.stringify як у старому коді.
- Кеш — in-memory, per-process. При горизонтальному масштабуванні кожен instance матиме свій кеш (це прийнятно для 60с TTL; якщо знадобиться спільний — Redis-adapter під той самий інтерфейс).

## Review & Testing Checklist for Human

- [ ] Переконатись, що на реальних Mono/Privat-запитах з клієнта продовжує працювати без змін у поведінці (happy path).
- [ ] Перевірити, що cache hit не видає stale data між різними юзерами — ключ включає hash токена, тому два користувачі з різними токенами мають окремі записи. Переконатись на тесті з двома акаунтами.
- [ ] Під час incident-а (Mono/Privat 5xx flap) переконатись, що circuit-breaker відкривається і клієнт бачить 503 швидко, а не чекає 45с таймаутів × 3.
- [ ] Прогнати `npm run check` локально — CI має пройти (окрім pre-existing TS-помилки у `src/core/lib/hubChatActions.test.ts:150`, не з цієї серії).
- [ ] Виміряти memory footprint in-memory кешу під навантаженням — `cacheMaxEntries=500` є м'яким upper-bound.

Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
