### PR TITLE
chore(ts): migrate src/core/components chat files to TypeScript

### DIFF
--- a/src/core/components/AssistantMessageBody.tsx
+++ b/src/core/components/AssistantMessageBody.tsx
@@ -1,11 +1,16 @@
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 
-export function AssistantMessageBody({ text }) {
+interface AssistantMessageBodyProps {
+  text: string;
+}
+
+export function AssistantMessageBody({ text }: AssistantMessageBodyProps) {
   return (
     <ReactMarkdown
       className="text-sm leading-relaxed [&_strong]:font-semibold [&_em]:italic [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:my-1 [&_li]:my-0.5 [&_a]:text-primary [&_a]:underline"
       components={{
-        a: ({ href, children }) => (
+        a: ({ href, children }: { href?: string; children?: ReactNode }) => (
           <a
             href={href}
             target="_blank"

--- a/src/core/components/ChatInput.tsx
+++ b/src/core/components/ChatInput.tsx
@@ -1,7 +1,27 @@
 import { cn } from "@shared/lib/cn";
 import { stopSpeaking, unlockTTS } from "../lib/hubChatSpeech.js";
 import { useSpeech } from "../hooks/useSpeech.js";
-import { useRef, useCallback, useEffect } from "react";
+import {
+  useRef,
+  useCallback,
+  useEffect,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+
+interface ChatInputProps {
+  input: string;
+  setInput: Dispatch<SetStateAction<string>>;
+  loading: boolean;
+  online: boolean;
+  speaking: boolean;
+  setSpeaking: Dispatch<SetStateAction<boolean>>;
+  onSend: () => void;
+  sendRef: MutableRefObject<
+    ((text?: string, fromVoice?: boolean) => void) | null
+  >;
+}
 
 export function ChatInput({
   input,
@@ -12,8 +32,8 @@ export function ChatInput({
   setSpeaking,
   onSend,
   sendRef,
-}) {
-  const inputRef = useRef(null);
+}: ChatInputProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     setTimeout(() => inputRef.current?.focus(), 100);

--- a/src/core/components/ChatMessage.tsx
+++ b/src/core/components/ChatMessage.tsx
@@ -1,8 +1,14 @@
 import { cn } from "@shared/lib/cn";
 import { AssistantMessageBody } from "./AssistantMessageBody.jsx";
 import { speak } from "../lib/hubChatSpeech.js";
+import type { ChatMessage as ChatMessageData } from "../lib/hubChatUtils.js";
 
-export function ChatMessage({ message, onSpeak }) {
+interface ChatMessageProps {
+  message: ChatMessageData;
+  onSpeak?: () => void;
+}
+
+export function ChatMessage({ message, onSpeak }: ChatMessageProps) {
   const { role, text } = message;
   const isAssistant = role === "assistant";
 

--- a/src/core/components/PushNotificationToggle.tsx
+++ b/src/core/components/PushNotificationToggle.tsx
@@ -1,7 +1,13 @@
 import { usePushNotifications } from "@shared/hooks/usePushNotifications.js";
 import { cn } from "@shared/lib/cn";
 
-export function PushNotificationToggle({ className }) {
+interface PushNotificationToggleProps {
+  className?: string;
+}
+
+export function PushNotificationToggle({
+  className,
+}: PushNotificationToggleProps) {
   const { supported, permission, subscribed, loading, subscribe, unsubscribe } =
     usePushNotifications();
 


### PR DESCRIPTION
## Summary

Migrates the 4 remaining `.jsx` files in `src/core/components/` to TypeScript:

- `AssistantMessageBody.jsx` → `.tsx` — typed `{ text: string }`, narrow types for `a` component renderer.
- `ChatInput.jsx` → `.tsx` — full prop interface (`input`, `setInput`, `loading`, `online`, `speaking`, `setSpeaking`, `onSend`, `sendRef`). `sendRef` typed as `MutableRefObject<((text?: string, fromVoice?: boolean) => void) | null>` to match the voice-recognition callback contract in `HubChat.tsx`.
- `ChatMessage.jsx` → `.tsx` — reuses the existing `ChatMessage` type from `src/core/lib/hubChatUtils.ts` (aliased to `ChatMessageData` to avoid collision with the component name).
- `PushNotificationToggle.jsx` → `.tsx` — typed `{ className?: string }`.

Callers in `HubChat.tsx` and `settings/NotificationsSection.tsx` already import via `.jsx` specifiers, which resolve to the new `.tsx` files under `moduleResolution: bundler` — no import changes required.

This closes out `src/core/components/` — all files there are now TS.

## Review & Testing Checklist for Human

- [ ] Open HubChat and confirm chat renders, typing indicator shows, voice input/output buttons work (mic + speaker + stop speech).
- [ ] Confirm push-notification toggle in Settings still renders/behaves correctly (states: unsupported, blocked, subscribed, unsubscribed).
- [ ] No runtime regressions — behavior should be byte-for-byte identical; only types added.

### Notes

Follow-up migration blocks (leaf utilities first):
1. Finyk lib/constants/utils
2. Finyk pages
3. Finyk components
4. Nutrition hooks
5. Nutrition components + NutritionApp + domain

`tsconfig.json` still has `allowJs: true`, `strict: false`, `noImplicitAny: false` — strict-mode enablement will follow once all `.js/.jsx` files are gone.

CI locally: `npm run typecheck`, `npm run lint`, and `npm test` (913 tests) all pass.

Link to Devin session: https://app.devin.ai/sessions/32c090a49ab0402ab5303d0b30901ea1
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
