### PR TITLE
feat(server): push sender (APNs + FCM HTTP v1)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,10 +14,12 @@
   },
   "dependencies": {
     "@better-auth/expo": "^1.6.5",
+    "@parse/node-apn": "^8.1.0",
     "@sentry/node": "^8.55.1",
     "@sergeant/shared": "workspace:*",
     "better-auth": "^1.6.4",
     "express": "^4.22.1",
+    "google-auth-library": "^10.6.2",
     "helmet": "^8.1.0",
     "pg": "^8.20.0",
     "pino": "^10.3.1",

--- a/apps/server/src/push/apnsClient.ts
+++ b/apps/server/src/push/apnsClient.ts
@@ -1,0 +1,132 @@
+import apn from "@parse/node-apn";
+import { logger } from "../obs/logger.js";
+
+/**
+ * Lazy APNs провайдер на основі JWT-ключа .p8.
+ *
+ * Інстансується при першому `getApnsProvider()`; якщо обовʼязкові env-и
+ * відсутні або невалідні — повертаємо `null`, caller (див. `send.ts`) дивиться
+ * на це як на «push sender disabled» і не крашиться. Один warn-лог на boot.
+ *
+ * Провайдер і конфіг кешуємо у модулі — node-apn тримає http2-сесію до APNs
+ * open, і відкривати її заново на кожен send — це і latency, і зайві TLS-
+ * handshake-и. `__resetApnsClient` використовується лише тестами.
+ */
+
+interface ApnsConfig {
+  key: string;
+  keyId: string;
+  teamId: string;
+  bundleId: string;
+  production: boolean;
+}
+
+let cachedConfig: ApnsConfig | null | undefined = undefined;
+let cachedProvider: apn.Provider | null = null;
+let warnedDisabled = false;
+
+/**
+ * Normalize `.p8` private-key text from env. APNs TLS вимагає справжні `\n`
+ * переноси у PEM-і; env-и часто приходять з `\r\n` (Windows clipboard) або
+ * з літеральними двосимвольними escape-ами `\\n`/`\\r\\n` (коли секрет
+ * ставлять через shell без quoting-у). Правильна нормалізація:
+ *
+ *   1. Спочатку перетворюємо літеральні `\\r\\n` / `\\n` → `\n`.
+ *   2. Потім схлопуємо native CRLF / CR → LF.
+ *   3. Обрізаємо пробіли/переводи навколо і гарантуємо фінальний `\n`.
+ *
+ * Типова помилка без (1): юзер підставив `APNS_P8_KEY=$(cat key.p8)` у
+ * `.env` з одинарними лапками — bash лишив символи `\n` як 2 байти,
+ * PEM-parser у node-apn не розпарсить і впаде з `unsupported`.
+ *
+ * Експортовано окремо, щоб покрити юнітами (див. `send.test.ts`).
+ */
+export function loadApnsKey(raw: string): string {
+  const unescaped = raw.replace(/\\r\\n/g, "\n").replace(/\\n/g, "\n");
+  const normalized = unescaped.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const trimmed = normalized.trim();
+  return trimmed.length > 0 ? `${trimmed}\n` : "";
+}
+
+function loadConfigFromEnv(): ApnsConfig | null {
+  const raw = process.env.APNS_P8_KEY;
+  if (!raw || !raw.trim()) {
+    if (!warnedDisabled) {
+      logger.warn({ msg: "push sender disabled — no APNS_P8_KEY" });
+      warnedDisabled = true;
+    }
+    return null;
+  }
+  const keyId = process.env.APNS_KEY_ID?.trim();
+  const teamId = process.env.APNS_TEAM_ID?.trim();
+  const bundleId = process.env.APNS_BUNDLE_ID?.trim();
+  if (!keyId || !teamId || !bundleId) {
+    // Окремий warn — щоб оператор одразу побачив, якого саме env-а бракує;
+    // ставити generic "disabled" без деталей → годинник дебагу в проді.
+    logger.warn({
+      msg: "push sender disabled — APNs config incomplete",
+      hasKeyId: Boolean(keyId),
+      hasTeamId: Boolean(teamId),
+      hasBundleId: Boolean(bundleId),
+    });
+    warnedDisabled = true;
+    return null;
+  }
+  const key = loadApnsKey(raw);
+  if (!key) {
+    logger.warn({
+      msg: "push sender disabled — APNS_P8_KEY empty after normalization",
+    });
+    warnedDisabled = true;
+    return null;
+  }
+  return {
+    key,
+    keyId,
+    teamId,
+    bundleId,
+    production: process.env.APNS_PRODUCTION === "true",
+  };
+}
+
+function getApnsConfig(): ApnsConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig;
+  cachedConfig = loadConfigFromEnv();
+  return cachedConfig;
+}
+
+/**
+ * Return a cached APNs `Provider`, or `null` if disabled.
+ *
+ * Перший виклик у процесі створює новий `apn.Provider` — це відкриває
+ * http2-сесію до APNs; подальші виклики повертають той самий інстанс.
+ */
+export function getApnsProvider(): apn.Provider | null {
+  if (cachedProvider) return cachedProvider;
+  const cfg = getApnsConfig();
+  if (!cfg) return null;
+  cachedProvider = new apn.Provider({
+    token: { key: cfg.key, keyId: cfg.keyId, teamId: cfg.teamId },
+    production: cfg.production,
+  });
+  return cachedProvider;
+}
+
+/** APNs topic (bundle id) або `null`, якщо конфіг не валідний. */
+export function apnsBundleId(): string | null {
+  return getApnsConfig()?.bundleId ?? null;
+}
+
+/** Test-only reset. НЕ використовуй у прод-коді. */
+export function __resetApnsClient(): void {
+  cachedConfig = undefined;
+  if (cachedProvider) {
+    try {
+      cachedProvider.shutdown();
+    } catch {
+      /* ignore shutdown errors on reset */
+    }
+    cachedProvider = null;
+  }
+  warnedDisabled = false;
+}

