### PR TITLE
feat(server): migrate server/routes/* to TypeScript

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -17,7 +17,7 @@ import {
  * `res.on("finish")` і кличе `next()`, тож навіть якщо лімітер відстрілить
  * 429, finish-listener все одно спрацює і метрика інкрементнеться коректно.
  */
-export function createAuthRouter() {
+export function createAuthRouter(): Router {
   const r = Router();
   r.use("/api/auth", authMetricsMiddleware);
   r.use("/api/auth", authSensitiveRateLimit);

--- a/server/routes/banks.ts
+++ b/server/routes/banks.ts
@@ -12,7 +12,7 @@ import privatHandler from "../modules/privat.js";
  * і так треба прочитати з заголовка, щоб передати далі в `fetch(...)`. Тому
  * middleware тут тільки тегує домен і rate-limit-ить.
  */
-export function createBanksRouter() {
+export function createBanksRouter(): Router {
   const r = Router();
   r.use("/api/mono", setModule("finyk"));
   r.use("/api/privat", setModule("finyk"));

--- a/server/routes/barcode.ts
+++ b/server/routes/barcode.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { asyncHandler, rateLimitExpress, setModule } from "../http/index.js";
 import barcodeHandler from "../modules/barcode.js";
 
-export function createBarcodeRouter() {
+export function createBarcodeRouter(): Router {
   const r = Router();
   r.get(
     "/api/barcode",

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -8,7 +8,7 @@ import {
 } from "../http/index.js";
 import chatHandler from "../modules/chat.js";
 
-export function createChatRouter() {
+export function createChatRouter(): Router {
   const r = Router();
   r.post(
     "/api/chat",

--- a/server/routes/coach.ts
+++ b/server/routes/coach.ts
@@ -19,7 +19,7 @@ import {
  *   - `GET/POST /memory` — читання/запис пам'яті; тільки session.
  *   - `POST /insight`   — генерація пораду через Anthropic; session + ключ + квота.
  */
-export function createCoachRouter() {
+export function createCoachRouter(): Router {
   const r = Router();
   r.use("/api/coach", setModule("coach"));
   r.use(

--- a/server/routes/food-search.ts
+++ b/server/routes/food-search.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { asyncHandler, rateLimitExpress, setModule } from "../http/index.js";
 import foodSearchHandler from "../modules/food-search.js";
 
-export function createFoodSearchRouter() {
+export function createFoodSearchRouter(): Router {
   const r = Router();
   r.get(
     "/api/food-search",

--- a/server/routes/frontend.ts
+++ b/server/routes/frontend.ts
@@ -1,17 +1,29 @@
 import express from "express";
 import { existsSync } from "fs";
 import { join } from "path";
+import type { Handler, RequestHandler } from "express";
+
+interface FrontendMiddlewareBundle {
+  assetsStatic: Handler;
+  rootStatic: Handler;
+  sendIndex: RequestHandler;
+}
+
+type FrontendMiddleware = RequestHandler | FrontendMiddlewareBundle;
 
 /**
  * SPA-serving для Replit-режиму (той самий процес хостить і API, і фронт).
- * Повертає middleware-функцію, яку `app.js` просто прикладає наприкінці.
+ * Повертає або одну 503-middleware-функцію (коли build відсутній), або
+ * пакет із трьох handler-ів, які app.js окремо монтує.
  *
  * Якщо `distPath` не існує — віддаємо 503 з підказкою, щоб не збити з пантелику
  * розробника, який запустив сервер без попереднього `npm run build`.
- *
- * @param {{ distPath: string }} opts
  */
-export function createFrontendMiddleware({ distPath }) {
+export function createFrontendMiddleware({
+  distPath,
+}: {
+  distPath: string;
+}): FrontendMiddleware {
   if (!existsSync(distPath)) {
     return (_req, res) => {
       res
@@ -24,7 +36,7 @@ export function createFrontendMiddleware({ distPath }) {
     immutable: true,
   });
   const rootStatic = express.static(distPath, { maxAge: 0 });
-  const sendIndex = (_req, res) => {
+  const sendIndex: RequestHandler = (_req, res) => {
     res.sendFile(join(distPath, "index.html"));
   };
   return { assetsStatic, rootStatic, sendIndex };

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import type { Pool } from "pg";
 import { createReadyzHandler, livezHandler } from "../http/index.js";
 import { metricsHandler } from "../obs/metrics.js";
 
@@ -7,10 +8,8 @@ import { metricsHandler } from "../obs/metrics.js";
  *
  * `/health` лишається аліасом для `/readyz` через історичні platform-probe-и
  * (Railway, старі Replit-пайплайни). Не видаляти без координації з деплоєм.
- *
- * @param {{ pool: import("pg").Pool }} deps
  */
-export function createHealthRouter({ pool }) {
+export function createHealthRouter({ pool }: { pool: Pool }): Router {
   const r = Router();
   r.get("/livez", livezHandler);
   r.get("/readyz", createReadyzHandler(pool));

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,3 +1,5 @@
+import type { Express } from "express";
+import type { Pool } from "pg";
 import { createAuthRouter } from "./auth.js";
 import { createBanksRouter } from "./banks.js";
 import { createBarcodeRouter } from "./barcode.js";
@@ -20,11 +22,8 @@ import { createWeeklyDigestRouter } from "./weekly-digest.js";
  * Порядок реєстрації відповідає тому, що був inline у `server/app.js`: спочатку
  * health/metrics, потім auth (перед глобальним CORS на /api — див. коментар у
  * `app.js`), потім решта доменних роутерів.
- *
- * @param {import("express").Express} app
- * @param {{ pool: import("pg").Pool }} deps
  */
-export function registerRoutes(app, { pool }) {
+export function registerRoutes(app: Express, { pool }: { pool: Pool }): void {
   app.use(createHealthRouter({ pool }));
   app.use(createAuthRouter());
   app.use(createSyncRouter());

--- a/server/routes/nutrition.ts
+++ b/server/routes/nutrition.ts
@@ -28,7 +28,7 @@ import shoppingList from "../modules/nutrition/shopping-list.js";
  * ходять у Anthropic і не мають тратити квоту, тому `requireAnthropicKey` /
  * `requireAiQuota` до них не застосовуємо.
  */
-export function createNutritionRouter() {
+export function createNutritionRouter(): Router {
   const r = Router();
   r.use("/api/nutrition", setModule("nutrition"));
   r.use(

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -25,7 +25,7 @@ import {
  * "server error" на фронті. `send` — внутрішній API cron/worker-ів,
  * захищений `X-Api-Secret`.
  */
-export function createPushRouter() {
+export function createPushRouter(): Router {
   const r = Router();
   r.use("/api/push", setModule("push"));
   r.get("/api/push/vapid-public", asyncHandler(vapidPublic));

--- a/server/routes/sync.ts
+++ b/server/routes/sync.ts
@@ -17,7 +17,7 @@ import {
  * `requireSession` унесені з handler-ів сюди: handler тепер просто читає
  * `req.user` і виконує бізнес-логіку.
  */
-export function createSyncRouter() {
+export function createSyncRouter(): Router {
   const r = Router();
   r.use("/api/sync", setModule("sync"));
   r.use(

--- a/server/routes/web-vitals.ts
+++ b/server/routes/web-vitals.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { asyncHandler, rateLimitExpress } from "../http/index.js";
 import webVitalsHandler from "../modules/web-vitals.js";
 
-export function createWebVitalsRouter() {
+export function createWebVitalsRouter(): Router {
   const r = Router();
   r.post(
     "/api/metrics/web-vitals",

--- a/server/routes/weekly-digest.ts
+++ b/server/routes/weekly-digest.ts
@@ -8,7 +8,7 @@ import {
 } from "../http/index.js";
 import weeklyDigest from "../modules/weekly-digest.js";
 
-export function createWeeklyDigestRouter() {
+export function createWeeklyDigestRouter(): Router {
   const r = Router();
   r.post(
     "/api/weekly-digest",


### PR DESCRIPTION
## Summary

Крок 5 TS-міграції (продовження після #320): 14 тонких router-файлів у `server/routes/*` (~502 рядки) перейменовано в `.ts` і проанотовано явними типами на public API. Runtime не зачеплений — tsx loader резолвить `.ts` прозоро, імпорти `from "./foo.js"` продовжують працювати.

Зміни — 33 вставки / 23 видалення, практично суто додавання type-annotations.

### Файли
- `auth.ts`, `banks.ts`, `barcode.ts`, `chat.ts`, `coach.ts`, `food-search.ts`, `health.ts`, `nutrition.ts`, `push.ts`, `sync.ts`, `web-vitals.ts`, `weekly-digest.ts`, `index.ts`, `frontend.ts`

### Типізація
- Усі `createXRouter()` мають `: Router` return type.
- `registerRoutes(app: Express, { pool }: { pool: Pool }): void` у `routes/index.ts` — раніше було в JSDoc, тепер у сигнатурі.
- `createHealthRouter({ pool }: { pool: Pool }): Router` — імпорт `import type { Pool } from "pg"`.
- `createFrontendMiddleware({ distPath }: { distPath: string }): RequestHandler | FrontendMiddlewareBundle` — явний union-тип відповідає runtime-дискримінації у `server/app.js` (`typeof fe === "function" ? ... : fe.sendIndex`). `FrontendMiddlewareBundle` — локальний interface `{ assetsStatic: Handler; rootStatic: Handler; sendIndex: RequestHandler }`.
- Решта (`chat`, `barcode`, `food-search`, `web-vitals`, `weekly-digest`, `sync`, `push`, `coach`, `banks`, `nutrition`) тільки отримали `: Router` — middleware-функції в `server/http/*` вже типізовані з попередніх PR-ів.

### Runtime
Поведінка НЕ змінена. `server/app.js` імпортує `from "./routes/index.js"` і `from "./routes/frontend.js"` — tsx резолвить ці шляхи на нові `.ts` файли.

### Локально
- `npm run typecheck` — зелене (3 tsconfigs).
- `npm run lint` — зелене (eslint + `scripts/check-imports.mjs`).
- `node scripts/vitest.mjs run` — **88 files / 880 tests passed**.

## Review & Testing Checklist for Human

- [ ] Зроби smoke-test `/livez`, `/readyz`, `/metrics` — health router єдиний, що приймає `pool` як dep.
- [ ] Перевір, що `/api/auth/*` (Better Auth) відповідає так само (особливо порядок middleware: metrics → rate-limit → handler).
- [ ] Перевір, що SPA-serving у Replit-режимі працює — `createFrontendMiddleware` тепер повертає union, app.js дискримінує через `typeof fe === "function"`; якщо `dist/` існує — має відреагувати bundle, якщо ні — 503 з підказкою про `npm run build`.

### Notes

- Наступна черга: `server/modules/*` top-level (chat/sync/coach/barcode/food-search/weekly-digest/push/privat/mono/web-vitals, ~2830 рядків) — основна "м'ясна" частина з pg-pool / Anthropic SDK type-puzzle.
- Після всіх source — `server/*.ts` корінь (aiQuota/index/db/auth/app/sentry/config, ~842 рядки), потім `*.test.js → *.test.ts`, потім `checkJs: true` / зняти `allowJs`.

Link to Devin session: https://app.devin.ai/sessions/d1e1c873c0754bc0bdfb4c93886b772b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
