### PR TITLE
chore(ts): migrate FinykApp.jsx to TypeScript

### DIFF
--- a/src/modules/finyk/FinykApp.tsx
+++ b/src/modules/finyk/FinykApp.tsx
@@ -132,7 +132,9 @@ const NAV_IDS = NAV_ITEMS.map((n) => n.id);
 
 const ALL_PAGE_IDS = PAGES.map((p) => p.id);
 
-function useHashRouter(defaultPage = "overview") {
+function useHashRouter(
+  defaultPage = "overview",
+): [string, (p: string) => void] {
   const getPage = useCallback(() => {
     // Accept both `#page` (canonical, matches fizruk/nutrition) and legacy `#/page`.
     let p =
@@ -146,7 +148,7 @@ function useHashRouter(defaultPage = "overview") {
     window.addEventListener("hashchange", handler);
     return () => window.removeEventListener("hashchange", handler);
   }, [getPage]);
-  const navigate = (p) => {
+  const navigate = (p: string) => {
     window.location.hash = p;
   };
   return [ALL_PAGE_IDS.includes(page) ? page : defaultPage, navigate];
@@ -154,11 +156,17 @@ function useHashRouter(defaultPage = "overview") {
 
 const PRIVAT_ENABLED = false;
 
+interface FinykAppProps {
+  onBackToHub?: () => void;
+  pwaAction?: string | null;
+  onPwaActionConsumed?: () => void;
+}
+
 export default function App({
   onBackToHub,
   pwaAction,
   onPwaActionConsumed,
-} = {}) {
+}: FinykAppProps = {}) {
   const mono = useMonobank();
   const privat = usePrivatbank(PRIVAT_ENABLED);
   const toast = useToast();


### PR DESCRIPTION
## Summary

Migrates `src/modules/finyk/FinykApp.jsx` → `.tsx` (787 lines, 1 file).

Two typing additions, no runtime changes:

1. **`FinykAppProps` interface** mirrors `FizrukAppProps` (`onBackToHub?`, `pwaAction?: string | null`, `onPwaActionConsumed?`) — same shape already used at the call site in <ref_snippet file="/home/ubuntu/repos/Sergeant/src/core/App.tsx" lines="420-425" />.
2. **`useHashRouter` return tuple** typed as `[string, (p: string) => void]`. Without this, TS widened the return to `(string | ((p: any) => void))[]`, which made the destructured `navigate(...)` calls appear uncallable.

## Review & Testing Checklist for Human

- [ ] Open the Finyk module, verify hash routing still works (overview / transactions / budgets / analytics / assets, plus the legacy `#/page` and `#payments`→`budgets` rewrite).
- [ ] Confirm «Далі без банку» manual-only flow, PWA `add_expense` intent, quick-add prefill, and «Назад до хабу» all still work.

### Notes

This unblocks migrating `finyk/pages/*`, `finyk/components/*`, `nutrition/hooks/*`, `nutrition/components/*` in subsequent PRs.

Local `typecheck`, `lint`, and `npm test` (917 tests) all pass.

Link to Devin session: https://app.devin.ai/sessions/32c090a49ab0402ab5303d0b30901ea1
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
