### PR TITLE
refactor(web): usePushNotifications → api.push.register via @sergeant/api-client

### DIFF
--- a/apps/web/src/shared/hooks/usePushNotifications.test.tsx
+++ b/apps/web/src/shared/hooks/usePushNotifications.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import {
+  PushRegisterRequestSchema,
+  type PushRegisterRequest,
+  type PushRegisterResponse,
+} from "@sergeant/api-client";
+import { ApiClientProvider } from "@sergeant/api-client/react";
+import type { ApiClient } from "@sergeant/api-client";
+
+// Mock `@shared/api` — уся web-сторона шарить один `createApiClient(...)`
+// інстанс, але у юніт-тестах не хочемо проганяти HTTP-шар: мокаємо
+// `pushApi.getVapidPublic` / `pushApi.unsubscribe`, а `register`
+// перевіряємо через підставлений у провайдер fake-`ApiClient`.
+vi.mock("@shared/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@shared/api")>("@shared/api");
+  return {
+    ...actual,
+    pushApi: {
+      getVapidPublic: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    },
+  };
+});
+
+import { usePushNotifications } from "./usePushNotifications.js";
+import { pushApi } from "@shared/api";
+
+const getVapidPublicMock = pushApi.getVapidPublic as unknown as ReturnType<
+  typeof vi.fn
+>;
+const unsubscribeMock = pushApi.unsubscribe as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+// Мінімальний мок `PushSubscription` — нам цікавий тільки `toJSON()`
+// (саме з нього береться `endpoint` + `keys`) і `endpoint` (для
+// unsubscribe-шляху). Інші поля інтерфейсу веб-API не використовуються.
+function makeMockPushSubscription(args: {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}) {
+  return {
+    endpoint: args.endpoint,
+    expirationTime: null,
+    options: {} as PushSubscriptionOptions,
+    getKey: () => null,
+    toJSON: () => ({
+      endpoint: args.endpoint,
+      keys: { p256dh: args.p256dh, auth: args.auth },
+    }),
+    unsubscribe: async () => true,
+  } as unknown as PushSubscription;
+}
+
+type NotificationStub = {
+  permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+};
+
+function stubNotification(permission: NotificationPermission) {
+  const requestPermission = vi.fn(async () => permission);
+  const stub: NotificationStub = { permission, requestPermission };
+  Object.defineProperty(globalThis, "Notification", {
+    configurable: true,
+    writable: true,
+    value: stub,
+  });
+  return requestPermission;
+}
+
+function stubServiceWorker(subscription: PushSubscription) {
+  const subscribeMock = vi.fn(async () => subscription);
+  const registration = {
+    pushManager: {
+      subscribe: subscribeMock,
+      getSubscription: vi.fn(async () => null),
+    },
+  };
+  Object.defineProperty(globalThis.navigator, "serviceWorker", {
+    configurable: true,
+    value: { ready: Promise.resolve(registration) },
+  });
+  // `PushManager` як глобал — використовується у `isPushSupported()`.
+  Object.defineProperty(globalThis, "PushManager", {
+    configurable: true,
+    value: function PushManager() {},
+  });
+  return subscribeMock;
+}
+
+function makeWrapper(apiClient: ApiClient) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ApiClientProvider client={apiClient}>{children}</ApiClientProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+type RegisterMock = ReturnType<
+  typeof vi.fn<(payload: PushRegisterRequest) => Promise<PushRegisterResponse>>
+>;
+
+function makeRegisterMock(response: PushRegisterResponse): RegisterMock {
+  return vi.fn<(payload: PushRegisterRequest) => Promise<PushRegisterResponse>>(
+    async () => response,
+  );
+}
+
+function makeApiClientWithRegisterMock(registerMock: RegisterMock) {
+  return {
+    push: {
+      register: registerMock,
+      getVapidPublic: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    },
+  } as unknown as ApiClient;
+}
+
+describe("usePushNotifications — subscribe via api.push.register", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    getVapidPublicMock.mockResolvedValue({ publicKey: "AAAA" });
+    unsubscribeMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("викликає api.push.register з web-payload `{ platform, token, keys }`", async () => {
+    stubNotification("granted");
+    const subscription = makeMockPushSubscription({
+      endpoint: "https://fcm.googleapis.com/wp/abc123",
+      p256dh: "p256dh-key",
+      auth: "auth-key",
+    });
+    stubServiceWorker(subscription);
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "web" });
+    const apiClient = makeApiClientWithRegisterMock(registerMock);
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = registerMock.mock.calls[0][0];
+    expect(payload).toEqual({
+      platform: "web",
+      token: "https://fcm.googleapis.com/wp/abc123",
+      keys: { p256dh: "p256dh-key", auth: "auth-key" },
+    });
+    // Payload має задовольняти runtime-схему з `@sergeant/api-client`,
+    // щоб зміни у shared-схемі ламали саме цей юніт, а не далеко у
+    // httpClient-і.
+    expect(() => PushRegisterRequestSchema.parse(payload)).not.toThrow();
+    expect(localStorage.getItem("hub_push_subscribed")).toBe("1");
+    expect(result.current.subscribed).toBe(true);
+  });
+
+  it("не викликає register, якщо permission НЕ granted", async () => {
+    stubNotification("denied");
+    const subscription = makeMockPushSubscription({
+      endpoint: "https://example/e",
+      p256dh: "p",
+      auth: "a",
+    });
+    stubServiceWorker(subscription);
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "web" });
+    const apiClient = makeApiClientWithRegisterMock(registerMock);
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    expect(registerMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem("hub_push_subscribed")).toBeNull();
+  });
+});

