### PR TITLE
design-system: add no-eyebrow-drift ESLint rule + migrate 48 call sites

### DIFF
--- a/eslint-plugins/sergeant-design/index.js
+++ b/eslint-plugins/sergeant-design/index.js
@@ -1,0 +1,66 @@
+/**
+ * sergeant-design — local ESLint plugin for Sergeant design-system guardrails.
+ *
+ * Rules:
+ *   - no-eyebrow-drift: forbid the combination of `uppercase`, `tracking-*`,
+ *     and `text-*` in a single className string. Use <SectionHeading> (or
+ *     <Label normalCase={false}>) instead. Add
+ *       // eslint-disable-next-line sergeant-design/no-eyebrow-drift
+ *     for intentional stylistic exceptions (e.g. narrative overlay stories).
+ */
+
+const EYEBROW_MESSAGE =
+  "Avoid the `uppercase` + `tracking-*` + `text-*` eyebrow combo in raw classNames — use <SectionHeading> (or <Label>) instead. Add // eslint-disable-next-line sergeant-design/no-eyebrow-drift only for intentional narrative / overlay typography.";
+
+// A className triggers the rule iff it contains all three markers.
+const RX_UPPERCASE = /(?:^|\s)uppercase(?:\s|$)/;
+const RX_TRACKING = /(?:^|\s)tracking-[\w-]+/;
+// Match any `text-*` utility (size OR color) — the drift is specifically the
+// colocation with `uppercase` + `tracking-`, regardless of which `text-*`.
+const RX_TEXT = /(?:^|\s)text-[\w-]+(?:\/\d+)?(?:\s|$)/;
+
+function classNameHasEyebrowDrift(value) {
+  if (typeof value !== "string") return false;
+  return (
+    RX_UPPERCASE.test(value) && RX_TRACKING.test(value) && RX_TEXT.test(value)
+  );
+}
+
+const noEyebrowDrift = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid the uppercase+tracking+text eyebrow combo outside the <SectionHeading> / <Label> design-system primitives.",
+    },
+    schema: [],
+    messages: { drift: EYEBROW_MESSAGE },
+  },
+  create(context) {
+    function report(node, value) {
+      if (classNameHasEyebrowDrift(value)) {
+        context.report({ node, messageId: "drift" });
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") report(node, node.value);
+      },
+      TemplateElement(node) {
+        if (node.value && typeof node.value.cooked === "string") {
+          report(node, node.value.cooked);
+        } else if (node.value && typeof node.value.raw === "string") {
+          report(node, node.value.raw);
+        }
+      },
+    };
+  },
+};
+
+const plugin = {
+  rules: {
+    "no-eyebrow-drift": noEyebrowDrift,
+  },
+};
+
+export default plugin;

