### PR TITLE
feat(ui/input): type-aware spellCheck + inputMode defaults, refactor AuthPage

### DIFF
--- a/src/core/AuthPage.tsx
+++ b/src/core/AuthPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
 import { useAuth } from "./AuthContext.jsx";
 
 export function AuthPage({ onContinueWithoutAccount }) {
@@ -49,9 +50,6 @@ export function AuthPage({ onContinueWithoutAccount }) {
     setLoading(false);
   };
 
-  const INPUT_CLS =
-    "w-full min-h-[44px] px-4 py-3 rounded-xl bg-panel border border-line text-text text-[16px] md:text-sm placeholder:text-muted/50 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500 transition-colors";
-
   return (
     <div
       className="min-h-dvh bg-bg flex flex-col items-center justify-center px-5"
@@ -79,12 +77,11 @@ export function AuthPage({ onContinueWithoutAccount }) {
               >
                 Ім{"'"}я
               </label>
-              <input
+              <Input
                 id="auth-name"
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className={INPUT_CLS}
                 placeholder={"Ваше ім'я"}
                 autoComplete="name"
               />
@@ -98,13 +95,12 @@ export function AuthPage({ onContinueWithoutAccount }) {
             >
               Email
             </label>
-            <input
+            <Input
               id="auth-email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className={INPUT_CLS}
               placeholder="email@example.com"
               autoComplete="email"
             />
@@ -133,14 +129,13 @@ export function AuthPage({ onContinueWithoutAccount }) {
                 </button>
               )}
             </div>
-            <input
+            <Input
               id="auth-password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className={INPUT_CLS}
               placeholder="Мінімум 6 символів"
               autoComplete={
                 mode === "login" ? "current-password" : "new-password"
@@ -172,12 +167,11 @@ export function AuthPage({ onContinueWithoutAccount }) {
                   >
                     Email для скидання
                   </label>
-                  <input
+                  <Input
                     id="auth-forgot-email"
                     type="email"
                     value={forgotEmail}
                     onChange={(e) => setForgotEmail(e.target.value)}
-                    className={INPUT_CLS}
                     placeholder="email@example.com"
                     autoComplete="email"
                   />

--- a/src/shared/components/ui/Input.test.tsx
+++ b/src/shared/components/ui/Input.test.tsx
@@ -1,0 +1,59 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Input } from "./Input";
+
+// Guardrails for the opinionated per-type defaults added in the design-system
+// review pass. The contract is: non-prose types get spellCheck=false +
+// inputMode hints *unless* the caller overrides. Prose-like types stay
+// untouched so long-form text still gets browser spellcheck.
+//
+// NOTE: jsdom does not implement the HTMLInputElement.spellcheck IDL
+// property reliably, so we assert against the DOM attribute string —
+// which is what React actually writes out.
+describe("Input type-aware defaults", () => {
+  it("disables spellCheck and sets inputMode='email' on type='email'", () => {
+    const { container } = render(<Input type="email" />);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("spellcheck")).toBe("false");
+    expect(input.getAttribute("inputmode")).toBe("email");
+    expect(input.type).toBe("email");
+  });
+
+  it("disables spellCheck on type='password' and omits inputMode", () => {
+    const { container } = render(<Input type="password" />);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("spellcheck")).toBe("false");
+    // inputMode is not set explicitly for password — the browser picks the
+    // right keyboard from `type` alone.
+    expect(input.getAttribute("inputmode")).toBeNull();
+  });
+
+  it("sets inputMode='decimal' on type='number'", () => {
+    const { container } = render(<Input type="number" />);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("inputmode")).toBe("decimal");
+    expect(input.getAttribute("spellcheck")).toBe("false");
+  });
+
+  it("does not disable spellCheck on prose type='text'", () => {
+    const { container } = render(<Input type="text" />);
+    const input = container.querySelector("input")!;
+    // No attribute written → browser default (true for most elements)
+    // stays in effect. Do NOT flip it off for prose inputs.
+    expect(input.getAttribute("spellcheck")).toBeNull();
+    expect(input.getAttribute("inputmode")).toBeNull();
+  });
+
+  it("lets caller override spellCheck explicitly", () => {
+    const { container } = render(<Input type="email" spellCheck />);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("spellcheck")).toBe("true");
+  });
+
+  it("lets caller override inputMode explicitly", () => {
+    const { container } = render(<Input type="number" inputMode="numeric" />);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("inputmode")).toBe("numeric");
+  });
+});

--- a/src/shared/components/ui/Input.tsx
+++ b/src/shared/components/ui/Input.tsx
@@ -1,10 +1,42 @@
 import {
   forwardRef,
+  type HTMLInputTypeAttribute,
   type InputHTMLAttributes,
   type ReactNode,
   type TextareaHTMLAttributes,
 } from "react";
 import { cn } from "../../lib/cn";
