### PR TITLE
refactor(ops): pg_advisory_lock around migrations + warn-on-boot for CSP_DISABLE

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -120,11 +120,30 @@ export async function query<R extends QueryResultRow = QueryResultRow>(
 }
 
 /**
+ * Стабільний 64-бітний id для advisory-lock міграцій. Значення — статичне,
+ * довільне, ключ — щоб два процеси `scripts/migrate.mjs` (паралельний
+ * release-stage на різних репліках, ручний `npm run db:migrate` під час
+ * деплою тощо) не стартували міграції одночасно й не зловили race на
+ * `INSERT schema_migrations` або DDL-колізію. Lock session-scoped —
+ * звільниться автоматично, якщо процес упаде.
+ */
+const MIGRATIONS_ADVISORY_LOCK_KEY = 7317483629462015n;
+
+/**
  * Incremental SQL migrations from server/migrations/*.sql (lexicographic order).
  * Tracked in schema_migrations. schema_migrations itself is the only table
  * created inline — everything else is defined in migration files.
+ *
+ * `pg_advisory_lock` серіалізує паралельні виклики: другий claim буде
+ * спати доти, доки перший не відпустить lock (у `ensureSchema.finally`).
+ * Після розблокування другий увійде, побачить уже застосовані файли у
+ * `schema_migrations` і тихо no-op-не.
  */
 async function runPendingSqlMigrations(client: PoolClient): Promise<void> {
+  await client.query("SELECT pg_advisory_lock($1)", [
+    MIGRATIONS_ADVISORY_LOCK_KEY.toString(),
+  ]);
+
   await client.query(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       name TEXT PRIMARY KEY,
@@ -173,6 +192,17 @@ export async function ensureSchema(): Promise<void> {
   try {
     await runPendingSqlMigrations(client);
   } finally {
+    // Best-effort відпускання advisory-lock. Якщо pg_advisory_lock ніколи
+    // не викликався (наприклад, connect впав), unlock поверне false і не
+    // кине. Release клієнта — окремо у finally, щоб lock не "зависнув"
+    // поки pg не задетектить дропнуту сесію.
+    try {
+      await client.query("SELECT pg_advisory_unlock($1)", [
+        MIGRATIONS_ADVISORY_LOCK_KEY.toString(),
+      ]);
+    } catch {
+      /* сесія однаково release-ається нижче */
+    }
     client.release();
   }
 }

--- a/server/http/security.ts
+++ b/server/http/security.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "express";
 import helmet from "helmet";
+import { logger } from "../obs/logger.js";
 
 export type ApiCspDirectives = Record<string, string[]>;
 
@@ -52,8 +53,24 @@ export function buildApiCspDirectives(): ApiCspDirectives {
 export function apiHelmetMiddleware({
   servesFrontend = false,
 }: ApiHelmetOptions = {}): RequestHandler {
-  const cspDisabled = process.env.CSP_DISABLE === "1" || servesFrontend;
+  const cspEnvDisabled = process.env.CSP_DISABLE === "1";
+  const cspDisabled = cspEnvDisabled || servesFrontend;
   const reportOnly = process.env.CSP_REPORT_ONLY === "1";
+
+  // Без явного лога CSP_DISABLE=1 став би тихою деградацією — ревʼю
+  // security-headers легко пропускає факт, що CSP взагалі не застосована.
+  // Логуємо один раз на boot з рівнем warn у проді і info у дев-режимі.
+  if (cspEnvDisabled) {
+    const isProd = process.env.NODE_ENV === "production";
+    const log = isProd ? logger.warn : logger.info;
+    log({
+      msg: "csp_disabled",
+      reason: "CSP_DISABLE=1",
+      env: process.env.NODE_ENV || "unknown",
+    });
+  } else if (reportOnly) {
+    logger.info({ msg: "csp_report_only" });
+  }
 
   return helmet({
     contentSecurityPolicy: cspDisabled


### PR DESCRIPTION
## Summary

Два низькоризикових ops-фікси з tech-debt аудиту (#8, #11). Без змін схеми, API-контракту, без нових залежностей.

### #11 `pg_advisory_lock` у міграціях
`server/db.ts`: `runPendingSqlMigrations` робить `pg_advisory_lock($key)` перед `CREATE TABLE IF NOT EXISTS schema_migrations` і будь-якими `INSERT`-ами, а `ensureSchema` у `finally` віддає `pg_advisory_unlock` перед `client.release`. Lock session-scoped — якщо процес впаде, Postgres звільнить його сам.

Навіщо: `scripts/migrate.mjs` запускається як release-stage. На rolling deploy із 2+ репліками або при ручному `npm run db:migrate` паралельно з авто-деплоєм раніше був race: два процеси одночасно робили `INSERT schema_migrations` або DDL одного й того ж файлу → один падав з `duplicate key` / `relation already exists`, деплой ішов у failed state. Тепер другий претендент чекає на lock, потім бачить уже застосовані файли у `schema_migrations` і тихо no-op-ить.

### #8 Warn-at-boot для `CSP_DISABLE=1`
`server/http/security.ts`: при `CSP_DISABLE=1` логуємо `{ msg: "csp_disabled", reason: "CSP_DISABLE=1", env }` — `warn` у проді (`NODE_ENV=production`), `info` в інших env. Також окремий `info` для `CSP_REPORT_ONLY=1` — щоб security-audit у Grafana/Sentry бачив обидва стани. Раніше один env-перемикач тихо вимикав CSP без жодного сліду в логах.

## Review & Testing Checklist for Human

- [ ] Перевірити dev-boot: `CSP_DISABLE=1 npm run dev` → у лозі має з'явитись `csp_disabled` (info у dev, warn у prod-подібному env).
- [ ] Sanity для advisory-lock: `npm run db:migrate` двічі паралельно (наприклад, у двох терміналах) — перший має застосувати, другий чекає і виходить з `migrate_ok` без inserts.
- [ ] Переглянути що advisory-lock не тримається довше за ensureSchema (у `finally` явний `pg_advisory_unlock`, плюс `client.release()`).

### Notes
- Lock key — статичний 64-bit `7317483629462015n`. Якщо колись захочете заділитись тим же app-lock-ом з іншого процесу, треба використовувати той самий ключ.
- 907 тестів, typecheck, lint — зелені локально. `smoke.test.ts` мокає `ensureSchema`, тож advisory-lock у реальному pg не викликається у тестовому CI.
- Graceful shutdown (#16), мігації з release-stage (#12) — вже зроблено до цього PR (див. `server/index.ts` + `scripts/migrate.mjs`).

Link to Devin session: https://app.devin.ai/sessions/335eaf143ebe42a489930c675746c04a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
