### PR TITLE
test(server): mirror .trim() in coach.test extractAnthropicText mock

### DIFF
--- a/server/modules/coach.test.js
+++ b/server/modules/coach.test.js
@@ -7,11 +7,15 @@ vi.mock("../db.js", () => {
 
 vi.mock("../lib/anthropic.js", () => ({
   anthropicMessages: vi.fn(),
+  // Дзеркалимо реальну реалізацію з `server/lib/anthropic.js`, включно з
+  // `.trim()` — без нього LLM-відповіді з trailing newline-ами проходили б у
+  // моку, але не у проді, а assert-и на точний `toBe()` давали б false-pass.
   extractAnthropicText: vi.fn((d) =>
     (d?.content || [])
       .filter((b) => b.type === "text")
       .map((b) => b.text)
-      .join("\n"),
+      .join("\n")
+      .trim(),
   ),
 }));
 


### PR DESCRIPTION
## Summary

Follow-up до PR #308 (test expansion for coach/sync). Devin Review показав, що
мок `extractAnthropicText` у `server/modules/coach.test.js` не включав `.trim()`,
який є в реальній імплементації (`server/lib/anthropic.js:199-205`).

Без цього мок-поведінка і прод-поведінка відрізняються на trailing newlines —
assert-и виду `toBe(exactString)` або `insight === "..."` могли б давати
false-pass у тестах, але ламатися в проді, якщо LLM поверне відповідь з
зайвими `\n` чи пробілами.

Зміна: додав `.trim()` у кінець ланцюжка + коментар, щоб майбутні правки
пам'ятали дзеркалити реальну реалізацію.

## Review & Testing Checklist for Human

- [ ] Побачити `npm test server/modules/coach.test.js` — 10 passed, поведінка
      ідентична.

### Notes

- 1 рядок коду + 3 рядки коментаря. Ризик нульовий.
- Покриття не змінюється (мок ж лиш уточнився).


Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