--- a/apps/server/src/push/fcmClient.ts
+++ b/apps/server/src/push/fcmClient.ts
@@ -1,0 +1,158 @@
+import { JWT } from "google-auth-library";
+import { logger } from "../obs/logger.js";
+
+/**
+ * Lazy FCM HTTP v1 клієнт — OAuth2 service-account → Bearer access_token.
+ *
+ * v1 API (`/v1/projects/{project_id}/messages:send`) обовʼязково вимагає
+ * Bearer OAuth2 token зі scope-ом `firebase.messaging`. Старий legacy API з
+ * `Authorization: key=...` Google деприкейтнув (Jun 2024) — не використовуємо.
+ *
+ * Access-token кешуємо у модулі з маржею 60 с до `expiresAt` — щоб не
+ * попадати у лотерею, коли токен протух між тест-імплементацією та мережевим
+ * запитом. JWT-обʼєкт з google-auth-library сам ре-підписує access-token-и;
+ * ми просто тримаємо його інстанс і `authorize()`-имо per-call.
+ */
+
+interface FcmConfig {
+  projectId: string;
+  clientEmail: string;
+  privateKey: string;
+}
+
+interface FcmAccessToken {
+  accessToken: string;
+  /** Unix ms when access token expires (as reported by Google). */
+  expiresAt: number;
+}
+
+let cachedConfig: FcmConfig | null | undefined = undefined;
+let cachedJwt: JWT | null = null;
+let cachedToken: FcmAccessToken | null = null;
+let warnedDisabled = false;
+
+/** Margin before expiry at which we proactively refresh the token. */
+const REFRESH_MARGIN_MS = 60_000;
+
+/**
+ * Decode a base64 service-account JSON blob and extract the three fields
+ * we actually need. Returns `null` (with a warn-log) for any failure mode —
+ * missing env, invalid base64, unparseable JSON, missing fields — so the
+ * sender gracefully degrades instead of crashing boot.
+ */
+function loadConfigFromEnv(): FcmConfig | null {
+  const raw = process.env.FCM_SERVICE_ACCOUNT_JSON;
+  if (!raw || !raw.trim()) {
+    if (!warnedDisabled) {
+      logger.warn({
+        msg: "push sender disabled — no FCM_SERVICE_ACCOUNT_JSON",
+      });
+      warnedDisabled = true;
+    }
+    return null;
+  }
+  let decoded: string;
+  try {
+    // `.trim()` — Railway/Docker-env іноді додають trailing newline; base64
+    // decoder на нього кидає «Invalid character». Ідемпотентно для чистих вводів.
+    decoded = Buffer.from(raw.trim(), "base64").toString("utf8");
+  } catch (e) {
+    logger.warn({
+      msg: "push sender disabled — FCM_SERVICE_ACCOUNT_JSON invalid base64",
+      err: { message: e instanceof Error ? e.message : String(e) },
+    });
+    warnedDisabled = true;
+    return null;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(decoded) as Record<string, unknown>;
+  } catch (e) {
+    logger.warn({
+      msg: "push sender disabled — FCM_SERVICE_ACCOUNT_JSON invalid JSON",
+      err: { message: e instanceof Error ? e.message : String(e) },
+    });
+    warnedDisabled = true;
+    return null;
+  }
+  const projectId =
+    typeof parsed.project_id === "string" ? parsed.project_id : null;
+  const clientEmail =
+    typeof parsed.client_email === "string" ? parsed.client_email : null;
+  const privateKey =
+    typeof parsed.private_key === "string" ? parsed.private_key : null;
+  if (!projectId || !clientEmail || !privateKey) {
+    logger.warn({
+      msg: "push sender disabled — FCM service account missing fields",
+      hasProjectId: Boolean(projectId),
+      hasClientEmail: Boolean(clientEmail),
+      hasPrivateKey: Boolean(privateKey),
+    });
+    warnedDisabled = true;
+    return null;
+  }
+  return { projectId, clientEmail, privateKey };
+}
+
+function getFcmConfig(): FcmConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig;
+  cachedConfig = loadConfigFromEnv();
+  return cachedConfig;
+}
+
+function getJwt(): JWT | null {
+  if (cachedJwt) return cachedJwt;
+  const cfg = getFcmConfig();
+  if (!cfg) return null;
+  cachedJwt = new JWT({
+    email: cfg.clientEmail,
+    key: cfg.privateKey,
+    scopes: ["https://www.googleapis.com/auth/firebase.messaging"],
+  });
+  return cachedJwt;
+}
+
+/**
+ * Return a valid FCM OAuth2 Bearer token, refreshing lazily. Returns `null`
+ * when FCM is disabled (missing/invalid service account).
+ *
+ * Throws only if Google's token endpoint replies with something we cannot
+ * interpret — caller (`sendFCM`) handles the throw as a transient error and
+ * retries with backoff.
+ */
+export async function getFcmAccessToken(): Promise<string | null> {
+  const jwt = getJwt();
+  if (!jwt) return null;
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt - REFRESH_MARGIN_MS > now) {
+    return cachedToken.accessToken;
+  }
+  const resp = await jwt.authorize();
+  if (!resp.access_token) {
+    throw new Error("FCM token request returned no access_token");
+  }
+  const expiresAt =
+    typeof resp.expiry_date === "number" && resp.expiry_date > 0
+      ? resp.expiry_date
+      : now + 3_600_000; // fallback: 1h (Google's default)
+  cachedToken = { accessToken: resp.access_token, expiresAt };
+  return resp.access_token;
+}
+
+/** FCM project id або `null`, якщо конфіг не валідний. */
+export function fcmProjectId(): string | null {
+  return getFcmConfig()?.projectId ?? null;
+}
+
+/** Test-only reset. НЕ використовуй у прод-коді. */
+export function __resetFcmClient(): void {
+  cachedConfig = undefined;
+  cachedJwt = null;
+  cachedToken = null;
+  warnedDisabled = false;
+}
+
+/** Test-only: вставити access-token напряму, щоб обійти мережевий OAuth. */
+export function __setFcmAccessTokenForTest(token: FcmAccessToken | null): void {
+  cachedToken = token;
+}

