### PR TITLE
fix(ui): dialog a11y — keyboard-reachable scrim, body scroll lock, overscroll-contain

### DIFF
--- a/src/shared/components/ui/ConfirmDialog.tsx
+++ b/src/shared/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react";
+import { useEffect, useRef, type KeyboardEvent, type ReactNode } from "react";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { cn } from "@shared/lib/cn";
 import { Button } from "./Button";
@@ -30,18 +30,36 @@ export function ConfirmDialog({
   const ref = useRef<HTMLDivElement>(null);
   useDialogFocusTrap(open, ref, { onEscape: onCancel });
 
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   if (!open) return null;
+
+  const handleScrimKey = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onCancel?.();
+    }
+  };
 
   return (
     <div
       className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center"
       role="presentation"
     >
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-text/40 backdrop-blur-sm motion-safe:animate-fade-in"
+      {/* Scrim — real <button> keeps dismiss reachable by keyboard & AT. */}
+      <button
+        type="button"
+        aria-label={cancelLabel}
         onClick={onCancel}
-        aria-hidden
+        onKeyDown={handleScrimKey}
+        className="absolute inset-0 bg-text/40 backdrop-blur-sm motion-safe:animate-fade-in"
       />
 
       {/* Sheet */}
@@ -50,8 +68,9 @@ export function ConfirmDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-title"
+        onPointerDown={(e) => e.stopPropagation()}
         className={cn(
-          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0",
+          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0 overscroll-contain",
           "bg-panel rounded-3xl shadow-float border border-line p-6",
           "animate-in slide-in-from-bottom-4 duration-200",
         )}

--- a/src/shared/components/ui/InputDialog.tsx
+++ b/src/shared/components/ui/InputDialog.tsx
@@ -5,6 +5,7 @@ import {
   useId,
   type FormEvent,
   type HTMLInputTypeAttribute,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
@@ -51,6 +52,15 @@ export function InputDialog({
     }
   }, [open, defaultValue]);
 
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   if (!open) return null;
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -58,15 +68,24 @@ export function InputDialog({
     onConfirm?.(value);
   };
 
+  const handleScrimKey = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onCancel?.();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-[200] flex items-end justify-center sm:items-center"
       role="presentation"
     >
-      <div
-        className="absolute inset-0 bg-text/40 backdrop-blur-sm"
+      <button
+        type="button"
+        aria-label={cancelLabel}
         onClick={onCancel}
-        aria-hidden
+        onKeyDown={handleScrimKey}
+        className="absolute inset-0 bg-text/40 backdrop-blur-sm"
       />
 
       <form
@@ -75,8 +94,9 @@ export function InputDialog({
         aria-modal="true"
         aria-labelledby={titleId}
         onSubmit={handleSubmit}
+        onPointerDown={(e) => e.stopPropagation()}
         className={cn(
-          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0",
+          "relative z-10 w-full max-w-sm mx-4 mb-4 sm:mb-0 overscroll-contain",
           "bg-panel rounded-3xl shadow-float border border-line p-6",
           "animate-in slide-in-from-bottom-4 duration-200",
         )}
@@ -98,7 +118,12 @@ export function InputDialog({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           placeholder={placeholder}
-          className="w-full h-12 rounded-xl bg-bg border border-line px-4 text-sm text-text placeholder:text-subtle outline-none focus:border-primary/60 transition-colors mb-4"
+          className={cn(
+            "w-full h-12 rounded-xl bg-bg border border-line px-4 text-sm text-text placeholder:text-subtle mb-4",
+            "transition-colors",
+            "focus:outline-none focus:border-brand-400",
+            "focus-visible:outline-none focus-visible:border-brand-400 focus-visible:ring-2 focus-visible:ring-brand-500/30",
+          )}
           autoComplete="off"
         />
         <div className="flex flex-col gap-2">

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -180,7 +180,7 @@ export function Modal({
 
         <div
           className={cn(
-            "overflow-y-auto px-5 pb-5",
+            "overflow-y-auto overscroll-contain px-5 pb-5",
             title || !hideClose ? "pt-0" : "pt-5",
             bodyClassName,
           )}


### PR DESCRIPTION
## Summary

Fixes three a11y/interaction gaps surfaced by the Vercel Web Interface Guidelines review of our shared dialog primitives. No behaviour change for mouse users; keyboard / AT / iOS scroll behaviour becomes consistent across `Modal` / `Sheet` / `ConfirmDialog` / `InputDialog`.

### `ConfirmDialog`
- Scrim is now a real `<button>` with `aria-label` + `onKeyDown` (Enter / Space) — previously a `<div onClick>` which was invisible to keyboard users and AT. Matches the pattern already used in `Modal.tsx:110-117`.
- Body scroll is locked while open (parity with `Modal` / `Sheet`).
- Panel gets `overscroll-contain` to stop iOS rubber-band scroll leaking to the body under the dialog.

### `InputDialog`
- Same scrim-as-button + keyboard handler.
- Same body scroll-lock + `overscroll-contain` on the panel.
- The inset input replaces the raw `outline-none focus:border-primary/60` (which left keyboard focus nearly invisible) with the canonical `focus-visible:ring-2 ring-brand-500/30` treatment used by `<Input>` and `<Button>`. Pointer clicks still don't flash the ring.

### `Modal`
- Adds `overscroll-contain` to the scroll region (parity with `Sheet.tsx:161`).

## Review & Testing Checklist for Human

- [ ] Tab into any `ConfirmDialog` / `InputDialog` caller, tab onto the scrim — focus ring is visible and Enter/Space dismisses.
- [ ] Open a `ConfirmDialog` on mobile Safari — body beneath no longer rubber-bands while the dialog is visible.
- [ ] Open `InputDialog` via keyboard — input receives focus and the ring is visible when it is keyboard-focused, but NOT when clicked.
- [ ] Pointer click on overlay still dismisses `ConfirmDialog` / `InputDialog` / `Modal` exactly as before.

### Notes

This is the first of a 4-PR series from a design-system review against Vercel Web Interface Guidelines. Remaining planned PRs (each small and scoped):

1. ✅ Dialog a11y (this PR)
2. Skip-link in `App.tsx` + `<main id="main">` in `HubMainContent`
3. `<Input>` defaults for `spellCheck` / `autoComplete` / `inputMode` + `AuthPage` refactor to use `<Input>`
4. `"..." → "…"` (ellipsis) fixes + ESLint rule to prevent regressions

No new tests — the affected files have no existing tests, and the change is purely keyboard/AT plumbing. Behaviour for mouse users is preserved.


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
