### PR TITLE
refactor(fizruk): decompose FizrukApp via shared layout primitives

### DIFF
--- a/src/modules/fizruk/FizrukApp.tsx
+++ b/src/modules/fizruk/FizrukApp.tsx
@@ -1,135 +1,26 @@
-import { useEffect, useRef, useState } from "react";
-import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
-import { Dashboard } from "./pages/Dashboard";
-import { Atlas } from "./pages/Atlas";
-import { Exercise } from "./pages/Exercise";
-import { Workouts } from "./pages/Workouts";
-import { Progress } from "./pages/Progress";
-import { Measurements } from "./pages/Measurements";
-import { Body } from "./pages/Body";
-import { Programs } from "./pages/Programs";
+import { useState } from "react";
+import {
+  ModuleShell,
+  ModuleSettingsDrawer,
+  StorageErrorBanner,
+} from "@shared/components/layout";
+import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
+import { useHashRoute } from "@shared/hooks/useHashRoute";
+import { usePwaAction } from "@shared/hooks/usePwaAction";
 import { WorkoutBackupBar } from "./components/workouts/WorkoutBackupBar";
-import { PlanCalendar } from "./pages/PlanCalendar";
-import { useMonthlyPlan } from "./hooks/useMonthlyPlan";
+import { useExerciseCatalog } from "./hooks/useExerciseCatalog";
+import { useFizrukProgramStart } from "./hooks/useFizrukProgramStart";
 import { useFizrukWorkoutReminder } from "./hooks/useFizrukWorkoutReminder";
+import { useMonthlyPlan } from "./hooks/useMonthlyPlan";
 import { useTrainingProgram } from "./hooks/useTrainingProgram";
 import {
   FIZRUK_WORKOUTS_STORAGE_ERROR,
   useWorkouts,
 } from "./hooks/useWorkouts";
