### PR TITLE
refactor(finyk): decompose FinykApp via shared layout primitives

### DIFF
--- a/src/modules/finyk/FinykApp.tsx
+++ b/src/modules/finyk/FinykApp.tsx
@@ -1,160 +1,32 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useEffect, useState } from "react";
+import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
+import { ModuleShell } from "@shared/components/layout/ModuleShell";
+import { useToast } from "@shared/hooks/useToast";
+import { usePwaAction } from "@shared/hooks/usePwaAction";
 import { useMonobank } from "./hooks/useMonobank";
 import { usePrivatbank } from "./hooks/usePrivatbank";
 import { useStorage } from "./hooks/useStorage";
+import { useUnifiedFinanceData } from "./hooks/useUnifiedFinanceData";
+import { useFinykPersonalization } from "./hooks/useFinykPersonalization";
+import { useSwipeTabs } from "./hooks/useSwipeTabs";
 import { readRaw, writeRaw } from "./lib/finykStorage.js";
 import {
   FINYK_MANUAL_ONLY_KEY,
   enableFinykManualOnly,
 } from "./lib/demoData.js";
-import { PAGES } from "./constants";
-import { Button } from "@shared/components/ui/Button";
-import { Input } from "@shared/components/ui/Input";
-import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
-import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
-import { cn } from "@shared/lib/cn";
-import { useToast } from "@shared/hooks/useToast";
-import { Overview } from "./pages/Overview.jsx";
-import { Transactions } from "./pages/Transactions.jsx";
-import { Budgets } from "./pages/Budgets.jsx";
-import { Assets } from "./pages/Assets.jsx";
-import { Analytics } from "./pages/Analytics.jsx";
-import { ManualExpenseSheet } from "./components/ManualExpenseSheet.jsx";
-import { useUnifiedFinanceData } from "./hooks/useUnifiedFinanceData";
-import { useFinykPersonalization } from "./hooks/useFinykPersonalization";
 import { consumePresetPrefill } from "../../core/onboarding/presetPrefill.js";
