### PR TITLE
docs(tech-debt): fix broken fenced-code in P0 status list

### DIFF
--- a/docs/backend-tech-debt.md
+++ b/docs/backend-tech-debt.md
@@ -549,9 +549,7 @@
 
 1. ~~Таймаути/ретраї/breaker на `mono`/`privat`/`web-push`~~ — ✅ `bankProxy.ts` + PR #335.
 2. ~~`aiQuota.consumeQuota` → атомарний upsert~~ — ✅ PR C.
-3. ```12 широких `catch(e){res.json({error:e.message})}` → `next(e)`~~ — ✅ PR A (grep → 0).
-
-   ```
+3. ~~12 широких `catch(e){res.json({error:e.message})}` → `next(e)`~~ — ✅ PR A (grep → 0).
 4. ~~Sync zod-схем з handler-ами (`RefinePhotoSchema`)~~ — ✅ PR A.
 5. ~~Supertest-smoke на 8 ендпоінтів через `createApp()` factory~~ — ✅ PR #336.
 


### PR DESCRIPTION
## Summary

Фікс markdown-рендерингу у `docs/backend-tech-debt.md`, секція **«Поточний залишок P0»**. Помічено [Devin Review](https://github.com/Skords-01/Sergeant/pull/337#discussion_r3107640501) у PR #337 уже після мержу.

**Проблема:** рядок 552 починався з ` ```12 широких` (три backtick-и) замість `~~12 широких` (strikethrough). Це відкривало fenced code block, через що:

- пункт 3 списку рендерився як код замість викресленого тексту;
- пункт 4 «Sync zod-схем...» візуально відривався від нумерації 1→5;
- закриваючий ` ``` ` на рядку 554 лишав порожній код-блок.

**Фікс:** заміна `` ```12 ...~~ `` → `~~12 ...~~`, видалення порожніх рядків з трейлінг-фенсом.

Діф:

```diff
-3. ```12 широких `catch(e){res.json({error:e.message})}` → `next(e)`~~ — ✅ PR A (grep → 0).
-
-   ```
+3. ~~12 широких `catch(e){res.json({error:e.message})}` → `next(e)`~~ — ✅ PR A (grep → 0).
 4. ~~Sync zod-схем з handler-ами (`RefinePhotoSchema`)~~ — ✅ PR A.
```

## Review & Testing Checklist for Human

- [ ] Перегляни preview `docs/backend-tech-debt.md` у GitHub markdown view — пункти 1–5 мають бути суцільним нумерованим списком зі strikethrough, без code-блоку між 3 і 4.

### Test plan

- `npx prettier --check docs/backend-tech-debt.md` — проходить локально.
- Жодних runtime-змін.

### Notes

Якщо Devin Review у PR #337 позначив ще одну знахідку (бейдж казав «View 1 additional finding»), і ти її хочеш зафіксувати — напиши, додам у цей PR або окремим коммітом.

Link to Devin session: https://app.devin.ai/sessions/48a578eeadce434eacc2d3d8851410bc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
