### PR TITLE
fix(a11y): skip-link target is a &lt;div&gt;, not &lt;main&gt; (avoid nested landmarks)

### DIFF
--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -396,7 +396,12 @@ function AppInner() {
       )}
 
       <Suspense fallback={<PageLoader />}>
-        <main
+        {/* Skip-link target — deliberately a `<div>` (not `<main>`) because
+            some modules (e.g. Routine) render their own `<main>` landmark
+            internally. Having two visible `<main>` elements violates the
+            HTML spec and confuses AT landmark navigation. The SkipLink only
+            needs an `id` + focusability to do its job. */}
+        <div
           key={activeModule}
           id="main"
           tabIndex={-1}
@@ -433,7 +438,7 @@ function AppInner() {
               />
             )}
           </ModuleErrorBoundary>
-        </main>
+        </div>
       </Suspense>
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to merged PR #341. Devin Review correctly flagged that the PR introduced **nested `<main>` landmarks** whenever the Routine module is active — `RoutineApp` already renders its own `<main id="routine-main">` internally ([`src/modules/routine/RoutineApp.tsx:582`](https://github.com/Skords-01/Sergeant/blob/main/src/modules/routine/RoutineApp.tsx#L582)). Two visible `<main>` elements violate the HTML spec and confuse assistive-tech landmark navigation — the exact opposite of what #341 aimed to achieve.

### Fix

Revert the outer module wrapper to a `<div>` while keeping the `id="main"` + `tabIndex={-1}` attributes the SkipLink actually needs. The SkipLink only requires an anchor target with an id and focusability — it does **not** need the `main` landmark role on that element.

A comment in the JSX records why we deliberately do NOT use `<main>` here, to prevent future refactors from reintroducing the bug.

### What stays the same

- `HubMainContent`'s `<main id="main">` is unchanged — that render path has no inner `<main>`, so it remains the single document-level landmark.
- SkipLink still works in every module (skip-link anchors to any element with `id="main"`, regardless of tag name).

## Review & Testing Checklist for Human

- [ ] Open Routine module, run axe-devtools or `document.querySelectorAll("main")` — exactly **one** `<main>` present (`#routine-main`).
- [ ] Skip-link still jumps focus to module content via Tab → Enter in all four modules.
- [ ] Hub shell (no active module) still exposes its `<main id="main">` landmark.

### Notes

Credit to Devin Review for the catch: https://app.devin.ai/review/skords-01/sergeant/pull/341

This is the 4th PR in the design-system review series, slotted ahead of the ellipsis PR because it's a regression fix for a merged PR.


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