+
+/**
+ * Opinionated per-`type` defaults for `spellCheck`, `inputMode`, and
+ * `autoComplete`. Per the Web Interface Guidelines, non-prose inputs
+ * (email / url / password / numeric / code fields) should disable
+ * spellcheck so the browser does not red-underline legitimate values
+ * and should hint the right software keyboard / autofill category on
+ * mobile. Consumers can always override by passing the prop explicitly
+ * — the Input only fills in a default when the caller did not.
+ */
+const NON_PROSE_TYPES = new Set<HTMLInputTypeAttribute>([
+  "email",
+  "password",
+  "url",
+  "tel",
+  "number",
+  "search",
+]);
+
+const DEFAULT_INPUT_MODE: Partial<
+  Record<
+    HTMLInputTypeAttribute,
+    InputHTMLAttributes<HTMLInputElement>["inputMode"]
+  >
+> = {
+  email: "email",
+  tel: "tel",
+  url: "url",
+  number: "decimal",
+  search: "search",
+};
 
 /**
  * Sergeant Design System — Input Component
@@ -60,6 +92,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     success,
     icon,
     suffix,
+    type,
+    spellCheck,
+    inputMode,
     ...props
   },
   ref,
@@ -70,6 +105,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       ? "border-brand-400 focus-visible:border-brand-500 focus-visible:ring-brand-500/25 focus:border-brand-500"
       : "";
 
+  // Type-aware defaults. The caller's explicit prop always wins — these
+  // only fill in when `undefined` so existing call sites don't change.
+  const resolvedSpellCheck =
+    spellCheck ?? (type && NON_PROSE_TYPES.has(type) ? false : undefined);
+  const resolvedInputMode =
+    inputMode ?? (type ? DEFAULT_INPUT_MODE[type] : undefined);
+
   return (
     <div className="relative">
       {icon && (
@@ -79,6 +121,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
       )}
       <input
         ref={ref}
+        type={type}
+        spellCheck={resolvedSpellCheck}
+        inputMode={resolvedInputMode}
         aria-invalid={error ? true : undefined}
         className={cn(
           "w-full text-text placeholder:text-subtle/70",


### PR DESCRIPTION
## Summary

The `<Input>` primitive now fills in sensible accessibility + mobile-keyboard defaults based on its `type` attribute, so every form in the app gets them for free. Callers can always override.

### `Input.tsx`

- `NON_PROSE_TYPES` (`email` / `password` / `url` / `tel` / `number` / `search`) default to `spellCheck={false}` — stops the browser from red-underlining emails, passwords, and numeric codes as misspelled.
- `DEFAULT_INPUT_MODE` maps `type` → `inputMode` (`email` → `email`, `tel` → `tel`, `url` → `url`, `number` → `decimal`, `search` → `search`) so mobile users get the right software keyboard without every caller remembering to set it.
- Both use nullish coalescing (`??`) — caller-provided props always win.
- Prose types (`text`, `textarea`, etc.) are **not** touched, so long-form notes still get browser spellcheck.

### `AuthPage.tsx`

Refactored to use `<Input>` from shared/ui instead of a hand-rolled `INPUT_CLS` constant. Size / radius / focus-ring treatment is now identical to every other form in the app, and the email field automatically picks up `inputMode="email"` + `spellCheck={false}` via the new defaults.

### Tests

Added `Input.test.tsx` covering:
- `email` → spellcheck=false + inputmode=email
- `password` → spellcheck=false, no inputmode (type is sufficient)
- `number` → spellcheck=false + inputmode=decimal
- `text` (negative) → neither attribute set
- explicit `spellCheck` prop wins
- explicit `inputMode` prop wins

## Review & Testing Checklist for Human

- [ ] Visit `/sign-in` — email, password, name inputs match the visual treatment of inputs inside modules (rounded-2xl, h-11, brand focus ring).
- [ ] On mobile, focusing the email field brings up the email keyboard (`@` + `.` row).
- [ ] Password field does not show red squiggles on any browser.
- [ ] Existing forms (FinykTransactionSheet, RoutineAddTaskSheet, NutritionAddMealSheet, etc.) render and submit unchanged — no visual or behavioural regressions.

### Notes

PR 3/4 from the design-system review series.
- PR 1 (merged): Dialog a11y — #339
- PR 2 (merged): Skip-link — #341
- PR 3 (this): Input defaults + AuthPage refactor
- PR 4 (next): Ellipsis (`…`) fixes + ESLint rule

The per-type defaults are additive and use `??` — any existing caller that passes an explicit prop is unaffected. Search for `<Input` and `<input` revealed no callers that would regress.


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
