### PR TITLE
test: harden mobile gestures, undo flows, and cloud-sync scheduler (Sprint 1)

### DIFF
--- a/src/core/cloudSync/hook/useSyncRetry.test.ts
+++ b/src/core/cloudSync/hook/useSyncRetry.test.ts
@@ -1,0 +1,134 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  replayOfflineQueueMock: vi.fn(() => Promise.resolve()),
+  getDirtyModulesMock: vi.fn<[], Record<string, unknown>>(() => ({})),
+}));
+const { replayOfflineQueueMock, getDirtyModulesMock } = mocks;
+
+vi.mock("../engine/replay", () => ({
+  replayOfflineQueue: mocks.replayOfflineQueueMock,
+}));
+vi.mock("../state/dirtyModules", () => ({
+  getDirtyModules: mocks.getDirtyModulesMock,
+}));
+vi.mock("../logger", () => ({
+  syncLog: { scheduleSync: vi.fn() },
+}));
+
+import { useSyncRetry } from "./useSyncRetry";
+import { SYNC_EVENT } from "../config";
+
+describe("useSyncRetry — scheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    replayOfflineQueueMock.mockReset();
+    replayOfflineQueueMock.mockImplementation(() => Promise.resolve());
+    getDirtyModulesMock.mockReset();
+    getDirtyModulesMock.mockReturnValue({});
+  });
+  afterEach(() => {
+    // vitest.config.js не вмикає `globals: true`, тому
+    // @testing-library/react не реєструє afterEach cleanup автоматично —
+    // без ручного виклику renderHook-листенери з попередніх тестів
+    // залишаються на window і ламають cross-test очікування.
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("online event → replayOfflineQueue, далі runSync", async () => {
+    const runSync = vi.fn();
+    renderHook(() => useSyncRetry(true, runSync));
+
+    window.dispatchEvent(new Event("online"));
+    // replayOfflineQueue — async Promise.resolve(). Пропускаємо мікротаски
+    // через `advanceTimersByTimeAsync(0)` — це прокачує микротаски і НЕ
+    // чіпає periodic interval (2хв), щоб не зірватись в infinite-loop guard.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(replayOfflineQueueMock).toHaveBeenCalledTimes(1);
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("серія SYNC_EVENT за 100 мс коалесить в один виклик runSync (5s debounce)", () => {
+    const runSync = vi.fn();
+    renderHook(() => useSyncRetry(true, runSync));
+
+    for (let i = 0; i < 5; i++) {
+      window.dispatchEvent(new Event(SYNC_EVENT));
+      vi.advanceTimersByTime(100);
+    }
+    // Поки debounce не дотік — runSync не викликався
+    expect(runSync).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5_000);
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("periodic (2 хв) нічого не робить якщо немає dirty модулів", () => {
+    const runSync = vi.fn();
+    renderHook(() => useSyncRetry(true, runSync));
+
+    getDirtyModulesMock.mockReturnValue({});
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    expect(runSync).not.toHaveBeenCalled();
+  });
+
+  it("periodic (2 хв) викликає runSync якщо є dirty модулі", () => {
+    const runSync = vi.fn();
+    renderHook(() => useSyncRetry(true, runSync));
+
+    getDirtyModulesMock.mockReturnValue({ finyk: true });
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("enabled=false: нічого не підписується", () => {
+    const runSync = vi.fn();
+    renderHook(() => useSyncRetry(false, runSync));
+
+    window.dispatchEvent(new Event("online"));
+    window.dispatchEvent(new Event(SYNC_EVENT));
+    vi.advanceTimersByTime(10 * 60 * 1000);
+
+    expect(runSync).not.toHaveBeenCalled();
+    expect(replayOfflineQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("unmount скасовує pending debounce (runSync після demount не спрацює)", () => {
+    const runSync = vi.fn();
+    const { unmount } = renderHook(() => useSyncRetry(true, runSync));
+
+    window.dispatchEvent(new Event(SYNC_EVENT));
+    vi.advanceTimersByTime(1_000);
+    unmount();
+    vi.advanceTimersByTime(10_000);
+
+    expect(runSync).not.toHaveBeenCalled();
+  });
+
+  it("unmount скасовує periodic interval", () => {
+    const runSync = vi.fn();
+    getDirtyModulesMock.mockReturnValue({ finyk: true });
+    const { unmount } = renderHook(() => useSyncRetry(true, runSync));
+
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    expect(runSync).toHaveBeenCalledTimes(1);
+
+    unmount();
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("online listener не залишається після unmount", () => {
+    const runSync = vi.fn();
+    const { unmount } = renderHook(() => useSyncRetry(true, runSync));
+    unmount();
+
+    window.dispatchEvent(new Event("online"));
+    vi.advanceTimersByTime(1_000);
+    expect(replayOfflineQueueMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/nutrition/hooks/useNutritionLog.js
+++ b/src/modules/nutrition/hooks/useNutritionLog.js
@@ -169,7 +169,14 @@ export function useNutritionLog() {
       clearTimeout(t);
       pendingThumbDeletesRef.current.delete(id);
     }
-    setNutritionLog((log) => addLogEntry(log, date, meal));
+    setNutritionLog((log) => {
+      // Idempotent undo — double-click на «Повернути» не повинен створювати
+      // дублікат у логу. Реальна скарга: користувач тапав 2 рази, бо перший
+      // тап здавалося «не спрацював», і отримував два ідентичні meal-и.
+      const dayMeals = Array.isArray(log?.[date]?.meals) ? log[date].meals : [];
+      if (dayMeals.some((m) => String(m?.id ?? "") === id)) return log;
+      return addLogEntry(log, date, meal);
+    });
   };
 
   /**

--- a/src/modules/nutrition/hooks/useNutritionLog.undo.test.jsx
+++ b/src/modules/nutrition/hooks/useNutritionLog.undo.test.jsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useNutritionLog } from "./useNutritionLog.js";
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function meal(id) {
+  return {
+    id,
+    name: "Яйце",
+    time: "09:00",
+    mealType: "breakfast",
+    label: "",
+    macros: { kcal: 70, protein_g: 6, fat_g: 5, carbs_g: 0 },
+    source: "manual",
+    macroSource: "manual",
+    amount_g: null,
+    foodId: null,
+  };
+}
+
+describe("useNutritionLog — delete + undo meal flow", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("handleRemoveMeal → handleRestoreMeal повертає той самий meal на ту саму дату", () => {
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
+    const date = "2025-01-15";
+    const m = meal("m1");
+
+    act(() => result.current.setSelectedDate(date));
+    act(() => result.current.handleAddMeal(m));
+    expect(result.current.nutritionLog[date]?.meals?.[0]?.id).toBe("m1");
+
+    act(() => result.current.handleRemoveMeal(date, "m1"));
+    expect(result.current.nutritionLog[date]?.meals ?? []).toHaveLength(0);
+
+    act(() => result.current.handleRestoreMeal(date, m));
+    const after = result.current.nutritionLog[date]?.meals ?? [];
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe("m1");
+  });
+
+  it("handleRestoreMeal скидає pending thumbnail delete (інакше фото видаляється через 6с навіть після undo)", () => {
+    // Регресія: handleRemoveMeal планує `deleteMealThumbnail` через 6с. Якщо
+    // юзер встигає undo — ми повинні прибрати цей timer, бо інакше фото
+    // буде видалене з IndexedDB асинхронно уже після того, як meal знову
+    // з'явився у логу.
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
+    const date = "2025-01-16";
+    const m = meal("m2");
+
+    act(() => result.current.setSelectedDate(date));
+    act(() => result.current.handleAddMeal(m));
+    act(() => result.current.handleRemoveMeal(date, "m2"));
+    act(() => result.current.handleRestoreMeal(date, m));
+
+    // Якщо таймер не скасували, тут би крутнувся async delete. Ми не
+    // ловимо безпосередньо IDB — ця перевірка опирається на те, що 6с
+    // пройшло, але meal усе одно в логу.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    const after = result.current.nutritionLog[date]?.meals ?? [];
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe("m2");
+  });
+
+  it("подвійний restore не дублює запис (ідемпотентність)", () => {
+    // Регресія: раніше `addLogEntry` просто апендив у масив без dedup —
+    // якщо юзер двічі тапнув "Повернути" (типова скарга на повільний фідбек),
+    // у логу з'являвся другий однаковий meal. Тепер handleRestoreMeal
+    // ігнорує повторний виклик з тим самим id на ту саму дату.
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
+    const date = "2025-01-17";
+    const m = meal("m3");
+
+    act(() => result.current.setSelectedDate(date));
+    act(() => result.current.handleAddMeal(m));
+    act(() => result.current.handleRemoveMeal(date, "m3"));
+    act(() => result.current.handleRestoreMeal(date, m));
+    act(() => result.current.handleRestoreMeal(date, m));
+
+    const after = result.current.nutritionLog[date]?.meals ?? [];
+    expect(after.filter((x) => x.id === "m3")).toHaveLength(1);
+  });
+
+  it("handleRemoveMeal ігнорує відсутній id без throw", () => {
+    const { result } = renderHook(() => useNutritionLog(), {
+      wrapper: makeWrapper(),
+    });
+    expect(() => {
+      act(() => result.current.handleRemoveMeal("2025-01-20", ""));
+      act(() => result.current.handleRemoveMeal("2025-01-20", { id: "" }));
+    }).not.toThrow();
+  });
+});

--- a/src/shared/components/ui/SwipeToAction.test.tsx
+++ b/src/shared/components/ui/SwipeToAction.test.tsx
@@ -1,0 +1,226 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import { SwipeToAction } from "./SwipeToAction";
+
+/**
+ * Знаходить внутрішній контейнер із touch-хендлерами. Він — прямий
+ * нащадок кореневого оверлея і містить children. Пошук по елементу з
+ * inline-стилем `transform: translateX(...)` найменш крихкий.
+ */
+function getTouchTarget(container: HTMLElement): HTMLDivElement {
+  const root = container.firstChild as HTMLElement;
+  const candidates = Array.from(root.querySelectorAll<HTMLDivElement>("div"));
+  const target = candidates.find((el) =>
+    (el.getAttribute("style") || "").includes("translateX("),
+  );
+  if (!target) throw new Error("Не знайшов touch-контейнер SwipeToAction");
+  return target;
+}
+
+function touches(x: number, y: number) {
+  // React тягне Touch[] з e.touches; для jsdom достатньо масива, що індексується.
+  return [{ clientX: x, clientY: y }] as unknown as TouchList;
+}
+
+describe("SwipeToAction — mobile gesture regressions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("горизонтальний свайп за threshold викликає onSwipeLeft рівно один раз", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(100, 50) }); // dx = -100
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500); // commit timeout (200ms) + запас
+    });
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it("подвійний свайп у межах commit-таймаута не дублює дію", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    // 1-й свайп
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(100, 50) });
+    fireEvent.touchEnd(target);
+
+    // 2-й свайп ДО того як commit-таймаут добіг (200ms)
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(100, 50) });
+    fireEvent.touchEnd(target);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it("вертикальний рух (dy > dx) не триггерить swipe навіть якщо потім dx великий", () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(100, 100) });
+    // Перший значимий рух — явно вертикальний. isHorizontal = false на
+    // весь drag, подальші горизонтальні рухи ігноруються.
+    fireEvent.touchMove(target, { touches: touches(102, 150) });
+    fireEvent.touchMove(target, { touches: touches(0, 150) }); // dx = -100
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("tap без переміщення (dx=dy<5) не тригерить свайп", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(100, 100) });
+    fireEvent.touchMove(target, { touches: touches(102, 101) }); // dx=2 dy=1
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("свайп НЕ за threshold повертає елемент у вихідне положення (offset=0)", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(160, 50) }); // dx = -40, < 60
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    // Офсет скидається — transform повертається до 0px
+    expect(target.getAttribute("style") || "").toMatch(/translateX\(0px\)/);
+  });
+
+  it("disabled — touchStart ігнорується і action не тригериться", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft} disabled>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(50, 50) });
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("multitouch (2 пальці) ігнорується: pinch-zoom не повинен тригерити свайп", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    // touchstart з двома точками (pinch) — гаситься на старті.
+    fireEvent.touchStart(target, {
+      touches: [
+        { clientX: 200, clientY: 50 },
+        { clientX: 150, clientY: 60 },
+      ] as unknown as TouchList,
+    });
+    fireEvent.touchMove(target, { touches: touches(50, 50) });
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("touchCancel у середині drag повертає offset у 0 та не викликає action", () => {
+    const onSwipeLeft = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeLeft={onSwipeLeft}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(120, 50) }); // dx = -80
+    fireEvent.touchCancel(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(target.getAttribute("style") || "").toMatch(/translateX\(0px\)/);
+  });
+
+  it("swipe у напрямку без хендлера (onSwipeLeft відсутній) не фризить offset", () => {
+    const onSwipeRight = vi.fn();
+    const { container } = render(
+      <SwipeToAction onSwipeRight={onSwipeRight}>
+        <div>tx</div>
+      </SwipeToAction>,
+    );
+    const target = getTouchTarget(container);
+
+    fireEvent.touchStart(target, { touches: touches(200, 50) });
+    fireEvent.touchMove(target, { touches: touches(100, 50) }); // вліво
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onSwipeRight).not.toHaveBeenCalled();
+    expect(target.getAttribute("style") || "").toMatch(/translateX\(0px\)/);
+  });
+});

