### PR TITLE
feat(server): web-push send hardening — timeout/retry/circuit-breaker

### DIFF
--- a/server/lib/webpushSend.test.ts
+++ b/server/lib/webpushSend.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PushSubscription } from "web-push";
+
+const { sendNotificationMock, WebPushErrorMock } = vi.hoisted(() => {
+  class WebPushErrorMock extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.name = "WebPushError";
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    sendNotificationMock: vi.fn(),
+    WebPushErrorMock,
+  };
+});
+
+vi.mock("web-push", () => ({
+  default: { sendNotification: sendNotificationMock },
+  WebPushError: WebPushErrorMock,
+  sendNotification: sendNotificationMock,
+}));
+
+import { sendWebPush, __webpushSendTestHooks } from "./webpushSend.js";
+
+const hooks = __webpushSendTestHooks();
+
+function sub(
+  endpoint: string = "https://fcm.googleapis.com/fcm/send/abc",
+): PushSubscription {
+  return {
+    endpoint,
+    keys: { p256dh: "p", auth: "a" },
+  } as unknown as PushSubscription;
+}
+
+beforeEach(() => {
+  hooks.reset();
+  // Швидші тести: нульові затримки retry.
+  hooks.configure({
+    retryDelaysMs: [0, 10],
+    retryJitterMs: 0,
+    timeoutMs: 50,
+    breakerFailThreshold: 3,
+    breakerOpenMs: 1000,
+  });
+  sendNotificationMock.mockReset();
+});
+
+describe("sendWebPush — happy path", () => {
+  it("returns outcome='ok' when sendNotification resolves", async () => {
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201, body: "" });
+    const r = await sendWebPush(sub(), "payload");
+    expect(r.outcome).toBe("ok");
+    expect(r.attempts).toBe(1);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets breaker on success after prior failures", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("boom", 500),
+    );
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("boom", 500),
+    );
+    await sendWebPush(sub(), "p");
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201 });
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("ok");
+    const breaker = hooks.state.breakers.get("https://fcm.googleapis.com");
+    expect(breaker?.failures).toBe(0);
+    expect(breaker?.openUntil).toBe(0);
+  });
+});
+
+describe("sendWebPush — classification", () => {
+  it("404 → invalid_endpoint and does not retry", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("gone", 404),
+    );
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("invalid_endpoint");
+    expect(r.statusCode).toBe(404);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("410 → invalid_endpoint", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("gone", 410),
+    );
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("invalid_endpoint");
+    expect(r.statusCode).toBe(410);
+  });
+
+  it("429 → rate_limited and does not retry", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("slow", 429),
+    );
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("rate_limited");
+    expect(r.statusCode).toBe(429);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("400 → error and does not retry (crypto/validation)", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("bad payload", 400),
+    );
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("error");
+    expect(r.statusCode).toBe(400);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sendWebPush — retry behavior", () => {
+  it("5xx is retried once, then reported as error on final failure", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("server error", 503),
+    );
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("server error", 503),
+    );
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("error");
+    expect(r.statusCode).toBe(503);
+    expect(r.attempts).toBe(2);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("5xx retried once succeeds on second attempt", async () => {
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("server error", 502),
+    );
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201 });
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("ok");
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("sendWebPush — timeout", () => {
+  it("reports timeout after timeoutMs and counts as breaker failure", async () => {
+    // Hang forever to force the timeout race to win.
+    sendNotificationMock.mockImplementation(() => new Promise(() => {}));
+    hooks.configure({ timeoutMs: 20, retryDelaysMs: [0] });
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("timeout");
+    const breaker = hooks.state.breakers.get("https://fcm.googleapis.com");
+    expect(breaker?.failures).toBe(1);
+  });
+});
+
+describe("sendWebPush — circuit breaker", () => {
+  it("opens after breakerFailThreshold failures and fast-fails next call", async () => {
+    hooks.configure({
+      retryDelaysMs: [0],
+      breakerFailThreshold: 2,
+      breakerOpenMs: 10_000,
+    });
+    sendNotificationMock.mockRejectedValue(
+      new WebPushErrorMock("server error", 500),
+    );
+
+    // Two 5xx failures to trip the breaker.
+    await sendWebPush(sub(), "p");
+    await sendWebPush(sub(), "p");
+
+    // Third call: breaker is open → short-circuit, no HTTP.
+    sendNotificationMock.mockClear();
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("circuit_open");
+    expect(r.attempts).toBe(0);
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("breaker is per-origin (FCM failures do not block Apple)", async () => {
+    hooks.configure({
+      retryDelaysMs: [0],
+      breakerFailThreshold: 1,
+      breakerOpenMs: 10_000,
+    });
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("server error", 500),
+    );
+    // Trip FCM breaker.
+    await sendWebPush(sub("https://fcm.googleapis.com/fcm/send/abc"), "p");
+
+    // Apple call should still go through (different origin).
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201 });
+    const r = await sendWebPush(sub("https://web.push.apple.com/xyz"), "p");
+    expect(r.outcome).toBe("ok");
+  });
+
+  it("404 does not trip the breaker", async () => {
+    hooks.configure({
+      retryDelaysMs: [0],
+      breakerFailThreshold: 1,
+      breakerOpenMs: 10_000,
+    });
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("gone", 404),
+    );
+    await sendWebPush(sub(), "p");
+
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201 });
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("ok");
+  });
+
+  it("429 does not trip the breaker", async () => {
+    hooks.configure({
+      retryDelaysMs: [0],
+      breakerFailThreshold: 1,
+      breakerOpenMs: 10_000,
+    });
+    sendNotificationMock.mockRejectedValueOnce(
+      new WebPushErrorMock("slow", 429),
+    );
+    await sendWebPush(sub(), "p");
+
+    sendNotificationMock.mockResolvedValueOnce({ statusCode: 201 });
+    const r = await sendWebPush(sub(), "p");
+    expect(r.outcome).toBe("ok");
+  });
+});

