### PR TITLE
feat(server): migrate server/modules/nutrition/* to TypeScript

### DIFF
--- a/server/modules/nutrition/analyze-photo.ts
+++ b/server/modules/nutrition/analyze-photo.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { AnalyzePhotoSchema } from "../../http/schemas.js";
@@ -7,6 +8,10 @@ import {
   extractAnthropicText,
 } from "../../lib/anthropic.js";
 import { normalizePhotoResult } from "../../lib/nutritionResponse.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
 const SYSTEM = `Ти нутріціолог-помічник. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -33,8 +38,11 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
  * Anthropic, мережа) — теж піднімаємо наверх, щоб Sentry/логи отримали
  * повноцінний контекст, а не замаскований `{ error: e.message }`.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(AnalyzePhotoSchema, req, res);
   if (!parsed.ok) return;
@@ -69,11 +77,14 @@ export default async function handler(req, res) {
     timeoutMs: 20000,
     endpoint: "analyze-photo",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const text = extractAnthropicText(data);
@@ -81,5 +92,5 @@ export default async function handler(req, res) {
   const jsonParsed = extractJsonFromText(text);
   const result = normalizePhotoResult(jsonParsed);
 
-  return res.status(200).json({ result, rawText: text || null });
+  res.status(200).json({ result, rawText: text || null });
 }

--- a/server/modules/nutrition/backup-download.ts
+++ b/server/modules/nutrition/backup-download.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Request, Response } from "express";
 import { NotFoundError } from "../../obs/errors.js";
 
-function safeKeyFromToken(req) {
+function safeKeyFromToken(req: Request): string {
   const tok = req?.headers?.["x-token"];
   const raw = tok ? String(tok) : "public";
   let h = 2166136261;
@@ -20,21 +21,24 @@ function safeKeyFromToken(req) {
  * Вузький catch тільки на очікувану ситуацію "файл відсутній" (ENOENT).
  * Пошкоджений JSON і файлові помилки летять наверх в errorHandler.
  */
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const dir = path.join(process.cwd(), ".data");
   const key = safeKeyFromToken(req);
   const file = path.join(dir, `nutrition-backup-${key}.json`);
 
-  let raw;
+  let raw: string;
   try {
     raw = await fs.readFile(file, "utf8");
-  } catch (e) {
-    if (e?.code === "ENOENT") {
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code === "ENOENT") {
       throw new NotFoundError("Бекап не знайдено");
     }
     throw e;
   }
 
   const blob = JSON.parse(raw);
-  return res.status(200).json({ ok: true, blob });
+  res.status(200).json({ ok: true, blob });
 }

--- a/server/modules/nutrition/backup-upload.ts
+++ b/server/modules/nutrition/backup-upload.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Request, Response } from "express";
 import { validateBody } from "../../http/validate.js";
 import { BackupUploadSchema } from "../../http/schemas.js";
 import { AppError } from "../../obs/errors.js";
 
