### PR TITLE
feat(a11y): add 'Skip to main content' link to app shell

### DIFF
--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { cn } from "@shared/lib/cn";
+import { SkipLink } from "@shared/components/ui/SkipLink";
 import ModuleErrorBoundary from "./ModuleErrorBoundary";
 import { useDarkMode } from "@shared/hooks/useDarkMode";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
@@ -277,6 +278,7 @@ function AppInner() {
     const inFtuxSession = !user && !isFirstRealEntryDone();
     return (
       <div className="min-h-dvh bg-bg flex flex-col safe-area-pt-pb page-enter">
+        <SkipLink />
         {!online && <OfflineBanner />}
 
         <HubHeader
@@ -353,6 +355,7 @@ function AppInner() {
 
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
+      <SkipLink />
       {!online && <OfflineBanner />}
       {/* Persistent "resume workout" shortcut — rendered in Finyk,
           Routine, Nutrition (but not inside Fizruk itself, where the
@@ -393,9 +396,11 @@ function AppInner() {
       )}
 
       <Suspense fallback={<PageLoader />}>
-        <div
+        <main
           key={activeModule}
-          className={cn(moduleAnimClass, "h-full flex flex-col")}
+          id="main"
+          tabIndex={-1}
+          className={cn(moduleAnimClass, "h-full flex flex-col outline-none")}
         >
           <ModuleErrorBoundary onBackToHub={goToHub}>
             {activeModule === "finyk" && (
@@ -428,7 +433,7 @@ function AppInner() {
               />
             )}
           </ModuleErrorBoundary>
-        </div>
+        </main>
       </Suspense>
     </div>
   );

--- a/src/core/app/HubMainContent.tsx
+++ b/src/core/app/HubMainContent.tsx
@@ -151,7 +151,11 @@ export function HubMainContent({
 
       {showIos && <IOSInstallBanner onDismiss={onDismissIos} />}
 
-      <main className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="flex-1 px-5 pb-28 max-w-lg mx-auto w-full overflow-y-auto outline-none"
+      >
         {hubView === "dashboard" && (
           <ErrorBoundary key="dashboard" fallback={HubSectionFallback}>
             <div className="flex flex-col gap-5 pt-2">

--- a/src/shared/components/ui/SkipLink.tsx
+++ b/src/shared/components/ui/SkipLink.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@shared/lib/cn";
+
+export interface SkipLinkProps {
+  /** Fragment target without the leading `#`. Defaults to `main`. */
+  targetId?: string;
+  /** Visible label. Defaults to Ukrainian copy. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Canonical "skip to main content" link — the first interactive element
+ * in document order. Keyboard-only and screen-reader users can jump
+ * straight past the header / tabs / chrome to the primary `<main>`
+ * region instead of tabbing through every nav item on every page load.
+ *
+ * Rendered visually-hidden by default; becomes visible when it gains
+ * keyboard focus. Mount it as the FIRST child of the app shell so Tab
+ * from the address bar lands on it immediately.
+ */
+export function SkipLink({
+  targetId = "main",
+  label = "Перейти до основного вмісту",
+  className,
+}: SkipLinkProps) {
+  return (
+    <a
+      href={`#${targetId}`}
+      className={cn(
+        // Visually hidden until focused — do NOT use display:none or
+        // visibility:hidden here, both remove the element from the
+        // accessibility tree.
+        "sr-only focus:not-sr-only",
+        // When focused: promote to a pinned top-left pill that sits
+        // above every surface in the app (modals, sheets, toasts all
+        // live ≤ z-[200]).
+        "focus:fixed focus:top-3 focus:left-3 focus:z-[300]",
+        "focus:px-4 focus:py-2 focus:rounded-xl",
+        "focus:bg-panel focus:text-text focus:shadow-float focus:border focus:border-line",
+        "focus:text-sm focus:font-semibold",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+        className,
+      )}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/shared/components/ui/index.ts
+++ b/src/shared/components/ui/index.ts
@@ -78,6 +78,9 @@ export type { SelectProps, SelectSize, SelectVariant } from "./Select";
 export { Skeleton, SkeletonText } from "./Skeleton";
 export type { SkeletonProps } from "./Skeleton";
 
+export { SkipLink } from "./SkipLink";
+export type { SkipLinkProps } from "./SkipLink";
+
 export { Spinner } from "./Spinner";
 export type { SpinnerProps, SpinnerSize } from "./Spinner";
 


### PR DESCRIPTION
## Summary

Adds a canonical **skip-link** as the first interactive element in document order so keyboard / screen-reader users can jump past the header, tabs, and chrome banners straight to the primary content on every page.

### New primitive

- `src/shared/components/ui/SkipLink.tsx` — visually-hidden anchor that becomes a pinned top-left pill when it receives keyboard focus. Uses the same `focus-visible:ring-2 ring-brand-500/45` treatment as `Button`/`Input`. Defaults to Ukrainian label "Перейти до основного вмісту" and target `#main`; both overridable.

### Wiring

- `HubMainContent.tsx` — `<main>` gets `id="main"` + `tabIndex={-1}` + `outline-none` so the anchor target accepts programmatic focus without showing a browser default outline.
- `App.tsx` —
  - Renders `<SkipLink />` as the first element inside **both** render paths (the hub shell at `/` and the active-module shell).
  - The active-module wrapper was a `<div>`; it is now a real `<main id="main">` so the skip-link works correctly regardless of whether the user is in Finyk / Fizruk / Routine / Nutrition.

No visual change for mouse users — the link only appears when it receives keyboard focus (via `sr-only focus:not-sr-only`).

## Review & Testing Checklist for Human

- [ ] Load `/`, press Tab once from the address bar — the "Перейти до основного вмісту" pill appears top-left with a visible focus ring.
- [ ] Press Enter — focus jumps to `<main>` content; subsequent Tab lands on the first dashboard/module interactive element, skipping the header.
- [ ] Repeat inside a module (e.g. Фізрук) — skip-link still appears and focus still lands on the module content.
- [ ] Mouse users see no visual difference — pill never appears on hover or click.

### Notes

This is PR 2/4 from the design-system review series.
- PR 1 (merged): Dialog a11y — #339
- PR 2 (this): Skip-link
- PR 3: `<Input>` defaults (`spellCheck`/`autoComplete`/`inputMode`) + `AuthPage` refactor
- PR 4: Ellipsis (`…`) fixes + ESLint rule

Axe-core CI check should pick up the new landmark on the next run.


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