--- a/apps/server/src/push/send.test.ts
+++ b/apps/server/src/push/send.test.ts
@@ -392,6 +392,16 @@ describe("sendFCM", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to HTTP status when error body is empty", async () => {
+    // Регресія: пусте тіло при 400 не мусить давати `error: ""` у логах —
+    // чекаємо stringified status code як fallback.
+    fetchMock.mockResolvedValueOnce(resp(400, ""));
+    const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(false);
+    expect(r.error).toBe("400");
+  });
+
   it("returns disabled when projectId is null", async () => {
     fcmProjectIdMock.mockReturnValueOnce(null);
     const r = await sendFCM("u1", "tok", { title: "hi" });

--- a/apps/server/src/push/send.test.ts
+++ b/apps/server/src/push/send.test.ts
@@ -1,0 +1,565 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Тестовий plan:
+ *   1. `loadApnsKey` — нормалізація CRLF / `\\n` / pad-whitespace.
+ *   2. Lazy clients: warn-log + disabled поведінка, коли ключів нема.
+ *   3. FCM OAuth token кешування (expiresAt - 60 с margin).
+ *   4. `sendAPNs`: happy path, 410 → dead, 500 → retry → delivered, retry exhaustion.
+ *   5. `sendFCM`: happy path, UNREGISTERED → dead, 429/5xx → retry.
+ *   6. `sendToUser`: no devices → no-op, fan-out із cleanup, mix платформ.
+ *
+ * Все мокаємо на module-level — pool.query, apnsClient, fcmClient, fetch,
+ * sendWebPush — щоб жоден тест не ходив у мережу і не торкав БД.
+ */
+
+// ────────────────────────── Module mocks ─────────────────────────
+// `vi.mock` calls are hoisted above all top-level code, so any referenced
+// identifiers inside the factory must also be hoisted — we declare them via
+// `vi.hoisted` to share one set of mocks across the factory and the tests.
+const {
+  poolMock,
+  loggerMock,
+  sendWebPushMock,
+  apnsProviderSendMock,
+  getApnsProviderMock,
+  apnsBundleIdMock,
+  getFcmAccessTokenMock,
+  fcmProjectIdMock,
+  pushSendsTotalMock,
+  fetchMock,
+} = vi.hoisted(() => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return {
+    poolMock: { query: vi.fn() },
+    loggerMock: logger,
+    sendWebPushMock: vi.fn(),
+    apnsProviderSendMock: vi.fn(),
+    getApnsProviderMock: vi.fn(),
+    apnsBundleIdMock: vi.fn(),
+    getFcmAccessTokenMock: vi.fn(),
+    fcmProjectIdMock: vi.fn(),
+    pushSendsTotalMock: { inc: vi.fn() },
+    fetchMock: vi.fn(),
+  };
+});
+
+vi.mock("../db.js", () => ({ default: poolMock, pool: poolMock }));
+
+vi.mock("../obs/logger.js", () => ({
+  logger: loggerMock,
+  childLogger: () => loggerMock,
+  serializeError: (e: unknown) => ({
+    message: e instanceof Error ? e.message : String(e),
+  }),
+}));
+
+vi.mock("../obs/metrics.js", () => ({
+  pushSendsTotal: pushSendsTotalMock,
+}));
+
+vi.mock("../lib/webpushSend.js", () => ({
+  sendWebPush: sendWebPushMock,
+}));
+
+vi.mock("./apnsClient.js", async () => {
+  // Keep `loadApnsKey` real — there's a dedicated suite that depends on it.
+  const actual =
+    await vi.importActual<typeof import("./apnsClient.js")>("./apnsClient.js");
+  return {
+    ...actual,
+    getApnsProvider: getApnsProviderMock,
+    apnsBundleId: apnsBundleIdMock,
+  };
+});
+
+vi.mock("./fcmClient.js", () => ({
+  getFcmAccessToken: getFcmAccessTokenMock,
+  fcmProjectId: fcmProjectIdMock,
+  __resetFcmClient: vi.fn(),
+  __setFcmAccessTokenForTest: vi.fn(),
+}));
+
+// `@parse/node-apn` імпортується лише як namespace для `apn.Notification` —
+// проста фабрика достатня, щоб не тягти реальний http2-стек у тести.
+vi.mock("@parse/node-apn", () => {
+  class FakeNotification {
+    topic = "";
+    alert: unknown = undefined;
+    sound: unknown = undefined;
+    badge: unknown = undefined;
+    threadId: unknown = undefined;
+    payload: unknown = undefined;
+  }
+  return {
+    default: { Notification: FakeNotification },
+    Notification: FakeNotification,
+  };
+});
+
+// global fetch — кожен тест підсуває поведінку.
+vi.stubGlobal("fetch", fetchMock);
+
+// ───────────────────────── Test imports ──────────────────────────
+import { sendAPNs, sendFCM, sendToUser } from "./send.js";
+import { loadApnsKey } from "./apnsClient.js";
+
+beforeEach(() => {
+  poolMock.query.mockReset();
+  sendWebPushMock.mockReset();
+  fetchMock.mockReset();
+  apnsProviderSendMock.mockReset();
+  getApnsProviderMock.mockReset();
+  apnsBundleIdMock.mockReset();
+  getFcmAccessTokenMock.mockReset();
+  fcmProjectIdMock.mockReset();
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─────────────────────────── loadApnsKey ─────────────────────────
+describe("loadApnsKey", () => {
+  it("passes through clean LF PEM", () => {
+    const raw =
+      "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----";
+    expect(loadApnsKey(raw)).toBe(
+      "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----\n",
+    );
+  });
+
+  it("normalizes native CRLF to LF", () => {
+    const raw =
+      "-----BEGIN PRIVATE KEY-----\r\nABC\r\nDEF\r\n-----END PRIVATE KEY-----\r\n";
+    expect(loadApnsKey(raw)).toBe(
+      "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----\n",
+    );
+  });
+
+  it("unescapes literal \\n sequences (shell-single-quoted env)", () => {
+    const raw =
+      "-----BEGIN PRIVATE KEY-----\\nABC\\nDEF\\n-----END PRIVATE KEY-----";
+    expect(loadApnsKey(raw)).toBe(
+      "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----\n",
+    );
+  });
+
+  it("unescapes literal \\r\\n sequences", () => {
+    const raw =
+      "-----BEGIN PRIVATE KEY-----\\r\\nABC\\r\\nDEF\\r\\n-----END PRIVATE KEY-----";
+    expect(loadApnsKey(raw)).toBe(
+      "-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----\n",
+    );
+  });
+
+  it("trims surrounding whitespace and always ends with exactly one LF", () => {
+    const raw =
+      "   \n-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----\n\n  ";
+    const out = loadApnsKey(raw);
+    expect(out.startsWith("-----BEGIN PRIVATE KEY-----")).toBe(true);
+    expect(out.endsWith("-----END PRIVATE KEY-----\n")).toBe(true);
+    expect(out.endsWith("\n\n")).toBe(false);
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(loadApnsKey("")).toBe("");
+    expect(loadApnsKey("   ")).toBe("");
+    expect(loadApnsKey("\r\n  \r\n")).toBe("");
+  });
+});
+
+// ─────────────────────────── sendAPNs ────────────────────────────
+describe("sendAPNs", () => {
+  beforeEach(() => {
+    apnsBundleIdMock.mockReturnValue("com.sergeant.app");
+    getApnsProviderMock.mockReturnValue({ send: apnsProviderSendMock });
+  });
+
+  it("returns delivered=true on success", async () => {
+    apnsProviderSendMock.mockResolvedValueOnce({
+      sent: [{ device: "tok1" }],
+      failed: [],
+    });
+    const r = await sendAPNs("u1", "tok1", { title: "hi", body: "world" });
+    expect(r).toEqual({ delivered: true, dead: false });
+    expect(apnsProviderSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns dead=true on 410 BadDeviceToken without retry", async () => {
+    apnsProviderSendMock.mockResolvedValueOnce({
+      sent: [],
+      failed: [
+        {
+          device: "tok1",
+          status: 410,
+          response: { reason: "BadDeviceToken" },
+        },
+      ],
+    });
+    const r = await sendAPNs("u1", "tok1", { title: "hi" });
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(true);
+    expect(r.error).toBe("BadDeviceToken");
+    expect(apnsProviderSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns dead=true on 400 Unregistered reason", async () => {
+    apnsProviderSendMock.mockResolvedValueOnce({
+      sent: [],
+      failed: [
+        {
+          device: "tok1",
+          status: 400,
+          response: { reason: "Unregistered" },
+        },
+      ],
+    });
+    const r = await sendAPNs("u1", "tok1", { title: "hi" });
+    expect(r.dead).toBe(true);
+  });
+
+  it("retries on 500 and succeeds on the second try", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 10 });
+    apnsProviderSendMock
+      .mockResolvedValueOnce({
+        sent: [],
+        failed: [
+          {
+            device: "tok1",
+            status: 500,
+            response: { reason: "InternalServerError" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        sent: [{ device: "tok1" }],
+        failed: [],
+      });
+    const p = sendAPNs("u1", "tok1", { title: "hi" });
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.delivered).toBe(true);
+    expect(apnsProviderSendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after MAX_ATTEMPTS on transient 500", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 10 });
+    apnsProviderSendMock.mockResolvedValue({
+      sent: [],
+      failed: [
+        {
+          device: "tok1",
+          status: 500,
+          response: { reason: "InternalServerError" },
+        },
+      ],
+    });
+    const p = sendAPNs("u1", "tok1", { title: "hi" });
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(false);
+    expect(apnsProviderSendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns disabled when provider is null", async () => {
+    getApnsProviderMock.mockReturnValueOnce(null);
+    apnsBundleIdMock.mockReturnValueOnce(null);
+    const r = await sendAPNs("u1", "tok1", { title: "hi" });
+    expect(r.delivered).toBe(false);
+    expect(r.error).toBe("apns_disabled");
+  });
+});
+
+// ─────────────────────────── sendFCM ─────────────────────────────
+describe("sendFCM", () => {
+  beforeEach(() => {
+    fcmProjectIdMock.mockReturnValue("sergeant-test");
+    getFcmAccessTokenMock.mockResolvedValue("ya29.test-token");
+  });
+
+  function resp(status: number, body: unknown): Response {
+    return {
+      status,
+      ok: status >= 200 && status < 300,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body),
+    } as unknown as Response;
+  }
+
+  it("returns delivered=true on 200", async () => {
+    fetchMock.mockResolvedValueOnce(
+      resp(200, { name: "projects/x/messages/1" }),
+    );
+    const r = await sendFCM("u1", "dev-token", { title: "hi" });
+    expect(r.delivered).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1/projects/sergeant-test/messages:send");
+    const parsed = JSON.parse((init as RequestInit).body as string);
+    expect(parsed.message.token).toBe("dev-token");
+    expect(parsed.message.notification.title).toBe("hi");
+  });
+
+  it("stringifies data map values for FCM v1", async () => {
+    fetchMock.mockResolvedValueOnce(resp(200, { name: "n" }));
+    await sendFCM("u1", "tok", {
+      title: "t",
+      data: { n: 1, s: "s", obj: { k: "v" } },
+    });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body.message.data).toEqual({
+      n: "1",
+      s: "s",
+      obj: '{"k":"v"}',
+    });
+  });
+
+  it("returns dead=true on UNREGISTERED status", async () => {
+    fetchMock.mockResolvedValueOnce(
+      resp(404, {
+        error: { code: 404, status: "UNREGISTERED", message: "gone" },
+      }),
+    );
+    const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.dead).toBe(true);
+    expect(r.error).toBe("UNREGISTERED");
+  });
+
+  it("returns dead=true on INVALID_ARGUMENT via details.errorCode", async () => {
+    fetchMock.mockResolvedValueOnce(
+      resp(400, {
+        error: {
+          code: 400,
+          status: "INVALID_ARGUMENT",
+          details: [
+            {
+              "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError",
+              errorCode: "INVALID_ARGUMENT",
+            },
+          ],
+        },
+      }),
+    );
+    const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.dead).toBe(true);
+  });
+
+  it("retries on 503 and succeeds", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 10 });
+    fetchMock
+      .mockResolvedValueOnce(resp(503, { error: { status: "UNAVAILABLE" } }))
+      .mockResolvedValueOnce(resp(200, { name: "n" }));
+    const p = sendFCM("u1", "tok", { title: "hi" });
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.delivered).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 429 up to MAX_ATTEMPTS", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 10 });
+    fetchMock.mockResolvedValue(
+      resp(429, { error: { status: "RESOURCE_EXHAUSTED" } }),
+    );
+    const p = sendFCM("u1", "tok", { title: "hi" });
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT retry on 401 (config error)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      resp(401, { error: { status: "UNAUTHENTICATED" } }),
+    );
+    const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns disabled when projectId is null", async () => {
+    fcmProjectIdMock.mockReturnValueOnce(null);
+    const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.error).toBe("fcm_disabled");
+  });
+});
+
+// ─────────────────────────── sendToUser ──────────────────────────
+describe("sendToUser", () => {
+  beforeEach(() => {
+    apnsBundleIdMock.mockReturnValue("com.sergeant.app");
+    getApnsProviderMock.mockReturnValue({ send: apnsProviderSendMock });
+    fcmProjectIdMock.mockReturnValue("sergeant-test");
+    getFcmAccessTokenMock.mockResolvedValue("ya29.test-token");
+  });
+
+  it("no-ops when user has no devices", async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [] }); // push_devices
+    poolMock.query.mockResolvedValueOnce({ rows: [] }); // push_subscriptions
+    const r = await sendToUser("u1", { title: "hi" });
+    expect(r).toEqual({
+      delivered: { ios: 0, android: 0, web: 0 },
+      cleaned: 0,
+      errors: [],
+    });
+    // Ні APNs, ні FCM, ні web не чіпали.
+    expect(apnsProviderSendMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sendWebPushMock).not.toHaveBeenCalled();
+  });
+
+  it("fan-outs to ios + android + web", async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        { token: "ios-tok", platform: "ios" },
+        { token: "and-tok", platform: "android" },
+      ],
+    });
+    poolMock.query.mockResolvedValueOnce({
+      rows: [{ endpoint: "https://fcm/x", p256dh: "p", auth: "a" }],
+    });
+
+    apnsProviderSendMock.mockResolvedValueOnce({
+      sent: [{ device: "ios-tok" }],
+      failed: [],
+    });
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      text: async () => "{}",
+    } as unknown as Response);
+    sendWebPushMock.mockResolvedValueOnce({
+      outcome: "ok",
+      durationMs: 1,
+      attempts: 1,
+    });
+
+    const r = await sendToUser("u1", { title: "hi", body: "b" });
+    expect(r.delivered).toEqual({ ios: 1, android: 1, web: 1 });
+    expect(r.cleaned).toBe(0);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("cleans up dead APNs token via DELETE", async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [{ token: "ios-tok", platform: "ios" }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1 }); // DELETE push_devices
+
+    apnsProviderSendMock.mockResolvedValueOnce({
+      sent: [],
+      failed: [
+        {
+          device: "ios-tok",
+          status: 410,
+          response: { reason: "Unregistered" },
+        },
+      ],
+    });
+
+    const r = await sendToUser("u1", { title: "hi" });
+    expect(r.delivered.ios).toBe(0);
+    expect(r.cleaned).toBe(1);
+    const deleteCall = poolMock.query.mock.calls.find((c) =>
+      String(c[0]).includes("DELETE FROM push_devices"),
+    );
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall?.[1]).toEqual(["ios", "ios-tok"]);
+  });
+
+  it("cleans up dead FCM token on UNREGISTERED", async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [{ token: "and-tok", platform: "android" }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1 });
+
+    fetchMock.mockResolvedValueOnce({
+      status: 404,
+      ok: false,
+      text: async () => JSON.stringify({ error: { status: "UNREGISTERED" } }),
+    } as unknown as Response);
+
+    const r = await sendToUser("u1", { title: "hi" });
+    expect(r.cleaned).toBe(1);
+    const deleteCall = poolMock.query.mock.calls.find((c) =>
+      String(c[0]).includes("DELETE FROM push_devices"),
+    );
+    expect(deleteCall?.[1]).toEqual(["android", "and-tok"]);
+  });
+
+  it("soft-deletes stale web subscription on invalid_endpoint", async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ endpoint: "https://fcm/x", p256dh: "p", auth: "a" }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1 });
+
+    sendWebPushMock.mockResolvedValueOnce({
+      outcome: "invalid_endpoint",
+      durationMs: 1,
+      attempts: 1,
+      statusCode: 410,
+    });
+
+    const r = await sendToUser("u1", { title: "hi" });
+    expect(r.cleaned).toBe(1);
+    const updateCall = poolMock.query.mock.calls.find((c) =>
+      String(c[0]).includes("UPDATE push_subscriptions"),
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toEqual(["https://fcm/x"]);
+  });
+
+  it("records transient error WITHOUT cleanup", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 10 });
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [{ token: "ios-tok", platform: "ios" }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    apnsProviderSendMock.mockResolvedValue({
+      sent: [],
+      failed: [
+        {
+          device: "ios-tok",
+          status: 503,
+          response: { reason: "ServiceUnavailable" },
+        },
+      ],
+    });
+
+    const p = sendToUser("u1", { title: "hi" });
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.errors).toEqual([
+      { platform: "ios", reason: "ServiceUnavailable" },
+    ]);
+    expect(r.cleaned).toBe(0);
+    // DELETE НЕ повинен був викликатися
+    const deleteCall = poolMock.query.mock.calls.find((c) =>
+      String(c[0]).includes("DELETE FROM push_devices"),
+    );
+    expect(deleteCall).toBeUndefined();
+  });
+});

