### PR TITLE
fix(server): accept null module fields in weekly-digest / coach schemas

### DIFF
--- a/server/http/schemas.ts
+++ b/server/http/schemas.ts
@@ -272,20 +272,25 @@ const RoutineDigestSchema = z
   })
   .partial();
 
+// Клієнтські агрегатори повертають `null`, коли у модулі немає даних за
+// тиждень (див. `aggregateFizruk`/`aggregateNutrition`/`aggregateRoutine` у
+// `src/core/useWeeklyDigest.ts`). `.nullish()` приймає і `null`, і
+// `undefined`, тож запит проходить валідацію незалежно від того, чи
+// клієнт пропускає поле, чи надсилає його як `null`.
 export const WeeklyDigestSchema = z.object({
   weekRange: z.string().max(80).optional(),
-  finyk: FinykDigestSchema.optional(),
-  fizruk: FizrukDigestSchema.optional(),
-  nutrition: NutritionDigestSchema.optional(),
-  routine: RoutineDigestSchema.optional(),
+  finyk: FinykDigestSchema.nullish(),
+  fizruk: FizrukDigestSchema.nullish(),
+  nutrition: NutritionDigestSchema.nullish(),
+  routine: RoutineDigestSchema.nullish(),
 });
 
 const CoachSnapshotSchema = z
   .object({
-    finyk: FinykDigestSchema.optional(),
-    fizruk: FizrukDigestSchema.optional(),
-    nutrition: NutritionDigestSchema.optional(),
-    routine: RoutineDigestSchema.optional(),
+    finyk: FinykDigestSchema.nullish(),
+    fizruk: FizrukDigestSchema.nullish(),
+    nutrition: NutritionDigestSchema.nullish(),
+    routine: RoutineDigestSchema.nullish(),
   })
   .partial();
 
@@ -299,9 +304,12 @@ const CoachMemoryEchoSchema = z
   })
   .partial();
 
+// `snapshot` і `memory` можуть надходити як `null` (нема даних / перший
+// сеанс без збереженої пам'яті), тому приймаємо `nullish`, а handler уже
+// коректно обробляє обидва випадки через `snapshot?.finyk` / `memory || null`.
 export const CoachInsightSchema = z.object({
-  snapshot: CoachSnapshotSchema.optional(),
-  memory: CoachMemoryEchoSchema.optional(),
+  snapshot: CoachSnapshotSchema.nullish(),
+  memory: CoachMemoryEchoSchema.nullish(),
 });
 
 // Розмірні ліміти на окремі поля не застосовуємо — загальний

--- a/server/http/validate.test.ts
+++ b/server/http/validate.test.ts
@@ -6,6 +6,8 @@ import {
   AnalyzePhotoSchema,
   ParsePantrySchema,
   RecommendRecipesSchema,
+  WeeklyDigestSchema,
+  CoachInsightSchema,
   z,
 } from "./schemas.js";
 
