### PR TITLE
feat(finyk-mobile): Assets page (accounts / debts / receivables)

### DIFF
--- a/apps/mobile/app/(tabs)/finyk/assets.tsx
+++ b/apps/mobile/app/(tabs)/finyk/assets.tsx
@@ -1,17 +1,5 @@
-import { FinykPageStub } from "@/modules/finyk/pages/PageStub";
+import { AssetsPage } from "@/modules/finyk/pages/Assets/AssetsPage";
 
 export default function FinykAssetsScreen() {
-  return (
-    <FinykPageStub
-      title="Активи"
-      description="Рахунки, підписки, борги та крива NetWorth."
-      plannedFeatures={[
-        "Картки банківських рахунків",
-        "NetworthChart (Victory Native XL)",
-        "Керування підписками (DEFAULT_SUBSCRIPTIONS)",
-        "Борги та погашення",
-        "Moto експорт JSON (expo-file-system + expo-sharing)",
-      ]}
-    />
-  );
+  return <AssetsPage testID="finyk-assets" />;
 }

--- a/apps/mobile/src/modules/finyk/components/assets/DebtSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/DebtSheet.tsx
@@ -1,0 +1,195 @@
+/**
+ * Finyk — Debt (я винен) create/edit sheet (React Native).
+ *
+ * Mirrors the inline debt form from the web Assets page. `totalAmount`
+ * + base `amount` stay in sync (the web file treats them as aliases
+ * for the original principal) so the domain helpers
+ * (`calcDebtRemaining`, `getDebtEffectiveTotal`) read consistent data.
+ */
+
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+import type { AssetsDebt } from "@sergeant/finyk-domain/domain";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Sheet } from "@/components/ui/Sheet";
+
+export interface DebtSheetProps {
+  open: boolean;
+  onClose: () => void;
+  debt: AssetsDebt | null;
+  onSubmit: (next: AssetsDebt) => void;
+  onDelete?: (id: string) => void;
+  testID?: string;
+}
+
+interface DraftState {
+  name: string;
+  emoji: string;
+  amount: string;
+  note: string;
+}
+
+const EMPTY_DRAFT: DraftState = {
+  name: "",
+  emoji: "💸",
+  amount: "",
+  note: "",
+};
+
+function toDraft(debt: AssetsDebt | null): DraftState {
+  if (!debt) return { ...EMPTY_DRAFT };
+  return {
+    name: debt.name || "",
+    emoji: debt.emoji || "💸",
+    amount: String(debt.totalAmount ?? debt.amount ?? ""),
+    note: debt.note || "",
+  };
+}
+
+export function DebtSheet({
+  open,
+  onClose,
+  debt,
+  onSubmit,
+  onDelete,
+  testID,
+}: DebtSheetProps) {
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(debt));
+  const [nameError, setNameError] = useState(false);
+  const [amountError, setAmountError] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft(toDraft(debt));
+    setNameError(false);
+    setAmountError(false);
+  }, [open, debt]);
+
+  const isEditing = !!debt;
+
+  function handleSubmit() {
+    const name = draft.name.trim();
+    const total = Number(draft.amount);
+    const invalidName = !name;
+    const invalidAmount = !Number.isFinite(total) || total <= 0;
+    if (invalidName || invalidAmount) {
+      setNameError(invalidName);
+      setAmountError(invalidAmount);
+      return;
+    }
+    const next: AssetsDebt = {
+      ...(debt ?? {}),
+      id: debt?.id ?? `${Date.now()}`,
+      name,
+      emoji: draft.emoji || "💸",
+      amount: total,
+      totalAmount: total,
+      note: draft.note,
+      linkedTxIds: debt?.linkedTxIds ?? [],
+    };
+    onSubmit(next);
+    onClose();
+  }
+
+  function handleDelete() {
+    if (debt && onDelete) {
+      onDelete(debt.id);
+      onClose();
+    }
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={isEditing ? "Редагувати борг" : "Новий борг"}
+      description="Скільки ти винен — повна сума."
+      footer={
+        <View className="flex-row gap-2">
+          {isEditing && onDelete ? (
+            <Button
+              variant="danger"
+              size="md"
+              onPress={handleDelete}
+              testID={testID ? `${testID}-delete` : undefined}
+            >
+              Видалити
+            </Button>
+          ) : null}
+          <View className="flex-1" />
+          <Button
+            variant="secondary"
+            size="md"
+            onPress={onClose}
+            testID={testID ? `${testID}-cancel` : undefined}
+          >
+            Скасувати
+          </Button>
+          <Button
+            variant="finyk"
+            size="md"
+            onPress={handleSubmit}
+            testID={testID ? `${testID}-submit` : undefined}
+          >
+            {isEditing ? "Зберегти" : "Додати"}
+          </Button>
+        </View>
+      }
+    >
+      <View className="gap-3">
+        <View>
+          <Text className="text-xs font-medium text-stone-700 mb-1">Назва</Text>
+          <Input
+            placeholder="Кому / за що"
+            value={draft.name}
+            onChangeText={(t) => setDraft((d) => ({ ...d, name: t }))}
+            error={nameError}
+            testID={testID ? `${testID}-name` : undefined}
+          />
+        </View>
+        <View className="flex-row gap-3">
+          <View className="w-24">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Емодзі
+            </Text>
+            <Input
+              value={draft.emoji}
+              onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
+              maxLength={2}
+              testID={testID ? `${testID}-emoji` : undefined}
+            />
+          </View>
+          <View className="flex-1">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Сума, ₴
+            </Text>
+            <Input
+              placeholder="0"
+              type="number"
+              value={draft.amount}
+              onChangeText={(t) => setDraft((d) => ({ ...d, amount: t }))}
+              error={amountError}
+              testID={testID ? `${testID}-amount` : undefined}
+            />
+          </View>
+        </View>
+        <View>
+          <Text className="text-xs font-medium text-stone-700 mb-1">
+            Нотатка
+          </Text>
+          <Input
+            placeholder="Необов'язково"
+            value={draft.note}
+            onChangeText={(t) => setDraft((d) => ({ ...d, note: t }))}
+            testID={testID ? `${testID}-note` : undefined}
+          />
+        </View>
+      </View>
+    </Sheet>
+  );
+}
+
+export default DebtSheet;

