### PR TITLE
refactor(R7): promote haptic contract to @sergeant/shared with web/mobile adapters

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -9,6 +9,9 @@ import { ApiClientProvider } from "@sergeant/api-client/react";
 
 import { apiClient } from "@/api/apiClient";
 import { PushRegistrar } from "@/features/push/PushRegistrar";
+// Registers the mobile `expo-haptics`-based adapter on the shared
+// haptic contract (`@sergeant/shared`). Import for side effects only.
+import "@/lib/haptic";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { CloudSyncProvider } from "@/sync";
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo": "~52.0.0",
     "expo-constants": "~17.0.8",
     "expo-dev-client": "~5.0.20",
+    "expo-haptics": "~14.0.1",
     "expo-linking": "~7.0.5",
     "expo-notifications": "~0.29.14",
     "expo-router": "~4.0.21",

--- a/apps/mobile/src/lib/haptic.ts
+++ b/apps/mobile/src/lib/haptic.ts
@@ -1,0 +1,56 @@
+/**
+ * Mobile adapter for the shared haptic contract.
+ *
+ * Maps the six contract primitives to `expo-haptics`:
+ *  - `tap`      → `Haptics.selectionAsync()` (subtle UI select feedback);
+ *  - `success`  → `Haptics.notificationAsync(Success)`;
+ *  - `warning`  → `Haptics.notificationAsync(Warning)`;
+ *  - `error`    → `Haptics.notificationAsync(Error)`;
+ *  - `cancel`   → a light impact (`ImpactFeedbackStyle.Light`) — there is
+ *    no native "cancel" haptic, so we fall back to the lightest impact
+ *    the user still perceives;
+ *  - `pattern`  → intentional no-op (see note below).
+ *
+ * Importing this module has the side-effect of registering the mobile
+ * adapter on the shared contract. Do this once from `app/_layout.tsx`.
+ */
+
+import * as Haptics from "expo-haptics";
+
+import { setHapticAdapter, type HapticAdapter } from "@sergeant/shared";
+
+function safe(run: () => Promise<unknown> | void): void {
+  try {
+    void run();
+  } catch {
+    /* expo-haptics rejects on web / unsupported hardware — swallow */
+  }
+}
+
+export const mobileHapticAdapter: HapticAdapter = {
+  tap: () => safe(() => Haptics.selectionAsync()),
+  success: () =>
+    safe(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success),
+    ),
+  warning: () =>
+    safe(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning),
+    ),
+  error: () =>
+    safe(() =>
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error),
+    ),
+  cancel: () =>
+    safe(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)),
+  // TODO: React Native / expo-haptics does not expose a vibrate-pattern
+  // API comparable to `navigator.vibrate([on, off, on, …])`. Android's
+  // Vibrator API restricts custom patterns on API 30+ without the
+  // VIBRATE permission, and iOS has no public custom-pattern hook.
+  // If we ever need cadenced haptics on mobile we can gate behind a
+  // Platform check and call `Vibration.vibrate(pattern)` from
+  // `react-native`.
+  pattern: () => {},
+};
+
+setHapticAdapter(mobileHapticAdapter);

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -6,6 +6,9 @@ import App from "./core/App";
 import "./index.css";
 import { storageManager } from "@shared/lib/storageManager.js";
 import { createAppQueryClient } from "@shared/lib/queryClient.js";
+// Registers the web `navigator.vibrate`-based adapter on the shared
+// haptic contract (`@sergeant/shared`). Import for side effects only.
+import "@shared/lib/haptic";
 import { ErrorBoundary } from "./core/ErrorBoundary.jsx";
 import { initSentry } from "./core/sentry.js";
 import { initWebVitals } from "./core/webVitals.js";

