### PR TITLE
fix(server/push): don't delete FCM tokens on INVALID_ARGUMENT

### DIFF
--- a/apps/server/src/push/send.test.ts
+++ b/apps/server/src/push/send.test.ts
@@ -338,7 +338,11 @@ describe("sendFCM", () => {
     expect(r.error).toBe("UNREGISTERED");
   });
 
-  it("returns dead=true on INVALID_ARGUMENT via details.errorCode", async () => {
+  it("does NOT mark token dead on INVALID_ARGUMENT (ambiguous between token and payload)", async () => {
+    // FCM v1 повертає INVALID_ARGUMENT як для malformed token, так і для
+    // malformed payload. Payload однаковий для всього fan-out-у, тож якщо
+    // позначити токен як dead у відповідь на payload-error — знесемо всі
+    // Android-токени юзера разом. Лишаємо у `errors[]`, без cleanup.
     fetchMock.mockResolvedValueOnce(
       resp(400, {
         error: {
@@ -354,7 +358,26 @@ describe("sendFCM", () => {
       }),
     );
     const r = await sendFCM("u1", "tok", { title: "hi" });
+    expect(r.delivered).toBe(false);
+    expect(r.dead).toBe(false);
+    expect(r.error).toBe("INVALID_ARGUMENT");
+  });
+
+  it("returns dead=true on SENDER_ID_MISMATCH", async () => {
+    // Токен зареєстровано під іншим Firebase project — нашим projectId він
+    // ніколи не стане валідним, безпечно DELETE.
+    fetchMock.mockResolvedValueOnce(
+      resp(403, {
+        error: {
+          code: 403,
+          status: "SENDER_ID_MISMATCH",
+          message: "SenderId mismatch",
+        },
+      }),
+    );
+    const r = await sendFCM("u1", "tok", { title: "hi" });
     expect(r.dead).toBe(true);
+    expect(r.error).toBe("SENDER_ID_MISMATCH");
   });
 
   it("retries on 503 and succeeds", async () => {

--- a/apps/server/src/push/send.ts
+++ b/apps/server/src/push/send.ts
@@ -236,10 +236,23 @@ export async function sendAPNs(
 /**
  * FCM error status codes that mean the token is permanently invalid. See
  * https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode.
+ *
+ * `INVALID_ARGUMENT` навмисно НЕ у цьому сеті: FCM v1 повертає його як для
+ * зламаного токена, так і для malformed-payload (наприклад, data зі значенням
+ * не-string — див. `stringifyDataMap`). Payload однаковий для всього fan-out-у,
+ * тож класифікація INVALID_ARGUMENT як dead означала б, що один багнутий
+ * payload знесе ВСІ Android-токени юзера разом. Краще лишити їх й дати мережі
+ * діагностувати, ніж проактивно видаляти валідні.
+ *
+ * `SENDER_ID_MISMATCH` — токен зареєстровано під іншим Firebase project, нашим
+ * проектом він ніколи не стане валідним → видаляємо.
+ *
+ * `NOT_FOUND` — не канонічний v1-код, але історично зустрічається у v1 wrappers
+ * і legacy HTTP API; лишаємо на випадок, якщо хтось прокинеться з старого SDK.
  */
 const FCM_DEAD_STATUSES = new Set([
   "UNREGISTERED",
-  "INVALID_ARGUMENT",
+  "SENDER_ID_MISMATCH",
   "NOT_FOUND",
 ]);
 


### PR DESCRIPTION
## Summary

Follow-up до #397 (session 5A). Devin Review знайшло реальний баг у dead-token cleanup правилах для FCM:

**Проблема.** `INVALID_ARGUMENT` у FCM v1 повертається і для malformed token, і для malformed payload ([docs](https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode)). У `sendToUser` той самий payload йде одночасно на всі Android-токени юзера, тож якщо відмарковувати dead на INVALID_ARGUMENT — **одна payload-регресія (наприклад, `badge: NaN` або `data` з не-string значенням) знесе ВСІ Android-токени юзера за один fan-out**. Юзеру довелось би перевстановлювати app або re-register-ити. Не круто.

**Фікс.** Прибрав `INVALID_ARGUMENT` з `FCM_DEAD_STATUSES`. Такі помилки тепер ідуть у `errors[]` без DELETE — upstream побачить реальний root cause у логах/метриках замість тихо зниклих токенів.

**Бонус.** Додав `SENDER_ID_MISMATCH` у dead-сет. Це «токен зареєстровано під іншим Firebase project» — нашим projectId він не стане валідним ніколи, безпечно DELETE. Канонічний FCM v1 error code; у PR #397 я його пропустив.

Тест `INVALID_ARGUMENT → dead=true` перефокусовано на поточну поведінку: `dead=false, error=INVALID_ARGUMENT`. Плюс новий тест `SENDER_ID_MISMATCH → dead=true`. 28/28 юнітів зелені, typecheck/lint чисті.

## Review & Testing Checklist for Human

- [ ] Підтвердити, що моя інтерпретація specʼа (`"FCM UNREGISTERED / INVALID_ARGUMENT (для токен-частини)"`) співпадає з очікуваною: INVALID_ARGUMENT без способу надійно відрізнити токен від payload → краще _не_ видаляти. Якщо потрібна агресивна cleanup-логіка — треба окрема heuristic на `error.details[*].errorCode === "INVALID_ARGUMENT"` + аналіз message, що хиткіше.
- [ ] Перевірити актуальні FCM error codes на `SENDER_ID_MISMATCH` — у поточному ingestion path точно повинні бути токени зі зміненим project-id? Якщо у вас rotation policy на FCM project, це релевантно.
- [ ] Swim-через тестові юніти: `pnpm --filter @sergeant/server test src/push/send.test.ts` — 28/28.

### Notes

- Live-smoke (session 5B/6A) природно покриє обидва сценарії: malformed-payload в staging → токени лишаються, dead-device → UNREGISTERED → cleanup.
- `NOT_FOUND` лишаю у dead-сеті — формально не канонічний v1-код, але зустрічається у wrapper-ах і legacy HTTP API; залишаю до першої реальної false-positive.

Link to Devin session: https://app.devin.ai/sessions/02f3960e250b4ae7b7cb88e05869cab8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