--- a/apps/mobile/src/modules/finyk/components/assets/ManualAssetSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/ManualAssetSheet.tsx
@@ -1,0 +1,223 @@
+/**
+ * Finyk — Manual Asset create/edit sheet (React Native).
+ *
+ * Mirrors the inline add-asset form on the web (`apps/web/src/modules/
+ * finyk/pages/Assets.tsx`, `newAsset` state + "+ Додати актив" branch).
+ * Ported into the shared `Sheet` primitive so mobile gets the same
+ * bottom-sheet affordance used by every other form (Habits, …).
+ */
+
+import { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import type { ManualAsset } from "@sergeant/finyk-domain/domain";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Sheet } from "@/components/ui/Sheet";
+
+export interface ManualAssetSheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** Existing asset when editing; `null` => create. */
+  asset: ManualAsset | null;
+  onSubmit: (next: ManualAsset) => void;
+  onDelete?: (id: string) => void;
+  testID?: string;
+}
+
+interface DraftState {
+  name: string;
+  emoji: string;
+  amount: string;
+  currency: string;
+}
+
+const EMPTY_DRAFT: DraftState = {
+  name: "",
+  emoji: "💰",
+  amount: "",
+  currency: "UAH",
+};
+
+function toDraft(asset: ManualAsset | null): DraftState {
+  if (!asset) return { ...EMPTY_DRAFT };
+  return {
+    name: asset.name,
+    emoji: asset.emoji || "💰",
+    amount: String(asset.amount ?? ""),
+    currency: asset.currency || "UAH",
+  };
+}
+
+export function ManualAssetSheet({
+  open,
+  onClose,
+  asset,
+  onSubmit,
+  onDelete,
+  testID,
+}: ManualAssetSheetProps) {
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(asset));
+  const [nameError, setNameError] = useState(false);
+  const [amountError, setAmountError] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft(toDraft(asset));
+    setNameError(false);
+    setAmountError(false);
+  }, [open, asset]);
+
+  const isEditing = !!asset;
+
+  function handleSubmit() {
+    const name = draft.name.trim();
+    const amountNum = Number(draft.amount);
+    const invalidName = !name;
+    const invalidAmount = !Number.isFinite(amountNum);
+    if (invalidName || invalidAmount) {
+      setNameError(invalidName);
+      setAmountError(invalidAmount);
+      return;
+    }
+    const next: ManualAsset = {
+      id: asset?.id ?? `${Date.now()}`,
+      name,
+      emoji: draft.emoji || "💰",
+      amount: amountNum,
+      currency: draft.currency || "UAH",
+    };
+    onSubmit(next);
+    onClose();
+  }
+
+  function handleDelete() {
+    if (asset && onDelete) {
+      onDelete(asset.id);
+      onClose();
+    }
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={isEditing ? "Редагувати актив" : "Новий актив"}
+      description="Готівка, брокерський рахунок, крипта тощо."
+      footer={
+        <View className="flex-row gap-2">
+          {isEditing && onDelete ? (
+            <Button
+              variant="danger"
+              size="md"
+              onPress={handleDelete}
+              accessibilityLabel="Видалити актив"
+              testID={testID ? `${testID}-delete` : undefined}
+            >
+              Видалити
+            </Button>
+          ) : null}
+          <View className="flex-1" />
+          <Button
+            variant="secondary"
+            size="md"
+            onPress={onClose}
+            testID={testID ? `${testID}-cancel` : undefined}
+          >
+            Скасувати
+          </Button>
+          <Button
+            variant="finyk"
+            size="md"
+            onPress={handleSubmit}
+            testID={testID ? `${testID}-submit` : undefined}
+          >
+            {isEditing ? "Зберегти" : "Додати"}
+          </Button>
+        </View>
+      }
+    >
+      <View className="gap-3">
+        <View>
+          <Text
+            className="text-xs font-medium text-stone-700 mb-1"
+            nativeID={testID ? `${testID}-name-label` : undefined}
+          >
+            Назва
+          </Text>
+          <Input
+            placeholder="Готівка, брокер, крипта…"
+            value={draft.name}
+            onChangeText={(t) => setDraft((d) => ({ ...d, name: t }))}
+            error={nameError}
+            aria-labelledby={testID ? `${testID}-name-label` : undefined}
+            testID={testID ? `${testID}-name` : undefined}
+          />
+        </View>
+        <View className="flex-row gap-3">
+          <View className="w-24">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Емодзі
+            </Text>
+            <Input
+              value={draft.emoji}
+              onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
+              maxLength={2}
+              testID={testID ? `${testID}-emoji` : undefined}
+            />
+          </View>
+          <View className="flex-1">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Сума
+            </Text>
+            <Input
+              placeholder="0"
+              type="number"
+              value={draft.amount}
+              onChangeText={(t) => setDraft((d) => ({ ...d, amount: t }))}
+              error={amountError}
+              testID={testID ? `${testID}-amount` : undefined}
+            />
+          </View>
+        </View>
+        <View>
+          <Text className="text-xs font-medium text-stone-700 mb-1">
+            Валюта
+          </Text>
+          <View className="flex-row gap-2">
+            {(["UAH", "USD", "EUR"] as const).map((c) => {
+              const active = draft.currency === c;
+              return (
+                <Pressable
+                  key={c}
+                  onPress={() => setDraft((d) => ({ ...d, currency: c }))}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  testID={testID ? `${testID}-currency-${c}` : undefined}
+                  className={
+                    active
+                      ? "h-9 px-3 rounded-lg bg-brand-500 items-center justify-center"
+                      : "h-9 px-3 rounded-lg bg-cream-100 border border-cream-300 items-center justify-center"
+                  }
+                >
+                  <Text
+                    className={
+                      active
+                        ? "text-sm font-medium text-white"
+                        : "text-sm font-medium text-stone-700"
+                    }
+                  >
+                    {c}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      </View>
+    </Sheet>
+  );
+}
+
+export default ManualAssetSheet;

--- a/apps/mobile/src/modules/finyk/components/assets/ReceivableSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/ReceivableSheet.tsx
@@ -1,0 +1,195 @@
+/**
+ * Finyk — Receivable (мені винні) create/edit sheet (React Native).
+ *
+ * Sibling of `DebtSheet` — receivables store their principal in the
+ * base `amount` field (see `packages/finyk-domain/src/domain/debtEngine.ts`),
+ * so only the field mapping differs.
+ */
+
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+import type { AssetsReceivable } from "@sergeant/finyk-domain/domain";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Sheet } from "@/components/ui/Sheet";
+
+export interface ReceivableSheetProps {
+  open: boolean;
+  onClose: () => void;
+  receivable: AssetsReceivable | null;
+  onSubmit: (next: AssetsReceivable) => void;
+  onDelete?: (id: string) => void;
+  testID?: string;
+}
+
+interface DraftState {
+  name: string;
+  emoji: string;
+  amount: string;
+  note: string;
+}
+
+const EMPTY_DRAFT: DraftState = {
+  name: "",
+  emoji: "👤",
+  amount: "",
+  note: "",
+};
+
+function toDraft(recv: AssetsReceivable | null): DraftState {
+  if (!recv) return { ...EMPTY_DRAFT };
+  return {
+    name: recv.name || "",
+    emoji: recv.emoji || "👤",
+    amount: String(recv.amount ?? ""),
+    note: recv.note || "",
+  };
+}
+
+export function ReceivableSheet({
+  open,
+  onClose,
+  receivable,
+  onSubmit,
+  onDelete,
+  testID,
+}: ReceivableSheetProps) {
+  const [draft, setDraft] = useState<DraftState>(() => toDraft(receivable));
+  const [nameError, setNameError] = useState(false);
+  const [amountError, setAmountError] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft(toDraft(receivable));
+    setNameError(false);
+    setAmountError(false);
+  }, [open, receivable]);
+
+  const isEditing = !!receivable;
+
+  function handleSubmit() {
+    const name = draft.name.trim();
+    const amount = Number(draft.amount);
+    const invalidName = !name;
+    const invalidAmount = !Number.isFinite(amount) || amount <= 0;
+    if (invalidName || invalidAmount) {
+      setNameError(invalidName);
+      setAmountError(invalidAmount);
+      return;
+    }
+    const next: AssetsReceivable = {
+      ...(receivable ?? {}),
+      id: receivable?.id ?? `${Date.now()}`,
+      name,
+      emoji: draft.emoji || "👤",
+      amount,
+      note: draft.note,
+      linkedTxIds: receivable?.linkedTxIds ?? [],
+    };
+    onSubmit(next);
+    onClose();
+  }
+
+  function handleDelete() {
+    if (receivable && onDelete) {
+      onDelete(receivable.id);
+      onClose();
+    }
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={isEditing ? "Редагувати дебіторку" : "Нова дебіторка"}
+      description="Скільки тобі винні."
+      footer={
+        <View className="flex-row gap-2">
+          {isEditing && onDelete ? (
+            <Button
+              variant="danger"
+              size="md"
+              onPress={handleDelete}
+              testID={testID ? `${testID}-delete` : undefined}
+            >
+              Видалити
+            </Button>
+          ) : null}
+          <View className="flex-1" />
+          <Button
+            variant="secondary"
+            size="md"
+            onPress={onClose}
+            testID={testID ? `${testID}-cancel` : undefined}
+          >
+            Скасувати
+          </Button>
+          <Button
+            variant="finyk"
+            size="md"
+            onPress={handleSubmit}
+            testID={testID ? `${testID}-submit` : undefined}
+          >
+            {isEditing ? "Зберегти" : "Додати"}
+          </Button>
+        </View>
+      }
+    >
+      <View className="gap-3">
+        <View>
+          <Text className="text-xs font-medium text-stone-700 mb-1">
+            Хто винен
+          </Text>
+          <Input
+            placeholder="Ім'я або назва"
+            value={draft.name}
+            onChangeText={(t) => setDraft((d) => ({ ...d, name: t }))}
+            error={nameError}
+            testID={testID ? `${testID}-name` : undefined}
+          />
+        </View>
+        <View className="flex-row gap-3">
+          <View className="w-24">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Емодзі
+            </Text>
+            <Input
+              value={draft.emoji}
+              onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
+              maxLength={2}
+              testID={testID ? `${testID}-emoji` : undefined}
+            />
+          </View>
+          <View className="flex-1">
+            <Text className="text-xs font-medium text-stone-700 mb-1">
+              Сума, ₴
+            </Text>
+            <Input
+              placeholder="0"
+              type="number"
+              value={draft.amount}
+              onChangeText={(t) => setDraft((d) => ({ ...d, amount: t }))}
+              error={amountError}
+              testID={testID ? `${testID}-amount` : undefined}
+            />
+          </View>
+        </View>
+        <View>
+          <Text className="text-xs font-medium text-stone-700 mb-1">
+            Нотатка
+          </Text>
+          <Input
+            placeholder="Необов'язково"
+            value={draft.note}
+            onChangeText={(t) => setDraft((d) => ({ ...d, note: t }))}
+            testID={testID ? `${testID}-note` : undefined}
+          />
+        </View>
+      </View>
+    </Sheet>
+  );
+}
+
+export default ReceivableSheet;

