### PR TITLE
refactor(R8): promote downloadJson contract to @sergeant/shared with web adapter + 3 consumers

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -12,6 +12,9 @@ import { PushRegistrar } from "@/features/push/PushRegistrar";
 // Registers the mobile `expo-haptics`-based adapter on the shared
 // haptic contract (`@sergeant/shared`). Import for side effects only.
 import "@/lib/haptic";
+// Registers the mobile file-download stub on the shared contract.
+// Replaced with an `expo-file-system` + `expo-sharing` adapter in Phase 4+.
+import "@/lib/fileDownload";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { CloudSyncProvider } from "@/sync";
 

--- a/apps/mobile/src/lib/fileDownload.ts
+++ b/apps/mobile/src/lib/fileDownload.ts
@@ -1,0 +1,32 @@
+/**
+ * Mobile stub for the shared file-download contract.
+ *
+ * A real implementation (Phase 4+) will write the JSON payload to
+ * `expo-file-system`'s `cacheDirectory` and hand the file URI to
+ * `expo-sharing.shareAsync` so the user picks a target app (Files,
+ * iMessage, email, Drive, …). Neither `expo-file-system` nor
+ * `expo-sharing` is a current `apps/mobile` dependency yet, so this
+ * module intentionally registers a warn-only adapter: no mobile
+ * consumers call `downloadJson` today, and when Phase 4 lands we'll
+ * replace this stub in one place without touching any consumer code.
+ *
+ * Importing this module has the side-effect of registering the stub.
+ * Do this once from `app/_layout.tsx`, next to the haptic adapter.
+ */
+
+import {
+  setFileDownloadAdapter,
+  type FileDownloadAdapter,
+} from "@sergeant/shared";
+
+export const mobileFileDownloadAdapter: FileDownloadAdapter = {
+  async downloadJson(filename) {
+    console.warn(
+      `[@sergeant/mobile] downloadJson("${filename}") is not wired up yet. ` +
+        `The mobile adapter will land in Phase 4+ as a thin wrapper over ` +
+        `expo-file-system.writeAsStringAsync + expo-sharing.shareAsync.`,
+    );
+  },
+};
+
+setFileDownloadAdapter(mobileFileDownloadAdapter);

