### PR TITLE
feat(api-client): apiPrefix option — default /api/v1

### DIFF
--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -14,7 +14,7 @@
  */
 import { createApiClient } from "@sergeant/api-client";
 
-import { apiUrl } from "@shared/lib/apiUrl";
+import { apiUrl, getApiPrefix } from "@shared/lib/apiUrl";
 
 function readNutritionToken(): string {
   try {
@@ -31,6 +31,9 @@ function readNutritionToken(): string {
 
 export const apiClient = createApiClient({
   baseUrl: apiUrl(""),
+  // `apiPrefix` синхронізує api-client із `apiUrl()` прямих `fetch`-викликів:
+  // обидва канали шлють у `/api/v1/*` (default) або `/api/*` (VITE_API_VERSION=none).
+  apiPrefix: getApiPrefix(),
   getNutritionToken: () => readNutritionToken(),
 });
 

--- a/apps/web/src/shared/lib/apiUrl.ts
+++ b/apps/web/src/shared/lib/apiUrl.ts
@@ -27,6 +27,21 @@ function getApiVersion(): string {
   return raw.replace(/^\/+|\/+$/g, "");
 }
 
+/**
+ * Значення, яке треба передати у `createApiClient({ apiPrefix })`, щоб
+ * поведінка `@sergeant/api-client` була консистентна з тим, що повертає
+ * `apiUrl()` для прямих `fetch`-викликів: або `/api/v1` (default), або
+ * `/api` у legacy-режимі `VITE_API_VERSION=none`.
+ *
+ * Завдяки цьому web-код, що досі ходить через `fetch(apiUrl(...))`, і
+ * код, що перейшов на api-client, завжди бʼють у один і той самий
+ * префікс — перемикнути обидва одразу можна через одну env-змінну.
+ */
+export function getApiPrefix(): string {
+  const version = getApiVersion();
+  return version ? `/api/${version}` : "/api";
+}
+
 function applyVersion(path: string): string {
   const version = getApiVersion();
   if (!version) return path;

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -20,6 +20,24 @@
 - **Гнучкий rollout для фронта.** `VITE_API_VERSION=none` повертає
   старий `/api/*` префікс без редеплою сервера — корисно як escape hatch.
 
+## `@sergeant/api-client` — дефолтний префікс
+
+Пакет `@sergeant/api-client` (який імпортує і web, і мобілка) переписує
+шляхи вигляду `/api/<rest>` на `${apiPrefix}<rest>` у середині `httpClient`:
+
+- За замовчуванням `apiPrefix === "/api/v1"`, тож виклик
+  `apiClient.push.subscribe(...)` фактично йде у `/api/v1/push/subscribe`.
+- `/api/auth/*` виключено — Better Auth-плагіни зашиті під
+  `basePath: "/api/auth"`.
+- Шляхи, що вже починаються з `apiPrefix` (напр. явний `/api/v1/foo`), —
+  ідемпотентні, префікс двічі не додається.
+- Escape hatch — передати `apiPrefix: "/api"` у `createApiClient(...)`
+  повертає легасі-поведінку без змін в endpoint-обгортках.
+
+Web прокидає `apiPrefix` через `getApiPrefix()` (див. `apps/web/src/shared/lib/apiUrl.ts`),
+щоб і прямі `fetch(apiUrl(...))`, і виклики через api-client одночасно
+перемикалися однією змінною `VITE_API_VERSION`.
+
 ## Авторизація — не версіонується
 
 `/api/auth/*` свідомо **не** переписується у `/api/v1/auth/*`:

--- a/packages/api-client/src/httpClient.test.ts
+++ b/packages/api-client/src/httpClient.test.ts
@@ -176,6 +176,68 @@ describe("httpClient — помилки", () => {
   });
 });
 
+describe("httpClient — apiPrefix versioning", () => {
+  it("за замовчуванням /api/* → /api/v1/*", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/sync/push-all");
+    const url = fn.mock.calls[0][0] as string;
+    expect(url).toBe("/api/v1/sync/push-all");
+  });
+
+  it("/api/auth/* НЕ версіонується (Better Auth basePath)", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/auth/session");
+    expect(fn.mock.calls[0][0]).toBe("/api/auth/session");
+  });
+
+  it("уже версіонований /api/v1/foo → залишається як є", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/v1/push/register");
+    expect(fn.mock.calls[0][0]).toBe("/api/v1/push/register");
+  });
+
+  it("не-/api/ шляхи прокидаються без змін", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/healthz");
+    expect(fn.mock.calls[0][0]).toBe("/healthz");
+  });
+
+  it("apiPrefix: '/api' — legacy-режим, без версіонування (escape hatch)", async () => {
+    const legacy = createHttpClient({ apiPrefix: "/api" });
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await legacy.get("/api/sync/push-all");
+    expect(fn.mock.calls[0][0]).toBe("/api/sync/push-all");
+  });
+
+  it("кастомний apiPrefix: /api/v2 → /api/v2/foo", async () => {
+    const v2 = createHttpClient({ apiPrefix: "/api/v2" });
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await v2.get("/api/coach/memory");
+    expect(fn.mock.calls[0][0]).toBe("/api/v2/coach/memory");
+  });
+
+  it("не чіпає /api-шляхи без слеша після (напр. /api-foo) щоб не поламати сусідні префікси", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api-foo");
+    expect(fn.mock.calls[0][0]).toBe("/api-foo");
+  });
+
+  it("прокидає baseUrl + apiPrefix у правильному порядку", async () => {
+    const remote = createHttpClient({ baseUrl: "https://api.example.com" });
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await remote.get("/api/me");
+    expect(fn.mock.calls[0][0]).toBe("https://api.example.com/api/v1/me");
+  });
+
+  it("query-параметри коректно додаються до переписаного шляху", async () => {
+    const fn = mockFetchOnce(jsonResponse({ ok: true }));
+    await http.get("/api/food-search", { query: { q: "банан" } });
+    const url = fn.mock.calls[0][0] as string;
+    expect(url.startsWith("/api/v1/food-search?")).toBe(true);
+    expect(url).toContain("q=%D0%B1%D0%B0%D0%BD%D0%B0%D0%BD");
+  });
+});
+
 describe("httpClient — AbortSignal", () => {
   it("прокидає signal у fetch", async () => {
     const fn = mockFetchOnce(jsonResponse({ ok: true }));

--- a/packages/api-client/src/httpClient.ts
+++ b/packages/api-client/src/httpClient.ts
@@ -18,6 +18,23 @@ export interface HttpClientConfig {
    */
   baseUrl?: string;
   /**
+   * API-префікс, під який переписуються шляхи виду `/api/...`. За
+   * замовчуванням — `/api/v1`, тож `http.post("/api/push/register", …)`
+   * фактично йде у `/api/v1/push/register`. Сервер тримає `/api/*` і
+   * `/api/v1/*` як дзеркало, тому переписування безпечне для існуючого
+   * вебу (див. `apiVersionRewrite` у `apps/server/src/app.ts`).
+   *
+   * Винятки, які НЕ чіпаються:
+   *   - `/api/auth/*` — Better Auth зашитий під фіксований `basePath`;
+   *   - шляхи, що вже починаються з `apiPrefix` (ідемпотентність —
+   *     сторонній код може давати `/api/v1/...` явно);
+   *   - шляхи, що не починаються з `/api/` — прокидаються як є.
+   *
+   * Щоб тимчасово повернути легасі-префікс (escape hatch під час rollout),
+   * передай `apiPrefix: "/api"` у `createApiClient`/`createHttpClient`.
+   */
+  apiPrefix?: string;
+  /**
    * Якщо надано — результат додається як `Authorization: Bearer <token>`
    * до кожного запиту. Повертає `null`/`undefined` коли токен не заданий,
    * тоді заголовок не ставимо.
@@ -36,6 +53,47 @@ export interface HttpClientConfig {
    * Дефолтні заголовки, що додаються до кожного запиту (після `getToken`).
    */
   defaultHeaders?: Record<string, string>;
+}
+
+/**
+ * Default API prefix. Mobile-клієнти і за замовчуванням web через
+ * `createApiClient()` ходять у `/api/v1/*`. `/api/auth/*` — виняток.
+ */
+export const DEFAULT_API_PREFIX = "/api/v1";
+const LEGACY_API_PREFIX = "/api";
+const AUTH_PATH_PREFIX = "/api/auth";
+
+function normalizeApiPrefix(prefix: string): string {
+  const trimmed = prefix.replace(/\/+$/, "");
+  if (!trimmed) return LEGACY_API_PREFIX;
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+/**
+ * Переписує шляхи виду `/api/<rest>` на `${prefix}/<rest>`.
+ *
+ * Правила (консистентно з `apps/web/src/shared/lib/apiUrl.ts`):
+ *   - не починається з `/api/` → повертаємо як є (fully-qualified URL, asset, ...);
+ *   - `/api/auth` або `/api/auth/...` → як є (Better Auth basePath);
+ *   - уже починається з `prefix/` або дорівнює `prefix` → як є (ідемпотентність);
+ *   - `prefix === "/api"` → як є (legacy mode, нічого не робимо);
+ *   - інакше: `/api<rest>` → `${prefix}<rest>`.
+ */
+export function applyApiPrefix(path: string, prefix: string): string {
+  const normalizedPrefix = normalizeApiPrefix(prefix);
+  if (normalizedPrefix === LEGACY_API_PREFIX) return path;
+  if (!path.startsWith(LEGACY_API_PREFIX)) return path;
+  // Точний сегментний збіг — щоб `/api-foo` / `/apiv2` (інший endpoint) не зачепило.
+  if (path !== LEGACY_API_PREFIX && !path.startsWith(`${LEGACY_API_PREFIX}/`)) {
+    return path;
+  }
+  if (path === AUTH_PATH_PREFIX || path.startsWith(`${AUTH_PATH_PREFIX}/`)) {
+    return path;
+  }
+  if (path === normalizedPrefix || path.startsWith(`${normalizedPrefix}/`)) {
+    return path;
+  }
+  return normalizedPrefix + path.slice(LEGACY_API_PREFIX.length);
 }
 
 export interface HttpClient {
@@ -167,6 +225,7 @@ function networkMessage(cause: unknown): string {
 export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
   const {
     baseUrl,
+    apiPrefix = DEFAULT_API_PREFIX,
     getToken,
     fetchImpl,
     defaultCredentials = "include",
@@ -204,7 +263,8 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
     path: string,
     opts: RequestOptions = {},
   ): Promise<T> {
-    const url = resolveUrl(baseUrl, path, opts.query);
+    const prefixed = applyApiPrefix(path, apiPrefix);
+    const url = resolveUrl(baseUrl, prefixed, opts.query);
     const fetchFn = fetchImpl ?? globalThis.fetch;
     const headers = await buildHeaders(opts);
     const { signal, cancel } = combineSignals(opts.signal, opts.timeoutMs);

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -3,7 +3,11 @@ export { createApiClient } from "./createApiClient";
 export type { ApiClient, ApiClientConfig } from "./createApiClient";
 
 // HTTP primitives
-export { createHttpClient } from "./httpClient";
+export {
+  createHttpClient,
+  applyApiPrefix,
+  DEFAULT_API_PREFIX,
+} from "./httpClient";
 export type { HttpClient, HttpClientConfig, TokenProvider } from "./httpClient";
 
 // Error types


### PR DESCRIPTION
## Summary

Підчищаю мобільну прев-роботу: пакет `@sergeant/api-client` за замовчуванням
шле у `/api/v1/*`, веб — на тому самому префіксі, що й прямі `fetch(apiUrl(...))`.

Основна ж робота (API-версіонування на сервері, bearer+expo-плагіни,
`trustedOrigins`, CORS, `/api/v1/me`, rate-limit по `userId`, міграція
`push_devices`, `POST /api/v1/push/register`, `docs/api-v1.md` і
`docs/mobile.md`, supertest на `/api/v1/*` + bearer) — вже в main через
PR #377. Єдина прогалина була в тому, що `@sergeant/api-client` (пакет
з'явився пізніше, у #379) захардкодив `/api/*` без `v1`.

### Що саме змінилось

- **`packages/api-client/src/httpClient.ts`**
  - Нова опція `HttpClientConfig.apiPrefix` (default `"/api/v1"`).
  - Хелпер `applyApiPrefix(path, prefix)` у тому ж файлі (експортований
    з package index): переписує `/api/<rest>` на `${prefix}<rest>` перед
    `resolveUrl`. Виключає `/api/auth*` (Better Auth фіксований basePath),
    ідемпотентно пропускає вже-версіоновані шляхи, `apiPrefix: "/api"` —
    escape hatch легасі-поведінки.
  - Точний сегментний збіг: `/api-foo`, `/apiv2` не зачіпаються.
  - Query-параметри, `baseUrl`, `getToken` — всі працюють як раніше,
    просто шлях до `resolveUrl` прилітає вже з правильним префіксом.

- **`packages/api-client/src/index.ts`** — експорт `applyApiPrefix`
  і `DEFAULT_API_PREFIX` для сторонніх інтеграцій/тестів.

- **`apps/web/src/shared/lib/apiUrl.ts`** — новий `getApiPrefix()`, що
  повертає той самий префікс, який використовує внутрішній
  `applyVersion()` для прямих `fetch`-викликів.

- **`apps/web/src/shared/api/index.ts`** — `createApiClient(...)` тепер
  отримує `apiPrefix: getApiPrefix()`. Тож і api-client, і прямі
  `fetch(apiUrl(...))` одночасно перемикаються на `/api/v1` (default) або
  `/api` (через `VITE_API_VERSION=none`) — однією змінною.

- **`docs/api-v1.md`** — нова секція "`@sergeant/api-client` — дефолтний
  префікс" з описом поведінки та escape-hatch.

### Тести

- `packages/api-client/src/httpClient.test.ts`: +8 кейсів
  - `/api/sync/push-all` → `/api/v1/sync/push-all`
  - `/api/auth/session` — без змін
  - `/api/v1/push/register` — ідемпотентно
  - `/healthz` — не /api/ шлях, без змін
  - `apiPrefix: "/api"` — legacy-режим
  - `apiPrefix: "/api/v2"` — кастомний префікс
  - `/api-foo` — не зачіпається (точний сегмент)
  - `baseUrl + apiPrefix` компонуються у правильному порядку
  - query-параметри після переписування

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (всі 7 пакетів, включно з
  web `713 passed`), `pnpm build` — зелені локально.

### Backward compatibility

- Web раніше ходив через api-client у `/api/*` (без v1), тепер — у
  `/api/v1/*`. Сервер тримає обидва префікси як дзеркало
  (`apiVersionRewrite` у `apps/server/src/app.ts` уже в main), тому
  переключення прозоре — ніяких змін у контрактах.
- `/api/auth/*` недоторкані.
- Будь-який код, що передавав явно `/api/v1/foo` у api-client раніше,
  працює без змін (ідемпотентність).

## Review & Testing Checklist for Human

- [ ] Smoke `npm run dev` локально: залогінитись (`/api/auth/sign-in/email`
      має лишатись під `/api/auth`), відкрити головні модулі
      (fizruk/nutrition/finyk/routine) — перевірити у DevTools Network,
      що api-client шле `/api/v1/*`, а прямий `fetch(apiUrl(...))` — теж.
- [ ] Запустити з `VITE_API_VERSION=none` і переконатися, що обидва
      канали повертаються на `/api/*` (escape hatch).
- [ ] Переконатися, що Service Worker (`apps/web/src/sw.js`) пропускає
      нові `/api/v1/*` запити — якщо `sw` матчиться на `/api/auth`, треба
      подивитись, чи не ламає він кешовання v1 роутів.

### Notes

- Пакет `@sergeant/api-client` у моноріпо зараз єдиний виклик через
  `createApiClient(...)`. Мобільний клієнт у наступній сесії просто
  створить свій інстанс (інший `baseUrl` — у продакшн-URL-сервера, свій
  `getToken` з `expo-secure-store`) — `apiPrefix: "/api/v1"` за
  замовчуванням підхопиться автоматично.
- Попередній PR #377 описує всю решту мобільного prep-а; цей PR —
  доповнення тільки в api-client прошарку.

Link to Devin session: https://app.devin.ai/sessions/ec23f4039a8c4f4795e2398bf065eddd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