-import { useExerciseCatalog } from "./hooks/useExerciseCatalog";
-import { ACTIVE_WORKOUT_KEY } from "./lib/workoutUi";
-import { cn } from "@shared/lib/cn";
-import { Icon } from "@shared/components/ui/Icon";
-import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
-import { Banner } from "@shared/components/ui/Banner";
-
-const NAV = [
-  {
-    id: "dashboard",
-    label: "Сьогодні",
-    icon: (
-      <svg
-        width="22"
-        height="22"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <polyline points="12 6 12 12 16 14" />
-      </svg>
-    ),
-  },
-  {
-    id: "workouts",
-    label: "Тренування",
-    icon: (
-      <svg
-        width="22"
-        height="22"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M6.5 6.5h11M6.5 17.5h11M3 12h18M6 9l-3 3 3 3M18 9l3 3-3 3" />
-      </svg>
-    ),
-  },
-  {
-    id: "plan",
-    label: "План",
-    icon: (
-      <svg
-        width="22"
-        height="22"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-        <line x1="16" y1="2" x2="16" y2="6" />
-        <line x1="8" y1="2" x2="8" y2="6" />
-        <line x1="3" y1="10" x2="21" y2="10" />
-      </svg>
-    ),
-  },
-  {
-    id: "body",
-    label: "Тіло",
-    icon: (
-      <svg
-        width="22"
-        height="22"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-      </svg>
-    ),
-  },
-];
-
-const VALID_FIZRUK_PAGES = [
-  "dashboard",
-  "plan",
-  "atlas",
-  "workouts",
-  "progress",
-  "measurements",
-  "programs",
-  "body",
-  "exercise",
-];
-
-function parseHash() {
-  // Accept both `#page` (canonical) and legacy `#/page` so deep-links keep working.
-  const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
-  if (!raw) return { page: "dashboard" };
-  const [page, ...rest] = raw.split("/").filter(Boolean);
-  if (page === "exercise" && rest[0]) return { page, exerciseId: rest[0] };
-  if (!VALID_FIZRUK_PAGES.includes(page)) return { page: "dashboard" };
-  return { page };
-}
-
-function setHash(next) {
-  const h = next ? `#${next}` : "#dashboard";
-  if (window.location.hash === h) return;
-  window.location.hash = h;
-}
+import { FIZRUK_NAV } from "./shell/fizrukNav";
+import { FizrukHeader } from "./shell/FizrukHeader";
+import { FizrukRouter } from "./shell/FizrukRouter";
+import { FIZRUK_PAGES, type FizrukPage } from "./shell/fizrukRoute";
 
 interface FizrukAppProps {
   onBackToHub?: () => void;
@@ -142,13 +33,13 @@ export default function FizrukApp({
   pwaAction,
   onPwaActionConsumed,
 }: FizrukAppProps = {}) {
-  const [route, setRoute] = useState(() => parseHash());
+  const { page, segments, navigate } = useHashRoute<FizrukPage>({
+    defaultPage: "dashboard",
+    validPages: FIZRUK_PAGES,
+  });
+  const exerciseId =
+    page === "exercise" && segments[0] ? segments[0] : undefined;
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const settingsPanelRef = useRef(null);
-  const page = route.page || "dashboard";
-  const isAtlas = page === "atlas";
-  const isExercise = page === "exercise";
-  const isPlan = page === "plan";
 
   const monthlyPlan = useMonthlyPlan();
   const {
@@ -169,340 +60,70 @@ export default function FizrukApp({
     days: monthlyPlan.days,
   });
 
-  useDialogFocusTrap(settingsOpen, settingsPanelRef, {
-    onEscape: () => setSettingsOpen(false),
+  const handleStartProgramWorkout = useFizrukProgramStart({
+    workouts,
+    createWorkout,
+    addItem,
+    exercises,
+    navigate,
   });
 
-  useEffect(() => {
-    const onHash = () => setRoute(parseHash());
-    window.addEventListener("hashchange", onHash);
-    return () => window.removeEventListener("hashchange", onHash);
-  }, []);
+  usePwaAction(pwaAction, onPwaActionConsumed, {
+    start_workout: () => navigate("workouts"),
+  });
 
-  // Persistent storage-error banner for workout writes. Matches the pattern
-  // used in Nutrition/Finyk — a quota failure won't self-resolve, so a
-  // transient toast is wrong. The event is dispatched from `useWorkouts`.
-  const [storageErrorMsg, setStorageErrorMsg] = useState<string | null>(null);
-  useEffect(() => {
-    const onErr = (ev: Event) => {
-      const detail = (ev as CustomEvent<{ message?: string }>).detail;
-      setStorageErrorMsg(detail?.message || "невідома помилка");
-    };
-    window.addEventListener(FIZRUK_WORKOUTS_STORAGE_ERROR, onErr);
-    return () =>
-      window.removeEventListener(FIZRUK_WORKOUTS_STORAGE_ERROR, onErr);
-  }, []);
-
-  // Normalize URL on mount so an invalid/legacy hash (e.g. `#/foo`) that
-  // silently falls back to dashboard doesn't persist after refresh.
-  useEffect(() => {
-    const raw = (window.location.hash || "").replace(/^#\/?/, "").trim();
-    const canonical = route.page === "exercise" ? raw : route.page;
-    // Guard the empty-hash case: a clean URL without any fragment must stay
-    // clean. We only normalize legacy/invalid hashes like `#/foo`.
-    if (raw && raw !== canonical) {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${window.location.search}#${canonical}`,
-      );
-    }
-    // Run only on mount — route changes after mount go through setHash().
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (pwaAction === "start_workout") {
-      setHash("workouts");
-      onPwaActionConsumed?.();
-    }
-  }, [onPwaActionConsumed, pwaAction]);
-
-  const handleStartProgramWorkout = (session, _prog) => {
-    if (!session) return;
-    const exIds = session.exerciseIds || [];
-    const picks = exIds
-      .map((id) => exercises.find((e) => e.id === id))
-      .filter(Boolean);
-    if (picks.length === 0) return;
-    const progressionKg = session.progressionKg ?? 0;
-    const w = createWorkout();
-    for (const ex of picks) {
-      const isCardio = ex.primaryGroup === "cardio";
-      let suggestedWeight = 0;
-      if (!isCardio && progressionKg > 0) {
-        const lastWorkoutWithEx = workouts.find((wo) =>
-          (wo.items || []).some((it) => it.exerciseId === ex.id),
-        );
-        if (lastWorkoutWithEx) {
-          const item = lastWorkoutWithEx.items.find(
-            (it) => it.exerciseId === ex.id,
-          );
-          const maxWeight = Math.max(
-            0,
-            ...(item?.sets || []).map((s) => s.weightKg || 0),
-          );
-          if (maxWeight > 0) {
-            suggestedWeight = Math.round((maxWeight + progressionKg) * 2) / 2;
-          }
-        }
-      }
-      addItem(w.id, {
-        exerciseId: ex.id,
-        nameUk: ex?.name?.uk || ex?.name?.en,
-        primaryGroup: ex.primaryGroup,
-        musclesPrimary: ex?.muscles?.primary || [],
-        musclesSecondary: ex?.muscles?.secondary || [],
-        type: isCardio ? "distance" : "strength",
-        sets: isCardio ? undefined : [{ weightKg: suggestedWeight, reps: 0 }],
-        durationSec: 0,
-        ...(isCardio ? { distanceM: 0 } : {}),
-      });
-    }
-    try {
-      localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
-      sessionStorage.setItem("fizruk_workouts_mode", "log");
-    } catch {}
-    setHash("workouts");
-  };
-
-  const headerTitle = isAtlas
-    ? "Атлас"
-    : isExercise
-      ? "Вправа"
-      : isPlan
-        ? "План"
-        : page === "programs"
-          ? "Програми"
-          : page === "body"
-            ? "Тіло"
-            : "ФІЗРУК";
+  const showBottomNav = page !== "atlas" && page !== "exercise";
 
   return (
-    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
-        <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
-          {isAtlas || isExercise ? (
-            <button
-              type="button"
-              onClick={() => setHash("dashboard")}
-              className="w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-              aria-label="Назад"
-            >
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M15 18l-6-6 6-6" />
-              </svg>
-            </button>
-          ) : typeof onBackToHub === "function" ? (
-            <button
-              type="button"
-              onClick={onBackToHub}
-              className="shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
-              aria-label="До хабу"
-              title="До хабу"
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <path d="M15 18l-6-6 6-6" />
-              </svg>
-              <span className="text-sm font-semibold">Хаб</span>
-            </button>
-          ) : (
-            <div
-              className={cn(
-                "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-                "bg-gradient-to-br from-teal-100 to-cyan-100",
-                "dark:from-teal-900/40 dark:to-cyan-900/30",
-                "text-teal-600 dark:text-teal-400",
-                "border border-teal-200/60 dark:border-teal-700/30",
-                "shadow-sm",
-              )}
-              aria-hidden
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M6.5 6.5h11M6.5 17.5h11M3 12h18M6 9l-3 3 3 3M18 9l3 3-3 3" />
-              </svg>
-            </div>
-          )}
-          <div className="min-w-0 flex-1">
-            {!isAtlas && !isExercise && (
-              // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker at text-3xs with text-success/70 tint; SectionHeading xs is text-2xs and doesn't expose a /70-opacity success tone.
-              <span className="text-3xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
-                ОСОБИСТИЙ ЖУРНАЛ
-              </span>
-            )}
-            <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-              {headerTitle}
-            </span>
-            {!isAtlas && !isExercise && (
-              <span className="text-2xs text-subtle font-medium truncate">
-                {isPlan
-                  ? "Календар · нагадування · відновлення"
-                  : page === "programs"
-                    ? activeProgram
-                      ? `Активна: ${activeProgram.name}`
-                      : "Оберіть тренувальну програму"
-                    : page === "body"
-                      ? "Вага · сон · самопочуття"
-                      : "Тренування · прогрес"}
-              </span>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={() => setSettingsOpen(true)}
-            className="shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
-            aria-label="Налаштування даних"
-            title="Налаштування даних"
-          >
-            <svg
-              width="22"
-              height="22"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.65"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-              <circle cx="12" cy="12" r="3" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {settingsOpen && (
-        <div
-          className="fixed inset-0 z-[80] flex justify-end"
-          role="presentation"
-        >
-          <button
-            type="button"
-            className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
-            aria-label="Закрити налаштування"
-            onClick={() => setSettingsOpen(false)}
-          />
-          <div
-            ref={settingsPanelRef}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="fizruk-settings-title"
-            className="relative w-full max-w-sm h-full bg-panel border-l border-line shadow-2xl flex flex-col safe-area-pt-pb"
-          >
-            <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line">
-              <h2
-                id="fizruk-settings-title"
-                className="text-base font-semibold text-text"
-              >
-                Дані й резер��ні копії
-              </h2>
-              <button
-                type="button"
-                onClick={() => setSettingsOpen(false)}
-                className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
-                aria-label="Закрити"
-              >
-                <Icon name="close" size={22} />
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto px-4 py-4">
-              <WorkoutBackupBar className="border-0 bg-transparent p-0" />
-            </div>
-          </div>
-        </div>
-      )}
-
-      {storageErrorMsg && (
-        <Banner
-          variant="danger"
-          role="alert"
-          className="mx-4 mt-3 flex items-start justify-between gap-3"
-        >
-          <span>
-            Не вдалося зберегти тренування ({storageErrorMsg}). Можливо, браузер
-            переповнив сховище — експортуй бекап або звільни місце.
-          </span>
-          <button
-            type="button"
-            onClick={() => setStorageErrorMsg(null)}
-            className="shrink-0 text-xs font-semibold text-danger/80 hover:text-danger"
-            aria-label="Закрити повідомлення"
-          >
-            Закрити
-          </button>
-        </Banner>
-      )}
-
-      <div className="flex-1 overflow-hidden flex flex-col">
-        {page === "dashboard" && (
-          <Dashboard
-            onOpenAtlas={() => setHash("atlas")}
-            onOpenPrograms={() => setHash("programs")}
-            activeProgram={activeProgram}
-            todaySession={todaySession}
-            onStartProgramWorkout={handleStartProgramWorkout}
-          />
-        )}
-        {page === "plan" && <PlanCalendar />}
-        {page === "atlas" && <Atlas />}
-        {page === "workouts" && <Workouts />}
-        {page === "progress" && <Progress />}
-        {page === "measurements" && <Measurements />}
-        {page === "programs" && (
-          <Programs
-            onStartWorkout={handleStartProgramWorkout}
-            activeProgramId={activeProgramId}
-            activeProgram={activeProgram}
-            activateProgram={activateProgram}
-            deactivateProgram={deactivateProgram}
-          />
-        )}
-        {page === "body" && (
-          <Body onOpenMeasurements={() => setHash("measurements")} />
-        )}
-        {page === "exercise" && <Exercise exerciseId={route.exerciseId} />}
-      </div>
-
-      {!isAtlas && !isExercise && (
-        <ModuleBottomNav
-          items={NAV.map((item) => ({
-            ...item,
-            badge: item.id === "programs" && !!activeProgram && !!todaySession,
-          }))}
-          activeId={page}
-          onChange={setHash}
-          module="fizruk"
+    <ModuleShell
+      header={
+        <FizrukHeader
+          page={page}
+          activeProgram={activeProgram}
+          onBackToHub={onBackToHub}
+          onBackToDashboard={() => navigate("dashboard")}
+          onOpenSettings={() => setSettingsOpen(true)}
         />
-      )}
-    </div>
+      }
+      overlays={
+        <ModuleSettingsDrawer
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          title="Дані й резервні копії"
+        >
+          <WorkoutBackupBar className="border-0 bg-transparent p-0" />
+        </ModuleSettingsDrawer>
+      }
+      banner={
+        <StorageErrorBanner
+          eventName={FIZRUK_WORKOUTS_STORAGE_ERROR}
+          formatMessage={(reason) =>
+            `Не вдалося зберегти тренування (${reason}). Можливо, браузер переповнив сховище — експортуй бекап або звільни місце.`
+          }
+        />
+      }
+      nav={
+        showBottomNav ? (
+          <ModuleBottomNav
+            items={FIZRUK_NAV}
+            activeId={page}
+            onChange={(id) => navigate(id)}
+            module="fizruk"
+          />
+        ) : null
+      }
+    >
+      <FizrukRouter
+        page={page}
+        exerciseId={exerciseId}
+        activeProgramId={activeProgramId}
+        activeProgram={activeProgram}
+        activateProgram={activateProgram}
+        deactivateProgram={deactivateProgram}
+        todaySession={todaySession}
+        onNavigate={(target) => navigate(target)}
+        onStartProgramWorkout={(session) => handleStartProgramWorkout(session)}
+      />
+    </ModuleShell>
   );
 }

--- a/src/modules/fizruk/hooks/useFizrukProgramStart.ts
+++ b/src/modules/fizruk/hooks/useFizrukProgramStart.ts
@@ -1,0 +1,93 @@
+import { useCallback } from "react";
+import { ACTIVE_WORKOUT_KEY } from "../lib/workoutUi";
+
+interface Exercise {
+  id: string;
+  name?: { uk?: string; en?: string };
+  primaryGroup?: string;
+  muscles?: { primary?: unknown[]; secondary?: unknown[] };
+}
+
+interface Session {
+  exerciseIds?: string[];
+  progressionKg?: number;
+}
+
+interface WorkoutsApi {
+  workouts: Array<{
+    items?: Array<{ exerciseId?: string; sets?: Array<{ weightKg?: number }> }>;
+  }>;
+  createWorkout: () => { id: string };
+  addItem: (workoutId: string, item: unknown) => void;
+}
+
+/**
+ * Factory hook for the "start today's program workout" button. Encodes
+ * the progression + last-weight logic previously inlined in FizrukApp so
+ * the main orchestrator doesn't need to know about `primaryGroup`,
+ * `progressionKg`, or the `ACTIVE_WORKOUT_KEY` session handoff.
+ */
+export function useFizrukProgramStart({
+  workouts,
+  createWorkout,
+  addItem,
+  exercises,
+  navigate,
+}: WorkoutsApi & {
+  exercises: readonly Exercise[];
+  navigate: (next: string) => void;
+}) {
+  return useCallback(
+    (session: Session | undefined | null) => {
+      if (!session) return;
+      const exIds = session.exerciseIds || [];
+      const picks = exIds
+        .map((id) => exercises.find((e) => e.id === id))
+        .filter((e): e is Exercise => Boolean(e));
+      if (picks.length === 0) return;
+      const progressionKg = session.progressionKg ?? 0;
+      const w = createWorkout();
+      for (const ex of picks) {
+        const isCardio = ex.primaryGroup === "cardio";
+        let suggestedWeight = 0;
+        if (!isCardio && progressionKg > 0) {
+          const lastWorkoutWithEx = workouts.find((wo) =>
+            (wo.items || []).some((it) => it.exerciseId === ex.id),
+          );
+          if (lastWorkoutWithEx) {
+            const item = lastWorkoutWithEx.items?.find(
+              (it) => it.exerciseId === ex.id,
+            );
+            const maxWeight = Math.max(
+              0,
+              ...(item?.sets || []).map((s) => s.weightKg || 0),
+            );
+            if (maxWeight > 0) {
+              suggestedWeight = Math.round((maxWeight + progressionKg) * 2) / 2;
+            }
+          }
+        }
+        addItem(w.id, {
+          exerciseId: ex.id,
+          nameUk: ex?.name?.uk || ex?.name?.en,
+          primaryGroup: ex.primaryGroup,
+          musclesPrimary: ex?.muscles?.primary || [],
+          musclesSecondary: ex?.muscles?.secondary || [],
+          type: isCardio ? "distance" : "strength",
+          sets: isCardio ? undefined : [{ weightKg: suggestedWeight, reps: 0 }],
+          durationSec: 0,
+          ...(isCardio ? { distanceM: 0 } : {}),
+        });
+      }
+      try {
+        localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
+        sessionStorage.setItem("fizruk_workouts_mode", "log");
+      } catch {
+        // best-effort session handoff; failure just means the Workouts
+        // page opens in its default mode.
+      }
+      navigate("workouts");
+    },
+    [workouts, createWorkout, addItem, exercises, navigate],
+  );
+}

--- a/src/modules/fizruk/shell/FizrukHeader.tsx
+++ b/src/modules/fizruk/shell/FizrukHeader.tsx
@@ -1,0 +1,143 @@
+import {
+  ModuleHeader,
+  ModuleHeaderBackButton,
+  ModuleHeaderChevronButton,
+  ModuleHeaderIconButton,
+} from "@shared/components/layout";
+import { cn } from "@shared/lib/cn";
+import type { FizrukPage } from "./fizrukRoute";
+
+interface ActiveProgramHeaderView {
+  name: string;
+}
+
+export interface FizrukHeaderProps {
+  page: FizrukPage;
+  activeProgram?: ActiveProgramHeaderView | null;
+  onBackToHub?: () => void;
+  onBackToDashboard: () => void;
+  onOpenSettings: () => void;
+}
+
+function titleFor(page: FizrukPage): string {
+  switch (page) {
+    case "atlas":
+      return "Атлас";
+    case "exercise":
+      return "Вправа";
+    case "plan":
+      return "План";
+    case "programs":
+      return "Програми";
+    case "body":
+      return "Тіло";
+    default:
+      return "ФІЗРУК";
+  }
+}
+
+function subtitleFor(
+  page: FizrukPage,
+  activeProgram?: ActiveProgramHeaderView | null,
+): string {
+  switch (page) {
+    case "plan":
+      return "Календар · нагадування · відновлення";
+    case "programs":
+      return activeProgram
+        ? `Активна: ${activeProgram.name}`
+        : "Оберіть тренувальну програму";
+    case "body":
+      return "Вага · сон · самопочуття";
+    default:
+      return "Тренування · прогрес";
+  }
+}
+
+function DumbbellBadge() {
+  return (
+    <div
+      className={cn(
+        "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
+        "bg-gradient-to-br from-teal-100 to-cyan-100",
+        "dark:from-teal-900/40 dark:to-cyan-900/30",
+        "text-teal-600 dark:text-teal-400",
+        "border border-teal-200/60 dark:border-teal-700/30",
+        "shadow-sm",
+      )}
+      aria-hidden
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M6.5 6.5h11M6.5 17.5h11M3 12h18M6 9l-3 3 3 3M18 9l3 3-3 3" />
+      </svg>
+    </div>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.65"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+export function FizrukHeader({
+  page,
+  activeProgram,
+  onBackToHub,
+  onBackToDashboard,
+  onOpenSettings,
+}: FizrukHeaderProps) {
+  const isAtlas = page === "atlas";
+  const isExercise = page === "exercise";
+  const showChevronBack = isAtlas || isExercise;
+
+  let left = null;
+  if (showChevronBack) {
+    left = <ModuleHeaderChevronButton onClick={onBackToDashboard} />;
+  } else if (typeof onBackToHub === "function") {
+    left = <ModuleHeaderBackButton onClick={onBackToHub} />;
+  } else {
+    left = <DumbbellBadge />;
+  }
+
+  const right = (
+    <ModuleHeaderIconButton
+      onClick={onOpenSettings}
+      ariaLabel="Налаштування даних"
+    >
+      <SettingsIcon />
+    </ModuleHeaderIconButton>
+  );
+
+  return (
+    <ModuleHeader
+      left={left}
+      right={right}
+      title={titleFor(page)}
+      eyebrow={showChevronBack ? undefined : "ОСОБИСТИЙ ЖУРНАЛ"}
+      subtitle={showChevronBack ? undefined : subtitleFor(page, activeProgram)}
+    />
+  );
+}

--- a/src/modules/fizruk/shell/FizrukRouter.tsx
+++ b/src/modules/fizruk/shell/FizrukRouter.tsx
@@ -1,0 +1,78 @@
+import { Dashboard } from "../pages/Dashboard";
+import { Atlas } from "../pages/Atlas";
+import { Exercise } from "../pages/Exercise";
+import { Workouts } from "../pages/Workouts";
+import { Progress } from "../pages/Progress";
+import { Measurements } from "../pages/Measurements";
+import { Body } from "../pages/Body";
+import { Programs } from "../pages/Programs";
+import { PlanCalendar } from "../pages/PlanCalendar";
+import type { FizrukPage } from "./fizrukRoute";
+
+export interface FizrukRouterProps {
+  page: FizrukPage;
+  exerciseId?: string;
+  activeProgramId: string | null;
+  activeProgram: unknown;
+  activateProgram: (id: string | null) => void;
+  deactivateProgram: () => void;
+  todaySession: unknown;
+  onNavigate: (page: FizrukPage) => void;
+  onStartProgramWorkout: (session: unknown, program: unknown) => void;
+}
+
+/**
+ * Thin page switch for Fizruk. Kept here (instead of inlining in
+ * FizrukApp) so adding/removing pages touches one small file and the
+ * top-level App stays focused on orchestration.
+ */
+export function FizrukRouter({
+  page,
+  exerciseId,
+  activeProgramId,
+  activeProgram,
+  activateProgram,
+  deactivateProgram,
+  todaySession,
+  onNavigate,
+  onStartProgramWorkout,
+}: FizrukRouterProps) {
+  switch (page) {
+    case "dashboard":
+      return (
+        <Dashboard
+          onOpenAtlas={() => onNavigate("atlas")}
+          onOpenPrograms={() => onNavigate("programs")}
+          activeProgram={activeProgram}
+          todaySession={todaySession}
+          onStartProgramWorkout={onStartProgramWorkout}
+        />
+      );
+    case "plan":
+      return <PlanCalendar />;
+    case "atlas":
+      return <Atlas />;
+    case "workouts":
+      return <Workouts />;
+    case "progress":
+      return <Progress />;
+    case "measurements":
+      return <Measurements />;
+    case "programs":
+      return (
+        <Programs
+          onStartWorkout={onStartProgramWorkout}
+          activeProgramId={activeProgramId}
+          activeProgram={activeProgram}
+          activateProgram={activateProgram}
+          deactivateProgram={deactivateProgram}
+        />
+      );
+    case "body":
+      return <Body onOpenMeasurements={() => onNavigate("measurements")} />;
+    case "exercise":
+      return <Exercise exerciseId={exerciseId} />;
+    default:
+      return null;
+  }
+}

--- a/src/modules/fizruk/shell/fizrukNav.tsx
+++ b/src/modules/fizruk/shell/fizrukNav.tsx
@@ -1,0 +1,60 @@
+import type { ModuleBottomNavItem } from "@shared/components/ui/ModuleBottomNav";
+import type { FizrukPage } from "./fizrukRoute";
+
+const NAV_SVG_PROPS = {
+  width: 22,
+  height: 22,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.6,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export interface FizrukNavItem extends ModuleBottomNavItem {
+  id: Extract<FizrukPage, "dashboard" | "workouts" | "plan" | "body">;
+}
+
+export const FIZRUK_NAV: readonly FizrukNavItem[] = [
+  {
+    id: "dashboard",
+    label: "Сьогодні",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+  },
+  {
+    id: "workouts",
+    label: "Тренування",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <path d="M6.5 6.5h11M6.5 17.5h11M3 12h18M6 9l-3 3 3 3M18 9l3 3-3 3" />
+      </svg>
+    ),
+  },
+  {
+    id: "plan",
+    label: "План",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+    ),
+  },
+  {
+    id: "body",
+    label: "Тіло",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+      </svg>
+    ),
+  },
+] as const;

--- a/src/modules/fizruk/shell/fizrukRoute.ts
+++ b/src/modules/fizruk/shell/fizrukRoute.ts
@@ -1,0 +1,41 @@
+import {
+  useHashRoute,
+  type UseHashRouteResult,
+} from "@shared/hooks/useHashRoute";
+
+export const FIZRUK_PAGES = [
+  "dashboard",
+  "plan",
+  "atlas",
+  "workouts",
+  "progress",
+  "measurements",
+  "programs",
+  "body",
+  "exercise",
+] as const;
+
+export type FizrukPage = (typeof FIZRUK_PAGES)[number];
+
+export interface FizrukRoute extends UseHashRouteResult<FizrukPage> {
+  exerciseId?: string;
+}
+
+/**
+ * Typed wrapper over `useHashRoute` for Fizruk. Exposes the usual
+ * `{ page, navigate }` shape plus the optional `exerciseId` segment
+ * used by deep links like `#exercise/<id>`.
+ */
+export function useFizrukRoute(): FizrukRoute {
+  const route = useHashRoute<FizrukPage>({
+    defaultPage: "dashboard",
+    validPages: FIZRUK_PAGES,
+  });
+  return {
+    ...route,
+    exerciseId:
+      route.page === "exercise" && route.segments[0]
+        ? route.segments[0]
+        : undefined,
+  };
+}

--- a/src/shared/components/layout/ModuleHeader.tsx
+++ b/src/shared/components/layout/ModuleHeader.tsx
@@ -1,0 +1,200 @@
+import type { ReactNode } from "react";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Sticky module header used by Фінік / Фізрук / Рутина.
+ *
+ * Owns the layout contract — safe-area padding, 68px min-height, divider,
+ * backdrop blur, sticky flex row — and exposes slots so each module can
+ * drop in its own back/hub/settings buttons without re-declaring the shell
+ * styles. Title/subtitle/eyebrow are conventional text rows; modules that
+ * need a completely custom title body can pass `titleSlot` instead.
+ *
+ * Typical composition:
+ *
+ *     <ModuleHeader
+ *       left={<ModuleHeaderBackButton onClick={onBackToHub} />}
+ *       right={<ModuleHeaderIconButton ... />}
+ *       title="ФІЗРУК"
+ *       eyebrow="ОСОБИСТИЙ ЖУРНАЛ"
+ *       subtitle="Тренування · прогрес"
+ *     />
+ */
+
+export interface ModuleHeaderProps {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  eyebrow?: ReactNode;
+  left?: ReactNode;
+  right?: ReactNode;
+  /** Override the default title/eyebrow/subtitle body entirely. */
+  titleSlot?: ReactNode;
+  className?: string;
+}
+
+export function ModuleHeader({
+  title,
+  subtitle,
+  eyebrow,
+  left,
+  right,
+  titleSlot,
+  className,
+}: ModuleHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt",
+        className,
+      )}
+    >
+      <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
+        {left}
+        <div className="min-w-0 flex-1">
+          {titleSlot ?? (
+            <>
+              {eyebrow ? (
+                // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker renders at text-3xs with text-success/70 tint; SectionHeading xs is text-2xs and does not expose a /70-opacity success tone.
+                <span className="text-3xs text-success/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
+                  {eyebrow}
+                </span>
+              ) : null}
+              {title ? (
+                <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
+                  {title}
+                </span>
+              ) : null}
+              {subtitle ? (
+                <span className="text-2xs text-subtle font-medium truncate">
+                  {subtitle}
+                </span>
+              ) : null}
+            </>
+          )}
+        </div>
+        {right}
+      </div>
+    </div>
+  );
+}
+
+export interface ModuleHeaderIconButtonProps {
+  onClick: () => void;
+  ariaLabel: string;
+  title?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Standardized 40×40 icon button used in module headers (back, settings).
+ */
+export function ModuleHeaderIconButton({
+  onClick,
+  ariaLabel,
+  title,
+  children,
+  className,
+}: ModuleHeaderIconButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "shrink-0 w-10 h-10 min-w-[40px] min-h-[40px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80",
+        className,
+      )}
+      aria-label={ariaLabel}
+      title={title ?? ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}
+
+export interface ModuleHeaderBackButtonProps {
+  onClick: () => void;
+  /** Visible label next to the chevron (e.g. "Хаб"). */
+  label?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * "Back" button variant — used for top-level "to hub" navigation. Renders
+ * a chevron + optional label inside the same 40-tall pill as icon buttons.
+ */
+export function ModuleHeaderBackButton({
+  onClick,
+  label = "Хаб",
+  ariaLabel = "До хабу",
+  className,
+}: ModuleHeaderBackButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80",
+        className,
+      )}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M15 18l-6-6 6-6" />
+      </svg>
+      {label ? <span className="text-sm font-semibold">{label}</span> : null}
+    </button>
+  );
+}
+
+/**
+ * Plain chevron-only back button (no label). Used inside a module when a
+ * sub-page (e.g. Atlas, Exercise) wants to return to the module's own
+ * dashboard rather than the global hub.
+ */
+export function ModuleHeaderChevronButton({
+  onClick,
+  ariaLabel = "Назад",
+  className,
+}: {
+  onClick: () => void;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "w-10 h-10 min-w-[40px] min-h-[40px] -ml-1 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors",
+        className,
+      )}
+      aria-label={ariaLabel}
+    >
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M15 18l-6-6 6-6" />
+      </svg>
+    </button>
+  );
+}

