### PR TITLE
fix(deploy): stop excluding apps/ and src/ from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,16 @@
+# Файл читається build context-ом Dockerfile.api. Виключаємо лише артефакти
+# і речі, які точно не потрібні в API-образі. Під монорепо-layout образ
+# явно COPY-ить apps/server + packages/shared + packages/config — ніколи
+# не виключати ці шляхи тут, інакше buildkit падає на
+# `failed to compute cache key: "/apps/server": not found`.
 node_modules
 dist
 .git
-apps
-src
-docs
-*.md
-.env*
+.github
+.husky
 .vercel
+.env*
+artifacts
+attached_assets
+apps/web
+apps/mobile


### PR DESCRIPTION
## Summary

`.dockerignore` на `main` ще з до-монорепо часів виключав `apps`, `src`, `docs`, `*.md`. Після мерджу pnpm+turbo монорепи (PR #379) сервер-source живе в `apps/server/`, а `Dockerfile.api` явно COPY-ить `apps/server` та `packages/*`. Тобто ми в .dockerignore забороняли саме ті каталоги, які Dockerfile очікує побачити.

**Наслідок на проді:** усі три останні деплої `Sergeant` на Railway (08:20 / 08:54 / 08:58 UTC 2026-04-20) падають з:
```
ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/apps/server": not found
Dockerfile.api:22
>>> COPY apps/server ./apps/server
```
API, який зараз слухає на `https://sergeant-production.up.railway.app`, — це 07:42 SUCCESS-деплой, який вижив лише на buildkit-кеші попередніх ітерацій; будь-який новий rebuild падає. Поки `.dockerignore` не виправлений, жоден env-var fix у Railway не доїде до runtime, бо redeploy також не збудується.

**Що змінюється:** замість бланкетних `apps` / `src` / `docs` / `*.md` тримаємо точкові виключення (`apps/web`, `apps/mobile`, `artifacts`, `attached_assets`, `.github`, `.husky`). Образ лишається мінімальним (web + mobile у API-бандлі не потрібні), але `apps/server` та `packages/*` тепер видимі для buildkit.

## Review & Testing Checklist for Human

- [ ] Перевір, що немає ще якогось шляху, який мав приїжджати в API-образ, а зараз виключений (наприклад, якщо додамо `apps/api-gateway` — треба буде знову правити). Наразі `Dockerfile.api` тягне лише `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `package.json`, `packages/shared/**`, `packages/config/**`, `apps/server/**` — всі видимі.
- [ ] Після мерджу глянь, що Railway-деплой `Sergeant` став SUCCESS (а не FAILED). Очікуваний розмір образу має лишитись приблизно як зараз — ми не починаємо копіювати масивні каталоги.
- [ ] Перевір, що `sergeant.vercel.app` немає регресії: якщо Vercel якимось чином використовує `.dockerignore` (він не повинен, бо бандлить через vite), треба глянути build-лог.

### Notes

- Це частина 1 з 2. Частина 2 — фікс env vars у Railway (`DATABASE_URL` зараз вказує на `postgres.railway.internal`, але Postgres живе в іншому Railway-проекті → ENOTFOUND на sign-in; `ALLOWED_ORIGINS` має API-домен замість Vercel-домену; `BETTER_AUTH_URL` взагалі відсутня). Env fix роблю GraphQL-ом одразу після того, як цей PR збере контейнер, який може стартувати.
- Без цього PR будь-яке оновлення змінних тригерить deploy, що падає на білді, і running-контейнер з старими env'ами продовжує віддавати 500.


Link to Devin session: https://app.devin.ai/sessions/897ace7e6be246dbbc26ab051ab8c8bc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