--- a/apps/web/src/shared/lib/haptic.ts
+++ b/apps/web/src/shared/lib/haptic.ts
@@ -1,20 +1,31 @@
 /**
- * Тонкий шар над `navigator.vibrate`, який:
- *  1) вимикається, коли користувач ввімкнув `prefers-reduced-motion`;
- *  2) тихо робить no-op на платформах без підтримки (iOS Safari, настільні);
- *  3) ловить винятки, бо деякі мобільні Chrome кидають `NotAllowedError`,
- *     якщо викликати `vibrate` поза user-gesture.
+ * Web adapter for the shared haptic contract.
  *
- * Патерни вибрані так, щоб співпасти з фізичним очікуванням від дії:
- *  - `tap`      — легкий тап (10 мс), primary CTA, toggle, tab change;
- *  - `success`  — подвійний короткий (12/40/18), успішне збереження;
- *  - `warning`  — 30 мс, destructive confirm;
- *  - `error`    — 60/60/60, помилка мережі / валідації.
+ * Binds the `@sergeant/shared` haptic contract to `navigator.vibrate`
+ * with the same guards the web app has always relied on:
+ *  1) no-op when the user has `prefers-reduced-motion: reduce`;
+ *  2) no-op on platforms without `navigator.vibrate` (iOS Safari,
+ *     desktop);
+ *  3) swallows exceptions — some mobile Chrome builds throw
+ *     `NotAllowedError` when `vibrate` is called outside a user
+ *     gesture, or throttle the call silently.
  *
- * Використовуй `hapticPattern` напряму для особливих сценаріїв (наприклад,
- * фінішер тренування вже вібрує [200, 100, 200] у Fizruk — цей модуль
- * не знижує його "силу").
+ * Importing this module has the side-effect of registering the web
+ * adapter on the shared contract, so existing
+ * `import { hapticTap } from "@shared/lib/haptic"` call sites keep
+ * working unchanged.
  */
+
+import {
+  hapticCancel,
+  hapticError,
+  hapticPattern,
+  hapticSuccess,
+  hapticTap,
+  hapticWarning,
+  setHapticAdapter,
+  type HapticAdapter,
+} from "@sergeant/shared";
 
 function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
@@ -30,7 +41,7 @@ function canVibrate(): boolean {
   return typeof navigator.vibrate === "function";
 }
 
