### PR TITLE
feat(hub-settings): port FinykSection / FizrukSection / AIDigestSection (RN, Phase 2)

### DIFF
--- a/apps/mobile/src/core/settings/AIDigestSection.test.tsx
+++ b/apps/mobile/src/core/settings/AIDigestSection.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Render tests for `<AIDigestSection>`.
+ *
+ * Covers:
+ *  - collapsed-by-default header with the "AI Звіт тижня" title;
+ *  - expanding reveals the week-range preview card, the deferred
+ *    generator placeholder, and the Monday-auto toggle;
+ *  - toggling "Автогенерація щопонеділка" persists `"1"` under
+ *    `STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO` (same key + value web
+ *    writes, so the CloudSync envelope stays identical);
+ *  - the week-range helper follows the web `getWeekRange` contract
+ *    (Mon–Sun for the date's ISO week).
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { AIDigestSection, getWeekRange } from "./AIDigestSection";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+describe("AIDigestSection", () => {
+  it("renders the collapsed group header", () => {
+    const { getByText, queryByText } = render(<AIDigestSection />);
+    expect(getByText("AI Звіт тижня")).toBeTruthy();
+    expect(queryByText("Поточний тиждень")).toBeNull();
+  });
+
+  it("expands to reveal the week-range card, deferred notice and toggle", () => {
+    const { getByText, getByTestId } = render(<AIDigestSection />);
+
+    fireEvent.press(getByText("AI Звіт тижня"));
+
+    expect(getByText("Поточний тиждень")).toBeTruthy();
+    expect(getByTestId("aidigest-week-range")).toBeTruthy();
+    expect(
+      getByText(
+        /Генерація звіту тижня підключиться з портом модуля AI-дайджести/,
+      ),
+    ).toBeTruthy();
+    expect(getByText("Автогенерація щопонеділка")).toBeTruthy();
+  });
+
+  it("persists the monday-auto toggle as '1' / '0' in the shared slice", () => {
+    const { getByText, getByTestId } = render(<AIDigestSection />);
+    fireEvent.press(getByText("AI Звіт тижня"));
+
+    fireEvent(getByTestId("aidigest-monday-auto-toggle"), "valueChange", true);
+
+    // `useLocalStorage` with a `string` slot writes strings verbatim
+    // (no JSON.stringify), so the raw MMKV value is literally "1"/"0".
+    const raw = _getMMKVInstance().getString(
+      STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO,
+    );
+    expect(raw).toBe("1");
+
+    fireEvent(getByTestId("aidigest-monday-auto-toggle"), "valueChange", false);
+    const raw2 = _getMMKVInstance().getString(
+      STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO,
+    );
+    expect(raw2).toBe("0");
+  });
+});
+
+describe("getWeekRange", () => {
+  it("returns a Mon–Sun range anchored on the ISO week of the input", () => {
+    // 2024-04-17 is a Wednesday → week is Mon 15 kvi → Nd 21 kvi.
+    const range = getWeekRange(new Date("2024-04-17T12:00:00Z"));
+    expect(range).toMatch(/15/);
+    expect(range).toMatch(/21/);
+  });
+
+  it("handles a Sunday input by anchoring to the Monday that starts the week", () => {
+    // 2024-04-21 is a Sunday → Monday is 15 kvi.
+    const range = getWeekRange(new Date("2024-04-21T12:00:00Z"));
+    expect(range).toMatch(/15/);
+    expect(range).toMatch(/21/);
+  });
+});

--- a/apps/mobile/src/core/settings/AIDigestSection.tsx
+++ b/apps/mobile/src/core/settings/AIDigestSection.tsx
@@ -1,0 +1,111 @@
+/**
+ * Sergeant Hub-core — AIDigestSection (React Native, first cut)
+ *
+ * Mobile mirror of `apps/web/src/core/settings/AIDigestSection.tsx`.
+ *
+ * Within-reach parity (does the real thing now):
+ *  - Week-range preview card — чистий date-помічник рахує Пн–Нд
+ *    поточного тижня (uk-UA `day: "numeric", month: "short"`), так
+ *    само як web `getWeekRange`. Карточка зверху pre-view-карти
+ *    «Поточний тиждень».
+ *  - "Автогенерація щопонеділка" toggle — персистить `"1"` / `"0"`
+ *    у MMKV під `STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO`. Ключ +
+ *    значення дзеркальні до web `AIDigestSection`, отож payload
+ *    їде під тим самим cloud-sync-конвертом без міграцій.
+ *
+ * Deferred (див. `docs/react-native-migration.md` Phase 2 /
+ * Hub-core, §2.4) — рендериться як `DeferredNotice`-карточка
+ * всередині групи:
+ *  - **Генерація звіту тижня.** Web викликає `useWeeklyDigest.generate`,
+ *    який тягне `coachApi`/`weeklyDigestApi` через React Query та
+ *    агрегує дані з локальних кешів фінансів/тренувань/харчування.
+ *    Жоден із цих доменних модулів не портований на mobile,
+ *    тому на mobile цей PR лише вмикає прапорець автогенерації —
+ *    саме AI-генерація підключиться разом із портом модуля
+ *    AI-дайджести.
+ */
+
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { Card } from "@/components/ui/Card";
+import { useLocalStorage } from "@/lib/storage";
+
+import { SettingsGroup, ToggleRow } from "./SettingsPrimitives";
+
+/**
+ * Локальна копія web `getWeekRange` — pure, без `Intl`-специфіки,
+ * яка могла б відрізнятися між web/hermes. Повертає рядок формату
+ * `"Пн 15 кві — Нд 21 кві"` для тижня, що містить `date` (Пн-Нд).
+ *
+ * Дублюємо тут замість ліфту у `@sergeant/shared`, щоб не розширювати
+ * публічну поверхню пакета заради одного помічника, що живе рівно
+ * у двох місцях (web `useWeeklyDigest.ts` + mobile AIDigestSection).
+ * Коли модуль AI-дайджести реально портуватиметься на mobile,
+ * спільний helper нормалізуємо разом з іншим доменним кодом.
+ */
+export function getWeekRange(date: Date = new Date()): string {
+  const monday = new Date(date);
+  monday.setDate(date.getDate() - ((date.getDay() + 6) % 7));
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const fmt = (dt: Date): string =>
+    dt.toLocaleDateString("uk-UA", { day: "numeric", month: "short" });
+  return `${fmt(monday)} — ${fmt(sunday)}`;
+}
+
+function DeferredNotice({ children }: { children: string }) {
+  return (
+    <Card variant="flat" radius="md" padding="md" className="border-dashed">
+      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+    </Card>
+  );
+}
+
+export function AIDigestSection() {
+  const [mondayAutoRaw, setMondayAutoRaw] = useLocalStorage<string>(
+    STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO,
+    "",
+  );
+  const mondayAuto = mondayAutoRaw === "1";
+
+  const weekRange = useMemo(() => getWeekRange(), []);
+
+  return (
+    <SettingsGroup title="AI Звіт тижня" emoji="📋">
+      <Text className="text-xs text-stone-500 leading-snug">
+        Тижневий AI-аналіз прогресу по всіх модулях: фінанси, тренування,
+        харчування та звички. Звіт доступний на дашборді щопонеділка або за
+        запитом.
+      </Text>
+      <Card variant="flat" radius="md" padding="md">
+        <Text className="text-xs font-semibold text-stone-900">
+          Поточний тиждень
+        </Text>
+        <Text
+          className="text-xs text-stone-500 mt-0.5"
+          testID="aidigest-week-range"
+        >
+          {weekRange}
+        </Text>
+      </Card>
+
+      <DeferredNotice>
+        Генерація звіту тижня підключиться з портом модуля AI-дайджести — зараз
+        налаштування автогенерації лише зберігається, сам виклик коуча ще не
+        портований на mobile.
+      </DeferredNotice>
+
+      <View className="pt-1">
+        <ToggleRow
+          label="Автогенерація щопонеділка"
+          description="Якщо ввімкнено, ранкова сесія в понеділок запускає звіт у фоні. Вимкнуто за замовчуванням — інакше AI-виклик зʼїдається без твого запиту."
+          checked={mondayAuto}
+          onChange={(next) => setMondayAutoRaw(next ? "1" : "0")}
+          testID="aidigest-monday-auto-toggle"
+        />
+      </View>
+    </SettingsGroup>
+  );
+}

--- a/apps/mobile/src/core/settings/FinykSection.test.tsx
+++ b/apps/mobile/src/core/settings/FinykSection.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Render tests for `<FinykSection>`.
+ *
+ * Covers:
+ *  - collapsed-by-default header with the "Фінік" title;
+ *  - expanding reveals the custom-categories sub-group (input +
+ *    "Додати" button + empty-state copy) plus the deferred
+ *    Monobank / Accounts notices;
+ *  - adding a category persists `{id, label}` into
+ *    `STORAGE_KEYS.FINYK_CUSTOM_CATS` — the same
+ *    `finyk_custom_cats_v1` key web writes to, so the payload
+ *    travels under the existing CloudSync envelope;
+ *  - removing a category is gated by a ConfirmDialog and drops the
+ *    entry on confirm.
+ */
+
+import { fireEvent, render, within } from "@testing-library/react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { FinykSection } from "./FinykSection";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+describe("FinykSection", () => {
+  it("renders the collapsed group header", () => {
+    const { getByText, queryByText } = render(<FinykSection />);
+    expect(getByText("Фінік")).toBeTruthy();
+    expect(queryByText("Власні категорії витрат")).toBeNull();
+  });
+
+  it("expands to reveal the custom-categories sub-group and deferred notices", () => {
+    const { getByText } = render(<FinykSection />);
+
+    fireEvent.press(getByText("Фінік"));
+
+    expect(getByText("Власні категорії витрат")).toBeTruthy();
+    expect(getByText("Поки немає власних категорій.")).toBeTruthy();
+    expect(getByText("Monobank")).toBeTruthy();
+    expect(
+      getByText(
+        /Підключення Monobank, статус підʼєднання та очистка кешу транзакцій/,
+      ),
+    ).toBeTruthy();
+    expect(getByText("Рахунки")).toBeTruthy();
+    expect(
+      getByText(
+        /Приховування рахунків з балансу та нетворсу тягне `finyk_info_cache`/,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("persists a newly added custom category into finyk_custom_cats_v1", () => {
+    const { getByText, getByTestId } = render(<FinykSection />);
+    fireEvent.press(getByText("Фінік"));
+
+    const input = getByTestId("finyk-custom-cat-input");
+    fireEvent.changeText(input, "🎨 Хобі");
+    fireEvent.press(getByTestId("finyk-custom-cat-add"));
+
+    const raw = _getMMKVInstance().getString(STORAGE_KEYS.FINYK_CUSTOM_CATS);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string) as Array<{
+      id: string;
+      label: string;
+    }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].label).toBe("🎨 Хобі");
+    expect(typeof parsed[0].id).toBe("string");
+    expect(parsed[0].id.length).toBeGreaterThan(0);
+  });
+
+  it("removes a category after confirming in the ConfirmDialog", () => {
+    _getMMKVInstance().set(
+      STORAGE_KEYS.FINYK_CUSTOM_CATS,
+      JSON.stringify([{ id: "c_1", label: "📚 Книги" }]),
+    );
+    const { getByText, getByTestId, queryByText } = render(<FinykSection />);
+    fireEvent.press(getByText("Фінік"));
+
+    expect(getByText("📚 Книги")).toBeTruthy();
+
+    fireEvent.press(getByTestId("finyk-custom-cat-remove-c_1"));
+
+    // ConfirmDialog is open — confirm label is "Видалити". There may be
+    // two "Видалити" strings on screen (row + confirm button); scope
+    // the lookup to the rendered Modal via the dialog title.
+    expect(getByText("Видалити категорію?")).toBeTruthy();
+    const modal = getByText("Видалити категорію?").parent?.parent as
+      | Parameters<typeof within>[0]
+      | undefined;
+    if (modal) {
+      fireEvent.press(within(modal).getByText("Видалити"));
+    } else {
+      // Fallback — should not happen given the component tree.
+      fireEvent.press(getByText("Видалити"));
+    }
+
+    expect(queryByText("📚 Книги")).toBeNull();
+
+    const raw = _getMMKVInstance().getString(STORAGE_KEYS.FINYK_CUSTOM_CATS);
+    expect(JSON.parse(raw as string)).toEqual([]);
+  });
+});

