### PR TITLE
style(typo): replace three-dot &quot;...&quot; with typographic &quot;…&quot; + ESLint rule

### DIFF
--- a/eslint-plugins/sergeant-design/index.js
+++ b/eslint-plugins/sergeant-design/index.js
@@ -7,6 +7,12 @@
  *     <Label normalCase={false}>) instead. Add
  *       // eslint-disable-next-line sergeant-design/no-eyebrow-drift
  *     for intentional stylistic exceptions (e.g. narrative overlay stories).
+ *
+ *   - no-ellipsis-dots: forbid three consecutive ASCII dots (`...`) inside
+ *     string literals and JSX text nodes — the typographic ellipsis `…`
+ *     (U+2026) is a single glyph, renders with correct kerning, and is
+ *     what Web Interface Guidelines recommend for truncation cues
+ *     ("Loading…", "Пошук…", etc.). Auto-fixable.
  */
 
 const EYEBROW_MESSAGE =
@@ -57,9 +63,68 @@ const noEyebrowDrift = {
   },
 };
 
+const ELLIPSIS_MESSAGE =
+  "Use `…` (U+2026, a single ellipsis glyph) instead of three ASCII dots `...` in user-facing strings. The typographic ellipsis renders with correct kerning and is what Web Interface Guidelines recommend for truncation cues (e.g. 'Loading…').";
+
+const RX_THREE_DOTS = /\.{3}/;
+
+function replaceEllipsisDots(text) {
+  return text.replace(/\.{3}/g, "…");
+}
+
+const noEllipsisDots = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Forbid three ASCII dots (`...`) inside string literals — use the typographic ellipsis `…` (U+2026).",
+    },
+    fixable: "code",
+    schema: [],
+    messages: { ellipsis: ELLIPSIS_MESSAGE },
+  },
+  create(context) {
+    function reportLiteral(node, raw) {
+      if (!RX_THREE_DOTS.test(raw)) return;
+      context.report({
+        node,
+        messageId: "ellipsis",
+        fix(fixer) {
+          const sourceCode = context.sourceCode ?? context.getSourceCode();
+          const text = sourceCode.getText(node);
+          return fixer.replaceText(node, replaceEllipsisDots(text));
+        },
+      });
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value !== "string") return;
+        reportLiteral(node, node.value);
+      },
+      TemplateElement(node) {
+        const raw = node.value && node.value.cooked;
+        if (typeof raw !== "string") return;
+        reportLiteral(node, raw);
+      },
+      JSXText(node) {
+        if (typeof node.value !== "string") return;
+        if (!RX_THREE_DOTS.test(node.value)) return;
+        context.report({
+          node,
+          messageId: "ellipsis",
+          fix(fixer) {
+            return fixer.replaceText(node, replaceEllipsisDots(node.value));
+          },
+        });
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
+    "no-ellipsis-dots": noEllipsisDots,
   },
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,11 @@ export default [
       // in one place. Add the file-scoped override below for the DS
       // primitives themselves.
       "sergeant-design/no-eyebrow-drift": "error",
+      // Typography guardrail — user-facing strings must use the single
+      // ellipsis glyph `…` (U+2026), not three ASCII dots `...`. The
+      // typographic glyph kerns correctly and is what Web Interface
+      // Guidelines recommend for truncation cues. Auto-fixable.
+      "sergeant-design/no-ellipsis-dots": "error",
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-unused-vars": [
         "error",
@@ -101,6 +106,15 @@ export default [
     ],
     rules: {
       "sergeant-design/no-eyebrow-drift": "off",
+    },
+  },
+  // The plugin that defines `no-ellipsis-dots` contains `...` in its
+  // own error message + docs — it would be tautological to lint
+  // itself.
+  {
+    files: ["eslint-plugins/sergeant-design/**/*.js"],
+    rules: {
+      "sergeant-design/no-ellipsis-dots": "off",
     },
   },
   eslintConfigPrettier,

--- a/src/core/AuthPage.tsx
+++ b/src/core/AuthPage.tsx
@@ -207,7 +207,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
             className="w-full"
           >
             {loading
-              ? "Зачекайте..."
+              ? "Зачекайте…"
               : mode === "login"
                 ? "Увійти"
                 : "Зареєструватися"}

