### PR TITLE
feat(routine): pure екстракція + мобільний Hub-календар (Phase 5 / PR 2)

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -10,6 +10,15 @@ module.exports = {
   preset: "jest-expo",
   testMatch: ["<rootDir>/src/**/*.test.{ts,tsx}"],
   setupFiles: ["<rootDir>/jest.setup.js"],
+  // `@sergeant/*-domain` packages use NodeNext `.js`-extension imports
+  // inside their TS source (required so they compile cleanly under the
+  // workspace `"module": "NodeNext"` toolchain). Jest resolves them
+  // straight from `src/index.ts` (see each package's `exports` map),
+  // so we need to strip the trailing `.js` at resolve-time otherwise
+  // jest-resolve reports "Cannot find module './types.js'".
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transformIgnorePatterns: [
     // Keep the default `node_modules/` ignore but punch holes for the RN
     // / Expo / NativeWind ecosystem, whose published artefacts still

--- a/apps/mobile/src/modules/routine/RoutineApp.test.tsx
+++ b/apps/mobile/src/modules/routine/RoutineApp.test.tsx
@@ -19,8 +19,10 @@ import { _getMMKVInstance } from "@/lib/storage";
 
 import { RoutineApp } from "./RoutineApp";
 
-const CALENDAR_DESCRIPTION =
-  "Хаб-календар рутини: звички, день, тиждень, місяць. Скоро — з підсвіткою планових тренувань Фізрука та платежів Фініка.";
+// Unique copy inside the mounted Calendar screen (the bottom-nav item
+// label is just "Календар", so we pin to the eyebrow kicker inside
+// `pages/Calendar.tsx` which only exists when that page is mounted).
+const CALENDAR_EYEBROW = "Hub календар";
 const STATS_DESCRIPTION =
   "Хітмеп виконання, стріки та топ-звички. Порт у наступних PR-ах Фази 5.";
 const SETTINGS_DESCRIPTION =
@@ -31,9 +33,9 @@ beforeEach(() => {
 });
 
 describe("RoutineApp shell", () => {
-  it("renders the Calendar placeholder by default", () => {
+  it("renders the Calendar screen by default", () => {
     const { getByText } = render(<RoutineApp />);
-    expect(getByText(CALENDAR_DESCRIPTION)).toBeTruthy();
+    expect(getByText(CALENDAR_EYEBROW)).toBeTruthy();
   });
 
   it("switches to the Stats placeholder when the Stats tab is pressed", () => {
@@ -43,7 +45,7 @@ describe("RoutineApp shell", () => {
 
     expect(getByText(STATS_DESCRIPTION)).toBeTruthy();
     // Calendar screen body is no longer mounted.
-    expect(queryByText(CALENDAR_DESCRIPTION)).toBeNull();
+    expect(queryByText(CALENDAR_EYEBROW)).toBeNull();
   });
 
   it("switches to the Settings placeholder when the Settings tab is pressed", () => {
@@ -78,6 +80,6 @@ describe("RoutineApp shell", () => {
 
     const { getByText } = render(<RoutineApp />);
 
-    expect(getByText(CALENDAR_DESCRIPTION)).toBeTruthy();
+    expect(getByText(CALENDAR_EYEBROW)).toBeTruthy();
   });
 });

--- a/apps/mobile/src/modules/routine/RoutineApp.tsx
+++ b/apps/mobile/src/modules/routine/RoutineApp.tsx
@@ -56,6 +56,7 @@ import {
   type RoutineMainTab,
 } from "./components/RoutineBottomNav";
 import { RoutineTabPlaceholder } from "./components/RoutineTabPlaceholder";
+import { Calendar } from "./pages/Calendar";
 
 const TAB_PERSIST_KEY = STORAGE_KEYS.ROUTINE_MAIN_TAB;
 
@@ -90,19 +91,7 @@ function RoutineShell() {
   return (
     <View className="flex-1 bg-cream-50">
       <View className="flex-1">
-        {mainTab === "calendar" ? (
-          <RoutineTabPlaceholder
-            title="Календар"
-            emoji="📅"
-            description="Хаб-календар рутини: звички, день, тиждень, місяць. Скоро — з підсвіткою планових тренувань Фізрука та платежів Фініка."
-            plannedFeatures={[
-              "Місячна сітка з бейджами подій по дню",
-              "Тижнева стрічка з прогрес-рингом",
-              "Список звичок на обраний день з тап-відміткою",
-              "Перегляд деталей дня у bottom-sheet",
-            ]}
-          />
-        ) : null}
+        {mainTab === "calendar" ? <Calendar /> : null}
         {mainTab === "stats" ? (
           <RoutineTabPlaceholder
             title="Статистика"

--- a/apps/mobile/src/modules/routine/lib/routineStore.ts
+++ b/apps/mobile/src/modules/routine/lib/routineStore.ts
@@ -1,0 +1,128 @@
+/**
+ * MMKV-backed routine state hook for the mobile app.
+ *
+ * Mirrors the shape of `apps/web/src/modules/routine/lib/routineStorage.ts`
+ * (Phase 5 / PR 2) but on top of MMKV via `@/lib/storage`. Delegates
+ * all normalization / reducer logic to `@sergeant/routine-domain` so
+ * mobile and web share the exact same `RoutineState` semantics.
+ *
+ * Scope of this file (Phase 5 / PR 2 — Calendar):
+ *  - `loadRoutineState()` + `saveRoutineState()` — raw MMKV I/O with
+ *    the shared `ROUTINE_STORAGE_KEY`.
+ *  - `useRoutineStore()` — React hook that returns the current state
+ *    plus action callbacks for the minimum set of mutations the
+ *    Calendar screen needs (toggle completion, bulk-mark day,
+ *    set completion note). Habits edit UI / reminders / backup /
+ *    delete ship in later PRs.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ROUTINE_STORAGE_KEY,
+  applyMarkAllScheduledHabitsComplete,
+  applySetCompletionNote,
+  applyToggleHabitCompletion,
+  defaultRoutineState,
+  ensureHabitOrder,
+  normalizeRoutineState,
+  type RoutineState,
+} from "@sergeant/routine-domain";
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+
+/** Читає й нормалізує повний стан Рутини з MMKV. */
+export function loadRoutineState(): RoutineState {
+  const raw = safeReadLS<unknown>(ROUTINE_STORAGE_KEY, null);
+  const merged = normalizeRoutineState(raw);
+  const { state, changed } = ensureHabitOrder(merged);
+  if (changed) {
+    safeWriteLS(ROUTINE_STORAGE_KEY, state);
+  }
+  return state;
+}
+
+/** Записує повний стан Рутини у MMKV. */
+export function saveRoutineState(next: RoutineState): boolean {
+  return safeWriteLS(ROUTINE_STORAGE_KEY, next);
+}
+
+export interface UseRoutineStoreReturn {
+  routine: RoutineState;
+  /** Примусово перечитати стан з MMKV (після зовнішнього запису). */
+  refresh: () => void;
+  /** Локально перезаписати весь стан (в обхід reducer-ів). */
+  setRoutine: (next: RoutineState) => void;
+  /** Тап по звичці у список дня — перемкнути відмітку на `dateKey`. */
+  toggleHabit: (habitId: string, dateKey: string) => void;
+  /** "Зробив усе" для дня — позначити кожну планову звичку виконаною. */
+  bulkMarkDay: (dateKey: string) => void;
+  /** Зберегти / стерти нотатку до відмітки. */
+  setCompletionNote: (habitId: string, dateKey: string, text: string) => void;
+}
+
+/**
+ * React-hook над MMKV: синхронний initial read, підписка на зовнішні
+ * записи у той самий ключ через `addOnValueChangedListener`.
+ */
+export function useRoutineStore(): UseRoutineStoreReturn {
+  const [routine, setRoutineState] = useState<RoutineState>(loadRoutineState);
+
+  const refresh = useCallback(() => {
+    setRoutineState(loadRoutineState());
+  }, []);
+
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey === ROUTINE_STORAGE_KEY) refresh();
+    });
+    return () => sub.remove();
+  }, [refresh]);
+
+  const setRoutine = useCallback((next: RoutineState) => {
+    setRoutineState(next);
+    saveRoutineState(next);
+  }, []);
+
+  const toggleHabit = useCallback((habitId: string, dateKey: string) => {
+    setRoutineState((prev) => {
+      const next = applyToggleHabitCompletion(prev, habitId, dateKey);
+      if (next === prev) return prev;
+      saveRoutineState(next);
+      return next;
+    });
+  }, []);
+
+  const bulkMarkDay = useCallback((dateKey: string) => {
+    setRoutineState((prev) => {
+      const next = applyMarkAllScheduledHabitsComplete(prev, dateKey);
+      if (next === prev) return prev;
+      saveRoutineState(next);
+      return next;
+    });
+  }, []);
+
+  const setCompletionNote = useCallback(
+    (habitId: string, dateKey: string, text: string) => {
+      setRoutineState((prev) => {
+        const next = applySetCompletionNote(prev, habitId, dateKey, text);
+        if (next === prev) return prev;
+        saveRoutineState(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  return {
+    routine,
+    refresh,
+    setRoutine,
+    toggleHabit,
+    bulkMarkDay,
+    setCompletionNote,
+  };
+}
+
+// Re-export for consumers that want the canonical default without a
+// second `@sergeant/routine-domain` import.
+export { defaultRoutineState };

--- a/apps/mobile/src/modules/routine/pages/Calendar.test.tsx
+++ b/apps/mobile/src/modules/routine/pages/Calendar.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Render + interaction tests for `pages/Calendar.tsx` (Phase 5 / PR 2).
+ *
+ * Covers:
+ *  - Порожній стан (без звичок) рендерить календар без краху;
+ *  - Перемикач режимів видимий (Сьогодні / Тиждень / Місяць);
+ *  - Звичку, запланована на сьогодні, видно у списку;
+ *  - Тап по її рядку викликає `applyToggleHabitCompletion` через
+ *    `useRoutineStore`, і стан зберігається у MMKV.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import {
+  dateKeyFromDate,
+  defaultRoutineState,
+  ROUTINE_STORAGE_KEY,
+  serializeRoutineState,
+  todayDate,
+  type Habit,
+} from "@sergeant/routine-domain";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { Calendar } from "./Calendar";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+function seedHabit(habit: Partial<Habit> = {}): void {
+  const base = defaultRoutineState();
+  const seeded: Habit = {
+    id: "h1",
+    name: "Випити воду",
+    emoji: "💧",
+    recurrence: "daily",
+    tagIds: [],
+    categoryId: null,
+    archived: false,
+    reminderTimes: [],
+    ...habit,
+  } as Habit;
+  const state = {
+    ...base,
+    habits: [seeded],
+    habitOrder: [seeded.id],
+    prefs: {
+      ...base.prefs,
+      showFizrukInCalendar: false,
+      showFinykSubscriptionsInCalendar: false,
+    },
+  };
+  _getMMKVInstance().set(ROUTINE_STORAGE_KEY, serializeRoutineState(state));
+}
+
+describe("Calendar (mobile)", () => {
+  it("renders without crashing when there are no habits", () => {
+    const { getByText } = render(<Calendar />);
+    expect(getByText("Hub календар")).toBeTruthy();
+    expect(getByText("Сьогодні")).toBeTruthy();
+  });
+
+  it("shows time-mode segmented control", () => {
+    const { getAllByText } = render(<Calendar />);
+    // "Сьогодні" used twice: mode button + "go-to-today" action when in
+    // month view — in initial "today" mode there is only the segmented
+    // entry, so this is still assertable via the label.
+    expect(getAllByText("Сьогодні").length).toBeGreaterThan(0);
+    expect(getAllByText("Тиждень").length).toBeGreaterThan(0);
+    expect(getAllByText("Місяць").length).toBeGreaterThan(0);
+  });
+
+  it("renders a seeded daily habit in today's list", () => {
+    seedHabit();
+    const { getByText } = render(<Calendar />);
+    expect(getByText("💧 Випити воду")).toBeTruthy();
+  });
+
+  it("toggles habit completion and persists to MMKV", () => {
+    seedHabit();
+    const todayKey = dateKeyFromDate(todayDate());
+    const { getByText } = render(<Calendar />);
+
+    fireEvent.press(getByText("💧 Випити воду"));
+
+    const raw = _getMMKVInstance().getString(ROUTINE_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw || "{}");
+    expect(parsed.completions?.h1 ?? []).toContain(todayKey);
+  });
+});

--- a/apps/mobile/src/modules/routine/pages/Calendar.tsx
+++ b/apps/mobile/src/modules/routine/pages/Calendar.tsx
@@ -1,0 +1,596 @@
+/**
+ * Sergeant Routine — Calendar screen (React Native)
+ *
+ * Mobile port of the Hub-календар з `apps/web/src/modules/routine/`
+ * (Phase 5 / PR 2). Працює поверх чистого `@sergeant/routine-domain`
+ * і MMKV через `@/lib/storage` (див. `../lib/routineStore`).
+ *
+ * Scope:
+ *  - Перемикач режимів: «Сьогодні» / «Тиждень» / «Місяць».
+ *  - Місячна сітка 6×7 із крапками-індикаторами запланованих подій по
+ *    дню, тап — вибір дня (+ перехід у режим «День» локально у view).
+ *  - Список звичок на обраний день / тиждень, згрупований за часом
+ *    доби (Ранок / День / Вечір / Будь-коли). Тап по картці — toggle
+ *    `completions[habitId][dateKey]` (через `applyToggleHabitCompletion`).
+ *  - CTA «Зробити все» для одного дня (активний поки щось заплановане
+ *    і ще не виконане).
+ *  - Статистика: поточна серія (max streak), completion rate за
+ *    вибраний діапазон, прогрес дня (виконано / заплановано).
+ *
+ * Поза scope цього PR (окремі майбутні PR Фази 5):
+ *  - редагування / створення / видалення звичок (PR 4);
+ *  - heatmap-сторінка (PR 5); нагадування expo-notifications (PR 6);
+ *  - drag-and-drop reorder, tag-фільтри, пошук, bottom-sheet деталей;
+ *  - події Fizruk-плану / Finyk-підписок (на мобілі додаються разом
+ *    із портом тих модулів).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  type PressableProps,
+} from "react-native";
+
+import {
+  addDays,
+  buildHubCalendarEvents,
+  completionRateForRange,
+  countEventsByDate,
+  dateKeyFromDate,
+  groupEventsForList,
+  habitScheduledOnDate,
+  maxActiveStreak,
+  monthBounds,
+  monthGrid,
+  parseDateKey,
+  startOfIsoWeek,
+  todayDate,
+  type HubCalendarEvent,
+} from "@sergeant/routine-domain";
+
+import { useRoutineStore } from "../lib/routineStore";
+
+type TimeMode = "today" | "week" | "month";
+
+interface MonthCursor {
+  y: number;
+  m: number;
+}
+
+const WEEK_HEADERS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"] as const;
+
+const MONTH_NAMES_UK = [
+  "Січень",
+  "Лютий",
+  "Березень",
+  "Квітень",
+  "Травень",
+  "Червень",
+  "Липень",
+  "Серпень",
+  "Вересень",
+  "Жовтень",
+  "Листопад",
+  "Грудень",
+] as const;
+
+function formatMonthTitle(c: MonthCursor): string {
+  return `${MONTH_NAMES_UK[c.m]} ${c.y}`;
+}
+
+function formatDayHeadline(dateKey: string): string {
+  try {
+    return parseDateKey(dateKey).toLocaleDateString("uk-UA", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    });
+  } catch {
+    return dateKey;
+  }
+}
+
+interface SegmentedProps {
+  value: TimeMode;
+  onChange: (next: TimeMode) => void;
+}
+
+function TimeModeSegmented({ value, onChange }: SegmentedProps) {
+  const items: Array<{ id: TimeMode; label: string }> = [
+    { id: "today", label: "Сьогодні" },
+    { id: "week", label: "Тиждень" },
+    { id: "month", label: "Місяць" },
+  ];
+  return (
+    <View className="flex-row rounded-2xl bg-panel border border-line p-1">
+      {items.map((it) => {
+        const active = value === it.id;
+        return (
+          <Pressable
+            key={it.id}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={it.label}
+            onPress={() => onChange(it.id)}
+            className={
+              "flex-1 min-h-[40px] items-center justify-center rounded-xl px-3 " +
+              (active ? "bg-cream-50" : "bg-transparent")
+            }
+          >
+            <Text
+              className={
+                "text-sm font-bold " +
+                (active ? "text-ink-900" : "text-ink-500")
+              }
+            >
+              {it.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+interface MonthHeaderProps {
+  cursor: MonthCursor;
+  onShift: (delta: number) => void;
+  onToday: () => void;
+}
+
+function MonthHeader({ cursor, onShift, onToday }: MonthHeaderProps) {
+  return (
+    <View className="flex-row items-center gap-2 px-1">
+      <NavButton
+        accessibilityLabel="Попередній місяць"
+        onPress={() => onShift(-1)}
+        glyph="‹"
+      />
+      <View className="flex-1 items-center">
+        <Text className="text-base font-bold text-ink-900 capitalize">
+          {formatMonthTitle(cursor)}
+        </Text>
+      </View>
+      <NavButton
+        accessibilityLabel="Наступний місяць"
+        onPress={() => onShift(1)}
+        glyph="›"
+      />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Перейти на сьогодні"
+        onPress={onToday}
+        className="ml-1 min-h-[36px] items-center justify-center rounded-xl border border-line bg-cream-50 px-3"
+      >
+        <Text className="text-xs font-bold text-ink-900">Сьогодні</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function NavButton({
+  onPress,
+  glyph,
+  accessibilityLabel,
+}: Pick<PressableProps, "onPress"> & {
+  glyph: string;
+  accessibilityLabel: string;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      className="h-10 w-10 items-center justify-center rounded-xl border border-line bg-panel"
+    >
+      <Text className="text-lg font-bold text-ink-700">{glyph}</Text>
+    </Pressable>
+  );
+}
+
+interface MonthGridProps {
+  cursor: MonthCursor;
+  selectedDay: string;
+  todayKey: string;
+  dayCounts: Map<string, number>;
+  onSelectDay: (dateKey: string) => void;
+}
+
+function MonthGridView({
+  cursor,
+  selectedDay,
+  todayKey,
+  dayCounts,
+  onSelectDay,
+}: MonthGridProps) {
+  const { cells } = monthGrid(cursor.y, cursor.m);
+  return (
+    <View className="rounded-2xl border border-line bg-panel p-2">
+      <View className="flex-row">
+        {WEEK_HEADERS.map((w) => (
+          <View key={w} className="flex-1 py-1 items-center">
+            <Text className="text-2xs font-semibold text-ink-500">{w}</Text>
+          </View>
+        ))}
+      </View>
+      <View className="flex-row flex-wrap">
+        {cells.map((d, idx) => {
+          if (d === null) {
+            return (
+              <View
+                key={`empty_${idx}`}
+                className="w-[14.2857%] aspect-square p-0.5"
+              />
+            );
+          }
+          const dk = dateKeyFromDate(new Date(cursor.y, cursor.m, d));
+          const count = dayCounts.get(dk) || 0;
+          const isToday = dk === todayKey;
+          const isSelected = dk === selectedDay;
+          return (
+            <Pressable
+              key={dk}
+              accessibilityRole="button"
+              accessibilityLabel={`Обрати день ${dk}`}
+              accessibilityState={{ selected: isSelected }}
+              onPress={() => onSelectDay(dk)}
+              className="w-[14.2857%] aspect-square p-0.5"
+            >
+              <View
+                className={
+                  "flex-1 items-center justify-center rounded-xl border " +
+                  (isSelected
+                    ? "bg-cream-100 border-ink-900"
+                    : isToday
+                      ? "bg-cream-50 border-line"
+                      : "bg-transparent border-transparent")
+                }
+              >
+                <Text
+                  className={
+                    "text-sm font-bold " +
+                    (isSelected || isToday ? "text-ink-900" : "text-ink-600")
+                  }
+                >
+                  {d}
+                </Text>
+                {count > 0 ? (
+                  <View className="mt-0.5 h-1 w-1 rounded-full bg-ink-500" />
+                ) : (
+                  <View className="mt-0.5 h-1 w-1 rounded-full bg-transparent" />
+                )}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+interface StatsPillProps {
+  streak: number;
+  rate: { completed: number; scheduled: number; rate: number };
+  dayProgress: { completed: number; scheduled: number };
+}
+
+function StatsPill({ streak, rate, dayProgress }: StatsPillProps) {
+  const pct = Math.round(rate.rate * 100);
+  return (
+    <View className="flex-row gap-2">
+      <StatChip label="🔥 Серія" value={`${streak} дн.`} />
+      <StatChip
+        label="✅ Виконано"
+        value={`${rate.completed}/${rate.scheduled} · ${pct}%`}
+      />
+      <StatChip
+        label="📅 День"
+        value={`${dayProgress.completed}/${dayProgress.scheduled}`}
+      />
+    </View>
+  );
+}
+
+function StatChip({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-1 rounded-xl border border-line bg-panel px-3 py-2">
+      <Text
+        className="text-3xs font-bold uppercase text-ink-500"
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <Text className="text-sm font-bold text-ink-900 mt-0.5" numberOfLines={1}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+interface EventRowProps {
+  event: HubCalendarEvent;
+  onToggle: () => void;
+}
+
+function EventRow({ event, onToggle }: EventRowProps) {
+  const isHabit = event.sourceKind === "habit";
+  const completed = !!event.completed;
+  return (
+    <Pressable
+      accessibilityRole={isHabit ? "checkbox" : "text"}
+      accessibilityLabel={event.title}
+      accessibilityState={isHabit ? { checked: completed } : undefined}
+      onPress={isHabit ? onToggle : undefined}
+      className={
+        "flex-row items-center gap-3 rounded-xl border px-3 py-2 " +
+        (completed ? "bg-cream-50 border-line" : "bg-panel border-line")
+      }
+    >
+      <View
+        className={
+          "h-6 w-6 rounded-full border-2 items-center justify-center " +
+          (completed
+            ? "bg-ink-900 border-ink-900"
+            : "bg-transparent border-ink-500")
+        }
+      >
+        {completed ? (
+          <Text className="text-xs font-bold text-cream-50">✓</Text>
+        ) : null}
+      </View>
+      <View className="flex-1 min-w-0">
+        <Text
+          className={
+            "text-sm font-bold " +
+            (completed ? "text-ink-500 line-through" : "text-ink-900")
+          }
+          numberOfLines={1}
+        >
+          {event.title}
+        </Text>
+        {event.subtitle ? (
+          <Text className="text-xs text-ink-500" numberOfLines={1}>
+            {event.subtitle}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+interface GroupedListProps {
+  grouped: Array<[string, HubCalendarEvent[]]>;
+  onToggleHabit: (habitId: string, dateKey: string) => void;
+}
+
+function GroupedEventList({ grouped, onToggleHabit }: GroupedListProps) {
+  if (grouped.length === 0) {
+    return (
+      <View className="rounded-2xl border border-line bg-panel p-4 items-center">
+        <Text className="text-sm text-ink-500">
+          Немає подій для цього діапазону.
+        </Text>
+      </View>
+    );
+  }
+  return (
+    <View className="gap-3">
+      {grouped.map(([head, rows]) => (
+        <View key={head} className="gap-2">
+          <Text className="text-3xs font-bold uppercase text-ink-500">
+            {head}
+          </Text>
+          <View className="gap-2">
+            {rows.map((e) => (
+              <EventRow
+                key={e.id}
+                event={e}
+                onToggle={() =>
+                  e.habitId ? onToggleHabit(e.habitId, e.date) : undefined
+                }
+              />
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/**
+ * Mobile Calendar page — index route of the Routine tab.
+ *
+ * Renders: stats pill, mode segmented, month navigation + grid, day
+ * headline, habit list grouped by time-of-day, bulk-mark CTA.
+ */
+export function Calendar() {
+  const { routine, toggleHabit, bulkMarkDay } = useRoutineStore();
+
+  const today = useMemo(() => todayDate(), []);
+  const todayKey = useMemo(() => dateKeyFromDate(today), [today]);
+
+  const [timeMode, setTimeMode] = useState<TimeMode>("today");
+  const [monthCursor, setMonthCursor] = useState<MonthCursor>(() => ({
+    y: today.getFullYear(),
+    m: today.getMonth(),
+  }));
+  const [selectedDay, setSelectedDay] = useState<string>(todayKey);
+
+  const range = useMemo(() => {
+    if (timeMode === "today") {
+      return { startKey: todayKey, endKey: todayKey };
+    }
+    if (timeMode === "week") {
+      const anchor = parseDateKey(selectedDay);
+      const s = startOfIsoWeek(anchor);
+      const e = addDays(s, 6);
+      return {
+        startKey: dateKeyFromDate(s),
+        endKey: dateKeyFromDate(e),
+      };
+    }
+    return monthBounds(monthCursor.y, monthCursor.m);
+  }, [timeMode, selectedDay, todayKey, monthCursor]);
+
+  const events = useMemo(
+    () =>
+      buildHubCalendarEvents(routine, range, {
+        showFizruk: routine.prefs.showFizrukInCalendar !== false,
+        showFinykSubs: routine.prefs.showFinykSubscriptionsInCalendar !== false,
+      }),
+    [routine, range],
+  );
+
+  const listEvents = useMemo(() => {
+    if (timeMode === "month") {
+      return events.filter((e) => e.date === selectedDay);
+    }
+    return events;
+  }, [events, timeMode, selectedDay]);
+
+  const grouped = useMemo(() => groupEventsForList(listEvents), [listEvents]);
+
+  const dayCounts = useMemo(() => countEventsByDate(events), [events]);
+
+  const shiftMonth = useCallback((delta: number) => {
+    setMonthCursor((c) => {
+      let m = c.m + delta;
+      let y = c.y;
+      if (m > 11) {
+        m = 0;
+        y++;
+      } else if (m < 0) {
+        m = 11;
+        y--;
+      }
+      return { y, m };
+    });
+  }, []);
+
+  const goToToday = useCallback(() => {
+    const t = todayDate();
+    setMonthCursor({ y: t.getFullYear(), m: t.getMonth() });
+    setSelectedDay(dateKeyFromDate(t));
+    setTimeMode("today");
+  }, []);
+
+  const streak = useMemo(
+    () => maxActiveStreak(routine.habits, routine.completions, todayKey),
+    [routine.habits, routine.completions, todayKey],
+  );
+
+  const completionRate = useMemo(
+    () =>
+      completionRateForRange(
+        routine.habits,
+        routine.completions,
+        range.startKey,
+        range.endKey,
+      ),
+    [routine.habits, routine.completions, range.startKey, range.endKey],
+  );
+
+  const dayProgress = useMemo(
+    () =>
+      completionRateForRange(
+        routine.habits,
+        routine.completions,
+        todayKey,
+        todayKey,
+      ),
+    [routine.habits, routine.completions, todayKey],
+  );
+
+  const focusedDay = timeMode === "today" ? todayKey : selectedDay;
+
+  const canBulkMark = useMemo(() => {
+    if (range.startKey !== range.endKey) return false;
+    const dk = range.startKey;
+    for (const h of routine.habits) {
+      if (h.archived) continue;
+      if (!habitScheduledOnDate(h, dk)) continue;
+      if (!(routine.completions[h.id] || []).includes(dk)) return true;
+    }
+    return false;
+  }, [range.startKey, range.endKey, routine.habits, routine.completions]);
+
+  const handleBulkMark = useCallback(() => {
+    if (!canBulkMark) return;
+    bulkMarkDay(range.startKey);
+  }, [canBulkMark, bulkMarkDay, range.startKey]);
+
+  const headline = useMemo(() => formatDayHeadline(focusedDay), [focusedDay]);
+
+  return (
+    <ScrollView
+      testID="routine-calendar-scroll"
+      className="flex-1 bg-cream-50"
+      contentContainerClassName="gap-4 px-4 pt-4 pb-8"
+    >
+      <View className="gap-1">
+        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker mirroring apps/web/src/modules/routine/RoutineApp.tsx */}
+        <Text className="text-3xs font-bold uppercase tracking-widest text-ink-500">
+          Hub календар
+        </Text>
+        <Text className="text-xl font-extrabold text-ink-900 capitalize">
+          {headline}
+        </Text>
+      </View>
+
+      <StatsPill
+        streak={streak}
+        rate={completionRate}
+        dayProgress={dayProgress}
+      />
+
+      <TimeModeSegmented value={timeMode} onChange={setTimeMode} />
+
+      {timeMode === "month" ? (
+        <View className="gap-2">
+          <MonthHeader
+            cursor={monthCursor}
+            onShift={shiftMonth}
+            onToday={goToToday}
+          />
+          <MonthGridView
+            cursor={monthCursor}
+            selectedDay={selectedDay}
+            todayKey={todayKey}
+            dayCounts={dayCounts}
+            onSelectDay={setSelectedDay}
+          />
+        </View>
+      ) : null}
+
+      {range.startKey === range.endKey ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canBulkMark }}
+          accessibilityLabel="Позначити всі заплановані звички виконаними"
+          disabled={!canBulkMark}
+          onPress={handleBulkMark}
+          className={
+            "items-center justify-center rounded-xl border py-3 " +
+            (canBulkMark ? "bg-ink-900 border-ink-900" : "bg-panel border-line")
+          }
+        >
+          <Text
+            className={
+              "text-sm font-bold " +
+              (canBulkMark ? "text-cream-50" : "text-ink-500")
+            }
+          >
+            Зробити все
+          </Text>
+        </Pressable>
+      ) : null}
+
+      <GroupedEventList grouped={grouped} onToggleHabit={toggleHabit} />
+    </ScrollView>
+  );
+}
+
+export default Calendar;

--- a/apps/web/src/modules/routine/lib/finykSubscriptionCalendar.ts
+++ b/apps/web/src/modules/routine/lib/finykSubscriptionCalendar.ts
@@ -2,9 +2,15 @@ import { safeReadLS } from "@shared/lib/storage.js";
 import { STORAGE_KEYS } from "@sergeant/shared";
 import { DEFAULT_SUBSCRIPTIONS } from "../../finyk/constants.js";
 import { getSubscriptionAmountMeta } from "@sergeant/finyk-domain/domain/subscriptionUtils";
-import { enumerateDateKeys, parseDateKey } from "./hubCalendarAggregate.js";
+import {
+  buildFinykSubscriptionEvents as buildFinykSubscriptionEventsPure,
+  FINYK_SUB_GROUP_LABEL,
+  type CalendarRange,
+  type FinykSubscriptionLike,
+  type HubCalendarEvent,
+} from "@sergeant/routine-domain";
 
-export const FINYK_SUB_GROUP_LABEL = "Фінік · підписки";
+export { FINYK_SUB_GROUP_LABEL };
 
 const SUBS_KEY = STORAGE_KEYS.FINYK_SUBS;
 const TX_CACHE_KEY = STORAGE_KEYS.FINYK_TX_CACHE;
@@ -18,59 +24,34 @@ export function loadFinykSubscriptionsFromStorage() {
 
 /** Транзакції з кешу Monobank (для сум і прив’язок). */
 export function loadFinykTransactionsFromStorage() {
-  const primary = safeReadLS(TX_CACHE_KEY, null);
+  const primary = safeReadLS<{ txs?: unknown[] } | null>(TX_CACHE_KEY, null);
   if (primary?.txs?.length) return primary.txs;
-  const fallback = safeReadLS(TX_LAST_GOOD_KEY, null);
+  const fallback = safeReadLS<{ txs?: unknown[] } | null>(
+    TX_LAST_GOOD_KEY,
+    null,
+  );
   if (fallback?.txs?.length) return fallback.txs;
   return [];
 }
 
-function scheduledBillingDom(year, monthIndex, billingDay) {
-  const dim = new Date(year, monthIndex + 1, 0).getDate();
-  return Math.min(Number(billingDay) || 1, dim);
-}
-
-function isBillingDateKey(dateKey, billingDay) {
-  const d = parseDateKey(dateKey);
-  const dom = scheduledBillingDom(d.getFullYear(), d.getMonth(), billingDay);
-  return d.getDate() === dom;
-}
-
 /**
  * Події календаря для підписок Фініка (планове списання раз на місяць).
+ * Тонкий адаптер над `buildFinykSubscriptionEvents` з
+ * `@sergeant/routine-domain`: тягне підписки + транзакції з localStorage
+ * і передає lookup-функцію у pure-builder.
  */
-export function buildFinykSubscriptionEvents(range) {
-  const { startKey, endKey } = range;
+export function buildFinykSubscriptionEvents(
+  range: CalendarRange,
+): HubCalendarEvent[] {
   const subs = loadFinykSubscriptionsFromStorage();
   const txs = loadFinykTransactionsFromStorage();
-  const days = enumerateDateKeys(startKey, endKey);
-  const out = [];
-
-  for (const sub of subs) {
-    const bd = Number(sub.billingDay);
-    if (!Number.isFinite(bd) || bd < 1 || bd > 31) continue;
-    const { amount, currency } = getSubscriptionAmountMeta(sub, txs);
-    const subTitle = `${sub.emoji || "📱"} ${sub.name || "Підписка"}`;
-    for (const date of days) {
-      if (!isBillingDateKey(date, bd)) continue;
-      const amtStr =
-        amount != null
-          ? `~${amount.toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ${currency}`
-          : "сума з транзакції або вручну у Фініку";
-      out.push({
-        id: `finyk_sub_${sub.id}_${date}`,
-        source: "finyk_subscription",
-        date,
-        title: subTitle,
-        subtitle: `Планове списання · ${amtStr}`,
-        tagLabels: [FINYK_SUB_GROUP_LABEL],
-        sortKey: `${date} 0b finyk_${sub.id}`,
-        fizruk: false,
-        finykSub: true,
-        sourceKind: "finyk_sub",
-      });
-    }
-  }
-
-  return out;
+  return buildFinykSubscriptionEventsPure(
+    range,
+    subs as FinykSubscriptionLike[],
+    (sub) =>
+      getSubscriptionAmountMeta(
+        sub,
+        txs as Parameters<typeof getSubscriptionAmountMeta>[1],
+      ),
+  );
 }

--- a/apps/web/src/modules/routine/lib/hubCalendarAggregate.ts
+++ b/apps/web/src/modules/routine/lib/hubCalendarAggregate.ts
@@ -4,12 +4,17 @@ import {
   TEMPLATES_STORAGE_KEY,
 } from "@sergeant/fizruk-domain";
 import {
-  completionNoteKey,
   dateKeyFromDate,
   enumerateDateKeys,
   habitScheduledOnDate,
   parseDateKey,
-  sortHabitsByOrder,
+  buildHubCalendarEvents as buildHubCalendarEventsPure,
+  countEventsByDate,
+  FIZRUK_GROUP_LABEL,
+  type BuildHubCalendarEventsOptions,
+  type CalendarRange,
+  type HubCalendarEvent,
+  type RoutineState,
 } from "@sergeant/routine-domain";
 import { buildFinykSubscriptionEvents } from "./finykSubscriptionCalendar.js";
 
@@ -21,9 +26,9 @@ export {
   parseDateKey,
   enumerateDateKeys,
   habitScheduledOnDate,
+  countEventsByDate,
+  FIZRUK_GROUP_LABEL,
 };
-
-export const FIZRUK_GROUP_LABEL = "Фізрук";
 
 export function loadMonthlyPlanDays() {
   const p = safeReadLS<{ days?: Record<string, { templateId?: string }> }>(
@@ -47,98 +52,30 @@ export function loadTemplateNameById() {
   return map;
 }
 
-function tagLabelsForHabit(state, habit) {
-  const ids = habit.tagIds || [];
-  const labels = ids
-    .map((id) => state.tags.find((t) => t.id === id)?.name)
-    .filter(Boolean);
-  if (habit.categoryId) {
-    const c = state.categories.find((x) => x.id === habit.categoryId);
-    if (c?.name) labels.push(c.name);
-  }
-  return labels.length ? labels : ["Без тегу"];
-}
-
+/**
+ * Тонкий web-адаптер над pure `buildHubCalendarEvents` з
+ * `@sergeant/routine-domain`: підтягує з localStorage Fizruk-план,
+ * імена шаблонів тренувань і події підписок Фініка, решту роботи
+ * робить pure-builder.
+ */
 export function buildHubCalendarEvents(
-  state,
-  range,
-  { showFizruk = true, showFinykSubs = true } = {},
-) {
-  const events = [];
-  const { startKey, endKey } = range;
-  const days = enumerateDateKeys(startKey, endKey);
-  const planDays = loadMonthlyPlanDays();
-  const tplNames = loadTemplateNameById();
-
-  if (showFizruk) {
-    for (const date of days) {
-      const tid = planDays[date]?.templateId;
-      if (!tid) continue;
-      const title = tplNames.get(tid) || "Тренування за планом";
-      events.push({
-        id: `fizruk_${date}_${tid}`,
-        source: "fizruk_plan",
-        date,
-        title,
-        subtitle: "План Фізрука",
-        tagLabels: [FIZRUK_GROUP_LABEL],
-        sortKey: `${date} 0 fizruk`,
-        fizruk: true,
-        sourceKind: "fizruk",
-      });
-    }
-  }
-
-  const notes =
-    state.completionNotes && typeof state.completionNotes === "object"
-      ? state.completionNotes
-      : {};
-  const activeHabits = sortHabitsByOrder(
-    state.habits.filter((h) => !h.archived),
-    state.habitOrder || [],
+  state: RoutineState,
+  range: CalendarRange,
+  {
+    showFizruk = true,
+    showFinykSubs = true,
+  }: BuildHubCalendarEventsOptions = {},
+): HubCalendarEvent[] {
+  const fizrukPlanDays = showFizruk ? loadMonthlyPlanDays() : undefined;
+  const fizrukTemplateNames = showFizruk ? loadTemplateNameById() : undefined;
+  const finykSubscriptionEvents =
+    showFinykSubs && state.prefs?.showFinykSubscriptionsInCalendar !== false
+      ? buildFinykSubscriptionEvents(range)
+      : undefined;
+  return buildHubCalendarEventsPure(
+    state,
+    range,
+    { showFizruk, showFinykSubs },
+    { fizrukPlanDays, fizrukTemplateNames, finykSubscriptionEvents },
   );
-  for (const date of days) {
-    for (const h of activeHabits) {
-      if (!habitScheduledOnDate(h, date)) continue;
-      const completions = state.completions[h.id] || [];
-      const completed = completions.includes(date);
-      const tagLabels = tagLabelsForHabit(state, h);
-      const t = h.timeOfDay ? String(h.timeOfDay).trim() : "";
-      const timePart = t ? ` · ${t}` : "";
-      const nk = completionNoteKey(h.id, date);
-      const note = notes[nk] ? String(notes[nk]) : "";
-      events.push({
-        id: `habit_${h.id}_${date}`,
-        source: "routine_habit",
-        date,
-        title: `${h.emoji} ${h.name}`,
-        subtitle: completed ? `Зроблено${timePart}` : `Звичка${timePart}`,
-        tagLabels,
-        sortKey: `${date} 1 ${h.name}`,
-        habitId: h.id,
-        completed,
-        note,
-        sourceKind: "habit",
-        timeOfDay: t,
-      });
-    }
-  }
-
-  if (
-    showFinykSubs &&
-    state.prefs?.showFinykSubscriptionsInCalendar !== false
-  ) {
-    events.push(...buildFinykSubscriptionEvents(range));
-  }
-
-  events.sort((a, b) => a.sortKey.localeCompare(b.sortKey, "uk"));
-  return events;
-}
-
-export function countEventsByDate(events) {
-  const map = new Map();
-  for (const e of events) {
-    map.set(e.date, (map.get(e.date) || 0) + 1);
-  }
-  return map;
 }

--- a/apps/web/src/modules/routine/lib/routineStorage.ts
+++ b/apps/web/src/modules/routine/lib/routineStorage.ts
@@ -1,21 +1,43 @@
 /** Hub «Рутина»: звички, теги, категорії (не-спорт), localStorage */
 
-import {
-  dateKeyFromDate,
-  habitScheduledOnDate,
-} from "./hubCalendarAggregate.js";
-import { completionNoteKey } from "./completionNoteKey.js";
 import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
-import type { CreateHabitOptions } from "./types";
+import {
+  ROUTINE_STORAGE_KEY,
+  ROUTINE_EVENT,
+  ROUTINE_STORAGE_ERROR,
+  applyCreateTag,
+  applyCreateCategory,
+  applyCreateHabit,
+  applyUpdateHabit,
+  applySetPref,
+  applyToggleHabitCompletion,
+  applyMarkAllScheduledHabitsComplete,
+  applySetHabitArchived,
+  applyDeleteHabit,
+  applyRestoreHabit,
+  applyAddPushupReps,
+  applyMoveHabitInOrder,
+  applySetHabitOrder,
+  applySetCompletionNote,
+  applyUpdateTag,
+  applyUpdateCategory,
+  applyDeleteCategory,
+  applyDeleteTag,
+  snapshotHabit as snapshotHabitPure,
+  normalizeRoutineState,
+  ensureHabitOrder,
+  defaultRoutineState,
+  ROUTINE_SCHEMA_VERSION,
+  type CreateHabitOptions,
+  type RoutineState,
+  type Habit,
+  type HabitSnapshot,
+} from "@sergeant/routine-domain";
 
 const storage = createModuleStorage({ name: "routine" });
 
-export const ROUTINE_STORAGE_KEY = "hub_routine_v1";
-
-export const ROUTINE_EVENT = "hub-routine-storage";
-
-/** Подія при невдалому localStorage.setItem (квота тощо) */
-export const ROUTINE_STORAGE_ERROR = "hub-routine-storage-error";
+// Re-export key constants so web callers can keep their existing imports.
+export { ROUTINE_STORAGE_KEY, ROUTINE_EVENT, ROUTINE_STORAGE_ERROR };
 
 export function emitRoutineStorage() {
   try {
@@ -25,102 +47,14 @@ export function emitRoutineStorage() {
   }
 }
 
-function uid(prefix) {
-  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
-}
-
-function normalizeReminderTimesStorage(rt) {
-  if (!Array.isArray(rt)) return [];
-  return rt.filter((t) => typeof t === "string" && /^\d{2}:\d{2}$/.test(t));
-}
-
-const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/** Prune duplicates and invalid date keys from a single habit's completion list. */
-function normalizeCompletionList(list) {
-  if (!Array.isArray(list)) return [];
-  const seen = new Set();
-  for (const v of list) {
-    if (typeof v === "string" && DATE_KEY_RE.test(v)) seen.add(v);
-  }
-  return [...seen].sort();
-}
-
-/** Coerce the whole completions map into `{ [habitId]: sortedUniqueDateKeys }`. */
-function normalizeCompletionsMap(raw) {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const out = {};
-  for (const [k, v] of Object.entries(raw)) {
-    out[k] = normalizeCompletionList(v);
-  }
-  return out;
-}
-
-function normalizeHabit(h) {
-  if (!h || typeof h !== "object") return h;
-  const created = h.createdAt
-    ? String(h.createdAt).slice(0, 10)
-    : dateKeyFromDate(new Date());
-  return {
-    ...h,
-    recurrence: h.recurrence || "daily",
-    startDate: h.startDate || created,
-    endDate: h.endDate === undefined ? null : h.endDate,
-    timeOfDay: h.timeOfDay === undefined ? "" : String(h.timeOfDay),
-    reminderTimes: normalizeReminderTimesStorage(h.reminderTimes),
-    weekdays:
-      Array.isArray(h.weekdays) && h.weekdays.length
-        ? h.weekdays
-        : [0, 1, 2, 3, 4, 5, 6],
-  };
-}
-
-const defaultState = () => ({
-  schemaVersion: 3,
-  prefs: {
-    showFizrukInCalendar: true,
-    /** Планові списання підписок Фініка в календарі Hub */
-    showFinykSubscriptionsInCalendar: true,
-    /** Браузерні нагадування у вказаний час (якщо дозволено Notification) */
-    routineRemindersEnabled: false,
-  },
-  tags: [],
-  categories: [],
-  habits: [],
-  completions: {},
-  /** "YYYY-MM-DD" -> кількість відтискань */
-  pushupsByDate: {},
-  /** порядок id активних звичок (drag/up-down) */
-  habitOrder: [],
-  /** completionNoteKey -> короткий текст */
-  completionNotes: {},
-});
-
-function ensureHabitOrder(state) {
-  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
-  const order = [...(state.habitOrder || [])].filter((id) =>
-    active.includes(id),
-  );
-  for (const id of active) {
-    if (!order.includes(id)) order.push(id);
-  }
-  const same =
-    order.length === (state.habitOrder || []).length &&
-    order.every((id, i) => id === (state.habitOrder || [])[i]);
-  if (same) return { state, changed: false };
-  return { state: { ...state, habitOrder: order }, changed: true };
-}
-
 /**
  * Normalize habit order and persist if changed.
  * Legacy pushup migration is handled by storageManager (routine_001_migrate_fizruk_pushups)
  * which runs before the React tree mounts, so by the time this is called the migration is done.
  */
-function finalizeLoadedRoutineState(state) {
-  let s = state;
-  const ord = ensureHabitOrder(s);
-  s = ord.state;
-  if (ord.changed) {
+function finalizeLoadedRoutineState(state: RoutineState): RoutineState {
+  const { state: s, changed } = ensureHabitOrder(state);
+  if (changed) {
     saveRoutineState(s);
   }
   return s;
@@ -128,42 +62,19 @@ function finalizeLoadedRoutineState(state) {
 
 /**
  * Load and normalize the full routine state from localStorage.
- * Falls back to `defaultState()` on parse errors or missing key.
- * Applies one-time data finalization (e.g. legacy pushup migration).
- * @returns {{ schemaVersion: number, habits: Array, completions: Record<string,Record<string,boolean>>, tags: Array, categories: Array, prefs: object, pushupsByDate: Record<string,number>, habitOrder: string[], completionNotes: object }}
+ * Falls back to default state on parse errors or missing key.
  */
-export function loadRoutineState() {
-  const p = storage.readJSON(ROUTINE_STORAGE_KEY, null);
-  if (!p || typeof p !== "object" || Array.isArray(p)) {
-    return finalizeLoadedRoutineState(defaultState());
-  }
-  const merged = {
-    ...defaultState(),
-    ...p,
-    prefs: { ...defaultState().prefs, ...(p.prefs || {}) },
-    tags: Array.isArray(p.tags) ? p.tags : [],
-    categories: Array.isArray(p.categories) ? p.categories : [],
-    habits: Array.isArray(p.habits) ? p.habits.map(normalizeHabit) : [],
-    completions: normalizeCompletionsMap(p.completions),
-    pushupsByDate:
-      typeof p.pushupsByDate === "object" && p.pushupsByDate
-        ? p.pushupsByDate
-        : {},
-    habitOrder: Array.isArray(p.habitOrder) ? p.habitOrder : [],
-    completionNotes:
-      typeof p.completionNotes === "object" && p.completionNotes
-        ? p.completionNotes
-        : {},
-  };
+export function loadRoutineState(): RoutineState {
+  const raw = storage.readJSON(ROUTINE_STORAGE_KEY, null);
+  const merged = normalizeRoutineState(raw);
   return finalizeLoadedRoutineState(merged);
 }
 
 /**
  * Persist routine state to localStorage and dispatch a storage event.
- * @param {ReturnType<typeof loadRoutineState>} next - the new state to save
- * @returns {boolean} `true` on success, `false` if localStorage threw (e.g. quota exceeded)
+ * Returns `true` on success, `false` if localStorage threw (e.g. quota exceeded).
  */
-export function saveRoutineState(next) {
+export function saveRoutineState(next: RoutineState): boolean {
   const ok = storage.writeJSON(ROUTINE_STORAGE_KEY, next);
   if (ok) {
     emitRoutineStorage();
@@ -181,22 +92,26 @@ export function saveRoutineState(next) {
   return false;
 }
 
-export function createTag(state, name) {
-  const n = (name || "").trim();
-  if (!n) return state;
-  const t = { id: uid("tag"), name: n, scope: "routine" };
-  const next = { ...state, tags: [...state.tags, t] };
+/** Generic wrapper: apply a pure reducer and persist the result. */
+function persist<T extends RoutineState>(next: T): T {
   saveRoutineState(next);
   return next;
 }
 
-export function createCategory(state, name, emoji = "") {
-  const n = (name || "").trim();
-  if (!n) return state;
-  const c = { id: uid("cat"), name: n, emoji: emoji || undefined };
-  const next = { ...state, categories: [...state.categories, c] };
-  saveRoutineState(next);
-  return next;
+export function createTag(state: RoutineState, name: string): RoutineState {
+  const next = applyCreateTag(state, name);
+  if (next === state) return state;
+  return persist(next);
+}
+
+export function createCategory(
+  state: RoutineState,
+  name: string,
+  emoji = "",
+): RoutineState {
+  const next = applyCreateCategory(state, name, emoji);
+  if (next === state) return state;
+  return persist(next);
 }
 
 /**
@@ -204,315 +119,155 @@ export function createCategory(state, name, emoji = "") {
  * Returns original state (unchanged) if `name` is empty/blank.
  */
 export function createHabit(
-  state,
-  {
-    name = "",
-    emoji = "✓",
-    tagIds = [],
-    categoryId = null,
-    recurrence = "daily",
-    startDate = null,
-    endDate = null,
-    timeOfDay = "",
-    reminderTimes = [],
-    weekdays = [0, 1, 2, 3, 4, 5, 6],
-  }: Partial<CreateHabitOptions> = {},
-) {
-  const n = (name || "").trim();
-  if (!n) return state;
-  const sd =
-    (startDate && String(startDate).trim()) || dateKeyFromDate(new Date());
-  const h = normalizeHabit({
-    id: uid("hab"),
-    name: n,
-    emoji: emoji || "✓",
-    tagIds: Array.isArray(tagIds) ? tagIds : [],
-    categoryId: categoryId || null,
-    createdAt: new Date().toISOString(),
-    archived: false,
-    recurrence,
-    startDate: sd,
-    endDate: endDate && String(endDate).trim() ? String(endDate).trim() : null,
-    timeOfDay:
-      timeOfDay && String(timeOfDay).trim()
-        ? String(timeOfDay).trim().slice(0, 5)
-        : "",
-    reminderTimes: normalizeReminderTimesStorage(reminderTimes),
-    weekdays: Array.isArray(weekdays)
-      ? [...new Set(weekdays)].sort((a, b) => a - b)
-      : [0, 1, 2, 3, 4, 5, 6],
-  });
-  const order = [...(state.habitOrder || []), h.id];
-  const next = {
-    ...state,
-    habits: [...state.habits, h],
-    completions: { ...state.completions },
-    habitOrder: order,
-  };
-  saveRoutineState(next);
-  return next;
+  state: RoutineState,
+  opts: Partial<CreateHabitOptions> = {},
+): RoutineState {
+  const next = applyCreateHabit(state, opts);
+  if (next === state) return state;
+  return persist(next);
 }
 
-/**
- * Apply a partial patch to a habit by id, persist, and return next state.
- * @param {ReturnType<typeof loadRoutineState>} state
- * @param {string} id - habit id
- * @param {Partial<ReturnType<typeof loadRoutineState>['habits'][0]>} patch
- * @returns {ReturnType<typeof loadRoutineState>}
- */
-export function updateHabit(state, id, patch) {
-  const next = {
-    ...state,
-    habits: state.habits.map((h) =>
-      h.id === id ? normalizeHabit({ ...h, ...patch }) : h,
-    ),
-  };
-  saveRoutineState(next);
-  return next;
+/** Apply a partial patch to a habit by id, persist, and return next state. */
+export function updateHabit(
+  state: RoutineState,
+  id: string,
+  patch: Partial<Habit>,
+): RoutineState {
+  return persist(applyUpdateHabit(state, id, patch));
 }
 
-export function setPref(state, key, value) {
-  const next = { ...state, prefs: { ...state.prefs, [key]: value } };
-  saveRoutineState(next);
-  return next;
+export function setPref<K extends string>(
+  state: RoutineState,
+  key: K,
+  value: unknown,
+): RoutineState {
+  return persist(applySetPref(state, key, value));
 }
 
 /**
  * Toggle a habit's completion for a given date.
  * No-op if the habit is not scheduled on that date (and it wasn't already marked).
- * @param {ReturnType<typeof loadRoutineState>} state
- * @param {string} habitId
- * @param {string} dateKey - ISO date string "YYYY-MM-DD"
- * @returns {ReturnType<typeof loadRoutineState>}
  */
-export function toggleHabitCompletion(state, habitId, dateKey) {
-  const habit = state.habits.find((h) => h.id === habitId);
-  if (!habit) return state;
-  const curSet = new Set(normalizeCompletionList(state.completions[habitId]));
-  if (curSet.has(dateKey)) {
-    curSet.delete(dateKey);
-  } else {
-    if (!habitScheduledOnDate(habit, dateKey)) return state;
-    curSet.add(dateKey);
-  }
-  const cur = [...curSet].sort();
-  const next = {
-    ...state,
-    completions: { ...state.completions, [habitId]: cur },
-  };
-  saveRoutineState(next);
-  return next;
+export function toggleHabitCompletion(
+  state: RoutineState,
+  habitId: string,
+  dateKey: string,
+): RoutineState {
+  const next = applyToggleHabitCompletion(state, habitId, dateKey);
+  if (next === state) return state;
+  return persist(next);
 }
 
 /** Усі активні звички, заплановані на день, отримують відмітку (якщо ще немає). */
-export function markAllScheduledHabitsComplete(state, dateKey) {
-  const active = state.habits.filter((h) => !h.archived);
-  const completions = { ...state.completions };
-  let changed = false;
-  for (const h of active) {
-    if (!habitScheduledOnDate(h, dateKey)) continue;
-    const set = new Set(normalizeCompletionList(completions[h.id]));
-    if (set.has(dateKey)) continue;
-    set.add(dateKey);
-    completions[h.id] = [...set].sort();
-    changed = true;
-  }
-  if (!changed) return state;
-  const next = { ...state, completions };
-  saveRoutineState(next);
-  return next;
+export function markAllScheduledHabitsComplete(
+  state: RoutineState,
+  dateKey: string,
+): RoutineState {
+  const next = applyMarkAllScheduledHabitsComplete(state, dateKey);
+  if (next === state) return state;
+  return persist(next);
 }
 
-export function setHabitArchived(state, id, archived) {
-  return updateHabit(state, id, { archived: !!archived });
+export function setHabitArchived(
+  state: RoutineState,
+  id: string,
+  archived: boolean,
+): RoutineState {
+  return persist(applySetHabitArchived(state, id, archived));
 }
 
-export function deleteHabit(state, id) {
-  const completions = { ...state.completions };
-  delete completions[id];
-  const notes = { ...(state.completionNotes || {}) };
-  const prefix = `${id}__`;
-  for (const k of Object.keys(notes)) {
-    if (k.startsWith(prefix)) delete notes[k];
-  }
-  const next = {
-    ...state,
-    habits: state.habits.filter((h) => h.id !== id),
-    completions,
-    completionNotes: notes,
-    habitOrder: (state.habitOrder || []).filter((x) => x !== id),
-  };
-  saveRoutineState(next);
-  return next;
+export function deleteHabit(state: RoutineState, id: string): RoutineState {
+  return persist(applyDeleteHabit(state, id));
 }
 
 /**
  * Snapshot усього, що потрібно для відновлення звички після `deleteHabit`:
- * сам запис звички, її completions, note-and, а також позицію в habitOrder.
+ * сам запис звички, її completions, notes, позиція в habitOrder.
  * Використовується undo-toast-ом у `RoutineSettingsSection`.
  */
-export function snapshotHabit(state, id) {
-  const habit = state.habits.find((h) => h.id === id);
-  if (!habit) return null;
-  const completions = Array.isArray(state.completions?.[id])
-    ? [...state.completions[id]]
-    : [];
-  const notes: Record<string, string> = {};
-  const prefix = `${id}__`;
-  const rawNotes = state.completionNotes || {};
-  for (const k of Object.keys(rawNotes)) {
-    if (k.startsWith(prefix)) notes[k] = rawNotes[k];
-  }
-  const order = Array.isArray(state.habitOrder) ? state.habitOrder : [];
-  const orderIndex = order.indexOf(id);
-  return { habit, completions, notes, orderIndex };
+export function snapshotHabit(
+  state: RoutineState,
+  id: string,
+): HabitSnapshot | null {
+  return snapshotHabitPure(state, id);
 }
 
 /**
  * Відновлює звичку зі знімка, отриманого `snapshotHabit`. Ідемпотентно:
  * якщо звичка з таким id уже є — повертає state без змін.
  */
-export function restoreHabit(state, snapshot) {
-  if (!snapshot || !snapshot.habit || !snapshot.habit.id) return state;
-  const { habit, completions, notes, orderIndex } = snapshot;
-  if (state.habits.some((h) => h.id === habit.id)) return state;
-  const nextCompletions = { ...state.completions };
-  if (Array.isArray(completions) && completions.length) {
-    nextCompletions[habit.id] = [...completions];
-  }
-  const nextNotes = { ...(state.completionNotes || {}), ...(notes || {}) };
-  const existingOrder = (state.habitOrder || []).filter((x) => x !== habit.id);
-  const insertAt =
-    typeof orderIndex === "number" && orderIndex >= 0
-      ? Math.min(orderIndex, existingOrder.length)
-      : existingOrder.length;
-  const nextOrder = [
-    ...existingOrder.slice(0, insertAt),
-    habit.id,
-    ...existingOrder.slice(insertAt),
-  ];
-  const next = {
-    ...state,
-    habits: [...state.habits, normalizeHabit(habit)],
-    completions: nextCompletions,
-    completionNotes: nextNotes,
-    habitOrder: nextOrder,
-  };
-  saveRoutineState(next);
-  return next;
+export function restoreHabit(
+  state: RoutineState,
+  snapshot: HabitSnapshot | null,
+): RoutineState {
+  const next = applyRestoreHabit(state, snapshot);
+  if (next === state) return state;
+  return persist(next);
 }
 
-export function addPushupReps(state, reps) {
-  const n = Number(reps);
-  if (!n || n <= 0) return state;
-  const today = dateKeyFromDate(new Date());
-  const cur = state.pushupsByDate?.[today] ?? 0;
-  const next = {
-    ...state,
-    pushupsByDate: { ...state.pushupsByDate, [today]: cur + n },
-  };
-  saveRoutineState(next);
-  return next;
+export function addPushupReps(
+  state: RoutineState,
+  reps: unknown,
+): RoutineState {
+  const next = applyAddPushupReps(state, reps);
+  if (next === state) return state;
+  return persist(next);
 }
 
-export function moveHabitInOrder(state, habitId, delta) {
-  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
-  const order = [...(state.habitOrder || [])].filter((id) =>
-    active.includes(id),
-  );
-  for (const id of active) {
-    if (!order.includes(id)) order.push(id);
-  }
-  const i = order.indexOf(habitId);
-  if (i < 0) return state;
-  const j = i + delta;
-  if (j < 0 || j >= order.length) return state;
-  const copy = [...order];
-  [copy[i], copy[j]] = [copy[j], copy[i]];
-  const next = { ...state, habitOrder: copy };
-  saveRoutineState(next);
-  return next;
+export function moveHabitInOrder(
+  state: RoutineState,
+  habitId: string,
+  delta: number,
+): RoutineState {
+  const next = applyMoveHabitInOrder(state, habitId, delta);
+  if (next === state) return state;
+  return persist(next);
 }
 
 /** Повний порядок активних звичок (наприклад після drag-and-drop) */
-export function setHabitOrder(state, orderedActiveIds) {
-  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
-  const seen = new Set();
-  const order = [];
-  for (const id of orderedActiveIds) {
-    if (active.includes(id) && !seen.has(id)) {
-      order.push(id);
-      seen.add(id);
-    }
-  }
-  for (const id of active) {
-    if (!seen.has(id)) order.push(id);
-  }
-  const next = { ...state, habitOrder: order };
-  saveRoutineState(next);
-  return next;
+export function setHabitOrder(
+  state: RoutineState,
+  orderedActiveIds: string[],
+): RoutineState {
+  return persist(applySetHabitOrder(state, orderedActiveIds));
 }
 
-export function setCompletionNote(state, habitId, dateKey, text) {
-  const k = completionNoteKey(habitId, dateKey);
-  const notes = { ...(state.completionNotes || {}) };
-  const t = (text || "").trim();
-  if (!t) {
-    if (!(k in notes)) return state;
-    delete notes[k];
-  } else {
-    const habitExists = state.habits.some((h) => h.id === habitId);
-    if (!habitExists) return state;
-    notes[k] = t.slice(0, 500);
-  }
-  const next = { ...state, completionNotes: notes };
-  saveRoutineState(next);
-  return next;
+export function setCompletionNote(
+  state: RoutineState,
+  habitId: string,
+  dateKey: string,
+  text: string,
+): RoutineState {
+  const next = applySetCompletionNote(state, habitId, dateKey, text);
+  if (next === state) return state;
+  return persist(next);
 }
 
 /**
  * Build a JSON-serializable backup payload for the Routine module.
- * @returns {{ kind: 'hub-routine-backup', schemaVersion: number, exportedAt: string, data: ReturnType<typeof loadRoutineState> }}
  */
 export function buildRoutineBackupPayload() {
   return {
-    kind: "hub-routine-backup",
-    schemaVersion: 3,
+    kind: "hub-routine-backup" as const,
+    schemaVersion: ROUTINE_SCHEMA_VERSION,
     exportedAt: new Date().toISOString(),
     data: loadRoutineState(),
   };
 }
 
-export function applyRoutineBackupPayload(parsed) {
+export function applyRoutineBackupPayload(parsed: unknown): void {
   if (
     !parsed ||
-    parsed.kind !== "hub-routine-backup" ||
-    !parsed.data ||
-    typeof parsed.data !== "object"
+    typeof parsed !== "object" ||
+    (parsed as { kind?: unknown }).kind !== "hub-routine-backup" ||
+    !(parsed as { data?: unknown }).data ||
+    typeof (parsed as { data?: unknown }).data !== "object"
   ) {
     throw new Error("Некоректний файл резервної копії Рутини.");
   }
-  const d = parsed.data;
-  const merged = {
-    ...defaultState(),
-    ...d,
-    prefs: { ...defaultState().prefs, ...(d.prefs || {}) },
-    tags: Array.isArray(d.tags) ? d.tags : [],
-    categories: Array.isArray(d.categories) ? d.categories : [],
-    habits: Array.isArray(d.habits) ? d.habits.map(normalizeHabit) : [],
-    completions: normalizeCompletionsMap(d.completions),
-    pushupsByDate:
-      typeof d.pushupsByDate === "object" && d.pushupsByDate
-        ? d.pushupsByDate
-        : {},
-    habitOrder: Array.isArray(d.habitOrder) ? d.habitOrder : [],
-    completionNotes:
-      typeof d.completionNotes === "object" && d.completionNotes
-        ? d.completionNotes
-        : {},
-  };
-  let s = merged;
-  s = ensureHabitOrder(s).state;
+  const d = (parsed as { data: unknown }).data;
+  const merged = normalizeRoutineState(d);
+  const { state: s } = ensureHabitOrder(merged);
   if (!saveRoutineState(s)) {
     throw new Error(
       "Не вдалося записати дані після імпорту (наприклад, переповнення сховища).",
@@ -520,59 +275,31 @@ export function applyRoutineBackupPayload(parsed) {
   }
 }
 
-export function updateTag(state, id, newName) {
-  const n = (newName || "").trim();
-  if (!n) return state;
-  const next = {
-    ...state,
-    tags: state.tags.map((t) => (t.id === id ? { ...t, name: n } : t)),
-  };
-  saveRoutineState(next);
-  return next;
+export function updateTag(
+  state: RoutineState,
+  id: string,
+  newName: string,
+): RoutineState {
+  const next = applyUpdateTag(state, id, newName);
+  if (next === state) return state;
+  return persist(next);
 }
 
-export function updateCategory(state, id, patch) {
-  const next = {
-    ...state,
-    categories: state.categories.map((c) =>
-      c.id === id
-        ? {
-            ...c,
-            ...(patch.name !== undefined
-              ? { name: (patch.name || "").trim() || c.name }
-              : {}),
-            ...(patch.emoji !== undefined
-              ? { emoji: patch.emoji || undefined }
-              : {}),
-          }
-        : c,
-    ),
-  };
-  saveRoutineState(next);
-  return next;
+export function updateCategory(
+  state: RoutineState,
+  id: string,
+  patch: { name?: string; emoji?: string },
+): RoutineState {
+  return persist(applyUpdateCategory(state, id, patch));
 }
 
-export function deleteCategory(state, id) {
-  const next = {
-    ...state,
-    categories: state.categories.filter((c) => c.id !== id),
-    habits: state.habits.map((h) =>
-      h.categoryId === id ? { ...h, categoryId: null } : h,
-    ),
-  };
-  saveRoutineState(next);
-  return next;
+export function deleteCategory(state: RoutineState, id: string): RoutineState {
+  return persist(applyDeleteCategory(state, id));
 }
 
-export function deleteTag(state, id) {
-  const next = {
-    ...state,
-    tags: state.tags.filter((t) => t.id !== id),
-    habits: state.habits.map((h) => ({
-      ...h,
-      tagIds: (h.tagIds || []).filter((x) => x !== id),
-    })),
-  };
-  saveRoutineState(next);
-  return next;
+export function deleteTag(state: RoutineState, id: string): RoutineState {
+  return persist(applyDeleteTag(state, id));
 }
+
+// Silence TS about the unused default import for backward-compat consumers.
+void defaultRoutineState;

--- a/packages/routine-domain/src/calendarEvents.ts
+++ b/packages/routine-domain/src/calendarEvents.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure Hub-calendar event builder.
+ *
+ * Aggregates routine habits (and optionally Fizruk plan entries +
+ * Finyk subscription charges) into a flat list of `HubCalendarEvent`s
+ * for rendering. All storage I/O is pushed to the caller — this module
+ * is DOM-/RN-/browser-free and works under Node, jsdom, or RN runtimes.
+ *
+ * Extracted from `apps/web/src/modules/routine/lib/hubCalendarAggregate.ts`
+ * and `finykSubscriptionCalendar.ts` (Phase 5 / PR 2). The web wrappers
+ * now inject their localStorage-backed readers when calling these.
+ */
+
+import { enumerateDateKeys, parseDateKey } from "./dateKeys.js";
+import { habitScheduledOnDate } from "./schedule.js";
+import { sortHabitsByOrder } from "./habitOrder.js";
+import { completionNoteKey } from "./completionNoteKey.js";
+import type { CalendarRange, HubCalendarEvent, RoutineState } from "./types.js";
+
+export const FIZRUK_GROUP_LABEL = "Фізрук";
+export const FINYK_SUB_GROUP_LABEL = "Фінік · підписки";
+
+export interface FizrukPlanDay {
+  templateId?: string;
+}
+
+export interface FinykSubscriptionLike {
+  id: string;
+  name?: string;
+  emoji?: string;
+  billingDay: number | string;
+  /** Optional fields used by the amount-lookup in the web adapter. */
+  linkedTxId?: string;
+  keyword?: string;
+  currency?: string;
+}
+
+export interface FinykSubscriptionAmountLookup {
+  (sub: FinykSubscriptionLike): {
+    amount: number | null | undefined;
+    currency?: string;
+  };
+}
+
+export interface BuildHubCalendarEventsDeps {
+  /** Опціонально: Fizruk-план на місяць (dateKey → { templateId }). */
+  fizrukPlanDays?: Record<string, FizrukPlanDay>;
+  /** Опціонально: templateId → назва шаблону. */
+  fizrukTemplateNames?: Map<string, string>;
+  /** Опціонально: події підписок Фініка (побудовані заздалегідь). */
+  finykSubscriptionEvents?: HubCalendarEvent[];
+}
+
+export interface BuildHubCalendarEventsOptions {
+  showFizruk?: boolean;
+  showFinykSubs?: boolean;
+}
+
+function tagLabelsForHabit(
+  state: RoutineState,
+  habit: RoutineState["habits"][number],
+): string[] {
+  const ids = habit.tagIds || [];
+  const labels = ids
+    .map((id) => state.tags.find((t) => t.id === id)?.name)
+    .filter((x): x is string => Boolean(x));
+  if (habit.categoryId) {
+    const c = state.categories.find((x) => x.id === habit.categoryId);
+    if (c?.name) labels.push(c.name);
+  }
+  return labels.length ? labels : ["Без тегу"];
+}
+
+/**
+ * Pure aggregator. Produces a flat, sorted list of hub-calendar events
+ * for the given date range from `state` plus any injected Fizruk /
+ * Finyk decorators.
+ */
+export function buildHubCalendarEvents(
+  state: RoutineState,
+  range: CalendarRange,
+  options: BuildHubCalendarEventsOptions = {},
+  deps: BuildHubCalendarEventsDeps = {},
+): HubCalendarEvent[] {
+  const { showFizruk = true, showFinykSubs = true } = options;
+  const {
+    fizrukPlanDays = {},
+    fizrukTemplateNames,
+    finykSubscriptionEvents,
+  } = deps;
+
+  const events: HubCalendarEvent[] = [];
+  const { startKey, endKey } = range;
+  const days = enumerateDateKeys(startKey, endKey);
+
+  if (showFizruk) {
+    for (const date of days) {
+      const tid = fizrukPlanDays[date]?.templateId;
+      if (!tid) continue;
+      const title = fizrukTemplateNames?.get(tid) || "Тренування за планом";
+      events.push({
+        id: `fizruk_${date}_${tid}`,
+        source: "fizruk_plan",
+        date,
+        title,
+        subtitle: "План Фізрука",
+        tagLabels: [FIZRUK_GROUP_LABEL],
+        sortKey: `${date} 0 fizruk`,
+        fizruk: true,
+        sourceKind: "fizruk",
+      });
+    }
+  }
+
+  const notes =
+    state.completionNotes && typeof state.completionNotes === "object"
+      ? state.completionNotes
+      : {};
+  const activeHabits = sortHabitsByOrder(
+    state.habits.filter((h) => !h.archived),
+    state.habitOrder || [],
+  );
+  for (const date of days) {
+    for (const h of activeHabits) {
+      if (!habitScheduledOnDate(h, date)) continue;
+      const completions = state.completions[h.id] || [];
+      const completed = completions.includes(date);
+      const tagLabels = tagLabelsForHabit(state, h);
+      const t = h.timeOfDay ? String(h.timeOfDay).trim() : "";
+      const timePart = t ? ` · ${t}` : "";
+      const nk = completionNoteKey(h.id, date);
+      const note = notes[nk] ? String(notes[nk]) : "";
+      events.push({
+        id: `habit_${h.id}_${date}`,
+        source: "routine_habit",
+        date,
+        title: `${h.emoji} ${h.name}`,
+        subtitle: completed ? `Зроблено${timePart}` : `Звичка${timePart}`,
+        tagLabels,
+        sortKey: `${date} 1 ${h.name}`,
+        habitId: h.id,
+        completed,
+        note,
+        sourceKind: "habit",
+        timeOfDay: t,
+      });
+    }
+  }
+
+  if (
+    showFinykSubs &&
+    state.prefs?.showFinykSubscriptionsInCalendar !== false &&
+    finykSubscriptionEvents
+  ) {
+    events.push(...finykSubscriptionEvents);
+  }
+
+  events.sort((a, b) => a.sortKey.localeCompare(b.sortKey, "uk"));
+  return events;
+}
+
+/** Підрахунок кількості подій по днях — для month-heatmap dots. */
+export function countEventsByDate(
+  events: HubCalendarEvent[],
+): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const e of events) {
+    map.set(e.date, (map.get(e.date) || 0) + 1);
+  }
+  return map;
+}
+
+// ── Finyk subscription calendar — pure ────────────────────────────────
+
+function scheduledBillingDom(
+  year: number,
+  monthIndex: number,
+  billingDay: number,
+): number {
+  const dim = new Date(year, monthIndex + 1, 0).getDate();
+  return Math.min(Number(billingDay) || 1, dim);
+}
+
+function isBillingDateKey(dateKey: string, billingDay: number): boolean {
+  const d = parseDateKey(dateKey);
+  const dom = scheduledBillingDom(d.getFullYear(), d.getMonth(), billingDay);
+  return d.getDate() === dom;
+}
+
+/**
+ * Pure builder for Finyk subscription events in the Hub calendar.
+ * Takes the subscription list and an amount-lookup (usually wrapping
+ * the Monobank transaction cache) from the caller.
+ */
+export function buildFinykSubscriptionEvents(
+  range: CalendarRange,
+  subs: FinykSubscriptionLike[],
+  getAmount: FinykSubscriptionAmountLookup,
+): HubCalendarEvent[] {
+  const { startKey, endKey } = range;
+  const days = enumerateDateKeys(startKey, endKey);
+  const out: HubCalendarEvent[] = [];
+
+  for (const sub of subs) {
+    const bd = Number(sub.billingDay);
+    if (!Number.isFinite(bd) || bd < 1 || bd > 31) continue;
+    const { amount, currency } = getAmount(sub);
+    const subTitle = `${sub.emoji || "📱"} ${sub.name || "Підписка"}`;
+    for (const date of days) {
+      if (!isBillingDateKey(date, bd)) continue;
+      const amtStr =
+        amount != null
+          ? `~${amount.toLocaleString("uk-UA", { maximumFractionDigits: 2 })} ${currency ?? ""}`.trim()
+          : "сума з транзакції або вручну у Фініку";
+      out.push({
+        id: `finyk_sub_${sub.id}_${date}`,
+        source: "finyk_subscription",
+        date,
+        title: subTitle,
+        subtitle: `Планове списання · ${amtStr}`,
+        tagLabels: [FINYK_SUB_GROUP_LABEL],
+        sortKey: `${date} 0b finyk_${sub.id}`,
+        fizruk: false,
+        finykSub: true,
+        sourceKind: "finyk_sub",
+      });
+    }
+  }
+  return out;
+}

--- a/packages/routine-domain/src/calendarGrid.test.ts
+++ b/packages/routine-domain/src/calendarGrid.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { FINYK_SUB_GROUP_LABEL, FIZRUK_GROUP_LABEL } from "./calendarEvents.js";
+import {
+  groupEventsForList,
+  monthBounds,
+  monthGrid,
+  timeOfDayBucket,
+  todayDate,
+} from "./calendarGrid.js";
+import type { HubCalendarEvent } from "./types.js";
+
+describe("todayDate", () => {
+  it("returns a Date snapped to 12:00 local", () => {
+    const d = todayDate();
+    expect(d.getHours()).toBe(12);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getSeconds()).toBe(0);
+    expect(d.getMilliseconds()).toBe(0);
+  });
+});
+
+describe("monthBounds", () => {
+  it("returns inclusive date-keys for a 31-day month", () => {
+    // Січень 2025.
+    expect(monthBounds(2025, 0)).toEqual({
+      startKey: "2025-01-01",
+      endKey: "2025-01-31",
+    });
+  });
+
+  it("handles lutyi у високосний рік", () => {
+    expect(monthBounds(2024, 1)).toEqual({
+      startKey: "2024-02-01",
+      endKey: "2024-02-29",
+    });
+  });
+
+  it("handles lutyi у звичайний рік", () => {
+    expect(monthBounds(2025, 1)).toEqual({
+      startKey: "2025-02-01",
+      endKey: "2025-02-28",
+    });
+  });
+});
+
+describe("monthGrid", () => {
+  it("returns 42 клітинок (6 тижнів × 7)", () => {
+    const { cells } = monthGrid(2025, 0);
+    expect(cells.length % 7).toBe(0);
+    expect(cells.length).toBeGreaterThanOrEqual(28);
+    expect(cells.length).toBeLessThanOrEqual(42);
+  });
+
+  it("pads with null before day 1 so week starts with Mon", () => {
+    // Лютий 2025 починається з суботи (JS getDay = 6 → ISO wd = 5).
+    const { cells } = monthGrid(2025, 1);
+    expect(cells[0]).toBeNull();
+    expect(cells[4]).toBeNull();
+    expect(cells[5]).toBe(1);
+  });
+
+  it("contains every day of the month", () => {
+    const { cells } = monthGrid(2025, 2);
+    const days = cells.filter((c): c is number => c !== null);
+    expect(days).toEqual(Array.from({ length: 31 }, (_, i) => i + 1));
+  });
+});
+
+describe("timeOfDayBucket", () => {
+  it("falls back to 'Будь-коли' on empty / malformed input", () => {
+    expect(timeOfDayBucket(null)).toBe("Будь-коли");
+    expect(timeOfDayBucket(undefined)).toBe("Будь-коли");
+    expect(timeOfDayBucket("")).toBe("Будь-коли");
+    expect(timeOfDayBucket("bad")).toBe("Будь-коли");
+  });
+
+  it("buckets by hour", () => {
+    expect(timeOfDayBucket("06:00")).toBe("Ранок");
+    expect(timeOfDayBucket("11:59")).toBe("Ранок");
+    expect(timeOfDayBucket("12:00")).toBe("День");
+    expect(timeOfDayBucket("18:00")).toBe("День");
+    expect(timeOfDayBucket("19:00")).toBe("Вечір");
+    expect(timeOfDayBucket("23:30")).toBe("Вечір");
+  });
+});
+
+describe("groupEventsForList", () => {
+  function habitEvent(
+    id: string,
+    time: string | null,
+    opts: Partial<HubCalendarEvent> = {},
+  ): HubCalendarEvent {
+    return {
+      id,
+      source: "routine",
+      sourceKind: "habit",
+      habitId: id,
+      date: "2025-01-15",
+      title: id,
+      subtitle: "",
+      sortKey: time ?? "",
+      timeOfDay: time ?? undefined,
+      tagLabels: [],
+      completed: false,
+      fizruk: false,
+      finykSub: false,
+      ...opts,
+    };
+  }
+
+  it("групує за часом доби у фіксованому порядку", () => {
+    const events: HubCalendarEvent[] = [
+      habitEvent("evening", "20:00"),
+      habitEvent("morning", "08:00"),
+      habitEvent("noon", "13:00"),
+      habitEvent("nullish", null),
+    ];
+    const groups = groupEventsForList(events);
+    expect(groups.map(([head]) => head)).toEqual([
+      "Ранок",
+      "День",
+      "Вечір",
+      "Будь-коли",
+    ]);
+  });
+
+  it("ставить Fizruk / Finyk у власні бакети після habit-груп", () => {
+    const events: HubCalendarEvent[] = [
+      habitEvent("a", "08:00"),
+      habitEvent("fz1", null, {
+        sourceKind: "fizruk",
+        habitId: null,
+        fizruk: true,
+      }),
+      habitEvent("fy1", null, {
+        sourceKind: "finykSub",
+        habitId: null,
+        finykSub: true,
+      }),
+    ];
+    const heads = groupEventsForList(events).map(([h]) => h);
+    expect(heads).toEqual(["Ранок", FIZRUK_GROUP_LABEL, FINYK_SUB_GROUP_LABEL]);
+  });
+
+  it("повертає пустий масив для пустого вводу", () => {
+    expect(groupEventsForList([])).toEqual([]);
+  });
+});

--- a/packages/routine-domain/src/calendarGrid.ts
+++ b/packages/routine-domain/src/calendarGrid.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure calendar grid / day-bucket helpers shared by web + mobile.
+ *
+ * Extracted from `apps/web/src/modules/routine/RoutineApp.tsx` (Phase 5
+ * / PR 2). Behaviour unchanged.
+ */
+
+import { dateKeyFromDate } from "./dateKeys.js";
+import type { CalendarRange, HubCalendarEvent } from "./types.js";
+import { FINYK_SUB_GROUP_LABEL, FIZRUK_GROUP_LABEL } from "./calendarEvents.js";
+
+/**
+ * Current local date snapped to 12:00 so day arithmetic never spills
+ * across a DST boundary.
+ */
+export function todayDate(): Date {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+/** First + last date-key ("YYYY-MM-DD") of a given calendar month. */
+export function monthBounds(y: number, m0: number): CalendarRange {
+  const start = new Date(y, m0, 1);
+  const end = new Date(y, m0 + 1, 0);
+  return {
+    startKey: dateKeyFromDate(start),
+    endKey: dateKeyFromDate(end),
+  };
+}
+
+/**
+ * 42-cell month-grid (6 rows × 7 cols, Monday-first). Leading /
+ * trailing days outside the current month are rendered as `null`.
+ */
+export function monthGrid(
+  y: number,
+  monthIndex: number,
+): { cells: Array<number | null> } {
+  const last = new Date(y, monthIndex + 1, 0).getDate();
+  const firstWd = (new Date(y, monthIndex, 1).getDay() + 6) % 7;
+  const cells: Array<number | null> = [];
+  for (let i = 0; i < firstWd; i++) cells.push(null);
+  for (let d = 1; d <= last; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+  return { cells };
+}
+
+/** Habit-list grouping order for the day/week list. */
+export const HABIT_TIME_GROUPS = [
+  "Ранок",
+  "День",
+  "Вечір",
+  "Будь-коли",
+] as const;
+export const GROUP_ORDER = [
+  ...HABIT_TIME_GROUPS,
+  FIZRUK_GROUP_LABEL,
+  FINYK_SUB_GROUP_LABEL,
+] as const;
+
+/** Bucket an `HH:MM` time-of-day into one of the four habit groups. */
+export function timeOfDayBucket(hhmm: string | null | undefined): string {
+  const t = (hhmm || "").trim();
+  if (!t) return "Будь-коли";
+  const m = /^(\d{1,2}):(\d{2})$/.exec(t);
+  if (!m) return "Будь-коли";
+  const h = Number(m[1]);
+  if (!Number.isFinite(h)) return "Будь-коли";
+  if (h < 12) return "Ранок";
+  if (h <= 18) return "День";
+  return "Вечір";
+}
+
+/**
+ * Group list events into ordered `[head, events[]]` tuples for the
+ * Day/Week views. Fizruk/Finyk events bucket into their own groups;
+ * routine habits bucket by `timeOfDay` fallback to "Будь-коли".
+ */
+export function groupEventsForList(
+  events: HubCalendarEvent[],
+): Array<[string, HubCalendarEvent[]]> {
+  const map = new Map<string, HubCalendarEvent[]>();
+  for (const e of events) {
+    let head: string;
+    if (e.fizruk) head = FIZRUK_GROUP_LABEL;
+    else if (e.finykSub) head = FINYK_SUB_GROUP_LABEL;
+    else if (e.sourceKind === "habit") head = timeOfDayBucket(e.timeOfDay);
+    else head = e.tagLabels[0] || "Інше";
+    const existing = map.get(head);
+    if (existing) existing.push(e);
+    else map.set(head, [e]);
+  }
+  return [...map.entries()].sort((a, b) => {
+    const ai = (GROUP_ORDER as readonly string[]).indexOf(a[0]);
+    const bi = (GROUP_ORDER as readonly string[]).indexOf(b[0]);
+    if (ai === -1 && bi === -1) return a[0].localeCompare(b[0], "uk");
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}

--- a/packages/routine-domain/src/index.ts
+++ b/packages/routine-domain/src/index.ts
@@ -2,11 +2,19 @@
 // бізнес-логіка Рутини, яку споживають `apps/web` і `apps/mobile`
 // без платформних залежностей (`localStorage`, `window`, `document`).
 //
-// Phase 5 / PR 2 — перший зріз: типи, константи, чисті helper-и для
-// date-keys, schedule, streaks, habit-order та habit-draft утиліт.
-// Storage-bound модулі (`routineStorage`, `hubCalendarAggregate`,
-// `finykSubscriptionCalendar`) лишаються у `apps/web/src/modules/routine/lib/`
-// до моменту, коли аналогічний MMKV-shim з'явиться в `apps/mobile`.
+// Phase 5 / PR 2:
+//   - типи, константи, pure helpers для date-keys, schedule, streaks,
+//     habit-order, habit-draft utils, completion-note composite key;
+//   - pure storage-нормалізація (keys / defaultState / normalize / parse
+//     / serialize / habit + completion нормалізатори) — платформні
+//     адаптери обгортають це localStorage-ом чи MMKV;
+//   - pure state reducers (`applyToggleHabitCompletion`, createHabit,
+//     updateHabit, setPref, snapshot/restore, делеції тегів, тощо);
+//   - pure Hub-calendar aggregator (`buildHubCalendarEvents`,
+//     `countEventsByDate`, group-label константи) + pure Finyk
+//     subscription events;
+//   - pure reminder-schedule builder (`buildReminderSchedule`,
+//     `reminderNotifyKey`, `isStaleNotifyKey`, `habitShouldNotifyNow`).
 
 export * from "./types.js";
 export * from "./constants.js";
@@ -16,3 +24,8 @@ export * from "./habitOrder.js";
 export * from "./schedule.js";
 export * from "./streaks.js";
 export * from "./drafts.js";
+export * from "./storage.js";
+export * from "./reducers.js";
+export * from "./calendarEvents.js";
+export * from "./calendarGrid.js";
+export * from "./reminders.js";

--- a/packages/routine-domain/src/reducers.ts
+++ b/packages/routine-domain/src/reducers.ts
@@ -1,0 +1,403 @@
+/**
+ * Pure state reducers for the Routine module.
+ *
+ * Each function takes a `RoutineState` (plus arguments) and returns a
+ * new `RoutineState` — no side effects, no persistence, no DOM access.
+ * Platform adapters (web `routineStorage.ts`, mobile MMKV hook) wrap
+ * these with their own save-and-emit logic.
+ *
+ * Extracted from `apps/web/src/modules/routine/lib/routineStorage.ts`
+ * (Phase 5 / PR 2). The web adapter now imports these verbatim and
+ * persists the returned state.
+ */
+
+import { dateKeyFromDate } from "./dateKeys.js";
+import { habitScheduledOnDate } from "./schedule.js";
+import { completionNoteKey } from "./completionNoteKey.js";
+import {
+  normalizeCompletionList,
+  normalizeHabit,
+  normalizeReminderTimesStorage,
+  routineUid,
+} from "./storage.js";
+import type {
+  Category,
+  CreateHabitOptions,
+  Habit,
+  RoutineState,
+  Tag,
+} from "./types.js";
+
+/** Додає новий тег. Ігнорує порожнє імʼя. */
+export function applyCreateTag(
+  state: RoutineState,
+  name: string,
+): RoutineState {
+  const n = (name || "").trim();
+  if (!n) return state;
+  const t: Tag = { id: routineUid("tag"), name: n, scope: "routine" };
+  return { ...state, tags: [...state.tags, t] };
+}
+
+export function applyCreateCategory(
+  state: RoutineState,
+  name: string,
+  emoji = "",
+): RoutineState {
+  const n = (name || "").trim();
+  if (!n) return state;
+  const c: Category = {
+    id: routineUid("cat"),
+    name: n,
+    emoji: emoji || undefined,
+  };
+  return { ...state, categories: [...state.categories, c] };
+}
+
+/**
+ * Створити нову звичку. Повертає незмінений state якщо `name` порожнє.
+ */
+export function applyCreateHabit(
+  state: RoutineState,
+  {
+    name = "",
+    emoji = "✓",
+    tagIds = [],
+    categoryId = null,
+    recurrence = "daily",
+    startDate = null,
+    endDate = null,
+    timeOfDay = "",
+    reminderTimes = [],
+    weekdays = [0, 1, 2, 3, 4, 5, 6],
+  }: Partial<CreateHabitOptions> = {},
+): RoutineState {
+  const n = (name || "").trim();
+  if (!n) return state;
+  const sd =
+    (startDate && String(startDate).trim()) || dateKeyFromDate(new Date());
+  const h = normalizeHabit({
+    id: routineUid("hab"),
+    name: n,
+    emoji: emoji || "✓",
+    tagIds: Array.isArray(tagIds) ? tagIds : [],
+    categoryId: categoryId || null,
+    createdAt: new Date().toISOString(),
+    archived: false,
+    recurrence,
+    startDate: sd,
+    endDate: endDate && String(endDate).trim() ? String(endDate).trim() : null,
+    timeOfDay:
+      timeOfDay && String(timeOfDay).trim()
+        ? String(timeOfDay).trim().slice(0, 5)
+        : "",
+    reminderTimes: normalizeReminderTimesStorage(reminderTimes),
+    weekdays: Array.isArray(weekdays)
+      ? [...new Set(weekdays)].sort((a, b) => a - b)
+      : [0, 1, 2, 3, 4, 5, 6],
+  });
+  const order = [...(state.habitOrder || []), h.id];
+  return {
+    ...state,
+    habits: [...state.habits, h],
+    completions: { ...state.completions },
+    habitOrder: order,
+  };
+}
+
+/**
+ * Часткове оновлення звички за id (нормалізуємо після мерджу).
+ */
+export function applyUpdateHabit(
+  state: RoutineState,
+  id: string,
+  patch: Partial<Habit>,
+): RoutineState {
+  return {
+    ...state,
+    habits: state.habits.map((h) =>
+      h.id === id ? normalizeHabit({ ...h, ...patch }) : h,
+    ),
+  };
+}
+
+export function applySetPref<K extends string>(
+  state: RoutineState,
+  key: K,
+  value: unknown,
+): RoutineState {
+  return { ...state, prefs: { ...state.prefs, [key]: value } };
+}
+
+/**
+ * Перемкнути відмітку виконання звички за день. No-op якщо звичка
+ * не запланована на цей день і ще не позначена.
+ */
+export function applyToggleHabitCompletion(
+  state: RoutineState,
+  habitId: string,
+  dateKey: string,
+): RoutineState {
+  const habit = state.habits.find((h) => h.id === habitId);
+  if (!habit) return state;
+  const curSet = new Set(normalizeCompletionList(state.completions[habitId]));
+  if (curSet.has(dateKey)) {
+    curSet.delete(dateKey);
+  } else {
+    if (!habitScheduledOnDate(habit, dateKey)) return state;
+    curSet.add(dateKey);
+  }
+  const cur = [...curSet].sort();
+  return {
+    ...state,
+    completions: { ...state.completions, [habitId]: cur },
+  };
+}
+
+/** Усі активні звички, заплановані на день, отримують відмітку (якщо ще немає). */
+export function applyMarkAllScheduledHabitsComplete(
+  state: RoutineState,
+  dateKey: string,
+): RoutineState {
+  const active = state.habits.filter((h) => !h.archived);
+  const completions = { ...state.completions };
+  let changed = false;
+  for (const h of active) {
+    if (!habitScheduledOnDate(h, dateKey)) continue;
+    const set = new Set(normalizeCompletionList(completions[h.id]));
+    if (set.has(dateKey)) continue;
+    set.add(dateKey);
+    completions[h.id] = [...set].sort();
+    changed = true;
+  }
+  if (!changed) return state;
+  return { ...state, completions };
+}
+
+export function applySetHabitArchived(
+  state: RoutineState,
+  id: string,
+  archived: boolean,
+): RoutineState {
+  return applyUpdateHabit(state, id, { archived: !!archived });
+}
+
+export function applyDeleteHabit(
+  state: RoutineState,
+  id: string,
+): RoutineState {
+  const completions = { ...state.completions };
+  delete completions[id];
+  const notes = { ...(state.completionNotes || {}) };
+  const prefix = `${id}__`;
+  for (const k of Object.keys(notes)) {
+    if (k.startsWith(prefix)) delete notes[k];
+  }
+  return {
+    ...state,
+    habits: state.habits.filter((h) => h.id !== id),
+    completions,
+    completionNotes: notes,
+    habitOrder: (state.habitOrder || []).filter((x) => x !== id),
+  };
+}
+
+export interface HabitSnapshot {
+  habit: Habit;
+  completions: string[];
+  notes: Record<string, string>;
+  orderIndex: number;
+}
+
+/**
+ * Повний знімок стану звички для undo-toast.
+ */
+export function snapshotHabit(
+  state: RoutineState,
+  id: string,
+): HabitSnapshot | null {
+  const habit = state.habits.find((h) => h.id === id);
+  if (!habit) return null;
+  const completions = Array.isArray(state.completions?.[id])
+    ? [...state.completions[id]]
+    : [];
+  const notes: Record<string, string> = {};
+  const prefix = `${id}__`;
+  const rawNotes = state.completionNotes || {};
+  for (const k of Object.keys(rawNotes)) {
+    if (k.startsWith(prefix)) notes[k] = rawNotes[k];
+  }
+  const order = Array.isArray(state.habitOrder) ? state.habitOrder : [];
+  const orderIndex = order.indexOf(id);
+  return { habit, completions, notes, orderIndex };
+}
+
+/**
+ * Відновити звичку зі знімка. Ідемпотентно: якщо звичка з таким id
+ * вже існує, повертаємо state без змін.
+ */
+export function applyRestoreHabit(
+  state: RoutineState,
+  snapshot: HabitSnapshot | null,
+): RoutineState {
+  if (!snapshot || !snapshot.habit || !snapshot.habit.id) return state;
+  const { habit, completions, notes, orderIndex } = snapshot;
+  if (state.habits.some((h) => h.id === habit.id)) return state;
+  const nextCompletions = { ...state.completions };
+  if (Array.isArray(completions) && completions.length) {
+    nextCompletions[habit.id] = [...completions];
+  }
+  const nextNotes = { ...(state.completionNotes || {}), ...(notes || {}) };
+  const existingOrder = (state.habitOrder || []).filter((x) => x !== habit.id);
+  const insertAt =
+    typeof orderIndex === "number" && orderIndex >= 0
+      ? Math.min(orderIndex, existingOrder.length)
+      : existingOrder.length;
+  const nextOrder = [
+    ...existingOrder.slice(0, insertAt),
+    habit.id,
+    ...existingOrder.slice(insertAt),
+  ];
+  return {
+    ...state,
+    habits: [...state.habits, normalizeHabit(habit)],
+    completions: nextCompletions,
+    completionNotes: nextNotes,
+    habitOrder: nextOrder,
+  };
+}
+
+export function applyAddPushupReps(
+  state: RoutineState,
+  reps: unknown,
+): RoutineState {
+  const n = Number(reps);
+  if (!Number.isFinite(n) || n <= 0) return state;
+  const today = dateKeyFromDate(new Date());
+  const cur = state.pushupsByDate?.[today] ?? 0;
+  return {
+    ...state,
+    pushupsByDate: { ...state.pushupsByDate, [today]: cur + n },
+  };
+}
+
+export function applyMoveHabitInOrder(
+  state: RoutineState,
+  habitId: string,
+  delta: number,
+): RoutineState {
+  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
+  const order = [...(state.habitOrder || [])].filter((id) =>
+    active.includes(id),
+  );
+  for (const id of active) {
+    if (!order.includes(id)) order.push(id);
+  }
+  const i = order.indexOf(habitId);
+  if (i < 0) return state;
+  const j = i + delta;
+  if (j < 0 || j >= order.length) return state;
+  const copy = [...order];
+  [copy[i], copy[j]] = [copy[j], copy[i]];
+  return { ...state, habitOrder: copy };
+}
+
+/** Повний порядок активних звичок (наприклад після drag-and-drop). */
+export function applySetHabitOrder(
+  state: RoutineState,
+  orderedActiveIds: string[],
+): RoutineState {
+  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const id of orderedActiveIds) {
+    if (active.includes(id) && !seen.has(id)) {
+      order.push(id);
+      seen.add(id);
+    }
+  }
+  for (const id of active) {
+    if (!seen.has(id)) order.push(id);
+  }
+  return { ...state, habitOrder: order };
+}
+
+export function applySetCompletionNote(
+  state: RoutineState,
+  habitId: string,
+  dateKey: string,
+  text: string,
+): RoutineState {
+  const k = completionNoteKey(habitId, dateKey);
+  const notes = { ...(state.completionNotes || {}) };
+  const t = (text || "").trim();
+  if (!t) {
+    if (!(k in notes)) return state;
+    delete notes[k];
+  } else {
+    const habitExists = state.habits.some((h) => h.id === habitId);
+    if (!habitExists) return state;
+    notes[k] = t.slice(0, 500);
+  }
+  return { ...state, completionNotes: notes };
+}
+
+export function applyUpdateTag(
+  state: RoutineState,
+  id: string,
+  newName: string,
+): RoutineState {
+  const n = (newName || "").trim();
+  if (!n) return state;
+  return {
+    ...state,
+    tags: state.tags.map((t) => (t.id === id ? { ...t, name: n } : t)),
+  };
+}
+
+export function applyUpdateCategory(
+  state: RoutineState,
+  id: string,
+  patch: { name?: string; emoji?: string },
+): RoutineState {
+  return {
+    ...state,
+    categories: state.categories.map((c) =>
+      c.id === id
+        ? {
+            ...c,
+            ...(patch.name !== undefined
+              ? { name: (patch.name || "").trim() || c.name }
+              : {}),
+            ...(patch.emoji !== undefined
+              ? { emoji: patch.emoji || undefined }
+              : {}),
+          }
+        : c,
+    ),
+  };
+}
+
+export function applyDeleteCategory(
+  state: RoutineState,
+  id: string,
+): RoutineState {
+  return {
+    ...state,
+    categories: state.categories.filter((c) => c.id !== id),
+    habits: state.habits.map((h) =>
+      h.categoryId === id ? { ...h, categoryId: null } : h,
+    ),
+  };
+}
+
+export function applyDeleteTag(state: RoutineState, id: string): RoutineState {
+  return {
+    ...state,
+    tags: state.tags.filter((t) => t.id !== id),
+    habits: state.habits.map((h) => ({
+      ...h,
+      tagIds: (h.tagIds || []).filter((x) => x !== id),
+    })),
+  };
+}

--- a/packages/routine-domain/src/reminders.ts
+++ b/packages/routine-domain/src/reminders.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure reminder-scheduling helpers for the Routine module.
+ *
+ * Produces descriptor objects that describe WHEN and WHAT to notify
+ * the user about — without actually calling `Notification`,
+ * `navigator.serviceWorker`, or any Expo/RN notification API. Platform
+ * adapters (web ServiceWorker, `expo-notifications` on mobile) consume
+ * these descriptors to register real alarms.
+ *
+ * Extracted from `apps/web/src/modules/routine/hooks/useRoutineReminders.ts`
+ * (Phase 5 / PR 2) — only the pure "which habit fires at which time
+ * today/tomorrow/…" logic. The DOM/service-worker plumbing stays on
+ * the web side.
+ */
+
+import { dateKeyFromDate, parseDateKey } from "./dateKeys.js";
+import { habitScheduledOnDate } from "./schedule.js";
+import { normalizeReminderTimes } from "./drafts.js";
+import type { Habit, RoutineState } from "./types.js";
+
+/** Prefix для idempotent-ключа "дана звичка вже повідомлена у цей день/час". */
+export const ROUTINE_NOTIFY_PREFIX = "routine_notify_";
+
+export interface RoutineReminderDescriptor {
+  /** Habit.id цієї нагадувалки. */
+  habitId: string;
+  /** Emoji + назва звички — готовий title для Notification. */
+  title: string;
+  /** Локальний день "YYYY-MM-DD" — коли звичка запланована. */
+  dateKey: string;
+  /** "HH:MM" — час спрацьовування (local). */
+  time: string;
+  /**
+   * Epoch-ms часу спрацьовування у локальному timezone. Стабільний для
+   * тестів (приймає base-now замість live-`Date.now()`).
+   */
+  fireAtMs: number;
+  /** Ідемпотентний ключ для "вже повідомлено". */
+  notifyKey: string;
+}
+
+export interface BuildReminderScheduleOptions {
+  /** "Зараз" — base timestamp, від якого рахуємо "у майбутньому". */
+  now: Date;
+  /** Скільки днів наперед включати у розклад. Default: 1 (сьогодні). */
+  daysAhead?: number;
+  /** Якщо істинне — не виключати звички, чиє фактичне виконання вже зафіксовано у `completions` для відповідного дня. */
+  includeAlreadyCompleted?: boolean;
+}
+
+function hmToFireAtMs(dateKey: string, hm: string): number {
+  const d = parseDateKey(dateKey);
+  const [h, m] = hm.split(":").map((x) => Number(x));
+  d.setHours(h || 0, m || 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Побудувати список нагадувань для activerних звичок у діапазоні
+ * `[now, now + daysAhead]`. Пропускає архівовані звички, звички поза
+ * розкладом, і (за замовчуванням) ті, що вже позначені виконаними на
+ * відповідний день.
+ */
+export function buildReminderSchedule(
+  state: RoutineState,
+  {
+    now,
+    daysAhead = 1,
+    includeAlreadyCompleted = false,
+  }: BuildReminderScheduleOptions,
+): RoutineReminderDescriptor[] {
+  if (!state.prefs?.routineRemindersEnabled) return [];
+  const out: RoutineReminderDescriptor[] = [];
+  const baseMs = now.getTime();
+
+  for (let i = 0; i < Math.max(1, daysAhead); i++) {
+    const day = new Date(now);
+    day.setDate(day.getDate() + i);
+    day.setHours(12, 0, 0, 0);
+    const dk = dateKeyFromDate(day);
+
+    for (const h of state.habits) {
+      if (h.archived) continue;
+      if (!habitScheduledOnDate(h, dk)) continue;
+      const times = normalizeReminderTimes(h);
+      if (times.length === 0) continue;
+      const completed = (state.completions[h.id] || []).includes(dk);
+      if (!includeAlreadyCompleted && completed) continue;
+
+      for (const hm of times) {
+        const fireAtMs = hmToFireAtMs(dk, hm);
+        if (i === 0 && fireAtMs < baseMs) continue;
+        out.push({
+          habitId: h.id,
+          title: `${h.emoji || "✓"} ${h.name}`,
+          dateKey: dk,
+          time: hm,
+          fireAtMs,
+          notifyKey: reminderNotifyKey(h.id, hm, dk),
+        });
+      }
+    }
+  }
+
+  out.sort((a, b) => a.fireAtMs - b.fireAtMs);
+  return out;
+}
+
+/** Ідемпотентний ключ "звичку вже повідомили у цей день/час". */
+export function reminderNotifyKey(
+  habitId: string,
+  hm: string,
+  dateKey: string,
+): string {
+  return `${ROUTINE_NOTIFY_PREFIX}${habitId}_${hm}_${dateKey}`;
+}
+
+/**
+ * Чи ключ `routine_notify_*` старіший за `maxAgeDays`. Використовується
+ * адаптерами для чистки застарілих idempotency-міток з MMKV/localStorage.
+ */
+export function isStaleNotifyKey(
+  key: string,
+  now: Date,
+  maxAgeDays = 45,
+): boolean {
+  if (!key.startsWith(ROUTINE_NOTIFY_PREFIX)) return false;
+  const m = key.match(/(\d{4}-\d{2}-\d{2})$/);
+  const d = m?.[1];
+  if (!d) return false;
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - maxAgeDays);
+  const cutoffKey = dateKeyFromDate(cutoff);
+  return d < cutoffKey;
+}
+
+/**
+ * Чи час `hm` (HH:MM) потрапляє "зараз" (той же локальний день і хвилина)
+ * відносно `now`. Використовується web-адаптером для polling-режиму.
+ */
+export function reminderDueNow(hm: string, now: Date): boolean {
+  const current = `${String(now.getHours()).padStart(2, "0")}:${String(
+    now.getMinutes(),
+  ).padStart(2, "0")}`;
+  return current === hm;
+}
+
+/** Чи звичка прямо зараз потребує нагадування? */
+export function habitShouldNotifyNow(
+  habit: Habit,
+  completionsForHabit: string[] | undefined,
+  now: Date,
+): { should: boolean; dateKey: string; time: string } | null {
+  if (habit.archived) return null;
+  const dk = dateKeyFromDate(now);
+  if (!habitScheduledOnDate(habit, dk)) return null;
+  const times = normalizeReminderTimes(habit);
+  if (times.length === 0) return null;
+  const completed = (completionsForHabit || []).includes(dk);
+  if (completed) return null;
+  for (const hm of times) {
+    if (reminderDueNow(hm, now)) {
+      return { should: true, dateKey: dk, time: hm };
+    }
+  }
+  return null;
+}

--- a/packages/routine-domain/src/storage.ts
+++ b/packages/routine-domain/src/storage.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure storage helpers for the Routine module — DOM-free.
+ *
+ * Owns the storage-key constants, event names, the canonical
+ * default-state shape, and pure normalization / parse helpers. Platform
+ * adapters (`apps/web/src/modules/routine/lib/routineStorage.ts` for
+ * localStorage, `apps/mobile/src/modules/routine/*` for MMKV) consume
+ * these to convert raw strings/objects into a valid `RoutineState`
+ * without any DOM or React Native APIs sneaking into this package.
+ *
+ * Extracted from `apps/web/src/modules/routine/lib/routineStorage.ts`
+ * (Phase 5 / PR 2). Behaviour is unchanged on web after extraction
+ * because the web adapter re-exports these under the historical names.
+ */
+
+import { dateKeyFromDate } from "./dateKeys.js";
+import type { Habit, RoutineState } from "./types.js";
+
+/** localStorage / MMKV key for the whole routine state blob. */
+export const ROUTINE_STORAGE_KEY = "hub_routine_v1";
+
+/** Custom DOM event name emitted on every successful state write. */
+export const ROUTINE_EVENT = "hub-routine-storage";
+
+/** Custom DOM event name emitted when persistence fails (quota etc.). */
+export const ROUTINE_STORAGE_ERROR = "hub-routine-storage-error";
+
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Current on-disk schema version. Bump with any breaking shape change. */
+export const ROUTINE_SCHEMA_VERSION = 3;
+
+/**
+ * Generate a reasonably-unique id with a domain prefix. Pure (reads
+ * `Date.now()` + `Math.random()`); not cryptographically random.
+ */
+export function routineUid(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+}
+
+/**
+ * Filter reminder-time strings to well-formed `HH:MM` entries. Used
+ * both on load/normalization and on createHabit/updateHabit.
+ */
+export function normalizeReminderTimesStorage(rt: unknown): string[] {
+  if (!Array.isArray(rt)) return [];
+  return rt.filter(
+    (t): t is string => typeof t === "string" && /^\d{2}:\d{2}$/.test(t),
+  );
+}
+
+/** Prune duplicates and invalid date keys from a single habit's completion list. */
+export function normalizeCompletionList(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  const seen = new Set<string>();
+  for (const v of list) {
+    if (typeof v === "string" && DATE_KEY_RE.test(v)) seen.add(v);
+  }
+  return [...seen].sort();
+}
+
+/** Coerce the whole completions map into `{ [habitId]: sortedUniqueDateKeys }`. */
+export function normalizeCompletionsMap(
+  raw: unknown,
+): Record<string, string[]> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    out[k] = normalizeCompletionList(v);
+  }
+  return out;
+}
+
+/** Normalize a single habit record into the canonical shape. */
+export function normalizeHabit(h: unknown): Habit {
+  if (!h || typeof h !== "object") return h as Habit;
+  const src = h as Partial<Habit> & Record<string, unknown>;
+  const created = src.createdAt
+    ? String(src.createdAt).slice(0, 10)
+    : dateKeyFromDate(new Date());
+  return {
+    ...(src as Habit),
+    recurrence: (src.recurrence as Habit["recurrence"]) || "daily",
+    startDate: src.startDate || created,
+    endDate: src.endDate === undefined ? null : (src.endDate ?? null),
+    timeOfDay: src.timeOfDay === undefined ? "" : String(src.timeOfDay),
+    reminderTimes: normalizeReminderTimesStorage(src.reminderTimes),
+    weekdays:
+      Array.isArray(src.weekdays) && src.weekdays.length > 0
+        ? (src.weekdays as number[])
+        : [0, 1, 2, 3, 4, 5, 6],
+  };
+}
+
+/**
+ * Canonical starting state for a fresh install. Pure — returns a new
+ * object on every call so callers can mutate it safely.
+ */
+export function defaultRoutineState(): RoutineState {
+  return {
+    schemaVersion: ROUTINE_SCHEMA_VERSION,
+    prefs: {
+      showFizrukInCalendar: true,
+      /** Планові списання підписок Фініка в календарі Hub */
+      showFinykSubscriptionsInCalendar: true,
+      /** Локальні нагадування у вказаний час */
+      routineRemindersEnabled: false,
+    },
+    tags: [],
+    categories: [],
+    habits: [],
+    completions: {},
+    /** "YYYY-MM-DD" -> кількість відтискань */
+    pushupsByDate: {},
+    /** порядок id активних звичок (drag/up-down) */
+    habitOrder: [],
+    /** completionNoteKey -> короткий текст */
+    completionNotes: {},
+  };
+}
+
+/**
+ * Return `state` with `habitOrder` normalized so it references every
+ * active habit exactly once, and flag whether it actually changed —
+ * so callers can persist only when needed.
+ */
+export function ensureHabitOrder(state: RoutineState): {
+  state: RoutineState;
+  changed: boolean;
+} {
+  const active = state.habits.filter((h) => !h.archived).map((h) => h.id);
+  const order = [...(state.habitOrder || [])].filter((id) =>
+    active.includes(id),
+  );
+  for (const id of active) {
+    if (!order.includes(id)) order.push(id);
+  }
+  const prev = state.habitOrder || [];
+  const same =
+    order.length === prev.length && order.every((id, i) => id === prev[i]);
+  if (same) return { state, changed: false };
+  return { state: { ...state, habitOrder: order }, changed: true };
+}
+
+/**
+ * Pure routine-state normalizer. Takes a parsed JSON payload (or `null`)
+ * from the persistence layer and produces a valid `RoutineState`.
+ *
+ * Intentionally does NOT perform any side-effectful "finalization" that
+ * the web adapter does — callers decide whether/how to persist the
+ * normalized result (e.g. `routineStorage.ts` finalizes + saves; the
+ * mobile hook just keeps it in memory until the next write).
+ */
+export function normalizeRoutineState(raw: unknown): RoutineState {
+  const base = defaultRoutineState();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return base;
+  }
+  const p = raw as Partial<RoutineState> & Record<string, unknown>;
+  return {
+    ...base,
+    ...p,
+    prefs: { ...base.prefs, ...((p.prefs as RoutineState["prefs"]) || {}) },
+    tags: Array.isArray(p.tags) ? p.tags : [],
+    categories: Array.isArray(p.categories) ? p.categories : [],
+    habits: Array.isArray(p.habits) ? p.habits.map(normalizeHabit) : [],
+    completions: normalizeCompletionsMap(p.completions),
+    pushupsByDate:
+      typeof p.pushupsByDate === "object" && p.pushupsByDate
+        ? (p.pushupsByDate as Record<string, number>)
+        : {},
+    habitOrder: Array.isArray(p.habitOrder) ? (p.habitOrder as string[]) : [],
+    completionNotes:
+      typeof p.completionNotes === "object" && p.completionNotes
+        ? (p.completionNotes as Record<string, string>)
+        : {},
+  };
+}
+
+/**
+ * Parse a raw string (e.g. read from MMKV/localStorage) into a
+ * `RoutineState`. Falls back to `defaultRoutineState()` on malformed
+ * JSON or wrong top-level shape.
+ */
+export function parseRoutineState(
+  raw: string | null | undefined,
+): RoutineState {
+  if (!raw) return defaultRoutineState();
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return normalizeRoutineState(parsed);
+  } catch {
+    return defaultRoutineState();
+  }
+}
+
+/** Serialize a `RoutineState` to a JSON string for persistence. */
+export function serializeRoutineState(state: RoutineState): string {
+  return JSON.stringify(state);
+}


### PR DESCRIPTION
## Summary

Phase 5 / PR 2 міграції PWA → React Native — див. [`docs/react-native-migration.md`](docs/react-native-migration.md) **§4 phase 5** (роутінг RN-табів Рутини) + **§5.4 Routine** (pure екстракція + календарна сторінка).

### 1) Екстракт pure-логіки у `@sergeant/routine-domain`

Усе без DOM / React Native / браузерних API — універсальна поверхня для web + mobile:

- `storage.ts` — `ROUTINE_STORAGE_KEY`, `ROUTINE_EVENT`, `ROUTINE_STORAGE_ERROR`, `ROUTINE_SCHEMA_VERSION`, `routineUid`, `normalizeReminderTimesStorage`, `normalizeCompletionList`, `normalizeCompletionsMap`, `normalizeHabit`, `defaultRoutineState`, `ensureHabitOrder`, `normalizeRoutineState`, `parseRoutineState`, `serializeRoutineState`.
- `reducers.ts` — іммутабельні `applyToggleHabitCompletion`, `applyCreateHabit`, `applyUpdateHabit`, `applySetPref`, `applyMarkAllScheduledHabitsComplete`, `applySetHabitArchived`, `applyDeleteHabit`, `applyRestoreHabit`, `applyAddPushupReps`, `applyMoveHabitInOrder`, `applySetHabitOrder`, `applySetCompletionNote`, `applyCreateTag`/`applyUpdateTag`/`applyDeleteTag`, `applyCreateCategory`/`applyUpdateCategory`/`applyDeleteCategory`, `snapshotHabit`.
- `calendarEvents.ts` — `buildHubCalendarEvents` (pure-агрегатор із dep-injection для Fizruk / Finyk), `countEventsByDate`, `buildFinykSubscriptionEvents`, `FIZRUK_GROUP_LABEL`, `FINYK_SUB_GROUP_LABEL`.
- `calendarGrid.ts` — `monthBounds`, `monthGrid`, `todayDate`, `timeOfDayBucket`, `groupEventsForList`, `HABIT_TIME_GROUPS`, `GROUP_ORDER`.
- `reminders.ts` — `buildReminderSchedule`, `reminderNotifyKey`, `isStaleNotifyKey`, `reminderDueNow`, `habitShouldNotifyNow`.

### 2) Адаптери на apps/web (без регресій)

Тонкі обгортки поверх domain — web далі читає/пише `localStorage` та слухає DOM-події, але сама логіка запозичена з `@sergeant/routine-domain`:

- `apps/web/src/modules/routine/lib/routineStorage.ts` — тепер делегує у `applyXxx()` + `saveRoutineState()` (≈580 → ≈280 рядків).
- `apps/web/src/modules/routine/lib/hubCalendarAggregate.ts` — завантажує Fizruk-план + шаблони з `localStorage` і передає в `buildHubCalendarEventsPure()`.
- `apps/web/src/modules/routine/lib/finykSubscriptionCalendar.ts` — завантажує Finyk-підписки + транзакції з `localStorage` і передає у pure-білдер.

Зворотна сумісність: константи та re-експорти (`dateKeyFromDate`, `parseDateKey`, `enumerateDateKeys`, `habitScheduledOnDate`, `countEventsByDate`, `FIZRUK_GROUP_LABEL`) збережені для існуючого UI. Усі існуючі web-тести (617) зелені.

### 3) Портування Hub-календаря на apps/mobile

- `apps/mobile/src/modules/routine/lib/routineStore.ts` — MMKV-адаптер над domain + `useRoutineStore()` хук (`routine`, `toggleHabit`, `bulkMarkDay`, `setCompletionNote`, `refresh`, `setRoutine`). Підписується на зміну `ROUTINE_STORAGE_KEY` через `addOnValueChangedListener` — працює симетрично web-версії.
- `apps/mobile/src/modules/routine/pages/Calendar.tsx` — RN-сторінка на NativeWind:
  - сегментований перемикач режимів («Сьогодні» / «Тиждень» / «Місяць»),
  - навігація по місяцях + кнопка «Сьогодні»,
  - 6×7 сітка з крапками-індикаторами запланованих подій,
  - заголовок-дата поточного фокусу + `StatsPill` (серія, completion rate, прогрес дня),
  - CTA «Зробити все» (активна лише для одноденного діапазону з незавершеними звичками),
  - список подій згрупований за часом доби (через `groupEventsForList`), toggle-рядок виконання на тап.
- `apps/mobile/src/modules/routine/RoutineApp.tsx` — під'єднав `<Calendar />` як index табу Routine (замість placeholder'а із PR #449).

### 4) Тести

- **vitest (`@sergeant/routine-domain`):** 46 тестів — додав 12 кейсів у `calendarGrid.test.ts` (monthBounds для високосного року, monthGrid padding, timeOfDayBucket edge cases, groupEventsForList порядок).
- **jest-expo (`@sergeant/mobile`):** `pages/Calendar.test.tsx` (рендер, сегментований контрол, seeded звичка у списку, toggle → MMKV персист), плюс оновлені shell-тести `RoutineApp.test.tsx` (тепер перевіряє `Hub календар` eyebrow замість старого placeholder'а).
- **vitest (`@sergeant/web`):** 617 тестів — без регресій.
- Додав `moduleNameMapper: { "^(\\.{1,2}/.*)\\.js$": "$1" }` у `apps/mobile/jest.config.js`, бо jest-resolve не стрипить `.js` з NodeNext-імпортів у TS-сорсах домен-пакета.

### Scope цього PR (фіксуємо)

ЛИШЕ Calendar. **Поза scope:**
- статистика / heatmap (окремий PR),
- редагування / створення / видалення звичок на мобілі (окремий PR),
- нагадування через `expo-notifications` (окремий PR),
- tag-фільтри, пошук, drag-reorder, bottom-sheet деталей дня.

## Review & Testing Checklist for Human

- [ ] Відкрити Рутину на вебі в dev-режимі (`pnpm --filter @sergeant/web dev`), переконатись, що: toggle звички зберігає статус, місячний календар показує бейджі подій, Fizruk-план і Finyk-підписки все ще підтягуються в календар.
- [ ] Зібрати мобільний застосунок (`pnpm --filter @sergeant/mobile start`), відкрити таб Рутина: календар має рендеритись за замовчуванням, toggle-звички має персистити у MMKV (перевірити через релоад).
- [ ] Перевірити, що експортовані з `@sergeant/routine-domain` pure-API не тягнуть platform-залежностей (жодних `window`/`document`/`AsyncStorage`/`MMKV` у `packages/routine-domain/src`).

### Notes

- Адаптерні шари (`routineStorage.ts` / `hubCalendarAggregate.ts` / `finykSubscriptionCalendar.ts`) зберігають публічну поверхню для існуючих імпортів на вебі — жоден UI-файл в `apps/web/src/modules/routine/components` чи `context` не чіпали.
- Stats / Settings таби на мобілі лишаються placeholder'ами — їх порт прийде окремими PR у цій фазі.
- Pre-existing cosmetic bug у `buildHubCalendarEvents`: коли `habit.emoji` is `undefined`, title виходить `"undefined <name>"`. Не виправляв у цьому PR (out of scope); обійдено у тестах через seeded emoji.

Link to Devin session: https://app.devin.ai/sessions/5a63aa59e6a04ed886e42cfe998c2cfd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
