### PR TITLE
chore(deps): pin react-server-dom-webpack ^19.0.2 via pnpm override (unblock Railway)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,10 @@
     "*.{json,md,css,html,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "react-server-dom-webpack": "^19.0.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react-server-dom-webpack: ^19.0.2
+
 importers:
   .:
     devDependencies:
@@ -11293,15 +11296,15 @@ packages:
       react-dom:
         optional: true
 
-  react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610:
+  react-server-dom-webpack@19.2.5:
     resolution:
       {
-        integrity: sha512-nr+IsOVD07QdeCr4BLvR5TALfLaZLi9AIaoa6vXymBc051iDPWedJujYYrjRJy5+9jp9oCx3G8Tt/Bs//TckJw==,
+        integrity: sha512-bYhdd2cZJhXHqyJBoloYaJrn8MrL9Egf3ZZVn0OrIODCCORm2goFD7C+xszf6xgfsSJi0rtgB/ichcuHfkJ4yQ==,
       }
     engines: { node: ">=0.10.0" }
     peerDependencies:
-      react: 19.0.0-rc-6230622a1a-20240610
-      react-dom: 19.0.0-rc-6230622a1a-20240610
+      react: ^19.2.5
+      react-dom: ^19.2.5
       webpack: ^5.59.0
 
   react-shallow-renderer@16.15.0:
@@ -19680,7 +19683,7 @@ snapshots:
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
-      react-server-dom-webpack: 19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.2)
+      react-server-dom-webpack: 19.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.2)
       react-test-renderer: 18.3.1(react@18.3.1)
       server-only: 0.0.1
       stacktrace-js: 2.0.2
@@ -21614,13 +21617,14 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.2):
+  react-server-dom-webpack@19.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.106.2):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       webpack: 5.106.2
+      webpack-sources: 3.3.4
 
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Railway-деплой на `main` зараз падає на security-gate з CRITICAL-вразливістю у транзитивній залежності, ще до того як встигає зібратись Docker-образ:

```
SECURITY VULNERABILITIES DETECTED
Found 1 vulnerable package(s):
  react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610
  Source: pnpm-lock.yaml
  Severity: CRITICAL
  Upgrade to 19.0.2: pnpm add react-server-dom-webpack@^19.0.2

CVE-2025-55183 (MEDIUM) — Next.js GHSA-w37m-7fhw-fmv9
CVE-2025-55184 (HIGH)  — Next.js GHSA-mwv6-3258-q52c
CVE-2025-66478 (CRITICAL) — Next.js GHSA-9qr9-h5gf-34mp
```

Цей пакет тягне транзитивно `jest-expo@52.0.6` (devDependency в `apps/mobile`). У нашому `Dockerfile.api` він не ставиться взагалі (`pnpm install --filter @sergeant/server... --filter @sergeant/shared...`), але сканер Railway читає повний `pnpm-lock.yaml`, а не фактично встановлений набір.

### Що зробив

Додав `pnpm.overrides` у корінь `package.json`, щоб прибити всі входження до залатаної версії `^19.0.2`:

```json
"pnpm": {
  "overrides": {
    "react-server-dom-webpack": "^19.0.2"
  }
}
```

Після `pnpm install` лок резолвнувся на `react-server-dom-webpack@19.2.5`.

### Перевірки

- `pnpm turbo run lint typecheck test` — 27 tasks, зелено (15 cached, 12 executed).
- `grep react-server-dom-webpack pnpm-lock.yaml` — усі записи вже на `19.2.5`.
- `pnpm install` виводить peer-warning'и виду «react-server-dom-webpack 19.2.5 wants react@^19.2.5, found 18.3.1» — це не регресія: RC-версія вимагала того ж, і `jest-expo` тільки вантажить код у тестовому хелпері. Фактична рантайм-поведінка не зачеплена.

### Why a one-shot chore PR

Останні 3 мерджі в main (#414, #416, #417) падали у Railway на цьому самому правилі. Після цього PR Railway має пустити наступний деплой.

## Review & Testing Checklist for Human

- [ ] Після мерджу — глянути наступний Railway-деплой, що він уже проходить security-gate.
- [ ] На всяк випадок — відкрити apps/web (Vercel-preview) і перевірити, що мобайл/тести й далі працюють локально (`pnpm turbo run test --filter @sergeant/mobile`).

### Notes

- Не торкався `apps/mobile` / Expo SDK — bump'ати `jest-expo` поза скоупом.
- Якщо Railway в майбутньому знайде ще CVE — робимо так само через `overrides`.

Link to Devin session: https://app.devin.ai/sessions/6dc57c1c89664ed9becd0d0d9522e676
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
