### PR TITLE
fix(mobile): catch async expo-haptics rejections in haptic adapter's safe() wrapper

### DIFF
--- a/apps/mobile/src/lib/haptic.ts
+++ b/apps/mobile/src/lib/haptic.ts
@@ -21,9 +21,17 @@ import { setHapticAdapter, type HapticAdapter } from "@sergeant/shared";
 
 function safe(run: () => Promise<unknown> | void): void {
   try {
-    void run();
+    // `expo-haptics` methods return Promises that may reject on
+    // unsupported hardware, simulator-without-haptics, or web preview.
+    // `try/catch` alone only catches synchronous throws; wrapping in
+    // `Promise.resolve(...).catch(...)` also swallows async rejections
+    // so React Native does not surface an unhandled-promise-rejection
+    // warning (or crash in production) for every silent haptic call.
+    void Promise.resolve(run()).catch(() => {
+      /* unsupported hardware / web — swallow */
+    });
   } catch {
-    /* expo-haptics rejects on web / unsupported hardware — swallow */
+    /* synchronous throw from the adapter body itself — swallow */
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to R7 / PR #425. Addresses a real functional bug flagged by Devin Review on `apps/mobile/src/lib/haptic.ts`.

The `safe()` wrapper was intended to swallow errors from `expo-haptics` — the inline comment even said *"expo-haptics rejects on web / unsupported hardware — swallow"*. But all wrapped `expo-haptics` methods (`selectionAsync`, `notificationAsync`, `impactAsync`) return Promises, and `try/catch` only catches synchronous throws. `void run()` calls `run()` and discards the returned Promise, so any async rejection becomes an **unhandled promise rejection**. In React Native this triggers LogBox warnings and, depending on `ErrorUtils` config, can crash the app in production.

**Fix**: wrap the call in `Promise.resolve(run()).catch(...)` so async rejections are explicitly caught. The outer `try/catch` stays because the adapter body itself could throw synchronously (e.g. `Haptics.selectionAsync` not being present on a broken SDK install).

```ts
function safe(run: () => Promise<unknown> | void): void {
  try {
    void Promise.resolve(run()).catch(() => {
      /* unsupported hardware / web — swallow */
    });
  } catch {
    /* synchronous throw from the adapter body itself — swallow */
  }
}
```

## Review & Testing Checklist for Human

Risk: green — one-line behavioural fix inside the mobile haptic adapter. No shared or web code touched. No new dependencies.

- [ ] On mobile dev client (iOS + Android), trigger `hapticTap` / `hapticSuccess` / `hapticWarning` / `hapticError` on hardware that does not support the given feedback (e.g. iOS Simulator, lower-tier Android without a haptic motor) — expect silent no-op, no LogBox "Possible Unhandled Promise Rejection" warning.
- [ ] Confirm expected haptic feedback still fires on supported hardware (iPhone, Pixel) for `selectionAsync` / `notificationAsync(Success)` / `impactAsync(Light)`.
- [ ] Confirm CI passes green for this PR (lint + typecheck + tests for `@sergeant/mobile`).

### Notes

- Addresses Devin Review finding [BUG_pr-review-job-df4c7e7ffeb540358f29d15052277062_0001](https://github.com/Skords-01/Sergeant/pull/425#discussion_r3113688058).
- `pattern` remains an intentional no-op on mobile — see R7 / PR #425 for rationale.
- Local verification: `pnpm turbo run lint typecheck test --filter=@sergeant/mobile` — all 3 tasks green (48 tests passing).


Link to Devin session: https://app.devin.ai/sessions/015aedb88c9648df8a49d80b960238db
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
