### PR TITLE
refactor(R8 follow-up): migrate remaining 2 downloadJson consumers in apps/web

### DIFF
--- a/apps/web/src/modules/finyk/hooks/useStorage.ts
+++ b/apps/web/src/modules/finyk/hooks/useStorage.ts
@@ -7,7 +7,7 @@ import {
   normalizeFinykSyncPayload,
   FINYK_BACKUP_VERSION,
 } from "../lib/finykBackup.js";
-import { toLocalISODate } from "@sergeant/shared";
+import { downloadJson, toLocalISODate } from "@sergeant/shared";
 import {
   readJSON,
   writeJSON,
@@ -383,7 +383,7 @@ export function useStorage({
     notifyFinykRoutineCalendarSync();
   };
 
-  const exportData = () => {
+  const exportData = async () => {
     const data = {
       version: FINYK_BACKUP_VERSION,
       budgets,
@@ -401,13 +401,7 @@ export function useStorage({
       customCategories,
       dismissedRecurring,
     };
-    const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `finyk-backup-${toLocalISODate()}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    await downloadJson(`finyk-backup-${toLocalISODate()}.json`, data);
   };
 
   /** @returns {Promise<boolean>} */

--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -217,16 +218,12 @@ export function Progress() {
       }));
   }, [workouts]);
 
-  const exportJson = () => {
+  const exportJson = async () => {
     const payload = buildFizrukFullBackupPayload();
-    const blob = new Blob([JSON.stringify(payload, null, 2)], {
-      type: "application/json",
-    });
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+    await downloadJson(
+      `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`,
+      payload,
+    );
   };
 
   const importJson = async (file) => {

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -565,19 +565,25 @@ Web використовує кастомні компоненти + canvas/SVG.
     UI-примітиви, `apps/web/*`) імпортують хелпери з `@sergeant/shared` без
     знання про платформу.
 - **R8.** 🔵 In progress (PR [#432](https://github.com/Skords-01/Sergeant/pull/432)
-  — web-адаптер + перші 3 споживача; mobile-адаптер = TODO-заглушка до Фази 4+).
-  Pure-контракт `FileDownloadAdapter` + `downloadJson(filename, payload)`
-  живе у `@sergeant/shared/lib/fileDownload` із безпечним no-op-дефолтом
-  (dev-warn, прод-тиша). Web-імплементація `Blob` + `URL.createObjectURL`
-  - `<a download>` у `apps/web/src/shared/lib/fileDownload.ts`, реєструється
-    у `apps/web/src/main.jsx`. Мігровано з inline-Blob-дублікатів:
+  - follow-up PR [#XXX](https://github.com/Skords-01/Sergeant/pull/XXX)
+    — web-адаптер + усі JSON-download-споживачі мігровано; mobile-адаптер
+    = TODO-заглушка до Фази 4+). Pure-контракт `FileDownloadAdapter` +
+    `downloadJson(filename, payload)` живе у `@sergeant/shared/lib/fileDownload`
+    із безпечним no-op-дефолтом (dev-warn, прод-тиша). Web-імплементація
+    `Blob` + `URL.createObjectURL` + `<a download>` у
+    `apps/web/src/shared/lib/fileDownload.ts`, реєструється у
+    `apps/web/src/main.jsx`. УСІ web-споживачі JSON-бекапу мігровано:
     `core/HubBackupPanel.tsx`, `modules/routine/components/RoutineBackupSection.tsx`,
-    `modules/fizruk/components/workouts/WorkoutBackupBar.tsx`. **Залишилось:**
-    решту 5 споживачів (`mealPhotoStorage`, `usePhotoAnalysis`, `LogCard`,
-    `useStorage`, `fizruk/pages/Progress`) мігрувати окремим PR. Mobile-адаптер
-    зараз — warn-stub у `apps/mobile/src/lib/fileDownload.ts`; Фаза 4+
-    замінить його на `expo-file-system.writeAsStringAsync`
-    (`cacheDirectory`) + `expo-sharing.shareAsync` без змін у споживачах.
+    `modules/fizruk/components/workouts/WorkoutBackupBar.tsx` (PR #432) +
+    `modules/fizruk/pages/Progress.tsx`, `modules/finyk/hooks/useStorage.ts`
+    (цей PR #XXX). Nutrition-модуль (`mealPhotoStorage`, `usePhotoAnalysis`,
+    `LogCard`) використовує `URL.createObjectURL` виключно для image-preview
+    (мініатюри страв, попередній перегляд фото перед аналізом) — це окремий
+    пайплайн `expo-image-picker`/`expo-image-manipulator` з §10 таблиці, не
+    JSON-download-контракт. Mobile-адаптер зараз — warn-stub у
+    `apps/mobile/src/lib/fileDownload.ts`; Фаза 4+ замінить його на
+    `expo-file-system.writeAsStringAsync` (`cacheDirectory`) +
+    `expo-sharing.shareAsync` без змін у споживачах.
 - **R9.** 🔵 In progress (PR [#433](https://github.com/Skords-01/Sergeant/pull/433) — shared hook + web/mobile адаптери + 5 споживачів
   мігровано + видалено дублікат у `routine/hooks`). Pure-контракт
   `VisualKeyboardInsetAdapter` + `useVisualKeyboardInset(active)` живе у


### PR DESCRIPTION
## Summary

Follow-up to [#432](https://github.com/Skords-01/Sergeant/pull/432) (R8 — pure `downloadJson` contract in `@sergeant/shared` + web adapter + first 3 consumers). This PR migrates the **remaining JSON-backup consumers** in `apps/web` from inline `new Blob(...)` + `URL.createObjectURL` + `<a download>` to `await downloadJson(filename, payload)` from `@sergeant/shared`.

After a full `grep -rn 'URL.createObjectURL\|a.download\|new Blob' apps/web/src`, only **2** real JSON-download consumers remain outside the 3 already migrated in #432 + the web adapter itself:

- `apps/web/src/modules/fizruk/pages/Progress.tsx` — `exportJson()` (fizruk full backup).
- `apps/web/src/modules/finyk/hooks/useStorage.ts` — `exportData()` (finyk backup).

The nutrition-module hits from the original task list (`mealPhotoStorage.ts:147`, `usePhotoAnalysis.ts:101`, `LogCard.tsx:65`) use `URL.createObjectURL` **only for image preview** — meal thumbnails from IndexedDB blobs, the pre-analysis photo preview, and the `fileToThumbnailBlob` canvas pipeline. They do not serialize JSON and are therefore not part of the `downloadJson` contract — they belong to the separate `expo-image-picker` / `expo-image-manipulator` track already tracked in §10 of the migration doc. The remaining `new Blob(...)` hits in `storageQuota.ts`, `nutritionStorage.ts`, and `webVitals.ts` are size-calc / `sendBeacon` payloads, not downloads. I've documented this reasoning in the updated §11 R8 so future readers don't re-flag the same files.

The `apps/web/src/modules/fizruk/pages/Progress.tsx` CSV export (`fizruk-workouts-*.csv`) still uses inline `Blob` + `URL.createObjectURL` + `<a download>` — it's a `text/csv;charset=utf-8` blob, out of scope for `downloadJson` (contract is JSON-only). Extending the contract to CSV would be a new R-item.

Also updated `docs/react-native-migration.md` §11 R8 to reflect the final migrated list (5 consumers total: 3 in #432 + 2 here) and to note the nutrition-module caveat.

### Files touched

- `apps/web/src/modules/fizruk/pages/Progress.tsx` — `exportJson` becomes `async`, uses `downloadJson` from `@sergeant/shared`; `document.createElement('a')` / `URL.createObjectURL` / `setTimeout(revokeObjectURL)` block removed. CSV path unchanged.
- `apps/web/src/modules/finyk/hooks/useStorage.ts` — `exportData` becomes `async`, appends `downloadJson` to the existing `import { toLocalISODate } from "@sergeant/shared"`; inline blob helper block replaced with a single `await downloadJson(...)` call. Payload shape unchanged.
- `docs/react-native-migration.md` §11 R8 — updated the "**Залишилось:** решту 5 споживачів … follow-up PR" wording to reflect the final state after this PR; added the nutrition image-preview caveat.

No new dependencies, no changes to the pure contract in `@sergeant/shared`, no changes to `apps/mobile`, no changes to payload shapes.

### Verification

- `pnpm --filter @sergeant/web lint` → 0 errors.
- `pnpm --filter @sergeant/web typecheck` → 0 errors.
- `pnpm --filter @sergeant/web test` → **630 / 630 passing (73 files)**.
- `pnpm turbo run lint typecheck test --filter=@sergeant/web --filter=@sergeant/shared` → **6 / 6 tasks successful**.
- `grep -rn 'URL.createObjectURL' apps/web/src` post-migration returns exactly the known-remaining hits: the web adapter (`shared/lib/fileDownload.ts`, expected), the fizruk CSV export (out-of-scope, not a JSON download), and the 3 nutrition image-preview URLs (out-of-scope, not downloads at all). No remaining JSON-download inline blobs.

## Review & Testing Checklist for Human

- [ ] Trigger `Експорт (backup)` on the fizruk Progress page (`/fizruk` → Прогрес tab) and confirm a `fizruk-backup-YYYY-MM-DD.json` file downloads with the same pretty-printed payload shape as before (the web adapter stringifies with `null, 2` — matches previous inline).
- [ ] Trigger finyk backup export wherever `useStorage().exportData` is wired in the UI (Settings → Finyk section / backup button) and confirm a `finyk-backup-YYYY-MM-DD.json` downloads with the same payload (note: previous inline used `JSON.stringify(data)` without indentation; the shared adapter pretty-prints with `null, 2` — byte-identical payload content, different whitespace. Flag if pretty-printed output is undesired.).
- [ ] Sanity-check that the fizruk **CSV** export (`Експорт CSV` → `fizruk-workouts-YYYY-MM-DD.csv`) still works — this PR does not touch that path but the file is in the same component.

### Notes

- Chose to make `exportData` / `exportJson` `async` (rather than wrapping in `.then()`) to match the pattern established in the 3 files migrated in #432 (`HubBackupPanel.tsx`, `WorkoutBackupBar.tsx`, `RoutineBackupSection.tsx`). `exportJson` in `Progress.tsx` is only consumed via `onClick`, and `exportData` in `useStorage.ts` is exposed from the hook's return but not currently called anywhere in the codebase (grep-verified), so the async propagation is contained.
- One previously-inline detail that does shift behaviorally: the finyk `exportData` used `JSON.stringify(data)` (no indentation) while the web adapter stringifies with `null, 2`. The downloaded JSON payload is semantically identical; only formatting changes. This matches the fizruk inline which already used `null, 2`.
- Docs PR-number placeholder: §11 R8 now contains a `#XXX` placeholder for this PR's number (same convention as R9 #433 / R7 doc sync); a separate trivial docs-only PR will replace it once this one is merged (mirrors how #435 did it for R9).


Link to Devin session: https://app.devin.ai/sessions/2a14253cadc54d69ae5537d600c2306b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
