### PR TITLE
feat(mobile): useUser() + native push registration flow

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -63,8 +63,10 @@ apps/mobile
 │       └── nutrition.tsx         # stub → порт apps/web/src/modules/nutrition
 ├── src/
 │   ├── api/apiUrl.ts             # /api/v1/* префіксатор (дзеркало web)
-│   ├── auth/authClient.ts        # Better Auth Expo + SecureStore
+│   ├── api/apiClient.ts          # createApiClient + bearer getToken (SecureStore)
+│   ├── auth/authClient.ts        # Better Auth Expo actions (signIn/signUp/signOut)
 │   ├── components/ModuleStub.tsx
+│   ├── features/push/            # registerPush + PushRegistrar (no-UI)
 │   ├── providers/QueryProvider.tsx
 │   └── theme.ts
 ├── app.json                      # scheme=sergeant, plugins
@@ -82,10 +84,49 @@ apps/mobile
 
 ## API
 
-Усі запити — у `/api/v1/*`, як описано в `docs/api-v1.md`. Використовуй
-`apiUrl("/api/<endpoint>")` з `@/api/apiUrl` — він автоматично додає
-версійний префікс, окрім `/api/auth/*`, який Better Auth тримає на
-фіксованому `basePath`.
+Усі запити — у `/api/v1/*`, як описано в `docs/api-v1.md`. У
+продакшн-коді ходи у сервер через `@sergeant/api-client`:
+
+- `useApiClient()` + хуки з `@sergeant/api-client/react` (`useUser`,
+  `usePushRegister` тощо) — для React-екранів;
+- `apiClient` з `src/api/apiClient.ts` — для імперативних викликів
+  (напр. `src/features/push/registerPush.ts`).
+
+`authClient.ts` залишено лише для actions-ендпоінтів Better Auth
+(`signIn.email`, `signUp.email`, `signOut`). Ідентичність
+користувача читай через `useUser()` (GET `/api/v1/me`), а НЕ
+`useSession()` — ці дані джерелом правди — сервер, а не локальне
+SecureStore.
+
+## Push notifications
+
+Push-флоу на mobile закриває `PushRegistrar`
+(`src/features/push/PushRegistrar.tsx`). Після логіну він:
+
+1. запитує дозвіл через `expo-notifications`;
+2. бере native APNs/FCM токен (`getDevicePushTokenAsync`) у dev-client
+   / standalone-білді;
+3. шле `api.push.register({ platform, token })` →
+   `POST /api/v1/push/register`;
+4. зберігає токен у `AsyncStorage` (`push:lastToken`), щоб не
+   шарашити сервер повторно.
+
+> **Expo Go не підтримує native APNs/FCM.** У Go ми падаємо на
+> `getExpoPushTokenAsync()` тільки для dev-дебагу — продакшн-пуші
+> через APNs/FCM потребують dev-client (`eas build --profile
+development`) або standalone збірку.
+
+Тестування з dev-build:
+
+```sh
+pnpm --filter @sergeant/mobile start --dev-client
+# на фізичному пристрої або симуляторі залогінься
+# перевір у Network logs POST /api/v1/push/register один раз
+# повторний запуск з тим самим токеном не шле запит
+```
+
+Серверний контракт і приклади payload-ів — у `docs/mobile.md`
+(секція «Push notifications»).
 
 ## Монорепо-правила
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -108,8 +108,10 @@ Push-флоу на mobile закриває `PushRegistrar`
    / standalone-білді;
 3. шле `api.push.register({ platform, token })` →
    `POST /api/v1/push/register`;
