### PR TITLE
feat(server): migrate server/obs/* to TypeScript + fix errorHandler serializeError

### DIFF
--- a/server/http/errorHandler.ts
+++ b/server/http/errorHandler.ts
@@ -53,7 +53,7 @@ export const errorHandler: ErrorRequestHandler = (
     status,
     code,
     module: mod,
-    err: serializeError(e, { includeStack: status >= 500 }),
+    err: serializeError(err, { includeStack: status >= 500 }),
   });
 
   // Явний виклик `Sentry.captureException` на справжні помилки (5xx /

--- a/server/obs/errors.ts
+++ b/server/obs/errors.ts
@@ -7,58 +7,71 @@
  * Все інше (undefined is not a function, DB ECONNREFUSED тощо) — це
  * programmer error: 500 + `error` + Sentry.
  */
+export interface AppErrorOptions {
+  status?: number;
+  code?: string;
+  cause?: unknown;
+}
+
 export class AppError extends Error {
-  constructor(message, { status = 500, code = "INTERNAL", cause } = {}) {
+  status: number;
+  code: string;
+  override cause?: unknown;
+
+  constructor(message: string, opts: AppErrorOptions = {}) {
     super(message);
     this.name = "AppError";
-    this.status = status;
-    this.code = code;
-    if (cause !== undefined) this.cause = cause;
+    this.status = opts.status ?? 500;
+    this.code = opts.code ?? "INTERNAL";
+    if (opts.cause !== undefined) this.cause = opts.cause;
   }
 }
 
 export class ValidationError extends AppError {
-  constructor(message, opts = {}) {
+  constructor(message: string, opts: AppErrorOptions = {}) {
     super(message, { status: 400, code: "VALIDATION", ...opts });
     this.name = "ValidationError";
   }
 }
 
 export class UnauthorizedError extends AppError {
-  constructor(message = "Unauthorized", opts = {}) {
+  constructor(message: string = "Unauthorized", opts: AppErrorOptions = {}) {
     super(message, { status: 401, code: "UNAUTHORIZED", ...opts });
     this.name = "UnauthorizedError";
   }
 }
 
 export class ForbiddenError extends AppError {
-  constructor(message = "Forbidden", opts = {}) {
+  constructor(message: string = "Forbidden", opts: AppErrorOptions = {}) {
     super(message, { status: 403, code: "FORBIDDEN", ...opts });
     this.name = "ForbiddenError";
   }
 }
 
 export class NotFoundError extends AppError {
-  constructor(message = "Not found", opts = {}) {
+  constructor(message: string = "Not found", opts: AppErrorOptions = {}) {
     super(message, { status: 404, code: "NOT_FOUND", ...opts });
     this.name = "NotFoundError";
   }
 }
 
 export class RateLimitError extends AppError {
-  constructor(message = "Rate limit exceeded", opts = {}) {
+  constructor(
+    message: string = "Rate limit exceeded",
+    opts: AppErrorOptions = {},
+  ) {
     super(message, { status: 429, code: "RATE_LIMIT", ...opts });
     this.name = "RateLimitError";
   }
 }
 
 export class ExternalServiceError extends AppError {
-  constructor(message, opts = {}) {
+  constructor(message: string, opts: AppErrorOptions = {}) {
     super(message, { status: 502, code: "EXTERNAL_SERVICE", ...opts });
     this.name = "ExternalServiceError";
   }
 }
 
-export function isOperationalError(err) {
+export function isOperationalError(err: unknown): err is AppError {
   return err instanceof AppError;
 }

--- a/server/obs/logger.ts
+++ b/server/obs/logger.ts
@@ -1,4 +1,4 @@
-import pino from "pino";
+import pino, { type Logger, type LoggerOptions } from "pino";
 import { als } from "./requestContext.js";
 
 /**
@@ -48,7 +48,7 @@ const redactPaths = [
 
 const usePretty = process.env.LOG_PRETTY === "1";
 
-export const logger = pino({
+const pinoOptions: LoggerOptions = {
   level,
   base: {
     service: "sergeant-api",
@@ -69,7 +69,7 @@ export const logger = pino({
   mixin() {
     const ctx = als.getStore();
     if (!ctx) return {};
-    const out = {};
+    const out: Record<string, string> = {};
     if (ctx.requestId) out.requestId = ctx.requestId;
     if (ctx.userId) out.userId = ctx.userId;
     if (ctx.module) out.module = ctx.module;
@@ -81,38 +81,65 @@ export const logger = pino({
         options: { colorize: true, translateTime: "SYS:HH:MM:ss.l" },
       }
     : undefined,
-});
+};
+
+export const logger: Logger = pino(pinoOptions);
 
 /** Дочірній логер із додатковими bindings (напр. `logger.child({ module: "nutrition" })`). */
-export function childLogger(bindings) {
+export function childLogger(bindings: Record<string, unknown>): Logger {
   return logger.child(bindings);
 }
+
+export interface SerializedError {
+  name?: string;
+  message: string;
+  code?: string;
+  status?: number;
+  stack?: string;
+  cause?: SerializedError;
+}
+
+export interface SerializeErrorOptions {
+  includeStack?: boolean;
+  depth?: number;
+}
+
+type ErrorShape = {
+  name?: string;
+  message?: string;
+  code?: string;
+  status?: number;
+  stack?: string;
+  cause?: unknown;
+};
 
 /**
  * Розгортає `err.cause` ланцюжком у plain об'єкт, безпечний для JSON/pino.
  * Корисно в `errorHandler` і process-level hooks, щоб у Loki/Grafana причину
  * бачити без розгортання stack.
- *
- * @param {unknown} err
- * @param {{ includeStack?: boolean, depth?: number }} [opts]
  */
-export function serializeError(err, { includeStack = false, depth = 4 } = {}) {
+export function serializeError(
+  err: unknown,
+  { includeStack = false, depth = 4 }: SerializeErrorOptions = {},
+): SerializedError | undefined {
   if (err == null || depth < 0) return undefined;
   if (typeof err !== "object") {
     return { message: String(err) };
   }
-  const out = {
-    name: err.name,
-    message: err.message || String(err),
+  const e = err as ErrorShape;
+  const out: SerializedError = {
+    name: e.name,
+    message: e.message || String(err),
   };
-  if (err.code !== undefined) out.code = err.code;
-  if (err.status !== undefined) out.status = err.status;
-  if (includeStack && err.stack) out.stack = err.stack;
-  if (err.cause) {
-    out.cause = serializeError(err.cause, {
+  if (e.code !== undefined) out.code = e.code;
+  if (e.status !== undefined) out.status = e.status;
+  if (includeStack && e.stack) out.stack = e.stack;
+  if (e.cause) {
+    const cause = serializeError(e.cause, {
       includeStack,
       depth: depth - 1,
     });
+    if (cause) out.cause = cause;
   }
   return out;
 }

--- a/server/obs/metrics.ts
+++ b/server/obs/metrics.ts
@@ -1,4 +1,7 @@
+import type { Request, Response } from "express";
 import client from "prom-client";
+import type { Counter, Histogram } from "prom-client";
+import type { Pool } from "pg";
 
 /**
  * Prometheus-реєстр з default-метриками (event loop lag, RSS, heap, GC)
@@ -264,8 +267,10 @@ export const webVitalsCls = new client.Histogram({
 });
 
 // ───────────────────────── Helpers ────────────────────────────
+export type StatusClass = "5xx" | "4xx" | "3xx" | "2xx" | "other";
+
 /** Класифікує HTTP-статус у одне з 4 відер для SLO / latency-дашбордів. */
-export function statusClass(status) {
+export function statusClass(status: number | string | undefined): StatusClass {
   const s = Number(status) || 0;
   if (s >= 500) return "5xx";
   if (s >= 400) return "4xx";
@@ -274,22 +279,22 @@ export function statusClass(status) {
   return "other";
 }
 
+export interface ObserveAsyncOptions<T> {
+  histogram: Histogram<string>;
+  labels: Record<string, string>;
+  counter?: Counter<string>;
+  counterLabels?: (outcome: string) => Record<string, string>;
+  classify?: (result: T) => string;
+}
+
 /**
  * Обгортка, що міряє тривалість async-операції в мс і пише в histogram
  * разом з outcome counter (опційно).
- *
- * @template T
- * @param {{
- *   histogram: import("prom-client").Histogram<string>,
- *   labels: Record<string, string>,
- *   counter?: import("prom-client").Counter<string>,
- *   counterLabels?: (outcome: string) => Record<string, string>,
- *   classify?: (result: T) => string,
- * }} opts
- * @param {() => Promise<T>} fn
- * @returns {Promise<T>}
  */
-export async function observeAsync(opts, fn) {
+export async function observeAsync<T>(
+  opts: ObserveAsyncOptions<T>,
+  fn: () => Promise<T>,
+): Promise<T> {
   const start = process.hrtime.bigint();
   let outcome = "ok";
   try {
@@ -303,7 +308,8 @@ export async function observeAsync(opts, fn) {
     }
     return result;
   } catch (e) {
-    outcome = e?.name === "AbortError" ? "timeout" : "error";
+    const name = (e as { name?: string } | null | undefined)?.name;
+    outcome = name === "AbortError" ? "timeout" : "error";
     throw e;
   } finally {
     const ms = Number(process.hrtime.bigint() - start) / 1e6;
@@ -325,11 +331,18 @@ export async function observeAsync(opts, fn) {
   }
 }
 
+export interface PoolSamplerOptions {
+  intervalMs?: number;
+}
+
 /**
  * Sample pg pool gauges periodically. Call once at boot.
  * Returns an unref-ed interval handle so the process can still exit cleanly.
  */
-export function startPoolSampler(pool, { intervalMs = 10_000 } = {}) {
+export function startPoolSampler(
+  pool: Pool,
+  { intervalMs = 10_000 }: PoolSamplerOptions = {},
+): NodeJS.Timeout {
   const sample = () => {
     try {
       dbPoolTotal.set(pool.totalCount ?? 0);
@@ -349,7 +362,7 @@ export function startPoolSampler(pool, { intervalMs = 10_000 } = {}) {
  * Express handler для `GET /metrics`. Якщо задано `METRICS_TOKEN` — вимагає
  * `Authorization: Bearer <token>`. У dev/локально можна не ставити токен.
  */
-export function metricsHandler(req, res) {
+export function metricsHandler(req: Request, res: Response): void {
   const expected = process.env.METRICS_TOKEN;
   if (expected) {
     const auth = req.get("authorization") || "";
@@ -365,10 +378,11 @@ export function metricsHandler(req, res) {
       res.setHeader("Content-Type", register.contentType);
       res.send(body);
     })
-    .catch((err) => {
-      res
-        .status(500)
-        .type("text/plain")
-        .send(`metrics_error: ${err?.message || err}`);
+    .catch((err: unknown) => {
+      const msg =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message?: unknown }).message)
+          : String(err);
+      res.status(500).type("text/plain").send(`metrics_error: ${msg}`);
     });
 }

--- a/server/obs/requestContext.ts
+++ b/server/obs/requestContext.ts
@@ -1,3 +1,4 @@
+import type { NextFunction, Request, Response } from "express";
 import { AsyncLocalStorage } from "async_hooks";
 
 /**
@@ -12,27 +13,37 @@ import { AsyncLocalStorage } from "async_hooks";
  *   setUserId("usr_123");                // коли сесія отримана
  *   setRequestModule("nutrition");       // коли відомий модуль
  */
-export const als = new AsyncLocalStorage();
+export interface RequestContextStore {
+  requestId: string | null;
+  userId: string | null;
+  module: string | null;
+}
 
-export function withRequestContext(req, _res, next) {
-  const store = {
-    requestId: req.requestId,
+export const als = new AsyncLocalStorage<RequestContextStore>();
+
+export function withRequestContext(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const store: RequestContextStore = {
+    requestId: (req as Request & { requestId?: string }).requestId ?? null,
     userId: null,
     module: null,
   };
   als.run(store, () => next());
 }
 
-export function getRequestContext() {
+export function getRequestContext(): RequestContextStore | null {
   return als.getStore() ?? null;
 }
 
-export function setUserId(userId) {
+export function setUserId(userId: string | null): void {
   const store = als.getStore();
   if (store) store.userId = userId;
 }
 
-export function setRequestModule(mod) {
+export function setRequestModule(mod: string | null): void {
   const store = als.getStore();
   if (store) store.module = mod;
 }


### PR DESCRIPTION
## Summary

Крок 3 TS-міграції (після #311 `server/lib/*`, #315 `server/http/*`): конвертація всіх 4 файлів `server/obs/*.js → .ts` з повноцінними типами + fix реального багу з Devin Review на #315.

**`server/obs/*` типізовано:**
- **`errors.ts`** — `AppErrorOptions` interface, strict constructor signatures для всіх підкласів (`ValidationError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `RateLimitError`, `ExternalServiceError`), `isOperationalError(err: unknown): err is AppError` — type-guard.
- **`logger.ts`** — pino config як `LoggerOptions`, `SerializedError` interface + `SerializeErrorOptions`, cause-chain narrowing через локальний `ErrorShape` type (без `any`).
- **`metrics.ts`** — generic `observeAsync<T>(opts: ObserveAsyncOptions<T>, fn)`, `PoolSamplerOptions`, `statusClass()` повертає `StatusClass` union (`"5xx" | "4xx" | "3xx" | "2xx" | "other"`), `metricsHandler` типізовано через `Request/Response` з `express`, `startPoolSampler(pool: Pool, ...)` — імпорт типу з `pg`.
- **`requestContext.ts`** — `RequestContextStore` interface, `AsyncLocalStorage<RequestContextStore>`, `withRequestContext(req, res, next)` типізовано; setters `setUserId` / `setRequestModule` приймають `string | null`.

**Fix з Devin Review на #315** (`server/http/errorHandler.ts`):
```diff
- err: serializeError(e, { includeStack: status >= 500 }),
+ err: serializeError(err, { includeStack: status >= 500 }),
```
Коли throw-ається non-object (напр. `throw "connection failed"`), narrowing `const e = (err && typeof err === "object" ? err : {})` робив `e = {}`, і `serializeError({})` писав у лог `{ message: "[object Object]" }`, втрачаючи оригінальне повідомлення. `serializeError` уже правильно обробляє non-object-и (`if (typeof err !== "object") return { message: String(err) }`), тож достатньо передати оригінальний `err`.

**Runtime-поведінка НЕ змінена** — файли резолвляться через tsx loader (#311) + `--import tsx` у Docker CMD (#313). Локально: `npm run lint / typecheck / test` — зелені (880 тестів).

## Review & Testing Checklist for Human

- [ ] `npm run typecheck` — має пройти без warnings.
- [ ] `npm test` — контракт-тести `errors.test.js` і `requestContext.test.js` без змін, мають лишитись зеленими.
- [ ] Перевір, що при `throw "some string"` з будь-якого API-handler-а структурний лог `request_failed` тепер містить `err.message === "some string"` (а не `"[object Object]"`).

### Notes

- Test-файли `errors.test.js` / `requestContext.test.js` НЕ конвертувались — mass-rename тестів буде окремо.
- Наступний крок: `server/modules/*.js → .ts` (поступово, по модулях).

Link to Devin session: https://app.devin.ai/sessions/9bbea11152644d3d9e89e7990e468273
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
