### PR TITLE
feat(fizruk-mobile): PR-E — PhotoProgress page

### DIFF
--- a/apps/mobile/app/(tabs)/fizruk/photos.tsx
+++ b/apps/mobile/app/(tabs)/fizruk/photos.tsx
@@ -1,0 +1,14 @@
+/**
+ * `/fizruk/photos` — Body-photo progress screen (Phase 6 · PR-E).
+ *
+ * Thin wrapper around `@/modules/fizruk/pages/Photos`. All logic lives
+ * in the module so the route file stays a no-op entry point, matching
+ * the convention the other Fizruk routes use (index, progress,
+ * measurements, …).
+ */
+
+import { Photos } from "@/modules/fizruk/pages/Photos";
+
+export default function FizrukPhotosRoute() {
+  return <Photos />;
+}

--- a/apps/mobile/src/modules/fizruk/components/photos/PhotoGallery.tsx
+++ b/apps/mobile/src/modules/fizruk/components/photos/PhotoGallery.tsx
@@ -1,0 +1,85 @@
+/**
+ * Fizruk — PhotoGallery (React Native).
+ *
+ * Grid of photo thumbnails grouped by month, rendered inside the parent
+ * screen's `ScrollView`. Taps on a thumbnail delegate to `onOpen` so
+ * the page owns viewer state — this component is a pure presentational
+ * view on top of `PhotoMonthGroup[]`.
+ *
+ * Uses the built-in `Image` component for rendering; once `expo-image`
+ * is added in the follow-up PR we'll swap to it for cached decoding
+ * and memory win on large grids. The switch is local — parent API
+ * doesn't change.
+ */
+
+import { Image, Pressable, Text, View } from "react-native";
+
+import type {
+  BodyPhotoMeta,
+  PhotoMonthGroup,
+} from "@sergeant/fizruk-domain/domain/photos/index";
+
+export interface PhotoGalleryProps {
+  groups: readonly PhotoMonthGroup[];
+  onOpen: (photo: BodyPhotoMeta) => void;
+  /** Accessibility label prefix for thumbnails. Defaults to "Фото". */
+  thumbnailLabel?: string;
+}
+
+export function PhotoGallery({
+  groups,
+  onOpen,
+  thumbnailLabel = "Фото",
+}: PhotoGalleryProps) {
+  return (
+    <View className="gap-4" testID="fizruk-photos-gallery">
+      {groups.map((group) => (
+        <View key={group.monthKey} className="gap-2">
+          <Text
+            className="text-xs font-semibold text-stone-500 uppercase"
+            accessibilityRole="header"
+          >
+            {group.label}
+          </Text>
+          <View className="flex-row flex-wrap -mx-1">
+            {group.photos.map((photo) => (
+              <View
+                key={photo.id}
+                style={{ width: "33.3333%" }}
+                className="px-1 mb-2"
+              >
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`${thumbnailLabel} ${photo.takenAt}`}
+                  testID={`fizruk-photo-thumb-${photo.id}`}
+                  onPress={() => onOpen(photo)}
+                  className="rounded-xl overflow-hidden bg-cream-100 border border-cream-300"
+                  style={{ aspectRatio: 3 / 4 }}
+                >
+                  <Image
+                    source={{ uri: photo.uri }}
+                    style={{ width: "100%", height: "100%" }}
+                    resizeMode="cover"
+                    accessibilityIgnoresInvertColors
+                  />
+                  {photo.note ? (
+                    <View className="absolute left-1 right-1 bottom-1 rounded-md bg-black/50 px-1.5 py-0.5">
+                      <Text
+                        className="text-[10px] text-white"
+                        numberOfLines={1}
+                      >
+                        {photo.note}
+                      </Text>
+                    </View>
+                  ) : null}
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export default PhotoGallery;

--- a/apps/mobile/src/modules/fizruk/components/photos/PhotoViewer.tsx
+++ b/apps/mobile/src/modules/fizruk/components/photos/PhotoViewer.tsx
@@ -1,0 +1,157 @@
+/**
+ * Fizruk — PhotoViewer (React Native).
+ *
+ * Full-screen modal that renders a single `BodyPhotoMeta` with prev /
+ * next chevrons driving the sibling navigation through
+ * `neighborPhoto` from `@sergeant/fizruk-domain/domain/photos`. Also
+ * exposes a "delete" action so the host screen can wire it to
+ * `useBodyPhotos().remove`.
+ *
+ * This component is intentionally imperative about what it renders —
+ * swipe-to-change (using `react-native-gesture-handler`) is a nice-to-
+ * have for a later PR; the chevrons + hardware back already satisfy
+ * the PR-E scope and they're deterministic under jest-native.
+ */
+
+import { useCallback } from "react";
+import {
+  Image,
+  Modal,
+  Pressable,
+  SafeAreaView,
+  Text,
+  View,
+} from "react-native";
+
+import {
+  formatTakenAtLabel,
+  neighborPhoto,
+  type BodyPhotoMeta,
+} from "@sergeant/fizruk-domain/domain/photos/index";
+
+export interface PhotoViewerProps {
+  /** Whole gallery the viewer navigates through (already sorted). */
+  photos: readonly BodyPhotoMeta[];
+  /** Currently-displayed photo — also drives `open`. */
+  current: BodyPhotoMeta | null;
+  onClose: () => void;
+  onChange: (next: BodyPhotoMeta) => void;
+  onDelete: (photo: BodyPhotoMeta) => void;
+}
+
+export function PhotoViewer({
+  photos,
+  current,
+  onClose,
+  onChange,
+  onDelete,
+}: PhotoViewerProps) {
+  const goDelta = useCallback(
+    (delta: number) => {
+      if (!current) return;
+      const next = neighborPhoto(photos, current.id, delta);
+      if (next) onChange(next);
+    },
+    [photos, current, onChange],
+  );
+
+  const canPrev = current
+    ? neighborPhoto(photos, current.id, -1) !== null
+    : false;
+  const canNext = current
+    ? neighborPhoto(photos, current.id, +1) !== null
+    : false;
+
+  const open = current !== null;
+
+  return (
+    <Modal
+      visible={open}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <SafeAreaView className="flex-1 bg-black" testID="fizruk-photo-viewer">
+        {current ? (
+          <View className="flex-1">
+            <View className="flex-row items-center justify-between px-4 py-3">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Закрити фото"
+                testID="fizruk-photo-viewer-close"
+                onPress={onClose}
+                className="h-11 w-11 items-center justify-center rounded-full bg-white/10"
+              >
+                <Text className="text-white text-lg">✕</Text>
+              </Pressable>
+              <Text className="text-white text-sm font-semibold">
+                {formatTakenAtLabel(current.takenAt)}
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Видалити фото"
+                testID="fizruk-photo-viewer-delete"
+                onPress={() => onDelete(current)}
+                className="h-11 w-11 items-center justify-center rounded-full bg-white/10"
+              >
+                <Text className="text-white text-lg">🗑</Text>
+              </Pressable>
+            </View>
+
+            <View className="flex-1 items-center justify-center">
+              <Image
+                source={{ uri: current.uri }}
+                style={{ width: "100%", height: "100%" }}
+                resizeMode="contain"
+                accessibilityIgnoresInvertColors
+                testID={`fizruk-photo-viewer-image-${current.id}`}
+              />
+            </View>
+
+            {current.note ? (
+              <View className="px-4 pb-2">
+                <Text className="text-white/90 text-xs">{current.note}</Text>
+              </View>
+            ) : null}
+
+            <View className="flex-row items-center justify-between px-4 pb-4">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Попереднє фото"
+                accessibilityState={{ disabled: !canPrev }}
+                testID="fizruk-photo-viewer-prev"
+                disabled={!canPrev}
+                onPress={() => goDelta(-1)}
+                className={`h-12 px-5 items-center justify-center rounded-full ${
+                  canPrev ? "bg-white/15" : "bg-white/5 opacity-40"
+                }`}
+              >
+                <Text className="text-white text-sm font-semibold">
+                  ‹ Попереднє
+                </Text>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Наступне фото"
+                accessibilityState={{ disabled: !canNext }}
+                testID="fizruk-photo-viewer-next"
+                disabled={!canNext}
+                onPress={() => goDelta(+1)}
+                className={`h-12 px-5 items-center justify-center rounded-full ${
+                  canNext ? "bg-white/15" : "bg-white/5 opacity-40"
+                }`}
+              >
+                <Text className="text-white text-sm font-semibold">
+                  Наступне ›
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+export default PhotoViewer;

--- a/apps/mobile/src/modules/fizruk/hooks/photoFileStore.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/photoFileStore.ts
@@ -1,0 +1,108 @@
+/**
+ * Fizruk — body-photo BLOB storage adapter (mobile).
+ *
+ * The web app stored photo BLOBs as base64 data URLs in IndexedDB. On
+ * React Native that pattern is a non-starter: MMKV is a tight key/value
+ * store, not a BLOB bucket, and stuffing large base64 strings in it
+ * balloons memory. The canonical layout on mobile is:
+ *
+ *   `FileSystem.documentDirectory + "fizruk/photos/<id>.jpg"`
+ *
+ * with only the lightweight metadata (`BodyPhotoMeta`) persisted in
+ * MMKV. This module is the thin adapter that the `useBodyPhotos` hook
+ * talks to so the React layer never has to know about `expo-file-system`
+ * directly.
+ *
+ * ────────────────────────────────────────────────────────────────────
+ * NOTE (Phase 6 / PR-E): `expo-file-system` is NOT in
+ * `apps/mobile/package.json` yet — per the PR spec we ship the Photos
+ * page with a stubbed BLOB pipeline and a clear TODO. The stub
+ * preserves the metadata-only MMKV contract so the follow-up PR that
+ * adds `expo-file-system` + `expo-image-picker` can swap in the real
+ * implementation without touching `useBodyPhotos` / `Photos.tsx` /
+ * `PhotoGallery.tsx` / `PhotoViewer.tsx`.
+ *
+ * The stub:
+ *  - `persistSourceUri` returns the input URI untouched. When callers
+ *    pass a URI that already lives inside the app sandbox (e.g. a
+ *    test fixture or a `file://` URI synthesised by the caller), the
+ *    metadata points at that URI directly.
+ *  - `deletePersistedUri` is a no-op (no file to clean up).
+ *
+ * When `expo-file-system` is wired up (follow-up PR):
+ *  - `persistSourceUri` MUST:
+ *      1. `await FileSystem.makeDirectoryAsync(photosDir, { intermediates: true })`
+ *      2. `await FileSystem.copyAsync({ from: sourceUri, to: targetUri })`
+ *      3. return `targetUri` so the hook writes that to MMKV.
+ *  - `deletePersistedUri` MUST:
+ *      - `await FileSystem.deleteAsync(uri, { idempotent: true })`
+ * ────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Logical directory under `FileSystem.documentDirectory` that owns
+ * body-photo BLOBs. Exported so the follow-up PR can build the
+ * `file://…` URI without re-hard-coding the string.
+ */
+export const PHOTOS_SUBDIR = "fizruk/photos";
+
+/** File extension we use for persisted photos. */
+export const PHOTOS_FILE_EXTENSION = "jpg";
+
+/**
+ * Build the target URI a persisted photo lives at. Exported so both
+ * this module (stub + real impl) and any future migration tooling
+ * (e.g. Android 14 storage-scoped relocation) converge on the same
+ * naming convention.
+ *
+ * @param documentDirectory Root sandbox dir. On mobile this is
+ *   `expo-file-system`'s `documentDirectory`. Pass `""` in the stub.
+ * @param id Photo id the caller minted.
+ */
+export function buildPhotoUri(documentDirectory: string, id: string): string {
+  const sep =
+    documentDirectory === "" || documentDirectory.endsWith("/") ? "" : "/";
+  return `${documentDirectory}${sep}${PHOTOS_SUBDIR}/${id}.${PHOTOS_FILE_EXTENSION}`;
+}
+
+/**
+ * Copy a source URI (typically returned by `expo-image-picker`) into
+ * the app's persistent photo directory and return the canonical URI
+ * the hook should write to MMKV.
+ *
+ * STUB: returns the input URI unchanged until `expo-file-system`
+ * lands. Safe to call from tests and UI code alike — no I/O is
+ * performed.
+ */
+export async function persistSourceUri(
+  sourceUri: string,
+  _id: string,
+): Promise<string> {
+  // TODO(fizruk-mobile, PR-E follow-up): import `expo-file-system` and
+  // copy `sourceUri` → `buildPhotoUri(FileSystem.documentDirectory,
+  // _id)`. Keep the signature identical so `useBodyPhotos` does not
+  // change. See the header comment for the full step list.
+  return sourceUri;
+}
+
+/**
+ * Delete the BLOB that backs a persisted photo.
+ *
+ * STUB: no-op. The follow-up PR routes this through
+ * `FileSystem.deleteAsync(uri, { idempotent: true })`.
+ */
+export async function deletePersistedUri(_uri: string): Promise<void> {
+  // TODO(fizruk-mobile, PR-E follow-up): `await
+  // FileSystem.deleteAsync(uri, { idempotent: true })`. No-op until
+  // the dep lands so deletion on the metadata side stays in sync with
+  // file-side cleanup once it's wired up.
+}
+
+/**
+ * Clear every BLOB under `PHOTOS_SUBDIR`. Used by the hook's `clear`
+ * CRUD op. Stub = no-op for the same reason as above.
+ */
+export async function clearAllPersistedPhotos(): Promise<void> {
+  // TODO(fizruk-mobile, PR-E follow-up): recursively delete
+  // `FileSystem.documentDirectory + PHOTOS_SUBDIR`.
+}

--- a/apps/mobile/src/modules/fizruk/hooks/useBodyPhotos.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/useBodyPhotos.ts
@@ -1,0 +1,224 @@
+/**
+ * Fizruk — `useBodyPhotos` hook (mobile).
+ *
+ * Native-first port of `apps/web/src/modules/fizruk/hooks/useBodyPhotos.ts`.
+ * Differences from the web hook:
+ *
+ * - **Storage backend.** Web stored the full photo BLOB as a base64
+ *   `dataUrl` in IndexedDB. Mobile writes only the lightweight
+ *   `BodyPhotoMeta` records to MMKV (via the shared `@/lib/storage`
+ *   helpers) and persists the BLOB on disk through the
+ *   `photoFileStore` adapter (see `photoFileStore.ts`).
+ * - **Ordering is delegated.** The web hook did an ad-hoc `localeCompare`
+ *   inside the reducer. Mobile (and the web port once it catches up)
+ *   calls `sortPhotosLatestFirst` from
+ *   `@sergeant/fizruk-domain/domain/photos` so the sort contract is
+ *   covered by vitest and shared across platforms.
+ * - **Sync API.** MMKV is synchronous, so the hook returns the current
+ *   value immediately on first render — no loading flash, `ready` is
+ *   always `true` on the mobile return. We keep the flag in the return
+ *   shape for parity with the web hook.
+ *
+ * CRUD surface: `list`, `add`, `update`, `remove`, `clear`. `photos` is
+ * the sorted snapshot; `list()` is a convenience accessor that returns
+ * the same value for callers that prefer calling a method.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { BODY_PHOTOS_STORAGE_KEY } from "@sergeant/fizruk-domain/constants";
+import {
+  filterValidPhotos,
+  sortPhotosLatestFirst,
+  type BodyPhotoMeta,
+} from "@sergeant/fizruk-domain/domain/photos/index";
+
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+
+import {
+  clearAllPersistedPhotos,
+  deletePersistedUri,
+  persistSourceUri,
+} from "./photoFileStore";
+
+/**
+ * Input shape for `add` — the picker (once wired) hands the hook a
+ * source URI; the hook is responsible for persisting the BLOB and
+ * writing the metadata row.
+ */
+export interface AddBodyPhotoInput {
+  /** Source URI from the image picker / camera. */
+  sourceUri: string;
+  /** ISO date-only string ("YYYY-MM-DD") — defaults to the current day. */
+  takenAt?: string;
+  /** Optional user-supplied note. */
+  note?: string;
+  /** Optional weight-in-kg snapshot. */
+  weightKg?: number;
+}
+
+/** Patch shape for `update` — id is passed separately. */
+export type UpdateBodyPhotoPatch = Partial<
+  Pick<BodyPhotoMeta, "takenAt" | "note" | "weightKg">
+>;
+
+export interface UseBodyPhotosReturn {
+  /** Sorted-latest-first snapshot. */
+  photos: BodyPhotoMeta[];
+  /** Always `true` on mobile (MMKV is sync) — kept for API parity. */
+  ready: boolean;
+  /** Same value as `photos`, exposed as a method for call-site taste. */
+  list: () => BodyPhotoMeta[];
+  /** Persist a new photo. Returns the written record. */
+  add: (input: AddBodyPhotoInput) => Promise<BodyPhotoMeta>;
+  /** Patch an existing record. No-op + resolves to `null` on unknown id. */
+  update: (
+    id: string,
+    patch: UpdateBodyPhotoPatch,
+  ) => Promise<BodyPhotoMeta | null>;
+  /** Delete a record and its on-disk BLOB. */
+  remove: (id: string) => Promise<void>;
+  /** Delete every record and wipe the photo directory. */
+  clear: () => Promise<void>;
+}
+
+/**
+ * Dependency-injection seam for jest tests. Production code passes
+ * nothing and the hook falls back to `Date.now()` / `Math.random()`.
+ */
+export interface UseBodyPhotosOptions {
+  /** Clock seam — defaults to `new Date()`. */
+  now?: () => Date;
+  /** Id seam — defaults to a time-prefixed base-36 string. */
+  generateId?: () => string;
+}
+
+function todayDateKey(clock: () => Date): string {
+  const d = clock();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function defaultIdFactory(clock: () => Date): () => string {
+  return () =>
+    `ph_${clock().getTime().toString(36)}_${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+}
+
+function readPhotos(): BodyPhotoMeta[] {
+  const raw = safeReadLS<unknown>(BODY_PHOTOS_STORAGE_KEY, []);
+  return sortPhotosLatestFirst(filterValidPhotos(raw));
+}
+
+function writePhotos(photos: readonly BodyPhotoMeta[]): void {
+  safeWriteLS(BODY_PHOTOS_STORAGE_KEY, photos);
+}
+
+export function useBodyPhotos(
+  options: UseBodyPhotosOptions = {},
+): UseBodyPhotosReturn {
+  const clock = useMemo(() => options.now ?? (() => new Date()), [options.now]);
+  const generateId = useMemo(
+    () => options.generateId ?? defaultIdFactory(clock),
+    [options.generateId, clock],
+  );
+
+  const [photos, setPhotos] = useState<BodyPhotoMeta[]>(() => readPhotos());
+
+  useEffect(() => {
+    // React to writes that originate outside the hook (e.g. a future
+    // settings screen that clears the photo store). MMKV's listener
+    // fires on every `set` — cheap enough to just re-read.
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((key) => {
+      if (key !== BODY_PHOTOS_STORAGE_KEY) return;
+      setPhotos(readPhotos());
+    });
+    return () => sub.remove();
+  }, []);
+
+  const list = useCallback(() => photos, [photos]);
+
+  const add = useCallback(
+    async (input: AddBodyPhotoInput): Promise<BodyPhotoMeta> => {
+      const id = generateId();
+      const createdAt = clock().toISOString();
+      const uri = await persistSourceUri(input.sourceUri, id);
+      const meta: BodyPhotoMeta = {
+        id,
+        takenAt: input.takenAt || todayDateKey(clock),
+        createdAt,
+        uri,
+      };
+      if (input.note && input.note.length > 0) meta.note = input.note;
+      if (typeof input.weightKg === "number" && Number.isFinite(input.weightKg))
+        meta.weightKg = input.weightKg;
+
+      const next = sortPhotosLatestFirst([meta, ...photos]);
+      writePhotos(next);
+      setPhotos(next);
+      return meta;
+    },
+    [clock, generateId, photos],
+  );
+
+  const update = useCallback(
+    async (
+      id: string,
+      patch: UpdateBodyPhotoPatch,
+    ): Promise<BodyPhotoMeta | null> => {
+      const existing = photos.find((p) => p.id === id);
+      if (!existing) return null;
+      const merged: BodyPhotoMeta = {
+        ...existing,
+        ...(patch.takenAt !== undefined ? { takenAt: patch.takenAt } : null),
+      };
+      // Scalar optional fields: an explicit `undefined` patch clears the
+      // field, a defined value replaces it.
+      if ("note" in patch) {
+        if (patch.note && patch.note.length > 0) merged.note = patch.note;
+        else delete merged.note;
+      }
+      if ("weightKg" in patch) {
+        if (
+          typeof patch.weightKg === "number" &&
+          Number.isFinite(patch.weightKg)
+        ) {
+          merged.weightKg = patch.weightKg;
+        } else {
+          delete merged.weightKg;
+        }
+      }
+      const next = sortPhotosLatestFirst(
+        photos.map((p) => (p.id === id ? merged : p)),
+      );
+      writePhotos(next);
+      setPhotos(next);
+      return merged;
+    },
+    [photos],
+  );
+
+  const remove = useCallback(
+    async (id: string): Promise<void> => {
+      const target = photos.find((p) => p.id === id);
+      if (!target) return;
+      const next = photos.filter((p) => p.id !== id);
+      writePhotos(next);
+      setPhotos(next);
+      await deletePersistedUri(target.uri);
+    },
+    [photos],
+  );
+
+  const clear = useCallback(async (): Promise<void> => {
+    writePhotos([]);
+    setPhotos([]);
+    await clearAllPersistedPhotos();
+  }, []);
+
+  return { photos, ready: true, list, add, update, remove, clear };
+}

--- a/apps/mobile/src/modules/fizruk/pages/Photos.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Photos.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Render + interaction tests for `pages/Photos.tsx` (Phase 6 / PR-E).
+ *
+ * Covers the four invariants called out in the PR spec:
+ *   1. Empty-state renders when no photos exist.
+ *   2. A 3-photo gallery renders every thumbnail (plus the month
+ *      heading above them).
+ *   3. Tapping a thumbnail opens the full-screen viewer and shows the
+ *      tapped photo.
+ *   4. Pressing the viewer's "delete" action invokes the hook's
+ *      `remove` CRUD op with the right id.
+ *
+ * The Photos page pulls from `useBodyPhotos`, which goes through
+ * `@/lib/storage` (MMKV) and the local `photoFileStore` adapter. Rather
+ * than mock both modules for every test, the page exposes a
+ * `photosAdapter` prop that matches the hook's return type — we inject
+ * a fake adapter with spy callbacks so tests only exercise the screen
+ * logic. The follow-up PR (once `expo-file-system` / `expo-image-picker`
+ * land) will add integration coverage that exercises the hook end-to-
+ * end with `jest.mock("expo-file-system", …)` + `jest.mock(
+ * "expo-image-picker", …)` — placeholders below call out the shape
+ * that mock must have.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { BodyPhotoMeta } from "@sergeant/fizruk-domain/domain/photos/index";
+
+import { Photos } from "./Photos";
+import type { UseBodyPhotosReturn } from "../hooks/useBodyPhotos";
+
+// The Photos page uses `SafeAreaView` from `react-native-safe-area-context`.
+// Other suites in this module stub it the same way — keep parity so the
+// screen renders under jest-expo's node env.
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// TODO(fizruk-mobile, PR-E follow-up): once `expo-file-system` +
+// `expo-image-picker` are in `apps/mobile/package.json`, add:
+//
+//   jest.mock("expo-file-system", () => ({
+//     documentDirectory: "file:///sandbox/",
+//     makeDirectoryAsync: jest.fn(() => Promise.resolve()),
+//     copyAsync: jest.fn(() => Promise.resolve()),
+//     deleteAsync: jest.fn(() => Promise.resolve()),
+//   }));
+//   jest.mock("expo-image-picker", () => ({
+//     requestMediaLibraryPermissionsAsync: jest.fn(() =>
+//       Promise.resolve({ granted: true }),
+//     ),
+//     launchImageLibraryAsync: jest.fn(() =>
+//       Promise.resolve({ canceled: false, assets: [{ uri: "file:///picked.jpg" }] }),
+//     ),
+//   }));
+//
+// Those mocks stay scoped to the integration tests that exercise the
+// real `useBodyPhotos` / `photoFileStore` modules end-to-end.
+
+function photo(
+  partial: Partial<BodyPhotoMeta> & { id: string },
+): BodyPhotoMeta {
+  return {
+    takenAt: "2026-04-10",
+    createdAt: "2026-04-10T08:00:00.000Z",
+    uri: `file:///photos/${partial.id}.jpg`,
+    ...partial,
+  };
+}
+
+function adapter(overrides: Partial<UseBodyPhotosReturn>): UseBodyPhotosReturn {
+  const photos = overrides.photos ?? [];
+  return {
+    photos,
+    ready: true,
+    list: () => photos,
+    add: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(async () => {}),
+    clear: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("Fizruk Photos screen (mobile)", () => {
+  it("renders the empty-state card when no photos exist", () => {
+    const { getByTestId, queryByTestId } = render(
+      <Photos photosAdapter={adapter({ photos: [] })} />,
+    );
+
+    expect(getByTestId("fizruk-photos-screen")).toBeTruthy();
+    expect(getByTestId("fizruk-photos-empty")).toBeTruthy();
+    expect(queryByTestId("fizruk-photos-gallery")).toBeNull();
+    expect(queryByTestId("fizruk-photo-viewer")).toBeNull();
+    expect(getByTestId("fizruk-photos-add")).toBeTruthy();
+  });
+
+  it("renders the gallery with every thumbnail when photos are present", () => {
+    const photos: BodyPhotoMeta[] = [
+      photo({ id: "p1", takenAt: "2026-04-01" }),
+      photo({ id: "p2", takenAt: "2026-04-15", note: "Тиждень 2" }),
+      photo({ id: "p3", takenAt: "2026-03-20" }),
+    ];
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <Photos photosAdapter={adapter({ photos })} />,
+    );
+
+    expect(queryByTestId("fizruk-photos-empty")).toBeNull();
+    expect(getByTestId("fizruk-photos-gallery")).toBeTruthy();
+    // Every thumbnail is mounted — the gallery does not virtualise.
+    expect(getByTestId("fizruk-photo-thumb-p1")).toBeTruthy();
+    expect(getByTestId("fizruk-photo-thumb-p2")).toBeTruthy();
+    expect(getByTestId("fizruk-photo-thumb-p3")).toBeTruthy();
+    // Month headings from `groupPhotosByMonth` are rendered (latest
+    // month first).
+    expect(getByText("квітень 2026")).toBeTruthy();
+    expect(getByText("березень 2026")).toBeTruthy();
+  });
+
+  it("opens the full-screen viewer when a thumbnail is tapped", () => {
+    const photos: BodyPhotoMeta[] = [
+      photo({ id: "p1", takenAt: "2026-04-01" }),
+      photo({ id: "p2", takenAt: "2026-04-15" }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <Photos photosAdapter={adapter({ photos })} />,
+    );
+
+    // Viewer is not mounted until a thumbnail is tapped.
+    expect(queryByTestId("fizruk-photo-viewer")).toBeNull();
+
+    fireEvent.press(getByTestId("fizruk-photo-thumb-p1"));
+    expect(getByTestId("fizruk-photo-viewer")).toBeTruthy();
+    expect(getByTestId("fizruk-photo-viewer-image-p1")).toBeTruthy();
+  });
+
+  it("removes the entry when the viewer's delete action is pressed", async () => {
+    const removeSpy = jest.fn(async (_id: string) => {});
+    const photos: BodyPhotoMeta[] = [
+      photo({ id: "p1", takenAt: "2026-04-01" }),
+      photo({ id: "p2", takenAt: "2026-04-15" }),
+    ];
+
+    const { getByTestId } = render(
+      <Photos photosAdapter={adapter({ photos, remove: removeSpy })} />,
+    );
+
+    fireEvent.press(getByTestId("fizruk-photo-thumb-p2"));
+    fireEvent.press(getByTestId("fizruk-photo-viewer-delete"));
+
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledWith("p2");
+  });
+});

--- a/apps/mobile/src/modules/fizruk/pages/Photos.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Photos.tsx
@@ -1,0 +1,162 @@
+/**
+ * Fizruk / Photos — body-photo progress screen (Phase 6 · PR-E).
+ *
+ * Mobile port of `apps/web/src/modules/fizruk/components/PhotoProgress.tsx`
+ * scoped to the PR-E deliverables (gallery grid + full-screen viewer +
+ * add flow). The before/after `CompareSlider` that web renders inline
+ * will follow in a dedicated UI PR — the pure `pairBeforeAfterOfMonth`
+ * selector is already shipped in `@sergeant/fizruk-domain` so the UI
+ * port is a pure addition.
+ *
+ * BLOB storage lives under `FileSystem.documentDirectory +
+ * "fizruk/photos/<id>.jpg"` (see `hooks/photoFileStore.ts`). Metadata
+ * lives in MMKV under the `BODY_PHOTOS_STORAGE_KEY` constant shipped
+ * in `@sergeant/fizruk-domain/constants`.
+ *
+ * IMPORTANT: `expo-image-picker` / `expo-file-system` / `expo-image`
+ * are NOT yet in `apps/mobile/package.json`. Per the PR-E spec we
+ * ship the screen with a stubbed "+ Додати" button (disabled with a
+ * visible TODO) + data-URI-friendly thumbnails. A follow-up PR swaps
+ * the stub for a real picker without touching the page structure.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  groupPhotosByMonth,
+  sortPhotosLatestFirst,
+  type BodyPhotoMeta,
+} from "@sergeant/fizruk-domain/domain/photos/index";
+
+import { Card } from "@/components/ui/Card";
+
+import { PhotoGallery } from "../components/photos/PhotoGallery";
+import { PhotoViewer } from "../components/photos/PhotoViewer";
+import { useBodyPhotos } from "../hooks/useBodyPhotos";
+import type { UseBodyPhotosReturn } from "../hooks/useBodyPhotos";
+
+export interface PhotosProps {
+  /**
+   * Dependency-injected hook return for jest tests / storybook. When
+   * omitted the screen reads from the real `useBodyPhotos` hook.
+   */
+  photosAdapter?: UseBodyPhotosReturn;
+}
+
+export function Photos({ photosAdapter }: PhotosProps = {}) {
+  const liveAdapter = useBodyPhotos();
+  const adapter: UseBodyPhotosReturn = photosAdapter ?? liveAdapter;
+  const { photos, remove } = adapter;
+
+  const sorted = useMemo(() => sortPhotosLatestFirst(photos), [photos]);
+  const groups = useMemo(() => groupPhotosByMonth(sorted), [sorted]);
+
+  const [viewerId, setViewerId] = useState<string | null>(null);
+  const current = useMemo(
+    () => sorted.find((p) => p.id === viewerId) ?? null,
+    [sorted, viewerId],
+  );
+
+  const handleOpen = useCallback((photo: BodyPhotoMeta) => {
+    setViewerId(photo.id);
+  }, []);
+
+  const handleClose = useCallback(() => setViewerId(null), []);
+
+  const handleChange = useCallback((next: BodyPhotoMeta) => {
+    setViewerId(next.id);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (photo: BodyPhotoMeta) => {
+      // Close first so the viewer unmounts synchronously — prevents a
+      // flash of a missing image before the parent re-renders with the
+      // shorter list.
+      setViewerId(null);
+      await remove(photo.id);
+    },
+    [remove],
+  );
+
+  const empty = sorted.length === 0;
+
+  return (
+    <SafeAreaView
+      className="flex-1 bg-cream-50"
+      edges={["bottom"]}
+      testID="fizruk-photos-screen"
+    >
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 96, gap: 12 }}
+      >
+        <View className="gap-1">
+          <Text className="text-[22px] font-bold text-stone-900">
+            Фото-прогрес
+          </Text>
+          <Text className="text-sm text-stone-600 leading-snug">
+            Додавай фото раз на тиждень — тут збережеться повна стрічка прогресу
+            по місяцях.
+          </Text>
+        </View>
+
+        {empty ? (
+          <Card
+            radius="lg"
+            padding="xl"
+            className="items-center"
+            testID="fizruk-photos-empty"
+          >
+            <Text className="text-3xl mb-2">{"📸"}</Text>
+            <Text className="text-sm font-semibold text-stone-900 mb-1">
+              {"Додай перше фото прогресу"}
+            </Text>
+            <Text className="text-xs text-stone-500 text-center">
+              {
+                "Коли додаси хоча б одне фото, воно зʼявиться в сітці нижче та у повноекранному перегляді"
+              }
+            </Text>
+          </Card>
+        ) : (
+          <PhotoGallery groups={groups} onOpen={handleOpen} />
+        )}
+
+        {/*
+         * `expo-image-picker` is NOT yet in `apps/mobile/package.json`.
+         * We ship the screen with a disabled stub so reviewers can see
+         * the visual and the intent. Follow-up PR adds the dep and
+         * swaps `disabled` for the real `launchImageLibraryAsync` call.
+         */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Додати фото"
+          accessibilityState={{ disabled: true }}
+          testID="fizruk-photos-add"
+          disabled
+          className="h-12 rounded-2xl border border-dashed border-teal-300 bg-teal-50/60 items-center justify-center opacity-70"
+        >
+          <Text className="text-sm font-semibold text-teal-700">
+            + Додати фото (скоро)
+          </Text>
+        </Pressable>
+        <Text className="text-[10px] text-stone-400 text-center">
+          {
+            "Фаза 6 · PR-E — сторінка з галереєю, переглядачем і CRUD-гуком. Кнопка додавання під'єднається у наступному PR разом із expo-image-picker."
+          }
+        </Text>
+      </ScrollView>
+
+      <PhotoViewer
+        photos={sorted}
+        current={current}
+        onClose={handleClose}
+        onChange={handleChange}
+        onDelete={handleDelete}
+      />
+    </SafeAreaView>
+  );
+}
+
+export default Photos;

--- a/packages/fizruk-domain/src/constants.ts
+++ b/packages/fizruk-domain/src/constants.ts
@@ -5,6 +5,7 @@
  * `apps/mobile` (React Native).
  */
 
+export const BODY_PHOTOS_STORAGE_KEY = "fizruk_body_photos_v1";
 export const WORKOUTS_STORAGE_KEY = "fizruk_workouts_v1";
 export const CUSTOM_EXERCISES_KEY = "fizruk_custom_exercises_v1";
 export const MEASUREMENTS_STORAGE_KEY = "fizruk_measurements_v1";

--- a/packages/fizruk-domain/src/domain/index.ts
+++ b/packages/fizruk-domain/src/domain/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export * from "./progress/index.js";
+export * from "./photos/index.js";

--- a/packages/fizruk-domain/src/domain/photos/helpers.test.ts
+++ b/packages/fizruk-domain/src/domain/photos/helpers.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterValidPhotos,
+  formatMonthLabel,
+  formatTakenAtLabel,
+  getPhotoIndex,
+  groupPhotosByMonth,
+  isDateKey,
+  isMonthKey,
+  monthKeyFromTakenAt,
+  neighborPhoto,
+  pairBeforeAfterOfMonth,
+  sortPhotosLatestFirst,
+} from "./helpers.js";
+import type { BodyPhotoMeta } from "./types.js";
+
+function photo(
+  partial: Partial<BodyPhotoMeta> & { id: string },
+): BodyPhotoMeta {
+  return {
+    takenAt: "2026-04-10",
+    createdAt: "2026-04-10T08:00:00.000Z",
+    uri: `file:///photos/${partial.id}.jpg`,
+    ...partial,
+  };
+}
+
+describe("isDateKey / isMonthKey", () => {
+  it("accepts well-formed YYYY-MM-DD and YYYY-MM keys", () => {
+    expect(isDateKey("2026-04-21")).toBe(true);
+    expect(isMonthKey("2026-04")).toBe(true);
+  });
+
+  it("rejects malformed or non-string input", () => {
+    expect(isDateKey("2026/04/21")).toBe(false);
+    expect(isDateKey("2026-4-21")).toBe(false);
+    expect(isDateKey(undefined)).toBe(false);
+    expect(isMonthKey("April 2026")).toBe(false);
+    expect(isMonthKey(20260421)).toBe(false);
+  });
+});
+
+describe("monthKeyFromTakenAt", () => {
+  it("returns the YYYY-MM prefix for a valid takenAt", () => {
+    expect(monthKeyFromTakenAt("2026-04-10")).toBe("2026-04");
+    expect(monthKeyFromTakenAt("2025-12-31")).toBe("2025-12");
+  });
+
+  it("returns null for malformed input", () => {
+    expect(monthKeyFromTakenAt("2026/04/10")).toBeNull();
+    expect(monthKeyFromTakenAt("")).toBeNull();
+  });
+});
+
+describe("formatMonthLabel / formatTakenAtLabel", () => {
+  it("formats a month key in Ukrainian nominative", () => {
+    expect(formatMonthLabel("2026-04")).toBe("квітень 2026");
+    expect(formatMonthLabel("2025-01")).toBe("січень 2025");
+    expect(formatMonthLabel("2024-12")).toBe("грудень 2024");
+  });
+
+  it("formats a date key as day + genitive month + year", () => {
+    expect(formatTakenAtLabel("2026-04-12")).toBe("12 квітня 2026");
+    expect(formatTakenAtLabel("2025-01-05")).toBe("5 січня 2025");
+  });
+
+  it("returns the raw input on malformed values", () => {
+    expect(formatMonthLabel("foo")).toBe("foo");
+    expect(formatMonthLabel("2026-13")).toBe("2026-13");
+    expect(formatTakenAtLabel("bar")).toBe("bar");
+  });
+});
+
+describe("sortPhotosLatestFirst", () => {
+  it("puts the most recent takenAt first", () => {
+    const sorted = sortPhotosLatestFirst([
+      photo({ id: "a", takenAt: "2026-03-01" }),
+      photo({ id: "b", takenAt: "2026-04-21" }),
+      photo({ id: "c", takenAt: "2026-01-15" }),
+    ]);
+    expect(sorted.map((p) => p.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("breaks ties by createdAt then id", () => {
+    const sorted = sortPhotosLatestFirst([
+      photo({
+        id: "z",
+        takenAt: "2026-04-10",
+        createdAt: "2026-04-10T08:00:00.000Z",
+      }),
+      photo({
+        id: "a",
+        takenAt: "2026-04-10",
+        createdAt: "2026-04-10T09:00:00.000Z",
+      }),
+      photo({
+        id: "m",
+        takenAt: "2026-04-10",
+        createdAt: "2026-04-10T08:00:00.000Z",
+      }),
+    ]);
+    // "a" wins on createdAt, then "m" before "z" on id tiebreak.
+    expect(sorted.map((p) => p.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      photo({ id: "b", takenAt: "2026-04-01" }),
+      photo({ id: "a", takenAt: "2026-05-01" }),
+    ];
+    const snap = [...input];
+    sortPhotosLatestFirst(input);
+    expect(input).toEqual(snap);
+  });
+});
+
+describe("groupPhotosByMonth", () => {
+  it("groups photos by YYYY-MM bucket with latest month first", () => {
+    const groups = groupPhotosByMonth([
+      photo({ id: "1", takenAt: "2026-04-01" }),
+      photo({ id: "2", takenAt: "2026-04-20" }),
+      photo({ id: "3", takenAt: "2026-03-15" }),
+      photo({ id: "4", takenAt: "2026-05-02" }),
+    ]);
+    expect(groups.map((g) => g.monthKey)).toEqual([
+      "2026-05",
+      "2026-04",
+      "2026-03",
+    ]);
+    const april = groups.find((g) => g.monthKey === "2026-04");
+    expect(april?.label).toBe("квітень 2026");
+    expect(april?.photos.map((p) => p.id)).toEqual(["2", "1"]);
+  });
+
+  it("drops photos with malformed takenAt values", () => {
+    const groups = groupPhotosByMonth([
+      photo({ id: "ok", takenAt: "2026-04-10" }),
+      photo({ id: "bad", takenAt: "nope" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.photos.map((p) => p.id)).toEqual(["ok"]);
+  });
+
+  it("returns an empty array when no photos are supplied", () => {
+    expect(groupPhotosByMonth([])).toEqual([]);
+  });
+});
+
+describe("pairBeforeAfterOfMonth", () => {
+  it("returns the earliest + latest photo of the month with ≥2 entries", () => {
+    const pair = pairBeforeAfterOfMonth([
+      photo({ id: "a", takenAt: "2026-04-01" }),
+      photo({ id: "b", takenAt: "2026-04-15" }),
+      photo({ id: "c", takenAt: "2026-04-30" }),
+    ]);
+    expect(pair?.before.id).toBe("a");
+    expect(pair?.after.id).toBe("c");
+  });
+
+  it("respects an explicit monthKey when provided", () => {
+    const pair = pairBeforeAfterOfMonth(
+      [
+        photo({ id: "a", takenAt: "2026-03-01" }),
+        photo({ id: "b", takenAt: "2026-03-25" }),
+        photo({ id: "c", takenAt: "2026-05-02" }),
+      ],
+      "2026-03",
+    );
+    expect(pair?.before.id).toBe("a");
+    expect(pair?.after.id).toBe("b");
+  });
+
+  it("returns null when no month has ≥2 photos", () => {
+    expect(
+      pairBeforeAfterOfMonth([
+        photo({ id: "a", takenAt: "2026-04-01" }),
+        photo({ id: "b", takenAt: "2026-05-01" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when the requested monthKey is missing", () => {
+    expect(
+      pairBeforeAfterOfMonth(
+        [photo({ id: "a", takenAt: "2026-04-01" })],
+        "2020-01",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("getPhotoIndex / neighborPhoto", () => {
+  const list = [
+    photo({ id: "a", takenAt: "2026-05-01" }),
+    photo({ id: "b", takenAt: "2026-04-15" }),
+    photo({ id: "c", takenAt: "2026-04-01" }),
+  ];
+
+  it("locates a photo by id", () => {
+    expect(getPhotoIndex(list, "b")).toBe(1);
+    expect(getPhotoIndex(list, "zzz")).toBe(-1);
+  });
+
+  it("walks forward / backward with clamp at the edges", () => {
+    expect(neighborPhoto(list, "a", +1)?.id).toBe("b");
+    expect(neighborPhoto(list, "b", -1)?.id).toBe("a");
+    expect(neighborPhoto(list, "a", -1)).toBeNull();
+    expect(neighborPhoto(list, "c", +1)).toBeNull();
+    expect(neighborPhoto(list, "missing", +1)).toBeNull();
+  });
+});
+
+describe("filterValidPhotos", () => {
+  it("drops entries missing required fields", () => {
+    const cleaned = filterValidPhotos([
+      {
+        id: "ok",
+        takenAt: "2026-04-01",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        uri: "file:///ok.jpg",
+      },
+      { id: "missing-uri", takenAt: "2026-04-01", createdAt: "x" },
+      null,
+      "string",
+      { id: 123, takenAt: "2026-04-01" },
+    ]);
+    expect(cleaned.map((p) => p.id)).toEqual(["ok"]);
+  });
+
+  it("preserves optional fields when they are present and valid", () => {
+    const cleaned = filterValidPhotos([
+      {
+        id: "ok",
+        takenAt: "2026-04-01",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        uri: "file:///ok.jpg",
+        note: "Week 1",
+        weightKg: 82.5,
+      },
+      {
+        id: "bad-weight",
+        takenAt: "2026-04-02",
+        createdAt: "2026-04-02T00:00:00.000Z",
+        uri: "file:///b.jpg",
+        weightKg: "not a number",
+        note: "",
+      },
+    ]);
+    expect(cleaned[0]).toMatchObject({ note: "Week 1", weightKg: 82.5 });
+    // Empty note is dropped; invalid weight is dropped.
+    expect(cleaned[1]?.note).toBeUndefined();
+    expect(cleaned[1]?.weightKg).toBeUndefined();
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(filterValidPhotos(null)).toEqual([]);
+    expect(filterValidPhotos("foo")).toEqual([]);
+    expect(filterValidPhotos({ id: "x" })).toEqual([]);
+  });
+});

--- a/packages/fizruk-domain/src/domain/photos/helpers.ts
+++ b/packages/fizruk-domain/src/domain/photos/helpers.ts
@@ -1,0 +1,214 @@
+/**
+ * Pure helpers backing the Fizruk photo-progress gallery.
+ *
+ * ALL ordering / grouping / date-bucket logic lives here so the mobile
+ * and web Photos screens share the same behaviour — the React layer
+ * only renders the shape these helpers return.
+ *
+ * Helpers are intentionally deterministic: no `Date.now()`, no
+ * `Math.random()`, no I/O. Callers pass in the clock (e.g. photo
+ * `takenAt` dates) so vitest can cover boundary behaviour without
+ * fragile mocks.
+ */
+
+import type { BodyPhotoMeta, PhotoMonthGroup, PhotoPair } from "./types.js";
+
+const UK_MONTHS = [
+  "січня",
+  "лютого",
+  "березня",
+  "квітня",
+  "травня",
+  "червня",
+  "липня",
+  "серпня",
+  "вересня",
+  "жовтня",
+  "листопада",
+  "грудня",
+] as const;
+
+const UK_MONTHS_NOMINATIVE = [
+  "січень",
+  "лютий",
+  "березень",
+  "квітень",
+  "травень",
+  "червень",
+  "липень",
+  "серпень",
+  "вересень",
+  "жовтень",
+  "листопад",
+  "грудень",
+] as const;
+
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_KEY_RE = /^\d{4}-\d{2}$/;
+
+/** Returns true iff the input is an ISO date-only string ("YYYY-MM-DD"). */
+export function isDateKey(value: unknown): value is string {
+  return typeof value === "string" && DATE_KEY_RE.test(value);
+}
+
+/** Returns true iff the input is a month key ("YYYY-MM"). */
+export function isMonthKey(value: unknown): value is string {
+  return typeof value === "string" && MONTH_KEY_RE.test(value);
+}
+
+/**
+ * Extract the month key ("YYYY-MM") from a `takenAt` date-only string.
+ * Returns `null` if the input is not a valid date key.
+ */
+export function monthKeyFromTakenAt(takenAt: string): string | null {
+  if (!isDateKey(takenAt)) return null;
+  return takenAt.slice(0, 7);
+}
+
+/**
+ * Human label for a month key, in Ukrainian by default
+ * ("2026-04" → "квітень 2026"). Returns the raw key on malformed input.
+ */
+export function formatMonthLabel(monthKey: string): string {
+  if (!isMonthKey(monthKey)) return monthKey;
+  const [yearStr, monthStr] = monthKey.split("-");
+  const monthIdx = Number(monthStr) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return monthKey;
+  return `${UK_MONTHS_NOMINATIVE[monthIdx]} ${yearStr}`;
+}
+
+/**
+ * Human label for a single photo's `takenAt` date ("12 квітня 2026").
+ * Returns the raw string on malformed input.
+ */
+export function formatTakenAtLabel(takenAt: string): string {
+  if (!isDateKey(takenAt)) return takenAt;
+  const [year, month, day] = takenAt.split("-");
+  const monthIdx = Number(month) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return takenAt;
+  const dayNum = Number(day);
+  return `${dayNum} ${UK_MONTHS[monthIdx]} ${year}`;
+}
+
+/**
+ * Stable copy of `photos`, sorted latest first by `takenAt`, with a
+ * `createdAt` tiebreak (later-created record wins) and finally `id`
+ * lexicographic ordering so the result is deterministic even when
+ * both fields collide.
+ */
+export function sortPhotosLatestFirst(
+  photos: readonly BodyPhotoMeta[],
+): BodyPhotoMeta[] {
+  return [...photos].sort((a, b) => {
+    const takenCmp = (b.takenAt || "").localeCompare(a.takenAt || "");
+    if (takenCmp !== 0) return takenCmp;
+    const createdCmp = (b.createdAt || "").localeCompare(a.createdAt || "");
+    if (createdCmp !== 0) return createdCmp;
+    return (a.id || "").localeCompare(b.id || "");
+  });
+}
+
+/**
+ * Group photos by month bucket, latest month first. Photos within
+ * each bucket are sorted latest-first via `sortPhotosLatestFirst`.
+ * Photos whose `takenAt` is not a valid date key are dropped — they
+ * cannot be assigned to a bucket.
+ */
+export function groupPhotosByMonth(
+  photos: readonly BodyPhotoMeta[],
+): PhotoMonthGroup[] {
+  const byMonth = new Map<string, BodyPhotoMeta[]>();
+  for (const photo of photos) {
+    const key = monthKeyFromTakenAt(photo.takenAt);
+    if (!key) continue;
+    const bucket = byMonth.get(key);
+    if (bucket) bucket.push(photo);
+    else byMonth.set(key, [photo]);
+  }
+  const keys = Array.from(byMonth.keys()).sort((a, b) => b.localeCompare(a));
+  return keys.map((monthKey) => ({
+    monthKey,
+    label: formatMonthLabel(monthKey),
+    photos: sortPhotosLatestFirst(byMonth.get(monthKey) ?? []),
+  }));
+}
+
+/**
+ * Earliest + latest photo of the same month — the "before / after"
+ * pair the comparison UI can render. Returns `null` if fewer than two
+ * photos exist in the requested bucket. When `monthKey` is omitted,
+ * falls back to the most recent month that has ≥2 photos.
+ */
+export function pairBeforeAfterOfMonth(
+  photos: readonly BodyPhotoMeta[],
+  monthKey?: string,
+): PhotoPair | null {
+  const groups = groupPhotosByMonth(photos);
+  const pick = monthKey
+    ? groups.find((g) => g.monthKey === monthKey)
+    : groups.find((g) => g.photos.length >= 2);
+  if (!pick || pick.photos.length < 2) return null;
+  // `pick.photos` is latest-first; after = first, before = last.
+  const after = pick.photos[0];
+  const before = pick.photos[pick.photos.length - 1];
+  if (!before || !after || before.id === after.id) return null;
+  return { before, after };
+}
+
+/**
+ * 0-based index of the photo with id `id` inside `photos`, or `-1`
+ * when the id is not found. The input is assumed to already be sorted
+ * in display order.
+ */
+export function getPhotoIndex(
+  photos: readonly BodyPhotoMeta[],
+  id: string,
+): number {
+  for (let i = 0; i < photos.length; i += 1) {
+    if (photos[i]?.id === id) return i;
+  }
+  return -1;
+}
+
+/**
+ * Sibling photo at `currentIndex + delta`, clamped to the bounds of
+ * `photos`. Returns `null` when the target index is out of range — the
+ * caller (viewer) uses this to disable prev/next chevrons at the edges.
+ */
+export function neighborPhoto(
+  photos: readonly BodyPhotoMeta[],
+  currentId: string,
+  delta: number,
+): BodyPhotoMeta | null {
+  const idx = getPhotoIndex(photos, currentId);
+  if (idx === -1) return null;
+  const next = idx + delta;
+  if (next < 0 || next >= photos.length) return null;
+  return photos[next] ?? null;
+}
+
+/**
+ * Narrow an arbitrary unknown value (e.g. MMKV JSON) into a
+ * `BodyPhotoMeta[]`. Entries missing required fields are dropped
+ * silently — the hook uses this to survive schema drift on upgrades.
+ */
+export function filterValidPhotos(raw: unknown): BodyPhotoMeta[] {
+  if (!Array.isArray(raw)) return [];
+  const out: BodyPhotoMeta[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const r = entry as Record<string, unknown>;
+    const id = typeof r.id === "string" ? r.id : null;
+    const takenAt = typeof r.takenAt === "string" ? r.takenAt : null;
+    const createdAt = typeof r.createdAt === "string" ? r.createdAt : null;
+    const uri = typeof r.uri === "string" ? r.uri : null;
+    if (!id || !takenAt || !createdAt || !uri) continue;
+    const meta: BodyPhotoMeta = { id, takenAt, createdAt, uri };
+    if (typeof r.note === "string" && r.note.length > 0) meta.note = r.note;
+    if (typeof r.weightKg === "number" && Number.isFinite(r.weightKg)) {
+      meta.weightKg = r.weightKg;
+    }
+    out.push(meta);
+  }
+  return out;
+}

--- a/packages/fizruk-domain/src/domain/photos/index.ts
+++ b/packages/fizruk-domain/src/domain/photos/index.ts
@@ -1,0 +1,9 @@
+/**
+ * `@sergeant/fizruk-domain/domain/photos` — pure helpers backing the
+ * Fizruk body-photo progress gallery (web + mobile). All ordering /
+ * grouping / date-bucket logic lives here so the React layer on both
+ * platforms is a thin view on top of the same deterministic shape.
+ */
+
+export * from "./types.js";
+export * from "./helpers.js";

--- a/packages/fizruk-domain/src/domain/photos/types.ts
+++ b/packages/fizruk-domain/src/domain/photos/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared domain types for the Fizruk body-photo sub-domain.
+ *
+ * Kept platform-neutral so both `apps/web` and `apps/mobile` consume
+ * the same helpers. The web `BodyPhoto` type (see `../types.ts`) embeds
+ * a `dataUrl` because the web app stored BLOBs in IndexedDB/base64;
+ * the mobile port persists BLOBs on disk (via `expo-file-system` in a
+ * follow-up PR) and keeps only lightweight metadata in MMKV. The
+ * `BodyPhotoMeta` shape below is the canonical source-of-truth for the
+ * metadata-only record — file bytes live under an OS-level `uri`.
+ */
+
+/**
+ * Metadata for a single body progress photo. The actual BLOB lives on
+ * disk; `uri` points at it (`file://.../fizruk/photos/<id>.jpg` on
+ * mobile or a blob/data URL on web).
+ */
+export interface BodyPhotoMeta {
+  /** Stable, unique id. */
+  id: string;
+  /**
+   * Date the photo was taken / the user is tagging it with, as an
+   * ISO date-only string ("YYYY-MM-DD"). Separate from `createdAt`
+   * because the user may be backfilling old photos.
+   */
+  takenAt: string;
+  /** ISO timestamp when the record was inserted. */
+  createdAt: string;
+  /** Free-form note — optional so the form can submit without one. */
+  note?: string;
+  /** Optional body-weight snapshot (kg) captured alongside the photo. */
+  weightKg?: number;
+  /**
+   * OS-level URI of the BLOB. On mobile this is a `file://` path under
+   * `FileSystem.documentDirectory + 'fizruk/photos/<id>.jpg'`; on web
+   * it can be a blob/data URL for parity with the legacy hook.
+   */
+  uri: string;
+}
+
+/** Monthly bucket used by gallery grouping. */
+export interface PhotoMonthGroup {
+  /** "YYYY-MM". */
+  monthKey: string;
+  /** Localised human label ("квітень 2026"). */
+  label: string;
+  /** Photos in this bucket, latest first. */
+  photos: BodyPhotoMeta[];
+}
+
+/** Before/after pair for the same month. */
+export interface PhotoPair {
+  before: BodyPhotoMeta;
+  after: BodyPhotoMeta;
+}


### PR DESCRIPTION
## Summary

Phase 6 / PR-E of the Fizruk React Native migration: port `PhotoProgress` +
`useBodyPhotos` from `apps/web` to `apps/mobile` with a native-first
architecture (no base64-in-MMKV).

- **New pure sub-domain** `@sergeant/fizruk-domain/domain/photos/*`
  (`types.ts` + `helpers.ts`). Houses all ordering / grouping / date-bucket
  logic — `sortPhotosLatestFirst`, `groupPhotosByMonth`,
  `pairBeforeAfterOfMonth`, `getPhotoIndex`, `neighborPhoto`,
  `monthKeyFromTakenAt`, `formatMonthLabel`, `formatTakenAtLabel`,
  `filterValidPhotos`, `isDateKey`, `isMonthKey`. Vitest covers **22
  cases** (well over the 10-case minimum from the spec).
- **New storage constant** `BODY_PHOTOS_STORAGE_KEY` (`fizruk_body_photos_v1`)
  in `@sergeant/fizruk-domain/constants` — the MMKV key mobile writes
  lightweight `BodyPhotoMeta` records to. BLOBs are persisted on disk via
  the `photoFileStore` adapter (see below).
- **Mobile hook** `apps/mobile/src/modules/fizruk/hooks/useBodyPhotos.ts`.
  Exposes the requested CRUD surface (`list`, `add`, `update`, `remove`,
  `clear`) plus `photos`/`ready` for parity with the web hook. Re-reads on
  external MMKV writes via `addOnValueChangedListener`. All ordering is
  delegated to `sortPhotosLatestFirst` so the reducer has no ad-hoc sort
  logic.
- **Storage adapter** `apps/mobile/src/modules/fizruk/hooks/photoFileStore.ts`
  — thin wrapper the hook calls (`persistSourceUri`, `deletePersistedUri`,
  `clearAllPersistedPhotos`, `buildPhotoUri`). Ships as a documented stub
  for PR-E (see **Stubs & follow-up** below); the contract stays fixed so
  swapping in `expo-file-system` is a single-file change.
- **Mobile UI**
  - `components/photos/PhotoGallery.tsx` — month-grouped grid, 3-col
    layout, lazy-loaded `<Image>` thumbnails, accessible pressables, note
    chip overlay.
  - `components/photos/PhotoViewer.tsx` — full-screen modal with
    prev / next chevrons driven by `neighborPhoto`, header title from
    `formatTakenAtLabel`, delete action + hardware-back / close.
  - `pages/Photos.tsx` — screen that wires `useBodyPhotos` into the
    gallery + viewer, renders the empty-state card, and exposes a
    disabled "Додати фото" stub (see below). Accepts a `photosAdapter`
    prop for jest tests.
- **Route wiring** `apps/mobile/app/(tabs)/fizruk/photos.tsx` — thin
  wrapper, mirrors the convention used by the merged `progress.tsx` /
  `measurements.tsx` / etc. routes in the fizruk nested Stack.
- **Jest coverage** `apps/mobile/src/modules/fizruk/pages/Photos.test.tsx`
  — exercises the four invariants the spec calls out: empty-state,
  3-photo gallery rendering, tap-opens-viewer, delete removes entry.

`pnpm check` is green locally: format + lint + typecheck + **199 passed**
jest tests (across all workspaces) + **144 passed** vitest tests + `pnpm
build` (web bundle).

### Stubs & follow-up (per the PR-E spec)

`expo-image-picker`, `expo-file-system`, and `expo-image` are **not** in
`apps/mobile/package.json` yet — per the spec, this PR does **not** add
them. To keep the page reviewable + visually correct:

- The "Додати фото" FAB renders as a disabled dashed button with a
  visible "скоро" label and a small caption pointing at the follow-up PR.
- `photoFileStore.persistSourceUri` returns the input URI unchanged;
  `deletePersistedUri` / `clearAllPersistedPhotos` are no-ops. The hook
  still writes / deletes metadata rows correctly (covered by the Photos
  test suite's delete case).
- Both files include `TODO(fizruk-mobile, PR-E follow-up)` comments
  pointing at the exact `FileSystem.copyAsync` / `FileSystem.deleteAsync`
  / `ImagePicker.launchImageLibraryAsync` calls the next PR must plug in.
- `Photos.test.tsx` documents the `jest.mock("expo-file-system", …)` /
  `jest.mock("expo-image-picker", …)` shapes the follow-up integration
  tests should use.

### Notes

- `FIZRUK_PAGES` in `shell/fizrukRoute.ts` was intentionally **not**
  extended with `"photos"` because the Dashboard nav-card coverage test
  (`__tests__/Dashboard.test.tsx`) is locked to the existing catalogue and
  `Dashboard.tsx` is listed as off-limits in the PR-E brief. The page is
  still reachable via expo-router file-based routing (`/fizruk/photos`);
  wiring it into the dashboard grid can land alongside the real image
  picker in the follow-up PR.
- Did not modify any of the pinned files
  (`apps/mobile/src/modules/routine/**`, `apps/mobile/src/modules/finyk/**`,
  `Progress.tsx` / `PlanCalendar.tsx` / `Dashboard.tsx` / `Workouts.tsx` /
  `Atlas.tsx` / `components/BodyAtlas.tsx`, `jest.config.js`,
  `tsconfig.json`, `apps/mobile/package.json`, or anything under
  `apps/web/**`).

## Review & Testing Checklist for Human

- [ ] Skim `packages/fizruk-domain/src/domain/photos/helpers.ts` — this is
      the one place that owns the "latest-first / group-by-month /
      before-after" contract; any future sorting questions should land in
      new vitest cases here, not in the React layer.
- [ ] Confirm the stubbed "+ Додати фото (скоро)" button + TODO comments
      in `photoFileStore.ts` are the right shape for the follow-up PR
      (vs. e.g. an inline `Alert.alert("TODO")`).
- [ ] Sanity check the metadata-only MMKV contract: open the app after
      this PR, pull `fizruk_body_photos_v1` from MMKV, confirm no base64
      `dataUrl` field leaks into storage. (Once the follow-up PR wires
      `ImagePicker` + `FileSystem`, the `uri` field should point at
      `file://.../fizruk/photos/<id>.jpg`.)


Link to Devin session: https://app.devin.ai/sessions/8c7bccc438fe4cb39b97da71d57877ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a body progress photo gallery that organizes images by month with an interactive thumbnail grid layout.
  * Added a full-screen photo viewer featuring navigation between photos and the ability to delete individual images.
  * Added support for photo metadata including notes and weight information to track alongside your progress photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->