### PR TITLE
UX: faster add-expense / add-meal / add-habit flows

### DIFF
--- a/src/modules/finyk/FinykApp.tsx
+++ b/src/modules/finyk/FinykApp.tsx
@@ -771,10 +771,10 @@ export default function App({
         onSave={(expense) => {
           if (expense?.id) {
             storage.editManualExpense?.(expense.id, expense);
-            showToast("✅ Витрату оновлено!");
+            showToast("Витрату оновлено");
           } else {
             storage.addManualExpense(expense);
-            showToast("✅ Витрату додано!");
+            showToast("Витрату додано");
           }
         }}
       />

--- a/src/modules/nutrition/NutritionApp.jsx
+++ b/src/modules/nutrition/NutritionApp.jsx
@@ -292,18 +292,24 @@ export default function NutritionApp({
 
   const wrappedSaveMeal = useCallback(
     async (meal) => {
-      if (editingMeal?.id) {
+      const isEdit = !!editingMeal?.id;
+      if (isEdit) {
         log.handleEditMeal(editingMeal.date, meal);
         setEditingMeal(null);
       } else {
         log.handleAddMeal(meal);
       }
+      // Сигналимо успіх як у Finyk (витрати) / Routine (звички) — тост із
+      // check-pop анімацією плюс haptic зроблено вже в `AddMealSheet`
+      // на `handleSave`. Без цього користувач бачив лише те, що модалка
+      // закрилась, — це не читалось як «збережено».
+      toast.success(isEdit ? "Страву оновлено." : "Страву додано.");
       if (meal.source === "photo" && photo.fileRef?.current?.files?.[0]) {
         const blob = await fileToThumbnailBlob(photo.fileRef.current.files[0]);
         if (blob) await saveMealThumbnail(meal.id, blob);
       }
     },
-    [editingMeal, log, photo.fileRef, setEditingMeal],
+    [editingMeal, log, photo.fileRef, setEditingMeal, toast],
   );
 
   const storageBanner = [

--- a/src/modules/nutrition/components/AddMealSheet.jsx
+++ b/src/modules/nutrition/components/AddMealSheet.jsx
@@ -235,10 +235,27 @@ export function AddMealSheet({
       >
         {step === "source" ? (
           <>
-            <p className="text-xs text-muted mb-3">
-              Оберіть джерело — або заповніть вручну. Макроси, назву й час
-              відредагуєте на наступному кроці.
-            </p>
+            {/* Intro row doubles as a primary shortcut: the old paragraph
+                ended with «…або заповніть вручну» which described an
+                action hidden at the bottom of the sheet, making first-time
+                users scroll past templates/pantry/search/barcode/photo just
+                to find it. Pair the hint with an inline «Ввести вручну →»
+                link so the quickest manual log is one tap from the sheet
+                opening. The full button stays below for discoverability
+                when users scroll past the sources. */}
+            <div className="mb-3 flex items-start justify-between gap-3">
+              <p className="text-xs text-muted">
+                Оберіть джерело нижче. Макроси, назву й час відредагуєте на
+                наступному кроці.
+              </p>
+              <button
+                type="button"
+                onClick={() => setStep("fill")}
+                className="shrink-0 text-xs font-semibold text-nutrition hover:text-nutrition-hover underline decoration-dotted underline-offset-2 transition-colors min-h-[36px] px-1"
+              >
+                Ввести вручну →
+              </button>
+            </div>
 
             {/* Templates / pantry rows disappear when empty so a
                   first-time user sees search + barcode as the whole step

--- a/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
+++ b/src/modules/nutrition/components/meal-sheet/NameTimeRow.jsx
@@ -1,10 +1,20 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseMealSpeech } from "../../../../core/lib/speechParsers.js";
+import { currentTime } from "./mealFormUtils.js";
 
 export function NameTimeRow({ form, field, setForm }) {
+  // 95%+ of the time the user logs a meal «right now». Showing the time
+  // input on every open forces an extra tap past the picker in the
+  // default case — parallels the «Не сьогодні? Змінити дату» collapse
+  // in `ManualExpenseSheet`. Reveal the field only when the time differs
+  // from «now» (editing an older meal) or the user explicitly expands it.
+  const [showTime, setShowTime] = useState(false);
+  const isNow = form.time === currentTime();
+  const timeVisible = showTime || !isNow;
+
   const handleVoiceMeal = useCallback(
     (transcript) => {
       const parsed = parseMealSpeech(transcript);
@@ -24,40 +34,59 @@ export function NameTimeRow({ form, field, setForm }) {
   );
 
   return (
-    <div className="grid grid-cols-[1fr_auto] gap-3 mb-4">
-      <div>
-        <SectionHeading
-          as="div"
-          size="xs"
-          className="mb-1 flex items-center gap-2"
-        >
-          Назва страви
-          <VoiceMicButton
-            size="sm"
-            onResult={handleVoiceMeal}
-            onError={(e) => setForm((s) => ({ ...s, err: e }))}
-            label="Голосовий ввід страви"
+    <div className="mb-4">
+      <div
+        className={
+          timeVisible
+            ? "grid grid-cols-[1fr_auto] gap-3"
+            : "grid grid-cols-1 gap-3"
+        }
+      >
+        <div>
+          <SectionHeading
+            as="div"
+            size="xs"
+            className="mb-1 flex items-center gap-2"
+          >
+            Назва страви
+            <VoiceMicButton
+              size="sm"
+              onResult={handleVoiceMeal}
+              onError={(e) => setForm((s) => ({ ...s, err: e }))}
+              label="Голосовий ввід страви"
+            />
+          </SectionHeading>
+          <Input
+            value={form.name}
+            onChange={(e) => field("name")(e.target.value)}
+            placeholder="Вівсянка з бананом"
+            aria-label="Назва страви"
           />
-        </SectionHeading>
-        <Input
-          value={form.name}
-          onChange={(e) => field("name")(e.target.value)}
-          placeholder="Вівсянка з бананом"
-          aria-label="Назва страви"
-        />
+        </div>
+        {timeVisible && (
+          <div>
+            <SectionHeading as="div" size="xs" className="mb-1">
+              Час
+            </SectionHeading>
+            <Input
+              type="time"
+              value={form.time}
+              onChange={(e) => field("time")(e.target.value)}
+              aria-label="Час"
+              className="w-[100px]"
+            />
+          </div>
+        )}
       </div>
-      <div>
-        <SectionHeading as="div" size="xs" className="mb-1">
-          Час
-        </SectionHeading>
-        <Input
-          type="time"
-          value={form.time}
-          onChange={(e) => field("time")(e.target.value)}
-          aria-label="Час"
-          className="w-[100px]"
-        />
-      </div>
+      {!timeVisible && (
+        <button
+          type="button"
+          onClick={() => setShowTime(true)}
+          className="mt-2 text-xs text-muted hover:text-text underline decoration-dotted underline-offset-2 transition-colors"
+        >
+          Не зараз? Змінити час ({form.time})
+        </button>
+      )}
     </div>
   );
 }

--- a/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useToast } from "@shared/hooks/useToast";
+import { hapticSuccess } from "@shared/lib/haptic";
 import { cn } from "@shared/lib/cn";
 import { createHabit } from "../lib/routineStorage.js";
 import {
@@ -96,6 +97,7 @@ export function HabitQuickCreateDialog({
     }
     setErrors({});
     setRoutine((s) => createHabit(s, patch));
+    hapticSuccess();
     toast.success("Звичку створено.");
     onClose();
   };

--- a/src/modules/routine/components/RoutineSettingsSection.tsx
+++ b/src/modules/routine/components/RoutineSettingsSection.tsx
@@ -1,6 +1,7 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
+import { hapticSuccess } from "@shared/lib/haptic";
 import { showUndoToast } from "@shared/lib/undoToast";
 import {
   loadRoutineState,
@@ -21,7 +22,7 @@ import {
 } from "../lib/routineDraftUtils.js";
 import { HabitDetailSheet } from "./HabitDetailSheet";
 import { RoutineBackupSection } from "./RoutineBackupSection";
-import { HabitForm } from "./settings/HabitForm";
+import { HabitForm, type HabitFormErrors } from "./settings/HabitForm";
 import { TagsSection } from "./settings/TagsSection";
 import { CategoriesSection } from "./settings/CategoriesSection";
 import { ActiveHabitsSection } from "./settings/ActiveHabitsSection";
@@ -73,6 +74,26 @@ export function RoutineSettingsSection({
   const [importConfirm, setImportConfirm] = useState<ImportConfirmState | null>(
     null,
   );
+  const [habitErrors, setHabitErrors] = useState<HabitFormErrors>({});
+
+  // Clear field errors as soon as the user edits the relevant field so the
+  // red border doesn't linger once they start fixing the input. Parallels
+  // the behaviour in `HabitQuickCreateDialog` — keeps validation feedback
+  // consistent between the two hosts of `HabitForm`.
+  useEffect(() => {
+    if (habitErrors.name && habitDraft.name.trim()) {
+      setHabitErrors((e) => ({ ...e, name: undefined }));
+    }
+  }, [habitDraft.name, habitErrors.name]);
+  useEffect(() => {
+    if (
+      habitErrors.weekdays &&
+      Array.isArray(habitDraft.weekdays) &&
+      habitDraft.weekdays.length > 0
+    ) {
+      setHabitErrors((e) => ({ ...e, weekdays: undefined }));
+    }
+  }, [habitDraft.weekdays, habitErrors.weekdays]);
 
   const loadHabitIntoDraft = (h: Habit) => {
     const times = normalizeReminderTimes(h);
@@ -96,23 +117,38 @@ export function RoutineSettingsSection({
   const cancelEdit = () => {
     setEditingId(null);
     setHabitDraft(emptyHabitDraft());
+    setHabitErrors({});
   };
 
   const saveHabit = () => {
     const patch = habitDraftToPatch(habitDraft);
-    if (!patch.name) return;
+    // Inline validation — mirror `HabitQuickCreateDialog` so the user sees
+    // exactly which field to fix (red border + message) instead of a
+    // silent no-op for the name or a toast-only warning for the weekdays.
+    const nextErrors: HabitFormErrors = {};
+    if (!patch.name) {
+      nextErrors.name = "Додай назву звички.";
+    }
     if (
       patch.recurrence === "weekly" &&
       (!patch.weekdays || patch.weekdays.length === 0)
     ) {
-      toast.warning("Обери хоча б один день тижня.");
+      nextErrors.weekdays = "Обери хоча б один день тижня.";
+    }
+    if (nextErrors.name || nextErrors.weekdays) {
+      setHabitErrors(nextErrors);
       return;
     }
+    setHabitErrors({});
     if (editingId) {
       setRoutine((s) => updateHabit(s, editingId, patch));
+      hapticSuccess();
+      toast.success("Звичку оновлено.");
       cancelEdit();
     } else {
       setRoutine((s) => createHabit(s, patch));
+      hapticSuccess();
+      toast.success("Звичку створено.");
       setHabitDraft(emptyHabitDraft());
     }
   };
@@ -139,6 +175,7 @@ export function RoutineSettingsSection({
         onSave={saveHabit}
         onCancel={cancelEdit}
         focusTick={habitFormFocusTick}
+        errors={habitErrors}
       />
 
       <TagsSection


### PR DESCRIPTION
## Summary

Three core logging flows — **додати витрату**, **додати їжу**, **додати звичку** — got trimmed so each one takes fewer taps, surfaces defaults more aggressively, and signals success consistently.

### Що знайдено

| Flow | Проблема |
| --- | --- |
| Їжа | Збереження тихе — тільки haptic, без toast. «Ввести вручну» закопана в самому низу sheet-а. Поле «Час» видно завжди, хоча дефолт — «зараз». |
| Звичка (таб Налаштування) | `saveHabit` без тосту; weekdays-валідація — warning-toast замість inline-ерори. Haptic немає. |
| Витрата | У тексті toast дублюється ✅ — Toast-іконка вже рендерить check-pop. |

### Що зроблено

1. **Finyk (`FinykApp.tsx`)** — прибрав `✅ ` з `showToast("Витрату додано/оновлено")`; тепер текст чистий, а check-pop іконку малює `Toast` сам.
2. **Nutrition (`NutritionApp.jsx`)** — у `wrappedSaveMeal` додав `toast.success("Страву додано.")` / `"Страву оновлено."` щоб meal-flow мав той самий візуальний сигнал, що Finyk і Routine.
3. **Nutrition (`AddMealSheet.jsx`)** — в «source» кроці поряд з інтро-текстом тепер є акцентований лінк `Ввести вручну →`, який перескакує прямо в `fill`. Зовнішня кнопка внизу лишається для discoverability.
4. **Nutrition (`NameTimeRow.jsx`)** — «Час» колапсується, коли дорівнює `currentTime()` (аналог hidden-today-date у `ManualExpenseSheet`). Під назвою з'являється `Не зараз? Змінити час (HH:MM)` — escape hatch для редагування старіших прийомів.
5. **Routine (`RoutineSettingsSection.tsx`)** — `saveHabit` тепер повертає `HabitFormErrors` (`name`, `weekdays`) як у `HabitQuickCreateDialog`, кличе `hapticSuccess()` + `toast.success("Звичку створено." / "Звичку оновлено.")`, і чистить помилки по мірі редагування через два `useEffect` на `habitDraft.name` / `habitDraft.weekdays`.
6. **Routine (`HabitQuickCreateDialog.tsx`)** — додав `hapticSuccess()` перед тостом, щоб три flows тримали той самий haptic + toast пейринг.

Дефолти, які вже були в коді (мейл-тайп за часом дня, «всі дні тижня» для звички, топ-часта категорія для витрати), лишились — ці зміни просто роблять їх швидшими до застосування.

## Review & Testing Checklist for Human

- [ ] Nutrition → Log → Додати прийом їжі → у source-step видно `Ввести вручну →` зверху; тап одразу переводить у fill-step.
- [ ] Після збереження прийому їжі показується тост «Страву додано.» з check-pop анімацією (і «Страву оновлено.» при редагуванні існуючого meal'а).
- [ ] У fill-step поле «Час» сховане, якщо = теперішньому часу; клік на «Не зараз? Змінити час (HH:MM)» розкриває поле без втрати значення.
- [ ] Routine → Налаштування → спроба зберегти звичку з порожньою назвою → inline-ерор «Додай назву звички.» (а не silent no-op). Для `weekly` без жодного дня — inline-ерор «Обери хоча б один день тижня.» (а не toast.warning).
- [ ] Успішне збереження звички з табу Налаштування показує toast «Звичку створено.» / «Звичку оновлено.» + haptic.
- [ ] Finyk → додавання/редагування витрати → toast без подвійного ✅ («Витрату додано», не «✅ Витрату додано!»), іконка check-pop рендериться з Toast-контейнера.

### Notes

- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm test` (921 tests), `npm run build` — всі зелені локально.
- Haptic на iOS Safari — no-op (як і раніше), на Chromium Mobile вібрує `[12, 40, 18]`; `prefers-reduced-motion` вимикає і вібрацію, і `motion-safe:animate-check-pop` на іконці.
- Цей PR — чиста UX-шліфовка, нових полів у сховищах не з'являється, міграції не потрібні.

Link to Devin session: https://app.devin.ai/sessions/c39042a852d3481493ab5d3294face1c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
