### PR TITLE
fix(stories): dedupe duplicate pointerup so tap advances exactly one slide

### DIFF
--- a/src/core/WeeklyDigestStories.tsx
+++ b/src/core/WeeklyDigestStories.tsx
@@ -600,6 +600,12 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   const touchStartRef = useRef(null);
   const dragYRef = useRef(0);
   const containerRef = useRef(null);
+  // Tracks the pointerId of the currently-active gesture. Cleared on
+  // pointerup/pointercancel. Duplicate pointerup events (iOS PWA + React's
+  // delegated pointer events re-dispatch through setPointerCapture) are
+  // ignored because activePointerIdRef is already null on the second fire,
+  // so each physical tap navigates exactly once.
+  const activePointerIdRef = useRef<number | null>(null);
   // Mirror of `index` and `progress` kept in refs so the navigation helpers
   // and the auto-advance timer can read/update them without stuffing side
   // effects into `setState` updaters (React requires updater fns to be pure).
@@ -675,6 +681,11 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   // Pointer events collapse all three input sources into one stream, so each
   // physical tap triggers exactly one press-start / press-end pair.
   const handlePressStart = (e) => {
+    // Only track one pointer at a time. A second finger mid-gesture must not
+    // spin up a parallel hold-timer / drag — it would desync the state and
+    // produce phantom taps when either finger lifts.
+    if (activePointerIdRef.current !== null) return;
+    activePointerIdRef.current = e.pointerId;
     // Capture the pointer so `pointermove`/`pointerup` keep arriving even if
     // the finger slides off the element — required for the swipe-to-close
     // gesture below. Try/catch because capture can throw in old WebKit.
@@ -694,6 +705,7 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   };
 
   const handlePointerMove = (e) => {
+    if (activePointerIdRef.current !== e.pointerId) return;
     if (!touchStartRef.current) return;
     const dy = e.clientY - touchStartRef.current.y;
     if (dy > 0) {
@@ -717,6 +729,15 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
   };
 
   const handlePressEnd = (e) => {
+    // Duplicate pointerup dedupe. On iOS PWA / some Android WebViews, React's
+    // root-level pointer event delegation occasionally re-fires onPointerUp
+    // for the same physical release when setPointerCapture is in use (see
+    // https://github.com/facebook/react/issues/17685). Without this guard the
+    // tap handler ran twice and `next()` advanced indexRef by two, making the
+    // stories appear to skip every other slide. We latch on the pointerId we
+    // opened the gesture with and bail on any repeat.
+    if (activePointerIdRef.current !== e.pointerId) return;
+    activePointerIdRef.current = null;
     try {
       e.currentTarget.releasePointerCapture?.(e.pointerId);
     } catch {
@@ -754,7 +775,9 @@ export function WeeklyDigestStories({ digest, weekKey, weekRange, onClose }) {
     else next();
   };
 
-  const handlePointerCancel = () => {
+  const handlePointerCancel = (e) => {
+    if (activePointerIdRef.current !== e.pointerId) return;
+    activePointerIdRef.current = null;
     if (holdTimerRef.current) {
       clearTimeout(holdTimerRef.current);
       holdTimerRef.current = null;


### PR DESCRIPTION
## Summary

Follow-up to #346. Користувач повідомив, що сторіс тижневого дайджесту **все одно перепригують через слайд** при тапі ліворуч/праворуч — навіть після міграції на pointer events.

**Корінь залишкового бага:** на iOS PWA / деяких Android-вебв'ю React делегує pointer events через корінь, і коли активний `setPointerCapture`, `onPointerUp` може **повторно диспатчитись для того самого фізичного release** (див. [facebook/react#17685](https://github.com/facebook/react/issues/17685) і суміжні тікети). Наш `handlePressEnd` синхронно викликав `next()`, який читає й інкрементує `indexRef.current` — тож два послідовних виклики в одному тику просували індекс на **+2** замість +1.

**Фікс:** латчимо `pointerId` активного жесту у `activePointerIdRef`.

- `handlePressStart` виставляє `activePointerIdRef.current = e.pointerId` і відкидає другий pointer-down (multi-touch), що збігся з живим жестом — інакше другий палець спін-апав паралельний hold-timer і ламав стан при його відпусканні.
- `handlePressEnd` одразу на вході: якщо `activePointerIdRef.current !== e.pointerId` — `return`. Інакше очищаємо ref **до** виклику `next()`/`prev()`, тож навіть якщо React ще раз диспатчне той самий pointerup для того самого ідентифікатора, він уже не збігнеться й буде проігнорований.
- `handlePointerMove` / `handlePointerCancel` теж фільтрують по `pointerId`, щоб drag і cancel не зачіпали стан, якщо подія прилетіла від сторонньої крапки дотику.

Поведінка збережена 1:1:

- Tap у ліву третину → `prev()`, у праві дві третини → `next()`.
- Press-and-hold > 180 ms → пауза; release без tap-у не перескакує слайд.
- Swipe-down > `SWIPE_CLOSE_THRESHOLD` → `onClose()`.
- Клавіатура (Arrow keys / Space / Escape) без змін.
- Close-button (×) без змін.

Зміни у <ref_file file="/home/ubuntu/repos/Sergeant/src/core/WeeklyDigestStories.tsx" />.

## Review & Testing Checklist for Human

- [ ] Мобільний Safari (iOS, real device — не DevTools-емуляція): відкрити щотижневий дайджест-сторіс, протапати всі слайди праворуч і рахувати. Має бути рівно 1 слайд на тап, без перескоку через один.
- [ ] Android Chrome / PWA — те саме: тап ліворуч/праворуч = 1 слайд, swipe-down-to-close працює.
- [ ] Desktop: 1 клік = 1 слайд; press-and-hold ставить на паузу і release **не** advance'ить.
- [ ] Multi-touch sanity: якщо покласти другий палець мимо — перший гест не зламаний, другий ігнорується.

### Test plan

Локально перед пушем:

- `npm run lint` — clean.
- `npm run typecheck` — clean.
- `npm test -- --run` — 983/983 passing (без регресій до існуючих тестів).

Кінцеву перевірку «1 тап = 1 слайд» потрібно зробити саме на реальному мобільному пристрої, де й відтворювався баг (jsdom+vitest не моделює iOS-специфіку double-dispatch, тож автотест був би зеленим і до цього фіксу).

### Notes

- Нічого не міняв у `next()`/`prev()`/auto-advance timer — вони коректні; проблема суто в тому, що `handlePressEnd` виконувався більш ніж один раз для одного фізичного tap.
- `touch-action: none`, `setPointerCapture`, `data-story-ui` stopPropagation — все залишається як у #346.

Link to Devin session: https://app.devin.ai/sessions/14ec3deea5314a8ab4bca84fef79f7f0
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