--- a/src/shared/components/layout/ModuleSettingsDrawer.tsx
+++ b/src/shared/components/layout/ModuleSettingsDrawer.tsx
@@ -1,0 +1,72 @@
+import { useId, useRef, type ReactNode } from "react";
+import { Icon } from "@shared/components/ui/Icon";
+import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Right-side settings drawer for module "cog" overlays.
+ *
+ * Fizruk/Finyk/Routine previously hand-rolled the same overlay: full-screen
+ * scrim + right-anchored sheet + focus trap + Escape-to-close + safe-area
+ * padding. This primitive owns the markup + a11y so modules just pass the
+ * body.
+ */
+
+export interface ModuleSettingsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ModuleSettingsDrawer({
+  open,
+  onClose,
+  title,
+  children,
+  className,
+}: ModuleSettingsDrawerProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const titleId = useId();
+
+  useDialogFocusTrap(open, panelRef, { onEscape: onClose });
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[80] flex justify-end" role="presentation">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
+        aria-label="Закрити налаштування"
+        onClick={onClose}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={cn(
+          "relative w-full max-w-sm h-full bg-panel border-l border-line shadow-2xl flex flex-col safe-area-pt-pb",
+          className,
+        )}
+      >
+        <div className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b border-line">
+          <h2 id={titleId} className="text-base font-semibold text-text">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            aria-label="Закрити"
+          >
+            <Icon name="close" size={22} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/layout/ModuleShell.tsx
+++ b/src/shared/components/layout/ModuleShell.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Module shell skeleton used by Фінік / Фізрук / Рутина / Харчування.
+ *
+ * Owns the full-viewport flex column, background tokens, and overflow
+ * discipline so every module entrypoint renders identically. Slots keep
+ * module-specific bits (header, banner, bottom nav, overlays) composable
+ * without forcing each module to re-declare the layout.
+ *
+ *     <ModuleShell
+ *       header={<ModuleHeader … />}
+ *       banner={<StorageErrorBanner eventName={…} />}
+ *       nav={<ModuleBottomNav … />}
+ *       overlays={<ModuleSettingsDrawer open={…} … />}
+ *     >
+ *       {page === "dashboard" && <Dashboard />}
+ *       …
+ *     </ModuleShell>
+ */
+
+export interface ModuleShellProps {
+  header?: ReactNode;
+  banner?: ReactNode;
+  nav?: ReactNode;
+  /** Rendered outside the main flex column — drawers, modal overlays, etc. */
+  overlays?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  mainClassName?: string;
+}
+
+export function ModuleShell({
+  header,
+  banner,
+  nav,
+  overlays,
+  children,
+  className,
+  mainClassName,
+}: ModuleShellProps) {
+  return (
+    <div
+      className={cn(
+        "h-dvh flex flex-col bg-bg text-text overflow-hidden",
+        className,
+      )}
+    >
+      {header}
+      {overlays}
+      {banner}
+      <div
+        className={cn("flex-1 overflow-hidden flex flex-col", mainClassName)}
+      >
+        {children}
+      </div>
+      {nav}
+    </div>
+  );
+}

--- a/src/shared/components/layout/StorageErrorBanner.tsx
+++ b/src/shared/components/layout/StorageErrorBanner.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Banner } from "@shared/components/ui/Banner";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Persistent storage-error banner shared by Sergeant modules.
+ *
+ * All four modules previously listened to a module-specific custom event
+ * (`ROUTINE_STORAGE_ERROR`, `FIZRUK_WORKOUTS_STORAGE_ERROR`, …) that the
+ * storage layer dispatches when a write fails (typically a quota
+ * violation). A quota failure won't self-resolve, so a 7s toast is wrong
+ * — the banner stays until the user acks it or frees space.
+ *
+ * This primitive encapsulates the event subscription + render so each
+ * module only has to wire up the event name and an optional message
+ * formatter.
+ */
+
+export interface StorageErrorBannerProps {
+  /** Custom event dispatched by the module's storage layer. */
+  eventName: string;
+  /** Format the final banner copy given the raw reason string. */
+  formatMessage?: (reason: string) => ReactNode;
+  /** aria-label for the dismiss button. Defaults to "Закрити повідомлення". */
+  dismissLabel?: string;
+  className?: string;
+}
+
+interface StorageErrorEventDetail {
+  message?: string;
+}
+
+const DEFAULT_FORMAT = (reason: string) =>
+  `Не вдалося зберегти дані (${reason}). Можливо, браузер переповнив сховище — експортуй бекап або звільни місце.`;
+
+export function StorageErrorBanner({
+  eventName,
+  formatMessage = DEFAULT_FORMAT,
+  dismissLabel = "Закрити повідомлення",
+  className,
+}: StorageErrorBannerProps) {
+  const [reason, setReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onError = (event: Event) => {
+      const detail = (event as CustomEvent<StorageErrorEventDetail>).detail;
+      setReason(detail?.message || "невідома помилка");
+    };
+    window.addEventListener(eventName, onError);
+    return () => window.removeEventListener(eventName, onError);
+  }, [eventName]);
+
+  if (!reason) return null;
+
+  return (
+    <Banner
+      variant="danger"
+      role="alert"
+      className={cn(
+        "mx-4 mt-3 flex items-start justify-between gap-3",
+        className,
+      )}
+    >
+      <span>{formatMessage(reason)}</span>
+      <button
+        type="button"
+        onClick={() => setReason(null)}
+        className="shrink-0 text-xs font-semibold text-danger/80 hover:text-danger"
+        aria-label={dismissLabel}
+      >
+        Закрити
+      </button>
+    </Banner>
+  );
+}

