### PR TITLE
refactor(web): AuthContext → useUser() (GET /api/v1/me) as single source of identity

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -14,6 +14,8 @@ import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { ToastProvider } from "@shared/hooks/useToast";
 import { ToastContainer } from "@shared/components/ui/Toast";
 import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/hubNav";
+import { ApiClientProvider } from "@sergeant/api-client/react";
+import { apiClient } from "@shared/api";
 import { AuthProvider, useAuth } from "./AuthContext.jsx";
 import { useCloudSync } from "./useCloudSync.js";
 import { PageLoader } from "./app/PageLoader.jsx";
@@ -74,9 +76,11 @@ export default function App() {
   return (
     <ToastProvider>
       <ToastContainer />
-      <AuthProvider>
-        <AppInner />
-      </AuthProvider>
+      <ApiClientProvider client={apiClient}>
+        <AuthProvider>
+          <AppInner />
+        </AuthProvider>
+      </ApiClientProvider>
     </ToastProvider>
   );
 }

--- a/apps/web/src/core/AuthContext.test.tsx
+++ b/apps/web/src/core/AuthContext.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+// The Better Auth actions layer is irrelevant to AuthContext's source of
+// truth — we stub the whole `authClient` module so tests don't hit the
+// network and we can assert which action was invoked.
+type AuthResult = { data: unknown; error: { message?: string } | null };
+const ok = (): AuthResult => ({ data: {}, error: null });
+const signInEmail: ReturnType<
+  typeof vi.fn<
+    (args: { email: string; password: string }) => Promise<AuthResult>
+  >
+> = vi.fn(async () => ok());
+const signUpEmail: ReturnType<
+  typeof vi.fn<
+    (args: {
+      email: string;
+      password: string;
+      name: string;
+    }) => Promise<AuthResult>
+  >
+> = vi.fn(async () => ok());
+const signOut: ReturnType<typeof vi.fn<() => Promise<void>>> = vi.fn(
+  async () => undefined,
+);
+const forgetPassword: ReturnType<
+  typeof vi.fn<
+    (args: { email: string; redirectTo?: string }) => Promise<AuthResult>
+  >
+> = vi.fn(async () => ok());
+
+vi.mock("./authClient.js", () => ({
+  signIn: {
+    email: (args: { email: string; password: string }) => signInEmail(args),
+  },
+  signUp: {
+    email: (args: { email: string; password: string; name: string }) =>
+      signUpEmail(args),
+  },
+  signOut: () => signOut(),
+  forgetPassword: (args: { email: string; redirectTo?: string }) =>
+    forgetPassword(args),
+}));
+
+// Mock `useUser` from `@sergeant/api-client/react`. The AuthContext must
+// drive off this hook — NOT off `better-auth/react#useSession`. The mock
+// keeps `apiQueryKeys` intact so invalidation assertions can compare
+// against the real query key tuple.
+const useUserMock = vi.fn();
+
+vi.mock("@sergeant/api-client/react", async () => {
+  const real = await vi.importActual<
+    typeof import("@sergeant/api-client/react")
+  >("@sergeant/api-client/react");
+  return {
+    ...real,
+    useUser: (opts?: unknown) => useUserMock(opts),
+  };
+});
+
+import { AuthProvider, useAuth } from "./AuthContext.js";
+import { apiQueryKeys } from "@sergeant/api-client/react";
+
+interface UseUserState {
+  data?:
+    | {
+        user: {
+          id: string;
+          email: string | null;
+          name: string | null;
+          image: string | null;
+          emailVerified: boolean;
+        };
+      }
+    | undefined;
+  isLoading?: boolean;
+  error?: unknown;
+}
+
+function setUser(state: UseUserState) {
+  useUserMock.mockReturnValue({
+    data: state.data,
+    isLoading: state.isLoading ?? false,
+    error: state.error ?? null,
+  });
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+  }
+  return { Wrapper, client, invalidateSpy };
+}
+
+const SAMPLE_USER = {
+  id: "u-1",
+  email: "a@b.c",
+  name: "A",
+  image: null,
+  emailVerified: true,
+};
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    signInEmail.mockClear();
+    signUpEmail.mockClear();
+    signOut.mockClear();
+    forgetPassword.mockClear();
+    useUserMock.mockReset();
+  });
+
+  it("drives `user`/`status` off useUser() — not better-auth/useSession", () => {
+    setUser({ data: { user: SAMPLE_USER } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    expect(useUserMock).toHaveBeenCalled();
+    expect(result.current.user).toEqual(SAMPLE_USER);
+    expect(result.current.status).toBe("authenticated");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("reports `loading` while useUser() is pending", () => {
+    setUser({ data: undefined, isLoading: true });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.status).toBe("loading");
+    expect(result.current.user).toBeNull();
+  });
+
+  it("reports `unauthenticated` when useUser() has no user", () => {
+    setUser({ data: undefined, isLoading: false });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    expect(result.current.status).toBe("unauthenticated");
+    expect(result.current.user).toBeNull();
+  });
+
+  it("invalidates apiQueryKeys.me.current() after successful login", async () => {
+    setUser({ data: undefined });
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const ok = await result.current.login("a@b.c", "pw");
+      expect(ok).toBe(true);
+    });
+    expect(signInEmail).toHaveBeenCalledWith({
+      email: "a@b.c",
+      password: "pw",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("surfaces login error and does NOT invalidate me on failure", async () => {
+    setUser({ data: undefined });
+    signInEmail.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Bad credentials" },
+    } as unknown as Awaited<ReturnType<typeof signInEmail>>);
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const ok = await result.current.login("a@b.c", "wrong");
+      expect(ok).toBe(false);
+    });
+    expect(result.current.authError).toBe("Bad credentials");
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("invalidates apiQueryKeys.me.current() after successful register", async () => {
+    setUser({ data: undefined });
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const ok = await result.current.register("a@b.c", "pw", "A");
+      expect(ok).toBe(true);
+    });
+    expect(signUpEmail).toHaveBeenCalledWith({
+      email: "a@b.c",
+      password: "pw",
+      name: "A",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("invalidates apiQueryKeys.me.current() on logout, even if signOut throws", async () => {
+    setUser({ data: { user: SAMPLE_USER } });
+    signOut.mockRejectedValueOnce(new Error("network down"));
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.logout();
+    });
+    expect(signOut).toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("refresh() invalidates apiQueryKeys.me.current()", async () => {
+    setUser({ data: { user: SAMPLE_USER } });
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("requestPasswordReset delegates to Better Auth without invalidating me", async () => {
+    setUser({ data: undefined });
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const ok = await result.current.requestPasswordReset("a@b.c");
+      expect(ok).toBe(true);
+    });
+    expect(forgetPassword).toHaveBeenCalled();
+    // Reset doesn't change identity, so me-cache must stay untouched.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("useAuth() throws when used outside AuthProvider", () => {
+    setUser({ data: undefined });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useAuth())).toThrow(
+      /useAuth must be used within AuthProvider/,
+    );
+    spy.mockRestore();
+  });
+
+  it("reflects useUser() transitions across logout/login (new user profile surfaces)", async () => {
+    setUser({ data: { user: { ...SAMPLE_USER, id: "u-1", name: "One" } } });
+    const { Wrapper } = makeWrapper();
+
+    function Probe() {
+      const { user, status } = useAuth();
+      return (
+        <div data-testid="probe">
+          {status}:{user?.id ?? ""}:{user?.name ?? ""}
+        </div>
+      );
+    }
+
+    const { getByTestId, rerender } = render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+    await waitFor(() =>
+      expect(getByTestId("probe").textContent).toBe("authenticated:u-1:One"),
+    );
+
+    // Simulate logout: useUser() now returns no user.
+    setUser({ data: undefined });
+    rerender(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+    await waitFor(() =>
+      expect(getByTestId("probe").textContent).toBe("unauthenticated::"),
+    );
+
+    // Simulate a new sign-in: useUser() now returns a different user.
+    setUser({
+      data: { user: { ...SAMPLE_USER, id: "u-2", name: "Two" } },
+    });
+    rerender(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+    await waitFor(() =>
+      expect(getByTestId("probe").textContent).toBe("authenticated:u-2:Two"),
+    );
+  });
+});

--- a/apps/web/src/core/AuthContext.tsx
+++ b/apps/web/src/core/AuthContext.tsx
@@ -1,62 +1,134 @@
-import { createContext, useContext, useCallback, useState } from "react";
 import {
-  useSession,
-  signIn,
-  signUp,
-  signOut,
-  forgetPassword,
-} from "./authClient.js";
+  createContext,
+  useContext,
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useUser, apiQueryKeys } from "@sergeant/api-client/react";
+import type { User } from "@sergeant/shared";
+import { signIn, signUp, signOut, forgetPassword } from "./authClient.js";
 
-const AuthContext = createContext(null);
+/**
+ * AuthContext — єдине джерело правди «хто я» для веб-додатку.
+ *
+ * Дані про поточного користувача тягнемо через `useUser()` з
+ * `@sergeant/api-client/react` (`GET /api/v1/me` + runtime-валідація
+ * `MeResponseSchema`). Better Auth лишається тільки як actions-layer
+ * (`signIn.email`, `signUp.email`, `signOut`, `forgetPassword`) — після
+ * кожної дії інвалідуємо `apiQueryKeys.me.current()`, щоб наступний
+ * рендер побачив свіжий профіль.
+ */
 
-export function AuthProvider({ children }) {
-  const sessionQuery = useSession();
-  const user = sessionQuery?.data?.user ?? null;
-  const isLoading = sessionQuery?.isPending ?? false;
+export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
 
-  const [authError, setAuthError] = useState(null);
+interface AuthContextValue {
+  user: User | null;
+  isLoading: boolean;
+  status: AuthStatus;
+  authError: string | null;
+  setAuthError: (msg: string | null) => void;
+  login: (email: string, password: string) => Promise<boolean>;
+  register: (email: string, password: string, name: string) => Promise<boolean>;
+  logout: () => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<boolean>;
+  refresh: () => Promise<void>;
+}
 
-  const login = useCallback(async (email, password) => {
-    setAuthError(null);
-    try {
-      const result = await signIn.email({ email, password });
-      if (result?.error) {
-        setAuthError(result.error.message || "Помилка входу");
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const queryClient = useQueryClient();
+  const meQuery = useUser({
+    // 401 від `/api/v1/me` для анонімного візитера — нормальний стан,
+    // а не «справжня» помилка: ми лишаємо `user = null` і рендеримо
+    // sign-in surface. Тому не ретраїмо і не завалюємо UI спінером.
+    retry: false,
+  });
+
+  const user = meQuery.data?.user ?? null;
+  const isLoading = meQuery.isLoading;
+  const status: AuthStatus = isLoading
+    ? "loading"
+    : user
+      ? "authenticated"
+      : "unauthenticated";
+
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const invalidateMe = useCallback(
+    () =>
+      queryClient.invalidateQueries({ queryKey: apiQueryKeys.me.current() }),
+    [queryClient],
+  );
+
+  const refresh = useCallback(async () => {
+    await invalidateMe();
+  }, [invalidateMe]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      setAuthError(null);
+      try {
+        const result = await signIn.email({ email, password });
+        if (result?.error) {
+          setAuthError(result.error.message || "Помилка входу");
+          return false;
+        }
+        await invalidateMe();
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Помилка входу";
+        setAuthError(message);
         return false;
       }
-      return true;
-    } catch (err) {
-      setAuthError(err?.message || "Помилка входу");
-      return false;
-    }
-  }, []);
+    },
+    [invalidateMe],
+  );
 
-  const register = useCallback(async (email, password, name) => {
-    setAuthError(null);
-    try {
-      const result = await signUp.email({ email, password, name });
-      if (result?.error) {
-        setAuthError(result.error.message || "Помилка реєстрації");
+  const register = useCallback(
+    async (email: string, password: string, name: string) => {
+      setAuthError(null);
+      try {
+        const result = await signUp.email({ email, password, name });
+        if (result?.error) {
+          setAuthError(result.error.message || "Помилка реєстрації");
+          return false;
+        }
+        await invalidateMe();
+        return true;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Помилка реєстрації";
+        setAuthError(message);
         return false;
       }
-      return true;
-    } catch (err) {
-      setAuthError(err?.message || "Помилка реєстрації");
-      return false;
-    }
-  }, []);
+    },
+    [invalidateMe],
+  );
 
   const logout = useCallback(async () => {
     try {
       await signOut();
-    } catch {}
-  }, []);
+    } catch {
+      // Ігноруємо: навіть якщо Better Auth endpoint повернув помилку,
+      // далі все одно викидаємо локальний me-кеш — UI має показати
+      // sign-in surface, а не застрягти в «напів-залогіненому» стані.
+    }
+    await invalidateMe();
+  }, [invalidateMe]);
 
   // Request a password reset email via Better Auth. Returns `true` when
   // the request was accepted (the server still answers OK even if the
   // address isn't registered — we don't leak account enumeration). The
   // UI uses that flag to show a neutral "check your inbox" state.
-  const requestPasswordReset = useCallback(async (email) => {
+  const requestPasswordReset = useCallback(async (email: string) => {
     setAuthError(null);
     try {
       const redirectTo = `${window.location.origin}/reset-password`;
@@ -69,30 +141,45 @@ export function AuthProvider({ children }) {
       }
       return true;
     } catch (err) {
-      setAuthError(err?.message || "Не вдалося надіслати лист для скидання.");
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Не вдалося надіслати лист для скидання.";
+      setAuthError(message);
       return false;
     }
   }, []);
 
-  return (
-    <AuthContext.Provider
-      value={{
-        user,
-        isLoading,
-        authError,
-        setAuthError,
-        login,
-        register,
-        logout,
-        requestPasswordReset,
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      isLoading,
+      status,
+      authError,
+      setAuthError,
+      login,
+      register,
+      logout,
+      requestPasswordReset,
+      refresh,
+    }),
+    [
+      user,
+      isLoading,
+      status,
+      authError,
+      login,
+      register,
+      logout,
+      requestPasswordReset,
+      refresh,
+    ],
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-export function useAuth() {
+export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used within AuthProvider");
   return ctx;

--- a/apps/web/src/core/authClient.ts
+++ b/apps/web/src/core/authClient.ts
@@ -49,11 +49,17 @@ const typedAuthClient = authClient as typeof authClient & {
   }) => Promise<PasswordResetResult>;
 };
 
+// NOTE: `useSession` is intentionally NOT re-exported here. The single
+// source of truth for "who am I" lives in `AuthContext`, which drives off
+// `useUser()` from `@sergeant/api-client/react` (→ `GET /api/v1/me`). Better
+// Auth survives only as the actions layer (sign-in / sign-up / sign-out /
+// password reset). If you need a one-off session check outside React (e.g.
+// service worker, Playwright helper), import `getSession` below.
 export const {
-  useSession,
   signIn,
   signUp,
   signOut,
+  getSession,
   forgetPassword,
   resetPassword,
 } = typedAuthClient;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -123,5 +123,31 @@ export default [
       "sergeant-design/no-ellipsis-dots": "off",
     },
   },
+  // AuthContext migration (Session 4B, PR after #390): "who am I" is
+  // single-sourced via `useUser()` from `@sergeant/api-client/react` → GET
+  // `/api/v1/me`. Better Auth stays only as the actions layer. Block
+  // reintroduction of `useSession` from `better-auth/react` anywhere in the
+  // web app except `authClient.ts`, which is the one legitimate adapter
+  // module — it owns the Better Auth client and intentionally does NOT
+  // re-export `useSession` (see the note in that file).
+  {
+    files: ["apps/web/src/**/*.{js,jsx,ts,tsx}"],
+    ignores: ["apps/web/src/core/authClient.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "better-auth/react",
+              importNames: ["useSession"],
+              message:
+                "Use `useAuth()` from `core/AuthContext` (backed by `useUser()` from `@sergeant/api-client/react` → GET /api/v1/me). `useSession` from Better Auth is only for the actions layer inside `core/authClient.ts`.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -58,7 +58,12 @@ describe("createMeEndpoints", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = fetchMock.mock.calls[0][0] as string;
-    expect(url).toContain("/api/me");
+    // `createHttpClient()` defaults to `apiPrefix = "/api/v1"` (see
+    // DEFAULT_API_PREFIX / PR #390), so `/api/me` is rewritten to
+    // `/api/v1/me` before fetch. The server mirrors both `/api/me` and
+    // `/api/v1/me` (see `apiVersionRewrite`), but the client-side URL
+    // we assert here is the post-rewrite one.
+    expect(url).toContain("/api/v1/me");
   });
 
   it("кидає ZodError на відповіді без поля user", async () => {


### PR DESCRIPTION
## Summary

Переводить «хто я» у `apps/web` з `better-auth/useSession()` на
`useUser()` з `@sergeant/api-client/react` (`GET /api/v1/me` +
`MeResponseSchema`). Better Auth лишається виключно як actions-layer
(`signIn.email`, `signUp.email`, `signOut`, `forgetPassword`) — це те, що
PR #389 свідомо відклав як окремий інваз-ний крок; тепер закриваємо.

**Risk:** 🟡 yellow — зміна auth-шару у веб-додатку. Логіка
actions (sign-in/sign-up/sign-out/forget/reset password) не торкалася.

### Що змінено

- `apps/web/src/core/AuthContext.tsx` — повна переписка на TS:
  - `const meQuery = useUser({ retry: false });` — джерело `user`,
    `status` (`loading | authenticated | unauthenticated`), `isLoading`.
  - Публічне API контексту (`user`, `isLoading`, `authError`,
    `setAuthError`, `login`, `register`, `logout`,
    `requestPasswordReset`) збережено; додано `status` і `refresh()`.
  - Після успішного `signIn`/`signUp` і завжди після `signOut` (навіть
    якщо Better Auth endpoint кинув помилку) — `queryClient
    .invalidateQueries({ queryKey: apiQueryKeys.me.current() })`.
- `apps/web/src/core/authClient.ts` — знімаємо `useSession` з експорту;
  додаємо `getSession` для one-off кейсів (service worker, Playwright).
  Файл лишається єдиним легітимним місцем, де дозволено імпортувати
  з `better-auth/react`.
- `apps/web/src/core/App.tsx` — `<ApiClientProvider client={apiClient}>`
  обгортає `<AuthProvider>` (необхідно для `useUser()`, який ходить
  через `useApiClient()`).
- `eslint.config.js` — нове правило `no-restricted-imports` блокує
  `useSession` з `better-auth/react` будь-де під `apps/web/src/**`,
  окрім `apps/web/src/core/authClient.ts`.
- `apps/web/src/core/AuthContext.test.tsx` (новий) — 11 тестів:
  - `useUser()` — джерело `user`/`status` (а не `useSession`);
  - loading/unauthenticated/authenticated переходи;
  - invalidation `apiQueryKeys.me.current()` після
    `signIn`/`signUp`/`signOut`/`refresh()`, через `QueryClient` spy;
  - на помилку login invalidation НЕ викликається;
  - `requestPasswordReset` не чіпає me-cache (identity не змінюється);
  - logout інвалідує me-cache навіть при кинутому signOut;
  - `useAuth()` без провайдера кидає помилку;
  - `Probe`-тест з `rerender`-ом перевіряє, що зміни
    `useUser()` коректно розлітаються у споживачів (emulating new
    sign-in → новий профіль показується).

### Що НЕ зроблено (свідомо)

- Web-PWA push-swap на `api.push.register` — Сесія 4C.
- Мобільна міграція `useSession` → `useUser` — Сесія 4D.
- Прибирання Better Auth як actions-layer — ми лишаємо
  `signIn`/`signUp`/`signOut`/`forgetPassword` на ньому.
- `scripts/test-auth.*` lifecycle-скрипти — інтеграційні ескейп-хатчі,
  за планом не мігруємо.

### Як перевіряв локально

- `pnpm install` — clean, lockfile untouched.
- `pnpm turbo run lint typecheck` — 14/14 tasks зелені.
- `pnpm --filter @sergeant/web test` — **77 test files, 724 tests
  passed** (було 713 до PR #390; +11 нових з `AuthContext.test.tsx`).
- `pnpm turbo run build` — web build OK (PWA service worker включно).
- Probe-файл, що імпортує `useSession` з `better-auth/react` поза
  `authClient.ts`, ловиться ESLint-ом:
  ```
  error  'useSession' import from 'better-auth/react' is restricted.
         Use `useAuth()` from `core/AuthContext` … no-restricted-imports
  ```
- `rg 'from "better-auth/react"' apps/web/src/` → тільки
  `apps/web/src/core/authClient.ts`.
- `rg 'useSession' apps/web/src/` → лише коментарі в
  `AuthContext.test.tsx` та `authClient.ts` (жодних імпортів).

## Review & Testing Checklist for Human

- [ ] **Вручну прогнати sign-in/sign-up/sign-out з `pnpm dev:server` +
  `pnpm --filter @sergeant/web dev`.** У DevTools → Network подивитися:
  (а) після успішного sign-in є `GET /api/v1/me`, користувач
  розлітається по хедеру, drawer-профілю, cloud-sync; (б) після
  sign-out новий `GET /api/v1/me` повертає 401/unauth і UI редіректить
  на `/sign-in`; (в) Better Auth endpoint-и (`/api/auth/sign-in/email`
  тощо) по-старому відповідають 2xx — ми їх не чіпали.
- [ ] **Перевірити cold-start і PWA standalone:** `useUser({ retry:
  false })` не має «замерзати» UI на анонімному візитері — `isLoading`
  має швидко зʼїхати у `unauthenticated` (401 не ретраїться).
- [ ] **Перемкнутись між двома акаунтами** (logout → login під іншим
  email) — після другого sign-in хедер/drawer повинні показати новий
  `email`/`name`/`image`. Якщо залишається попередній — це означає, що
  invalidation me-кешу не долетів (регрес).

### Notes

- `<ApiClientProvider>` раніше ніде не був зареєстрований у веб-деревi
  (prompt згадує PR #379/#389, але фактично до цієї PR-и його там не
  було — `apiClient` лише реекспортувався через `@shared/api`). Додано
  поруч з `<AuthProvider>` у `App.tsx` — це мінімальна зміна, без якої
  `useUser()` кине «`useApiClient must be used inside
  <ApiClientProvider>`».
- Better Auth `useSession` навмисно більше не реекспортується з
  `authClient.ts` (замість `@deprecated` JSDoc — фізичне видалення
  плюс ESLint guard). Якщо комусь у майбутньому знадобиться session
  outside React, є `getSession` там же.

Link to Devin session: https://app.devin.ai/sessions/a0222858425d4c59a9fcad96cd09ee80
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
