### PR TITLE
fix(docker): install tsx at runtime so production Node can load .ts lib files

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -11,4 +11,6 @@ COPY server ./server
 COPY scripts ./scripts
 
 ENV NODE_ENV=production
-CMD ["node", "server/index.js"]
+# tsx loader потрібен тому, що server/lib/* тепер .ts (див. PR #311);
+# імпорти з .js-модулів виду `from "./foo.js"` tsx резолвить на .ts.
+CMD ["node", "--import", "tsx", "server/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-router-dom": "^7.14.1",
         "react-virtuoso": "^4.18.5",
         "tailwind-merge": "^2.6.0",
+        "tsx": "^4.21.0",
         "web-push": "^3.6.7",
         "web-vitals": "^5.2.0",
         "zod": "^4.3.6"
@@ -64,7 +65,6 @@
         "prettier": "^3.8.2",
         "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.17",
-        "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^6.4.2",
@@ -1802,7 +1802,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,7 +1818,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1836,7 +1834,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,7 +1850,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,7 +1866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,7 +1882,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,7 +1898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,7 +1914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1938,7 +1930,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1962,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,7 +1978,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,7 +1994,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,7 +2010,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2040,7 +2026,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,7 +2042,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,7 +2073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,7 +2089,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2105,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2121,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,7 +2137,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,7 +2153,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,7 +2169,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,7 +2185,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,7 +2201,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7289,7 +7264,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -10819,7 +10793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -12050,7 +12023,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -12073,7 +12045,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12087,7 +12058,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12129,7 +12099,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-router-dom": "^7.14.1",
     "react-virtuoso": "^4.18.5",
     "tailwind-merge": "^2.6.0",
+    "tsx": "^4.21.0",
     "web-push": "^3.6.7",
     "web-vitals": "^5.2.0",
     "zod": "^4.3.6"
@@ -80,7 +81,6 @@
     "prettier": "^3.8.2",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.17",
-    "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^6.4.2",


### PR DESCRIPTION
## Summary

Hotfix для regression, який знайшов Devin Review на merged PR [#311](https://github.com/Skords-01/Sergeant/pull/311): Railway/Docker-деплой зламається з `ERR_MODULE_NOT_FOUND`, бо `server/lib/*.ts` файли не резолвляться без `tsx` loader.

**Що не так після #311**:
1. `tsx` у `devDependencies` → `RUN npm ci --omit=dev` у `Dockerfile.api` його НЕ встановить
2. `CMD ["node", "server/index.js"]` у `Dockerfile.api` НЕ передає `--import tsx`

Будь-який імпорт виду `from "./anthropic.js"` (а таких ~10+ у server/modules/*) спробує завантажити неіснуючий `.js` → краш на старті.

**Зміни**:
- `package.json`: перенесено `tsx` з `devDependencies` у `dependencies` (runtime-залежність, бо `node --import tsx` потрібен для резолвінгу `.ts` з `.js`-імпортів)
- `Dockerfile.api`: `CMD` змінено на `["node", "--import", "tsx", "server/index.js"]`
- `package-lock.json` перегенеровано відповідно (`npm install --package-lock-only`)

**Дзеркалить** те, що вже було у `start`-скриптах у #311: `"start": "node --import tsx server/index.js"`. Тепер Docker робить те саме.

## Review & Testing Checklist for Human

- [ ] Локальний smoke: `docker build -f Dockerfile.api -t hub-api-test .` має завершитись без `tsx` warnings
- [ ] Смоук-запуск контейнера з мінімальним env: `docker run --rm -e DATABASE_URL=postgres://dummy -e BETTER_AUTH_SECRET=x hub-api-test` має показати `server_listening` лог (далі БД-ping впаде, це очікувано)
- [ ] На Railway після деплою: первший запит до `/livez` повертає `ok` — підтверджує, що `tsx` loader підчепив `.ts` lib-файли

### Notes

- Перевірив локально: `rm -rf node_modules && npm ci --omit=dev --ignore-scripts` → `node_modules/.bin/tsx` існує; базові імпорти `./lib/anthropic.js` → `.ts` резолвляться через `--import tsx`.
- `typescript` НЕ переносив у deps: `tsx` має власний esbuild, TS-компілятор у runtime не потрібен.
- Lint / typecheck (всі 3 конфіги) / test (880) — зелені локально.
- Альтернатива ("build-step через `tsc`") не вибрана свідомо: зберігаємо single-source-of-truth (`server/**/*.ts` виконуються безпосередньо, без `dist-server/`), і не додаємо build-stage у Docker. `tsx` у runtime-deps додає ~5 MB до образу, але це дешевше за build-stage complexity.
- Це hotfix до ще-не-задеплоєного PR-а (Vercel preview з #311 пройшов, а Railway деплой робиться після merge; якщо Railway ще не перезапускався після merge — цей PR мерджимо до нього і це unblock-ує production).


Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