--- a/apps/server/src/push/send.ts
+++ b/apps/server/src/push/send.ts
@@ -353,8 +353,7 @@ export async function sendFCM(
       statusName ??
       detailCode ??
       parsed?.error?.message ??
-      bodyText.slice(0, 200) ??
-      String(resp.status);
+      (bodyText.slice(0, 200) || String(resp.status));
 
     const effectiveCode = statusName ?? detailCode;
     const dead =

--- a/apps/server/src/push/send.ts
+++ b/apps/server/src/push/send.ts
@@ -1,0 +1,540 @@
+import apn from "@parse/node-apn";
+import pool from "../db.js";
+import { sendWebPush } from "../lib/webpushSend.js";
+import { logger } from "../obs/logger.js";
+import { pushSendsTotal } from "../obs/metrics.js";
+import { apnsBundleId, getApnsProvider } from "./apnsClient.js";
+import { fcmProjectId, getFcmAccessToken } from "./fcmClient.js";
+import type { PushPayload, PushPlatform, SendToUserResult } from "./types.js";
+
+export type { PushPayload, SendToUserResult } from "./types.js";
+
+/**
+ * Єдина точка для серверного fan-out push-у.
+ *
+ *   `sendToUser(userId, payload)` читає всі активні пристрої юзера з
+ *   `push_devices` (+ web-push-підписки з `push_subscriptions`) і
+ *   паралельно відправляє payload на APNs/FCM/web. Повертає аґреговану
+ *   статистику; nobody-home (юзер без жодного пристрою) — не помилка,
+ *   віддаємо {delivered:{0,0,0}, cleaned:0, errors:[]}.
+ *
+ * Сам `sendToUser` НЕ кидає — у fan-out-і одна впала платформа не має
+ * валити решту. Винятки з мережевих слоїв обгортаємо у структуровані
+ * `errors[]` і логуємо.
+ */
+
+// ─────────────────────────── Retry policy ───────────────────────────
+// Exponential backoff: 3 total attempts, delays between them 200 ms / 1 s / 3 s.
+// Без значної jitter-и — native push-сервіси мають стабільний QPS ліміт і
+// перевантаження тут — рідкість; 200/1000/3000 — стандартна послідовність
+// що дає ~4.2 с worst-case на один токен до повернення failed.
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS: readonly number[] = [200, 1000, 3000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─────────────────────────── Metrics ───────────────────────────────
+/**
+ * Інкрементуємо `push_sends_total{outcome}` для узгодження з існуючими
+ * дашбордами web-push-у. try/catch — metrics ніколи не мають ламати send.
+ */
+function recordDomainOutcome(outcome: string): void {
+  try {
+    pushSendsTotal.inc({ outcome });
+  } catch {
+    /* ignore */
+  }
+}
+
+// ─────────────────────────── DB layer ──────────────────────────────
+interface DeviceRow {
+  token: string;
+  platform: "ios" | "android";
+}
+
+interface WebSubRow {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+async function loadNativeDevices(userId: string): Promise<DeviceRow[]> {
+  const { rows } = await pool.query<DeviceRow>(
+    `SELECT token, platform
+       FROM push_devices
+      WHERE user_id = $1
+        AND platform IN ('ios', 'android')
+        AND deleted_at IS NULL`,
+    [userId],
+  );
+  return rows;
+}
+
+async function loadWebSubscriptions(userId: string): Promise<WebSubRow[]> {
+  const { rows } = await pool.query<WebSubRow>(
+    `SELECT endpoint, p256dh, auth
+       FROM push_subscriptions
+      WHERE user_id = $1 AND deleted_at IS NULL`,
+    [userId],
+  );
+  return rows;
+}
+
+/**
+ * Permanently remove a native device token. APNs 410/BadDeviceToken/
+ * Unregistered and FCM UNREGISTERED/INVALID_ARGUMENT signal that the token
+ * is not valid any more (app uninstalled, token rotated, wrong env). Keeping
+ * the row around would mean retry-storming the upstream на кожному пуші.
+ */
+async function deleteNativeDevice(
+  userId: string,
+  platform: "ios" | "android",
+  token: string,
+  reason: string,
+): Promise<void> {
+  await pool.query(
+    `DELETE FROM push_devices WHERE platform = $1 AND token = $2`,
+    [platform, token],
+  );
+  logger.info({
+    msg: "push_dead_token_cleanup",
+    user_id: userId,
+    platform,
+    reason,
+  });
+}
+
+/**
+ * Soft-delete a stale web-push subscription. Mirror семантики існуючого
+ * `sendPush` handler-а — `push_subscriptions` live-soft-delete, не hard DELETE.
+ */
+async function softDeleteWebSubscription(
+  userId: string,
+  endpoint: string,
+): Promise<void> {
+  await pool.query(
+    `UPDATE push_subscriptions
+        SET deleted_at = NOW()
+      WHERE endpoint = $1 AND deleted_at IS NULL`,
+    [endpoint],
+  );
+  logger.info({
+    msg: "push_dead_token_cleanup",
+    user_id: userId,
+    platform: "web",
+    reason: "invalid_endpoint",
+  });
+}
+
+// ─────────────────────────── APNs send ─────────────────────────────
+interface SendOutcome {
+  delivered: boolean;
+  /** Upstream classified this token as permanently invalid — caller deletes. */
+  dead: boolean;
+  /** Error reason if we want to record it in `errors[]`. */
+  error?: string;
+}
+
+/**
+ * Send a single APNs notification with retry. `@parse/node-apn` вже
+ * обгортає http2-транспорт і повертає структурований `{sent, failed}` замість
+ * throw-а для upstream-помилок. Ми покриваємо його лише retry-логікою й
+ * класифікацією «dead-token vs transient vs permanent».
+ *
+ * Exported for unit testing.
+ */
+export async function sendAPNs(
+  userId: string,
+  token: string,
+  payload: PushPayload,
+): Promise<SendOutcome> {
+  const provider = getApnsProvider();
+  const bundleId = apnsBundleId();
+  if (!provider || !bundleId) {
+    return { delivered: false, dead: false, error: "apns_disabled" };
+  }
+
+  const note = new apn.Notification();
+  note.topic = bundleId;
+  note.alert = { title: payload.title, body: payload.body ?? "" };
+  note.sound = "default";
+  if (typeof payload.badge === "number") note.badge = payload.badge;
+  if (payload.threadId) note.threadId = payload.threadId;
+  if (payload.data) {
+    // APNs дозволяє довільні top-level поля поруч з `aps`. Мокаємо це через
+    // `note.payload`, щоб клієнт отримав payload.data як частину notification.
+    note.payload = { ...payload.data };
+  }
+
+  let lastReason = "unknown";
+  let lastStatus: number | undefined = undefined;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(RETRY_DELAYS_MS[attempt - 1] ?? 1000);
+
+    let result: apn.Responses<apn.ResponseSent, apn.ResponseFailure>;
+    try {
+      result = await provider.send(note, token);
+    } catch (e) {
+      // Мережеві/http2-помилки node-apn кидає throw-ом; класифікуємо як
+      // transient і даємо ретрай шанс — це часто просто rekey-розрив.
+      lastReason = e instanceof Error ? e.message : String(e);
+      if (attempt < MAX_ATTEMPTS - 1) continue;
+      logger.warn({
+        msg: "apns_send_error",
+        user_id: userId,
+        err: { message: lastReason },
+      });
+      return { delivered: false, dead: false, error: lastReason };
+    }
+
+    if (result.sent.length > 0) {
+      return { delivered: true, dead: false };
+    }
+
+    const failure = result.failed[0];
+    lastStatus =
+      failure?.status !== undefined ? Number(failure.status) : undefined;
+    lastReason =
+      failure?.response?.reason ?? failure?.error?.message ?? "unknown";
+
+    // 410 у будь-якій формі, плюс BadDeviceToken/Unregistered — безповоротно
+    // мертвий token. Apple явно рекомендує DELETE у таких випадках
+    // (https://developer.apple.com/documentation/usernotifications — Error codes).
+    const dead =
+      lastStatus === 410 ||
+      lastReason === "BadDeviceToken" ||
+      lastReason === "Unregistered";
+    if (dead) {
+      return { delivered: false, dead: true, error: lastReason };
+    }
+
+    // Транзієнтні: 5xx (Apple internal), 429 (rate-limit). Решта 4xx —
+    // per-payload/per-cred помилки, retry не допоможе (InvalidPushType,
+    // PayloadTooLarge, etc).
+    const transient =
+      (typeof lastStatus === "number" &&
+        lastStatus >= 500 &&
+        lastStatus < 600) ||
+      lastStatus === 429;
+    if (transient && attempt < MAX_ATTEMPTS - 1) continue;
+    break;
+  }
+
+  logger.warn({
+    msg: "apns_send_failed",
+    user_id: userId,
+    status: lastStatus,
+    reason: lastReason,
+  });
+  return { delivered: false, dead: false, error: lastReason };
+}
+
+// ─────────────────────────── FCM send ──────────────────────────────
+/**
+ * FCM error status codes that mean the token is permanently invalid. See
+ * https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode.
+ */
+const FCM_DEAD_STATUSES = new Set([
+  "UNREGISTERED",
+  "INVALID_ARGUMENT",
+  "NOT_FOUND",
+]);
+
+interface FcmErrorBody {
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
+    details?: Array<{ errorCode?: string; "@type"?: string }>;
+  };
+}
+
+/**
+ * Send a single FCM HTTP v1 notification with retry. Повертає виключно
+ * класифіковані результати — трансопртні помилки (network/auth/etc.) йдуть
+ * у `error` без dead-cleanup, токен-level помилки → `dead: true`.
+ *
+ * Exported for unit testing.
+ */
+export async function sendFCM(
+  userId: string,
+  token: string,
+  payload: PushPayload,
+): Promise<SendOutcome> {
+  const projectId = fcmProjectId();
+  if (!projectId) {
+    return { delivered: false, dead: false, error: "fcm_disabled" };
+  }
+
+  const body = {
+    message: {
+      token,
+      notification: {
+        title: payload.title,
+        body: payload.body ?? "",
+      },
+      // FCM v1 vимагає `data` як map<string,string> — number/bool кидають
+      // INVALID_ARGUMENT. Stringify усього, хай клієнт сам JSON.parse-ить.
+      ...(payload.data ? { data: stringifyDataMap(payload.data) } : {}),
+      ...(typeof payload.badge === "number"
+        ? { apns: { payload: { aps: { badge: payload.badge } } } }
+        : {}),
+    },
+  };
+  const url = `https://fcm.googleapis.com/v1/projects/${encodeURIComponent(
+    projectId,
+  )}/messages:send`;
+
+  let lastReason = "unknown";
+  let lastStatus: number | undefined = undefined;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(RETRY_DELAYS_MS[attempt - 1] ?? 1000);
+
+    let accessToken: string | null;
+    try {
+      accessToken = await getFcmAccessToken();
+    } catch (e) {
+      lastReason = e instanceof Error ? e.message : String(e);
+      // OAuth-flap є транзієнтним (Google token endpoint 5xx/network).
+      if (attempt < MAX_ATTEMPTS - 1) continue;
+      logger.warn({
+        msg: "fcm_token_fetch_failed",
+        user_id: userId,
+        err: { message: lastReason },
+      });
+      return { delivered: false, dead: false, error: lastReason };
+    }
+    if (!accessToken) {
+      return { delivered: false, dead: false, error: "fcm_disabled" };
+    }
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (e) {
+      lastReason = e instanceof Error ? e.message : String(e);
+      if (attempt < MAX_ATTEMPTS - 1) continue;
+      logger.warn({
+        msg: "fcm_send_network_error",
+        user_id: userId,
+        err: { message: lastReason },
+      });
+      return { delivered: false, dead: false, error: lastReason };
+    }
+
+    lastStatus = resp.status;
+    if (resp.status >= 200 && resp.status < 300) {
+      return { delivered: true, dead: false };
+    }
+
+    let bodyText = "";
+    try {
+      bodyText = await resp.text();
+    } catch {
+      /* ignore — worst case lastReason залишається status */
+    }
+    const parsed = safeParseFcmError(bodyText);
+    const statusName = parsed?.error?.status;
+    const detailCode = parsed?.error?.details?.find(
+      (d) => typeof d.errorCode === "string",
+    )?.errorCode;
+    lastReason =
+      statusName ??
+      detailCode ??
+      parsed?.error?.message ??
+      bodyText.slice(0, 200) ??
+      String(resp.status);
+
+    const effectiveCode = statusName ?? detailCode;
+    const dead =
+      effectiveCode !== undefined && FCM_DEAD_STATUSES.has(effectiveCode);
+    if (dead) {
+      return { delivered: false, dead: true, error: lastReason };
+    }
+
+    // 5xx / 429 — transient. Все інше (400 без dead-коду, 401/403 —
+    // мис-конфіг) не варто ретраїти: ретраєм через 200 мс ти все одно
+    // отримаєш ту ж саму 401.
+    const transient = resp.status >= 500 || resp.status === 429;
+    if (transient && attempt < MAX_ATTEMPTS - 1) continue;
+    break;
+  }
+
+  logger.warn({
+    msg: "fcm_send_failed",
+    user_id: userId,
+    status: lastStatus,
+    reason: lastReason,
+  });
+  return { delivered: false, dead: false, error: lastReason };
+}
+
+function safeParseFcmError(raw: string): FcmErrorBody | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as FcmErrorBody;
+  } catch {
+    return null;
+  }
+}
+
+function stringifyDataMap(
+  data: Record<string, unknown>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (v === undefined || v === null) continue;
+    out[k] = typeof v === "string" ? v : JSON.stringify(v);
+  }
+  return out;
+}
+
+// ─────────────────────────── Public API ────────────────────────────
+/**
+ * Delivery dispatcher. Реальне API для caller-ів (coach, reminders, …).
+ *
+ * Контракт:
+ *   - no-op + `errors=[]` коли у юзера жодного пристрою.
+ *   - transient fails → count у `errors[]`, не cleanup.
+ *   - token-dead fails → cleanup + count у `cleaned`.
+ *   - ніколи не throw-ає (винятки БД всередині Promise.all промокають
+ *     нагору лише у разі повної недоступності `pool.query`, яке й так
+ *     класифікується як critical-alert у sentry).
+ */
+export async function sendToUser(
+  userId: string,
+  payload: PushPayload,
+): Promise<SendToUserResult> {
+  const result: SendToUserResult = {
+    delivered: { ios: 0, android: 0, web: 0 },
+    cleaned: 0,
+    errors: [],
+  };
+
+  const [devices, webSubs] = await Promise.all([
+    loadNativeDevices(userId),
+    loadWebSubscriptions(userId),
+  ]);
+
+  if (devices.length === 0 && webSubs.length === 0) {
+    return result;
+  }
+
+  const webPayloadJson = JSON.stringify({
+    title: payload.title,
+    body: payload.body ?? "",
+    data: payload.data ?? null,
+  });
+
+  // Per-device Promise.all. Одна впала не рве fan-out: кожен sender-ок
+  // повертає або SendOutcome, або структурований error.
+  const tasks: Promise<void>[] = [];
+
+  for (const d of devices) {
+    if (d.platform === "ios") {
+      tasks.push(
+        sendAPNs(userId, d.token, payload).then(async (r) => {
+          await applyNativeOutcome(result, userId, "ios", d.token, r);
+        }),
+      );
+    } else if (d.platform === "android") {
+      tasks.push(
+        sendFCM(userId, d.token, payload).then(async (r) => {
+          await applyNativeOutcome(result, userId, "android", d.token, r);
+        }),
+      );
+    }
+  }
+
+  for (const sub of webSubs) {
+    tasks.push(
+      sendWebPush(
+        {
+          endpoint: sub.endpoint,
+          keys: { p256dh: sub.p256dh, auth: sub.auth },
+        },
+        webPayloadJson,
+      ).then(async (wr) => {
+        recordDomainOutcome(wr.outcome);
+        if (wr.outcome === "ok") {
+          result.delivered.web++;
+          return;
+        }
+        if (wr.outcome === "invalid_endpoint") {
+          result.cleaned++;
+          try {
+            await softDeleteWebSubscription(userId, sub.endpoint);
+          } catch (e) {
+            logger.warn({
+              msg: "web_push_cleanup_failed",
+              user_id: userId,
+              err: { message: e instanceof Error ? e.message : String(e) },
+            });
+          }
+          return;
+        }
+        // rate_limited / timeout / circuit_open / error — логуємо per-push,
+        // і реєструємо як error-запис (без cleanup).
+        result.errors.push({
+          platform: "web",
+          reason: wr.errorMessage ?? wr.outcome,
+        });
+      }),
+    );
+  }
+
+  await Promise.all(tasks);
+
+  return result;
+}
+
+async function applyNativeOutcome(
+  result: SendToUserResult,
+  userId: string,
+  platform: "ios" | "android",
+  token: string,
+  r: SendOutcome,
+): Promise<void> {
+  if (r.delivered) {
+    result.delivered[platform]++;
+    recordDomainOutcome("ok");
+    return;
+  }
+  if (r.dead) {
+    result.cleaned++;
+    recordDomainOutcome("invalid_endpoint");
+    try {
+      await deleteNativeDevice(userId, platform, token, r.error ?? "unknown");
+    } catch (e) {
+      logger.warn({
+        msg: "native_token_cleanup_failed",
+        user_id: userId,
+        platform,
+        err: { message: e instanceof Error ? e.message : String(e) },
+      });
+    }
+    return;
+  }
+  recordDomainOutcome("error");
+  result.errors.push({
+    platform: platform as PushPlatform,
+    reason: r.error ?? "unknown",
+  });
+}
+
+// ─────────────────────────── Exports for tests ─────────────────────
+export const __TEST__ = {
+  RETRY_DELAYS_MS,
+  MAX_ATTEMPTS,
+};

