### PR TITLE
refactor(cloudSync): explicit queue/scheduler/executor layers in useCloudSync

### DIFF
--- a/src/core/cloudSync/hook/useCloudSync.ts
+++ b/src/core/cloudSync/hook/useCloudSync.ts
@@ -10,32 +10,60 @@ import { useInitialSyncOnUser } from "./useInitialSyncOnUser";
 import { useSyncRetry } from "./useSyncRetry";
 
 /**
- * React hook that orchestrates the cloud-sync engine. Owns React state
- * (`syncing`, `lastSync`, `syncError`, `migrationPending`) and wires the
- * engine to retry triggers (online listener, 5s debounce on SYNC_EVENT,
- * 2-min periodic) and the initial-sync-on-user effect.
+ * Cloud-sync orchestrator. Three clearly-separated layers, read top-down:
+ *
+ *   1. Queue (where changes accumulate)
+ *      Handled outside this hook — the patched `localStorage` in
+ *      `storagePatch.ts` calls `enqueueChange` on every write to a tracked
+ *      key. That writes the dirty map and dispatches `SYNC_EVENT`.
+ *
+ *   2. Scheduler (when to run a sync)
+ *      `useSyncRetry` wires three triggers — online / change-event /
+ *      periodic timer — to the executor below.
+ *
+ *   3. Executor (how to actually call the API)
+ *      The `run*` callbacks below each wrap one engine entry point in the
+ *      in-flight guard (`runExclusive`) so we never fire concurrent syncs.
+ *
+ * Public state surface:
+ *   - `isSyncing`   (legacy alias: `syncing`)
+ *   - `lastSyncAt`  (legacy alias: `lastSync`)
+ *   - `hasError`    derived from the underlying error message; legacy alias
+ *                   `syncError` still exposes the raw message.
+ *   - `migrationPending` drives the first-run migration modal.
  */
 export function useCloudSync(user: CurrentUser | null | undefined) {
   const [migrationPending, setMigrationPending] = useState(false);
   const { engineArgs, lifecycle } = useEngineArgs(user);
-  const { syncing, lastSync, syncError, runExclusive, claimBusy } = lifecycle;
+  const {
+    isSyncing,
+    lastSyncAt,
+    hasError,
+    syncing,
+    lastSync,
+    syncError,
+    runExclusive,
+    claimBusy,
+  } = lifecycle;
 
-  const doPushDirty = useCallback(
+  // --- 3. Executor: API calls, each serialized through the in-flight guard.
+
+  const runSync = useCallback(
     () => runExclusive(() => pushDirty(engineArgs), undefined),
     [engineArgs, runExclusive],
   );
 
-  const doPushAll = useCallback(
+  const runPushAll = useCallback(
     () => runExclusive(() => pushAll(engineArgs), undefined),
     [engineArgs, runExclusive],
   );
 
-  const doPullAll = useCallback(
+  const runPullAll = useCallback(
     () => runExclusive(() => pullAll(engineArgs), false),
     [engineArgs, runExclusive],
   );
 
-  const doInitialSync = useCallback(
+  const runInitialSync = useCallback(
     (): Promise<boolean> =>
       runExclusive(
         () =>
@@ -48,7 +76,7 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     [engineArgs, runExclusive],
   );
 
-  const doUploadLocalData = useCallback(async () => {
+  const runUploadLocal = useCallback(async () => {
     if (!user?.id) return;
     // Intentionally bypasses the in-flight guard: this is user-initiated
     // from the migration modal and must proceed even if a background retry
@@ -70,18 +98,25 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     () => setMigrationPending(false),
     [],
   );
-  useInitialSyncOnUser(user, doInitialSync, clearMigrationPending);
 
-  useSyncRetry(!!user, doPushDirty);
+  // --- 2. Scheduler: subscribe the executor to online/change/periodic.
+
+  useInitialSyncOnUser(user, runInitialSync, clearMigrationPending);
+  useSyncRetry(!!user, runSync);
 
   return {
+    // Explicit state names.
+    isSyncing,
+    lastSyncAt,
+    hasError,
+    // Legacy aliases kept so existing consumers (App.tsx, tests) compile.
     syncing,
     lastSync,
     syncError,
-    pushAll: doPushAll,
-    pullAll: doPullAll,
+    pushAll: runPushAll,
+    pullAll: runPullAll,
     migrationPending,
-    uploadLocalData: doUploadLocalData,
+    uploadLocalData: runUploadLocal,
     skipMigration,
   };
 }

--- a/src/core/cloudSync/hook/useSyncCallbacks.ts
+++ b/src/core/cloudSync/hook/useSyncCallbacks.ts
@@ -1,12 +1,18 @@
 import { useCallback, useRef, useState } from "react";
+import { syncLog } from "../logger";
 import type { SyncCallbacks } from "../types";
 
 export type { SyncCallbacks };
 
 export interface SyncLifecycle extends SyncCallbacks {
+  // Legacy names — kept because existing consumers (App.tsx, tests) read them.
   syncing: boolean;
   lastSync: Date | null;
   syncError: string | null;
+  // Explicit, self-documenting aliases. Prefer these in new code.
+  isSyncing: boolean;
+  lastSyncAt: Date | null;
+  hasError: boolean;
   /**
    * Run `fn` only if no other sync operation is in flight; otherwise return
    * `fallback` synchronously. Sets the in-flight flag before calling `fn`
@@ -82,23 +88,26 @@ export async function runExclusiveWith<T>(
  * that into each engine entry point.
  */
 export function useSyncCallbacks(): SyncLifecycle {
-  const [syncing, setSyncing] = useState(false);
-  const [lastSync, setLastSync] = useState<Date | null>(null);
-  const [syncError, setSyncError] = useState<string | null>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [lastSyncAt, setLastSyncAt] = useState<Date | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const guardRef = useRef<InFlightGuard>(createInFlightGuard());
 
   const onStart = useCallback(() => {
-    setSyncing(true);
-    setSyncError(null);
+    syncLog.syncStart();
+    setIsSyncing(true);
+    setErrorMessage(null);
   }, []);
   const onSuccess = useCallback((when: Date) => {
-    setLastSync(when);
+    syncLog.syncSuccess({ at: when });
+    setLastSyncAt(when);
   }, []);
   const onError = useCallback((message: string) => {
-    setSyncError(message);
+    syncLog.syncError({ message });
+    setErrorMessage(message);
   }, []);
   const onSettled = useCallback(() => {
-    setSyncing(false);
+    setIsSyncing(false);
     guardRef.current.release();
   }, []);
 
@@ -113,9 +122,14 @@ export function useSyncCallbacks(): SyncLifecycle {
   }, []);
 
   return {
-    syncing,
-    lastSync,
-    syncError,
+    // Legacy aliases (kept to preserve public shape).
+    syncing: isSyncing,
+    lastSync: lastSyncAt,
+    syncError: errorMessage,
+    // Explicit names.
+    isSyncing,
+    lastSyncAt,
+    hasError: errorMessage !== null,
     onStart,
     onSuccess,
     onError,

--- a/src/core/cloudSync/hook/useSyncRetry.ts
+++ b/src/core/cloudSync/hook/useSyncRetry.ts
@@ -1,47 +1,91 @@
 import { useEffect } from "react";
 import { SYNC_EVENT } from "../config";
 import { replayOfflineQueue } from "../engine/replay";
+import { syncLog } from "../logger";
 import { getDirtyModules } from "../state/dirtyModules";
 
+/**
+ * How long to wait after a local change before firing a sync. Collapses
+ * bursts of writes into a single API call.
+ */
 const DEBOUNCE_MS = 5000;
+
+/**
+ * Fallback cadence: even without change events we retry every 2 minutes as
+ * long as there are dirty modules (e.g. after a previous network failure).
+ */
 const PERIODIC_MS = 2 * 60 * 1000;
 
 /**
- * Wires the three retry triggers that drive dirty-module pushes while a
- * user is signed in:
- *   - browser `online` event  → replay the offline queue, then `onTrigger`
- *   - `SYNC_EVENT` (tracked localStorage write) → debounced by 5s so bursts
- *     coalesce into a single push
- *   - 2-minute interval → `onTrigger` only if there are dirty modules
+ * Wires the three scheduler triggers that drive `runSync` while a user is
+ * signed in. Each trigger is one named function so the wiring reads as a
+ * flat list of "which event → what we do".
+ *
+ * Triggers:
+ *   - browser `online`     → replay the offline queue, then `runSync`
+ *   - `SYNC_EVENT`         → debounced by 5s so bursts coalesce
+ *   - 2-minute interval    → `runSync` only if there are dirty modules
  *
  * The effect is a no-op while `enabled` is `false` (e.g. no signed-in user).
  */
-export function useSyncRetry(enabled: boolean, onTrigger: () => void): void {
+export function useSyncRetry(enabled: boolean, runSync: () => void): void {
   useEffect(() => {
     if (!enabled) return;
 
-    const onOnline = () => {
-      replayOfflineQueue().then(onTrigger);
+    const debouncer = createDebouncer(DEBOUNCE_MS);
+
+    const scheduleFromOnline = () => {
+      syncLog.scheduleSync({ reason: "online" });
+      replayOfflineQueue().then(runSync);
     };
 
-    let debounceId: ReturnType<typeof setTimeout> | null = null;
-    const onSyncDirty = () => {
-      if (debounceId) clearTimeout(debounceId);
-      debounceId = setTimeout(onTrigger, DEBOUNCE_MS);
+    const scheduleFromChange = () => {
+      syncLog.scheduleSync({ reason: "change" });
+      debouncer.schedule(runSync);
     };
 
-    const periodic = setInterval(() => {
-      if (Object.keys(getDirtyModules()).length > 0) onTrigger();
-    }, PERIODIC_MS);
+    const scheduleFromTimer = () => {
+      if (Object.keys(getDirtyModules()).length === 0) return;
+      syncLog.scheduleSync({ reason: "periodic" });
+      runSync();
+    };
 
-    window.addEventListener("online", onOnline);
-    window.addEventListener(SYNC_EVENT, onSyncDirty);
+    const periodicId = setInterval(scheduleFromTimer, PERIODIC_MS);
+    window.addEventListener("online", scheduleFromOnline);
+    window.addEventListener(SYNC_EVENT, scheduleFromChange);
 
     return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener(SYNC_EVENT, onSyncDirty);
-      if (debounceId) clearTimeout(debounceId);
-      clearInterval(periodic);
+      window.removeEventListener("online", scheduleFromOnline);
+      window.removeEventListener(SYNC_EVENT, scheduleFromChange);
+      debouncer.cancel();
+      clearInterval(periodicId);
     };
-  }, [enabled, onTrigger]);
+  }, [enabled, runSync]);
+}
+
+interface Debouncer {
+  schedule(fn: () => void): void;
+  cancel(): void;
+}
+
+/**
+ * Minimal trailing-edge debouncer. Extracted so the scheduler reads as
+ * "schedule vs. fire" instead of open-coding `setTimeout`/`clearTimeout`
+ * handles next to the event wiring.
+ */
+function createDebouncer(delayMs: number): Debouncer {
+  let pending: ReturnType<typeof setTimeout> | null = null;
+  return {
+    schedule(fn) {
+      if (pending) clearTimeout(pending);
+      pending = setTimeout(() => {
+        pending = null;
+        fn();
+      }, delayMs);
+    },
+    cancel() {
+      if (pending) clearTimeout(pending);
+      pending = null;
+    },
+  };
 }

--- a/src/core/cloudSync/index.ts
+++ b/src/core/cloudSync/index.ts
@@ -13,7 +13,7 @@ export { SYNC_EVENT, SYNC_STATUS_EVENT } from "./config";
 export { getDirtyModules } from "./state/dirtyModules";
 export { getOfflineQueue } from "./queue/offlineQueue";
 
-export { notifySyncDirty } from "./storagePatch";
+export { enqueueChange, notifySyncDirty } from "./storagePatch";
 
 export { useCloudSync } from "./hook/useCloudSync";
 export { useSyncStatus } from "./hook/useSyncStatus";

--- a/src/core/cloudSync/logger.ts
+++ b/src/core/cloudSync/logger.ts
@@ -1,0 +1,55 @@
+/**
+ * Centralized, opt-in debug logger for the cloud-sync subsystem.
+ *
+ * Silent in production by default. Turned on when any of:
+ *   - `import.meta.env.DEV` is true (vite dev build), OR
+ *   - `localStorage.HUB_DEBUG_SYNC === "1"` (runtime opt-in without a rebuild)
+ *
+ * Writes go through `console.debug` so they stay out of the default
+ * production console view. Callers never need a `try/catch` — the logger
+ * itself swallows any throw (e.g. jsdom without CustomEvent patched,
+ * localStorage disabled, SSR).
+ */
+
+type LogPayload = Record<string, unknown> | undefined;
+
+function isEnabled(): boolean {
+  try {
+    const env = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env;
+    if (env?.DEV) return true;
+  } catch {
+    /* import.meta.env unavailable (tests, ssr) — fall through */
+  }
+  try {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("HUB_DEBUG_SYNC") === "1";
+    }
+  } catch {
+    /* localStorage can throw in private mode / jsdom edge cases */
+  }
+  return false;
+}
+
+function write(event: string, payload?: LogPayload): void {
+  if (!isEnabled()) return;
+  try {
+    if (payload === undefined) {
+      console.debug(`[cloud-sync] ${event}`);
+    } else {
+      console.debug(`[cloud-sync] ${event}`, payload);
+    }
+  } catch {
+    /* never let logging break the caller */
+  }
+}
+
+export const syncLog = {
+  enqueue: (info: { key?: string; module?: string | null }) =>
+    write("enqueue", info),
+  scheduleSync: (info: { reason: "online" | "change" | "periodic" }) =>
+    write("schedule", info),
+  syncStart: () => write("sync:start"),
+  syncSuccess: (info: { at: Date }) =>
+    write("sync:success", { at: info.at.toISOString() }),
+  syncError: (info: { message: string }) => write("sync:error", info),
+};

--- a/src/core/cloudSync/storagePatch.ts
+++ b/src/core/cloudSync/storagePatch.ts
@@ -4,6 +4,7 @@
 import "./state/dirtyModules";
 
 import { ALL_TRACKED_KEYS, keyToModule } from "./config";
+import { syncLog } from "./logger";
 import { markModuleDirty } from "./state/dirtyModules";
 import { emitSyncEvent } from "./state/events";
 
@@ -20,35 +21,41 @@ declare global {
   }
 }
 
+/**
+ * Queue layer — single entry point for "a local change just happened".
+ *
+ * If the changed localStorage key belongs to a tracked module, mark that
+ * module dirty (persisted through `DIRTY_MODULES_KEY`). Always dispatch the
+ * `SYNC_EVENT` so the scheduler layer can debounce and fire a sync. Keeping
+ * this as the one place that writes to the dirty map avoids the earlier
+ * duplication between the patched `setItem`/`removeItem` and the public
+ * `notifySyncDirty` helper.
+ */
+export function enqueueChange(changedKey?: string): void {
+  let module: string | null = null;
+  if (changedKey && ALL_TRACKED_KEYS.has(changedKey)) {
+    module = keyToModule(changedKey);
+    if (module) markModuleDirty(module);
+  }
+  syncLog.enqueue({ key: changedKey, module });
+  emitSyncEvent();
+}
+
+/**
+ * Kept for backward compatibility with existing consumers and tests that
+ * import `notifySyncDirty` from the barrel. New code should call
+ * `enqueueChange` directly.
+ */
+export const notifySyncDirty = enqueueChange;
+
 if (!window.__hubSyncPatched) {
   window.__hubSyncPatched = true;
   localStorage.setItem = function (key: string, value: string) {
     origSetItem(key, value);
-    if (ALL_TRACKED_KEYS.has(key)) {
-      const mod = keyToModule(key);
-      if (mod) markModuleDirty(mod);
-      emitSyncEvent();
-    }
+    if (ALL_TRACKED_KEYS.has(key)) enqueueChange(key);
   };
   localStorage.removeItem = function (key: string) {
     origRemoveItem(key);
-    if (ALL_TRACKED_KEYS.has(key)) {
-      const mod = keyToModule(key);
-      if (mod) markModuleDirty(mod);
-      emitSyncEvent();
-    }
+    if (ALL_TRACKED_KEYS.has(key)) enqueueChange(key);
   };
-}
-
-/**
- * Notify the sync system that a storage key changed by other means. If the
- * key belongs to a tracked module, mark that module dirty; always dispatch
- * the SYNC_EVENT so listeners (e.g. debounced push) can react.
- */
-export function notifySyncDirty(changedKey?: string): void {
-  if (changedKey && ALL_TRACKED_KEYS.has(changedKey)) {
-    const mod = keyToModule(changedKey);
-    if (mod) markModuleDirty(mod);
-  }
-  emitSyncEvent();
 }


### PR DESCRIPTION
## Summary

Рефакторинг `useCloudSync` і сусідніх модулів щоб код читався зверху вниз по трьох чітких рівнях, без зміни поведінки.

**Три рівні (як попросила задача):**

1. **Queue** — `src/core/cloudSync/storagePatch.ts`
   - Єдиний entry point `enqueueChange(key?)` замість двох паралельних шляхів (пропатчений `setItem`/`removeItem` та публічний `notifySyncDirty` робили майже те саме). Тепер обидва шляхи йдуть через одну функцію, яка маркує модуль dirty і диспатчить `SYNC_EVENT`.
   - `notifySyncDirty` збережений як alias — тести й існуючі імпорти працюють без змін.
   - Барель `index.ts` експортує обидва імені.

2. **Scheduler** — `src/core/cloudSync/hook/useSyncRetry.ts`
   - Три тригери (`online`, `SYNC_EVENT`, 2-хв інтервал) розділені на три названі функції (`scheduleFromOnline` / `scheduleFromChange` / `scheduleFromTimer`) замість перемішаних `const onX = ...` + `if (...)` у тілі ефекту.
   - Винесений `createDebouncer(ms)` — прибирає дублікат ручного `setTimeout`/`clearTimeout` поруч з event-wiring; cleanup використовує той самий handle.

3. **Executor** — `src/core/cloudSync/hook/useCloudSync.ts`
   - Публічні callback'и перейменовані зсередини на `runSync` (dirty push), `runPushAll`, `runPullAll`, `runInitialSync`, `runUploadLocal` — узгоджено з назвою, яку попросила задача.
   - Коментарями явно розмічені секції `// --- 3. Executor` / `// --- 2. Scheduler` так, що хук читається строго зверху вниз.

**Явні стани (додано без ламання існуючого API):**

`useSyncCallbacks` тепер повертає додатково `isSyncing` / `lastSyncAt` / `hasError`. Старі `syncing` / `lastSync` / `syncError` залишені як alias — `App.tsx` та тести працюють без змін.

**Логування:**

Новий `src/core/cloudSync/logger.ts` — opt-in через `import.meta.env.DEV` або `localStorage.HUB_DEBUG_SYNC = "1"`. Повідомляє:
- `enqueue` (з key та module)
- `schedule` (з reason: `online` / `change` / `periodic`)
- `sync:start`, `sync:success` (з ISO датою), `sync:error` (з повідомленням)

В production мовчить, бо всі виклики йдуть через `console.debug`, який ще й самозахищений від throw.

**Що НЕ змінилось (перевірено існуючими тестами):**

- Той самий API хука (`syncing` / `lastSync` / `syncError` / `pushAll` / `pullAll` / `migrationPending` / `uploadLocalData` / `skipMigration`) — `App.tsx` не чіпався.
- Ті самі тригери: `online` → replay → push, `SYNC_EVENT` дебаунс 5с, 2-хв періодичний з перевіркою dirty.
- Ті ж самі семантики `runExclusive` / `claimBusy`, той самий in-flight guard.
- `pushDirty` / `pushAll` / `pullAll` / `initialSync` / `uploadLocalData` engine-функції НЕ змінювались.
- Усі 189 юніт-тестів проходять (`vitest run src/core`), `npm run lint`, `npm run typecheck`, `npm run format:check` — чисто.

## Review & Testing Checklist for Human

- [ ] Перегляньте `useCloudSync.ts` — секції `// --- 3. Executor` та `// --- 2. Scheduler` справді роблять послідовність queue→scheduler→executor очевидною? Якщо ні — назви/коментарі змінюються тривіально.
- [ ] `storagePatch.ts`: впевніться, що пропатчений `setItem`/`removeItem` і далі не диспатчить `SYNC_EVENT` для untracked ключів (поведінка збережена — `enqueueChange` викликається лише якщо `ALL_TRACKED_KEYS.has(key)`). Публічний `notifySyncDirty(...)` / `enqueueChange(...)` натомість диспатчить завжди — це історична поведінка, яка покрита тестом `"завжди диспатчить SYNC_EVENT (навіть для untracked)"`.
- [ ] `useSyncRetry.ts`: `createDebouncer` не змінює часи (`DEBOUNCE_MS = 5000`, `PERIODIC_MS = 120000`). Перевірте, що періодичний тригер і далі викликає `runSync` напряму (без дебаунсу) — в коді це `scheduleFromTimer`, а не через `debouncer.schedule`.
- [ ] Ручна перевірка в dev-режимі: відкрити app → зробити зміну в Фініку/Фізруку → в консолі мають з'явитися `[cloud-sync] enqueue …` → після 5с `[cloud-sync] schedule {reason:"change"}` → `[cloud-sync] sync:start` → `sync:success`. Якщо не показуються, перевірити `localStorage.HUB_DEBUG_SYNC = "1"`.
- [ ] (Опційно) Увімкнути `HUB_DEBUG_SYNC` в проді через `localStorage.setItem("HUB_DEBUG_SYNC","1")` для діагностики реальних користувачів — логи йдуть у `console.debug`, тому за замовчуванням приховані.

### Notes

- `notifySyncDirty` залишений як alias спеціально — його імпортують тести (`useCloudSync.behavior.test.ts`) і він потенційно використовується іншим кодом; прибирати цю поверхню в рамках цього PR ризикованіше, ніж тримати alias.
- Зовнішні імена (`syncing`, `lastSync`, `syncError`) я НЕ видалив, хоч задача просила `isSyncing`/`lastSyncAt`/`hasError` — видалення зламало б `App.tsx` і всі споживачі, що суперечило б обмеженню "не міняти поведінку". Нові імена додані поруч; коли захочеш мігрувати споживачів — можна зробити окремим step'ом.

Link to Devin session: https://app.devin.ai/sessions/a92d83ba47604a87aabe556e43432a93
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
