### PR TITLE
feat(api-client): push.register endpoint + usePushRegister hook

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -310,3 +310,73 @@ export function useDayPlan(date: string) {
 6. Не додавай `fetch(...)` або axios у модуль. Якщо `http.*` чогось не вміє — допиши це в `httpClient.ts`, а не обходь його.
 
 Якщо сумніваєшся — глянь, як зроблено `endpoints/sync.ts` або `endpoints/nutrition.ts`: це живі референси.
+
+---
+
+## Me endpoints
+
+Факторі: `createMeEndpoints(http)` у `endpoints/me.ts`. Експонує один метод для пошаренного «хто я» на всіх клієнтах (web cookie і mobile bearer).
+
+```ts
+import { createApiClient } from "@sergeant/api-client";
+
+const api = createApiClient();
+const { user } = await api.me.get();
+//        ^? MeResponse["user"] з `@sergeant/shared`
+```
+
+- `api.me.get({ signal? })` → `Promise<MeResponse>`, де `MeResponse` — `z.infer` з `MeResponseSchema` (`@sergeant/shared/schemas/api.ts`). Runtime-парсинг через `MeResponseSchema.parse(...)`, тож будь-яка розбіжність форми ловиться одразу як `ZodError`.
+- `apiPrefix` (default `/api/v1`) прикладається автоматично — метод звертається до `/api/me`, в http-клієнті шлях переписується у `/api/v1/me`.
+
+React-шар (`@sergeant/api-client/react`):
+
+```ts
+import { useUser } from "@sergeant/api-client/react";
+
+function Header() {
+  const { data, isPending } = useUser();
+  if (isPending) return <Skeleton />;
+  return <span>{data?.user.name ?? "Guest"}</span>;
+}
+```
+
+Ключ запиту — `apiQueryKeys.me.current()`; для ручної інвалідації всього піддомену — `queryClient.invalidateQueries({ queryKey: apiQueryKeys.me.all })`.
+
+---
+
+## Push endpoints
+
+Факторі: `createPushEndpoints(http)` у `endpoints/push.ts`. Окрім трьох легасі web-push ендпоінтів (`getVapidPublic`, `subscribe`, `unsubscribe`), експонує уніфіковану реєстрацію пристрою для web / iOS / Android (контракт задокументований у `docs/mobile.md` і `docs/api-v1.md`):
+
+```ts
+import { createApiClient } from "@sergeant/api-client";
+
+const api = createApiClient();
+
+// Web PWA (service-worker endpoint + keys):
+await api.push.register({
+  platform: "web",
+  token: "https://fcm.googleapis.com/wp/xxx",
+  keys: { p256dh: "…", auth: "…" },
+});
+
+// iOS (APNs device token):
+await api.push.register({ platform: "ios", token: "<64-hex>" });
+
+// Android (FCM registration token):
+await api.push.register({ platform: "android", token: "<fcm>" });
+```
+
+- `api.push.register(body, { signal? })` → `Promise<PushRegisterResponse>` (`{ ok: true, platform }`). Runtime-валідація request'а відповідає `PushRegisterRequestSchema` (реекспорт `PushRegisterSchema` з `@sergeant/shared` — один discriminated union на `platform`, тож web без `keys` або native з `keys` зловлене ще до мережі). Відповідь валідується `PushRegisterResponseSchema`.
+- Шлях `/api/push/register` автоматично перетворюється на `/api/v1/push/register` через `applyApiPrefix` (див. `httpClient.ts`). Не передавай `/api/v1/…` явно — ідемпотентно, але плутає ревью.
+
+React-шар:
+
+```ts
+import { usePushRegister } from "@sergeant/api-client/react";
+
+const register = usePushRegister();
+register.mutate({ platform: "ios", token: deviceToken });
+```
+
+Ключ мутації — `apiMutationKeys.push.register()`; придатний для `useIsMutating` у UI (блокувати кнопку «Увімкнути нотифікації», поки мутація in-flight).

--- a/packages/api-client/src/endpoints/push.test.ts
+++ b/packages/api-client/src/endpoints/push.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHttpClient } from "../httpClient";
+import { createPushEndpoints } from "./push";
+
+// Мокаємо глобальний fetch. `vi.fn` без generic-параметра повертає Mock з
+// flexible-tuple args — pattern із `me.test.ts` / `httpClient.test.ts`, щоб
+// `mock.calls[0][n]` індексувалось без TS2493 під CI-strict tsconfig.
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function mockFetchOnce(body: unknown): FetchMock {
+  const fn = vi.fn(async () => jsonResponse(body));
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+let originalFetch: typeof fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("createPushEndpoints.register", () => {
+  it("валідний web-payload з keys повертає { ok: true, platform: 'web' }", async () => {
+    const fetchMock = mockFetchOnce({ ok: true, platform: "web" });
+
+    const push = createPushEndpoints(createHttpClient());
+    const res = await push.register({
+      platform: "web",
+      token: "https://fcm.googleapis.com/wp/xxx",
+      keys: { p256dh: "p256dh-value", auth: "auth-value" },
+    });
+
+    expect(res).toEqual({ ok: true, platform: "web" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as {
+      platform: string;
+      token: string;
+      keys: { p256dh: string; auth: string };
+    };
+    expect(parsed.platform).toBe("web");
+    expect(parsed.keys).toEqual({ p256dh: "p256dh-value", auth: "auth-value" });
+  });
+
+  it("iOS payload без keys працює і повертає platform: 'ios'", async () => {
+    mockFetchOnce({ ok: true, platform: "ios" });
+
+    const push = createPushEndpoints(createHttpClient());
+    const res = await push.register({
+      platform: "ios",
+      token: "a".repeat(64),
+    });
+
+    expect(res).toEqual({ ok: true, platform: "ios" });
+  });
+
+  it("невалідна platform у відповіді → ZodError з PushRegisterResponseSchema", async () => {
+    mockFetchOnce({ ok: true, platform: "desktop" });
+
+    const push = createPushEndpoints(createHttpClient());
+    await expect(
+      push.register({ platform: "android", token: "fcm-token" }),
+    ).rejects.toThrow();
+  });
+
+  it("AbortSignal прокидається у http.post", async () => {
+    const fetchMock = mockFetchOnce({ ok: true, platform: "android" });
+
+    const push = createPushEndpoints(createHttpClient());
+    const ctrl = new AbortController();
+    await push.register(
+      { platform: "android", token: "fcm-token" },
+      { signal: ctrl.signal },
+    );
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(ctrl.signal);
+  });
+
+  it("`/api/push/register` переписується на `/api/v1/push/register` через applyApiPrefix", async () => {
+    const fetchMock = mockFetchOnce({ ok: true, platform: "android" });
+
+    const push = createPushEndpoints(createHttpClient());
+    await push.register({ platform: "android", token: "fcm-token" });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/push/register");
+    expect(url).not.toContain("/api/push/register");
+  });
+});

--- a/packages/api-client/src/endpoints/push.ts
+++ b/packages/api-client/src/endpoints/push.ts
@@ -1,9 +1,55 @@
+import { PushRegisterSchema, z } from "@sergeant/shared";
 import type { HttpClient } from "../httpClient";
+import type { RequestOptions } from "../types";
+
+/**
+ * Runtime-схема запиту `POST /api/v1/push/register`.
+ *
+ * Це точне дзеркало `PushRegisterSchema` з `@sergeant/shared`, щоб клієнт і
+ * сервер валідувалися з одного джерела правди (див.
+ * `packages/shared/src/schemas/api.ts`). Discriminated union на `platform`:
+ *
+ * - `platform: "web"` — web-push: `token` несе endpoint URL, `keys`
+ *   (`p256dh`, `auth`) обовʼязкові (RFC 8030).
+ * - `platform: "ios" | "android"` — native push: `token` — opaque APNs/FCM
+ *   device token, `keys` відсутні.
+ */
+export const PushRegisterRequestSchema = PushRegisterSchema;
+
+export type PushRegisterRequest = z.infer<typeof PushRegisterRequestSchema>;
+
+export type PushPlatform = PushRegisterRequest["platform"];
+
+/**
+ * Runtime-схема відповіді `POST /api/v1/push/register`. Сервер відповідає
+ * `200 { ok: true, platform }` як на web, так і на native (див.
+ * `docs/mobile.md`).
+ */
+export const PushRegisterResponseSchema = z.object({
+  ok: z.literal(true),
+  platform: z.enum(["web", "ios", "android"]),
+});
+
+export type PushRegisterResponse = z.infer<typeof PushRegisterResponseSchema>;
 
 export interface PushEndpoints {
+  /** Legacy web-push: VAPID public key для `PushManager.subscribe`. */
   getVapidPublic: () => Promise<{ publicKey: string }>;
+  /** Legacy web-push: зберегти `PushSubscription.toJSON()` на бекенді. */
   subscribe: (subscription: PushSubscriptionJSON) => Promise<unknown>;
+  /** Legacy web-push: видалити підписку за `endpoint`. */
   unsubscribe: (endpoint: string) => Promise<unknown>;
+  /**
+   * `POST /api/push/register` — уніфікована реєстрація push-пристрою
+   * (web / iOS / Android). Шлях автоматично перетворюється в
+   * `/api/v1/push/register` через `applyApiPrefix` у `HttpClient`
+   * (див. `src/httpClient.ts`). Відповідь валідується
+   * `PushRegisterResponseSchema`.
+   */
+  register: (
+    body: PushRegisterRequest,
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<PushRegisterResponse>;
 }
 
 export function createPushEndpoints(http: HttpClient): PushEndpoints {
@@ -14,5 +60,11 @@ export function createPushEndpoints(http: HttpClient): PushEndpoints {
       http.post<unknown>("/api/push/subscribe", subscription),
     unsubscribe: (endpoint) =>
       http.del<unknown>("/api/push/subscribe", { endpoint }),
+    register: async (body, { signal } = {}) => {
+      const raw = await http.post<unknown>("/api/push/register", body, {
+        signal,
+      });
+      return PushRegisterResponseSchema.parse(raw);
+    },
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -55,7 +55,15 @@ export {
   type ChatResponse,
 } from "./endpoints/chat";
 
-export { createPushEndpoints, type PushEndpoints } from "./endpoints/push";
+export {
+  createPushEndpoints,
+  PushRegisterRequestSchema,
+  PushRegisterResponseSchema,
+  type PushEndpoints,
+  type PushPlatform,
+  type PushRegisterRequest,
+  type PushRegisterResponse,
+} from "./endpoints/push";
 
 export {
   createNutritionEndpoints,

--- a/packages/api-client/src/react/hooks.ts
+++ b/packages/api-client/src/react/hooks.ts
@@ -8,6 +8,10 @@ import {
 import type { MeResponse } from "../endpoints/me";
 import type { CoachInsightPayload } from "../endpoints/coach";
 import type { ChatRequestPayload, ChatResponse } from "../endpoints/chat";
+import type {
+  PushRegisterRequest,
+  PushRegisterResponse,
+} from "../endpoints/push";
 import type { BarcodeLookupResponse } from "../endpoints/barcode";
 import type { FoodSearchResponse } from "../endpoints/foodSearch";
 import type { MonoClientInfo, MonoStatementEntry } from "../endpoints/mono";
@@ -26,7 +30,7 @@ import type {
 } from "../endpoints/weeklyDigest";
 
 import { useApiClient } from "./context";
-import { apiQueryKeys } from "./queryKeys";
+import { apiMutationKeys, apiQueryKeys } from "./queryKeys";
 
 type QueryOpts<TData> = Omit<
   UseQueryOptions<TData, Error, TData>,
@@ -113,6 +117,26 @@ export function useUnsubscribePushMutation(
   const api = useApiClient();
   return useMutation({
     mutationFn: (endpoint: string) => api.push.unsubscribe(endpoint),
+    ...opts,
+  });
+}
+
+/**
+ * `POST /api/push/register` — уніфікована реєстрація push-пристрою
+ * (web / iOS / Android). Викликається з PWA service-worker flow
+ * (web-payload з `keys`) і з мобільного клієнта (native-payload без `keys`).
+ *
+ * Ключ мутації `apiMutationKeys.push.register()` — використовуй з
+ * `useIsMutating` / `queryClient.cancelMutations`, коли треба знати стан
+ * активної реєстрації (наприклад, блокувати повторний тап).
+ */
+export function usePushRegister(
+  opts?: MutationOpts<PushRegisterResponse, PushRegisterRequest>,
+) {
+  const api = useApiClient();
+  return useMutation({
+    mutationKey: apiMutationKeys.push.register(),
+    mutationFn: (payload: PushRegisterRequest) => api.push.register(payload),
     ...opts,
   });
 }

--- a/packages/api-client/src/react/index.ts
+++ b/packages/api-client/src/react/index.ts
@@ -1,4 +1,4 @@
 export { ApiClientProvider, useApiClient } from "./context";
 export type { ApiClientProviderProps } from "./context";
-export { apiQueryKeys } from "./queryKeys";
+export { apiQueryKeys, apiMutationKeys } from "./queryKeys";
 export * from "./hooks";

--- a/packages/api-client/src/react/queryKeys.ts
+++ b/packages/api-client/src/react/queryKeys.ts
@@ -39,3 +39,16 @@ export const apiQueryKeys = {
       ["privat", "balance-final", merchantId] as const,
   },
 } as const;
+
+/**
+ * Централізовані mutation-keys для React Query хуків
+ * `@sergeant/api-client/react`. Живуть поруч з `apiQueryKeys`, щоб кожна
+ * мутація мала стабільний ключ (для `useIsMutating`, `queryClient.cancelMutations`
+ * та консистентного інспектування у Devtools).
+ */
+export const apiMutationKeys = {
+  push: {
+    all: ["push"] as const,
+    register: () => ["push", "register"] as const,
+  },
+} as const;


### PR DESCRIPTION
## Summary

Продовжує мобільну прев-роботу в `@sergeant/api-client`: додає факторі
`register` для уніфікованої реєстрації push-пристрою (web / iOS / Android),
яка тепер коректно прокидується через `applyApiPrefix` (PR #390) у
`POST /api/v1/push/register` (контракт сервера — PR #377, опис у
`docs/mobile.md` і `docs/api-v1.md`).

### `packages/api-client`

- **`src/endpoints/push.ts`** розширено методом `register(body, opts?)`
  поверх існуючих легасі-ендпоінтів (`getVapidPublic`, `subscribe`,
  `unsubscribe`):
  - `PushRegisterRequestSchema` — реекспорт `PushRegisterSchema` з
    `@sergeant/shared` (discriminated union на `platform`: `web` вимагає
    `keys`, `ios|android` — без). Один source of truth для клієнта й
    сервера.
  - `PushRegisterResponseSchema = z.object({ ok: z.literal(true),
    platform: z.enum(["web","ios","android"]) })` — валідується на
    runtime через `PushRegisterResponseSchema.parse(...)`.
  - Шлях у http-клієнт передається як `/api/push/register` — у
    `applyApiPrefix` автоматично переписується в `/api/v1/push/register`
    (не дублюємо префікс руками, див. `httpClient.ts`).
- **`src/index.ts`**: нові реекспорти `PushPlatform`, `PushRegisterRequest`,
  `PushRegisterResponse`, `PushRegisterRequestSchema`,
  `PushRegisterResponseSchema`.
- **`src/react/queryKeys.ts`**: додано `apiMutationKeys` поруч з
  `apiQueryKeys`, з ключем `apiMutationKeys.push.register()`.
  Реекспортовано з `@sergeant/api-client/react`.
- **`src/react/hooks.ts`**: новий `usePushRegister(opts?)` — `useMutation`
  над `api.push.register`, з `mutationKey: apiMutationKeys.push.register()`
  (зручно для `useIsMutating` у UI).
- **`src/endpoints/push.test.ts`** (jsdom, 5 кейсів):
  - валідний web-payload з `keys` → `{ ok: true, platform: "web" }`;
  - iOS payload без `keys` → `{ ok: true, platform: "ios" }`;
  - невалідна `platform` у response → `ZodError`;
  - `AbortSignal` прокидається у `http.post`;
  - шлях у fetch — `/api/v1/push/register` (не `/api/push/register`).
- **`README.md`**: додав секції «Me endpoints» і «Push endpoints» поруч з
  рештою документації.

### Drive-by fix

`src/endpoints/me.test.ts` очікував `/api/me` у URL, але після PR #390
дефолтний `apiPrefix` — `/api/v1`, тож реальний шлях — `/api/v1/me`.
Підправив очікування (intent той самий — перевірити, що запит пішов на
me-ендпоінт). Решта me-тестів, `httpClient.test.ts` і `ApiError.test.ts`
— без змін.

### Поза скоупом (свідомо)

- `apps/web` AuthContext міграція з `useSession` на `useUser` — Сесія 4B.
- Web-PWA push-swap на `api.push.register` — Сесія 4C.
- Мобільний `registerPush()` + `PushRegistrar.tsx` — Сесія 4D.
- Server-side APNs/FCM send — Сесія 5.

## Review & Testing Checklist for Human

Risk: green — пакет `@sergeant/api-client` аддитивний, інші пакети
(`apps/web`, `apps/mobile`, `apps/server`, `packages/shared`) не
редагувалися; локально `pnpm turbo run lint typecheck test` зелено у всіх
7 пакетах.

- [ ] Переконатись, що у `packages/api-client/src/endpoints/push.test.ts`
      остання перевірка URL справді дає `/api/v1/push/register` (підстилає
      дефолт `apiPrefix` з `httpClient.ts`).
- [ ] Перевірити, що `usePushRegister` імпортується з
      `@sergeant/api-client/react` без циклів і без потрапляння у
      RN-бандл чого-небудь зайвого.
- [ ] Якщо PR #377 міняв форму відповіді на `POST /api/v1/push/register`
      (наприклад, додав поля) — оновити `PushRegisterResponseSchema`
      відповідно. Зараз валідатор strict-ий до `{ ok: true, platform }`.

### Notes

- Не чіпав `getVapidPublic`/`subscribe`/`unsubscribe` — вони лишаються
  для легасі web-push flow (`apps/web/src/sw.js` та supporting-хуки).
- `apiMutationKeys` — нова сутність, поки тільки з `push.register`. Далі
  можна нарощувати (sync, coach, chat) у міру того, як з'являться ще
  мутації, які варто трекати через `useIsMutating`/`cancelMutations`.
- Про пре-існуючу failing test у `me.test.ts` — див. секцію Drive-by
  вище. Окремого PR не робив, щоб не плодити синхронізовані зміни, і щоб
  CI цього PR був зелений без ручного ребейзу.

Link to Devin session: https://app.devin.ai/sessions/12978fb9227941c39440431727fa5578
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
