### PR TITLE
fix(ci): migrate workflows and husky from npm to pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,34 +18,38 @@ jobs:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # pnpm/action-setup v4.1.0 (SHA-pinned for supply-chain hardening)
+      # Version is read from packageManager in root package.json.
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+
       # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-          cache: npm
+          cache: pnpm
 
       - name: Install
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Audit (critical only)
-        run: npm audit --audit-level=critical --omit=dev
+        run: pnpm audit --audit-level=critical --prod
 
       - name: Audit (high, non-blocking)
-        run: npm audit --audit-level=high --omit=dev || true
+        run: pnpm audit --audit-level=high --prod || true
 
       - name: Audit full tree (non-blocking)
-        run: npm audit --audit-level=high || true
+        run: pnpm audit --audit-level=high || true
 
       - name: License policy check (production tree)
         run: >-
-          npx --yes license-checker-rseidelsohn@4.4.2
+          pnpm dlx license-checker-rseidelsohn@4.4.2
           --production
-          --excludePackages "sergeant@0.1.0"
+          --excludePackages "sergeant@0.1.0;@sergeant/web@0.1.0;@sergeant/server@0.1.0;@sergeant/shared@0.1.0;@sergeant/api-client@0.1.0;@sergeant/config@0.1.0;eslint-plugin-sergeant-design@0.0.1"
           --onlyAllow
           "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;MIT-0;0BSD;BlueOak-1.0.0;CC0-1.0;MPL-2.0;(Unlicense OR Apache-2.0)"
 
       - name: Format, lint, test, build
-        run: npm run check
+        run: pnpm check
 
   a11y:
     name: Accessibility (axe-core)
@@ -55,20 +59,23 @@ jobs:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # pnpm/action-setup v4.1.0 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+
       # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
-          cache: npm
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: pnpm --filter @sergeant/web exec playwright install --with-deps chromium
 
       - name: Run axe accessibility checks
-        run: npm run test:a11y
+        run: pnpm test:a11y
         env:
           CI: "true"
 
@@ -78,6 +85,6 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: playwright-a11y-report
-          path: playwright-report
+          path: apps/web/playwright-report
           if-no-files-found: ignore
           retention-days: 7

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
## Summary

Slave fix після міграції моноріпи на pnpm+turbo (#379): `.github/workflows/ci.yml` і `.husky/pre-commit` досі викликали `npm ci` / `npm run check` / `npx lint-staged`, хоча у репо уже є тільки `pnpm-lock.yaml` і ніякого `package-lock.json`. Через це CI зараз зламаний на main.

### Що змінюю
**`.github/workflows/ci.yml`**
- додаю `pnpm/action-setup@fe02b34...` (SHA-pinned, версія читається з `packageManager` у корені).
- `actions/setup-node` → `cache: pnpm` замість `cache: npm`.
- `npm ci` → `pnpm install --frozen-lockfile` (у обох jobs — `check` і `a11y`).
- `npm audit --omit=dev` → `pnpm audit --prod` (семантика та ж; pnpm обрізає devDependencies прапорцем `--prod`).
- `npx license-checker-rseidelsohn@4.4.2` → `pnpm dlx license-checker-rseidelsohn@4.4.2`. Розширив `--excludePackages` на **всі** workspace-пакети (`sergeant`, `@sergeant/web`, `@sergeant/server`, `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/config`, `eslint-plugin-sergeant-design`) — інакше license-checker фейлиться, бо наші внутрішні пакети без `license` полів попадають під `onlyAllow`-фільтр.
- `npm run check` → `pnpm check` (скрипт той самий: format:check → lint → typecheck → test → build через turbo).
- A11y job: `pnpm --filter @sergeant/web exec playwright install --with-deps chromium` + `pnpm test:a11y`. Артефакт тепер `apps/web/playwright-report` (playwright тепер працює з `apps/web/`, не з кореня).

**`.husky/pre-commit`**
- `npx lint-staged` → `pnpm exec lint-staged`.

### Локальна перевірка (pnpm 9.15.1 / Node 20.20.2)
- `pnpm install --frozen-lockfile` — OK, `Lockfile is up to date, resolution step is skipped`.
- `pnpm audit --audit-level=critical --prod` — `No known vulnerabilities found`.
- `pnpm dlx license-checker-rseidelsohn@4.4.2 --production ...` з оновленим excludePackages — exit 0.
- `pnpm check` — зелений (format:check → lint → typecheck → test → build).

## Review & Testing Checklist for Human

Зелений CI — необхідно, але недостатньо.

- [ ] Переконатись, що цей PR проходить `check` і `a11y` jobs на GitHub Actions (місце, де справжнє тестування — саме CI-раннер, а не локальна машина).
- [ ] Vercel preview на цьому PR не має змінитись (у цьому PR не чіпаю `vercel.json`), але варто швидко глянути що deploy взагалі відбувається.
- [ ] Що `pnpm exec lint-staged` у pre-commit хуці спрацьовує — зробити умисний лінт-баг у будь-якому `.ts`/`.tsx` і спробувати закомітити; має впасти.

### Notes
- У ci.yml є окремий крок `Audit full tree (non-blocking)` з `|| true` — залишив як було (тільки npm→pnpm). Якщо захочеш жорсткіше — можна прибрати `|| true`.
- `license-checker-rseidelsohn` читає workspace-пакети без `license` полів як порушників. Якщо у майбутньому буде додано новий workspace-пакет — треба дописати його у `--excludePackages` тут. Альтернатива — додати `"license": "UNLICENSED"` у кожний workspace `package.json`.
- Якщо `pnpm-lock.yaml` оновлюється — локально запусти `pnpm install --frozen-lockfile`: якщо pnpm каже, що lockfile застарів, значить lockfile треба пересоздати перед push (pnpm 9 суворий щодо цього в CI).


Link to Devin session: https://app.devin.ai/sessions/369de3b0f14f4d2a94b2271169f05f02
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