--- a/src/shared/components/ui/SwipeToAction.tsx
+++ b/src/shared/components/ui/SwipeToAction.tsx
@@ -38,6 +38,10 @@ function SwipeToActionImpl({
   const startX = useRef<number | null>(null);
   const startY = useRef<number | null>(null);
   const isHorizontal = useRef<boolean | null>(null);
+  // Synchronous guard against a second touchStart landing inside the 200ms
+  // commit animation — setCommitted() is async, so we cannot read the state
+  // back in onTouchStart to ignore the duplicate.
+  const committingRef = useRef<boolean>(false);
 
   const reset = useCallback(() => {
     setOffset(0);
@@ -50,6 +54,14 @@ function SwipeToActionImpl({
   const onTouchStart = useCallback(
     (e: TouchEvent<HTMLDivElement>) => {
       if (disabled) return;
+      // A previous swipe is still inside its 200ms commit animation. If we
+      // accept a new touch now the commit timeout will fire twice (same
+      // action, same row) — a real regression reported by users on fast
+      // double-swipes of list items.
+      if (committingRef.current) return;
+      // Multi-touch (pinch-zoom, two-finger scroll) should never be
+      // interpreted as a horizontal swipe — ignore entirely.
+      if (e.touches.length !== 1) return;
       setCommitted(false);
       startX.current = e.touches[0].clientX;
       startY.current = e.touches[0].clientY;
@@ -89,23 +101,35 @@ function SwipeToActionImpl({
     if (!isDragging) return;
     if (offset < -SWIPE_THRESHOLD && onSwipeLeft) {
       setCommitted(true);
+      committingRef.current = true;
       setTimeout(() => {
         onSwipeLeft();
         reset();
         setCommitted(false);
+        committingRef.current = false;
       }, 200);
     } else if (offset > SWIPE_THRESHOLD && onSwipeRight) {
       setCommitted(true);
+      committingRef.current = true;
       setTimeout(() => {
         onSwipeRight();
         reset();
         setCommitted(false);
+        committingRef.current = false;
       }, 200);
     } else {
       reset();
     }
     setIsDragging(false);
   }, [isDragging, offset, onSwipeLeft, onSwipeRight, reset]);
+
+  const onTouchCancel = useCallback(() => {
+    // System cancel (iOS bounce / app switcher / pinch) — abandon the drag
+    // without firing the action. Without this handler the row would stay
+    // translated until the next touch.
+    if (committingRef.current) return;
+    reset();
+  }, [reset]);
 
   const showLeft = offset < 0 && onSwipeLeft;
   const showRight = offset > 0 && onSwipeRight;
@@ -160,6 +184,7 @@ function SwipeToActionImpl({
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
+        onTouchCancel={onTouchCancel}
       >
         {children}
       </div>

--- a/src/shared/lib/undoToast.test.tsx
+++ b/src/shared/lib/undoToast.test.tsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ToastApi } from "@shared/hooks/useToast";
+import { showUndoToast } from "./undoToast";
+
+function makeToast(): ToastApi & {
+  _captured: { action?: { onClick: () => void } };
+} {
+  const captured: { action?: { onClick: () => void } } = {};
+  const api: ToastApi = {
+    show: vi.fn((_msg, _type, _duration, action) => {
+      if (action) captured.action = action;
+      return 1;
+    }),
+    success: vi.fn(() => 1),
+    error: vi.fn(() => 2),
+    info: vi.fn(() => 1),
+    warning: vi.fn(() => 1),
+    dismiss: vi.fn(),
+  };
+  return Object.assign(api, { _captured: captured });
+}
+
+describe("showUndoToast", () => {
+  beforeEach(() => {
+    // @ts-expect-error jsdom не має navigator.vibrate — підклеюємо noop щоб
+    // хаптик не бив по undefined під час click.
+    navigator.vibrate = vi.fn();
+  });
+
+  it("викликає onUndo один раз при кліку", () => {
+    const onUndo = vi.fn();
+    const toast = makeToast();
+    showUndoToast(toast, { msg: "Видалено", onUndo });
+
+    toast._captured.action?.onClick();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("якщо onUndo кидає помилку — показується error-toast (не silent)", () => {
+    // Регресія: попередня реалізація ковтала виключення у `catch {}`,
+    // і користувач ніколи не дізнавався, що restore не спрацював.
+    const onUndo = vi.fn(() => {
+      throw new Error("storage quota exceeded");
+    });
+    const toast = makeToast();
+
+    showUndoToast(toast, { msg: "Видалено", onUndo });
+    // Click не повинен пробросити виняток наверх (toast listener не має
+    // шансу залогувати, якщо throw іде далі).
+    expect(() => toast._captured.action?.onClick()).not.toThrow();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Не вдалось повернути. Спробуй ще раз.",
+    );
+  });
+
+  it("дозволяє кастомне повідомлення для помилки undo", () => {
+    const onUndo = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const toast = makeToast();
+
+    showUndoToast(toast, {
+      msg: "Видалено звичку",
+      onUndo,
+      onUndoErrorMsg: "Не вдалось повернути звичку",
+    });
+    toast._captured.action?.onClick();
+    expect(toast.error).toHaveBeenCalledWith("Не вдалось повернути звичку");
+  });
+
+  it("використовує default duration=5000 і info-тип", () => {
+    const toast = makeToast();
+    showUndoToast(toast, { msg: "Видалено", onUndo: () => {} });
+
+    expect(toast.show).toHaveBeenCalledTimes(1);
+    const call = (toast.show as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]).toBe("info");
+    expect(call[2]).toBe(5000);
+  });
+});

--- a/src/shared/lib/undoToast.tsx
+++ b/src/shared/lib/undoToast.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { ToastApi } from "@shared/hooks/useToast";
-import { hapticTap, hapticWarning } from "./haptic";
+import { hapticError, hapticTap, hapticWarning } from "./haptic";
 
 export interface UndoToastOptions {
   /** Текст, який бачить користувач ("Видалено звичку «Вода»"). */
@@ -11,6 +11,13 @@ export interface UndoToastOptions {
   undoLabel?: string;
   /** Викликається, коли юзер натиснув undo — ти відновлюєш локальний state / БД. */
   onUndo: () => void;
+  /**
+   * Повідомлення, яке показується окремим error-toast-ом, якщо `onUndo` кидає
+   * помилку. Без цього користувач раніше ніколи не дізнавався, що відновлення
+   * не спрацювало — toast зникав без сліду і дані залишались видаленими.
+   * Default: "Не вдалось повернути. Спробуй ще раз.".
+   */
+  onUndoErrorMsg?: ReactNode;
 }
 
 /**
@@ -30,10 +37,21 @@ export interface UndoToastOptions {
  * Haptic: викликається `hapticWarning()` на появу toast, і `hapticTap()`
  * на натискання undo — щоб користувач фізично відчув і небезпечну дію,
  * і виправлення.
+ *
+ * Error handling: якщо `onUndo` кидає, показуємо error-toast замість
+ * беззвучного ковтання винятку. Історично `catch {}` тут ховав реальні
+ * помилки (наприклад, коли restore не міг поставити запис через квоту
+ * localStorage) — юзер думав, що дані повернулись, а їх насправді не було.
  */
 export function showUndoToast(
   toast: ToastApi,
-  { msg, duration = 5000, undoLabel = "Повернути", onUndo }: UndoToastOptions,
+  {
+    msg,
+    duration = 5000,
+    undoLabel = "Повернути",
+    onUndo,
+    onUndoErrorMsg = "Не вдалось повернути. Спробуй ще раз.",
+  }: UndoToastOptions,
 ): number {
   hapticWarning();
   return toast.show(msg, "info", duration, {
@@ -43,7 +61,8 @@ export function showUndoToast(
       try {
         onUndo();
       } catch {
-        /* caller повинен сам лапати помилки — undo ідемпотентне */
+        hapticError();
+        toast.error(onUndoErrorMsg);
       }
     },
   });


### PR DESCRIPTION
## Summary

Sprint 1 з reliability-плану (див. `sergeant-test-strategy.md`). Націлений покрив на три зони, з яких історично прилітали більшість багів — mobile gestures, undo flows, cloud-sync — плюс реальні баги, які ці тести виявили.

### Фікси (знайдені під час написання тестів)

**SwipeToAction** — `src/shared/components/ui/SwipeToAction.tsx`
- Другий `touchStart`, що прилітав всередині 200 мс commit-анімації, перезаряджав жест і `onSwipeLeft/Right` викликався двічі. `setCommitted()` — async, тому спостерігати стан назад у хендлері не можна. Додано синхронний `committingRef`.
- Додано reject мультитачу (`e.touches.length !== 1`) — pinch/two-finger таскання більше не маскується під свайп.
- Підключено `onTouchCancel` — скасований жест коректно скидає стан.

**undoToast** — `src/shared/lib/undoToast.tsx`
- Замінено `catch {}` на явний error-toast + `hapticError`. Раніше silent-catch ковтав виключення у `onUndo`, і користувач ніколи не дізнавався, що відновлення не спрацювало. Повідомлення перевизначається через `onUndoErrorMsg`.

**useNutritionLog.handleRestoreMeal** — `src/modules/nutrition/hooks/useNutritionLog.js`
- Подвійний тап по «Повернути» дублював meal у логу. Додано idempotency-гард — якщо meal з таким `id` вже є на дату, `addLogEntry` пропускається.

### Нові тести (+25, було 983 → стало 1008)

- `SwipeToAction.test.tsx` — 9 кейсів: threshold, вертикальна невразливість, подвійний свайп, мультитач, touchCancel.
- `undoToast.test.tsx` — 4 кейси: виконання `onUndo`, error propagation, кастомне повідомлення.
- `useNutritionLog.undo.test.jsx` — 4 кейси: restore, ідемпотентність подвійного restore, скасування pending-таймера, missing-id no-op.
- `useSyncRetry.test.ts` — 8 кейсів: `online`→replay→runSync, 5с debounce коалесить бурсти `SYNC_EVENT`, periodic тригер тільки при dirty модулях, unmount скасовує всі три тригери.

## Review & Testing Checklist for Human

Ризик **жовтий** — зміни у gesture-коді впливають на всі споживачі `SwipeToAction` (finyk `TxListItem`, nutrition `LogCard`, fizruk журнал, routine календар). Undo-фікси торкаються будь-якого delete-flow. Рекомендую:

- [ ] Ручна перевірка swipe-делеут у finyk-транзакціях на реальному iOS/Android (momentum scroll + swipe одночасно).
- [ ] Подвійний swipe-делеут (двічі поспіль за ~200 мс) — перевірити що видаляється рівно 1 раз.
- [ ] Видалити meal у Nutrition, натиснути «Повернути» 2 рази швидко — має повернутись 1 запис.
- [ ] Видалити звичку в Routine, тригернути помилку `restoreHabit` (наприклад, якщо quota exceeded у localStorage) — має показатись error-toast, а не тиха пропажа.

### Notes

- Sprint 2 (initialSync e2e, offline queue overflow, webpush 410, bank retry backoff, push lifecycle) — окремим PR.
- Lint: `npm run lint` — clean.
- Tests: `npm test` — 1008/1008 pass.
- Повна стратегія та пріоритизація у `sergeant-test-strategy.md` (не комічу — він був лише для обговорення).

Link to Devin session: https://app.devin.ai/sessions/5377c85d22b1487589c6c17f58a277ee
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
