### PR TITLE
docs(rn-migration): replace R9 #XXX placeholder with merged PR #433 link

### DIFF
--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -561,7 +561,7 @@ Web використовує кастомні компоненти + canvas/SVG.
     зараз — warn-stub у `apps/mobile/src/lib/fileDownload.ts`; Фаза 4+
     замінить його на `expo-file-system.writeAsStringAsync`
     (`cacheDirectory`) + `expo-sharing.shareAsync` без змін у споживачах.
-- **R9.** 🔵 In progress (PR #XXX — shared hook + web/mobile адаптери + 5 споживачів
+- **R9.** 🔵 In progress (PR [#433](https://github.com/Skords-01/Sergeant/pull/433) — shared hook + web/mobile адаптери + 5 споживачів
   мігровано + видалено дублікат у `routine/hooks`). Pure-контракт
   `VisualKeyboardInsetAdapter` + `useVisualKeyboardInset(active)` живе у
   `@sergeant/shared/hooks/useVisualKeyboardInset` із безпечним no-op-дефолтом,


### PR DESCRIPTION
## Summary

Follow-up до змердженого [#433](https://github.com/Skords-01/Sergeant/pull/433).
У §11 R9 у `docs/react-native-migration.md` заміняю placeholder `PR #XXX` на
реальний markdown-лінк `[#433](https://github.com/Skords-01/Sergeant/pull/433)` —
такий самий формат, як у R7 (#425) / R8 (#432) записах у тій самій секції.

Docs-only, жодних code changes.

## Review & Testing Checklist for Human

- [ ] Перевірити, що `docs/react-native-migration.md` §11 R9 тепер посилається на реальний PR #433, як R7/R8.

### Notes

- Причина окремого PR — `#XXX` був залишений у `#433`, бо номер майбутнього PR
  невідомо на момент його створення; R7/R8 теж отримали фінальні номери лише
  після merge (див. PR #431 / #432 для аналогічних sync-update'ів docs).

Link to Devin session: https://app.devin.ai/sessions/78be2a0af5d14e20bac28b1dd8b1de65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
