### PR TITLE
feat(mobile/fizruk): нативний BodyAtlas на react-native-svg (Фаза 6 · PR-C)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -49,6 +49,7 @@
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
+    "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
     "zod": "^4.3.6"
   },

--- a/apps/mobile/src/modules/fizruk/__tests__/BodyAtlas.test.tsx
+++ b/apps/mobile/src/modules/fizruk/__tests__/BodyAtlas.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Behavior + snapshot tests for the RN BodyAtlas (Phase 6 · PR-C).
+ *
+ * Asserts the three public-surface invariants:
+ *
+ *   1. Snapshot stability — the silhouette is a visual contract that
+ *      design tokens consumers (and later recovery-data wiring) must
+ *      not accidentally change. Front + back views are both snapped.
+ *   2. Tap behaviour — pressing a muscle fires `onMusclePress` with
+ *      the canonical atlas id (not a domain id, not a localised label),
+ *      and only that id.
+ *   3. Accessibility — each muscle `G` carries a Ukrainian
+ *      `accessibilityLabel` that includes the muscle name and (when
+ *      active) the intensity percentage.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { BodyAtlas, type ActiveMuscle } from "../components/BodyAtlas";
+
+// SafeAreaContext is only used by the Atlas page, not the atlas
+// component itself — but we still mock it here for consistency with
+// other fizruk tests and in case a future diff pulls it in.
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+const SAMPLE: readonly ActiveMuscle[] = [
+  { id: "chest", intensity: 0.8 },
+  { id: "biceps", intensity: 0.6 },
+  { id: "quadriceps", intensity: 1 },
+];
+
+describe("BodyAtlas", () => {
+  it("matches snapshot for the front view", () => {
+    const { toJSON } = render(
+      <BodyAtlas muscles={SAMPLE} side="front" showToggle={false} />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("matches snapshot for the back view", () => {
+    const { toJSON } = render(
+      <BodyAtlas
+        muscles={[{ id: "hamstring", intensity: 0.7 }]}
+        side="back"
+        showToggle={false}
+      />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("fires onMusclePress with the canonical muscle id", () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BodyAtlas
+        muscles={SAMPLE}
+        side="front"
+        showToggle={false}
+        onMusclePress={onPress}
+      />,
+    );
+    fireEvent.press(getByTestId("body-atlas-muscle-chest"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith("chest");
+
+    fireEvent.press(getByTestId("body-atlas-muscle-biceps"));
+    expect(onPress).toHaveBeenCalledTimes(2);
+    expect(onPress).toHaveBeenLastCalledWith("biceps");
+  });
+
+  it("fires onMusclePress from the back view with the correct id", () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <BodyAtlas
+        muscles={[]}
+        side="back"
+        showToggle={false}
+        onMusclePress={onPress}
+      />,
+    );
+    fireEvent.press(getByTestId("body-atlas-muscle-gluteal"));
+    expect(onPress).toHaveBeenCalledWith("gluteal");
+  });
+
+  it("labels muscles in Ukrainian with intensity percentage", () => {
+    const { getByTestId } = render(
+      <BodyAtlas muscles={SAMPLE} side="front" showToggle={false} />,
+    );
+    const chest = getByTestId("body-atlas-muscle-chest");
+    // `accessibilityLabel` lives on the group for VoiceOver / TalkBack.
+    expect(chest.props.accessibilityLabel).toBe("Груди, інтенсивність 80%");
+
+    const quads = getByTestId("body-atlas-muscle-quadriceps");
+    expect(quads.props.accessibilityLabel).toBe(
+      "Квадрицепс, інтенсивність 100%",
+    );
+
+    // Non-highlighted muscle: no percentage suffix.
+    const forearm = getByTestId("body-atlas-muscle-forearm");
+    expect(forearm.props.accessibilityLabel).toBe("Передпліччя");
+  });
+
+  it("toggles between front and back when uncontrolled", () => {
+    const { getByTestId, queryByTestId } = render(
+      <BodyAtlas muscles={SAMPLE} />,
+    );
+    // Default side is `front`.
+    expect(getByTestId("body-atlas-front")).toBeTruthy();
+    expect(queryByTestId("body-atlas-back")).toBeNull();
+
+    fireEvent.press(getByTestId("body-atlas-toggle-back"));
+
+    expect(getByTestId("body-atlas-back")).toBeTruthy();
+    expect(queryByTestId("body-atlas-front")).toBeNull();
+  });
+
+  it("hides the toggle for an empty muscle list", () => {
+    const { getByTestId } = render(<BodyAtlas muscles={[]} />);
+    expect(getByTestId("body-atlas-svg")).toBeTruthy();
+    expect(getByTestId("body-atlas-front")).toBeTruthy();
+  });
+
+  it("clamps intensity values into [0, 1]", () => {
+    const { getByTestId } = render(
+      <BodyAtlas
+        side="front"
+        showToggle={false}
+        muscles={[
+          { id: "chest", intensity: 5 },
+          { id: "biceps", intensity: -3 },
+        ]}
+      />,
+    );
+    // Over-1 intensity becomes 100%.
+    expect(
+      getByTestId("body-atlas-muscle-chest").props.accessibilityLabel,
+    ).toBe("Груди, інтенсивність 100%");
+    // Sub-0 intensity becomes the plain label (no percentage suffix).
+    expect(
+      getByTestId("body-atlas-muscle-biceps").props.accessibilityLabel,
+    ).toBe("Біцепс");
+  });
+});

--- a/apps/mobile/src/modules/fizruk/__tests__/__snapshots__/BodyAtlas.test.tsx.snap
+++ b/apps/mobile/src/modules/fizruk/__tests__/__snapshots__/BodyAtlas.test.tsx.snap
@@ -1,0 +1,1350 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BodyAtlas matches snapshot for the back view 1`] = `
+<View
+  className="gap-2"
+  testID="body-atlas"
+>
+  <View
+    className="items-center justify-center"
+  >
+    <RNSVGSvgView
+      align="xMidYMid"
+      bbHeight={420}
+      bbWidth={200}
+      focusable={false}
+      height={420}
+      meetOrSlice={0}
+      minX={0}
+      minY={0}
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          {
+            "flex": 0,
+            "height": 420,
+            "width": 200,
+          },
+        ]
+      }
+      testID="body-atlas-svg"
+      vbHeight={420}
+      vbWidth={200}
+      width={200}
+    >
+      <RNSVGGroup
+        fill={
+          {
+            "payload": 4278190080,
+            "type": 0,
+          }
+        }
+      >
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4293387748,
+              "type": 0,
+            }
+          }
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+            ]
+          }
+          stroke={
+            {
+              "payload": 4289241758,
+              "type": 0,
+            }
+          }
+          strokeWidth={1}
+        >
+          <RNSVGCircle
+            cx="100"
+            cy="38"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+            r="22"
+          />
+          <RNSVGPath
+            d="M65 80 Q65 72 85 72 L115 72 Q135 72 135 80 L140 210 Q140 222 128 222 L72 222 Q60 222 60 210 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M65 218 L135 218 L142 260 L58 260 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M66 258 L98 258 L96 400 L74 400 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M102 258 L134 258 L126 400 L104 400 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M40 90 L65 82 L68 200 L46 200 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M160 90 L135 82 L132 200 L154 200 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+        </RNSVGGroup>
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4278190080,
+              "type": 0,
+            }
+          }
+          testID="body-atlas-back"
+        >
+          <RNSVGGroup
+            accessibilityLabel="Шия"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-neck"
+          >
+            <RNSVGRect
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              height="14"
+              rx="4"
+              width="20"
+              x="90"
+              y="58"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Трапеція"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-trapezius"
+          >
+            <RNSVGPath
+              d="M72 76 Q100 68 128 76 L120 110 Q100 102 80 110 Z"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Задні дельти"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-back-deltoids"
+          >
+            <RNSVGEllipse
+              cx="60"
+              cy="94"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="12"
+            />
+            <RNSVGEllipse
+              cx="140"
+              cy="94"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="12"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Верх спини"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-upper-back"
+          >
+            <RNSVGPath
+              d="M76 106 Q100 100 124 106 L132 166 Q100 160 68 166 Z"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Низ спини"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-lower-back"
+          >
+            <RNSVGRect
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              height="44"
+              rx="8"
+              width="36"
+              x="82"
+              y="170"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Трицепс"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-triceps"
+          >
+            <RNSVGEllipse
+              cx="54"
+              cy="132"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+            <RNSVGEllipse
+              cx="146"
+              cy="132"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Передпліччя"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-forearm"
+          >
+            <RNSVGEllipse
+              cx="52"
+              cy="180"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="9"
+              ry="20"
+            />
+            <RNSVGEllipse
+              cx="148"
+              cy="180"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="9"
+              ry="20"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Сідниці"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-gluteal"
+          >
+            <RNSVGEllipse
+              cx="84"
+              cy="238"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="16"
+              ry="16"
+            />
+            <RNSVGEllipse
+              cx="116"
+              cy="238"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="16"
+              ry="16"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Відвідні м'язи"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-abductors"
+          >
+            <RNSVGEllipse
+              cx="66"
+              cy="258"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="7"
+              ry="16"
+            />
+            <RNSVGEllipse
+              cx="134"
+              cy="258"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="7"
+              ry="16"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Задня поверхня стегна, інтенсивність 70%"
+            accessible={true}
+            fill={
+              {
+                "payload": 4279548070,
+                "type": 0,
+              }
+            }
+            fillOpacity={0.8049999999999999}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-hamstring"
+          >
+            <RNSVGEllipse
+              cx="82"
+              cy="300"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="34"
+            />
+            <RNSVGEllipse
+              cx="118"
+              cy="300"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="34"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Литки"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-calves"
+          >
+            <RNSVGEllipse
+              cx="84"
+              cy="370"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+            <RNSVGEllipse
+              cx="116"
+              cy="370"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+          </RNSVGGroup>
+        </RNSVGGroup>
+      </RNSVGGroup>
+    </RNSVGSvgView>
+  </View>
+</View>
+`;
+
+exports[`BodyAtlas matches snapshot for the front view 1`] = `
+<View
+  className="gap-2"
+  testID="body-atlas"
+>
+  <View
+    className="items-center justify-center"
+  >
+    <RNSVGSvgView
+      align="xMidYMid"
+      bbHeight={420}
+      bbWidth={200}
+      focusable={false}
+      height={420}
+      meetOrSlice={0}
+      minX={0}
+      minY={0}
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+            "borderWidth": 0,
+          },
+          {
+            "flex": 0,
+            "height": 420,
+            "width": 200,
+          },
+        ]
+      }
+      testID="body-atlas-svg"
+      vbHeight={420}
+      vbWidth={200}
+      width={200}
+    >
+      <RNSVGGroup
+        fill={
+          {
+            "payload": 4278190080,
+            "type": 0,
+          }
+        }
+      >
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4293387748,
+              "type": 0,
+            }
+          }
+          propList={
+            [
+              "fill",
+              "stroke",
+              "strokeWidth",
+            ]
+          }
+          stroke={
+            {
+              "payload": 4289241758,
+              "type": 0,
+            }
+          }
+          strokeWidth={1}
+        >
+          <RNSVGCircle
+            cx="100"
+            cy="38"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+            r="22"
+          />
+          <RNSVGPath
+            d="M65 80 Q65 72 85 72 L115 72 Q135 72 135 80 L140 210 Q140 222 128 222 L72 222 Q60 222 60 210 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M65 218 L135 218 L142 260 L58 260 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M66 258 L98 258 L96 400 L74 400 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M102 258 L134 258 L126 400 L104 400 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M40 90 L65 82 L68 200 L46 200 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+          <RNSVGPath
+            d="M160 90 L135 82 L132 200 L154 200 Z"
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+          />
+        </RNSVGGroup>
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4278190080,
+              "type": 0,
+            }
+          }
+          testID="body-atlas-front"
+        >
+          <RNSVGGroup
+            accessibilityLabel="Шия"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-neck"
+          >
+            <RNSVGRect
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              height="14"
+              rx="4"
+              width="20"
+              x="90"
+              y="58"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Трапеція"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-trapezius"
+          >
+            <RNSVGPath
+              d="M70 76 Q100 66 130 76 L126 86 Q100 78 74 86 Z"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Передні дельти"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-front-deltoids"
+          >
+            <RNSVGEllipse
+              cx="60"
+              cy="92"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="12"
+            />
+            <RNSVGEllipse
+              cx="140"
+              cy="92"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="12"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Груди, інтенсивність 80%"
+            accessible={true}
+            fill={
+              {
+                "payload": 4279548070,
+                "type": 0,
+              }
+            }
+            fillOpacity={0.87}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-chest"
+          >
+            <RNSVGEllipse
+              cx="86"
+              cy="110"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="18"
+              ry="14"
+            />
+            <RNSVGEllipse
+              cx="114"
+              cy="110"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="18"
+              ry="14"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Біцепс, інтенсивність 60%"
+            accessible={true}
+            fill={
+              {
+                "payload": 4279548070,
+                "type": 0,
+              }
+            }
+            fillOpacity={0.74}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-biceps"
+          >
+            <RNSVGEllipse
+              cx="54"
+              cy="130"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="18"
+            />
+            <RNSVGEllipse
+              cx="146"
+              cy="130"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="18"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Передпліччя"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-forearm"
+          >
+            <RNSVGEllipse
+              cx="52"
+              cy="176"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="9"
+              ry="20"
+            />
+            <RNSVGEllipse
+              cx="148"
+              cy="176"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="9"
+              ry="20"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Прес"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-abs"
+          >
+            <RNSVGRect
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              height="72"
+              rx="6"
+              width="20"
+              x="90"
+              y="130"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Косі м'язи"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-obliques"
+          >
+            <RNSVGEllipse
+              cx="78"
+              cy="176"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="8"
+              ry="22"
+            />
+            <RNSVGEllipse
+              cx="122"
+              cy="176"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="8"
+              ry="22"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Квадрицепс, інтенсивність 100%"
+            accessible={true}
+            fill={
+              {
+                "payload": 4279548070,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-quadriceps"
+          >
+            <RNSVGEllipse
+              cx="82"
+              cy="292"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="34"
+            />
+            <RNSVGEllipse
+              cx="118"
+              cy="292"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="14"
+              ry="34"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Привідні м'язи"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-adductor"
+          >
+            <RNSVGEllipse
+              cx="92"
+              cy="282"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="6"
+              ry="22"
+            />
+            <RNSVGEllipse
+              cx="108"
+              cy="282"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="6"
+              ry="22"
+            />
+          </RNSVGGroup>
+          <RNSVGGroup
+            accessibilityLabel="Литки"
+            accessible={true}
+            fill={
+              {
+                "payload": 4293387748,
+                "type": 0,
+              }
+            }
+            fillOpacity={1}
+            propList={
+              [
+                "fill",
+                "fillOpacity",
+                "stroke",
+                "strokeWidth",
+              ]
+            }
+            stroke={
+              {
+                "payload": 4289241758,
+                "type": 0,
+              }
+            }
+            strokeWidth={0.75}
+            testID="body-atlas-muscle-calves"
+          >
+            <RNSVGEllipse
+              cx="84"
+              cy="370"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+            <RNSVGEllipse
+              cx="116"
+              cy="370"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              rx="10"
+              ry="22"
+            />
+          </RNSVGGroup>
+        </RNSVGGroup>
+      </RNSVGGroup>
+    </RNSVGSvgView>
+  </View>
+</View>
+`;

--- a/apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx
@@ -1,0 +1,508 @@
+/**
+ * Fizruk BodyAtlas — React Native port (Phase 6 · PR-C).
+ *
+ * Web counterpart: `apps/web/src/modules/fizruk/components/BodyAtlas.tsx`,
+ * which renders a silhouette through the web-only `body-highlighter`
+ * package. React Native has no DOM, so this component implements
+ * §6.8 path A of `docs/react-native-migration.md` — a hand-tuned
+ * silhouette on `react-native-svg`, sharing the muscle-id contract with
+ * the web renderer through `@sergeant/fizruk-domain` (see
+ * `packages/fizruk-domain/src/data/bodyAtlas.ts`).
+ *
+ * Design goals for this first cut:
+ *
+ *   - Type-safe, minimal public surface: `muscles` (list of highlighted
+ *     muscle groups + 0..1 intensity), optional controlled `side`, and
+ *     an `onMusclePress` callback. Everything else (legend, toggle,
+ *     height) has a safe default.
+ *   - Same muscle id keyspace as the web client, so the same
+ *     `statusByMuscle` payload feeds both platforms (recovery /
+ *     atlas data-layer ports unchanged — see Atlas page wiring).
+ *   - Accessible: each interactive region carries a Ukrainian
+ *     `accessibilityLabel` (e.g. «Груди, інтенсивність 80%»).
+ *   - Styled via NativeWind on the shell + `@sergeant/design-tokens`
+ *     hex values for SVG fill / stroke (SVG paints are inline
+ *     attributes, not Tailwind classes — tokens are the canonical
+ *     source so web and mobile stay visually aligned).
+ *
+ * The silhouette is stylised (ellipses / rounded rects via `<Path>`)
+ * rather than anatomically accurate — the purpose is legibility at
+ * small sizes and offline rendering with no bitmap assets. Refinement
+ * lands in a follow-up PR once mobile-native designers have a pass.
+ */
+
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import Svg, {
+  Circle,
+  Ellipse,
+  G,
+  Path,
+  Rect,
+  type GProps,
+} from "react-native-svg";
+
+import { statusColors } from "@sergeant/design-tokens/tokens";
+import {
+  BODY_ATLAS_MUSCLE_LABELS_UK,
+  BODY_ATLAS_MUSCLE_SIDE,
+  type BodyAtlasMuscleId,
+  type BodyAtlasSide,
+} from "@sergeant/fizruk-domain/data/bodyAtlas";
+
+/** A single highlighted muscle entry. */
+export interface ActiveMuscle {
+  id: BodyAtlasMuscleId;
+  /**
+   * Highlight intensity, 0..1. 0 means "not highlighted" and falls back
+   * to the baseline silhouette fill. 1 is the maximum accent colour.
+   * Values in-between drive `fillOpacity` on the SVG shape.
+   */
+  intensity: number;
+}
+
+export interface BodyAtlasProps {
+  /** Highlighted muscle groups. Defaults to none (plain silhouette). */
+  muscles?: readonly ActiveMuscle[];
+  /**
+   * Which side to display. When provided, the component is controlled
+   * and the built-in front/back toggle is hidden. When omitted,
+   * a local state seeded to `"front"` powers the toggle buttons.
+   */
+  side?: BodyAtlasSide;
+  /** Optional tap-through handler (receives the canonical muscle id). */
+  onMusclePress?: (id: BodyAtlasMuscleId) => void;
+  /** Height of the SVG viewport in px. Aspect-ratio is preserved. */
+  height?: number;
+  /** Show the side toggle (ignored when `side` is controlled). */
+  showToggle?: boolean;
+  /** testID prefix for tests (defaults to `"body-atlas"`). */
+  testID?: string;
+}
+
+// Hex values live in the shared design tokens so web + mobile match.
+// Shapes are painted through inline SVG attributes (not NativeWind),
+// which is why we resolve hex strings eagerly here.
+const ACCENT_HEX = "#14b8a6"; // teal-500 (Fizruk primary).
+const SILHOUETTE_FILL = "#e7e5e4"; // stone-200 — neutral body colour.
+const SILHOUETTE_STROKE = "#a8a29e"; // stone-400 — subtle outline.
+
+/** Clamp `n` into [min, max]. */
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+/**
+ * Build an a11y label like «Груди, інтенсивність 80%» (no suffix when
+ * intensity is 0 so screen readers don't announce empty state).
+ */
+function buildAccessibilityLabel(
+  id: BodyAtlasMuscleId,
+  intensity: number,
+): string {
+  const label = BODY_ATLAS_MUSCLE_LABELS_UK[id];
+  if (intensity <= 0) return label;
+  const pct = Math.round(intensity * 100);
+  return `${label}, інтенсивність ${pct}%`;
+}
+
+/**
+ * Render one muscle shape. Shapes are declared as JSX so each muscle
+ * can use the primitive that fits its silhouette (ellipse / rounded
+ * rect / custom path) rather than a one-size-fits-all data table.
+ */
+interface MuscleShellProps {
+  id: BodyAtlasMuscleId;
+  intensity: number;
+  onPress?: (id: BodyAtlasMuscleId) => void;
+  children: GProps["children"];
+  testID?: string;
+}
+
+function MuscleShell({
+  id,
+  intensity,
+  onPress,
+  children,
+  testID,
+}: MuscleShellProps) {
+  const effective = clamp(intensity, 0, 1);
+  return (
+    <G
+      onPress={onPress ? () => onPress(id) : undefined}
+      fill={effective > 0 ? ACCENT_HEX : SILHOUETTE_FILL}
+      fillOpacity={effective > 0 ? 0.35 + effective * 0.65 : 1}
+      stroke={SILHOUETTE_STROKE}
+      strokeWidth={0.75}
+      accessible
+      accessibilityRole={onPress ? "button" : "image"}
+      accessibilityLabel={buildAccessibilityLabel(id, effective)}
+      testID={testID}
+    >
+      {children}
+    </G>
+  );
+}
+
+/**
+ * Lookup helper — finds the intensity for a muscle id in the sparse
+ * `muscles` list. Highest entry wins when duplicates sneak in (shouldn't
+ * happen in normal data flow, but defensive anyway).
+ */
+function resolveIntensity(
+  list: readonly ActiveMuscle[] | undefined,
+  id: BodyAtlasMuscleId,
+): number {
+  if (!list || list.length === 0) return 0;
+  let best = 0;
+  for (const entry of list) {
+    if (entry?.id !== id) continue;
+    const v = clamp(entry.intensity, 0, 1);
+    if (v > best) best = v;
+  }
+  return best;
+}
+
+/** Aspect ratio of the SVG viewport (height ÷ width). */
+const VIEWPORT_RATIO = 420 / 200;
+
+/**
+ * Public BodyAtlas component — see file-level JSDoc for the design
+ * rationale. This component deliberately avoids any web-only API
+ * (`createBodyHighlighter`, `document`, Tailwind on SVG nodes).
+ */
+export function BodyAtlas({
+  muscles,
+  side: controlledSide,
+  onMusclePress,
+  height = 420,
+  showToggle = true,
+  testID = "body-atlas",
+}: BodyAtlasProps) {
+  const [uncontrolledSide, setUncontrolledSide] =
+    useState<BodyAtlasSide>("front");
+  const isControlled = controlledSide !== undefined;
+  const side: BodyAtlasSide = controlledSide ?? uncontrolledSide;
+
+  const width = Math.round(height / VIEWPORT_RATIO);
+
+  // Precompute intensity for every muscle — cheap and keeps JSX terse.
+  const iNeck = resolveIntensity(muscles, "neck");
+  const iTrap = resolveIntensity(muscles, "trapezius");
+  const iChest = resolveIntensity(muscles, "chest");
+  const iFrontDelts = resolveIntensity(muscles, "front-deltoids");
+  const iBackDelts = resolveIntensity(muscles, "back-deltoids");
+  const iBiceps = resolveIntensity(muscles, "biceps");
+  const iTriceps = resolveIntensity(muscles, "triceps");
+  const iForearm = resolveIntensity(muscles, "forearm");
+  const iAbs = resolveIntensity(muscles, "abs");
+  const iObliques = resolveIntensity(muscles, "obliques");
+  const iUpperBack = resolveIntensity(muscles, "upper-back");
+  const iLowerBack = resolveIntensity(muscles, "lower-back");
+  const iGluteal = resolveIntensity(muscles, "gluteal");
+  const iQuads = resolveIntensity(muscles, "quadriceps");
+  const iHamstring = resolveIntensity(muscles, "hamstring");
+  const iAdductor = resolveIntensity(muscles, "adductor");
+  const iAbductors = resolveIntensity(muscles, "abductors");
+  const iCalves = resolveIntensity(muscles, "calves");
+
+  return (
+    <View className="gap-2" testID={testID}>
+      {(!isControlled && showToggle) || (isControlled && showToggle) ? (
+        <View className="flex-row items-center justify-center gap-2">
+          <Pressable
+            testID={`${testID}-toggle-front`}
+            accessibilityRole="button"
+            accessibilityLabel="Показати вигляд спереду"
+            accessibilityState={{ selected: side === "front" }}
+            onPress={
+              isControlled ? undefined : () => setUncontrolledSide("front")
+            }
+            disabled={isControlled}
+            className={
+              side === "front"
+                ? "px-3 py-1.5 rounded-full bg-teal-600"
+                : "px-3 py-1.5 rounded-full border border-stone-300 bg-white"
+            }
+          >
+            <Text
+              className={
+                side === "front"
+                  ? "text-xs font-semibold text-white"
+                  : "text-xs font-semibold text-stone-700"
+              }
+            >
+              Спереду
+            </Text>
+          </Pressable>
+          <Pressable
+            testID={`${testID}-toggle-back`}
+            accessibilityRole="button"
+            accessibilityLabel="Показати вигляд ззаду"
+            accessibilityState={{ selected: side === "back" }}
+            onPress={
+              isControlled ? undefined : () => setUncontrolledSide("back")
+            }
+            disabled={isControlled}
+            className={
+              side === "back"
+                ? "px-3 py-1.5 rounded-full bg-teal-600"
+                : "px-3 py-1.5 rounded-full border border-stone-300 bg-white"
+            }
+          >
+            <Text
+              className={
+                side === "back"
+                  ? "text-xs font-semibold text-white"
+                  : "text-xs font-semibold text-stone-700"
+              }
+            >
+              Ззаду
+            </Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      <View className="items-center justify-center">
+        <Svg
+          width={width}
+          height={height}
+          viewBox="0 0 200 420"
+          testID={`${testID}-svg`}
+        >
+          {/* Silhouette baseline — head + torso + limbs outline. */}
+          <G fill={SILHOUETTE_FILL} stroke={SILHOUETTE_STROKE} strokeWidth={1}>
+            {/* Head */}
+            <Circle cx="100" cy="38" r="22" />
+            {/* Torso (rounded rect via Path) */}
+            <Path d="M65 80 Q65 72 85 72 L115 72 Q135 72 135 80 L140 210 Q140 222 128 222 L72 222 Q60 222 60 210 Z" />
+            {/* Hips */}
+            <Path d="M65 218 L135 218 L142 260 L58 260 Z" />
+            {/* Left leg */}
+            <Path d="M66 258 L98 258 L96 400 L74 400 Z" />
+            {/* Right leg */}
+            <Path d="M102 258 L134 258 L126 400 L104 400 Z" />
+            {/* Left arm */}
+            <Path d="M40 90 L65 82 L68 200 L46 200 Z" />
+            {/* Right arm */}
+            <Path d="M160 90 L135 82 L132 200 L154 200 Z" />
+          </G>
+
+          {side === "front" ? (
+            <G testID={`${testID}-front`}>
+              {BODY_ATLAS_MUSCLE_SIDE.neck !== "back" ? (
+                <MuscleShell
+                  id="neck"
+                  intensity={iNeck}
+                  onPress={onMusclePress}
+                  testID={`${testID}-muscle-neck`}
+                >
+                  <Rect x="90" y="58" width="20" height="14" rx="4" />
+                </MuscleShell>
+              ) : null}
+              <MuscleShell
+                id="trapezius"
+                intensity={iTrap}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-trapezius`}
+              >
+                <Path d="M70 76 Q100 66 130 76 L126 86 Q100 78 74 86 Z" />
+              </MuscleShell>
+              <MuscleShell
+                id="front-deltoids"
+                intensity={iFrontDelts}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-front-deltoids`}
+              >
+                <Ellipse cx="60" cy="92" rx="14" ry="12" />
+                <Ellipse cx="140" cy="92" rx="14" ry="12" />
+              </MuscleShell>
+              <MuscleShell
+                id="chest"
+                intensity={iChest}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-chest`}
+              >
+                <Ellipse cx="86" cy="110" rx="18" ry="14" />
+                <Ellipse cx="114" cy="110" rx="18" ry="14" />
+              </MuscleShell>
+              <MuscleShell
+                id="biceps"
+                intensity={iBiceps}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-biceps`}
+              >
+                <Ellipse cx="54" cy="130" rx="10" ry="18" />
+                <Ellipse cx="146" cy="130" rx="10" ry="18" />
+              </MuscleShell>
+              <MuscleShell
+                id="forearm"
+                intensity={iForearm}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-forearm`}
+              >
+                <Ellipse cx="52" cy="176" rx="9" ry="20" />
+                <Ellipse cx="148" cy="176" rx="9" ry="20" />
+              </MuscleShell>
+              <MuscleShell
+                id="abs"
+                intensity={iAbs}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-abs`}
+              >
+                <Rect x="90" y="130" width="20" height="72" rx="6" />
+              </MuscleShell>
+              <MuscleShell
+                id="obliques"
+                intensity={iObliques}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-obliques`}
+              >
+                <Ellipse cx="78" cy="176" rx="8" ry="22" />
+                <Ellipse cx="122" cy="176" rx="8" ry="22" />
+              </MuscleShell>
+              <MuscleShell
+                id="quadriceps"
+                intensity={iQuads}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-quadriceps`}
+              >
+                <Ellipse cx="82" cy="292" rx="14" ry="34" />
+                <Ellipse cx="118" cy="292" rx="14" ry="34" />
+              </MuscleShell>
+              <MuscleShell
+                id="adductor"
+                intensity={iAdductor}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-adductor`}
+              >
+                <Ellipse cx="92" cy="282" rx="6" ry="22" />
+                <Ellipse cx="108" cy="282" rx="6" ry="22" />
+              </MuscleShell>
+              <MuscleShell
+                id="calves"
+                intensity={iCalves}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-calves`}
+              >
+                <Ellipse cx="84" cy="370" rx="10" ry="22" />
+                <Ellipse cx="116" cy="370" rx="10" ry="22" />
+              </MuscleShell>
+            </G>
+          ) : (
+            <G testID={`${testID}-back`}>
+              <MuscleShell
+                id="neck"
+                intensity={iNeck}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-neck`}
+              >
+                <Rect x="90" y="58" width="20" height="14" rx="4" />
+              </MuscleShell>
+              <MuscleShell
+                id="trapezius"
+                intensity={iTrap}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-trapezius`}
+              >
+                <Path d="M72 76 Q100 68 128 76 L120 110 Q100 102 80 110 Z" />
+              </MuscleShell>
+              <MuscleShell
+                id="back-deltoids"
+                intensity={iBackDelts}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-back-deltoids`}
+              >
+                <Ellipse cx="60" cy="94" rx="14" ry="12" />
+                <Ellipse cx="140" cy="94" rx="14" ry="12" />
+              </MuscleShell>
+              <MuscleShell
+                id="upper-back"
+                intensity={iUpperBack}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-upper-back`}
+              >
+                <Path d="M76 106 Q100 100 124 106 L132 166 Q100 160 68 166 Z" />
+              </MuscleShell>
+              <MuscleShell
+                id="lower-back"
+                intensity={iLowerBack}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-lower-back`}
+              >
+                <Rect x="82" y="170" width="36" height="44" rx="8" />
+              </MuscleShell>
+              <MuscleShell
+                id="triceps"
+                intensity={iTriceps}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-triceps`}
+              >
+                <Ellipse cx="54" cy="132" rx="10" ry="22" />
+                <Ellipse cx="146" cy="132" rx="10" ry="22" />
+              </MuscleShell>
+              <MuscleShell
+                id="forearm"
+                intensity={iForearm}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-forearm`}
+              >
+                <Ellipse cx="52" cy="180" rx="9" ry="20" />
+                <Ellipse cx="148" cy="180" rx="9" ry="20" />
+              </MuscleShell>
+              <MuscleShell
+                id="gluteal"
+                intensity={iGluteal}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-gluteal`}
+              >
+                <Ellipse cx="84" cy="238" rx="16" ry="16" />
+                <Ellipse cx="116" cy="238" rx="16" ry="16" />
+              </MuscleShell>
+              <MuscleShell
+                id="abductors"
+                intensity={iAbductors}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-abductors`}
+              >
+                <Ellipse cx="66" cy="258" rx="7" ry="16" />
+                <Ellipse cx="134" cy="258" rx="7" ry="16" />
+              </MuscleShell>
+              <MuscleShell
+                id="hamstring"
+                intensity={iHamstring}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-hamstring`}
+              >
+                <Ellipse cx="82" cy="300" rx="14" ry="34" />
+                <Ellipse cx="118" cy="300" rx="14" ry="34" />
+              </MuscleShell>
+              <MuscleShell
+                id="calves"
+                intensity={iCalves}
+                onPress={onMusclePress}
+                testID={`${testID}-muscle-calves`}
+              >
+                <Ellipse cx="84" cy="370" rx="10" ry="22" />
+                <Ellipse cx="116" cy="370" rx="10" ry="22" />
+              </MuscleShell>
+            </G>
+          )}
+        </Svg>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Re-export the design-tokens status palette alongside the component so
+ * screens that want to map recovery status → intensity colour can do so
+ * without adding another import line. Keeps the atlas a one-stop shop
+ * for Fizruk consumers.
+ */
+export const BODY_ATLAS_STATUS_COLORS = statusColors;
+
+export default BodyAtlas;

--- a/apps/mobile/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Atlas.tsx
@@ -1,26 +1,72 @@
 /**
- * Fizruk / Atlas page — mobile placeholder (Phase 6 / PR-1).
+ * Fizruk / Atlas page (mobile) — Phase 6 · PR-C wiring.
  *
- * Web counterpart: `apps/web/src/modules/fizruk/pages/Atlas.tsx` (90 LOC).
- * The full-screen body atlas with recovery-status highlighting. Full port
- * lands in Phase 6 · PR-C — React-Native body atlas (ADR in that PR body).
+ * The heavy lifting lives in `../components/BodyAtlas.tsx`; this page
+ * just renders a hero + `Card` + `BodyAtlas` on the existing route
+ * scaffold (PR #450). The full recovery-driven wiring
+ * (`useRecovery` → `statusByMuscle`) lands in the later Fizruk PR that
+ * ports the recovery hook; until then the page shows the baseline
+ * silhouette with a small placeholder highlight so reviewers can see
+ * the interactive states without pulling unrelated hooks into this PR.
  */
 
-import { PagePlaceholder } from "./PagePlaceholder";
+import { useState } from "react";
+import { ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { Card } from "@/components/ui/Card";
+
+import { BodyAtlas, type ActiveMuscle } from "../components/BodyAtlas";
+import {
+  BODY_ATLAS_MUSCLE_LABELS_UK,
+  type BodyAtlasMuscleId,
+} from "@sergeant/fizruk-domain/data/bodyAtlas";
+
+// Demo payload until `useRecovery()` is ported. Values loosely mirror
+// the mid-level `yellow` / high-level `red` recovery statuses the web
+// Atlas produces for a user with recent chest + quad sessions.
+const DEMO_MUSCLES: readonly ActiveMuscle[] = [
+  { id: "chest", intensity: 0.8 },
+  { id: "quadriceps", intensity: 1 },
+  { id: "biceps", intensity: 0.6 },
+];
 
 export function Atlas() {
+  const [selected, setSelected] = useState<BodyAtlasMuscleId | null>(null);
+
   return (
-    <PagePlaceholder
-      title="Атлас тіла"
-      description="Інтерактивна карта тіла з підсвіткою груп м'язів за статусом відновлення (recovery)."
-      plannedFeatures={[
-        "BodyAtlas (react-native-svg) — front / back",
-        "1:1 мапинг bodyZone id з web-версією",
-        "Підсвітка за recovery-статусом (ready / yellow / red)",
-        "Тап по зоні → deep-link у Exercise з фільтром",
-      ]}
-      phaseHint="Фаза 6 · PR-C — BodyAtlas (ADR: react-native-svg vs react-native-body-highlighter)"
-    />
+    <SafeAreaView className="flex-1 bg-cream-50" edges={["bottom"]}>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 12 }}
+      >
+        <View>
+          <Text className="text-[22px] font-bold text-stone-900">
+            {"Атлас м'язів"}
+          </Text>
+          <Text className="text-sm text-stone-600 leading-snug">
+            {
+              "Інтерактивна карта груп м'язів. Тапни зону — отримаєш назву, інтенсивність навантаження та можливість перейти до вправ у наступних PR."
+            }
+          </Text>
+        </View>
+
+        <Card radius="lg" padding="md">
+          <BodyAtlas
+            muscles={DEMO_MUSCLES}
+            onMusclePress={(id) => setSelected(id)}
+            height={420}
+          />
+          <View className="mt-2 items-center">
+            <Text className="text-xs text-stone-500">
+              {selected
+                ? `Обрано: ${BODY_ATLAS_MUSCLE_LABELS_UK[selected]}`
+                : "Натисни на м'яз, щоб побачити деталі."}
+            </Text>
+          </View>
+        </Card>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/packages/fizruk-domain/src/data/bodyAtlas.test.ts
+++ b/packages/fizruk-domain/src/data/bodyAtlas.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure tests for the BodyAtlas muscle mapping (Phase 6 / PR-C).
+ *
+ * These live in `@sergeant/fizruk-domain` so both web and mobile
+ * renderers can rely on the same mapping contract. The data layer
+ * (recovery statuses keyed by domain muscle id) must not care which
+ * client renders it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BODY_ATLAS_MUSCLE_IDS,
+  BODY_ATLAS_MUSCLE_LABELS_UK,
+  BODY_ATLAS_MUSCLE_SIDE,
+  isBodyAtlasMuscleId,
+  mapDomainMuscleToAtlas,
+  statusToIntensity,
+  type BodyAtlasMuscleId,
+} from "./bodyAtlas.js";
+
+describe("BODY_ATLAS_MUSCLE_IDS", () => {
+  it("covers every web body-highlighter key used by Atlas.tsx", () => {
+    // Mirrors the inline `map()` switch in
+    // apps/web/src/modules/fizruk/pages/Atlas.tsx — these ids are the
+    // public contract with the web client.
+    const webKeys: readonly BodyAtlasMuscleId[] = [
+      "chest",
+      "upper-back",
+      "lower-back",
+      "trapezius",
+      "biceps",
+      "triceps",
+      "forearm",
+      "front-deltoids",
+      "back-deltoids",
+      "abs",
+      "obliques",
+      "quadriceps",
+      "hamstring",
+      "calves",
+      "adductor",
+      "abductors",
+      "gluteal",
+      "neck",
+    ];
+    for (const key of webKeys) {
+      expect(BODY_ATLAS_MUSCLE_IDS).toContain(key);
+    }
+  });
+
+  it("provides a Ukrainian label for every atlas muscle id", () => {
+    for (const id of BODY_ATLAS_MUSCLE_IDS) {
+      expect(BODY_ATLAS_MUSCLE_LABELS_UK[id]).toBeTruthy();
+    }
+  });
+
+  it("assigns every muscle to front / back / both", () => {
+    for (const id of BODY_ATLAS_MUSCLE_IDS) {
+      expect(["front", "back", "both"]).toContain(BODY_ATLAS_MUSCLE_SIDE[id]);
+    }
+  });
+});
+
+describe("isBodyAtlasMuscleId", () => {
+  it("accepts every canonical id", () => {
+    for (const id of BODY_ATLAS_MUSCLE_IDS) {
+      expect(isBodyAtlasMuscleId(id)).toBe(true);
+    }
+  });
+
+  it("rejects unknown strings", () => {
+    expect(isBodyAtlasMuscleId("teres_major")).toBe(false);
+    expect(isBodyAtlasMuscleId("")).toBe(false);
+    expect(isBodyAtlasMuscleId(null)).toBe(false);
+    expect(isBodyAtlasMuscleId(undefined)).toBe(false);
+    expect(isBodyAtlasMuscleId(42)).toBe(false);
+  });
+});
+
+describe("mapDomainMuscleToAtlas", () => {
+  it("mirrors the web Atlas.tsx map() for known ids", () => {
+    // Pairs copied verbatim from apps/web/src/modules/fizruk/pages/Atlas.tsx.
+    const pairs: Array<[string, BodyAtlasMuscleId]> = [
+      ["pectoralis_major", "chest"],
+      ["pectoralis_minor", "chest"],
+      ["latissimus_dorsi", "upper-back"],
+      ["rhomboids", "upper-back"],
+      ["upper_back", "upper-back"],
+      ["erector_spinae", "lower-back"],
+      ["trapezius", "trapezius"],
+      ["biceps", "biceps"],
+      ["triceps", "triceps"],
+      ["forearms", "forearm"],
+      ["front_deltoid", "front-deltoids"],
+      ["rear_deltoid", "back-deltoids"],
+      ["rectus_abdominis", "abs"],
+      ["obliques", "obliques"],
+      ["quadriceps", "quadriceps"],
+      ["hamstrings", "hamstring"],
+      ["calves", "calves"],
+      ["adductors", "adductor"],
+      ["abductors", "abductors"],
+      ["gluteus_maximus", "gluteal"],
+      ["gluteus_medius", "gluteal"],
+      ["neck", "neck"],
+    ];
+    for (const [domain, atlas] of pairs) {
+      expect(mapDomainMuscleToAtlas(domain)).toBe(atlas);
+    }
+  });
+
+  it("returns null for unknown / empty ids", () => {
+    expect(mapDomainMuscleToAtlas("teres_major")).toBeNull();
+    expect(mapDomainMuscleToAtlas("")).toBeNull();
+    expect(mapDomainMuscleToAtlas(null)).toBeNull();
+    expect(mapDomainMuscleToAtlas(undefined)).toBeNull();
+  });
+});
+
+describe("statusToIntensity", () => {
+  it("maps green/yellow/red into a monotonic 0..1 scale", () => {
+    const g = statusToIntensity("green");
+    const y = statusToIntensity("yellow");
+    const r = statusToIntensity("red");
+    expect(g).toBe(0);
+    expect(r).toBe(1);
+    expect(y).toBeGreaterThan(g);
+    expect(y).toBeLessThan(r);
+  });
+});

--- a/packages/fizruk-domain/src/data/bodyAtlas.ts
+++ b/packages/fizruk-domain/src/data/bodyAtlas.ts
@@ -1,0 +1,177 @@
+/**
+ * Canonical muscle-group ids for the Fizruk BodyAtlas.
+ *
+ * The web client renders the atlas through the `body-highlighter` npm
+ * package (web-only SVG). Its muscle keys (`chest`, `front-deltoids`,
+ * `upper-back`, …) are mirrored here so the mobile `BodyAtlas` (Phase 6
+ * PR-C, `react-native-svg`) can consume the very same `statusByMuscle`
+ * shape that `apps/web/src/modules/fizruk/pages/Atlas.tsx` builds from
+ * `useRecovery()`.
+ *
+ * In other words: the data layer (`useRecovery` + `mapDomainMuscleToAtlas`)
+ * is platform-agnostic; only the rendering differs.
+ */
+
+/** Canonical BodyAtlas muscle ids (mirror `body-highlighter` web keys). */
+export const BODY_ATLAS_MUSCLE_IDS = [
+  "neck",
+  "trapezius",
+  "chest",
+  "front-deltoids",
+  "back-deltoids",
+  "biceps",
+  "triceps",
+  "forearm",
+  "abs",
+  "obliques",
+  "upper-back",
+  "lower-back",
+  "gluteal",
+  "quadriceps",
+  "hamstring",
+  "adductor",
+  "abductors",
+  "calves",
+] as const;
+
+/** Type-safe union of all canonical atlas muscle ids. */
+export type BodyAtlasMuscleId = (typeof BODY_ATLAS_MUSCLE_IDS)[number];
+
+/** Side of the body a muscle group is drawn on. */
+export type BodyAtlasSide = "front" | "back";
+
+/** Ukrainian labels for atlas muscle groups (used by `accessibilityLabel`). */
+export const BODY_ATLAS_MUSCLE_LABELS_UK: Record<BodyAtlasMuscleId, string> = {
+  neck: "Шия",
+  trapezius: "Трапеція",
+  chest: "Груди",
+  "front-deltoids": "Передні дельти",
+  "back-deltoids": "Задні дельти",
+  biceps: "Біцепс",
+  triceps: "Трицепс",
+  forearm: "Передпліччя",
+  abs: "Прес",
+  obliques: "Косі м'язи",
+  "upper-back": "Верх спини",
+  "lower-back": "Низ спини",
+  gluteal: "Сідниці",
+  quadriceps: "Квадрицепс",
+  hamstring: "Задня поверхня стегна",
+  adductor: "Привідні м'язи",
+  abductors: "Відвідні м'язи",
+  calves: "Литки",
+};
+
+/** On which side (front / back / both) each muscle group is rendered. */
+export const BODY_ATLAS_MUSCLE_SIDE: Record<
+  BodyAtlasMuscleId,
+  "front" | "back" | "both"
+> = {
+  neck: "both",
+  trapezius: "both",
+  chest: "front",
+  "front-deltoids": "front",
+  "back-deltoids": "back",
+  biceps: "front",
+  triceps: "back",
+  forearm: "both",
+  abs: "front",
+  obliques: "front",
+  "upper-back": "back",
+  "lower-back": "back",
+  gluteal: "back",
+  quadriceps: "front",
+  hamstring: "back",
+  adductor: "front",
+  abductors: "back",
+  calves: "both",
+};
+
+/**
+ * Type guard for the canonical atlas muscle union. Useful when mapping
+ * from a broader domain muscle id space into the atlas keyspace.
+ */
+export function isBodyAtlasMuscleId(
+  value: unknown,
+): value is BodyAtlasMuscleId {
+  return (
+    typeof value === "string" &&
+    (BODY_ATLAS_MUSCLE_IDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Maps a `@sergeant/fizruk-domain` muscle id (the stable, snake_case
+ * identifiers used by `exercises.gymup.json` and `MuscleState.id`) to
+ * the canonical atlas muscle id. Returns `null` for muscles that the
+ * atlas does not render (e.g. very fine subdivisions like `teres_major`).
+ *
+ * The mapping mirrors the inline `map()` function inside
+ * `apps/web/src/modules/fizruk/pages/Atlas.tsx` so web and mobile paint
+ * the same silhouette from the same recovery data.
+ */
+export function mapDomainMuscleToAtlas(
+  domainMuscleId: string | null | undefined,
+): BodyAtlasMuscleId | null {
+  if (!domainMuscleId) return null;
+  switch (domainMuscleId) {
+    case "pectoralis_major":
+    case "pectoralis_minor":
+      return "chest";
+    case "latissimus_dorsi":
+    case "rhomboids":
+    case "upper_back":
+      return "upper-back";
+    case "erector_spinae":
+      return "lower-back";
+    case "trapezius":
+      return "trapezius";
+    case "biceps":
+      return "biceps";
+    case "triceps":
+      return "triceps";
+    case "forearms":
+      return "forearm";
+    case "front_deltoid":
+      return "front-deltoids";
+    case "rear_deltoid":
+      return "back-deltoids";
+    case "rectus_abdominis":
+      return "abs";
+    case "obliques":
+      return "obliques";
+    case "quadriceps":
+      return "quadriceps";
+    case "hamstrings":
+      return "hamstring";
+    case "calves":
+      return "calves";
+    case "adductors":
+      return "adductor";
+    case "abductors":
+      return "abductors";
+    case "gluteus_maximus":
+    case "gluteus_medius":
+      return "gluteal";
+    case "neck":
+      return "neck";
+    default:
+      return null;
+  }
+}
+
+/** Recovery-style status used by the web atlas (`green` / `yellow` / `red`). */
+export type BodyAtlasStatus = "green" | "yellow" | "red";
+
+/** Convert a 3-level status into a 0..1 highlight intensity. */
+export function statusToIntensity(status: BodyAtlasStatus): number {
+  switch (status) {
+    case "red":
+      return 1;
+    case "yellow":
+      return 0.6;
+    case "green":
+    default:
+      return 0;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         version: 14.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
       nativewind:
         specifier: ^4.1.23
-        version: 4.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -157,6 +157,9 @@ importers:
       react-native-screens:
         specifier: ~4.4.0
         version: 4.4.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      react-native-svg:
+        specifier: 15.8.0
+        version: 15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5486,6 +5489,12 @@ packages:
       }
     engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
+  boolbase@1.0.0:
+    resolution:
+      {
+        integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
+      }
+
   bplist-creator@0.0.7:
     resolution:
       {
@@ -6204,12 +6213,32 @@ packages:
         integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==,
       }
 
+  css-select@5.2.2:
+    resolution:
+      {
+        integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==,
+      }
+
+  css-tree@1.1.3:
+    resolution:
+      {
+        integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==,
+      }
+    engines: { node: ">=8.0.0" }
+
   css-tree@3.2.1:
     resolution:
       {
         integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
+
+  css-what@6.2.2:
+    resolution:
+      {
+        integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
+      }
+    engines: { node: ">= 6" }
 
   css.escape@1.5.1:
     resolution:
@@ -6563,6 +6592,18 @@ packages:
         integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
       }
 
+  dom-serializer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
+      }
+
+  domelementtype@2.3.0:
+    resolution:
+      {
+        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
+      }
+
   domexception@4.0.0:
     resolution:
       {
@@ -6570,6 +6611,19 @@ packages:
       }
     engines: { node: ">=12" }
     deprecated: Use your platform's native DOMException instead
+
+  domhandler@5.0.3:
+    resolution:
+      {
+        integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
+      }
+    engines: { node: ">= 4" }
+
+  domutils@3.2.2:
+    resolution:
+      {
+        integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
+      }
 
   dotenv-expand@11.0.7:
     resolution:
@@ -6675,6 +6729,13 @@ packages:
         integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==,
       }
     engines: { node: ">=10.13.0" }
+
+  entities@4.5.0:
+    resolution:
+      {
+        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
+      }
+    engines: { node: ">=0.12" }
 
   entities@6.0.1:
     resolution:
@@ -9642,6 +9703,12 @@ packages:
         integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
       }
 
+  mdn-data@2.0.14:
+    resolution:
+      {
+        integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==,
+      }
+
   mdn-data@2.27.1:
     resolution:
       {
@@ -10288,6 +10355,12 @@ packages:
         integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  nth-check@2.1.1:
+    resolution:
+      {
+        integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
+      }
 
   nullthrows@1.1.1:
     resolution:
@@ -11339,6 +11412,15 @@ packages:
     resolution:
       {
         integrity: sha512-c7zc7Zwjty6/pGyuuvh9gK3YBYqHPOxrhXfG1lF4gHlojQSmIx2piNbNaV+Uykj+RDTmFXK0e/hA+fucw/Qozg==,
+      }
+    peerDependencies:
+      react: "*"
+      react-native: "*"
+
+  react-native-svg@15.8.0:
+    resolution:
+      {
+        integrity: sha512-KHJzKpgOjwj1qeZzsBjxNdoIgv2zNCO9fVcoq2TEhTRsVV5DGTZ9JzUZwybd7q4giT/H3RdtqC3u44dWdO0Ffw==,
       }
     peerDependencies:
       react: "*"
@@ -17557,6 +17639,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.0.7:
     dependencies:
       stream-buffers: 2.2.0
@@ -17970,10 +18054,25 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -18140,9 +18239,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -18190,6 +18307,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -20524,6 +20643,8 @@ snapshots:
     dependencies:
       "@types/mdast": 4.0.4
 
+  mdn-data@2.0.14: {}
+
   mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
@@ -20943,11 +21064,11 @@ snapshots:
 
   nanostores@1.3.0: {}
 
-  nativewind@4.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
+  nativewind@4.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       comment-json: 4.6.2
       debug: 4.4.3
-      react-native-css-interop: 0.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      react-native-css-interop: 0.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - react
@@ -21018,6 +21139,10 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
 
@@ -21591,7 +21716,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-css-interop@0.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
+  react-native-css-interop@0.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       "@babel/helper-module-imports": 7.28.6
       "@babel/traverse": 7.29.0
@@ -21605,6 +21730,7 @@ snapshots:
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       react-native-safe-area-context: 4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21662,6 +21788,14 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-freeze: 1.0.4(react@18.3.1)
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+      warn-once: 0.1.1
+
+  react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 18.3.1
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
       warn-once: 0.1.1
 


### PR DESCRIPTION
## Summary

Нативний аналог `apps/web/src/modules/fizruk/components/BodyAtlas.tsx` для `apps/mobile`, згідно плану міграції [`docs/react-native-migration.md`](docs/react-native-migration.md):

- §4 Phase 6 (рядок «PR-C BodyAtlas» для модуля Fizruk);
- §5.3 «Fizruk» (BodyAtlas як web-only SVG → RN-порт);
- §6.8 «Body Atlas» (шлях A vs B).

**Обрано шлях A (власна SVG-модель на `react-native-svg`).** Причини:

- §6.8 прямо називає цей варіант «найгнучкішим» і рекомендованим;
- web-залежність `body-highlighter` базується на DOM-овому SVG і не запускається в React Native — порт неминуче був би реплікацією набору `<path>`-ів, тож краще тримати їх in-repo;
- `react-native-svg` вже запланований як залежність для Routine Heatmap (§5 PR 5) і `Toast`/`RoutineBottomNav` (див. коментарі-TODO у `apps/mobile/src/components/ui/Toast.tsx`, `apps/mobile/src/modules/routine/RoutineApp.tsx`) — цей PR і ставить його в apps/mobile;
- API сумісний з нашими дизайн-токенами й NativeWind-шелом, не тягне нових runtime-залежностей з MIT-несумісними ліцензіями.

Публічний API компонента (`apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx`):

```ts
interface ActiveMuscle { id: BodyAtlasMuscleId; intensity: number } // 0..1
interface BodyAtlasProps {
  muscles?: readonly ActiveMuscle[];
  side?: "front" | "back";          // optional controlled toggle
  onMusclePress?: (id: BodyAtlasMuscleId) => void;
  height?: number;
  showToggle?: boolean;
  testID?: string;
}
```

Ідентифікатори м'язів (`BodyAtlasMuscleId`) — один-в-один з ключами `body-highlighter` у web-версії (`chest`, `front-deltoids`, `upper-back`, …). Мапінг з gymup-домену (`pectoralis_major` → `chest`, `rear_deltoid` → `back-deltoids`, …) винесено в `@sergeant/fizruk-domain` як `mapDomainMuscleToAtlas`, щоб web і mobile живилися однаковим `statusByMuscle` payload'ом. Порт `useRecovery()` приходить окремим PR — поки що `Atlas.tsx` показує демо-стан.

### Зміни

- `packages/fizruk-domain/src/data/bodyAtlas.ts` — канонічний список атлас-id, UA-лейбли, side-map, guard `isBodyAtlasMuscleId`, `mapDomainMuscleToAtlas` (паритет з web `apps/web/src/modules/fizruk/pages/Atlas.tsx`), `statusToIntensity` + vitest-тести.
- `apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx` — стилізований силует (Circle / Ellipse / Rect / Path) на `react-native-svg`, два види (спереду / ззаду), `onPress` на кожному `<G>`, `accessibilityLabel` формату «Груди, інтенсивність 80%», кольори з `@sergeant/design-tokens`.
- `apps/mobile/src/modules/fizruk/pages/Atlas.tsx` — підключення компонента на існуючий route-скафолд (PR #450), без інших Fizruk-фіч.
- `apps/mobile/package.json` + `pnpm-lock.yaml` — додано `react-native-svg@15.8.0` (версія, сумісна з `expo@~52`).
- `apps/mobile/src/modules/fizruk/__tests__/BodyAtlas.test.tsx` — 2 snapshot-тести (front/back) + behavior-тести: тап по м'язу викликає `onMusclePress("chest")`/`("biceps")`/`("gluteal")`, UA a11y-лейбли, clamp інтенсивності в `[0,1]`, перемикання toggle.

### Перевірено локально

- `pnpm lint` — зелено;
- `pnpm typecheck` — зелено;
- `pnpm test` — 11/11 workspace-пакетів, зокрема `@sergeant/mobile` (26 suites, **142 tests**, 2 snapshots) і `@sergeant/fizruk-domain` (7 suites, **58 tests**, з них 8 нових для BodyAtlas-мапінгу).

## Review & Testing Checklist for Human

- [ ] Відкрити `fizruk/atlas` у Expo Go / dev-client на iOS та Android, переконатися що (a) silhouette рендериться без пропусків, (b) toggle «Спереду/Ззаду» перемикає view, (c) тап по м'язу оновлює нижній лейбл.
- [ ] Перевірити, що id-сет у `BODY_ATLAS_MUSCLE_IDS` і `mapDomainMuscleToAtlas` збігається з тим, що використовує web `apps/web/src/modules/fizruk/pages/Atlas.tsx` (якщо майбутній web-рефакторинг додасть/перейменує ключі — мапінг треба синхронізувати).
- [ ] VoiceOver / TalkBack: проговорити, чи читається «Груди, інтенсивність 80%» для активних зон і просто «Передпліччя» для неактивних (візуальний контроль під час ручного QA).

### Notes

- Силует свідомо стилізований (еліпси / заокруглені прямокутники), а не анатомічно точний — мета цього PR: закрити контракт даних + жести + a11y, щоб `useRecovery` міг підключатися до готового UI. Подальша художня доробка шейпів — окремий PR після дизайн-рев'ю.
- `react-native-svg` optional-peer у `nativewind`; transformIgnorePatterns у `apps/mobile/jest.config.js` уже мав hole для нього, тож jest-expo-прогін не потребував змін у конфігу.
- Snapshots містять повну SVG-структуру. Перший візуальний рефакторинг силуета очікувано оновить їх — це нормально, коментар у тесті явно описує інваріанти.


Link to Devin session: https://app.devin.ai/sessions/06ef8751a46345e5afc4e0e0952fc481
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive body atlas visualization with clickable muscle regions that respond to selection.
  * Implemented front and back view toggle to display different muscle groups.
  * Added intensity-based muscle highlighting with visual feedback.
  * Integrated Ukrainian muscle labels and accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->