### PR TITLE
refactor(server): уніфікація валідації + пагінація food-search

### DIFF
--- a/server/http/schemas.ts
+++ b/server/http/schemas.ts
@@ -400,15 +400,26 @@ export const PushSendSchema = z.object({
   tag: z.string().max(120).optional().nullable(),
 });
 
+// ────────────────────── Pagination ──────────────────────
+// Переused у будь-якому endpoint-і, що повертає список. Query-params завжди
+// приходять рядками — `z.coerce.number()` конвертує "8" → 8 автоматично.
+export const PaginationSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 // ────────────────────── Food-search / barcode ──────────────────────
 export const FoodSearchQuerySchema = z.object({
   q: z.string().trim().min(2).max(120),
+  // `limit` — скільки результатів повернути (1–20, default 8). Query-param
+  // приходить рядком — coerce конвертує автоматично.
+  limit: z.coerce.number().int().min(1).max(20).default(8),
 });
 
 export const BarcodeQuerySchema = z.object({
   // клієнт може присилати з пробілами/знаками — нормалізуємо у handler-і,
   // тут лише обмежуємо довжину й склад.
-  barcode: z.string().trim().max(32),
+  barcode: z.string().trim().min(1, "Штрихкод не може бути порожнім").max(32),
 });
 
 export { z };

--- a/server/modules/barcode.js
+++ b/server/modules/barcode.js
@@ -1,6 +1,7 @@
 import { recordExternalHttp } from "../lib/externalHttp.js";
-import { barcodeLookupsTotal } from "../obs/metrics.js";
 import { BarcodeQuerySchema } from "../http/schemas.js";
