### PR TITLE
fix(mobile): address Devin Review findings on #384

### DIFF
--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -88,7 +88,7 @@ export default function SignUpScreen() {
             (pressed || loading) && styles.buttonPressed,
           ]}
           onPress={onSubmit}
-          disabled={loading || !email || password.length < 10}
+          disabled={loading || !name || !email || password.length < 10}
         >
           {loading ? (
             <ActivityIndicator color={colors.text} />

--- a/apps/mobile/src/api/apiUrl.ts
+++ b/apps/mobile/src/api/apiUrl.ts
@@ -42,11 +42,11 @@ export function getApiBaseURL(): string {
 
 export function apiUrl(path: string): string {
   const base = getApiBaseURL();
-  const versioned = applyVersion(path);
+  const rawPath = path.startsWith("/") ? path : `/${path}`;
+  const versioned = applyVersion(rawPath);
   if (!base) return versioned;
   if (versioned.startsWith("http://") || versioned.startsWith("https://")) {
     return versioned;
   }
-  if (!versioned.startsWith("/")) return `${base}/${versioned}`;
   return `${base}${versioned}`;
 }


### PR DESCRIPTION
## Summary

Дві правки за ревʼю мобайл-скафолду (#384), обидві — легітимні баги:

1. **`apps/mobile/src/api/apiUrl.ts`** — нормалізуємо шлях до провідного `/` перед `applyVersion`, дзеркально до `apps/web/src/shared/lib/apiUrl.ts:58`. Без цього `apiUrl("api/foo")` (без `/`) проходить повз перевірку `path.startsWith("/api/")` і віддає невідверсіонований `api/foo` замість `/api/v1/foo`. Критично для порту web-модулів: якщо якийсь колер передасть шлях без `/`, запит піде в legacy `/api/*` замість `/api/v1/*`.
2. **`apps/mobile/app/(auth)/sign-up.tsx`** — кнопка тепер `disabled` і коли `name` порожній. Better Auth `signUp.email` обовʼязково вимагає `name` (див. `apps/server/src/auth.ts`), інакше сервер поверне 400. Раніше кнопка вмикалась і юзер бачив помилку вже після submit-у.

Локально `pnpm --filter @sergeant/mobile typecheck` і `lint` зелені.

## Review & Testing Checklist for Human

- [ ] `pnpm typecheck` / `pnpm lint` зелені.
- [ ] У формі реєстрації кнопка залишається неактивною, поки ім'я порожнє (разом з email/password-валідаціями).
- [ ] Будь-який подальший порт web-модулів, що передає `apiUrl("api/...")` без `/`, тепер попадає у `/api/v1/*`.

### Notes

Інші 5 знахідок з Devin Review не перевіряв окремо — вони не потрапили у цей нотифай. Якщо треба покрити, скажи і я пройдусь по повному списку в `https://app.devin.ai/review/skords-01/sergeant/pull/384`.


Link to Devin session: https://app.devin.ai/sessions/37786129d16942748303e3b037b3bd5a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
