### PR TITLE
fix(security): don't detach pino log method — fix boot crash when CSP_DISABLE=1

### DIFF
--- a/server/http/security.ts
+++ b/server/http/security.ts
@@ -62,12 +62,15 @@ export function apiHelmetMiddleware({
   // Логуємо один раз на boot з рівнем warn у проді і info у дев-режимі.
   if (cspEnvDisabled) {
     const isProd = process.env.NODE_ENV === "production";
-    const log = isProd ? logger.warn : logger.info;
-    log({
+    // pino-методи читають `this` внутрішньо (this[writeSym], this[msgPrefixSym]),
+    // тож витягання у змінну без .bind() крашне процес у strict-mode ESM.
+    const payload = {
       msg: "csp_disabled",
       reason: "CSP_DISABLE=1",
       env: process.env.NODE_ENV || "unknown",
-    });
+    };
+    if (isProd) logger.warn(payload);
+    else logger.info(payload);
   } else if (reportOnly) {
     logger.info({ msg: "csp_report_only" });
   }


### PR DESCRIPTION
## Summary

Hotfix до вмерженого #345. Devin Review на #345 показав реальний runtime-баг: `logger.warn` / `logger.info` витягнуті в локальну змінну гублять контекст `this`, і при виклику `log({...})` pino падає з `TypeError: Cannot read properties of undefined (reading 'Symbol(...writeSym)')`. Це крашне сервер на старті будь-коли, коли `CSP_DISABLE=1` виставлений в env.

Причина:
- pino-методи (`info`, `warn`, `error`...) — звичайні функції на prototype, які всередині читають `this[writeSym]`, `this[msgPrefixSym]`, `this[formatOptsSym]`.
- ESM в strict-mode: виклик detached-методу дає `this === undefined` → TypeError.

Фікс: перенести branch на call-site, викликати `logger.warn` / `logger.info` напряму з тією ж payload. Простіше за `.bind(logger)` і без зайвої алокації bound-функції.

## Review & Testing Checklist for Human

- [ ] `CSP_DISABLE=1 node dist/server/index.js` не крашне (має залогувати `{"msg":"csp_disabled",...}` і продовжити).
- [ ] `unset CSP_DISABLE && CSP_REPORT_ONLY=1 npm run dev` → має з'явитись `csp_report_only` info-лог.

### Notes
- Typecheck, lint — зелені. Unit-test-ів для цього conditional немає, ручна перевірка на boot.
- Патерн "витягти метод у змінну" більше ніде в коді не використовується (`rg "= logger\.\w+$"` = 0 матчів), тож це локалізований фікс.

Link to Devin session: https://app.devin.ai/sessions/335eaf143ebe42a489930c675746c04a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