--- a/apps/mobile/src/modules/finyk/components/assets/rows.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/rows.tsx
@@ -1,0 +1,201 @@
+/**
+ * Finyk — Assets row components (React Native).
+ *
+ * One file, three sibling rows (AccountRow / ManualAssetRow / DebtRow /
+ * ReceivableRow) so they can share the row chrome (radius, border,
+ * press feedback, typography). Every row is a thin presentational
+ * component — all math runs in `@sergeant/finyk-domain/domain/assets`.
+ */
+
+import { memo } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import {
+  calcDebtRemaining,
+  calcReceivableRemaining,
+  getAccountCurrencySymbol,
+  getManualAssetCurrencySymbol,
+  type AssetsDebt,
+  type AssetsReceivable,
+  type ManualAsset,
+  type MonoAccount,
+  type Transaction,
+} from "@sergeant/finyk-domain/domain";
+
+// Mirrors `getAccountShortName` from `apps/web/src/modules/finyk/components/TxRow.tsx`.
+// The label is purely cosmetic — the domain layer treats accounts by id —
+// so we keep it local to the mobile row until the web helper is promoted
+// to the shared domain package.
+const ACCOUNT_TYPE_LABEL: Record<string, string> = {
+  white: "⬜ Біла картка",
+  black: "🖤 Кредитна картка",
+  platinum: "💳 Platinum",
+  iron: "🪙 Iron",
+  yellow: "💛 Жовта",
+  fop: "🧾 ФОП",
+};
+
+function getAccountLabel(account: MonoAccount): string {
+  if (account.type && ACCOUNT_TYPE_LABEL[account.type]) {
+    return ACCOUNT_TYPE_LABEL[account.type];
+  }
+  return account.type || "Рахунок";
+}
+
+function fmtMajor(uah: number): string {
+  return uah.toLocaleString("uk-UA", { maximumFractionDigits: 2 });
+}
+
+function fmtKop(amountKop: number): string {
+  return (amountKop / 100).toLocaleString("uk-UA", {
+    minimumFractionDigits: 2,
+  });
+}
+
+interface BaseRowProps {
+  testID?: string;
+}
+
+export interface AccountRowProps extends BaseRowProps {
+  account: MonoAccount;
+}
+
+export const AccountRow = memo(function AccountRow({
+  account,
+  testID,
+}: AccountRowProps) {
+  const symbol = getAccountCurrencySymbol(account.currencyCode ?? null);
+  return (
+    <View
+      className="flex-row items-center justify-between py-2.5 px-1 border-b border-cream-200 last:border-b-0"
+      testID={testID}
+    >
+      <View className="flex-row items-center gap-3 min-w-0 flex-1">
+        <Text className="text-xl">💳</Text>
+        <View className="min-w-0 flex-1">
+          <Text
+            className="text-sm font-medium text-stone-900"
+            numberOfLines={1}
+          >
+            {getAccountLabel(account)}
+          </Text>
+          <Text className="text-xs text-stone-500 mt-0.5">
+            {fmtKop(account.balance ?? 0)} {symbol}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+export interface ManualAssetRowProps extends BaseRowProps {
+  asset: ManualAsset;
+  onPress: () => void;
+}
+
+export const ManualAssetRow = memo(function ManualAssetRow({
+  asset,
+  onPress,
+  testID,
+}: ManualAssetRowProps) {
+  const symbol = getManualAssetCurrencySymbol(asset.currency);
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Редагувати ${asset.name}`}
+      testID={testID}
+      className="flex-row items-center justify-between py-2.5 px-1 border-b border-cream-200 last:border-b-0"
+    >
+      <View className="flex-row items-center gap-3 min-w-0 flex-1">
+        <Text className="text-xl">{asset.emoji || "💰"}</Text>
+        <Text
+          className="text-sm font-medium text-stone-900 flex-1"
+          numberOfLines={1}
+        >
+          {asset.name}
+        </Text>
+      </View>
+      <Text className="text-sm font-semibold text-stone-900">
+        {fmtMajor(asset.amount)} {symbol}
+      </Text>
+    </Pressable>
+  );
+});
+
+export interface DebtRowProps extends BaseRowProps {
+  debt: AssetsDebt;
+  transactions: readonly Transaction[];
+  onPress: () => void;
+}
+
+export const DebtRow = memo(function DebtRow({
+  debt,
+  transactions,
+  onPress,
+  testID,
+}: DebtRowProps) {
+  const remaining = calcDebtRemaining(debt, transactions as Transaction[]);
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Редагувати борг ${debt.name ?? ""}`}
+      testID={testID}
+      className="flex-row items-center justify-between py-2.5 px-1 border-b border-cream-200 last:border-b-0"
+    >
+      <View className="flex-row items-center gap-3 min-w-0 flex-1">
+        <Text className="text-xl">{debt.emoji || "💸"}</Text>
+        <Text
+          className="text-sm font-medium text-stone-900 flex-1"
+          numberOfLines={1}
+        >
+          {debt.name || "Борг"}
+        </Text>
+      </View>
+      <Text className="text-sm font-semibold text-rose-600">
+        −{fmtMajor(remaining)} ₴
+      </Text>
+    </Pressable>
+  );
+});
+
+export interface ReceivableRowProps extends BaseRowProps {
+  receivable: AssetsReceivable;
+  transactions: readonly Transaction[];
+  onPress: () => void;
+}
+
+export const ReceivableRow = memo(function ReceivableRow({
+  receivable,
+  transactions,
+  onPress,
+  testID,
+}: ReceivableRowProps) {
+  const remaining = calcReceivableRemaining(
+    receivable,
+    transactions as Transaction[],
+  );
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Редагувати дебіторку ${receivable.name ?? ""}`}
+      testID={testID}
+      className="flex-row items-center justify-between py-2.5 px-1 border-b border-cream-200 last:border-b-0"
+    >
+      <View className="flex-row items-center gap-3 min-w-0 flex-1">
+        <Text className="text-xl">{receivable.emoji || "👤"}</Text>
+        <Text
+          className="text-sm font-medium text-stone-900 flex-1"
+          numberOfLines={1}
+        >
+          {receivable.name || "Дебіторка"}
+        </Text>
+      </View>
+      <Text className="text-sm font-semibold text-emerald-600">
+        +{fmtMajor(remaining)} ₴
+      </Text>
+    </Pressable>
+  );
+});

--- a/apps/mobile/src/modules/finyk/lib/assetsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/assetsStore.ts
@@ -1,0 +1,162 @@
+/**
+ * MMKV-backed Assets store for Finyk (mobile).
+ *
+ * Mirrors the shape used on web by the root `Finyk` container —
+ * `manualAssets` (`finyk_assets`), `manualDebts` (`finyk_debts`),
+ * `receivables` (`finyk_recv`), `hiddenAccounts` (`finyk_hidden`). All
+ * four are persisted independently under the canonical keys declared
+ * in `@sergeant/finyk-domain/storage-keys` so the mobile port can
+ * consume a JSON backup exported from the web build unchanged.
+ *
+ * This hook is deliberately local to `modules/finyk/lib/` — the top
+ * Finyk store is scheduled for a later PR (#453's siblings). We only
+ * need the four slices the Assets page owns here, plus a seam for
+ * tests to inject a pre-populated state.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { FINYK_BACKUP_STORAGE_KEYS } from "@sergeant/finyk-domain";
+import type {
+  AssetsDebt,
+  AssetsReceivable,
+  ManualAsset,
+  MonoAccount,
+  Transaction,
+} from "@sergeant/finyk-domain/domain";
+
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+
+const KEY_ASSETS = FINYK_BACKUP_STORAGE_KEYS.manualAssets;
+const KEY_DEBTS = FINYK_BACKUP_STORAGE_KEYS.manualDebts;
+const KEY_RECV = FINYK_BACKUP_STORAGE_KEYS.receivables;
+const KEY_HIDDEN = FINYK_BACKUP_STORAGE_KEYS.hiddenAccounts;
+
+function read<T>(key: string, fallback: T): T {
+  const v = safeReadLS<T>(key, fallback);
+  return v == null ? fallback : v;
+}
+
+/**
+ * Snapshot of every slice the Assets page reads. Accepted as a seed by
+ * {@link useFinykAssetsStore} so tests can render the page deterministically.
+ */
+export interface FinykAssetsSeed {
+  manualAssets?: ManualAsset[];
+  manualDebts?: AssetsDebt[];
+  receivables?: AssetsReceivable[];
+  hiddenAccounts?: string[];
+  accounts?: MonoAccount[];
+  transactions?: Transaction[];
+}
+
+export interface UseFinykAssetsStoreReturn {
+  /** Mono accounts — still seeded-only until the live Monobank client lands on mobile. */
+  accounts: MonoAccount[];
+  /** Transactions used by debt / receivable remainder selectors. */
+  transactions: Transaction[];
+  hiddenAccounts: string[];
+  manualAssets: ManualAsset[];
+  manualDebts: AssetsDebt[];
+  receivables: AssetsReceivable[];
+  setManualAssets: (next: ManualAsset[]) => void;
+  setManualDebts: (next: AssetsDebt[]) => void;
+  setReceivables: (next: AssetsReceivable[]) => void;
+  setHiddenAccounts: (next: string[]) => void;
+}
+
+/**
+ * Read-through MMKV hook for the four slices the Assets page owns.
+ * `seed` lets tests pre-populate state without reaching into the MMKV
+ * shim; passed values are written through on first mount so the rest of
+ * the hook reads them via the same code path as production.
+ */
+export function useFinykAssetsStore(
+  seed?: FinykAssetsSeed,
+): UseFinykAssetsStoreReturn {
+  const [manualAssets, setAssetsState] = useState<ManualAsset[]>(
+    () => seed?.manualAssets ?? read<ManualAsset[]>(KEY_ASSETS, []),
+  );
+  const [manualDebts, setDebtsState] = useState<AssetsDebt[]>(
+    () => seed?.manualDebts ?? read<AssetsDebt[]>(KEY_DEBTS, []),
+  );
+  const [receivables, setRecvState] = useState<AssetsReceivable[]>(
+    () => seed?.receivables ?? read<AssetsReceivable[]>(KEY_RECV, []),
+  );
+  const [hiddenAccounts, setHiddenState] = useState<string[]>(
+    () => seed?.hiddenAccounts ?? read<string[]>(KEY_HIDDEN, []),
+  );
+
+  // On first mount, flush any seed values through MMKV so both consumers
+  // of this hook (and the change-listener below) see the same state.
+  useEffect(() => {
+    if (!seed) return;
+    if (seed.manualAssets) safeWriteLS(KEY_ASSETS, seed.manualAssets);
+    if (seed.manualDebts) safeWriteLS(KEY_DEBTS, seed.manualDebts);
+    if (seed.receivables) safeWriteLS(KEY_RECV, seed.receivables);
+    if (seed.hiddenAccounts) safeWriteLS(KEY_HIDDEN, seed.hiddenAccounts);
+    // Intentionally only runs once — `seed` is expected to be stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Pick up writes from other consumers of these keys.
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      switch (changedKey) {
+        case KEY_ASSETS:
+          setAssetsState(read<ManualAsset[]>(KEY_ASSETS, []));
+          break;
+        case KEY_DEBTS:
+          setDebtsState(read<AssetsDebt[]>(KEY_DEBTS, []));
+          break;
+        case KEY_RECV:
+          setRecvState(read<AssetsReceivable[]>(KEY_RECV, []));
+          break;
+        case KEY_HIDDEN:
+          setHiddenState(read<string[]>(KEY_HIDDEN, []));
+          break;
+        default:
+          break;
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  const setManualAssets = useCallback((next: ManualAsset[]) => {
+    setAssetsState(next);
+    safeWriteLS(KEY_ASSETS, next);
+  }, []);
+  const setManualDebts = useCallback((next: AssetsDebt[]) => {
+    setDebtsState(next);
+    safeWriteLS(KEY_DEBTS, next);
+  }, []);
+  const setReceivables = useCallback((next: AssetsReceivable[]) => {
+    setRecvState(next);
+    safeWriteLS(KEY_RECV, next);
+  }, []);
+  const setHiddenAccounts = useCallback((next: string[]) => {
+    setHiddenState(next);
+    safeWriteLS(KEY_HIDDEN, next);
+  }, []);
+
+  // Mono accounts + transactions are not persisted here — they come
+  // from the network layer (to be wired in a follow-up PR). For now we
+  // accept them via the `seed` only so the render can already reflect
+  // real data in tests / storybooks.
+  const accounts = seed?.accounts ?? [];
+  const transactions = seed?.transactions ?? [];
+
+  return {
+    accounts,
+    transactions,
+    hiddenAccounts,
+    manualAssets,
+    manualDebts,
+    receivables,
+    setManualAssets,
+    setManualDebts,
+    setReceivables,
+    setHiddenAccounts,
+  };
+}

--- a/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.test.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Jest render + behaviour tests for `AssetsPage` (Phase 4 / Assets).
+ *
+ * Covers:
+ *  - Empty state renders per section.
+ *  - Seeded 2 accounts + 1 manual asset + 1 debt + 1 receivable
+ *    produces the expected networth headline.
+ *  - "+ Add" buttons open the correct sheet (asset / debt / receivable).
+ *  - Tapping an existing row opens the sheet pre-populated for edit.
+ */
+
+import { AccessibilityInfo } from "react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { AssetsPage } from "./AssetsPage";
+import type { FinykAssetsSeed } from "@/modules/finyk/lib/assetsStore";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+  jest
+    .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+    .mockResolvedValue(false);
+  jest
+    .spyOn(AccessibilityInfo, "addEventListener")
+    .mockImplementation(() => ({ remove: () => {} }) as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const SEED: FinykAssetsSeed = {
+  accounts: [
+    { id: "acc-1", balance: 500_00, currencyCode: 980, type: "white" },
+    {
+      id: "acc-2",
+      balance: 300_00,
+      creditLimit: 1000_00,
+      currencyCode: 980,
+      type: "black",
+    },
+  ],
+  manualAssets: [
+    { id: "ma-1", name: "Готівка", emoji: "💵", amount: 200, currency: "UAH" },
+  ],
+  manualDebts: [
+    {
+      id: "d-1",
+      name: "Батя",
+      emoji: "👨",
+      amount: 100,
+      totalAmount: 100,
+      linkedTxIds: [],
+    },
+  ],
+  receivables: [
+    { id: "r-1", name: "Оля", emoji: "👧", amount: 50, linkedTxIds: [] },
+  ],
+  transactions: [],
+};
+
+describe("AssetsPage", () => {
+  it("renders empty states for every section when no data is seeded", () => {
+    render(<AssetsPage testID="assets" />);
+
+    expect(screen.getByText("Активи")).toBeTruthy();
+    expect(screen.getByTestId("assets-accounts-empty")).toBeTruthy();
+    expect(screen.getByTestId("assets-debts-empty")).toBeTruthy();
+    expect(screen.getByTestId("assets-receivables-empty")).toBeTruthy();
+  });
+
+  it("renders seeded rows + computes networth from the summary", () => {
+    render(<AssetsPage testID="assets" seed={SEED} />);
+
+    // Rows render with their labels.
+    expect(screen.getByText("⬜ Біла картка")).toBeTruthy();
+    expect(screen.getByText("🖤 Кредитна картка")).toBeTruthy();
+    expect(screen.getByText("Готівка")).toBeTruthy();
+    expect(screen.getByText("Батя")).toBeTruthy();
+    expect(screen.getByText("Оля")).toBeTruthy();
+
+    // networth = (500 + 200 + 50) − (700 + 100) = 750 − 800 = −50
+    expect(
+      screen.getByTestId("assets-networth-value").props.children.join(""),
+    ).toContain("-50");
+  });
+
+  it("'+ Додати актив' opens the asset sheet in new-asset mode", () => {
+    render(<AssetsPage testID="assets" />);
+
+    expect(screen.queryByText("Новий актив")).toBeNull();
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("assets-accounts-add"));
+    });
+
+    expect(screen.getByText("Новий актив")).toBeTruthy();
+  });
+
+  it("'+ Додати борг' opens the debt sheet in new-debt mode", () => {
+    render(<AssetsPage testID="assets" />);
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("assets-debts-add"));
+    });
+
+    expect(screen.getByText("Новий борг")).toBeTruthy();
+  });
+
+  it("'+ Додати дебіторку' opens the receivable sheet in new-receivable mode", () => {
+    render(<AssetsPage testID="assets" />);
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("assets-receivables-add"));
+    });
+
+    expect(screen.getByText("Нова дебіторка")).toBeTruthy();
+  });
+
+  it("tapping an existing manual asset row opens the sheet prefilled", () => {
+    render(<AssetsPage testID="assets" seed={SEED} />);
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("assets-asset-ma-1"));
+    });
+
+    expect(screen.getByText("Редагувати актив")).toBeTruthy();
+    // Prefilled name input is visible.
+    expect(screen.getByDisplayValue("Готівка")).toBeTruthy();
+  });
+
+  it("tapping an existing debt row opens the sheet prefilled", () => {
+    render(<AssetsPage testID="assets" seed={SEED} />);
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("assets-debt-d-1"));
+    });
+
+    expect(screen.getByText("Редагувати борг")).toBeTruthy();
+    expect(screen.getByDisplayValue("Батя")).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.tsx
@@ -1,0 +1,429 @@
+/**
+ * Sergeant Finyk — AssetsPage (React Native)
+ *
+ * Mobile port of `apps/web/src/modules/finyk/pages/Assets.tsx` (~937 LOC).
+ * Scope of this cut: three collapsible sections — Рахунки (Mono +
+ * manual), Борги (я винен), Дебіторка (мені винні) — stacked below a
+ * Networth header that reuses the same math as the Overview hero
+ * (`apps/mobile/src/modules/finyk/pages/Overview/NetworthSection.tsx`,
+ * merged in PR #460).
+ *
+ * All aggregations run through
+ * `@sergeant/finyk-domain/domain/assets` — the page is a pure view
+ * over `computeAssetsSummary`, `calcDebtRemaining`,
+ * `calcReceivableRemaining`. Mutations flow through the MMKV-backed
+ * `useFinykAssetsStore` hook so state survives app relaunches without
+ * a second storage layer.
+ *
+ * Deferred to follow-up PRs (flagged in the PR body):
+ *  - Live Monobank API sync — `accounts` / `transactions` are still
+ *    seeded-only; the MMKV slice for both lands with the Monobank
+ *    client port.
+ *  - Transaction-picker sheet for linking payments to debts /
+ *    receivables — depends on #453's `TxListItem`.
+ *  - Subscriptions section + recurring-detector suggestions — out of
+ *    scope for this PR; the Routine module owns that surface on
+ *    mobile now.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  computeAssetsSummary,
+  type AssetsDebt,
+  type AssetsReceivable,
+  type ManualAsset,
+} from "@sergeant/finyk-domain/domain";
+
+import {
+  useFinykAssetsStore,
+  type FinykAssetsSeed,
+} from "@/modules/finyk/lib/assetsStore";
+
+import { DebtSheet } from "@/modules/finyk/components/assets/DebtSheet";
+import { ManualAssetSheet } from "@/modules/finyk/components/assets/ManualAssetSheet";
+import { ReceivableSheet } from "@/modules/finyk/components/assets/ReceivableSheet";
+import {
+  AccountRow,
+  DebtRow,
+  ManualAssetRow,
+  ReceivableRow,
+} from "@/modules/finyk/components/assets/rows";
+
+type SheetState =
+  | { kind: "closed" }
+  | { kind: "asset"; asset: ManualAsset | null }
+  | { kind: "debt"; debt: AssetsDebt | null }
+  | { kind: "receivable"; receivable: AssetsReceivable | null };
+
+const CLOSED: SheetState = { kind: "closed" };
+
+function fmt(uah: number): string {
+  return uah.toLocaleString("uk-UA", { maximumFractionDigits: 0 });
+}
+
+export interface AssetsPageProps {
+  /** Test/storybook seed — pre-populates the MMKV slices this page owns. */
+  seed?: FinykAssetsSeed;
+  testID?: string;
+}
+
+interface SectionHeaderProps {
+  title: string;
+  summary: string;
+  open: boolean;
+  onToggle: () => void;
+  testID?: string;
+}
+
+function SectionHeader({
+  title,
+  summary,
+  open,
+  onToggle,
+  testID,
+}: SectionHeaderProps) {
+  return (
+    <Pressable
+      onPress={onToggle}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: open }}
+      testID={testID}
+      className="flex-row items-center justify-between px-4 py-3 bg-cream-50 border border-cream-300 rounded-2xl"
+    >
+      <View className="flex-row items-center gap-2 min-w-0 flex-1">
+        <Text
+          className="text-sm font-semibold text-stone-900"
+          numberOfLines={1}
+        >
+          {title}
+        </Text>
+      </View>
+      <View className="flex-row items-center gap-3">
+        <Text className="text-sm font-medium text-stone-700">{summary}</Text>
+        <Text className="text-xs text-stone-500">{open ? "▲" : "▼"}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export function AssetsPage({ seed, testID }: AssetsPageProps) {
+  const store = useFinykAssetsStore(seed);
+
+  const [sheet, setSheet] = useState<SheetState>(CLOSED);
+  const [open, setOpen] = useState({
+    accounts: true,
+    debts: true,
+    receivables: true,
+  });
+
+  const summary = useMemo(
+    () =>
+      computeAssetsSummary({
+        accounts: store.accounts,
+        hiddenAccounts: store.hiddenAccounts,
+        manualAssets: store.manualAssets,
+        manualDebts: store.manualDebts,
+        receivables: store.receivables,
+        transactions: store.transactions,
+      }),
+    [
+      store.accounts,
+      store.hiddenAccounts,
+      store.manualAssets,
+      store.manualDebts,
+      store.receivables,
+      store.transactions,
+    ],
+  );
+
+  const visibleAccounts = useMemo(() => {
+    const hidden = new Set(store.hiddenAccounts);
+    return store.accounts.filter(
+      (a) => !(a.id !== undefined && hidden.has(a.id)),
+    );
+  }, [store.accounts, store.hiddenAccounts]);
+
+  const closeSheet = useCallback(() => setSheet(CLOSED), []);
+
+  const submitAsset = useCallback(
+    (next: ManualAsset) => {
+      const existing = store.manualAssets.findIndex((a) => a.id === next.id);
+      if (existing === -1) {
+        store.setManualAssets([...store.manualAssets, next]);
+      } else {
+        store.setManualAssets(
+          store.manualAssets.map((a) => (a.id === next.id ? next : a)),
+        );
+      }
+    },
+    [store],
+  );
+  const deleteAsset = useCallback(
+    (id: string) => {
+      store.setManualAssets(store.manualAssets.filter((a) => a.id !== id));
+    },
+    [store],
+  );
+
+  const submitDebt = useCallback(
+    (next: AssetsDebt) => {
+      const existing = store.manualDebts.findIndex((d) => d.id === next.id);
+      if (existing === -1) {
+        store.setManualDebts([...store.manualDebts, next]);
+      } else {
+        store.setManualDebts(
+          store.manualDebts.map((d) => (d.id === next.id ? next : d)),
+        );
+      }
+    },
+    [store],
+  );
+  const deleteDebt = useCallback(
+    (id: string) => {
+      store.setManualDebts(store.manualDebts.filter((d) => d.id !== id));
+    },
+    [store],
+  );
+
+  const submitReceivable = useCallback(
+    (next: AssetsReceivable) => {
+      const existing = store.receivables.findIndex((r) => r.id === next.id);
+      if (existing === -1) {
+        store.setReceivables([...store.receivables, next]);
+      } else {
+        store.setReceivables(
+          store.receivables.map((r) => (r.id === next.id ? next : r)),
+        );
+      }
+    },
+    [store],
+  );
+  const deleteReceivable = useCallback(
+    (id: string) => {
+      store.setReceivables(store.receivables.filter((r) => r.id !== id));
+    },
+    [store],
+  );
+
+  return (
+    <SafeAreaView
+      className="flex-1 bg-cream-50"
+      edges={["top"]}
+      testID={testID}
+    >
+      <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
+        <Text className="text-[22px]">🏦</Text>
+        <Text className="text-[22px] font-bold text-stone-900 flex-1">
+          Активи
+        </Text>
+      </View>
+      <Text className="px-4 text-sm text-stone-600 leading-snug mb-2">
+        Рахунки, борги і дебіторка в одному місці.
+      </Text>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 96, gap: 12 }}
+      >
+        {/* Networth hero */}
+        <View
+          className="rounded-2xl bg-emerald-700 p-4"
+          testID={testID ? `${testID}-networth` : undefined}
+        >
+          <Text className="text-xs font-medium uppercase text-emerald-100/80">
+            Чисті активи
+          </Text>
+          <Text
+            className="text-3xl font-extrabold text-white mt-1"
+            testID={testID ? `${testID}-networth-value` : undefined}
+          >
+            {fmt(summary.networth)} ₴
+          </Text>
+          <Text className="text-xs text-emerald-100/85 mt-1">
+            Активи: {fmt(summary.totalAssets)} ₴ · Пасиви: −
+            {fmt(summary.totalLiabilities)} ₴
+          </Text>
+        </View>
+
+        {/* Accounts section */}
+        <View className="gap-2">
+          <SectionHeader
+            title="💳 Рахунки"
+            summary={`${fmt(summary.monoBalance + summary.manualAssetTotal)} ₴`}
+            open={open.accounts}
+            onToggle={() => setOpen((v) => ({ ...v, accounts: !v.accounts }))}
+            testID={testID ? `${testID}-accounts-toggle` : undefined}
+          />
+          {open.accounts ? (
+            <View className="rounded-2xl border border-cream-300 bg-white px-3 py-1">
+              {visibleAccounts.length === 0 &&
+              store.manualAssets.length === 0 ? (
+                <Text
+                  className="text-sm text-stone-500 py-4 text-center"
+                  testID={testID ? `${testID}-accounts-empty` : undefined}
+                >
+                  Ще немає рахунків
+                </Text>
+              ) : (
+                <>
+                  {visibleAccounts.map((a, i) => (
+                    <AccountRow
+                      key={a.id ?? `acc-${i}`}
+                      account={a}
+                      testID={
+                        testID ? `${testID}-account-${a.id ?? i}` : undefined
+                      }
+                    />
+                  ))}
+                  {store.manualAssets.map((a) => (
+                    <ManualAssetRow
+                      key={a.id}
+                      asset={a}
+                      onPress={() => setSheet({ kind: "asset", asset: a })}
+                      testID={testID ? `${testID}-asset-${a.id}` : undefined}
+                    />
+                  ))}
+                </>
+              )}
+              <Pressable
+                onPress={() => setSheet({ kind: "asset", asset: null })}
+                accessibilityRole="button"
+                accessibilityLabel="Додати актив"
+                testID={testID ? `${testID}-accounts-add` : undefined}
+                className="py-2.5 items-center justify-center border-t border-cream-200 mt-1"
+              >
+                <Text className="text-sm font-medium text-brand-600">
+                  + Додати актив
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
+
+        {/* Debts section */}
+        <View className="gap-2">
+          <SectionHeader
+            title="💸 Борги"
+            summary={`−${fmt(summary.manualDebtTotal + summary.monoDebt)} ₴`}
+            open={open.debts}
+            onToggle={() => setOpen((v) => ({ ...v, debts: !v.debts }))}
+            testID={testID ? `${testID}-debts-toggle` : undefined}
+          />
+          {open.debts ? (
+            <View className="rounded-2xl border border-cream-300 bg-white px-3 py-1">
+              {store.manualDebts.length === 0 ? (
+                <Text
+                  className="text-sm text-stone-500 py-4 text-center"
+                  testID={testID ? `${testID}-debts-empty` : undefined}
+                >
+                  Ще немає боргів
+                </Text>
+              ) : (
+                store.manualDebts.map((d) => (
+                  <DebtRow
+                    key={d.id}
+                    debt={d}
+                    transactions={store.transactions}
+                    onPress={() => setSheet({ kind: "debt", debt: d })}
+                    testID={testID ? `${testID}-debt-${d.id}` : undefined}
+                  />
+                ))
+              )}
+              <Pressable
+                onPress={() => setSheet({ kind: "debt", debt: null })}
+                accessibilityRole="button"
+                accessibilityLabel="Додати борг"
+                testID={testID ? `${testID}-debts-add` : undefined}
+                className="py-2.5 items-center justify-center border-t border-cream-200 mt-1"
+              >
+                <Text className="text-sm font-medium text-brand-600">
+                  + Додати борг
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
+
+        {/* Receivables section */}
+        <View className="gap-2">
+          <SectionHeader
+            title="🤝 Дебіторка"
+            summary={`+${fmt(summary.receivableTotal)} ₴`}
+            open={open.receivables}
+            onToggle={() =>
+              setOpen((v) => ({ ...v, receivables: !v.receivables }))
+            }
+            testID={testID ? `${testID}-receivables-toggle` : undefined}
+          />
+          {open.receivables ? (
+            <View className="rounded-2xl border border-cream-300 bg-white px-3 py-1">
+              {store.receivables.length === 0 ? (
+                <Text
+                  className="text-sm text-stone-500 py-4 text-center"
+                  testID={testID ? `${testID}-receivables-empty` : undefined}
+                >
+                  Ще немає дебіторки
+                </Text>
+              ) : (
+                store.receivables.map((r) => (
+                  <ReceivableRow
+                    key={r.id}
+                    receivable={r}
+                    transactions={store.transactions}
+                    onPress={() =>
+                      setSheet({ kind: "receivable", receivable: r })
+                    }
+                    testID={testID ? `${testID}-receivable-${r.id}` : undefined}
+                  />
+                ))
+              )}
+              <Pressable
+                onPress={() =>
+                  setSheet({ kind: "receivable", receivable: null })
+                }
+                accessibilityRole="button"
+                accessibilityLabel="Додати дебіторку"
+                testID={testID ? `${testID}-receivables-add` : undefined}
+                className="py-2.5 items-center justify-center border-t border-cream-200 mt-1"
+              >
+                <Text className="text-sm font-medium text-brand-600">
+                  + Додати дебіторку
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
+      </ScrollView>
+
+      <ManualAssetSheet
+        open={sheet.kind === "asset"}
+        onClose={closeSheet}
+        asset={sheet.kind === "asset" ? sheet.asset : null}
+        onSubmit={submitAsset}
+        onDelete={deleteAsset}
+        testID={testID ? `${testID}-asset-sheet` : undefined}
+      />
+      <DebtSheet
+        open={sheet.kind === "debt"}
+        onClose={closeSheet}
+        debt={sheet.kind === "debt" ? sheet.debt : null}
+        onSubmit={submitDebt}
+        onDelete={deleteDebt}
+        testID={testID ? `${testID}-debt-sheet` : undefined}
+      />
+      <ReceivableSheet
+        open={sheet.kind === "receivable"}
+        onClose={closeSheet}
+        receivable={sheet.kind === "receivable" ? sheet.receivable : null}
+        onSubmit={submitReceivable}
+        onDelete={deleteReceivable}
+        testID={testID ? `${testID}-receivable-sheet` : undefined}
+      />
+    </SafeAreaView>
+  );
+}
+
+export default AssetsPage;

--- a/packages/finyk-domain/src/domain/assets/aggregates.test.ts
+++ b/packages/finyk-domain/src/domain/assets/aggregates.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeAssetsSummary,
+  filterVisibleAccounts,
+  getAccountCurrencySymbol,
+  getManualAssetCurrencySymbol,
+  sumDebtsRemaining,
+  sumManualAssetsUAH,
+  sumReceivablesRemaining,
+} from "./aggregates.js";
+import type {
+  AssetsDebt,
+  AssetsReceivable,
+  ManualAsset,
+  MonoAccount,
+} from "./types.js";
+
+const asTx = <T extends object>(tx: T): never => tx as never;
+
+describe("assets — sumManualAssetsUAH", () => {
+  it("повертає 0 для порожнього/відсутнього списку", () => {
+    expect(sumManualAssetsUAH([])).toBe(0);
+    expect(sumManualAssetsUAH(undefined)).toBe(0);
+    expect(sumManualAssetsUAH(null)).toBe(0);
+  });
+
+  it("ігнорує не-UAH валюти", () => {
+    const assets: ManualAsset[] = [
+      { id: "a", name: "cash", amount: 1000, currency: "UAH" },
+      { id: "b", name: "brokerage", amount: 500, currency: "USD" },
+      { id: "c", name: "eu cash", amount: 200, currency: "EUR" },
+    ];
+    expect(sumManualAssetsUAH(assets)).toBe(1000);
+  });
+
+  it("сумує кілька UAH записів", () => {
+    const assets: ManualAsset[] = [
+      { id: "a", name: "cash", amount: 250, currency: "UAH" },
+      { id: "b", name: "safe", amount: 750.5, currency: "UAH" },
+    ];
+    expect(sumManualAssetsUAH(assets)).toBe(1000.5);
+  });
+
+  it("толерує string-сумісну `amount`", () => {
+    const assets = [
+      { id: "a", name: "cash", amount: "500", currency: "UAH" },
+      { id: "b", name: "empty", amount: "", currency: "UAH" },
+    ] as unknown as ManualAsset[];
+    expect(sumManualAssetsUAH(assets)).toBe(500);
+  });
+});
+
+describe("assets — sumDebtsRemaining", () => {
+  it("повертає 0 коли боргів немає", () => {
+    expect(sumDebtsRemaining([])).toBe(0);
+    expect(sumDebtsRemaining(undefined)).toBe(0);
+  });
+
+  it("сумує залишки кількох боргів", () => {
+    const debts: AssetsDebt[] = [
+      { id: "d1", amount: 100, totalAmount: 1000, linkedTxIds: [] },
+      { id: "d2", amount: 50, totalAmount: 400, linkedTxIds: [] },
+    ];
+    expect(sumDebtsRemaining(debts, [])).toBe(1400);
+  });
+
+  it("враховує лінковані платежі (amount < 0) як сплати", () => {
+    const debts: AssetsDebt[] = [
+      { id: "d1", amount: 0, totalAmount: 500, linkedTxIds: ["p"] },
+    ];
+    const tx = [asTx({ id: "p", amount: -200_00 })];
+    expect(sumDebtsRemaining(debts, tx)).toBe(300);
+  });
+
+  it("не йде нижче нуля при переплаті", () => {
+    const debts: AssetsDebt[] = [
+      { id: "d1", amount: 0, totalAmount: 100, linkedTxIds: ["p"] },
+    ];
+    const tx = [asTx({ id: "p", amount: -500_00 })];
+    expect(sumDebtsRemaining(debts, tx)).toBe(0);
+  });
+});
+
+describe("assets — sumReceivablesRemaining", () => {
+  it("повертає 0 коли дебіторів немає", () => {
+    expect(sumReceivablesRemaining([])).toBe(0);
+    expect(sumReceivablesRemaining(undefined)).toBe(0);
+  });
+
+  it("сумує залишки дебіторки з урахуванням погашень", () => {
+    const recv: AssetsReceivable[] = [
+      { id: "r1", amount: 300, linkedTxIds: [] },
+      { id: "r2", amount: 200, linkedTxIds: ["p"] },
+    ];
+    const tx = [asTx({ id: "p", amount: 50_00 })];
+    expect(sumReceivablesRemaining(recv, tx)).toBe(450);
+  });
+});
+
+describe("assets — filterVisibleAccounts", () => {
+  it("відсікає сховані рахунки по id", () => {
+    const accounts: MonoAccount[] = [
+      { id: "a", balance: 0 },
+      { id: "b", balance: 0 },
+      { id: "c", balance: 0 },
+    ];
+    expect(filterVisibleAccounts(accounts, ["b"]).map((a) => a.id)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  it("зберігає рахунки без id навіть у hidden-списку", () => {
+    const accounts: MonoAccount[] = [
+      { balance: 100 },
+      { id: "b", balance: 200 },
+    ];
+    const visible = filterVisibleAccounts(accounts, ["b"]);
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.balance).toBe(100);
+  });
+});
+
+describe("assets — currency symbols", () => {
+  it("getAccountCurrencySymbol мапить канонічні коди", () => {
+    expect(getAccountCurrencySymbol(980)).toBe("₴");
+    expect(getAccountCurrencySymbol(840)).toBe("$");
+    expect(getAccountCurrencySymbol(978)).toBe("€");
+  });
+
+  it("getAccountCurrencySymbol фолбечить на ₴ при невідомому/відсутньому коді", () => {
+    expect(getAccountCurrencySymbol(123)).toBe("₴");
+    expect(getAccountCurrencySymbol(undefined)).toBe("₴");
+    expect(getAccountCurrencySymbol(null)).toBe("₴");
+  });
+
+  it("getManualAssetCurrencySymbol мапить alpha-коди", () => {
+    expect(getManualAssetCurrencySymbol("UAH")).toBe("₴");
+    expect(getManualAssetCurrencySymbol("USD")).toBe("$");
+    expect(getManualAssetCurrencySymbol("EUR")).toBe("€");
+    expect(getManualAssetCurrencySymbol("PLN")).toBe("PLN");
+  });
+});
+
+describe("assets — computeAssetsSummary", () => {
+  it("порожній стейт → всі нулі", () => {
+    const summary = computeAssetsSummary({
+      accounts: [],
+      manualAssets: [],
+      manualDebts: [],
+      receivables: [],
+      transactions: [],
+    });
+    expect(summary).toEqual({
+      monoBalance: 0,
+      monoDebt: 0,
+      manualAssetTotal: 0,
+      manualDebtTotal: 0,
+      receivableTotal: 0,
+      totalAssets: 0,
+      totalLiabilities: 0,
+      networth: 0,
+    });
+  });
+
+  it("networth = totalAssets − totalLiabilities", () => {
+    const accounts: MonoAccount[] = [
+      // +500 ₴ UAH asset (balance у копійках, UAH=980)
+      { id: "a1", balance: 500_00, currencyCode: 980 },
+      // Кредитка: creditLimit=1000_00, balance=300_00 → борг = 700₴
+      {
+        id: "a2",
+        balance: 300_00,
+        creditLimit: 1000_00,
+        currencyCode: 980,
+      },
+    ];
+    const manualAssets: ManualAsset[] = [
+      { id: "m1", name: "готівка", amount: 200, currency: "UAH" },
+      { id: "m2", name: "FX", amount: 999, currency: "USD" },
+    ];
+    const manualDebts: AssetsDebt[] = [
+      { id: "d1", amount: 0, totalAmount: 100, linkedTxIds: [] },
+    ];
+    const receivables: AssetsReceivable[] = [
+      { id: "r1", amount: 50, linkedTxIds: [] },
+    ];
+
+    const summary = computeAssetsSummary({
+      accounts,
+      hiddenAccounts: [],
+      manualAssets,
+      manualDebts,
+      receivables,
+      transactions: [],
+    });
+
+    expect(summary.monoBalance).toBe(500);
+    expect(summary.monoDebt).toBe(700);
+    expect(summary.manualAssetTotal).toBe(200);
+    expect(summary.manualDebtTotal).toBe(100);
+    expect(summary.receivableTotal).toBe(50);
+    expect(summary.totalAssets).toBe(500 + 200 + 50);
+    expect(summary.totalLiabilities).toBe(700 + 100);
+    expect(summary.networth).toBe(
+      summary.totalAssets - summary.totalLiabilities,
+    );
+  });
+
+  it("виключає сховані рахунки з mono-активів", () => {
+    const accounts: MonoAccount[] = [
+      { id: "visible", balance: 400_00, currencyCode: 980 },
+      { id: "hidden", balance: 900_00, currencyCode: 980 },
+    ];
+    const summary = computeAssetsSummary({
+      accounts,
+      hiddenAccounts: ["hidden"],
+      manualAssets: [],
+      manualDebts: [],
+      receivables: [],
+      transactions: [],
+    });
+    expect(summary.monoBalance).toBe(400);
+    expect(summary.totalAssets).toBe(400);
+  });
+
+  it("враховує лінковані платежі при підсумку боргів", () => {
+    const manualDebts: AssetsDebt[] = [
+      { id: "d1", amount: 0, totalAmount: 500, linkedTxIds: ["p1"] },
+    ];
+    const transactions = [asTx({ id: "p1", amount: -200_00 })];
+    const summary = computeAssetsSummary({
+      accounts: [],
+      manualAssets: [],
+      manualDebts,
+      receivables: [],
+      transactions,
+    });
+    expect(summary.manualDebtTotal).toBe(300);
+    expect(summary.totalLiabilities).toBe(300);
+    expect(summary.networth).toBe(-300);
+  });
+});

--- a/packages/finyk-domain/src/domain/assets/aggregates.ts
+++ b/packages/finyk-domain/src/domain/assets/aggregates.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure aggregation helpers for the Finyk Assets page.
+ *
+ * Mirrors the hand-rolled reductions that
+ * `apps/web/src/modules/finyk/pages/Assets.tsx` performs inline. Moving
+ * the math here keeps the web + mobile ports bit-for-bit identical and
+ * lets us unit-test rollups (networth, total-assets, total-liabilities)
+ * without spinning up React.
+ *
+ * Everything is deterministic, DOM-free, and safe for `useMemo` /
+ * server-side use.
+ */
+
+import { calcDebtRemaining, calcReceivableRemaining } from "../debtEngine.js";
+import { getMonoTotals, type MonoAccount } from "../../lib/accounts.js";
+import { CURRENCY } from "../../constants.js";
+import type { Transaction } from "../types.js";
+import type {
+  AssetsDebt,
+  AssetsReceivable,
+  AssetsSummary,
+  AssetsSummaryInput,
+  ManualAsset,
+} from "./types.js";
+
+/**
+ * Sum UAH-denominated manual assets. Non-UAH entries are ignored —
+ * Assets (and Overview) treat the FX portfolio as out-of-scope for
+ * networth until a live FX rate is wired up.
+ */
+export function sumManualAssetsUAH(
+  manualAssets: readonly ManualAsset[] | null | undefined,
+): number {
+  if (!manualAssets) return 0;
+  return manualAssets
+    .filter((a) => a.currency === "UAH")
+    .reduce((sum, a) => sum + Number(a.amount || 0), 0);
+}
+
+/**
+ * Sum the "remaining" (still-owed) amount across a list of debts. Each
+ * debt's own remaining amount is clamped to `≥ 0` inside
+ * {@link calcDebtRemaining}.
+ */
+export function sumDebtsRemaining(
+  debts: readonly AssetsDebt[] | null | undefined,
+  transactions: readonly Transaction[] = [],
+): number {
+  if (!debts) return 0;
+  return debts.reduce(
+    (sum, d) => sum + calcDebtRemaining(d, transactions as Transaction[]),
+    0,
+  );
+}
+
+/**
+ * Sum the "remaining" amount owed to the user across receivables. Same
+ * clamp semantics as {@link sumDebtsRemaining}.
+ */
+export function sumReceivablesRemaining(
+  receivables: readonly AssetsReceivable[] | null | undefined,
+  transactions: readonly Transaction[] = [],
+): number {
+  if (!receivables) return 0;
+  return receivables.reduce(
+    (sum, r) => sum + calcReceivableRemaining(r, transactions as Transaction[]),
+    0,
+  );
+}
+
+/**
+ * Hide-list-aware filter for Mono accounts. Mirrors
+ * `accounts.filter((a) => !hiddenAccounts.includes(a.id))` used on web
+ * but accepts both `undefined` ids and read-only inputs.
+ */
+export function filterVisibleAccounts(
+  accounts: readonly MonoAccount[],
+  hiddenAccounts: readonly string[] = [],
+): MonoAccount[] {
+  const hidden = new Set(hiddenAccounts);
+  return accounts.filter((a) => !(a.id !== undefined && hidden.has(a.id)));
+}
+
+const CURRENCY_SYMBOL_BY_CODE: Record<number, string> = {
+  [CURRENCY.UAH as number]: "₴",
+  [CURRENCY.USD as number]: "$",
+  [CURRENCY.EUR as number]: "€",
+};
+
+/**
+ * Map an ISO-4217 numeric currency code to its symbol. Defaults to `₴`
+ * so unknown / missing codes render as the local currency — same
+ * behaviour as `apps/web/src/modules/finyk/pages/Assets.tsx`.
+ */
+export function getAccountCurrencySymbol(
+  currencyCode: number | null | undefined,
+): string {
+  if (currencyCode == null) return "₴";
+  return CURRENCY_SYMBOL_BY_CODE[currencyCode] ?? "₴";
+}
+
+/**
+ * Map an ISO-4217 alpha code (manual-asset `currency` field) to its
+ * symbol. Unknown codes round-trip back as the input so the UI can
+ * still display them without crashing.
+ */
+export function getManualAssetCurrencySymbol(currency: string): string {
+  if (currency === "UAH") return "₴";
+  if (currency === "USD") return "$";
+  if (currency === "EUR") return "€";
+  return currency;
+}
+
+/**
+ * Compute the complete Assets-page rollup in a single pass. Consumers
+ * (mobile `AssetsPage`, web `Assets.tsx`) can spread the result straight
+ * into the networth header without re-running any of the individual
+ * sub-selectors.
+ */
+export function computeAssetsSummary(input: AssetsSummaryInput): AssetsSummary {
+  const {
+    accounts,
+    hiddenAccounts = [],
+    manualAssets,
+    manualDebts,
+    receivables,
+    transactions,
+  } = input;
+
+  const { balance: monoBalance, debt: monoDebt } = getMonoTotals(
+    accounts,
+    // getMonoTotals takes a mutable `string[]` — readonly → string[] is
+    // safe because `getMonoTotals` only reads the array.
+    hiddenAccounts as string[],
+  );
+
+  const manualAssetTotal = sumManualAssetsUAH(manualAssets);
+  const manualDebtTotal = sumDebtsRemaining(manualDebts, transactions);
+  const receivableTotal = sumReceivablesRemaining(receivables, transactions);
+
+  const totalAssets = monoBalance + manualAssetTotal + receivableTotal;
+  const totalLiabilities = monoDebt + manualDebtTotal;
+  const networth = totalAssets - totalLiabilities;
+
+  return {
+    monoBalance,
+    monoDebt,
+    manualAssetTotal,
+    manualDebtTotal,
+    receivableTotal,
+    totalAssets,
+    totalLiabilities,
+    networth,
+  };
+}

--- a/packages/finyk-domain/src/domain/assets/index.ts
+++ b/packages/finyk-domain/src/domain/assets/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./aggregates.js";

--- a/packages/finyk-domain/src/domain/assets/types.ts
+++ b/packages/finyk-domain/src/domain/assets/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Strict types for the Finyk Assets page domain.
+ *
+ * Kept separate from {@link ./aggregates} so both the mobile/web UI and
+ * the pure selectors can import the exact same shapes without a runtime
+ * cycle. All types model the user-facing view of a UAH-first ledger —
+ * bank accounts (Monobank), user-managed manual assets (cash, crypto,
+ * brokerage…), outgoing debts (liabilities), and incoming receivables
+ * (money owed to the user).
+ */
+
+import type { MonoAccount } from "../../lib/accounts.js";
+import type { Debt, Receivable } from "../debtEngine.js";
+import type { Transaction } from "../types.js";
+
+export type { MonoAccount };
+
+/** Three-letter ISO-4217 currency code. Kept open for forward-compat. */
+export type AssetCurrency = "UAH" | "USD" | "EUR" | (string & {});
+
+/**
+ * User-added "manual" asset row rendered in the Assets page.
+ * The canonical persisted shape (keys match `finyk_assets` localStorage /
+ * MMKV entries). `amount` is in major units (UAH, not копійки) so it
+ * lines up with how the Assets UI reads it.
+ */
+export interface ManualAsset {
+  id: string;
+  name: string;
+  emoji?: string;
+  amount: number;
+  currency: AssetCurrency;
+}
+
+/**
+ * Extension of the base `Debt` / `Receivable` domain with the optional
+ * UI fields Assets edits (name, emoji, due date, note).
+ */
+export interface AssetsDebt extends Debt {
+  name?: string;
+  emoji?: string;
+  dueDate?: string | null;
+  note?: string;
+}
+
+export interface AssetsReceivable extends Receivable {
+  name?: string;
+  emoji?: string;
+  dueDate?: string | null;
+  note?: string;
+}
+
+/** Aggregated totals used by the Assets page networth header. */
+export interface AssetsSummary {
+  /** Mono (real-bank) UAH balance sum — excludes hidden accounts. */
+  monoBalance: number;
+  /** Mono credit-card debt in UAH. */
+  monoDebt: number;
+  /** Sum of UAH-denominated manual assets. */
+  manualAssetTotal: number;
+  /** Sum of manual-debt remaining amounts (≥ 0 per row). */
+  manualDebtTotal: number;
+  /** Sum of receivable remaining amounts (≥ 0 per row). */
+  receivableTotal: number;
+  /** Assets side: mono + manual + receivables. */
+  totalAssets: number;
+  /** Liability side: mono credit debt + manual debts. */
+  totalLiabilities: number;
+  /** Networth = totalAssets − totalLiabilities. */
+  networth: number;
+}
+
+/** Shape consumed by {@link computeAssetsSummary}. */
+export interface AssetsSummaryInput {
+  accounts: MonoAccount[];
+  hiddenAccounts?: readonly string[];
+  manualAssets: readonly ManualAsset[];
+  manualDebts: readonly AssetsDebt[];
+  receivables: readonly AssetsReceivable[];
+  transactions: readonly Transaction[];
+}

--- a/packages/finyk-domain/src/domain/index.ts
+++ b/packages/finyk-domain/src/domain/index.ts
@@ -7,3 +7,4 @@ export * from "./personalization.js";
 export * from "./selectors.js";
 export * from "./subscriptionUtils.js";
 export * from "./overview.js";
+export * from "./assets/index.js";


### PR DESCRIPTION
## Summary

Ports the web Assets page (`apps/web/src/modules/finyk/pages/Assets.tsx`, ~937 LOC) to React Native as the fourth Finyk screen in the mobile tab. Moves all aggregation math into `@sergeant/finyk-domain` so the web and mobile renderers sit on the same pure selectors.

**Domain layer** — new `packages/finyk-domain/src/domain/assets/*`:
- `types.ts` — `ManualAsset`, `AssetsDebt`, `AssetsReceivable`, `AssetsSummary`, `AssetsSummaryInput`; re-exports `MonoAccount` / `Transaction` so consumers import a single namespace.
- `aggregates.ts` — `sumManualAssetsUAH`, `sumDebtsRemaining`, `sumReceivablesRemaining`, `filterVisibleAccounts`, `getAccountCurrencySymbol`, `getManualAssetCurrencySymbol`, `computeAssetsSummary`. Reuses existing `getMonoTotals`, `calcDebtRemaining`, `calcReceivableRemaining` — no duplication.
- `aggregates.test.ts` — **19 vitest cases** covering empty/seeded branches, hidden-account filtering, linked-payment rollups, non-UAH ignore path, currency-symbol fallbacks, and full `computeAssetsSummary` formula.
- Re-exported from `src/domain/index.ts`.

**Mobile UI** — new `apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.tsx` + sub-components:
- Three collapsible sections (Рахунки / Борги / Дебіторка), each with empty state, list of rows, and `+ Додати …` inline CTA.
- `NetworthSection`-style hero at the top, values driven by `computeAssetsSummary`.
- Tap-row → bottom-sheet for edit/delete using the existing `Sheet` primitive (the same one Habits uses).
- `components/assets/rows.tsx` — memoised `AccountRow` / `ManualAssetRow` / `DebtRow` / `ReceivableRow`.
- `components/assets/{ManualAssetSheet,DebtSheet,ReceivableSheet}.tsx` — create + edit + delete forms, all validated before submit.
- `lib/assetsStore.ts` — MMKV-backed hook, reads/writes `finyk_assets` / `finyk_debts` / `finyk_recv` / `finyk_hidden` through the canonical `FINYK_BACKUP_STORAGE_KEYS`, with an explicit `seed` seam for tests/storybooks.
- `apps/mobile/app/(tabs)/finyk/assets.tsx` — replaces the `FinykPageStub` with the new page.

**Tests** — `AssetsPage.test.tsx`: empty-state per section, seeded-data render + networth, FAB opens correct sheet (asset / debt / receivable), edit-row pre-populates sheet.

**Deferred** (flagged for follow-ups, not regressions of the web build):
- Live Monobank API sync — `accounts` / `transactions` still come from `seed` only on mobile; the network client lives in the Finyk root store which lands with the `TxListItem` / `SwipeToAction` migration (#453 siblings).
- Transaction-picker for linking payments to debts / receivables — depends on #453's `TxListItem`.
- Subscriptions section / recurring-detector — Routine owns that surface on mobile now.

Constraints respected: no touches to `apps/mobile/src/modules/{fizruk,routine}/**`, no touches to `apps/mobile/src/modules/finyk/pages/Overview/**`, no touches to #453-owned components (`TxRow`, `TxListItem`, `SwipeToAction`, `ManualExpenseSheet`), no changes to `apps/mobile/{jest.config.js,tsconfig.json,package.json}`, no new root dependencies, no changes under `apps/web/**`.

`pnpm check` is green locally (format:check + lint + typecheck + test + build, 202 mobile tests + 206 domain tests).

## Review & Testing Checklist for Human

- [ ] Open the Finyk Активи tab — networth hero renders, all three sections expand/collapse, empty-state copy appears before seeding.
- [ ] Add a manual asset / debt / receivable via the `+ Додати …` buttons, confirm it shows up immediately and persists across a cold relaunch (MMKV).
- [ ] Tap an existing row, edit the name + amount, confirm values update in place and the networth hero recomputes.
- [ ] Tap "Видалити" in the edit sheet, confirm the row disappears and persisted state is cleared.
- [ ] Because `accounts` / `transactions` are still seed-only on mobile, the Mono totals in the Рахунки summary will be `0 ₴` until the Monobank client lands — that's expected in this PR.

### Notes
- Domain selectors are reused by both web and mobile; the existing `debtEngine` helpers are not modified.
- `getAccountLabel` is currently inlined in `rows.tsx` mirroring `getAccountShortName` from the web `TxRow`; it'll move into the shared domain when the full accounts helper ships.


Link to Devin session: https://app.devin.ai/sessions/fc2107d8f7a2405d91e5486594e56482
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
