### PR TITLE
fix(web): a11y follow-ups from #387 review (routine preset + button dark overrides)

### DIFF
--- a/apps/web/src/core/onboarding/PresetSheet.tsx
+++ b/apps/web/src/core/onboarding/PresetSheet.tsx
@@ -22,7 +22,7 @@ const PRESETS = {
   routine: {
     title: "Яку звичку почнемо?",
     desc: "Одне натискання — і вона у твоєму списку сьогодні.",
-    accent: "text-routine bg-routine-soft",
+    accent: "text-routine-strong dark:text-routine bg-routine-surface",
     moduleIcon: "check",
     fallback: { action: "add_habit", label: "Своя звичка", icon: "plus" },
     items: [

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -64,13 +64,13 @@ const variants: Record<ButtonVariant, string> = {
 
   // Soft module variants (for secondary actions within modules)
   "finyk-soft":
-    "bg-finyk-soft text-finyk-strong border border-finyk-ring/50 hover:bg-brand-100 active:scale-[0.98]",
+    "bg-finyk-soft text-finyk-strong dark:text-finyk border border-finyk-ring/50 hover:bg-brand-100 active:scale-[0.98]",
   "fizruk-soft":
-    "bg-fizruk-soft text-fizruk-strong border border-fizruk-ring/50 hover:bg-teal-100 active:scale-[0.98]",
+    "bg-fizruk-soft text-fizruk-strong dark:text-fizruk border border-fizruk-ring/50 hover:bg-teal-100 active:scale-[0.98]",
   "routine-soft":
-    "bg-routine-surface text-routine-strong border border-routine-ring/50 hover:bg-coral-100 active:scale-[0.98]",
+    "bg-routine-surface text-routine-strong dark:text-routine border border-routine-ring/50 hover:bg-coral-100 active:scale-[0.98]",
   "nutrition-soft":
-    "bg-nutrition-soft text-nutrition-strong border border-nutrition-ring/50 hover:bg-lime-100 active:scale-[0.98]",
+    "bg-nutrition-soft text-nutrition-strong dark:text-nutrition border border-nutrition-ring/50 hover:bg-lime-100 active:scale-[0.98]",
 };
 
 const sizes: Record<ButtonSize, string> = {


### PR DESCRIPTION
## Summary

Follow-up fixes for the two valid Devin Review findings on #387:

1. **`PresetSheet.tsx`** — the `routine` preset `accent` was missed in the first pass. It was still `"text-routine bg-routine-soft"` while `finyk` / `fizruk` / `nutrition` were updated. Now `"text-routine-strong dark:text-routine bg-routine-surface"` to match the other three modules.
2. **`Button.tsx` soft variants** — the `finyk-soft` / `fizruk-soft` / `routine-soft` / `nutrition-soft` variants were changed to `text-<module>-strong` in #387 but didn't include a `dark:text-<module>` override, so in dark mode text used the light-mode-tuned darker shade. Now matches the pattern already used in `Badge`, `Tabs`, and `Segmented` (`text-<module>-strong dark:text-<module>`).

No behavioural / layout changes. Typecheck + lint pass.

## Review & Testing Checklist for Human

- [ ] Open the preset sheet for each of the four modules in light mode and confirm the icon tile tint reads as the module colour family (routine = coral, etc.) and is legible against the soft background.
- [ ] Switch to dark mode and confirm the soft-variant buttons (`finyk-soft` / `fizruk-soft` / `routine-soft` / `nutrition-soft`) render with the bright base module colour, not the `-strong` shade tuned for light mode.

### Notes

- Follows the same token convention established in #387. No new tokens added.


Link to Devin session: https://app.devin.ai/sessions/37786129d16942748303e3b037b3bd5a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
