### PR TITLE
apiUrl: tighten /api/auth exclusion to exact segment match

### DIFF
--- a/apps/web/src/shared/lib/apiUrl.ts
+++ b/apps/web/src/shared/lib/apiUrl.ts
@@ -33,7 +33,12 @@ function applyVersion(path: string): string {
   if (!path.startsWith("/api/")) return path;
   if (path === "/api" || path === "/api/") return `/api/${version}`;
   // Auth plugin-и Better Auth client зашиті під `/api/auth/*` — не чіпаємо.
-  if (path.startsWith("/api/auth") || path.startsWith("/api/auth/")) {
+  // Жорстка перевірка сегмента (а не `startsWith("/api/auth")`), щоб
+  // `/api/authorize`, `/api/authentication` та інші майбутні endpoint-и з
+  // таким префіксом не провалилися повз версіонування. Консистентно з
+  // `src/sw.js` (пошук "api/auth"), де auth-шляхи теж виключаються
+  // точним сегментом.
+  if (path === "/api/auth" || path.startsWith("/api/auth/")) {
     return path;
   }
   // Уже явно версіонований шлях (напр. сторонній код, що вказав `/api/v1/...`)

--- a/apps/web/src/shared/lib/apiUrl.ts
+++ b/apps/web/src/shared/lib/apiUrl.ts
@@ -36,8 +36,8 @@ function applyVersion(path: string): string {
   // Жорстка перевірка сегмента (а не `startsWith("/api/auth")`), щоб
   // `/api/authorize`, `/api/authentication` та інші майбутні endpoint-и з
   // таким префіксом не провалилися повз версіонування. Консистентно з
-  // `src/sw.js` (пошук "api/auth"), де auth-шляхи теж виключаються
-  // точним сегментом.
+  // `apps/web/src/sw.js` (пошук "api/auth"), де auth-шляхи теж
+  // виключаються точним сегментом.
   if (path === "/api/auth" || path.startsWith("/api/auth/")) {
     return path;
   }


### PR DESCRIPTION
## Summary

Follow-up на Devin Review-finding з #377 (`src/shared/lib/apiUrl.ts:36`).

Було: `path.startsWith("/api/auth") || path.startsWith("/api/auth/")` — перша умова матчить `/api/authorize`, `/api/authentication` і будь-які майбутні endpoint-и з таким префіксом, через що вони б мовчки пропускали версіонування. Друга умова — redundant.

Стало: `path === "/api/auth" || path.startsWith("/api/auth/")` — точне співпадіння сегмента. Це консистентно з тим, як `src/sw.js` виключає auth-шляхи.

## Review & Testing Checklist for Human

- [ ] Перевірити, що звичайний логін/logout (Better Auth `/api/auth/sign-in/email`, `/api/auth/sign-out`, `/api/auth/session`) продовжує працювати — шляхи не повинні змінитися.
- [ ] Якщо у бекенді коли-небудь з'явиться endpoint `/api/authX/...` (не auth) — він тепер коректно піде через `/api/v1/...`, а не silently як `/api/authX/...`.

### Notes

Lint, typecheck локально зелені. Тест-файл `server/routes/apiV1.test.ts` перевіряє позитивний кейс (`/api/v1/auth/session` → переписується у `/api/auth/session` для better-auth), додаткового покриття негативного кейсу (`/api/authorize` теоретично міг би bypass-нути) не додавав, бо такого endpoint-у в репо нема; основний тест на неверсіоновану auth-гілку стоїть і має захистити регрес.

Link to Devin session: https://app.devin.ai/sessions/0ff02c9bf42c491c8a103d61bb5716b8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
