### PR TITLE
fix(stories): unify tap nav via pointer events so a single tap advances one slide

### DIFF
--- a/src/core/WeeklyDigestStories.tsx
+++ b/src/core/WeeklyDigestStories.tsx
@@ -668,25 +668,34 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
     };
   }, [next, prev, onClose]);
 
+  // Single unified pointer pipeline (mouse + touch + pen). Binding both
+  // onMouse* and onTouch* on the same element used to double-fire every tap:
+  // real browsers dispatch `touchend` first, then synthesize `mouseup`
+  // ~300 ms later, which made a single right-tap advance two slides.
+  // Pointer events collapse all three input sources into one stream, so each
+  // physical tap triggers exactly one press-start / press-end pair.
   const handlePressStart = (e) => {
+    // Capture the pointer so `pointermove`/`pointerup` keep arriving even if
+    // the finger slides off the element — required for the swipe-to-close
+    // gesture below. Try/catch because capture can throw in old WebKit.
+    try {
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+    } catch {
+      /* best-effort */
+    }
     // Press-and-hold pauses progress after ~180ms — a quick tap still
     // registers as a navigation click.
     holdTimerRef.current = setTimeout(() => {
       setPaused(true);
       holdTimerRef.current = null;
     }, 180);
-    const touch = e.touches?.[0];
-    if (touch) {
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
-      dragYRef.current = 0;
-    }
+    touchStartRef.current = { x: e.clientX, y: e.clientY };
+    dragYRef.current = 0;
   };
 
-  const handleTouchMove = (e) => {
+  const handlePointerMove = (e) => {
     if (!touchStartRef.current) return;
-    const touch = e.touches?.[0];
-    if (!touch) return;
-    const dy = touch.clientY - touchStartRef.current.y;
+    const dy = e.clientY - touchStartRef.current.y;
     if (dy > 0) {
       dragYRef.current = dy;
       if (containerRef.current) {
@@ -708,6 +717,11 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   };
 
   const handlePressEnd = (e) => {
+    try {
+      e.currentTarget.releasePointerCapture?.(e.pointerId);
+    } catch {
+      /* best-effort */
+    }
     const wasHeld = holdTimerRef.current === null;
     if (holdTimerRef.current) {
       clearTimeout(holdTimerRef.current);
@@ -735,10 +749,18 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
     const target = e.target;
     if (target?.closest?.("[data-story-ui]")) return;
     const rect = e.currentTarget.getBoundingClientRect();
-    const x =
-      (e.changedTouches?.[0]?.clientX ?? e.clientX ?? rect.left) - rect.left;
+    const x = e.clientX - rect.left;
     if (x < rect.width / 3) prev();
     else next();
+  };
+
+  const handlePointerCancel = () => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    setPaused(false);
+    resetDrag();
   };
 
   if (!slides.length) return null;
@@ -763,42 +785,27 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
       aria-label="Щотижневий дайджест — сторіс"
     >
       <div className="absolute inset-0 bg-black/90" />
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions --
-          Mouse/touch handlers provide tap-to-navigate and press-to-pause on
-          this fullscreen surface. Keyboard navigation (Arrow keys, Space,
-          Escape) is wired up at the window level via the effect above, and a
-          visible close button supplies the focus-reachable escape hatch. */}
+      {/* Pointer handlers provide tap-to-navigate and press-to-pause on this
+          fullscreen surface. Keyboard nav (Arrow keys, Space, Escape) is
+          wired up at the window level via the effect above, and a visible
+          close button supplies the focus-reachable escape hatch. */}
       <div
         ref={containerRef}
-        className="absolute inset-0 transition-[transform,opacity] duration-150 ease-out"
-        onMouseDown={handlePressStart}
-        onMouseUp={handlePressEnd}
-        onMouseLeave={() => {
-          if (holdTimerRef.current) {
-            clearTimeout(holdTimerRef.current);
-            holdTimerRef.current = null;
-          }
-          // Unconditional — `paused` may be stale in this closure if the
-          // hold-timer just fired, and we must not leave the stories stuck.
-          setPaused(false);
-          resetDrag();
-        }}
-        onTouchStart={handlePressStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handlePressEnd}
+        className="absolute inset-0 transition-[transform,opacity] duration-150 ease-out touch-none"
+        onPointerDown={handlePressStart}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePressEnd}
+        onPointerCancel={handlePointerCancel}
       >
         {renderSlide(slide)}
 
-        {/* Top chrome: progress bars + header */}
-        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions --
-            Stops pointer events from bubbling to the parent navigation surface
-            so that interactions with the progress bar / close button don't
-            trigger tap-to-advance. */}
+        {/* Top chrome: progress bars + header. `stopPropagation` prevents
+            taps on the progress bar / close button from bubbling to the
+            parent navigation surface and triggering tap-to-advance. */}
         <div
           data-story-ui
           className="absolute inset-x-0 top-0 px-3 pt-[max(0.5rem,env(safe-area-inset-top,0px))] pb-2"