-function safeKeyFromToken(req) {
+function safeKeyFromToken(req: Request): string {
   const tok = req?.headers?.["x-token"];
   const raw = tok ? String(tok) : "public";
   // tiny stable key; not a security boundary (token check happens separately)
@@ -20,7 +21,10 @@ function safeKeyFromToken(req) {
  * POST /api/nutrition/backup-upload — залити шифрований бекап.
  * CORS / token / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const parsed = validateBody(BackupUploadSchema, req, res);
   if (!parsed.ok) return;
   const { blob } = parsed.data;
@@ -41,5 +45,5 @@ export default async function handler(req, res) {
   const file = path.join(dir, `nutrition-backup-${key}.json`);
   await fs.writeFile(file, raw, "utf8");
 
-  return res.status(200).json({ ok: true, savedAt: Date.now() });
+  res.status(200).json({ ok: true, savedAt: Date.now() });
 }

--- a/server/modules/nutrition/day-hint.ts
+++ b/server/modules/nutrition/day-hint.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { DayHintSchema } from "../../http/schemas.js";
@@ -6,13 +7,17 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-function safeNonNegOrNull(x) {
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+function safeNonNegOrNull(x: unknown): number | null {
   if (x == null || x === "") return null;
   const n = Number(x);
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
-function normalizeHint(text) {
+function normalizeHint(text: unknown): string {
   const t = String(text || "").trim();
   return t.slice(0, 1200);
 }
@@ -21,8 +26,11 @@ function normalizeHint(text) {
  * POST /api/nutrition/day-hint — коротка порада по денних макросах.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(DayHintSchema, req, res);
   if (!parsed.ok) return;
@@ -66,21 +74,24 @@ ${contextNote}${sourcesNote}Факт за день: ккал ${m.kcal ?? "—"},
     timeoutMs: 20000,
     endpoint: "day-hint",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
   let hint = "";
   try {
     const jsonParsed = extractJsonFromText(out);
-    hint = normalizeHint(jsonParsed?.hint);
+    hint = normalizeHint((jsonParsed as { hint?: unknown } | null)?.hint);
   } catch {
     hint = normalizeHint(out);
   }
   if (!hint) hint = "Не вдалося сформувати підказку.";
-  return res.status(200).json({ hint });
+  res.status(200).json({ hint });
 }

--- a/server/modules/nutrition/day-plan.ts
+++ b/server/modules/nutrition/day-plan.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { DayPlanSchema } from "../../http/schemas.js";
@@ -6,6 +7,33 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+type MealType = "breakfast" | "lunch" | "dinner" | "snack";
+
+interface PlanMeal {
+  type: MealType;
+  label: string;
+  name: string;
+  description: string;
+  ingredients: string[];
+  kcal: number | null;
+  protein_g: number | null;
+  fat_g: number | null;
+  carbs_g: number | null;
+}
+
+interface NormalizedDayPlan {
+  meals: PlanMeal[];
+  totalKcal: number | null;
+  totalProtein_g: number | null;
+  totalFat_g: number | null;
+  totalCarbs_g: number | null;
+  note: string;
+}
+
 const SYSTEM = `Ти нутріціолог і шеф-кухар. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -39,68 +67,53 @@ const SYSTEM = `Ти нутріціолог і шеф-кухар. Відпові
 - ingredients — список ключових інгредієнтів з кількостями
 - Якщо цільові макроси не задані — пропонуй збалансоване харчування ~2000 ккал`;
 
-function normalizeDayPlan(parsed) {
+function numOrNull(v: unknown): number | null {
+  return v != null && Number.isFinite(Number(v)) ? Number(v) : null;
+}
+
+function normalizeDayPlan(parsed: unknown): NormalizedDayPlan {
   const obj =
     parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed
-      : {};
-  const meals = Array.isArray(obj.meals) ? obj.meals : [];
-  const validTypes = ["breakfast", "lunch", "dinner", "snack"];
+      ? (parsed as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  const meals = Array.isArray(obj.meals) ? (obj.meals as unknown[]) : [];
+  const validTypes: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+  const typeLabels: Record<MealType, string> = {
+    breakfast: "Сніданок",
+    lunch: "Обід",
+    dinner: "Вечеря",
+    snack: "Перекус",
+  };
   return {
     meals: meals
-      .map((m) => {
+      .map((m): PlanMeal | null => {
         if (!m || typeof m !== "object") return null;
-        const type = validTypes.includes(m.type) ? m.type : "snack";
-        const typeLabels = {
-          breakfast: "Сніданок",
-          lunch: "Обід",
-          dinner: "Вечеря",
-          snack: "Перекус",
-        };
+        const rec = m as Record<string, unknown>;
+        const type: MealType = validTypes.includes(rec.type as MealType)
+          ? (rec.type as MealType)
+          : "snack";
         return {
           type,
-          label: String(m.label || typeLabels[type]),
-          name: String(m.name || "").trim(),
-          description: String(m.description || "").trim(),
-          ingredients: Array.isArray(m.ingredients)
-            ? m.ingredients.map((x) => String(x).trim()).filter(Boolean)
+          label: String(rec.label || typeLabels[type]),
+          name: String(rec.name || "").trim(),
+          description: String(rec.description || "").trim(),
+          ingredients: Array.isArray(rec.ingredients)
+            ? (rec.ingredients as unknown[])
+                .map((x) => String(x).trim())
+                .filter(Boolean)
             : [],
-          kcal:
-            m.kcal != null && Number.isFinite(Number(m.kcal))
-              ? Number(m.kcal)
-              : null,
-          protein_g:
-            m.protein_g != null && Number.isFinite(Number(m.protein_g))
-              ? Number(m.protein_g)
-              : null,
-          fat_g:
-            m.fat_g != null && Number.isFinite(Number(m.fat_g))
-              ? Number(m.fat_g)
-              : null,
-          carbs_g:
-            m.carbs_g != null && Number.isFinite(Number(m.carbs_g))
-              ? Number(m.carbs_g)
-              : null,
+          kcal: numOrNull(rec.kcal),
+          protein_g: numOrNull(rec.protein_g),
+          fat_g: numOrNull(rec.fat_g),
+          carbs_g: numOrNull(rec.carbs_g),
         };
       })
-      .filter(Boolean)
+      .filter((v): v is PlanMeal => Boolean(v))
       .slice(0, 6),
-    totalKcal:
-      obj.totalKcal != null && Number.isFinite(Number(obj.totalKcal))
-        ? Number(obj.totalKcal)
-        : null,
-    totalProtein_g:
-      obj.totalProtein_g != null && Number.isFinite(Number(obj.totalProtein_g))
-        ? Number(obj.totalProtein_g)
-        : null,
-    totalFat_g:
-      obj.totalFat_g != null && Number.isFinite(Number(obj.totalFat_g))
-        ? Number(obj.totalFat_g)
-        : null,
-    totalCarbs_g:
-      obj.totalCarbs_g != null && Number.isFinite(Number(obj.totalCarbs_g))
-        ? Number(obj.totalCarbs_g)
-        : null,
+    totalKcal: numOrNull(obj.totalKcal),
+    totalProtein_g: numOrNull(obj.totalProtein_g),
+    totalFat_g: numOrNull(obj.totalFat_g),
+    totalCarbs_g: numOrNull(obj.totalCarbs_g),
     note: String(obj.note || "").trim(),
   };
 }
@@ -109,8 +122,11 @@ function normalizeDayPlan(parsed) {
  * POST /api/nutrition/day-plan — згенерувати план харчування на день.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(DayPlanSchema, req, res);
   if (!parsed.ok) return;
@@ -170,18 +186,21 @@ ${regenStr}`;
     timeoutMs: 30000,
     endpoint: "day-plan",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
   const jsonParsed = extractJsonFromText(out);
   const plan = normalizeDayPlan(jsonParsed);
 
-  return res.status(200).json({
+  res.status(200).json({
     plan,
     rawText: plan.meals.length === 0 ? out || null : null,
   });

--- a/server/modules/nutrition/parse-pantry.ts
+++ b/server/modules/nutrition/parse-pantry.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { ParsePantrySchema } from "../../http/schemas.js";
@@ -7,6 +8,10 @@ import {
   extractAnthropicText,
 } from "../../lib/anthropic.js";
 import { normalizePantryItems } from "../../lib/nutritionResponse.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
 const SYSTEM = `Ти помічник з харчування. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -34,8 +39,11 @@ const SYSTEM = `Ти помічник з харчування. Відповід�
  * POST /api/nutrition/parse-pantry — розпарсити сирий список продуктів.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(ParsePantrySchema, req, res);
   if (!parsed.ok) return;
@@ -58,16 +66,19 @@ export default async function handler(req, res) {
     timeoutMs: 20000,
     endpoint: "parse-pantry",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
 
   const jsonParsed = extractJsonFromText(out);
   const items = normalizePantryItems(jsonParsed);
-  return res.status(200).json({ items, rawText: out || null });
+  res.status(200).json({ items, rawText: out || null });
 }

--- a/server/modules/nutrition/recommend-recipes.ts
+++ b/server/modules/nutrition/recommend-recipes.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { RecommendRecipesSchema } from "../../http/schemas.js";
@@ -7,6 +8,10 @@ import {
   extractAnthropicText,
 } from "../../lib/anthropic.js";
 import { normalizeRecipes } from "../../lib/nutritionResponse.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
 const SYSTEM = `Ти шеф-кухар і нутріціолог. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -35,8 +40,11 @@ const SYSTEM = `Ти шеф-кухар і нутріціолог. Відпові
  * POST /api/nutrition/recommend-recipes — рецепти з наявних продуктів.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(RecommendRecipesSchema, req, res);
   if (!parsed.ok) return;
@@ -93,18 +101,21 @@ export default async function handler(req, res) {
     timeoutMs: 45000,
     endpoint: "recommend-recipes",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
 
   const jsonParsed = extractJsonFromText(out);
   const recipes = normalizeRecipes(jsonParsed);
-  return res.status(200).json({
+  res.status(200).json({
     recipes,
     rawText: recipes.length === 0 ? out || null : null,
   });

--- a/server/modules/nutrition/refine-photo.ts
+++ b/server/modules/nutrition/refine-photo.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { RefinePhotoSchema } from "../../http/schemas.js";
@@ -7,6 +8,10 @@ import {
   extractAnthropicText,
 } from "../../lib/anthropic.js";
 import { normalizePhotoResult } from "../../lib/nutritionResponse.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
 const SYSTEM = `Ти нутріціолог-помічник. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -28,8 +33,11 @@ const SYSTEM = `Ти нутріціолог-помічник. Відповіда
  * POST /api/nutrition/refine-photo — уточнити результати analyze-photo.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(RefinePhotoSchema, req, res);
   if (!parsed.ok) return;
@@ -73,11 +81,14 @@ export default async function handler(req, res) {
     timeoutMs: 20000,
     endpoint: "refine-photo",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const text = extractAnthropicText(data);
@@ -85,10 +96,10 @@ export default async function handler(req, res) {
   const jsonParsed = extractJsonFromText(text);
   const result = normalizePhotoResult(jsonParsed, { fallbackGrams: grams });
 
-  return res.status(200).json({ result, rawText: text || null });
+  res.status(200).json({ result, rawText: text || null });
 }
 
-function safeJson(v) {
+function safeJson(v: unknown): string {
   try {
     return JSON.stringify(v ?? null);
   } catch {

--- a/server/modules/nutrition/shopping-list.ts
+++ b/server/modules/nutrition/shopping-list.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { ShoppingListSchema } from "../../http/schemas.js";
@@ -6,6 +7,23 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+interface ShoppingItem {
+  id: string;
+  name: string;
+  quantity: string;
+  note: string;
+  checked: false;
+}
+
+interface ShoppingCategory {
+  name: string;
+  items: ShoppingItem[];
+}
+
 const SYSTEM = `Ти помічник з планування покупок і харчування. Відповідай ТІЛЬКИ українською.
 Поверни ТІЛЬКИ валідний JSON без markdown і без додаткового тексту.
 
@@ -42,8 +60,11 @@ const SYSTEM = `Ти помічник з планування покупок і 
  * POST /api/nutrition/shopping-list — скласти список покупок з рецептів.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(ShoppingListSchema, req, res);
   if (!parsed.ok) return;
@@ -73,7 +94,11 @@ export default async function handler(req, res) {
         return `• ${title}: ${ings || "без деталей"}`;
       })
       .join("\n");
-  } else if (weekPlan?.days?.length > 0) {
+  } else if (
+    weekPlan &&
+    Array.isArray(weekPlan.days) &&
+    weekPlan.days.length > 0
+  ) {
     ingredientsList = weekPlan.days
       .map((d) => {
         const day = d?.label || "День";
@@ -109,55 +134,64 @@ ${ingredientsList}
     timeoutMs: 25000,
     endpoint: "shopping-list",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
   const jsonParsed = extractJsonFromText(out);
 
-  const obj =
+  const obj: Record<string, unknown> =
     jsonParsed && typeof jsonParsed === "object" && !Array.isArray(jsonParsed)
-      ? jsonParsed
+      ? (jsonParsed as Record<string, unknown>)
       : {};
 
-  const seenNames = new Set();
-  const normalize = (s) => s.toLowerCase().replace(/\s+/g, " ").trim();
+  const seenNames = new Set<string>();
+  const normalize = (s: string): string =>
+    s.toLowerCase().replace(/\s+/g, " ").trim();
 
-  const categories = Array.isArray(obj.categories)
-    ? obj.categories
-        .map((cat) => {
-          if (!cat || typeof cat !== "object") return null;
-          const name = String(cat.name || "Інше").trim();
-          const items = Array.isArray(cat.items)
-            ? cat.items
-                .map((item) => {
-                  if (!item || typeof item !== "object") return null;
-                  const itemName = String(item.name || "").trim();
-                  if (!itemName) return null;
-                  const key = normalize(itemName);
-                  if (seenNames.has(key)) return null;
-                  seenNames.add(key);
-                  return {
-                    id: `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-                    name: itemName,
-                    quantity: String(item.quantity || "").trim(),
-                    note: String(item.note || "").trim(),
-                    checked: false,
-                  };
-                })
-                .filter(Boolean)
-            : [];
-          if (items.length === 0) return null;
-          return { name, items };
-        })
-        .filter(Boolean)
+  const rawCategories = Array.isArray(obj.categories)
+    ? (obj.categories as unknown[])
     : [];
 
-  return res.status(200).json({
+  const categories: ShoppingCategory[] = rawCategories
+    .map((cat): ShoppingCategory | null => {
+      if (!cat || typeof cat !== "object") return null;
+      const catRec = cat as Record<string, unknown>;
+      const name = String(catRec.name || "Інше").trim();
+      const rawItems = Array.isArray(catRec.items)
+        ? (catRec.items as unknown[])
+        : [];
+      const items = rawItems
+        .map((item): ShoppingItem | null => {
+          if (!item || typeof item !== "object") return null;
+          const itemRec = item as Record<string, unknown>;
+          const itemName = String(itemRec.name || "").trim();
+          if (!itemName) return null;
+          const key = normalize(itemName);
+          if (seenNames.has(key)) return null;
+          seenNames.add(key);
+          return {
+            id: `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            name: itemName,
+            quantity: String(itemRec.quantity || "").trim(),
+            note: String(itemRec.note || "").trim(),
+            checked: false,
+          };
+        })
+        .filter((v): v is ShoppingItem => Boolean(v));
+      if (items.length === 0) return null;
+      return { name, items };
+    })
+    .filter((v): v is ShoppingCategory => Boolean(v));
+
+  res.status(200).json({
     categories,
     rawText: categories.length === 0 ? out || null : null,
   });

--- a/server/modules/nutrition/week-plan.ts
+++ b/server/modules/nutrition/week-plan.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { extractJsonFromText } from "../../http/jsonSafe.js";
 import { validateBody } from "../../http/validate.js";
 import { WeekPlanSchema } from "../../http/schemas.js";
@@ -6,21 +7,39 @@ import {
   anthropicMessages,
   extractAnthropicText,
 } from "../../lib/anthropic.js";
-function normalizeWeekPlan(parsed) {
+
+type AnthropicErrorPayload = { error?: { message?: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+interface WeekDay {
+  label: string;
+  note: string;
+  meals: string[];
+}
+
+interface NormalizedWeekPlan {
+  days: WeekDay[];
+  shoppingList: string[];
+}
+
+function normalizeWeekPlan(parsed: unknown): NormalizedWeekPlan {
   const obj =
     parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed
-      : {};
-  const days = Array.isArray(obj.days) ? obj.days : [];
-  const shoppingList = Array.isArray(obj.shoppingList) ? obj.shoppingList : [];
+      ? (parsed as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  const days = Array.isArray(obj.days) ? (obj.days as unknown[]) : [];
+  const shoppingList = Array.isArray(obj.shoppingList)
+    ? (obj.shoppingList as unknown[])
+    : [];
   return {
-    days: days.slice(0, 7).map((d, i) => {
+    days: days.slice(0, 7).map((d, i): WeekDay => {
       if (!d || typeof d !== "object")
         return { label: `День ${i + 1}`, note: "", meals: [] };
-      const label = String(d.label || `День ${i + 1}`).slice(0, 40);
-      const note = String(d.note || "").slice(0, 500);
-      const meals = Array.isArray(d.meals)
-        ? d.meals
+      const rec = d as Record<string, unknown>;
+      const label = String(rec.label || `День ${i + 1}`).slice(0, 40);
+      const note = String(rec.note || "").slice(0, 500);
+      const meals = Array.isArray(rec.meals)
+        ? (rec.meals as unknown[])
             .slice(0, 8)
             .map((x) => String(x || "").trim())
             .filter(Boolean)
@@ -50,8 +69,11 @@ const SYSTEM = `Ти шеф-кухар і планувальник харчув�
  * POST /api/nutrition/week-plan — згенерувати план харчування на тиждень.
  * CORS / token / quota / rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(WeekPlanSchema, req, res);
   if (!parsed.ok) return;
@@ -86,22 +108,23 @@ export default async function handler(req, res) {
     timeoutMs: 35000,
     endpoint: "week-plan",
   });
-  if (!response.ok) {
-    throw new ExternalServiceError(data?.error?.message || "AI error", {
-      status: response.status,
-      code: "ANTHROPIC_ERROR",
-    });
+  if (!response || !response.ok) {
+    throw new ExternalServiceError(
+      (data as AnthropicErrorPayload)?.error?.message || "AI error",
+      {
+        status: response?.status,
+        code: "ANTHROPIC_ERROR",
+      },
+    );
   }
 
   const out = extractAnthropicText(data);
-  let plan = { days: [], shoppingList: [] };
+  let plan: NormalizedWeekPlan = { days: [], shoppingList: [] };
   try {
     const jsonParsed = extractJsonFromText(out);
     plan = normalizeWeekPlan(jsonParsed);
   } catch {
     plan = { days: [], shoppingList: [] };
   }
-  return res
-    .status(200)
-    .json({ plan, rawText: plan.days.length === 0 ? out : null });
+  res.status(200).json({ plan, rawText: plan.days.length === 0 ? out : null });
 }


### PR DESCRIPTION
## Summary

Крок 4 TS-міграції: конвертація 10 nutrition-хендлерів у `.ts` із повноцінною типізацією. Self-contained "vertical slice" — жоден callsite поза `server/modules/nutrition/` не змінений (tsx loader резолвить `*.js` імпорти на `.ts`-файли без змін у `server/routes/nutrition.js`).

Файли:
- `analyze-photo.ts` (85 → 96 рядків)
- `refine-photo.ts` (97 → 108)
- `parse-pantry.ts` (73 → 84)
- `recommend-recipes.ts` (111 → 118)
- `day-hint.ts` (86 → 97)
- `day-plan.ts` (188 → 196)
- `week-plan.ts` (105 → 130)
- `shopping-list.ts` (164 → 177)
- `backup-upload.ts` (45 → 49)
- `backup-download.ts` (40 → 44)

Всього: `10 files changed, 314 insertions(+), 175 deletions(-)`.

### Типізація

- Handler-и отримали сигнатуру `(req: Request, res: Response) => Promise<void>`.
- `req.anthropicKey` через локальний `type WithAnthropicKey = Request & { anthropicKey?: string }` — той самий патерн, що й у `server/http/requireAnthropicKey.ts` (без глобальної `Express.Request` augmentation, щоб не розширювати blast-radius цього PR).
- `data?.error?.message` з Anthropic payload через локальний `type AnthropicErrorPayload = { error?: { message?: string } }` — бо `anthropicMessages` повертає `data: Record<string, unknown>`.
- `response` в результаті `anthropicMessages` може бути `null` (коли всі ретраї впали до return), тому `!response || !response.ok` замість `!response.ok`. Runtime-ефект: раніше в цьому маловірогідному кейсі летіло б `TypeError: Cannot read properties of null (reading 'ok')`, тепер — семантично коректний `ExternalServiceError` зі статусом.
- Повні interfaces `PlanMeal` / `WeekDay` / `ShoppingItem` / `ShoppingCategory` у `day-plan`, `week-plan`, `shopping-list` — щоб shape нормалізаторів був явний.
- `NotFoundError` на `ENOENT` у `backup-download.ts` через `NodeJS.ErrnoException` narrow.

### Runtime

Поведінка НЕ змінена — tsx loader резолвить `.ts` прозоро. Імпорти в `server/routes/nutrition.js` залишаються `from "../modules/nutrition/analyze-photo.js"` — це standard ESM з tsx-ром.

### Локально

- `npm run typecheck` — зелене (`tsconfig.json` + `tsconfig.server.json` + `tsconfig.sw.json`).
- `npm run lint` — зелене (eslint + `scripts/check-imports.mjs`).
- `node scripts/vitest.mjs run` — **88 files / 880 tests passed**.

## Review & Testing Checklist for Human

- [ ] Перевір, що всі 9 AI-endpoint-ів відповідають так само, як і раніше, для реальних кейсів:
  - `POST /api/nutrition/analyze-photo` (з фото JPEG/PNG)
  - `POST /api/nutrition/refine-photo` (з prior_result + portion_grams)
  - `POST /api/nutrition/parse-pantry` (сирий текст → items)
  - `POST /api/nutrition/recommend-recipes` (pantry → recipes)
  - `POST /api/nutrition/day-hint` (macros + targets → hint)
  - `POST /api/nutrition/day-plan` (pantry + targets → meals)
  - `POST /api/nutrition/week-plan` (pantry → 7 days)
  - `POST /api/nutrition/shopping-list` (recipes або weekPlan → categories)
- [ ] Перевір `POST /api/nutrition/backup-upload` та `backup-download` із різними токенами (має бути ізоляція ключів).
- [ ] Перевір, що на справжній Anthropic-error (напр. 429) зовнішній fallback-текст у відповіді не змінився (як і раніше — або `data.error.message`, або `"AI error"`).

### Notes

- Не чіпав `server/routes/nutrition.js` — він у наступному кроці (`server/routes/* → .ts`).
- Тести `*.test.js` теж залишено як є — їх конвертуємо гуртом після всіх source-міграцій.
- Patterns, які в наступних чергах (`modules/*` top-level, `routes/*`, `server/*.ts` корінь) можна уніфікувати: (а) винести `WithAnthropicKey` у `server/http/types.d.ts`, (б) винести `extractAnthropicErrorMessage(data)` у `server/lib/anthropic.ts`. Свідомо не робив тут, щоб не розширювати blast-radius.

Link to Devin session: https://app.devin.ai/sessions/d1e1c873c0754bc0bdfb4c93886b772b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