--- a/apps/web/src/core/HubBackupPanel.tsx
+++ b/apps/web/src/core/HubBackupPanel.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
@@ -8,16 +9,12 @@ export function HubBackupPanel({ className }) {
   const fileRef = useRef(null);
   const toast = useToast();
 
-  const exportJson = () => {
+  const exportJson = async () => {
     const payload = buildHubBackupPayload({ includeChat: false });
-    const blob = new Blob([JSON.stringify(payload, null, 2)], {
-      type: "application/json",
-    });
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = `hub-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    await downloadJson(
+      `hub-backup-${new Date().toISOString().slice(0, 10)}.json`,
+      payload,
+    );
   };
 
   const runImport = (e) => {

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -9,6 +9,9 @@ import { createAppQueryClient } from "@shared/lib/queryClient.js";
 // Registers the web `navigator.vibrate`-based adapter on the shared
 // haptic contract (`@sergeant/shared`). Import for side effects only.
 import "@shared/lib/haptic";
+// Registers the web Blob + <a download>-based adapter on the shared
+// file-download contract (`@sergeant/shared`). Import for side effects only.
+import "@shared/lib/fileDownload";
 import { ErrorBoundary } from "./core/ErrorBoundary.jsx";
 import { initSentry } from "./core/sentry.js";
 import { initWebVitals } from "./core/webVitals.js";

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
@@ -14,16 +15,12 @@ export function WorkoutBackupBar({ className }) {
   const toast = useToast();
   const [confirmReplace, setConfirmReplace] = useState(false);
 
-  const exportJson = () => {
+  const exportJson = async () => {
     const payload = buildFizrukBackupPayload();
-    const blob = new Blob([JSON.stringify(payload, null, 2)], {
-      type: "application/json",
-    });
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    await downloadJson(
+      `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`,
+      payload,
+    );
   };
 
   const runImport = (e, replace) => {

--- a/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
@@ -1,4 +1,5 @@
 import { useRef, type ChangeEvent } from "react";
+import { downloadJson } from "@sergeant/shared";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
@@ -38,16 +39,11 @@ export function RoutineBackupSection({
         <Button
           type="button"
           className={cn("font-bold", theme?.primary)}
-          onClick={() => {
-            const blob = new Blob(
-              [JSON.stringify(buildRoutineBackupPayload(), null, 2)],
-              { type: "application/json" },
+          onClick={async () => {
+            await downloadJson(
+              `hub-routine-backup-${new Date().toISOString().slice(0, 10)}.json`,
+              buildRoutineBackupPayload(),
             );
-            const a = document.createElement("a");
-            a.href = URL.createObjectURL(blob);
-            a.download = `hub-routine-backup-${new Date().toISOString().slice(0, 10)}.json`;
-            a.click();
-            setTimeout(() => URL.revokeObjectURL(a.href), 1500);
           }}
         >
           Експорт JSON

--- a/apps/web/src/shared/lib/fileDownload.ts
+++ b/apps/web/src/shared/lib/fileDownload.ts
@@ -1,0 +1,43 @@
+/**
+ * Web adapter for the shared file-download contract.
+ *
+ * Binds `downloadJson` from `@sergeant/shared` to the classic browser
+ * `Blob` + `URL.createObjectURL` + `<a download>` dance, with guards
+ * against SSR / jsdom-without-DOM environments.
+ *
+ * Importing this module has the side-effect of registering the web
+ * adapter, so the side-effect import in `apps/web/src/main.jsx` is all
+ * the app shell needs.
+ */
+
+import {
+  setFileDownloadAdapter,
+  type FileDownloadAdapter,
+} from "@sergeant/shared";
+
+export const webFileDownloadAdapter: FileDownloadAdapter = {
+  async downloadJson(filename, payload) {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const json = JSON.stringify(payload, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.click();
+    } finally {
+      // Revoke on next tick so the click has time to initiate the
+      // download. Matches what the legacy inline helpers in
+      // `RoutineBackupSection` used (setTimeout 1500) — we use
+      // `setTimeout(…, 0)` because modern browsers keep the URL alive
+      // for the lifetime of the download once `a.click()` returns.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  },
+};
+
+setFileDownloadAdapter(webFileDownloadAdapter);

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -539,11 +539,20 @@ Web використовує кастомні компоненти + canvas/SVG.
     `apps/mobile/app/_layout.tsx`. Консьюмери (`@sergeant/finyk-domain`,
     UI-примітиви, `apps/web/*`) імпортують хелпери з `@sergeant/shared` без
     знання про платформу.
-- **R8.** Винести `downloadJson(filename, payload)` у адаптер:
-  web — `Blob` + `URL.createObjectURL` + `a.download`; mobile —
-  `expo-file-system.writeAsStringAsync` у `cacheDirectory` +
-  `expo-sharing.shareAsync`. Усуне дублікати у `routine/components/RoutineBackupSection`,
-  `fizruk/pages/Progress`, `nutrition/hooks/useNutritionCloudBackup`.
+- **R8.** 🔵 In progress (PR [#XXX](https://github.com/Skords-01/Sergeant/pull/XXX)
+  — web-адаптер + перші 3 споживача; mobile-адаптер = TODO-заглушка до Фази 4+).
+  Pure-контракт `FileDownloadAdapter` + `downloadJson(filename, payload)`
+  живе у `@sergeant/shared/lib/fileDownload` із безпечним no-op-дефолтом
+  (dev-warn, прод-тиша). Web-імплементація `Blob` + `URL.createObjectURL`
+  - `<a download>` у `apps/web/src/shared/lib/fileDownload.ts`, реєструється
+    у `apps/web/src/main.jsx`. Мігровано з inline-Blob-дублікатів:
+    `core/HubBackupPanel.tsx`, `modules/routine/components/RoutineBackupSection.tsx`,
+    `modules/fizruk/components/workouts/WorkoutBackupBar.tsx`. **Залишилось:**
+    решту 5 споживачів (`mealPhotoStorage`, `usePhotoAnalysis`, `LogCard`,
+    `useStorage`, `fizruk/pages/Progress`) мігрувати окремим PR. Mobile-адаптер
+    зараз — warn-stub у `apps/mobile/src/lib/fileDownload.ts`; Фаза 4+
+    замінить його на `expo-file-system.writeAsStringAsync`
+    (`cacheDirectory`) + `expo-sharing.shareAsync` без змін у споживачах.
 - **R9.** Винести `useVisualKeyboardInset` у платформенний хук:
   web — `window.visualViewport.resize/scroll`; mobile — `Keyboard.addListener`
   або `useAnimatedKeyboard` з `react-native-keyboard-controller`. Усуне

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -539,7 +539,7 @@ Web використовує кастомні компоненти + canvas/SVG.
     `apps/mobile/app/_layout.tsx`. Консьюмери (`@sergeant/finyk-domain`,
     UI-примітиви, `apps/web/*`) імпортують хелпери з `@sergeant/shared` без
     знання про платформу.
-- **R8.** 🔵 In progress (PR [#XXX](https://github.com/Skords-01/Sergeant/pull/XXX)
+- **R8.** 🔵 In progress (PR [#432](https://github.com/Skords-01/Sergeant/pull/432)
   — web-адаптер + перші 3 споживача; mobile-адаптер = TODO-заглушка до Фази 4+).
   Pure-контракт `FileDownloadAdapter` + `downloadJson(filename, payload)`
   живе у `@sergeant/shared/lib/fileDownload` із безпечним no-op-дефолтом

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,3 +12,6 @@ export * from "./lib/storageKeys";
 
 // DOM-free haptic contract (platform adapters register at app bootstrap).
 export * from "./lib/haptic";
+
+// DOM-free file-download contract (platform adapters register at app bootstrap).
+export * from "./lib/fileDownload";

--- a/packages/shared/src/lib/fileDownload.test.ts
+++ b/packages/shared/src/lib/fileDownload.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  downloadJson,
+  resetFileDownloadAdapter,
+  setFileDownloadAdapter,
+  type FileDownloadAdapter,
+} from "./fileDownload";
+
+function makeMockAdapter(): FileDownloadAdapter {
+  return {
+    downloadJson: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("shared file-download contract", () => {
+  beforeEach(() => {
+    resetFileDownloadAdapter();
+  });
+
+  it("no-op default adapter resolves without throwing", async () => {
+    // Silence the dev-mode warning emitted by the default no-op so the
+    // test output stays clean.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(downloadJson("x.json", { a: 1 })).resolves.toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("routes downloadJson calls to the registered adapter", async () => {
+    const adapter = makeMockAdapter();
+    setFileDownloadAdapter(adapter);
+
+    await downloadJson("hub-backup.json", { ok: true });
+    await downloadJson("fizruk-backup.json", [1, 2, 3]);
+
+    expect(adapter.downloadJson).toHaveBeenCalledTimes(2);
+    expect(adapter.downloadJson).toHaveBeenNthCalledWith(1, "hub-backup.json", {
+      ok: true,
+    });
+    expect(adapter.downloadJson).toHaveBeenNthCalledWith(
+      2,
+      "fizruk-backup.json",
+      [1, 2, 3],
+    );
+  });
+
+  it("supports swapping adapters at runtime", async () => {
+    const first = makeMockAdapter();
+    const second = makeMockAdapter();
+
+    setFileDownloadAdapter(first);
+    await downloadJson("a.json", 1);
+
+    setFileDownloadAdapter(second);
+    await downloadJson("b.json", 2);
+
+    expect(first.downloadJson).toHaveBeenCalledTimes(1);
+    expect(first.downloadJson).toHaveBeenCalledWith("a.json", 1);
+    expect(second.downloadJson).toHaveBeenCalledTimes(1);
+    expect(second.downloadJson).toHaveBeenCalledWith("b.json", 2);
+  });
+
+  it("resetFileDownloadAdapter restores the no-op default", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const adapter = makeMockAdapter();
+      setFileDownloadAdapter(adapter);
+      await downloadJson("x.json", {});
+      expect(adapter.downloadJson).toHaveBeenCalledTimes(1);
+
+      resetFileDownloadAdapter();
+      await downloadJson("y.json", {});
+      // No further calls on the previously-registered adapter.
+      expect(adapter.downloadJson).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("awaits adapter.downloadJson — rejections propagate to the caller", async () => {
+    const boom = new Error("disk full");
+    setFileDownloadAdapter({
+      downloadJson: vi.fn().mockRejectedValue(boom),
+    });
+
+    await expect(downloadJson("x.json", {})).rejects.toBe(boom);
+  });
+});

--- a/packages/shared/src/lib/fileDownload.ts
+++ b/packages/shared/src/lib/fileDownload.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure, DOM-free contract for exporting JSON blobs to the user's file
+ * system. Mirrors the R7 haptic adapter pattern (see
+ * `./haptic.ts`): consumers (UI components, feature modules, domain
+ * packages) call `downloadJson(filename, payload)` without caring
+ * whether they're running in a browser (`Blob` + `URL.createObjectURL`
+ * + `a.click()`) or a React Native app (eventually:
+ * `expo-file-system.writeAsStringAsync` in the cache directory plus
+ * `expo-sharing.shareAsync`).
+ *
+ * The app shell registers the appropriate adapter once at startup via
+ * `setFileDownloadAdapter`. Until an adapter registers, a built-in
+ * no-op is active so that calls from SSR, unit tests, or pure domain
+ * code are safe — the default emits a single `console.warn` in
+ * development builds so misconfigurations surface early, and is
+ * completely silent in production.
+ */
+
+export interface FileDownloadAdapter {
+  downloadJson(filename: string, payload: unknown): Promise<void>;
+}
+
+function isDev(): boolean {
+  try {
+    // Works under Vite (define'd), Metro, Node, and plain browser —
+    // `process` may be undefined in some bundler configs, hence the
+    // try/catch + optional chain.
+    return (
+      typeof process !== "undefined" && process.env?.NODE_ENV !== "production"
+    );
+  } catch {
+    return false;
+  }
+}
+
+const noopAdapter: FileDownloadAdapter = {
+  async downloadJson(filename) {
+    if (isDev()) {
+      console.warn(
+        `[@sergeant/shared] downloadJson("${filename}") called before a file-download adapter was registered. ` +
+          `Register one from apps/web/src/main.jsx or apps/mobile/app/_layout.tsx.`,
+      );
+    }
+  },
+};
+
+let currentAdapter: FileDownloadAdapter = noopAdapter;
+
+/**
+ * Registers the active file-download adapter. Call once at app startup
+ * (web: `apps/web/src/main.jsx`, mobile: `apps/mobile/app/_layout.tsx`).
+ * Later calls replace the previously-registered adapter, which is
+ * useful for test harnesses.
+ */
+export function setFileDownloadAdapter(adapter: FileDownloadAdapter): void {
+  currentAdapter = adapter;
+}
+
+/**
+ * Restores the built-in no-op adapter. Intended for unit tests;
+ * production code should not need this.
+ */
+export function resetFileDownloadAdapter(): void {
+  currentAdapter = noopAdapter;
+}
+
+/**
+ * Serialises `payload` to pretty-printed JSON and hands it to the
+ * registered adapter for platform-specific delivery:
+ *   - web   → blob download via `a.click()`;
+ *   - mobile (eventually, Phase 4+) → write to cache + share sheet.
+ *
+ * Callers pass the desired default filename (including extension —
+ * e.g. `"hub-backup-2026-04-20.json"`); the adapter is free to sanitise
+ * it for the target platform.
+ */
+export async function downloadJson(
+  filename: string,
+  payload: unknown,
+): Promise<void> {
+  await currentAdapter.downloadJson(filename, payload);
+}


### PR DESCRIPTION
## Summary

Mirrors the R7 haptic-adapter pattern (#425) for JSON file export. Promotes the `Blob` + `URL.createObjectURL` + `<a download>` dance out of 3 web components and into a pure, DOM-free contract in `@sergeant/shared`, behind a platform adapter.

**What changed**

- **`@sergeant/shared/lib/fileDownload`** — new pure contract:
  - `FileDownloadAdapter` interface: `{ downloadJson(filename: string, payload: unknown): Promise<void> }`.
  - `setFileDownloadAdapter(adapter)` + `resetFileDownloadAdapter()` (test helper).
  - Top-level `downloadJson(filename, payload)` async function that delegates to the registered adapter.
  - Built-in no-op default: `console.warn` in development (so misconfigurations surface early), completely silent in production.
  - Re-exported from `packages/shared/src/index.ts`.
  - Unit test `fileDownload.test.ts` covers: no-op default resolves without throwing; `setFileDownloadAdapter` routes calls; adapters can be swapped; `resetFileDownloadAdapter` restores the no-op; rejections from the adapter propagate to the caller.
- **`apps/web/src/shared/lib/fileDownload.ts`** — thin web-only adapter on top of `Blob` + `URL.createObjectURL` + `<a download>`. Guards against SSR / jsdom-without-DOM (`typeof window === "undefined" || typeof document === "undefined"`). Revokes the object URL on the next tick (via `setTimeout(…, 0)`) so `a.click()` has time to initiate the download. Registers itself on import.
- **`apps/web/src/main.jsx`** — adds a single side-effect import (`import "@shared/lib/fileDownload";`) next to the existing R7 haptic registration. No other changes in this file.
- **3 consumers migrated** — inline `Blob` + `URL.createObjectURL` + `a.download` code removed; each now calls `await downloadJson(fileName, payload)` from `@sergeant/shared`:
  - `apps/web/src/core/HubBackupPanel.tsx`
  - `apps/web/src/modules/routine/components/RoutineBackupSection.tsx`
  - `apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx`
- **`apps/mobile/src/lib/fileDownload.ts`** — intentional warn-only stub. Emits a `console.warn` on call, explaining that the real adapter (backed by `expo-file-system.writeAsStringAsync` in `cacheDirectory` + `expo-sharing.shareAsync`) lands in Phase 4+. **No new mobile dependencies** added — neither `expo-file-system` nor `expo-sharing` is pulled in by this PR.
- **`apps/mobile/app/_layout.tsx`** — side-effect import of `@/lib/fileDownload` added next to the R7 haptic registration.
- **`docs/react-native-migration.md` §11 R8** — updated from "планується" bullet to 🔵 In progress with a link to this PR, scope (web adapter + 3 consumers), and remaining work (5 other consumers + real mobile adapter in Phase 4+).

**Adapter registration pattern (mirrors R7)**

```
┌──────────────────────────────────────┐
│ @sergeant/shared/lib/fileDownload    │
│ FileDownloadAdapter +                │
│ setFileDownloadAdapter +             │
│ downloadJson(filename, payload)      │
│ default: dev-warn / prod-silent no-op│
└────────────┬─────────────────────────┘
             │ imported by
    ┌────────┴─────────┐
    ▼                  ▼
apps/web            apps/mobile
side-effect         side-effect
import registers    import registers
Blob + <a download> warn-stub
adapter             (Phase 4+: expo-file-system
                     + expo-sharing)
```

**Why this matters now**

Prerequisite for Phase 4+ (mobile backup/export flows for routine, fizruk, hub). Consumers already read/write structured payloads without caring how they leave the device — shipping the adapter split + one migrated batch now means Phase 4 only has to drop a real mobile adapter into one file and every consumer (including the 5 not yet migrated) works everywhere.

**Remaining work (explicitly out of scope per task)**

5 other consumers still inline the Blob dance (`mealPhotoStorage`, `usePhotoAnalysis`, `LogCard`, `useStorage`, `fizruk/pages/Progress`). These will migrate in a follow-up PR — keeping this one small + surgical was an explicit requirement.

**Verification (local, all green)**

- `pnpm --filter @sergeant/shared test` — 6 test files, 35 tests pass (adds `src/lib/fileDownload.test.ts` with 5 new tests).
- `pnpm turbo run lint typecheck test --filter=@sergeant/web --filter=@sergeant/mobile` — 6/6 tasks successful.
- No changes to `package.json` / `pnpm-lock.yaml` beyond what the workspace-local helpers already provide. **No new dependencies.**

## Review & Testing Checklist for Human

Risk: yellow — touches 3 user-facing backup/export flows. Behaviour should be byte-identical to `main`, but worth verifying.

- [ ] Hub backup export (`core/HubBackupPanel.tsx`) — click "Експорт", confirm a `hub-backup-YYYY-MM-DD.json` download lands and parses back into the import flow.
- [ ] Routine backup export (`modules/routine/components/RoutineBackupSection.tsx`) — same as above, filename `hub-routine-backup-YYYY-MM-DD.json`.
- [ ] Fizruk workout backup export (`modules/fizruk/components/workouts/WorkoutBackupBar.tsx`) — same, filename `fizruk-backup-YYYY-MM-DD.json`.

### Notes

- Hard constraints respected: no new dependencies; other 5 consumers untouched; `main.jsx` touched only for the single new side-effect import; `pnpm-lock.yaml` unchanged.
- Before merge, please update the placeholder `#XXX` in `docs/react-native-migration.md` §11 R8 to this PR's number — happy to push a follow-up commit with the real number once the PR opens if you prefer.
- The default no-op warns in dev (`NODE_ENV !== "production"`) using a guarded `typeof process !== "undefined"` check so the helper stays safe to import from any bundler config.


Link to Devin session: https://app.devin.ai/sessions/015aedb88c9648df8a49d80b960238db
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