-
-const NAV_ICONS = {
-  overview: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-    </svg>
-  ),
-  transactions: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
-      <rect x="9" y="3" width="6" height="4" rx="1" />
-      <line x1="9" y1="12" x2="15" y2="12" />
-      <line x1="9" y1="16" x2="13" y2="16" />
-    </svg>
-  ),
-  budgets: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-      <line x1="16" y1="2" x2="16" y2="6" />
-      <line x1="8" y1="2" x2="8" y2="6" />
-      <line x1="3" y1="10" x2="21" y2="10" />
-    </svg>
-  ),
-  assets: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="2" y="5" width="20" height="14" rx="2" />
-      <line x1="2" y1="10" x2="22" y2="10" />
-    </svg>
-  ),
-  analytics: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="18" y1="20" x2="18" y2="10" />
-      <line x1="12" y1="20" x2="12" y2="4" />
-      <line x1="6" y1="20" x2="6" y2="14" />
-    </svg>
-  ),
-  settings: (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-    </svg>
-  ),
-};
-
-const NAV_ITEMS = [
-  { id: "overview", label: "Огляд" },
-  { id: "transactions", label: "Операції" },
-  { id: "budgets", label: "Планування" },
-  { id: "analytics", label: "Аналітика" },
-  { id: "assets", label: "Активи" },
-];
-const NAV_IDS = NAV_ITEMS.map((n) => n.id);
-
-const ALL_PAGE_IDS = PAGES.map((p) => p.id);
-
-function useHashRouter(
-  defaultPage = "overview",
-): [string, (p: string) => void] {
-  const getPage = useCallback(() => {
-    // Accept both `#page` (canonical, matches fizruk/nutrition) and legacy `#/page`.
-    let p =
-      window.location.hash.replace(/^#\/?/, "").split("/")[0] || defaultPage;
-    if (p === "payments") p = "budgets";
-    return p;
-  }, [defaultPage]);
-  const [page, setPageState] = useState(getPage);
-  useEffect(() => {
-    const handler = () => setPageState(getPage());
-    window.addEventListener("hashchange", handler);
-    return () => window.removeEventListener("hashchange", handler);
-  }, [getPage]);
-  const navigate = (p: string) => {
-    window.location.hash = p;
-  };
-  return [ALL_PAGE_IDS.includes(page) ? page : defaultPage, navigate];
-}
+import { ManualExpenseSheet } from "./components/ManualExpenseSheet.jsx";
+import { FinykHeader, type SyncTone } from "./shell/FinykHeader";
+import { FinykRouter } from "./shell/FinykRouter";
+import { FinykLoginScreen } from "./shell/FinykLoginScreen";
+import { FinykAuthErrorBanner } from "./shell/FinykAuthErrorBanner";
+import { FinykAddExpenseFab } from "./shell/FinykAddExpenseFab";
+import { FINYK_NAV } from "./shell/finykNav";
+import { useFinykRoute, type FinykPage } from "./shell/finykRoute";
 
 const PRIVAT_ENABLED = false;
+const FAB_PAGES: readonly FinykPage[] = ["overview", "transactions", "budgets"];
+const NAV_IDS = FINYK_NAV.map((item) => item.id);
 
 interface FinykAppProps {
   onBackToHub?: () => void;
@@ -162,7 +34,14 @@ interface FinykAppProps {
   onPwaActionConsumed?: () => void;
 }
 
-export default function App({
+function deriveSyncTone(status: string | undefined): SyncTone {
+  if (status === "error") return { dot: "bg-danger", text: "помилка" };
+  if (status === "partial") return { dot: "bg-warning", text: "частково" };
+  if (status === "loading") return { dot: "bg-muted", text: "оновлення" };
+  return { dot: "bg-success", text: "ок" };
+}
+
+export default function FinykApp({
   onBackToHub,
   pwaAction,
   onPwaActionConsumed,
@@ -170,33 +49,28 @@ export default function App({
   const mono = useMonobank();
   const privat = usePrivatbank(PRIVAT_ENABLED);
   const toast = useToast();
-  // Pass the full toast API to storage so it can dispatch `success`/`error`
-  // variants directly — the old `showToast(msg, type)` wrapper silently
-  // collapsed everything except `error` to `success`, which blocked any
-  // `warning`/`info`/`action` usage from the shared Toast module.
   const storage = useStorage({ toast });
-  const [page, navigate] = useHashRouter();
-  const [tokenInput, setTokenInput] = useState("");
-  const [showToken, setShowToken] = useState(false);
-  const [rememberToken, setRememberToken] = useState(
-    () => !!readRaw("finyk_token_remembered", ""),
-  );
-  const [categoryFilter, setCategoryFilter] = useState(null);
+  const { page, navigate } = useFinykRoute();
+
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const [showBalance, setShowBalance] = useState(
     () => readRaw("finyk_show_balance_v1", "1") !== "0",
   );
   const [showExpenseSheet, setShowExpenseSheet] = useState(false);
-  const [editingManualExpenseId, setEditingManualExpenseId] = useState(null);
-  // Для prefill категорії при кліку на quick-add картку з Overview.
-  const [quickAddCategory, setQuickAddCategory] = useState(null);
+  const [editingManualExpenseId, setEditingManualExpenseId] = useState<
+    string | null
+  >(null);
+  const [quickAddCategory, setQuickAddCategory] = useState<string | null>(null);
   // Prefill опису з FTUX preset sheet («Кава», «Таксі», «Обід»). Окрема
   // стейт-клітинка, бо quick-add з Overview задає лише категорію —
   // description лишається порожнім і поповнюється користувачем.
-  const [quickAddDescription, setQuickAddDescription] = useState(null);
+  const [quickAddDescription, setQuickAddDescription] = useState<string | null>(
+    null,
+  );
   // "Manual only" bypass: user completed onboarding without Monobank or
-  // pressed «Далі без банку» on the login screen. When set, we render the
-  // normal Finyk UI populated from manual expenses even if `clientInfo` is
-  // still null — the bank can still be connected later from settings.
+  // pressed «Далі без банку» on the login screen. When set, we render
+  // the normal Finyk UI populated from manual expenses even if
+  // `clientInfo` is still null.
   const [manualOnly, setManualOnly] = useState(
     () => readRaw(FINYK_MANUAL_ONLY_KEY, "") === "1",
   );
@@ -212,17 +86,15 @@ export default function App({
       else toast.error("Не вдалось завантажити синк-дані");
     }
     // Одноразово при монтуванні: ?sync= у URL
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- storage/toast не повинні перезапускати імпорт з URL
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (pwaAction === "add_expense") {
+  usePwaAction(pwaAction, onPwaActionConsumed, {
+    add_expense: () => {
       // FTUX preset sheet може стешити `item.data` у sessionStorage
       // (див. `writePresetPrefill`), щоб плитки «Кава» / «Таксі» / «Обід»
       // не деградували до трьох ідентичних порожніх форм. Споживаємо
-      // prefill ТІЛЬКИ для нового запису — без `editingManualExpenseId`,
-      // щоб випадковий stale prefill не перезаписав категорію під час
-      // редагування існуючої витрати.
+      // prefill ТІЛЬКИ для нового запису — без `editingManualExpenseId`.
       const prefill = consumePresetPrefill("finyk");
       navigate("transactions");
       setEditingManualExpenseId(null);
@@ -233,560 +105,146 @@ export default function App({
         typeof prefill?.description === "string" ? prefill.description : null,
       );
       setShowExpenseSheet(true);
-      onPwaActionConsumed?.();
-    }
-    // `navigate` — стабільна локальна функція useHashRouter, не ре-створюється між рендерами.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pwaAction, onPwaActionConsumed]);
-
-  useEffect(() => {
-    const h = window.location.hash;
-    if (h === "#/payments" || h === "#payments") {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}#budgets`,
-      );
-    }
-  }, []);
+    },
+  });
 
   const { mergedMono } = useUnifiedFinanceData({ mono, privat });
-
-  // Частотна персоналізація: топ-категорії/мерчанти користувача.
-  // Використовуються у quick add, dashboard-картці та підказках.
   const { frequentCategories, frequentMerchants } = useFinykPersonalization({
     mono: mergedMono,
     storage,
   });
 
   const { clientInfo, connecting, error, authError, connect } = mono;
-  const syncTone =
-    mergedMono?.syncState?.status === "error"
-      ? { dot: "bg-danger", text: "помилка" }
-      : mergedMono?.syncState?.status === "partial"
-        ? { dot: "bg-warning", text: "частково" }
-        : mergedMono?.syncState?.status === "loading"
-          ? { dot: "bg-muted", text: "оновлення" }
-          : { dot: "bg-success", text: "ок" };
+  const syncTone = deriveSyncTone(mergedMono?.syncState?.status);
 
-  // Свайп між вкладками (без pull-to-refresh: скрол живе всередині сторінок, зовнішній scrollTop завжди 0)
-  const touchStartX = useRef(null);
-  const touchStartY = useRef(null);
+  const swipeHandlers = useSwipeTabs({
+    tabIds: NAV_IDS,
+    activeId: page,
+    onChange: (id) => navigate(id as FinykPage),
+  });
 
-  const handleTouchStart = (e) => {
-    touchStartX.current = e.touches[0].clientX;
-    touchStartY.current = e.touches[0].clientY;
-  };
-  const handleTouchEnd = (e) => {
-    if (touchStartX.current === null || touchStartY.current === null) return;
-    const dx = touchStartX.current - e.changedTouches[0].clientX;
-    const dy = touchStartY.current - e.changedTouches[0].clientY;
-    touchStartX.current = null;
-    touchStartY.current = null;
-
-    // Require a clearly horizontal swipe so vertical scrolls in nested lists
-    // (transactions, budgets) never trigger tab switches: |dx| must exceed
-    // both a comfortable threshold (60px) AND ~1.5× the vertical travel.
-    if (Math.abs(dx) < 60 || Math.abs(dx) < Math.abs(dy) * 1.5) return;
-    const curIdx = NAV_IDS.indexOf(page);
-    if (curIdx === -1) return;
-    const next = curIdx + (dx > 0 ? 1 : -1);
-    if (next >= 0 && next < NAV_IDS.length) navigate(NAV_IDS[next]);
-  };
-
-  // ── Login screen ──────────────────────────────────────────────────────
   if (!clientInfo && !manualOnly) {
     return (
-      <div className="min-h-dvh flex items-center justify-center p-5 bg-bg safe-area-pt-pb">
-        <div className="w-full max-w-sm">
-          <div className="text-center mb-8">
-            <div
-              className={cn(
-                "w-20 h-20 mx-auto rounded-3xl flex items-center justify-center mb-4",
-                "bg-gradient-to-br from-brand-100 to-brand-200",
-                "dark:from-brand-900/40 dark:to-brand-800/30",
-                "border border-brand-200/60 dark:border-brand-700/30",
-                "shadow-card",
-              )}
-            >
-              <svg
-                width="40"
-                height="40"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-brand-600 dark:text-brand-400"
-                aria-hidden
-              >
-                <rect x="3" y="8" width="18" height="12" rx="2" />
-                <path d="M7 8V6a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2" />
-                <line x1="3" y1="12" x2="21" y2="12" />
-              </svg>
-            </div>
-            <h1 className="text-2xl font-bold text-text">ФІНІК</h1>
-            <p className="text-sm text-muted mt-1">
-              Персональний фінансовий менеджер
-            </p>
-          </div>
-
-          <div
-            className={cn(
-              "bg-panel/95 backdrop-blur-xl border rounded-3xl p-6 shadow-float",
-              "border-line dark:border-line",
-            )}
-          >
-            <label
-              className="text-sm text-muted mb-2 block"
-              htmlFor="finyk-mono-token"
-            >
-              API токен Monobank
-            </label>
-            <p className="text-xs text-subtle mb-2">
-              Mono → Налаштування → Інші → API
-            </p>
-            <div className="relative mt-1">
-              <Input
-                id="finyk-mono-token"
-                className="pr-20"
-                type={showToken ? "text" : "password"}
-                placeholder="Вставте токен Mono API"
-                value={tokenInput}
-                onChange={(e) => setTokenInput(e.target.value)}
-                onKeyDown={(e) =>
-                  e.key === "Enter" &&
-                  connect(tokenInput.trim(), false, rememberToken)
-                }
-                autoComplete="off"
-              />
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                className="absolute right-10 top-1/2 -translate-y-1/2 h-8 w-8 p-0 border-0"
-                aria-label="Вставити з буфера обміну"
-                title="Вставити з буфера"
-                onClick={async () => {
-                  try {
-                    setTokenInput(
-                      (await navigator.clipboard.readText()).trim(),
-                    );
-                  } catch {
-                    toast.error("Не вдалось прочитати буфер обміну");
-                  }
-                }}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden
-                >
-                  <rect x="9" y="9" width="13" height="13" rx="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                </svg>
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0 border-0"
-                aria-label={showToken ? "Приховати токен" : "Показати токен"}
-                onClick={() => setShowToken((v) => !v)}
-              >
-                {showToken ? (
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                    <line x1="1" y1="1" x2="23" y2="23" />
-                  </svg>
-                ) : (
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                    <circle cx="12" cy="12" r="3" />
-                  </svg>
-                )}
-              </Button>
-            </div>
-
-            <label className="flex items-center gap-2.5 mt-3 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                className="w-4 h-4 rounded accent-emerald-600 cursor-pointer"
-                checked={rememberToken}
-                onChange={(e) => setRememberToken(e.target.checked)}
-              />
-              <span className="text-sm text-muted">
-                Запам{"'"}ятати токен на цьому пристрої
-              </span>
-            </label>
-
-            {authError && (
-              <div className="mt-3 text-sm bg-warning/15 border border-warning/40 rounded-xl px-3 py-2.5 space-y-1">
-                <p className="font-semibold text-text">
-                  Токен потребує оновлення
-                </p>
-                <p className="text-xs text-muted">{authError}</p>
-                <p className="text-xs text-muted">
-                  Отримайте новий токен: Monobank → Налаштування → API
-                </p>
-              </div>
-            )}
-            {error && !authError && (
-              <p className="mt-3 text-sm text-danger bg-danger/10 rounded-xl px-3 py-2">
-                {error}
-              </p>
-            )}
-
-            <Button
-              type="button"
-              className={cn(
-                "mt-4 w-full h-12 min-h-[48px] text-base border-0",
-                "bg-gradient-to-r from-brand-600 to-brand-700",
-                "hover:from-brand-700 hover:to-brand-800",
-                "text-white font-semibold",
-                "shadow-md hover:shadow-glow",
-                "transition-all duration-200",
-                "active:scale-[0.98]",
-              )}
-              onClick={() => {
-                enableFinykManualOnly();
-                setManualOnly(true);
-              }}
-            >
-              Почати без банку
-            </Button>
-            <p className="mt-2 text-center text-xs text-subtle">
-              Ручні витрати, бюджети та аналітика — без API-токена. Monobank
-              можна підключити пізніше.
-            </p>
-
-            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-                "або через API" divider row — structurally a delimiter
-                between two bg-line spans, not a heading. */}
-            <div className="my-4 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
-              <span className="flex-1 h-px bg-line" />
-              або через API
-              <span className="flex-1 h-px bg-line" />
-            </div>
-            <Button
-              type="button"
-              variant="secondary"
-              className="w-full min-h-[48px]"
-              onClick={() => connect(tokenInput.trim(), false, rememberToken)}
-              disabled={connecting || !tokenInput.trim()}
-            >
-              {connecting ? "Підключення…" : "Підключити Monobank"}
-            </Button>
-            {typeof onBackToHub === "function" && (
-              <Button
-                type="button"
-                variant="ghost"
-                className="mt-1 w-full min-h-[44px]"
-                onClick={onBackToHub}
-              >
-                ← Назад до хабу
-              </Button>
-            )}
-            <p className="mt-4 text-center text-xs text-subtle flex items-center justify-center gap-1.5">
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <rect x="3" y="11" width="18" height="11" rx="2" />
-                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-              </svg>
-              Токен зберігається лише у твоєму браузері
-            </p>
-          </div>
-        </div>
-      </div>
+      <FinykLoginScreen
+        connecting={connecting}
+        error={error}
+        authError={authError}
+        onConnect={connect}
+        onStartManualOnly={() => {
+          enableFinykManualOnly();
+          setManualOnly(true);
+        }}
+        onClipboardError={() =>
+          toast.error("Не вдалось прочитати буфер обміну")
+        }
+        onBackToHub={onBackToHub}
+      />
     );
   }
 
-  // ── Main app ──────────────────────────────────────────────────────────
   return (
-    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      {/* Header */}
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
-        <div className="flex h-14 items-center justify-between px-4 sm:px-5 gap-3">
-          <div className="flex items-center gap-2.5 min-w-0">
-            <div
-              className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 border border-emerald-500/15"
-              aria-hidden
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <rect x="2" y="5" width="20" height="14" rx="2" />
-                <line x1="2" y1="10" x2="22" y2="10" />
-              </svg>
-            </div>
-            <div className="min-w-0">
-              <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-                ФІНІК
-              </span>
-              <span className="text-2xs text-subtle font-medium hidden sm:block truncate">
-                Monobank · бюджети
-              </span>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-2 text-xs text-subtle select-none">
-              <span className={cn("w-2 h-2 rounded-full", syncTone.dot)} />
-              <span className="hidden sm:inline">{syncTone.text}</span>
-            </div>
-            <button
-              type="button"
-              onClick={() => setShowBalance((v) => !v)}
-              className="w-11 h-11 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors"
-              aria-label={showBalance ? "Приховати суми" : "Показати суми"}
-              title={showBalance ? "Приховати суми" : "Показати суми"}
-            >
-              {showBalance ? (
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden
-                >
-                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                  <circle cx="12" cy="12" r="3" />
-                </svg>
-              ) : (
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden
-                >
-                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
-                  <line x1="1" y1="1" x2="23" y2="23" />
-                </svg>
-              )}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Page content */}
+    <ModuleShell
+      header={
+        <FinykHeader
+          syncTone={syncTone}
+          showBalance={showBalance}
+          onToggleBalance={() => setShowBalance((v) => !v)}
+        />
+      }
+      overlays={
+        <>
+          {mono.authError && (
+            <FinykAuthErrorBanner
+              message={mono.authError}
+              onDismiss={() => mono.setAuthError("")}
+              onOpenHub={onBackToHub}
+            />
+          )}
+          {FAB_PAGES.includes(page) && (
+            <FinykAddExpenseFab
+              onClick={() => {
+                setEditingManualExpenseId(null);
+                setShowExpenseSheet(true);
+              }}
+            />
+          )}
+          <ManualExpenseSheet
+            open={showExpenseSheet}
+            onClose={() => {
+              setShowExpenseSheet(false);
+              setEditingManualExpenseId(null);
+              setQuickAddCategory(null);
+              setQuickAddDescription(null);
+            }}
+            initialExpense={
+              editingManualExpenseId
+                ? (storage.manualExpenses || []).find(
+                    (e: { id: string | number }) =>
+                      String(e.id) === String(editingManualExpenseId),
+                  ) || null
+                : null
+            }
+            initialCategory={quickAddCategory}
+            initialDescription={quickAddDescription}
+            frequentCategories={frequentCategories}
+            frequentMerchants={frequentMerchants}
+            onSave={(expense: { id?: string | number }) => {
+              if (expense?.id) {
+                storage.editManualExpense?.(expense.id, expense);
+                toast.success("Витрату оновлено.");
+              } else {
+                storage.addManualExpense(expense);
+                toast.success("Витрату додано.");
+              }
+            }}
+          />
+        </>
+      }
+      nav={
+        <ModuleBottomNav
+          items={FINYK_NAV}
+          activeId={page}
+          onChange={(id) => navigate(id as FinykPage)}
+          module="finyk"
+        />
+      }
+      mainClassName="min-h-0 touch-pan-y"
+    >
       <div
-        className="flex-1 overflow-hidden flex flex-col min-h-0 touch-pan-y"
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
+        className="flex-1 overflow-hidden flex flex-col min-h-0"
+        onTouchStart={swipeHandlers.onTouchStart}
+        onTouchEnd={swipeHandlers.onTouchEnd}
       >
         <div
           key={`page-${page}`}
           className="flex-1 overflow-hidden flex flex-col min-h-0 motion-safe:animate-fade-in"
         >
-          {page === "overview" && (
-            <SectionErrorBoundary
-              key="page-overview"
-              title="Не вдалось показати «Огляд»"
-            >
-              <Overview
-                mono={mergedMono}
-                storage={storage}
-                onNavigate={navigate}
-                onCategoryClick={(catId) => {
-                  setCategoryFilter(catId);
-                  navigate("transactions");
-                }}
-                showBalance={showBalance}
-                frequentCategories={frequentCategories}
-                frequentMerchants={frequentMerchants}
-                onQuickAdd={(manualLabel) => {
-                  setEditingManualExpenseId(null);
-                  setQuickAddCategory(manualLabel || null);
-                  setShowExpenseSheet(true);
-                }}
-              />
-            </SectionErrorBoundary>
-          )}
-          {page === "transactions" && (
-            <SectionErrorBoundary
-              key="page-transactions"
-              title="Не вдалось показати «Операції»"
-            >
-              <Transactions
-                mono={mergedMono}
-                storage={storage}
-                showBalance={showBalance}
-                categoryFilter={categoryFilter}
-                onClearCategoryFilter={() => setCategoryFilter(null)}
-                onEditManualExpense={(id) => {
-                  setEditingManualExpenseId(String(id));
-                  setShowExpenseSheet(true);
-                }}
-              />
-            </SectionErrorBoundary>
-          )}
-          {page === "budgets" && (
-            <SectionErrorBoundary
-              key="page-budgets"
-              title="Не вдалось показати «Планування»"
-            >
-              <Budgets mono={mergedMono} storage={storage} />
-            </SectionErrorBoundary>
-          )}
-          {page === "analytics" && (
-            <SectionErrorBoundary
-              key="page-analytics"
-              title="Не вдалось показати «Аналітику»"
-            >
-              <Analytics mono={mergedMono} storage={storage} />
-            </SectionErrorBoundary>
-          )}
-          {page === "assets" && (
-            <SectionErrorBoundary
-              key="page-assets"
-              title="Не вдалось показати «Активи»"
-            >
-              <Assets
-                mono={mergedMono}
-                storage={storage}
-                showBalance={showBalance}
-              />
-            </SectionErrorBoundary>
-          )}
+          <FinykRouter
+            page={page}
+            mono={mergedMono}
+            storage={storage}
+            navigate={navigate}
+            showBalance={showBalance}
+            categoryFilter={categoryFilter}
+            onCategoryClick={(catId) => {
+              setCategoryFilter(catId);
+              navigate("transactions");
+            }}
+            onClearCategoryFilter={() => setCategoryFilter(null)}
+            onEditManualExpense={(id) => {
+              setEditingManualExpenseId(String(id));
+              setShowExpenseSheet(true);
+            }}
+            onQuickAdd={(manualLabel) => {
+              setEditingManualExpenseId(null);
+              setQuickAddCategory(manualLabel || null);
+              setShowExpenseSheet(true);
+            }}
+            frequentCategories={frequentCategories}
+            frequentMerchants={frequentMerchants}
+          />
         </div>
       </div>
-
-      {(page === "overview" ||
-        page === "transactions" ||
-        page === "budgets") && (
-        <button
-          onClick={() => {
-            setEditingManualExpenseId(null);
-            setShowExpenseSheet(true);
-          }}
-          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
-          aria-label="Додати витрату"
-        >
-          +
-        </button>
-      )}
-
-      {mono.authError && (
-        <div className="fixed top-[calc(56px+env(safe-area-inset-top,0px)+8px)] left-4 right-4 z-50 max-w-lg mx-auto">
-          <div className="bg-warning/15 border border-warning/40 rounded-2xl px-4 py-3 flex items-start gap-3 shadow-card">
-            <span className="text-lg shrink-0 mt-0.5">⚠️</span>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-semibold text-text">
-                Токен потребує оновлення
-              </p>
-              <p className="text-xs text-muted mt-0.5">{mono.authError}</p>
-              {onBackToHub && (
-                <button
-                  onClick={onBackToHub}
-                  className="text-xs font-semibold text-primary mt-2 hover:underline"
-                >
-                  Оновити токен у Налаштуваннях Hub
-                </button>
-              )}
-            </div>
-            <button
-              onClick={() => mono.setAuthError("")}
-              className="text-muted hover:text-text transition-colors shrink-0"
-              aria-label="Закрити"
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-      )}
-
-      <ManualExpenseSheet
-        open={showExpenseSheet}
-        onClose={() => {
-          setShowExpenseSheet(false);
-          setEditingManualExpenseId(null);
-          setQuickAddCategory(null);
-          setQuickAddDescription(null);
-        }}
-        initialExpense={
-          editingManualExpenseId
-            ? (storage.manualExpenses || []).find(
-                (e) => String(e.id) === String(editingManualExpenseId),
-              ) || null
-            : null
-        }
-        initialCategory={quickAddCategory}
-        initialDescription={quickAddDescription}
-        frequentCategories={frequentCategories}
-        frequentMerchants={frequentMerchants}
-        onSave={(expense) => {
-          if (expense?.id) {
-            storage.editManualExpense?.(expense.id, expense);
-            toast.success("Витрату оновлено.");
-          } else {
-            storage.addManualExpense(expense);
-            toast.success("Витрату додано.");
-          }
-        }}
-      />
-
-      {/* Bottom navigation */}
-      <ModuleBottomNav
-        items={NAV_ITEMS.map((item) => ({
-          id: item.id,
-          label: item.label,
-          icon: NAV_ICONS[item.id],
-        }))}
-        activeId={page}
-        onChange={navigate}
-        module="finyk"
-      />
-    </div>
+    </ModuleShell>
   );
 }

--- a/src/modules/finyk/hooks/useSwipeTabs.ts
+++ b/src/modules/finyk/hooks/useSwipeTabs.ts
@@ -1,0 +1,55 @@
+import { useRef, type TouchEvent } from "react";
+
+export interface UseSwipeTabsOptions {
+  tabIds: readonly string[];
+  activeId: string;
+  onChange: (id: string) => void;
+  /** Minimum horizontal travel before treating a touch as a swipe. */
+  minDeltaX?: number;
+  /** Horizontal delta must exceed vertical delta by this factor to
+   *  avoid hijacking list scrolls. */
+  directionalityRatio?: number;
+}
+
+export interface SwipeTabHandlers {
+  onTouchStart: (e: TouchEvent) => void;
+  onTouchEnd: (e: TouchEvent) => void;
+}
+
+/**
+ * Produces touchStart/touchEnd handlers that advance/retreat a tab set
+ * on horizontal swipes. Rejects gestures that are mostly vertical so
+ * list scrolling inside a page isn't misread as a tab switch.
+ */
+export function useSwipeTabs({
+  tabIds,
+  activeId,
+  onChange,
+  minDeltaX = 60,
+  directionalityRatio = 1.5,
+}: UseSwipeTabsOptions): SwipeTabHandlers {
+  const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
+
+  return {
+    onTouchStart: (e) => {
+      startX.current = e.touches[0].clientX;
+      startY.current = e.touches[0].clientY;
+    },
+    onTouchEnd: (e) => {
+      if (startX.current === null || startY.current === null) return;
+      const dx = startX.current - e.changedTouches[0].clientX;
+      const dy = startY.current - e.changedTouches[0].clientY;
+      startX.current = null;
+      startY.current = null;
+
+      if (Math.abs(dx) < minDeltaX) return;
+      if (Math.abs(dx) < Math.abs(dy) * directionalityRatio) return;
+
+      const curIdx = tabIds.indexOf(activeId);
+      if (curIdx === -1) return;
+      const next = curIdx + (dx > 0 ? 1 : -1);
+      if (next >= 0 && next < tabIds.length) onChange(tabIds[next]);
+    },
+  };
+}

--- a/src/modules/finyk/shell/FinykAddExpenseFab.tsx
+++ b/src/modules/finyk/shell/FinykAddExpenseFab.tsx
@@ -1,0 +1,21 @@
+export interface FinykAddExpenseFabProps {
+  onClick: () => void;
+}
+
+/**
+ * Floating "add expense" button anchored above the bottom nav. Only
+ * visible on overview / transactions / budgets — other pages don't
+ * benefit from the shortcut. Rendered as a shell overlay so it floats
+ * above the scrollable page area without being clipped.
+ */
+export function FinykAddExpenseFab({ onClick }: FinykAddExpenseFabProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-all duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+      aria-label="Додати витрату"
+    >
+      +
+    </button>
+  );
+}

--- a/src/modules/finyk/shell/FinykAuthErrorBanner.tsx
+++ b/src/modules/finyk/shell/FinykAuthErrorBanner.tsx
@@ -1,0 +1,46 @@
+export interface FinykAuthErrorBannerProps {
+  message: string;
+  onDismiss: () => void;
+  onOpenHub?: () => void;
+}
+
+/**
+ * Floating banner shown at the top of the main Finyk view when Monobank
+ * rejects the saved token. Stays module-local because the wording and
+ * action (open hub settings to refresh the token) is Finyk-specific —
+ * shared StorageErrorBanner is for quota failures.
+ */
+export function FinykAuthErrorBanner({
+  message,
+  onDismiss,
+  onOpenHub,
+}: FinykAuthErrorBannerProps) {
+  return (
+    <div className="fixed top-[calc(56px+env(safe-area-inset-top,0px)+8px)] left-4 right-4 z-50 max-w-lg mx-auto">
+      <div className="bg-warning/15 border border-warning/40 rounded-2xl px-4 py-3 flex items-start gap-3 shadow-card">
+        <span className="text-lg shrink-0 mt-0.5">⚠️</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-text">
+            Токен потребує оновлення
+          </p>
+          <p className="text-xs text-muted mt-0.5">{message}</p>
+          {onOpenHub && (
+            <button
+              onClick={onOpenHub}
+              className="text-xs font-semibold text-primary mt-2 hover:underline"
+            >
+              Оновити токен у Налаштуваннях Hub
+            </button>
+          )}
+        </div>
+        <button
+          onClick={onDismiss}
+          className="text-muted hover:text-text transition-colors shrink-0"
+          aria-label="Закрити"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/finyk/shell/FinykHeader.tsx
+++ b/src/modules/finyk/shell/FinykHeader.tsx
@@ -1,0 +1,118 @@
+import { cn } from "@shared/lib/cn";
+
+export interface SyncTone {
+  dot: string;
+  text: string;
+}
+
+export interface FinykHeaderProps {
+  syncTone: SyncTone;
+  showBalance: boolean;
+  onToggleBalance: () => void;
+}
+
+function FinykWalletBadge() {
+  return (
+    <div
+      className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 border border-emerald-500/15"
+      aria-hidden
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <rect x="2" y="5" width="20" height="14" rx="2" />
+        <line x1="2" y1="10" x2="22" y2="10" />
+      </svg>
+    </div>
+  );
+}
+
+function EyeIcon() {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function EyeOffIcon() {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  );
+}
+
+/**
+ * Top bar for Finyk's main view. The primary app header differs enough
+ * from ModuleHeader's title/subtitle/back idiom — no back button, a sync
+ * status dot, and a show-balance toggle — that it stays module-specific
+ * instead of squeezing into ModuleHeader's slots.
+ */
+export function FinykHeader({
+  syncTone,
+  showBalance,
+  onToggleBalance,
+}: FinykHeaderProps) {
+  return (
+    <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
+      <div className="flex h-14 items-center justify-between px-4 sm:px-5 gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <FinykWalletBadge />
+          <div className="min-w-0">
+            <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
+              ФІНІК
+            </span>
+            <span className="text-2xs text-subtle font-medium hidden sm:block truncate">
+              Monobank · бюджети
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 text-xs text-subtle select-none">
+            <span className={cn("w-2 h-2 rounded-full", syncTone.dot)} />
+            <span className="hidden sm:inline">{syncTone.text}</span>
+          </div>
+          <button
+            type="button"
+            onClick={onToggleBalance}
+            className="w-11 h-11 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors"
+            aria-label={showBalance ? "Приховати суми" : "Показати суми"}
+            title={showBalance ? "Приховати суми" : "Показати суми"}
+          >
+            {showBalance ? <EyeIcon /> : <EyeOffIcon />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/finyk/shell/FinykLoginScreen.tsx
+++ b/src/modules/finyk/shell/FinykLoginScreen.tsx
@@ -1,0 +1,291 @@
+import { useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
+import { cn } from "@shared/lib/cn";
+import { readRaw } from "../lib/finykStorage.js";
+
+export interface FinykLoginScreenProps {
+  connecting: boolean;
+  error: string | null;
+  authError: string | null;
+  onConnect: (token: string, _flag: boolean, remember: boolean) => void;
+  onStartManualOnly: () => void;
+  onClipboardError: () => void;
+  onBackToHub?: () => void;
+}
+
+function FinykLogo() {
+  return (
+    <div
+      className={cn(
+        "w-20 h-20 mx-auto rounded-3xl flex items-center justify-center mb-4",
+        "bg-gradient-to-br from-brand-100 to-brand-200",
+        "dark:from-brand-900/40 dark:to-brand-800/30",
+        "border border-brand-200/60 dark:border-brand-700/30",
+        "shadow-card",
+      )}
+    >
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-brand-600 dark:text-brand-400"
+        aria-hidden
+      >
+        <rect x="3" y="8" width="18" height="12" rx="2" />
+        <path d="M7 8V6a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+      </svg>
+    </div>
+  );
+}
+
+function ClipboardIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function EyeOff16() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  );
+}
+
+function Eye16() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+export function FinykLoginScreen({
+  connecting,
+  error,
+  authError,
+  onConnect,
+  onStartManualOnly,
+  onClipboardError,
+  onBackToHub,
+}: FinykLoginScreenProps) {
+  const [tokenInput, setTokenInput] = useState("");
+  const [showToken, setShowToken] = useState(false);
+  const [rememberToken, setRememberToken] = useState(
+    () => !!readRaw("finyk_token_remembered", ""),
+  );
+
+  const submit = () => onConnect(tokenInput.trim(), false, rememberToken);
+
+  return (
+    <div className="min-h-dvh flex items-center justify-center p-5 bg-bg safe-area-pt-pb">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <FinykLogo />
+          <h1 className="text-2xl font-bold text-text">ФІНІК</h1>
+          <p className="text-sm text-muted mt-1">
+            Персональний фінансовий менеджер
+          </p>
+        </div>
+
+        <div
+          className={cn(
+            "bg-panel/95 backdrop-blur-xl border rounded-3xl p-6 shadow-float",
+            "border-line dark:border-line",
+          )}
+        >
+          <label
+            className="text-sm text-muted mb-2 block"
+            htmlFor="finyk-mono-token"
+          >
+            API токен Monobank
+          </label>
+          <p className="text-xs text-subtle mb-2">
+            Mono → Налаштування → Інші → API
+          </p>
+          <div className="relative mt-1">
+            <Input
+              id="finyk-mono-token"
+              className="pr-20"
+              type={showToken ? "text" : "password"}
+              placeholder="Вставте токен Mono API"
+              value={tokenInput}
+              onChange={(e) => setTokenInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+              autoComplete="off"
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="absolute right-10 top-1/2 -translate-y-1/2 h-8 w-8 p-0 border-0"
+              aria-label="Вставити з буфера обміну"
+              title="Вставити з буфера"
+              onClick={async () => {
+                try {
+                  setTokenInput((await navigator.clipboard.readText()).trim());
+                } catch {
+                  onClipboardError();
+                }
+              }}
+            >
+              <ClipboardIcon />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0 border-0"
+              aria-label={showToken ? "Приховати токен" : "Показати токен"}
+              onClick={() => setShowToken((v) => !v)}
+            >
+              {showToken ? <EyeOff16 /> : <Eye16 />}
+            </Button>
+          </div>
+
+          <label className="flex items-center gap-2.5 mt-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="w-4 h-4 rounded accent-emerald-600 cursor-pointer"
+              checked={rememberToken}
+              onChange={(e) => setRememberToken(e.target.checked)}
+            />
+            <span className="text-sm text-muted">
+              Запам{"'"}ятати токен на цьому пристрої
+            </span>
+          </label>
+
+          {authError && (
+            <div className="mt-3 text-sm bg-warning/15 border border-warning/40 rounded-xl px-3 py-2.5 space-y-1">
+              <p className="font-semibold text-text">
+                Токен потребує оновлення
+              </p>
+              <p className="text-xs text-muted">{authError}</p>
+              <p className="text-xs text-muted">
+                Отримайте новий токен: Monobank → Налаштування → API
+              </p>
+            </div>
+          )}
+          {error && !authError && (
+            <p className="mt-3 text-sm text-danger bg-danger/10 rounded-xl px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            className={cn(
+              "mt-4 w-full h-12 min-h-[48px] text-base border-0",
+              "bg-gradient-to-r from-brand-600 to-brand-700",
+              "hover:from-brand-700 hover:to-brand-800",
+              "text-white font-semibold",
+              "shadow-md hover:shadow-glow",
+              "transition-all duration-200",
+              "active:scale-[0.98]",
+            )}
+            onClick={onStartManualOnly}
+          >
+            Почати без банку
+          </Button>
+          <p className="mt-2 text-center text-xs text-subtle">
+            Ручні витрати, бюджети та аналітика — без API-токена. Monobank можна
+            підключити пізніше.
+          </p>
+
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+              "або через API" divider row — structurally a delimiter
+              between two bg-line spans, not a heading. */}
+          <div className="my-4 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
+            <span className="flex-1 h-px bg-line" />
+            або через API
+            <span className="flex-1 h-px bg-line" />
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            className="w-full min-h-[48px]"
+            onClick={submit}
+            disabled={connecting || !tokenInput.trim()}
+          >
+            {connecting ? "Підключення…" : "Підключити Monobank"}
+          </Button>
+          {typeof onBackToHub === "function" && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="mt-1 w-full min-h-[44px]"
+              onClick={onBackToHub}
+            >
+              ← Назад до хабу
+            </Button>
+          )}
+          <p className="mt-4 text-center text-xs text-subtle flex items-center justify-center gap-1.5">
+            <LockIcon />
+            Токен зберігається лише у твоєму браузері
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/finyk/shell/FinykRouter.tsx
+++ b/src/modules/finyk/shell/FinykRouter.tsx
@@ -1,0 +1,118 @@
+import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
+import { Overview } from "../pages/Overview.jsx";
+import { Transactions } from "../pages/Transactions.jsx";
+import { Budgets } from "../pages/Budgets.jsx";
+import { Assets } from "../pages/Assets.jsx";
+import { Analytics } from "../pages/Analytics.jsx";
+import type { FinykPage } from "./finykRoute";
+
+// Upstream hooks (`useMonobank`, `useStorage`, `useFinykPersonalization`,
+// `useUnifiedFinanceData`) are still in untyped JS / mixed-inferred land;
+// each page destructures the fields it cares about without declaring a
+// full contract. Typing these as a widened record here would just shift
+// the lie one level up. Keep them as `any` in the seam between the
+// shell and the pages, matching the existing convention — a future
+// hook-typing pass can tighten this without changing call sites.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface FinykRouterProps {
+  page: FinykPage;
+  mono: any;
+  storage: any;
+  navigate: (page: FinykPage) => void;
+  showBalance: boolean;
+  categoryFilter: string | null;
+  onCategoryClick: (catId: string) => void;
+  onClearCategoryFilter: () => void;
+  onEditManualExpense: (id: string) => void;
+  onQuickAdd: (manualLabel: string | null) => void;
+  frequentCategories: any;
+  frequentMerchants: any;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Page switch for Finyk's main surface. Each route is wrapped in
+ * SectionErrorBoundary so a crash in one page (e.g. bad Monobank data
+ * shape) doesn't take down the whole shell — the user can still swap
+ * tabs via bottom nav.
+ */
+export function FinykRouter({
+  page,
+  mono,
+  storage,
+  navigate,
+  showBalance,
+  categoryFilter,
+  onCategoryClick,
+  onClearCategoryFilter,
+  onEditManualExpense,
+  onQuickAdd,
+  frequentCategories,
+  frequentMerchants,
+}: FinykRouterProps) {
+  switch (page) {
+    case "overview":
+      return (
+        <SectionErrorBoundary
+          key="page-overview"
+          title="Не вдалось показати «Огляд»"
+        >
+          <Overview
+            mono={mono}
+            storage={storage}
+            onNavigate={navigate}
+            onCategoryClick={onCategoryClick}
+            showBalance={showBalance}
+            frequentCategories={frequentCategories}
+            frequentMerchants={frequentMerchants}
+            onQuickAdd={onQuickAdd}
+          />
+        </SectionErrorBoundary>
+      );
+    case "transactions":
+      return (
+        <SectionErrorBoundary
+          key="page-transactions"
+          title="Не вдалось показати «Операції»"
+        >
+          <Transactions
+            mono={mono}
+            storage={storage}
+            showBalance={showBalance}
+            categoryFilter={categoryFilter}
+            onClearCategoryFilter={onClearCategoryFilter}
+            onEditManualExpense={onEditManualExpense}
+          />
+        </SectionErrorBoundary>
+      );
+    case "budgets":
+      return (
+        <SectionErrorBoundary
+          key="page-budgets"
+          title="Не вдалось показати «Планування»"
+        >
+          <Budgets mono={mono} storage={storage} />
+        </SectionErrorBoundary>
+      );
+    case "analytics":
+      return (
+        <SectionErrorBoundary
+          key="page-analytics"
+          title="Не вдалось показати «Аналітику»"
+        >
+          <Analytics mono={mono} storage={storage} />
+        </SectionErrorBoundary>
+      );
+    case "assets":
+      return (
+        <SectionErrorBoundary
+          key="page-assets"
+          title="Не вдалось показати «Активи»"
+        >
+          <Assets mono={mono} storage={storage} showBalance={showBalance} />
+        </SectionErrorBoundary>
+      );
+    default:
+      return null;
+  }
+}

--- a/src/modules/finyk/shell/finykNav.tsx
+++ b/src/modules/finyk/shell/finykNav.tsx
@@ -1,0 +1,77 @@
+import type { ModuleBottomNavItem } from "@shared/components/ui/ModuleBottomNav";
+import type { FinykPage } from "./finykRoute";
+
+const NAV_SVG_PROPS = {
+  width: 22,
+  height: 22,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export interface FinykNavItem extends ModuleBottomNavItem {
+  id: Extract<
+    FinykPage,
+    "overview" | "transactions" | "budgets" | "analytics" | "assets"
+  >;
+}
+
+export const FINYK_NAV: readonly FinykNavItem[] = [
+  {
+    id: "overview",
+    label: "Огляд",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+  },
+  {
+    id: "transactions",
+    label: "Операції",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
+        <rect x="9" y="3" width="6" height="4" rx="1" />
+        <line x1="9" y1="12" x2="15" y2="12" />
+        <line x1="9" y1="16" x2="13" y2="16" />
+      </svg>
+    ),
+  },
+  {
+    id: "budgets",
+    label: "Планування",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+    ),
+  },
+  {
+    id: "analytics",
+    label: "Аналітика",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <line x1="18" y1="20" x2="18" y2="10" />
+        <line x1="12" y1="20" x2="12" y2="4" />
+        <line x1="6" y1="20" x2="6" y2="14" />
+      </svg>
+    ),
+  },
+  {
+    id: "assets",
+    label: "Активи",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <rect x="2" y="5" width="20" height="14" rx="2" />
+        <line x1="2" y1="10" x2="22" y2="10" />
+      </svg>
+    ),
+  },
+] as const;

--- a/src/modules/finyk/shell/finykRoute.ts
+++ b/src/modules/finyk/shell/finykRoute.ts
@@ -1,0 +1,29 @@
+import {
+  useHashRoute,
+  type UseHashRouteResult,
+} from "@shared/hooks/useHashRoute";
+
+export const FINYK_PAGES = [
+  "overview",
+  "transactions",
+  "budgets",
+  "analytics",
+  "assets",
+] as const;
+
+export type FinykPage = (typeof FINYK_PAGES)[number];
+
+// Retired: the legacy `payments` tab became `budgets` when monthly
+// planning was merged into the budgets page. Keep the alias so deep
+// links from older shortcuts, notifications, and bookmarks still work.
+const FINYK_ALIASES: Readonly<Record<string, FinykPage>> = {
+  payments: "budgets",
+};
+
+export function useFinykRoute(): UseHashRouteResult<FinykPage> {
+  return useHashRoute<FinykPage>({
+    defaultPage: "overview",
+    validPages: FINYK_PAGES,
+    aliases: FINYK_ALIASES,
+  });
+}

--- a/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
+++ b/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
@@ -297,12 +297,11 @@ export function useNutritionRemoteActions({
       setDayPlanBusy(true);
       setErr("");
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onSuccess: ({
       plan,
       regenerateMealType,
     }: {
-      plan: any;
+      plan: { meals?: unknown[] } & Record<string, unknown>;
       regenerateMealType: string | null | undefined;
     }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Second step of the `*App.tsx` decomposition plan kicked off by #374. Same
pattern: reuse `ModuleShell` / `useHashRoute` / `usePwaAction` from
`@shared`, extract module-specific pieces into `shell/` and `hooks/`, and
leave `FinykApp.tsx` as pure orchestration.

**Line count:** `FinykApp.tsx` 792 → 250 (−68%). It stays larger than
`FizrukApp.tsx` (136) because Finyk carries more local state — balance
visibility, category filter, manual-expense edit/prefill, manual-only
bypass, sync-tone derivation, quick-add prefill from FTUX preset sheets.
Each is deliberate and collocated with the sheet/router it feeds.

### New files
| path | role |
| --- | --- |
| `shell/finykRoute.ts` | `FinykPage` union + `useFinykRoute` (aliases retired `payments` → `budgets`) |
| `shell/finykNav.tsx` | `FINYK_NAV` items with inline SVG icons |
| `shell/FinykHeader.tsx` | Top bar: logo, sync-status dot, show-balance toggle |
| `shell/FinykRouter.tsx` | `SectionErrorBoundary`-wrapped page switch for all 5 pages |
| `shell/FinykLoginScreen.tsx` | Monobank token / "Почати без банку" entry screen |
| `shell/FinykAuthErrorBanner.tsx` | Floating warning when Mono rejects the saved token |
| `shell/FinykAddExpenseFab.tsx` | Bottom-anchored "+" button |
| `hooks/useSwipeTabs.ts` | Horizontal swipe → tab change handlers (rejects mostly-vertical gestures) |

### Incidental fix
`src/modules/nutrition/hooks/useNutritionRemoteActions.ts` had `plan: any`
with a no-op `eslint-disable` from the nutrition TS migration (#373) that
broke `npm run lint` on current `main`. Tightened to
`{ meals?: unknown[] } & Record<string, unknown>` so this PR's CI is
green. Unrelated to the refactor, but caught as a side-effect of this
branch rebasing onto the merged Fizruk commit.

### Local verification
- `npm run format:check` — clean
- `npm run lint` — clean (incl. `scripts/check-imports.mjs`)
- `npm run typecheck` — clean across `tsconfig.json`, `tsconfig.server.json`, `tsconfig.sw.json`
- `npm run test` — 1030/1030 pass (99 test files, 11 skipped, same as main)
- `npm run build` — clean

## Review & Testing Checklist for Human

- [ ] **Login screen still works.** Enter a Mono token → connect succeeds. Press "Почати без банку" → goes to manual-only view.
- [ ] **Deep-link aliases.** `#/payments` and `#payments` should both normalize to `#budgets` on load.
- [ ] **Swipe between tabs** on mobile (overview ↔ transactions ↔ budgets ↔ analytics ↔ assets). Vertical scroll inside transactions/budgets lists must still work without hijacking to a neighboring tab.
- [ ] **Add-expense FAB** is only visible on overview / transactions / budgets.
- [ ] **Stale-token banner** appears when `mono.authError` is set; dismiss button clears it; "Оновити токен у Налаштуваннях Hub" calls `onBackToHub` if provided.
- [ ] **PWA deep link** `?module=finyk&action=add_expense` opens Transactions + ManualExpenseSheet and consumes any FTUX preset prefill (category/description).

### Notes
- No shared-primitive API changes — reusing what #374 shipped as-is.
- Next up (if approved): Routine (728 → ~200, more complex state) and Nutrition (574).


Link to Devin session: https://app.devin.ai/sessions/bd30d4f5ec2347328e37822cd0495bbb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