@@ -196,6 +198,63 @@ describe("RecommendRecipesSchema", () => {
     const r = RecommendRecipesSchema.safeParse({
       pantry: [{ name: "яйце", qty: 5, unit: "шт" }],
       count: 3,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("WeeklyDigestSchema", () => {
+  // На новому пристрої `aggregateFizruk`/`aggregateNutrition`/`aggregateRoutine`
+  // повертають null, коли у модулі ще немає даних, — клієнт серіалізує
+  // їх як `null` у JSON-теле запиту. Схема має приймати null поряд із
+  // undefined, інакше сервер віддає 400 на цілком валідний запит.
+  it("приймає null для модулів без даних", () => {
+    const r = WeeklyDigestSchema.safeParse({
+      weekRange: "14 кві — 20 кві",
+      finyk: { totalSpent: 0, totalIncome: 0, txCount: 0, topCategories: [] },
+      fizruk: null,
+      nutrition: null,
+      routine: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("приймає пропущені поля модулів", () => {
+    const r = WeeklyDigestSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("приймає валідний повний payload", () => {
+    const r = WeeklyDigestSchema.safeParse({
+      weekRange: "14 кві — 20 кві",
+      finyk: {
+        totalSpent: 1234,
+        totalIncome: 500,
+        monthlyBudget: 20000,
+        txCount: 10,
+        topCategories: [{ name: "Їжа", amount: 800 }],
+      },
+      fizruk: {
+        workoutsCount: 3,
+        totalVolume: 4000,
+        recoveryLabel: "Готовий до тренування",
+        topExercises: [{ name: "Присідання", totalVolume: 1500 }],
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("CoachInsightSchema", () => {
+  it("приймає null для snapshot і memory (перший сеанс)", () => {
+    const r = CoachInsightSchema.safeParse({ snapshot: null, memory: null });
+    expect(r.success).toBe(true);
+  });
+
+  it("приймає null для внутрішніх модулів snapshot-у", () => {
+    const r = CoachInsightSchema.safeParse({
+      snapshot: { finyk: null, fizruk: null, nutrition: null, routine: null },
+      memory: null,
     });
     expect(r.success).toBe(true);
   });


### PR DESCRIPTION
## Summary

На скріні з Railway логів видно дві різні проблеми:

1. **`/api/weekly-digest` → 400** на iPhone-клієнті. Причина — zod-схема `WeeklyDigestSchema` використовувала `.optional()` для полів модулів (`finyk/fizruk/nutrition/routine`), а клієнт у <ref_snippet file="/home/ubuntu/Sergeant/src/core/useWeeklyDigest.ts" lines="395-410" /> надсилає `null`, коли у модуля немає даних за тиждень (`aggregateFizruk`/`aggregateNutrition`/`aggregateRoutine` повертають `null`). У zod `.optional()` дозволяє лише `undefined`, тож валідний запит падав з `Invalid input: expected object, received null` → 400.

   **Фікс**: `.optional()` → `.nullish()` у `WeeklyDigestSchema`. Хендлер у <ref_snippet file="/home/ubuntu/Sergeant/server/modules/weekly-digest.ts" lines="71-143" /> уже коректно обробляє `undefined`/`null` через `if (finyk)` / `if (fizruk)`, тож логіка не змінюється — розширюється лише те, що схема приймає.

2. **`ai_quota_store_unavailable` з `reason: db_error`, `err.message: getaddrinfo ENOTFOUND…`** на модулі `weekly-digest`. Це **не кодова** проблема: DATABASE_URL у Railway вказує на хост, який не резолвиться з самого сервіса. Код уже fail-open у <ref_snippet file="/home/ubuntu/Sergeant/server/aiQuota.ts" lines="190-195" /> — квота не блокує запити, Anthropic upstream-ліміти працюють. Це треба полагодити у Railway (перевірити, чи Postgres-плагін активний і змінна DATABASE_URL під’єднана до `sergeant-api`).

Також профілактично поширив `.nullish()` на `CoachSnapshotSchema` (внутрішні модулі) та `CoachInsightSchema` (`snapshot`, `memory`) — той самий клас баги для авторизованих користувачів, які першого разу викликають `/api/coach/insight` без збереженої памʼяті.

Додав юніт-тести у `server/http/validate.test.ts` для `WeeklyDigestSchema` і `CoachInsightSchema`, які явно перевіряють `null`-значення.

## Review & Testing Checklist for Human

- [ ] **Полагодити DATABASE_URL на Railway** — це окреме питання поза цим PR. У логах видно `getaddrinfo ENOTFOUND` на хост PG; без цього AI-квота продовжить логувати error-ами, а інші модулі (coach memory, sync, better-auth) ламатимуться, бо там fail-open немає.
- [ ] Перевірити, що після деплою `/api/weekly-digest` із тілом, де `fizruk/nutrition/routine: null`, повертає 200 (а не 400), і що звіт справді генерується на iPhone.
- [ ] Глянути coach-інсайт на свіжому акаунті (ще немає записаної памʼяті) — раніше мав шанс упасти з 400 на тих самих `null`-ах.

### Notes

- `.nullish()` у zod v4 еквівалентне `.optional().nullable()` — дозволяє і `undefined`, і `null`, шейп `parsed.data` стає `X | null | undefined`, що сумісне з існуючими `if (…)`-гвардами в хендлерах.
- 401-и на `/api/coach/*` у тому ж логу — очікувані: користувач не авторизований.
- Лог-рівень `ai_quota_store_unavailable` залишив `error` (не міняв у цьому PR), бо це вже окреме рішення про шум у Sentry; можу підняти окремий PR, якщо захочеш downgrade до `warn` при fail-open.

Link to Devin session: https://app.devin.ai/sessions/6a1b3a21e3504048a941414ff3f7de25
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
