### PR TITLE
fix(mobile/sync): address Devin Review findings on Phase 3 CloudSync

### DIFF
--- a/apps/mobile/src/sync/__tests__/online.test.ts
+++ b/apps/mobile/src/sync/__tests__/online.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the `startOnlineTracker` reference-counter.
+ *
+ * These guard against a previous bug where a boolean `started` flag
+ * let the first unmounting caller tear down the NetInfo subscription
+ * for the entire app, silently disabling offline→online replay.
+ */
+import NetInfo from "@react-native-community/netinfo";
+
+import {
+  _resetOnlineForTest,
+  isOnline,
+  onOnlineChange,
+  startOnlineTracker,
+} from "../net/online";
+
+type NetInfoTestApi = typeof NetInfo & {
+  __setState: (next: {
+    isConnected?: boolean;
+    isInternetReachable?: boolean | null;
+  }) => void;
+  __reset: () => void;
+};
+
+const netInfo = NetInfo as NetInfoTestApi;
+
+beforeEach(() => {
+  netInfo.__reset();
+  _resetOnlineForTest(true);
+});
+
+describe("startOnlineTracker — reference counting", () => {
+  it("keeps the NetInfo listener alive when one of several callers unmounts", () => {
+    const listener = jest.fn();
+    const unsubListener = onOnlineChange(listener);
+
+    const unsubA = startOnlineTracker();
+    const unsubB = startOnlineTracker();
+
+    // A unmounts first (e.g. child hook teardown). B must keep the
+    // NetInfo listener alive.
+    unsubA();
+
+    // Flip connectivity offline → online.
+    netInfo.__setState({ isConnected: false, isInternetReachable: false });
+    netInfo.__setState({ isConnected: true, isInternetReachable: true });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(isOnline()).toBe(true);
+
+    unsubB();
+    unsubListener();
+  });
+
+  it("tears down the NetInfo listener only when the final subscriber unmounts", () => {
+    const listener = jest.fn();
+    const unsubListener = onOnlineChange(listener);
+
+    const unsubA = startOnlineTracker();
+    const unsubB = startOnlineTracker();
+    unsubA();
+    unsubB();
+
+    // After everyone unmounted, offline→online transitions no longer
+    // reach our subscribers. (This is the expected steady state when
+    // the whole sync layer is torn down.)
+    netInfo.__setState({ isConnected: false, isInternetReachable: false });
+    netInfo.__setState({ isConnected: true, isInternetReachable: true });
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubListener();
+  });
+
+  it("is safe against double-release from the same caller", () => {
+    const unsubA = startOnlineTracker();
+    const unsubB = startOnlineTracker();
+
+    // Double-release on A must not decrement the counter into
+    // negative territory or prematurely kill B's subscription.
+    unsubA();
+    unsubA();
+
+    const listener = jest.fn();
+    const unsubListener = onOnlineChange(listener);
+    netInfo.__setState({ isConnected: false, isInternetReachable: false });
+    netInfo.__setState({ isConnected: true, isInternetReachable: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubB();
+    unsubListener();
+  });
+});

--- a/apps/mobile/src/sync/__tests__/useCloudSync.userChange.test.ts
+++ b/apps/mobile/src/sync/__tests__/useCloudSync.userChange.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test: when the signed-in user changes, `useCloudSync`
+ * must wipe the previous user's sync-managed MMKV slice BEFORE
+ * replaying the offline queue + pulling. Otherwise user A's queued
+ * offline changes would be pushed under user B's auth, corrupting
+ * user B's cloud state. Mirrors the web behaviour in
+ * `apps/web/src/core/cloudSync/hook/useInitialSyncOnUser.ts`.
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useCloudSync } from "../hook/useCloudSync";
+import { _resetOnlineForTest } from "../net/online";
+import type { CurrentUser } from "../types";
+
+const mockClearSyncManagedData = jest.fn();
+const mockReplayOfflineQueue = jest.fn().mockResolvedValue(undefined);
+const mockEngPullAll = jest.fn().mockResolvedValue(true);
+
+jest.mock("../state/moduleData", () => ({
+  clearSyncManagedData: (...args: unknown[]) =>
+    mockClearSyncManagedData(...args),
+  collectModuleData: jest.fn(() => ({})),
+  applyModuleData: jest.fn(),
+  hasLocalData: jest.fn(() => false),
+}));
+
+jest.mock("../engine/replay", () => ({
+  replayOfflineQueue: (...args: unknown[]) => mockReplayOfflineQueue(...args),
+  _resetReplayGuardForTest: jest.fn(),
+}));
+
+jest.mock("../engine/pull", () => ({
+  pullAll: (...args: unknown[]) => mockEngPullAll(...args),
+}));
+
+jest.mock("../engine/push", () => ({
+  pushAll: jest.fn().mockResolvedValue(undefined),
+  pushDirty: jest.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  mockClearSyncManagedData.mockReset();
+  mockReplayOfflineQueue.mockClear();
+  mockEngPullAll.mockClear();
+  _resetOnlineForTest(true);
+});
+
+function userOf(id: string | null): CurrentUser | null {
+  return id ? ({ id } as CurrentUser) : null;
+}
+
+describe("useCloudSync — user-id change", () => {
+  it("does NOT wipe managed data on the very first sign-in", async () => {
+    const { rerender } = renderHook(
+      ({ user }: { user: CurrentUser | null }) => useCloudSync(user),
+      { initialProps: { user: null as CurrentUser | null } },
+    );
+
+    await act(async () => {
+      rerender({ user: userOf("user-a") });
+      // Flush the effect's scheduled promise chain.
+      await Promise.resolve();
+    });
+
+    expect(mockClearSyncManagedData).not.toHaveBeenCalled();
+  });
+
+  it("wipes managed data when switching from user A to user B", async () => {
+    const { rerender } = renderHook(
+      ({ user }: { user: CurrentUser | null }) => useCloudSync(user),
+      { initialProps: { user: userOf("user-a") } },
+    );
+
+    // Baseline: first sign-in must not wipe.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockClearSyncManagedData).not.toHaveBeenCalled();
+    mockReplayOfflineQueue.mockClear();
+
+    await act(async () => {
+      rerender({ user: userOf("user-b") });
+      await Promise.resolve();
+    });
+
+    expect(mockClearSyncManagedData).toHaveBeenCalledTimes(1);
+
+    // Call order: clear must happen BEFORE the user-B replay so the
+    // new user's session never sees the previous user's queued changes.
+    const clearOrder = mockClearSyncManagedData.mock.invocationCallOrder[0];
+    const replayOrder = mockReplayOfflineQueue.mock.invocationCallOrder[0];
+    expect(clearOrder).toBeLessThan(replayOrder);
+  });
+
+  it("wipes managed data on sign-out (user becomes null after non-null)", async () => {
+    const { rerender } = renderHook(
+      ({ user }: { user: CurrentUser | null }) => useCloudSync(user),
+      { initialProps: { user: userOf("user-a") } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    mockClearSyncManagedData.mockClear();
+    mockEngPullAll.mockClear();
+
+    await act(async () => {
+      rerender({ user: null });
+      await Promise.resolve();
+    });
+
+    expect(mockClearSyncManagedData).toHaveBeenCalledTimes(1);
+    // But no pull for a signed-out state.
+    expect(mockEngPullAll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/sync/hook/useCloudSync.ts
+++ b/apps/mobile/src/sync/hook/useCloudSync.ts
@@ -25,6 +25,7 @@ import { onSyncEvent, SYNC_EVENT } from "../events";
 import { onOnlineChange, startOnlineTracker } from "../net/online";
 import { getOfflineQueue } from "../queue/offlineQueue";
 import { getDirtyModules } from "../state/dirtyModules";
+import { clearSyncManagedData } from "../state/moduleData";
 import type { CurrentUser, SyncCallbacks } from "../types";
 import { useSyncCallbacks } from "./useSyncCallbacks";
 
@@ -139,10 +140,21 @@ export function useCloudSync(
 
   // (4) Initial sync on user-id change: drain queue + pull fresh
   // cloud state so a just-signed-in device adopts server data.
+  //
+  // When the previous user was non-null, wipe every sync-managed MMKV
+  // slice (module data + dirty map + offline queue + modified-times)
+  // BEFORE replaying, mirroring the web `useInitialSyncOnUser` in
+  // apps/web/src/core/cloudSync/hook/useInitialSyncOnUser.ts. Without
+  // this, user A's queued offline changes would be replayed under user
+  // B's session on the same device, corrupting user B's cloud state.
   const lastUserRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
     const id = user?.id ?? null;
-    if (lastUserRef.current === id) return;
+    const previousId = lastUserRef.current;
+    if (previousId === id) return;
+    if (previousId !== undefined && previousId !== null) {
+      clearSyncManagedData();
+    }
     lastUserRef.current = id;
     if (!id) return;
     void runExclusive(async (cb) => {

--- a/apps/mobile/src/sync/net/online.ts
+++ b/apps/mobile/src/sync/net/online.ts
@@ -30,7 +30,15 @@ import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 
 type Listener = () => void;
 
-let started = false;
+// Reference-count tracker subscriptions rather than using a boolean
+// `started` flag: `startOnlineTracker()` is called from multiple hooks
+// (`useCloudSync`, `useSyncStatus`), and React runs child effect
+// cleanups before parent cleanups. A boolean flag would let the first
+// unmounting caller tear down the NetInfo subscription for the entire
+// app, silently disabling offline→online replay. The counter only
+// removes the NetInfo listener when the last consumer unsubscribes.
+let subscriberCount = 0;
+let netInfoUnsubscribe: (() => void) | null = null;
 // Default to `true` so first-render engines don't see a spurious
 // "offline" before NetInfo delivers its first snapshot. NetInfo's own
 // `fetch()` below corrects this immediately on mount.
@@ -60,23 +68,31 @@ function applyState(state: NetInfoState): void {
 
 /**
  * Install the single NetInfo subscription. Safe to call multiple
- * times — subsequent calls are no-ops.
+ * times — each caller gets its own cleanup and the underlying
+ * listener is only torn down when the final subscriber unmounts.
  */
 export function startOnlineTracker(): () => void {
-  if (started) return () => {};
-  started = true;
-  // Seed synchronously-ish: NetInfo.fetch is async, but the
-  // subscription fires its current state almost immediately on most
-  // platforms.
-  NetInfo.fetch()
-    .then(applyState)
-    .catch(() => {
-      /* swallow — default `online = true` stays */
-    });
-  const unsubscribe = NetInfo.addEventListener(applyState);
+  subscriberCount += 1;
+  if (subscriberCount === 1) {
+    // Seed synchronously-ish: NetInfo.fetch is async, but the
+    // subscription fires its current state almost immediately on most
+    // platforms.
+    NetInfo.fetch()
+      .then(applyState)
+      .catch(() => {
+        /* swallow — default `online = true` stays */
+      });
+    netInfoUnsubscribe = NetInfo.addEventListener(applyState);
+  }
+  let released = false;
   return () => {
-    unsubscribe();
-    started = false;
+    if (released) return;
+    released = true;
+    subscriberCount = Math.max(0, subscriberCount - 1);
+    if (subscriberCount === 0 && netInfoUnsubscribe) {
+      netInfoUnsubscribe();
+      netInfoUnsubscribe = null;
+    }
   };
 }
 
@@ -91,7 +107,11 @@ export function onOnlineChange(listener: Listener): () => void {
 
 /** Test-only: reset module state between suites. */
 export function _resetOnlineForTest(initial = true): void {
-  started = false;
+  subscriberCount = 0;
+  if (netInfoUnsubscribe) {
+    netInfoUnsubscribe();
+    netInfoUnsubscribe = null;
+  }
   online = initial;
   listeners.clear();
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged Phase 3 CloudSync PR [#420](https://github.com/Skords-01/Sergeant/pull/420). Devin Review flagged two real production bugs in `apps/mobile/src/sync/*`:

### Bug 1 — `startOnlineTracker` listener lost to first unmounter

`apps/mobile/src/sync/net/online.ts` used a boolean `started` flag for idempotency. The function is called from both `useCloudSync` (root `CloudSyncProvider`) and `useSyncStatus` (descendant components, e.g. future `SyncStatusIndicator`). React runs child effect cleanups **before** parent cleanups, so the first unmounting descendant would tear down the NetInfo listener for the entire app — silently disabling offline→online replay. Users' queued offline changes would then only flush on the 2-minute periodic retry, or be lost if the app was backgrounded first.

**Fix:** replaced the boolean with a reference counter that only tears down the NetInfo subscription when the final subscriber unmounts. Also added per-caller double-release safety so accidental double-cleanup can't decrement the counter past zero or free another caller's subscription.

### Bug 2 — `useCloudSync` did not wipe managed data on user switch

The user-id-change effect in `apps/mobile/src/sync/hook/useCloudSync.ts` immediately called `replayOfflineQueue()` + `engPullAll()` without first wiping the previous user's sync-managed MMKV slice. Web's `useInitialSyncOnUser` ([web](https://github.com/Skords-01/Sergeant/blob/main/apps/web/src/core/cloudSync/hook/useInitialSyncOnUser.ts#L29-L31)) calls `clearSyncManagedData()` whenever the user ID flips. Without this on mobile, when user A signs out and user B signs in on the same device, user A's queued offline changes would be pushed under user B's session, corrupting user B's cloud state.

**Fix:** on any user-id change where the previous id was non-null (including sign-out), call `clearSyncManagedData()` from `../state/moduleData` before scheduling replay + pull. The very first sign-in (previous id === `undefined`) still skips the wipe, matching the web semantics.

### Tests added

- `apps/mobile/src/sync/__tests__/online.test.ts` — three focused tests exercising the refcount: keep-listener-alive-when-one-of-several-unmounts; tear-down-on-final-unmount; safe-against-double-release.
- `apps/mobile/src/sync/__tests__/useCloudSync.userChange.test.ts` — three tests: first sign-in does NOT wipe; user-A→user-B wipes and the wipe happens *before* the replay (invocation-order assertion); sign-out wipes without pulling.

All 54 mobile tests pass locally (`pnpm --filter @sergeant/mobile test`), lint + typecheck clean.

## Review & Testing Checklist for Human

Risk: **yellow** — sync-layer behaviour change that's covered by unit tests but inherently hard to cover without multi-user device testing.

- [ ] Sign in as user A in the mobile dev-client, `enqueueChange(STORAGE_KEYS.SOMETHING)` from a debug screen, toggle airplane mode so the change sits in the queue, sign out, then sign in as user B. Confirm user B's cloud state is NOT polluted with user A's queued change and that MMKV under the sync-managed keys is clean at the moment user B signs in.
- [ ] Mount any two components that call `useCloudSync` + `useSyncStatus` (e.g. a screen that renders the future `SyncStatusIndicator`), unmount the `useSyncStatus` child, then flip connectivity offline→online. Verify `[CloudSync replay-on-online]` still fires and the queue drains.
- [ ] Confirm no web regression — `pnpm --filter @sergeant/web test` locally (728 tests) stays green; web `useInitialSyncOnUser.ts` is untouched.

### Notes

- Only the two flagged lines are changed plus a small `_resetOnlineForTest` adjustment for the refcounter. No API surface changes — consumer hooks (`useCloudSync`, `useSyncStatus`, `CloudSyncProvider`) keep their exact current signatures.
- Auto-fix triggered by the Devin Review comments on #420; see original findings at https://app.devin.ai/review/skords-01/sergeant/pull/420.

Link to Devin session: https://app.devin.ai/sessions/71a8e3e251ee4c49821e9d98fb36e2f8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
