### PR TITLE
docs: fix R2 PR reference in react-native-migration.md

### DIFF
--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -411,7 +411,7 @@ Web використовує кастомні компоненти + canvas/SVG.
 у пакети. План рефакторингів-супутників:
 
 - **R1.** ✅ Done (PR [#405](https://github.com/Skords-01/Sergeant/pull/405)). `storageKeys.ts` → `@sergeant/shared`.
-- **R2.** ✅ Done (PR [#415](https://github.com/Skords-01/Sergeant/pull/415)). `hubSearchEngine.ts` (pure-скорінг) +
+- **R2.** ✅ Done (PR [#414](https://github.com/Skords-01/Sergeant/pull/414)). `hubSearchEngine.ts` (pure-скорінг) +
   типи/реєстр рекомендацій + усі finance-правила вийняті у новий
   DOM-free пакет `@sergeant/insights`; LS-обгортки (`buildFinanceContext`,
   recents для пошуку, orchestrator `generateRecommendations`) лишились у


### PR DESCRIPTION
## Summary

Follow-up до [#414](https://github.com/Skords-01/Sergeant/pull/414) — у `docs/react-native-migration.md` §11 пункт R2 вказував PR `#415`, бо в момент написання опису я не знав фактичного номера мерджу. Правильний номер — `#414`.

Зміна — одна цифра.

## Review & Testing Checklist for Human

- [ ] Глянути, що посилання R2 веде на справжній мерджнутий PR.

### Notes

Нульовий ризик — тільки markdown.

Link to Devin session: https://app.devin.ai/sessions/6dc57c1c89664ed9becd0d0d9522e676
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
