### PR TITLE
feat(shared): Web Vitals schemas — single source of truth client/server

### DIFF
--- a/apps/server/src/modules/web-vitals.ts
+++ b/apps/server/src/modules/web-vitals.ts
@@ -1,5 +1,9 @@
 import type { Request, Response } from "express";
-import { z } from "zod";
+import {
+  WEB_VITALS_TIMING_METRIC_NAMES,
+  WebVitalsPayloadSchema,
+  type WebVitalsTimingMetricName,
+} from "@sergeant/shared";
 import { logger } from "../obs/logger.js";
 import { webVitalsCls, webVitalsDurationMs } from "../obs/metrics.js";
 
@@ -19,40 +23,21 @@ import { webVitalsCls, webVitalsDurationMs } from "../obs/metrics.js";
  *
  * Валідно відхилені записи логуються один раз із `sample=1%` щоб не засмічувати
  * Pino потоком з публічного endpoint.
+ *
+ * Схема `WebVitalsPayloadSchema` живе в `@sergeant/shared` — клієнт
+ * (`apps/web/src/core/webVitals.ts`) валідує той самий payload, тож будь-яка
+ * зміна shape рухається одночасно на обох сторонах.
  */
 
-const TIMING_METRICS = new Set<"LCP" | "INP" | "FCP" | "TTFB">([
-  "LCP",
-  "INP",
-  "FCP",
-  "TTFB",
-]);
-
-// CLS — безрозмірний, в реальних умовах 0..1+ (0.25 вже "poor"). Таймінги
-// (LCP/INP/FCP/TTFB) — мс, з приватним upper-bound 120_000 (2 хв — будь-що
-// більше означає зламаний client-side таймер). Окремий upper-bound для CLS
-// важливий: без нього анонімний endpoint приймає value=100000 і інфлейтить
-// `web_vitals_cls_sum` на порядки, роблячи `avg = _sum / _count` безглуздим.
-const MetricSchema = z
-  .object({
-    name: z.enum(["LCP", "INP", "FCP", "TTFB", "CLS"]),
-    value: z.number().finite().min(0),
-    rating: z.enum(["good", "needs-improvement", "poor"]),
-  })
-  .refine((m) => (m.name === "CLS" ? m.value <= 10 : m.value <= 120_000), {
-    message: "value out of range for metric",
-    path: ["value"],
-  });
-
-const PayloadSchema = z.object({
-  metrics: z.array(MetricSchema).min(1).max(10),
-});
+const TIMING_METRICS = new Set<WebVitalsTimingMetricName>(
+  WEB_VITALS_TIMING_METRIC_NAMES,
+);
 
 export default function webVitalsHandler(req: Request, res: Response): void {
   // sendBeacon з `type: "application/json"` приходить як Buffer/string залежно
   // від middleware-а — Express `express.json()` уже парсить у req.body, але
   // якщо клієнт помилиться з content-type, body може бути undefined.
-  const parsed = PayloadSchema.safeParse(req.body);
+  const parsed = WebVitalsPayloadSchema.safeParse(req.body);
   if (!parsed.success) {
     if (Math.random() < 0.01) {
       logger.warn({
@@ -68,7 +53,7 @@ export default function webVitalsHandler(req: Request, res: Response): void {
     try {
       if (m.name === "CLS") {
         webVitalsCls.observe({ rating: m.rating }, m.value);
-      } else if (TIMING_METRICS.has(m.name as "LCP" | "INP" | "FCP" | "TTFB")) {
+      } else if (TIMING_METRICS.has(m.name as WebVitalsTimingMetricName)) {
         webVitalsDurationMs.observe(
           { metric: m.name, rating: m.rating },
           m.value,

--- a/apps/web/src/core/webVitals.ts
+++ b/apps/web/src/core/webVitals.ts
@@ -1,3 +1,8 @@
+import {
+  WEB_VITALS_MAX_BATCH,
+  WebVitalsMetricSchema,
+  type WebVitalsMetric,
+} from "@sergeant/shared";
 import { apiUrl } from "@shared/lib/apiUrl";
 
 /**
@@ -13,13 +18,22 @@ import { apiUrl } from "@shared/lib/apiUrl";
  * - Динамічний `import("web-vitals")` після initSentry → не в критичному шляху.
  * - Єдиний ReadyState guard `sent` на метрику щоб не дублювати INP/CLS, які
  *   `web-vitals` шле кілька разів (finalValue on report callback).
+ * - Payload валідується через спільну `WebVitalsMetricSchema` із
+ *   `@sergeant/shared` — та сама схема, що й у server-handler-і. Клієнт
+ *   застосовує `safeParse` перед додаванням у буфер, щоб битий entry
+ *   від `web-vitals` не тротював валідний батч на сервері
+ *   (який на помилку просто мовчки дропає увесь payload).
  *
  * Без `VITE_WEB_VITALS_ENDPOINT=0` — no-op (flag для аварійного вимкнення без
  * re-deploy). Дефолт — увімкнено.
  */
 
 const ENDPOINT_PATH = "/api/metrics/web-vitals";
-export const MAX_BATCH = 10;
+/**
+ * Ре-експорт для сумісності з легасі-консьюмерами (тестами) цього модуля.
+ * Канонічне джерело — `WEB_VITALS_MAX_BATCH` у `@sergeant/shared`.
+ */
+export const MAX_BATCH = WEB_VITALS_MAX_BATCH;
 
 const buffer = [];
 let flushScheduled = false;
@@ -101,15 +115,8 @@ export function __resetForTests() {
 }
 
 export function enqueue(metric) {
-  if (
-    !metric ||
-    typeof metric.value !== "number" ||
-    !Number.isFinite(metric.value) ||
-    metric.value < 0
-  ) {
-    return;
-  }
-  buffer.push({
+  if (!metric || typeof metric.value !== "number") return;
+  const candidate = {
     name: metric.name,
     value:
       // CLS — безрозмірний, не округлюємо. Решта — ms, ціле число.
@@ -117,7 +124,14 @@ export function enqueue(metric) {
         ? Number(metric.value.toFixed(4))
         : Math.round(metric.value),
     rating: metric.rating,
-  });
+  };
+  // Той самий Zod-refine, що і на сервері: відкидаємо NaN/від'ємні, невідомі
+  // `name`, та значення поза межами (CLS > 10, таймінг > 120_000). Якщо
+  // пропустити це тут, сервер `safeParse`-не failedне і мовчки дропне
+  // увесь батч (див. `modules/web-vitals.ts`).
+  const parsed = WebVitalsMetricSchema.safeParse(candidate);
+  if (!parsed.success) return;
+  buffer.push(parsed.data satisfies WebVitalsMetric);
   if (buffer.length >= MAX_BATCH) {
     flush();
   } else {

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -58,7 +58,12 @@ describe("createMeEndpoints", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain("/api/me");
+    // `createHttpClient()` за замовчуванням переписує `/api/...` → `/api/v1/...`
+    // (див. `DEFAULT_API_PREFIX` у httpClient.ts). Сервер віддає обидва
+    // префікси як дзеркало через `apiVersionRewrite`, тож фактичне попадання —
+    // у `/api/v1/me`. Перевіряємо семантичне «закінчується на /me».
+    expect(url).toMatch(/\/me$/);
+    expect(url).toContain("/api/v1/me");
   });
 
   it("кидає ZodError на відповіді без поля user", async () => {

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -476,4 +476,50 @@ export const BarcodeQuerySchema = z.object({
   barcode: z.string().trim().min(1, "Штрихкод не може бути порожнім").max(32),
 });
 
+// ────────────────────── Web Vitals (POST /api/metrics/web-vitals) ──────────────────────
+// Спільна схема для клієнта (sendBeacon payload) і сервера (request body
+// validator). Три метрики таймінгу в мс — LCP/INP/FCP/TTFB, плюс
+// безрозмірний CLS. `refine` накладає метрико-специфічний upper-bound:
+// CLS ≤ 10 (0.25 вже "poor"; >10 — точно битий клієнт), таймінги ≤ 120_000
+// (2 хв — будь-що більше = зламаний перфомансний таймер). Без цього обмеження
+// анонімний endpoint легко отруює Prometheus histogram.
+export const WEB_VITALS_METRIC_NAMES = [
+  "LCP",
+  "INP",
+  "FCP",
+  "TTFB",
+  "CLS",
+] as const;
+export type WebVitalsMetricName = (typeof WEB_VITALS_METRIC_NAMES)[number];
+
+/** Метрики таймінгу — мс. CLS живе окремо (безрозмірний). */
+export const WEB_VITALS_TIMING_METRIC_NAMES = [
+  "LCP",
+  "INP",
+  "FCP",
+  "TTFB",
+] as const;
+export type WebVitalsTimingMetricName =
+  (typeof WEB_VITALS_TIMING_METRIC_NAMES)[number];
+
+/** Максимум метрик у одному батчі (обмежено і на клієнті, і на сервері). */
+export const WEB_VITALS_MAX_BATCH = 10;
+
+export const WebVitalsMetricSchema = z
+  .object({
+    name: z.enum(WEB_VITALS_METRIC_NAMES),
+    value: z.number().finite().min(0),
+    rating: z.enum(["good", "needs-improvement", "poor"]),
+  })
+  .refine((m) => (m.name === "CLS" ? m.value <= 10 : m.value <= 120_000), {
+    message: "value out of range for metric",
+    path: ["value"],
+  });
+export type WebVitalsMetric = z.infer<typeof WebVitalsMetricSchema>;
+
+export const WebVitalsPayloadSchema = z.object({
+  metrics: z.array(WebVitalsMetricSchema).min(1).max(WEB_VITALS_MAX_BATCH),
+});
+export type WebVitalsPayload = z.infer<typeof WebVitalsPayloadSchema>;
+
 export { z };

--- a/packages/shared/src/schemas/webVitals.test.ts
+++ b/packages/shared/src/schemas/webVitals.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  WEB_VITALS_MAX_BATCH,
+  WEB_VITALS_METRIC_NAMES,
+  WEB_VITALS_TIMING_METRIC_NAMES,
+  WebVitalsMetricSchema,
+  WebVitalsPayloadSchema,
+} from "./api";
+
+describe("WebVitalsMetricSchema", () => {
+  it.each(["LCP", "INP", "FCP", "TTFB"] as const)(
+    "приймає таймінг %s у межах 0..120000 мс",
+    (name) => {
+      expect(
+        WebVitalsMetricSchema.parse({ name, value: 1234, rating: "good" }),
+      ).toEqual({ name, value: 1234, rating: "good" });
+    },
+  );
+
+  it("приймає CLS у 0..10 як float", () => {
+    expect(
+      WebVitalsMetricSchema.parse({ name: "CLS", value: 0.25, rating: "poor" }),
+    ).toEqual({ name: "CLS", value: 0.25, rating: "poor" });
+  });
+
+  it.each(["LCP", "INP", "FCP", "TTFB"] as const)(
+    "відкидає таймінг %s > 120000",
+    (name) => {
+      expect(
+        WebVitalsMetricSchema.safeParse({
+          name,
+          value: 120_001,
+          rating: "poor",
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("відкидає CLS > 10", () => {
+    expect(
+      WebVitalsMetricSchema.safeParse({
+        name: "CLS",
+        value: 10.1,
+        rating: "poor",
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -0.001])(
+    "відкидає value %p",
+    (value) => {
+      expect(
+        WebVitalsMetricSchema.safeParse({
+          name: "LCP",
+          value,
+          rating: "good",
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("відкидає невідому метрику", () => {
+    expect(
+      WebVitalsMetricSchema.safeParse({
+        name: "TBT",
+        value: 10,
+        rating: "good",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("відкидає невідомий rating", () => {
+    expect(
+      WebVitalsMetricSchema.safeParse({
+        name: "LCP",
+        value: 10,
+        rating: "meh",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("WebVitalsPayloadSchema", () => {
+  it("потребує min 1 метрику", () => {
+    expect(WebVitalsPayloadSchema.safeParse({ metrics: [] }).success).toBe(
+      false,
+    );
+  });
+
+  it(`приймає до ${WEB_VITALS_MAX_BATCH} метрик`, () => {
+    const metrics = Array.from({ length: WEB_VITALS_MAX_BATCH }, () => ({
+      name: "LCP" as const,
+      value: 100,
+      rating: "good" as const,
+    }));
+    expect(WebVitalsPayloadSchema.parse({ metrics }).metrics).toHaveLength(
+      WEB_VITALS_MAX_BATCH,
+    );
+  });
+
+  it(`відкидає > ${WEB_VITALS_MAX_BATCH} метрик`, () => {
+    const metrics = Array.from({ length: WEB_VITALS_MAX_BATCH + 1 }, () => ({
+      name: "LCP" as const,
+      value: 100,
+      rating: "good" as const,
+    }));
+    expect(WebVitalsPayloadSchema.safeParse({ metrics }).success).toBe(false);
+  });
+});
+
+describe("WEB_VITALS_METRIC_NAMES / WEB_VITALS_TIMING_METRIC_NAMES", () => {
+  it("таймінги — підмножина всіх метрик", () => {
+    for (const name of WEB_VITALS_TIMING_METRIC_NAMES) {
+      expect(WEB_VITALS_METRIC_NAMES).toContain(name);
+    }
+  });
+
+  it("CLS — поза таймінгами", () => {
+    expect(WEB_VITALS_TIMING_METRIC_NAMES).not.toContain(
+      "CLS" as unknown as (typeof WEB_VITALS_TIMING_METRIC_NAMES)[number],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Друга хвиля моноріпа-рефактора поверх PR #389 (`/api/me`). Виніс Zod-схеми Core Web Vitals з `apps/server` у `@sergeant/shared`, щоб клієнт (браузерний collector) і сервер (Prometheus sink) використовували **одну** схему — будь-яка зміна shape їде обома сторонами одночасно.

**`@sergeant/shared`** — нові експорти у `schemas/api.ts`:
- `WebVitalsMetricSchema` — один metric із refine-правилом: `CLS ≤ 10`, таймінги (`LCP|INP|FCP|TTFB`) ≤ 120_000 мс. Без цього bound анонімний endpoint отруює `web_vitals_*` histogram-и (value=1_000_000 на CLS робить avg безглуздим).
- `WebVitalsPayloadSchema` — `{ metrics: Metric[] }`, min 1 / max `WEB_VITALS_MAX_BATCH` (= 10).
- Константи `WEB_VITALS_METRIC_NAMES`, `WEB_VITALS_TIMING_METRIC_NAMES`, `WEB_VITALS_MAX_BATCH` та типи `WebVitalsMetric`, `WebVitalsPayload`, `WebVitalsMetricName`, `WebVitalsTimingMetricName`.
- Юніт-тести (`schemas/webVitals.test.ts`): метрико-специфічний upper-bound, min/max батча, інваріант «таймінги ⊂ всі метрики».

**`apps/server`** (`src/modules/web-vitals.ts`):
- Видалив локальні `MetricSchema` / `PayloadSchema`, імпортую з `@sergeant/shared`. Поведінка handler-а незмінна (завжди 204, sampled warn-лог на invalid).
- `TIMING_METRICS` сет генерується з `WEB_VITALS_TIMING_METRIC_NAMES` — неможливо «забути» додати нову метрику на одній стороні.

**`apps/web`** (`src/core/webVitals.ts`):
- `enqueue()` тепер прогоняє candidate через ту саму `WebVitalsMetricSchema` перед додаванням у буфер. Битий entry від `web-vitals` (невідоме `name`, NaN, від'ємне, поза bound) більше **не тротить валідний батч** — сервер на провалений `safeParse` мовчки дропає увесь payload, тож фільтрувати треба вже на клієнті.
- Існуючі тести (`webVitals.test.ts`: NaN/negative/string/null → дроп, LCP округлюється, CLS 4 знаки) зберігають поведінку.
- `MAX_BATCH` ре-експортовано з `@sergeant/shared` для сумісності з легасі-консьюмерами (тестами).

**`packages/api-client`** (`src/endpoints/me.test.ts`):
- Підправив assert URL після PR #390 (`DEFAULT_API_PREFIX = "/api/v1"`): очікуваний URL `/api/v1/me` замість `/api/me`. Код endpoint-а не чіпав.

## Review & Testing Checklist for Human

- [ ] Переконайся, що `WEB_VITALS_METRIC_NAMES` як `as const` коректно звужує тип у `z.enum(...)` — Zod v4 приймає це без caveats.
- [ ] Ручна перевірка: відкрити веб-сайт, у DevTools → Network подивитись що `POST /api/metrics/web-vitals` шле валідний payload (3-5 метрик, правильний rating/value), відповідь 204.
- [ ] (опціонально) У Grafana/Prometheus перевірити, що `web_vitals_duration_ms_count{metric="LCP"}` і `web_vitals_cls_count` продовжують рости після деплою — ніщо не зламалось у збиранні.

## Test Plan

1. `pnpm turbo run typecheck` — 7/7 зелено ✓
2. `pnpm turbo run test --filter=@sergeant/{shared,api-client,server,web}` — всі зелено локально ✓
3. `pnpm turbo run lint` — 7/7 зелено ✓
4. Ручна перевірка у проді/preview: Web Vitals шлються, 204, метрики ростуть у Prometheus.

### Notes

- Це **вузький slice** — свідомо одна фіча (Web Vitals schemas) + один bug-fix по тесту після #390. Наступні хвилі: (a) extract `FlagDefinition` → `@sergeant/shared` + `useFlag` в api-client, (b) `AuthContext` з `better-auth/useSession` → `@sergeant/api-client/useUser`, (c) domain types (Transaction/Workout/Habit) поверх `useSyncPullModule`.
- `packages/api-client` **нічого** додаткового не експортує — це телеметричний endpoint, браузер шле напряму через `sendBeacon` (keepalive), не через React Query. React-хуку `useWebVitals()` не створював.
- `recommendationEngine` і `typedStore`/`featureFlags` лишаються у `apps/web` (перший тягне `localStorage`, другі — браузерні stores з DOM-subscriber через `useSyncExternalStore`). Міграцію flag-definitions у shared зроблю окремим PR, якщо буде потреба ділитись реєстром прапорів між веб і майбутньою RN-збіркою.

Link to Devin session: https://app.devin.ai/sessions/7db4e8d94e4c4da093fcc881e0b56366
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