--- a/server/lib/webpushSend.ts
+++ b/server/lib/webpushSend.ts
@@ -1,0 +1,354 @@
+import webpush, { WebPushError } from "web-push";
+import type { PushSubscription } from "web-push";
+import { logger } from "../obs/logger.js";
+import { recordExternalHttp } from "./externalHttp.js";
+
+/**
+ * Transport-шар для `webpush.sendNotification`. Додає:
+ *
+ *   1. AbortController-таймаут (web-push library сама таймаут не підтримує).
+ *      Без нього повільний push-сервіс тримав би async-задачу живою аж до
+ *      TCP RST, а при `sendPush` fan-out-і ще й блокував би pg-connection.
+ *   2. Per-origin circuit breaker. Коли FCM/Apple/Mozilla-проксі деградує,
+ *      подальші виклики до того ж origin-а одразу fail-fast-ять → fan-out
+ *      не витрачає ресурси на заздалегідь приречені запити.
+ *   3. Один retry на timeout/5xx з малим backoff. 4xx (400/403/404/410/413)
+ *      не ретраїмо — це per-subscription семантика (неправильний ключ,
+ *      gone endpoint, невалідний payload).
+ *   4. Уніфіковані метрики через `recordExternalHttp("push", outcome, ms)`.
+ *
+ * Класифікація результату повертається у `WebPushSendResult.outcome`:
+ *
+ *   ok              — successfull delivery (2xx)
+ *   invalid_endpoint — 404/410 → soft-delete підписки (caller вирішує)
+ *   rate_limited    — 429
+ *   timeout         — AbortController спрацював
+ *   circuit_open    — breaker open, запит навіть не відправлявся
+ *   error           — все інше (4xx crypto/validation, 5xx після retry,
+ *                     мережева помилка)
+ *
+ * Wrapper НЕ кидає для упаковних помилок — повертає result-обʼєкт з
+ * `outcome` і зберігає оригінальний `error` для логування caller-ом.
+ * Це свідоме: push fan-out у `sendPush` паралелить N підписок, і одна
+ * невдала не повинна рвати загальну Promise.all.
+ */
+
+type BreakerState = {
+  failures: number;
+  openUntil: number;
+};
+
+interface WebPushConfig {
+  timeoutMs: number;
+  retryDelaysMs: number[];
+  retryJitterMs: number;
+  breakerFailThreshold: number;
+  breakerOpenMs: number;
+}
+
+interface WebPushMutableState extends WebPushConfig {
+  breakers: Map<string, BreakerState>;
+}
+
+const DEFAULTS: Readonly<WebPushConfig> = Object.freeze({
+  timeoutMs: 10_000,
+  // [first-attempt-delay, retry-delay]. Нульова перша затримка + один retry.
+  retryDelaysMs: [0, 500],
+  retryJitterMs: 100,
+  breakerFailThreshold: 5,
+  breakerOpenMs: 30_000,
+});
+
+const state: WebPushMutableState = {
+  timeoutMs: DEFAULTS.timeoutMs,
+  retryDelaysMs: [...DEFAULTS.retryDelaysMs],
+  retryJitterMs: DEFAULTS.retryJitterMs,
+  breakerFailThreshold: DEFAULTS.breakerFailThreshold,
+  breakerOpenMs: DEFAULTS.breakerOpenMs,
+  breakers: new Map(),
+};
+
+export type WebPushOutcome =
+  | "ok"
+  | "invalid_endpoint"
+  | "rate_limited"
+  | "timeout"
+  | "circuit_open"
+  | "error";
+
+export interface WebPushSendResult {
+  outcome: WebPushOutcome;
+  /** Upstream HTTP status, якщо відомо. Timeout/circuit — undefined. */
+  statusCode?: number;
+  /** Серіалізоване повідомлення помилки для логування caller-ом. */
+  errorMessage?: string;
+  /** Весь час wrapper-а, включно з breaker-check і retry-sleep-ами. */
+  durationMs: number;
+  /** Скільки разів реально викликали webpush.sendNotification. */
+  attempts: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function jitteredDelay(base: number): number {
+  if (base <= 0) return 0;
+  return base + Math.floor(Math.random() * state.retryJitterMs);
+}
+
+/**
+ * Ключ для breaker-а — origin push-ендпоінту (схема+host), НЕ повний endpoint.
+ * FCM/Apple/Mozilla мають одиничні origin-и, і деградація там глобальна —
+ * відмічаємо весь сервіс, а не per-subscription.
+ */
+function originOf(endpoint: string): string {
+  try {
+    const u = new URL(endpoint);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "unknown";
+  }
+}
+
+function getBreaker(origin: string): BreakerState {
+  let s = state.breakers.get(origin);
+  if (!s) {
+    s = { failures: 0, openUntil: 0 };
+    state.breakers.set(origin, s);
+  }
+  return s;
+}
+
+function onBreakerFailure(origin: string): void {
+  const s = getBreaker(origin);
+  s.failures += 1;
+  if (s.failures >= state.breakerFailThreshold) {
+    s.openUntil = Date.now() + state.breakerOpenMs;
+  }
+}
+
+function onBreakerSuccess(origin: string): void {
+  const s = getBreaker(origin);
+  s.failures = 0;
+  s.openUntil = 0;
+}
+
+function isBreakerOpen(origin: string): boolean {
+  const s = getBreaker(origin);
+  if (!s.openUntil) return false;
+  if (Date.now() < s.openUntil) return true;
+  // Half-open: вікно минуло → дозволяємо один пробний запит. Успіх
+  // обнулить `failures`, fail-ла знову зведе `openUntil` у майбутнє.
+  s.openUntil = 0;
+  return false;
+}
+
+function isRetryableStatus(s?: number): boolean {
+  return typeof s === "number" && s >= 500 && s <= 599;
+}
+
+function isAbortError(e: unknown): boolean {
+  if (!e || typeof e !== "object") return false;
+  const err = e as { name?: string; code?: string | number };
+  return (
+    err.name === "AbortError" || err.code === "ABORT_ERR" || err.code === 20
+  );
+}
+
+/**
+ * Promise.race з таймаут-обіцянкою. web-push library не приймає AbortSignal,
+ * тож AbortController тут — це контракт сigналу: ми НЕ можемо примусово
+ * перервати https-запит під капотом, але можемо вчасно відпустити event-loop
+ * / caller-а. Висячий socket закриється сам по серверному TCP-keepalive.
+ */
+async function withTimeout<T>(
+  p: Promise<T>,
+  timeoutMs: number,
+  controller: AbortController,
+): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`Timeout after ${timeoutMs}ms`);
+      (err as Error & { name: string }).name = "AbortError";
+      controller.abort();
+      reject(err);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([p, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+interface SendOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * Єдина точка відправки web-push-у. Заміна прямому виклику
+ * `webpush.sendNotification(sub, payload)`. Не кидає для передбачуваних
+ * помилок — повертає структурований `WebPushSendResult`.
+ */
+export async function sendWebPush(
+  subscription: PushSubscription,
+  payload: string,
+  options: SendOptions = {},
+): Promise<WebPushSendResult> {
+  const timeoutMs = options.timeoutMs ?? state.timeoutMs;
+  const origin = originOf(subscription.endpoint);
+  const start = process.hrtime.bigint();
+  const elapsed = (): number => Number(process.hrtime.bigint() - start) / 1e6;
+
+  if (isBreakerOpen(origin)) {
+    const ms = elapsed();
+    recordExternalHttp("push", "circuit_open", ms);
+    return {
+      outcome: "circuit_open",
+      durationMs: ms,
+      attempts: 0,
+    };
+  }
+
+  const maxAttempts = state.retryDelaysMs.length;
+  let lastError: unknown = undefined;
+  let lastStatus: number | undefined = undefined;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const delay = jitteredDelay(state.retryDelaysMs[attempt]);
+    if (delay > 0) await sleep(delay);
+
+    const controller = new AbortController();
+    try {
+      await withTimeout(
+        webpush.sendNotification(subscription, payload),
+        timeoutMs,
+        controller,
+      );
+      // 2xx — успіх.
+      const ms = elapsed();
+      onBreakerSuccess(origin);
+      recordExternalHttp("push", "ok", ms);
+      return {
+        outcome: "ok",
+        statusCode: 201,
+        durationMs: ms,
+        attempts: attempt + 1,
+      };
+    } catch (e: unknown) {
+      lastError = e;
+      const timedOut = isAbortError(e);
+      const status = e instanceof WebPushError ? e.statusCode : undefined;
+      lastStatus = status;
+
+      // Ретраїмо лише timeout або 5xx. Все інше (4xx, crypto, невідоме) —
+      // ваговий сигнал per-subscription, retry не допоможе.
+      const retryable =
+        (timedOut || isRetryableStatus(status)) && attempt < maxAttempts - 1;
+      if (retryable) continue;
+      break;
+    }
+  }
+
+  // Фіналізуємо outcome для не-успіху.
+  const ms = elapsed();
+  const timedOut = isAbortError(lastError);
+  const message =
+    lastError instanceof Error
+      ? lastError.message
+      : String(lastError ?? "unknown");
+
+  if (timedOut) {
+    onBreakerFailure(origin);
+    recordExternalHttp("push", "timeout", ms);
+    logger.warn({
+      msg: "push_send_timeout",
+      origin,
+      timeoutMs,
+      err: { message },
+    });
+    return {
+      outcome: "timeout",
+      durationMs: ms,
+      errorMessage: message,
+      attempts: maxAttempts,
+    };
+  }
+
+  if (lastStatus === 404 || lastStatus === 410) {
+    // 404/410 — не availability-issue, breaker НЕ торкаємо.
+    recordExternalHttp("push", "invalid_endpoint", ms);
+    return {
+      outcome: "invalid_endpoint",
+      statusCode: lastStatus,
+      durationMs: ms,
+      errorMessage: message,
+      attempts: maxAttempts,
+    };
+  }
+
+  if (lastStatus === 429) {
+    // Throttle від push-сервісу — не availability-issue.
+    recordExternalHttp("push", "rate_limited", ms);
+    logger.warn({
+      msg: "push_rate_limited",
+      status: lastStatus,
+      err: { message },
+    });
+    return {
+      outcome: "rate_limited",
+      statusCode: lastStatus,
+      durationMs: ms,
+      errorMessage: message,
+      attempts: maxAttempts,
+    };
+  }
+
+  // 5xx після retry або невідома помилка → breaker-фейл.
+  if (isRetryableStatus(lastStatus) || lastStatus === undefined) {
+    onBreakerFailure(origin);
+  }
+  recordExternalHttp("push", "error", ms);
+  logger.warn({
+    msg: "push_send_error",
+    status: lastStatus,
+    err: { message },
+  });
+  return {
+    outcome: "error",
+    statusCode: lastStatus,
+    durationMs: ms,
+    errorMessage: message,
+    attempts: maxAttempts,
+  };
+}
+
+export interface WebPushSendTestHooks {
+  configure(overrides: Partial<WebPushConfig>): void;
+  reset(): void;
+  state: WebPushMutableState;
+}
+
+/** Test-only hooks. Не використовуй у прод-коді. */
+export function __webpushSendTestHooks(): WebPushSendTestHooks {
+  return {
+    configure(overrides) {
+      for (const [k, v] of Object.entries(overrides)) {
+        if (k in state) {
+          (state as unknown as Record<string, unknown>)[k] = v as unknown;
+        }
+      }
+    },
+    reset() {
+      state.breakers.clear();
+      state.timeoutMs = DEFAULTS.timeoutMs;
+      state.retryDelaysMs = [...DEFAULTS.retryDelaysMs];
+      state.retryJitterMs = DEFAULTS.retryJitterMs;
+      state.breakerFailThreshold = DEFAULTS.breakerFailThreshold;
+      state.breakerOpenMs = DEFAULTS.breakerOpenMs;
+    },
+    state,
+  };
+}

--- a/server/modules/push.ts
+++ b/server/modules/push.ts
@@ -1,8 +1,7 @@
 import type { Request, Response } from "express";
-import webpush, { WebPushError } from "web-push";
+import webpush from "web-push";
 import pool from "../db.js";
-import { logger } from "../obs/logger.js";
-import { recordExternalHttp } from "../lib/externalHttp.js";
+import { sendWebPush } from "../lib/webpushSend.js";
 import { pushSendsTotal } from "../obs/metrics.js";
 import { validateBody } from "../http/validate.js";
 import {
@@ -14,18 +13,17 @@ import {
 type WithSessionUser = Request & { user?: { id: string } };
 
 /**
- * Дублюємо два лейбли для одного outcome: історичну domain-метрику
- * `push_sends_total` (яку можуть читати старі дашборди/алерти) та уніфіковану
- * `external_http_requests_total{upstream="push"}`. Це свідома тимчасова
- * дуплікація — якщо й зносити, то окремим PR зі знесенням дашборду.
+ * Historical domain-metric `push_sends_total` — зберігаємо для сумісності
+ * з існуючими дашбордами/алертами. Уніфікована `external_http_requests_total
+ * {upstream="push"}` вже інкрементиться всередині `sendWebPush` через
+ * `recordExternalHttp`, тож тут лише дублюємо domain-лейбл.
  */
-function recordSend(outcome: string): void {
+function recordDomainOutcome(outcome: string): void {
   try {
     pushSendsTotal.inc({ outcome });
   } catch {
     /* ignore */
   }
-  recordExternalHttp("push", outcome);
 }
 
 const VAPID_PUBLIC = process.env.VAPID_PUBLIC_KEY;
@@ -148,40 +146,24 @@ export async function sendPush(req: Request, res: Response): Promise<void> {
   let sent = 0;
   const stale: string[] = [];
 
-  // Вузький per-subscription catch: одна невдала підписка не повинна
-  // зривати весь fan-out. Інші помилки (DB, тощо) летять наверх в errorHandler.
+  // Per-subscription fan-out: sendWebPush всередині вже має timeout/retry/
+  // circuit-breaker і повертає структурований `outcome`. Одна невдала
+  // підписка не зриває весь fan-out — Promise.all резолвиться завжди, бо
+  // sendWebPush не кидає для очікуваних помилок (4xx/5xx/timeout/breaker).
   await Promise.all(
     rows.map(async (row) => {
       const sub = {
         endpoint: row.endpoint,
         keys: { p256dh: row.p256dh, auth: row.auth },
       };
-      try {
-        await webpush.sendNotification(sub, payload);
+      const result = await sendWebPush(sub, payload);
+      recordDomainOutcome(result.outcome);
+      if (result.outcome === "ok") {
         sent++;
-        recordSend("ok");
-      } catch (e: unknown) {
-        const statusCode = e instanceof WebPushError ? e.statusCode : undefined;
-        const message = e instanceof Error ? e.message : String(e);
-        if (statusCode === 404 || statusCode === 410) {
-          stale.push(row.endpoint);
-          recordSend("invalid_endpoint");
-        } else if (statusCode === 429) {
-          recordSend("rate_limited");
-          logger.warn({
-            msg: "push_rate_limited",
-            status: statusCode,
-            err: { message },
-          });
-        } else {
-          recordSend("error");
-          logger.warn({
-            msg: "push_send_error",
-            status: statusCode,
-            err: { message },
-          });
-        }
+      } else if (result.outcome === "invalid_endpoint") {
+        stale.push(row.endpoint);
       }
+      // timeout/rate_limited/circuit_open/error — вже залоговані у sendWebPush.
     }),
   );
 


### PR DESCRIPTION
## Summary

Загортає `webpush.sendNotification` у новий transport-шар `server/lib/webpushSend.ts`. До цього push.ts дзвонив web-push library напряму — **без таймауту, без retry, без circuit-breaker**. На практиці це означало, що повільний push-сервіс (наприклад, деградація FCM) міг тримати кілька підписок «висіти» у fan-out-і `sendPush`-а, блокуючи pg-worker, поки весь Promise.all не резолвиться. Це P0-пункт з `docs/backend-tech-debt.md` (рядок 42 — «Банки/web-push: таймаутів немає»), який був вже вирішений для банків у `lib/bankProxy.ts`, але лишався відкритим для web-push.

### Що робить новий wrapper

- **Timeout** (default 10s, з env-overrides через test-hooks): AbortController + Promise.race. Web-push library не приймає AbortSignal нативно, тож ми не перериваємо HTTP-запит під капотом, але вчасно звільняємо event-loop і caller-а. Висячий socket закриється по TCP-keepalive.
- **Per-origin circuit breaker** (5 fails / 30s window): FCM/Apple/Mozilla мають одиничні origin-и, тож деградація одного провайдера не б'є по інших.
- **1 retry** на timeout/5xx з малим backoff + jitter. 4xx (400/403/404/410/413) не ретраїмо — це per-subscription семантика, retry там шкідливий.
- **Класифікація `outcome`**: `ok | invalid_endpoint | rate_limited | timeout | circuit_open | error` — стабільний лейбл для метрик і доменної логіки (caller не мусить знати про `WebPushError.statusCode`).
- **Уніфіковані метрики** через `recordExternalHttp("push", outcome, ms)`. Історична domain-метрика `push_sends_total` залишається (дублюємо лейбл у handler-і для сумісності з існуючими дашбордами).

`sendPush` handler у `modules/push.ts` спрощується: вузький per-subscription `try/catch` зникає, бо `sendWebPush` не throw-ить для очікуваних помилок. Fan-out лишається таким же resilient (Promise.all резолвиться завжди), і логіка soft-delete stale endpoint-ів зберігається.

## Review & Testing Checklist for Human

- [ ] Перевір, що існуючі Grafana/алерти на `push_sends_total{outcome=...}` і далі зелені — я зберіг саме ті домен-лейбли (`ok`, `invalid_endpoint`, `rate_limited`, `error`), плюс додав нові `timeout` і `circuit_open`. Якщо алерт жорстко whitelist-ає конкретний `outcome`, його треба буде оновити.
- [ ] Підтверди, що 10s timeout адекватний для твого push-трафіку (FCM у 99% випадків відповідає <500ms, Apple буває повільніше). Можна знизити до 5s, щоб агресивніше відсікати висячі запити.
- [ ] Перевір, чи не ламає цей комміт існуючий cron/worker, який б'є `/api/push/send` — відповідь JSON-форма не змінилась (`{sent, stale}`), але поведінка під деградацією тепер інша (раніше `error` тягнувся до кінця таймауту node-default, зараз — 10s + 1 retry).
- [ ] Переглянь class-ифікацію у <ref_snippet file="/home/ubuntu/repos/Sergeant/server/lib/webpushSend.ts" lines="200-280" />: особливо логіку `isRetryableStatus` і breaker-accounting (429 не торкає breaker, 5xx/timeout/unknown — торкають).

### Test plan

```bash
# швидкий unit-гіт
npx vitest run server/lib/webpushSend.test.ts

# повний suite + lint + typecheck
npm run check
```

Додано 13 unit-тестів, що покривають: happy-path, класифікацію 404/410/429/400/503, retry на 5xx (успіх на 2-й спробі + фінальний fail), timeout із breaker-account-ом, відкриття breaker-а після N фейлів, per-origin ізоляцію (FCM fails != Apple fails), нон-accounting для 404 і 429.

### Notes

- `retryDelaysMs: [0, 500]` — два «слоти», перший нульовий, другий — 500ms + jitter. Легко конфігурується через `__webpushSendTestHooks` для unit-тестів. Якщо захочеш tune-нути у проді, можна перетягнути у env (`WEB_PUSH_TIMEOUT_MS`, `WEB_PUSH_BREAKER_FAIL_THRESHOLD`...) — не робив це тут, щоб не розширювати scope.
- Breaker keyed by `new URL(endpoint).origin` — так самі FCM-підписки різних юзерів ділять один breaker, що коректно (це сервіс-рівнева деградація).
- Logger-виклики всередині wrapper-а (`push_send_timeout`, `push_rate_limited`, `push_send_error`) зберігають ті самі `msg`-ключі, що й раніше у handler-і — existing log-based alerts/searches не ламаються.

Link to Devin session: https://app.devin.ai/sessions/48a578eeadce434eacc2d3d8851410bc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