-4. зберігає токен у `AsyncStorage` (`push:lastToken`), щоб не
-   шарашити сервер повторно.
+4. зберігає токен у `AsyncStorage` під ключем
+   `push:lastToken:<userId>`, щоб не шарашити сервер повторно, і
+   водночас гарантовано перереєструвати пристрій на іншого юзера
+   (native push-токени пер-девайс, а не пер-акаунт).
 
 > **Expo Go не підтримує native APNs/FCM.** У Go ми падаємо на
 > `getExpoPushTokenAsync()` тільки для dev-дебагу — продакшн-пуші

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,7 +16,10 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.sergeant.app"
+      "bundleIdentifier": "com.sergeant.app",
+      "infoPlist": {
+        "UIBackgroundModes": ["remote-notification"]
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -32,6 +35,7 @@
     "plugins": [
       "expo-router",
       "expo-secure-store",
+      "expo-notifications",
       [
         "expo-splash-screen",
         {

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,11 +1,11 @@
 import { Redirect, Stack } from "expo-router";
-import { useSession } from "@/auth/authClient";
+import { useUser } from "@sergeant/api-client/react";
 import { colors } from "@/theme";
 
 export default function AuthLayout() {
-  const { data: session, isPending } = useSession();
+  const { data, isLoading } = useUser();
 
-  if (!isPending && session) {
+  if (!isLoading && data?.user) {
     return <Redirect href="/" />;
   }
 

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Redirect, Tabs } from "expo-router";
 import { Text } from "react-native";
-import { useSession } from "@/auth/authClient";
+import { useUser } from "@sergeant/api-client/react";
 import { colors } from "@/theme";
 
 type TabIconProps = {
@@ -25,9 +25,9 @@ function TabIcon({ emoji }: { emoji: string }) {
 }
 
 export default function TabsLayout() {
-  const { data: session, isPending } = useSession();
+  const { data, isLoading } = useUser();
 
-  if (!isPending && !session) {
+  if (!isLoading && !data?.user) {
     return <Redirect href="/(auth)/sign-in" />;
   }
 
@@ -54,7 +54,7 @@ export default function TabsLayout() {
       />
       <Tabs.Screen
         name="fizruk"
-        options={{ title: "ФІЗРУК", tabBarIcon: TabIcon({ emoji: "🏋️" }) }}
+        options={{ title: "ФІЗРУК", tabBarIcon: TabIcon({ emoji: "🏋" }) }}
       />
       <Tabs.Screen
         name="routine"
@@ -62,7 +62,7 @@ export default function TabsLayout() {
       />
       <Tabs.Screen
         name="nutrition"
-        options={{ title: "Їжа", tabBarIcon: TabIcon({ emoji: "🍽️" }) }}
+        options={{ title: "Їжа", tabBarIcon: TabIcon({ emoji: "🍽" }) }}
       />
     </Tabs>
   );

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,17 +1,19 @@
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useSession, signOut } from "@/auth/authClient";
+import { useUser } from "@sergeant/api-client/react";
+import { signOut } from "@/auth/authClient";
 import { Pressable } from "react-native";
 import { colors, radius, spacing } from "@/theme";
 
 export default function HubScreen() {
-  const { data: session } = useSession();
+  const { data } = useUser();
+  const user = data?.user;
 
   return (
     <SafeAreaView style={styles.container} edges={["top"]}>
       <Text style={styles.title}>Sergeant</Text>
       <Text style={styles.subtitle}>
-        Привіт, {session?.user?.name ?? session?.user?.email ?? "друже"}
+        Привіт, {user?.name ?? user?.email ?? "друже"}
       </Text>
 
       <View style={styles.card}>

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useQueryClient } from "@tanstack/react-query";
 import { useUser } from "@sergeant/api-client/react";
 import { signOut } from "@/auth/authClient";
 import { Pressable } from "react-native";
@@ -8,6 +9,20 @@ import { colors, radius, spacing } from "@/theme";
 export default function HubScreen() {
   const { data } = useUser();
   const user = data?.user;
+  const queryClient = useQueryClient();
+
+  // useUser() під капотом — react-query, який не є реактивним до
+  // змін Better Auth SecureStore. Без явного скидання кешу auth-guard
+  // у `(tabs)/_layout.tsx` продовжить бачити старого `data.user` і не
+  // зредиректить на /(auth)/sign-in. Скидаємо весь кеш, бо на виході
+  // інвалідний не лише `/me`, а й усі юзер-скоуплені дані.
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+    } finally {
+      queryClient.clear();
+    }
+  };
 
   return (
     <SafeAreaView style={styles.container} edges={["top"]}>
@@ -27,7 +42,7 @@ export default function HubScreen() {
 
       <Pressable
         style={({ pressed }) => [styles.signOut, pressed && styles.pressed]}
-        onPress={() => signOut()}
+        onPress={handleSignOut}
       >
         <Text style={styles.signOutText}>Вийти</Text>
       </Pressable>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -2,6 +2,11 @@ import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+
+import { ApiClientProvider } from "@sergeant/api-client/react";
+
+import { apiClient } from "@/api/apiClient";
+import { PushRegistrar } from "@/features/push/PushRegistrar";
 import { QueryProvider } from "@/providers/QueryProvider";
 
 export default function RootLayout() {
@@ -9,12 +14,15 @@ export default function RootLayout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <QueryProvider>
-          <StatusBar style="light" />
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="(auth)" options={{ presentation: "modal" }} />
-            <Stack.Screen name="+not-found" />
-          </Stack>
+          <ApiClientProvider client={apiClient}>
+            <StatusBar style="light" />
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="(auth)" options={{ presentation: "modal" }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <PushRegistrar />
+          </ApiClientProvider>
         </QueryProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
     "expo": "~52.0.0",
     "expo-constants": "~17.0.8",
     "expo-linking": "~7.0.5",
+    "expo-notifications": "~0.29.14",
     "expo-router": "~4.0.21",
     "expo-secure-store": "~14.0.1",
     "expo-splash-screen": "~0.29.24",

--- a/apps/mobile/src/api/apiClient.ts
+++ b/apps/mobile/src/api/apiClient.ts
@@ -1,0 +1,60 @@
+import { createApiClient, type ApiClient } from "@sergeant/api-client";
+import * as SecureStore from "expo-secure-store";
+
+import { getApiBaseURL } from "@/api/apiUrl";
+
+/**
+ * Мобільний `ApiClient` — один інстанс на весь додаток. Підключається в
+ * `app/_layout.tsx` через `<ApiClientProvider client={apiClient}>`, щоб
+ * `useApiClient()`/хуки з `@sergeant/api-client/react` (`useUser`,
+ * `usePushRegister`, ...) працювали у всіх екранах.
+ *
+ * Auth-токен береться зі сховища, куди його записує
+ * `@better-auth/expo/client` (див. `src/auth/authClient.ts`): після
+ * `signIn.email`/`signUp.email` Better Auth зберігає cookie-JSON у
+ * `expo-secure-store` під ключем `sergeant_cookie` (формат
+ * `{ "better-auth.session_token": { value, expires, ... }, ... }`).
+ *
+ * Для наших REST-ендпоінтів (`/api/v1/*`) сервер приймає той самий
+ * signed session-токен як `Authorization: Bearer <value>` (див.
+ * `better-auth` `bearer()` плагін у `apps/server/src/auth.ts`). Тож
+ * `getToken` читає `better-auth.session_token.value` з SecureStore і
+ * повертає його як bearer.
+ */
+const COOKIE_STORAGE_KEY = "sergeant_cookie";
+const SESSION_COOKIE_NAMES = [
+  "better-auth.session_token",
+  "__Secure-better-auth.session_token",
+];
+
+type StoredCookieEntry = { value?: string };
+
+function extractSessionToken(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, StoredCookieEntry>;
+    for (const name of SESSION_COOKIE_NAMES) {
+      const entry = parsed[name];
+      if (entry?.value) return entry.value;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function readBearerToken(): Promise<string | null> {
+  try {
+    const raw = await SecureStore.getItemAsync(COOKIE_STORAGE_KEY);
+    return extractSessionToken(raw);
+  } catch {
+    return null;
+  }
+}
+
+export const apiClient: ApiClient = createApiClient({
+  baseUrl: getApiBaseURL(),
+  getToken: readBearerToken,
+});
+
+export { readBearerToken, extractSessionToken };

--- a/apps/mobile/src/auth/authClient.ts
+++ b/apps/mobile/src/auth/authClient.ts
@@ -26,5 +26,11 @@ const authClient = createAuthClient({
   ],
 });
 
-export const { useSession, signIn, signUp, signOut, getSession } = authClient;
+// Публічний API мобільного Better Auth клієнта навмисно обмежений
+// actions-ендпоінтами. `useSession` з `better-auth/react` НЕ
+// реекспортується — замість нього у продакшн-коді використовуй
+// `useUser()` з `@sergeant/api-client/react` (GET `/api/v1/me`), щоб
+// mobile і web читали ту саму ідентичність. Див. `docs/mobile.md` і
+// `app/_layout.tsx`, де піднято `ApiClientProvider`.
+export const { signIn, signUp, signOut, getSession } = authClient;
 export { authClient };

--- a/apps/mobile/src/features/push/PushRegistrar.tsx
+++ b/apps/mobile/src/features/push/PushRegistrar.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+
+import { useApiClient, useUser } from "@sergeant/api-client/react";
+
+import { registerPush } from "./registerPush";
+
+/**
+ * No-UI компонент, що монтується у root-дереві (`app/_layout.tsx`) і
+ * відповідає за передачу native push-токена на сервер після логіну.
+ *
+ * Чому useUser, а не окремий гуард зверху: root `_layout.tsx` у expo-
+ * router живе над групами `(auth)` та `(tabs)`, тож ми не можемо
+ * рендерити `PushRegistrar` «фізично всередині authenticated-гілки» без
+ * дублювання провайдерів. Замість цього компонент сам перевіряє статус
+ * через `useUser()` і запускає `registerPush` лише коли зʼявляється
+ * активний `data.user`. Після sign-out (`data.user === null`) прапорець
+ * скидається, тому наступний логін знову тригерить реєстрацію (з
+ * AsyncStorage-кешем у `registerPush`).
+ *
+ * Помилки ловимо і логуємо — пуші це побічна фіча, не ламаємо UI.
+ */
+export function PushRegistrar() {
+  const api = useApiClient();
+  const { data } = useUser();
+  const hasUser = !!data?.user;
+
+  const inFlightRef = useRef(false);
+  const registeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasUser) {
+      registeredRef.current = false;
+      return;
+    }
+    if (registeredRef.current || inFlightRef.current) return;
+    inFlightRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await registerPush(api);
+        if (cancelled) return;
+        registeredRef.current = true;
+        if (result.status === "registered") {
+          console.info(
+            `[PushRegistrar] registered ${result.platform} push token`,
+          );
+        } else {
+          console.info(`[PushRegistrar] skipped: ${result.reason}`);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.warn("[PushRegistrar] failed to register push token", error);
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, hasUser]);
+
+  return null;
+}

--- a/apps/mobile/src/features/push/PushRegistrar.tsx
+++ b/apps/mobile/src/features/push/PushRegistrar.tsx
@@ -22,25 +22,25 @@ import { registerPush } from "./registerPush";
 export function PushRegistrar() {
   const api = useApiClient();
   const { data } = useUser();
-  const hasUser = !!data?.user;
+  const userId = data?.user?.id ?? null;
 
   const inFlightRef = useRef(false);
-  const registeredRef = useRef(false);
+  const lastRegisteredUserRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!hasUser) {
-      registeredRef.current = false;
+    if (!userId) {
+      lastRegisteredUserRef.current = null;
       return;
     }
-    if (registeredRef.current || inFlightRef.current) return;
+    if (lastRegisteredUserRef.current === userId || inFlightRef.current) return;
     inFlightRef.current = true;
 
     let cancelled = false;
     void (async () => {
       try {
-        const result = await registerPush(api);
+        const result = await registerPush(api, userId);
         if (cancelled) return;
-        registeredRef.current = true;
+        lastRegisteredUserRef.current = userId;
         if (result.status === "registered") {
           console.info(
             `[PushRegistrar] registered ${result.platform} push token`,
@@ -60,7 +60,7 @@ export function PushRegistrar() {
     return () => {
       cancelled = true;
     };
-  }, [api, hasUser]);
+  }, [api, userId]);
 
   return null;
 }

--- a/apps/mobile/src/features/push/registerPush.ts
+++ b/apps/mobile/src/features/push/registerPush.ts
@@ -1,0 +1,134 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import Constants, { ExecutionEnvironment } from "expo-constants";
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+
+import type { ApiClient } from "@sergeant/api-client";
+
+type NativePushPlatform = "ios" | "android";
+
+/**
+ * Мобільний push-реєстратор.
+ *
+ * Викликається з `PushRegistrar` відразу після того, як `useUser()`
+ * повертає авторизованого користувача. Логіка:
+ *
+ * 1. Перевіряємо/просимо дозвіл через `expo-notifications`.
+ * 2. Отримуємо нативний APNs/FCM токен через `getDevicePushTokenAsync()`
+ *    для dev-build / standalone. В Expo Go нативний канал недоступний,
+ *    тому fallback — `getExpoPushTokenAsync()` (лише для dev-дебагу, для
+ *    прод-пушів сервер має говорити з APNs/FCM напряму, див.
+ *    `docs/mobile.md`).
+ * 3. Шлемо `api.push.register({ platform, token })` — не прямий `fetch`.
+ * 4. На успіх кладемо токен в `AsyncStorage` (`push:lastToken`), щоб не
+ *    шарашити сервер повторно на кожен старт.
+ */
+const STORAGE_KEY = "push:lastToken";
+
+export type RegisterPushResult =
+  | { status: "registered"; platform: NativePushPlatform; token: string }
+  | { status: "skipped"; reason: RegisterPushSkipReason };
+
+export type RegisterPushSkipReason =
+  | "permission-denied"
+  | "unsupported-platform"
+  | "token-unavailable"
+  | "already-synced";
+
+export interface RegisterPushOptions {
+  /**
+   * Якщо true — шле запит навіть коли в `AsyncStorage` той самий токен
+   * уже збережений. Корисно для ручного «Повторити реєстрацію».
+   */
+  force?: boolean;
+}
+
+function resolvePlatform(): NativePushPlatform | null {
+  if (Platform.OS === "ios") return "ios";
+  if (Platform.OS === "android") return "android";
+  return null;
+}
+
+function isExpoGo(): boolean {
+  return Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
+}
+
+async function ensurePermissions(): Promise<boolean> {
+  const current = await Notifications.getPermissionsAsync();
+  if (
+    current.granted ||
+    current.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  ) {
+    return true;
+  }
+  if (current.status === "denied" && !current.canAskAgain) return false;
+  const next = await Notifications.requestPermissionsAsync();
+  return (
+    next.granted ||
+    next.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  );
+}
+
+async function getNativeToken(): Promise<string | null> {
+  if (isExpoGo()) {
+    // Expo Go не має entitlements для APNs/FCM. Dev-fallback — Expo
+    // push token. Продакшн-сервер очікує native token, тому логуємо
+    // попередження.
+    console.warn(
+      "[registerPush] Running inside Expo Go — falling back to Expo push token. " +
+        "Build a dev-client (`eas build --profile development`) to get native " +
+        "APNs/FCM tokens for production push.",
+    );
+    try {
+      const expoToken = await Notifications.getExpoPushTokenAsync();
+      return expoToken.data ?? null;
+    } catch (error) {
+      console.warn("[registerPush] getExpoPushTokenAsync failed", error);
+      return null;
+    }
+  }
+  try {
+    const device = await Notifications.getDevicePushTokenAsync();
+    return typeof device.data === "string" ? device.data : null;
+  } catch (error) {
+    console.warn("[registerPush] getDevicePushTokenAsync failed", error);
+    return null;
+  }
+}
+
+/**
+ * Основна точка входу. Поверне `{ status: "registered", ... }` якщо
+ * сервер прийняв токен. У разі skip — поверне причину, без кидання
+ * помилки (PushRegistrar сам вирішує, чи ретраїти).
+ */
+export async function registerPush(
+  api: ApiClient,
+  { force = false }: RegisterPushOptions = {},
+): Promise<RegisterPushResult> {
+  const platform = resolvePlatform();
+  if (!platform) return { status: "skipped", reason: "unsupported-platform" };
+
+  const allowed = await ensurePermissions();
+  if (!allowed) return { status: "skipped", reason: "permission-denied" };
+
+  const token = await getNativeToken();
+  if (!token) return { status: "skipped", reason: "token-unavailable" };
+
+  if (!force) {
+    const cached = await AsyncStorage.getItem(STORAGE_KEY);
+    if (cached === token) {
+      return { status: "skipped", reason: "already-synced" };
+    }
+  }
+
+  await api.push.register({ platform, token });
+  await AsyncStorage.setItem(STORAGE_KEY, token);
+
+  return { status: "registered", platform, token };
+}
+
+export const __testables = {
+  STORAGE_KEY,
+  extractSessionTokenReason: (result: RegisterPushResult) =>
+    result.status === "skipped" ? result.reason : null,
+};

--- a/apps/mobile/src/features/push/registerPush.ts
+++ b/apps/mobile/src/features/push/registerPush.ts
@@ -20,10 +20,18 @@ type NativePushPlatform = "ios" | "android";
  *    прод-пушів сервер має говорити з APNs/FCM напряму, див.
  *    `docs/mobile.md`).
  * 3. Шлемо `api.push.register({ platform, token })` — не прямий `fetch`.
- * 4. На успіх кладемо токен в `AsyncStorage` (`push:lastToken`), щоб не
- *    шарашити сервер повторно на кожен старт.
+ * 4. На успіх кладемо токен в `AsyncStorage` під ключем, що містить
+ *    `userId` (`push:lastToken:<userId>`), щоб не шарашити сервер
+ *    повторно на кожен старт — і водночас гарантовано перереєструвати
+ *    токен, якщо на тому самому пристрої залогінився інший користувач
+ *    (native push токени пер-девайс, а не пер-юзер — без userId-scope
+ *    сервер би так і залишив токен прив’язаним до попереднього акаунта).
  */
-const STORAGE_KEY = "push:lastToken";
+const STORAGE_KEY_PREFIX = "push:lastToken:";
+
+function storageKey(userId: string) {
+  return `${STORAGE_KEY_PREFIX}${userId}`;
+}
 
 export type RegisterPushResult =
   | { status: "registered"; platform: NativePushPlatform; token: string }
@@ -103,6 +111,7 @@ async function getNativeToken(): Promise<string | null> {
  */
 export async function registerPush(
   api: ApiClient,
+  userId: string,
   { force = false }: RegisterPushOptions = {},
 ): Promise<RegisterPushResult> {
   const platform = resolvePlatform();
@@ -114,21 +123,23 @@ export async function registerPush(
   const token = await getNativeToken();
   if (!token) return { status: "skipped", reason: "token-unavailable" };
 
+  const key = storageKey(userId);
   if (!force) {
-    const cached = await AsyncStorage.getItem(STORAGE_KEY);
+    const cached = await AsyncStorage.getItem(key);
     if (cached === token) {
       return { status: "skipped", reason: "already-synced" };
     }
   }
 
   await api.push.register({ platform, token });
-  await AsyncStorage.setItem(STORAGE_KEY, token);
+  await AsyncStorage.setItem(key, token);
 
   return { status: "registered", platform, token };
 }
 
 export const __testables = {
-  STORAGE_KEY,
+  STORAGE_KEY_PREFIX,
+  storageKey,
   extractSessionTokenReason: (result: RegisterPushResult) =>
     result.status === "skipped" ? result.reason : null,
 };

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -65,6 +65,28 @@ Content-Type: application/json
 реєстрація того самого токена просто оновлює `updated_at` (див.
 `server/migrations/006_push_devices.sql`).
 
+### Клієнтський виклик (Expo)
+
+Мобільний клієнт НЕ шле прямий `fetch` — усі виклики йдуть через
+`@sergeant/api-client`. Після логіну `PushRegistrar`
+(`apps/mobile/src/features/push/PushRegistrar.tsx`) автоматично:
+
+1. питає дозвіл через `expo-notifications`;
+2. бере native APNs/FCM токен (`getDevicePushTokenAsync()`); у Expo Go
+   — fallback на `getExpoPushTokenAsync()` з попередженням у консолі;
+3. кладе його у `AsyncStorage` ключ `push:lastToken` і шле:
+
+```ts
+import { useApiClient } from "@sergeant/api-client/react";
+
+const api = useApiClient();
+await api.push.register({ platform: "ios", token: devicePushToken });
+// → POST /api/v1/push/register, валідовано PushRegisterResponseSchema
+```
+
+Повторні логіни з тим самим токеном не тригерять повторний запит —
+`registerPush` перевіряє `AsyncStorage`-кеш.
+
 ### Сервер → пристрій
 
 - **Web** — існуючий flow `POST /api/push/send` через `web-push` + VAPID.

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -74,7 +74,9 @@ Content-Type: application/json
 1. питає дозвіл через `expo-notifications`;
 2. бере native APNs/FCM токен (`getDevicePushTokenAsync()`); у Expo Go
    — fallback на `getExpoPushTokenAsync()` з попередженням у консолі;
-3. кладе його у `AsyncStorage` ключ `push:lastToken` і шле:
+3. кладе його у `AsyncStorage` під ключем `push:lastToken:<userId>`
+   (scoped на юзера — щоб після зміни акаунта на тому самому пристрої
+   знову відбулась реєстрація) і шле:
 
 ```ts
 import { useApiClient } from "@sergeant/api-client/react";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       expo-linking:
         specifier: ~7.0.5
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-notifications:
+        specifier: ~0.29.14
+        version: 0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-router:
         specifier: ~4.0.21
         version: 4.0.22(rtgdbvkbo5gvhvuxmdok4gwjkm)
@@ -2385,7 +2388,7 @@ packages:
       {
         integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==,
       }
-    engines: { "0": node >=0.10.0 }
+    engines: { node: ">=0.10.0" }
 
   "@expo/cli@0.22.28":
     resolution:
@@ -2585,6 +2588,12 @@ packages:
         integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
       }
     engines: { node: ">=18.18" }
+
+  "@ide/backoff@1.0.0":
+    resolution:
+      {
+        integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==,
+      }
 
   "@isaacs/cliui@8.0.2":
     resolution:
@@ -4615,6 +4624,12 @@ packages:
         integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==,
       }
 
+  assert@2.1.0:
+    resolution:
+      {
+        integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==,
+      }
+
   assertion-error@2.0.1:
     resolution:
       {
@@ -4822,6 +4837,12 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     peerDependencies:
       "@babel/core": ^7.0.0
+
+  badgin@1.2.3:
+    resolution:
+      {
+        integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==,
+      }
 
   bail@2.0.2:
     resolution:
@@ -6370,6 +6391,14 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
+  expo-application@6.0.2:
+    resolution:
+      {
+        integrity: sha512-qcj6kGq3mc7x5yIb5KxESurFTJCoEKwNEL34RdPEvTB/xhl7SeVZlu05sZBqxB1V4Ryzq/LsCb7NHNfBbb3L7A==,
+      }
+    peerDependencies:
+      expo: "*"
+
   expo-asset@11.0.5:
     resolution:
       {
@@ -6437,6 +6466,16 @@ packages:
       {
         integrity: sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==,
       }
+
+  expo-notifications@0.29.14:
+    resolution:
+      {
+        integrity: sha512-AVduNx9mKOgcAqBfrXS1OHC9VAQZrDQLbVbcorMjPDGXW7m0Q5Q+BG6FYM/saVviF2eO8fhQRsTT40yYv5/bhQ==,
+      }
+    peerDependencies:
+      expo: "*"
+      react: "*"
+      react-native: "*"
 
   expo-router@4.0.22:
     resolution:
@@ -7381,6 +7420,13 @@ packages:
         integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
       }
 
+  is-arguments@1.2.0:
+    resolution:
+      {
+        integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==,
+      }
+    engines: { node: ">= 0.4" }
+
   is-array-buffer@3.0.5:
     resolution:
       {
@@ -7573,6 +7619,13 @@ packages:
       {
         integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==,
       }
+
+  is-nan@1.3.2:
+    resolution:
+      {
+        integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-negative-zero@2.0.3:
     resolution:
@@ -9096,6 +9149,13 @@ packages:
     resolution:
       {
         integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
+
+  object-is@1.1.6:
+    resolution:
+      {
+        integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==,
       }
     engines: { node: ">= 0.4" }
 
@@ -11727,6 +11787,12 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  util@0.12.5:
+    resolution:
+      {
+        integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
+      }
+
   utils-merge@1.0.1:
     resolution:
       {
@@ -13953,6 +14019,8 @@ snapshots:
 
   "@humanwhocodes/retry@0.4.3": {}
 
+  "@ide/backoff@1.0.0": {}
+
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -15457,6 +15525,14 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -15616,6 +15692,8 @@ snapshots:
       "@babel/core": 7.29.0
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+
+  badgin@1.2.3: {}
 
   bail@2.0.2: {}
 
@@ -16621,6 +16699,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  expo-application@6.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+
   expo-asset@11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
       "@expo/image-utils": 0.6.5
@@ -16683,6 +16765,21 @@ snapshots:
   expo-modules-core@2.2.3:
     dependencies:
       invariant: 2.2.4
+
+  expo-notifications@0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      "@expo/image-utils": 0.6.5
+      "@ide/backoff": 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-application: 6.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
+      expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
+      react: 18.3.1
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
 
   expo-router@4.0.22(rtgdbvkbo5gvhvuxmdok4gwjkm):
     dependencies:
@@ -17317,6 +17414,11 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.9
@@ -17412,6 +17514,11 @@ snapshots:
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -18490,6 +18597,11 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -20175,6 +20287,14 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   utils-merge@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Переводить `apps/mobile` з `better-auth/react#useSession` на `useUser()` з `@sergeant/api-client/react` і замикає мобільний push-флоу: після логіну Expo-клієнт бере native APNs/FCM токен через `expo-notifications` і шле його на `/api/v1/push/register` через `api.push.register(...)`.

**Auth-шар.** `apps/mobile/src/auth/authClient.ts` більше не реекспортує `useSession` — Better Auth лишається тільки як actions-layer (`signIn.email`, `signUp.email`, `signOut`, `getSession`). Ідентичність читаємо через `useUser()` (GET `/api/v1/me`) — джерело правди одне й те саме, що й на web (PR #392). Оновлені споживачі:
- `app/(tabs)/_layout.tsx` — guard → `if (!isLoading && !data?.user) Redirect("/(auth)/sign-in")`;
- `app/(auth)/_layout.tsx` — дзеркальний редірект для залогінених;
- `app/(tabs)/index.tsx` — `Привіт, {user?.name ?? user?.email}`.

**ApiClient.** Доданий `apps/mobile/src/api/apiClient.ts`, що будує єдиний `ApiClient` через `createApiClient({ baseUrl, getToken })`. `getToken` читає `sergeant_cookie` з `expo-secure-store` (куди `@better-auth/expo` кладе JSON з cookies після логіну), витягує значення `better-auth.session_token` і віддає як bearer — сервер-side `bearer()` плагін приймає підписаний session-токен у `Authorization: Bearer`. Провайдер піднятий у `app/_layout.tsx` через `<ApiClientProvider client={apiClient}>` — так хуки з `@sergeant/api-client/react` (`useUser`, `usePushRegister`) працюють у всіх екранах.

**Push-флоу.** Два нові модулі під `apps/mobile/src/features/push`:
- `registerPush.ts` — питає дозвіл (`getPermissionsAsync` → `requestPermissionsAsync`), бере native токен (`getDevicePushTokenAsync` у dev-client/standalone, fallback на `getExpoPushTokenAsync` в Expo Go з `console.warn`), резолвить платформу (`ios`/`android`), шле `api.push.register({ platform, token })`, кешує токен у `AsyncStorage` під `push:lastToken`. Не шле запит повторно, якщо токен не змінився (опція `force` для ручного retry).
- `PushRegistrar.tsx` — no-UI компонент, монтується у root-дереві і реагує на `useUser().data?.user`: при появі користувача тригерить `registerPush(api)` один раз; після sign-out (`data.user === null`) скидає прапорець, тож наступний логін знову тригерить реєстрацію (але `registerPush` все ще пропускає HTTP-виклик, якщо `push:lastToken` == current token — AsyncStorage-кеш).

**Конфіг Expo.** `app.json` отримав плагін `expo-notifications` і `ios.infoPlist.UIBackgroundModes: ["remote-notification"]` (на майбутнє для silent-пушів; не шкодить зараз). `expo-notifications` додано як залежність `~0.29.14` через `npx expo install` — версія сумісна з Expo SDK 52.

**Документація.** `docs/mobile.md` і `apps/mobile/README.md` отримали секції «Push notifications» з прикладом клієнтського виклику через `api.push.register` і попередженням про Expo Go.

## Review & Testing Checklist for Human

**Risk: yellow** (міняємо auth-layer у mobile + native push permissions).

- [ ] **Auth-міграція не зламала навігацію.** Залогінься в Expo Go / dev-client → табери відкриваються; sign-out редіректить у `/(auth)/sign-in`. Перевір, що `rg 'from "better-auth/react"' apps/mobile/` не повертає нічого, окрім `src/auth/authClient.ts`.
- [ ] **Authorization header відпрацьовує.** У серверних логах або через проксі перевір, що `GET /api/v1/me` і `POST /api/v1/push/register` йдуть з `Authorization: Bearer <signed-session-token>`. Якщо 401 — перевір, що `better-auth.session_token` дійсно в `sergeant_cookie` SecureStore entry (formát: `{ "better-auth.session_token": { "value": "...", ... } }`).
- [ ] **Push-реєстрація ідемпотентна.** Перший логін → 1 запит `POST /api/v1/push/register`; повторний запуск додатка з тим самим токеном → 0 запитів (AsyncStorage-кеш). Sign-out → sign-in з тим самим токеном → теж 0 запитів. Змінити токен можна, очистивши `push:lastToken` у DevTools.

### Notes

- PushRegistrar перевіряє стан через `useUser()` (а не гуард над провайдером), бо root `_layout.tsx` у expo-router живе над групами `(auth)`/`(tabs)` — фізично «всередину authenticated-гілки» без дубляжу провайдерів не зашити. Рантайм-поведінка еквівалентна: реєстрація тригериться тільки коли `data.user` з’явився.
- Expo Go **не має entitlements** для APNs/FCM, тому там fallback на Expo push token тільки для dev-дебагу. Продакшн-пуші требують dev-client (`eas build --profile development`) — див. `docs/mobile.md`.
- Серверну відправку (APNs/FCM) свідомо НЕ включено — Сесія 5 (окремий PR).
- `pnpm-lock.yaml` оновлено лише через `npx expo install expo-notifications` + `pnpm install --lockfile-only`. CI з `--frozen-lockfile` має бути зелений на тому ж `packageManager: pnpm@9.15.1`.

Link to Devin session: https://app.devin.ai/sessions/023be4e1181c47f594a01dbfcf9c4175
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