--- a/apps/mobile/src/core/settings/FinykSection.tsx
+++ b/apps/mobile/src/core/settings/FinykSection.tsx
@@ -1,0 +1,201 @@
+/**
+ * Sergeant Hub-core — FinykSection (React Native, first cut)
+ *
+ * Mobile mirror of `apps/web/src/core/settings/FinykSection.tsx`.
+ *
+ * Within-reach parity (does the real thing now):
+ *  - "Власні категорії витрат" — input + "Додати" + список із
+ *    "Видалити" кнопкою біля кожної. Персистимо у MMKV під
+ *    `STORAGE_KEYS.FINYK_CUSTOM_CATS` (`finyk_custom_cats_v1`) —
+ *    ЙДЕ тим самим cloud-sync-конвертом, що й web, бо ключ
+ *    `FINYK_CUSTOM_CATS` уже входить у `cloudSync/config.ts`
+ *    webʼу. Shape `[{ id, label }]` ідентичний web-варіанту
+ *    (`apps/web/src/modules/finyk/hooks/useStorage.ts`).
+ *    Видалення — через `ConfirmDialog`, щоб не зʼєсти запис
+ *    випадковим тапом (аналог `AttentionModal` + fade у web).
+ *
+ * Deferred (див. `docs/react-native-migration.md` Phase 2 /
+ * Hub-core, §2.4) — рендериться як `DeferredNotice`-карточка:
+ *  - **Monobank: статус, очистка кешу, disconnect.** Web читає
+ *    `finyk_info_cache` + `finyk_token` (одне підʼєднане через
+ *    OAuth-flow Фініка). Mobile ще не має власного Monobank-флоу
+ *    (Phase 4+ — інтеграції/токени), тому секція тут — плейсхолдер
+ *    із поясненням, що підключиться разом із портом модуля Фінік.
+ *  - **Рахунки (сховати/показати).** Залежить від `finyk_info_cache`
+ *    з того самого Monobank-флоу — плейсхолдер з тим самим
+ *    обґрунтуванням.
+ *  - **Privat24.** На web `PRIVAT_ENABLED = false`, тобто й там
+ *    секція прихована. Ніякого UI для неї не портуємо.
+ */
+
+import { useState } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Input } from "@/components/ui/Input";
+import { useLocalStorage } from "@/lib/storage";
+
+import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
+
+interface CustomCategory {
+  id: string;
+  label: string;
+}
+
+const CUSTOM_CATS_KEY = STORAGE_KEYS.FINYK_CUSTOM_CATS;
+const MAX_LABEL_LENGTH = 80;
+
+function makeCategoryId(): string {
+  // `Math.random().toString(36)` is good enough for a local-only id —
+  // mirrors the web `useStorage` hook that also seeds its ids from
+  // `crypto.randomUUID()` + fallback. We keep it simple here to avoid
+  // pulling in `expo-crypto` for a sub-categorical affordance.
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `c_${ts}_${rand}`;
+}
+
+function DeferredNotice({ children }: { children: string }) {
+  return (
+    <Card variant="flat" radius="md" padding="md" className="border-dashed">
+      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+    </Card>
+  );
+}
+
+export function FinykSection() {
+  const [customCategories, setCustomCategories] = useLocalStorage<
+    CustomCategory[]
+  >(CUSTOM_CATS_KEY, []);
+  const [newCategoryLabel, setNewCategoryLabel] = useState("");
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const trimmedLabel = newCategoryLabel.trim();
+  const canAdd = trimmedLabel.length > 0;
+
+  const addCategory = () => {
+    if (!canAdd) return;
+    const label = trimmedLabel.slice(0, MAX_LABEL_LENGTH);
+    setCustomCategories((prev) => {
+      const list = Array.isArray(prev) ? prev : [];
+      return [...list, { id: makeCategoryId(), label }];
+    });
+    setNewCategoryLabel("");
+  };
+
+  const confirmRemove = () => {
+    if (!pendingDeleteId) return;
+    const id = pendingDeleteId;
+    setCustomCategories((prev) => {
+      const list = Array.isArray(prev) ? prev : [];
+      return list.filter((c) => c.id !== id);
+    });
+    setPendingDeleteId(null);
+  };
+
+  const pendingLabel = pendingDeleteId
+    ? (customCategories.find((c) => c.id === pendingDeleteId)?.label ?? "")
+    : "";
+
+  return (
+    <SettingsGroup title="Фінік" emoji="💳">
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        title="Видалити категорію?"
+        description={
+          pendingLabel
+            ? `«${pendingLabel}» більше не зʼявлятиметься у списку категорій.`
+            : "Категорію буде видалено з списку."
+        }
+        confirmLabel="Видалити"
+        danger
+        onConfirm={confirmRemove}
+        onCancel={() => setPendingDeleteId(null)}
+      />
+
+      <SettingsSubGroup title="Власні категорії витрат">
+        <Text className="text-xs text-stone-500 leading-snug">
+          Додаються до списку категорій у транзакціях, сплітах і лімітах (можна
+          вказати емодзі на початку назви).
+        </Text>
+        <View className="flex-row gap-2 items-stretch">
+          <Input
+            value={newCategoryLabel}
+            onChangeText={setNewCategoryLabel}
+            placeholder="Напр. 🎨 Хобі"
+            maxLength={MAX_LABEL_LENGTH}
+            returnKeyType="done"
+            onSubmitEditing={addCategory}
+            containerClassName="flex-1"
+            testID="finyk-custom-cat-input"
+          />
+          <Button
+            onPress={addCategory}
+            disabled={!canAdd}
+            variant="finyk"
+            testID="finyk-custom-cat-add"
+          >
+            Додати
+          </Button>
+        </View>
+        {customCategories.length > 0 ? (
+          <FlatList
+            data={customCategories}
+            keyExtractor={(item) => item.id}
+            scrollEnabled={false}
+            // The outer ScrollView already owns scrolling; this list is
+            // only here for the styled row separators + keyExtractor.
+            renderItem={({ item, index }) => (
+              <View
+                className={`flex-row items-center justify-between gap-2 py-3 ${
+                  index > 0 ? "border-t border-cream-300" : ""
+                }`}
+                testID={`finyk-custom-cat-row-${item.id}`}
+              >
+                <Text
+                  className="text-sm font-medium text-stone-900 flex-1 min-w-0"
+                  numberOfLines={1}
+                >
+                  {item.label}
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Видалити «${item.label}»`}
+                  onPress={() => setPendingDeleteId(item.id)}
+                  testID={`finyk-custom-cat-remove-${item.id}`}
+                  className="shrink-0 px-2 py-1"
+                >
+                  <Text className="text-xs font-semibold text-red-500">
+                    Видалити
+                  </Text>
+                </Pressable>
+              </View>
+            )}
+          />
+        ) : (
+          <Text className="text-xs text-stone-500">
+            Поки немає власних категорій.
+          </Text>
+        )}
+      </SettingsSubGroup>
+
+      <SettingsSubGroup title="Monobank">
+        <DeferredNotice>
+          Підключення Monobank, статус підʼєднання та очистка кешу транзакцій
+          підключаться з портом модуля Фінік (Phase 4+). На web вони живуть
+          поверх OAuth-флоу, який на mobile ще не портований.
+        </DeferredNotice>
+      </SettingsSubGroup>
+
+      <SettingsSubGroup title="Рахунки">
+        <DeferredNotice>
+          Приховування рахунків з балансу та нетворсу тягне `finyk_info_cache` з
+          Monobank-флоу — підключиться разом із портом модуля Фінік.
+        </DeferredNotice>
+      </SettingsSubGroup>
+    </SettingsGroup>
+  );
+}

--- a/apps/mobile/src/core/settings/FizrukSection.test.tsx
+++ b/apps/mobile/src/core/settings/FizrukSection.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Render tests for `<FizrukSection>`.
+ *
+ * Covers:
+ *  - collapsed-by-default header with the "Фізрук" title;
+ *  - expanding reveals the rest-timer sub-group with one row per
+ *    `REST_CATEGORY_LABELS` entry from `@sergeant/fizruk-domain`;
+ *  - tapping a preset pill persists the matching category/seconds
+ *    pair into the shared `fizruk_rest_settings_v1` MMKV slice (same
+ *    key web's `useRestSettings` writes to);
+ *  - the backup/data sub-group surfaces its deferred-port placeholder
+ *    (Phase 6).
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { FizrukSection } from "./FizrukSection";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+describe("FizrukSection", () => {
+  it("renders the collapsed group header", () => {
+    const { getByText, queryByText } = render(<FizrukSection />);
+    expect(getByText("Фізрук")).toBeTruthy();
+    expect(queryByText("Таймер відпочинку")).toBeNull();
+  });
+
+  it("expands to reveal rest-timer rows and the deferred backup notice", () => {
+    const { getByText } = render(<FizrukSection />);
+
+    fireEvent.press(getByText("Фізрук"));
+
+    expect(getByText("Таймер відпочинку")).toBeTruthy();
+    expect(getByText("Базові (compound)")).toBeTruthy();
+    expect(getByText("Ізолюючі")).toBeTruthy();
+    expect(getByText("Кардіо")).toBeTruthy();
+
+    expect(getByText("Резервні копії та дані")).toBeTruthy();
+    expect(
+      getByText(
+        /Експорт та імпорт тренувань чекають реального mobile-адаптера downloadJson/,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("persists a selected rest preset into fizruk_rest_settings_v1", () => {
+    const { getByText, getByTestId } = render(<FizrukSection />);
+    fireEvent.press(getByText("Фізрук"));
+
+    fireEvent.press(getByTestId("fizruk-rest-compound-120"));
+
+    const stored = _getMMKVInstance().getString(
+      STORAGE_KEYS.FIZRUK_REST_SETTINGS,
+    );
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored as string)).toMatchObject({ compound: 120 });
+  });
+});

--- a/apps/mobile/src/core/settings/FizrukSection.tsx
+++ b/apps/mobile/src/core/settings/FizrukSection.tsx
@@ -1,0 +1,139 @@
+/**
+ * Sergeant Hub-core — FizrukSection (React Native, first cut)
+ *
+ * Mobile mirror of `apps/web/src/core/settings/FizrukSection.tsx`.
+ *
+ * Within-reach parity (does the real thing now):
+ *  - "Таймер відпочинку" — 30/60/90/120/180s pills per rest category
+ *    (`compound` / `isolation` / `cardio`). `REST_CATEGORY_LABELS` та
+ *    `REST_DEFAULTS` беремо з `@sergeant/fizruk-domain` — той самий
+ *    DOM-free пакет, з якого читає web-хук `useRestSettings`. Вибір
+ *    користувача персистимо через MMKV-бекований `useLocalStorage`
+ *    у `STORAGE_KEYS.FIZRUK_REST_SETTINGS` (той самий ключ
+ *    `fizruk_rest_settings_v1` використовує web — payload рідe під
+ *    тим самим cloud-sync-конвертом, нічого мігрувати не треба).
+ *
+ * Deferred (див. `docs/react-native-migration.md` Phase 2 / Hub-core,
+ * §2.4) — рендериться як `DeferredNotice`-карточка:
+ *  - **Резервні копії та дані** (`WorkoutBackupBar` на web).
+ *    Експорт / імпорт тренувань чекають реальний mobile-адаптер
+ *    `downloadJson` (expo-file-system + expo-sharing) та
+ *    `expo-document-picker` для імпорту — сьогодні у коді є лише
+ *    warn-only stub у `apps/mobile/src/lib/fileDownload.ts`. Підключиться
+ *    з портом модуля Фізрук (Phase 6) разом із рештою backup-flows.
+ */
+
+import { useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { STORAGE_KEYS } from "@sergeant/shared";
+import {
+  REST_CATEGORY_LABELS,
+  REST_DEFAULTS,
+  type RestCategory,
+} from "@sergeant/fizruk-domain/lib/restSettings";
+
+import { Card } from "@/components/ui/Card";
+import { useLocalStorage } from "@/lib/storage";
+
+import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
+
+const REST_KEY = STORAGE_KEYS.FIZRUK_REST_SETTINGS;
+
+// Mirrors the web pill set 1:1 (30/60/90/120/180 seconds).
+const REST_PRESETS: readonly number[] = [30, 60, 90, 120, 180] as const;
+
+type RestSettings = Partial<Record<RestCategory, number>>;
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+function DeferredNotice({ children }: { children: string }) {
+  return (
+    <Card variant="flat" radius="md" padding="md" className="border-dashed">
+      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+    </Card>
+  );
+}
+
+export function FizrukSection() {
+  const [settings, setSettings] = useLocalStorage<RestSettings>(REST_KEY, {});
+
+  const resolved = useMemo<Record<RestCategory, number>>(() => {
+    return { ...REST_DEFAULTS, ...settings };
+  }, [settings]);
+
+  const categories = useMemo(
+    () =>
+      (Object.entries(REST_CATEGORY_LABELS) as [RestCategory, string][]).map(
+        ([cat, label]) => ({ cat, label }),
+      ),
+    [],
+  );
+
+  return (
+    <SettingsGroup title="Фізрук" emoji="🏋️">
+      <SettingsSubGroup title="Таймер відпочинку">
+        <Text className="text-xs text-stone-500 leading-snug">
+          Рекомендований час відпочинку підбирається автоматично за типом
+          вправи. Ці значення з&apos;являться як кнопка за замовчуванням у
+          кожній вправі.
+        </Text>
+        <View className="gap-3">
+          {categories.map(({ cat, label }) => (
+            <View
+              key={cat}
+              className="flex-row items-center gap-3"
+              testID={`fizruk-rest-row-${cat}`}
+            >
+              <Text className="text-xs text-stone-900 flex-1 min-w-0">
+                {label}
+              </Text>
+              <View className="flex-row items-center gap-1 flex-wrap justify-end">
+                {REST_PRESETS.map((sec) => {
+                  const selected = resolved[cat] === sec;
+                  return (
+                    <Pressable
+                      key={sec}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected }}
+                      accessibilityLabel={`${label}: ${sec} секунд`}
+                      testID={`fizruk-rest-${cat}-${sec}`}
+                      onPress={() =>
+                        setSettings((prev) => ({ ...prev, [cat]: sec }))
+                      }
+                      className={cx(
+                        "h-9 w-14 rounded-xl border items-center justify-center",
+                        selected
+                          ? "border-brand-500 bg-brand-50"
+                          : "border-cream-300 bg-cream-50",
+                      )}
+                    >
+                      <Text
+                        className={cx(
+                          "text-xs font-semibold",
+                          selected ? "text-brand-700" : "text-stone-500",
+                        )}
+                      >
+                        {sec}с
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          ))}
+        </View>
+      </SettingsSubGroup>
+
+      <SettingsSubGroup title="Резервні копії та дані">
+        <DeferredNotice>
+          Експорт та імпорт тренувань чекають реального mobile-адаптера
+          downloadJson (expo-file-system + expo-sharing) та expo-document-picker
+          — сьогодні у коді є лише warn-only заглушка. Підключиться з портом
+          модуля Фізрук (Phase 6).
+        </DeferredNotice>
+      </SettingsSubGroup>
+    </SettingsGroup>
+  );
+}

--- a/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
@@ -1,11 +1,10 @@
 /**
  * Render smoke test for the Hub-core Settings shell.
  *
- * Keeps the scope tight: the shell renders the screen title, the four
- * first-cut section headers (General / Notifications / Routine /
- * Experimental), and each of the "буде портовано" placeholders for
- * sections that still need porting. Section-level behaviour is
- * covered by the per-section suites.
+ * Keeps the scope tight: the shell renders the screen title and all
+ * seven Hub-core section headers (General / Notifications / Routine /
+ * Finyk / Fizruk / AIDigest / Experimental). Section-level behaviour
+ * is covered by the per-section suites.
  */
 
 import { render } from "@testing-library/react-native";
@@ -38,25 +37,16 @@ beforeEach(() => {
 });
 
 describe("HubSettingsPage", () => {
-  it("renders the screen title and all first-cut section headers", () => {
+  it("renders the screen title and all seven section headers", () => {
     const { getByText } = render(<HubSettingsPage />);
 
     expect(getByText("Налаштування")).toBeTruthy();
     expect(getByText("Загальні")).toBeTruthy();
     expect(getByText("Сповіщення")).toBeTruthy();
     expect(getByText("Рутина")).toBeTruthy();
+    expect(getByText("Фінік")).toBeTruthy();
+    expect(getByText("Фізрук")).toBeTruthy();
+    expect(getByText("AI Звіт тижня")).toBeTruthy();
     expect(getByText("Експериментальне")).toBeTruthy();
-  });
-
-  it("renders placeholders for the not-yet-ported sections", () => {
-    const { getByText, getAllByText } = render(<HubSettingsPage />);
-
-    for (const title of ["AI-дайджести", "Фізрук", "Фінік"]) {
-      expect(getByText(title)).toBeTruthy();
-    }
-    // Three placeholders share the same "Скоро" chip + caption after
-    // GeneralSection and NotificationsSection took over their spots.
-    expect(getAllByText("Скоро")).toHaveLength(3);
-    expect(getAllByText("Буде портовано у наступному PR.")).toHaveLength(3);
   });
 });

--- a/apps/mobile/src/core/settings/HubSettingsPage.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.tsx
@@ -3,66 +3,38 @@
  *
  * Mobile port of `apps/web/src/core/HubSettingsPage.tsx`.
  *
- * Scope of this first cut (Phase 2 / Hub-core):
+ * Scope of this cut (Phase 2 / Hub-core — remaining sections PR):
  *  - Shell with a screen title ("Налаштування") and a vertical stack of
  *    collapsible `SettingsGroup` cards, one per section.
- *  - Four sections ported: `GeneralSection`, `RoutineSection`,
- *    `ExperimentalSection`, `NotificationsSection`.
- *  - Three remaining sections (Finyk / Fizruk / AIDigest) are rendered
- *    as `<PlaceholderSection>` cards with a "Скоро — буде портовано"
- *    label + the same `emoji + title` shape as `SettingsGroup` so the
- *    visual hierarchy is already final.
+ *  - All seven Hub-core sections now porting in: `GeneralSection`,
+ *    `NotificationsSection`, `RoutineSection`, `FinykSection`,
+ *    `FizrukSection`, `AIDigestSection`, `ExperimentalSection`.
  *
  * Intentional differences from the web shell:
- *  - No `Tabs` group switcher and no fuzzy search input yet — both would
- *    pull in a sizeable chunk of layout logic that is better added once
- *    all sections are ported. For now the UX is "scroll through a
- *    single list of groups", which is the common mobile settings
- *    pattern (iOS/Android system settings, Linear, Things, etc).
- *  - `GeneralSection` on mobile is self-contained (reads prefs from MMKV
- *    under the shared `hub_prefs_v1` slice); web wires `dark` /
+ *  - No `Tabs` group switcher and no fuzzy search input yet — both
+ *    would pull in a sizeable chunk of layout logic that is better
+ *    added once every section is polished. For now the UX is
+ *    "scroll through a single list of groups", which is the common
+ *    mobile-settings pattern (iOS/Android system settings, Linear,
+ *    Things, etc).
+ *  - `GeneralSection` on mobile is self-contained (reads prefs from
+ *    MMKV under the shared `hub_prefs_v1` slice); web wires `dark` /
  *    `onToggleDark` / `syncing` / `onSync` / `onPull` / `user` via
  *    prop-drilling from the App root. The mobile equivalent for the
  *    cloud-sync buttons lands in a follow-up (see GeneralSection.tsx
  *    header for the rationale).
  */
 
-import { ScrollView, Text, View } from "react-native";
+import { ScrollView, Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { Card } from "@/components/ui/Card";
-
+import { AIDigestSection } from "./AIDigestSection";
 import { ExperimentalSection } from "./ExperimentalSection";
+import { FinykSection } from "./FinykSection";
+import { FizrukSection } from "./FizrukSection";
 import { GeneralSection } from "./GeneralSection";
 import { NotificationsSection } from "./NotificationsSection";
 import { RoutineSection } from "./RoutineSection";
-
-interface PlaceholderSectionProps {
-  title: string;
-  emoji: string;
-}
-
-/**
- * Visual twin of `SettingsGroup` (collapsed state) for sections that
- * have not been ported yet. See the Phase 2 roadmap in
- * `docs/react-native-migration.md`.
- */
-function PlaceholderSection({ title, emoji }: PlaceholderSectionProps) {
-  return (
-    <Card radius="lg" padding="md">
-      <View className="flex-row items-center gap-2">
-        <Text className="text-base">{emoji}</Text>
-        <Text className="text-sm font-semibold text-stone-900 flex-1">
-          {title}
-        </Text>
-        <Text className="text-xs text-stone-500">Скоро</Text>
-      </View>
-      <Text className="text-xs text-stone-500 mt-1 leading-snug">
-        Буде портовано у наступному PR.
-      </Text>
-    </Card>
-  );
-}
 
 export function HubSettingsPage() {
   return (
@@ -79,13 +51,10 @@ export function HubSettingsPage() {
         <GeneralSection />
         <NotificationsSection />
         <RoutineSection />
+        <FinykSection />
+        <FizrukSection />
+        <AIDigestSection />
         <ExperimentalSection />
-
-        {/* TODO(mobile-migration): порт секцій іде окремими PR-ами.
-            Див. docs/react-native-migration.md (Phase 2 / Hub-core). */}
-        <PlaceholderSection title="AI-дайджести" emoji="🤖" />
-        <PlaceholderSection title="Фізрук" emoji="🏋️" />
-        <PlaceholderSection title="Фінік" emoji="💰" />
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary

Закриває залишок Phase 2 (Hub-core) з `docs/react-native-migration.md` (§2.0 «Стратегія» та §4 «Фазований план» — рядок "Phase 2 · Hub-core", §5.1 «Hub» — розділ HubSettings). У `apps/mobile/src/core/settings/` зʼявляються три секції, які раніше були `PlaceholderSection`:

- **`FinykSection`** — порт власних категорій витрат (`finyk_custom_cats_v1`): Input + "Додати" + список із `ConfirmDialog`-гейтованим "Видалити". Ключ ідентичний web-хуку `useFinykStorage`, тому запис їде під уже сконфігурованим CloudSync-конвертом (`apps/web/src/core/cloudSync/config.ts`). Monobank-підключення / очистку кешу / приховування рахунків (uahAccounts з `finyk_info_cache`) залишаємо як `DeferredNotice` — вони тягнуть OAuth-флоу Фініка, який підʼєднається з портом самого модуля (Phase 4+). Privat24 з web-секції не беремо (`PRIVAT_ENABLED = false` на web).
- **`FizrukSection`** — rest-timer preset pills (30/60/90/120/180 с) по кожній категорії з `REST_CATEGORY_LABELS` / `REST_DEFAULTS` (імпорт через subpath `@sergeant/fizruk-domain/lib/restSettings`, щоб jest не резолвив кореневий `index.ts` з `.js`-суфіксами). Пише в `STORAGE_KEYS.FIZRUK_REST_SETTINGS` — той самий ключ, що й web `useRestSettings`. Workout-backup (downloadJson + document-picker) — `DeferredNotice`, підключиться у Phase 6.
- **`AIDigestSection`** — картка прев'ю поточного тижня (локальний `getWeekRange` з `uk-UA`-форматом, Mon–Sun ISO-тижня) + toggle «Автогенерація щопонеділка», що пише `"1"`/`"0"` у `STORAGE_KEYS.WEEKLY_DIGEST_MONDAY_AUTO` — формат сумісний із web-варіантом `useWeeklyDigest`. Саму генерацію digest-а (потребує коуча + `useWeeklyDigest`) залишаємо як `DeferredNotice`.

`HubSettingsPage.tsx` оновлено: усі три `PlaceholderSection` замінено на реальні секції; `PlaceholderSection` хелпер видалено разом із зайвими імпортами.

Дотримано правил §6 (cross-cutting) і §7 (web-only API → RN заміни): жодних `<div>` / `<button>` / `<input>` / `<localStorage>` / `emotion` — лише `View`/`Text`/`Pressable`/`Switch`/`FlatList` + існуючі UI-компоненти (`Button`, `Card`, `Input`, `ConfirmDialog`) і `useLocalStorage` поверх MMKV. Styling — NativeWind з токенами `@sergeant/design-tokens`.

### Тести (jest-expo)

Додано по snapshot-free behavior-suite на секцію + розширено shell-тест:

- `FinykSection.test.tsx` — колапс-рендер заголовка, розкриття → input/add-кнопка/empty-state, персист `{id, label}` у `finyk_custom_cats_v1`, потік ConfirmDialog → видалення.
- `FizrukSection.test.tsx` — колапс-рендер, розкриття → три рядки категорій + deferred-notice бекапу, персист `{compound: 120}` у `fizruk_rest_settings_v1` після тапу по pill-у.
- `AIDigestSection.test.tsx` — колапс-рендер, розкриття → картка тижня + deferred-notice + toggle; монд-ауто пише `"1"`/`"0"`; окремий describe на `getWeekRange` з sanity-перевірками для Wed- і Sun-інпутів.
- `HubSettingsPage.test.tsx` — всі сім заголовків секцій рендеряться у шелі.

Локально:
- `pnpm --filter @sergeant/mobile lint` → green
- `pnpm --filter @sergeant/mobile test` → **28/28 suites, 145/145 tests green**
- `pnpm --filter @sergeant/mobile typecheck` → падає на pre-existing помилках у `packages/fizruk-domain/src/lib/{workoutStats,recoveryCompute,recoveryConflict,trainingPrograms}.ts` та `src/data/index.ts` (42 імпліцитних `any`). Перевірив повторно зі `stash`-нутими локальними змінами — ті самі 42 помилки в тих самих 5 файлах на чистому `main` (після `8627c8b` / PR #455). PR їх не торкається згідно з правилом «не чіпати інших модулів».

## Review & Testing Checklist for Human

- [ ] Перевірити ручний флоу у Фініку: додати/видалити 1–2 категорії → перевірити, що список тримається між reload-ами (MMKV під `finyk_custom_cats_v1`) і що веб-хаб (якщо підʼєднаний CloudSync-конверт) бачить ту саму категорію.
- [ ] Тапнути pill-и у Фізрук-секції для кожної категорії — підсвічення має переключатись і зберігатись (MMKV `fizruk_rest_settings_v1`).
- [ ] Увімкнути/вимкнути «Автогенерація щопонеділка» й переконатись, що `WEEKLY_DIGEST_MONDAY_AUTO` тримає `"1"`/`"0"` (на web — сумісний формат).
- [ ] Перевірити візуальну відповідність колапс/експанд заголовків трьох нових секцій із уже готовими (General/Routine/Notifications/Experimental) — стек має лишатись візуально однорідним.

### Notes

- Monobank / Privat24 / hidden accounts свідомо лишились як `DeferredNotice` — будь-яка спроба повноцінного порту без модуля Фінік потягне за собою OAuth-флоу / `finyk_info_cache` / `privatApi`, що виходить за межі Hub-core.
- Pre-existing typecheck-помилки у `packages/fizruk-domain` зʼявились після PR #455 (landed перед цим PR) і відтворюються на чистому `main`; виправлення виходить за scope «settings-шел only».
- Для `FizrukSection` використаний subpath-імпорт `@sergeant/fizruk-domain/lib/restSettings` — кореневий `@sergeant/fizruk-domain` index зараз містить `export * from "./constants.js"` та не резолвиться jest-ом через пакет-екстрактор (не торкаю у цьому PR, щоб лишатись консервативним у shared-коді).

Link to Devin session: https://app.devin.ai/sessions/5bafd2d257814839bb727352f48de02f
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI weekly digest settings with week-range preview and auto-generation toggle
  * Added custom expense category management with add/remove functionality
  * Added rest timer presets by exercise category for workout recovery
  * Completed settings sections previously shown as coming soon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->