### PR TITLE
fix(mobile): compute Sheet `maxHeight` from `useWindowDimensions` (viewport-relative)

### DIFF
--- a/apps/mobile/src/components/ui/Sheet.test.tsx
+++ b/apps/mobile/src/components/ui/Sheet.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from "@testing-library/react-native";
-import { AccessibilityInfo, Modal, Text } from "react-native";
+import { AccessibilityInfo, Modal, SafeAreaView, Text } from "react-native";
 
 import { Sheet } from "./Sheet";
 
@@ -103,5 +103,20 @@ describe("Sheet", () => {
       </Sheet>,
     );
     expect(queryByText("Футер шита")).toBeNull();
+  });
+
+  it("applies an absolute-pixel `maxHeight` derived from the window size (not a % string)", () => {
+    // RN percentage `maxHeight` resolves against the parent's height,
+    // not the viewport — mirroring web `max-h-[90vh]` requires an
+    // absolute pixel value.
+    const { UNSAFE_getByType } = render(
+      <Sheet open onClose={() => {}} title="Назва шита">
+        <Text>Вміст шита</Text>
+      </Sheet>,
+    );
+    const panel = UNSAFE_getByType(SafeAreaView);
+    const style = panel.props.style as { maxHeight: number };
+    expect(typeof style.maxHeight).toBe("number");
+    expect(style.maxHeight).toBeGreaterThan(0);
   });
 });

--- a/apps/mobile/src/components/ui/Sheet.tsx
+++ b/apps/mobile/src/components/ui/Sheet.tsx
@@ -31,6 +31,12 @@
  * - Respects `AccessibilityInfo.isReduceMotionEnabled()` — when enabled
  *   we drop the slide animation to `animationType="none"` per WCAG
  *   2.3.3 / Apple HIG. Same approach as `Skeleton` (PR #423).
+ * - `maxHeight` is computed as an absolute pixel value off
+ *   `useWindowDimensions()` (mirroring web's `max-h-[90vh]`) — RN's
+ *   percentage `maxHeight` resolves against the parent's resolved
+ *   height, and our wrapping `KeyboardAvoidingView` wraps content, so
+ *   a `"90%"` string would cap the panel at 90% of its own height
+ *   rather than the viewport.
  * - `role="dialog"` is applied via the RN ≥0.71 ARIA-role prop on the
  *   panel wrapper; the legacy `accessibilityRole` union has no
  *   `"dialog"` member.
@@ -51,6 +57,7 @@ import {
   SafeAreaView,
   ScrollView,
   Text,
+  useWindowDimensions,
   View,
 } from "react-native";
 
@@ -88,6 +95,7 @@ export function Sheet({
   maxHeight = 0.9,
 }: SheetProps) {
   const [reduceMotion, setReduceMotion] = useState(false);
+  const { height: windowHeight } = useWindowDimensions();
 
   useEffect(() => {
     let mounted = true;
@@ -114,7 +122,14 @@ export function Sheet({
   // null;`) and avoids keeping child state alive between opens.
   if (!open) return null;
 
+  // Percentage `maxHeight` on a RN View resolves against its parent's
+  // height. Our panel sits inside a `KeyboardAvoidingView` that wraps
+  // its content (no flex:1 / explicit height), so a `"90%"` string
+  // would resolve against the panel's own content — not the viewport.
+  // Mirror the web `max-h-[90vh]` by computing an absolute pixel value
+  // off `useWindowDimensions()`.
   const heightFraction = Math.max(0.1, Math.min(1, maxHeight));
+  const maxPanelHeight = Math.round(windowHeight * heightFraction);
 
   return (
     <Modal
@@ -146,7 +161,7 @@ export function Sheet({
             className={cx(
               "bg-cream-50 border-t border-cream-300 rounded-t-3xl shadow-lg",
             )}
-            style={{ maxHeight: `${heightFraction * 100}%` }}
+            style={{ maxHeight: maxPanelHeight }}
           >
             <View className="flex items-center pt-3 pb-1">
               <View


### PR DESCRIPTION
## Summary

Follow-up to #426 addressing a concrete layout bug flagged by Devin Review ([findings](https://app.devin.ai/review/skords-01/sergeant/pull/426), inline comment on `apps/mobile/src/components/ui/Sheet.tsx:149`).

The previous implementation capped the panel via `style={{ maxHeight: \`${heightFraction * 100}%\` }}`. In RN's Yoga layout, a percentage `maxHeight` resolves against the **parent's resolved height** — and the panel's parent is a `KeyboardAvoidingView` that wraps its content (no `flex: 1` / explicit height). So the cap resolved against the panel's own content height, not the viewport. Small content was unnecessarily clipped to 90% of its natural size; large content could overflow the screen.

The web analogue (<ref_snippet file="/home/ubuntu/repos/Sergeant/apps/web/src/shared/components/ui/Sheet.tsx" lines="117-117" />) uses `max-h-[90vh]`, which is viewport-relative. This PR restores parity by computing an absolute pixel value off `useWindowDimensions()`:

```tsx
const { height: windowHeight } = useWindowDimensions();
const heightFraction = Math.max(0.1, Math.min(1, maxHeight));
const maxPanelHeight = Math.round(windowHeight * heightFraction);
// …
style={{ maxHeight: maxPanelHeight }}
```

Also updates the Sheet docblock to document the choice (alongside the existing reduce-motion / keyboard / `role="dialog"` notes) and adds a regression test asserting the rendered `maxHeight` is a **number** (`>0`), not a percentage string.

`pnpm --filter @sergeant/mobile lint typecheck test` and `pnpm turbo run lint typecheck test --filter=@sergeant/mobile --filter=@sergeant/shared` are green locally (8 suites / 56 tests — Sheet suite now 8 tests, the rest untouched). No files in `apps/web` are touched, no new dependencies, no lockfile changes, `apps/mobile/src/sync/**` untouched.

## Review & Testing Checklist for Human

- [ ] On a short device (iPhone SE / small Android), open a sheet whose body contains enough content to want to scroll — confirm the panel caps at ~90 % of the screen height (not 100 %) and the `ScrollView` handles the overflow.
- [ ] On a large-content sheet (e.g. a long form), confirm the body scrolls internally while the header and footer stay pinned — the previous `"90%"` string could either clip tiny sheets or overflow tall ones.
- [ ] Rotate the device while a sheet is open: the panel should re-cap against the new viewport height since `useWindowDimensions()` is dimension-reactive.

### Notes

- No behavioural change to `open` / `onClose` / `title` / `description` / `footer` / scrim / close-button / Android-back / reduce-motion paths — those 7 existing Sheet tests still pass unchanged.
- `ConfirmDialog` port in the parallel session (#427) is unaffected; it doesn't share the layout wrapper.


Link to Devin session: https://app.devin.ai/sessions/64f2d4adc1b8472c9832195bd2aa3d42
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
