### PR TITLE
feat(fizruk-mobile): PR-D — Progress page (victory-native charts)

### DIFF
--- a/apps/mobile/src/modules/fizruk/__tests__/Progress.test.tsx
+++ b/apps/mobile/src/modules/fizruk/__tests__/Progress.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Render tests for the Fizruk Progress screen (Phase 6 · PR-D).
+ *
+ * These tests cover the four invariants the mobile Progress page must
+ * uphold per the migration plan §4 / §6.7:
+ *   1. Empty state (no workouts, no measurements) renders the
+ *      dashed "Даних ще немає" card.
+ *   2. With ≥2 weight samples, the weight chart renders (not the
+ *      empty-state copy).
+ *   3. With <2 body-fat samples, the body-fat chart falls back to the
+ *      "Замало точок" empty-state copy.
+ *   4. The KPI strip renders the computed PR / Заміри counts.
+ */
+
+import { render } from "@testing-library/react-native";
+
+import { Progress } from "../pages/Progress";
+import type { FizrukProgressData } from "../pages/useFizrukProgressData";
+
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// victory-native's default Jest transform still trips on its ESM bundle
+// on some CI matrices. Stub the three primitives we touch with simple
+// RN views so tests exercise the screen's own logic, not the chart
+// internals (which are covered upstream).
+jest.mock("victory-native", () => {
+  const React = jest.requireActual("react");
+  const RN = jest.requireActual("react-native");
+  const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(RN.View, null, children);
+  return {
+    __esModule: true,
+    VictoryGroup: Passthrough,
+    VictoryArea: () => null,
+    VictoryLine: () => null,
+  };
+});
+
+function emptyData(): FizrukProgressData {
+  return { workouts: [], entries: [] };
+}
+
+describe("Fizruk Progress screen (mobile)", () => {
+  it("renders the empty-state card when there are no workouts or entries", () => {
+    const { getByTestId, queryByTestId } = render(
+      <Progress data={emptyData()} />,
+    );
+
+    expect(getByTestId("fizruk-progress-kpis")).toBeTruthy();
+    expect(getByTestId("fizruk-progress-empty")).toBeTruthy();
+    expect(queryByTestId("fizruk-progress-weight")).toBeNull();
+    expect(queryByTestId("fizruk-progress-bodyfat")).toBeNull();
+  });
+
+  it("renders the weight chart when ≥2 weight samples are present", () => {
+    const data: FizrukProgressData = {
+      workouts: [],
+      entries: [
+        { at: "2026-04-10T00:00:00Z", weightKg: 81 },
+        { at: "2026-04-01T00:00:00Z", weightKg: 82 },
+      ],
+    };
+    const { getByTestId, queryByTestId } = render(<Progress data={data} />);
+
+    expect(queryByTestId("fizruk-progress-empty")).toBeNull();
+    expect(getByTestId("fizruk-progress-weight")).toBeTruthy();
+    expect(getByTestId("fizruk-progress-weight-chart")).toBeTruthy();
+    // No body-fat samples → body-fat section collapses to empty-state copy.
+    expect(getByTestId("fizruk-progress-bodyfat-empty")).toBeTruthy();
+  });
+
+  it("renders the body-fat empty-state when only one body-fat sample exists", () => {
+    const data: FizrukProgressData = {
+      workouts: [],
+      entries: [
+        { at: "2026-04-10T00:00:00Z", weightKg: 81, bodyFatPct: 17 },
+        { at: "2026-04-01T00:00:00Z", weightKg: 82 },
+      ],
+    };
+    const { getByTestId } = render(<Progress data={data} />);
+
+    expect(getByTestId("fizruk-progress-bodyfat-empty")).toBeTruthy();
+  });
+
+  it("renders the KPI section with computed PR / entries counts", () => {
+    const data: FizrukProgressData = {
+      workouts: [
+        {
+          startedAt: "2026-04-10T10:00:00Z",
+          endedAt: "2026-04-10T11:00:00Z",
+          items: [
+            {
+              exerciseId: "bench",
+              type: "strength",
+              sets: [{ weightKg: 60, reps: 8 }],
+            },
+          ],
+        },
+      ],
+      entries: [{ at: "2026-04-10T00:00:00Z", weightKg: 81 }],
+    };
+    const { getByTestId } = render(<Progress data={data} />);
+
+    const prsStat = getByTestId("fizruk-progress-prs-stat");
+    const entriesStat = getByTestId("fizruk-progress-entries-stat");
+    // `1` appears both as PR count and Заміри count — one per tile.
+    expect(prsStat).toBeTruthy();
+    expect(entriesStat).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/modules/fizruk/components/progress/MeasurementsChartSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/MeasurementsChartSection.tsx
@@ -1,0 +1,42 @@
+/**
+ * MeasurementsChartSection — body-fat-% trend card on the Fizruk
+ * Progress screen.
+ *
+ * Mobile counterpart of the "Тренд % жиру" card in
+ * `apps/web/src/modules/fizruk/pages/Progress.tsx`. A follow-up PR
+ * will extend this component to show additional body-composition
+ * metrics (neck / waist / hips). For now the single body-fat-% trend
+ * matches the migration plan §4 / §6.7 scope.
+ */
+import { memo } from "react";
+import { Text } from "react-native";
+
+import { Card } from "@/components/ui/Card";
+
+import { TrendChart } from "./TrendChart";
+import type { MeasurementPoint } from "./types";
+
+export interface MeasurementsChartSectionProps {
+  bodyFatTrend: readonly MeasurementPoint[];
+}
+
+const MeasurementsChartSectionImpl = function MeasurementsChartSection({
+  bodyFatTrend,
+}: MeasurementsChartSectionProps) {
+  return (
+    <Card radius="lg" padding="lg" testID="fizruk-progress-bodyfat">
+      <Text className="text-xs font-semibold text-stone-500 mb-3">
+        {"Тренд % жиру"}
+      </Text>
+      <TrendChart
+        series={bodyFatTrend}
+        strokeColor="#eab308"
+        unit="%"
+        metricLabel="відсоток жиру"
+        testIDPrefix="fizruk-progress-bodyfat"
+      />
+    </Card>
+  );
+};
+
+export const MeasurementsChartSection = memo(MeasurementsChartSectionImpl);

--- a/apps/mobile/src/modules/fizruk/components/progress/ProgressKPIs.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/ProgressKPIs.tsx
@@ -1,0 +1,59 @@
+/**
+ * ProgressKPIs — top-of-page KPI strip for the Fizruk Progress screen.
+ *
+ * Mobile port of the `<h1>` header block plus the PR / Заміри tiles
+ * in `apps/web/src/modules/fizruk/pages/Progress.tsx`. All numbers
+ * come from `@sergeant/fizruk-domain`'s pure `computeProgressKpis`
+ * selector so web and mobile stay in sync.
+ */
+import { memo } from "react";
+import { Text, View } from "react-native";
+
+import {
+  formatLatestWorkoutLabel,
+  NO_LATEST_WORKOUT_LABEL,
+  type ProgressKpis,
+} from "@sergeant/fizruk-domain/domain";
+
+import { Card } from "@/components/ui/Card";
+
+export interface ProgressKPIsProps {
+  kpis: ProgressKpis;
+}
+
+const ProgressKPIsImpl = function ProgressKPIs({ kpis }: ProgressKPIsProps) {
+  const latestLabel = formatLatestWorkoutLabel(kpis.latestWorkoutIso);
+  const subtitle =
+    latestLabel !== NO_LATEST_WORKOUT_LABEL
+      ? `Останнє: ${latestLabel} · ${kpis.prsCount} PR`
+      : "Аналітика тренувань";
+
+  return (
+    <Card radius="lg" padding="lg" testID="fizruk-progress-kpis">
+      <View className="flex-row items-start justify-between gap-3">
+        <View className="flex-1 min-w-0">
+          <Text className="text-xl font-bold text-stone-900">{"Прогрес"}</Text>
+          <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+            {subtitle}
+          </Text>
+        </View>
+        <View className="flex-row items-center gap-4">
+          <View className="items-center" testID="fizruk-progress-prs-stat">
+            <Text className="text-xs text-stone-500">{"PR"}</Text>
+            <Text className="text-base font-extrabold text-stone-900 tabular-nums">
+              {kpis.prsCount}
+            </Text>
+          </View>
+          <View className="items-center" testID="fizruk-progress-entries-stat">
+            <Text className="text-xs text-stone-500">{"Заміри"}</Text>
+            <Text className="text-base font-extrabold text-stone-900 tabular-nums">
+              {kpis.entriesCount}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Card>
+  );
+};
+
+export const ProgressKPIs = memo(ProgressKPIsImpl);

--- a/apps/mobile/src/modules/fizruk/components/progress/TrendChart.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/TrendChart.tsx
@@ -1,0 +1,161 @@
+/**
+ * TrendChart — shared victory-native area + line chart for Progress
+ * measurement trends (body weight, body-fat %, …).
+ *
+ * Mobile port of `apps/web/src/modules/fizruk/components/MiniLineChart.tsx`.
+ * Uses the same compact no-axis style as the Finyk
+ * {@link import("../../../finyk/pages/Overview/NetworthSection.tsx").NetworthSection}
+ * chart so cards stay visually consistent across modules.
+ *
+ * Empty-state copy mirrors the web counterpart so users see the same
+ * messages when they have no samples or only one sample.
+ */
+import { memo } from "react";
+import { Dimensions, Text, View } from "react-native";
+import { VictoryArea, VictoryGroup, VictoryLine } from "victory-native";
+
+import { countValidPoints } from "@sergeant/fizruk-domain/domain";
+
+import type { MeasurementPoint } from "./types";
+
+export interface TrendChartProps {
+  /** Series points (oldest-first). `null` values are skipped. */
+  series: readonly MeasurementPoint[];
+  /** Stroke colour for the line and a derived translucent fill. */
+  strokeColor: string;
+  /** e.g. `"кг"` / `"%"`. Rendered next to the latest value. */
+  unit: string;
+  /** Descriptive name of the metric — used in empty-state copy. */
+  metricLabel: string;
+  /**
+   * testID prefix for the outer view. Two suffixes are applied
+   * automatically: `-empty` when the chart is collapsed to an
+   * empty-state, `-chart` when a chart renders.
+   */
+  testIDPrefix: string;
+}
+
+/**
+ * Convert the stroke colour into a translucent area-fill. Accepts
+ * `#rrggbb` and `rgb(r g b)` formats (the ones used by the web
+ * MiniLineChart call-sites). Unknown inputs fall back to a fixed
+ * soft emerald fill.
+ */
+function deriveAreaFill(stroke: string): string {
+  const hex = stroke.trim().match(/^#([0-9a-f]{6})$/i);
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    const r = (n >> 16) & 0xff;
+    const g = (n >> 8) & 0xff;
+    const b = n & 0xff;
+    return `rgba(${r}, ${g}, ${b}, 0.18)`;
+  }
+  const rgb = stroke.trim().match(/^rgb\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)\s*\)$/);
+  if (rgb) {
+    return `rgba(${rgb[1]}, ${rgb[2]}, ${rgb[3]}, 0.18)`;
+  }
+  return "rgba(16, 185, 129, 0.18)";
+}
+
+const TrendChartImpl = function TrendChart({
+  series,
+  strokeColor,
+  unit,
+  metricLabel,
+  testIDPrefix,
+}: TrendChartProps) {
+  const validCount = countValidPoints(series);
+
+  if (validCount === 0) {
+    return (
+      <View
+        testID={`${testIDPrefix}-empty`}
+        className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
+      >
+        <Text className="text-sm font-semibold text-stone-900">
+          {"Немає числових даних"}
+        </Text>
+        <Text className="text-xs text-stone-500 mt-1">
+          {`Додай записи в розділі «Заміри», щоб відстежувати ${metricLabel}.`}
+        </Text>
+      </View>
+    );
+  }
+
+  if (validCount < 2) {
+    return (
+      <View
+        testID={`${testIDPrefix}-empty`}
+        className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
+      >
+        <Text className="text-sm font-semibold text-stone-900">
+          {"Замало точок для лінії"}
+        </Text>
+        <Text className="text-xs text-stone-500 mt-1">
+          {`Потрібні щонайменше два заміри з ${metricLabel}, щоб побудувати тренд.`}
+        </Text>
+      </View>
+    );
+  }
+
+  const points = series
+    .map((p, i) => ({ x: i, y: p.value, raw: p }))
+    .filter((p): p is { x: number; y: number; raw: MeasurementPoint } => {
+      return p.y != null;
+    });
+
+  const latest = points[points.length - 1];
+  const first = points[0];
+  const delta = latest.y - first.y;
+
+  const screenWidth = Dimensions.get("window").width;
+  const chartWidth = Math.max(220, screenWidth - 80);
+  const chartHeight = 96;
+  const fill = deriveAreaFill(strokeColor);
+
+  return (
+    <View testID={`${testIDPrefix}-chart`}>
+      <View className="flex-row items-baseline justify-between mb-2">
+        <Text className="text-base font-bold text-stone-900 tabular-nums">
+          {`${latest.y}${unit}`}
+        </Text>
+        <Text
+          testID={`${testIDPrefix}-delta`}
+          className={
+            delta > 0
+              ? "text-xs font-semibold text-amber-700 tabular-nums"
+              : delta < 0
+                ? "text-xs font-semibold text-emerald-700 tabular-nums"
+                : "text-xs font-semibold text-stone-500 tabular-nums"
+          }
+        >
+          {`${delta > 0 ? "+" : ""}${delta.toFixed(1)}${unit}`}
+        </Text>
+      </View>
+      <View accessibilityLabel={`Графік: ${metricLabel}`}>
+        <VictoryGroup
+          data={points.map((p) => ({ x: p.x, y: p.y }))}
+          width={chartWidth}
+          height={chartHeight}
+          padding={{ top: 6, bottom: 6, left: 6, right: 6 }}
+          standalone={true}
+        >
+          <VictoryArea
+            interpolation="monotoneX"
+            style={{ data: { fill, stroke: "transparent" } }}
+          />
+          <VictoryLine
+            interpolation="monotoneX"
+            style={{ data: { stroke: strokeColor, strokeWidth: 2 } }}
+          />
+        </VictoryGroup>
+      </View>
+      <View className="flex-row items-center justify-between mt-1">
+        <Text className="text-[10px] text-stone-400">{first.raw.label}</Text>
+        <Text className="text-[10px] text-stone-400">{latest.raw.label}</Text>
+      </View>
+    </View>
+  );
+};
+
+export const TrendChart = memo(TrendChartImpl);

--- a/apps/mobile/src/modules/fizruk/components/progress/WeightChartSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/WeightChartSection.tsx
@@ -1,0 +1,41 @@
+/**
+ * WeightChartSection — body-weight trend card on the Fizruk Progress
+ * screen.
+ *
+ * Mobile counterpart of the "Тренд ваги" card in
+ * `apps/web/src/modules/fizruk/pages/Progress.tsx`. Renders either a
+ * victory-native line chart or the same "замало точок" empty-state
+ * copy the web screen shows.
+ */
+import { memo } from "react";
+import { Text } from "react-native";
+
+import { Card } from "@/components/ui/Card";
+
+import { TrendChart } from "./TrendChart";
+import type { MeasurementPoint } from "./types";
+
+export interface WeightChartSectionProps {
+  weightTrend: readonly MeasurementPoint[];
+}
+
+const WeightChartSectionImpl = function WeightChartSection({
+  weightTrend,
+}: WeightChartSectionProps) {
+  return (
+    <Card radius="lg" padding="lg" testID="fizruk-progress-weight">
+      <Text className="text-xs font-semibold text-stone-500 mb-3">
+        {"Тренд ваги"}
+      </Text>
+      <TrendChart
+        series={weightTrend}
+        strokeColor="#16a34a"
+        unit=" кг"
+        metricLabel="вагу тіла"
+        testIDPrefix="fizruk-progress-weight"
+      />
+    </Card>
+  );
+};
+
+export const WeightChartSection = memo(WeightChartSectionImpl);

--- a/apps/mobile/src/modules/fizruk/components/progress/index.ts
+++ b/apps/mobile/src/modules/fizruk/components/progress/index.ts
@@ -1,0 +1,13 @@
+export { ProgressKPIs } from "./ProgressKPIs";
+export type { ProgressKPIsProps } from "./ProgressKPIs";
+
+export { WeightChartSection } from "./WeightChartSection";
+export type { WeightChartSectionProps } from "./WeightChartSection";
+
+export { MeasurementsChartSection } from "./MeasurementsChartSection";
+export type { MeasurementsChartSectionProps } from "./MeasurementsChartSection";
+
+export { TrendChart } from "./TrendChart";
+export type { TrendChartProps } from "./TrendChart";
+
+export type { MeasurementPoint } from "./types";

--- a/apps/mobile/src/modules/fizruk/components/progress/types.ts
+++ b/apps/mobile/src/modules/fizruk/components/progress/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared prop types for the mobile Fizruk Progress sections.
+ *
+ * Re-exports the platform-neutral {@link MeasurementPoint} from
+ * `@sergeant/fizruk-domain` so section components don't import the
+ * domain package directly (keeps the boundary explicit).
+ */
+
+export type { MeasurementPoint } from "@sergeant/fizruk-domain/domain";

--- a/apps/mobile/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Progress.tsx
@@ -1,27 +1,96 @@
 /**
- * Fizruk / Progress page — mobile placeholder (Phase 6 / PR-1).
+ * Fizruk / Progress — mobile screen (Phase 6 · PR-D).
  *
- * Web counterpart: `apps/web/src/modules/fizruk/pages/Progress.tsx` (737 LOC).
- * Volume/wellbeing charts, photo progress, JSON backup controls. Lands
- * across PR-D (charts), PR-E (PhotoProgress) in Phase 6.
+ * Mobile port of `apps/web/src/modules/fizruk/pages/Progress.tsx`
+ * scoped to the PR-D deliverables (body-weight timeseries +
+ * body-composition timeseries + KPI strip). Photo progress and the
+ * JSON / CSV backup surfaces land in later Phase 6 PRs (PR-E).
+ *
+ * All numeric selectors (weight trend, body-fat trend, KPIs) come
+ * from `@sergeant/fizruk-domain`'s pure `domain/progress/*` module so
+ * web and mobile stay in sync.
  */
+import { useMemo } from "react";
+import { ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { PagePlaceholder } from "./PagePlaceholder";
+import {
+  buildBodyFatTrend,
+  buildWeightTrend,
+  computeProgressKpis,
+} from "@sergeant/fizruk-domain/domain";
 
-export function Progress() {
+import { Card } from "@/components/ui/Card";
+
+import { MeasurementsChartSection } from "../components/progress/MeasurementsChartSection";
+import { ProgressKPIs } from "../components/progress/ProgressKPIs";
+import { WeightChartSection } from "../components/progress/WeightChartSection";
+import type { FizrukProgressData } from "./useFizrukProgressData";
+import { useFizrukProgressData } from "./useFizrukProgressData";
+
+export interface ProgressProps {
+  /**
+   * Optional dependency-injected data override — used by jest tests
+   * and storybook fixtures. Production callers should leave this
+   * unset so `useFizrukProgressData()` runs.
+   */
+  data?: FizrukProgressData;
+}
+
+export function Progress({ data }: ProgressProps = {}) {
+  const hookData = useFizrukProgressData();
+  const { workouts, entries } = data ?? hookData;
+
+  const weightTrend = useMemo(() => buildWeightTrend(entries), [entries]);
+  const bodyFatTrend = useMemo(() => buildBodyFatTrend(entries), [entries]);
+  const kpis = useMemo(
+    () => computeProgressKpis(workouts, entries.length),
+    [workouts, entries.length],
+  );
+
+  const hasAny = workouts.length > 0 || entries.length > 0;
+
   return (
-    <PagePlaceholder
-      title="Прогрес"
-      description="Щотижневий об'єм, самопочуття, фотопрогрес і бекап даних Фізрука."
-      plannedFeatures={[
-        "Щотижневий об'єм (WeeklyVolumeChart — victory-native)",
-        "Графік самопочуття (WellbeingChart)",
-        "Mini-line chart для конкретної вправи",
-        "Фотопрогрес: порівняння до/після (expo-image-picker)",
-        "Експорт / імпорт JSON-бекапу через shared `downloadJson`",
-      ]}
-      phaseHint="Фаза 6 · PR-D (charts) + PR-E (PhotoProgress)"
-    />
+    <SafeAreaView className="flex-1 bg-cream-50" edges={["bottom"]}>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 12 }}
+        testID="fizruk-progress-scroll"
+      >
+        <ProgressKPIs kpis={kpis} />
+
+        {!hasAny && (
+          <Card
+            radius="lg"
+            padding="xl"
+            className="items-center"
+            testID="fizruk-progress-empty"
+          >
+            <Text className="text-3xl mb-2">{"📈"}</Text>
+            <Text className="text-sm font-semibold text-stone-900 mb-1">
+              {"Даних ще немає"}
+            </Text>
+            <Text className="text-xs text-stone-500 text-center">
+              {"Додай тренування або заміри — і тут зʼявиться аналітика"}
+            </Text>
+          </Card>
+        )}
+
+        {hasAny && (
+          <>
+            <WeightChartSection weightTrend={weightTrend} />
+            <MeasurementsChartSection bodyFatTrend={bodyFatTrend} />
+            <View testID="fizruk-progress-phase-hint" className="pt-1">
+              <Text className="text-[10px] text-stone-400 text-center">
+                {
+                  "Фаза 6 · PR-D — графіки (victory-native). Фотопрогрес і бекап — у PR-E."
+                }
+              </Text>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/apps/mobile/src/modules/fizruk/pages/useFizrukProgressData.ts
+++ b/apps/mobile/src/modules/fizruk/pages/useFizrukProgressData.ts
@@ -1,0 +1,38 @@
+/**
+ * Stub data hook for the Fizruk Progress screen.
+ *
+ * Mirrors the Finyk
+ * {@link import("../../finyk/pages/Overview/useFinykOverviewData.ts").useFinykOverviewData}
+ * pattern: Phase 6 / PR-D lands the chart UI only, so this hook
+ * returns an empty, schema-valid payload that drives the zero-state
+ * branches of each section. A later PR swaps the internals for
+ * MMKV-backed `useWorkouts` / `useMeasurements` hooks without having
+ * to touch any screen-level component — the Progress UI just re-runs
+ * with real data.
+ */
+import { useMemo } from "react";
+
+import type {
+  ProgressMeasurementInput,
+  ProgressWorkoutInput,
+} from "@sergeant/fizruk-domain/domain";
+
+export interface FizrukProgressData {
+  /** Raw workout sessions (newest- or oldest-first — selectors tolerate both). */
+  workouts: readonly ProgressWorkoutInput[];
+  /**
+   * Measurement entries sorted newest-first (`at` desc), to match the
+   * contract the web `useMeasurements()` hook already emits.
+   */
+  entries: readonly ProgressMeasurementInput[];
+}
+
+export function useFizrukProgressData(): FizrukProgressData {
+  return useMemo<FizrukProgressData>(
+    () => ({
+      workouts: [],
+      entries: [],
+    }),
+    [],
+  );
+}

--- a/packages/fizruk-domain/src/domain/index.ts
+++ b/packages/fizruk-domain/src/domain/index.ts
@@ -1,1 +1,2 @@
 export * from "./types.js";
+export * from "./progress/index.js";

--- a/packages/fizruk-domain/src/domain/progress/index.ts
+++ b/packages/fizruk-domain/src/domain/progress/index.ts
@@ -1,0 +1,8 @@
+/**
+ * `@sergeant/fizruk-domain/domain/progress` — pure selectors backing
+ * the Fizruk Progress page (web + mobile).
+ */
+
+export * from "./types.js";
+export * from "./measurementSeries.js";
+export * from "./progressKpis.js";

--- a/packages/fizruk-domain/src/domain/progress/measurementSeries.test.ts
+++ b/packages/fizruk-domain/src/domain/progress/measurementSeries.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBodyFatTrend,
+  buildMeasurementSeries,
+  buildWeightTrend,
+  computeMeasurementDelta,
+  countValidPoints,
+  MEASUREMENT_TREND_WINDOW,
+} from "./measurementSeries.js";
+
+describe("buildMeasurementSeries", () => {
+  it("returns an empty array for null / undefined / empty input", () => {
+    expect(buildMeasurementSeries(undefined, "weightKg")).toEqual([]);
+    expect(buildMeasurementSeries(null, "weightKg")).toEqual([]);
+    expect(buildMeasurementSeries([], "weightKg")).toEqual([]);
+  });
+
+  it("sorts entries ascending by `at` timestamp", () => {
+    const entries = [
+      { at: "2026-01-05T00:00:00Z", weightKg: 80 },
+      { at: "2026-01-02T00:00:00Z", weightKg: 82 },
+      { at: "2026-01-04T00:00:00Z", weightKg: 81 },
+    ];
+    const series = buildMeasurementSeries(entries, "weightKg");
+    expect(series.map((p) => p.iso)).toEqual([
+      "2026-01-02T00:00:00Z",
+      "2026-01-04T00:00:00Z",
+      "2026-01-05T00:00:00Z",
+    ]);
+  });
+
+  it("keeps only the last `limit` entries", () => {
+    const entries = Array.from({ length: 12 }, (_, i) => ({
+      at: `2026-02-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+      weightKg: 70 + i,
+    }));
+    const series = buildMeasurementSeries(entries, "weightKg", 5);
+    expect(series).toHaveLength(5);
+    expect(series[0]?.iso).toBe("2026-02-08T00:00:00Z");
+    expect(series[4]?.iso).toBe("2026-02-12T00:00:00Z");
+  });
+
+  it("honours the default 8-entry window", () => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      at: `2026-03-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+      weightKg: i,
+    }));
+    const series = buildMeasurementSeries(entries, "weightKg");
+    expect(series).toHaveLength(MEASUREMENT_TREND_WINDOW);
+  });
+
+  it("maps missing / empty / non-numeric fields to `null` values", () => {
+    const entries = [
+      { at: "2026-01-01T00:00:00Z", weightKg: 80 },
+      { at: "2026-01-02T00:00:00Z", weightKg: "" },
+      { at: "2026-01-03T00:00:00Z" },
+      { at: "2026-01-04T00:00:00Z", weightKg: "abc" },
+      { at: "2026-01-05T00:00:00Z", weightKg: "81.5" },
+    ];
+    const series = buildMeasurementSeries(entries, "weightKg");
+    expect(series.map((p) => p.value)).toEqual([80, null, null, null, 81.5]);
+  });
+
+  it("includes a short locale-formatted label", () => {
+    const series = buildMeasurementSeries(
+      [{ at: "2026-04-15T00:00:00Z", weightKg: 80 }],
+      "weightKg",
+    );
+    expect(series[0]?.label).toMatch(/\w+/);
+    expect(series[0]?.label.length).toBeLessThan(20);
+  });
+
+  it("buildWeightTrend + buildBodyFatTrend pick the right field", () => {
+    const entries = [
+      { at: "2026-01-01T00:00:00Z", weightKg: 80, bodyFatPct: 18 },
+      { at: "2026-01-02T00:00:00Z", weightKg: 79, bodyFatPct: 17.5 },
+    ];
+    const weight = buildWeightTrend(entries);
+    const fat = buildBodyFatTrend(entries);
+    expect(weight.map((p) => p.value)).toEqual([80, 79]);
+    expect(fat.map((p) => p.value)).toEqual([18, 17.5]);
+  });
+});
+
+describe("countValidPoints", () => {
+  it("counts only points with a non-null value", () => {
+    const series = [
+      { iso: "a", value: 1, label: "" },
+      { iso: "b", value: null, label: "" },
+      { iso: "c", value: 2.5, label: "" },
+    ];
+    expect(countValidPoints(series)).toBe(2);
+  });
+
+  it("returns 0 for empty series", () => {
+    expect(countValidPoints([])).toBe(0);
+  });
+});
+
+describe("computeMeasurementDelta", () => {
+  it("returns null for null/empty/short input", () => {
+    expect(computeMeasurementDelta(null, "weightKg")).toBeNull();
+    expect(computeMeasurementDelta([], "weightKg")).toBeNull();
+    expect(
+      computeMeasurementDelta(
+        [{ at: "2026-01-01T00:00:00Z", weightKg: 80 }],
+        "weightKg",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns latest - prev for newest-first entries", () => {
+    const entries = [
+      { at: "2026-01-02T00:00:00Z", weightKg: 79 },
+      { at: "2026-01-01T00:00:00Z", weightKg: 80 },
+    ];
+    expect(computeMeasurementDelta(entries, "weightKg")).toBe(-1);
+  });
+
+  it("returns null when either side is non-numeric", () => {
+    const entries = [
+      { at: "2026-01-02T00:00:00Z", weightKg: "" },
+      { at: "2026-01-01T00:00:00Z", weightKg: 80 },
+    ];
+    expect(computeMeasurementDelta(entries, "weightKg")).toBeNull();
+  });
+});

--- a/packages/fizruk-domain/src/domain/progress/measurementSeries.ts
+++ b/packages/fizruk-domain/src/domain/progress/measurementSeries.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure builders for measurement timeseries on the Progress page.
+ *
+ * Ported verbatim from the inline `useMemo`s inside
+ * `apps/web/src/modules/fizruk/pages/Progress.tsx`:
+ *  - `weightTrend`  — last N body-weight samples, sorted oldest-first.
+ *  - `fatTrend`     — last N body-fat-% samples, sorted oldest-first.
+ *
+ * Both use the same shape so a single chart component can render
+ * either series (mobile: `WeightChartSection` / `MeasurementsChartSection`).
+ */
+
+import type {
+  MeasurementDelta,
+  MeasurementPoint,
+  ProgressMeasurementInput,
+} from "./types.js";
+
+/** Default number of points kept in a trend (matches web "last 8" window). */
+export const MEASUREMENT_TREND_WINDOW = 8;
+
+function toFiniteNumber(input: unknown): number | null {
+  if (input == null || input === "") return null;
+  const n = Number(input);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatTickLabel(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "";
+  return new Date(t).toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+/**
+ * Build a timeseries of measurement values for a given numeric field.
+ *
+ * Entries are sorted by their ISO `at` ascending so the resulting
+ * array reads left-to-right as "oldest → newest". The final `limit`
+ * entries are kept, mirroring the web behaviour (`.slice(-8)`).
+ *
+ * @param entries Raw measurement records (any order; may contain
+ *                strings or nulls in the measured field).
+ * @param field   Name of the numeric field to extract (e.g.
+ *                `"weightKg"` or `"bodyFatPct"`).
+ * @param limit   How many of the most-recent entries to keep.
+ */
+export function buildMeasurementSeries(
+  entries: readonly ProgressMeasurementInput[] | null | undefined,
+  field: string,
+  limit: number = MEASUREMENT_TREND_WINDOW,
+): MeasurementPoint[] {
+  const source = Array.isArray(entries) ? entries : [];
+  const sorted = [...source].sort((a, b) => a.at.localeCompare(b.at));
+  const windowed =
+    limit > 0 && sorted.length > limit
+      ? sorted.slice(sorted.length - limit)
+      : sorted;
+
+  return windowed.map((entry) => {
+    const raw = entry[field];
+    const value =
+      typeof raw === "number" || typeof raw === "string"
+        ? toFiniteNumber(raw)
+        : null;
+    return {
+      iso: entry.at,
+      value,
+      label: formatTickLabel(entry.at),
+    };
+  });
+}
+
+/** Convenience: last-N body-weight series. */
+export function buildWeightTrend(
+  entries: readonly ProgressMeasurementInput[] | null | undefined,
+  limit: number = MEASUREMENT_TREND_WINDOW,
+): MeasurementPoint[] {
+  return buildMeasurementSeries(entries, "weightKg", limit);
+}
+
+/** Convenience: last-N body-fat-% series. */
+export function buildBodyFatTrend(
+  entries: readonly ProgressMeasurementInput[] | null | undefined,
+  limit: number = MEASUREMENT_TREND_WINDOW,
+): MeasurementPoint[] {
+  return buildMeasurementSeries(entries, "bodyFatPct", limit);
+}
+
+/**
+ * Count how many points in a series have a finite numeric value.
+ * Mirrors the web `trend.filter((d) => d.value != null).length`
+ * guard used to decide whether to render a chart at all.
+ */
+export function countValidPoints(series: readonly MeasurementPoint[]): number {
+  let n = 0;
+  for (const p of series) if (p.value != null) n += 1;
+  return n;
+}
+
+/**
+ * Signed delta between the two most recent entries for a field.
+ *
+ * Follows the web implementation: entries are assumed to be ordered
+ * newest-first (matching the `useMeasurements()` contract where the
+ * hook sorts by `at desc`). Returns `null` when either side is
+ * missing/non-numeric so the UI can show an em-dash instead of `0`.
+ *
+ * @param entries Newest-first measurement entries.
+ * @param field   Numeric field to diff (e.g. `"weightKg"`).
+ */
+export function computeMeasurementDelta(
+  entries: readonly ProgressMeasurementInput[] | null | undefined,
+  field: string,
+): MeasurementDelta {
+  const source = Array.isArray(entries) ? entries : [];
+  const latest = source[0] ?? null;
+  const prev = source[1] ?? null;
+  if (!latest || !prev) return null;
+  const a = toFiniteNumber(latest[field]);
+  const b = toFiniteNumber(prev[field]);
+  if (a == null || b == null) return null;
+  return a - b;
+}

--- a/packages/fizruk-domain/src/domain/progress/progressKpis.test.ts
+++ b/packages/fizruk-domain/src/domain/progress/progressKpis.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeProgressKpis,
+  countExercisePRs,
+  formatLatestWorkoutLabel,
+  NO_LATEST_WORKOUT_LABEL,
+} from "./progressKpis.js";
+
+describe("countExercisePRs", () => {
+  it("returns 0 for empty / null input", () => {
+    expect(countExercisePRs(null)).toBe(0);
+    expect(countExercisePRs(undefined)).toBe(0);
+    expect(countExercisePRs([])).toBe(0);
+  });
+
+  it("counts distinct strength exercises with a positive 1RM", () => {
+    const workouts = [
+      {
+        items: [
+          {
+            exerciseId: "bench",
+            type: "strength",
+            sets: [{ weightKg: 60, reps: 8 }],
+          },
+          {
+            exerciseId: "squat",
+            type: "strength",
+            sets: [{ weightKg: 100, reps: 5 }],
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            exerciseId: "bench",
+            type: "strength",
+            sets: [{ weightKg: 70, reps: 5 }],
+          },
+        ],
+      },
+    ];
+    expect(countExercisePRs(workouts)).toBe(2);
+  });
+
+  it("ignores non-strength items and missing exerciseId", () => {
+    const workouts = [
+      {
+        items: [
+          { exerciseId: "run", type: "distance", sets: [] },
+          {
+            exerciseId: null,
+            type: "strength",
+            sets: [{ weightKg: 40, reps: 10 }],
+          },
+        ],
+      },
+    ];
+    expect(countExercisePRs(workouts)).toBe(0);
+  });
+
+  it("ignores sets with zero weight or reps", () => {
+    const workouts = [
+      {
+        items: [
+          {
+            exerciseId: "bench",
+            type: "strength",
+            sets: [
+              { weightKg: 0, reps: 5 },
+              { weightKg: 50, reps: 0 },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(countExercisePRs(workouts)).toBe(0);
+  });
+});
+
+describe("computeProgressKpis", () => {
+  it("returns zeros for empty input", () => {
+    expect(computeProgressKpis([], 0)).toEqual({
+      doneCount: 0,
+      prsCount: 0,
+      entriesCount: 0,
+      latestWorkoutIso: null,
+    });
+  });
+
+  it("computes doneCount / prsCount / latestWorkoutIso", () => {
+    const workouts = [
+      {
+        startedAt: "2026-01-10T10:00:00Z",
+        endedAt: "2026-01-10T11:00:00Z",
+        items: [
+          {
+            exerciseId: "bench",
+            type: "strength",
+            sets: [{ weightKg: 60, reps: 5 }],
+          },
+        ],
+      },
+      {
+        startedAt: "2026-02-01T10:00:00Z",
+        endedAt: null,
+        items: [],
+      },
+      {
+        startedAt: "2026-01-20T10:00:00Z",
+        endedAt: "2026-01-20T11:00:00Z",
+        items: [
+          {
+            exerciseId: "squat",
+            type: "strength",
+            sets: [{ weightKg: 100, reps: 5 }],
+          },
+        ],
+      },
+    ];
+    const kpis = computeProgressKpis(workouts, 3);
+    expect(kpis.doneCount).toBe(2);
+    expect(kpis.prsCount).toBe(2);
+    expect(kpis.entriesCount).toBe(3);
+    expect(kpis.latestWorkoutIso).toBe("2026-01-20T10:00:00Z");
+  });
+
+  it("clamps negative / fractional entries counts", () => {
+    const kpis = computeProgressKpis([], -5);
+    expect(kpis.entriesCount).toBe(0);
+    const kpis2 = computeProgressKpis([], 2.7);
+    expect(kpis2.entriesCount).toBe(2);
+  });
+
+  it("ignores completed workouts with invalid startedAt when picking the latest", () => {
+    const workouts = [
+      {
+        startedAt: "not-a-date",
+        endedAt: "2026-01-10T11:00:00Z",
+        items: [],
+      },
+      {
+        startedAt: "2026-01-05T10:00:00Z",
+        endedAt: "2026-01-05T11:00:00Z",
+        items: [],
+      },
+    ];
+    const kpis = computeProgressKpis(workouts, 0);
+    expect(kpis.latestWorkoutIso).toBe("2026-01-05T10:00:00Z");
+  });
+});
+
+describe("formatLatestWorkoutLabel", () => {
+  it("returns the em-dash sentinel for null / invalid input", () => {
+    expect(formatLatestWorkoutLabel(null)).toBe(NO_LATEST_WORKOUT_LABEL);
+    expect(formatLatestWorkoutLabel("")).toBe(NO_LATEST_WORKOUT_LABEL);
+    expect(formatLatestWorkoutLabel("nope")).toBe(NO_LATEST_WORKOUT_LABEL);
+  });
+
+  it("formats a valid ISO timestamp with a locale date-like label", () => {
+    const label = formatLatestWorkoutLabel("2026-04-15T00:00:00Z");
+    expect(label).not.toBe(NO_LATEST_WORKOUT_LABEL);
+    expect(label.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/fizruk-domain/src/domain/progress/progressKpis.ts
+++ b/packages/fizruk-domain/src/domain/progress/progressKpis.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure KPI aggregator for the Fizruk Progress header.
+ *
+ * Mobile port of the `quickStats` + PR-count `useMemo`s that live at
+ * the top of `apps/web/src/modules/fizruk/pages/Progress.tsx`. Keeping
+ * the logic here (rather than inside the RN screen) means:
+ *  - both web and mobile can share the numbers,
+ *  - the numbers are covered by vitest unit tests,
+ *  - the screen renders stay pure-presentational.
+ */
+
+import type { ProgressKpis, ProgressWorkoutInput } from "./types.js";
+
+/** Sentinel used by the web copy when no completed workout exists. */
+export const NO_LATEST_WORKOUT_LABEL = "—";
+
+/**
+ * Epley 1RM estimator, re-implemented locally with strict types so the
+ * typed consumers (mobile, `strict: true`) don't pull in the loose
+ * `lib/workoutStats.ts` surface. Mirrors the formula used by
+ * `@sergeant/fizruk-domain/lib`'s `epley1rm`.
+ */
+function epley1rmStrict(
+  weightKg: number | string | null | undefined,
+  reps: number | string | null | undefined,
+): number {
+  const wg = Number(weightKg ?? 0);
+  const r = Number(reps ?? 0);
+  if (!Number.isFinite(wg) || !Number.isFinite(r) || wg <= 0 || r <= 0) {
+    return 0;
+  }
+  return wg * (1 + r / 30);
+}
+
+function parseStartedAtMs(workout: ProgressWorkoutInput): number | null {
+  const ts = workout.startedAt ? Date.parse(workout.startedAt) : NaN;
+  return Number.isFinite(ts) ? ts : null;
+}
+
+/**
+ * Count exercises with at least one positive Epley 1RM across all
+ * workouts (completed or not — matches web behaviour which folds
+ * in-progress sessions into the PR board until they are discarded).
+ */
+export function countExercisePRs(
+  workouts: readonly ProgressWorkoutInput[] | null | undefined,
+): number {
+  const seen = new Set<string>();
+  if (!Array.isArray(workouts)) return 0;
+  for (const w of workouts) {
+    for (const it of w.items ?? []) {
+      if (!it.exerciseId || it.type !== "strength") continue;
+      for (const s of it.sets ?? []) {
+        if (epley1rmStrict(s.weightKg, s.reps) > 0) {
+          seen.add(it.exerciseId);
+          break;
+        }
+      }
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * Compute the KPI strip shown above the charts.
+ *
+ * @param workouts       Raw workout sessions (completed or not).
+ * @param entriesCount   Number of measurement entries the user has
+ *                       logged. Passed in (rather than entries
+ *                       themselves) because the caller already keeps
+ *                       them memoised for the trend builders.
+ */
+export function computeProgressKpis(
+  workouts: readonly ProgressWorkoutInput[] | null | undefined,
+  entriesCount: number,
+): ProgressKpis {
+  const source = Array.isArray(workouts) ? workouts : [];
+  const done = source.filter((w) => Boolean(w.endedAt));
+
+  let latestWorkoutIso: string | null = null;
+  let latestMs = -Infinity;
+  for (const w of done) {
+    const ts = parseStartedAtMs(w);
+    if (ts == null) continue;
+    if (ts > latestMs) {
+      latestMs = ts;
+      latestWorkoutIso = w.startedAt ?? null;
+    }
+  }
+
+  return {
+    doneCount: done.length,
+    prsCount: countExercisePRs(source),
+    entriesCount: Math.max(0, Math.floor(entriesCount)),
+    latestWorkoutIso,
+  };
+}
+
+/**
+ * Format a KPI's latest-workout ISO into the short Ukrainian label
+ * the header uses (e.g. "12 кві"). Returns {@link NO_LATEST_WORKOUT_LABEL}
+ * for a null/invalid input.
+ */
+export function formatLatestWorkoutLabel(iso: string | null): string {
+  if (!iso) return NO_LATEST_WORKOUT_LABEL;
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return NO_LATEST_WORKOUT_LABEL;
+  return new Date(ts).toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+}

--- a/packages/fizruk-domain/src/domain/progress/types.ts
+++ b/packages/fizruk-domain/src/domain/progress/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared domain types for the Fizruk Progress page.
+ *
+ * Kept platform-neutral so both `apps/web` and `apps/mobile` consume
+ * the same selectors without pulling in DOM or React Native specifics.
+ */
+
+/**
+ * Subset of {@link import("../types.js").MeasurementEntry} that the
+ * Progress selectors rely on. Intentionally narrow — accepts anything
+ * with an ISO `at` timestamp plus numeric/string measurement fields —
+ * so callers (hooks that return loosely-typed persisted records) do
+ * not need to widen/cast before passing data in.
+ */
+export interface ProgressMeasurementInput {
+  at: string;
+  weightKg?: number | string | null;
+  bodyFatPct?: number | string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Subset of {@link import("../types.js").Workout} used by the Progress
+ * KPI aggregator. A completed workout is one with a truthy `endedAt`.
+ */
+export interface ProgressWorkoutInput {
+  startedAt?: string | null;
+  endedAt?: string | null;
+  items?: readonly {
+    exerciseId?: string | null;
+    type?: string;
+    sets?: readonly {
+      weightKg?: number | string | null;
+      reps?: number | string | null;
+    }[];
+  }[];
+}
+
+/**
+ * A single point on a measurement trend chart. `value` is `null` when
+ * the measurement record exists but that specific field was missing,
+ * so consumers (victory-native, MiniLineChart) can skip nulls without
+ * re-filtering the raw entries.
+ */
+export interface MeasurementPoint {
+  /** ISO timestamp of the source measurement entry. */
+  iso: string;
+  /** Numeric field value, or `null` if the field is missing/invalid. */
+  value: number | null;
+  /** Short locale-formatted tick label ("12 кві"). */
+  label: string;
+}
+
+/** Signed delta between the two most recent numeric measurements. */
+export type MeasurementDelta = number | null;
+
+/** Aggregate KPI strip shown above the charts. */
+export interface ProgressKpis {
+  /** Number of completed (`endedAt` set) workouts. */
+  doneCount: number;
+  /** Count of unique strength exercises with a positive Epley 1RM. */
+  prsCount: number;
+  /** Count of measurement entries the user has logged. */
+  entriesCount: number;
+  /** ISO timestamp of the latest completed workout (or `null`). */
+  latestWorkoutIso: string | null;
+}


### PR DESCRIPTION
## Summary

Ports the Fizruk **Progress** page from web to React Native for **Phase 6 / PR-D** of the migration plan (`docs/react-native-migration.md` §4, §6.7). Turns the 28-LOC placeholder at `apps/mobile/src/modules/fizruk/pages/Progress.tsx` into a real screen with KPIs + two timeseries charts, backed by shared pure selectors.

### What changed

**`@sergeant/fizruk-domain` — new `domain/progress/*` module (pure, platform-neutral):**
- `types.ts` — `ProgressMeasurementInput`, `ProgressWorkoutInput`, `MeasurementPoint`, `MeasurementDelta`, `ProgressKpis`.
- `measurementSeries.ts` — `buildMeasurementSeries` / `buildWeightTrend` / `buildBodyFatTrend` (last-N oldest→newest with per-field null-coercion), `countValidPoints`, `computeMeasurementDelta`.
- `progressKpis.ts` — `countExercisePRs`, `computeProgressKpis`, `formatLatestWorkoutLabel`. Ships a strict local `epley1rmStrict` so typed consumers (mobile) don't pull in the loose `lib/workoutStats.ts` surface.
- Re-exported from `@sergeant/fizruk-domain/domain` (the existing barrel).
- **22 new vitest cases** covering sort/window, field extraction, null/non-numeric coercion, delta, PR counting and latest-workout picking.

**`apps/mobile` — Progress screen + 3 sections + 1 shared chart primitive:**
- `pages/Progress.tsx` — orchestrator, runs the domain selectors, renders KPIs + chart sections or a dashed empty card when no workouts nor entries exist. Accepts optional `data` for DI in tests.
- `pages/useFizrukProgressData.ts` — stub hook returning `{ workouts: [], entries: [] }` for now, mirroring the Finyk `useFinykOverviewData` pattern. Swap-point for the follow-up MMKV-backed hooks.
- `components/progress/ProgressKPIs.tsx` — header tile with PR and Заміри counts + latest-workout label.
- `components/progress/WeightChartSection.tsx` — "Тренд ваги" card, `#16a34a` stroke, "кг" unit.
- `components/progress/MeasurementsChartSection.tsx` — "Тренд % жиру" card, `#eab308` stroke, "%" unit.
- `components/progress/TrendChart.tsx` — shared victory-native `VictoryGroup` + `VictoryArea` + `VictoryLine` primitive used by both section cards. Implements the two empty-state branches from the web `MiniLineChart` ("Немає числових даних" / "Замало точок для лінії").
- **4 new Jest cases** (`__tests__/Progress.test.tsx`): empty-state, weight chart rendering with ≥2 samples, body-fat fallback with only one sample, KPI tiles.

No new root-level deps, `apps/web/**` untouched, `PlanCalendar.tsx` / `routine/**` / `apps/mobile/jest.config.js` / `apps/mobile/tsconfig.json` / `apps/mobile/package.json` all untouched. Existing `/fizruk/progress` route wrapper from PR #450 already imports from `@/modules/fizruk/pages/Progress`, so no route edits were needed.

### Verification
- `pnpm check` ✅ green locally (format:check + lint + typecheck + test + build). 181 Jest tests + 80 Vitest tests pass.
- Strict TS throughout — no `any`, `as any`, or `@ts-expect-error`.

## Review & Testing Checklist for Human

This PR touches two packages (mobile app + shared domain). Risk: **yellow** (isolated new module, stubbed data source, chart library already in use elsewhere).

- [ ] Confirm the `@sergeant/fizruk-domain/domain/progress/*` module is exported correctly by `pnpm --filter @sergeant/fizruk-domain test` and that the new 22 tests run.
- [ ] Open the mobile app and navigate to `/fizruk/progress` — verify the empty-state card ("Даних ще немає") renders and the KPI tiles show `0 PR` / `0 Заміри`. The two chart sections should be hidden until real data lands.
- [ ] Sanity-check the test `data` seam: replace `useFizrukProgressData` temporarily with a fixture (two weight samples / one body-fat sample) and confirm the weight chart draws while the body-fat card shows the "Замало точок" empty-state copy.

### Notes
- Only body-weight + body-fat-% timeseries and the KPI strip are in this PR, matching the scope the plan reserves for PR-D. Photo progress, JSON/CSV backup and the full PR-board land in the subsequent Phase 6 PRs (PR-E/onward).
- The victory-native mock in `Progress.test.tsx` stubs `VictoryGroup` / `VictoryArea` / `VictoryLine` so the test asserts screen-level logic (which section renders, which `testID` is present) without exercising the chart internals — they're covered upstream in the chart library.
- `epley1rm` was re-implemented locally (as `epley1rmStrict`) in `progressKpis.ts` to avoid importing the loosely-typed `lib/workoutStats.ts` surface from the strict mobile tsconfig. Same formula, stricter signature.

Link to Devin session: https://app.devin.ai/sessions/d824ee1c60f444c88c7dd5c3c3bae7d1
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Progress analytics page displaying key workout metrics (PRs, measurement entries, and latest workout date).
  * Added interactive trend charts visualizing weight and body fat percentage changes over time.
  * Implemented empty-state messaging when insufficient data is available.
  * Added comprehensive test coverage for the Progress screen and analytics components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->