--- a/src/core/app/MigrationPrompt.tsx
+++ b/src/core/app/MigrationPrompt.tsx
@@ -32,7 +32,7 @@ export function MigrationPrompt({ onUpload, onSkip, syncing }) {
             loading={syncing}
             className="w-full"
           >
-            {syncing ? "Завантаження..." : "Завантажити в хмару"}
+            {syncing ? "Завантаження…" : "Завантажити в хмару"}
           </Button>
           <Button
             type="button"

--- a/src/core/app/UserMenuButton.tsx
+++ b/src/core/app/UserMenuButton.tsx
@@ -96,7 +96,7 @@ export function UserMenuButton({
               className="w-full text-left px-3 py-2 rounded-xl text-sm text-text hover:bg-panelHi transition-colors disabled:opacity-50 flex items-center gap-2"
             >
               <Icon name="upload" size={16} />
-              {syncing ? "Синхронізація..." : "Зберегти в хмару"}
+              {syncing ? "Синхронізація…" : "Зберегти в хмару"}
             </button>
             <button
               type="button"

--- a/src/core/lib/hubChatActions.ts
+++ b/src/core/lib/hubChatActions.ts
@@ -830,7 +830,7 @@ export function executeAction(action: ChatAction): string {
         const id = String(tx_id || "").trim();
         if (!id) return "Потрібен tx_id для видалення.";
         if (!id.startsWith("m_")) {
-          return `Транзакцію ${id} не видалено: можна видаляти лише ручні (m_...). Для монобанк-транзакцій використайте hide_transaction.`;
+          return `Транзакцію ${id} не видалено: можна видаляти лише ручні (m_…). Для монобанк-транзакцій використайте hide_transaction.`;
         }
         const list = ls<Array<{ id: string }>>("finyk_manual_expenses_v1", []);
         const idx = list.findIndex((t) => t.id === id);

--- a/src/core/settings/FinykSection.tsx
+++ b/src/core/settings/FinykSection.tsx
@@ -487,7 +487,7 @@ export function FinykSection() {
                 onClick={connectPrivat}
                 disabled={privatConnecting}
               >
-                {privatConnecting ? "Підключення..." : "Підключити ПриватБанк"}
+                {privatConnecting ? "Підключення…" : "Підключити ПриватБанк"}
               </Button>
             </div>
           )}

--- a/src/modules/finyk/FinykApp.jsx
+++ b/src/modules/finyk/FinykApp.jsx
@@ -497,7 +497,7 @@ export default function App({
               onClick={() => connect(tokenInput.trim(), false, rememberToken)}
               disabled={connecting || !tokenInput.trim()}
             >
-              {connecting ? "Підключення..." : "Підключити Monobank"}
+              {connecting ? "Підключення…" : "Підключити Monobank"}
             </Button>
             {typeof onBackToHub === "function" && (
               <Button

--- a/src/modules/finyk/components/ManualExpenseSheet.jsx
+++ b/src/modules/finyk/components/ManualExpenseSheet.jsx
@@ -368,7 +368,7 @@ export function ManualExpenseSheet({
           </Label>
           <Input
             id={descId}
-            placeholder="Кава, продукти, таксі..."
+            placeholder="Кава, продукти, таксі…"
             value={form.description}
             onChange={(e) =>
               setForm((f) => ({ ...f, description: e.target.value }))

--- a/src/modules/finyk/pages/Assets.jsx
+++ b/src/modules/finyk/pages/Assets.jsx
@@ -837,7 +837,7 @@ export function Assets({
                 <div className="flex gap-2">
                   <Input
                     className="flex-1"
-                    placeholder="Назва пасиву (кредит, борг...)"
+                    placeholder="Назва пасиву (кредит, борг…)"
                     value={newDebt.name}
                     onChange={(e) =>
                       setNewDebt((a) => ({ ...a, name: e.target.value }))

--- a/src/modules/finyk/pages/Overview.jsx
+++ b/src/modules/finyk/pages/Overview.jsx
@@ -515,7 +515,7 @@ export function Overview({
           </button>
         )}
         {loadingTx && (
-          <p className="text-center text-xs text-subtle py-4">Оновлення...</p>
+          <p className="text-center text-xs text-subtle py-4">Оновлення…</p>
         )}
       </div>
     </div>

--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -488,7 +488,7 @@ export function Transactions({
         {syncState?.status !== "idle" && (
           <div className={cn("text-xs mb-1", syncColor)}>
             {syncState.status === "loading"
-              ? "⟳ оновлення..."
+              ? "⟳ оновлення…"
               : syncState.status === "success"
                 ? "✓ синхронізовано"
                 : syncState.status === "partial"
@@ -522,7 +522,7 @@ export function Transactions({
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Пошук по транзакціях..."
+            placeholder="Пошук по транзакціях…"
             className="w-full bg-panelHi border border-line rounded-2xl pl-9 pr-4 py-2.5 text-sm text-text placeholder:text-subtle focus:outline-none focus:border-primary/50 transition-colors"
           />
           {search && (
@@ -662,7 +662,7 @@ export function Transactions({
         )}
 
         {activeLoading && activeTx.length > 0 && (
-          <p className="text-center text-xs text-subtle py-2">⟳ оновлення...</p>
+          <p className="text-center text-xs text-subtle py-2">⟳ оновлення…</p>
         )}
       </div>
 

--- a/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
+++ b/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
@@ -20,7 +20,7 @@ export function WorkoutCatalogSection({
     <>
       <div className="relative mb-3">
         <Input
-          placeholder="Пошук (жим, підтягування, спина...)"
+          placeholder="Пошук (жим, підтягування, спина…)"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />

--- a/src/modules/nutrition/lib/nutritionApi.test.ts
+++ b/src/modules/nutrition/lib/nutritionApi.test.ts
@@ -116,6 +116,7 @@ describe("nutritionApi adapter postJson", () => {
       new ApiError({
         kind: "parse",
         message: "Unexpected token <",
+        // eslint-disable-next-line sergeant-design/no-ellipsis-dots -- literal HTML fixture, not user-facing copy
         bodyText: "<!doctype html><html>...</html>",
         url: URL,
       }),
@@ -125,6 +126,7 @@ describe("nutritionApi adapter postJson", () => {
     expect(err.message).toBe(
       "API повернув HTML замість JSON (ймовірно, rewrite перехоплює /api/*).",
     );
+    // eslint-disable-next-line sergeant-design/no-ellipsis-dots -- literal HTML fixture, not user-facing copy
     expect(err.bodyText).toBe("<!doctype html><html>...</html>");
   });
 


### PR DESCRIPTION
## Summary

Web Interface Guidelines recommend the single ellipsis glyph `…` (U+2026) for truncation cues — it kerns correctly, is semantically one glyph, and matches the treatment used across every polished design system. Audit (PR #341 / previous message) counted `...` in user-facing strings across several modules.

### 1. Fixed 11 user-facing strings across 9 files

| File | Before | After |
|---|---|---|
| `src/core/AuthPage.tsx` | `Зачекайте...` | `Зачекайте…` |
| `src/core/app/UserMenuButton.tsx` | `Синхронізація...` | `Синхронізація…` |
| `src/core/app/MigrationPrompt.tsx` | `Завантаження...` | `Завантаження…` |
| `src/modules/finyk/pages/Overview.jsx` | `Оновлення...` | `Оновлення…` |
| `src/modules/finyk/pages/Transactions.jsx` | `⟳ оновлення...` (×2) | `⟳ оновлення…` |
| `src/modules/finyk/pages/Transactions.jsx` | `Пошук по транзакціях...` | `Пошук по транзакціях…` |
| `src/modules/finyk/FinykApp.jsx` | `Підключення...` (Monobank) | `Підключення…` |
| `src/core/settings/FinykSection.tsx` | `Підключення...` (Приват) | `Підключення…` |
| `src/modules/finyk/components/ManualExpenseSheet.jsx` | `Кава, продукти, таксі...` | `Кава, продукти, таксі…` |
| `src/modules/fizruk/…/WorkoutCatalogSection.tsx` | `спина...` | `спина…` |
| `src/modules/finyk/pages/Assets.jsx` | `кредит, борг...` | `кредит, борг…` |
| `src/core/lib/hubChatActions.ts` | `(m_...)` | `(m_…)` |

### 2. New ESLint rule: `sergeant-design/no-ellipsis-dots` (auto-fixable)

- Flags three ASCII dots (`\.{3}`) inside `Literal`, `TemplateElement`, and `JSXText` nodes.
- Ships with a **fixer** so `eslint --fix` migrates any reintroduction automatically.
- Lives next to the existing `no-eyebrow-drift` rule in `eslint-plugins/sergeant-design/index.js`.
- Wired as `error` in `eslint.config.js` with a header comment explaining the rationale.

**Exemptions (narrow, with justification):**
- `eslint-plugins/sergeant-design/**/*.js` — the rule file itself contains `...` inside its own error message and docs. Tautological to lint itself. Scoped `files` block in `eslint.config.js`.
- Two `nutritionApi.test.ts` fixtures where a literal HTML body string contains `"<!doctype html><html>...</html>"` — not user-facing copy, the `...` represents "rest of payload elided". Disabled inline with `// eslint-disable-next-line sergeant-design/no-ellipsis-dots -- literal HTML fixture, not user-facing copy`.

## Review & Testing Checklist for Human

- [ ] Eyeball the changed strings — `…` renders correctly in Auth / UserMenu / Migration / finyk pages. No mojibake (the file is UTF-8).
- [ ] Run `npm run lint` locally — passes, and introducing a new `"Foo..."` anywhere fails with the new rule message.
- [ ] Run `eslint --fix path/to/Foo.tsx` on a deliberate regression — fixer rewrites `...` → `…`.

### Notes

Last PR in the Critical + High Forms/Typography design-system review series (PRs 1-5 of the plan).

Previously landed:
- PR #339 — Dialog a11y (keyboard-reachable scrim, body scroll lock, overscroll-contain)
- PR #341 — Skip-link in App.tsx + `<main id="main">`
- PR #343 — `<Input>` type-aware spellCheck + inputMode defaults, AuthPage refactor
- PR #344 — Follow-up: skip-link target `<div>` to avoid nested `<main>` landmarks
- PR #347 — Follow-up: conditional `<main>` / `<div>` so non-Routine modules keep the landmark

The ESLint rule is the first typography guardrail in the sergeant-design plugin family. If it proves useful, it could be joined later by other no-X rules (e.g. `no-hyphen-dash` for `—` vs `-`, `no-straight-quotes` for `"` vs `"/"`).


Link to Devin session: https://app.devin.ai/sessions/ea5d8b99e8b045a98557c623da77883c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
