### PR TITLE
refactor(cloudSync): explicit state machine + retry + duplicate protection + debug hook

### DIFF
--- a/src/core/cloudSync/debugState.ts
+++ b/src/core/cloudSync/debugState.ts
@@ -1,0 +1,63 @@
+import type { SyncError, SyncState } from "./types";
+
+/**
+ * Actions the debug panel cares about, ordered loosely by how a user
+ * reads them in a log: something was enqueued, then scheduled, then a
+ * sync ran, possibly with retries, and ended in success or error.
+ */
+export type SyncDebugAction =
+  | "enqueue"
+  | "schedule"
+  | "sync"
+  | "retry"
+  | "success"
+  | "error"
+  | null;
+
+export interface CloudSyncDebugSnapshot {
+  /** Current high-level state of the sync lifecycle. */
+  state: SyncState;
+  /** Last time `onSuccess` fired — `null` until the first success. */
+  lastSyncAt: Date | null;
+  /** Last normalized error — `null` once a success lands afterwards. */
+  lastError: SyncError | null;
+  /** Most recent action the subsystem performed. */
+  lastAction: SyncDebugAction;
+  /** Monotonically-increasing id of the most recent `onStart`. */
+  syncId: number;
+}
+
+/**
+ * Module-level snapshot with a tiny pub/sub so the `useCloudSyncDebug`
+ * hook can re-render without re-implementing all the derivations here.
+ * Using module state (instead of React Context) keeps the debug hook
+ * usable from any component without adding a provider at the root.
+ */
+let snapshot: CloudSyncDebugSnapshot = {
+  state: "idle",
+  lastSyncAt: null,
+  lastError: null,
+  lastAction: null,
+  syncId: 0,
+};
+
+type Listener = (next: CloudSyncDebugSnapshot) => void;
+const listeners = new Set<Listener>();
+
+export function getDebugSnapshot(): CloudSyncDebugSnapshot {
+  return snapshot;
+}
+
+export function updateDebugSnapshot(
+  patch: Partial<CloudSyncDebugSnapshot>,
+): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) listener(snapshot);
+}
+
+export function subscribeDebug(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/core/cloudSync/engine/initialSync.ts
+++ b/src/core/cloudSync/engine/initialSync.ts
@@ -12,6 +12,7 @@ import { getModuleVersion, setModuleVersion } from "../state/versions";
 import type { EngineArgs, PullAllModuleBody, PullAllResponse } from "../types";
 import { buildModulesPayload } from "./buildPayload";
 import { replayOfflineQueue } from "./replay";
+import { retryAsync } from "./retryAsync";
 
 export type InitialSyncArgs = EngineArgs & {
   onNeedMigration(): void;
@@ -58,7 +59,9 @@ async function applyMerge(
   // markMigrationDone is skipped — matches pre-refactor behavior where
   // `if (pushRes.ok) clearAllDirty()` combined with the syncApi-throwing
   // transport meant a push failure aborted the whole initialSync.
-  await syncApi.pushAll(modules);
+  await retryAsync(() => syncApi.pushAll(modules), {
+    label: "initialSync.merge",
+  });
   clearAllDirty();
 }
 
@@ -80,8 +83,10 @@ export async function initialSync(args: InitialSyncArgs): Promise<boolean> {
   try {
     await replayOfflineQueue();
 
-    const { modules: cloudModules } =
-      (await syncApi.pullAll()) as PullAllResponse;
+    const { modules: cloudModules } = (await retryAsync(
+      () => syncApi.pullAll(),
+      { label: "initialSync.pull" },
+    )) as PullAllResponse;
 
     const plan = resolveInitialSync({
       cloud: cloudModules as
@@ -115,6 +120,7 @@ export async function initialSync(args: InitialSyncArgs): Promise<boolean> {
     onSuccess(new Date());
     return true;
   } catch (err) {
+    args.onErrorRaw?.(err);
     onError(err instanceof Error ? err.message : String(err));
     return false;
   } finally {

--- a/src/core/cloudSync/engine/pull.ts
+++ b/src/core/cloudSync/engine/pull.ts
@@ -2,6 +2,7 @@ import { syncApi } from "@shared/api";
 import { applyModuleData } from "../state/moduleData";
 import { setModuleVersion } from "../state/versions";
 import type { EngineArgs, PullAllResponse } from "../types";
+import { retryAsync } from "./retryAsync";
 
 export type PullArgs = EngineArgs;
 
@@ -9,7 +10,9 @@ export async function pullAll(args: PullArgs): Promise<boolean> {
   const { user, onStart, onSuccess, onError, onSettled } = args;
   onStart();
   try {
-    const { modules } = (await syncApi.pullAll()) as PullAllResponse;
+    const { modules } = (await retryAsync(() => syncApi.pullAll(), {
+      label: "pullAll",
+    })) as PullAllResponse;
     if (modules) {
       for (const [mod, payload] of Object.entries(modules)) {
         if (payload?.data) {
@@ -23,6 +26,7 @@ export async function pullAll(args: PullArgs): Promise<boolean> {
     onSuccess(new Date());
     return true;
   } catch (err) {
+    args.onErrorRaw?.(err);
     onError(err instanceof Error ? err.message : String(err));
     return false;
   } finally {

--- a/src/core/cloudSync/engine/push.ts
+++ b/src/core/cloudSync/engine/push.ts
@@ -12,6 +12,7 @@ import { setModuleVersion } from "../state/versions";
 import type { EngineArgs, PushAllResponse } from "../types";
 import { buildModulesPayload } from "./buildPayload";
 import { replayOfflineQueue } from "./replay";
+import { retryAsync } from "./retryAsync";
 
 export type PushArgs = EngineArgs;
 
@@ -50,7 +51,9 @@ export async function pushDirty(args: PushArgs): Promise<void> {
 
     await replayOfflineQueue();
 
-    const result = (await syncApi.pushAll(modules)) as PushAllResponse;
+    const result = (await retryAsync(() => syncApi.pushAll(modules), {
+      label: "pushDirty",
+    })) as PushAllResponse;
     const currentModified = getModuleModifiedTimes();
     if (result?.results) {
       for (const [mod, r] of Object.entries(result.results)) {
@@ -71,6 +74,7 @@ export async function pushDirty(args: PushArgs): Promise<void> {
     if (Object.keys(modules).length > 0) {
       addToOfflineQueue({ type: "push", modules });
     }
+    args.onErrorRaw?.(err);
     onError(err instanceof Error ? err.message : String(err));
   } finally {
     onSettled();
@@ -100,7 +104,9 @@ export async function pushAll(args: PushArgs): Promise<void> {
       return;
     }
 
-    const result = (await syncApi.pushAll(modules)) as PushAllResponse;
+    const result = (await retryAsync(() => syncApi.pushAll(modules), {
+      label: "pushAll",
+    })) as PushAllResponse;
     if (user?.id && result?.results) {
       for (const [mod, r] of Object.entries(result.results)) {
         if (r?.version) setModuleVersion(user.id, mod, r.version);
@@ -109,6 +115,7 @@ export async function pushAll(args: PushArgs): Promise<void> {
     clearAllDirty();
     onSuccess(new Date());
   } catch (err) {
+    args.onErrorRaw?.(err);
     onError(err instanceof Error ? err.message : String(err));
   } finally {
     onSettled();

--- a/src/core/cloudSync/engine/replay.ts
+++ b/src/core/cloudSync/engine/replay.ts
@@ -1,6 +1,7 @@
 import { syncApi } from "@shared/api";
 import { collectQueuedModules } from "../queue/collectQueued";
 import { clearOfflineQueue, getOfflineQueue } from "../queue/offlineQueue";
+import { retryAsync } from "./retryAsync";
 
 // Module-scoped re-entry guard. The original hook used a `replayingRef`; for
 // a singleton hook instance (the app mounts `useCloudSync` once) a module-
@@ -30,7 +31,9 @@ export async function replayOfflineQueue(): Promise<void> {
 
   replaying = true;
   try {
-    await syncApi.pushAll(modulesToPush);
+    await retryAsync(() => syncApi.pushAll(modulesToPush), {
+      label: "replayOfflineQueue",
+    });
     clearOfflineQueue();
   } catch {
     // Network/transport failure during replay must not break callers

--- a/src/core/cloudSync/engine/retryAsync.ts
+++ b/src/core/cloudSync/engine/retryAsync.ts
@@ -1,0 +1,53 @@
+import { updateDebugSnapshot } from "../debugState";
+import { isRetryableError } from "../errorNormalizer";
+import { syncLog } from "../logger";
+
+/**
+ * Exponential-backoff retry wrapper for engine → `syncApi` calls.
+ *
+ * Retries only for transport failures and 5xx HTTP statuses, as classified
+ * by `isRetryableError`. 4xx, parse errors, aborts and non-ApiError throws
+ * are surfaced immediately so callers never loop on an unrecoverable
+ * condition (e.g. 401 from a revoked session, or a malformed payload).
+ *
+ * Default schedule: 3 retries after the initial attempt, waiting 1s → 2s
+ * → 4s between attempts (4 total tries max).
+ */
+export interface RetryAsyncOptions {
+  maxRetries?: number;
+  delaysMs?: readonly number[];
+  /** Human-readable label included in `[cloud-sync] retry` log entries. */
+  label?: string;
+  /** Override for tests so they don't actually wait between attempts. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_DELAYS = [1000, 2000, 4000] as const;
+const DEFAULT_MAX_RETRIES = 3;
+
+export async function retryAsync<T>(
+  fn: () => Promise<T>,
+  opts: RetryAsyncOptions = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const delays = opts.delaysMs ?? DEFAULT_DELAYS;
+  const sleep =
+    opts.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let attempt = 0;
+  // We break out via `return` on success or `throw` on a terminal failure,
+  // so a plain infinite loop is clearer than instrumenting the condition.
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= maxRetries || !isRetryableError(err)) throw err;
+      const delay = delays[Math.min(attempt, delays.length - 1)];
+      syncLog.retry({ attempt: attempt + 1, delay, label: opts.label });
+      updateDebugSnapshot({ lastAction: "retry" });
+      await sleep(delay);
+      attempt += 1;
+    }
+  }
+}

--- a/src/core/cloudSync/engine/upload.ts
+++ b/src/core/cloudSync/engine/upload.ts
@@ -4,6 +4,7 @@ import { clearAllDirty, getModuleModifiedTimes } from "../state/dirtyModules";
 import { markMigrationDone } from "../state/migration";
 import type { EngineArgs } from "../types";
 import { buildModulesPayload } from "./buildPayload";
+import { retryAsync } from "./retryAsync";
 
 export type UploadArgs = EngineArgs & {
   onMigrated(): void;
@@ -23,13 +24,16 @@ export async function uploadLocalData(args: UploadArgs): Promise<void> {
       getModuleModifiedTimes(),
     );
     if (Object.keys(modules).length > 0) {
-      await syncApi.pushAll(modules);
+      await retryAsync(() => syncApi.pushAll(modules), {
+        label: "uploadLocalData",
+      });
     }
     markMigrationDone(user.id);
     clearAllDirty();
     onSuccess(new Date());
     onMigrated();
   } catch (err) {
+    args.onErrorRaw?.(err);
     onError(err instanceof Error ? err.message : String(err));
   } finally {
     onSettled();

--- a/src/core/cloudSync/errorNormalizer.ts
+++ b/src/core/cloudSync/errorNormalizer.ts
@@ -1,0 +1,71 @@
+import { isApiError } from "@shared/api";
+import type { SyncError } from "./types";
+
+/**
+ * Map any thrown value into the normalized `SyncError` shape surfaced by
+ * the hook and debug panel. Keeps the decision of "what counts as a
+ * network error" / "what counts as retryable" in one place so engines and
+ * retry logic agree.
+ *
+ * Rules:
+ *   - ApiError { kind: "network" | "aborted" }  → type: "network", retryable: true
+ *   - ApiError { kind: "http", 5xx }           → type: "server",  retryable: true
+ *   - ApiError { kind: "http", 4xx }           → type: "server",  retryable: false
+ *   - ApiError { kind: "parse" }               → type: "server",  retryable: false
+ *   - plain Error / unknown                    → type: "unknown", retryable: false
+ */
+export function toSyncError(err: unknown): SyncError {
+  if (isApiError(err)) {
+    if (err.kind === "network") {
+      return {
+        message: err.message || "Network error",
+        type: "network",
+        retryable: true,
+      };
+    }
+    if (err.kind === "aborted") {
+      // Aborted requests are transient but not user-retryable: the caller
+      // intentionally cancelled. Classify as network so UI treats it like
+      // a transient issue, but mark non-retryable to avoid looping.
+      return {
+        message: err.message || "Request aborted",
+        type: "network",
+        retryable: false,
+      };
+    }
+    if (err.kind === "http") {
+      const retryable = err.status >= 500 && err.status < 600;
+      return {
+        message: err.serverMessage || err.message || `HTTP ${err.status}`,
+        type: "server",
+        retryable,
+      };
+    }
+    // parse
+    return {
+      message: err.message || "Parse error",
+      type: "server",
+      retryable: false,
+    };
+  }
+  if (err instanceof Error) {
+    return {
+      message: err.message || "Unknown error",
+      type: "unknown",
+      retryable: false,
+    };
+  }
+  return { message: String(err), type: "unknown", retryable: false };
+}
+
+/**
+ * `true` iff the caller should retry the failed request. Matches the
+ * classification used by `toSyncError` (network + 5xx → retry; 4xx, parse,
+ * aborted, unknown → no retry).
+ */
+export function isRetryableError(err: unknown): boolean {
+  if (!isApiError(err)) return false;
+  if (err.kind === "network") return true;
+  if (err.kind === "http" && err.status >= 500 && err.status < 600) return true;
+  return false;
+}

--- a/src/core/cloudSync/hook/useCloudSync.ts
+++ b/src/core/cloudSync/hook/useCloudSync.ts
@@ -4,7 +4,7 @@ import { pullAll } from "../engine/pull";
 import { pushAll, pushDirty } from "../engine/push";
 import { uploadLocalData } from "../engine/upload";
 import { markMigrationDone } from "../state/migration";
-import type { CurrentUser } from "../types";
+import type { CurrentUser, EngineArgs, SyncCallbacks } from "../types";
 import { useEngineArgs } from "./useEngineArgs";
 import { useInitialSyncOnUser } from "./useInitialSyncOnUser";
 import { useSyncRetry } from "./useSyncRetry";
@@ -22,14 +22,19 @@ import { useSyncRetry } from "./useSyncRetry";
  *      periodic timer — to the executor below.
  *
  *   3. Executor (how to actually call the API)
- *      The `run*` callbacks below each wrap one engine entry point in the
- *      in-flight guard (`runExclusive`) so we never fire concurrent syncs.
+ *      The `run*` callbacks below each wrap one engine entry point in
+ *      `runExclusive`, which combines the in-flight guard with freshly
+ *      sync-id-bound lifecycle callbacks. This is what prevents a
+ *      preempted engine (see `runUploadLocal`) from overwriting state
+ *      belonging to a newer sync.
  *
  * Public state surface:
- *   - `isSyncing`   (legacy alias: `syncing`)
+ *   - `state`       new explicit state-machine value
+ *   - `isSyncing`   (legacy alias: `syncing`) — derived from `state`
  *   - `lastSyncAt`  (legacy alias: `lastSync`)
- *   - `hasError`    derived from the underlying error message; legacy alias
- *                   `syncError` still exposes the raw message.
+ *   - `hasError`    derived from `state`; legacy alias `syncError` still
+ *                   exposes the raw message and `syncErrorDetail` exposes
+ *                   the structured { type, retryable } shape.
  *   - `migrationPending` drives the first-run migration modal.
  */
 export function useCloudSync(user: CurrentUser | null | undefined) {
@@ -42,51 +47,63 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     syncing,
     lastSync,
     syncError,
+    state,
+    syncErrorDetail,
     runExclusive,
-    claimBusy,
+    runBypassed,
   } = lifecycle;
 
-  // --- 3. Executor: API calls, each serialized through the in-flight guard.
+  // --- 3. Executor: API calls, each serialized through the in-flight
+  // guard and invoked with sync-id-bound callbacks that no-op if a newer
+  // sync supersedes this one.
+
+  const withCb = useCallback(
+    (cb: SyncCallbacks): EngineArgs => ({ ...engineArgs, ...cb }),
+    [engineArgs],
+  );
 
   const runSync = useCallback(
-    () => runExclusive(() => pushDirty(engineArgs), undefined),
-    [engineArgs, runExclusive],
+    () => runExclusive((cb) => pushDirty(withCb(cb)), undefined),
+    [withCb, runExclusive],
   );
 
   const runPushAll = useCallback(
-    () => runExclusive(() => pushAll(engineArgs), undefined),
-    [engineArgs, runExclusive],
+    () => runExclusive((cb) => pushAll(withCb(cb)), undefined),
+    [withCb, runExclusive],
   );
 
   const runPullAll = useCallback(
-    () => runExclusive(() => pullAll(engineArgs), false),
-    [engineArgs, runExclusive],
+    () => runExclusive((cb) => pullAll(withCb(cb)), false),
+    [withCb, runExclusive],
   );
 
   const runInitialSync = useCallback(
     (): Promise<boolean> =>
       runExclusive(
-        () =>
+        (cb) =>
           initialSync({
-            ...engineArgs,
+            ...withCb(cb),
             onNeedMigration: () => setMigrationPending(true),
           }),
         false,
       ),
-    [engineArgs, runExclusive],
+    [withCb, runExclusive],
   );
 
   const runUploadLocal = useCallback(async () => {
     if (!user?.id) return;
     // Intentionally bypasses the in-flight guard: this is user-initiated
-    // from the migration modal and must proceed even if a background retry
-    // is mid-flight.
-    claimBusy();
-    await uploadLocalData({
-      ...engineArgs,
-      onMigrated: () => setMigrationPending(false),
-    });
-  }, [user, engineArgs, claimBusy]);
+    // from the migration modal and must proceed even if a background
+    // retry is mid-flight. `runBypassed` pairs the force-claim with a
+    // fresh sync-id so stale callbacks from the preempted retry can't
+    // overwrite the upload's lifecycle state.
+    await runBypassed((cb) =>
+      uploadLocalData({
+        ...withCb(cb),
+        onMigrated: () => setMigrationPending(false),
+      }),
+    );
+  }, [user, withCb, runBypassed]);
 
   const skipMigration = useCallback(() => {
     if (!user?.id) return;
@@ -109,6 +126,8 @@ export function useCloudSync(user: CurrentUser | null | undefined) {
     isSyncing,
     lastSyncAt,
     hasError,
+    state,
+    syncErrorDetail,
     // Legacy aliases kept so existing consumers (App.tsx, tests) compile.
     syncing,
     lastSync,

--- a/src/core/cloudSync/hook/useCloudSyncDebug.ts
+++ b/src/core/cloudSync/hook/useCloudSyncDebug.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { SYNC_EVENT, SYNC_STATUS_EVENT } from "../config";
+import {
+  getDebugSnapshot,
+  subscribeDebug,
+  type CloudSyncDebugSnapshot,
+} from "../debugState";
+import { getOfflineQueue } from "../queue/offlineQueue";
+
+/**
+ * Everything `useCloudSyncDebug` exposes for inline diagnostics: the live
+ * `CloudSyncDebugSnapshot` (state machine + last error + last action +
+ * sync-id) plus a live `queueSize` reading off the offline queue.
+ *
+ * This is intended for a dev-only debug panel or `console.log` bindings —
+ * NOT the user-facing sync UI. UI consumers should keep using
+ * `useCloudSync` / `useSyncStatus`.
+ */
+export interface CloudSyncDebugView extends CloudSyncDebugSnapshot {
+  queueSize: number;
+}
+
+function readQueueSize(): number {
+  try {
+    return getOfflineQueue().length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Read-only debug view of the cloud-sync subsystem. Subscribes to the
+ * module-level debug snapshot (written by `useSyncCallbacks`, the logger,
+ * and the scheduler) plus the existing `SYNC_EVENT` / `SYNC_STATUS_EVENT`
+ * window events, so the returned `queueSize` stays in sync without us
+ * polling.
+ */
+export function useCloudSyncDebug(): CloudSyncDebugView {
+  const [snapshot, setSnapshot] = useState<CloudSyncDebugSnapshot>(() =>
+    getDebugSnapshot(),
+  );
+  const [queueSize, setQueueSize] = useState<number>(() => readQueueSize());
+
+  useEffect(() => subscribeDebug(setSnapshot), []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const update = () => setQueueSize(readQueueSize());
+    // Prime on mount so a consumer rendered after the queue was populated
+    // doesn't wait for the next event to see a non-zero size.
+    update();
+    window.addEventListener(SYNC_EVENT, update);
+    window.addEventListener(SYNC_STATUS_EVENT, update);
+    return () => {
+      window.removeEventListener(SYNC_EVENT, update);
+      window.removeEventListener(SYNC_STATUS_EVENT, update);
+    };
+  }, []);
+
+  return { ...snapshot, queueSize };
+}

--- a/src/core/cloudSync/hook/useEngineArgs.ts
+++ b/src/core/cloudSync/hook/useEngineArgs.ts
@@ -28,10 +28,10 @@ export function useEngineArgs(
   user: CurrentUser | null | undefined,
 ): UseEngineArgsResult {
   const lifecycle = useSyncCallbacks();
-  const { onStart, onSuccess, onError, onSettled } = lifecycle;
+  const { onStart, onSuccess, onError, onErrorRaw, onSettled } = lifecycle;
   const engineArgs: EngineArgs = useMemo(
-    () => ({ user, onStart, onSuccess, onError, onSettled }),
-    [user, onStart, onSuccess, onError, onSettled],
+    () => ({ user, onStart, onSuccess, onError, onErrorRaw, onSettled }),
+    [user, onStart, onSuccess, onError, onErrorRaw, onSettled],
   );
   return { engineArgs, lifecycle };
 }

--- a/src/core/cloudSync/hook/useSyncCallbacks.ts
+++ b/src/core/cloudSync/hook/useSyncCallbacks.ts
@@ -1,32 +1,60 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { updateDebugSnapshot } from "../debugState";
+import { toSyncError } from "../errorNormalizer";
 import { syncLog } from "../logger";
-import type { SyncCallbacks } from "../types";
+import type { SyncCallbacks, SyncError, SyncState } from "../types";
 
 export type { SyncCallbacks };
 
 export interface SyncLifecycle extends SyncCallbacks {
-  // Legacy names — kept because existing consumers (App.tsx, tests) read them.
+  // --- Legacy field names — kept because existing consumers (App.tsx,
+  // UserMenuButton, useCloudSyncHelpers tests) read them. New code should
+  // prefer `isSyncing`/`lastSyncAt`/`hasError`/`state`.
   syncing: boolean;
   lastSync: Date | null;
   syncError: string | null;
-  // Explicit, self-documenting aliases. Prefer these in new code.
+
+  // --- Explicit, self-documenting aliases.
   isSyncing: boolean;
   lastSyncAt: Date | null;
   hasError: boolean;
+
+  // --- New state-machine surface.
+  /** Current state of the cloud-sync lifecycle. */
+  state: SyncState;
+  /** Normalized error shape (type, retryable) — `null` on success paths. */
+  syncErrorDetail: SyncError | null;
+
   /**
-   * Run `fn` only if no other sync operation is in flight; otherwise return
-   * `fallback` synchronously. Sets the in-flight flag before calling `fn`
-   * and clears it unconditionally once `fn` settles (success OR failure OR
-   * early return), so an engine path that returns before its own try/finally
-   * cannot leave the guard stuck. `onSettled` is still responsible for
-   * clearing `syncing` state inside React; the release here is idempotent
-   * with that.
+   * Run `engine` under the in-flight guard: acquires the guard, bumps the
+   * sync-id counter, passes `engine` a freshly-bound `SyncCallbacks` that
+   * refuse to mutate lifecycle state after a newer sync has started, and
+   * releases the guard when the engine settles. Returns `fallback`
+   * synchronously if another sync is already in flight.
+   *
+   * The bound callbacks carry the id assigned at acquisition time. If a
+   * later operation bypasses the guard via `claimBusy`, its fresh callbacks
+   * (obtained from a subsequent `runExclusive` or from `runBypassed`) use a
+   * newer id and any stale callback invocations from the preempted engine
+   * become no-ops — they cannot overwrite `state` / `lastSyncAt` /
+   * `syncError` belonging to the newer sync.
    */
-  runExclusive<T>(fn: () => Promise<T>, fallback: T): Promise<T>;
+  runExclusive<T>(
+    engine: (cb: SyncCallbacks) => Promise<T>,
+    fallback: T,
+  ): Promise<T>;
+
   /**
-   * Force the in-flight flag to `true` without checking. Used by
-   * user-initiated operations (currently just the migration upload) that
-   * must not be blocked by a background retry.
+   * Force-claim the guard and run `engine` with fresh sync-id-bound
+   * callbacks. Used by the migration upload path, which must preempt any
+   * background retry that is mid-flight.
+   */
+  runBypassed<T>(engine: (cb: SyncCallbacks) => Promise<T>): Promise<T>;
+
+  /**
+   * Force the in-flight flag to `true` without checking. Retained for
+   * backward compatibility; new code should prefer `runBypassed` so the
+   * bound callbacks are established together with the guard claim.
    */
   claimBusy(): void;
 }
@@ -82,59 +110,255 @@ export async function runExclusiveWith<T>(
 }
 
 /**
- * Owns the React state that reflects the cloud-sync lifecycle (`syncing`,
- * `lastSync`, `syncError`) together with the in-flight concurrency guard.
- * The orchestrator composes these into an `engineArgs` bag once and passes
- * that into each engine entry point.
+ * Owns the React state that reflects the cloud-sync lifecycle (`state`,
+ * `lastSyncAt`, error) together with the in-flight concurrency guard and
+ * a monotonically-increasing sync-id counter. The orchestrator composes
+ * these into an `engineArgs` bag once and, for each run, passes freshly
+ * bound callbacks (tied to an id) into the engine.
  */
 export function useSyncCallbacks(): SyncLifecycle {
-  const [isSyncing, setIsSyncing] = useState(false);
+  const [state, setStateValue] = useState<SyncState>("idle");
   const [lastSyncAt, setLastSyncAt] = useState<Date | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const guardRef = useRef<InFlightGuard>(createInFlightGuard());
+  const [syncErrorDetail, setSyncErrorDetail] = useState<SyncError | null>(
+    null,
+  );
 
-  const onStart = useCallback(() => {
-    syncLog.syncStart();
-    setIsSyncing(true);
-    setErrorMessage(null);
+  const stateRef = useRef<SyncState>("idle");
+  const guardRef = useRef<InFlightGuard>(createInFlightGuard());
+  const syncIdCounterRef = useRef<number>(0);
+  const activeSyncIdRef = useRef<number>(0);
+
+  const setState = useCallback((next: SyncState, syncId?: number) => {
+    const from = stateRef.current;
+    if (from === next) return;
+    stateRef.current = next;
+    setStateValue(next);
+    syncLog.stateChange({ from, to: next, syncId });
+    updateDebugSnapshot({ state: next });
   }, []);
-  const onSuccess = useCallback((when: Date) => {
-    syncLog.syncSuccess({ at: when });
-    setLastSyncAt(when);
-  }, []);
-  const onError = useCallback((message: string) => {
-    syncLog.syncError({ message });
-    setErrorMessage(message);
-  }, []);
-  const onSettled = useCallback(() => {
-    setIsSyncing(false);
-    guardRef.current.release();
-  }, []);
+
+  /**
+   * Build a fresh set of callbacks tied to a specific `syncId`. Each
+   * callback short-circuits when its captured id no longer matches the
+   * currently-active id, preventing a preempted engine from clobbering
+   * state that belongs to the newer sync.
+   *
+   * `onErrorRaw(err)` is invoked by engines immediately before
+   * `onError(message)` and stashes the raw thrown value in a closure slot
+   * so the subsequent `onError` call can classify it via `toSyncError`
+   * without changing its historical single-argument string signature.
+   */
+  const makeBoundCallbacks = useCallback(
+    (syncId: number): SyncCallbacks => {
+      const isActive = () => activeSyncIdRef.current === syncId;
+      let lastRawError: { value: unknown; set: boolean } = {
+        value: undefined,
+        set: false,
+      };
+      return {
+        onStart: () => {
+          if (!isActive()) {
+            syncLog.supersededCallback({
+              kind: "onStart",
+              staleSyncId: syncId,
+              activeSyncId: activeSyncIdRef.current,
+            });
+            return;
+          }
+          syncLog.syncStart({ syncId });
+          setErrorMessage(null);
+          setSyncErrorDetail(null);
+          updateDebugSnapshot({
+            lastAction: "sync",
+            lastError: null,
+            syncId,
+          });
+          setState("syncing", syncId);
+        },
+        onSuccess: (when: Date) => {
+          if (!isActive()) {
+            syncLog.supersededCallback({
+              kind: "onSuccess",
+              staleSyncId: syncId,
+              activeSyncId: activeSyncIdRef.current,
+            });
+            return;
+          }
+          syncLog.syncSuccess({ at: when, syncId });
+          setLastSyncAt(when);
+          updateDebugSnapshot({
+            lastSyncAt: when,
+            lastAction: "success",
+            lastError: null,
+          });
+          setState("success", syncId);
+        },
+        onErrorRaw: (err: unknown) => {
+          // Stash the raw error so the subsequent `onError(message)`
+          // can classify it without changing its single-arg signature.
+          lastRawError = { value: err, set: true };
+        },
+        onError: (message: string) => {
+          if (!isActive()) {
+            syncLog.supersededCallback({
+              kind: "onError",
+              staleSyncId: syncId,
+              activeSyncId: activeSyncIdRef.current,
+            });
+            // Drain the raw-error stash even on a superseded path so it
+            // does not leak into a later call in the same closure.
+            lastRawError = { value: undefined, set: false };
+            return;
+          }
+          const detail: SyncError = lastRawError.set
+            ? toSyncError(lastRawError.value)
+            : { message, type: "unknown", retryable: false };
+          lastRawError = { value: undefined, set: false };
+          syncLog.syncError({ message, error: detail, syncId });
+          setErrorMessage(message);
+          setSyncErrorDetail(detail);
+          updateDebugSnapshot({ lastError: detail, lastAction: "error" });
+          setState("error", syncId);
+        },
+        onSettled: () => {
+          // Always release the guard, even for superseded callbacks — a
+          // stale engine's `finally { onSettled() }` is our signal that
+          // the preempted request actually finished, and keeping the
+          // guard held would block the newer sync we just started.
+          guardRef.current.release();
+          if (!isActive()) {
+            syncLog.supersededCallback({
+              kind: "onSettled",
+              staleSyncId: syncId,
+              activeSyncId: activeSyncIdRef.current,
+            });
+            return;
+          }
+          // If the engine forgot to transition (e.g. bypassed both
+          // onSuccess and onError), fall back to `idle` so the UI
+          // doesn't stay stuck in `syncing`.
+          if (stateRef.current === "syncing") setState("idle", syncId);
+        },
+      };
+    },
+    [setState],
+  );
 
   const runExclusive = useCallback(
-    <T>(fn: () => Promise<T>, fallback: T): Promise<T> =>
-      runExclusiveWith(guardRef.current, fn, fallback),
-    [],
+    async <T>(
+      engine: (cb: SyncCallbacks) => Promise<T>,
+      fallback: T,
+    ): Promise<T> => {
+      if (!guardRef.current.tryAcquire()) return fallback;
+      syncIdCounterRef.current += 1;
+      const mySyncId = syncIdCounterRef.current;
+      activeSyncIdRef.current = mySyncId;
+      const boundCallbacks = makeBoundCallbacks(mySyncId);
+      try {
+        return await engine(boundCallbacks);
+      } finally {
+        // `onSettled` already releases the guard on the happy path; this is
+        // a belt-and-braces release for engine paths that throw before
+        // reaching their own finally, so the guard cannot stay held.
+        guardRef.current.release();
+      }
+    },
+    [makeBoundCallbacks],
+  );
+
+  const runBypassed = useCallback(
+    async <T>(engine: (cb: SyncCallbacks) => Promise<T>): Promise<T> => {
+      guardRef.current.forceClaim();
+      syncIdCounterRef.current += 1;
+      const mySyncId = syncIdCounterRef.current;
+      activeSyncIdRef.current = mySyncId;
+      const boundCallbacks = makeBoundCallbacks(mySyncId);
+      try {
+        return await engine(boundCallbacks);
+      } finally {
+        guardRef.current.release();
+      }
+    },
+    [makeBoundCallbacks],
   );
 
   const claimBusy = useCallback(() => {
     guardRef.current.forceClaim();
   }, []);
 
-  return {
-    // Legacy aliases (kept to preserve public shape).
-    syncing: isSyncing,
-    lastSync: lastSyncAt,
-    syncError: errorMessage,
-    // Explicit names.
-    isSyncing,
-    lastSyncAt,
-    hasError: errorMessage !== null,
-    onStart,
-    onSuccess,
-    onError,
-    onSettled,
-    runExclusive,
-    claimBusy,
-  };
+  // --- Passthrough SyncCallbacks for callers that reach through
+  // `SyncLifecycle` itself (rare, but kept for backward compatibility).
+  // These use the *latest* active sync-id so they still participate in
+  // the guard / no-op-on-supersede contract.
+  const onStart = useCallback(() => {
+    makeBoundCallbacks(activeSyncIdRef.current).onStart();
+  }, [makeBoundCallbacks]);
+  const onSuccess = useCallback(
+    (when: Date) => {
+      makeBoundCallbacks(activeSyncIdRef.current).onSuccess(when);
+    },
+    [makeBoundCallbacks],
+  );
+  const onError = useCallback(
+    (message: string) => {
+      makeBoundCallbacks(activeSyncIdRef.current).onError(message);
+    },
+    [makeBoundCallbacks],
+  );
+  const onErrorRaw = useCallback(
+    (err: unknown) => {
+      const cb = makeBoundCallbacks(activeSyncIdRef.current);
+      cb.onErrorRaw?.(err);
+    },
+    [makeBoundCallbacks],
+  );
+  const onSettled = useCallback(() => {
+    makeBoundCallbacks(activeSyncIdRef.current).onSettled();
+  }, [makeBoundCallbacks]);
+
+  const isSyncing = state === "syncing";
+  const hasError = state === "error";
+
+  return useMemo<SyncLifecycle>(
+    () => ({
+      // Legacy aliases.
+      syncing: isSyncing,
+      lastSync: lastSyncAt,
+      syncError: errorMessage,
+      // Explicit names.
+      isSyncing,
+      lastSyncAt,
+      hasError,
+      // State machine.
+      state,
+      syncErrorDetail,
+      // Callbacks (usable directly but normally invoked via bound callbacks).
+      onStart,
+      onSuccess,
+      onError,
+      onErrorRaw,
+      onSettled,
+      // Concurrency controls.
+      runExclusive,
+      runBypassed,
+      claimBusy,
+    }),
+    [
+      isSyncing,
+      lastSyncAt,
+      errorMessage,
+      hasError,
+      state,
+      syncErrorDetail,
+      onStart,
+      onSuccess,
+      onError,
+      onErrorRaw,
+      onSettled,
+      runExclusive,
+      runBypassed,
+      claimBusy,
+    ],
+  );
 }

--- a/src/core/cloudSync/hook/useSyncRetry.ts
+++ b/src/core/cloudSync/hook/useSyncRetry.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { SYNC_EVENT } from "../config";
+import { updateDebugSnapshot } from "../debugState";
 import { replayOfflineQueue } from "../engine/replay";
 import { syncLog } from "../logger";
 import { getDirtyModules } from "../state/dirtyModules";
@@ -36,17 +37,20 @@ export function useSyncRetry(enabled: boolean, runSync: () => void): void {
 
     const scheduleFromOnline = () => {
       syncLog.scheduleSync({ reason: "online" });
+      updateDebugSnapshot({ lastAction: "schedule" });
       replayOfflineQueue().then(runSync);
     };
 
     const scheduleFromChange = () => {
       syncLog.scheduleSync({ reason: "change" });
+      updateDebugSnapshot({ lastAction: "schedule" });
       debouncer.schedule(runSync);
     };
 
     const scheduleFromTimer = () => {
       if (Object.keys(getDirtyModules()).length === 0) return;
       syncLog.scheduleSync({ reason: "periodic" });
+      updateDebugSnapshot({ lastAction: "schedule" });
       runSync();
     };
 

--- a/src/core/cloudSync/index.ts
+++ b/src/core/cloudSync/index.ts
@@ -16,7 +16,13 @@ export { getOfflineQueue } from "./queue/offlineQueue";
 export { enqueueChange, notifySyncDirty } from "./storagePatch";
 
 export { useCloudSync } from "./hook/useCloudSync";
+export { useCloudSyncDebug } from "./hook/useCloudSyncDebug";
+export type { CloudSyncDebugView } from "./hook/useCloudSyncDebug";
 export { useSyncStatus } from "./hook/useSyncStatus";
+export type { CloudSyncDebugSnapshot, SyncDebugAction } from "./debugState";
+export type { SyncError, SyncState } from "./types";
+export { toSyncError, isRetryableError } from "./errorNormalizer";
+export { retryAsync } from "./engine/retryAsync";
 
 // Internal exports kept for existing tests — see useCloudSync.hardening.test.js
 export { parseDateSafe as __internal_parseDateSafe } from "./conflict/parseDate";

--- a/src/core/cloudSync/logger.ts
+++ b/src/core/cloudSync/logger.ts
@@ -11,6 +11,8 @@
  * localStorage disabled, SSR).
  */
 
+import type { SyncError, SyncState } from "./types";
+
 type LogPayload = Record<string, unknown> | undefined;
 
 function isEnabled(): boolean {
@@ -48,8 +50,18 @@ export const syncLog = {
     write("enqueue", info),
   scheduleSync: (info: { reason: "online" | "change" | "periodic" }) =>
     write("schedule", info),
-  syncStart: () => write("sync:start"),
-  syncSuccess: (info: { at: Date }) =>
-    write("sync:success", { at: info.at.toISOString() }),
-  syncError: (info: { message: string }) => write("sync:error", info),
+  syncStart: (info?: { syncId?: number }) => write("sync:start", info),
+  syncSuccess: (info: { at: Date; syncId?: number }) =>
+    write("sync:success", { at: info.at.toISOString(), syncId: info.syncId }),
+  syncError: (info: { message: string; error?: SyncError; syncId?: number }) =>
+    write("sync:error", info),
+  stateChange: (info: { from: SyncState; to: SyncState; syncId?: number }) =>
+    write("state", info),
+  retry: (info: { attempt: number; delay: number; label?: string }) =>
+    write("retry", info),
+  supersededCallback: (info: {
+    kind: "onStart" | "onSuccess" | "onError" | "onSettled";
+    staleSyncId: number;
+    activeSyncId: number;
+  }) => write("superseded", info),
 };

--- a/src/core/cloudSync/storagePatch.ts
+++ b/src/core/cloudSync/storagePatch.ts
@@ -4,6 +4,7 @@
 import "./state/dirtyModules";
 
 import { ALL_TRACKED_KEYS, keyToModule } from "./config";
+import { updateDebugSnapshot } from "./debugState";
 import { syncLog } from "./logger";
 import { markModuleDirty } from "./state/dirtyModules";
 import { emitSyncEvent } from "./state/events";
@@ -38,6 +39,7 @@ export function enqueueChange(changedKey?: string): void {
     if (module) markModuleDirty(module);
   }
   syncLog.enqueue({ key: changedKey, module });
+  updateDebugSnapshot({ lastAction: "enqueue" });
   emitSyncEvent();
 }
 

--- a/src/core/cloudSync/types.ts
+++ b/src/core/cloudSync/types.ts
@@ -1,14 +1,64 @@
 import type { ModuleName } from "./config";
 
 /**
+ * Explicit state machine for the cloud-sync lifecycle. Historically the
+ * hook exposed a handful of booleans (`syncing`, `syncError`, …) that had
+ * to be read together to reason about what the sync subsystem was doing.
+ * A single `SyncState` value makes transitions auditable and avoids the
+ * "two bools disagree" class of bugs. The legacy booleans are kept as
+ * derived getters on the hook return value so existing consumers compile
+ * unchanged.
+ *
+ * Transitions (intent):
+ *   idle   → dirty            (local write marked a module dirty)
+ *   dirty  → queued           (offline enqueue before server reached)
+ *   *      → syncing          (onStart)
+ *   syncing → success         (onSuccess)
+ *   syncing → error           (onError)
+ *   success|error → idle      (onSettled, if nothing new is queued)
+ */
+export type SyncState =
+  | "idle"
+  | "dirty"
+  | "queued"
+  | "syncing"
+  | "success"
+  | "error";
+
+/**
+ * Normalized error shape exposed to the UI and debug hook. Engines emit raw
+ * errors (typically `ApiError` from the transport layer) and the lifecycle
+ * layer maps them into this shape via `toSyncError`.
+ *
+ * `retryable` is `true` for transport failures (network) and 5xx HTTP
+ * statuses; it is `false` for 4xx (auth / validation) and `parse` errors,
+ * so callers never loop on an unrecoverable state.
+ */
+export interface SyncError {
+  message: string;
+  type: "network" | "server" | "unknown";
+  retryable: boolean;
+}
+
+/**
  * Lifecycle callbacks every engine entry point (pushDirty, pushAll,
  * pullAll, initialSync, uploadLocalData) accepts. The React hook owns
  * the implementations via `useSyncCallbacks`; engines only invoke them.
+ *
+ * `onError` keeps its historical single-argument string shape so existing
+ * engines and tests compile and match unchanged. The optional
+ * `onErrorRaw` sidecar is invoked immediately before `onError` by the
+ * engines and carries the original thrown value so the lifecycle layer
+ * can classify it (network vs. 5xx vs. unknown) without parsing message
+ * text. Consumers that don't care about structured errors (e.g. unit
+ * tests that mock only `onError`) can simply leave `onErrorRaw`
+ * undefined — engines invoke it via optional chaining.
  */
 export interface SyncCallbacks {
   onStart(): void;
   onSuccess(when: Date): void;
   onError(message: string): void;
+  onErrorRaw?(err: unknown): void;
   onSettled(): void;
 }
 


### PR DESCRIPTION
## Summary

Reworks `src/core/cloudSync` so it reads as an explicit state machine, retries transient failures, cannot be clobbered by a preempted sync, and exposes a dedicated debug surface — all without touching API responses, transport, the localStorage schema, or the existing test suite.

### 1. Explicit `SyncState` machine
- New `SyncState = "idle" | "dirty" | "queued" | "syncing" | "success" | "error"` in `types.ts`.
- `useSyncCallbacks` now owns a `stateRef` + `setState(next, syncId)` and emits a `[cloud-sync] state` log on every transition.
- Legacy fields (`syncing`, `lastSync`, `syncError`) are kept as derived aliases on the hook return value — no consumer change required. A new `syncErrorDetail: SyncError | null` and `state: SyncState` are exposed alongside.

### 2. Retry with exponential backoff
- New `engine/retryAsync.ts` wraps `syncApi` calls with `maxRetries = 3`, delays `1s → 2s → 4s`.
- Retries only on `ApiError` where `kind === "network"` or HTTP 5xx. Does **not** retry 4xx, parse, aborted, or non-ApiError throws — classification is centralized in `errorNormalizer.ts#isRetryableError`.
- Wired into `pushDirty`, `pushAll`, `pullAll`, `initialSync` (both `pullAll` and the merge-path `pushAll`), `replayOfflineQueue`, and `uploadLocalData`.

### 3. Protection against duplicate syncs
- `useSyncCallbacks` keeps a monotonic `syncIdCounterRef` + `activeSyncIdRef`.
- New `runExclusive((cb) => engine(cb), fallback)` bumps the counter at acquire time and passes engines freshly-bound `SyncCallbacks` tied to that id. A preempted engine's later `onSuccess` / `onError` / `onSettled` no-op instead of clobbering state belonging to the newer sync (logged as `[cloud-sync] superseded`).
- New `runBypassed((cb) => ...)` replaces the raw `claimBusy()` pattern for the migration upload path so preemption pairs the force-claim with a fresh sync-id.

### 4. Normalized `SyncError` shape
- `SyncError = { message, type: "network" | "server" | "unknown", retryable: boolean }`.
- New `errorNormalizer.ts#toSyncError` classifies `ApiError.kind` + HTTP status into this shape.
- Engines add an optional `onErrorRaw?(err)` sidecar call immediately before `onError(message)`. `onError`'s historical single-argument string signature is preserved (so existing tests using `toHaveBeenCalledWith("network down")` still match), and the hook consumes the stashed raw error to populate `syncErrorDetail`.

### 5. `useCloudSyncDebug()` hook
- Returns `{ state, lastSyncAt, lastError, lastAction, syncId, queueSize }` from a module-level `debugState` snapshot that is updated by the lifecycle, scheduler, retry wrapper, and `enqueueChange`.
- Read-only — intended for a dev-only debug panel / `console.log`, **not** for UI. UI callers keep using `useCloudSync` / `useSyncStatus`.

### 6. Mutex for parallel operations
- The existing in-flight guard already prevents concurrent push/pull/initialSync. `runExclusive` now additionally ties the guard to the sync-id mechanism, so "force-claim from upload preempts background retry" is safe (stale callbacks no-op).

### 7. Richer `[cloud-sync]` logs
- New methods on `syncLog`: `stateChange({from, to, syncId})`, `retry({attempt, delay, label})`, `supersededCallback({kind, staleSyncId, activeSyncId})`.
- `syncStart` / `syncSuccess` / `syncError` now carry `syncId` so log traces can be correlated.

### 8. Not touched
- `@shared/api` transport (`httpClient`, `syncApi`), API response shapes, localStorage keys / serialization, or any existing test file.

### Backward compatibility
- `useCloudSync` return shape keeps every previously-public field. `syncing` / `lastSync` / `syncError` still behave identically from a consumer's point of view. New fields (`state`, `syncErrorDetail`) are additive.
- `SyncCallbacks.onError(message: string)` is unchanged; the new `onErrorRaw?` is optional and invoked via optional chaining, so mocks that only provide `onError` still work.

## Review & Testing Checklist for Human

- [ ] Spot-check `useSyncCallbacks.ts` — the sync-id closure per `makeBoundCallbacks` is the most subtle piece; confirm the "superseded callback no-ops" intent reads correctly for `onSettled` (which still releases the guard even when superseded, by design).
- [ ] Enable `localStorage.HUB_DEBUG_SYNC = "1"` (or a dev build) and watch the console while switching between offline and online: you should see a `[cloud-sync] state` trace going `idle → syncing → success`, and after a 5xx/network fault a `[cloud-sync] retry { attempt: 1, delay: 1000 }` followed by eventual success or `[cloud-sync] state { from: "syncing", to: "error" }`.
- [ ] Sanity-check the migration flow (first sign-in with local data): `runBypassed` should preempt any in-flight retry so the upload's `onSuccess` lands without a stale `onError` from the cancelled retry flipping `syncErrorDetail`.
- [ ] Optional: add a `useCloudSyncDebug()` panel in the dev menu and verify `queueSize`, `lastAction`, and `syncId` update as expected across offline-queue → replay → success.

### Notes
- `runExclusive`'s signature changed from `(() => Promise<T>, fallback)` to `((cb: SyncCallbacks) => Promise<T>, fallback)`. Only `useCloudSync.ts` calls it, and all call sites are updated. The lower-level pure helper `runExclusiveWith(guard, fn, fallback)` (used by unit tests in `useSyncCallbacks.test.ts`) is unchanged.
- `retryAsync`'s classification delegates to `isRetryableError` so any future change to what counts as "retryable" stays in one file.
- Existing test suite passes: 98 test files / 983 tests green locally (`npm run test`), and `npm run typecheck` + `npm run lint` are clean.


Link to Devin session: https://app.devin.ai/sessions/e619561dc22a47bebf9f4b995069ba82
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
