### PR TITLE
feat(server): migrate modules/{barcode,food-search,weekly-digest,coach} to TypeScript

### DIFF
--- a/server/modules/barcode.ts
+++ b/server/modules/barcode.ts
@@ -1,7 +1,51 @@
+import type { Request, Response } from "express";
 import { recordExternalHttp } from "../lib/externalHttp.js";
 import { BarcodeQuerySchema } from "../http/schemas.js";
 import { validateQuery } from "../http/validate.js";
 import { barcodeLookupsTotal } from "../obs/metrics.js";
+
+interface NormalizedProduct {
+  name: string;
+  brand: string | null;
+  kcal_100g: number | null;
+  protein_100g: number | null;
+  fat_100g: number | null;
+  carbs_100g: number | null;
+  servingSize: string | null;
+  servingGrams: number | null;
+  source: "off" | "usda" | "upcitemdb";
+  partial?: boolean;
+}
+
+interface OFFProduct {
+  product_name?: string;
+  product_name_uk?: string;
+  brands?: string;
+  nutriments?: Record<string, unknown>;
+  serving_size?: string;
+  serving_quantity?: number | string;
+}
+
+interface USDAFoodNutrient {
+  nutrientId?: number;
+  nutrient?: { id?: number };
+  value?: number;
+  amount?: number;
+}
+
+interface USDAFood {
+  description?: string;
+  brandOwner?: string;
+  brandName?: string;
+  foodNutrients?: USDAFoodNutrient[];
+  servingSize?: number;
+  servingSizeUnit?: string;
+  gtinUpc?: string;
+}
+
+function hasErrorName(e: unknown, name: string): boolean {
+  return !!e && typeof e === "object" && (e as { name?: string }).name === name;
+}
 
 /**
  * Record-helper одночасно емітить і domain-specific метрику
@@ -9,7 +53,7 @@ import { barcodeLookupsTotal } from "../obs/metrics.js";
  * уніфіковану `external_http_requests_total{upstream=source,outcome}`.
  * Свідоме дублювання — знести domain-метрику лише після оновлення дашбордів.
  */
