### PR TITLE
feat(server): atomic aiQuota upsert + tool-use bucket with per-tool limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 # AI_DAILY_USER_LIMIT=120
 # AI_DAILY_ANON_LIMIT=40
 # AI_QUOTA_DISABLED=0
+# Tool-use квота (окремий bucket у ai_usage_daily). Кожен виклик tool-а (наприклад
+# change_category, create_debt) коштує AI_QUOTA_TOOL_COST одиниць у власному
+# лічильнику tool:<name>. Ліміти на кожен tool задаються JSON-ом у AI_QUOTA_TOOL_LIMITS;
+# tool-и, не вказані у JSON, беруть AI_QUOTA_TOOL_DEFAULT_LIMIT (або unlimited якщо пусто).
+# AI_QUOTA_TOOL_COST=3
+# AI_QUOTA_TOOL_DEFAULT_LIMIT=60
+# AI_QUOTA_TOOL_LIMITS={"change_category":30,"create_debt":10,"create_receivable":10,"hide_transaction":30,"set_budget_limit":10,"set_monthly_plan":5,"mark_habit_done":30,"plan_workout":10,"create_habit":10}
 
 # ── Nutrition API Token ───────────────────────────────────────
 # Використовується для захисту nutrition endpoints (опціонально)

--- a/server/aiQuota.js
+++ b/server/aiQuota.js
@@ -4,6 +4,26 @@ import { getIp } from "./http/rateLimit.js";
 import { logger } from "./obs/logger.js";
 import { aiQuotaBlocksTotal, aiQuotaFailOpenTotal } from "./obs/metrics.js";
 
+/**
+ * Денна AI-квота. Зберігається в `ai_usage_daily` як лічильник по (subject, day,
+ * bucket). Є два типи bucket-ів: `default` — звичайний chat/coach/digest/nutrition
+ * (cost=1), `tool:<name>` — окремий tool-use виклик (cost = AI_QUOTA_TOOL_COST,
+ * default 3). tool-ліміти задаються JSON-ом через AI_QUOTA_TOOL_LIMITS.
+ *
+ * Інкремент — атомарний UPSERT з умовою `request_count + cost <= limit` на
+ * ON CONFLICT DO UPDATE. Raceʼу між паралельними запитами немає: у Postgres
+ * ON CONFLICT взаємовиключний per-row, тож два конкурентні інкременти не
+ * можуть одночасно перевищити ліміт.
+ *
+ * Сховище advisory: при недоступності БД (no DATABASE_URL, ECONNREFUSED, no
+ * table) — fail-open, щоб збій квоти не поклав усі AI-фічі. Це прийнятно, бо
+ * upstream-ліміти Anthropic і per-route rate-limit все одно працюють.
+ */
+
+const DEFAULT_BUCKET = "default";
+const TOOL_BUCKET_PREFIX = "tool:";
+const DEFAULT_TOOL_COST = 3;
+
 function parseLimit(name, fallback) {
   const v = process.env[name];
   if (v === undefined || v === "") return fallback;
@@ -23,6 +43,35 @@ function effectiveLimits() {
   };
 }
 
