### PR TITLE
fix(deploy): use tsx loader at runtime in Dockerfile.api (Railway crash fix)

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -11,4 +11,7 @@ COPY server ./server
 COPY scripts ./scripts
 
 ENV NODE_ENV=production
-CMD ["node", "server/index.js"]
+# `server/lib/*` is TypeScript (see PR #311). We need the tsx loader at
+# runtime to resolve `.ts` files imported via `.js` specifiers. `tsx` is
+# now a regular dependency so it survives `npm ci --omit=dev`.
+CMD ["node", "--import", "tsx", "server/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-router-dom": "^7.14.1",
         "react-virtuoso": "^4.18.5",
         "tailwind-merge": "^2.6.0",
+        "tsx": "^4.21.0",
         "web-push": "^3.6.7",
         "web-vitals": "^5.2.0",
         "zod": "^4.3.6"
@@ -64,7 +65,6 @@
         "prettier": "^3.8.2",
         "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.17",
-        "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^6.4.2",
@@ -1802,7 +1802,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,7 +1818,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1836,7 +1834,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,7 +1850,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,7 +1866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,7 +1882,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,7 +1898,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,7 +1914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1938,7 +1930,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1962,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,7 +1978,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,7 +1994,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,7 +2010,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2040,7 +2026,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,7 +2042,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,7 +2073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,7 +2089,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2105,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2121,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,7 +2137,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,7 +2153,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,7 +2169,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,7 +2185,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,7 +2201,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7289,7 +7264,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -10819,7 +10793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -12050,7 +12023,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -12073,7 +12045,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12087,7 +12058,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12129,7 +12099,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-router-dom": "^7.14.1",
     "react-virtuoso": "^4.18.5",
     "tailwind-merge": "^2.6.0",
+    "tsx": "^4.21.0",
     "web-push": "^3.6.7",
     "web-vitals": "^5.2.0",
     "zod": "^4.3.6"
@@ -80,7 +81,6 @@
     "prettier": "^3.8.2",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.17",
-    "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^6.4.2",


### PR DESCRIPTION
## Summary

Виправляє Railway crash з `ERR_MODULE_NOT_FOUND`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/server/lib/bankProxy.js'
imported from /app/server/modules/mono.js
```

**Root cause** — комбінація двох речей:

1. [PR #311](https://github.com/Skords-01/Sergeant/pull/311) перевів `server/lib/*.js` у TypeScript (`bankProxy.ts`, `anthropic.ts`, `externalHttp.ts`, `nutritionResponse.ts`) і додав `tsx` runtime-loader у npm `start` скрипт: `node --import tsx server/index.js`. Імпорти в модулях продовжують писати `.js` suffix (правильно для ESM + tsx).
2. `Dockerfile.api` не оновлювався під це — він і далі виконує:
   - `npm ci --omit=dev` → `tsx` був у `devDependencies`, тому в production-образі його нема
   - `CMD ["node", "server/index.js"]` → без `--import tsx`, тому Node намагається знайти `.js` файли яких фізично нема

При старті контейнера перший імпорт з `.ts`-файлу крашить процес.

**Fix (3 міні-зміни):**

- `package.json` — перемістив `tsx@^4.21.0` з `devDependencies` у `dependencies`. Це тепер runtime-залежність сервера, не tooling.
- `Dockerfile.api` — змінив `CMD ["node", "server/index.js"]` → `CMD ["node", "--import", "tsx", "server/index.js"]` (дзеркалить `npm start`).
- `package-lock.json` — перегенеровано відповідно.

**Локальна перевірка** (симуляція того що робить Railway):

```bash
# Clean room з package.json/lock
cd /tmp/railway-sim
npm ci --omit=dev --ignore-scripts
# tsx binary присутній:
ls node_modules/.bin/tsx  # OK
# Loader працює:
node --import tsx -e "import('./node_modules/tsx/package.json', \
  { with: { type: 'json' } }).then(m => console.log('tsx version:', m.default.version))"
# → "tsx version: 4.21.0"
```

Також пройшли:
- `npm run lint` → exit 0
- `npm run typecheck` → exit 0
- `npm test` → 880/880 passed

## Review & Testing Checklist for Human

- [ ] Після мержа перевірити Railway deploy — має стартувати без `ERR_MODULE_NOT_FOUND`. Якщо досі крашить — завантажте повний deploy log (перші 100 рядків), швидко за ним видно чи це інший missing module.
- [ ] Перевірити що hit на `/api/banks/mono/*` і `/api/banks/privat/*` endpoints повертає 200 (обидва через `bankProxyFetch` з `server/lib/bankProxy.ts`).
- [ ] Healthcheck endpoint (зазвичай `/healthz` або `/api/health`) відповідає після деплою.

### Notes

`tsx` додає ~3 MB до production image — тривіально на фоні node_modules. Альтернатива (прекомпілювати `.ts` → `.js` як build-step у Docker) складніша і непотрібна для поточних розмірів server/lib.

Попередні PR в архіві — `server/modules/*.js` і `server/modules/**.test.js` не зачіпаю; вони завжди були `.js` і імпорт `'../lib/bankProxy.js'` з tsx loader'ом резолвиться в `bankProxy.ts` автоматично.

Link to Devin session: https://app.devin.ai/sessions/be64ee66b3e74e829999608ec00ffda6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
