### PR TITLE
design-system: migrate red-* danger colors to semantic tokens

### DIFF
--- a/src/core/HubReports.tsx
+++ b/src/core/HubReports.tsx
@@ -250,7 +250,7 @@ function Delta({ cur, prev, higherIsBetter = true }) {
     <span
       className={cn(
         "text-xs font-medium",
-        positive ? "text-emerald-600 dark:text-emerald-400" : "text-red-500",
+        positive ? "text-success" : "text-danger",
       )}
     >
       {sign}

--- a/src/index.css
+++ b/src/index.css
@@ -340,10 +340,10 @@
   }
 
   .badge-danger {
-    @apply badge bg-red-100 text-red-700;
+    @apply badge bg-danger-soft text-danger;
   }
   .dark .badge-danger {
-    @apply bg-red-900/30 text-red-400;
+    @apply bg-danger/15 text-danger;
   }
 
   .badge-neutral {
@@ -824,7 +824,7 @@ textarea {
 }
 
 .module-card-routine {
-  @apply module-card bg-gradient-to-br from-red-50/80 via-orange-50/30 to-white;
+  @apply module-card bg-gradient-to-br from-coral-50/80 via-orange-50/30 to-white;
   border-color: rgba(255, 212, 203, 0.6);
 }
 

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -459,7 +459,7 @@ export function ManualExpenseSheet({
           </div>
         </div>
 
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && <p className="text-xs text-danger">{error}</p>}
       </div>
     </Sheet>
   );

--- a/src/modules/finyk/components/budgets/AddBudgetForm.jsx
+++ b/src/modules/finyk/components/budgets/AddBudgetForm.jsx
@@ -131,7 +131,7 @@ function AddBudgetFormComponent({
         </>
       )}
       {formError && (
-        <p className="text-xs text-red-500 bg-red-500/10 rounded-xl px-3 py-2">
+        <p className="text-xs text-danger bg-danger-soft rounded-xl px-3 py-2">
           {formError}
         </p>
       )}

--- a/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
+++ b/src/modules/finyk/pages/overview/IncomeExpensePills.jsx
@@ -37,7 +37,7 @@ const IncomeExpensePillsImpl = function IncomeExpensePills({
         </p>
       </Card>
       <Card radius="lg">
-        <div className="flex items-center gap-2 text-red-500">
+        <div className="flex items-center gap-2 text-danger">
           <svg
             width="16"
             height="16"

--- a/src/modules/fizruk/pages/Exercise.tsx
+++ b/src/modules/fizruk/pages/Exercise.tsx
@@ -20,9 +20,9 @@ function roundTo2_5(kg) {
 const CALC_ZONES = [
   {
     goal: "Сила",
-    color: "text-red-500",
-    bgColor: "bg-red-500/10",
-    borderColor: "border-red-500/20",
+    color: "text-danger",
+    bgColor: "bg-danger/10",
+    borderColor: "border-danger/20",
     percents: [95, 90, 85],
     desc: "85–95% від 1RM",
   },

--- a/src/shared/components/ui/Badge.tsx
+++ b/src/shared/components/ui/Badge.tsx
@@ -53,7 +53,7 @@ const softVariants: Record<BadgeVariant, string> = {
   warning:
     "bg-amber-50 text-amber-700 border-amber-200/70 dark:bg-amber-500/15 dark:text-amber-300 dark:border-amber-500/30",
   danger:
-    "bg-red-50 text-red-700 border-red-200/70 dark:bg-danger/15 dark:text-red-300 dark:border-danger/30",
+    "bg-danger-soft text-danger border-danger/30 dark:bg-danger/15 dark:border-danger/30",
   info: "bg-blue-50 text-blue-700 border-blue-200/70 dark:bg-info/15 dark:text-blue-300 dark:border-info/30",
   finyk:
     "bg-finyk-soft text-finyk border-finyk-ring/50 dark:bg-finyk/15 dark:border-finyk/30",

--- a/src/shared/components/ui/Button.tsx
+++ b/src/shared/components/ui/Button.tsx
@@ -46,9 +46,9 @@ const variants: Record<ButtonVariant, string> = {
   ghost:
     "bg-transparent text-muted hover:bg-panelHi hover:text-text active:bg-line/50",
   danger:
-    "bg-red-50 text-red-600 border border-red-200/50 hover:bg-red-100 hover:border-red-300 active:scale-[0.98]",
+    "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
-    "bg-danger text-white shadow-sm hover:bg-red-600 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
+    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 active:scale-[0.98]",
 

--- a/src/shared/components/ui/FormField.tsx
+++ b/src/shared/components/ui/FormField.tsx
@@ -129,7 +129,7 @@ export function FormField({
       {hasError ? (
         <p
           id={`${controlId}-error`}
-          className="text-xs text-red-500 mt-1"
+          className="text-xs text-danger mt-1"
           role="alert"
         >
           {error}


### PR DESCRIPTION
## Summary

Пріоритет №2 з handoff-у: `rg "bg-red-\d+|text-red-\d+|border-red-\d+" src/` → заміна на існуючі семантичні токени (`bg-danger-soft` / `text-danger` / `border-danger` / `border-danger/30`). Токени вже були в `tailwind.config.js` (PR #293) — тут суто міграція спожитих місць.

### Зміни

- **`Badge.tsx`** — `danger` soft-варіант: `bg-danger-soft text-danger border-danger/30` (+ dark-override для симетрії з іншими варіантами).
- **`Button.tsx`**
  - `danger` (м'яка деструктив-кнопка): `bg-danger-soft text-danger border-danger/30 hover:bg-danger/15 hover:border-danger/50`.
  - `destructive` (солідна CTA): прибрав `hover:bg-red-600`, тепер `hover:brightness-110` (зберігає існуючий ring-glow).
- **`FormField.tsx`** — inline-помилка: `text-xs text-danger mt-1`.
- **`Exercise.tsx`** (Fizruk 1RM-калькулятор) — зона «Сила»: `text-danger` / `bg-danger/10` / `border-danger/20`.
- **`IncomeExpensePills.jsx`** (Finyk Overview) — хедер expense-картки: `text-danger`.
- **`AddBudgetForm.jsx`** — `formError` pill: `text-danger bg-danger-soft`.
- **`ManualExpenseSheet.jsx`** — inline-помилка під чипсами: `text-danger`.
- **`HubReports.tsx`** — delta pct: `positive ? text-success : text-danger` (прибрано `text-emerald-600 dark:text-emerald-400`).
- **`index.css`**
  - `.badge-danger` → `bg-danger-soft text-danger` + `.dark .badge-danger` → `bg-danger/15 text-danger`.
  - `.module-card-routine` градієнт: `from-red-50/80` → `from-coral-50/80` (корал — module-accent рутини).

### Що залишилось (поза скопом цього PR)

- `info` / `amber` варіанти Badge ще мають light-mode на `bg-blue-50`/`bg-amber-50` — не red-*, тому залишив. Якщо треба, окремий PR.
- Коментар у `index.css` на рядку 68 містить літерал `bg-red-50` як приклад міграції — лишив, бо це саме про те, як токени замінюють старий патерн.
- Сам `THEME_HEX.danger` ще використовує `#dc2626` (red-600) для SVG body-highlighter і деяких inline стилів — це не clas, не попадає в regex, тому не чіпаю.

### CI / локально

- `npm run lint` — ✅
- `npm run typecheck` — ✅
- Хук lint-staged при commit — ✅
- `rg "(bg|text|border|ring|from|to|via|fill|stroke|divide|placeholder|outline)-red-\d+" src/` → залишився лише 1 match в коментарі `index.css:68` (навмисно).

## Review & Testing Checklist for Human

Ризик: 🟢 зелений — чиста заміна класів на семантичні токени, що вже резолвяться через CSS-vars. Візуально dark mode стане послідовнішим (раніше danger-badge/button мали окремі dark:overrides з red-300/red-400, тепер один колір `text-danger`).

- [ ] Відкрити форму, викликати помилку (порожнє обов'язкове поле або невалідний бюджет) → текст помилки має червоний `text-danger`.
- [ ] Finyk Overview → блок витрат підсвічений `text-danger` (іконка стрілки вниз).
- [ ] Fizruk → Вправа з 1RM → зона «Сила» має червоне тло/обвідку/текст.
- [ ] Routine Hub-картка (на /hub) — перевірити, що радіальний градієнт тепер з коралового `from-coral-50/80` (а не червоного); пастель не повинна зрушитись — `from-coral-50` і `from-red-50` візуально близькі, але коралова версія «тепліша».
- [ ] Badge з variant=`danger` (наприклад, у `WeeklyDigestStories` чи debug pill) — однаково червоний у light і dark.
- [ ] Hub Reports → delta % для гірших показників — `text-danger` замість старого `text-red-500`.

### Notes

- `hover:bg-red-600` на destructive був семантично неправильний (брендового «danger-hover» токена немає); `hover:brightness-110` зберігає візуальний ефект затемнення і не вводить нового хардкоду.
- `module-card-routine` перенесено на `coral-50` замість `red-50` бо модуль рутини — коралового брендового кольору, а не семантичного `danger`.

Link to Devin session: https://app.devin.ai/sessions/be64ee66b3e74e829999608ec00ffda6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
