### PR TITLE
feat(ux): pass 2 — Finyk storage banner, haptic gaps, aria-live, first-run CTA

### DIFF
--- a/src/core/cloudSync/hook/useSyncRetry.test.ts
+++ b/src/core/cloudSync/hook/useSyncRetry.test.ts
@@ -4,7 +4,7 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   replayOfflineQueueMock: vi.fn(() => Promise.resolve()),
-  getDirtyModulesMock: vi.fn<[], Record<string, unknown>>(() => ({})),
+  getDirtyModulesMock: vi.fn<() => Record<string, unknown>>(() => ({})),
 }));
 const { replayOfflineQueueMock, getDirtyModulesMock } = mocks;
 

--- a/src/modules/finyk/FinykApp.tsx
+++ b/src/modules/finyk/FinykApp.tsx
@@ -14,6 +14,11 @@ import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
+import { Banner } from "@shared/components/ui/Banner";
+import {
+  STORAGE_WRITE_ERROR_EVENT,
+  type StorageWriteErrorDetail,
+} from "@shared/lib/storage";
 import { Overview } from "./pages/Overview.jsx";
 import { Transactions } from "./pages/Transactions.jsx";
 import { Budgets } from "./pages/Budgets.jsx";
@@ -204,6 +209,22 @@ export default function App({
   useEffect(() => {
     writeRaw("finyk_show_balance_v1", showBalance ? "1" : "0");
   }, [showBalance]);
+
+  // Persistent storage-error banner. Finyk writes go through
+  // `safeJsonSet` / `safeWriteLS` which swallow quota/private-mode errors and
+  // return `false` — without this listener the user would silently lose data.
+  // Matches the pattern in Routine/Fizruk/Nutrition. Filter by the `finyk_`
+  // prefix so shared events from other modules don't show up here.
+  const [storageErrorMsg, setStorageErrorMsg] = useState<string | null>(null);
+  useEffect(() => {
+    const onErr = (ev: Event) => {
+      const detail = (ev as CustomEvent<StorageWriteErrorDetail>).detail;
+      if (!detail?.key || !detail.key.startsWith("finyk_")) return;
+      setStorageErrorMsg(detail.message || "невідома помилка");
+    };
+    window.addEventListener(STORAGE_WRITE_ERROR_EVENT, onErr);
+    return () => window.removeEventListener(STORAGE_WRITE_ERROR_EVENT, onErr);
+  }, []);
 
   useEffect(() => {
     if (window.location.search.includes("sync=")) {
@@ -619,9 +640,33 @@ export default function App({
         </div>
       </div>
 
+      {storageErrorMsg && (
+        <Banner
+          variant="danger"
+          role="alert"
+          className="mx-4 mt-3 flex items-start justify-between gap-3"
+        >
+          <span>
+            Не вдалося зберегти дані Фініка ({storageErrorMsg}). Можливо,
+            браузер переповнив сховище — звільни місце або експортуй резервну
+            копію.
+          </span>
+          <button
+            type="button"
+            onClick={() => setStorageErrorMsg(null)}
+            className="shrink-0 text-xs font-semibold text-danger/80 hover:text-danger"
+            aria-label="Закрити повідомлення"
+          >
+            Закрити
+          </button>
+        </Banner>
+      )}
+
       {/* Page content */}
       <div
         className="flex-1 overflow-hidden flex flex-col min-h-0 touch-pan-y"
+        aria-live="polite"
+        aria-atomic="false"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >

--- a/src/modules/finyk/components/CategoryManager.tsx
+++ b/src/modules/finyk/components/CategoryManager.tsx
@@ -7,6 +7,7 @@ import { cn } from "@shared/lib/cn";
 import { Card } from "@shared/components/ui/Card";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
+import { hapticTap, hapticSuccess } from "@shared/lib/haptic";
 
 const PRESET_COLORS = [
   "#10b981",
@@ -374,15 +375,18 @@ export function CategoryManager({
           // inside `removeCustomCategory`).
           const snapshot = customCategories.find((c) => c.id === deletingId);
           onRemove(deletingId);
+          hapticTap();
           if (snapshot) {
             showUndoToast(toast, {
               msg: `Категорію «${snapshot.label}» видалено`,
-              onUndo: () =>
+              onUndo: () => {
                 onAdd?.(snapshot.label, {
                   color: snapshot.color,
                   icon: snapshot.icon,
                   parentId: snapshot.parentId,
-                }),
+                });
+                hapticSuccess();
+              },
             });
           }
           setDeletingId(null);

--- a/src/modules/finyk/components/TxListItem.tsx
+++ b/src/modules/finyk/components/TxListItem.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { cn } from "@shared/lib/cn";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { Icon } from "@shared/components/ui/Icon";
+import { hapticTap, hapticWarning } from "@shared/lib/haptic";
 import { TxRow } from "./TxRow";
 
 function TxListItemImpl({
@@ -68,8 +69,14 @@ function TxListItemImpl({
           onSwipeLeft={
             canSwipeLeft
               ? isManual
-                ? () => onSwipeDeleteManual(tx)
-                : () => onSwipeHideTx(tx.id)
+                ? () => {
+                    hapticTap();
+                    onSwipeDeleteManual(tx);
+                  }
+                : () => {
+                    hapticWarning();
+                    onSwipeHideTx(tx.id);
+                  }
               : undefined
           }
           onSwipeRight={undefined}

--- a/src/modules/nutrition/NutritionApp.jsx
+++ b/src/modules/nutrition/NutritionApp.jsx
@@ -55,7 +55,12 @@ export default function NutritionApp({
   const [pantrySubTab, setPantrySubTab] = useState("items");
   const [menuSubTab, setMenuSubTab] = useState("plan");
 
-  const pantry = useNutritionPantries({ setBusy, setErr, setStatusText });
+  const pantry = useNutritionPantries({
+    setBusy,
+    setErr,
+    setStatusText,
+    toast,
+  });
   const log = useNutritionLog();
   const ui = useNutritionUiState();
   const photo = usePhotoAnalysis({ setBusy, setErr, setStatusText });
@@ -324,7 +329,11 @@ export default function NutritionApp({
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       <NutritionHeader busy={busy} onBackToHub={onBackToHub} />
 
-      <div className="flex-1 overflow-y-auto">
+      <div
+        className="flex-1 overflow-y-auto"
+        aria-live="polite"
+        aria-atomic="false"
+      >
         <div className="max-w-2xl mx-auto px-4 pt-4 pb-6 w-full">
           <NutritionPantrySelector pantry={pantry} busy={busy} />
 

--- a/src/modules/nutrition/components/LogCard.jsx
+++ b/src/modules/nutrition/components/LogCard.jsx
@@ -7,6 +7,7 @@ import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
+import { hapticTap } from "@shared/lib/haptic";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import {
@@ -211,7 +212,9 @@ export function LogCard({
           {searchQuery.trim() && (
             <ul className="max-h-48 overflow-y-auto text-sm space-y-1">
               {searchHits.length === 0 && (
-                <li className="text-muted text-xs">Нічого не знайдено</li>
+                <li>
+                  <EmptyState compact title="Нічого не знайдено" />
+                </li>
               )}
               {searchHits.map(({ date, meal }) => {
                 const mac = meal.macros || {};
@@ -382,7 +385,7 @@ export function LogCard({
               Калорії по днях (останні {Math.min(statsRange, statsRows.length)})
             </SectionHeading>
             {statsRows.length === 0 ? (
-              <div className="text-xs text-muted">Поки що порожньо</div>
+              <EmptyState compact title="Поки що порожньо" />
             ) : (
               (() => {
                 const kcals = statsRows.map((r) => Number(r.kcal) || 0);
@@ -411,7 +414,7 @@ export function LogCard({
                 Топ страв
               </SectionHeading>
               {statsTop.length === 0 ? (
-                <div className="text-xs text-muted">Поки що порожньо</div>
+                <EmptyState compact title="Поки що порожньо" />
               ) : (
                 <ol className="space-y-1">
                   {statsTop.map((x) => (
@@ -435,7 +438,7 @@ export function LogCard({
                 Розподіл прийомів
               </SectionHeading>
               {Object.keys(statsMealTypes).length === 0 ? (
-                <div className="text-xs text-muted">Поки що порожньо</div>
+                <EmptyState compact title="Поки що порожньо" />
               ) : (
                 <ul className="space-y-1">
                   {MEAL_ORDER.filter((t) => statsMealTypes[t]?.count > 0).map(
@@ -480,7 +483,18 @@ export function LogCard({
               </svg>
             }
             title="Поки немає записів"
-            description="Додайте перший прийом їжі, щоб почати вести журнал."
+            description="Додай перший прийом їжі, щоб почати вести журнал."
+            action={
+              onAddMeal ? (
+                <button
+                  type="button"
+                  onClick={onAddMeal}
+                  className="px-4 h-10 rounded-xl bg-nutrition text-white font-semibold text-sm hover:bg-nutrition/90 transition-colors"
+                >
+                  Додати перший прийом їжі
+                </button>
+              ) : undefined
+            }
           />
         ) : (
           <VirtualMealList
@@ -564,7 +578,10 @@ function VirtualMealList({
         return (
           <div className="mb-1.5">
             <SwipeToAction
-              onSwipeLeft={() => onRemoveMeal(selectedDate, item.meal)}
+              onSwipeLeft={() => {
+                hapticTap();
+                onRemoveMeal(selectedDate, item.meal);
+              }}
               rightLabel="🗑 Видалити"
               rightColor="bg-danger"
             >

--- a/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
+++ b/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
@@ -12,6 +12,7 @@ import {
   decryptBlobToJson,
   encryptJsonToBlob,
 } from "../lib/nutritionCloudBackup.js";
+import { hapticSuccess } from "@shared/lib/haptic";
 import type {
   BackupPasswordDialogState,
   RestoreConfirmState,
@@ -79,6 +80,7 @@ export function useNutritionCloudBackup({
       setErr("");
     },
     onSuccess: () => {
+      hapticSuccess();
       toast.success("Бекап завантажено.");
     },
     onError: (err: unknown) => {

--- a/src/modules/nutrition/hooks/useNutritionPantries.js
+++ b/src/modules/nutrition/hooks/useNutritionPantries.js
@@ -16,7 +16,12 @@ import {
   parseLoosePantryText,
 } from "../lib/pantryTextParser.js";
 
-export function useNutritionPantries({ setBusy, setErr, setStatusText }) {
+export function useNutritionPantries({
+  setBusy,
+  setErr,
+  setStatusText,
+  toast,
+}) {
   const [pantries, setPantries] = useState(() =>
     loadPantries(NUTRITION_PANTRIES_KEY, NUTRITION_ACTIVE_PANTRY_KEY),
   );
@@ -175,6 +180,7 @@ export function useNutritionPantries({ setBusy, setErr, setStatusText }) {
       setPantries((cur) =>
         updatePantry(cur, activePantryId, (p) => ({ ...p, name })),
       );
+      toast?.success?.(`Склад «${name}» перейменовано.`);
     } else {
       const id = `p_${Date.now()}`;
       setPantries((cur) => [
@@ -182,6 +188,7 @@ export function useNutritionPantries({ setBusy, setErr, setStatusText }) {
         { id, name, items: [], text: "" },
       ]);
       setActivePantryId(id);
+      toast?.success?.(`Склад «${name}» створено.`);
     }
     setPantryManagerOpen(false);
   };
@@ -189,11 +196,13 @@ export function useNutritionPantries({ setBusy, setErr, setStatusText }) {
   const onConfirmDeletePantry = () => {
     const arr = Array.isArray(pantries) ? pantries : [];
     if (arr.length <= 1) return;
+    const removed = arr.find((p) => p.id === activePantryId);
     const next = arr.filter((p) => p.id !== activePantryId);
     setPantries(next);
     setActivePantryId(next[0]?.id || "home");
     setConfirmDeleteOpen(false);
     setPantryManagerOpen(false);
+    if (removed?.name) toast?.success?.(`Склад «${removed.name}» видалено.`);
   };
 
   const onSaveItemEdit = (idx, qty, unit) => {

--- a/src/shared/lib/storage.ts
+++ b/src/shared/lib/storage.ts
@@ -46,7 +46,42 @@ export function safeReadStringLS(
 }
 
 /**
+ * Window event fired whenever `safeWriteLS` / `safeRemoveLS` trap a storage
+ * error (quota exceeded, Safari private mode, disabled storage). Listeners
+ * can surface a persistent `<Banner variant="danger">` so users know their
+ * data is no longer persisting, instead of silently losing writes.
+ *
+ * `detail.key` is the storage key that failed so listeners can filter by
+ * module prefix (e.g. `finyk.` / `nutrition.`) and avoid cross-module noise.
+ */
+export const STORAGE_WRITE_ERROR_EVENT = "app-storage-write-error";
+
+export interface StorageWriteErrorDetail {
+  key: string;
+  op: "write" | "remove";
+  message: string;
+}
+
+function emitStorageWriteError(
+  key: string,
+  op: "write" | "remove",
+  err: unknown,
+): void {
+  try {
+    const message = err instanceof Error ? err.message : "unknown";
+    window.dispatchEvent(
+      new CustomEvent<StorageWriteErrorDetail>(STORAGE_WRITE_ERROR_EVENT, {
+        detail: { key, op, message },
+      }),
+    );
+  } catch {
+    /* dispatchEvent can throw in exotic embeddings — ignore */
+  }
+}
+
+/**
  * Write a JSON-serialized value to localStorage. Returns true on success.
+ * On failure, dispatches `STORAGE_WRITE_ERROR_EVENT` so UI can surface it.
  */
 export function safeWriteLS(key: string, value: unknown): boolean {
   try {
@@ -54,7 +89,8 @@ export function safeWriteLS(key: string, value: unknown): boolean {
       typeof value === "string" ? value : JSON.stringify(value);
     localStorage.setItem(key, serialized);
     return true;
-  } catch {
+  } catch (err) {
+    emitStorageWriteError(key, "write", err);
     return false;
   }
 }
@@ -66,7 +102,8 @@ export function safeRemoveLS(key: string): boolean {
   try {
     localStorage.removeItem(key);
     return true;
-  } catch {
+  } catch (err) {
+    emitStorageWriteError(key, "remove", err);
     return false;
   }
 }

--- a/src/shared/lib/storageQuota.ts
+++ b/src/shared/lib/storageQuota.ts
@@ -2,8 +2,34 @@
  * Minimal localStorage quota guard.
  * Goal: avoid "silent" data loss on QuotaExceededError and prevent writing very large payloads.
  */
+import { STORAGE_WRITE_ERROR_EVENT } from "./storage";
+import type { StorageWriteErrorDetail } from "./storage";
 
 export const DEFAULT_MAX_BYTES = 4_000_000; // ~4MB safety (varies by browser)
+
+function emitQuotaWriteError(
+  key: string,
+  reason: "too_large" | "exception",
+  err?: unknown,
+  bytes?: number,
+  maxBytes?: number,
+): void {
+  try {
+    const message =
+      reason === "too_large"
+        ? `payload ${bytes ?? "?"}B exceeds ${maxBytes ?? "?"}B limit`
+        : err instanceof Error
+          ? err.message
+          : "unknown";
+    window.dispatchEvent(
+      new CustomEvent<StorageWriteErrorDetail>(STORAGE_WRITE_ERROR_EVENT, {
+        detail: { key, op: "write", message },
+      }),
+    );
+  } catch {
+    /* dispatchEvent can throw in exotic embeddings — ignore */
+  }
+}
 
 export interface SafeSetOptions {
   maxBytes?: number;
@@ -34,11 +60,13 @@ export function safeSetItem(
     const s = String(value ?? "");
     const bytes = estimateUtf8Bytes(s);
     if (maxBytes && bytes > maxBytes) {
+      emitQuotaWriteError(String(key), "too_large", undefined, bytes, maxBytes);
       return { ok: false, reason: "too_large", bytes, maxBytes };
     }
     localStorage.setItem(String(key), s);
     return { ok: true, bytes };
   } catch (e) {
+    emitQuotaWriteError(String(key), "exception", e);
     return { ok: false, reason: "exception", error: e };
   }
 }
@@ -52,6 +80,7 @@ export function safeJsonSet(
     const s = JSON.stringify(obj ?? null);
     return safeSetItem(key, s, { maxBytes });
   } catch (e) {
+    emitQuotaWriteError(String(key), "exception", e);
     return { ok: false, reason: "exception", error: e };
   }
 }

--- a/src/shared/lib/undoToast.test.tsx
+++ b/src/shared/lib/undoToast.test.tsx
@@ -23,8 +23,8 @@ function makeToast(): ToastApi & {
 
 describe("showUndoToast", () => {
   beforeEach(() => {
-    // @ts-expect-error jsdom не має navigator.vibrate — підклеюємо noop щоб
-    // хаптик не бив по undefined під час click.
+    // jsdom не має navigator.vibrate — підклеюємо noop щоб хаптик
+    // не бив по undefined під час click.
     navigator.vibrate = vi.fn();
   });
 


### PR DESCRIPTION
## Summary

Second-pass UX аудит після merge #370. 7 знахідок (4× P0, 3× P1), ~175 LOC.

**P0:**
1. **Finyk storage-error Banner** — `safeWriteLS` / `safeJsonSet` / `safeSetItem` тепер емітять `app-storage-write-error` на помилку запису (quota / Safari private mode). FinykApp слухає цей event і показує persistent `<Banner variant="danger">` замість мовчазної втрати даних. Фільтр за префіксом `finyk_` щоб не ловити події з інших модулів.
2. **Haptic gaps**:
   - Finyk `CategoryManager` — `hapticTap()` при видаленні категорії, `hapticSuccess()` при undo
   - Finyk `TxListItem` — `hapticTap()` при swipe-delete manual tx, `hapticWarning()` при swipe-hide tx
   - Nutrition `LogCard` — `hapticTap()` при swipe-remove прийому їжі
   - Nutrition cloud backup — `hapticSuccess()` при успішному завантаженні
3. **Nutrition LogCard inline empty-states** — 4 місця (`<div className="text-xs text-muted">Поки що порожньо</div>`) замінено на `<EmptyState compact title="…" />`
4. **aria-live regions** — Finyk content div і Nutrition scroll-container тепер мають `aria-live="polite" aria-atomic="false"` щоб toast-и озвучувалися screen-reader-ами

**P1:**
5. **Swipe-label space** — вже коректно в main (був false-positive у pass-2 audit: `🙈 Приховати`)
6. **First-run CTA** — Nutrition LogCard top-level empty state тепер має `action={<button>Додати перший прийом їжі</button>}`. Routine/Fizruk уже мали first-run CTA в main (перевірив)
7. **Nutrition toast gaps** — `useNutritionPantries` тепер приймає `toast` і викликає `toast.success()` на create/rename/delete складу

### Shared infrastructure

- `src/shared/lib/storage.ts`: додано `STORAGE_WRITE_ERROR_EVENT` + `StorageWriteErrorDetail` interface + `emitStorageWriteError()` helper; `safeWriteLS` / `safeRemoveLS` тепер dispatch'ать event на `catch`
- `src/shared/lib/storageQuota.ts`: `safeSetItem` / `safeJsonSet` dispatch'ать той самий event на `too_large` і `exception`

Це робить patern доступним для всіх модулів — не тільки Routine/Fizruk (Pass 1) і Finyk (цей PR), але й для будь-якого майбутнього модуля який просто має додати listener.

## Review & Testing Checklist for Human

- [ ] Заповнити localStorage до quota (DevTools → Application → Storage → ~4MB payload) і перевірити що Finyk показує persistent `<Banner variant="danger">` замість мовчазної втрати транзакції
- [ ] Swipe-видалити прийом їжі в Nutrition — має бути haptic pulse (на мобільному або з `prefers-reduced-motion: no-preference`)
- [ ] Screen-reader тест: відкрити VoiceOver/NVDA на Nutrition або Finyk, тригернути toast (наприклад save налаштувань) — має озвучитися
- [ ] Створити/перейменувати/видалити склад у Nutrition — має з'явитися success-toast
- [ ] Відкрити Nutrition з порожнім журналом — має бути видна CTA-кнопка «Додати перший прийом їжі» всередині EmptyState

### Notes

- Pre-existing typecheck errors на main (`useSyncRetry.test.ts:7`, `undoToast.test.tsx:26`) не стосуються цих змін — перевірив через `git stash && npm run typecheck`.
- 1047 тестів проходять (stash/pop підтвердив що нові зміни не зламали тестів).
- Не міняв API `toast` — новий параметр `useNutritionPantries({ toast })` опціональний (тест `useNutritionPantries.test.jsx` не потребує правок).
- P2 знахідки (Skeleton coverage, Button variant alias) свідомо залишені для наступного проходу — user обрав лише P0+P1.

Link to Devin session: https://app.devin.ai/sessions/61e0c8eba0d5497ab04b8bfd5be7a44c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