-export function hapticPattern(pattern: number | number[]): void {
+function vibrate(pattern: number | number[]): void {
   if (!canVibrate() || prefersReducedMotion()) return;
   try {
     navigator.vibrate(pattern);
@@ -39,32 +50,32 @@ export function hapticPattern(pattern: number | number[]): void {
   }
 }
 
-/** Легкий tap — головні CTAs, toggles, tab switch. */
-export function hapticTap(): void {
-  hapticPattern(10);
-}
+export const webHapticAdapter: HapticAdapter = {
+  tap: () => vibrate(10),
+  success: () => vibrate([12, 40, 18]),
+  warning: () => vibrate(30),
+  error: () => vibrate([60, 60, 60]),
+  cancel: () => {
+    // Intentionally bypasses the reduced-motion guard — cancelling an
+    // in-flight vibration should always succeed regardless of the
+    // user's motion preference.
+    if (!canVibrate()) return;
+    try {
+      navigator.vibrate(0);
+    } catch {
+      /* noop */
+    }
+  },
+  pattern: vibrate,
+};
 
-/** Успішне збереження / завершення дії. */
-export function hapticSuccess(): void {
-  hapticPattern([12, 40, 18]);
-}
+setHapticAdapter(webHapticAdapter);
 
-/** Попередження / destructive confirm. */
-export function hapticWarning(): void {
-  hapticPattern(30);
-}
-
-/** Помилка (мережа, валідація, немає доступу). */
-export function hapticError(): void {
-  hapticPattern([60, 60, 60]);
-}
-
-/** Скасовує поточну вібрацію (наприклад, під час довгого натискання). */
-export function hapticCancel(): void {
-  if (!canVibrate()) return;
-  try {
-    navigator.vibrate(0);
-  } catch {
-    /* noop */
-  }
-}
+export {
+  hapticCancel,
+  hapticError,
+  hapticPattern,
+  hapticSuccess,
+  hapticTap,
+  hapticWarning,
+};

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -515,12 +515,20 @@ Web використовує кастомні компоненти + canvas/SVG.
   `@sergeant/shared/schemas`, перевірити, щоб `apps/mobile` тягнув
   звідти, а не дублював.
 - **R6.** ✅ Done (PR [#406](https://github.com/Skords-01/Sergeant/pull/406)). Tailwind preset + дизайн-токени у `@sergeant/design-tokens`; `apps/web/tailwind.config.js` і `apps/mobile/tailwind.config.js` обидва споживають один preset.
-- **R7.** Винести `shared/lib/haptic.ts` у двох-адаптерний вигляд:
-  PURE-контракт (`hapticTap/Success/Warning/Error/Cancel`) у
-  `@sergeant/shared`, web-імплементація на `navigator.vibrate`
-  залишається в `apps/web`, mobile-імплементація через `expo-haptics`
-  у `apps/mobile/src/lib/haptic.ts`. Консьюмери (`@sergeant/finyk-domain`,
-  UI-примітиви) імпортують з `@sergeant/shared`.
+- **R7.** ✅ Done (PR [#424](https://github.com/Skords-01/Sergeant/pull/424)).
+  `shared/lib/haptic.ts` розібрано на два адаптери. PURE-контракт
+  (`HapticAdapter` + `setHapticAdapter` + `hapticTap/Success/Warning/Error/Cancel/Pattern`)
+  живе у `@sergeant/shared/lib/haptic` із безпечним no-op-адаптером за
+  замовчуванням. Web-імплементація на `navigator.vibrate` (з reduced-motion
+  - feature-detect + try/catch) залишається у
+    `apps/web/src/shared/lib/haptic.ts` і реєструється один раз у
+    `apps/web/src/main.jsx` через side-effect-імпорт. Mobile-імплементація
+    через `expo-haptics` (`selectionAsync`, `notificationAsync(Success/Warning/Error)`,
+    `impactAsync(Light)` для cancel; `pattern` — no-op з TODO) живе у
+    `apps/mobile/src/lib/haptic.ts` і реєструється у
+    `apps/mobile/app/_layout.tsx`. Консьюмери (`@sergeant/finyk-domain`,
+    UI-примітиви, `apps/web/*`) імпортують хелпери з `@sergeant/shared` без
+    знання про платформу.
 - **R8.** Винести `downloadJson(filename, payload)` у адаптер:
   web — `Blob` + `URL.createObjectURL` + `a.download`; mobile —
   `expo-file-system.writeAsStringAsync` у `cacheDirectory` +

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,6 @@ export * from "./types";
 
 // Shared, DOM-free constants (storage keys, etc.)
 export * from "./lib/storageKeys";
+
+// DOM-free haptic contract (platform adapters register at app bootstrap).
+export * from "./lib/haptic";

--- a/packages/shared/src/lib/haptic.test.ts
+++ b/packages/shared/src/lib/haptic.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  hapticCancel,
+  hapticError,
+  hapticPattern,
+  hapticSuccess,
+  hapticTap,
+  hapticWarning,
+  resetHapticAdapter,
+  setHapticAdapter,
+  type HapticAdapter,
+} from "./haptic";
+
+function makeMockAdapter(): HapticAdapter {
+  return {
+    tap: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    cancel: vi.fn(),
+    pattern: vi.fn(),
+  };
+}
+
+describe("shared haptic contract", () => {
+  beforeEach(() => {
+    resetHapticAdapter();
+  });
+
+  it("no-op default adapter does not throw", () => {
+    expect(() => hapticTap()).not.toThrow();
+    expect(() => hapticSuccess()).not.toThrow();
+    expect(() => hapticWarning()).not.toThrow();
+    expect(() => hapticError()).not.toThrow();
+    expect(() => hapticCancel()).not.toThrow();
+    expect(() => hapticPattern(10)).not.toThrow();
+    expect(() => hapticPattern([10, 20, 30])).not.toThrow();
+  });
+
+  it("routes every helper to the registered adapter", () => {
+    const adapter = makeMockAdapter();
+    setHapticAdapter(adapter);
+
+    hapticTap();
+    hapticSuccess();
+    hapticWarning();
+    hapticError();
+    hapticCancel();
+    hapticPattern(25);
+    hapticPattern([10, 20, 30]);
+
+    expect(adapter.tap).toHaveBeenCalledTimes(1);
+    expect(adapter.success).toHaveBeenCalledTimes(1);
+    expect(adapter.warning).toHaveBeenCalledTimes(1);
+    expect(adapter.error).toHaveBeenCalledTimes(1);
+    expect(adapter.cancel).toHaveBeenCalledTimes(1);
+    expect(adapter.pattern).toHaveBeenCalledTimes(2);
+    expect(adapter.pattern).toHaveBeenNthCalledWith(1, 25);
+    expect(adapter.pattern).toHaveBeenNthCalledWith(2, [10, 20, 30]);
+  });
+
+  it("supports swapping adapters at runtime", () => {
+    const first = makeMockAdapter();
+    const second = makeMockAdapter();
+
+    setHapticAdapter(first);
+    hapticTap();
+
+    setHapticAdapter(second);
+    hapticTap();
+    hapticSuccess();
+
+    expect(first.tap).toHaveBeenCalledTimes(1);
+    expect(first.success).not.toHaveBeenCalled();
+    expect(second.tap).toHaveBeenCalledTimes(1);
+    expect(second.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetHapticAdapter restores the no-op default", () => {
+    const adapter = makeMockAdapter();
+    setHapticAdapter(adapter);
+    hapticTap();
+    expect(adapter.tap).toHaveBeenCalledTimes(1);
+
+    resetHapticAdapter();
+    hapticTap();
+    // No further calls on the previously-registered adapter.
+    expect(adapter.tap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/lib/haptic.ts
+++ b/packages/shared/src/lib/haptic.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure, DOM-free haptic contract for cross-platform (web + mobile) use.
+ *
+ * The contract defines the six primitives (`tap`, `success`, `warning`,
+ * `error`, `cancel`, `pattern`) that every consumer calls through the
+ * top-level helpers exported from this module. The actual physical
+ * implementation is registered once at app bootstrap via
+ * `setHapticAdapter`:
+ *   - `apps/web` registers a `navigator.vibrate`-based adapter with
+ *     reduced-motion + feature-detect guards.
+ *   - `apps/mobile` registers an `expo-haptics`-based adapter.
+ *
+ * Before any adapter registers, a built-in no-op adapter is active, so
+ * calling any of the helpers from SSR / unit tests / pure domain code is
+ * safe.
+ */
+
+export interface HapticAdapter {
+  tap(): void;
+  success(): void;
+  warning(): void;
+  error(): void;
+  cancel(): void;
+  pattern(pattern: number | number[]): void;
+}
+
+const noopAdapter: HapticAdapter = {
+  tap: () => {},
+  success: () => {},
+  warning: () => {},
+  error: () => {},
+  cancel: () => {},
+  pattern: () => {},
+};
+
+let currentAdapter: HapticAdapter = noopAdapter;
+
+/**
+ * Registers the active haptic adapter. Call once at app startup (web:
+ * `apps/web/src/main.jsx`, mobile: `apps/mobile/app/_layout.tsx`).
+ * Later calls replace the previously-registered adapter, which is useful
+ * for test harnesses and storybook-like showcases.
+ */
+export function setHapticAdapter(adapter: HapticAdapter): void {
+  currentAdapter = adapter;
+}
+
+/**
+ * Restores the built-in no-op adapter. Intended for unit tests; production
+ * code should not need this.
+ */
+export function resetHapticAdapter(): void {
+  currentAdapter = noopAdapter;
+}
+
+/** Light tap — primary CTAs, toggles, tab switches. */
+export function hapticTap(): void {
+  currentAdapter.tap();
+}
+
+/** Successful save / completion. */
+export function hapticSuccess(): void {
+  currentAdapter.success();
+}
+
+/** Warning / destructive confirm. */
+export function hapticWarning(): void {
+  currentAdapter.warning();
+}
+
+/** Error (network / validation / denied). */
+export function hapticError(): void {
+  currentAdapter.error();
+}
+
+/** Cancels any currently running haptic feedback. */
+export function hapticCancel(): void {
+  currentAdapter.cancel();
+}
+
+/**
+ * Plays a custom pattern. Accepts a single duration in ms or an array of
+ * `[on, off, on, off, …]` durations. Mobile implementations may treat
+ * this as a no-op — see `apps/mobile/src/lib/haptic.ts`.
+ */
+export function hapticPattern(pattern: number | number[]): void {
+  currentAdapter.pattern(pattern);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       expo-dev-client:
         specifier: ~5.0.20
         version: 5.0.20(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
+      expo-haptics:
+        specifier: ~14.0.1
+        version: 14.0.1(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-linking:
         specifier: ~7.0.5
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -7111,6 +7114,14 @@ packages:
     peerDependencies:
       expo: "*"
       react: "*"
+
+  expo-haptics@14.0.1:
+    resolution:
+      {
+        integrity: sha512-V81FZ7xRUfqM6uSI6FA1KnZ+QpEKnISqafob/xEfcx1ymwhm4V3snuLWWFjmAz+XaZQTqlYa8z3QbqEXz7G63w==,
+      }
+    peerDependencies:
+      expo: "*"
 
   expo-json-utils@0.14.0:
     resolution:
@@ -18604,6 +18615,10 @@ snapshots:
       expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       fontfaceobserver: 2.3.0
       react: 18.3.1
+
+  expo-haptics@14.0.1(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
 
   expo-json-utils@0.14.0: {}
 


### PR DESCRIPTION
## Summary

Promotes the haptic helper API to a pure, DOM-free contract in `@sergeant/shared` and splits the platform-specific implementations into per-app adapters. Precedent: R1 / PR #405 (`storageKeys` promotion).

**What changed**

- **`@sergeant/shared/lib/haptic`** — new pure contract:
  - `HapticAdapter` interface: `{ tap, success, warning, error, cancel, pattern(pattern: number | number[]) }`.
  - Module-level `setHapticAdapter(adapter)` + `resetHapticAdapter()` (test helper).
  - Six top-level helpers (`hapticTap`, `hapticSuccess`, `hapticWarning`, `hapticError`, `hapticCancel`, `hapticPattern`) that delegate to the currently-registered adapter.
  - Built-in no-op adapter is installed by default, so calls from SSR, unit tests, or pure domain code are safe before any app bootstrap has run.
  - Re-exported from `packages/shared/src/index.ts`.
  - Unit test (`haptic.test.ts`) covers: no-op default does not throw; every helper routes to the registered adapter; adapters can be swapped at runtime; `resetHapticAdapter` restores the no-op.
- **`apps/web/src/shared/lib/haptic.ts`** — rewritten as a thin web-only adapter on top of `navigator.vibrate`. Preserves all three historical guards exactly: `prefers-reduced-motion` check, `typeof navigator.vibrate === "function"` feature-detect, `try/catch` around the call for `NotAllowedError` / browser throttling. `cancel` intentionally bypasses the reduced-motion guard (same as before). Importing the file registers `webHapticAdapter` via `setHapticAdapter` and re-exports the six helpers from `@sergeant/shared`, so every existing `import { hapticX } from "@shared/lib/haptic"` call site keeps working unchanged (10 call sites in `apps/web/src/**`, none rewritten).
- **`apps/web/src/main.jsx`** — side-effect import of `@shared/lib/haptic` added alongside the other web-only bootstraps (`storageManager`, query client) so registration is unambiguous even if the first consumer hasn't loaded yet.
- **`apps/mobile/package.json`** — adds `expo-haptics: ~14.0.1` (the version bundled with Expo SDK 52). `pnpm install` resolved cleanly; `pnpm-lock.yaml` updated.
- **`apps/mobile/src/lib/haptic.ts`** — new mobile adapter built on `expo-haptics`: `selectionAsync()` for `tap`, `notificationAsync(Success/Warning/Error)` for the three feedback kinds, `impactAsync(ImpactFeedbackStyle.Light)` for `cancel` (there is no native "cancel" haptic, so the lightest impact is the closest analogue). `pattern` is an intentional no-op with a TODO explaining why — `expo-haptics` has no direct vibrate-pattern API and Android 10+ restricts custom `Vibrator` patterns without the `VIBRATE` permission. All calls are wrapped in a `safe()` helper so unsupported hardware or web-preview mode degrades gracefully.
- **`apps/mobile/app/_layout.tsx`** — side-effect import of `@/lib/haptic` added so the mobile adapter registers once at root-layout mount.
- **`docs/react-native-migration.md` §11 R7** — updated from "планується" to ✅ Done with a link to this PR, matching the format used for R1/R2/R3/R4/R6.

**Adapter registration pattern**

```
┌──────────────────────────────────┐
│    @sergeant/shared/lib/haptic   │
│  HapticAdapter + setHapticAdapter│
│  hapticTap / hapticSuccess / …   │
│  default: built-in no-op adapter │
└────────────┬─────────────────────┘
             │ imported by
    ┌────────┴─────────┐
    ▼                  ▼
apps/web            apps/mobile
side-effect         side-effect
import registers    import registers
navigator.vibrate   expo-haptics
adapter             adapter
```

Every consumer (UI primitives, `@sergeant/finyk-domain`, `@sergeant/fizruk-domain`, feature code) imports platform-agnostic helpers from `@sergeant/shared`. The app shell registers the right adapter once at bootstrap. No DOM / `navigator` references leak into `@sergeant/shared`.

**Why this matters now**

Prerequisite for mobile Phases 2, 4, and 6 — once `Button`, `Toggle`, `Tabs`, finance, routine, and fizruk modules port to RN, they need to call the same `hapticTap` / `hapticSuccess` helpers without caring whether they're on web or native. Shipping this adapter split before those phases keeps each mobile-port PR small and focused on UI, not plumbing.

**Verification**

- `pnpm turbo run lint typecheck test --filter=@sergeant/shared --filter=@sergeant/mobile --filter=@sergeant/web` — all 9 tasks green locally.
- New shared unit test (`src/lib/haptic.test.ts`) — 4 tests, all pass (5 test files / 30 tests in `@sergeant/shared` overall).
- Spot-check: `grep -rn 'from "@shared/lib/haptic"' apps/web/src` — still resolves to 10 existing imports, none rewritten.

## Review & Testing Checklist for Human

Risk: yellow — pure-ish refactor, but it touches every `hapticX` call site indirectly and adds a new native module (`expo-haptics`) to the mobile runtime.

- [ ] On web (PWA on Android Chrome), confirm `hapticTap` / `hapticSuccess` / `hapticWarning` / `hapticError` still vibrate (toggle a habit, save a manual expense, trigger a destructive confirm, submit a form with a validation error). Compare against `main` — perception of strength should be identical.
- [ ] On web with OS-level "Reduce motion" enabled (Android → Accessibility → Remove animations, or iOS → Settings → Accessibility → Motion), confirm vibration is silent — the reduced-motion guard must still kick in.
- [ ] On mobile dev client, confirm the haptic adapter registers at app start (no runtime error importing `@/lib/haptic` from `_layout.tsx`) and that a primary CTA / tab switch produces the expected `selectionAsync` feedback on iOS and Android.
- [ ] Confirm CI passes green on this PR (lint + typecheck + tests for all affected packages).

### Notes

- Hard constraints were respected: no UI primitive code was touched, no `sync/*` code was touched, no web call sites were rewritten. The shared package stays DOM-free (no `window` / `navigator` references).
- `hapticPattern(...)` is a no-op on mobile by design. The only heavy use of a custom pattern today is the Fizruk workout finisher (`[200, 100, 200]`) on web — that path is unchanged because it runs through the web adapter.
- `expo-haptics` is pinned to `~14.0.1` (Expo SDK 52 bundled native module version). `pnpm install` resolved cleanly against the existing lock.


Link to Devin session: https://app.devin.ai/sessions/015aedb88c9648df8a49d80b960238db
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