--- a/apps/server/src/push/types.ts
+++ b/apps/server/src/push/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Типи серверного push-send шляху.
+ *
+ * `PushPayload` — cross-package контракт, живе у `@sergeant/shared`. Тут його
+ * лише ре-експортуємо, щоб всі серверні імпорти тримати у одному місці
+ * (`./push/types.js`), а пересунути джерело без dragnet-у по всьому apps/server.
+ */
+
+export type { PushPayload } from "@sergeant/shared";
+
+/** Платформи пушу, що підтримуються `sendToUser`. */
+export type PushPlatform = "ios" | "android" | "web";
+
+/**
+ * Структурований результат `sendToUser(userId, payload)`.
+ *
+ *   - `delivered` — скільки пушей успішно прийнято upstream-ом per platform.
+ *     Для APNs/FCM це 1 на кожен token, що повернув 2xx. Для web — 1 на кожну
+ *     підписку, що повернула `outcome: ok`.
+ *   - `cleaned` — скільки «мертвих» токенів/підписок ми видалили з БД у цьому
+ *     виклику (APNs 410/BadDeviceToken/Unregistered, FCM UNREGISTERED/
+ *     INVALID_ARGUMENT, web 404/410).
+ *   - `errors`  — per-platform список відмов, які НЕ призвели до cleanup
+ *     (транзієнтні 5xx/429 після retry-вичерпання, мережеві помилки,
+ *     невідомі reason-и). Caller може показувати, логувати або ігнорувати.
+ */
+export interface SendToUserResult {
+  delivered: { ios: number; android: number; web: number };
+  cleaned: number;
+  errors: { platform: PushPlatform; reason: string }[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,8 +1,39 @@
 /**
  * Спільні типи, що використовуються і на клієнті, і на сервері.
- * Наразі пусто — більшість доменних типів виводимо з Zod-схем через `z.infer`.
  *
- * Якщо знадобиться додати тип, що не має прямого Zod-відповідника (напр.
- * utility-типи, union, template literal), кидай його сюди.
+ * Більшість доменних типів виводимо з Zod-схем через `z.infer`; сюди йдуть
+ * лише ті, що не мають прямого Zod-відповідника (utility, union, cross-
+ * package контракти без валідації).
  */
-export {};
+
+/**
+ * Універсальний контракт вхідного push-payload-а для `sendToUser(userId, payload)`
+ * на сервері.
+ *
+ * Один shape для iOS/Android/Web — сервер сам мапить поля у APNs-aps /
+ * FCM-notification / web-push JSON відповідно:
+ *
+ *   - `title`/`body` → APNs `aps.alert.{title,body}`, FCM `notification.{title,body}`,
+ *     web-push JSON `{title, body}`.
+ *   - `data`        → APNs custom root keys, FCM `data` (stringified values), web-push
+ *                     JSON inline.
+ *   - `badge`       → APNs `aps.badge` (iOS app-icon counter). Android не має аналогу.
+ *   - `threadId`    → APNs `aps.thread-id` — групування нотифікацій у одну
+ *                     «розмову» на iOS. На інших платформах ігнорується.
+ *
+ * Контракт винесено в `@sergeant/shared` (а не тримано лише на сервері), щоб
+ * mobile/web handler-и могли типізувати свою сторону (payload.data у JS-коді
+ * клієнта) без дублювання форми.
+ */
+export interface PushPayload {
+  /** Заголовок нотифікації. Обов'язковий — всі три канали його вимагають. */
+  title: string;
+  /** Основний текст нотифікації. Порожній рядок — валідний. */
+  body?: string;
+  /** Додаткові дані клієнтського handler-а (серіалізуються у JSON). */
+  data?: Record<string, unknown>;
+  /** Бейдж iOS (число на іконці застосунку). Нуль скидає бейдж. */
+  badge?: number;
+  /** APNs `thread-id` — групує нотифікації у одному threadі на iOS. */
+  threadId?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       "@better-auth/expo":
         specifier: ^1.6.5
         version: 1.6.5(rq4ckbk645sy7enix3uajyasde)
+      "@parse/node-apn":
+        specifier: ^8.1.0
+        version: 8.1.0
       "@sentry/node":
         specifier: ^8.55.1
         version: 8.55.1
@@ -155,6 +158,9 @@ importers:
       express:
         specifier: ^4.22.1
         version: 4.22.1
+      google-auth-library:
+        specifier: ^10.6.2
+        version: 10.6.2
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -3108,6 +3114,13 @@ packages:
         integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==,
       }
 
+  "@parse/node-apn@8.1.0":
+    resolution:
+      {
+        integrity: sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA==,
+      }
+    engines: { node: 20 || 22 || 24 }
+
   "@pinojs/redact@0.4.0":
     resolution:
       {
@@ -4624,6 +4637,13 @@ packages:
         integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==,
       }
 
+  assert-plus@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==,
+      }
+    engines: { node: ">=0.8" }
+
   assert@2.1.0:
     resolution:
       {
@@ -4972,6 +4992,12 @@ packages:
         integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==,
       }
     engines: { node: ">=0.6" }
+
+  bignumber.js@9.3.1:
+    resolution:
+      {
+        integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==,
+      }
 
   binary-extensions@2.3.0:
     resolution:
@@ -5608,6 +5634,12 @@ packages:
         integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==,
       }
 