--- a/src/shared/components/layout/index.ts
+++ b/src/shared/components/layout/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Sergeant Design System — module-layout primitives.
+ *
+ * Shared shell for module entrypoints (Фінік / Фізрук / Рутина /
+ * Харчування). Import from `@shared/components/layout` to keep deep
+ * paths stable and autocomplete focused on the public surface.
+ */
+
+export { ModuleShell } from "./ModuleShell";
+export type { ModuleShellProps } from "./ModuleShell";
+
+export {
+  ModuleHeader,
+  ModuleHeaderBackButton,
+  ModuleHeaderChevronButton,
+  ModuleHeaderIconButton,
+} from "./ModuleHeader";
+export type {
+  ModuleHeaderBackButtonProps,
+  ModuleHeaderIconButtonProps,
+  ModuleHeaderProps,
+} from "./ModuleHeader";
+
+export { ModuleSettingsDrawer } from "./ModuleSettingsDrawer";
+export type { ModuleSettingsDrawerProps } from "./ModuleSettingsDrawer";
+
+export { StorageErrorBanner } from "./StorageErrorBanner";
+export type { StorageErrorBannerProps } from "./StorageErrorBanner";

--- a/src/shared/hooks/useHashRoute.test.ts
+++ b/src/shared/hooks/useHashRoute.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useHashRoute } from "./useHashRoute";
+
+type FizrukPage = "dashboard" | "workouts" | "exercise";
+
+const options = {
+  defaultPage: "dashboard" as FizrukPage,
+  validPages: [
+    "dashboard",
+    "workouts",
+    "exercise",
+  ] as const satisfies readonly FizrukPage[],
+  aliases: { payments: "workouts" } as Readonly<Record<string, FizrukPage>>,
+};
+
+function setHash(raw: string) {
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${window.location.search}${raw}`,
+  );
+  window.dispatchEvent(new HashChangeEvent("hashchange"));
+}
+
+describe("useHashRoute", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
+  it("returns defaultPage for empty hash", () => {
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("dashboard");
+    expect(result.current.segments).toEqual([]);
+  });
+
+  it("parses canonical #page", () => {
+    window.location.hash = "workouts";
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("workouts");
+  });
+
+  it("parses #page/segment tail", () => {
+    window.location.hash = "exercise/abc-123";
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("exercise");
+    expect(result.current.segments).toEqual(["abc-123"]);
+  });
+
+  it("normalizes legacy #/page on mount", () => {
+    window.location.hash = "/workouts";
+    renderHook(() => useHashRoute(options));
+    expect(window.location.hash).toBe("#workouts");
+  });
+
+  it("resolves aliases", () => {
+    window.location.hash = "payments";
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("workouts");
+  });
+
+  it("falls back to default for unknown pages", () => {
+    window.location.hash = "nope";
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("dashboard");
+  });
+
+  it("responds to hashchange", () => {
+    const { result } = renderHook(() => useHashRoute(options));
+    expect(result.current.page).toBe("dashboard");
+    act(() => setHash("#workouts"));
+    expect(result.current.page).toBe("workouts");
+  });
+
+  it("navigate() writes to the hash", () => {
+    const { result } = renderHook(() => useHashRoute(options));
+    act(() => result.current.navigate("workouts"));
+    expect(window.location.hash).toBe("#workouts");
+  });
+
+  it("navigate() accepts segment path", () => {
+    const { result } = renderHook(() => useHashRoute(options));
+    act(() => result.current.navigate("exercise/xyz"));
+    expect(window.location.hash).toBe("#exercise/xyz");
+  });
+
+  it("navigate() is a no-op when the target equals current hash", () => {
+    window.location.hash = "workouts";
+    const { result } = renderHook(() => useHashRoute(options));
+    const before = window.location.hash;
+    act(() => result.current.navigate("workouts"));
+    expect(window.location.hash).toBe(before);
+  });
+});

--- a/src/shared/hooks/useHashRoute.ts
+++ b/src/shared/hooks/useHashRoute.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Hash-based router primitive shared across Sergeant modules.
+ *
+ * Every module (Фінік / Фізрук / Рутина / Харчування) historically rolled
+ * its own `parseHash` + `setHash` + hashchange effect. They all shared the
+ * same canonical shape (`#page` or `#page/seg1/seg2`) and the same legacy
+ * tolerance (`#/page` → `#page`), so this hook captures it once.
+ *
+ * Given a whitelist of valid pages and a default, it returns the current
+ * page + any extra `/`-separated segments, plus a `navigate` function that
+ * writes the hash. Legacy `#/page` URLs are normalized on mount via
+ * `history.replaceState`. `aliases` maps retired page ids to canonical
+ * ones (Finyk's `payments` → `budgets`, Nutrition's legacy routes etc.).
+ *
+ * Navigation accepts either a bare page id (`navigate("dashboard")`) or
+ * a full hash with segments (`navigate("exercise/abc123")`).
+ */
+
+export interface UseHashRouteOptions<TPage extends string> {
+  defaultPage: TPage;
+  validPages: readonly TPage[];
+  /** Retired page ids that should resolve to a canonical page. */
+  aliases?: Readonly<Record<string, TPage>>;
+}
+
+export interface HashRoute<TPage extends string> {
+  page: TPage;
+  /** Extra path segments after `#page/`. Empty for bare `#page`. */
+  segments: readonly string[];
+}
+
+export interface UseHashRouteResult<
+  TPage extends string,
+> extends HashRoute<TPage> {
+  navigate: (next: TPage | string) => void;
+}
+
+function parseRaw<TPage extends string>(
+  raw: string,
+  options: UseHashRouteOptions<TPage>,
+): HashRoute<TPage> {
+  const normalized = raw.replace(/^#\/?/, "").trim();
+  if (!normalized) {
+    return { page: options.defaultPage, segments: [] };
+  }
+  const [head, ...rest] = normalized.split("/").filter(Boolean);
+  const aliased = options.aliases?.[head];
+  const candidate = (aliased ?? head) as TPage;
+  if (!options.validPages.includes(candidate)) {
+    return { page: options.defaultPage, segments: [] };
+  }
+  return { page: candidate, segments: rest };
+}
+
+function readHashFromLocation(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.hash || "";
+}
+
+export function useHashRoute<TPage extends string>(
+  options: UseHashRouteOptions<TPage>,
+): UseHashRouteResult<TPage> {
+  const [route, setRoute] = useState<HashRoute<TPage>>(() =>
+    parseRaw(readHashFromLocation(), options),
+  );
+
+  // Keep an effect-stable reference to options so callers can pass inline
+  // objects without tearing down the hashchange listener on every render.
+  // The listener reads the latest options via closure over this state slot.
+  const [frozen] = useState(options);
+
+  useEffect(() => {
+    const onHash = () => setRoute(parseRaw(readHashFromLocation(), frozen));
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, [frozen]);
+
+  // One-time normalization of legacy `#/page` or aliased hashes. We only
+  // rewrite when the raw hash differs from the canonical one so clean
+  // URLs without any fragment stay clean. Compare against the fragment
+  // body (hash minus the leading `#`) rather than the stripped form so
+  // the legacy `#/page` prefix is actually detected as different.
+  useEffect(() => {
+    const body = readHashFromLocation().replace(/^#/, "");
+    if (!body) return;
+    const parsed = parseRaw(readHashFromLocation(), frozen);
+    const canonical =
+      parsed.segments.length > 0
+        ? `${parsed.page}/${parsed.segments.join("/")}`
+        : parsed.page;
+    if (body !== canonical) {
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}#${canonical}`,
+      );
+    }
+    // Mount-only — subsequent changes go through navigate().
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const navigate = useCallback((next: string) => {
+    const target = next.startsWith("#") ? next : `#${next}`;
+    if (window.location.hash === target) return;
+    window.location.hash = target;
+  }, []);
+
+  return { page: route.page, segments: route.segments, navigate };
+}

--- a/src/shared/hooks/usePwaAction.ts
+++ b/src/shared/hooks/usePwaAction.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+/**
+ * PWA-action dispatcher.
+ *
+ * The host app (src/core/App.tsx) reads `?module=<id>&action=<name>` from
+ * the initial URL and passes `pwaAction` down to the active module. Each
+ * module historically implemented its own `useEffect` that switched on
+ * `pwaAction`, invoked a handler, and called `onPwaActionConsumed`. This
+ * hook captures that pattern.
+ *
+ * Usage:
+ *
+ *     usePwaAction(pwaAction, onPwaActionConsumed, {
+ *       start_workout: () => navigate("workouts"),
+ *       add_habit: () => setQuickAddOpen(true),
+ *     });
+ *
+ * Handlers may return a cleanup function (e.g. to cancel a deferred
+ * file-picker click) — it is passed through as the effect cleanup.
+ */
+
+export type PwaActionHandler = () => void | (() => void);
+
+export function usePwaAction(
+  action: string | null | undefined,
+  onConsumed: (() => void) | undefined,
+  handlers: Record<string, PwaActionHandler>,
+): void {
+  useEffect(() => {
+    if (!action) return;
+    const handler = handlers[action];
+    if (!handler) return;
+    const cleanup = handler();
+    onConsumed?.();
+    return typeof cleanup === "function" ? cleanup : undefined;
+    // handlers is intentionally not in the dep list — callers pass an
+    // inline object and we key off the action string, which is the
+    // meaningful trigger. This matches the original per-module effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [action, onConsumed]);
+}


### PR DESCRIPTION
## Summary

Pilot module of the *App.tsx decomposition plan. Introduces a reusable
layout-primitives kit under `@shared/components/layout` + two router/PWA
hooks under `@shared/hooks`, and migrates **FizrukApp** on top of them.

### New shared primitives

| File | Role |
|---|---|
| `@shared/components/layout/ModuleShell` | Full-viewport flex-column skeleton with `header` / `banner` / `nav` / `overlays` slots (`h-dvh flex flex-col bg-bg text-text overflow-hidden`). |
| `@shared/components/layout/ModuleHeader` + `ModuleHeaderBackButton` / `ModuleHeaderChevronButton` / `ModuleHeaderIconButton` | Sticky 68 px header row, safe-area padded, with standardised 40 × 40 icon/back buttons. |
| `@shared/components/layout/ModuleSettingsDrawer` | Right-anchored overlay with focus trap + `Escape`-to-close + safe-area wrapper. |
| `@shared/components/layout/StorageErrorBanner` | Subscribes to a module-specific storage-error event, renders persistent `<Banner variant="danger">` (quota errors don't self-resolve, so a transient toast is wrong). |
| `@shared/hooks/useHashRoute` | Typed hash router: `{ page, segments, navigate }`, normalises legacy `#/page` via `history.replaceState`, supports aliases for retired page ids. |
| `@shared/hooks/usePwaAction` | Consumes PWA deep-link action → handler map + `onConsumed`. |

`useHashRoute` has 10 unit tests covering the default page, canonical
parsing, segment tails, `#/page` normalisation, aliases, unknown-page
fallback, hashchange reactivity, and `navigate()` semantics.

### FizrukApp pilot

`src/modules/fizruk/FizrukApp.tsx`: **508 → 136 lines** (pure orchestration).

New files under `src/modules/fizruk/`:

- `shell/fizrukRoute.ts` — `FIZRUK_PAGES` union + `useFizrukRoute`
- `shell/fizrukNav.tsx` — `FIZRUK_NAV` items (inline nav SVGs extracted from App)
- `shell/FizrukHeader.tsx` — module-specific header body (titles, subtitles, dumbbell badge, atlas/exercise back button)
- `shell/FizrukRouter.tsx` — page `switch` extracted from App
- `hooks/useFizrukProgramStart.ts` — program workout kickoff logic (progression-kg lookup, `ACTIVE_WORKOUT_KEY` handoff)

No behavioural changes vs the original FizrukApp. Removed a dead
`item.id === "programs"` badge check that never fired (FIZRUK_NAV has no
`programs` item).

### Verification

```
npm run format:check   ✓
npm run lint           ✓  (eslint + scripts/check-imports.mjs)
npm run typecheck      ✓  (tsconfig.json / server / sw)
npm run test           ✓  110 files · 1064 tests
npm run build          ✓  vite + PWA
```

## Review & Testing Checklist for Human

- [ ] Open Fizruk from the hub: header back-to-hub button still works and `onBackToHub` unwinds to the hub.
- [ ] From Fizruk dashboard, open Atlas and Exercise — chevron back button returns to `#dashboard`; bottom-nav is hidden on those two pages (unchanged behaviour).
- [ ] Deep-link `/#/plan` (legacy slash-prefixed hash) — URL should normalise to `/#plan` after mount and Plan tab should render.
- [ ] Open the settings cog in Fizruk — drawer opens, focus traps, `Esc` closes, scrim click closes, focus returns to the cog button.
- [ ] Trigger a workouts storage error (e.g. fill localStorage) — red banner appears once and stays until dismissed.
- [ ] PWA shortcut "Розпочати тренування" (`?module=fizruk&action=start_workout`) still navigates into `#workouts`.

### Notes

- `ModuleSettingsDrawer` and `StorageErrorBanner` are currently only consumed by Fizruk; the follow-up PRs (Finyk / Routine / Nutrition) will adopt the same primitives, which is where the deduplication really lands.
- `useHashRoute` supersedes Finyk's `useHashRouter`, Fizruk's `parseHash` + `setHash`, and Nutrition's `useNutritionHashRoute`; those will be migrated in per-module follow-up PRs.
- Safe to merge standalone — no other module imports the new layout barrel yet, so regression surface is limited to Fizruk.


Link to Devin session: https://app.devin.ai/sessions/bd30d4f5ec2347328e37822cd0495bbb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
