### PR TITLE
fix(nutrition): move eslint-disable to correct line in useNutritionRemoteActions

### DIFF
--- a/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
+++ b/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
@@ -297,11 +297,11 @@ export function useNutritionRemoteActions({
       setDayPlanBusy(true);
       setErr("");
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onSuccess: ({
       plan,
       regenerateMealType,
     }: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       plan: any;
       regenerateMealType: string | null | undefined;
     }) => {


### PR DESCRIPTION
## Summary

Fast-follow after #373.

На `main` `npm run lint` впав з помилкою у <ref_file file="/home/ubuntu/repos/Sergeant/src/modules/nutrition/hooks/useNutritionRemoteActions.ts" />:

```
300:5   warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')
305:13  error    Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

`// eslint-disable-next-line` стояв перед `onSuccess: ({` (рядок 300), де жодного `any` нема — тому директива вважалась невикористаною, а власне `plan: any;` (рядок 305) був не прикритий.

Перенесено коментар безпосередньо перед `plan: any;` всередині type-annotation об'єкта — там, де порушення реально виникає.

Локально ✅ `npm run lint` / `typecheck` / `test` / `build`.

## Review & Testing Checklist for Human

- [ ] Перевірити, що CI (`check` job) стає зеленим на цьому PR.

### Notes

Поведінка коду не змінюється — лише переміщення eslint-директиви.

Link to Devin session: https://app.devin.ai/sessions/c8ec9be656df485582b9704ce77fa17c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
