### PR TITLE
fix(fizruk): functional setState у useWorkoutTemplates — fix stale closure в undo-toast

### DIFF
--- a/src/modules/fizruk/hooks/useWorkoutTemplates.test.tsx
+++ b/src/modules/fizruk/hooks/useWorkoutTemplates.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useWorkoutTemplates } from "./useWorkoutTemplates";
+
+describe("useWorkoutTemplates", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("restoreTemplate повертає видалений шаблон на ту саму позицію", () => {
+    const { result } = renderHook(() => useWorkoutTemplates());
+
+    act(() => {
+      result.current.addTemplate("A", ["e1"]);
+    });
+    act(() => {
+      result.current.addTemplate("B", ["e2"]);
+    });
+    act(() => {
+      result.current.addTemplate("C", ["e3"]);
+    });
+
+    // sorted by updatedAt desc → [C, B, A]
+    const b = result.current.templates.find((t) => t.name === "B");
+    expect(b).toBeDefined();
+    const bId = b!.id;
+    const bIndex = result.current.templates.findIndex((t) => t.id === bId);
+
+    act(() => {
+      result.current.removeTemplate(bId);
+    });
+    expect(result.current.templates.find((t) => t.id === bId)).toBeUndefined();
+
+    act(() => {
+      result.current.restoreTemplate(b, bIndex);
+    });
+    expect(result.current.templates.find((t) => t.id === bId)).toBeDefined();
+  });
+
+  it("restoreTemplate переживає stale closure: захоплена до deletion функція все одно відновлює шаблон", () => {
+    const { result } = renderHook(() => useWorkoutTemplates());
+
+    let created;
+    act(() => {
+      created = result.current.addTemplate("X", ["e1"]);
+    });
+    // Захоплюємо restoreTemplate до того як відбудеться видалення — саме так
+    // це стається у showUndoToast.onUndo, і раніше тут ламалась ідемпотентна
+    // перевірка на stale `templates`.
+    const capturedRestore = result.current.restoreTemplate;
+
+    act(() => {
+      result.current.removeTemplate(created.id);
+    });
+    expect(result.current.templates).toHaveLength(0);
+
+    act(() => {
+      capturedRestore(created, 0);
+    });
+    expect(result.current.templates.map((t) => t.id)).toEqual([created.id]);
+  });
+
+  it("restoreTemplate ідемпотентний: повторний виклик не дублює шаблон", () => {
+    const { result } = renderHook(() => useWorkoutTemplates());
+    let created;
+    act(() => {
+      created = result.current.addTemplate("Y", []);
+    });
+    act(() => {
+      result.current.removeTemplate(created.id);
+    });
+    act(() => {
+      result.current.restoreTemplate(created, 0);
+    });
+    act(() => {
+      result.current.restoreTemplate(created, 0);
+    });
+    expect(
+      result.current.templates.filter((t) => t.id === created.id),
+    ).toHaveLength(1);
+  });
+
+  it("restoreTemplate ігнорує null/undefined/invalid template", () => {
+    const { result } = renderHook(() => useWorkoutTemplates());
+    act(() => {
+      result.current.restoreTemplate(null, 0);
+    });
+    act(() => {
+      result.current.restoreTemplate({ id: "" }, 0);
+    });
+    expect(result.current.templates).toHaveLength(0);
+  });
+});

--- a/src/modules/fizruk/hooks/useWorkoutTemplates.ts
+++ b/src/modules/fizruk/hooks/useWorkoutTemplates.ts
@@ -16,9 +16,15 @@ export function useWorkoutTemplates() {
     if (Array.isArray(parsed)) setTemplates(parsed);
   }, []);
 
