### PR TITLE
fix: plug 9 bugs found in code review (rate-limit bypass, sync, web vitals, SW)

### DIFF
--- a/server/http/rateLimit.ts
+++ b/server/http/rateLimit.ts
@@ -11,9 +11,27 @@ function recordRateLimit(key: string, outcome: Outcome): void {
   }
 }
 
+/**
+ * Resolves the client's originating IP. Prefer Express's `req.ip`, which
+ * respects `app.set('trust proxy', …)` and correctly peels off hops from
+ * X-Forwarded-For — taking the first entry of a raw X-Forwarded-For is a
+ * trivial rate-limit / quota bypass (a client can prepend any value and the
+ * proxy only appends the real IP after it).
+ *
+ * We only fall back to parsing headers directly when Express did not surface
+ * an IP (no trust-proxy configured AND no socket.remoteAddress), and even
+ * then we pick the LAST entry — that's the one closest to our infra.
+ */
 export function getIp(req: Request): string {
+  const fromExpress = req?.ip;
+  if (typeof fromExpress === "string" && fromExpress.trim()) {
+    return fromExpress.trim();
+  }
   const xf = req?.headers?.["x-forwarded-for"];
-  if (typeof xf === "string" && xf.trim()) return xf.split(",")[0].trim();
+  if (typeof xf === "string" && xf.trim()) {
+    const parts = xf.split(",");
+    return parts[parts.length - 1].trim();
+  }
   const real = req?.headers?.["x-real-ip"];
   if (typeof real === "string" && real.trim()) return real.trim();
   return "unknown";
@@ -22,6 +40,10 @@ export function getIp(req: Request): string {
 interface Bucket {
   startMs: number;
   count: number;
+  // Per-bucket window so the global sweep never evicts a long-window
+  // bucket based on another route's short window. Stored with the entry
+  // rather than inferred from the current request.
+  windowMs: number;
 }
 
 export interface RateLimitOptions {
@@ -42,19 +64,22 @@ export interface RateLimitResult {
 const buckets = new Map<string, Bucket>();
 let lastSweepMs = 0;
 
-function sweepBuckets(now: number, ttlMs: number): void {
+function sweepBuckets(now: number): void {
   if (now - lastSweepMs < 30_000) return;
   lastSweepMs = now;
 
   if (buckets.size === 0) return;
-  const max = Math.max(60_000, Number(ttlMs) || 0);
   for (const [k, v] of buckets.entries()) {
     const start = v?.startMs;
     if (typeof start !== "number") {
       buckets.delete(k);
       continue;
     }
-    if (now - start > max) buckets.delete(k);
+    // Each bucket carries its own window; we only evict once the window
+    // has elapsed with some slack, so a sweep triggered by a short-window
+    // route cannot wipe still-valid state for a long-window route.
+    const bucketWindow = Math.max(60_000, Number(v.windowMs) || 0);
+    if (now - start > bucketWindow) buckets.delete(k);
   }
 }
 
@@ -67,11 +92,11 @@ export function checkRateLimit(
 ): RateLimitResult {
   const ip = getIp(req);
   const now = Date.now();
-  sweepBuckets(now, Math.max(5 * (Number(windowMs) || 0), 10 * 60_000));
+  sweepBuckets(now);
   const k = `${key}:${ip}`;
   const cur = buckets.get(k);
   if (!cur || now - cur.startMs >= windowMs) {
-    buckets.set(k, { startMs: now, count: 1 });
+    buckets.set(k, { startMs: now, count: 1, windowMs });
     recordRateLimit(key, "allowed");
     return {
       ok: true,

--- a/server/modules/food-search.ts
+++ b/server/modules/food-search.ts
@@ -4,10 +4,11 @@ import { validateQuery } from "../http/validate.js";
 
 const OFF_SEARCH = "https://world.openfoodfacts.org/api/v2/search";
 const OFF_FIELDS =
-  "product_name,product_name_uk,brands,nutriments,serving_quantity";
+  "code,product_name,product_name_uk,brands,nutriments,serving_quantity";
 const USDA_SEARCH = "https://api.nal.usda.gov/fdc/v1/foods/search";
 
 interface OFFSearchProduct {
+  code?: string;
   product_name?: string;
   product_name_uk?: string;
   brands?: string;
@@ -16,8 +17,24 @@ interface OFFSearchProduct {
 }
 
 interface USDASearchFood {
+  fdcId?: number;
   description?: string;
   foodNutrients?: Array<{ nutrientId?: number; value?: number }>;
+}
+
+// Deterministic fallback id based on product content — used when the upstream
+// record has no stable code (OFF `code` / USDA `fdcId`). Avoids embedding
+// request-time `Date.now()` into search-result ids, which would cause React
+// to churn keys and break any client-side dedup/caching across searches.
+function stableId(prefix: string, parts: Array<string | null | undefined>) {
+  const canonical = parts
+    .map((p) => (p ? String(p).trim().toLowerCase() : ""))
+    .join("|");
+  let hash = 0;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) - hash + canonical.charCodeAt(i)) | 0;
+  }
+  return `${prefix}_${(hash >>> 0).toString(36)}`;
 }
 
 interface NormalizedSearchProduct {
@@ -148,7 +165,6 @@ function translateFirstToken(query: string): string | null {
 
 function normalizeOFFProduct(
   product: OFFSearchProduct | null | undefined,
-  idx: number,
 ): NormalizedSearchProduct | null {
   const n = (product?.nutriments || {}) as Record<string, unknown>;
 
@@ -157,11 +173,13 @@ function normalizeOFFProduct(
       ? Math.round(Number(v) * 10) / 10
       : null;
 
-  // Дозволяємо друковані символи латиниці + кирилиця (без керуючих символів)
+  // Дозволяємо друковані символи латиниці + кирилиця (без керуючих символів).
+  // \u0020-\u024F вже охоплює ASCII-цифри та пунктуацію, тож окремих
+  // \d.,()\-/ у діапазоні не треба.
   const name =
     product?.product_name_uk ||
     (product?.product_name &&
-    /^[\u0020-\u024F\u0400-\u04FF\d.,()\-/]+$/.test(product.product_name)
+    /^[\u0020-\u024F\u0400-\u04FF]+$/.test(product.product_name)
       ? product.product_name
       : null) ||
     null;
@@ -181,7 +199,9 @@ function normalizeOFFProduct(
   }
 
   return {
-    id: `off_${idx}_${Date.now()}`,
+    id: product?.code
+      ? `off_${String(product.code).replace(/^0+/, "") || "0"}`
+      : stableId("off", [name, brand]),
     name,
     brand,
     source: "off",
@@ -200,7 +220,6 @@ function normalizeOFFProduct(
 // USDA nutrient IDs: 1008=Energy(kcal), 1003=Protein, 1004=Fat, 1005=Carbs
 function normalizeUSDAProduct(
   food: USDASearchFood | null | undefined,
-  idx: number,
 ): NormalizedSearchProduct | null {
   const name = food?.description;
   if (!name) return null;
@@ -228,7 +247,10 @@ function normalizeUSDAProduct(
   }
 
   return {
-    id: `usda_${idx}_${Date.now()}`,
+    id:
+      food?.fdcId != null
+        ? `usda_${String(food.fdcId)}`
+        : stableId("usda", [name]),
     name,
     brand: null,
     source: "usda",
@@ -312,11 +334,11 @@ export default async function handler(
     ]);
 
     const offProducts = [...ukOff, ...enOff]
-      .map((p, i) => normalizeOFFProduct(p, i))
+      .map((p) => normalizeOFFProduct(p))
       .filter((p): p is NormalizedSearchProduct => p != null);
 
     const usdaProducts = usdaRaw
-      .map((p, i) => normalizeUSDAProduct(p, i))
+      .map((p) => normalizeUSDAProduct(p))
       .filter((p): p is NormalizedSearchProduct => p != null);
 
     // OFF (з українськими назвами) йде першим, USDA — як fallback

--- a/server/modules/push.ts
+++ b/server/modules/push.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import webpush from "web-push";
 import pool from "../db.js";
 import { sendWebPush } from "../lib/webpushSend.js";
+import { logger } from "../obs/logger.js";
 import { pushSendsTotal } from "../obs/metrics.js";
 import { validateBody } from "../http/validate.js";
 import {
@@ -28,9 +29,30 @@ function recordDomainOutcome(outcome: string): void {
 
 const VAPID_PUBLIC = process.env.VAPID_PUBLIC_KEY;
 const VAPID_PRIVATE = process.env.VAPID_PRIVATE_KEY;
-const VAPID_EMAIL = process.env.VAPID_EMAIL || "mailto:admin@example.com";
 
-if (VAPID_PUBLIC && VAPID_PRIVATE) {
+/**
+ * Resolve the VAPID contact. Some push services downgrade or drop requests
+ * from unroutable addresses (example.com), so in production we require a
+ * real `VAPID_EMAIL` rather than silently shipping a bogus default. In
+ * non-prod we keep the placeholder to avoid breaking local dev when only
+ * the keys are configured.
+ */
+function resolveVapidEmail(): string | null {
+  const raw = process.env.VAPID_EMAIL?.trim();
+  if (raw) return raw.startsWith("mailto:") ? raw : `mailto:${raw}`;
+  if (process.env.NODE_ENV === "production") {
+    logger.error({
+      msg: "vapid_email_missing",
+      hint: "Set VAPID_EMAIL (e.g. mailto:admin@your-domain) to avoid push deliverability issues",
+    });
+    return null;
+  }
+  return "mailto:admin@example.com";
+}
+
+const VAPID_EMAIL = resolveVapidEmail();
+
+if (VAPID_PUBLIC && VAPID_PRIVATE && VAPID_EMAIL) {
   webpush.setVapidDetails(VAPID_EMAIL, VAPID_PUBLIC, VAPID_PRIVATE);
 }
 

--- a/src/core/cloudSync/engine/push.ts
+++ b/src/core/cloudSync/engine/push.ts
@@ -39,6 +39,7 @@ export async function pushDirty(args: PushArgs): Promise<void> {
   try {
     if (Object.keys(modules).length === 0) {
       clearAllDirty();
+      onSuccess(new Date());
       return;
     }
 
@@ -89,7 +90,10 @@ export async function pushAll(args: PushArgs): Promise<void> {
       Object.keys(SYNC_MODULES),
       getModuleModifiedTimes(),
     );
-    if (Object.keys(modules).length === 0) return;
+    if (Object.keys(modules).length === 0) {
+      onSuccess(new Date());
+      return;
+    }
 
     if (!navigator.onLine) {
       addToOfflineQueue({ type: "push", modules });

--- a/src/core/cloudSync/state/dirtyModules.ts
+++ b/src/core/cloudSync/state/dirtyModules.ts
@@ -29,5 +29,9 @@ export function clearDirtyModule(moduleName: string): void {
 
 export function clearAllDirty(): void {
   safeWriteLS(DIRTY_MODULES_KEY, {});
+  // Reset the modified-times map too. Otherwise it grows unbounded across
+  // every module that was ever dirtied on this device, wasting localStorage
+  // and keeping stale snapshots for `pushDirty`'s mid-flight change check.
+  safeWriteLS(MODULE_MODIFIED_KEY, {});
   emitStatusEvent();
 }

--- a/src/core/webVitals.ts
+++ b/src/core/webVitals.ts
@@ -31,6 +31,11 @@ function flush() {
   if (buffer.length === 0) return;
 
   const batch = buffer.splice(0, MAX_BATCH);
+  // If enqueue() pushed more than one batch worth of metrics in a single
+  // tick, the leftover would sit in the buffer until the next report or
+  // pagehide — on fast unload that means data loss. Reschedule the next
+  // flush on the same microtask boundary so the buffer drains in order.
+  if (buffer.length > 0) scheduleFlush();
   const payload = JSON.stringify({ metrics: batch });
   const url = apiUrl(ENDPOINT_PATH);
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -108,10 +108,26 @@ function habitScheduledOnDateSW(h, dk) {
 }
 
 const notifiedKeys = new Set();
+let lastPrunedDk = null;
 let routineData = null;
 let fizrukData = null;
 let nutritionData = null;
 let scheduledTimerId = null;
+
+/**
+ * Drop dedupe keys tied to past days so the Set does not grow without bound
+ * across the SW lifetime. All keys end with a `YYYY-MM-DD` suffix (see the
+ * three `*_notify_*_<dk>` emit sites above), so we keep only entries ending
+ * in the current `dk`.
+ */
+function pruneOldNotifiedKeys(currentDk) {
+  if (lastPrunedDk === currentDk) return;
+  lastPrunedDk = currentDk;
+  const suffix = `_${currentDk}`;
+  for (const k of notifiedKeys) {
+    if (!k.endsWith(suffix)) notifiedKeys.delete(k);
+  }
+}
 
 function normalizeReminderTimesSW(h) {
   if (Array.isArray(h.reminderTimes) && h.reminderTimes.length > 0) {
@@ -223,6 +239,7 @@ function checkNutritionReminders() {
 }
 
 function checkReminders() {
+  pruneOldNotifiedKeys(todayKey());
   checkRoutineReminders();
   checkFizrukReminders();
   checkNutritionReminders();


### PR DESCRIPTION
## Summary

Fixes 9 bugs/small issues surfaced during a code review. One of them (rate-limit/quota IP bypass) is a real security issue; the rest are correctness / UX / hygiene.

Per-fix detail:

1. **`server/http/rateLimit.ts` — IP bypass via `X-Forwarded-For` (security).** `getIp()` previously returned `xf.split(",")[0]`, but with `app.set("trust proxy", 1)` the real client IP is appended by the proxy **at the end** of the header. A client sending `X-Forwarded-For: 1.1.1.1` ended up bucketed as `1.1.1.1` — trivial to rotate and bypass `rateLimitExpress`, and the same `getIp` feeds `aiQuota.subjectFor` for anonymous callers, so daily AI quota was also bypassable. Fixed by preferring `req.ip` (which already respects trust-proxy), falling back to the **last** XFF entry only when Express didn't surface an IP.

2. **`server/http/rateLimit.ts` — `sweepBuckets` shared TTL.** The sweep was called with the current request's `windowMs`, so a short-window route could evict valid state belonging to a long-window route (all routes share the same `buckets` Map). Each bucket now carries its own `windowMs` and the sweep uses it per-entry.

3. **`src/core/cloudSync/engine/push.ts` — `pushDirty` / `pushAll` empty payload.** When every dirty module produced an empty payload, `clearAllDirty()` ran but `onSuccess(new Date())` didn't, so the "last synced" indicator never advanced even though the sync effectively completed. `pushAll` had the same early return. Both now call `onSuccess`.

4. **`src/core/cloudSync/state/dirtyModules.ts` — `clearAllDirty` leaks `MODULE_MODIFIED_KEY`.** `clearAllDirty()` cleared the dirty-flags map but left `MODULE_MODIFIED_KEY` to grow for every module that was ever touched on the device. Now resets both.

5. **`server/modules/food-search.ts` — unstable ids.** Responses used `off_${idx}_${Date.now()}` / `usda_${idx}_${Date.now()}`, so identical products returned different ids on every call — breaks React `key={id}`, breaks any client-side dedup/caching. Now uses `OFF.code` / `USDA.fdcId` when available, with a deterministic content-hash fallback (`stableId`). Added `code` to the OFF field list and the TS types; removed the now-unused `idx` argument.

6. **`src/core/webVitals.ts` — `flush` strands overflow.** If `enqueue` pushed `>MAX_BATCH` items in one tick, `buffer.splice(0, MAX_BATCH)` sent the batch but the remainder sat in the buffer until the next report or `pagehide` — on a fast unload that means lost metrics. Now re-schedules the next flush when the buffer is non-empty after the splice.

7. **`src/sw.js` — `notifiedKeys` grows without pruning.** All three reminder kinds (`routine_notify_*`, `fizruk_notify_*`, `nutrition_notify_*`) share one Set, keyed by `<prefix>_<...>_<dk>`. Entries were never removed for previous days. Added a cheap per-tick prune that drops keys not ending with today's `dk`.

8. **`server/modules/push.ts` — unroutable default VAPID contact.** `VAPID_EMAIL` fell back to `mailto:admin@example.com`. Push services often penalise unroutable contacts. In production we now require an explicit `VAPID_EMAIL` (logs and skips `setVapidDetails` if missing, so the server still boots but `/api/push/*` returns 503 until configured). Dev/test keep the placeholder so local setup still works with just the keys.

9. **`server/modules/food-search.ts` — cosmetic regex cleanup.** The allowed-name regex was `[\u0020-\u024F\u0400-\u04FF\d.,()\-/]`; `\u0020-\u024F` already covers ASCII digits and that punctuation, so the trailing classes were redundant. Simplified to `[\u0020-\u024F\u0400-\u04FF]`.

Intentionally **not** fixed in this PR:
- `safeReadLS` returning `fallback` for stored JSON `null` / `0` / `""`. There is an explicit test (`src/shared/lib/storage.test.ts`) asserting that `'null'` → fallback, so this is the documented contract, not a bug. No in-repo caller actually stores those values, so the theoretical foot-gun isn't exercised today. Happy to revisit as a separate PR if we want to change the contract.

Local verification: `npm run lint` (0), `npm run typecheck` (0), `npm run test` (913/913 pass).

## Review & Testing Checklist for Human

Yellow risk — security-adjacent change on a critical path (rate-limit/quota) plus a few client-side data-shape tweaks.

- [ ] **Confirm `app.set("trust proxy", 1)` is still the right level for the current deployment.** The new `getIp()` assumes it. If the app is ever fronted by more than one proxy hop without bumping this, `req.ip` would again be a proxy IP. `server/config.ts` already notes Railway's single-proxy setup — just re-verify before merge.
- [ ] **Hit a rate-limited endpoint from the same real IP while forging different `X-Forwarded-For` values** (e.g. `curl -H 'X-Forwarded-For: 1.2.3.4'` vs `curl -H 'X-Forwarded-For: 5.6.7.8'`). You should see a single shared bucket now instead of two.
- [ ] **Food search UI**: search, note some product ids, re-run the same search — ids should be identical across calls (they were different before). Double-check clients don't cache the old `off_${idx}_${Date.now()}` shape anywhere I missed.
- [ ] **Prod config**: before deploying, ensure `VAPID_EMAIL` is set in the prod env. If it isn't, `/api/push/subscribe` will start returning 503 instead of silently using `admin@example.com`.
- [ ] Cloud sync last-synced indicator actually advances on a "no-op" sync (e.g. trigger sync with nothing dirty).

### Notes

- Nothing in this PR modifies tests. All pre-existing tests still pass.
- The `stableId` hash is only used when OFF has no `code` and USDA has no `fdcId`, which is rare — in practice ids will be `off_<barcode>` / `usda_<fdcId>`.

Link to Devin session: https://app.devin.ai/sessions/fc8e42b76a1c4fa6b0940f68591f4913
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