+  core-util-is@1.0.2:
+    resolution:
+      {
+        integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
+      }
+
   cosmiconfig@5.2.1:
     resolution:
       {
@@ -5694,6 +5726,13 @@ packages:
       {
         integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==,
       }
+
+  data-uri-to-buffer@4.0.1:
+    resolution:
+      {
+        integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==,
+      }
+    engines: { node: ">= 12" }
 
   data-urls@7.0.0:
     resolution:
@@ -6572,6 +6611,13 @@ packages:
         integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
       }
 
+  extsprintf@1.4.1:
+    resolution:
+      {
+        integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==,
+      }
+    engines: { "0": node >=0.6.0 }
+
   fast-copy@4.0.3:
     resolution:
       {
@@ -6662,6 +6708,13 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution:
+      {
+        integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==,
+      }
+    engines: { node: ^12.20 || >= 14.13 }
 
   fetch-retry@4.1.1:
     resolution:
@@ -6798,6 +6851,13 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  formdata-polyfill@4.0.10:
+    resolution:
+      {
+        integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==,
+      }
+    engines: { node: ">=12.20.0" }
+
   formidable@3.5.4:
     resolution:
       {
@@ -6913,6 +6973,20 @@ packages:
       {
         integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
       }
+
+  gaxios@7.1.4:
+    resolution:
+      {
+        integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==,
+      }
+    engines: { node: ">=18" }
+
+  gcp-metadata@8.1.2:
+    resolution:
+      {
+        integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==,
+      }
+    engines: { node: ">=18" }
 
   generator-function@2.0.1:
     resolution:
@@ -7075,6 +7149,20 @@ packages:
         integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
       }
     engines: { node: ">=10" }
+
+  google-auth-library@10.6.2:
+    resolution:
+      {
+        integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==,
+      }
+    engines: { node: ">=18" }
+
+  google-logging-utils@1.1.3:
+    resolution:
+      {
+        integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==,
+      }
+    engines: { node: ">=14" }
 
   gopd@1.2.0:
     resolution:
@@ -8024,6 +8112,12 @@ packages:
     engines: { node: ">=6" }
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution:
+      {
+        integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==,
+      }
+
   json-buffer@3.0.1:
     resolution:
       {
@@ -8080,6 +8174,13 @@ packages:
         integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==,
       }
     engines: { node: ">=0.10.0" }
+
+  jsonwebtoken@9.0.3:
+    resolution:
+      {
+        integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==,
+      }
+    engines: { node: ">=12", npm: ">=6" }
 
   jsx-ast-utils@3.3.5:
     resolution:
@@ -8312,10 +8413,52 @@ packages:
         integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
       }
 
