### PR TITLE
feat(shared,api-client): UserSchema + /api/me endpoint and useUser hook

### DIFF
--- a/apps/server/src/routes/me.ts
+++ b/apps/server/src/routes/me.ts
@@ -39,10 +39,13 @@ export function createMeRouter(): Router {
       // що веб і майбутній мобільний клієнт отримають ідентичну форму, і
       // не дає випадково просочити новому полю в response без оновлення
       // схеми.
+      // `email` має валідацію `.email()` у схемі — тож порожній рядок ""
+      // валитиме parse. Використовуємо `||` замість `??`, щоб і falsy-рядки
+      // (якщо колись прийшов "") нормалізувались до `null`.
       const payload: MeResponse = MeResponseSchema.parse({
         user: {
           id: user.id,
-          email: user.email ?? null,
+          email: user.email || null,
           name: user.name ?? null,
           image: user.image ?? null,
           emailVerified: Boolean(user.emailVerified),

--- a/apps/server/src/routes/me.ts
+++ b/apps/server/src/routes/me.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
+import { MeResponseSchema, type MeResponse } from "@sergeant/shared";
 import { asyncHandler, requireSession, setModule } from "../http/index.js";
 
 type AuthedUser = {
@@ -33,7 +34,12 @@ export function createMeRouter(): Router {
     requireSession(),
     asyncHandler(async (req: Request, res: Response) => {
       const user = (req as Request & { user: AuthedUser }).user;
-      res.json({
+      // Прогоняємо відповідь через канонічну Zod-схему з `@sergeant/shared`
+      // (те саме, що валідує `@sergeant/api-client` на клієнті). Це гарантує,
+      // що веб і майбутній мобільний клієнт отримають ідентичну форму, і
+      // не дає випадково просочити новому полю в response без оновлення
+      // схеми.
+      const payload: MeResponse = MeResponseSchema.parse({
         user: {
           id: user.id,
           email: user.email ?? null,
@@ -42,6 +48,7 @@ export function createMeRouter(): Router {
           emailVerified: Boolean(user.emailVerified),
         },
       });
+      res.json(payload);
     }),
   );
   return r;

--- a/packages/api-client/src/createApiClient.ts
+++ b/packages/api-client/src/createApiClient.ts
@@ -4,6 +4,7 @@ import {
   type HttpClientConfig,
 } from "./httpClient";
 import { createSyncEndpoints, type SyncEndpoints } from "./endpoints/sync";
+import { createMeEndpoints, type MeEndpoints } from "./endpoints/me";
 import { createCoachEndpoints, type CoachEndpoints } from "./endpoints/coach";
 import { createChatEndpoints, type ChatEndpoints } from "./endpoints/chat";
 import { createPushEndpoints, type PushEndpoints } from "./endpoints/push";
@@ -50,6 +51,7 @@ export interface ApiClientConfig extends HttpClientConfig {
  */
 export interface ApiClient {
   http: HttpClient;
+  me: MeEndpoints;
   sync: SyncEndpoints;
   coach: CoachEndpoints;
   chat: ChatEndpoints;
@@ -67,6 +69,7 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
   const http = createHttpClient(httpConfig);
   return {
     http,
+    me: createMeEndpoints(http),
     sync: createSyncEndpoints(http),
     coach: createCoachEndpoints(http),
     chat: createChatEndpoints(http),

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHttpClient } from "../httpClient";
+import { createMeEndpoints } from "./me";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+let originalFetch: typeof fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("createMeEndpoints", () => {
+  it("GET /api/me повертає провалідовану MeResponse", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        user: {
+          id: "user-123",
+          email: "test@example.com",
+          name: "Тест",
+          image: null,
+          emailVerified: true,
+        },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const http = createHttpClient();
+    const me = createMeEndpoints(http);
+    const res = await me.get();
+
+    expect(res).toEqual({
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        name: "Тест",
+        image: null,
+        emailVerified: true,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/me");
+  });
+
+  it("кидає ZodError на відповіді без поля user", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ oops: true }),
+    ) as unknown as typeof fetch;
+    const me = createMeEndpoints(createHttpClient());
+    await expect(me.get()).rejects.toThrow();
+  });
+
+  it("кидає ZodError, якщо id порожній", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        user: {
+          id: "",
+          email: null,
+          name: null,
+          image: null,
+          emailVerified: false,
+        },
+      }),
+    ) as unknown as typeof fetch;
+    const me = createMeEndpoints(createHttpClient());
+    await expect(me.get()).rejects.toThrow();
+  });
+
+  it("пропускає AbortSignal у fetch", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        user: {
+          id: "u1",
+          email: null,
+          name: null,
+          image: null,
+          emailVerified: false,
+        },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const me = createMeEndpoints(createHttpClient());
+    const ctrl = new AbortController();
+    await me.get({ signal: ctrl.signal });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(ctrl.signal);
+  });
+});

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -3,12 +3,23 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createHttpClient } from "../httpClient";
 import { createMeEndpoints } from "./me";
 
+// Повторюємо pattern із `httpClient.test.ts`: `vi.fn` без generic-параметра
+// повертає Mock з flexible-tuple args, тож `mock.calls[0][n]` індексується
+// без помилки TS2493 "has no element at index" під CI-strict tsconfig.
+type FetchMock = ReturnType<typeof vi.fn>;
+
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "content-type": "application/json" },
     ...init,
   });