-  const persist = useCallback((next) => {
-    setTemplates(next);
-    safeWriteLS(KEY, next);
+  // Функціональний updater через setTemplates, щоб уникнути stale closure:
+  // колбеки в undo-toast можуть викликатись після того, як state оновився
+  // (див. AGENTS.md §5.11).
+  const persist = useCallback((updater) => {
+    setTemplates((prev) => {
+      const next = typeof updater === "function" ? updater(prev) : updater;
+      safeWriteLS(KEY, next);
+      return next;
+    });
   }, []);
 
   const addTemplate = useCallback(
@@ -37,56 +43,58 @@ export function useWorkoutTemplates() {
         groups: Array.isArray(groups) ? groups : [],
         updatedAt: new Date().toISOString(),
       };
-      persist([t, ...templates]);
+      persist((prev) => [t, ...prev]);
       return t;
     },
-    [persist, templates],
+    [persist],
   );
 
   const updateTemplate = useCallback(
     (id, patch) => {
-      persist(
-        templates.map((t) =>
+      persist((prev) =>
+        prev.map((t) =>
           t.id === id
             ? { ...t, ...patch, updatedAt: new Date().toISOString() }
             : t,
         ),
       );
     },
-    [persist, templates],
+    [persist],
   );
 
   const removeTemplate = useCallback(
     (id) => {
-      persist(templates.filter((t) => t.id !== id));
+      persist((prev) => prev.filter((t) => t.id !== id));
     },
-    [persist, templates],
+    [persist],
   );
 
   const restoreTemplate = useCallback(
     (template, atIndex) => {
       if (!template || !template.id) return;
-      if (templates.some((t) => t.id === template.id)) return;
-      const next = [...templates];
-      const idx =
-        typeof atIndex === "number" && atIndex >= 0
-          ? Math.min(atIndex, next.length)
-          : next.length;
-      next.splice(idx, 0, template);
-      persist(next);
+      persist((prev) => {
+        if (prev.some((t) => t.id === template.id)) return prev;
+        const next = [...prev];
+        const idx =
+          typeof atIndex === "number" && atIndex >= 0
+            ? Math.min(atIndex, next.length)
+            : next.length;
+        next.splice(idx, 0, template);
+        return next;
+      });
     },
-    [persist, templates],
+    [persist],
   );
 
   const markTemplateUsed = useCallback(
     (id) => {
-      persist(
-        templates.map((t) =>
+      persist((prev) =>
+        prev.map((t) =>
           t.id === id ? { ...t, lastUsedAt: new Date().toISOString() } : t,
         ),
       );
     },
-    [persist, templates],
+    [persist],
   );
 
   const sorted = useMemo(


### PR DESCRIPTION
## Summary

Follow-up до #352 (merged). Devin Review знайшло критичний баг: **undo-toast для видалення шаблону тренування мовчки не робив нічого**.

Причина — stale closure у `useWorkoutTemplates.restoreTemplate`:
- `restoreTemplate` був `useCallback` з залежністю `[persist, templates]` і читав `templates` прямо зі свого closure.
- На момент `onConfirm` у `WorkoutTemplatesSection` ми захоплювали **поточний** `restoreTemplate`, викликали `removeTemplate`, а потім передавали захоплену функцію в `showUndoToast.onUndo`.
- Коли юзер тиснув «Повернути», цей захоплений `restoreTemplate` все ще бачив **pre-deletion** `templates` array, тому ідемпотентна перевірка `templates.some((t) => t.id === template.id)` була `true` — і функція мовчки повертала без відновлення.
- Те саме порушувало `AGENTS.md §5.11 (Use Functional setState Updates)`.

### Fix

`persist` тепер приймає functional updater (`(prev) => next`), і всі мутатори (`addTemplate`, `updateTemplate`, `removeTemplate`, `restoreTemplate`, `markTemplateUsed`) використовують його. Це гарантує, що колбеки завжди працюють зі свіжим state — незалежно від того, коли і де вони були захоплені.

Так само зникла залежність `templates` у `useCallback`, тож ці функції тепер стабільні між рендерами (менше rerenders у child-компонентах, менший шанс повторити схожий баг у майбутньому).

### Tests

Додано `useWorkoutTemplates.test.tsx` з 4 тестами, один з яких **явно відтворює stale-closure-сценарій**: захоплюємо `restoreTemplate` до видалення (як це робить `showUndoToast.onUndo`), видаляємо, потім викликаємо захоплену функцію — шаблон має відновитися. До фіксу цей тест би падав.

Regression у `RoutineSettingsSection` / `Finyk.Transactions` / `NutritionApp` не потрібен — вони вже використовують функціональні updater-и (`setRoutine((s) => ...)`, `setManualExpenses((prev) => ...)`, `setNutritionLog((log) => ...)`).

## Review & Testing Checklist for Human

- [ ] Fizruk → Templates → видалити шаблон → «Повернути» → шаблон реально відновлюється (раніше undo був no-op).
- [ ] Швидкий regression для решти template-flow: створення, редагування, `markTemplateUsed`, `recentlyUsed` — нічого не поламалось.

### Notes

- Не міг подивитись решту 4 знахідок з Devin Review (інтерфейс закритий і URL-ки не віддають тіло). Ця PR закриває єдиний **critical bug** зі знайдених; якщо в Review є ще коментарі — підкажи, і я підчеплюсь новим PR-ом.
- У всіх 4 основних destructive actions (`RoutineSettingsSection`, `Finyk.Transactions`, `NutritionApp`, `WorkoutTemplatesSection`) тепер функціональні state updaters у undo-шляхах.


Link to Devin session: https://app.devin.ai/sessions/c9e89bf7189e41fc8429788ca5aed076
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