-          onMouseDown={(e) => e.stopPropagation()}
-          onTouchStart={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
         >
           <div className="flex items-center gap-1">
             {slides.map((s, i) => {


### PR DESCRIPTION
## Summary

Виправлено подвійний advance у `WeeklyDigestStories` (тижневий дайджест у сторіс): один тап справа **перескакував через слайд**, показуючи слайд N+2 замість N+1.

**Корінь:** контейнер біндив одночасно два набори обробників — `onMouseDown/onMouseUp` і `onTouchStart/onTouchEnd`. На touch-девайсах (Android Chrome, iOS Safari, а також у touch-емуляції DevTools) після справжнього `touchend` браузер приблизно через ~300 ms ще додатково синтезує `mousedown` + `mouseup` для того самого тапу (ghost click). Через це `handlePressEnd` запускався **двічі підряд**, і `next()` викликався двічі — звідси стрибок через слайд.

**Фікс:** консолідувати весь input у єдиний пайплайн Pointer Events (`onPointerDown/Move/Up/Cancel`). Pointer events схлопують mouse + touch + pen в один потік, і React дає **рівно одну** `press-start/press-end` пару на фізичний тап — без жодних ghost-подій.

Ключові зміни у <ref_file file="/home/ubuntu/repos/Sergeant/src/core/WeeklyDigestStories.tsx" />:

- `onMouseDown/Up/Leave` + `onTouchStart/Move/End` → `onPointerDown/Move/Up/Cancel` (той самий контейнер, ті самі обробники).
- `handlePressStart` викликає `setPointerCapture(pointerId)`, `handlePressEnd` — `releasePointerCapture` — щоб swipe-down-to-close продовжував отримувати `pointermove` навіть якщо палець уходить за межі елемента (раніше це працювало через `onTouchMove`).
- Новий `handlePointerCancel` бере на себе роль `onMouseLeave`: зупиняє hold-таймер і скидає drag.
- Доданий `touch-action: none` на контейнер — інакше браузер може «вкрасти» pointer-потік під pan/zoom.
- Видалені два `eslint-disable-next-line jsx-a11y/no-static-element-interactions` — правило не спрацьовує на pointer-обробники, і прямих warning-ів уже не було.
- Хелпер для прогрес-бара / close-button (`data-story-ui`) тепер теж `onPointerDown={stopPropagation}` замість пари mouse+touch.

**Поведінка збережена 1:1:**

- Тап у ліву третину → `prev()`, у праві дві третини → `next()`.
- Press-and-hold 180 ms → пауза; release без tap-у не перескакує слайд.
- Swipe-down > `SWIPE_CLOSE_THRESHOLD` → `onClose()`.
- Клавіатура (Arrow keys / Space / Escape) — без змін.
- Close-button — без змін (окремий `onClick` + `stopPropagation`).

## Review & Testing Checklist for Human

- [ ] Мобільний Safari (iOS, real device, не емуляція) — тап справа просуває рівно на 1 слайд.
- [ ] Android Chrome — те саме + swipe-down-to-close працює (pointer-capture).
- [ ] Desktop Chrome click — як раніше, 1 клік = 1 слайд.
- [ ] Press-and-hold (mouse або фінгер) > ~200 ms ставить на паузу, і release **не** призводить до advance.
- [ ] Клавіатурна навігація (→ / ← / Space / Esc) не зламана.
- [ ] Клік на close-button (×) у правому верхньому куті закриває сторіс (не advance).

### Test plan

Локально:

- `npx eslint src/core/WeeklyDigestStories.tsx` — 0 помилок, 0 попереджень.
- `npx tsc -p tsconfig.json --noEmit` — clean.
- `npx vitest run` — 90 файлів, 907 тестів, всі зелені (`src/core/WeeklyDigestStories.test.tsx` відсутній; рекомендую додати fake `PointerEvent` smoke у follow-up).

Мануально (сторіс реально існують у weekly-digest hub-і) — клікати в правий бік і рахувати слайди.

### Notes

- Pointer events підтримуються у всіх цільових браузерах (iOS 13+, Android 6+, всі desktop). `setPointerCapture` присутній у тих самих версіях. Для дуже старих WebKit фоллбек — `try/catch` навколо `setPointerCapture` / `releasePointerCapture`, щоб не падало.
- Alternative-підхід (додати timestamp-guard + `e.preventDefault()` на `onTouchEnd`) свідомо не брав — це work-around, а не fix. Pointer events — канонічне рішення проблеми duplicated input.
- Follow-up: у тому ж файлі (`WeeklyDigestStories.tsx`, 867 рядків) помічено що компонент в P1-backlog на розпил. Цей PR свідомо не торкається структури, тільки подієвої моделі.

Link to Devin session: https://app.devin.ai/sessions/48a578eeadce434eacc2d3d8851410bc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
