### PR TITLE
feat(mobile/core): add SyncStatusIndicator (Phase 2 / Hub-core)

### DIFF
--- a/apps/mobile/src/core/SyncStatusIndicator.test.tsx
+++ b/apps/mobile/src/core/SyncStatusIndicator.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Render tests for `<SyncStatusIndicator>`.
+ *
+ * `useSyncStatus` is mocked so each state (`idle` / `syncing` /
+ * `offline` / `error`) can be asserted in isolation without standing
+ * up the whole CloudSync stack. `AccessibilityInfo` is stubbed to
+ * match `Skeleton.test.tsx` — we don't exercise the animated pulse,
+ * only its presence + accessibility affordances.
+ */
+import { fireEvent, render } from "@testing-library/react-native";
+import { AccessibilityInfo } from "react-native";
+
+import { SyncStatusIndicator } from "./SyncStatusIndicator";
+
+jest.mock("@/sync/hook/useSyncStatus", () => ({
+  useSyncStatus: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useSyncStatus } = require("@/sync/hook/useSyncStatus") as {
+  useSyncStatus: jest.Mock;
+};
+
+function mockStatus(overrides: {
+  dirtyCount?: number;
+  queuedCount?: number;
+  isOnline?: boolean;
+}) {
+  useSyncStatus.mockReturnValue({
+    dirtyCount: overrides.dirtyCount ?? 0,
+    queuedCount: overrides.queuedCount ?? 0,
+    isOnline: overrides.isOnline ?? true,
+  });
+}
+
+describe("SyncStatusIndicator", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+      .mockResolvedValue(false);
+    jest
+      .spyOn(AccessibilityInfo, "addEventListener")
+      .mockImplementation(() => ({ remove: () => {} }) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    useSyncStatus.mockReset();
+  });
+
+  describe("idle state", () => {
+    it("renders the compact 'Синк: on' pill when online and nothing pending", () => {
+      mockStatus({});
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("Синк: on")).toBeTruthy();
+    });
+
+    it("collapses to null with variant=silent-when-idle", () => {
+      mockStatus({});
+      const { toJSON } = render(
+        <SyncStatusIndicator variant="silent-when-idle" />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it("still renders non-idle states regardless of variant=silent-when-idle", () => {
+      mockStatus({ isOnline: false, queuedCount: 2 });
+      const { getByText } = render(
+        <SyncStatusIndicator variant="silent-when-idle" />,
+      );
+      expect(getByText(/Офлайн/)).toBeTruthy();
+    });
+  });
+
+  describe("syncing state", () => {
+    it("shows 'Синхронізація…' when queued or dirty work is pending", () => {
+      mockStatus({ queuedCount: 3 });
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("Синхронізація…")).toBeTruthy();
+    });
+
+    it("shows the pending pluralization when queue is non-empty", () => {
+      mockStatus({ queuedCount: 5 });
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("5 змін у черзі")).toBeTruthy();
+    });
+
+    it("prefers max(dirtyCount, queuedCount) as the pending count", () => {
+      mockStatus({ dirtyCount: 7, queuedCount: 2 });
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("7 змін у черзі")).toBeTruthy();
+    });
+  });
+
+  describe("offline state", () => {
+    it("shows the offline pill with the pending count when there is a queue", () => {
+      mockStatus({ isOnline: false, queuedCount: 2 });
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("Офлайн — 2 зміни у черзі")).toBeTruthy();
+    });
+
+    it("shows a bare offline pill when nothing is queued", () => {
+      mockStatus({ isOnline: false });
+      const { getByText } = render(<SyncStatusIndicator />);
+      expect(getByText("Офлайн")).toBeTruthy();
+    });
+  });
+
+  describe("error state", () => {
+    it("switches to the error pill when the `error` prop is truthy", () => {
+      mockStatus({});
+      const { getByText } = render(
+        <SyncStatusIndicator error="Server unreachable" />,
+      );
+      expect(getByText("Помилка синхронізації")).toBeTruthy();
+    });
+
+    it("renders the retry button when both `error` and `onRetry` are provided", () => {
+      mockStatus({});
+      const onRetry = jest.fn();
+      const { getByText } = render(
+        <SyncStatusIndicator error="Boom" onRetry={onRetry} />,
+      );
+      const retry = getByText("Повторити");
+      expect(retry).toBeTruthy();
+      fireEvent.press(retry);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the retry button when `onRetry` is not provided", () => {
+      mockStatus({});
+      const { queryByText } = render(<SyncStatusIndicator error="Boom" />);
+      expect(queryByText("Повторити")).toBeNull();
+    });
+
+    it("takes precedence over offline/syncing derived states", () => {
+      mockStatus({ isOnline: false, queuedCount: 5 });
+      const { getByText, queryByText } = render(
+        <SyncStatusIndicator error="Boom" />,
+      );
+      expect(getByText("Помилка синхронізації")).toBeTruthy();
+      expect(queryByText(/Офлайн/)).toBeNull();
+    });
+  });
+});

