### PR TITLE
fix(deploy): run scripts/migrate.mjs with tsx loader so it resolves server/db.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
-    "db:migrate": "node scripts/migrate.mjs",
+    "db:migrate": "node --import tsx scripts/migrate.mjs",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Railway зараз не публікує жодного деплоя з main — 5 останніх підряд деплойментів у FAILED. Причина — release-stage `npm run db:migrate`, який запускався у pre-deploy контейнері, падав з `ERR_MODULE_NOT_FOUND`.

**Корінь:**

- [`scripts/migrate.mjs`](https://github.com/Skords-01/Sergeant/blob/main/scripts/migrate.mjs#L49) робить `await import("../server/db.js")`.
- У Dockerfile.api копіюється `server/` — там лежить **лише** `server/db.ts` (після TS-міграції у PR #311), `server/db.js` у образі немає.
- `start` у `package.json` уже використовує `node --import tsx ...`, і tsx резолвить імпорти виду `./foo.js` → `./foo.ts`. Але `db:migrate` запускався без tsx-loader-а, тому падав одразу на require-resolve:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/server/db.js'
imported from /app/scripts/migrate.mjs
```

(Повний лог Railway deployment `b9edbe96-6c6e-4803-b967-cce7b87c7db8`, 2026-04-19 22:59:50Z.)

**Фікс — 1 символ сценарію:**

```diff
-    "db:migrate": "node scripts/migrate.mjs",
+    "db:migrate": "node --import tsx scripts/migrate.mjs",
```

`tsx` уже у `dependencies` (не `devDependencies`), тому після `npm ci --omit=dev` у `Dockerfile.api` він залишається у node_modules.

**Верифіковано локально:**

```
DATABASE_URL='postgres://nouser:nopw@127.0.0.1:1/nodb' \
node --import tsx scripts/migrate.mjs
# {"level":"error","msg":"migrate_failed","err":{"message":"connect ECONNREFUSED 127.0.0.1:1","code":"ECONNREFUSED"}}
```

Тобто резолв модуля тепер проходить, єдина помилка — з'єднання (ECONNREFUSED для fake URL, як і очікувалось). На Railway `MIGRATE_DATABASE_URL` має бути справжній public proxy URL Postgres.

## Review & Testing Checklist for Human

- [ ] Перевір, що `MIGRATE_DATABASE_URL` (або `DATABASE_URL`) у Railway prod-env виставлений на **публічний** proxy URL Postgres (`${{ Postgres.DATABASE_PUBLIC_URL }}`) — бо `postgres.railway.internal` у pre-deploy контейнері не резолвиться (див. коментар [scripts/migrate.mjs:17-24](https://github.com/Skords-01/Sergeant/blob/main/scripts/migrate.mjs#L17-L24)).
- [ ] Після мержу — перевір у Railway, що наступний deploy проходить pre-deploy крок (`npm run db:migrate`) і що контейнер стартує.
- [ ] Якщо є інші скрипти, які ще імпортують `server/*.js` без tsx loader-а — окремий audit (швидка перевірка: `grep -rn 'from.*"\.\./server/.*\.js"' scripts/`).

### Test plan

- Локально: `DATABASE_URL=... node --import tsx scripts/migrate.mjs` — module resolution проходить (див. Summary).
- На Railway: редеплой main; у deploy-логах повинно з'явитися `{"level":"info","msg":"migrate_ok"}` замість `ERR_MODULE_NOT_FOUND`.

### Notes

- Альтернатива, яку свідомо не брав: перейменувати `migrate.mjs` → `migrate.ts` і запускати `tsx scripts/migrate.ts`. Мінімальніша зміна — додати `--import tsx` у тому ж форматі, що й `start` у `package.json`.
- Пропоную у follow-up винести `scripts/migrate.mjs` теж у `.ts` разом із `server/` (або додати `scripts/` у перевірку `lint:imports`), щоб тип-чек ловив подібні неконсистентності на CI, а не вже у prod-логах.

Link to Devin session: https://app.devin.ai/sessions/48a578eeadce434eacc2d3d8851410bc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
