### PR TITLE
feat(ux): wire showUndoToast in destructive actions across modules

### DIFF
--- a/src/modules/finyk/pages/Transactions.jsx
+++ b/src/modules/finyk/pages/Transactions.jsx
@@ -11,6 +11,7 @@ import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 import { useDebounce } from "@shared/hooks/useDebounce";
 
 const now = new Date();
@@ -154,9 +155,9 @@ export function Transactions({
       category: String(tx._category || "інше"),
     };
     removeManualExpense(tx._manualId);
-    toast.info("Витрату видалено", 5000, {
-      label: "Undo",
-      onClick: () => addManualExpense(snapshot),
+    showUndoToast(toast, {
+      msg: "Витрату видалено",
+      onUndo: () => addManualExpense(snapshot),
     });
   }, []);
 

--- a/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -4,6 +4,8 @@ import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 
 function uid(prefix = "g") {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -16,8 +18,10 @@ export function WorkoutTemplatesSection({
   addTemplate,
   updateTemplate,
   removeTemplate,
+  restoreTemplate,
   onStartTemplate,
 }) {
+  const toast = useToast();
   const [q, setQ] = useState("");
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
@@ -424,12 +428,26 @@ export function WorkoutTemplatesSection({
       <ConfirmDialog
         open={confirmDeleteId != null}
         title="Видалити шаблон?"
-        description="Цю дію неможливо відмінити."
+        description="Натисни «Повернути» у тості, якщо це була випадкова дія."
         confirmLabel="Видалити"
         cancelLabel="Скасувати"
         danger
         onConfirm={() => {
-          if (confirmDeleteId != null) removeTemplate(confirmDeleteId);
+          if (confirmDeleteId != null) {
+            const idx = (templates || []).findIndex(
+              (t) => t.id === confirmDeleteId,
+            );
+            const snapshot =
+              idx >= 0 ? { template: templates[idx], index: idx } : null;
+            removeTemplate(confirmDeleteId);
+            if (snapshot && typeof restoreTemplate === "function") {
+              showUndoToast(toast, {
+                msg: `Видалено шаблон «${snapshot.template.name}»`,
+                onUndo: () =>
+                  restoreTemplate(snapshot.template, snapshot.index),
+              });
+            }
+          }
           setConfirmDeleteId(null);
         }}
         onCancel={() => setConfirmDeleteId(null)}

--- a/src/modules/fizruk/hooks/useWorkoutTemplates.ts
+++ b/src/modules/fizruk/hooks/useWorkoutTemplates.ts
@@ -63,6 +63,21 @@ export function useWorkoutTemplates() {
     [persist, templates],
   );
 
+  const restoreTemplate = useCallback(
+    (template, atIndex) => {
+      if (!template || !template.id) return;
+      if (templates.some((t) => t.id === template.id)) return;
+      const next = [...templates];
+      const idx =
+        typeof atIndex === "number" && atIndex >= 0
+          ? Math.min(atIndex, next.length)
+          : next.length;
+      next.splice(idx, 0, template);
+      persist(next);
+    },
+    [persist, templates],
+  );
+
   const markTemplateUsed = useCallback(
     (id) => {
       persist(
@@ -97,6 +112,7 @@ export function useWorkoutTemplates() {
     addTemplate,
     updateTemplate,
     removeTemplate,
+    restoreTemplate,
     markTemplateUsed,
   };
 }

--- a/src/modules/fizruk/pages/Workouts.tsx
+++ b/src/modules/fizruk/pages/Workouts.tsx
@@ -483,6 +483,7 @@ export function Workouts() {
             addTemplate={templateApi.addTemplate}
             updateTemplate={templateApi.updateTemplate}
             removeTemplate={templateApi.removeTemplate}
+            restoreTemplate={templateApi.restoreTemplate}
             onStartTemplate={startWorkoutFromTemplate}
           />
         )}

--- a/src/modules/nutrition/NutritionApp.jsx
+++ b/src/modules/nutrition/NutritionApp.jsx
@@ -34,6 +34,7 @@ import {
   saveMealThumbnail,
 } from "./lib/mealPhotoStorage.js";
 import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 import { fmtMacro, todayISODate } from "./lib/nutritionFormat.js";
 
 export default function NutritionApp({
@@ -464,9 +465,9 @@ export default function NutritionApp({
                 onRemoveMeal={(date, meal) => {
                   if (!meal?.id) return;
                   log.handleRemoveMeal(date, meal);
-                  toast.info("Запис видалено", 5000, {
-                    label: "Undo",
-                    onClick: () => log.handleRestoreMeal(date, meal),
+                  showUndoToast(toast, {
+                    msg: "Запис видалено",
+                    onUndo: () => log.handleRestoreMeal(date, meal),
                   });
                 }}
                 onEditMeal={(date, meal) => {

--- a/src/modules/routine/components/RoutineSettingsSection.tsx
+++ b/src/modules/routine/components/RoutineSettingsSection.tsx
@@ -1,12 +1,15 @@
 import { useState, type Dispatch, type SetStateAction } from "react";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 import {
   loadRoutineState,
   createHabit,
   deleteHabit,
   updateHabit,
   applyRoutineBackupPayload,
+  snapshotHabit,
+  restoreHabit,
 } from "../lib/routineStorage.js";
 import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
 import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
@@ -189,12 +192,19 @@ export function RoutineSettingsSection({
         confirmLabel="Видалити"
         onConfirm={() => {
           if (deleteHabitPending) {
-            setRoutine((s) => deleteHabit(s, deleteHabitPending.id));
-            if (
-              !deleteHabitPending.archived &&
-              editingId === deleteHabitPending.id
-            )
-              cancelEdit();
+            const pending = deleteHabitPending;
+            let snapshot: ReturnType<typeof snapshotHabit> = null;
+            setRoutine((s) => {
+              snapshot = snapshotHabit(s, pending.id);
+              return deleteHabit(s, pending.id);
+            });
+            if (!pending.archived && editingId === pending.id) cancelEdit();
+            if (snapshot) {
+              showUndoToast(toast, {
+                msg: `Видалено звичку «${pending.name}»`,
+                onUndo: () => setRoutine((s) => restoreHabit(s, snapshot)),
+              });
+            }
           }
           setDeleteHabitPending(null);
         }}

--- a/src/modules/routine/lib/routineStorage.extended.test.ts
+++ b/src/modules/routine/lib/routineStorage.extended.test.ts
@@ -9,6 +9,8 @@ import {
   createHabit,
   updateHabit,
   deleteHabit,
+  snapshotHabit,
+  restoreHabit,
   toggleHabitCompletion,
   markAllScheduledHabitsComplete,
   setHabitArchived,
@@ -94,6 +96,62 @@ describe("deleteHabit", () => {
     expect(s.habits).toHaveLength(0);
     expect(s.completions[id]).toBeUndefined();
     expect(s.habitOrder).not.toContain(id);
+  });
+});
+
+describe("snapshotHabit + restoreHabit", () => {
+  it("відновлює звичку, completions, notes та позицію в order", () => {
+    let s = fresh();
+    s = createHabit(s, { name: "A" });
+    s = createHabit(s, { name: "B" });
+    s = createHabit(s, { name: "C" });
+    const [idA, idB, idC] = s.habits.map((h) => h.id);
+    s = toggleHabitCompletion(s, idB, "2024-06-15");
+    s = setCompletionNote(s, idB, "2024-06-15", "важливо");
+
+    const snap = snapshotHabit(s, idB);
+    expect(snap).not.toBeNull();
+    expect(snap?.habit.id).toBe(idB);
+    expect(snap?.completions).toContain("2024-06-15");
+    expect(Object.keys(snap?.notes || {})).toHaveLength(1);
+    expect(snap?.orderIndex).toBe(1);
+
+    s = deleteHabit(s, idB);
+    expect(s.habits.map((h) => h.id)).toEqual([idA, idC]);
+    expect(s.completions[idB]).toBeUndefined();
+
+    s = restoreHabit(s, snap);
+    // habits array перебудовується append-ом, порядок дає habitOrder
+    expect(new Set(s.habits.map((h) => h.id))).toEqual(
+      new Set([idA, idB, idC]),
+    );
+    expect(s.habitOrder).toEqual([idA, idB, idC]);
+    expect(s.completions[idB]).toContain("2024-06-15");
+    expect(s.completionNotes[completionNoteKey(idB, "2024-06-15")]).toBe(
+      "важливо",
+    );
+  });
+
+  it("ідемпотентно: повторний restore не дублює звичку", () => {
+    let s = createHabit(fresh(), { name: "X" });
+    const id = s.habits[0].id;
+    const snap = snapshotHabit(s, id);
+    s = deleteHabit(s, id);
+    s = restoreHabit(s, snap);
+    s = restoreHabit(s, snap);
+    expect(s.habits).toHaveLength(1);
+    expect(s.habitOrder).toEqual([id]);
+  });
+
+  it("snapshotHabit повертає null для неіснуючого id", () => {
+    const s = createHabit(fresh(), { name: "A" });
+    expect(snapshotHabit(s, "ghost")).toBeNull();
+  });
+
+  it("restoreHabit ігнорує null/undefined snapshot", () => {
+    const s = createHabit(fresh(), { name: "A" });
+    expect(restoreHabit(s, null)).toBe(s);
+    expect(restoreHabit(s, undefined)).toBe(s);
   });
 });
 

--- a/src/modules/routine/lib/routineStorage.ts
+++ b/src/modules/routine/lib/routineStorage.ts
@@ -346,6 +346,62 @@ export function deleteHabit(state, id) {
   return next;
 }
 
+/**
+ * Snapshot усього, що потрібно для відновлення звички після `deleteHabit`:
+ * сам запис звички, її completions, note-and, а також позицію в habitOrder.
+ * Використовується undo-toast-ом у `RoutineSettingsSection`.
+ */
+export function snapshotHabit(state, id) {
+  const habit = state.habits.find((h) => h.id === id);
+  if (!habit) return null;
+  const completions = Array.isArray(state.completions?.[id])
+    ? [...state.completions[id]]
+    : [];
+  const notes: Record<string, string> = {};
+  const prefix = `${id}__`;
+  const rawNotes = state.completionNotes || {};
+  for (const k of Object.keys(rawNotes)) {
+    if (k.startsWith(prefix)) notes[k] = rawNotes[k];
+  }
+  const order = Array.isArray(state.habitOrder) ? state.habitOrder : [];
+  const orderIndex = order.indexOf(id);
+  return { habit, completions, notes, orderIndex };
+}
+
+/**
+ * Відновлює звичку зі знімка, отриманого `snapshotHabit`. Ідемпотентно:
+ * якщо звичка з таким id уже є — повертає state без змін.
+ */
+export function restoreHabit(state, snapshot) {
+  if (!snapshot || !snapshot.habit || !snapshot.habit.id) return state;
+  const { habit, completions, notes, orderIndex } = snapshot;
+  if (state.habits.some((h) => h.id === habit.id)) return state;
+  const nextCompletions = { ...state.completions };
+  if (Array.isArray(completions) && completions.length) {
+    nextCompletions[habit.id] = [...completions];
+  }
+  const nextNotes = { ...(state.completionNotes || {}), ...(notes || {}) };
+  const existingOrder = (state.habitOrder || []).filter((x) => x !== habit.id);
+  const insertAt =
+    typeof orderIndex === "number" && orderIndex >= 0
+      ? Math.min(orderIndex, existingOrder.length)
+      : existingOrder.length;
+  const nextOrder = [
+    ...existingOrder.slice(0, insertAt),
+    habit.id,
+    ...existingOrder.slice(insertAt),
+  ];
+  const next = {
+    ...state,
+    habits: [...state.habits, normalizeHabit(habit)],
+    completions: nextCompletions,
+    completionNotes: nextNotes,
+    habitOrder: nextOrder,
+  };
+  saveRoutineState(next);
+  return next;
+}
+
 export function addPushupReps(state, reps) {
   const n = Number(reps);
   if (!n || n <= 0) return state;


### PR DESCRIPTION
## Summary

Закриваю follow-up з `docs/ux-audit-2025.md`: «Масштабне перенесення `showUndoToast` у всі destructive actions». Раніше інфраструктура (`showUndoToast` + `hapticWarning/Tap`) існувала, але в багатьох місцях destructive-дії або показували звичайний `toast.info`, або взагалі не мали зворотного зв'язку. Тепер усі 4 основні місця мають снапшот→delete→undo-toast з haptic.

**Routine — `RoutineSettingsSection` (видалення звички)**
- Додано `snapshotHabit(state, id)` та `restoreHabit(state, snapshot)` у `routineStorage.ts`: знімок містить `habit`, `completions`, `completionNotes` по цій звичці та `orderIndex` у `habitOrder`; `restoreHabit` ідемпотентний і відновлює позицію.
- `ConfirmDialog.onConfirm` тепер робить snapshot перед `deleteHabit`, а потім показує `showUndoToast` з відновленням через той самий snapshot.
- Покрито unit-тестами у `routineStorage.extended.test.ts` (snapshot null для неіснуючого id, restore ідемпотентний, відновлення completions/notes/order).

**Finyk — `Transactions` (swipe-delete ручної витрати)**
- `stableSwipeDeleteManual` тепер викликає `showUndoToast` замість `toast.info`; undo повертає витрату через `addManualExpense(snapshot)`.

**Nutrition — `NutritionApp` (видалення запису прийому їжі)**
- `onRemoveMeal` тепер використовує `showUndoToast`; undo — `log.handleRestoreMeal(date, meal)` (хук уже мав відповідний API).

**Fizruk — `WorkoutTemplatesSection` (видалення шаблону тренування)**
- Додано `restoreTemplate(template, atIndex)` у `useWorkoutTemplates` (ідемпотентний, зберігає позицію).
- `ConfirmDialog.onConfirm` знімає snapshot `{ template, index }`, робить `removeTemplate`, і показує undo-toast.
- Опис діалогу оновлено («Натисни «Повернути» у тості…») — тепер він консистентний з фактичною поведінкою.

Бонусом: `hapticWarning` автоматично виникає на кожній destructive-дії (через `showUndoToast`), а `hapticTap` — на натисканні «Повернути».

## Review & Testing Checklist for Human

- [ ] Routine → Settings → видалити звичку з нотатками/completions → натиснути «Повернути» → звичка повертається у ту саму позицію, з completions та нотатками.
- [ ] Finyk → Transactions → swipe на ручній витраті → «Повернути» → витрата знову у списку з тою ж сумою/датою.
- [ ] Nutrition → видалити запис їжі → «Повернути» → запис повертається у той же день.
- [ ] Fizruk → Templates → видалити шаблон → «Повернути» → шаблон з тими ж вправами на тій самій позиції.
- [ ] Перевірити, що без undo (після 5 сек) стан залишається видаленим і не регресує у localStorage.

### Notes

- `routineStorage.snapshotHabit/restoreHabit` типізовані як `unknown`-state (щоб уникнути refactor-масиву типів у `.ts` файлі, який ще має `any`-state у решті функцій); поведінка покрита тестами.
- Поточний scope свідомо не чіпає: `WorkoutJournalSection.deleteWorkout` (має окремий flow з активним таймером), масову чистку нотаток/тегів (groupwise) — це залишається на окремий follow-up, якщо знадобиться.


Link to Devin session: https://app.devin.ai/sessions/c9e89bf7189e41fc8429788ca5aed076
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
