### PR TITLE
fix(ftux): restore preset differentiation + stop premature FTUX dismi…

### DIFF
--- a/src/core/onboarding/FirstActionSheet.tsx
+++ b/src/core/onboarding/FirstActionSheet.tsx
@@ -115,13 +115,21 @@ export function FirstActionHeroCard({ onDismiss }) {
     setActivePresetId(id);
   };
 
-  const handlePresetPick = () => {
-    // The preset writer already persisted the entry; dismiss the hero
-    // card so the next dashboard render surfaces the celebration toast
-    // (from `useFirstEntryCelebration`) against a clean layout.
-    clearFirstActionPending();
+  const handlePresetPick = ({ persisted } = { persisted: true }) => {
+    // Тільки routine-пресет дійсно пише запис у storage. Для
+    // finyk/fizruk/nutrition ми лише навігуємо у повний add-sheet
+    // модуля, а реальне збереження відбудеться, коли користувач
+    // натисне «Зберегти» там. Якщо б ми гасили FTUX-прапор одразу,
+    // hero-картка зникала б назавжди навіть коли юзер скасував
+    // add-sheet — і `detectFirstRealEntry` → `useFirstEntryCelebration`
+    // ніколи б не спрацювали. Натомість лишаємо прапор висіти: при
+    // наступному маунті дашборду hero-картка повертається, а коли
+    // справжній запис з'явиться — обидва механізми знімуть її разом.
     setActivePresetId(null);
-    onDismiss?.();
+    if (persisted) {
+      clearFirstActionPending();
+      onDismiss?.();
+    }
   };
 
   if (!primary) return null;

--- a/src/core/onboarding/PresetSheet.tsx
+++ b/src/core/onboarding/PresetSheet.tsx
@@ -5,6 +5,7 @@ import { Sheet } from "@shared/components/ui/Sheet";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { applyPreset } from "./presetApply.js";
+import { writePresetPrefill } from "./presetPrefill.js";
 
 /**
  * Per-module "tap-to-log" presets. Each entry is deliberately narrow —
@@ -84,36 +85,18 @@ const PRESETS = {
   },
   nutrition: {
     title: "Що з'їв зараз?",
-    desc: "Відкрию форму з назвою — калорії підтвердиш у модулі.",
+    desc: "Відкрию форму добавляння страви — калорії підтвердиш у модулі.",
     accent: "text-nutrition bg-nutrition-soft",
     moduleIcon: "utensils",
-    fallback: { action: "add_meal", label: "Своя страва", icon: "plus" },
-    // Fake kcal-и («~420 ккал») прибрані: модуль сам рахує макро на
-    // основі ваги/складу у своєму повному sheet-і, а не у preset data.
+    fallback: { action: "add_meal", label: "Додати страву", icon: "plus" },
+    // Три плитки (Омлет / Салат / Яблуко) свого часу давали
+    // різні дані — але без каналу прокидування `item.data` у
+    // `AddMealSheet` усі три тапи відкривали один і той самий порожній
+    // sheet. Три візуально-різні CTA з однаковим результатом — це
+    // міні-обман: краще одна чесна кнопка, ніж три, що вдають вибір.
+    // Коли модуль отримає prefill-канал — повернемо плитки.
     action: "add_meal" as const,
-    items: [
-      {
-        id: "omelette",
-        emoji: "🍳",
-        title: "Омлет з авокадо",
-        desc: "сніданок · у модулі",
-        data: { name: "Омлет з авокадо", mealType: "breakfast" },
-      },
-      {
-        id: "salad",
-        emoji: "🥗",
-        title: "Салат з куркою",
-        desc: "обід · у модулі",
-        data: { name: "Салат з куркою", mealType: "lunch" },
-      },
-      {
-        id: "snack",
-        emoji: "🍎",
-        title: "Яблуко + горіхи",
-        desc: "перекус · у модулі",
-        data: { name: "Яблуко + горіхи", mealType: "snack" },
-      },
-    ],
+    items: [],
   },
   fizruk: {
     title: "Швидкий старт",
@@ -122,33 +105,15 @@ const PRESETS = {
     moduleIcon: "dumbbell",
     fallback: {
       action: "start_workout",
-      label: "Своє тренування",
+      label: "Почати тренування",
       icon: "plus",
     },
+    // Те ж саме, що й у nutrition: fizruk не має prefill-каналу для
+    // імені тренування, тому три плитки («Розминка», «Прогулянка»,
+    // «Швидке HIIT») всі деградували до одного й того ж старту без
+    // імені. Лишаємо один fallback-CTA.
     action: "start_workout" as const,
-    items: [
-      {
-        id: "warmup",
-        emoji: "🤸",
-        title: "Розминка",
-        desc: "легко · запусти таймер",
-        data: { name: "Розминка" },
-      },
-      {
-        id: "walk",
-        emoji: "🚶",
-        title: "Прогулянка",
-        desc: "кардіо · запусти таймер",
-        data: { name: "Прогулянка" },
-      },
-      {
-        id: "quick",
-        emoji: "⚡",
-        title: "Швидке HIIT",
-        desc: "інтенсив · запусти таймер",
-        data: { name: "Швидке HIIT" },
-      },
-    ],
+    items: [],
   },
 };
 
@@ -184,16 +149,21 @@ export function PresetSheet({ open, moduleId, onClose, onPick }) {
       module: moduleId,
       presetId: item.id,
     });
-    // Routine преcets пишуться одразу — звичка це «ім'я + ✓», тут
-    // немає метрики, яку можна сфабрикувати. Для finyk/fizruk/nutrition
-    // натомість відкриваємо повний add-sheet модуля (без fake-сум і
-    // fake-ккал у ledger-і), зберігаючи «одне тапання до дії».
+    // Routine preсети пишуться одразу — звичка це «ім'я + ✓», тут
+    // немає метрики, яку можна сфабрикувати. Для finyk (а в перспективі
+    // й інших) натомість стешимо `item.data` у sessionStorage і
+    // відкриваємо повний add-sheet модуля — без фейкових сум у ledger-і,
+    // але з префіллом назви/категорії, щоб три плитки не деградували
+    // до трьох ідентичних порожніх форм.
+    let persisted = false;
     if (moduleId === "routine") {
       applyPreset(moduleId, item.data);
+      persisted = true;
     } else if (config.action) {
+      writePresetPrefill(moduleId, item.data);
       openHubModuleWithAction(moduleId, config.action);
     }
-    onPick?.({ moduleId, presetId: item.id });
+    onPick?.({ moduleId, presetId: item.id, persisted });
     onClose?.();
   };
 
@@ -202,7 +172,11 @@ export function PresetSheet({ open, moduleId, onClose, onPick }) {
       module: moduleId,
       via: "fallback",
     });
-    onPick?.({ moduleId, presetId: null, custom: true });
+    // Fallback CTA = явне «без префілу». Стираємо будь-який stale prefill
+    // від попередньої відкритої плитки, щоб наступний `consumePresetPrefill`
+    // у модулі не підчепив чужі дані.
+    writePresetPrefill(moduleId, null);
+    onPick?.({ moduleId, presetId: null, custom: true, persisted: false });
     onClose?.();
     openHubModuleWithAction(moduleId, config.fallback.action);
   };

--- a/src/core/onboarding/presetPrefill.ts
+++ b/src/core/onboarding/presetPrefill.ts
@@ -1,0 +1,47 @@
+// Ephemeral session-scoped bridge for forwarding a preset tile's
+// `item.data` into the target module's AddSheet.
+//
+// The FTUX preset sheet navigates with `openHubModuleWithAction(moduleId,
+// action)` — the `HUB_OPEN_MODULE_EVENT` payload has no room for
+// arbitrary per-item data without changing every consumer of that event.
+// Instead we stash the picked preset's data here, and each module's
+// existing `pwaAction` effect consumes it on the way into the AddSheet.
+//
+// `sessionStorage` (not `localStorage`) is intentional: the prefill is a
+// one-shot, current-tab-only handoff. A stale prefill must never survive
+// a reload or leak across tabs — it would silently steer the next manual
+// FAB tap into someone else's category.
+
+const KEY_PREFIX = "hub_preset_prefill_v1:";
+
+export type PresetPrefill = Record<string, unknown>;
+
+export function writePresetPrefill(
+  moduleId: string,
+  data: PresetPrefill | null | undefined,
+): void {
+  try {
+    if (data && typeof data === "object") {
+      sessionStorage.setItem(KEY_PREFIX + moduleId, JSON.stringify(data));
+    } else {
+      sessionStorage.removeItem(KEY_PREFIX + moduleId);
+    }
+  } catch {
+    /* noop — SSR / quota / disabled */
+  }
+}
+
+export function consumePresetPrefill(moduleId: string): PresetPrefill | null {
+  try {
+    const raw = sessionStorage.getItem(KEY_PREFIX + moduleId);
+    if (!raw) return null;
+    sessionStorage.removeItem(KEY_PREFIX + moduleId);
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as PresetPrefill;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -22,6 +22,7 @@ import { Analytics } from "./pages/Analytics.jsx";
 import { ManualExpenseSheet } from "./components/ManualExpenseSheet.jsx";
 import { useUnifiedFinanceData } from "./hooks/useUnifiedFinanceData";
 import { useFinykPersonalization } from "./hooks/useFinykPersonalization";
+import { consumePresetPrefill } from "../../core/onboarding/presetPrefill.js";
 
 const NAV_ICONS = {
   overview: (
@@ -183,6 +184,10 @@ export default function App({
   const [editingManualExpenseId, setEditingManualExpenseId] = useState(null);
   // Для prefill категорії при кліку на quick-add картку з Overview.
   const [quickAddCategory, setQuickAddCategory] = useState(null);
+  // Prefill опису з FTUX preset sheet («Кава», «Таксі», «Обід»). Окрема
+  // стейт-клітинка, бо quick-add з Overview задає лише категорію —
+  // description лишається порожнім і поповнюється користувачем.
+  const [quickAddDescription, setQuickAddDescription] = useState(null);
   // "Manual only" bypass: user completed onboarding without Monobank or
   // pressed «Далі без банку» on the login screen. When set, we render the
   // normal Finyk UI populated from manual expenses even if `clientInfo` is
@@ -207,7 +212,21 @@ export default function App({
 
   useEffect(() => {
     if (pwaAction === "add_expense") {
+      // FTUX preset sheet може стешити `item.data` у sessionStorage
+      // (див. `writePresetPrefill`), щоб плитки «Кава» / «Таксі» / «Обід»
+      // не деградували до трьох ідентичних порожніх форм. Споживаємо
+      // prefill ТІЛЬКИ для нового запису — без `editingManualExpenseId`,
+      // щоб випадковий stale prefill не перезаписав категорію під час
+      // редагування існуючої витрати.
+      const prefill = consumePresetPrefill("finyk");
       navigate("transactions");
+      setEditingManualExpenseId(null);
+      setQuickAddCategory(
+        typeof prefill?.category === "string" ? prefill.category : null,
+      );
+      setQuickAddDescription(
+        typeof prefill?.description === "string" ? prefill.description : null,
+      );
       setShowExpenseSheet(true);
       onPwaActionConsumed?.();
     }
@@ -728,6 +747,7 @@ export default function App({
           setShowExpenseSheet(false);
           setEditingManualExpenseId(null);
           setQuickAddCategory(null);
+          setQuickAddDescription(null);
         }}
         initialExpense={
           editingManualExpenseId
@@ -737,6 +757,7 @@ export default function App({
             : null
         }
         initialCategory={quickAddCategory}
+        initialDescription={quickAddDescription}
         frequentCategories={frequentCategories}
         frequentMerchants={frequentMerchants}
         onSave={(expense) => {

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -124,6 +124,7 @@ export function ManualExpenseSheet({
   frequentCategories = [],
   frequentMerchants = [],
   initialCategory,
+  initialDescription,
 }) {
   const formId = useId();
   const descId = `${formId}-desc`;
@@ -173,7 +174,8 @@ export function ManualExpenseSheet({
           }
         }
         setForm({
-          description: "",
+          description:
+            typeof initialDescription === "string" ? initialDescription : "",
           amount: "",
           category: startCategory,
           date: toLocalISODate(),
@@ -181,8 +183,9 @@ export function ManualExpenseSheet({
       }
       setError("");
     }
-    // frequentCategories/initialCategory лише задають стартовий стан при
-    // відкритті — навмисно не реагуємо на їхні оновлення у відкритому sheet.
+    // frequentCategories/initialCategory/initialDescription лише задають
+    // стартовий стан при відкритті — навмисно не реагуємо на їхні
+    // оновлення у відкритому sheet.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, initialExpense]);
 


### PR DESCRIPTION
…ssal

PR #323 swapped non-routine PresetSheet picks from applyPreset() (writes entry to storage) to openHubModuleWithAction() (navigate only). That removed fake amounts/kcal from the ledger — but introduced two regressions flagged by Devin Review:

1. All three finyk/nutrition/fizruk preset tiles opened the same blank add-form. The HUB_OPEN_MODULE_EVENT has no payload channel, so item.data was silently dropped. Three visually-distinct CTAs with one outcome = mini-deception.

2. The FTUX pending flag was cleared on every preset tap via handlePresetPick → clearFirstActionPending(). But for non-routine no real entry was written, so a user cancelling the add-sheet lost the hero card forever, and useFirstEntryCelebration never fired.

Fix:

- New presetPrefill sessionStorage bridge (tab-scoped, one-shot) lets PresetSheet stash item.data and the target module consume it inside its existing pwaAction effect. FinykApp now pulls description + category and threads them into ManualExpenseSheet's initialCategory (existing) + new initialDescription, so Кава/Таксі/Обід again land the user in three distinctly-prefilled forms without writing fake amounts to the ledger.
- Nutrition/fizruk have no prefill surface yet, so their items[] is collapsed to empty — the sheet renders only the honest single fallback CTA instead of three identical-outcome tiles. When those modules grow a prefill channel the items return.
- handlePresetPick now accepts { persisted } and only clears the FTUX flag + dismisses the hero when routine actually wrote an entry. For non-routine navigations the flag stays, so the hero reappears on the next dashboard mount and useFirstEntryCelebration takes over once a real entry lands.

Validated: lint + typecheck + 880/880 tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