+function toolCost() {
+  return parseLimit("AI_QUOTA_TOOL_COST", DEFAULT_TOOL_COST);
+}
+
+/**
+ * Парсить AI_QUOTA_TOOL_LIMITS як JSON {"tool_name": maxPerDay, ...}.
+ * Повертає ліміт для конкретного tool-а, або null (unlimited). На битому
+ * JSON-і — null + лог-попередження (advisory-фіча не повинна блокувати запити).
+ */
+function toolLimit(toolName) {
+  const raw = process.env.AI_QUOTA_TOOL_LIMITS;
+  if (!raw) {
+    return parseLimit("AI_QUOTA_TOOL_DEFAULT_LIMIT", null);
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && toolName in parsed) {
+      const v = parsed[toolName];
+      if (typeof v === "number" && Number.isFinite(v) && v >= 0) return v;
+    }
+  } catch (e) {
+    logger.warn({
+      msg: "ai_quota_tool_limits_parse_failed",
+      err: { message: e?.message || String(e) },
+    });
+  }
+  return parseLimit("AI_QUOTA_TOOL_DEFAULT_LIMIT", null);
+}
+
 async function safeSessionUser(req) {
   try {
     return await getSessionUser(req);
@@ -35,14 +84,17 @@ async function safeSessionUser(req) {
   }
 }
 
+function subjectFor(sessionUser, req) {
+  return sessionUser ? `u:${sessionUser.id}` : `ip:${getIp(req)}`;
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
 /**
- * Перевірка та збільшення денного лічильника AI для залогіненого користувача або IP.
- * Повертає false, якщо відповідь вже відправлена (429).
- *
- * Квота зберігається в Postgres (ai_usage_daily). Якщо сховище тимчасово недоступне
- * (немає DATABASE_URL, впала БД, відсутня таблиця тощо) — fail-open: пропускаємо запит
- * і логуємо подію. Це advisory-ліміт, а не механізм безпеки: upstream (Anthropic) і
- * роут-специфічні `checkRateLimit` все одно захищають від зловживань.
+ * Default-bucket (plain chat) quota check. Shape збережено (backwards compat):
+ * повертає true/false; при вичерпанні сама відправляє 429 у `res`.
  */
 export async function assertAiQuota(req, res) {
   if (isAiQuotaDisabled()) return true;
@@ -72,11 +124,15 @@ export async function assertAiQuota(req, res) {
     return true;
   }
 
-  const subject = sessionUser ? `u:${sessionUser.id}` : `ip:${getIp(req)}`;
-  const day = new Date().toISOString().slice(0, 10);
-
+  const subject = subjectFor(sessionUser, req);
   try {
-    const result = await consumeQuota(subject, day, limit);
+    const result = await consumeQuota({
+      subject,
+      day: today(),
+      limit,
+      cost: 1,
+      bucket: DEFAULT_BUCKET,
+    });
     if (!result.ok) {
       try {
         aiQuotaBlocksTotal.inc({ reason: "limit" });
@@ -94,9 +150,67 @@ export async function assertAiQuota(req, res) {
     return true;
   } catch (e) {
     logQuotaStoreUnavailable("db_error", e);
-    // Fail-open: краще пропустити запит, ніж блокувати всі AI-фічі через збій сховища квот.
     setRemainingHeader(res, "unknown");
     return true;
+  }
+}
+
+/**
+ * Per-tool quota check. Викликається з chat-хендлера, коли Anthropic повертає
+ * tool_use-блок (або при обробці tool_results). Тут НЕ відправляється 429
+ * автоматично — caller сам вирішує, як сигналізувати користувачу (напр.,
+ * повернути текстову відповідь "ліміт вичерпано" замість виклику tool-а).
+ *
+ * Повертає `{ok, remaining, limit, reason?}`. `reason` — `"disabled" | "limit"
+ * | "store_unavailable"` — для телеметрії.
+ *
+ * @param {import("express").Request} req
+ * @param {string} toolName
+ */
+export async function consumeToolQuota(req, toolName) {
+  if (isAiQuotaDisabled()) {
+    return { ok: true, remaining: null, limit: null };
+  }
+  const limit = toolLimit(toolName);
+  if (limit == null) {
+    return { ok: true, remaining: null, limit: null };
+  }
+  if (limit === 0) {
+    try {
+      aiQuotaBlocksTotal.inc({ reason: "tool_disabled" });
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, remaining: 0, limit: 0, reason: "disabled" };
+  }
+
+  if (!process.env.DATABASE_URL) {
+    logQuotaStoreUnavailable("database_url_missing");
+    return { ok: true, remaining: null, limit, reason: "store_unavailable" };
+  }
+
+  const sessionUser = await safeSessionUser(req);
+  const subject = subjectFor(sessionUser, req);
+  try {
+    const result = await consumeQuota({
+      subject,
+      day: today(),
+      limit,
+      cost: toolCost(),
+      bucket: `${TOOL_BUCKET_PREFIX}${toolName}`,
+    });
+    if (!result.ok) {
+      try {
+        aiQuotaBlocksTotal.inc({ reason: "tool_limit" });
+      } catch {
+        /* ignore */
+      }
+      return { ...result, reason: "limit" };
+    }
+    return result;
+  } catch (e) {
+    logQuotaStoreUnavailable("db_error", e);
+    return { ok: true, remaining: null, limit, reason: "store_unavailable" };
   }
 }
 
@@ -121,41 +235,45 @@ function logQuotaStoreUnavailable(reason, e) {
   });
 }
 
-async function consumeQuota(subject, day, limit) {
-  const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
-    const sel = await client.query(
-      `SELECT request_count FROM ai_usage_daily WHERE subject_key = $1 AND usage_day = $2::date FOR UPDATE`,
-      [subject, day],
-    );
-    const cur = sel.rows[0]?.request_count ?? 0;
-    if (cur >= limit) {
-      await client.query("ROLLBACK");
-      return { ok: false, remaining: 0, limit };
-    }
-    const next = cur + 1;
-    if (sel.rows.length === 0) {
-      await client.query(
-        `INSERT INTO ai_usage_daily (subject_key, usage_day, request_count) VALUES ($1, $2::date, 1)`,
-        [subject, day],
-      );
-    } else {
-      await client.query(
-        `UPDATE ai_usage_daily SET request_count = $3 WHERE subject_key = $1 AND usage_day = $2::date`,
-        [subject, day, next],
-      );
-    }
-    await client.query("COMMIT");
-    return { ok: true, remaining: limit - next, limit };
-  } catch (e) {
-    try {
-      await client.query("ROLLBACK");
-    } catch {
-      /* ignore */
-    }
-    throw e;
-  } finally {
-    client.release();
+/**
+ * Атомарний інкремент лічильника з verifi-ON-CONFLICT:
+ *   INSERT (cost) — якщо рядка ще немає (завжди проходить, бо cost <= limit
+ *                   перевіряємо наперед).
+ *   ON CONFLICT UPDATE count = count + cost WHERE count + cost <= limit
+ *                — якщо рядок існує і новий count не перевищить limit.
+ *
+ * Якщо WHERE на DO UPDATE false — RETURNING повертає 0 рядків → блокуємо.
+ *
+ * NOTE: pre-check `cost > limit` покриває крайовий випадок: коли рядка ще
+ * немає, ON CONFLICT WHERE не спрацьовує, і ми б вставили count=cost > limit.
+ *
+ * @param {{subject:string, day:string, limit:number, cost:number, bucket:string}} opts
+ * @returns {Promise<{ok:boolean, remaining:number, limit:number}>}
+ */
+async function consumeQuota({ subject, day, limit, cost, bucket }) {
+  if (cost > limit) {
+    return { ok: false, remaining: 0, limit };
   }
+
+  const sql = `
+    INSERT INTO ai_usage_daily AS t (subject_key, usage_day, bucket, request_count)
+    VALUES ($1, $2::date, $3, $4)
+    ON CONFLICT (subject_key, usage_day, bucket)
+    DO UPDATE SET request_count = t.request_count + EXCLUDED.request_count
+      WHERE t.request_count + EXCLUDED.request_count <= $5
+    RETURNING request_count
+  `;
+  const r = await pool.query(sql, [subject, day, bucket, cost, limit]);
+  if (r.rows.length === 0) {
+    return { ok: false, remaining: 0, limit };
+  }
+  const next = r.rows[0].request_count;
+  return { ok: true, remaining: Math.max(0, limit - next), limit };
 }
+
+/** Test-only: прямий доступ до атомарного інкременту без HTTP-прошарку. */
+export const __aiQuotaTestHooks = {
+  consumeQuota,
+  DEFAULT_BUCKET,
+  TOOL_BUCKET_PREFIX,
+};

--- a/server/aiQuota.test.js
+++ b/server/aiQuota.test.js
@@ -5,13 +5,17 @@ vi.mock("./auth.js", () => ({
 }));
 
 vi.mock("./db.js", () => {
-  const pool = { connect: vi.fn() };
+  const pool = { connect: vi.fn(), query: vi.fn() };
   return { default: pool, pool };
 });
 
 import { getSessionUser } from "./auth.js";
 import pool from "./db.js";
-import { assertAiQuota } from "./aiQuota.js";
+import {
+  assertAiQuota,
+  consumeToolQuota,
+  __aiQuotaTestHooks,
+} from "./aiQuota.js";
 
 function makeRes() {
   return {
@@ -43,6 +47,9 @@ const ENV_VARS = [
   "AI_QUOTA_DISABLED",
   "AI_DAILY_USER_LIMIT",
   "AI_DAILY_ANON_LIMIT",
+  "AI_QUOTA_TOOL_COST",
+  "AI_QUOTA_TOOL_LIMITS",
+  "AI_QUOTA_TOOL_DEFAULT_LIMIT",
   "DATABASE_URL",
 ];
 const savedEnv = {};
@@ -59,7 +66,65 @@ afterEach(() => {
   }
 });
 
-describe("assertAiQuota", () => {
+/**
+ * Мок `pool.query`, що емулює атомарність UPSERT-а з ON CONFLICT DO UPDATE
+ * WHERE — тобто ту саму поведінку, яку дає Postgres per-row lock. Тримає
+ * стан у Map `(subject|day|bucket) -> count` і серіалізує запити через
+ * queue-мутекс, щоб паралельні виклики проходили один-за-одним (як у реальній
+ * БД з row-lock).
+ */
+function makeAtomicPoolMock() {
+  const store = new Map();
+  const queue = [];
+  let running = false;
+  function enqueue(fn) {
+    return new Promise((resolve, reject) => {
+      queue.push({ fn, resolve, reject });
+      flush();
+    });
+  }
+  function flush() {
+    if (running) return;
+    const next = queue.shift();
+    if (!next) return;
+    running = true;
+    Promise.resolve()
+      .then(next.fn)
+      .then((v) => {
+        running = false;
+        next.resolve(v);
+        flush();
+      })
+      .catch((e) => {
+        running = false;
+        next.reject(e);
+        flush();
+      });
+  }
+  const query = vi.fn(async (text, values) => {
+    return enqueue(() => {
+      const isUpsert = /INSERT INTO ai_usage_daily/i.test(text);
+      if (!isUpsert) return { rows: [], rowCount: 0 };
+      const [subject, day, bucket, cost, limit] = values;
+      const key = `${subject}|${day}|${bucket}`;
+      const cur = store.get(key) ?? 0;
+      const next = cur + cost;
+      if (next > limit) {
+        if (cur === 0) {
+          // новий рядок, cost > limit — не вставляємо
+          return { rows: [], rowCount: 0 };
+        }
+        // існуючий рядок, WHERE на ON CONFLICT блокує оновлення
+        return { rows: [], rowCount: 0 };
+      }
+      store.set(key, next);
+      return { rows: [{ request_count: next }], rowCount: 1 };
+    });
+  });
+  return { query, store };
+}
+
+describe("assertAiQuota (default bucket)", () => {
   it("returns true (no-op) when AI_QUOTA_DISABLED=1", async () => {
     process.env.AI_QUOTA_DISABLED = "1";
     const res = makeRes();
@@ -67,7 +132,7 @@ describe("assertAiQuota", () => {
     expect(ok).toBe(true);
     expect(res.statusCode).toBe(200);
     expect(getSessionUser).not.toHaveBeenCalled();
-    expect(pool.connect).not.toHaveBeenCalled();
+    expect(pool.query).not.toHaveBeenCalled();
   });
 
   it("fails open when DATABASE_URL is missing", async () => {
@@ -79,14 +144,14 @@ describe("assertAiQuota", () => {
     expect(ok).toBe(true);
     expect(res.statusCode).toBe(200);
     expect(res.headers["X-AI-Quota-Remaining"]).toBe("unknown");
-    expect(pool.connect).not.toHaveBeenCalled();
+    expect(pool.query).not.toHaveBeenCalled();
   });
 
   it("fails open when the quota DB call throws", async () => {
     process.env.DATABASE_URL = "postgres://ignored";
     process.env.AI_QUOTA_DISABLED = "0";
     getSessionUser.mockResolvedValue(null);
-    pool.connect.mockRejectedValue(
+    pool.query.mockRejectedValue(
       Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }),
     );
     const res = makeRes();
@@ -101,7 +166,7 @@ describe("assertAiQuota", () => {
     process.env.DATABASE_URL = "postgres://ignored";
     process.env.AI_QUOTA_DISABLED = "0";
     getSessionUser.mockRejectedValue(new Error("auth db down"));
-    pool.connect.mockRejectedValue(new Error("db down"));
+    pool.query.mockRejectedValue(new Error("db down"));
     const res = makeRes();
     const ok = await assertAiQuota(makeReq(), res);
     expect(ok).toBe(true);
@@ -109,20 +174,13 @@ describe("assertAiQuota", () => {
     expect(res.headers["X-AI-Quota-Remaining"]).toBe("unknown");
   });
 
-  it("returns 429 when daily limit is reached", async () => {
+  it("returns 429 when daily limit would be exceeded", async () => {
     process.env.DATABASE_URL = "postgres://ignored";
     process.env.AI_QUOTA_DISABLED = "0";
     process.env.AI_DAILY_ANON_LIMIT = "2";
     getSessionUser.mockResolvedValue(null);
-    const client = {
-      query: vi.fn(),
-      release: vi.fn(),
-    };
-    client.query
-      .mockResolvedValueOnce({}) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ request_count: 2 }] }) // SELECT
-      .mockResolvedValueOnce({}); // ROLLBACK
-    pool.connect.mockResolvedValue(client);
+    // Емулюємо: поточний count=2, cost=1 → WHERE 2+1<=2 false → 0 рядків.
+    pool.query.mockResolvedValue({ rows: [], rowCount: 0 });
     const res = makeRes();
     const ok = await assertAiQuota(makeReq(), res);
     expect(ok).toBe(false);
@@ -135,20 +193,173 @@ describe("assertAiQuota", () => {
     process.env.AI_QUOTA_DISABLED = "0";
     process.env.AI_DAILY_ANON_LIMIT = "10";
     getSessionUser.mockResolvedValue(null);
-    const client = {
-      query: vi.fn(),
-      release: vi.fn(),
-    };
-    client.query
-      .mockResolvedValueOnce({}) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ request_count: 3 }] }) // SELECT
-      .mockResolvedValueOnce({}) // UPDATE
-      .mockResolvedValueOnce({}); // COMMIT
-    pool.connect.mockResolvedValue(client);
+    pool.query.mockResolvedValue({ rows: [{ request_count: 4 }], rowCount: 1 });
     const res = makeRes();
     const ok = await assertAiQuota(makeReq(), res);
     expect(ok).toBe(true);
     expect(res.statusCode).toBe(200);
     expect(res.headers["X-AI-Quota-Remaining"]).toBe("6");
+    // Перевіряємо, що це ATOMIC UPSERT, а не BEGIN/SELECT FOR UPDATE/UPDATE/COMMIT.
+    expect(pool.query).toHaveBeenCalledOnce();
+    const [sql, values] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO ai_usage_daily/);
+    expect(sql).toMatch(/ON CONFLICT \(subject_key, usage_day, bucket\)/);
+    expect(sql).toMatch(/DO UPDATE/);
+    expect(values[2]).toBe("default");
+    expect(values[3]).toBe(1); // cost for plain chat
+    expect(values[4]).toBe(10); // limit
+  });
+});
+
+describe("consumeToolQuota (tool buckets)", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgres://ignored";
+    process.env.AI_QUOTA_DISABLED = "0";
+  });
+
+  it("returns ok + unlimited when AI_QUOTA_TOOL_LIMITS is not set", async () => {
+    delete process.env.AI_QUOTA_TOOL_LIMITS;
+    delete process.env.AI_QUOTA_TOOL_DEFAULT_LIMIT;
+    const r = await consumeToolQuota(makeReq(), "change_category");
+    expect(r.ok).toBe(true);
+    expect(r.limit).toBeNull();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it("uses AI_QUOTA_TOOL_DEFAULT_LIMIT when env JSON is absent", async () => {
+    delete process.env.AI_QUOTA_TOOL_LIMITS;
+    process.env.AI_QUOTA_TOOL_DEFAULT_LIMIT = "12";
+    process.env.AI_QUOTA_TOOL_COST = "3";
+    getSessionUser.mockResolvedValue(null);
+    pool.query.mockResolvedValue({ rows: [{ request_count: 3 }], rowCount: 1 });
+    const r = await consumeToolQuota(makeReq(), "change_category");
+    expect(r.ok).toBe(true);
+    expect(r.limit).toBe(12);
+    expect(pool.query).toHaveBeenCalledOnce();
+    const [, values] = pool.query.mock.calls[0];
+    expect(values[2]).toBe("tool:change_category");
+    expect(values[3]).toBe(3); // cost
+    expect(values[4]).toBe(12); // limit
+  });
+
+  it("uses per-tool limit from AI_QUOTA_TOOL_LIMITS JSON", async () => {
+    process.env.AI_QUOTA_TOOL_LIMITS = JSON.stringify({
+      change_category: 20,
+      create_debt: 5,
+    });
+    process.env.AI_QUOTA_TOOL_COST = "3";
+    getSessionUser.mockResolvedValue(null);
+    pool.query.mockResolvedValue({ rows: [{ request_count: 3 }], rowCount: 1 });
+
+    await consumeToolQuota(makeReq(), "create_debt");
+    const [, values] = pool.query.mock.calls[0];
+    expect(values[4]).toBe(5);
+    expect(values[2]).toBe("tool:create_debt");
+  });
+
+  it("blocks with reason=limit when tool-bucket is exhausted", async () => {
+    process.env.AI_QUOTA_TOOL_LIMITS = JSON.stringify({ create_debt: 3 });
+    process.env.AI_QUOTA_TOOL_COST = "3";
+    getSessionUser.mockResolvedValue(null);
+    pool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const r = await consumeToolQuota(makeReq(), "create_debt");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("limit");
+    expect(r.remaining).toBe(0);
+  });
+
+  it("returns ok on broken AI_QUOTA_TOOL_LIMITS JSON (advisory fail-open)", async () => {
+    process.env.AI_QUOTA_TOOL_LIMITS = "{not valid";
+    delete process.env.AI_QUOTA_TOOL_DEFAULT_LIMIT;
+    const r = await consumeToolQuota(makeReq(), "change_category");
+    expect(r.ok).toBe(true);
+    expect(r.limit).toBeNull();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it("does NOT consume from default bucket (separate quota)", async () => {
+    process.env.AI_QUOTA_TOOL_LIMITS = JSON.stringify({ change_category: 30 });
+    process.env.AI_QUOTA_TOOL_COST = "3";
+    getSessionUser.mockResolvedValue(null);
+    pool.query.mockResolvedValue({ rows: [{ request_count: 3 }], rowCount: 1 });
+    await consumeToolQuota(makeReq(), "change_category");
+    const [, values] = pool.query.mock.calls[0];
+    expect(values[2]).not.toBe("default");
+    expect(values[2]).toBe("tool:change_category");
+  });
+});
+
+describe("atomic consumeQuota — concurrent increments", () => {
+  it("20 parallel increments with limit=10 yield exactly 10 ok + 10 blocked", async () => {
+    const { query } = makeAtomicPoolMock();
+    pool.query = query;
+
+    const calls = Array.from({ length: 20 }, () =>
+      __aiQuotaTestHooks.consumeQuota({
+        subject: "u:test",
+        day: "2026-01-01",
+        limit: 10,
+        cost: 1,
+        bucket: "default",
+      }),
+    );
+    const results = await Promise.all(calls);
+
+    const okCount = results.filter((r) => r.ok).length;
+    const blockedCount = results.filter((r) => !r.ok).length;
+    expect(okCount).toBe(10);
+    expect(blockedCount).toBe(10);
+
+    // Після 10 успішних, remaining монотонно спадає до 0.
+    const remainings = results.filter((r) => r.ok).map((r) => r.remaining);
+    expect(remainings).toContain(0);
+    expect(Math.max(...remainings)).toBe(9);
+  });
+
+  it("concurrent tool-use (cost=3) + plain (cost=1) use independent buckets", async () => {
+    const { query, store } = makeAtomicPoolMock();
+    pool.query = query;
+
+    const plain = Array.from({ length: 5 }, () =>
+      __aiQuotaTestHooks.consumeQuota({
+        subject: "u:x",
+        day: "2026-01-01",
+        limit: 3,
+        cost: 1,
+        bucket: "default",
+      }),
+    );
+    const tools = Array.from({ length: 5 }, () =>
+      __aiQuotaTestHooks.consumeQuota({
+        subject: "u:x",
+        day: "2026-01-01",
+        limit: 9,
+        cost: 3,
+        bucket: "tool:create_debt",
+      }),
+    );
+    const [plainRes, toolsRes] = await Promise.all([
+      Promise.all(plain),
+      Promise.all(tools),
+    ]);
+    expect(plainRes.filter((r) => r.ok).length).toBe(3);
+    expect(toolsRes.filter((r) => r.ok).length).toBe(3);
+    expect(store.get("u:x|2026-01-01|default")).toBe(3);
+    expect(store.get("u:x|2026-01-01|tool:create_debt")).toBe(9);
+  });
+
+  it("rejects cost that alone exceeds limit (pre-check)", async () => {
+    const { query } = makeAtomicPoolMock();
+    pool.query = query;
+    const r = await __aiQuotaTestHooks.consumeQuota({
+      subject: "u:y",
+      day: "2026-01-01",
+      limit: 2,
+      cost: 3,
+      bucket: "tool:expensive",
+    });
+    expect(r.ok).toBe(false);
+    expect(query).not.toHaveBeenCalled();
   });
 });

--- a/server/migrations/004_ai_usage_daily_tool_bucket.sql
+++ b/server/migrations/004_ai_usage_daily_tool_bucket.sql
@@ -1,0 +1,12 @@
+-- Розділяємо денний лічильник AI за "бакетами": `default` для plain chat,
+-- `tool:<name>` для окремих tool-use викликів. Це дає окремі ліміти і робить
+-- tool-use дорожчим за звичайний чат (через cost-коефіцієнт у хендлері).
+ALTER TABLE ai_usage_daily
+  ADD COLUMN IF NOT EXISTS bucket TEXT NOT NULL DEFAULT 'default';
+
+-- Primary key тепер включає bucket. Старий PK був (subject_key, usage_day) —
+-- поточні записи коректно перекваліфікуються як bucket='default' через DEFAULT.
+ALTER TABLE ai_usage_daily
+  DROP CONSTRAINT IF EXISTS ai_usage_daily_pkey;
+ALTER TABLE ai_usage_daily
+  ADD PRIMARY KEY (subject_key, usage_day, bucket);


### PR DESCRIPTION
## Summary

Переписує `server/aiQuota.js` так, щоб денний AI-лічильник інкрементувався атомарно (`INSERT … ON CONFLICT (subject_key, usage_day, bucket) DO UPDATE SET request_count = t.request_count + EXCLUDED.request_count WHERE t.request_count + EXCLUDED.request_count <= $limit RETURNING request_count`) замість старого `BEGIN / SELECT FOR UPDATE / UPDATE / COMMIT`. Postgres виконує ON CONFLICT per-row атомарно, тому race condition між паралельними запитами на одного користувача зникає без явних блокувань.

Додає окремі «buckets» для tool-use у тій самій таблиці `ai_usage_daily`:

- Нова колонка `bucket TEXT NOT NULL DEFAULT 'default'` і композитний PK `(subject_key, usage_day, bucket)` (міграція 004, ідемпотентна).
- Plain-chat як і раніше використовує `bucket='default'`, поведінка `assertAiQuota` незмінна (429 при перевищенні, fail-open якщо БД недоступна, header `X-AI-Quota-Remaining`).
- Новий експорт `consumeToolQuota(req, toolName)` рахує використання у `bucket='tool:<toolName>'` і стягує `AI_QUOTA_TOOL_COST` (default `3`) за виклик.
- Ліміти на конкретні tool-и читаються з `AI_QUOTA_TOOL_LIMITS` (JSON-env, напр. `{"change_category":30,"create_debt":10}`), для відсутніх у JSON береться `AI_QUOTA_TOOL_DEFAULT_LIMIT` (якщо не заданий — unlimited). Битий JSON логиться як warning і не блокує запит.
- Метрика `ai_quota_blocks_total` отримує нові reason-и: `tool_limit`, `tool_disabled`.

`chat.js` поки НЕ модифікований — інтеграція `consumeToolQuota` у pipeline tool-use буде окремим PR (щоб цей PR залишався хірургічним).

### Файли
- `server/migrations/004_ai_usage_daily_tool_bucket.sql` — нова міграція (bucket column + композитний PK).
- `server/aiQuota.js` — повністю переписано на атомарний UPSERT; додано `consumeToolQuota`, `toolCost`, `toolLimit`, `__aiQuotaTestHooks`.
- `server/aiQuota.test.js` — 15 тестів: існуючі fail-open/429/success + нові для `consumeToolQuota` + concurrent-test (Promise.all × 20 з limit=10 → рівно 10 ok, 10 blocked).
- `.env.example` — додано `AI_QUOTA_TOOL_COST`, `AI_QUOTA_TOOL_DEFAULT_LIMIT`, `AI_QUOTA_TOOL_LIMITS`.

## Review & Testing Checklist for Human

- [ ] Застосувати міграцію `004_ai_usage_daily_tool_bucket.sql` у проді — перевірити, що наявні рядки `ai_usage_daily` коректно отримують `bucket='default'` і що новий composite PK створюється без конфлікту з існуючим `(subject_key, usage_day)`.
- [ ] Переконатися, що після деплою `X-AI-Quota-Remaining` header на реальних AI-запитах відповідає інкрементованому лічильнику (через pgAdmin/psql глянути `SELECT * FROM ai_usage_daily WHERE bucket='default'`).
- [ ] Додати `AI_QUOTA_TOOL_LIMITS` до prod-env (рекомендовані значення вже в `.env.example`). Без цього env-варіабля tool-use не має ліміту взагалі.
- [ ] Свідомо відкласти інтеграцію `consumeToolQuota` у `chat.js` на наступний PR? Якщо хочеш одразу в цьому — дай знати, додам.

### Notes
- Міграція 004 робить `DROP CONSTRAINT IF EXISTS ai_usage_daily_pkey` + `ADD PRIMARY KEY (subject_key, usage_day, bucket)`. На великих таблицях це може зайняти помітний час через rebuild індекса — на поточній таблиці `ai_usage_daily` це дешево, але варто знати.
- `assertAiQuota` залишився fail-open (будь-яка помилка БД → `X-AI-Quota-Remaining: unknown`, `ok:true`). Це свідомо: upstream Anthropic rate-limit все одно захищає нас від runaway spend, а локальна недоступність квот-БД не має блокувати AI-фічі.
- `consumeQuota` винесено у внутрішню функцію + експортовано через `__aiQuotaTestHooks`, щоб concurrent-тест міг дзвонити напряму без мокання `auth.js`.


Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