--- a/apps/web/src/shared/hooks/usePushNotifications.ts
+++ b/apps/web/src/shared/hooks/usePushNotifications.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useApiClient } from "@sergeant/api-client/react";
+import type { PushRegisterRequest } from "@sergeant/api-client";
 import { isApiError, pushApi } from "@shared/api";
 import { pushKeys } from "@shared/lib/queryKeys";
 
@@ -52,6 +54,7 @@ export interface UsePushNotificationsResult {
 export function usePushNotifications(): UsePushNotificationsResult {
   const supported = isPushSupported();
   const queryClient = useQueryClient();
+  const api = useApiClient();
 
   const [permission, setPermission] = useState<NotificationPermission>(
     supported ? Notification.permission : "denied",
@@ -104,7 +107,23 @@ export function usePushNotifications(): UsePushNotificationsResult {
         applicationServerKey: urlBase64ToUint8Array(publicKey),
       });
 
-      await pushApi.subscribe(sub.toJSON());
+      // `PushSubscription.toJSON()` повертає `{ endpoint, keys: { p256dh, auth } }`
+      // (RFC 8030). Мапимо у web-варіант `PushRegisterRequest`, щоб
+      // zod-валідація у `createPushEndpoints.register` пройшла без
+      // модифікацій payload.
+      const json = sub.toJSON();
+      const endpoint = json.endpoint;
+      const p256dh = json.keys?.p256dh;
+      const auth = json.keys?.auth;
+      if (!endpoint || !p256dh || !auth) {
+        throw new Error("Push subscription is missing endpoint or keys");
+      }
+      const payload: PushRegisterRequest = {
+        platform: "web",
+        token: endpoint,
+        keys: { p256dh, auth },
+      };
+      await api.push.register(payload);
 
       localStorage.setItem(PUSH_SUB_KEY, "1");
       setSubscribed(true);


### PR DESCRIPTION
## Summary

Переводимо web-PWA push-флоу у `apps/web/src/shared/hooks/usePushNotifications.ts` з legacy
`pushApi.subscribe(sub.toJSON())` (який бив у `POST /api/push/subscribe`) на уніфікований
`api.push.register({ platform: "web", token, keys })` через `useApiClient()` / `@sergeant/api-client`.

- `useApiClient()` із `@sergeant/api-client/react` дає типізований `ApiClient` через
  вже-змонтований `ApiClientProvider` у `apps/web/src/core/App.tsx` — новий код не створює
  ще один інстанс клієнта.
- `PushSubscription.toJSON()` мапимо у web-варіант `PushRegisterRequest` з `@sergeant/api-client`:
  `endpoint → token`, `keys: { p256dh, auth }`. Guard фейлить мутацію, якщо браузер не повернув
  `keys` (в жодному гра-шопі за RFC 8030 це не має статися, але краще читабельна помилка, ніж
  zod-крик глибоко в api-client).
- Endpoint не змінюється: сервер обслуговує той самий `POST /api/v1/push/register`
  (`apps/server/src/routes/push.ts`), і api-client переписує `/api/push/register → /api/v1/push/register`
  через `applyApiPrefix` у `HttpClient`.
- Unsubscribe-шлях (`pushApi.unsubscribe(endpoint)` → `DELETE /api/push/subscribe`) та
  service-worker (`apps/web/src/sw.js`) свідомо поза скоупом — це окремі сесії 4D/5.

Додано юніт `apps/web/src/shared/hooks/usePushNotifications.test.tsx`:
- Happy-path: `api.push.register` викликається рівно один раз з очікуваним web-payload,
  payload проходить `PushRegisterRequestSchema.parse` без помилки, localStorage-мітка
  `hub_push_subscribed` виставлена у `"1"`, і хук репортує `subscribed: true`.
- Denied-permission: `api.push.register` не викликається, localStorage лишається чистим.

Існуючих `features/push/*` каталога у `apps/web/src` не існує — весь push-флоу живе у
shared-хуку, тож grep-акцепт `rg "push/register" apps/web/src/` повертає 0 збігів (URL
живе тепер лише в api-client-і).

## Review & Testing Checklist for Human

Risk: green

- [ ] `pnpm install && pnpm turbo run lint typecheck && pnpm --filter @sergeant/web test && pnpm turbo run build` — усе зелене локально.
- [ ] Ручне: `pnpm dev:server` + `pnpm --filter @sergeant/web dev`, у Settings натиснути toggle
  push-сповіщень; у DevTools → Network має полетіти `POST /api/v1/push/register` з тілом
  `{ platform: "web", token, keys: { p256dh, auth } }`, відповідь `{ ok: true, platform: "web" }`.
- [ ] Повторне натискання toggle (off → on) не ламає UX — сервер ідемпотентний (див. PR #377).

### Notes

- Не чіпали `apps/web/src/sw.js` / push-SW-код — він не імпортує api-client і в нього немає
  окремого `fetch("/api/push/register")` сьогодні.
- `packages/api-client/src/endpoints/push.ts#createPushEndpoints.register` вже йде через
  `http.post` з `applyApiPrefix`, так що web і mobile ділять один `/api/v1/push/register` шлях.


Link to Devin session: https://app.devin.ai/sessions/8bc41e8aea8d4e41953bca52838dd376
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