--- a/apps/mobile/src/core/SyncStatusIndicator.tsx
+++ b/apps/mobile/src/core/SyncStatusIndicator.tsx
@@ -1,0 +1,274 @@
+/**
+ * Sergeant Hub-core — SyncStatusIndicator (React Native)
+ *
+ * Mobile port of the web `SyncStatusIndicator` pill. Thin UI-consumer
+ * of `useSyncStatus()` from `apps/mobile/src/sync/hook/useSyncStatus`.
+ *
+ * @see apps/web/src/core/SyncStatusIndicator.jsx — canonical source of truth
+ * @see apps/web/src/modules/finyk/components/SyncStatusBadge.tsx — similar finyk-scoped badge
+ *
+ * States (derived from the hook + props):
+ *  - `offline`  — `isOnline === false`
+ *                 → bg-warning pill with "Офлайн — N змін у черзі"
+ *                 (N = max(queuedCount, dirtyCount); hidden when 0).
+ *  - `syncing`  — online + pending work (queuedCount > 0 || dirtyCount > 0)
+ *                 → pulse dot + "Синхронізація…" (+ pending count).
+ *  - `error`    — `error` prop provided
+ *                 → bg-danger pill + optional `Retry` ghost button.
+ *  - `idle`     — online + nothing pending
+ *                 → tiny "Синк: on" pill, or nothing when
+ *                 `variant="silent-when-idle"`.
+ *
+ * Error state lives behind a prop rather than the hook because
+ * `useSyncStatus()` deliberately stays read-only (dirtyCount /
+ * queuedCount / isOnline). Parents that already hold a
+ * `useCloudSync()` instance can feed its `syncError` / `pullAll`
+ * into `error` / `onRetry`.
+ *
+ * Accessibility:
+ *  - Respects `AccessibilityInfo.isReduceMotionEnabled()` for the
+ *    syncing pulse, mirroring `Skeleton.tsx`.
+ *  - Sets `accessibilityRole="status"` + `accessibilityLiveRegion`
+ *    on Android so VoiceOver / TalkBack announce state transitions.
+ *
+ * Non-goals (kept out of this PR by design):
+ *  - Not mounted into `_layout.tsx` or any screen — wiring is a
+ *    separate Phase-2 task once Dashboard / HubSettings land.
+ *  - No `lastSyncedAt` formatting (the mobile hook does not expose
+ *    it; a timestamp row can land later with a parallel hook
+ *    extension).
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { AccessibilityInfo, Animated, Text, View } from "react-native";
+import { pluralUa } from "@sergeant/shared";
+
+import { Button } from "@/components/ui/Button";
+import { useSyncStatus } from "@/sync/hook/useSyncStatus";
+
+export type SyncStatusIndicatorVariant = "default" | "silent-when-idle";
+
+export interface SyncStatusIndicatorProps {
+  /**
+   * `silent-when-idle` — collapse to `null` while the sync state is
+   * idle (nothing pending, online, no error). Use this in dense
+   * surfaces (Dashboard hero, HubSettings header) where a static
+   * "Синк: on" pill would be noise.
+   */
+  variant?: SyncStatusIndicatorVariant;
+  /**
+   * Latest sync-error message. When truthy the indicator switches
+   * to the danger state regardless of connectivity. Mirrors the
+   * shape of `useCloudSync(user).syncError`.
+   */
+  error?: string | null;
+  /**
+   * Retry handler. When provided *and* `error` is truthy, renders a
+   * ghost `Button` next to the error message. Typically wired to
+   * `useCloudSync(user).pullAll` or `pushAll`.
+   */
+  onRetry?: () => void;
+  className?: string;
+}
+
+type DerivedStatus = "idle" | "syncing" | "offline" | "error";
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+/**
+ * Reduced-motion-aware pulse. Mirrors `Skeleton.tsx` so the two
+ * components feel part of the same motion family.
+ */
+function usePulse(active: boolean): Animated.AnimatedInterpolation<number> | 1 {
+  const progress = useRef(new Animated.Value(0)).current;
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (mounted) setReduceMotion(enabled);
+      })
+      .catch(() => {
+        // Platforms that don't expose the API default to motion-on.
+      });
+
+    const sub = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      (enabled) => setReduceMotion(enabled),
+    );
+
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      progress.stopAnimation();
+      progress.setValue(0);
+      return undefined;
+    }
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(progress, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(progress, {
+          toValue: 0,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [active, progress, reduceMotion]);
+
+  if (!active || reduceMotion) return 1;
+  return progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [1, 0.4],
+  });
+}
+
+function pendingLabel(count: number): string {
+  return `${count} ${pluralUa(count, {
+    one: "зміна",
+    few: "зміни",
+    many: "змін",
+  })} у черзі`;
+}
+
+export function SyncStatusIndicator({
+  variant = "default",
+  error = null,
+  onRetry,
+  className,
+}: SyncStatusIndicatorProps) {
+  const { dirtyCount, queuedCount, isOnline } = useSyncStatus();
+  const pending = Math.max(dirtyCount, queuedCount);
+
+  const status: DerivedStatus = error
+    ? "error"
+    : !isOnline
+      ? "offline"
+      : pending > 0
+        ? "syncing"
+        : "idle";
+
+  const dotOpacity = usePulse(status === "syncing");
+
+  if (status === "idle" && variant === "silent-when-idle") {
+    return null;
+  }
+
+  if (status === "idle") {
+    return (
+      <View
+        accessibilityRole="text"
+        accessibilityLabel="Синхронізація активна"
+        className={cx(
+          "flex-row items-center gap-2 self-start",
+          "rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1",
+          className,
+        )}
+      >
+        <View className="h-2 w-2 rounded-full bg-emerald-500" />
+        <Text className="text-[11px] font-medium text-emerald-800">
+          Синк: on
+        </Text>
+      </View>
+    );
+  }
+
+  if (status === "syncing") {
+    return (
+      <View
+        accessibilityRole="progressbar"
+        accessibilityLiveRegion="polite"
+        accessibilityLabel={
+          pending > 0
+            ? `Синхронізація, ${pendingLabel(pending)}`
+            : "Синхронізація"
+        }
+        className={cx(
+          "flex-row items-center gap-2 self-start",
+          "rounded-full border border-cream-300 bg-cream-50 px-3 py-1",
+          className,
+        )}
+      >
+        <Animated.View
+          style={{ opacity: dotOpacity }}
+          className="h-2 w-2 rounded-full bg-amber-500"
+        />
+        <Text className="text-xs font-medium text-stone-900">
+          Синхронізація…
+        </Text>
+        {pending > 0 ? (
+          <Text className="text-xs text-stone-500">
+            {pendingLabel(pending)}
+          </Text>
+        ) : null}
+      </View>
+    );
+  }
+
+  if (status === "offline") {
+    return (
+      <View
+        accessibilityRole="alert"
+        accessibilityLiveRegion="polite"
+        accessibilityLabel={
+          pending > 0 ? `Офлайн, ${pendingLabel(pending)}` : "Офлайн"
+        }
+        className={cx(
+          "flex-row items-center gap-2 self-start",
+          "rounded-full border border-amber-300 bg-amber-50 px-3 py-1",
+          className,
+        )}
+      >
+        <View className="h-2 w-2 rounded-full bg-amber-500" />
+        <Text className="text-xs font-semibold text-amber-900">
+          {pending > 0 ? `Офлайн — ${pendingLabel(pending)}` : "Офлайн"}
+        </Text>
+      </View>
+    );
+  }
+
+  // status === "error"
+  return (
+    <View
+      accessibilityRole="alert"
+      accessibilityLiveRegion="assertive"
+      accessibilityLabel={
+        error ? `Помилка синхронізації: ${error}` : "Помилка синхронізації"
+      }
+      className={cx(
+        "flex-row items-center gap-2 self-start",
+        "rounded-full border border-red-300 bg-red-50 px-3 py-1",
+        className,
+      )}
+    >
+      <View className="h-2 w-2 rounded-full bg-red-500" />
+      <Text className="text-xs font-semibold text-red-900" numberOfLines={1}>
+        Помилка синхронізації
+      </Text>
+      {onRetry ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onPress={onRetry}
+          accessibilityLabel="Повторити синхронізацію"
+        >
+          Повторити
+        </Button>
+      ) : null}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 (Hub-ядро) порт web-компонента `SyncStatusIndicator` у
`apps/mobile` — тонкий UI-споживач уже готового мобільного хука
`useSyncStatus()` з `apps/mobile/src/sync/hook/useSyncStatus.ts`.
Слідує за сусідніми Hub-core PR-ами (`ErrorBoundary` /
`ModuleErrorBoundary` у #434) і лежить поруч із ними в
`apps/mobile/src/core/`.

Компонент — чистий UI без власної sync-логіки:

- **idle** — online, нічого не в черзі → компактна пілюля `Синк: on`
  (або `null`, якщо `variant="silent-when-idle"` — для щільних
  поверхонь типу Dashboard / HubSettings header).
- **syncing** — online + `queuedCount > 0 || dirtyCount > 0` →
  pulse-індикатор + `Синхронізація…` + pending count
  (`N змін у черзі` через `pluralUa` з `@sergeant/shared`).
- **offline** — `!isOnline` → bg-warning пілюля `Офлайн — N змін
  у черзі` (N = `max(queuedCount, dirtyCount)`; хідемо тихим
  `Офлайн`, коли черга порожня). Дзеркально до
  `apps/web/src/core/app/OfflineBanner.tsx`.
- **error** — ентрі-поінт для помилки винесено за проп
  (`error?: string | null`, `onRetry?: () => void`). Хук
  `useSyncStatus` навмисно read-only (`dirtyCount` / `queuedCount`
  / `isOnline`) — його web-близнюк теж не експозить помилку.
  Батьки, які вже тримають `useCloudSync(user)`, можуть передати
  `syncError` + `pullAll` у ці пропси без перепаковки хука.
  Помилка бере пріоритет над offline/syncing (як у web-бейджі).

Pulse-анімація — через `Animated` opacity loop, **з повагою до**
`AccessibilityInfo.isReduceMotionEnabled()` — те саме плече, що у
`Skeleton.tsx`. На `useNativeDriver: true` — жодного JS-thread
navigate. Без Reanimated (overkill для одноіндикаторного pulse).

Лягає на shared UI-примітиви (`Button` ghost size-sm для retry) і
концертні `cream-*` / `emerald-*` / `amber-*` / `red-*` токени —
той самий тимчасовий fallback, що у Banner / Skeleton / Card до
моменту, поки мобільні семантичні CSS-змінні підв'яжуться до
`@sergeant/design-tokens`.

Сам індикатор **не** підключений до `_layout.tsx` чи будь-якого
екрану — це свідомо окрема задача з плану (`docs/react-native-migration.md`)
і буде в наступному PR-і Hub-core-інтеграції.

### Docs
Оновлю `docs/react-native-migration.md` (секції 2.0, 2.4, 4) з
посиланням на цей PR у наступному коміті, відразу після створення
PR — так само, як робили попередні Phase 2 кроки.

### Тести
Unit-тест `SyncStatusIndicator.test.tsx` (jest-expo +
`@testing-library/react-native`): render для кожного з 4 станів,
пріоритет error-над-offline, `variant="silent-when-idle"` колапс
до `null`, `onRetry` press-поведінка, відсутність retry-кнопки
коли `onRetry` не передано. `useSyncStatus` замоканий.

## Review & Testing Checklist for Human

- [ ] Подивитись, що текст/тон дзеркальний до web-версії (OfflineBanner / SyncStatusBadge) і читається природно в мобільному контексті.
- [ ] Візуальний smoke у Expo Dev Client: змонтувати `<SyncStatusIndicator />` у тестовому екрані, вимкнути Wi-Fi → очікується offline-пілюля; увімкнути + enqueue змін → syncing → idle.
- [ ] Перевірити, що Reduce Motion (Settings → Accessibility → Motion → Reduce Motion) вимикає pulse-анімацію, але компонент все одно рендериться в коректному кольорі/тексті.

### Notes

- Розмір: ~250 LOC нового коду + ~140 LOC тесту — у межах "малого PR" з плану.
- Без нових runtime-deps.
- `lint` / `typecheck` / `jest-expo` — зелені локально.


Link to Devin session: https://app.devin.ai/sessions/59585499c6524c1697f5b4033275b676
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
