### PR TITLE
fix(a11y): conditional &lt;main&gt;/&lt;div&gt; tag for skip-link target

### DIFF
--- a/src/core/App.tsx
+++ b/src/core/App.tsx
@@ -396,49 +396,60 @@ function AppInner() {
       )}
 
       <Suspense fallback={<PageLoader />}>
-        {/* Skip-link target — deliberately a `<div>` (not `<main>`) because
-            some modules (e.g. Routine) render their own `<main>` landmark
-            internally. Having two visible `<main>` elements violates the
-            HTML spec and confuses AT landmark navigation. The SkipLink only
-            needs an `id` + focusability to do its job. */}
-        <div
-          key={activeModule}
-          id="main"
-          tabIndex={-1}
-          className={cn(moduleAnimClass, "h-full flex flex-col outline-none")}
-        >
-          <ModuleErrorBoundary onBackToHub={goToHub}>
-            {activeModule === "finyk" && (
-              <FinykApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-            {activeModule === "fizruk" && (
-              <FizrukApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-            {activeModule === "routine" && (
-              <RoutineApp
-                onBackToHub={goToHub}
-                onOpenModule={openModule}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-            {activeModule === "nutrition" && (
-              <NutritionApp
-                onBackToHub={goToHub}
-                pwaAction={pwaAction}
-                onPwaActionConsumed={clearPwaAction}
-              />
-            )}
-          </ModuleErrorBoundary>
-        </div>
+        {/* Skip-link target. We render `<main>` by default so every screen
+            exposes a `main` landmark for AT users. One exception: the
+            Routine module renders its own `<main id="routine-main">`
+            internally (src/modules/routine/RoutineApp.tsx) — in that case
+            we fall back to `<div>` here so the DOM never has two visible
+            `<main>` elements (HTML spec violation, confuses AT landmark
+            navigation). Either way, the SkipLink's target contract
+            (`id="main"` + focusability) is preserved. */}
+        {(() => {
+          const Tag = activeModule === "routine" ? "div" : "main";
+          return (
+            <Tag
+              key={activeModule}
+              id="main"
+              tabIndex={-1}
+              className={cn(
+                moduleAnimClass,
+                "h-full flex flex-col outline-none",
+              )}
+            >
+              <ModuleErrorBoundary onBackToHub={goToHub}>
+                {activeModule === "finyk" && (
+                  <FinykApp
+                    onBackToHub={goToHub}
+                    pwaAction={pwaAction}
+                    onPwaActionConsumed={clearPwaAction}
+                  />
+                )}
+                {activeModule === "fizruk" && (
+                  <FizrukApp
+                    onBackToHub={goToHub}
+                    pwaAction={pwaAction}
+                    onPwaActionConsumed={clearPwaAction}
+                  />
+                )}
+                {activeModule === "routine" && (
+                  <RoutineApp
+                    onBackToHub={goToHub}
+                    onOpenModule={openModule}
+                    pwaAction={pwaAction}
+                    onPwaActionConsumed={clearPwaAction}
+                  />
+                )}
+                {activeModule === "nutrition" && (
+                  <NutritionApp
+                    onBackToHub={goToHub}
+                    pwaAction={pwaAction}
+                    onPwaActionConsumed={clearPwaAction}
+                  />
+                )}
+              </ModuleErrorBoundary>
+            </Tag>
+          );
+        })()}
       </Suspense>
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to merged PR #344. Devin Review [correctly flagged](https://app.devin.ai/review/skords-01/sergeant/pull/344) that after #344 reverted the module wrapper to `<div>`, three of four modules (**Finyk**, **Fizruk**, **Nutrition**) no longer have a `<main>` landmark **at all** — because only `RoutineApp` renders its own `<main id="routine-main">` internally ([`src/modules/routine/RoutineApp.tsx:582`](https://github.com/Skords-01/Sergeant/blob/main/src/modules/routine/RoutineApp.tsx#L582)). AT users who navigate by landmarks would find no main-content region on Finyk/Fizruk/Nutrition screens — the opposite of what the skip-link refactor was trying to achieve.

### Fix

Pick the wrapper tag per active module:

| activeModule | Tag | Why |
|---|---|---|
| `"routine"` | `<div>` | `RoutineApp` already owns the `<main>` landmark |
| anything else | `<main>` | This wrapper **is** the landmark |

Either way `id="main"` + `tabIndex={-1}` are preserved, so the SkipLink target contract is unchanged. A JSX comment documents the trade-off so future refactors don't revert either direction blindly.

```tsx
{(() => {
  const Tag = activeModule === "routine" ? "div" : "main";
  return (
    <Tag key={activeModule} id="main" tabIndex={-1} className={...}>
      ...
    </Tag>
  );
})()}
```

## Review & Testing Checklist for Human

- [ ] Open Finyk / Fizruk / Nutrition — `document.querySelectorAll("main")` returns exactly one element: the App.tsx wrapper.
- [ ] Open Routine — `document.querySelectorAll("main")` returns exactly one element: `#routine-main` inside RoutineApp.
- [ ] axe-devtools clean on all four modules (no "document-should-have-landmarks" or duplicate-landmark violations).
- [ ] Skip-link still jumps focus to the module content in all four modules via Tab → Enter from the address bar.

### Notes

Credit to Devin Review for the follow-up catch: https://app.devin.ai/review/skords-01/sergeant/pull/344

This closes out the skip-link / main-landmark cluster. After this the design-system review series has only the ellipsis (`…`) fix + ESLint rule PR remaining.


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
