### PR TITLE
feat(fizruk-mobile): PR-G — PlanCalendar page

### DIFF
--- a/apps/mobile/src/modules/fizruk/hooks/useMonthlyPlan.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/useMonthlyPlan.ts
@@ -1,0 +1,153 @@
+/**
+ * MMKV-backed monthly plan hook for the Fizruk mobile module.
+ *
+ * Mirrors the shape of `apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts`
+ * (Phase 6 / PR-G) but on top of MMKV via `@/lib/storage`. Delegates
+ * all normalization / reducer logic to `@sergeant/fizruk-domain` so
+ * mobile and web share the exact same `MonthlyPlanState` semantics.
+ *
+ * Scope of this file (Phase 6 / PR-G — PlanCalendar):
+ *  - Raw MMKV I/O for the shared `MONTHLY_PLAN_STORAGE_KEY`.
+ *  - React hook returning the current state + a minimum set of action
+ *    callbacks the PlanCalendar screen needs. Reminder-related
+ *    mutations (enable / time) are plumbed through as well so follow-up
+ *    settings UIs can reuse the hook without another refactor.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { MONTHLY_PLAN_STORAGE_KEY } from "@sergeant/fizruk-domain/constants";
+import {
+  applySetDayTemplate,
+  applySetReminder,
+  applySetReminderEnabled,
+  defaultMonthlyPlanState,
+  getTemplateForDate,
+  getTodayTemplateId,
+  normalizeMonthlyPlanState,
+  todayDateKey,
+  type MonthlyPlanDay,
+  type MonthlyPlanState,
+} from "@sergeant/fizruk-domain/domain/plan/index";
+
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+
+/** Read and normalise the monthly plan state from MMKV. */
+export function loadMonthlyPlanState(): MonthlyPlanState {
+  const raw = safeReadLS<unknown>(MONTHLY_PLAN_STORAGE_KEY, null);
+  return normalizeMonthlyPlanState(raw);
+}
+
+/** Persist the monthly plan state to MMKV. */
+export function saveMonthlyPlanState(next: MonthlyPlanState): boolean {
+  return safeWriteLS(MONTHLY_PLAN_STORAGE_KEY, next);
+}
+
+export interface UseMonthlyPlanReturn {
+  reminderEnabled: boolean;
+  reminderHour: number;
+  reminderMinute: number;
+  days: Record<string, MonthlyPlanDay>;
+  /** Full normalised state — handy for passing into pure selectors. */
+  state: MonthlyPlanState;
+  /** Template id assigned to `dateKey`, or `null`. */
+  getTemplateForDate: (dateKey: string) => string | null;
+  /** Template id assigned to today, or `null`. */
+  todayTemplateId: string | null;
+  /** Local-date key for "today". */
+  getTodayDateKey: () => string;
+  /**
+   * Assign (or clear, when `templateId` is null/empty) the template
+   * for a given `dateKey`. No-ops when the value is already set.
+   */
+  setDayTemplate: (
+    dateKey: string,
+    templateId: string | null | undefined,
+  ) => void;
+  /** Update the reminder time (hour/minute). Clamped by the reducer. */
+  setReminder: (hour: number, minute: number) => void;
+  /** Toggle the daily plan reminder. */
+  setReminderEnabled: (enabled: boolean) => void;
+  /** Re-read state from MMKV (useful after external writes, e.g. backup apply). */
+  refresh: () => void;
+}
+
+/**
+ * React hook over MMKV that returns the current monthly plan state +
+ * action callbacks. Subscribes to MMKV value-change events on
+ * `MONTHLY_PLAN_STORAGE_KEY` so writes from other consumers in the
+ * same app re-hydrate this hook's copy.
+ */
+export function useMonthlyPlan(): UseMonthlyPlanReturn {
+  const [state, setState] = useState<MonthlyPlanState>(loadMonthlyPlanState);
+
+  const refresh = useCallback(() => {
+    setState(loadMonthlyPlanState());
+  }, []);
+
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey === MONTHLY_PLAN_STORAGE_KEY) refresh();
+    });
+    return () => sub.remove();
+  }, [refresh]);
+
+  const setDayTemplate = useCallback<UseMonthlyPlanReturn["setDayTemplate"]>(
+    (dateKey, templateId) => {
+      setState((prev) => {
+        const next = applySetDayTemplate(prev, dateKey, templateId);
+        if (next === prev) return prev;
+        saveMonthlyPlanState(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setReminder = useCallback<UseMonthlyPlanReturn["setReminder"]>(
+    (hour, minute) => {
+      setState((prev) => {
+        const next = applySetReminder(prev, hour, minute);
+        if (next === prev) return prev;
+        saveMonthlyPlanState(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setReminderEnabled = useCallback<
+    UseMonthlyPlanReturn["setReminderEnabled"]
+  >((enabled) => {
+    setState((prev) => {
+      const next = applySetReminderEnabled(prev, enabled);
+      if (next === prev) return prev;
+      saveMonthlyPlanState(next);
+      return next;
+    });
+  }, []);
+
+  const getTemplateForDateFn = useCallback(
+    (dateKey: string) => getTemplateForDate(state, dateKey),
+    [state],
+  );
+
+  return {
+    reminderEnabled: state.reminderEnabled,
+    reminderHour: state.reminderHour,
+    reminderMinute: state.reminderMinute,
+    days: state.days,
+    state,
+    getTemplateForDate: getTemplateForDateFn,
+    todayTemplateId: getTodayTemplateId(state),
+    getTodayDateKey: todayDateKey,
+    setDayTemplate,
+    setReminder,
+    setReminderEnabled,
+    refresh,
+  };
+}
+
+/** Re-export the default factory for callers/tests that want a seed. */
+export { defaultMonthlyPlanState };

--- a/apps/mobile/src/modules/fizruk/pages/PlanCalendar.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/PlanCalendar.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Render + interaction tests for `pages/PlanCalendar.tsx` (Phase 6 / PR-G).
+ *
+ * Covers the four invariants called out in the PR spec:
+ *   - Empty-state renders when the month has no templates and no
+ *     planned workouts, with a CTA that routes to `/fizruk/workouts`.
+ *   - Month with ≥2 planned days shows the workout indicator on the
+ *     correct cells.
+ *   - Tap-day opens the bottom sheet; selecting a template assigns it
+ *     and persists to MMKV.
+ *   - Month navigation (‹ / ›) moves the cursor and the title follows.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { MONTHLY_PLAN_STORAGE_KEY } from "@sergeant/fizruk-domain/constants";
+import {
+  serializeMonthlyPlanState,
+  type PlannedWorkoutLike,
+} from "@sergeant/fizruk-domain/domain/plan/index";
+import type { WorkoutTemplate } from "@sergeant/fizruk-domain/domain/types";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { PlanCalendar } from "./PlanCalendar";
+
+jest.mock("expo-router", () => ({
+  router: { push: jest.fn() },
+}));
+
+// Both the Dashboard and BodyAtlas test suites stub SafeArea the same
+// way — keep parity so the screen renders in jest-expo's node env.
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+import { router } from "expo-router";
+
+const NOW = new Date(2025, 2, 15, 9, 0, 0); // Saturday, 15 March 2025
+
+const SAMPLE_TEMPLATES: WorkoutTemplate[] = [
+  {
+    id: "tpl_a",
+    name: "Груди + трицепс",
+    exerciseIds: ["e1", "e2"],
+    groups: [],
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  },
+  {
+    id: "tpl_b",
+    name: "Спина + біцепс",
+    exerciseIds: ["e3"],
+    groups: [],
+    updatedAt: "2025-01-02T00:00:00.000Z",
+  },
+];
+
+const SAMPLE_WORKOUTS: PlannedWorkoutLike[] = [
+  {
+    id: "w1",
+    planned: true,
+    startedAt: "2025-03-10T08:30:00.000Z",
+    note: "Пробіжка",
+    items: [{ id: "i1", nameUk: "Біг" }],
+  },
+  {
+    id: "w2",
+    planned: true,
+    startedAt: "2025-03-20T18:00:00.000Z",
+    note: null,
+    items: [],
+  },
+  {
+    id: "w3",
+    planned: false,
+    startedAt: "2025-03-22T10:00:00.000Z",
+    note: "not planned",
+  },
+];
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+  (router.push as jest.Mock).mockClear();
+});
+
+describe("PlanCalendar (mobile)", () => {
+  it("shows the empty-state CTA when the month has no plan + no workouts", () => {
+    const { getByText, getByLabelText } = render(
+      <PlanCalendar now={NOW} templates={[]} workouts={[]} />,
+    );
+
+    expect(getByText("Порожній місяць")).toBeTruthy();
+    fireEvent.press(getByLabelText("Перейти до тренувань"));
+    expect(router.push).toHaveBeenCalledWith("/fizruk/workouts");
+  });
+
+  it("hides the empty-state when there are ≥2 planned days in the month", () => {
+    const { queryByText, getByText } = render(
+      <PlanCalendar
+        now={NOW}
+        templates={SAMPLE_TEMPLATES}
+        workouts={SAMPLE_WORKOUTS}
+      />,
+    );
+
+    // Empty-state card is gone because March 10 + March 20 are both
+    // planned.
+    expect(queryByText("Порожній місяць")).toBeNull();
+    // Two planned days → two 🏋 markers in the grid.
+    expect(getByText("10")).toBeTruthy();
+    expect(getByText("20")).toBeTruthy();
+  });
+
+  it("opens the bottom sheet when a day is tapped and assigns a template", () => {
+    const { getByLabelText, getByText } = render(
+      <PlanCalendar
+        now={NOW}
+        templates={SAMPLE_TEMPLATES}
+        workouts={SAMPLE_WORKOUTS}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("День 15"));
+    // Template list is visible — both sample template names render.
+    expect(getByText("Груди + трицепс")).toBeTruthy();
+    expect(getByText("Спина + біцепс")).toBeTruthy();
+
+    fireEvent.press(getByText("Груди + трицепс"));
+
+    // The template id for 2025-03-15 was written to MMKV.
+    const raw = _getMMKVInstance().getString(MONTHLY_PLAN_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw || "{}");
+    expect(parsed.days?.["2025-03-15"]?.templateId).toBe("tpl_a");
+  });
+
+  it("navigates between months via the ‹ / › chevrons", () => {
+    const { getByLabelText, getByText, queryByText } = render(
+      <PlanCalendar
+        now={NOW}
+        templates={SAMPLE_TEMPLATES}
+        workouts={SAMPLE_WORKOUTS}
+      />,
+    );
+
+    // Start in March: day 20 (planned) is visible.
+    expect(getByText("20")).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Наступний місяць"));
+    // April has 30 days, so 31 is *not* a real day cell — use the
+    // planned indicator's absence as the signal. The sheet-opener
+    // label for March 20 is no longer present because we're in April.
+    expect(queryByText("🏋")).toBeNull();
+
+    fireEvent.press(getByLabelText("Попередній місяць"));
+    // Back in March → the planned markers return.
+    expect(getByText("20")).toBeTruthy();
+  });
+
+  it("snaps the cursor back to today when the quick-action is tapped", () => {
+    const { getByLabelText, getByText } = render(
+      <PlanCalendar
+        now={NOW}
+        templates={SAMPLE_TEMPLATES}
+        workouts={SAMPLE_WORKOUTS}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Наступний місяць"));
+    fireEvent.press(getByLabelText("Наступний місяць"));
+    fireEvent.press(getByLabelText("Перейти до поточного місяця"));
+    // Title should now be the March-2025 label again. `toLocaleDateString`
+    // returns "березень 2025" under a `uk-UA` locale; under a missing-ICU
+    // Hermes it falls back to "March 2025". Both start with the month
+    // name, so we just assert the year is back.
+    expect(getByText(/2025/)).toBeTruthy();
+  });
+
+  it("preserves state loaded from MMKV on mount", () => {
+    _getMMKVInstance().set(
+      MONTHLY_PLAN_STORAGE_KEY,
+      serializeMonthlyPlanState({
+        reminderEnabled: true,
+        reminderHour: 18,
+        reminderMinute: 0,
+        days: { "2025-03-15": { templateId: "tpl_b" } },
+      }),
+    );
+
+    const { getByText } = render(
+      <PlanCalendar
+        now={NOW}
+        templates={SAMPLE_TEMPLATES}
+        workouts={SAMPLE_WORKOUTS}
+      />,
+    );
+
+    // Template b's name appears under day 15 — the cell shows the
+    // template label.
+    expect(getByText("Спина + біцепс")).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -1,26 +1,520 @@
 /**
- * Fizruk / PlanCalendar page — mobile placeholder (Phase 6 / PR-1).
+ * Fizruk / PlanCalendar — monthly training plan screen (mobile port).
  *
- * Web counterpart: `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx` (349 LOC).
- * Monthly plan grid with training templates per day. Integrates with the
- * Hub `showFizrukInCalendar` setting (RoutineSection) — see PR-G.
+ * Phase 6 / PR-G. Mobile port of
+ * `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx` (349 LOC). All
+ * pure state + date logic lives in `@sergeant/fizruk-domain/domain/plan`
+ * so mobile and web share the same `MonthlyPlanState` semantics and
+ * produce byte-identical buckets of planned workouts per day.
+ *
+ * Scope for this PR:
+ *  1. Monday-first month grid with template + planned-workout indicator
+ *     per day. Today's cell is visually highlighted.
+ *  2. "Today" quick-action that snaps the cursor back to the current
+ *     month.
+ *  3. Month-prev / month-next navigation.
+ *  4. Tap-day opens a bottom `Sheet` listing planned workouts for that
+ *     date and the set of `WorkoutTemplate`s the user has defined. The
+ *     top "Без плану" row clears the template for the date.
+ *  5. Empty-state card when the month has zero templates and zero
+ *     planned workouts (with a CTA that nudges the user to Workouts).
+ *
+ * Intentionally OUT of scope for this PR (will come in follow-ups):
+ *  - Recovery-forecast section (needs `useExerciseCatalog` / `useRecovery`
+ *    on mobile — neither is ported yet).
+ *  - Reminder settings UI (`reminderEnabled` / `reminderHour` /
+ *    `reminderMinute`) — the hook surfaces the state but the UI lands
+ *    with the Fizruk settings PR.
+ *
+ * Workouts / templates are read directly from MMKV under the shared
+ * fizruk storage keys (`WORKOUTS_STORAGE_KEY`, `TEMPLATES_STORAGE_KEY`)
+ * — there is no `useWorkouts` / `useWorkoutTemplates` hook on mobile
+ * yet and landing them here would balloon the PR. The aggregation
+ * remains pure (`aggregatePlannedByDate` from `@sergeant/fizruk-domain`)
+ * so swapping to a typed hook later is a one-line change. Imports use
+ * the package's subpath entrypoints (`/constants`, `/domain/plan/index`,
+ * `/domain/types`) to avoid pulling in the non-strict `lib/*` JS files
+ * through the top-level barrel — same pattern as `Workouts.tsx` /
+ * `Atlas.tsx`.
  */
 
-import { PagePlaceholder } from "./PagePlaceholder";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router } from "expo-router";
 
-export function PlanCalendar() {
+import {
+  TEMPLATES_STORAGE_KEY,
+  WORKOUTS_STORAGE_KEY,
+} from "@sergeant/fizruk-domain/constants";
+import {
+  aggregatePlannedByDate,
+  dateKeyFromYMD,
+  monthCursorFromDate,
+  monthGrid,
+  monthIsEmpty,
+  shiftMonthCursor,
+  todayDateKey,
+  type MonthCursor,
+  type PlannedWorkoutLike,
+} from "@sergeant/fizruk-domain/domain/plan/index";
+import type { WorkoutTemplate } from "@sergeant/fizruk-domain/domain/types";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Sheet } from "@/components/ui/Sheet";
+import { _getMMKVInstance, safeReadLS } from "@/lib/storage";
+
+import { fizrukRouteFor } from "../shell/fizrukRoute";
+import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
+
+const WEEKDAYS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"] as const;
+
+/** Narrow the raw MMKV payload into `WorkoutTemplate[]`. */
+function readTemplates(): WorkoutTemplate[] {
+  const raw = safeReadLS<unknown>(TEMPLATES_STORAGE_KEY, []);
+  if (!Array.isArray(raw)) return [];
+  const out: WorkoutTemplate[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const { id, name, exerciseIds, groups, updatedAt } = entry as Partial<
+      Record<keyof WorkoutTemplate, unknown>
+    >;
+    if (typeof id !== "string" || typeof name !== "string") continue;
+    out.push({
+      id,
+      name,
+      exerciseIds: Array.isArray(exerciseIds)
+        ? exerciseIds.filter((x): x is string => typeof x === "string")
+        : [],
+      groups: Array.isArray(groups)
+        ? (groups as WorkoutTemplate["groups"])
+        : [],
+      updatedAt: typeof updatedAt === "string" ? updatedAt : "",
+    });
+  }
+  return out;
+}
+
+/** Narrow the raw MMKV payload into `PlannedWorkoutLike[]`. */
+function readWorkouts(): PlannedWorkoutLike[] {
+  const raw = safeReadLS<unknown>(WORKOUTS_STORAGE_KEY, []);
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (w): w is PlannedWorkoutLike =>
+      !!w &&
+      typeof w === "object" &&
+      typeof (w as { id?: unknown }).id === "string",
+  );
+}
+
+interface OpenSheet {
+  dateKey: string;
+  day: number;
+  templateId: string | null;
+  planned: PlannedWorkoutLike[];
+}
+
+function formatMonthTitle(y: number, m: number): string {
+  try {
+    return new Date(y, m, 1).toLocaleDateString("uk-UA", {
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return `${y}-${String(m + 1).padStart(2, "0")}`;
+  }
+}
+
+function formatSheetTitle(key: string): string {
+  try {
+    return new Date(`${key}T12:00:00`).toLocaleDateString("uk-UA", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    });
+  } catch {
+    return key;
+  }
+}
+
+function formatTime(startedAt: string | null | undefined): string | null {
+  if (!startedAt) return null;
+  try {
+    return new Date(startedAt).toLocaleTimeString("uk-UA", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return null;
+  }
+}
+
+export interface PlanCalendarProps {
+  /** `Date.now()` seam for deterministic jest tests. */
+  now?: Date;
+  /**
+   * Dependency-injected templates + workouts for jest tests. Production
+   * code leaves both unset and the component reads from MMKV via
+   * `safeReadLS`.
+   */
+  templates?: readonly WorkoutTemplate[];
+  workouts?: readonly PlannedWorkoutLike[];
+}
+
+export function PlanCalendar({
+  now: nowOverride,
+  templates: injectedTemplates,
+  workouts: injectedWorkouts,
+}: PlanCalendarProps = {}) {
+  const now = useMemo(() => nowOverride ?? new Date(), [nowOverride]);
+  const [cursor, setCursor] = useState<MonthCursor>(() =>
+    monthCursorFromDate(now),
+  );
+
+  const { days, getTemplateForDate, setDayTemplate } = useMonthlyPlan();
+
+  // Templates + workouts are read synchronously from MMKV (no async
+  // network hop). We re-read on mount + whenever the MMKV key changes
+  // so edits from the Workouts screen reflect here without a full
+  // navigation cycle.
+  const [templates, setTemplates] = useState<WorkoutTemplate[]>(() =>
+    injectedTemplates ? [...injectedTemplates] : readTemplates(),
+  );
+  const [workouts, setWorkouts] = useState<PlannedWorkoutLike[]>(() =>
+    injectedWorkouts ? [...injectedWorkouts] : readWorkouts(),
+  );
+
+  useEffect(() => {
+    if (injectedTemplates || injectedWorkouts) return;
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((key) => {
+      if (key === TEMPLATES_STORAGE_KEY) setTemplates(readTemplates());
+      else if (key === WORKOUTS_STORAGE_KEY) setWorkouts(readWorkouts());
+    });
+    return () => sub.remove();
+  }, [injectedTemplates, injectedWorkouts]);
+
+  const plannedByDate = useMemo(
+    () => aggregatePlannedByDate(workouts),
+    [workouts],
+  );
+
+  const { cells } = useMemo(
+    () => monthGrid(cursor.y, cursor.m),
+    [cursor.y, cursor.m],
+  );
+
+  const monthTitle = useMemo(
+    () => formatMonthTitle(cursor.y, cursor.m),
+    [cursor.y, cursor.m],
+  );
+
+  const isEmpty = useMemo(
+    () =>
+      monthIsEmpty(
+        { reminderEnabled: true, reminderHour: 0, reminderMinute: 0, days },
+        plannedByDate,
+        cursor.y,
+        cursor.m,
+      ),
+    [days, plannedByDate, cursor.y, cursor.m],
+  );
+
+  const todayKey = useMemo(() => todayDateKey(now), [now]);
+  const [sheet, setSheet] = useState<OpenSheet | null>(null);
+
+  const go = useCallback((delta: number) => {
+    setCursor((c) => shiftMonthCursor(c, delta));
+  }, []);
+
+  const goToday = useCallback(() => {
+    setCursor(monthCursorFromDate(now));
+  }, [now]);
+
+  const openDay = useCallback(
+    (day: number) => {
+      const key = dateKeyFromYMD(cursor.y, cursor.m, day);
+      setSheet({
+        dateKey: key,
+        day,
+        templateId: getTemplateForDate(key),
+        planned: plannedByDate[key] ?? [],
+      });
+    },
+    [cursor.y, cursor.m, getTemplateForDate, plannedByDate],
+  );
+
+  const applySheet = useCallback(
+    (templateId: string | null) => {
+      if (!sheet) return;
+      setDayTemplate(sheet.dateKey, templateId);
+      setSheet(null);
+    },
+    [sheet, setDayTemplate],
+  );
+
+  const closeSheet = useCallback(() => setSheet(null), []);
+
   return (
-    <PagePlaceholder
-      title="План на місяць"
-      description="Календар тренувань по днях: шаблон на день, нагадування, інтеграція з Рутиною."
-      plannedFeatures={[
-        "Місячна сітка з шаблонами тренувань",
-        "Щоденні нагадування (expo-notifications)",
-        "Інтеграція з `showFizrukInCalendar` з HubSettings",
-        "Перенесення тренувань між днями (drag-and-drop → long-press menu)",
-      ]}
-      phaseHint="Фаза 6 · PR-G — PlanCalendar + Routine integration"
-    />
+    <SafeAreaView className="flex-1 bg-cream-50" edges={["bottom"]}>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 14 }}
+      >
+        <View>
+          <Text className="text-[22px] font-bold text-stone-900">
+            План на місяць
+          </Text>
+          <Text className="text-sm text-stone-500">
+            Шаблон тренування на кожен день + заплановані сесії.
+          </Text>
+        </View>
+
+        <Card radius="lg" padding="md">
+          <View className="flex-row items-center justify-between gap-2 mb-3">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Попередній місяць"
+              onPress={() => go(-1)}
+              className="w-10 h-10 rounded-xl border border-stone-200 items-center justify-center"
+            >
+              <Text className="text-lg text-stone-700">‹</Text>
+            </Pressable>
+            <Text className="text-base font-bold text-stone-900 capitalize">
+              {monthTitle}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Наступний місяць"
+              onPress={() => go(1)}
+              className="w-10 h-10 rounded-xl border border-stone-200 items-center justify-center"
+            >
+              <Text className="text-lg text-stone-700">›</Text>
+            </Pressable>
+          </View>
+
+          <View className="flex-row items-center justify-between mb-2">
+            <Text className="text-[11px] text-stone-500">
+              {days && Object.keys(days).length > 0
+                ? `${Object.keys(days).length} днів із шаблоном`
+                : "Ще немає призначених шаблонів"}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Перейти до поточного місяця"
+              onPress={goToday}
+              className="px-2 py-1 rounded-lg active:opacity-60"
+            >
+              <Text className="text-xs font-semibold text-teal-700">
+                Сьогодні
+              </Text>
+            </Pressable>
+          </View>
+
+          <View className="flex-row mb-1">
+            {WEEKDAYS.map((w) => (
+              <View key={w} className="w-[14.2857%] items-center">
+                <Text className="text-[10px] font-semibold text-stone-400">
+                  {w}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+          <View className="flex-row flex-wrap">
+            {cells.map((day, i) => {
+              if (day == null) {
+                return (
+                  <View key={`e-${i}`} className="w-[14.2857%] p-0.5">
+                    <View className="min-h-[52px] rounded-xl bg-stone-100/40" />
+                  </View>
+                );
+              }
+              const key = dateKeyFromYMD(cursor.y, cursor.m, day);
+              const tid = days[key]?.templateId;
+              const tpl = tid
+                ? (templates.find((t) => t.id === tid) ?? null)
+                : null;
+              const planned = plannedByDate[key] ?? [];
+              const isToday = key === todayKey;
+              const hasPlan = planned.length > 0;
+
+              const borderClass = isToday
+                ? "border-emerald-500 bg-emerald-50"
+                : hasPlan
+                  ? "border-emerald-400/60 bg-emerald-50/60"
+                  : "border-stone-200 bg-stone-100/40";
+
+              return (
+                <View key={key} className="w-[14.2857%] p-0.5">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`День ${day}`}
+                    onPress={() => openDay(day)}
+                    className={`min-h-[52px] rounded-xl border ${borderClass} p-1 items-center active:opacity-70`}
+                  >
+                    <Text className="text-xs font-bold text-stone-900">
+                      {day}
+                    </Text>
+                    {tpl ? (
+                      <Text
+                        numberOfLines={1}
+                        className="text-[9px] text-stone-500 leading-tight mt-0.5"
+                      >
+                        {tpl.name}
+                      </Text>
+                    ) : null}
+                    {hasPlan ? (
+                      <Text className="text-[9px] text-emerald-700 font-bold leading-tight mt-0.5">
+                        {planned.length > 1 ? `🏋 ×${planned.length}` : "🏋"}
+                      </Text>
+                    ) : null}
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+
+          <Text className="text-[11px] text-stone-500 mt-3">
+            Натисни день, щоб призначити або зняти шаблон.
+          </Text>
+        </Card>
+
+        {isEmpty ? (
+          <Card radius="lg" padding="lg">
+            <Text className="text-sm font-semibold text-stone-900">
+              Порожній місяць
+            </Text>
+            <Text className="text-xs text-stone-500 leading-snug mt-1">
+              Ще немає ні шаблонів на день, ні запланованих тренувань. Створи
+              перше тренування або шаблон — і вони з&apos;являться тут.
+            </Text>
+            <View className="mt-3">
+              <Button
+                variant="fizruk"
+                size="md"
+                onPress={() => router.push(fizrukRouteFor("workouts"))}
+                accessibilityLabel="Перейти до тренувань"
+              >
+                До тренувань
+              </Button>
+            </View>
+          </Card>
+        ) : null}
+      </ScrollView>
+
+      <Sheet
+        open={!!sheet}
+        onClose={closeSheet}
+        title={sheet ? formatSheetTitle(sheet.dateKey) : ""}
+        footer={
+          <Button
+            variant="ghost"
+            size="md"
+            onPress={closeSheet}
+            accessibilityLabel="Закрити"
+          >
+            Закрити
+          </Button>
+        }
+      >
+        {sheet ? (
+          <View className="gap-3">
+            {sheet.planned.length > 0 ? (
+              <View>
+                <Text className="text-xs font-bold text-emerald-700 mb-2">
+                  🏋 Заплановані тренування
+                </Text>
+                <View className="gap-2">
+                  {sheet.planned.map((w) => {
+                    const time = formatTime(
+                      typeof w.startedAt === "string" ? w.startedAt : null,
+                    );
+                    const itemNames = Array.isArray(w.items)
+                      ? w.items
+                          .map((it) => {
+                            const rec = it as {
+                              nameUk?: unknown;
+                              name?: unknown;
+                            };
+                            if (typeof rec.nameUk === "string")
+                              return rec.nameUk;
+                            if (typeof rec.name === "string") return rec.name;
+                            return null;
+                          })
+                          .filter((x): x is string => !!x)
+                      : [];
+                    return (
+                      <View
+                        key={w.id}
+                        className="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2"
+                      >
+                        <Text className="text-sm font-semibold text-stone-900">
+                          {time ? (
+                            <Text className="text-emerald-700">{time} </Text>
+                          ) : null}
+                          {typeof w.note === "string" && w.note
+                            ? w.note
+                            : "Тренування"}
+                        </Text>
+                        {itemNames.length > 0 ? (
+                          <Text className="text-xs text-stone-500 mt-0.5">
+                            {itemNames.join(" · ")}
+                          </Text>
+                        ) : null}
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+            ) : null}
+
+            <View>
+              <Text className="text-xs text-stone-500 mb-2">
+                Шаблон тренування
+              </Text>
+              <View className="gap-2">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Без плану"
+                  onPress={() => applySheet(null)}
+                  className={`px-3 py-3 rounded-xl border ${
+                    !sheet.templateId
+                      ? "border-emerald-500 bg-emerald-50"
+                      : "border-stone-200"
+                  }`}
+                >
+                  <Text className="text-sm text-stone-900">
+                    Без плану (вихідний)
+                  </Text>
+                </Pressable>
+                {templates.map((t) => (
+                  <Pressable
+                    key={t.id}
+                    accessibilityRole="button"
+                    accessibilityLabel={t.name}
+                    onPress={() => applySheet(t.id)}
+                    className={`px-3 py-3 rounded-xl border ${
+                      sheet.templateId === t.id
+                        ? "border-emerald-500 bg-emerald-50"
+                        : "border-stone-200"
+                    }`}
+                  >
+                    <Text className="text-sm text-stone-900">{t.name}</Text>
+                  </Pressable>
+                ))}
+              </View>
+              {templates.length === 0 ? (
+                <Text className="text-xs text-stone-500 mt-2">
+                  Спочатку створи шаблон у «Тренування → Шаблони».
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+      </Sheet>
+    </SafeAreaView>
   );
 }
 

--- a/packages/fizruk-domain/src/domain/plan/calendar.test.ts
+++ b/packages/fizruk-domain/src/domain/plan/calendar.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dateKeyFromDate,
+  dateKeyFromYMD,
+  monthCursorFromDate,
+  monthGrid,
+  parseDateKey,
+  shiftMonthCursor,
+  todayDateKey,
+} from "./calendar.js";
+
+describe("dateKeyFromYMD", () => {
+  it("zero-pads month and day", () => {
+    expect(dateKeyFromYMD(2025, 0, 1)).toBe("2025-01-01");
+    expect(dateKeyFromYMD(2025, 10, 9)).toBe("2025-11-09");
+  });
+});
+
+describe("dateKeyFromDate", () => {
+  it("uses local date components (no UTC shift)", () => {
+    expect(dateKeyFromDate(new Date(2025, 2, 15, 23, 30))).toBe("2025-03-15");
+  });
+});
+
+describe("todayDateKey", () => {
+  it("returns a YYYY-MM-DD string for the provided now", () => {
+    expect(todayDateKey(new Date(2025, 11, 31))).toBe("2025-12-31");
+  });
+});
+
+describe("parseDateKey", () => {
+  it("round-trips YYYY-MM-DD to a local Date noon-anchored", () => {
+    const d = parseDateKey("2025-06-15");
+    expect(d.getFullYear()).toBe(2025);
+    expect(d.getMonth()).toBe(5);
+    expect(d.getDate()).toBe(15);
+    expect(d.getHours()).toBe(12);
+  });
+});
+
+describe("monthCursorFromDate", () => {
+  it("extracts year + 0-indexed month", () => {
+    expect(monthCursorFromDate(new Date(2025, 4, 20))).toEqual({
+      y: 2025,
+      m: 4,
+    });
+  });
+});
+
+describe("shiftMonthCursor", () => {
+  it("shifts forward across a year boundary", () => {
+    expect(shiftMonthCursor({ y: 2025, m: 11 }, 1)).toEqual({ y: 2026, m: 0 });
+  });
+  it("shifts backward across a year boundary", () => {
+    expect(shiftMonthCursor({ y: 2025, m: 0 }, -1)).toEqual({ y: 2024, m: 11 });
+  });
+  it("handles large positive and negative deltas", () => {
+    expect(shiftMonthCursor({ y: 2025, m: 3 }, 25)).toEqual({ y: 2027, m: 4 });
+    expect(shiftMonthCursor({ y: 2025, m: 3 }, -25)).toEqual({ y: 2023, m: 2 });
+  });
+  it("is a no-op for delta 0", () => {
+    expect(shiftMonthCursor({ y: 2025, m: 6 }, 0)).toEqual({ y: 2025, m: 6 });
+  });
+});
+
+describe("monthGrid", () => {
+  it("pads leading nulls so day 1 aligns with its weekday column (Monday-first)", () => {
+    // 2025-03-01 is a Saturday → weekday index 5 in Monday-first ordering.
+    const { cells } = monthGrid(2025, 2);
+    expect(cells.slice(0, 5)).toEqual([null, null, null, null, null]);
+    expect(cells[5]).toBe(1);
+  });
+
+  it("contains each calendar day exactly once", () => {
+    const { cells } = monthGrid(2025, 1); // Feb 2025 (28 days)
+    const days = cells.filter((c) => c !== null);
+    expect(days).toEqual(Array.from({ length: 28 }, (_, i) => i + 1));
+  });
+
+  it("length is always a multiple of 7", () => {
+    for (let m = 0; m < 12; m++) {
+      const { cells } = monthGrid(2025, m);
+      expect(cells.length % 7).toBe(0);
+    }
+  });
+
+  it("handles a month that begins on Monday with no leading padding", () => {
+    // 2024-04-01 is Monday.
+    const { cells } = monthGrid(2024, 3);
+    expect(cells[0]).toBe(1);
+  });
+});

--- a/packages/fizruk-domain/src/domain/plan/calendar.ts
+++ b/packages/fizruk-domain/src/domain/plan/calendar.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure calendar helpers for the Fizruk monthly-plan view.
+ *
+ * Deliberately self-contained (no `routine-domain` dep) so `fizruk-domain`
+ * keeps a minimal footprint. Semantics match the web implementation in
+ * `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx` (Monday-first,
+ * local-time `YYYY-MM-DD` keys, padded trailing cells up to a multiple
+ * of 7 — *not* always 42). Callers that need a fixed 42-cell grid can
+ * pad on top of this.
+ */
+
+import type { MonthCursor, MonthGridResult } from "./types.js";
+
+/** Format a local-date `YYYY-MM-DD` key from `(year, monthIndex, day)`. */
+export function dateKeyFromYMD(
+  year: number,
+  monthIndex: number,
+  day: number,
+): string {
+  return `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Format a local-date `YYYY-MM-DD` key from a `Date`. */
+export function dateKeyFromDate(d: Date): string {
+  return dateKeyFromYMD(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+/**
+ * Current local date as a `YYYY-MM-DD` key. The `now` seam makes
+ * deterministic testing trivial (`todayDateKey(new Date("2025-03-15"))`).
+ */
+export function todayDateKey(now: Date = new Date()): string {
+  return dateKeyFromDate(now);
+}
+
+/** Parse a `YYYY-MM-DD` key into a local-time `Date` (noon-anchored). */
+export function parseDateKey(key: string): Date {
+  const [y, m, d] = key.split("-").map(Number);
+  const out = new Date(
+    Number.isFinite(y) ? y : 1970,
+    (Number.isFinite(m) ? m : 1) - 1,
+    Number.isFinite(d) ? d : 1,
+  );
+  out.setHours(12, 0, 0, 0);
+  return out;
+}
+
+/** Build a `MonthCursor` from a `Date`. */
+export function monthCursorFromDate(d: Date): MonthCursor {
+  return { y: d.getFullYear(), m: d.getMonth() };
+}
+
+/**
+ * Shift a `MonthCursor` by `delta` months, wrapping around year
+ * boundaries. `delta` may be any integer.
+ */
+export function shiftMonthCursor(c: MonthCursor, delta: number): MonthCursor {
+  const total = c.y * 12 + c.m + delta;
+  const y = Math.floor(total / 12);
+  const m = ((total % 12) + 12) % 12;
+  return { y, m };
+}
+
+/**
+ * Monday-first month grid. Padded with leading `null` cells to align
+ * day-1 on its weekday column and trailing `null` cells to a multiple
+ * of 7 so the final row is never short. Matches the legacy web
+ * implementation exactly.
+ */
+export function monthGrid(year: number, monthIndex: number): MonthGridResult {
+  const last = new Date(year, monthIndex + 1, 0).getDate();
+  const firstWd = (new Date(year, monthIndex, 1).getDay() + 6) % 7;
+  const cells: Array<number | null> = [];
+  for (let i = 0; i < firstWd; i++) cells.push(null);
+  for (let d = 1; d <= last; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+  return { cells };
+}

--- a/packages/fizruk-domain/src/domain/plan/index.ts
+++ b/packages/fizruk-domain/src/domain/plan/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Barrel for the Fizruk monthly-plan sub-domain.
+ *
+ * Exposes:
+ *  - Types: `MonthlyPlanState`, `MonthlyPlanDay`, `PlannedWorkoutLike`,
+ *    `PlannedByDate`, `MonthCursor`, `MonthGridResult`.
+ *  - Calendar helpers: `monthGrid`, `dateKeyFromYMD`, `dateKeyFromDate`,
+ *    `parseDateKey`, `todayDateKey`, `monthCursorFromDate`,
+ *    `shiftMonthCursor`.
+ *  - State lifecycle: `defaultMonthlyPlanState`, `normalizeMonthlyPlanState`,
+ *    `serializeMonthlyPlanState`.
+ *  - Reducers: `applySetDayTemplate`, `applySetReminder`,
+ *    `applySetReminderEnabled`.
+ *  - Selectors: `getTemplateForDate`, `getTodayTemplateId`,
+ *    `aggregatePlannedByDate`, `countPlannedDaysInMonth`,
+ *    `countPlannedTemplatesInMonth`, `monthIsEmpty`.
+ */
+
+export * from "./types.js";
+export * from "./calendar.js";
+export * from "./state.js";
+export * from "./reducers.js";
+export * from "./selectors.js";

--- a/packages/fizruk-domain/src/domain/plan/reducers.test.ts
+++ b/packages/fizruk-domain/src/domain/plan/reducers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySetDayTemplate,
+  applySetReminder,
+  applySetReminderEnabled,
+} from "./reducers.js";
+import { defaultMonthlyPlanState } from "./state.js";
+
+describe("applySetDayTemplate", () => {
+  it("assigns a new template for a previously empty date", () => {
+    const base = defaultMonthlyPlanState();
+    const next = applySetDayTemplate(base, "2025-03-15", "tpl_a");
+    expect(next).not.toBe(base);
+    expect(next.days["2025-03-15"]).toEqual({ templateId: "tpl_a" });
+  });
+
+  it("replaces the template for an existing date", () => {
+    const base = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    const next = applySetDayTemplate(base, "2025-03-15", "tpl_b");
+    expect(next.days["2025-03-15"]).toEqual({ templateId: "tpl_b" });
+  });
+
+  it("clears the entry for null / empty templateId", () => {
+    const base = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    const cleared = applySetDayTemplate(base, "2025-03-15", null);
+    expect(cleared.days["2025-03-15"]).toBeUndefined();
+    const cleared2 = applySetDayTemplate(base, "2025-03-15", "");
+    expect(cleared2.days["2025-03-15"]).toBeUndefined();
+  });
+
+  it("is a no-op (same reference) when assigning the same templateId", () => {
+    const base = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    const same = applySetDayTemplate(base, "2025-03-15", "tpl_a");
+    expect(same).toBe(base);
+  });
+
+  it("is a no-op (same reference) when clearing an already-empty date", () => {
+    const base = defaultMonthlyPlanState();
+    const same = applySetDayTemplate(base, "2025-03-15", null);
+    expect(same).toBe(base);
+  });
+
+  it("leaves unrelated dates untouched", () => {
+    const base = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    const next = applySetDayTemplate(base, "2025-03-16", "tpl_b");
+    expect(next.days["2025-03-15"]).toEqual({ templateId: "tpl_a" });
+    expect(next.days["2025-03-16"]).toEqual({ templateId: "tpl_b" });
+  });
+});
+
+describe("applySetReminder", () => {
+  it("clamps hour to [0,23] and minute to [0,59]", () => {
+    const next = applySetReminder(defaultMonthlyPlanState(), 99, -5);
+    expect(next.reminderHour).toBe(23);
+    expect(next.reminderMinute).toBe(0);
+  });
+
+  it("returns the same reference for a no-op update", () => {
+    const base = defaultMonthlyPlanState();
+    const same = applySetReminder(base, base.reminderHour, base.reminderMinute);
+    expect(same).toBe(base);
+  });
+
+  it("truncates fractional inputs", () => {
+    const next = applySetReminder(defaultMonthlyPlanState(), 7.9, 30.4);
+    expect(next.reminderHour).toBe(7);
+    expect(next.reminderMinute).toBe(30);
+  });
+});
+
+describe("applySetReminderEnabled", () => {
+  it("toggles the reminder", () => {
+    const base = defaultMonthlyPlanState();
+    expect(base.reminderEnabled).toBe(true);
+    const off = applySetReminderEnabled(base, false);
+    expect(off.reminderEnabled).toBe(false);
+    const on = applySetReminderEnabled(off, true);
+    expect(on.reminderEnabled).toBe(true);
+  });
+
+  it("is a no-op for unchanged truthy values", () => {
+    const base = defaultMonthlyPlanState();
+    const same = applySetReminderEnabled(base, true);
+    expect(same).toBe(base);
+  });
+});

--- a/packages/fizruk-domain/src/domain/plan/reducers.ts
+++ b/packages/fizruk-domain/src/domain/plan/reducers.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure reducers for `MonthlyPlanState` mutations.
+ *
+ * All reducers are structurally-stable: if the mutation would be a
+ * no-op they return the *same* state reference so React hooks can
+ * short-circuit the persist round-trip.
+ */
+
+import type { MonthlyPlanState } from "./types.js";
+
+/** Set (or clear, when `templateId` is `null`/`""`) the template for a date. */
+export function applySetDayTemplate(
+  state: MonthlyPlanState,
+  dateKey: string,
+  templateId: string | null | undefined,
+): MonthlyPlanState {
+  const cleared = templateId == null || templateId === "";
+  const existing = state.days[dateKey];
+
+  if (cleared) {
+    if (!existing) return state;
+    const nextDays = { ...state.days };
+    delete nextDays[dateKey];
+    return { ...state, days: nextDays };
+  }
+
+  if (existing && existing.templateId === templateId) return state;
+  return {
+    ...state,
+    days: { ...state.days, [dateKey]: { templateId } },
+  };
+}
+
+/** Update reminder time (hour / minute). Clamps out-of-range values. */
+export function applySetReminder(
+  state: MonthlyPlanState,
+  hour: number,
+  minute: number,
+): MonthlyPlanState {
+  const nextHour = Math.max(0, Math.min(23, Math.trunc(hour)));
+  const nextMinute = Math.max(0, Math.min(59, Math.trunc(minute)));
+  if (state.reminderHour === nextHour && state.reminderMinute === nextMinute) {
+    return state;
+  }
+  return { ...state, reminderHour: nextHour, reminderMinute: nextMinute };
+}
+
+/** Toggle the reminder on/off. Coerces truthy/falsy values to a bool. */
+export function applySetReminderEnabled(
+  state: MonthlyPlanState,
+  enabled: boolean,
+): MonthlyPlanState {
+  const next = !!enabled;
+  if (state.reminderEnabled === next) return state;
+  return { ...state, reminderEnabled: next };
+}

--- a/packages/fizruk-domain/src/domain/plan/selectors.test.ts
+++ b/packages/fizruk-domain/src/domain/plan/selectors.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregatePlannedByDate,
+  countPlannedDaysInMonth,
+  countPlannedTemplatesInMonth,
+  getTemplateForDate,
+  getTodayTemplateId,
+  monthIsEmpty,
+} from "./selectors.js";
+import { applySetDayTemplate } from "./reducers.js";
+import { defaultMonthlyPlanState } from "./state.js";
+import type { PlannedWorkoutLike } from "./types.js";
+
+describe("getTemplateForDate", () => {
+  it("returns the templateId for assigned dates, null otherwise", () => {
+    const state = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    expect(getTemplateForDate(state, "2025-03-15")).toBe("tpl_a");
+    expect(getTemplateForDate(state, "2025-03-16")).toBeNull();
+  });
+});
+
+describe("getTodayTemplateId", () => {
+  it("uses the injected `now` to look up today's template", () => {
+    const state = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-15",
+      "tpl_a",
+    );
+    expect(getTodayTemplateId(state, new Date(2025, 2, 15, 9))).toBe("tpl_a");
+    expect(getTodayTemplateId(state, new Date(2025, 2, 16, 9))).toBeNull();
+  });
+});
+
+describe("aggregatePlannedByDate", () => {
+  const sample: PlannedWorkoutLike[] = [
+    { id: "a", planned: true, startedAt: "2025-03-15T08:00:00.000Z" },
+    { id: "b", planned: true, startedAt: "2025-03-15T18:30:00.000Z" },
+    { id: "c", planned: true, startedAt: "2025-03-16T10:00:00.000Z" },
+    { id: "d", planned: false, startedAt: "2025-03-17T10:00:00.000Z" },
+    { id: "e", planned: true, startedAt: null },
+    { id: "f", planned: true }, // no startedAt
+    { id: "g", planned: true, startedAt: "bad" }, // too short
+  ];
+
+  it("buckets planned workouts by YYYY-MM-DD prefix and preserves input order", () => {
+    const map = aggregatePlannedByDate(sample);
+    expect(Object.keys(map).sort()).toEqual(["2025-03-15", "2025-03-16"]);
+    expect(map["2025-03-15"].map((w) => w.id)).toEqual(["a", "b"]);
+    expect(map["2025-03-16"].map((w) => w.id)).toEqual(["c"]);
+  });
+
+  it("ignores non-planned workouts, null/undefined startedAt, and bad keys", () => {
+    const map = aggregatePlannedByDate(sample);
+    expect(map["2025-03-17"]).toBeUndefined();
+    expect(map["bad"]).toBeUndefined();
+  });
+
+  it("returns an empty map for null/undefined/empty input", () => {
+    expect(aggregatePlannedByDate(null)).toEqual({});
+    expect(aggregatePlannedByDate(undefined)).toEqual({});
+    expect(aggregatePlannedByDate([])).toEqual({});
+  });
+});
+
+describe("countPlannedDaysInMonth", () => {
+  it("counts distinct dates with ≥1 planned workout inside the month", () => {
+    const map = aggregatePlannedByDate([
+      { id: "a", planned: true, startedAt: "2025-03-01T08:00:00Z" },
+      { id: "b", planned: true, startedAt: "2025-03-15T08:00:00Z" },
+      { id: "c", planned: true, startedAt: "2025-03-15T18:00:00Z" },
+      { id: "d", planned: true, startedAt: "2025-04-02T08:00:00Z" },
+    ]);
+    expect(countPlannedDaysInMonth(map, 2025, 2)).toBe(2); // March
+    expect(countPlannedDaysInMonth(map, 2025, 3)).toBe(1); // April
+    expect(countPlannedDaysInMonth(map, 2025, 0)).toBe(0); // January
+  });
+});
+
+describe("countPlannedTemplatesInMonth", () => {
+  it("counts templated dates inside the month", () => {
+    let state = defaultMonthlyPlanState();
+    state = applySetDayTemplate(state, "2025-03-05", "tpl_a");
+    state = applySetDayTemplate(state, "2025-03-20", "tpl_b");
+    state = applySetDayTemplate(state, "2025-04-01", "tpl_c");
+    expect(countPlannedTemplatesInMonth(state, 2025, 2)).toBe(2);
+    expect(countPlannedTemplatesInMonth(state, 2025, 3)).toBe(1);
+    expect(countPlannedTemplatesInMonth(state, 2025, 0)).toBe(0);
+  });
+});
+
+describe("monthIsEmpty", () => {
+  it("is true when there are neither templates nor planned workouts", () => {
+    expect(monthIsEmpty(defaultMonthlyPlanState(), {}, 2025, 2)).toBe(true);
+  });
+
+  it("is false when at least one template is assigned", () => {
+    const state = applySetDayTemplate(
+      defaultMonthlyPlanState(),
+      "2025-03-05",
+      "tpl_a",
+    );
+    expect(monthIsEmpty(state, {}, 2025, 2)).toBe(false);
+  });
+
+  it("is false when at least one planned workout exists", () => {
+    const map = aggregatePlannedByDate([
+      { id: "a", planned: true, startedAt: "2025-03-05T08:00:00Z" },
+    ]);
+    expect(monthIsEmpty(defaultMonthlyPlanState(), map, 2025, 2)).toBe(false);
+  });
+});

--- a/packages/fizruk-domain/src/domain/plan/selectors.ts
+++ b/packages/fizruk-domain/src/domain/plan/selectors.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure selectors over `MonthlyPlanState` + planned-workout lists.
+ *
+ * These mirror the `useMemo` bodies of the legacy web `PlanCalendar`
+ * (aggregation of planned workouts by date, today's template lookup,
+ * etc.) so both platforms stay byte-identical in their computed views.
+ */
+
+import { dateKeyFromYMD, todayDateKey } from "./calendar.js";
+import type {
+  MonthlyPlanState,
+  PlannedByDate,
+  PlannedWorkoutLike,
+} from "./types.js";
+
+/** Template id assigned to a given date (or `null` when unset). */
+export function getTemplateForDate(
+  state: MonthlyPlanState,
+  dateKey: string,
+): string | null {
+  return state.days[dateKey]?.templateId ?? null;
+}
+
+/**
+ * Template id assigned to today (or `null`). Accepts a `now` seam so
+ * tests can freeze the clock without stubbing `Date` globally.
+ */
+export function getTodayTemplateId(
+  state: MonthlyPlanState,
+  now: Date = new Date(),
+): string | null {
+  return getTemplateForDate(state, todayDateKey(now));
+}
+
+/**
+ * Bucket `workouts[]` into a `{ [dateKey]: Workout[] }` map keyed by
+ * the local-date prefix of `startedAt`. Only `planned` workouts with
+ * a non-empty `startedAt` contribute; order within a bucket follows
+ * the input array so callers can sort upstream if they need to.
+ *
+ * Matches the web `plannedByDate` memo in
+ * `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx`.
+ */
+export function aggregatePlannedByDate(
+  workouts: readonly PlannedWorkoutLike[] | null | undefined,
+): PlannedByDate {
+  const out: PlannedByDate = {};
+  if (!workouts) return out;
+  for (const w of workouts) {
+    if (!w || w.planned !== true) continue;
+    const started = typeof w.startedAt === "string" ? w.startedAt : "";
+    if (started.length < 10) continue;
+    const key = started.slice(0, 10);
+    const list = out[key];
+    if (list) list.push(w);
+    else out[key] = [w];
+  }
+  return out;
+}
+
+/** Count of dates in `(year, monthIndex)` that have ≥1 planned workout. */
+export function countPlannedDaysInMonth(
+  plannedByDate: PlannedByDate,
+  year: number,
+  monthIndex: number,
+): number {
+  const last = new Date(year, monthIndex + 1, 0).getDate();
+  let n = 0;
+  for (let d = 1; d <= last; d++) {
+    const k = dateKeyFromYMD(year, monthIndex, d);
+    const list = plannedByDate[k];
+    if (list && list.length > 0) n++;
+  }
+  return n;
+}
+
+/** Count of dates in `(year, monthIndex)` that have a template assigned. */
+export function countPlannedTemplatesInMonth(
+  state: MonthlyPlanState,
+  year: number,
+  monthIndex: number,
+): number {
+  const last = new Date(year, monthIndex + 1, 0).getDate();
+  let n = 0;
+  for (let d = 1; d <= last; d++) {
+    const k = dateKeyFromYMD(year, monthIndex, d);
+    if (state.days[k]?.templateId) n++;
+  }
+  return n;
+}
+
+/**
+ * `true` when the month at `(year, monthIndex)` has no planned
+ * workouts *and* no assigned templates — i.e. the calendar grid is
+ * entirely empty and callers can render an empty-state CTA.
+ */
+export function monthIsEmpty(
+  state: MonthlyPlanState,
+  plannedByDate: PlannedByDate,
+  year: number,
+  monthIndex: number,
+): boolean {
+  return (
+    countPlannedTemplatesInMonth(state, year, monthIndex) === 0 &&
+    countPlannedDaysInMonth(plannedByDate, year, monthIndex) === 0
+  );
+}

--- a/packages/fizruk-domain/src/domain/plan/state.test.ts
+++ b/packages/fizruk-domain/src/domain/plan/state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultMonthlyPlanState,
+  normalizeMonthlyPlanState,
+  serializeMonthlyPlanState,
+} from "./state.js";
+
+describe("defaultMonthlyPlanState", () => {
+  it("enables reminders at 18:00 with no assigned days", () => {
+    expect(defaultMonthlyPlanState()).toEqual({
+      reminderEnabled: true,
+      reminderHour: 18,
+      reminderMinute: 0,
+      days: {},
+    });
+  });
+
+  it("returns a fresh object on each call (no shared mutation)", () => {
+    const a = defaultMonthlyPlanState();
+    const b = defaultMonthlyPlanState();
+    expect(a).not.toBe(b);
+    expect(a.days).not.toBe(b.days);
+  });
+});
+
+describe("normalizeMonthlyPlanState", () => {
+  it("returns defaults for null/undefined/garbage", () => {
+    expect(normalizeMonthlyPlanState(null)).toEqual(defaultMonthlyPlanState());
+    expect(normalizeMonthlyPlanState(undefined)).toEqual(
+      defaultMonthlyPlanState(),
+    );
+    expect(normalizeMonthlyPlanState("oops")).toEqual(
+      defaultMonthlyPlanState(),
+    );
+    expect(normalizeMonthlyPlanState(42)).toEqual(defaultMonthlyPlanState());
+  });
+
+  it("clamps out-of-range reminderHour / reminderMinute", () => {
+    const s = normalizeMonthlyPlanState({
+      reminderHour: 99,
+      reminderMinute: -5,
+    });
+    expect(s.reminderHour).toBe(23);
+    expect(s.reminderMinute).toBe(0);
+  });
+
+  it("coerces reminderEnabled to a boolean (default true)", () => {
+    expect(normalizeMonthlyPlanState({}).reminderEnabled).toBe(true);
+    expect(
+      normalizeMonthlyPlanState({ reminderEnabled: false }).reminderEnabled,
+    ).toBe(false);
+  });
+
+  it("keeps well-formed day entries, drops malformed ones", () => {
+    const s = normalizeMonthlyPlanState({
+      days: {
+        "2025-03-03": { templateId: "tpl_a" },
+        "2025-03-04": { templateId: "" }, // empty id → drop
+        "2025-03-05": { templateId: 42 }, // wrong type → drop
+        "2025-03-06": null, // not an object → drop
+        "2025-03-07": { templateId: "tpl_b" },
+      },
+    });
+    expect(s.days).toEqual({
+      "2025-03-03": { templateId: "tpl_a" },
+      "2025-03-07": { templateId: "tpl_b" },
+    });
+  });
+
+  it("is idempotent", () => {
+    const payload = {
+      reminderEnabled: true,
+      reminderHour: 7,
+      reminderMinute: 30,
+      days: { "2025-03-03": { templateId: "tpl_a" } },
+    };
+    const once = normalizeMonthlyPlanState(payload);
+    expect(normalizeMonthlyPlanState(once)).toEqual(once);
+  });
+});
+
+describe("serializeMonthlyPlanState", () => {
+  it("round-trips via JSON", () => {
+    const s = {
+      reminderEnabled: false,
+      reminderHour: 7,
+      reminderMinute: 15,
+      days: { "2025-03-03": { templateId: "tpl_a" } },
+    };
+    const raw = serializeMonthlyPlanState(s);
+    expect(normalizeMonthlyPlanState(JSON.parse(raw))).toEqual(s);
+  });
+});

--- a/packages/fizruk-domain/src/domain/plan/state.ts
+++ b/packages/fizruk-domain/src/domain/plan/state.ts
@@ -1,0 +1,68 @@
+/**
+ * Load / normalise / serialise helpers for `MonthlyPlanState`.
+ *
+ * Pure — no `localStorage`, no MMKV, no `window`. Apps hand us whatever
+ * `JSON.parse(raw)` produced (or `null` on a fresh install) and we
+ * return a safe `MonthlyPlanState`.
+ */
+
+import type { MonthlyPlanDay, MonthlyPlanState } from "./types.js";
+
+const DEFAULT_HOUR = 18;
+const DEFAULT_MINUTE = 0;
+
+/** Blank plan state for a fresh install. */
+export function defaultMonthlyPlanState(): MonthlyPlanState {
+  return {
+    reminderEnabled: true,
+    reminderHour: DEFAULT_HOUR,
+    reminderMinute: DEFAULT_MINUTE,
+    days: {},
+  };
+}
+
+function clampHour(v: unknown): number {
+  const n = typeof v === "number" && Number.isFinite(v) ? v : DEFAULT_HOUR;
+  return Math.max(0, Math.min(23, Math.trunc(n)));
+}
+
+function clampMinute(v: unknown): number {
+  const n = typeof v === "number" && Number.isFinite(v) ? v : DEFAULT_MINUTE;
+  return Math.max(0, Math.min(59, Math.trunc(n)));
+}
+
+function normalizeDays(raw: unknown): Record<string, MonthlyPlanDay> {
+  if (!raw || typeof raw !== "object") return {};
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, MonthlyPlanDay> = {};
+  for (const key of Object.keys(src)) {
+    const entry = src[key];
+    if (!entry || typeof entry !== "object") continue;
+    const templateId = (entry as { templateId?: unknown }).templateId;
+    if (typeof templateId !== "string" || templateId === "") continue;
+    out[key] = { templateId };
+  }
+  return out;
+}
+
+/**
+ * Normalise arbitrary JSON (parsed MMKV/localStorage payload) into a
+ * `MonthlyPlanState`. Missing / malformed fields fall back to defaults;
+ * unknown extras are dropped. Idempotent — `normalizeMonthlyPlanState`
+ * applied twice yields the same value as once.
+ */
+export function normalizeMonthlyPlanState(raw: unknown): MonthlyPlanState {
+  if (!raw || typeof raw !== "object") return defaultMonthlyPlanState();
+  const src = raw as Record<string, unknown>;
+  return {
+    reminderEnabled: src.reminderEnabled !== false,
+    reminderHour: clampHour(src.reminderHour),
+    reminderMinute: clampMinute(src.reminderMinute),
+    days: normalizeDays(src.days),
+  };
+}
+
+/** JSON-serialise a `MonthlyPlanState` for persistence. */
+export function serializeMonthlyPlanState(state: MonthlyPlanState): string {
+  return JSON.stringify(state);
+}

--- a/packages/fizruk-domain/src/domain/plan/types.ts
+++ b/packages/fizruk-domain/src/domain/plan/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Types for the monthly plan (calendar) sub-domain of Fizruk.
+ *
+ * Pure / DOM-free. Shared by the web `useMonthlyPlan` hook and the
+ * mobile `useMonthlyPlan` / `PlanCalendar` screen. All storage I/O
+ * lives in the respective apps — this file only describes shapes.
+ */
+
+/** A single day's monthly-plan entry. */
+export interface MonthlyPlanDay {
+  /** Id of the `WorkoutTemplate` assigned to this date. */
+  templateId: string;
+}
+
+/**
+ * Persisted monthly-plan state.
+ *
+ * - `days` is keyed by local ISO date (`"YYYY-MM-DD"`).
+ * - `reminderHour` / `reminderMinute` use local wall-clock time
+ *   (0–23 / 0–59). Validation lives in `reducers.applySetReminder`.
+ */
+export interface MonthlyPlanState {
+  reminderEnabled: boolean;
+  reminderHour: number;
+  reminderMinute: number;
+  days: Record<string, MonthlyPlanDay>;
+}
+
+/**
+ * Loose shape for "a workout record we can bucket by date". Both the
+ * web `useWorkouts` payload and the mobile MMKV-backed list satisfy it;
+ * anything beyond `startedAt` / `planned` is untyped here so callers
+ * can pass their full `Workout` through without casting.
+ */
+export interface PlannedWorkoutLike {
+  id: string;
+  startedAt?: string | null;
+  planned?: boolean | null;
+  note?: string | null;
+  items?: Array<{ id: string } & Record<string, unknown>> | null;
+  [key: string]: unknown;
+}
+
+/** Map of local-date key → ordered list of planned workouts on that date. */
+export type PlannedByDate = Record<string, PlannedWorkoutLike[]>;
+
+/** Calendar cursor (year + 0-indexed month) used by `monthGrid`. */
+export interface MonthCursor {
+  y: number;
+  m: number;
+}
+
+/** Result of `monthGrid(y, m)` — 6×7 = 42-cell Monday-first grid. */
+export interface MonthGridResult {
+  cells: Array<number | null>;
+}


### PR DESCRIPTION
## Summary

Phase 6 / PR-G of the React Native migration: port the Fizruk **PlanCalendar** page (monthly training plan) from web to mobile and extract its pure state + date logic into `@sergeant/fizruk-domain` so both platforms share the same `MonthlyPlanState` semantics.

### What lands

- **New pure domain module** `@sergeant/fizruk-domain/domain/plan/*`:
  - `types.ts` — `MonthlyPlanDay`, `MonthlyPlanState`, `PlannedWorkoutLike`, `MonthCursor`, `MonthGridResult`, `PlannedByDate`.
  - `calendar.ts` — Monday-first `monthGrid(y, m)`, `dateKeyFromYMD` / `dateKeyFromDate` / `parseDateKey`, `monthCursorFromDate`, `shiftMonthCursor`, `todayDateKey`.
  - `state.ts` — `defaultMonthlyPlanState`, `normalizeMonthlyPlanState` (clamps hour `[0..23]` / minute `[0..59]`, normalises days map), `serializeMonthlyPlanState`.
  - `reducers.ts` — `applySetDayTemplate`, `applySetReminder`, `applySetReminderEnabled`. All return the same reference on no-ops so React state setters short-circuit.
  - `selectors.ts` — `getTemplateForDate`, `getTodayTemplateId`, `aggregatePlannedByDate`, `countPlannedDaysInMonth`, `countPlannedTemplatesInMonth`, `monthIsEmpty`.
  - 42 new Vitest tests (`calendar.test.ts` · 13, `state.test.ts` · 8, `reducers.test.ts` · 11, `selectors.test.ts` · 10). Full `packages/fizruk-domain` suite: **100 / 100 green**.

- **Mobile hook** `apps/mobile/src/modules/fizruk/hooks/useMonthlyPlan.ts`:
  - Mirrors the web hook's public shape (`reminderEnabled`, `reminderHour`, `reminderMinute`, `days`, `getTemplateForDate`, `todayTemplateId`, `setDayTemplate`, `setReminder`, `setReminderEnabled`, `refresh`).
  - MMKV-backed via `@/lib/storage` (`safeReadLS` / `safeWriteLS` + `_getMMKVInstance().addOnValueChangedListener`).
  - All normalisation + mutation logic is delegated to the pure domain reducers so mobile and web can't drift.

- **Mobile screen** `apps/mobile/src/modules/fizruk/pages/PlanCalendar.tsx` (replaces the 27-LOC `PagePlaceholder` stub):
  - Monday-first month grid, 7 × 6 cells with null padding.
  - Per-day cell shows `day`, the assigned template name (if any), and a 🏋 badge with the planned-workout count. Today's cell is highlighted emerald; days with ≥1 planned workout get a softer emerald tint.
  - Month navigation via ‹ / › chevrons + a "Сьогодні" quick-action that snaps the cursor back to the current month.
  - Tap-day opens a bottom `Sheet` showing the planned workouts for that date and a radio-style list of `WorkoutTemplate`s (pulled from MMKV under `TEMPLATES_STORAGE_KEY`). Selecting a row persists via `setDayTemplate` and closes the sheet; the top "Без плану (вихідний)" row clears the template.
  - Empty-state card renders when the month has zero templates and zero planned workouts, with a CTA that `router.push`-es to `/fizruk/workouts`.
  - Re-reads templates + workouts when either MMKV key changes, so edits from the Workouts screen reflect without a full navigation cycle.

- **Jest tests** `apps/mobile/src/modules/fizruk/pages/PlanCalendar.test.tsx` (6 tests):
  - Empty-state CTA routes to `/fizruk/workouts`.
  - Empty-state is hidden when ≥2 planned days exist in the month.
  - Tap-day opens the sheet, selecting a template writes `{ days: { [dateKey]: { templateId } } }` to MMKV.
  - ‹ / › chevrons move the cursor and the grid updates accordingly.
  - "Сьогодні" quick-action snaps the cursor back.
  - MMKV-loaded state re-hydrates on mount (template name renders under the matching day).

### Intentionally OUT of scope

- **Recovery-forecast section** (`forecastFullRecoveryByDate`) from the web version — it needs `useExerciseCatalog` + `useRecovery` on mobile and neither is ported yet. The fizruk `lib/recoveryCompute.ts` / `lib/recoveryForecast.ts` modules also have pre-existing implicit-`any` parameters that can't be pulled through the mobile strict-TS barrel today. Will land with a dedicated follow-up once those hooks exist.
- **Reminder settings UI** (`reminderEnabled` / `reminderHour` / `reminderMinute`) — the hook surfaces the state + mutations but the UI is deferred to the Fizruk settings PR.
- **Drag-and-drop between days** — the placeholder mentioned it as "long-press menu"; not in scope for this PR.

### Wiring notes

- `apps/mobile/app/(tabs)/fizruk/plan.tsx` is already a thin wrapper from PR #450 and required no changes.
- All `@sergeant/fizruk-domain` imports use **subpath entrypoints** (`/constants`, `/domain/plan/index`, `/domain/types`) matching the pattern in `Workouts.tsx` / `Atlas.tsx` / `FizrukSection.tsx` — this avoids pulling the non-strict `lib/*.ts` files through the top-level barrel under mobile's strict `tsc`.
- No root-level dependencies added. `jest.config.js`, `tsconfig.json`, and `package.json` in `apps/mobile` are untouched.
- `apps/web/**`, `apps/mobile/src/modules/fizruk/pages/Progress.tsx`, `apps/mobile/src/modules/fizruk/components/progress/**`, and `apps/mobile/src/modules/routine/**` are untouched (parallel sessions).

### Test results (`pnpm check` — green)

- `pnpm format:check` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
  - `packages/fizruk-domain` — **100 / 100** Vitest (42 new in `domain/plan/*`)
  - `apps/mobile` — **35 suites / 183 tests** Jest (6 new in `PlanCalendar.test.tsx`)
- `pnpm build` ✅

## Review & Testing Checklist for Human

- [ ] Skim `packages/fizruk-domain/src/domain/plan/state.ts` to confirm the `normalizeMonthlyPlanState` clamps + validation match web expectations for pre-existing MMKV payloads (the same shape is shared across platforms).
- [ ] On a device / simulator, tap a day, assign a template, re-open the sheet and confirm the selected template stays highlighted and persists across app restart (MMKV write).
- [ ] Navigate forward ≥2 months then tap "Сьогодні" — grid should snap back to the current month and today's cell should be visibly highlighted.
- [ ] Confirm the empty-state CTA navigates to the Workouts tab (`/fizruk/workouts`) when the month has no templates and no planned workouts.

### Notes

- Pure logic is the contract boundary: `aggregatePlannedByDate` + `monthGrid` produce the same buckets on web and mobile; any visual diff between platforms comes from JSX / NativeWind, not domain logic.
- The MMKV change listener in `PlanCalendar.tsx` is scoped — it only re-reads templates / workouts when injected props are absent, so the jest `templates` / `workouts` props bypass it deterministically.


Link to Devin session: https://app.devin.ai/sessions/d55e21ef19b3451bbb6d5dcfc28a085e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
