### PR TITLE
a11y: add axe-core/Playwright WCAG check for hub surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist
 .env.local
 .vercel
 .vitest-localstorage.json*
+
+# Playwright (a11y tests)
+playwright-report/
+test-results/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,8 @@ export default [
       ".agents/**",
       "artifacts/**",
       "mcps/**",
+      "playwright-report/**",
+      "test-results/**",
     ],
   },
   js.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,9 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@eslint/js": "^9.15.0",
+        "@playwright/test": "^1.59.1",
         "@tanstack/react-query-devtools": "^5.99.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -120,6 +122,19 @@
       "version": "2.3.9",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2754,6 +2769,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
@@ -6254,6 +6285,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -9142,6 +9188,38 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "dev": true,
@@ -11607,6 +11685,21 @@
         "@vite-pwa/assets-generator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "test": "node scripts/vitest.mjs run",
     "test:watch": "node scripts/vitest.mjs",
+    "test:a11y": "playwright test",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.server.json --noEmit && tsc -p tsconfig.sw.json --noEmit",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build",
     "db:up": "docker compose up -d",
@@ -50,7 +51,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@eslint/js": "^9.15.0",
+    "@playwright/test": "^1.59.1",
     "@tanstack/react-query-devtools": "^5.99.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config used exclusively for the accessibility (axe-core)
+ * pass. We don't run end-to-end flows here — the goal is to snapshot the
+ * four major hub surfaces and fail the build on WCAG `serious` /
+ * `critical` violations. See `tests/a11y/axe.spec.ts`.
+ *
+ * The project is currently a Vite SPA; `npm run preview` serves the
+ * built assets on :4173. We let Playwright start/stop the server so
+ * CI doesn't have to manage a background process by itself.
+ */
+export default defineConfig({
+  testDir: "./tests/a11y",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: process.env.PW_BASE_URL || "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: process.env.PW_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command:
+          "npm run build && npm run preview -- --port 4173 --host 127.0.0.1",
+        url: "http://127.0.0.1:4173",
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+});

