### PR TITLE
fix(mobile): hoist pnpm deps + add missing Expo deps so Metro can bundle

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-haptics": "~14.0.1",
     "expo-keep-awake": "~14.0.1",
     "expo-linking": "~7.0.5",
+    "expo-network": "~7.0.5",
     "expo-notifications": "~0.29.14",
     "expo-router": "~4.0.21",
     "expo-secure-store": "~14.0.1",
@@ -50,6 +51,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
+    "react-native-worklets": "^0.8.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
     dependencies:
       "@better-auth/expo":
         specifier: ^1.6.5
-        version: 1.6.5(rq4ckbk645sy7enix3uajyasde)
+        version: 1.6.5(wbkshj5quv4vgvh5bqmd44gtyi)
       "@expo/metro-runtime":
         specifier: ~4.0.1
         version: 4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
@@ -112,6 +112,9 @@ importers:
       expo-linking:
         specifier: ~7.0.5
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-network:
+        specifier: ~7.0.5
+        version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react@18.3.1)
       expo-notifications:
         specifier: ~0.29.14
         version: 0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -160,6 +163,9 @@ importers:
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-native-worklets:
+        specifier: ^0.8.1
+        version: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -196,7 +202,7 @@ importers:
     dependencies:
       "@better-auth/expo":
         specifier: ^1.6.5
-        version: 1.6.5(rq4ckbk645sy7enix3uajyasde)
+        version: 1.6.5(wbkshj5quv4vgvh5bqmd44gtyi)
       "@parse/node-apn":
         specifier: ^8.1.0
         version: 8.1.0