+  lodash.includes@4.3.0:
+    resolution:
+      {
+        integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==,
+      }
+
+  lodash.isboolean@3.0.3:
+    resolution:
+      {
+        integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==,
+      }
+
+  lodash.isinteger@4.0.4:
+    resolution:
+      {
+        integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==,
+      }
+
+  lodash.isnumber@3.0.3:
+    resolution:
+      {
+        integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==,
+      }
+
+  lodash.isplainobject@4.0.6:
+    resolution:
+      {
+        integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==,
+      }
+
+  lodash.isstring@4.0.1:
+    resolution:
+      {
+        integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
+      }
+
   lodash.merge@4.6.2:
     resolution:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
+
+  lodash.once@4.1.1:
+    resolution:
+      {
+        integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
       }
 
   lodash.sortby@4.7.0:
@@ -9045,6 +9188,14 @@ packages:
       }
     engines: { node: ">= 0.10.5" }
 
+  node-domexception@1.0.0:
+    resolution:
+      {
+        integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==,
+      }
+    engines: { node: ">=10.5.0" }
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution:
       {
@@ -9063,6 +9214,13 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution:
+      {
+        integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   node-forge@1.4.0:
     resolution:
@@ -11828,6 +11986,13 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  verror@1.10.1:
+    resolution:
+      {
+        integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==,
+      }
+    engines: { node: ">=0.6.0" }
+
   vfile-message@4.0.3:
     resolution:
       {
@@ -14440,6 +14605,15 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.8.0
 
+  "@parse/node-apn@8.1.0":
+    dependencies:
+      debug: 4.4.3
+      jsonwebtoken: 9.0.3
+      node-forge: 1.4.0
+      verror: 1.10.1
+    transitivePeerDependencies:
+      - supports-color
+
   "@pinojs/redact@0.4.0": {}
 
   "@pkgjs/parseargs@0.11.0":
@@ -15525,6 +15699,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assert-plus@1.0.0: {}
+
   assert@2.1.0:
     dependencies:
       call-bind: 1.0.9
@@ -15751,6 +15927,8 @@ snapshots:
       require-from-string: 2.0.2
 
   big-integer@1.6.52: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -16113,6 +16291,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-util-is@1.0.2: {}
+
   cosmiconfig@5.2.1:
     dependencies:
       import-fresh: 2.0.0
@@ -16165,6 +16345,8 @@ snapshots:
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -16906,6 +17088,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extsprintf@1.4.1: {}
+
   fast-copy@4.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -16959,6 +17143,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fetch-retry@4.1.1: {}
 
@@ -17058,6 +17247,10 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       "@paralleldrive/cuid2": 2.3.1
@@ -17122,6 +17315,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -17225,6 +17434,19 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -17795,6 +18017,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -17818,6 +18044,19 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -17955,7 +18194,21 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.sortby@4.7.0: {}
 
@@ -18548,6 +18801,8 @@ snapshots:
     dependencies:
       minimatch: 3.1.5
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -18558,6 +18813,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.4.0: {}
 
@@ -20305,6 +20566,12 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  verror@1.10.1:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
 
   vfile-message@4.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Сесія 5A великого переходу Sergeant → native. PR додає **реальний серверний push sender** — до цього комміту сервер умів лише зберегти токен у `push_devices`, але не вмів з ним нічого зробити (жодного вихідного пуша).

Контракт — `sendToUser(userId, payload)` в `apps/server/src/push/send.ts`. Цей PR нічого не інтегрує у coach/reminders (сесія 5B) і не чіпає web legacy `/api/push/subscribe` (сесія 4C).

### Що додано

- **`apps/server/src/push/send.ts`** — `sendToUser`, `sendAPNs`, `sendFCM` та dead-token cleanup. Читає `push_devices` (для iOS/Android) + `push_subscriptions` (web), fan-out через `Promise.all`, повертає `{ delivered: { ios, android, web }, cleaned, errors }`. Ніколи не throw-ає; одна впала платформа не валить решту.
- **`apps/server/src/push/apnsClient.ts`** — lazy `@parse/node-apn` Provider з JWT-ключем. `loadApnsKey` нормалізує CRLF/`\r\n`/літеральні `\\n` у справжні `\n` перед передачею в TLS (типова помилка — `.env` з одинарними лапками, де bash лишив `\n` як 2 байти).
- **`apps/server/src/push/fcmClient.ts`** — OAuth2 через `google-auth-library`, кеш access-token-у з margin 60 с до `expiresAt`. FCM HTTP v1 endpoint (`/v1/projects/{project_id}/messages:send`); legacy `key=...` не використовуємо.
- **`apps/server/src/push/types.ts`** + **`packages/shared/src/types/index.ts`** — `PushPayload = { title, body?, data?, badge?, threadId? }` винесено у `@sergeant/shared`, щоб mobile/web handler-и могли типізувати свою сторону без дублювання.
- **`apps/server/src/push/send.test.ts`** — 26 юнітів: `loadApnsKey` едж-кейси, `sendAPNs` happy/dead/retry/exhaustion, `sendFCM` happy/UNREGISTERED/INVALID_ARGUMENT/503/429/401, `sendToUser` no-op/fan-out/cleanup. Все мокаємо — ні мережа, ні БД, ні `apn` http2 не чіпаються.

### Ключові рішення

**Retry policy.** 3 total attempts, exponential backoff delays між ними `200 мс → 1 с → 3 с`. Транзієнтні — APNs 5xx, FCM 5xx та 429. Решта 4xx (InvalidPushType, PayloadTooLarge, 401/403 мис-конфіг) — без retry: `setTimeout(200)` + повторна 401 це просто витрачені 200 мс.

**Dead-token cleanup.** APNs 410 / reason `BadDeviceToken` / `Unregistered` → `DELETE FROM push_devices WHERE platform = $1 AND token = $2`. FCM `UNREGISTERED` / `INVALID_ARGUMENT` (status або `details[*].errorCode`) / `NOT_FOUND` → те ж саме. Web 404/410 → soft-delete у `push_subscriptions` (mirror існуючого `sendPush` handler-а). Кожен cleanup супроводжує `logger.info` з `user_id`, `platform`, `reason`.

**Graceful degradation.** Без `APNS_P8_KEY` / `FCM_SERVICE_ACCOUNT_JSON` — warn-лог на boot (`"push sender disabled — no APNS_P8_KEY"`), `sendToUser` повертає `{ delivered: {0,0,0}, errors: [] }` і не крашиться. Per-env перевірки pokрyto warn-логами з показом, якого саме поля бракує (KeyId/TeamId/BundleId/projectId/clientEmail/privateKey).

**FCM OAuth-токен — кеш.** `google-auth-library`'s `JWT.authorize()` виконуємо lazy і кешуємо у модулі з margin 60 с до `expiresAt`. Margin потрібен бо між `getAccessToken()` та власне `fetch(...)` може пройти кілька секунд — без margin-у легко попасти у race, де токен зʼяснюється expired саме посередині call-у.

**FCM data serialization.** v1 API вимагає `data: map<string, string>`; number/bool/object кидають `INVALID_ARGUMENT`. `stringifyDataMap` конвертує все у string (number/bool → `String()`, objects → `JSON.stringify`), clients роблять `JSON.parse` зі свого боку. `undefined`/`null` дропаються.

### Секрети (опціонально)

Все gracefully degrade-иться без них. Якщо є — sender автоматично активується:

- `APNS_P8_KEY` — повний `.p8` content з `-----BEGIN PRIVATE KEY-----` (CRLF/escape-и нормалізуються автоматично)
- `APNS_KEY_ID` (10 символів), `APNS_TEAM_ID` (10 символів), `APNS_BUNDLE_ID` (наприклад `com.sergeant.app`), `APNS_PRODUCTION` (`true`/`false`, default `false`)
- `FCM_SERVICE_ACCOUNT_JSON` — **base64-encoded** service-account JSON (декодується і парситься на boot)

### Залежності

- `@parse/node-apn@^8.1.0` — http2 APNs client з JWT .p8 auth
- `google-auth-library@^10.6.2` — OAuth2 service-account JWT → access token для FCM v1

HTTP до FCM — вбудований `fetch` (Node 20+), жодних `axios`/`undici` dep-ів.

## Review & Testing Checklist for Human

- [ ] Запустити `pnpm --filter @sergeant/server test src/push/send.test.ts` — 26 юнітів мають бути зелені.
- [ ] Запустити сервер з пустими APNs/FCM env-ами — переконатись що НЕ крашиться й у логах є `"push sender disabled — no APNS_P8_KEY"` + `"push sender disabled — no FCM_SERVICE_ACCOUNT_JSON"`.
- [ ] (live-smoke) На dev-середовищі з реальними секретами викликати `sendToUser(userId, { title, body })` з REPL/test-endpoint-а і перевірити що пуш реально приходить на iOS-пристрій (встановлений через TestFlight/sandbox) — запланована для сесії 5B, але добре б переконатись зараз локально на sandbox, якщо є time.

### Test Plan

1. Юніт-покриття у `send.test.ts` — happy/dead/retry/exhaustion по APNs та FCM, no-op при 0 пристроїв, fan-out на всі 3 платформи, транзієнтні помилки у `errors[]` без cleanup.
2. Не потрібно ставити реальні APNs/FCM credentials у CI — код має degrade без них (перевірено тестом `returns disabled when provider is null` та `returns disabled when projectId is null`).

### Notes

- **НЕ** інтегрував `sendToUser` у coach/reminders — це сесія 5B.
- **НЕ** чіпав web legacy `/api/push/subscribe` — це сесія 4C.
- **НЕ** додавав `/api/v1/push/test` ендпоінт — це сесія 5B.
- Web fan-out викликає існуючий `sendWebPush` з `apps/server/src/lib/webpushSend.js` (circuit-breaker, timeout-и, retry — reusable у тому ж вигляді). Якщо пустити web-push через native fan-out без refactor-у — це саме те, що потрібно для сесії 4C, де `push_subscriptions` злиється у `push_devices`.

Link to Devin session: https://app.devin.ai/sessions/02f3960e250b4ae7b7cb88e05869cab8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