--- a/tests/a11y/axe.spec.ts
+++ b/tests/a11y/axe.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Pre-seed localStorage so the SPA skips the onboarding redirect
+ * (`/welcome`) and lands directly on the targeted hub surface. The
+ * keys mirror the ones used in `src/core/OnboardingWizard.tsx` and
+ * `src/core/onboarding/vibePicks.js`.
+ */
+const SEEDED_LS: Record<string, string> = {
+  hub_onboarding_done_v1: "1",
+  hub_first_action_done_v1: "1",
+  // Minimal vibe-picks payload so `isFirstRealEntryDone()` returns true
+  // without requiring real fixture entries in the four module stores.
+  hub_vibe_picks_v1: JSON.stringify({
+    picks: ["finyk", "fizruk", "nutrition", "routine"],
+    firstActionPending: null,
+    firstActionStartedAt: null,
+    firstRealEntryAt: Date.now(),
+    updatedAt: Date.now(),
+  }),
+};
+
+async function seedLocalStorage(page: Page) {
+  await page.addInitScript((entries: Record<string, string>) => {
+    try {
+      for (const [k, v] of Object.entries(entries)) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, SEEDED_LS);
+}
+
+/**
+ * Four surfaces we care about per the design-system handoff:
+ * Hub / Finyk overview / Fizruk progress / Nutrition dashboard.
+ * Routine is included as well since it shares the same hub shell and
+ * accessibility is no less relevant there.
+ */
+const SURFACES: Array<{ name: string; path: string }> = [
+  { name: "hub-root", path: "/" },
+  { name: "finyk-overview", path: "/?module=finyk" },
+  { name: "fizruk-dashboard", path: "/?module=fizruk" },
+  { name: "nutrition-dashboard", path: "/?module=nutrition" },
+  { name: "routine-dashboard", path: "/?module=routine" },
+];
+
+for (const { name, path } of SURFACES) {
+  test(`a11y: ${name} has no serious/critical violations`, async ({ page }) => {
+    await seedLocalStorage(page);
+
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    // Modules are lazy-loaded via React.lazy — wait for either the
+    // hub tabs or the module shell to settle before axe takes its
+    // snapshot.
+    await page
+      .waitForLoadState("networkidle", { timeout: 15_000 })
+      .catch(() => {
+        /* allow-through: some surfaces keep long-polling connections open */
+      });
+    // Give the Suspense fallback (PageLoader) time to resolve into the
+    // real UI. Playwright's default 30s test timeout protects us from
+    // hangs; here we just ask for the first interactive element.
+    await page
+      .locator("main, [role='main'], [data-a11y-root], #root > *")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const results = await new AxeBuilder({ page })
+      // Standard WCAG 2.1 AA rule set + best-practices. We scope to the
+      // document root; route-level portals (toasts, chat overlay) are
+      // included naturally because they render under `#root`.
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"])
+      .analyze();
+
+    const blocking = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+
+    if (blocking.length > 0) {
+      const summary = blocking
+        .map(
+          (v) =>
+            `- [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node${
+              v.nodes.length === 1 ? "" : "s"
+            })\n    ${v.helpUrl}`,
+        )
+        .join("\n");
+      throw new Error(
+        `axe found ${blocking.length} serious/critical violation(s) on ${path}:\n${summary}`,
+      );
+    }
+
+    // Soft-signal: surface non-blocking violations in the report so PR
+    // reviewers have visibility into the full axe output.
+    const softCount = results.violations.length - blocking.length;
+    if (softCount > 0) {
+      test.info().annotations.push({
+        type: "axe-soft",
+        description: `${softCount} non-blocking violation(s) on ${path} (minor/moderate).`,
+      });
+    }
+
+    // Sanity: SPA bootstrap should not print console errors on these
+    // top-level surfaces in a fresh profile.
+    expect(
+      consoleErrors.filter(
+        (e) =>
+          // vite-plugin-pwa registerSW noise in preview mode.
+          !e.includes("workbox") && !e.includes("Service worker"),
+      ),
+      `console errors on ${path}:\n${consoleErrors.join("\n")}`,
+    ).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary

Priority 4 з handoff — axe-based WCAG-чек у CI. Кожен push / PR прогонить `@axe-core/playwright` по п'яти основних hub-поверхнях і фейлить збірку, якщо знайдені `serious` або `critical` violations.

**Що додано:**

- **Deps:** `@playwright/test` + `@axe-core/playwright` (обидва у `devDependencies`).
- **`playwright.config.ts`** — Chromium-only конфіг; `webServer` section сам запускає `npm run build && npm run preview -- --port 4173`, тож CI не мусить тримати окремий крок для preview-сервера.
- **`tests/a11y/axe.spec.ts`** — пять тестів (`hub-root`, `finyk-overview`, `fizruk-dashboard`, `nutrition-dashboard`, `routine-dashboard`). Перед `goto()` через `page.addInitScript` у localStorage сідаються ключі `hub_onboarding_done_v1`, `hub_vibe_picks_v1`, `hub_first_action_done_v1`, щоб SPA не редиректила на `/welcome`. Після завантаження `<AxeBuilder>` з тегами `wcag2a/aa, wcag21a/aa, best-practice` аналізує весь документ. Тест фейлиться **лише** на `impact: serious | critical` — мінорні / модератні violations потрапляють у `test.info().annotations` для видимості без блокування PR'а.
- **`npm run test:a11y`** — однорядковий alias на `playwright test`.
- **`.gitignore` / `eslint.config.js`** — ігноримо `playwright-report/` і `test-results/`.

**Що НЕ в цьому PR'і і що треба додати вручну:**

`.github/workflows/ci.yml` зміни **не запушені** — GitHub відхилив push з повідомленням:

> `refusing to allow an OAuth App to create or update workflow '.github/workflows/ci.yml' without 'workflow' scope`

Нижче — точний diff, який треба застосувати в gitHub web-editor (він має потрібні permissions). Додає новий job `a11y` який залежить від існуючого `check`, ставить Chromium і прогонить `npm run test:a11y`:

```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,41 @@ jobs:

       - name: Format, lint, test, build
         run: npm run check
+
+  a11y:
+    name: Accessibility (axe-core)
+    runs-on: ubuntu-latest
+    # Keep this in a separate job so the main `check` pipeline stays
+    # under 3 minutes; browsers + preview-server + axe typically adds
+    # ~90s to a cold run and we don't want that on every push.
+    needs: check
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        # --with-deps pulls in the apt packages playwright needs on
+        # ubuntu-latest. We only run Chromium, not the full browser matrix.
+        run: npx playwright install --with-deps chromium
+
+      - name: Run axe accessibility checks
+        run: npm run test:a11y
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report
+        if: always()
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: playwright-a11y-report
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
```

Як застосувати:
1. Відкрити https://github.com/Skords-01/Sergeant/edit/devin/1776628815-axe-wcag-ci/.github/workflows/ci.yml
2. Вставити блок нижче existing `check` job (як у diff вище).
3. Commit `ci: add a11y axe job` у цю ж гілку.

Після цього CI автоматично прогонить новий job і покаже результати.

## Review & Testing Checklist for Human

- [ ] Застосувати diff до `ci.yml` (див. секцію вище) і перевірити що `a11y` job з'являється у PR checks.
- [ ] Якщо axe знайде реальні серйозні violations — прочитати HTML-report з `playwright-a11y-report` artifact. Це найімовірніше місце де ми впираємось: color contrast на brand accent tones, missing aria-labels на icon-only buttons, `<dialog>` без `aria-labelledby`. У такому випадку — ліпше фіксити UI, а не понижати threshold.
- [ ] Локально можна прогнати: `npm run build && npm run test:a11y`. Вимагає `npx playwright install chromium` одноразово.
- [ ] Перевірити що localStorage-seeding у spec'і (`hub_vibe_picks_v1`, `hub_onboarding_done_v1`) дійсно пропускає onboarding splash — якщо ключі/формат змінились у `src/core/OnboardingWizard.tsx` / `vibePicks.js`, треба оновити spec.

### Notes

- Тест зараз запускається тільки у Chromium. Якщо знадобиться WebKit / Firefox — додати у `projects` в `playwright.config.ts`, але на CI це ~3× дорожче.
- Console-error assertion фільтрує workbox / service-worker шум з `vite-plugin-pwa`. Якщо інший SPA bootstrap почне логувати errors, test впаде з повним console dump — це фіча, не баг.
- Non-blocking violations (`minor`/`moderate`) не фейлять CI, але видно в Playwright report'і як `axe-soft` annotations — це дає куди цілитися без постійного redlight CI.
- Порядок запуску: `a11y` job явно `needs: check`, тобто не палить GitHub runner minutes, якщо lint/typecheck/tests вже впали.

Link to Devin session: https://app.devin.ai/sessions/be64ee66b3e74e829999608ec00ffda6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
