### PR TITLE
docs(rn-migration): close R-track — mark R5 / R8 / R9 complete in §11

### DIFF
--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -546,9 +546,15 @@ Web використовує кастомні компоненти + canvas/SVG.
   `apps/web` і тепер імпортують pure-ядро з пакета.
 - **R3.** ✅Done (PR [#415](https://github.com/Skords-01/Sergeant/pull/415)). `modules/finyk/lib/*`, `domain/*`, `constants.ts`, `utils.ts` повністю реюзаються з `@sergeant/finyk-domain`; web-шіми у `apps/web/src/modules/finyk/{domain,lib}/*.ts` видалено, імпорти у `apps/web` переведено на `@sergeant/finyk-domain/*`, pure-юніт-тести перенесені у пакет. У `apps/web` лишились тільки DOM/localStorage-залежні артефакти (`lib/{demoData,finykBackup,finykStorage,lsStats,storageManager}.ts`, `hubRoutineSync.ts`, `hooks/*`, `constants/chartPalette.js`).
 - **R4.** ✅Done (PR [#418](https://github.com/Skords-01/Sergeant/pull/418)). `modules/fizruk/data/*` (exercise library) + pure `domain/*` і `lib/*` винесено у новий pure-пакет `@sergeant/fizruk-domain`. У `apps/web` залишилась лише тонка `localStorage`-обгортка (`lib/fizrukStorage.ts`), React-хуки і UI. Нуль DOM-залежностей у пакеті — готовий до `apps/mobile` (Фаза 6).
-- **R5.** Централізувати Zod-schemas `shared/schemas` → уже у
-  `@sergeant/shared/schemas`, перевірити, щоб `apps/mobile` тягнув
-  звідти, а не дублював.
+- **R5.** ✅ Done (by-construction — перевірено 2026-04-20). Усі domain- та
+  HTTP-schemas централізовано у `packages/shared/src/schemas/` (`api.ts`,
+  `finyk.ts` + re-export через `@sergeant/shared`). `apps/mobile/src` не
+  використовує `zod` взагалі (жодного `z.object` / `z.string` / `from "zod"`).
+  Єдині залишки `zod` у `apps/web/src` — інфраструктурні: `shared/lib/typedStore.ts`
+  (generic-обгортка, приймає будь-яку схему) + `core/lib/featureFlags.ts`
+  (`FlagValuesSchema = z.record(z.string(), z.boolean())`, web-only runtime-конфіг).
+  Жодного дублю business-схем між `@sergeant/shared`, `apps/web` і `apps/mobile`
+  немає — R5 закрито без окремого PR.
 - **R6.** ✅ Done (PR [#406](https://github.com/Skords-01/Sergeant/pull/406)). Tailwind preset + дизайн-токени у `@sergeant/design-tokens`; `apps/web/tailwind.config.js` і `apps/mobile/tailwind.config.js` обидва споживають один preset.
 - **R7.** ✅ Done (PR [#425](https://github.com/Skords-01/Sergeant/pull/425) + follow-up [#428](https://github.com/Skords-01/Sergeant/pull/428)).
   `shared/lib/haptic.ts` розібрано на два адаптери. PURE-контракт
@@ -564,8 +570,8 @@ Web використовує кастомні компоненти + canvas/SVG.
     `apps/mobile/app/_layout.tsx`. Консьюмери (`@sergeant/finyk-domain`,
     UI-примітиви, `apps/web/*`) імпортують хелпери з `@sergeant/shared` без
     знання про платформу.
-- **R8.** 🔵 In progress (PR [#432](https://github.com/Skords-01/Sergeant/pull/432)
-  — web-адаптер + перші 3 споживача; mobile-адаптер = TODO-заглушка до Фази 4+).
+- **R8.** ✅ Done (PR [#432](https://github.com/Skords-01/Sergeant/pull/432)
+  — pure-контракт + web-адаптер + перші 3 споживача; mobile-адаптер = TODO-заглушка до Фази 4+; решта 5 web-споживачів — follow-up PR перед Phase 2).
   Pure-контракт `FileDownloadAdapter` + `downloadJson(filename, payload)`
   живе у `@sergeant/shared/lib/fileDownload` із безпечним no-op-дефолтом
   (dev-warn, прод-тиша). Web-імплементація `Blob` + `URL.createObjectURL`
@@ -578,7 +584,7 @@ Web використовує кастомні компоненти + canvas/SVG.
     зараз — warn-stub у `apps/mobile/src/lib/fileDownload.ts`; Фаза 4+
     замінить його на `expo-file-system.writeAsStringAsync`
     (`cacheDirectory`) + `expo-sharing.shareAsync` без змін у споживачах.
-- **R9.** 🔵 In progress (PR [#433](https://github.com/Skords-01/Sergeant/pull/433) — shared hook + web/mobile адаптери + 5 споживачів
+- **R9.** ✅ Done (PR [#433](https://github.com/Skords-01/Sergeant/pull/433) — shared hook + web/mobile адаптери + 5 споживачів
   мігровано + видалено дублікат у `routine/hooks`). Pure-контракт
   `VisualKeyboardInsetAdapter` + `useVisualKeyboardInset(active)` живе у
   `@sergeant/shared/hooks/useVisualKeyboardInset` із безпечним no-op-дефолтом,


### PR DESCRIPTION
## Summary

Закриття R-треку перед стартом Phase 2 (Hub-core). Три точкові зміни у `docs/react-native-migration.md` §11 **Рефакторинги-супутники**:

- **R5** (Zod-schemas): `🔘 не стартовано` → **✅ Done (by-construction)**. Верифікація 2026-04-20:
  - Усі domain / HTTP-схеми вже консолідовано у `packages/shared/src/schemas/` (`api.ts`, `finyk.ts` + `index.ts` + re-export через `packages/shared/src/index.ts`).
  - `apps/mobile/src` не містить жодного `zod`-імпорту (`grep -r "from ['\"']zod['\"']" apps/mobile/src` → 0 matches).
  - Єдині залишки `zod` у `apps/web/src` — інфраструктурні, **не** business-схеми:
    - `apps/web/src/shared/lib/typedStore.ts` — generic-обгортка, приймає будь-яку схему як параметр.
    - `apps/web/src/core/lib/featureFlags.ts` — `FlagValuesSchema = z.record(z.string(), z.boolean())` (web-only runtime-конфіг feature flags).
  - Жодного дублю business-схем між `@sergeant/shared`, `apps/web`, `apps/mobile` → R5 закрито без окремого PR.

- **R8** (`downloadJson`): `🔵 In progress` → **✅ Done**. PR [#432](https://github.com/Skords-01/Sergeant/pull/432) змерджено з pure-контрактом + web-адаптером + перші 3 споживача. Додано явну примітку, що решта 5 споживачів (`mealPhotoStorage`, `usePhotoAnalysis`, `LogCard`, `useStorage`, `fizruk/pages/Progress`) мігруватимуться follow-up PR-ом перед Phase 2.

- **R9** (`useVisualKeyboardInset`): `🔵 In progress` → **✅ Done**. PR [#433](https://github.com/Skords-01/Sergeant/pull/433) змерджено (shared hook + web/mobile адаптери + 5 споживачів + видалено дубль у `routine/hooks`).

Ніяких кодових змін — тільки текст у §11.

## Review & Testing Checklist for Human

- [ ] §11 R5 правильно формулює, що `featureFlags.ts` і `typedStore.ts` залишаються у `apps/web` саме тому, що це інфра, а не business-схеми.
- [ ] §11 R8 / R9 правильно посилаються на змерджені PR-и (#432 / #433).

### Notes

Після цього PR-у §11 R-track повністю закрито (R1–R9: R1 ✅, R2 ✅, R3 ✅, R4 ✅, R5 ✅ by-construction, R6 ✅, R7 ✅, R8 ✅, R9 ✅), єдиний залишок — follow-up PR на решту 5 `downloadJson`-споживачів. Phase 2 Hub-core уже стартовано через PR [#434](https://github.com/Skords-01/Sergeant/pull/434) (`ErrorBoundary` + `ModuleErrorBoundary`).

Link to Devin session: https://app.devin.ai/sessions/71a8e3e251ee4c49821e9d98fb36e2f8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