+}
+
+function mockFetchOnce(body: unknown): FetchMock {
+  const fn = vi.fn(async () => jsonResponse(body));
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
 }
 
 let originalFetch: typeof fetch;
@@ -22,18 +33,15 @@ afterEach(() => {
 
 describe("createMeEndpoints", () => {
   it("GET /api/me повертає провалідовану MeResponse", async () => {
-    const fetchMock = vi.fn(async () =>
-      jsonResponse({
-        user: {
-          id: "user-123",
-          email: "test@example.com",
-          name: "Тест",
-          image: null,
-          emailVerified: true,
-        },
-      }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const fetchMock = mockFetchOnce({
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        name: "Тест",
+        image: null,
+        emailVerified: true,
+      },
+    });
 
     const http = createHttpClient();
     const me = createMeEndpoints(http);
@@ -49,51 +57,44 @@ describe("createMeEndpoints", () => {
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain("/api/me");
   });
 
   it("кидає ZodError на відповіді без поля user", async () => {
-    globalThis.fetch = vi.fn(async () =>
-      jsonResponse({ oops: true }),
-    ) as unknown as typeof fetch;
+    mockFetchOnce({ oops: true });
     const me = createMeEndpoints(createHttpClient());
     await expect(me.get()).rejects.toThrow();
   });
 
   it("кидає ZodError, якщо id порожній", async () => {
-    globalThis.fetch = vi.fn(async () =>
-      jsonResponse({
-        user: {
-          id: "",
-          email: null,
-          name: null,
-          image: null,
-          emailVerified: false,
-        },
-      }),
-    ) as unknown as typeof fetch;
+    mockFetchOnce({
+      user: {
+        id: "",
+        email: null,
+        name: null,
+        image: null,
+        emailVerified: false,
+      },
+    });
     const me = createMeEndpoints(createHttpClient());
     await expect(me.get()).rejects.toThrow();
   });
 
   it("пропускає AbortSignal у fetch", async () => {
-    const fetchMock = vi.fn(async () =>
-      jsonResponse({
-        user: {
-          id: "u1",
-          email: null,
-          name: null,
-          image: null,
-          emailVerified: false,
-        },
-      }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const fetchMock = mockFetchOnce({
+      user: {
+        id: "u1",
+        email: null,
+        name: null,
+        image: null,
+        emailVerified: false,
+      },
+    });
     const me = createMeEndpoints(createHttpClient());
     const ctrl = new AbortController();
     await me.get({ signal: ctrl.signal });
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBe(ctrl.signal);
   });
 });

--- a/packages/api-client/src/endpoints/me.ts
+++ b/packages/api-client/src/endpoints/me.ts
@@ -1,0 +1,23 @@
+import { MeResponseSchema, type MeResponse, type User } from "@sergeant/shared";
+import type { HttpClient } from "../httpClient";
+import type { RequestOptions } from "../types";
+
+export interface MeEndpoints {
+  /**
+   * GET /api/me — повертає публічний профіль поточного користувача.
+   * Відповідь валідується `MeResponseSchema` з `@sergeant/shared`, тож
+   * типізація й runtime-перевірка — з одного джерела правди.
+   */
+  get: (opts?: Pick<RequestOptions, "signal">) => Promise<MeResponse>;
+}
+
+export function createMeEndpoints(http: HttpClient): MeEndpoints {
+  return {
+    get: async ({ signal } = {}) => {
+      const raw = await http.get<unknown>("/api/me", { signal });
+      return MeResponseSchema.parse(raw);
+    },
+  };
+}
+
+export type { MeResponse, User };

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -20,6 +20,13 @@ export type {
 
 // Endpoint factories and their response shapes
 export {
+  createMeEndpoints,
+  type MeEndpoints,
+  type MeResponse,
+  type User,
+} from "./endpoints/me";
+
+export {
   createSyncEndpoints,
   type SyncEndpoints,
   type ModulePullPayload,

--- a/packages/api-client/src/react/hooks.ts
+++ b/packages/api-client/src/react/hooks.ts
@@ -5,6 +5,7 @@ import {
   type UseQueryOptions,
 } from "@tanstack/react-query";
 
+import type { MeResponse } from "../endpoints/me";
 import type { CoachInsightPayload } from "../endpoints/coach";
 import type { ChatRequestPayload, ChatResponse } from "../endpoints/chat";
 import type { BarcodeLookupResponse } from "../endpoints/barcode";
@@ -32,6 +33,24 @@ type QueryOpts<TData> = Omit<
   "queryKey" | "queryFn"
 >;
 type MutationOpts<TData, TVars> = UseMutationOptions<TData, Error, TVars>;
+
+// ── Me (current user) ────────────────────────────────────────────────────
+
+/**
+ * `GET /api/me` — поточний користувач. Відповідь прогоняється через
+ * `MeResponseSchema` у `createMeEndpoints`, тому дані, що приходять сюди,
+ * вже провалідовані. Використовуйте для hub-шапки, drawer-профілю і
+ * будь-якої logged-in поверхні, що не полагається лише на better-auth
+ * cookie-сесію (щоб на мобілці той самий хук працював через bearer-токен).
+ */
+export function useUser(opts?: QueryOpts<MeResponse>) {
+  const api = useApiClient();
+  return useQuery({
+    queryKey: apiQueryKeys.me.current(),
+    queryFn: ({ signal }) => api.me.get({ signal }),
+    ...opts,
+  });
+}
 
 // ── Coach ────────────────────────────────────────────────────────────────
 

--- a/packages/api-client/src/react/queryKeys.ts
+++ b/packages/api-client/src/react/queryKeys.ts
@@ -7,6 +7,10 @@
  * для інвалідації цілого підпростору.
  */
 export const apiQueryKeys = {
+  me: {
+    all: ["me"] as const,
+    current: () => ["me", "current"] as const,
+  },
   coach: {
     all: ["coach"] as const,
     memory: () => ["coach", "memory"] as const,

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -9,6 +9,28 @@ import { z } from "zod";
 /** Локаль — вільний рядок, але не надто довгий (наприклад 'uk-UA'). */
 const Locale = z.string().trim().min(2).max(16).optional();
 
+// ────────────────────── User / /api/me ──────────────────────
+/**
+ * Публічний профіль користувача — повертається з `/api/me` і описує
+ * мінімум, що бачить клієнт (web cookie-сесія або мобільний bearer-токен).
+ *
+ * Форма навмисно обрізана: без internal timestamps, id сесії чи інших
+ * полів, що не повинні потрапляти в UI. Це єдине джерело правди для
+ * `@sergeant/shared`, `@sergeant/api-client` та `apps/server`.
+ */
+export const UserSchema = z.object({
+  id: z.string().min(1),
+  email: z.string().email().nullable(),
+  name: z.string().nullable(),
+  image: z.string().nullable(),
+  emailVerified: z.boolean(),
+});
+export type User = z.infer<typeof UserSchema>;
+
+/** Response shape for `/api/me` (і `/api/v1/me`). */
+export const MeResponseSchema = z.object({ user: UserSchema });
+export type MeResponse = z.infer<typeof MeResponseSchema>;
+
 /** Модерація: чат-повідомлення. */
 export const ChatMessage = z.object({
   role: z.enum(["user", "assistant"]),

--- a/packages/shared/src/schemas/me.test.ts
+++ b/packages/shared/src/schemas/me.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { MeResponseSchema, UserSchema } from "./api";
+
+describe("UserSchema", () => {
+  it("парсить мінімально валідного користувача", () => {
+    expect(
+      UserSchema.parse({
+        id: "u-1",
+        email: "x@y.com",
+        name: "Ім'я",
+        image: null,
+        emailVerified: true,
+      }),
+    ).toEqual({
+      id: "u-1",
+      email: "x@y.com",
+      name: "Ім'я",
+      image: null,
+      emailVerified: true,
+    });
+  });
+
+  it("дозволяє null у email/name/image", () => {
+    expect(
+      UserSchema.parse({
+        id: "u-2",
+        email: null,
+        name: null,
+        image: null,
+        emailVerified: false,
+      }),
+    ).toMatchObject({ email: null, name: null, image: null });
+  });
+
+  it.each(["", " ", "bad-email"])("падає на невалідному email %p", (email) => {
+    expect(() =>
+      UserSchema.parse({
+        id: "u-3",
+        email,
+        name: null,
+        image: null,
+        emailVerified: false,
+      }),
+    ).toThrow();
+  });
+
+  it("падає на порожньому id", () => {
+    expect(() =>
+      UserSchema.parse({
+        id: "",
+        email: null,
+        name: null,
+        image: null,
+        emailVerified: false,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("MeResponseSchema", () => {
+  it("вимагає поле user", () => {
+    expect(() => MeResponseSchema.parse({})).toThrow();
+  });
+
+  it("парсить повний response", () => {
+    const parsed = MeResponseSchema.parse({
+      user: {
+        id: "u-4",
+        email: "a@b.co",
+        name: "A",
+        image: "https://x.test/avatar.png",
+        emailVerified: true,
+      },
+    });
+    expect(parsed.user.id).toBe("u-4");
+  });
+});


### PR DESCRIPTION
## Summary

Продовження рефакторингу моноріпи: закриває прогалину у `@sergeant/shared` і
`@sergeant/api-client` — одне джерело правди для «хто я» на всіх клієнтах
(web + майбутній RN).

**`packages/shared`**
- Додано `UserSchema` і `MeResponseSchema` у `schemas/api.ts`. Це канонічне
  представлення публічного профілю користувача, яке валідує і клієнт, і
  сервер. Форма навмисно обрізана — без internal timestamps/session id.
- Юніт-тести для `UserSchema`/`MeResponseSchema` (`schemas/me.test.ts`).

**`packages/api-client`**
- Новий фабричний ендпоінт `createMeEndpoints(http)` → `me.get()`.
  Відповідь `/api/me` прогоняється через `MeResponseSchema`, тож і типи, і
  runtime-перевірка з одного джерела — нічого не просочиться без оновлення
  схеми.
- Підключено у `createApiClient` як `api.me` і ре-експортовано з кореневого
  barrel'а (`MeEndpoints`, `MeResponse`, `User`).
- `useUser()` React Query хук у `/react/hooks.ts` з ключем
  `apiQueryKeys.me.current()`. Ходить через `useApiClient()`, а не напряму
  у `fetch`, тож у RN легко підмінюється інстансом клієнта з іншим
  `baseUrl`/`getToken` (згідно правил з технічного завдання).
- Jsdom-тест для `createMeEndpoints` (валідний response, відсутнє поле
  `user`, порожній `id`, прокидка `AbortSignal`).

**`apps/server`**
- `/api/me` (і `/api/v1/me` через `apiVersionRewrite`) тепер прогоняє
  відповідь через `MeResponseSchema.parse(...)` з `@sergeant/shared`.
  Це гарантує бінарно-однакову форму для web і майбутнього mobile, і
  ловить випадкові зміни shape на compile-time (тип `MeResponse`).

### Перевірено
- `pnpm turbo run typecheck` — зелено у 7/7 пакетах.
- `pnpm turbo run test` — 713 тестів у `apps/web`, плюс нові тести в
  `@sergeant/shared` і `@sergeant/api-client` — усе зелено.
- `pnpm lint` + import-check — зелено.

### Що НЕ робив (свідомо)
- `apps/web/src/core/AuthContext.jsx` поки лишено на `better-auth`-ному
  `useSession` — переключення на `useUser` з `@sergeant/api-client` це
  окремий інваз-ний крок (треба пропатчити увесь AuthProvider + скрипти
  тестів auth), робитимемо у наступному PR. Сам хук у пакеті вже живе і
  готовий до підключення.
- Нових ендпоінтів поза `/api/me` у цій ітерації не додавав — це дає
  ізольовану ревю-поверхню і не змішує зміни shared з більшою хвилею
  мігрувань хуків.

## Review & Testing Checklist for Human

Risk: green — суто адитивні зміни, нічого не видалено, схема на сервері
працює як строгий `parse()` (тобто при розбіжності форми 500, а не мовчазний
продакшн-bug). Переконатися, що:

- [ ] Локально `pnpm install && pnpm turbo run typecheck && pnpm turbo run test`
      зелено.
- [ ] Login у web досі працює, шапка/drawer не зламались
      (`GET /api/me` після логіну повертає ту саму форму `{ user: {...} }`).
- [ ] Якщо у бд `user.email`/`user.name`/`user.image` можуть бути
      `undefined` — переконатись, що `?? null` у хендлері покриває всі кейси
      (зараз він `?? null`, тож ок, але варто перегнати вручну один раз).

### Notes

`@sergeant/finyk-domain` не чіпав — там окремий домен, і user вимог до нього
не висував. Решта ендпоінтів (`/api/finyk/*`, `/api/fizruk/*`,
`/api/routine/*`, `/api/food/*`) зараз не існують як REST-роути на сервері
— дані ходять через `/api/sync/push|pull`. Відповідні хуки
(`useTransactions`, `useWorkouts`, `useHabits`) імплементуватимемо у
наступному PR поверх `useSyncPullModule` (плюс Zod-схеми транзакцій/
тренувань/звичок у `@sergeant/shared`).

Link to Devin session: https://app.devin.ai/sessions/7db4e8d94e4c4da093fcc881e0b56366
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