+import { validateQuery } from "../http/validate.js";
+import { barcodeLookupsTotal } from "../obs/metrics.js";
 
 /**
  * Record-helper одночасно емітить і domain-specific метрику
@@ -271,10 +272,8 @@ async function lookupUPCitemdb(barcode) {
  * module-tag і rate-limit; тут лише бізнес-логіка.
  */
 export default async function handler(req, res) {
-  const parsed = BarcodeQuerySchema.safeParse(req.query);
-  if (!parsed.success) {
-    return res.status(400).json({ error: "Невірний штрихкод (8–14 цифр)" });
-  }
+  const parsed = validateQuery(BarcodeQuerySchema, req, res);
+  if (!parsed.ok) return;
   const barcode = parsed.data.barcode.replace(/\D/g, "");
   if (!/^\d{8,14}$/.test(barcode)) {
     return res.status(400).json({ error: "Невірний штрихкод (8–14 цифр)" });

--- a/server/modules/food-search.js
+++ b/server/modules/food-search.js
@@ -1,4 +1,5 @@
 import { FoodSearchQuerySchema } from "../http/schemas.js";
+import { validateQuery } from "../http/validate.js";
 
 const OFF_SEARCH = "https://world.openfoodfacts.org/api/v2/search";
 const OFF_FIELDS =
@@ -243,11 +244,9 @@ async function fetchUSDA(query, signal) {
  * CORS і rate-limit виставляє роутер.
  */
 export default async function handler(req, res) {
-  const parsed = FoodSearchQuerySchema.safeParse(req.query);
-  if (!parsed.success) {
-    return res.status(400).json({ error: "Запит занадто короткий" });
-  }
-  const query = parsed.data.q;
+  const parsed = validateQuery(FoodSearchQuerySchema, req, res);
+  if (!parsed.ok) return;
+  const { q: query, limit } = parsed.data;
 
   const signal = AbortSignal.timeout(8000);
 
@@ -290,7 +289,7 @@ export default async function handler(req, res) {
         const n = (p.name || "").toLowerCase();
         return allTokens.some((t) => n.includes(t));
       })
-      .slice(0, 8);
+      .slice(0, limit);
 
     return res.status(200).json({ products });
   } catch (e) {

--- a/server/modules/sync.js
+++ b/server/modules/sync.js
@@ -1,4 +1,10 @@
 import pool from "../db.js";
+import { validateBody } from "../http/validate.js";
+import {
+  SyncPullSchema,
+  SyncPushAllSchema,
+  SyncPushSchema,
+} from "../http/schemas.js";
 import { logger } from "../obs/logger.js";
 import {
   syncConflictsTotal,
@@ -75,19 +81,18 @@ export async function syncPush(req, res) {
   const start = process.hrtime.bigint();
   const user = req.user;
 
-  const { module, data, clientUpdatedAt } = req.body || {};
-
-  if (!module || !VALID_MODULES.has(module)) {
-    recordSync("push", module || "unknown", "invalid", {
-      ms: elapsedMs(start),
-    });
-    return res.status(400).json({ error: "Invalid module" });
+  const parsed = validateBody(SyncPushSchema, req, res);
+  if (!parsed.ok) {
+    const rawModule = req.body?.module;
+    recordSync(
+      "push",
+      typeof rawModule === "string" ? rawModule.slice(0, 32) : "unknown",
+      "invalid",
+      { ms: elapsedMs(start) },
+    );
+    return;
   }
-
-  if (data === undefined || data === null) {
-    recordSync("push", module, "invalid", { ms: elapsedMs(start) });
-    return res.status(400).json({ error: "Missing data" });
-  }
+  const { module, data, clientUpdatedAt } = parsed.data;
 
   const blob = JSON.stringify(data);
   if (blob.length > MAX_BLOB_SIZE) {
@@ -166,14 +171,18 @@ export async function syncPull(req, res) {
   const start = process.hrtime.bigint();
   const user = req.user;
 
-  const { module } = req.body || {};
-
-  if (!module || !VALID_MODULES.has(module)) {
-    recordSync("pull", module || "unknown", "invalid", {
-      ms: elapsedMs(start),
-    });
-    return res.status(400).json({ error: "Invalid module" });
+  const parsed = validateBody(SyncPullSchema, req, res);
+  if (!parsed.ok) {
+    const rawModule = req.body?.module;
+    recordSync(
+      "pull",
+      typeof rawModule === "string" ? rawModule.slice(0, 32) : "unknown",
+      "invalid",
+      { ms: elapsedMs(start) },
+    );
+    return;
   }
+  const { module } = parsed.data;
 
   try {
     // EXPLAIN ANALYZE: Index Scan using module_data_user_id_module_key,
@@ -271,11 +280,12 @@ export async function syncPushAll(req, res) {
   const start = process.hrtime.bigint();
   const user = req.user;
 
-  const { modules } = req.body || {};
-  if (!modules || typeof modules !== "object") {
+  const parsed = validateBody(SyncPushAllSchema, req, res);
+  if (!parsed.ok) {
     recordSync("push_all", "all", "invalid", { ms: elapsedMs(start) });
-    return res.status(400).json({ error: "Missing modules object" });
+    return;
   }
+  const { modules } = parsed.data;
 
   const results = {};
   // Per-module метрики `push` накопичуємо тут і емітимо ЛИШЕ після COMMIT.

--- a/server/modules/sync.test.js
+++ b/server/modules/sync.test.js
@@ -376,7 +376,10 @@ describe("syncPush (singular) — contract tests", () => {
     const res = makeRes();
     await syncPush(makeReq({ module: "not-a-module", data: { x: 1 } }), res);
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "Invalid module" });
+    expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "module" })]),
+    );
     expect(pool.query).not.toHaveBeenCalled();
     expect(syncOperationsTotal.inc.mock.calls.map(([l]) => l)).toContainEqual(
       expect.objectContaining({ op: "push", outcome: "invalid" }),
@@ -387,7 +390,10 @@ describe("syncPush (singular) — contract tests", () => {
     const res = makeRes();
     await syncPush(makeReq({ module: "finyk" }), res);
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "Missing data" });
+    expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "data" })]),
+    );
     expect(pool.query).not.toHaveBeenCalled();
   });
 
@@ -519,7 +525,10 @@ describe("syncPull (singular) — contract tests", () => {
     const res = makeRes();
     await syncPull(makeReq({ module: "coach" }), res);
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "Invalid module" });
+    expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: "module" })]),
+    );
     expect(pool.query).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
- sync.js: замінено ручну валідацію на validateBody(SyncPush/Pull/PushAllSchema)
  для syncPush, syncPull, syncPushAll — єдиний формат помилок 400 по всьому API
- barcode.js: замінено inline safeParse на validateQuery(BarcodeQuerySchema)
- food-search.js: замінено inline safeParse на validateQuery(FoodSearchQuerySchema),
  limit тепер береться з query-param (1–20, default 8) замість хардкоду .slice(0,8)
- schemas.ts: додано PaginationSchema (limit/offset, reusable); FoodSearchQuerySchema
  розширено полем limit; BarcodeQuerySchema отримав мін-валідацію з повідомленням
- sync.test.js: оновлено 3 тести під новий формат Zod-помилок (details array)
- 880/880 тестів зелені, typecheck OK, lint OK

https://claude.ai/code/session_01LPkSq5bGP1eSDn6HoESrCW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
