### PR TITLE
feat(server): obs polish — http_errors_total per route, requestId test, .env.example audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,3 +111,53 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # ── Пароль (опціонально, override за потреби) ─────────────────
 # MIN_PASSWORD_LENGTH=10
 # MAX_PASSWORD_LENGTH=128
+
+# ── Observability / Logging ───────────────────────────────────
+# Рівень pino-логів. Дефолт: debug у dev, info у production.
+# LOG_LEVEL=info
+# LOG_PRETTY=1 → human-readable вивід у dev (pino-pretty). Не вмикати у prod.
+# LOG_PRETTY=0
+
+# Bearer-токен для захисту /metrics (Prometheus scrape endpoint).
+# Якщо не заданий — /metrics вимкнений. Для Grafana Agent / Railway scraper:
+#   `Authorization: Bearer <METRICS_TOKEN>`
+# METRICS_TOKEN=change_me_to_a_long_random_string
+
+# ── Postgres pool tuning ──────────────────────────────────────
+# Максимум клієнтів у пулі pg. Railway Hobby: 10 — комфортно.
+# PG_POOL_MAX=10
+# Поріг для `db_slow` попереджень у логах (мс). Усе, що вище — iнкрементує
+# `db_slow_queries_total` і летить у warn-лог.
+# DB_SLOW_MS=200
+
+# ── Graceful shutdown ─────────────────────────────────────────
+# Скільки чекати in-flight запитів після SIGTERM, перш ніж force-close.
+# SHUTDOWN_GRACE_MS=15000
+# Hard-cut після якого process.exit(1) — захист від зависання.
+# SHUTDOWN_HARD_TIMEOUT_MS=25000
+
+# ── SSE heartbeat ─────────────────────────────────────────────
+# Інтервал comment-frame у /api/chat SSE-стрімі (мс), щоб проксі/браузер
+# не ріжчив з'єднання за idle timeout.
+# SSE_HEARTBEAT_MS=15000
+
+# ── Regex-allow-list для CORS (опціонально) ───────────────────
+# Одинокий regex (без прапорців), що повинен матчити допустимі origin-и.
+# Використовується на доповнення до `ALLOWED_ORIGINS` (не замість).
+# ALLOWED_ORIGIN_REGEX=^https://pr-\d+\.preview\.example\.com$
+
+# ── Server mode (опціонально) ─────────────────────────────────
+# `replit` | `api` | `full`. Авто-детектиться по REPLIT_DEV_DOMAIN, якщо не задано.
+# SERVER_MODE=api
+
+# ── USDA FDC альтернативний ключ (нутриційний пошук) ──────────
+# Деякі внутрішні скрипти використовують `USDA_API_KEY` замість `USDA_FDC_API_KEY`.
+# Значення можна задати однакове — не плутати з FDC_API_KEY, який є помилковим
+# історичним ім'ям.
+# USDA_API_KEY=
+
+# ── Monobank / PrivatBank ─────────────────────────────────────
+# УВАГА: токени банків НЕ читаються з env — вони надходять від клієнта через
+# заголовок `X-Token` і форвардяться до upstream. Сервер їх зберігає лише у
+# memory кешу TTL=60с (хешовано). Якщо потрібно підкрутити resilience,
+# робиться це редагуванням `server/lib/bankProxy.js` (немає env-конфігу).