@@ -3398,12 +3404,28 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@react-native/babel-plugin-codegen@0.85.2":
+    resolution:
+      {
+        integrity: sha512-5Dqn08kRTUIxPLYju9hExI0cR1ESX+P5tEv5yv0q0UZcisRTw0VB8iUWDIph2LdY1i5Dc8PIvuaWMRNCw3vnKg==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   "@react-native/babel-preset@0.76.9":
     resolution:
       {
         integrity: sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@babel/core": "*"
+
+  "@react-native/babel-preset@0.85.2":
+    resolution:
+      {
+        integrity: sha512-7d2yW23eKkVt0FbbnZLxqO7KybGLtQXOuvvcO1NUOYGtjzVh6ihNKn0TIHrhSNpMyHwYLDoiiuj95wLtcg3IwQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
     peerDependencies:
       "@babel/core": "*"
 
@@ -3415,6 +3437,15 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@babel/preset-env": ^7.1.6
+
+  "@react-native/codegen@0.85.2":
+    resolution:
+      {
+        integrity: sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+    peerDependencies:
+      "@babel/core": "*"
 
   "@react-native/community-cli-plugin@0.76.9":
     resolution:
@@ -3456,6 +3487,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@react-native/js-polyfills@0.85.2":
+    resolution:
+      {
+        integrity: sha512-esGEAmKVM40DV/yVmNljCKZTIeUo7qXqc+Hwffkv3TG+b3E24xyFovHrbP98gGxZr2ZsEyx+2sKLdXF5asY5nw==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   "@react-native/metro-babel-transformer@0.76.9":
     resolution:
       {
@@ -3464,6 +3502,22 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@babel/core": "*"
+
+  "@react-native/metro-babel-transformer@0.85.2":
+    resolution:
+      {
+        integrity: sha512-lU9XOGahpHvQff30H5lnvh9RYbVwC1zpSHpl84E+7BD2zj0FvW+pD7MBh7CWbmbWmegjtAb+U/2bokXcDVA+jA==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+    peerDependencies:
+      "@babel/core": "*"
+
+  "@react-native/metro-config@0.85.2":
+    resolution:
+      {
+        integrity: sha512-YkTIMfTPeyMUrtpQo/7zd3oybVYJCfTp8626PqoakOvEiWi9PxsUpZ8j44a5GFtOIq8Nc6WWVBiFRn/6qdi1uQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   "@react-native/normalize-colors@0.74.89":
     resolution:
@@ -4780,6 +4834,13 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  accepts@2.0.0:
+    resolution:
+      {
+        integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
+      }
+    engines: { node: ">= 0.6" }
+
   acorn-globals@7.0.1:
     resolution:
       {
@@ -5273,6 +5334,12 @@ packages:
     resolution:
       {
         integrity: sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==,
+      }
+
+  babel-plugin-syntax-hermes-parser@0.33.3:
+    resolution:
+      {
+        integrity: sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==,
       }
 
   babel-plugin-transform-flow-enums@0.0.2:
@@ -7199,6 +7266,15 @@ packages:
         integrity: sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==,
       }
 
+  expo-network@7.0.5:
+    resolution:
+      {
+        integrity: sha512-5dlowKAimhIDN1/lBRnN6SSH6c07f12R3QrfLf3b3GEr6D+EijH2wE537mmwPh1p+254LAkm0Z5ZEXxbwII4sA==,
+      }
+    peerDependencies:
+      expo: "*"
+      react: "*"
+
   expo-notifications@0.29.14:
     resolution:
       {
@@ -7976,6 +8052,18 @@ packages:
         integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==,
       }
 
+  hermes-estree@0.33.3:
+    resolution:
+      {
+        integrity: sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==,
+      }
+
+  hermes-estree@0.35.0:
+    resolution:
+      {
+        integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==,
+      }
+
   hermes-parser@0.23.1:
     resolution:
       {
@@ -7986,6 +8074,18 @@ packages:
     resolution:
       {
         integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==,
+      }
+
+  hermes-parser@0.33.3:
+    resolution:
+      {
+        integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==,
+      }
+
+  hermes-parser@0.35.0:
+    resolution:
+      {
+        integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==,
       }
 
   hoist-non-react-statics@3.3.2:
@@ -9707,12 +9807,26 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-babel-transformer@0.84.3:
+    resolution:
+      {
+        integrity: sha512-svAA+yMLpeMiGcz/jKJs4oHpIGEx4nBqNEJ5AGj4CYIg1efvK+A0TjR6tgIuc6tKO5e8JmN/1lglpN2+f3/z/w==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro-cache-key@0.81.5:
     resolution:
       {
         integrity: sha512-lGWnGVm1UwO8faRZ+LXQUesZSmP1LOg14OVR+KNPBip8kbMECbQJ8c10nGesw28uQT7AE0lwQThZPXlxDyCLKQ==,
       }
     engines: { node: ">=18.18" }
+
+  metro-cache-key@0.84.3:
+    resolution:
+      {
+        integrity: sha512-TnSL1Fdvrw+2glTdBSRmA5TL8l/i16ECjsrUdf3E5HncA+sNx8KcwDG8r+3ct1UhfYcusJypzZqTN55FZZcwGg==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-cache@0.81.5:
     resolution:
@@ -9721,12 +9835,26 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-cache@0.84.3:
+    resolution:
+      {
+        integrity: sha512-0QElxwLaHqLZf+Xqio8QrjVbuXP/8sJfQBGSPiITlKDVXrVLefuzYVSH9Sj+QL6lrPj2gYZd/iwQh1yZuVKnLA==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro-config@0.81.5:
     resolution:
       {
         integrity: sha512-oDRAzUvj6RNRxratFdcVAqtAsg+T3qcKrGdqGZFUdwzlFJdHGR9Z413sW583uD2ynsuOjA2QB6US8FdwiBdNKg==,
       }
     engines: { node: ">=18.18" }
+
+  metro-config@0.84.3:
+    resolution:
+      {
+        integrity: sha512-JmCzZWOETR+O22q8oPBWyQppx3roU9EbkbGzD8Gf1jukQ4b5T1fTzqqHruu6K4sTiNq5zVQySmKF6bp4kVARew==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-core@0.81.5:
     resolution:
@@ -9735,12 +9863,26 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-core@0.84.3:
+    resolution:
+      {
+        integrity: sha512-cc0pvAa80ai1nDmqqz0P59a+0ZqCZ/YHU/3jEekZL6spFnYDfX8iDLdn9FR6kX+67rmzKxHNrbrSRFLX2AYocw==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro-file-map@0.81.5:
     resolution:
       {
         integrity: sha512-mW1PKyiO3qZvjeeVjj1brhkmIotObA3/9jdbY1fQQYvEWM6Ml7bN/oJCRDGn2+bJRlG+J8pwyJ+DgdrM4BsKyg==,
       }
     engines: { node: ">=18.18" }
+
+  metro-file-map@0.84.3:
+    resolution:
+      {
+        integrity: sha512-1cL4m4Jv1yRUt9RJExZQLfccscdlMNOcRG6LHLtmJhf3BG9j3MujPVc7CIpKYdFl+KUl+sdjge6oO3+meKCHQA==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-minify-terser@0.81.5:
     resolution:
@@ -9749,12 +9891,26 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-minify-terser@0.84.3:
+    resolution:
+      {
+        integrity: sha512-3ofrG2OQyJbO9RNhCfOcl8QU7EE2WrSsnN5dFkuZaJO5+4Imujr9bUXmspeNlXRsOVk0F/rVRbEFH98lFSCkBQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro-resolver@0.81.5:
     resolution:
       {
         integrity: sha512-6BX8Nq3g3go3FxcyXkVbWe7IgctjDTk6D9flq+P201DfHHQ28J+DWFpVelFcrNTn4tIfbP/Bw7u/0g2BGmeXfQ==,
       }
     engines: { node: ">=18.18" }
+
+  metro-resolver@0.84.3:
+    resolution:
+      {
+        integrity: sha512-pjEzGDtoM8DTHAIPK/9u9ZxszEiuRohYUVImWvgbnB91V4gqYJpQcoEYUugf2NIm1lrX5HNu0OvNqWmPBnGYjA==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-runtime@0.81.5:
     resolution:
@@ -9763,12 +9919,26 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-runtime@0.84.3:
+    resolution:
+      {
+        integrity: sha512-o7HLRfMyVk9N2dUZ9VjQfB6xxUItL9Pi9WcqxURE7MEKOH6wbGt9/E92YdYLluTOtkzYAEVfdC6h6lcxqA+hMQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro-source-map@0.81.5:
     resolution:
       {
         integrity: sha512-Jz+CjvCKLNbJZYJTBeN3Kq9kIJf6b61MoLBdaOQZJ5Ajhw6Pf95Nn21XwA8BwfUYgajsi6IXsp/dTZsYJbN00Q==,
       }
     engines: { node: ">=18.18" }
+
+  metro-source-map@0.84.3:
+    resolution:
+      {
+        integrity: sha512-jS48CeSzw78M8y6VE0f9uy3lVmfbOS677j2VCxnlmlYmnahcXuC6IhoN9K6LynNvos9517yUadcfgioju38xYQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-symbolicate@0.81.5:
     resolution:
@@ -9778,12 +9948,27 @@ packages:
     engines: { node: ">=18.18" }
     hasBin: true
 
+  metro-symbolicate@0.84.3:
+    resolution:
+      {
+        integrity: sha512-J9Tpo8NCycYrozRvBIUyOwGAu4xkawOsAppmTscFiaegK0WvuDGwIM53GbzVSnytCHjVAF0io5GQxpkrKTuc7g==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+    hasBin: true
+
   metro-transform-plugins@0.81.5:
     resolution:
       {
         integrity: sha512-MmHhVx/1dJC94FN7m3oHgv5uOjKH8EX8pBeu1pnPMxbJrx6ZuIejO0k84zTSaQTZ8RxX1wqwzWBpXAWPjEX8mA==,
       }
     engines: { node: ">=18.18" }
+
+  metro-transform-plugins@0.84.3:
+    resolution:
+      {
+        integrity: sha512-8S3baq2XhBaafHEH5Q8sJW6tmzsEJk80qKc3RU/nZV1MsnYq94RdjTUR6AyKjQd6Rfsk1BtBxhtiNnk7mgslCg==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-transform-worker@0.81.5:
     resolution:
@@ -9792,12 +9977,27 @@ packages:
       }
     engines: { node: ">=18.18" }
 
+  metro-transform-worker@0.84.3:
+    resolution:
+      {
+        integrity: sha512-Wjba7PyYktNRsHbPmkx2J2UX32rAzcDXjCu49zPHeF/viJlYJhwRaNePQcHaCRqQ+kmgQT4ThprsnJfDj71ZMA==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
+
   metro@0.81.5:
     resolution:
       {
         integrity: sha512-YpFF0DDDpDVygeca2mAn7K0+us+XKmiGk4rIYMz/CRdjFoCGqAei/IQSpV0UrGfQbToSugpMQeQJveaWSH88Hg==,
       }
     engines: { node: ">=18.18" }
+    hasBin: true
+
+  metro@0.84.3:
+    resolution:
+      {
+        integrity: sha512-1h3lbVrE6hGf1e/764HfhPGg/bGrWMJDDh7G2rc4gFYZboVuI40BlG/y+UhtbhQDNlO/csMvrcnK0YrTlHUVew==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
     hasBin: true
 
   micromark-core-commonmark@2.0.3:
@@ -9953,6 +10153,13 @@ packages:
         integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
       }
     engines: { node: ">= 0.6" }
+
+  mime-types@3.0.2:
+    resolution:
+      {
+        integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
+      }
+    engines: { node: ">=18" }
 
   mime@1.6.0:
     resolution:
@@ -10176,6 +10383,13 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  negotiator@1.0.0:
+    resolution:
+      {
+        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
+      }
+    engines: { node: ">= 0.6" }
+
   neo-async@2.6.2:
     resolution:
       {
@@ -10307,6 +10521,13 @@ packages:
         integrity: sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==,
       }
     engines: { node: ">=18.18" }
+
+  ob1@0.84.3:
+    resolution:
+      {
+        integrity: sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==,
+      }
+    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   object-assign@4.1.1:
     resolution:
@@ -11352,6 +11573,17 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  react-native-worklets@0.8.1:
+    resolution:
+      {
+        integrity: sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==,
+      }
+    peerDependencies:
+      "@babel/core": "*"
+      "@react-native/metro-config": "*"
+      react: "*"
+      react-native: 0.81 - 0.85
 
   react-native@0.76.9:
     resolution:
@@ -14881,7 +15113,7 @@ snapshots:
       "@better-auth/core": 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       "@better-auth/utils": 0.4.0
 
-  "@better-auth/expo@1.6.5(rq4ckbk645sy7enix3uajyasde)":
+  "@better-auth/expo@1.6.5(wbkshj5quv4vgvh5bqmd44gtyi)":
     dependencies:
       "@better-auth/core": 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       "@better-fetch/fetch": 1.1.21
@@ -14891,6 +15123,7 @@ snapshots:
     optionalDependencies:
       expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
       expo-linking: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-network: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react@18.3.1)
       expo-web-browser: 14.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
 
   "@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)":
@@ -16089,6 +16322,14 @@ snapshots:
       - "@babel/preset-env"
       - supports-color
 
+  "@react-native/babel-plugin-codegen@0.85.2(@babel/core@7.29.0)":
+    dependencies:
+      "@babel/traverse": 7.29.0
+      "@react-native/codegen": 0.85.2(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - "@babel/core"
+      - supports-color
+
   "@react-native/babel-preset@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/core": 7.29.0
@@ -16140,6 +16381,44 @@ snapshots:
       - "@babel/preset-env"
       - supports-color
 
+  "@react-native/babel-preset@0.85.2(@babel/core@7.29.0)":
+    dependencies:
+      "@babel/core": 7.29.0
+      "@babel/plugin-proposal-export-default-from": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.0)
+      "@babel/plugin-syntax-export-default-from": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.0)
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.0)
+      "@babel/plugin-transform-async-generator-functions": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-async-to-generator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-block-scoping": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-class-properties": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-classes": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-destructuring": 7.28.5(@babel/core@7.29.0)
+      "@babel/plugin-transform-flow-strip-types": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-for-of": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-modules-commonjs": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-optional-catch-binding": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-private-methods": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-private-property-in-object": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-display-name": 7.28.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-jsx": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-regenerator": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-runtime": 7.29.0(@babel/core@7.29.0)
+      "@babel/plugin-transform-typescript": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-regex": 7.27.1(@babel/core@7.29.0)
+      "@react-native/babel-plugin-codegen": 0.85.2(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.33.3
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
   "@react-native/codegen@0.76.9(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/parser": 7.29.2
@@ -16153,6 +16432,16 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+
+  "@react-native/codegen@0.85.2(@babel/core@7.29.0)":
+    dependencies:
+      "@babel/core": 7.29.0
+      "@babel/parser": 7.29.2
+      hermes-parser: 0.33.3
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.16
+      yargs: 17.7.2
 
   "@react-native/community-cli-plugin@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
@@ -16200,6 +16489,8 @@ snapshots:
 
   "@react-native/js-polyfills@0.76.9": {}
 
+  "@react-native/js-polyfills@0.85.2": {}
+
   "@react-native/metro-babel-transformer@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/core": 7.29.0
@@ -16209,6 +16500,27 @@ snapshots:
     transitivePeerDependencies:
       - "@babel/preset-env"
       - supports-color
+
+  "@react-native/metro-babel-transformer@0.85.2(@babel/core@7.29.0)":
+    dependencies:
+      "@babel/core": 7.29.0
+      "@react-native/babel-preset": 0.85.2(@babel/core@7.29.0)
+      hermes-parser: 0.33.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@react-native/metro-config@0.85.2(@babel/core@7.29.0)":
+    dependencies:
+      "@react-native/js-polyfills": 0.85.2
+      "@react-native/metro-babel-transformer": 0.85.2(@babel/core@7.29.0)
+      metro-config: 0.84.3
+      metro-runtime: 0.84.3
+    transitivePeerDependencies:
+      - "@babel/core"
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   "@react-native/normalize-colors@0.74.89": {}
 
@@ -17108,6 +17420,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-globals@7.0.1:
     dependencies:
       acorn: 8.16.0
@@ -17423,6 +17740,10 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.25.1:
     dependencies:
       hermes-parser: 0.25.1
+
+  babel-plugin-syntax-hermes-parser@0.33.3:
+    dependencies:
+      hermes-parser: 0.33.3
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
@@ -18691,6 +19012,11 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
+  expo-network@7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
   expo-notifications@0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
       "@expo/image-utils": 0.6.5
@@ -19257,6 +19583,10 @@ snapshots:
 
   hermes-estree@0.25.1: {}
 
+  hermes-estree@0.33.3: {}
+
+  hermes-estree@0.35.0: {}
+
   hermes-parser@0.23.1:
     dependencies:
       hermes-estree: 0.23.1
@@ -19264,6 +19594,14 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hermes-parser@0.33.3:
+    dependencies:
+      hermes-estree: 0.33.3
+
+  hermes-parser@0.35.0:
+    dependencies:
+      hermes-estree: 0.35.0
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -20553,7 +20891,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-babel-transformer@0.84.3:
+    dependencies:
+      "@babel/core": 7.29.0
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.35.0
+      metro-cache-key: 0.84.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-cache-key@0.81.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache-key@0.84.3:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -20562,6 +20914,15 @@ snapshots:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
       metro-core: 0.81.5
+
+  metro-cache@0.84.3:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.84.3
+    transitivePeerDependencies:
+      - supports-color
 
   metro-config@0.81.5:
     dependencies:
@@ -20578,15 +20939,50 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.84.3:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.3
+      metro-cache: 0.84.3
+      metro-core: 0.84.3
+      metro-runtime: 0.84.3
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-core@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.81.5
 
+  metro-core@0.84.3:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.84.3
+
   metro-file-map@0.81.5:
     dependencies:
       debug: 2.6.9
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-file-map@0.84.3:
+    dependencies:
+      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -20603,11 +20999,25 @@ snapshots:
       flow-enums-runtime: 0.0.6
       terser: 5.46.1
 
+  metro-minify-terser@0.84.3:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.46.1
+
   metro-resolver@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
 
+  metro-resolver@0.84.3:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   metro-runtime@0.81.5:
+    dependencies:
+      "@babel/runtime": 7.29.2
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.84.3:
     dependencies:
       "@babel/runtime": 7.29.2
       flow-enums-runtime: 0.0.6
@@ -20627,6 +21037,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-source-map@0.84.3:
+    dependencies:
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.84.3
+      nullthrows: 1.1.1
+      ob1: 0.84.3
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-symbolicate@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -20638,7 +21062,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-symbolicate@0.84.3:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.84.3
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-transform-plugins@0.81.5:
+    dependencies:
+      "@babel/core": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/template": 7.28.6
+      "@babel/traverse": 7.29.0
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.84.3:
     dependencies:
       "@babel/core": 7.29.0
       "@babel/generator": 7.29.1
@@ -20663,6 +21109,26 @@ snapshots:
       metro-minify-terser: 0.81.5
       metro-source-map: 0.81.5
       metro-transform-plugins: 0.81.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-transform-worker@0.84.3:
+    dependencies:
+      "@babel/core": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.84.3
+      metro-babel-transformer: 0.84.3
+      metro-cache: 0.84.3
+      metro-cache-key: 0.84.3
+      metro-minify-terser: 0.84.3
+      metro-source-map: 0.84.3
+      metro-transform-plugins: 0.84.3
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
@@ -20705,6 +21171,53 @@ snapshots:
       metro-transform-plugins: 0.81.5
       metro-transform-worker: 0.81.5
       mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.84.3:
+    dependencies:
+      "@babel/code-frame": 7.29.0
+      "@babel/core": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/parser": 7.29.2
+      "@babel/template": 7.28.6
+      "@babel/traverse": 7.29.0
+      "@babel/types": 7.29.0
+      accepts: 2.0.0
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.84.3
+      metro-cache: 0.84.3
+      metro-cache-key: 0.84.3
+      metro-config: 0.84.3
+      metro-core: 0.84.3
+      metro-file-map: 0.84.3
+      metro-resolver: 0.84.3
+      metro-runtime: 0.84.3
+      metro-source-map: 0.84.3
+      metro-symbolicate: 0.84.3
+      metro-transform-plugins: 0.84.3
+      metro-transform-worker: 0.84.3
+      mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
@@ -20862,6 +21375,10 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@1.6.0: {}
 
   mime@2.6.0: {}
@@ -20963,6 +21480,8 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
@@ -21024,6 +21543,10 @@ snapshots:
   nwsapi@2.2.23: {}
 
   ob1@0.81.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  ob1@0.84.3:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -21679,6 +22202,26 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+
+  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      "@babel/core": 7.29.0
+      "@babel/plugin-transform-arrow-functions": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-class-properties": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-classes": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
+      "@babel/plugin-transform-shorthand-properties": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-template-literals": 7.27.1(@babel/core@7.29.0)
+      "@babel/plugin-transform-unicode-regex": 7.27.1(@babel/core@7.29.0)
+      "@babel/preset-typescript": 7.28.5(@babel/core@7.29.0)
+      "@react-native/metro-config": 0.85.2(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      react: 18.3.1
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Fix mobile dev-server startup (`pnpm --filter @sergeant/mobile start`) which was failing on a clean `pnpm install` with cascading Metro resolver errors.

Three independent issues, one minimal fix each:

1. **pnpm's default isolated linker hides transitive deps from Metro.** `metro.config.js` already sets `nodeModulesPaths: [apps/mobile/node_modules, monorepo/node_modules]` with `disableHierarchicalLookup: true`, but pnpm's default store puts `react-native-css-interop`, `@babel/runtime/helpers/*`, etc. in `.pnpm/<hash>/node_modules/...` with no direct symlink for transitives — so Metro can't find them. Adding root `.npmrc` with `node-linker=hoisted` flattens the tree so Metro's resolver works. This is the standard Expo-in-pnpm-monorepo recommendation.

2. **NativeWind's babel plugin requires `react-native-worklets/plugin`.** `babel-preset-expo` with `jsxImportSource: "nativewind"` + `nativewind/babel` transitively pulls in `react-native-css-interop`'s babel transformer, which `require()`s `react-native-worklets/plugin` during bundling. It wasn't declared, so Babel throws `Cannot find module 'react-native-worklets/plugin'`.

3. **`@better-auth/expo` dynamically imports `expo-network` at runtime.** Metro statically analyzes the `import("expo-network")` in its `client.js` and fails the web bundle with `Unable to resolve module expo-network`. Picked `~7.0.5` via `expo install` (SDK-52 aligned); peer-dep warning from `@better-auth/expo@1.6.5` wants `>=8.0.7` but 8.x requires SDK ≥53 and the only usage is `addNetworkStateListener`, which exists in 7.0.5.

After these three changes `pnpm --filter @sergeant/mobile start --web` bundles successfully and the Better Auth sign-in screen renders at `http://localhost:8081/sign-in`.

## Review & Testing Checklist for Human

- [ ] `rm -rf node_modules && pnpm install` on a clean checkout and confirm `pnpm --filter @sergeant/mobile start --web` bundles without Metro "Unable to resolve module …" errors.
- [ ] Confirm `node-linker=hoisted` doesn't break any non-mobile workspace (`apps/web`, `apps/server`, domain packages) — hoisted linker is more permissive but can mask missing `dependencies` entries in other packages.
- [ ] Check that `expo-network@~7.0.5` is OK at runtime for `@better-auth/expo`'s `addNetworkStateListener` call (peer wants `>=8.0.7`; I verified the API exists in 7.0.5 but only on-device smoke-test confirms behavior). If you hit issues, the alternative is upgrading `@better-auth/expo` to a version that accepts `expo-network` 7.x — but I didn't want to change auth dep versions in a resolver-fix PR.
- [ ] Sanity-check that EAS builds (`eas build --profile development`) still produce valid Dev Client artifacts — adding `react-native-worklets` as a direct dep can introduce a second worklets runtime if something else also brings it transitively; with SDK 52's `react-native-reanimated@~3.16.1` it should be a no-op but worth verifying.

### Notes

- Pre-existing typecheck errors in `src/modules/fizruk/pages/Dashboard.tsx` (`router.push(fizrukRouteFor(...))`) reproduce on `main` without this branch — out of scope here.
- Peer-dep warning about node 20.x vs 22.x is environmental on my VM, not introduced by this PR.


Link to Devin session: https://app.devin.ai/sessions/a5ff5bc1b6914d828ef8554873088221
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
