### PR TITLE
fix(theme): improve dark-mode contrast for text, borders and surfaces

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,7 @@
        AA for small tertiary copy (eyebrow headings, captions, meta). */
     --c-text: 250 247 241; /* #faf7f1 — warm white */
     --c-muted: 180 174 169; /* #b4aea9 — medium warm gray (brightened) */
-    --c-subtle: 135 128 121; /* #87807a — readable tertiary (was #57534e) */
+    --c-subtle: 135 128 121; /* #878079 — readable tertiary (was #57534e) */
     --c-primary: 250 247 241; /* reversed */
 
     --shadow-card:

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,8 @@
 
   /* ═══════════════════════════════════════════════════════════════════════
      DARK THEME — Rich, Cozy, Premium
+     Contrast tuned to WCAG AA: tertiary text (subtle) ≥ 4.5:1, prominent
+     dividers (border-strong) ≥ 3:1 against the page background.
      ═══════════════════════════════════════════════════════════════════════ */
   .dark {
     color-scheme: dark;
@@ -90,17 +92,20 @@
     /* Page background — deep warm charcoal */
     --c-bg: 23 20 18; /* #171412 — warm dark */
 
-    /* Cards/panels — elevated warm surface */
+    /* Cards/panels — elevated warm surface. `panel-hi` is bumped so hover
+       and input backgrounds are distinguishable from the base panel. */
     --c-panel: 32 28 25; /* #201c19 — warm elevated */
-    --c-panel-hi: 41 36 32; /* #292420 — warm input/hover */
+    --c-panel-hi: 48 42 37; /* #302a25 — warm input/hover (was #292420) */
 
-    /* Borders — warm muted */
-    --c-line: 58 52 46; /* #3a342e — warm border */
+    /* Borders — warm muted. Raised from #3a342e (≈1.5:1) so card edges,
+       dividers, and input outlines are actually visible. */
+    --c-line: 82 74 65; /* #524a41 — warm border (was #3a342e) */
 
-    /* Text hierarchy */
+    /* Text hierarchy — `subtle` raised from #57534e (≈2.4:1) to meet WCAG
+       AA for small tertiary copy (eyebrow headings, captions, meta). */
     --c-text: 250 247 241; /* #faf7f1 — warm white */
-    --c-muted: 168 162 158; /* #a8a29e — medium warm gray */
-    --c-subtle: 87 83 78; /* #57534e — dimmed labels */
+    --c-muted: 180 174 169; /* #b4aea9 — medium warm gray (brightened) */
+    --c-subtle: 135 128 121; /* #87807a — readable tertiary (was #57534e) */
     --c-primary: 250 247 241; /* reversed */
 
     --shadow-card:
@@ -113,12 +118,14 @@
 
     --shadow-soft: 0 8px 32px rgba(0, 0, 0, 0.5);
 
-    /* Dark-theme overrides for the new semantic tokens added above. */
-    --c-border-strong: 74 66 58; /* warm elevated divider for dark theme */
-    --c-success-soft: 6 78 59; /* emerald-900-ish */
-    --c-warning-soft: 120 53 15; /* amber-900-ish */
-    --c-danger-soft: 127 29 29; /* red-900-ish */
-    --c-info-soft: 12 74 110; /* sky-900-ish */
+    /* Dark-theme overrides for the new semantic tokens added above.
+       `border-strong` now clears the 3:1 UI-contrast threshold so
+       separators between sections read clearly on the dark bg. */
+    --c-border-strong: 112 102 90; /* #70665a — prominent divider (was #4a423a) */
+    --c-success-soft: 6 95 70; /* slightly brighter emerald-900 */
+    --c-warning-soft: 146 64 14; /* slightly brighter amber-900 */
+    --c-danger-soft: 153 27 27; /* red-800 — brighter than red-900 */
+    --c-info-soft: 7 89 133; /* sky-800 — brighter than sky-900 */
   }
 
   /* ═══════════════════════════════════════════════════════════════════════
@@ -637,7 +644,7 @@ textarea {
 }
 
 .dark .glass-subtle {
-  @apply bg-white/5 border-white/10;
+  @apply bg-white/[0.08] border-white/20;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Tightens the dark-theme design tokens in `src/index.css` so tertiary copy, borders and hover surfaces read clearly against the warm charcoal background. No component markup was changed — only the CSS custom properties on `.dark`, so every screen that consumes the semantic tokens (`text-subtle`, `text-muted`, `border-line`, `border-border-strong`, `bg-panel-hi`, soft status tints, `glass-subtle`) benefits automatically.

Concrete changes to the `.dark` scope:

| Token | Before | After | Why |
| --- | --- | --- | --- |
| `--c-subtle` | `#57534e` (~2.4:1) | `#87807a` (~4.6:1) | Eyebrow headings, captions and meta text now meet WCAG AA for small text. `SectionHeading` defaults xs/sm sizes to `text-subtle`, so this lifts 80+ section titles across modules. |
| `--c-muted` | `#a8a29e` | `#b4aea9` | Slight brighten so secondary labels/icons sit comfortably above the subtle tier. |
| `--c-line` | `#3a342e` (~1.5:1) | `#524a41` (~2.1:1) | Card edges, table rows, scrollbar thumbs and skeleton placeholders were nearly invisible. |
| `--c-border-strong` | `#4a423a` (~2:1) | `#70665a` (~3.6:1) | Prominent dividers/inputs clear the 3:1 UI-contrast threshold. |
| `--c-panel-hi` | `#292420` | `#302a25` | Hover/input surface is now distinguishable from the base `panel`. |
| `--c-success/warning/danger/info-soft` | `*-900` | bumped to `*-800`/brighter `*-900` | Soft status tints are visible as actual backgrounds behind badges and banners. |
| `.dark .glass-subtle` | `bg-white/5 border-white/10` | `bg-white/[0.08] border-white/20` | The "subtle glass" chrome is now perceptible on the warm dark panel. |

Light theme is untouched.

## Review & Testing Checklist for Human

- [ ] Toggle dark mode (the moon icon in the hub header, or run `document.documentElement.classList.add('dark')` in devtools) and confirm the app still feels "warm / cozy" — no colours have shifted into cold grey.
- [ ] Walk through each module hub (Finyk, Fizruk, Routine, Nutrition) in dark mode and check that:
  - section eyebrow titles (xs/sm `SectionHeading`) are now clearly legible;
  - card borders, table row dividers and input outlines are visible;
  - status banners / badges (success / warning / danger / info) still read properly.
- [ ] Verify the light theme looks identical to before (only `.dark` overrides were touched, so this should be a no-op, but worth a quick sanity sweep).

### Notes

- No JSX / component files were modified; this is purely a theme-token tweak.
- Prettier, ESLint and `tsc` all pass locally.
- Contrast ratios quoted above are computed against the dark page background `#171412`.

Link to Devin session: https://app.devin.ai/sessions/a7c2b1cdb81144c9b18c89d1eb9090f3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
