### PR TITLE
feat(server): migrate modules/{mono,privat,web-vitals,push} to TypeScript

### DIFF
--- a/server/modules/mono.ts
+++ b/server/modules/mono.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { bankProxyFetch } from "../lib/bankProxy.js";
 import { validateQuery } from "../http/validate.js";
 import { MonoQuerySchema } from "../http/schemas.js";
@@ -10,11 +11,15 @@ import { MonoQuerySchema } from "../http/schemas.js";
  */
 const ALLOWED_PATHS = ["/personal/client-info", "/personal/statement"];
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const token = req.headers["x-token"];
 
   if (!token) {
-    return res.status(401).json({ error: "Токен відсутній" });
+    res.status(401).json({ error: "Токен відсутній" });
+    return;
   }
 
   const parsedQ = validateQuery(MonoQuerySchema, req, res);
@@ -25,7 +30,8 @@ export default async function handler(req, res) {
     (allowed) => path === allowed || path.startsWith(allowed + "/"),
   );
   if (!pathAllowed) {
-    return res.status(400).json({ error: "Недозволений API шлях" });
+    res.status(400).json({ error: "Недозволений API шлях" });
+    return;
   }
 
   const { status, body, contentType } = await bankProxyFetch({
@@ -37,18 +43,20 @@ export default async function handler(req, res) {
   });
 
   if (status < 200 || status >= 300) {
-    return res.status(status).json({
+    res.status(status).json({
       error: status === 429 ? "Занадто багато запитів" : body,
     });
+    return;
   }
 
-  let data;
+  let data: unknown;
   try {
     data = JSON.parse(body);
   } catch {
     // upstream повернув не-JSON на 2xx — віддаємо як plain text, щоб не мовчки ковтати.
     res.setHeader("Content-Type", contentType || "text/plain; charset=utf-8");
-    return res.status(status).send(body);
+    res.status(status).send(body);
+    return;
   }
   res.status(200).json(data);
 }

--- a/server/modules/privat.ts
+++ b/server/modules/privat.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { bankProxyFetch } from "../lib/bankProxy.js";
 import { validateQuery } from "../http/validate.js";
 import { PrivatQuerySchema } from "../http/schemas.js";
@@ -10,12 +11,16 @@ import { PrivatQuerySchema } from "../http/schemas.js";
  */
 const ALLOWED_PATHS = ["/statements/balance/final", "/statements/transactions"];
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const merchantId = req.headers["x-privat-id"];
   const merchantToken = req.headers["x-privat-token"];
 
   if (!merchantId || !merchantToken) {
-    return res.status(401).json({ error: "Credentials відсутні" });
+    res.status(401).json({ error: "Credentials відсутні" });
+    return;
   }
 
   const parsedQ = validateQuery(PrivatQuerySchema, req, res);
@@ -26,11 +31,12 @@ export default async function handler(req, res) {
     (p) => path === p || path.startsWith(p + "/"),
   );
   if (!pathAllowed) {
-    return res.status(400).json({ error: "Недозволений API шлях" });
+    res.status(400).json({ error: "Недозволений API шлях" });
+    return;
   }
 
   // Відкидаємо небезпечні символи у значеннях заголовків (CRLF-injection захист).
-  const safeHeader = (v) => {
+  const safeHeader = (v: unknown): string | null => {
     const s = String(v);
     if (/[\r\n]/.test(s)) return null;
     return s;
@@ -38,10 +44,11 @@ export default async function handler(req, res) {
   const safeId = safeHeader(merchantId);
   const safeToken = safeHeader(merchantToken);
   if (!safeId || !safeToken) {
-    return res.status(400).json({ error: "Недозволений заголовок" });
+    res.status(400).json({ error: "Недозволений заголовок" });
+    return;
   }
 
-  const queryParams = new URLSearchParams(req.query);
+  const queryParams = new URLSearchParams(req.query as Record<string, string>);
   queryParams.delete("path");
   const query = Object.fromEntries(queryParams.entries());
 
@@ -65,15 +72,17 @@ export default async function handler(req, res) {
         : status === 401 || status === 403
           ? "Невірні credentials PrivatBank"
           : body || `Помилка ${status}`;
-    return res.status(status).json({ error: errorMessage });
+    res.status(status).json({ error: errorMessage });
+    return;
   }
 
-  let data;
+  let data: unknown;
   try {
     data = JSON.parse(body);
   } catch {
     res.setHeader("Content-Type", contentType || "text/plain; charset=utf-8");
-    return res.status(status).send(body);
+    res.status(status).send(body);
+    return;
   }
   res.status(200).json(data);
 }

--- a/server/modules/push.ts
+++ b/server/modules/push.ts
@@ -1,4 +1,5 @@
-import webpush from "web-push";
+import type { Request, Response } from "express";
+import webpush, { WebPushError } from "web-push";
 import pool from "../db.js";
 import { logger } from "../obs/logger.js";
 import { recordExternalHttp } from "../lib/externalHttp.js";
@@ -10,13 +11,15 @@ import {
   PushUnsubscribeSchema,
 } from "../http/schemas.js";
 
+type WithSessionUser = Request & { user?: { id: string } };
+
 /**
  * Дублюємо два лейбли для одного outcome: історичну domain-метрику
  * `push_sends_total` (яку можуть читати старі дашборди/алерти) та уніфіковану
  * `external_http_requests_total{upstream="push"}`. Це свідома тимчасова
  * дуплікація — якщо й зносити, то окремим PR зі знесенням дашборду.
  */
-function recordSend(outcome) {
+function recordSend(outcome: string): void {
   try {
     pushSendsTotal.inc({ outcome });
   } catch {
@@ -34,19 +37,22 @@ if (VAPID_PUBLIC && VAPID_PRIVATE) {
 }
 
 /** GET /api/push/vapid-public — повертає публічний VAPID ключ для підписки. */
-export async function vapidPublic(_req, res) {
+export async function vapidPublic(_req: Request, res: Response): Promise<void> {
   if (!VAPID_PUBLIC) {
-    return res.status(503).json({ error: "Push not configured" });
+    res.status(503).json({ error: "Push not configured" });
+    return;
   }
   res.json({ publicKey: VAPID_PUBLIC });
 }
 
 /** POST /api/push/subscribe — зберегти підписку. Session в `req.user`. */
-export async function subscribe(req, res) {
-  if (!VAPID_PUBLIC)
-    return res.status(503).json({ error: "Push not configured" });
+export async function subscribe(req: Request, res: Response): Promise<void> {
+  if (!VAPID_PUBLIC) {
+    res.status(503).json({ error: "Push not configured" });
+    return;
+  }
 
-  const user = req.user;
+  const user = (req as WithSessionUser).user!;
   const parsed = validateBody(PushSubscribeSchema, req, res);
   if (!parsed.ok) return;
   const { endpoint, keys } = parsed.data;
@@ -71,8 +77,8 @@ export async function subscribe(req, res) {
 }
 
 /** DELETE /api/push/subscribe — soft-delete підписки. Session в `req.user`. */
-export async function unsubscribe(req, res) {
-  const user = req.user;
+export async function unsubscribe(req: Request, res: Response): Promise<void> {
+  const user = (req as WithSessionUser).user!;
   const parsed = validateBody(PushUnsubscribeSchema, req, res);
   if (!parsed.ok) return;
   const { endpoint } = parsed.data;
@@ -94,6 +100,12 @@ export async function unsubscribe(req, res) {
   res.json({ ok: true });
 }
 
+interface PushSubscriptionRow {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
 /**
  * POST /api/push/send — надіслати push конкретному користувачу (внутрішній API).
  * Body: { userId, title, body, module, tag }
@@ -101,9 +113,11 @@ export async function unsubscribe(req, res) {
  * Auth через `X-Api-Secret` зроблено в `requireApiSecret("API_SECRET")` на
  * рівні роутера; handler вже отримує запит з перевіреним секретом.
  */
-export async function sendPush(req, res) {
-  if (!VAPID_PUBLIC)
-    return res.status(503).json({ error: "Push not configured" });
+export async function sendPush(req: Request, res: Response): Promise<void> {
+  if (!VAPID_PUBLIC) {
+    res.status(503).json({ error: "Push not configured" });
+    return;
+  }
 
   const parsed = validateBody(PushSendSchema, req, res);
   if (!parsed.ok) return;
@@ -114,13 +128,16 @@ export async function sendPush(req, res) {
   //     Index Cond: (user_id = $1)
   //     (фільтр deleted_at IS NULL уже вбудований у partial-index,
   //      тому Rows Removed by Filter = 0)
-  const { rows } = await pool.query(
+  const { rows } = await pool.query<PushSubscriptionRow>(
     `SELECT endpoint, p256dh, auth
        FROM push_subscriptions
       WHERE user_id = $1 AND deleted_at IS NULL`,
     [userId],
   );
-  if (rows.length === 0) return res.json({ sent: 0 });
+  if (rows.length === 0) {
+    res.json({ sent: 0 });
+    return;
+  }
 
   const payload = JSON.stringify({
     title,
@@ -129,7 +146,7 @@ export async function sendPush(req, res) {
     tag: tag || null,
   });
   let sent = 0;
-  const stale = [];
+  const stale: string[] = [];
 
   // Вузький per-subscription catch: одна невдала підписка не повинна
   // зривати весь fan-out. Інші помилки (DB, тощо) летять наверх в errorHandler.
@@ -143,23 +160,25 @@ export async function sendPush(req, res) {
         await webpush.sendNotification(sub, payload);
         sent++;
         recordSend("ok");
-      } catch (e) {
-        if (e.statusCode === 404 || e.statusCode === 410) {
+      } catch (e: unknown) {
+        const statusCode = e instanceof WebPushError ? e.statusCode : undefined;
+        const message = e instanceof Error ? e.message : String(e);
+        if (statusCode === 404 || statusCode === 410) {
           stale.push(row.endpoint);
           recordSend("invalid_endpoint");
-        } else if (e.statusCode === 429) {
+        } else if (statusCode === 429) {
           recordSend("rate_limited");
           logger.warn({
             msg: "push_rate_limited",
-            status: e.statusCode,
-            err: { message: e?.message },
+            status: statusCode,
+            err: { message },
           });
         } else {
           recordSend("error");
           logger.warn({
             msg: "push_send_error",
-            status: e.statusCode,
-            err: { message: e?.message },
+            status: statusCode,
+            err: { message },
           });
         }
       }

--- a/server/modules/web-vitals.ts
+++ b/server/modules/web-vitals.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { z } from "zod";
 import { logger } from "../obs/logger.js";
 import { webVitalsCls, webVitalsDurationMs } from "../obs/metrics.js";
@@ -20,7 +21,12 @@ import { webVitalsCls, webVitalsDurationMs } from "../obs/metrics.js";
  * Pino потоком з публічного endpoint.
  */
 
-const TIMING_METRICS = new Set(["LCP", "INP", "FCP", "TTFB"]);
+const TIMING_METRICS = new Set<"LCP" | "INP" | "FCP" | "TTFB">([
+  "LCP",
+  "INP",
+  "FCP",
+  "TTFB",
+]);
 
 // CLS — безрозмірний, в реальних умовах 0..1+ (0.25 вже "poor"). Таймінги
 // (LCP/INP/FCP/TTFB) — мс, з приватним upper-bound 120_000 (2 хв — будь-що
@@ -42,7 +48,7 @@ const PayloadSchema = z.object({
   metrics: z.array(MetricSchema).min(1).max(10),
 });
 
-export default function webVitalsHandler(req, res) {
+export default function webVitalsHandler(req: Request, res: Response): void {
   // sendBeacon з `type: "application/json"` приходить як Buffer/string залежно
   // від middleware-а — Express `express.json()` уже парсить у req.body, але
   // якщо клієнт помилиться з content-type, body може бути undefined.
@@ -54,14 +60,15 @@ export default function webVitalsHandler(req, res) {
         issues: parsed.error.issues?.slice(0, 3),
       });
     }
-    return res.status(204).end();
+    res.status(204).end();
+    return;
   }
 
   for (const m of parsed.data.metrics) {
     try {
       if (m.name === "CLS") {
         webVitalsCls.observe({ rating: m.rating }, m.value);
-      } else if (TIMING_METRICS.has(m.name)) {
+      } else if (TIMING_METRICS.has(m.name as "LCP" | "INP" | "FCP" | "TTFB")) {
         webVitalsDurationMs.observe(
           { metric: m.name, rating: m.rating },
           m.value,
@@ -72,5 +79,5 @@ export default function webVitalsHandler(req, res) {
     }
   }
 
-  return res.status(204).end();
+  res.status(204).end();
 }


### PR DESCRIPTION
## Summary

Крок 6 TS-міграції (після #320, #322): 4 «легкі» модулі з `server/modules/*` переведено в `.ts` — без Anthropic SDK, без складного type-puzzle. Разом ~392 рядки.

### Файли
- `modules/mono.ts` (54) — Monobank proxy handler
- `modules/privat.ts` (79) — PrivatBank proxy handler
- `modules/web-vitals.ts` (76) — Core Web Vitals POST-endpoint
- `modules/push.ts` (183) — Web Push subscribe/unsubscribe/send

### Типізація
- Handler signatures `(req: Request, res: Response): Promise<void> | void` (імпорт `import type { Request, Response } from "express"`).
- `push.ts`:
  - `type WithSessionUser = Request & { user?: { id: string } }` — середина з `requireSession` middleware, консистентно з паттерном із попередніх міграцій (`requireSession.ts` кладе `user` у `req`).
  - `WebPushError instanceof` narrowing замість `any.statusCode` — типізовані 404/410 (stale), 429 (rate-limited), інше (error).
  - `pool.query<PushSubscriptionRow>()` для SELECT — відстежуваний row-shape `{ endpoint, p256dh, auth }`.
- `web-vitals.ts`: `TIMING_METRICS: Set<"LCP" | "INP" | "FCP" | "TTFB">` замість `Set<string>`, щоб `.has(m.name)` звужував тип для `.observe({ metric: m.name, ... })`.
- `mono.ts`, `privat.ts`: return-early на валідаційних помилках — явний `return;` після `res.status(...).send()` (тому що повертаємо `Promise<void>`).

### Runtime
Поведінка НЕ змінена. tsx резолвить `.ts` прозоро. Маршрути (`server/routes/banks.ts`, `server/routes/push.ts`, `server/routes/web-vitals.ts`) імпортують `from "../modules/mono.js"` (`.js` у специфікаторі — норма для ESM + NodeNext; tsx мапить на `.ts`). Жоден роутер не змінений.

### Локально
- `npm run typecheck` — зелене.
- `npm run lint` — зелене.
- `node scripts/vitest.mjs run` — **88 files / 880 tests passed** (в т.ч. `bankProxy.test.js` та push-related тести у `modules/push.test.*`).

## Review & Testing Checklist for Human

- [ ] `/api/mono`, `/api/privat` smoke-test: валідний `path`, невалідний `path`, відсутній токен/credentials — поведінка не змінилась.
- [ ] `/api/push/subscribe` → `/api/push/send` → `/api/push/unsubscribe` вручну — потік працює; `push_sends_total{outcome="ok"}` та `external_http_requests_total{upstream="push",status="ok"}` тікають.
- [ ] Відправка web-vitals beacon-ом з фронту: 204 повертається, `web_vitals_duration_ms_*` і `web_vitals_cls_*` рахуються в `/metrics`.

### Notes

Наступний крок (за попередньою домовленістю) — 1b (`barcode/food-search/weekly-digest/coach`, ~1080 рядків, Anthropic + DB). Після нього — 1c `chat.js` (917) і 1d `sync.js` (357) окремими PR.

Link to Devin session: https://app.devin.ai/sessions/d1e1c873c0754bc0bdfb4c93886b772b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
