### PR TITLE
docs: sync roadmap/audit docs with #439 dead-exports cleanup

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -87,8 +87,8 @@ Back-compat: старі токени `panel` / `panelHi` / `line` продовж
 - `chartSeries.finyk / .fizruk / .routine / .nutrition` — бренд-акценти
   серій для модуля (primary + secondary + surface).
 - `chartPaletteList` — 8-кольорова гармонійна палітра для pie/категорій.
-- `chartAxis` / `chartGrid` / `chartTick` / `chartTooltip` — спільні
-  Tailwind-класи для осей, сітки, тіків, тултіпів.
+- `chartAxis` / `chartGrid` / `chartTick` — спільні Tailwind-класи
+  для осей, сітки, тіків.
 - `chartGradients.finyk` тощо — пари stop'ів для area-fill градієнтів.
 
 > Не імпортуй hex із chartPalette.js напряму в компонент — бери через

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -609,6 +609,14 @@ Web використовує кастомні компоненти + canvas/SVG.
 Кожен R-пункт робиться окремим PR перед відповідною Фазою (щоб
 mobile PR був маленький і тільки про UI).
 
+**Post-R-track cleanup.** Після закриття R1–R9 виконано точкове
+прибирання мертвих експортів у `apps/web/src` (PR
+[#439](https://github.com/Skords-01/Sergeant/pull/439)): ~18
+символів у 7 секціях (constants, types, runtime helpers, pantry
+CRUD, foodDb export/import, UI). Жодних змін у публічному API
+`@sergeant/*` пакетів чи в `apps/mobile` — чисто зачистка
+наслідків R-рефакторингів.
+
 ## 12. Ризики
 
 - **Expo SDK upgrade cadence** — ми на SDK 52 (остання LTS на

--- a/docs/ux-audit-2025.md
+++ b/docs/ux-audit-2025.md
@@ -38,7 +38,9 @@ HubChat, HubSearch, онбординг, a11y, PWA). Цей документ — 
   для debug-режиму.
 - `motion-safe:` префікс у 8 файлах для `animate-pulse` / `animate-spin`.
 - Новий `SkeletonList` компонент — уніфікована заміна спінерам у
-  списках (transactions / workouts / habits / meals).
+  списках (transactions / workouts / habits / meals). _Прибраний як
+  невикористаний у PR [#439](https://github.com/Skords-01/Sergeant/pull/439);
+  усі місця використовують `Skeleton`-примітив напряму._
 
 ## 3. Мікровзаємодії
 
@@ -160,7 +162,8 @@ HubChat, HubSearch, онбординг, a11y, PWA). Цей документ — 
 
 - `src/shared/lib/haptic.ts`
 - `src/shared/lib/undoToast.tsx`
-- `src/shared/components/ui/SkeletonList.tsx`
+- `src/shared/components/ui/SkeletonList.tsx` _(видалено в
+  PR [#439](https://github.com/Skords-01/Sergeant/pull/439) — dead code)_
 - `src/core/hubSearchEngine.ts`
 - `docs/ux-audit-2025.md`
 


### PR DESCRIPTION
## Summary

Точкова актуалізація docs/ після merge [#439](https://github.com/Skords-01/Sergeant/pull/439) (прибирання ~18 мертвих експортів у `apps/web/src` після закриття R-track).

Зміни:

- **`docs/design-system.md`** — прибрано `chartTooltip` зі списку живих chart-токенів (видалено в #439). Live лишаються `chartAxis` / `chartGrid` / `chartTick`.
- **`docs/ux-audit-2025.md`** — у 2 місцях (опис нових компонентів + список файлів PR) додано inline-нотатки, що `SkeletonList` прибраний як невикористаний у #439. Історичний опис минулого UX-PR зберігається, але читач бачить актуальний стан.
- **`docs/react-native-migration.md` §11** — додано підсумкову нотатку "Post-R-track cleanup" з посиланням на #439, після списку R1–R9.

`README.md` не чіпав: у його дереві `src/` немає згадок жодного з видалених символів (рівень — підкаталоги + ключові файли, не окремі export'и).

## Review & Testing Checklist for Human

- [ ] Переглянути 3 diff'и — чи формулювання вас задовольняють (особливо нотатка в §11).
- [ ] Вирішити, чи залишати історичний `SkeletonList` у списку нових файлів у ux-audit-2025.md з footnote, чи прибрати повністю.

### Notes

- Чистий docs-only PR — ні коду, ні CI-критичних змін.
- lint/typecheck/test по `@sergeant/web` не зачіпаються (нічого не мігрувалося в `.ts`).

Link to Devin session: https://app.devin.ai/sessions/121c8e966fe34e4ab592e0b0d6385ada
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
