### PR TITLE
ci: switch to pnpm (matches monorepo layout from #379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm --filter @sergeant/web exec playwright install --with-deps chromium
 
       - name: Run axe accessibility checks
         run: pnpm run test:a11y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,34 +18,40 @@ jobs:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # pnpm/action-setup v4.0.0 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        with:
+          version: 9.15.1
+          run_install: false
+
       # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-          cache: npm
+          cache: pnpm
 
       - name: Install
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Audit (critical only)
-        run: npm audit --audit-level=critical --omit=dev
+        run: pnpm audit --audit-level=critical --prod
 
       - name: Audit (high, non-blocking)
-        run: npm audit --audit-level=high --omit=dev || true
+        run: pnpm audit --audit-level=high --prod || true
 
       - name: Audit full tree (non-blocking)
-        run: npm audit --audit-level=high || true
+        run: pnpm audit --audit-level=high || true
 
       - name: License policy check (production tree)
         run: >-
-          npx --yes license-checker-rseidelsohn@4.4.2
+          pnpm dlx license-checker-rseidelsohn@4.4.2
           --production
           --excludePackages "sergeant@0.1.0"
           --onlyAllow
           "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;MIT-0;0BSD;BlueOak-1.0.0;CC0-1.0;MPL-2.0;(Unlicense OR Apache-2.0)"
 
       - name: Format, lint, test, build
-        run: npm run check
+        run: pnpm run check
 
   a11y:
     name: Accessibility (axe-core)
@@ -55,20 +61,26 @@ jobs:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # pnpm/action-setup v4.0.0 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+        with:
+          version: 9.15.1
+          run_install: false
+
       # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-          cache: npm
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run axe accessibility checks
-        run: npm run test:a11y
+        run: pnpm run test:a11y
         env:
           CI: "true"
 


### PR DESCRIPTION
## Summary

Після #379 (міграція на pnpm+turbo monorepo) репо містить `pnpm-lock.yaml` і більше не має `package-lock.json`, але `.github/workflows/ci.yml` і далі робив `npm ci` з `cache: npm`. Результат: CI падає на кожному PR проти `main` з:

```
Error: Dependencies lock file is not found in /home/runner/work/Sergeant/Sergeant.
Supported file patterns: package-lock.json, yarn.lock, npm-shrinkwrap.json
```

Цей PR синхронізує ci.yml з package manager-ом, який реально використовується:
- `pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2` (v4.0.0, SHA-pinned, версія зафіксована `9.15.1` під `packageManager` у package.json)
- `actions/setup-node` з `cache: pnpm`
- `npm ci` → `pnpm install --frozen-lockfile`
- `npm audit` → `pnpm audit` (`--omit=dev` → `--prod`)
- `npx license-checker-rseidelsohn` → `pnpm dlx license-checker-rseidelsohn`
- `npm run check/test:a11y` → `pnpm run check/test:a11y`
- `npx playwright install` → `pnpm exec playwright install`

Жодних змін у самих командах, крок `check` (`format:check && lint && typecheck && test && build`) працює ідентично, просто через pnpm.

Локально перевірено: `pnpm install --frozen-lockfile` + `pnpm run check` — зелені.

## Review & Testing Checklist for Human

Yellow risk (CI config change, torkає всі майбутні запуски).

- [ ] CI на цьому PR проходить `check` і `Accessibility (axe-core)` — це і є перевірка, що новий workflow живий.
- [ ] `pnpm/action-setup@fe02b34...` SHA відповідає v4.0.0 (це стандартна практика SHA-pinning у цьому репо, як `actions/checkout` і `actions/setup-node`). Можна звірити зі сторінкою релізу: https://github.com/pnpm/action-setup/releases/tag/v4.0.0.
- [ ] `pnpm audit --prod` може репортити вужчий або ширший набір, ніж `npm audit --omit=dev` — якщо впаде на критикалі, перевір чи це legit нова знахідка.
- [ ] `pnpm dlx license-checker-rseidelsohn` працює поверх pnpm-layout-у (node_modules у pnpm shaped по-іншому). Локально не ганяв саме цю утиліту — якщо впаде, можна або замінити на pnpm-native license-checker, або додати `pnpm install --shamefully-hoist` перед кроком.

### Notes

- Окремий malий scoped PR, щоб розблокувати CI для всіх інших PR (зокрема #378, який не може зелено змерджитися через цю ж причину).
- Не чіпаю `check-imports.mjs`, turbo-конфіг, або самі команди всередині `check` — тільки runner-layer.

Link to Devin session: https://app.devin.ai/sessions/0ff02c9bf42c491c8a103d61bb5716b8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