--- a/server/http/requestId.test.js
+++ b/server/http/requestId.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { requestIdMiddleware } from "./requestId.js";
+
+function mockReq({ headers = {} } = {}) {
+  return {
+    get(name) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function mockRes() {
+  const headers = {};
+  return {
+    setHeader(name, value) {
+      headers[name] = value;
+    },
+    getHeader(name) {
+      return headers[name];
+    },
+  };
+}
+
+describe("requestIdMiddleware", () => {
+  it("генерує UUID і кладе у req.requestId + response header", () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = vi.fn();
+    requestIdMiddleware(req, res, next);
+    expect(typeof req.requestId).toBe("string");
+    expect(req.requestId.length).toBeGreaterThanOrEqual(36);
+    expect(res.getHeader("X-Request-Id")).toBe(req.requestId);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("поважає валідний X-Request-Id з запиту", () => {
+    const id = "req-abc-123";
+    const req = mockReq({ headers: { "x-request-id": id } });
+    const res = mockRes();
+    requestIdMiddleware(req, res, vi.fn());
+    expect(req.requestId).toBe(id);
+    expect(res.getHeader("X-Request-Id")).toBe(id);
+  });
+
+  it("ігнорує надто довгий X-Request-Id (>128 символів)", () => {
+    const huge = "a".repeat(129);
+    const req = mockReq({ headers: { "x-request-id": huge } });
+    const res = mockRes();
+    requestIdMiddleware(req, res, vi.fn());
+    expect(req.requestId).not.toBe(huge);
+    expect(req.requestId.length).toBeLessThanOrEqual(128);
+  });
+
+  it("тримує response header навіть коли клієнт не передав ID", () => {
+    const req = mockReq();
+    const res = mockRes();
+    requestIdMiddleware(req, res, vi.fn());
+    // Інваріант: будь-яка відповідь від /api/* мусить мати X-Request-Id
+    // для кореляції з Sentry/логами в service-desk тікеті.
+    expect(res.getHeader("X-Request-Id")).toBeDefined();
+    expect(res.getHeader("X-Request-Id")).toBe(req.requestId);
+  });
+});

--- a/server/http/requestLog.js
+++ b/server/http/requestLog.js
@@ -1,6 +1,7 @@
 import { logger } from "../obs/logger.js";
 import { als } from "../obs/requestContext.js";
 import {
+  httpErrorsTotal,
   httpInFlight,
   httpRequestDurationMs,
   httpRequestsTotal,
@@ -54,6 +55,7 @@ export function requestLogMiddleware(req, res, next) {
     });
 
     try {
+      const sc = statusClass(status);
       httpRequestsTotal.inc({
         method: req.method,
         path,
@@ -61,9 +63,20 @@ export function requestLogMiddleware(req, res, next) {
         module: mod,
       });
       httpRequestDurationMs.observe(
-        { method: req.method, path, status_class: statusClass(status) },
+        { method: req.method, path, status_class: sc },
         ms,
       );
+      // Дедикований лічильник помилок: інкрементуємо ТІЛЬКИ для 4xx/5xx,
+      // щоб PromQL для error-rate був `rate(http_errors_total[5m]) / rate(...count)`
+      // без регекс-фільтра по `status`.
+      if (status >= 400) {
+        httpErrorsTotal.inc({
+          method: req.method,
+          path,
+          status_class: sc,
+          module: mod,
+        });
+      }
     } catch {
       /* metrics must never break a request */
     }

--- a/server/obs/metrics.js
+++ b/server/obs/metrics.js
@@ -24,6 +24,19 @@ export const httpRequestDurationMs = new client.Histogram({
   registers: [register],
 });
 
+// Дедикований лічильник 4xx/5xx по route: інкрементуємо тільки коли
+// `status >= 400`, тож error-rate формулою стає
+//   sum by (path) (rate(http_errors_total[5m]))
+//   / sum by (path) (rate(http_request_duration_ms_count[5m]))
+// без фільтра регексом по `status`. `module` лейбл із ALS потрібен, щоб
+// алерти могли бути per-domain.
+export const httpErrorsTotal = new client.Counter({
+  name: "http_errors_total",
+  help: "HTTP responses with status >= 400 by route",
+  labelNames: ["method", "path", "status_class", "module"],
+  registers: [register],
+});
+
 export const httpInFlight = new client.Gauge({
   name: "http_in_flight",
   help: "In-flight HTTP requests",


### PR DESCRIPTION
## Summary

PR E серії backend-hardening. Полірування observability + audit `.env.example`.

### Що робимо

1. **Новий дедикований counter `http_errors_total{method, path, status_class, module}`** у `server/obs/metrics.js`.
   - Раніше error-rate доводилось тягнути з `http_requests_total` фільтром по regex `status=~"4..|5.."`, що незручно в алертах і має вищу cardinality (10+ статусів vs 2 класи).
   - Новий counter інкрементується **тільки** для `status >= 400` у `requestLogMiddleware`, тому PromQL стає:
     ```promql
     sum by (path) (rate(http_errors_total[5m]))
       / sum by (path) (rate(http_request_duration_ms_count[5m]))
     ```
   - Cardinality контрольована: `path` уже route-pattern (`/api/foo/:id`), `status_class` ∈ {2xx,3xx,4xx,5xx,other}, `module` з ALS (≤10 значень).

2. **Тест `server/http/requestId.test.js`** — лок-ін інваріант, що `X-Request-Id` завжди є у `res` (чи то згенерований, чи то прокинутий з клієнта), включно з обмеженням ≤128 символів. Раніше middleware не мав unit-тестів.

3. **Audit `.env.example`** — додані секції, що реально зчитуються з коду, але не були задокументовані:
   - `LOG_LEVEL`, `LOG_PRETTY`
   - `METRICS_TOKEN` (bearer для `/metrics`)
   - `PG_POOL_MAX`, `DB_SLOW_MS`
   - `SHUTDOWN_GRACE_MS`, `SHUTDOWN_HARD_TIMEOUT_MS`
   - `SSE_HEARTBEAT_MS`
   - `ALLOWED_ORIGIN_REGEX`
   - `SERVER_MODE`
   - `USDA_API_KEY` (альтернативне ім'я до `USDA_FDC_API_KEY`)
   - Окрема нотатка про Monobank/PrivatBank — токени **НЕ** приходять з env, лише з клієнта через `X-Token`. Це часте джерело плутанини при onboarding.

### Що вже добре і НЕ чіпаємо

- **`X-Request-Id` response header** — уже встановлюється у `requestIdMiddleware` і потрапляє у `res.body.requestId` в `errorHandler`. Гапу немає, додав лише тести.
- **Per-route latency histogram** — `http_request_duration_ms{method, path, status_class}` уже є.
- **Pino ALS context (requestId/userId/module)** — працює через `mixin()` у `server/obs/logger.js`; `setUserId()` кличеться у `getSessionUser`, `setModule()` middleware на всіх доменних роутерах. Всі логи автоматично мають ці поля.

## Review & Testing Checklist for Human

- [ ] Після деплою перевірити `/metrics` — `http_errors_total` повинен з'явитись у scrape (нульовий, доки хтось не отримає 4xx).
- [ ] Залити тестовий 404 → `curl /api/does-not-exist` → переконатися, що counter проінкрементувався (`http_errors_total{status_class="4xx"}`).
- [ ] Перевірити `X-Request-Id` у відповіді: `curl -v https://prod/api/health 2>&1 | grep -i request-id`.
- [ ] Опційно: замінити існуючі алерти на `rate(http_requests_total{status=~"5.."})` новими на `rate(http_errors_total{status_class="5xx"})` — читабельніше і дешевше по cardinality.

### Notes
- Нова метрика НЕ замінює `http_requests_total` (для dashboard-safety лишаємо обидві). Якщо дашборди мігрують — можна буде видалити `status`-label з `http_requests_total` окремим PR через 2-3 тижні.
- 862 тестів проходить (було 858). Lint/typecheck чисті.
- Файли: `server/obs/metrics.js` (+9), `server/http/requestLog.js` (+12), `server/http/requestId.test.js` (новий), `.env.example` (+52).


Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
