### PR TITLE
diag(server): DB connectivity script + explicit weekly-digest 400 reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "db:migrate": "node scripts/migrate.mjs",
+    "db:diagnose": "node scripts/diagnose-db.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/diagnose-db.mjs
+++ b/scripts/diagnose-db.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Standalone Railway/Postgres connectivity diagnostic.
+ *
+ * Мета: за одну команду зрозуміти, чому прод віддає `ai_quota_store_unavailable`
+ * з `getaddrinfo ENOTFOUND`. Перевіряє весь шлях:
+ *
+ *   1. Наявність `DATABASE_URL` / `MIGRATE_DATABASE_URL`
+ *   2. Парсинг URL-а (схема, host, port, db)
+ *   3. DNS-резолв хоста
+ *   4. TCP-connect на порт
+ *   5. Postgres handshake + `SELECT 1`
+ *   6. Наявність ключових таблиць: `ai_usage_daily`, `user`, `session`, `module_data`
+ *
+ * Як запустити:
+ *   # локально з `.env`:
+ *   npm run db:diagnose
+ *
+ *   # на Railway проти прод-БД (pre-deploy shell):
+ *   DATABASE_URL='<runtime-url>' node scripts/diagnose-db.mjs
+ *
+ * Виходить 0 при повному успіху, 1 при будь-якій помилці. JSON-вивід
+ * безпечний для pipe-а в jq.
+ */
+
+import { promises as dns } from "node:dns";
+import net from "node:net";
+
+const STEP_TIMEOUT_MS = Number(process.env.DIAGNOSE_STEP_TIMEOUT_MS) || 7_000;
+
+/** @param {string} msg @param {Record<string, unknown>=} extra */
+function logInfo(msg, extra) {
+  console.log(JSON.stringify({ level: "info", msg, ...(extra || {}) }));
+}
+/** @param {string} msg @param {Record<string, unknown>=} extra */
+function logErr(msg, extra) {
+  console.error(JSON.stringify({ level: "error", msg, ...(extra || {}) }));
+}
+
+/**
+ * Маскує пароль у connection string для безпечного логу.
+ * postgres://user:pass@host:5432/db → postgres://user:***@host:5432/db
+ * @param {string} url
+ */
+function redactUrl(url) {
+  try {
+    const u = new URL(url);
+    if (u.password) u.password = "***";
+    return u.toString();
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
+/** @template T @param {Promise<T>} p @param {number} ms @param {string} label @returns {Promise<T>} */
+function withTimeout(p, ms, label) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/** @param {string} host @param {number} port */
+function tcpProbe(host, port) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port });
+    socket.once("connect", () => {
+      socket.end();
+      resolve(undefined);
+    });
+    socket.once("error", (err) => {
+      socket.destroy();
+      reject(err);
+    });
+  });
+}
+
+async function main() {
+  const source = process.env.MIGRATE_DATABASE_URL
+    ? "MIGRATE_DATABASE_URL"
+    : "DATABASE_URL";
+  const url =
+    process.env.MIGRATE_DATABASE_URL || process.env.DATABASE_URL || "";
+
+  if (!url) {
+    logErr("database_url_missing", {
+      hint: "Set DATABASE_URL (або MIGRATE_DATABASE_URL для Railway pre-deploy). Railway runtime зазвичай має ${{ Postgres.DATABASE_URL }}.",
+    });
+    process.exit(1);
+  }
+
+  logInfo("diagnose_start", { source, url: redactUrl(url) });
+
+  /** @type {URL} */
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (err) {
+    logErr("url_parse_failed", {
+      err: { message: /** @type {Error} */ (err).message },
+    });
+    process.exit(1);
+  }
+
+  const host = parsed.hostname;
+  const port = Number(parsed.port || 5432);
+  const db = parsed.pathname.replace(/^\//, "") || "<none>";
+  logInfo("url_parsed", {
+    scheme: parsed.protocol.replace(/:$/, ""),
+    host,
+    port,
+    db,
+    user: parsed.username || "<none>",
+    sslmode: parsed.searchParams.get("sslmode") || "<default>",
+  });
+
+  // ── 1. DNS ──────────────────────────────────────────────────────────
+  let failures = 0;
+  try {
+    const addrs = await withTimeout(
+      dns.lookup(host, { all: true }),
+      STEP_TIMEOUT_MS,
+      "dns.lookup",
+    );
+    logInfo("dns_ok", { host, addresses: addrs });
+  } catch (err) {
+    failures++;
+    const e = /** @type {Error & {code?: string}} */ (err);
+    const isRailwayInternal = host.endsWith(".railway.internal");
+    logErr("dns_failed", {
+      host,
+      err: { message: e.message, code: e.code },
+      ...(isRailwayInternal
+        ? {
+            hint: "*.railway.internal резолвиться ТІЛЬКИ з Railway runtime-мережі. З локальної машини це нормально. Перевіряй зі shell самого API-сервісу.",
+          }
+        : {
+            hint: "Публічний хост не резолвиться. Перевір, чи Postgres-сервіс не видалено і DATABASE_URL актуальний.",
+          }),
+    });
+    // Без DNS далі нема сенсу.
+    await finalize(failures);
+    return;
+  }
+
+  // ── 2. TCP ──────────────────────────────────────────────────────────
+  try {
+    await withTimeout(tcpProbe(host, port), STEP_TIMEOUT_MS, "tcp.connect");
+    logInfo("tcp_ok", { host, port });
+  } catch (err) {
+    failures++;
+    const e = /** @type {Error & {code?: string}} */ (err);
+    logErr("tcp_failed", {
+      host,
+      port,
+      err: { message: e.message, code: e.code },
+      hint: "DNS резолвнувся, але TCP не встановився. Postgres може бути зупинений, файрвол блокує, або пор неправильний.",
+    });
+  }
+
+  // ── 3. pg handshake + basic queries ─────────────────────────────────
+  let pg;
+  try {
+    pg = (await import("pg")).default;
+  } catch (err) {
+    logErr("pg_import_failed", {
+      err: { message: /** @type {Error} */ (err).message },
+      hint: "Запусти з корня репо після `npm ci`.",
+    });
+    await finalize(failures + 1);
+    return;
+  }
+
+  const client = new pg.Client({
+    connectionString: url,
+    connectionTimeoutMillis: STEP_TIMEOUT_MS,
+    statement_timeout: STEP_TIMEOUT_MS,
+  });
+
+  try {
+    await withTimeout(client.connect(), STEP_TIMEOUT_MS, "pg.connect");
+    logInfo("pg_connect_ok");
+  } catch (err) {
+    failures++;
+    const e = /** @type {Error & {code?: string}} */ (err);
+    logErr("pg_connect_failed", {
+      err: { message: e.message, code: e.code },
+      hint: "Credentials/SSL-режим не сходяться, або Postgres не приймає з'єднання (pg_hba).",
+    });
+    await finalize(failures);
+    return;
+  }
+
+  try {
+    const r = await client.query("SELECT 1 AS ok");
+    logInfo("pg_select1_ok", { rows: r.rowCount });
+  } catch (err) {
+    failures++;
+    logErr("pg_select1_failed", {
+      err: { message: /** @type {Error} */ (err).message },
+    });
+  }
+
+  for (const table of [
+    "ai_usage_daily",
+    "user",
+    "session",
+    "module_data",
+    "schema_migrations",
+  ]) {
+    try {
+      const r = await client.query("SELECT to_regclass($1) AS regclass", [
+        table,
+      ]);
+      const regclass = r.rows[0]?.regclass;
+      if (regclass) {
+        logInfo("table_found", { table });
+      } else {
+        failures++;
+        logErr("table_missing", {
+          table,
+          hint:
+            table === "schema_migrations"
+              ? "Міграції ніколи не запускалися — виконай `npm run db:migrate`."
+              : `Таблиця відсутня — міграції не застосовані або інша БД. Запусти npm run db:migrate.`,
+        });
+      }
+    } catch (err) {
+      failures++;
+      logErr("table_check_failed", {
+        table,
+        err: { message: /** @type {Error} */ (err).message },
+      });
+    }
+  }
+
+  try {
+    await client.end();
+  } catch {
+    /* best-effort */
+  }
+
+  await finalize(failures);
+}
+
+/** @param {number} failures */
+async function finalize(failures) {
+  if (failures === 0) {
+    logInfo("diagnose_ok");
+    process.exit(0);
+  }
+  logErr("diagnose_failed", { failures });
+  process.exit(1);
+}
+
+main().catch((err) => {
+  logErr("diagnose_unhandled", {
+    err: { message: /** @type {Error} */ (err).message },
+  });
+  process.exit(1);
+});

--- a/server/http/validate.ts
+++ b/server/http/validate.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 import type { ZodTypeAny } from "zod";
+import { logger } from "../obs/logger.js";
+import { als } from "../obs/requestContext.js";
 
 export type ValidationResult<T> = { ok: true; data: T } | { ok: false };
 
@@ -32,8 +34,18 @@ export function validateBody<S extends ZodTypeAny>(
     path: i.path.join("."),
     message: i.message,
   }));