-function recordLookup(source, outcome, ms) {
+function recordLookup(source: string, outcome: string, ms: number): void {
   try {
     barcodeLookupsTotal.inc({ source, outcome });
   } catch {
@@ -18,7 +62,7 @@ function recordLookup(source, outcome, ms) {
   recordExternalHttp(source, outcome, ms);
 }
 
-function elapsedMs(start) {
+function elapsedMs(start: bigint): number {
   return Number(process.hrtime.bigint() - start) / 1e6;
 }
 
@@ -29,14 +73,16 @@ const OFF_BASE = "https://world.openfoodfacts.org/api/v2/product";
 const OFF_FIELDS =
   "product_name,product_name_uk,brands,nutriments,serving_size,serving_quantity";
 
-function normalizeOFF(product) {
-  const n = product?.nutriments || {};
+function normalizeOFF(
+  product: OFFProduct | null | undefined,
+): NormalizedProduct | null {
+  const n = (product?.nutriments || {}) as Record<string, unknown>;
   const name = product?.product_name_uk || product?.product_name || null;
   const brand = product?.brands
     ? String(product.brands).split(",")[0].trim()
     : null;
 
-  const round1 = (v) =>
+  const round1 = (v: unknown): number | null =>
     v != null && Number.isFinite(Number(v))
       ? Math.round(Number(v) * 10) / 10
       : null;
@@ -73,7 +119,7 @@ function normalizeOFF(product) {
   };
 }
 
-async function lookupOFF(barcode) {
+async function lookupOFF(barcode: string): Promise<NormalizedProduct | null> {
   const url = `${OFF_BASE}/${barcode}.json?fields=${OFF_FIELDS}`;
   const start = process.hrtime.bigint();
   try {
@@ -88,7 +134,7 @@ async function lookupOFF(barcode) {
       recordLookup("off", "miss", elapsedMs(start));
       return null;
     }
-    const data = await r.json();
+    const data = (await r.json()) as { status?: number; product?: OFFProduct };
     if (data?.status !== 1 || !data?.product) {
       recordLookup("off", "miss", elapsedMs(start));
       return null;
@@ -96,10 +142,10 @@ async function lookupOFF(barcode) {
     const product = normalizeOFF(data.product);
     recordLookup("off", product ? "hit" : "miss", elapsedMs(start));
     return product;
-  } catch (e) {
+  } catch (e: unknown) {
     recordLookup(
       "off",
-      e?.name === "TimeoutError" ? "timeout" : "error",
+      hasErrorName(e, "TimeoutError") ? "timeout" : "error",
       elapsedMs(start),
     );
     throw e;
@@ -119,16 +165,18 @@ const FDC_NUTRIENT = {
   protein: 1003,
   fat: 1004,
   carbs: 1005,
-};
+} as const;
 
-function normalizeUSDA(food) {
+function normalizeUSDA(
+  food: USDAFood | null | undefined,
+): NormalizedProduct | null {
   if (!food) return null;
   const name = food.description || null;
   if (!name) return null;
 
   const brand = food.brandOwner || food.brandName || null;
 
-  const nutrientMap = {};
+  const nutrientMap: Record<number, number> = {};
   for (const n of food.foodNutrients || []) {
     const id = n.nutrientId ?? n.nutrient?.id;
     const value = n.value ?? n.amount;
@@ -167,7 +215,7 @@ function normalizeUSDA(food) {
   };
 }
 
-async function lookupUSDA(barcode) {
+async function lookupUSDA(barcode: string): Promise<NormalizedProduct | null> {
   const key = process.env.USDA_FDC_API_KEY || "DEMO_KEY";
   // Search Branded Foods by GTIN/UPC (barcode is stored in gtinUpc field)
   const url = `${FDC_BASE}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&pageSize=5&api_key=${key}`;
@@ -181,7 +229,7 @@ async function lookupUSDA(barcode) {
       recordLookup("usda", "miss", elapsedMs(start));
       return null;
     }
-    const data = await r.json();
+    const data = (await r.json()) as { foods?: USDAFood[] };
     const foods = data?.foods;
     if (!Array.isArray(foods) || foods.length === 0) {
       recordLookup("usda", "miss", elapsedMs(start));
@@ -198,10 +246,10 @@ async function lookupUSDA(barcode) {
     const product = normalizeUSDA(food);
     recordLookup("usda", product ? "hit" : "miss", elapsedMs(start));
     return product;
-  } catch (e) {
+  } catch (e: unknown) {
     recordLookup(
       "usda",
-      e?.name === "TimeoutError" ? "timeout" : "error",
+      hasErrorName(e, "TimeoutError") ? "timeout" : "error",
       elapsedMs(start),
     );
     throw e;
@@ -213,7 +261,9 @@ async function lookupUSDA(barcode) {
 // Returns product name/brand but rarely has nutrition data for food items.
 // We mark partial: true so the frontend can prompt the user to fill in macros.
 // ──────────────────────────────────────────────────────────────────────────────
-async function lookupUPCitemdb(barcode) {
+async function lookupUPCitemdb(
+  barcode: string,
+): Promise<NormalizedProduct | null> {
   const url = `https://api.upcitemdb.com/prod/trial/lookup?upc=${encodeURIComponent(barcode)}`;
   const start = process.hrtime.bigint();
   try {
@@ -225,7 +275,9 @@ async function lookupUPCitemdb(barcode) {
       recordLookup("upcitemdb", "miss", elapsedMs(start));
       return null;
     }
-    const data = await r.json();
+    const data = (await r.json()) as {
+      items?: Array<{ title?: string; brand?: string }>;
+    };
     const item = Array.isArray(data?.items) ? data.items[0] : null;
     if (!item) {
       recordLookup("upcitemdb", "miss", elapsedMs(start));
@@ -253,10 +305,10 @@ async function lookupUPCitemdb(barcode) {
       source: "upcitemdb",
       partial: true, // no nutrition data — frontend should prompt user to fill in macros
     };
-  } catch (e) {
+  } catch (e: unknown) {
     recordLookup(
       "upcitemdb",
-      e?.name === "TimeoutError" ? "timeout" : "error",
+      hasErrorName(e, "TimeoutError") ? "timeout" : "error",
       elapsedMs(start),
     );
     throw e;
@@ -271,17 +323,21 @@ async function lookupUPCitemdb(barcode) {
  * Middleware-и роутера (`setModule`, `rateLimitExpress`) забезпечують
  * module-tag і rate-limit; тут лише бізнес-логіка.
  */
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const parsed = validateQuery(BarcodeQuerySchema, req, res);
   if (!parsed.ok) return;
   const barcode = parsed.data.barcode.replace(/\D/g, "");
   if (!/^\d{8,14}$/.test(barcode)) {
-    return res.status(400).json({ error: "Невірний штрихкод (8–14 цифр)" });
+    res.status(400).json({ error: "Невірний штрихкод (8–14 цифр)" });
+    return;
   }
 
   try {
     // Cascade: OFF → USDA → UPCitemdb
-    let product = null;
+    let product: NormalizedProduct | null = null;
 
     try {
       product = await lookupOFF(barcode);
@@ -304,16 +360,19 @@ export default async function handler(req, res) {
     }
 
     if (!product) {
-      return res.status(404).json({ error: "Продукт не знайдено" });
+      res.status(404).json({ error: "Продукт не знайдено" });
+      return;
     }
 
-    return res.status(200).json({ product });
-  } catch (e) {
-    if (e?.name === "TimeoutError" || e?.name === "AbortError") {
-      return res
+    res.status(200).json({ product });
+  } catch (e: unknown) {
+    if (hasErrorName(e, "TimeoutError") || hasErrorName(e, "AbortError")) {
+      res
         .status(504)
         .json({ error: "Сервіс недоступний (таймаут). Спробуй пізніше." });
+      return;
     }
-    return res.status(500).json({ error: e?.message || "Server error" });
+    const message = e instanceof Error ? e.message : "Server error";
+    res.status(500).json({ error: message });
   }
 }

--- a/server/modules/coach.ts
+++ b/server/modules/coach.ts
@@ -1,36 +1,75 @@
+import type { Request, Response } from "express";
 import pool from "../db.js";
 import { anthropicMessages, extractAnthropicText } from "../lib/anthropic.js";
 import { MAX_BLOB_SIZE } from "./sync.js";
 import { validateBody } from "../http/validate.js";
 import { CoachInsightSchema, CoachMemoryPostSchema } from "../http/schemas.js";
 
-async function getMemory(userId) {
+type WithSessionUser = Request & { user?: { id: string } };
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+interface AnthropicErrorPayload {
+  error?: { message?: string };
+}
+
+interface WeeklyDigestEntry {
+  weekKey: string;
+  weekRange?: string;
+  generatedAt: string;
+  finyk?: { summary?: string } | null;
+  fizruk?: { summary?: string } | null;
+  nutrition?: { summary?: string } | null;
+  routine?: { summary?: string } | null;
+  overallRecommendations?: string[];
+}
+
+interface CoachMemory {
+  weeklyDigests: WeeklyDigestEntry[];
+  lastInsightDate: string | null;
+  lastInsightText: string | null;
+}
+
+interface IncomingMemory {
+  weeklyDigest?: {
+    weekKey: string;
+    weekRange?: string;
+    generatedAt?: string;
+    finyk?: { summary?: string } | null;
+    fizruk?: { summary?: string } | null;
+    nutrition?: { summary?: string } | null;
+    routine?: { summary?: string } | null;
+    overallRecommendations?: string[];
+  };
+}
+
+async function getMemory(userId: string): Promise<CoachMemory | null> {
   // EXPLAIN ANALYZE: Index Scan using module_data_user_id_module_key
   //   на UNIQUE(user_id, module) — point-lookup, O(log N), < 1мс.
-  const result = await pool.query(
+  const result = await pool.query<{ data: unknown }>(
     `SELECT data FROM module_data WHERE user_id = $1 AND module = 'coach'`,
     [userId],
   );
   if (result.rows.length === 0) return null;
   const raw = result.rows[0].data;
   try {
-    return typeof raw === "string" ? JSON.parse(raw) : raw;
+    return (typeof raw === "string" ? JSON.parse(raw) : raw) as CoachMemory;
   } catch {
-    return raw;
+    return raw as CoachMemory;
   }
 }
 
 // Власний тип помилки, щоб handler міг відрізнити overflow від інших DB-фейлів
 // і повернути 413 замість 500.
 export class CoachMemoryTooLargeError extends Error {
-  constructor(bytes) {
+  public readonly bytes: number;
+  constructor(bytes: number) {
     super(`coach memory blob too large: ${bytes} bytes`);
     this.name = "CoachMemoryTooLargeError";
     this.bytes = bytes;
   }
 }
 
-async function saveMemory(userId, memory) {
+async function saveMemory(userId: string, memory: CoachMemory): Promise<void> {
   const blob = JSON.stringify(memory);
   // Ділимо той самий `MAX_BLOB_SIZE`, що й sync: це один стовпчик `module_data.data`
   // і той самий пейлоад-транспорт, тож будь-яке різне ліміти-рішення буде сюрпризом.
@@ -46,8 +85,11 @@ async function saveMemory(userId, memory) {
   );
 }
 
-function mergeMemory(existing, incoming) {
-  const base = existing || {
+function mergeMemory(
+  existing: CoachMemory | null,
+  incoming: IncomingMemory,
+): CoachMemory {
+  const base: CoachMemory = existing || {
     weeklyDigests: [],
     lastInsightDate: null,
     lastInsightText: null,
@@ -58,7 +100,7 @@ function mergeMemory(existing, incoming) {
     : [];
 
   if (incoming.weeklyDigest) {
-    const entry = {
+    const entry: WeeklyDigestEntry = {
       weekKey: incoming.weeklyDigest.weekKey,
       weekRange: incoming.weeklyDigest.weekRange,
       generatedAt:
@@ -87,7 +129,7 @@ function mergeMemory(existing, incoming) {
   };
 }
 
-function buildMemorySummary(memory) {
+function buildMemorySummary(memory: CoachMemory | null): string {
   if (
     !memory ||
     !Array.isArray(memory.weeklyDigests) ||
@@ -96,13 +138,13 @@ function buildMemorySummary(memory) {
     return "Пам'яті ще немає — це перший сеанс.";
   }
 
-  const lines = [];
+  const lines: string[] = [];
   const digests = memory.weeklyDigests.slice(0, 8);
   lines.push(`Накопичено даних за ${digests.length} тижнів.`);
 
   const finykSummaries = digests
     .filter((d) => d.finyk?.summary)
-    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.finyk.summary}`);
+    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.finyk!.summary}`);
   if (finykSummaries.length) {
     lines.push("Фінанси (по тижнях):");
     lines.push(...finykSummaries.slice(0, 4));
@@ -110,7 +152,7 @@ function buildMemorySummary(memory) {
 
   const fizrukSummaries = digests
     .filter((d) => d.fizruk?.summary)
-    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.fizruk.summary}`);
+    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.fizruk!.summary}`);
   if (fizrukSummaries.length) {
     lines.push("Тренування (по тижнях):");
     lines.push(...fizrukSummaries.slice(0, 4));
@@ -118,7 +160,7 @@ function buildMemorySummary(memory) {
 
   const nutritionSummaries = digests
     .filter((d) => d.nutrition?.summary)
-    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.nutrition.summary}`);
+    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.nutrition!.summary}`);
   if (nutritionSummaries.length) {
     lines.push("Харчування (по тижнях):");
     lines.push(...nutritionSummaries.slice(0, 4));
@@ -126,7 +168,7 @@ function buildMemorySummary(memory) {
 
   const routineSummaries = digests
     .filter((d) => d.routine?.summary)
-    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.routine.summary}`);
+    .map((d) => `  • ${d.weekRange || d.weekKey}: ${d.routine!.summary}`);
   if (routineSummaries.length) {
     lines.push("Звички (по тижнях):");
     lines.push(...routineSummaries.slice(0, 4));
@@ -147,41 +189,72 @@ function buildMemorySummary(memory) {
  * GET /api/coach/memory — віддати поточну coach-пам'ять користувача.
  * `req.user` гарантовано заповнений middleware-ом `requireSession`.
  */
-export async function coachMemoryGet(req, res) {
-  const memory = await getMemory(req.user.id);
-  return res.json({ ok: true, memory: memory || null });
+export async function coachMemoryGet(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const userId = (req as WithSessionUser).user!.id;
+  const memory = await getMemory(userId);
+  res.json({ ok: true, memory: memory || null });
 }
 
 /**
  * POST /api/coach/memory — merge incoming digest у збережену пам'ять.
  * `req.user` гарантовано заповнений middleware-ом `requireSession`.
  */
-export async function coachMemoryPost(req, res) {
+export async function coachMemoryPost(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const parsed = validateBody(CoachMemoryPostSchema, req, res);
   if (!parsed.ok) return;
-  const incoming = parsed.data;
-  const existing = await getMemory(req.user.id);
+  const incoming = parsed.data as IncomingMemory;
+  const userId = (req as WithSessionUser).user!.id;
+  const existing = await getMemory(userId);
   const merged = mergeMemory(existing, incoming);
   try {
-    await saveMemory(req.user.id, merged);
-  } catch (err) {
+    await saveMemory(userId, merged);
+  } catch (err: unknown) {
     if (err instanceof CoachMemoryTooLargeError) {
-      return res.status(413).json({ error: "Coach memory blob too large" });
+      res.status(413).json({ error: "Coach memory blob too large" });
+      return;
     }
     throw err;
   }
-  return res.json({ ok: true });
+  res.json({ ok: true });
 }
 
 /**
  * POST /api/coach/insight — згенерувати AI-повідомлення дня.
  * `req.user`, `req.anthropicKey` і квота гарантуються middleware-ами роутера.
  */
-export async function coachInsight(req, res) {
-  const apiKey = req.anthropicKey;
+export async function coachInsight(req: Request, res: Response): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
   const parsed = validateBody(CoachInsightSchema, req, res);
   if (!parsed.ok) return;
-  const { snapshot, memory } = parsed.data;
+  const { snapshot, memory } = parsed.data as {
+    snapshot: {
+      finyk?: {
+        totalSpent?: number;
+        totalIncome?: number;
+        txCount?: number;
+        topCategories?: Array<{ name: string; amount: number }>;
+      };
+      fizruk?: {
+        workoutsCount?: number;
+        totalVolume?: number;
+        recoveryLabel?: string;
+      };
+      nutrition?: {
+        avgKcal?: number;
+        targetKcal?: number;
+        avgProtein?: number;
+        daysLogged?: number;
+      };
+      routine?: { overallRate?: number; habitCount?: number };
+    };
+    memory: CoachMemory | null;
+  };
 
   const memorySummary = buildMemorySummary(memory);
 
@@ -245,12 +318,14 @@ ${snapshotText}
   );
 
   if (!aiRes?.ok) {
-    return res
+    const errData = aiData as AnthropicErrorPayload | null | undefined;
+    res
       .status(aiRes?.status || 500)
-      .json({ error: aiData?.error?.message || "AI error" });
+      .json({ error: errData?.error?.message || "AI error" });
+    return;
   }
 
   const text = extractAnthropicText(aiData);
 
-  return res.json({ ok: true, insight: text });
+  res.json({ ok: true, insight: text });
 }

--- a/server/modules/food-search.ts
+++ b/server/modules/food-search.ts
@@ -1,3 +1,4 @@
+import type { Request, Response } from "express";
 import { FoodSearchQuerySchema } from "../http/schemas.js";
 import { validateQuery } from "../http/validate.js";
 
@@ -6,8 +7,39 @@ const OFF_FIELDS =
   "product_name,product_name_uk,brands,nutriments,serving_quantity";
 const USDA_SEARCH = "https://api.nal.usda.gov/fdc/v1/foods/search";
 
+interface OFFSearchProduct {
+  product_name?: string;
+  product_name_uk?: string;
+  brands?: string;
+  nutriments?: Record<string, unknown>;
+  serving_quantity?: number | string;
+}
+
+interface USDASearchFood {
+  description?: string;
+  foodNutrients?: Array<{ nutrientId?: number; value?: number }>;
+}
+
+interface NormalizedSearchProduct {
+  id: string;
+  name: string;
+  brand: string | null;
+  source: "off" | "usda";
+  per100: {
+    kcal: number;
+    protein_g: number;
+    fat_g: number;
+    carbs_g: number;
+  };
+  defaultGrams: number;
+}
+
+function hasErrorName(e: unknown, name: string): boolean {
+  return !!e && typeof e === "object" && (e as { name?: string }).name === name;
+}
+
 // Перший токен запиту → англійський еквівалент для USDA / OFF-en пошуку
-const UK_TO_EN = {
+const UK_TO_EN: Record<string, string> = {
   груша: "pear",
   яблуко: "apple",
   банан: "banana",
@@ -102,7 +134,7 @@ const UK_TO_EN = {
 };
 
 // Точний або prefix-match (напр. "груш" → "груша" → "pear")
-function translateFirstToken(query) {
+function translateFirstToken(query: string): string | null {
   const token = query.trim().toLowerCase().split(/\s+/)[0];
   if (!token || token.length < 2) return null;
   if (UK_TO_EN[token]) return UK_TO_EN[token];
@@ -114,10 +146,13 @@ function translateFirstToken(query) {
   return null;
 }
 
-function normalizeOFFProduct(product, idx) {
-  const n = product?.nutriments || {};
+function normalizeOFFProduct(
+  product: OFFSearchProduct | null | undefined,
+  idx: number,
+): NormalizedSearchProduct | null {
+  const n = (product?.nutriments || {}) as Record<string, unknown>;
 
-  const round1 = (v) =>
+  const round1 = (v: unknown): number | null =>
     v != null && Number.isFinite(Number(v))
       ? Math.round(Number(v) * 10) / 10
       : null;
@@ -163,11 +198,14 @@ function normalizeOFFProduct(product, idx) {
 }
 
 // USDA nutrient IDs: 1008=Energy(kcal), 1003=Protein, 1004=Fat, 1005=Carbs
-function normalizeUSDAProduct(food, idx) {
+function normalizeUSDAProduct(
+  food: USDASearchFood | null | undefined,
+  idx: number,
+): NormalizedSearchProduct | null {
   const name = food?.description;
   if (!name) return null;
 
-  const round1 = (v) =>
+  const round1 = (v: unknown): number | null =>
     v != null && Number.isFinite(Number(v))
       ? Math.round(Number(v) * 10) / 10
       : null;
@@ -175,7 +213,7 @@ function normalizeUSDAProduct(food, idx) {
   const nutrients = Array.isArray(food?.foodNutrients)
     ? food.foodNutrients
     : [];
-  const get = (id) => {
+  const get = (id: number): number | null => {
     const n = nutrients.find((x) => x.nutrientId === id);
     return n?.value != null ? Number(n.value) : null;
   };
@@ -204,7 +242,11 @@ function normalizeUSDAProduct(food, idx) {
   };
 }
 
-async function fetchOFF(searchTerms, lc, signal) {
+async function fetchOFF(
+  searchTerms: string,
+  lc: string,
+  signal: AbortSignal,
+): Promise<OFFSearchProduct[]> {
   const url = new URL(OFF_SEARCH);
   url.searchParams.set("search_terms", searchTerms);
   url.searchParams.set("page_size", "20");
@@ -221,11 +263,14 @@ async function fetchOFF(searchTerms, lc, signal) {
     signal,
   });
   if (!r.ok) return [];
-  const data = await r.json();
+  const data = (await r.json()) as { products?: OFFSearchProduct[] };
   return data?.products || [];
 }
 
-async function fetchUSDA(query, signal) {
+async function fetchUSDA(
+  query: string,
+  signal: AbortSignal,
+): Promise<USDASearchFood[]> {
   const apiKey = process.env.USDA_API_KEY || "DEMO_KEY";
   const url = new URL(USDA_SEARCH);
   url.searchParams.set("query", query);
@@ -235,7 +280,7 @@ async function fetchUSDA(query, signal) {
 
   const r = await fetch(url.toString(), { signal });
   if (!r.ok) return [];
-  const data = await r.json();
+  const data = (await r.json()) as { foods?: USDASearchFood[] };
   return data?.foods || [];
 }
 
@@ -243,7 +288,10 @@ async function fetchUSDA(query, signal) {
  * GET /api/food-search?q=… — каскадний пошук через Open Food Facts + USDA.
  * CORS і rate-limit виставляє роутер.
  */
-export default async function handler(req, res) {
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const parsed = validateQuery(FoodSearchQuerySchema, req, res);
   if (!parsed.ok) return;
   const { q: query, limit } = parsed.data;
@@ -254,23 +302,28 @@ export default async function handler(req, res) {
     const enTerm = translateFirstToken(query);
 
     const [ukOff, enOff, usdaRaw] = await Promise.all([
-      fetchOFF(query, "uk", signal).catch(() => []),
+      fetchOFF(query, "uk", signal).catch((): OFFSearchProduct[] => []),
       enTerm
-        ? fetchOFF(enTerm, "en", signal).catch(() => [])
-        : Promise.resolve([]),
-      enTerm ? fetchUSDA(enTerm, signal).catch(() => []) : Promise.resolve([]),
+        ? fetchOFF(enTerm, "en", signal).catch((): OFFSearchProduct[] => [])
+        : Promise.resolve<OFFSearchProduct[]>([]),
+      enTerm
+        ? fetchUSDA(enTerm, signal).catch((): USDASearchFood[] => [])
+        : Promise.resolve<USDASearchFood[]>([]),
     ]);
 
     const offProducts = [...ukOff, ...enOff]
       .map((p, i) => normalizeOFFProduct(p, i))
-      .filter(Boolean);
+      .filter((p): p is NormalizedSearchProduct => p != null);
 
     const usdaProducts = usdaRaw
       .map((p, i) => normalizeUSDAProduct(p, i))
-      .filter(Boolean);
+      .filter((p): p is NormalizedSearchProduct => p != null);
 
     // OFF (з українськими назвами) йде першим, USDA — як fallback
-    const allProducts = [...offProducts, ...usdaProducts];
+    const allProducts: NormalizedSearchProduct[] = [
+      ...offProducts,
+      ...usdaProducts,
+    ];
 
     const qTokens = query
       .toLowerCase()
@@ -279,7 +332,7 @@ export default async function handler(req, res) {
     const enTokens = enTerm ? enTerm.toLowerCase().split(/\s+/) : [];
     const allTokens = [...qTokens, ...enTokens];
 
-    const seen = new Set();
+    const seen = new Set<string>();
     const products = allProducts
       .filter((p) => {
         const key = `${(p.name || "").toLowerCase()}|${(p.brand || "").toLowerCase()}`;
@@ -291,13 +344,15 @@ export default async function handler(req, res) {
       })
       .slice(0, limit);
 
-    return res.status(200).json({ products });
-  } catch (e) {
-    if (e?.name === "TimeoutError" || e?.name === "AbortError") {
-      return res
+    res.status(200).json({ products });
+  } catch (e: unknown) {
+    if (hasErrorName(e, "TimeoutError") || hasErrorName(e, "AbortError")) {
+      res
         .status(504)
         .json({ error: "Сервіс недоступний (таймаут). Спробуй пізніше." });
+      return;
     }
-    return res.status(500).json({ error: e?.message || "Server error" });
+    const message = e instanceof Error ? e.message : "Server error";
+    res.status(500).json({ error: message });
   }
 }

--- a/server/modules/weekly-digest.ts
+++ b/server/modules/weekly-digest.ts
@@ -1,9 +1,16 @@
+import type { Request, Response } from "express";
 import { anthropicMessages, extractAnthropicText } from "../lib/anthropic.js";
 import { validateBody } from "../http/validate.js";
 import { WeeklyDigestSchema } from "../http/schemas.js";
 import { ExternalServiceError, ValidationError } from "../obs/errors.js";
 
-function extractJsonObject(raw) {
+type WithAnthropicKey = Request & { anthropicKey?: string };
+
+interface AnthropicErrorPayload {
+  error?: { message?: string };
+}
+
+function extractJsonObject(raw: unknown): unknown {
   if (typeof raw !== "string") return null;
   let text = raw.trim();
   // Прибираємо markdown-обгортку ```json ... ``` або ``` ... ```
@@ -55,14 +62,17 @@ function extractJsonObject(raw) {
  * забезпечені middleware-ами роутера; тут лише бізнес-логіка. Ключ Anthropic
  * читається з `req.anthropicKey`.
  */
-export default async function handler(req, res) {
-  const apiKey = req.anthropicKey;
+export default async function handler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const apiKey = (req as WithAnthropicKey).anthropicKey as string;
 
   const parsed = validateBody(WeeklyDigestSchema, req, res);
   if (!parsed.ok) return;
   const { weekRange, finyk, fizruk, nutrition, routine } = parsed.data;
 
-  const sections = [];
+  const sections: string[] = [];
 
   if (finyk) {
     const budgetLine = finyk.monthlyBudget
@@ -178,7 +188,8 @@ ${dataContext}`;
   );
 
   if (!aiRes?.ok) {
-    throw new ExternalServiceError(aiData?.error?.message || "AI error", {
+    const errData = aiData as AnthropicErrorPayload | null | undefined;
+    throw new ExternalServiceError(errData?.error?.message || "AI error", {
       status: aiRes?.status || 502,
       code: "ANTHROPIC_ERROR",
     });
@@ -194,7 +205,5 @@ ${dataContext}`;
     });
   }
 
-  return res
-    .status(200)
-    .json({ report, generatedAt: new Date().toISOString() });
+  res.status(200).json({ report, generatedAt: new Date().toISOString() });
 }


### PR DESCRIPTION
## Summary

Phase 1b of the `server/modules/*` TypeScript migration. Converts 4 "medium" modules (~1080 LOC) from `.js` → `.ts` with explicit type annotations. Purely mechanical type-addition — runtime behavior unchanged thanks to the `tsx` loader.

Files migrated:
- `server/modules/barcode.js` → `.ts` (319 lines) — cascade lookup OFF → USDA → UPCitemdb. Added `NormalizedProduct`, `OFFProduct`, `USDAFood`, `USDAFoodNutrient` interfaces; typed all helpers; narrowed `catch (e)` with `e instanceof Error` / `hasErrorName(e, "TimeoutError")`.
- `server/modules/food-search.js` → `.ts` (303 lines) — OFF + USDA search. Added `OFFSearchProduct`, `USDASearchFood`, `NormalizedSearchProduct` interfaces; type-guard filter `(p): p is NormalizedSearchProduct => p != null`; typed `UK_TO_EN` as `Record<string, string>`.
- `server/modules/weekly-digest.js` → `.ts` (200 lines) — Anthropic weekly digest. Added `WithAnthropicKey`, `AnthropicErrorPayload`; typed `extractJsonObject(raw: unknown): unknown`; explicit `Promise<void>` handler.
- `server/modules/coach.js` → `.ts` (256 lines) — pg memory + Anthropic insight. Added `CoachMemory`, `WeeklyDigestEntry`, `IncomingMemory` interfaces; typed `pool.query<{ data: unknown }>`; typed `CoachMemoryTooLargeError.bytes: number`; `WithSessionUser` / `WithAnthropicKey` Request-augmentation pattern.

Local verification:
- `npm run typecheck` — all 3 tsconfig files pass
- `npm run lint` — clean
- `node scripts/vitest.mjs run` — 880 tests across 88 files pass

## Review & Testing Checklist for Human

- [ ] Verify the 4 routers (`server/routes/barcode.ts`, `food-search.ts`, `weekly-digest.ts`, `coach.ts`) still resolve `../modules/...js` specifiers correctly at runtime via tsx loader
- [ ] Smoke-test each endpoint in staging: GET `/api/barcode?barcode=...`, GET `/api/food-search?q=...`, POST `/api/weekly-digest`, GET/POST `/api/coach/memory`, POST `/api/coach/insight`
- [ ] Confirm `CoachMemoryTooLargeError` still correctly returns 413 on oversized memory blobs (behavior preserved via `instanceof` check)

### Notes

Narrowed `catch (e)` handlers from implicit `any` to explicit `e: unknown` with an `hasErrorName()` helper to safely probe `e.name` for `TimeoutError`/`AbortError`. No change to existing behavior — just satisfies TS strict mode.

Remaining in `server/modules/*` queue: `sync.js` (357 lines, 1d).

Link to Devin session: https://app.devin.ai/sessions/d1e1c873c0754bc0bdfb4c93886b772b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