--- a/eslint-plugins/sergeant-design/package.json
+++ b/eslint-plugins/sergeant-design/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "eslint-plugin-sergeant-design",
+  "version": "0.0.1",
+  "private": true,
+  "main": "index.js",
+  "type": "module"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
+import sergeantDesign from "./eslint-plugins/sergeant-design/index.js";
 
 const tsRecommendedScoped = tseslint.configs.recommended.map((cfg) => ({
   ...cfg,
@@ -36,9 +37,15 @@ export default [
     },
     plugins: {
       "react-hooks": reactHooks,
+      "sergeant-design": sergeantDesign,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      // Design-system guardrail — the canonical eyebrow label must go
+      // through <SectionHeading> (or <Label>) so tone/size changes stay
+      // in one place. Add the file-scoped override below for the DS
+      // primitives themselves.
+      "sergeant-design/no-eyebrow-drift": "error",
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-unused-vars": [
         "error",
@@ -77,6 +84,21 @@ export default [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+    },
+  },
+  // DS primitives that legitimately define the eyebrow treatment.
+  // SectionHeading owns the uppercase+tracking+text size tokens, Label
+  // owns the field-label eyebrow variant, and chartTheme defines the
+  // tooltip label token — all three are the single source-of-truth
+  // callers should import from.
+  {
+    files: [
+      "src/shared/components/ui/SectionHeading.tsx",
+      "src/shared/components/ui/FormField.tsx",
+      "src/shared/charts/chartTheme.ts",
+    ],
+    rules: {
+      "sergeant-design/no-eyebrow-drift": "off",
     },
   },
   eslintConfigPrettier,

--- a/src/core/AuthPage.tsx
+++ b/src/core/AuthPage.tsx
@@ -234,6 +234,10 @@ export function AuthPage({ onContinueWithoutAccount }) {
 
         {typeof onContinueWithoutAccount === "function" && (
           <>
+            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                Inline "або" divider between two <span> rules — structurally
+                a delimiter, not a heading, so SectionHeading is the wrong
+                abstraction. */}
             <div className="my-6 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
               <span className="flex-1 h-px bg-line" />
               або

--- a/src/core/HubSearch.tsx
+++ b/src/core/HubSearch.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { hapticTap } from "@shared/lib/haptic";
 import {
   scoreMatch,
@@ -427,9 +428,9 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
         {showRecents && (
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <p className="text-xs font-semibold text-muted uppercase tracking-wider">
+              <SectionHeading as="p" size="sm" tone="muted">
                 Недавні запити
-              </p>
+              </SectionHeading>
               <button
                 type="button"
                 onClick={() => {
@@ -489,9 +490,9 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
 
         {Object.entries(grouped).map(([moduleId, group]) => (
           <div key={moduleId}>
-            <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-1.5">
+            <SectionHeading as="p" size="sm" tone="muted" className="mb-1.5">
               {group.label}
-            </p>
+            </SectionHeading>
             <div className="space-y-1">
               {group.items.map((item) => {
                 runningIdx += 1;

--- a/src/core/TodayFocusCard.tsx
+++ b/src/core/TodayFocusCard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import {
   openHubModuleWithAction,
   type HubModuleAction,
@@ -184,9 +185,9 @@ function EmptyFocus() {
       )}
     >
       <div className="flex items-center justify-between gap-2 mb-2">
-        <span className="text-2xs font-semibold uppercase tracking-widest text-muted">
+        <SectionHeading as="span" size="xs" tone="muted">
           Зараз
-        </span>
+        </SectionHeading>
         {reward && (
           <span
             className={cn(
@@ -311,9 +312,9 @@ export function TodayFocusCard({
 
       <div className="pl-3">
         <div className="flex items-center justify-between gap-3 mb-1">
-          <span className="text-2xs font-semibold uppercase tracking-widest text-muted">
+          <SectionHeading as="span" size="xs" tone="muted">
             Зараз
-          </span>
+          </SectionHeading>
         </div>
 
         <h2 className="text-base font-bold text-text leading-snug text-balance">

--- a/src/core/WeeklyDigestCard.tsx
+++ b/src/core/WeeklyDigestCard.tsx
@@ -267,6 +267,10 @@ function DigestContent({
             {Array.isArray(digest.overallRecommendations) &&
               digest.overallRecommendations.length > 0 && (
                 <div className="rounded-xl border border-primary/20 bg-primary/5 px-3 py-2.5 space-y-1.5">
+                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                      Recommendation block eyebrow uses `text-primary` (a bespoke
+                      accent not exposed through SectionHeading tone tokens) so
+                      it stays inline until a `primary` tone is added to DS. */}
                   <p className="text-2xs font-bold text-primary uppercase tracking-wider">
                     Загальні рекомендації
                   </p>

--- a/src/core/WeeklyDigestStories.tsx
+++ b/src/core/WeeklyDigestStories.tsx
@@ -1,3 +1,14 @@
+/*
+ * WeeklyDigestStories is an Instagram-style full-screen narrative overlay,
+ * not a regular page. The uppercase+tracking+text eyebrow treatment is
+ * repeated across every card variant (recap of Finyk / Fizruk / Nutrition
+ * / Routine stats) at bespoke text sizes (`text-[13px]`, `text-2xs`,
+ * `tracking-[0.3em]`) that don't map cleanly onto <SectionHeading>'s
+ * canonical xs/sm tokens. Disabling the design-system rule file-wide
+ * keeps the narrative typography intact without scattering 11 local
+ * exemptions. Revisit when a dedicated <StoryEyebrow> variant lands.
+ */
+/* eslint-disable sergeant-design/no-eyebrow-drift */
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@shared/lib/cn";

--- a/src/core/onboarding/FirstActionSheet.tsx
+++ b/src/core/onboarding/FirstActionSheet.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
 import { PresetSheet, getPresetModule } from "./PresetSheet.jsx";
@@ -133,9 +134,9 @@ export function FirstActionHeroCard({ onDismiss }) {
       >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <div className="text-xs font-semibold uppercase tracking-wide text-subtle">
+            <SectionHeading as="div" size="sm" tone="subtle">
               Старт
-            </div>
+            </SectionHeading>
             <h2 className="text-base font-bold text-text mt-0.5">
               Зроби одну річ — і хаб твій
             </h2>

--- a/src/core/settings/SettingsPrimitives.tsx
+++ b/src/core/settings/SettingsPrimitives.tsx
@@ -81,6 +81,10 @@ export function SettingsSubGroup({
         className="flex items-center gap-1.5 w-full text-left group mb-1"
       >
         <ChevronIcon expanded={open} />
+        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+            Collapsible header uses `group-hover:text-text` interactive state +
+            transition-colors, which SectionHeading can't express via its
+            static tone tokens. */}
         <span className="text-xs font-bold text-muted uppercase tracking-widest group-hover:text-text transition-colors">
           {title}
         </span>

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -463,6 +463,9 @@ export default function App({
               можна підключити пізніше.
             </p>
 
+            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                "або через API" divider row — structurally a delimiter
+                between two bg-line spans, not a heading. */}
             <div className="my-4 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
               <span className="flex-1 h-px bg-line" />
               або через API

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useId, useMemo } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Label } from "@shared/components/ui/FormField";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech } from "../../../core/lib/speechParsers.js";
@@ -270,9 +271,9 @@ export function ManualExpenseSheet({
                     role="group"
                     aria-label="Часті суми"
                   >
-                    <span className="text-2xs text-subtle uppercase tracking-wide font-semibold">
+                    <SectionHeading as="span" size="xs" tone="subtle">
                       Часте
-                    </span>
+                    </SectionHeading>
                     {frequentAmounts.map((v) => (
                       <button
                         key={`f-${v}`}
@@ -293,9 +294,9 @@ export function ManualExpenseSheet({
                     role="group"
                     aria-label="Швидкі суми"
                   >
-                    <span className="text-2xs text-subtle uppercase tracking-wide font-semibold">
+                    <SectionHeading as="span" size="xs" tone="subtle">
                       Швидко
-                    </span>
+                    </SectionHeading>
                     {quickAmounts.map((v) => (
                       <button
                         key={`q-${v}`}
@@ -401,9 +402,14 @@ export function ManualExpenseSheet({
             role="group"
             aria-label="Нещодавні мерчанти"
           >
-            <span className="text-2xs text-subtle uppercase tracking-wide font-semibold w-full">
+            <SectionHeading
+              as="span"
+              size="xs"
+              tone="subtle"
+              className="w-full"
+            >
               Нещодавнє
-            </span>
+            </SectionHeading>
             {merchantSuggestions.map((m) => (
               <button
                 key={m.key}
@@ -434,6 +440,7 @@ export function ManualExpenseSheet({
         <div>
           <div
             id={catLabelId}
+            // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Category group label needs a stable id (catLabelId) for aria-labelledby; Label would require dropping htmlFor.
             className="block text-xs text-muted uppercase tracking-wide font-semibold mb-1"
           >
             Категорія

--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -335,6 +335,7 @@ export default function FizrukApp({
           )}
           <div className="min-w-0 flex-1">
             {!isAtlas && !isExercise && (
+              // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker at text-3xs with text-success/70 tint; SectionHeading xs is text-2xs and doesn't expose a /70-opacity success tone.
               <span className="text-3xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
                 ОСОБИСТИЙ ЖУРНАЛ
               </span>

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -284,6 +284,7 @@ export function WorkoutTemplatesSection({
                       </span>
                       {group && (
                         <span
+                          // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Inline superset/circuit pill at text-3xs with dynamic module tint; defer Badge migration.
                           className={`text-3xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${group.type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
                         >
                           {group.type === "circuit" ? "Коло" : "СС"}

--- a/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -129,6 +129,7 @@ function WarmupCooldownChecklist({ title, items, onToggle, onInit, color }) {
 function SupersetBadge({ type }) {
   return (
     <span
+      // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Superset/circuit indicator pill at text-3xs with dynamic module tint; defer Badge migration.
       className={`text-3xs font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full ${type === "circuit" ? "bg-fizruk/15 text-fizruk border border-fizruk/30" : "bg-success/15 text-success border border-success/30"}`}
     >
       {type === "circuit" ? "Коло" : "Суперсет"}
@@ -617,6 +618,10 @@ export function ActiveWorkoutPanel({
               {cardioMetrics && (
                 <div className="grid grid-cols-2 gap-2">
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
+                    {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                        Cardio metric caption at text-3xs (smaller than
+                        SectionHeading xs's text-2xs) inside a compact stat
+                        tile; intentional microtype. */}
                     <div className="text-3xs font-bold text-subtle uppercase tracking-widest">
                       Темп
                     </div>
@@ -625,6 +630,8 @@ export function ActiveWorkoutPanel({
                     </div>
                   </div>
                   <div className="rounded-xl border border-line bg-bg px-3 py-2 text-center">
+                    {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                        Matching caption on the speed tile; see sibling above. */}
                     <div className="text-3xs font-bold text-subtle uppercase tracking-widest">
                       Швидкість
                     </div>

--- a/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -158,6 +158,10 @@ export function WorkoutFinishSheets({
             <div className="fizruk-summary-header">
               <div className="flex items-start justify-between gap-2">
                 <div>
+                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                      "Завершено" hero kicker in module tint (`text-fizruk`)
+                      over `fizruk-summary-header` — intentional branded
+                      treatment. */}
                   <div className="text-xs font-bold tracking-widest uppercase text-fizruk">
                     Завершено
                   </div>
@@ -176,6 +180,9 @@ export function WorkoutFinishSheets({
               </div>
               <div className="grid grid-cols-3 gap-2 mt-3">
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
+                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                      Summary-sheet stat caption on dark hero background —
+                      `text-white/60` isn't expressed by SectionHeading tones. */}
                   <div className="text-2xs uppercase tracking-wide text-white/60">
                     Час
                   </div>
@@ -184,6 +191,8 @@ export function WorkoutFinishSheets({
                   </div>
                 </div>
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
+                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                      Sibling caption; same rationale as above. */}
                   <div className="text-2xs uppercase tracking-wide text-white/60">
                     Вправ
                   </div>
@@ -192,6 +201,8 @@ export function WorkoutFinishSheets({
                   </div>
                 </div>
                 <div className="rounded-xl bg-white/10 border border-white/15 p-2.5 text-center">
+                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                      Sibling caption; same rationale as above. */}
                   <div className="text-2xs uppercase tracking-wide text-white/60">
                     Обʼєм
                   </div>

--- a/src/modules/fizruk/pages/Atlas.tsx
+++ b/src/modules/fizruk/pages/Atlas.tsx
@@ -53,6 +53,8 @@ export function Atlas() {
           className="rounded-3xl p-5 border border-line/20 bg-hero-teal"
           aria-label="Атлас мʼязів"
         >
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+              Module hero kicker in branded `text-fizruk` above an h1. */}
           <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
             Атлас мʼязів
           </p>

--- a/src/modules/fizruk/pages/Dashboard.tsx
+++ b/src/modules/fizruk/pages/Dashboard.tsx
@@ -265,6 +265,8 @@ export function Dashboard({
           className="rounded-3xl p-6 overflow-hidden bg-hero-teal"
           aria-label="Привітання"
         >
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+              Branded fizruk hero kicker above h1 — dynamic greeting string. */}
           <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
             {greeting} · {today}
           </p>

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -308,6 +308,9 @@ export function AddMealSheet({
               </div>
             )}
 
+            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                "або" divider row between two bg-line spans — delimiter, not
+                a section heading. */}
             <div className="mt-5 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
               <span className="flex-1 h-px bg-line" />
               або

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Badge } from "@shared/components/ui/Badge";
 import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
@@ -616,12 +617,15 @@ function MealRow({ meal, onRemove, onEdit }) {
             <span className="text-xs text-subtle shrink-0">{meal.time}</span>
           )}
           {sourceLabel && (
-            <span
-              className="text-2xs px-1.5 py-0.5 rounded-full bg-line/60 text-subtle font-bold uppercase tracking-wider shrink-0"
+            <Badge
+              variant="neutral"
+              tone="soft"
+              size="xs"
+              className="shrink-0 rounded-full uppercase tracking-wider"
               title="Походження КБЖВ"
             >
               {sourceLabel}
-            </span>
+            </Badge>
           )}
         </div>
         <div className="flex gap-2 mt-0.5 flex-wrap">

--- a/src/modules/nutrition/components/NutritionHeader.jsx
+++ b/src/modules/nutrition/components/NutritionHeader.jsx
@@ -65,6 +65,9 @@ export function NutritionHeader({ busy: _busy, onBackToHub }) {
         )}
 
         <div className="min-w-0 flex-1">
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+              Module hero kicker with bespoke light/dark lime tints at
+              text-3xs; mirrors FizrukApp / RoutineApp header kickers. */}
           <span className="text-3xs text-lime-600/80 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
             ХАРЧУВАННЯ
           </span>

--- a/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
+++ b/src/modules/nutrition/components/meal-sheet/FoodPickerSection.jsx
@@ -90,6 +90,7 @@ export function FoodPickerSection({
                 {offHits.length > 0 && (
                   <>
                     {foodHits.length > 0 && (
+                      // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Group-separator <li> inside a <ul> combobox listbox; SectionHeading would change semantics.
                       <li className="px-3 py-1.5 text-2xs text-subtle bg-panelHi/50 font-semibold uppercase tracking-widest">
                         🌍 Open Food Facts
                       </li>

--- a/src/modules/routine/RoutineApp.tsx
+++ b/src/modules/routine/RoutineApp.tsx
@@ -544,6 +544,7 @@ export default function RoutineApp({
           <div className="min-w-0 flex-1">
             <span
               className={cn(
+                // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker composed via cn(..., C.eyebrow) with dynamic routine-branded class; SectionHeading can't express the conditional tint.
                 "text-3xs font-bold tracking-widest uppercase block leading-none mb-0.5",
                 C.eyebrow,
               )}

--- a/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -44,9 +44,9 @@ export function HabitLeadersBlock({
       </SectionHeading>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div className="rounded-xl border border-routine-line/40 dark:border-routine/20 bg-routine-surface/30 dark:bg-routine/8 p-3">
-          <p className="text-2xs uppercase tracking-wide text-subtle mb-1">
+          <SectionHeading as="p" size="xs" tone="subtle" className="mb-1">
             Найстабільніша
-          </p>
+          </SectionHeading>
           <p className="text-sm font-semibold text-text truncate">
             {best.habit.emoji} {best.habit.name}
           </p>
@@ -56,9 +56,9 @@ export function HabitLeadersBlock({
         </div>
         {worst && (
           <div className="rounded-xl border border-line bg-panel p-3">
-            <p className="text-2xs uppercase tracking-wide text-subtle mb-1">
+            <SectionHeading as="p" size="xs" tone="subtle" className="mb-1">
               Найслабша
-            </p>
+            </SectionHeading>
             <p className="text-sm font-semibold text-text truncate">
               {worst.habit.emoji} {worst.habit.name}
             </p>

--- a/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -134,6 +134,7 @@ export function RoutineCalendarPanel({
       >
         <p
           className={cn(
+            // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Calendar hero kicker composed with dynamic C.heroKicker routine tint; see RoutineApp header for the sibling pattern.
             "text-xs font-bold tracking-widest uppercase",
             C.heroKicker,
           )}
@@ -149,25 +150,25 @@ export function RoutineCalendarPanel({
           />
           <div className="flex-1 grid grid-cols-2 gap-2 w-full sm:grid-cols-2 lg:grid-cols-4">
             <div className={C.statCard}>
-              <p className="text-2xs uppercase tracking-wide text-subtle">
+              <SectionHeading as="p" size="xs" tone="subtle">
                 Подій у зрізі
-              </p>
+              </SectionHeading>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {filtered.length}
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-2xs uppercase tracking-wide text-subtle">
+              <SectionHeading as="p" size="xs" tone="subtle">
                 Звичок активних
-              </p>
+              </SectionHeading>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {routine.habits.filter((h) => !h.archived).length}
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-2xs uppercase tracking-wide text-subtle">
+              <SectionHeading as="p" size="xs" tone="subtle">
                 Виконання
-              </p>
+              </SectionHeading>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {Math.round(completionRate.rate * 100)}%
               </p>
@@ -176,9 +177,9 @@ export function RoutineCalendarPanel({
               </p>
             </div>
             <div className={C.statCard}>
-              <p className="text-2xs uppercase tracking-wide text-subtle">
+              <SectionHeading as="p" size="xs" tone="subtle">
                 Поточна серія
-              </p>
+              </SectionHeading>
               <p className="text-2xl font-black text-text tabular-nums mt-0.5">
                 {currentStreak}
               </p>

--- a/src/modules/routine/components/WeekDayStrip.tsx
+++ b/src/modules/routine/components/WeekDayStrip.tsx
@@ -57,6 +57,9 @@ export function WeekDayStrip({
                 isToday && !isSel && "ring-1 ring-routine/40",
               )}
             >
+              {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+                  Day-of-week caption at text-3xs inside a compact day-picker
+                  tile — smaller than SectionHeading xs's text-2xs. */}
               <span className="text-3xs uppercase tracking-wide text-subtle">
                 {short[i]}
               </span>


### PR DESCRIPTION
## Summary

Priority 3 з handoff — ESLint-правило проти `uppercase` + `tracking-*` + `text-*` drift'у в raw classNames, щоб централізувати eyebrow-типографіку в `<SectionHeading>` / `<Label>` / `<Badge>` примітивах.

**Що додано:**

- **Локальний плагін `eslint-plugin-sergeant-design`** (у `eslint-plugins/sergeant-design/`) з rule `no-eyebrow-drift`, що детектує три маркери одночасно в string / template literals.
- **Інтеграція в `eslint.config.js`**: rule увімкнено globally (`"error"`) + file-scoped override, що виключає три DS-примітиви з перевірки (вони самі володіють eyebrow-токенами): `SectionHeading.tsx`, `FormField.tsx`, `chartTheme.ts`.

**Міграції (48 виявлених violations):**

- **14 → `<SectionHeading>`** — обʼєктивно heading-like вживання з канонічним toned token:
  - `TodayFocusCard` (2× "Зараз"), `HubSearch` (2× "Недавні запити" / групи), `FirstActionSheet` ("Старт"), `HabitLeadersBlock` (2× "Найстабільніша" / "Найслабша"), `RoutineCalendarPanel` stat cards (4), `ManualExpenseSheet` чіп-лейбли (3× "Часте", "Швидко", "Нещодавнє").
- **1 → `<Badge variant="neutral" tone="soft" size="xs">`** — `LogCard` джерело-калорій pill (явна інструкція з handoff'у).
- **11 → file-level `/* eslint-disable */`** на `WeeklyDigestStories.tsx` — Instagram-style narrative overlay з `tracking-[0.3em]`, `text-[13px]` та іншими bespoke tokens, що не мапляться на `SectionHeading` xs/sm (handoff: *"більшість — в WeeklyDigestStories overlay (OK, лишити з disable-коментарем)"*).
- **22 → inline `eslint-disable-next-line`** з коротким `-- reason` описом:
  - Divider-рядки між `bg-line` лініями (`AuthPage`, `FinykApp`, `AddMealSheet`) — структурно делімітери, не заголовки.
  - Branded hero kickers з динамічною модульною тонаціюю через `cn(..., C.eyebrow)` / `text-fizruk` / `text-success/70` / `text-white/60` / `text-primary`, яку tone-токени SectionHeading не покривають (Atlas, Dashboard, FizrukApp, RoutineApp, RoutineCalendarPanel hero, NutritionHeader, WorkoutFinishSheets, WeeklyDigestCard).
  - `text-3xs` мікро-caption'и в компактних стат-тайлах і day-picker стрічках (SectionHeading xs = `text-2xs`).
  - `SupersetBadge` / `WorkoutTemplatesSection` pill-badges із `text-3xs` — відкладено повну міграцію на `<Badge>`.
  - `SettingsPrimitives` заголовок із `group-hover:text-text` interactive state.
  - `ManualExpenseSheet` "Категорія" label з `id={catLabelId}` для `aria-labelledby` (Label не підтримує id-only API).
  - `FoodPickerSection` group-separator `<li>` у `<ul>` combobox (зміна на SectionHeading ламала б семантику списку).

**Верифікація:**

```
$ npx eslint .
$ npm run typecheck
```

Обидві — exit 0 (без помилок / warnings з цього правила). Rule тепер готовий блокувати нові drift-точки в майбутніх PR'ах.

## Review & Testing Checklist for Human

- [ ] Переконатися що візуально `Найстабільніша` / `Найслабша` (HabitLeadersBlock) та 4 stat-карти в RoutineCalendarPanel не змінили габаритів — `SectionHeading` size=xs = `text-2xs font-bold uppercase tracking-widest`, original було `text-2xs … tracking-wide font-semibold` → трохи сильніший weight і wider tracking.
- [ ] `TodayFocusCard` "Зараз" (2 місця), `HubSearch` заголовки груп, `FirstActionSheet` "Старт", `ManualExpenseSheet` чіп-лейбли — так само: перевірити що нова типографіка читається нативно в контексті карти.
- [ ] `LogCard` meal-source pill — тепер `<Badge variant="neutral" tone="soft" size="xs">` (висота 20px, border-line, bg-surface-muted). Перевірити що не конфліктує з поруч `text-subtle meal.time`.
- [ ] Run `rg "uppercase" src/ | rg "tracking-" | rg "text-"` на предмет нових drift-точок, що могли прокрастись між migration і lint-run.

### Notes

- Plugin використовує `"type": "module"` у власному `package.json`, щоб матчити ESM `eslint.config.js`.
- Всі eslint-disable директиви мають `--` пояснення — щоб code-reviewer'и розуміли намір, а не просто "відключено бо набридло".
- Three canonical files залишаються exempt через файл-скоуп override, не через disable-comments, — так вони не захаращують власний файл.
- Перехід `LogCard` span → `<Badge>` — єдине місце, де візуально поміняли pill: `rounded-full` → `rounded-md` (через `sizes.xs` у Badge). Якщо pill-shape важливий візуально, додав `rounded-full` в className, щоб override'нути.

Link to Devin session: https://app.devin.ai/sessions/be64ee66b3e74e829999608ec00ffda6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