+  // Warn-level: аби в проді бачити, які саме поля клієнт відправляє некоректно.
+  // Метадані `module`/`requestId` додаються через ALS-mixin у logger.ts.
+  // Публікуємо лише path+message (без оригінального value, щоб PII не просочиться).
+  logger.warn({
+    msg: "request_validation_failed",
+    target: "body",
+    module: als.getStore()?.module,
+    issues,
+  });
   res.status(400).json({
     error: "Некоректні дані запиту",
+    code: "VALIDATION",
     details: issues,
   });
   return { ok: false };
@@ -56,8 +68,15 @@ export function validateQuery<S extends ZodTypeAny>(
     path: i.path.join("."),
     message: i.message,
   }));
+  logger.warn({
+    msg: "request_validation_failed",
+    target: "query",
+    module: als.getStore()?.module,
+    issues,
+  });
   res.status(400).json({
     error: "Некоректні параметри запиту",
+    code: "VALIDATION",
     details: issues,
   });
   return { ok: false };

--- a/server/modules/sync.test.js
+++ b/server/modules/sync.test.js
@@ -11,6 +11,9 @@ vi.mock("../db.js", () => {
 
 vi.mock("../obs/requestContext.js", () => ({
   setRequestModule: vi.fn(),
+  setUserId: vi.fn(),
+  getRequestContext: () => null,
+  als: { getStore: () => null, run: (_s, fn) => fn() },
 }));
 
 vi.mock("../obs/metrics.js", () => ({

--- a/server/modules/weekly-digest.ts
+++ b/server/modules/weekly-digest.ts
@@ -3,6 +3,44 @@ import { anthropicMessages, extractAnthropicText } from "../lib/anthropic.js";
 import { validateBody } from "../http/validate.js";
 import { WeeklyDigestSchema } from "../http/schemas.js";
 import { ExternalServiceError, ValidationError } from "../obs/errors.js";
+import { logger } from "../obs/logger.js";
+
+/**
+ * Мапа «секція → чи прийшов непустий об'єкт у payload-і». Логуємо лише
+ * присутність і розмір, без PII (числа/категорії/звички залишаються в body
+ * і не йдуть у логи). Потрібна для діагностики клієнтських `{}` / частково
+ * заповнених payload-ів, які інакше проходять zod, але падають у 400
+ * «Немає даних».
+ */
+interface DigestPayloadShape {
+  hasFinyk: boolean;
+  hasFizruk: boolean;
+  hasNutrition: boolean;
+  hasRoutine: boolean;
+  hasWeekRange: boolean;
+  payloadBytes: number;
+}
+
+function digestPayloadShape(body: unknown): DigestPayloadShape {
+  const b =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const isNonEmpty = (v: unknown) =>
+    !!v && typeof v === "object" && Object.keys(v as object).length > 0;
+  let bytes = 0;
+  try {
+    bytes = Buffer.byteLength(JSON.stringify(body ?? null), "utf8");
+  } catch {
+    /* non-fatal — не блокуємо основний потік через лог */
+  }
+  return {
+    hasFinyk: isNonEmpty(b.finyk),
+    hasFizruk: isNonEmpty(b.fizruk),
+    hasNutrition: isNonEmpty(b.nutrition),
+    hasRoutine: isNonEmpty(b.routine),
+    hasWeekRange: typeof b.weekRange === "string" && b.weekRange.length > 0,
+    payloadBytes: bytes,
+  };
+}
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
 
@@ -67,6 +105,11 @@ export default async function handler(
   res: Response,
 ): Promise<void> {
   const apiKey = (req as WithAnthropicKey).anthropicKey as string;
+
+  // Форма payload-у потрібна і для успіху, і для 400 — логуємо один раз.
+  // ALS-контекст додасть `module="weekly-digest"` і `requestId` автоматично.
+  const shape = digestPayloadShape(req.body);
+  logger.debug({ msg: "weekly_digest_payload", ...shape });
 
   const parsed = validateBody(WeeklyDigestSchema, req, res);
   if (!parsed.ok) return;
@@ -139,7 +182,24 @@ ${habitsInfo}`);
   }
 
   if (!sections.length) {
-    throw new ValidationError("Немає даних для генерації звіту");
+    const present = [
+      shape.hasFinyk && "finyk",
+      shape.hasFizruk && "fizruk",
+      shape.hasNutrition && "nutrition",
+      shape.hasRoutine && "routine",
+    ].filter(Boolean) as string[];
+    logger.warn({
+      msg: "weekly_digest_empty_sections",
+      ...shape,
+      expectedNonEmpty: ["finyk", "fizruk", "nutrition", "routine"],
+      nonEmptyInPayload: present,
+    });
+    throw new ValidationError(
+      present.length === 0
+        ? "Немає даних для генерації звіту: жоден з модулів (finyk/fizruk/nutrition/routine) не містить даних."
+        : `Немає даних для генерації звіту: у payload-і лише ${present.join(", ")}, але після валідації секції порожні.`,
+      { code: "WEEKLY_DIGEST_EMPTY" },
+    );
   }
 
   const dataContext = sections.join("\n\n");


### PR DESCRIPTION
## Summary

Реакція на прод-помилки у Railway (див. логи: `ai_quota_store_unavailable` з `getaddrinfo ENOTFOUND` у `weekly-digest`; `/api/weekly-digest` → 400 без зрозумілої причини; фонові 401 на `/api/coach/*`).

**Контекст.** Root-cause `ai_quota_store_unavailable` — інфраструктурний (API-под не може зарезолвити хост Postgres). Код уже коректно fail-open'ить квоту (див. <ref_snippet file="server/aiQuota.ts" lines="267-281" />), тож це не бекенд-баг. 401 на `/api/coach/memory|insight` — очікуваний `UNAUTHORIZED` без валідної better-auth cookie (див. <ref_snippet file="server/routes/coach.ts" lines="22-38" />), не регресія.

Цей PR додає інструментарій, щоб діагностувати такі інциденти без гадання, і усуває непрозорий 400 у `/api/weekly-digest`.

### Зміни

1. **`scripts/diagnose-db.mjs` + `npm run db:diagnose`**
   Single-shot діагностика PostgreSQL connectivity: DNS → TCP → `pg` handshake → `SELECT 1` → наявність ключових таблиць (`ai_usage_daily`, `user`, `session`, `module_data`, `schema_migrations`). JSON-output для pipe-а у jq. Маскує пароль у logах. Пояснює різницю для `*.railway.internal` (резолвиться тільки з runtime-мережі). Виходить 1 за будь-якої помилки.

2. **`/api/weekly-digest` — точніша причина 400** (<ref_file file="server/modules/weekly-digest.ts" />)
   - Додає debug-лог `weekly_digest_payload` з формою payload-у (presence-прапорці + `payloadBytes`, **без даних** — PII безпечно).
   - Для «Немає даних для генерації звіту» тепер вказує, які модулі були у payload-і і чому сума секцій вийшла 0 (`code: "WEEKLY_DIGEST_EMPTY"`).
   - Розділяє два підкейси: `payload повністю порожній` vs `присутні модулі, але після валідації секцій 0`.

3. **`validateBody`/`validateQuery` — log + `code`** (<ref_file file="server/http/validate.ts" />)
   - Warn-лог `request_validation_failed` із `{target, module, issues[]}` (тільки path+message, без value). Дозволяє у проді бачити, **які саме поля** клієнт відправляє некоректно.
   - У JSON-відповідь додано `code: "VALIDATION"` поряд із `details[]` для стабільної клієнтської диспетчеризації.

4. **Тест-мок у `server/modules/sync.test.js`**
   Розширено мок `../obs/requestContext.js` (`als`, `setUserId`, `getRequestContext`), бо `validate.ts` тепер читає ALS-контекст.

## Review & Testing Checklist for Human

- [ ] У Railway shell API-сервісу запустити `npm run db:diagnose` — переконатись, що скрипт показує, **де саме** ланцюжок рветься (DNS/TCP/handshake/таблиця). Для швидкого локального sanity-тесту: `DATABASE_URL=postgres://invalid.host.example:5432/db npm run db:diagnose` має вивалитись на `dns_failed` і вийти з кодом 1.
- [ ] Перевірити, що клієнт `useWeeklyDigest` при `fizruk/nutrition/routine` = `null` більше не отримує зашифрований 400: новий response має `code: "WEEKLY_DIGEST_EMPTY"` + конкретний текст із переліком модулів. У серверних логах Railway з'являється `weekly_digest_empty_sections` + `weekly_digest_payload` для diff.
- [ ] Глянути, чи інші споживачі фронту НЕ ламаються на нове поле `code` у 400-response (має бути нейтрально, бо існуючі клієнти читали `error` і `details`).

### Notes

- Це НЕ виправляє root-cause DNS-фейлу на Railway. Фікс там — у Variables сервісу API: `DATABASE_URL` має референсити `${{ Postgres.DATABASE_URL }}` і Postgres-сервіс має бути «Running» (див. <ref_file file="docs/railway-vercel.md" />).
- `ai_quota_store_unavailable` свідомо залишено на рівні `error`, бо runbook <ref_snippet file="docs/observability/runbook.md" lines="168-188" /> вимагає цього сигналу для алерту (fail-open пропускає AI-запити без ліку → ризик Anthropic-білу).
- Локально: `npm run lint` / `npm run typecheck` / `npm test` — усе зелене (880/880 тестів).


Link to Devin session: https://app.devin.ai/sessions/2a4ec921c0b5493590bfd496e88f28fe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
