### PR TITLE
feat(mobile-observability): Sentry RN init scaffold (gated by EXPO_PUBLIC_SENTRY_DSN)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,3 +161,11 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # заголовок `X-Token` і форвардяться до upstream. Сервер їх зберігає лише у
 # memory кешу TTL=60с (хешовано). Якщо потрібно підкрутити resilience,
 # робиться це редагуванням `server/lib/bankProxy.js` (немає env-конфігу).
+
+# ── Mobile (Expo) — apps/mobile ───────────────────────────────
+# Публічний Sentry DSN для RN-клієнта. Інлайниться у бандл на
+# build-time (префікс EXPO_PUBLIC_ → доступно в `process.env`).
+# optional — без нього `initObservability()` виконує no-op і
+# жодних подій у Sentry не відправляється.
+# Див. `apps/mobile/src/lib/observability.ts`.
+# EXPO_PUBLIC_SENTRY_DSN=

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -56,6 +56,13 @@ const config = (): ExpoConfig => ({
         imageWidth: 200,
       },
     ],
+    // Sentry native plugin — required by `@sentry/react-native` for
+    // the iOS/Android native build to link the RNSentry module. Source
+    // maps are only uploaded at EAS build time when `SENTRY_AUTH_TOKEN`
+    // + `SENTRY_ORG` + `SENTRY_PROJECT` are set; otherwise the plugin
+    // no-ops and JS Sentry still initialises via `EXPO_PUBLIC_SENTRY_DSN`
+    // (see `src/lib/observability.ts`).
+    "@sentry/react-native/expo",
   ],
   experiments: {
     typedRoutes: true,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,5 +1,6 @@
 import "../global.css";
 
+import { useEffect } from "react";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -19,10 +20,15 @@ import "@/lib/fileDownload";
 // visual-keyboard-inset contract (`@sergeant/shared`). Import for side
 // effects only.
 import "@/hooks/useVisualKeyboardInset";
+import { initObservability } from "@/lib/observability";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { CloudSyncProvider } from "@/sync";
 
 export default function RootLayout() {
+  useEffect(() => {
+    initObservability();
+  }, []);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@expo/metro-runtime": "~4.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "11.4.1",
+    "@sentry/react-native": "~6.10.0",
     "@sergeant/api-client": "workspace:*",
     "@sergeant/design-tokens": "workspace:*",
     "@sergeant/finyk-domain": "workspace:^",

--- a/apps/mobile/src/core/ErrorBoundary.tsx
+++ b/apps/mobile/src/core/ErrorBoundary.tsx
@@ -40,6 +40,7 @@ import { router } from "expo-router";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { captureError } from "@/lib/observability";
 
 interface FallbackProps {
   error: Error;
@@ -104,10 +105,14 @@ export class ErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    // TODO(phase-10): forward via `@sentry/react-native` once mobile
-    // observability is wired up (see `apps/web/src/core/sentry.ts` and
-    // `docs/react-native-migration.md` §2.4). For now we just log —
-    // the boundary itself must never throw because of telemetry.
+    // Forward to Sentry when a DSN is configured; `captureError`
+    // falls back to `console.error` in no-op mode so the diagnostic
+    // is never silently dropped. The boundary itself must never
+    // throw because of telemetry — `captureError` is wrapped in
+    // try/catch internally, and this outer guard is belt-and-braces
+    // for the `console.error` call itself (RN's console is backed
+    // by a LogBox bridge that has been known to throw on very large
+    // payloads).
     try {
       console.error("[ErrorBoundary] caught error", error, {
         componentStack: info?.componentStack,
@@ -115,6 +120,7 @@ export class ErrorBoundary extends Component<
     } catch {
       /* noop */
     }
+    captureError(error, { componentStack: info?.componentStack });
   }
 
   render() {

--- a/apps/mobile/src/lib/observability.test.ts
+++ b/apps/mobile/src/lib/observability.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Jest coverage for `initObservability` / `captureError` —
+ * gating behaviour around `EXPO_PUBLIC_SENTRY_DSN`, Sentry handoff
+ * when the DSN is set, and the `console.error` fallback in no-op mode.
+ *
+ * The DSN read lives in `./observability/env` so we can `jest.mock`
+ * it here without fighting Expo's babel `EXPO_PUBLIC_*` env-inlining
+ * plugin. `@sentry/react-native` is also mocked at module level so
+ * we don't boot the native RNSentry bridge (unavailable under
+ * jest-expo's node-side preset).
+ */
+
+jest.mock("@sentry/react-native", () => ({
+  __esModule: true,
+  init: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+jest.mock("./observability/env", () => ({
+  __esModule: true,
+  getSentryDsn: jest.fn(),
+}));
+
+import * as Sentry from "@sentry/react-native";
+
+import {
+  __resetObservabilityForTests,
+  captureError,
+  initObservability,
+} from "./observability";
+import { getSentryDsn } from "./observability/env";
+
+const initMock = Sentry.init as jest.Mock;
+const captureExceptionMock = Sentry.captureException as jest.Mock;
+const getSentryDsnMock = getSentryDsn as jest.Mock;
+
+describe("observability", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetObservabilityForTests();
+    initMock.mockReset();
+    captureExceptionMock.mockReset();
+    getSentryDsnMock.mockReset();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  describe("initObservability", () => {
+    it("is a no-op when EXPO_PUBLIC_SENTRY_DSN is absent and logs a diagnostic", () => {
+      getSentryDsnMock.mockReturnValue(undefined);
+
+      initObservability();
+
+      expect(initMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "[observability] sentry disabled (no DSN)",
+      );
+    });
+
+    it("is a no-op when EXPO_PUBLIC_SENTRY_DSN is an empty string", () => {
+      getSentryDsnMock.mockReturnValue("");
+
+      initObservability();
+
+      expect(initMock).not.toHaveBeenCalled();
+    });
+
+    it("calls Sentry.init with the DSN and the expected scaffold config when DSN is set", () => {
+      getSentryDsnMock.mockReturnValue("https://example@sentry.io/1");
+
+      initObservability();
+
+      expect(initMock).toHaveBeenCalledTimes(1);
+      const arg = initMock.mock.calls[0][0] as {
+        dsn: string;
+        enableAutoSessionTracking: boolean;
+        tracesSampleRate: number;
+      };
+      expect(arg.dsn).toBe("https://example@sentry.io/1");
+      expect(arg.enableAutoSessionTracking).toBe(true);
+      expect(arg.tracesSampleRate).toBe(0);
+    });
+
+    it("is idempotent — re-entry does not re-init Sentry", () => {
+      getSentryDsnMock.mockReturnValue("https://example@sentry.io/1");
+
+      initObservability();
+      initObservability();
+      initObservability();
+
+      expect(initMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("captureError", () => {
+    it("falls back to console.error when Sentry is not initialised", () => {
+      getSentryDsnMock.mockReturnValue(undefined);
+      initObservability(); // no-op path
+
+      const err = new Error("boom");
+      captureError(err, { componentStack: "stack" });
+
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[observability] captureError",
+        err,
+        { componentStack: "stack" },
+      );
+    });
+
+    it("forwards to Sentry.captureException with extras when Sentry is initialised", () => {
+      getSentryDsnMock.mockReturnValue("https://example@sentry.io/1");
+      initObservability();
+
+      const err = new Error("kaboom");
+      captureError(err, { foo: "bar" });
+
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(captureExceptionMock).toHaveBeenCalledWith(err, {
+        extra: { foo: "bar" },
+      });
+      // Must not also hit console.error on the happy path.
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("falls back to console.error if Sentry.captureException throws", () => {
+      getSentryDsnMock.mockReturnValue("https://example@sentry.io/1");
+      initObservability();
+      captureExceptionMock.mockImplementationOnce(() => {
+        throw new Error("sentry down");
+      });
+
+      const err = new Error("kaboom");
+      captureError(err);
+
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[observability] captureError",
+        err,
+        undefined,
+      );
+    });
+
+    it("accepts a missing context argument without throwing", () => {
+      getSentryDsnMock.mockReturnValue(undefined);
+      initObservability();
+
+      expect(() => captureError(new Error("x"))).not.toThrow();
+    });
+  });
+});

--- a/apps/mobile/src/lib/observability.ts
+++ b/apps/mobile/src/lib/observability.ts
@@ -1,0 +1,73 @@
+/**
+ * Sergeant mobile — observability (Sentry RN) bootstrap.
+ *
+ * Phase 12 scaffold: wires `@sentry/react-native` behind the
+ * `EXPO_PUBLIC_SENTRY_DSN` env var so the app remains a clean no-op
+ * when the DSN is absent (local dev, forks, PR previews without
+ * secrets). No user-PII capture, no HTTP breadcrumbs, no performance
+ * tracing — those land in follow-up phases.
+ *
+ * @see docs/react-native-migration.md §4 (Phase 12)
+ * @see apps/web/src/core/sentry.ts — web-side analogue
+ */
+
+import * as Sentry from "@sentry/react-native";
+
+import { getSentryDsn } from "./observability/env";
+
+/** Module-scope flag flipped the first time `initObservability()`
+ *  successfully hands a DSN to `Sentry.init`. Used by `captureError`
+ *  to pick between the real `captureException` tap and the
+ *  `console.error` fallback. */
+let initialized = false;
+
+/**
+ * Initialises Sentry RN iff `EXPO_PUBLIC_SENTRY_DSN` is set.
+ *
+ * Must be called exactly once, from a `useEffect` at the root of the
+ * Expo Router tree (see `apps/mobile/app/_layout.tsx`). No side effects
+ * at import time — tests can `jest.resetModules()` cleanly.
+ */
+export function initObservability(): void {
+  if (initialized) return;
+  const dsn = getSentryDsn();
+  if (!dsn) {
+    console.log("[observability] sentry disabled (no DSN)");
+    return;
+  }
+  Sentry.init({
+    dsn,
+    enableAutoSessionTracking: true,
+    tracesSampleRate: 0,
+    debug: __DEV__,
+  });
+  initialized = true;
+}
+
+/**
+ * Forwards `error` to `Sentry.captureException` when Sentry is
+ * initialised, otherwise logs to `console.error` so the diagnostic
+ * never silently disappears. Safe to call from error boundaries —
+ * never throws.
+ */
+export function captureError(
+  error: unknown,
+  context?: Record<string, unknown>,
+): void {
+  if (initialized) {
+    try {
+      Sentry.captureException(error, { extra: context });
+      return;
+    } catch {
+      // Sentry must never break the host app — fall through to
+      // console.error so we at least get a local trace.
+    }
+  }
+  console.error("[observability] captureError", error, context);
+}
+
+/** Test-only reset. Exported from a `__test__` prefix so it's obvious
+ *  at call-sites that this is not for production use. */
+export function __resetObservabilityForTests(): void {
+  initialized = false;
+}

--- a/apps/mobile/src/lib/observability/env.ts
+++ b/apps/mobile/src/lib/observability/env.ts
@@ -1,0 +1,11 @@
+/**
+ * DSN accessor split into its own module so Jest can `jest.mock` the
+ * read and drive `initObservability` through both the DSN-set and
+ * DSN-absent branches in a single test file. At production build time
+ * Expo's babel preset inlines the `process.env.EXPO_PUBLIC_SENTRY_DSN`
+ * literal here — the inlined value is the only thing that ships.
+ */
+
+export function getSentryDsn(): string | undefined {
+  return process.env.EXPO_PUBLIC_SENTRY_DSN;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       "@react-native-community/netinfo":
         specifier: 11.4.1
         version: 11.4.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))
+      "@sentry/react-native":
+        specifier: ~6.10.0
+        version: 6.10.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       "@sergeant/api-client":
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -3895,10 +3898,24 @@ packages:
         integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==,
       }
 
+  "@sentry-internal/browser-utils@8.54.0":
+    resolution:
+      {
+        integrity: sha512-DKWCqb4YQosKn6aD45fhKyzhkdG7N6goGFDeyTaJFREJDFVDXiNDsYZu30nJ6BxMM7uQIaARhPAC5BXfoED3pQ==,
+      }
+    engines: { node: ">=14.18" }
+
   "@sentry-internal/browser-utils@8.55.1":
     resolution:
       {
         integrity: sha512-SipXiwVhJrxzy3/4kf+YIFmpYlLKtGSRD+er7SBCcuSBtv31Fee8IXMDvk+bq24gRXxyjOLUmT//GGXjy2LL6w==,
+      }
+    engines: { node: ">=14.18" }
+
+  "@sentry-internal/feedback@8.54.0":
+    resolution:
+      {
+        integrity: sha512-nQqRacOXoElpE0L0ADxUUII0I3A94niqG9Z4Fmsw6057QvyrV/LvTiMQBop6r5qLjwMqK+T33iR4/NQI5RhsXQ==,
       }
     engines: { node: ">=14.18" }
 
@@ -3909,10 +3926,24 @@ packages:
       }
     engines: { node: ">=14.18" }
 
+  "@sentry-internal/replay-canvas@8.54.0":
+    resolution:
+      {
+        integrity: sha512-K/On3OAUBeq/TV2n+1EvObKC+WMV9npVXpVyJqCCyn8HYMm8FUGzuxeajzm0mlW4wDTPCQor6mK9/IgOquUzCw==,
+      }
+    engines: { node: ">=14.18" }
+
   "@sentry-internal/replay-canvas@8.55.1":
     resolution:
       {
         integrity: sha512-2sKRu96Qe70y6TiYdYbwkhg4um2prgzH/ZJRItuoSEAjPjoFYYlP+1qjE2CcBw4RPS8/PimV7SFheSaeZs2GCw==,
+      }
+    engines: { node: ">=14.18" }
+
+  "@sentry-internal/replay@8.54.0":
+    resolution:
+      {
+        integrity: sha512-8xuBe06IaYIGJec53wUC12tY2q4z2Z0RPS2s1sLtbA00EvK1YDGuXp96IDD+HB9mnDMrQ/jW5f97g9TvPsPQUg==,
       }
     engines: { node: ">=14.18" }
 
@@ -3923,10 +3954,101 @@ packages:
       }
     engines: { node: ">=14.18" }
 
+  "@sentry/babel-plugin-component-annotate@3.2.2":
+    resolution:
+      {
+        integrity: sha512-D+SKQ266ra/wo87s9+UI/rKQi3qhGPCR8eSCDe0VJudhjHsqyNU+JJ5lnIGCgmZaWFTXgdBP/gdr1Iz1zqGs4Q==,
+      }
+    engines: { node: ">= 14" }
+
+  "@sentry/browser@8.54.0":
+    resolution:
+      {
+        integrity: sha512-BgUtvxFHin0fS0CmJVKTLXXZcke0Av729IVfi+2fJ4COX8HO7/HAP02RKaSQGmL2HmvWYTfNZ7529AnUtrM4Rg==,
+      }
+    engines: { node: ">=14.18" }
+
   "@sentry/browser@8.55.1":
     resolution:
       {
         integrity: sha512-OEn2eg8h3Mr7BmBGQ28BqbWehYA/NklZ0pAZB1FypPPl+kMd85AbaRdGTnaSjgmpc8bKbBO64edq4Y14sbCs5w==,
+      }
+    engines: { node: ">=14.18" }
+
+  "@sentry/cli-darwin@2.42.4":
+    resolution:
+      {
+        integrity: sha512-PZV4Y97VDWBR4rIt0HkJfXaBXlebIN2s/FDzC3iHINZE5OG62CDFsnC4/lbGlf2/UZLDaGGIK7mYwSHhTvN+HQ==,
+      }
+    engines: { node: ">=10" }
+    os: [darwin]
+
+  "@sentry/cli-linux-arm64@2.42.4":
+    resolution:
+      {
+        integrity: sha512-Ex8vRnryyzC/9e43daEmEqPS+9uirY/l6Hw2lAvhBblFaL7PTWNx52H+8GnYGd9Zy2H3rWNyBDYfHwnErg38zA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [linux, freebsd]
+
+  "@sentry/cli-linux-arm@2.42.4":
+    resolution:
+      {
+        integrity: sha512-lBn0oeeg62h68/4Eo6zbPq99Idz5t0VRV48rEU/WKeM4MtQCvG/iGGQ3lBFW2yNiUBzXZIK9poXLEcgbwmcRVw==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm]
+    os: [linux, freebsd]
+
+  "@sentry/cli-linux-i686@2.42.4":
+    resolution:
+      {
+        integrity: sha512-IBJg0aHjsLCL4LvcFa3cXIjA+4t5kPqBT9y+PoDu4goIFxYD8zl7mbUdGJutvJafTk8Akf4ss4JJXQBjg019zA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x86, ia32]
+    os: [linux, freebsd]
+
+  "@sentry/cli-linux-x64@2.42.4":
+    resolution:
+      {
+        integrity: sha512-gXI5OEiOSNiAEz7VCE6AZcAgHJ47mlgal3+NmbE8XcHmFOnyDws9FNie6PJAy8KZjXi3nqoBP9JVAbnmOix3uA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [linux, freebsd]
+
+  "@sentry/cli-win32-i686@2.42.4":
+    resolution:
+      {
+        integrity: sha512-vZuR3UPHKqOMniyrijrrsNwn9usaRysXq78F6WV0cL0ZyPLAmY+KBnTDSFk1Oig2pURnzaTm+RtcZu2fc8mlzg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x86, ia32]
+    os: [win32]
+
+  "@sentry/cli-win32-x64@2.42.4":
+    resolution:
+      {
+        integrity: sha512-OIBj3uaQ6nAERSm5Dcf8UIhyElEEwMNsZEEppQpN4IKl0mrwb/57AznM23Dvpu6GR8WGbVQUSolt879YZR5E9g==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [win32]
+
+  "@sentry/cli@2.42.4":
+    resolution:
+      {
+        integrity: sha512-BoSZDAWJiz/40tu6LuMDkSgwk4xTsq6zwqYoUqLU3vKBR/VsaaQGvu6EWxZXORthfZU2/5Agz0+t220cge6VQw==,
+      }
+    engines: { node: ">= 10" }
+    hasBin: true
+
+  "@sentry/core@8.54.0":
+    resolution:
+      {
+        integrity: sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==,
       }
     engines: { node: ">=14.18" }
 
@@ -3958,6 +4080,29 @@ packages:
       "@opentelemetry/sdk-trace-base": ^1.30.1
       "@opentelemetry/semantic-conventions": ^1.28.0
 
+  "@sentry/react-native@6.10.0":
+    resolution:
+      {
+        integrity: sha512-B56vc+pnFHMiu3cabFb454v4qD0zObW6JVzJ5Gb6fIMdt93AFIJg10ZErzC+ump7xM4BOEROFFRuLiyvadvlPA==,
+      }
+    hasBin: true
+    peerDependencies:
+      expo: ">=49.0.0"
+      react: ">=17.0.0"
+      react-native: ">=0.65.0"
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  "@sentry/react@8.54.0":
+    resolution:
+      {
+        integrity: sha512-42T/fp8snYN19Fy/2P0Mwotu4gcdy+1Lx+uYCNcYP1o7wNGigJ7qb27sW7W34GyCCHjoCCfQgeOqDQsyY8LC9w==,
+      }
+    engines: { node: ">=14.18" }
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
   "@sentry/react@8.55.1":
     resolution:
       {
@@ -3966,6 +4111,20 @@ packages:
     engines: { node: ">=14.18" }
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  "@sentry/types@8.54.0":
+    resolution:
+      {
+        integrity: sha512-wztdtr7dOXQKi0iRvKc8XJhJ7HaAfOv8lGu0yqFOFwBZucO/SHnu87GOPi8mvrTiy1bentQO5l+zXWAaMvG4uw==,
+      }
+    engines: { node: ">=14.18" }
+
+  "@sentry/utils@8.54.0":
+    resolution:
+      {
+        integrity: sha512-JL8UDjrsKxKclTdLXfuHfE7B3KbrAPEYP7tMyN/xiO2vsF6D84fjwYyalO0ZMtuFZE6vpSze8ZOLEh6hLnPYsw==,
+      }
+    engines: { node: ">=14.18" }
 
   "@sinclair/typebox@0.27.10":
     resolution:
@@ -11549,6 +11708,12 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
+  proxy-from-env@1.1.0:
+    resolution:
+      {
+        integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
+      }
+
   psl@1.15.0:
     resolution:
       {
@@ -17218,23 +17383,51 @@ snapshots:
       component-type: 1.2.2
       join-component: 1.1.0
 
+  "@sentry-internal/browser-utils@8.54.0":
+    dependencies:
+      "@sentry/core": 8.54.0
+
   "@sentry-internal/browser-utils@8.55.1":
     dependencies:
       "@sentry/core": 8.55.1
 
+  "@sentry-internal/feedback@8.54.0":
+    dependencies:
+      "@sentry/core": 8.54.0
+
   "@sentry-internal/feedback@8.55.1":
     dependencies:
       "@sentry/core": 8.55.1
+
+  "@sentry-internal/replay-canvas@8.54.0":
+    dependencies:
+      "@sentry-internal/replay": 8.54.0
+      "@sentry/core": 8.54.0
 
   "@sentry-internal/replay-canvas@8.55.1":
     dependencies:
       "@sentry-internal/replay": 8.55.1
       "@sentry/core": 8.55.1
 
+  "@sentry-internal/replay@8.54.0":
+    dependencies:
+      "@sentry-internal/browser-utils": 8.54.0
+      "@sentry/core": 8.54.0
+
   "@sentry-internal/replay@8.55.1":
     dependencies:
       "@sentry-internal/browser-utils": 8.55.1
       "@sentry/core": 8.55.1
+
+  "@sentry/babel-plugin-component-annotate@3.2.2": {}
+
+  "@sentry/browser@8.54.0":
+    dependencies:
+      "@sentry-internal/browser-utils": 8.54.0
+      "@sentry-internal/feedback": 8.54.0
+      "@sentry-internal/replay": 8.54.0
+      "@sentry-internal/replay-canvas": 8.54.0
+      "@sentry/core": 8.54.0
 
   "@sentry/browser@8.55.1":
     dependencies:
@@ -17243,6 +17436,48 @@ snapshots:
       "@sentry-internal/replay": 8.55.1
       "@sentry-internal/replay-canvas": 8.55.1
       "@sentry/core": 8.55.1
+
+  "@sentry/cli-darwin@2.42.4":
+    optional: true
+
+  "@sentry/cli-linux-arm64@2.42.4":
+    optional: true
+
+  "@sentry/cli-linux-arm@2.42.4":
+    optional: true
+
+  "@sentry/cli-linux-i686@2.42.4":
+    optional: true
+
+  "@sentry/cli-linux-x64@2.42.4":
+    optional: true
+
+  "@sentry/cli-win32-i686@2.42.4":
+    optional: true
+
+  "@sentry/cli-win32-x64@2.42.4":
+    optional: true
+
+  "@sentry/cli@2.42.4":
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      "@sentry/cli-darwin": 2.42.4
+      "@sentry/cli-linux-arm": 2.42.4
+      "@sentry/cli-linux-arm64": 2.42.4
+      "@sentry/cli-linux-i686": 2.42.4
+      "@sentry/cli-linux-x64": 2.42.4
+      "@sentry/cli-win32-i686": 2.42.4
+      "@sentry/cli-win32-x64": 2.42.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@sentry/core@8.54.0": {}
 
   "@sentry/core@8.55.1": {}
 
@@ -17296,12 +17531,44 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.40.0
       "@sentry/core": 8.55.1
 
+  "@sentry/react-native@6.10.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@sentry/babel-plugin-component-annotate": 3.2.2
+      "@sentry/browser": 8.54.0
+      "@sentry/cli": 2.42.4
+      "@sentry/core": 8.54.0
+      "@sentry/react": 8.54.0(react@18.3.1)
+      "@sentry/types": 8.54.0
+      "@sentry/utils": 8.54.0
+      react: 18.3.1
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@sentry/react@8.54.0(react@18.3.1)":
+    dependencies:
+      "@sentry/browser": 8.54.0
+      "@sentry/core": 8.54.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+
   "@sentry/react@8.55.1(react@18.3.1)":
     dependencies:
       "@sentry/browser": 8.55.1
       "@sentry/core": 8.55.1
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
+
+  "@sentry/types@8.54.0":
+    dependencies:
+      "@sentry/core": 8.54.0
+
+  "@sentry/utils@8.54.0":
+    dependencies:
+      "@sentry/core": 8.54.0
 
   "@sinclair/typebox@0.27.10": {}
 
@@ -22602,6 +22869,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 12 scaffold — wires `@sentry/react-native` into the mobile app
behind the `EXPO_PUBLIC_SENTRY_DSN` env var so the app still runs as
a clean no-op when no DSN is configured (local dev, forks, PR previews
without secrets). No event filtering, breadcrumb shaping, or performance
tracing yet — those land in follow-up phases.

Changes:

- Add `@sentry/react-native@~6.10.0` to `apps/mobile/package.json`. This
  is the version pinned in Expo SDK 52's `bundledNativeModules.json`
  (the repo's current SDK — see `expo: ~52.0.0`; SDK 54 mentioned in
  the task brief is a future-phase upgrade that isn't in this repo yet).
- New `apps/mobile/src/lib/observability.ts`:
  - `initObservability()` — reads `process.env.EXPO_PUBLIC_SENTRY_DSN`;
    if absent, logs `[observability] sentry disabled (no DSN)` and
    returns. When set, calls
    `Sentry.init({ dsn, enableAutoSessionTracking: true,
     tracesSampleRate: 0, debug: __DEV__ })` exactly once (idempotent).
  - `captureError(error, context?)` — forwards to
    `Sentry.captureException(error, { extra: context })` when init'd,
    otherwise falls back to `console.error` so diagnostics never
    silently disappear. Never throws.
  - Strict TS, no `any`, zero side-effects at import time.
- The DSN read lives in a separate `src/lib/observability/env.ts` so Jest
  can `jest.mock` it and drive both branches without fighting Expo's
  babel `EXPO_PUBLIC_*` env-inlining plugin (which makes runtime
  `process.env` mutations ineffective in tests after a file is
  transformed).
- Wire `initObservability()` into `apps/mobile/app/_layout.tsx` via
  `useEffect(() => { initObservability(); }, [])` at the Expo Router
  root. Not moved to module scope per the task spec.
- Update `apps/mobile/src/core/ErrorBoundary.tsx` `componentDidCatch` to
  also call `captureError(error, { componentStack })`. Existing
  `console.error` log preserved.
- Register the `@sentry/react-native/expo` config plugin in
  `apps/mobile/app.config.ts`. Source-map upload at EAS build time is
  only activated when `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` +
  `SENTRY_PROJECT` are set — otherwise the plugin no-ops and JS Sentry
  still initialises via the DSN at runtime.
- Add a new `# ── Mobile (Expo) — apps/mobile ──` section to the
  repo-level `.env.example` with an optional, commented
  `EXPO_PUBLIC_SENTRY_DSN` entry so contributors know the scaffold is
  no-op by default.
- Jest: new `apps/mobile/src/lib/observability.test.ts` — 8 specs
  covering no-op path, empty-string DSN, Sentry.init call shape,
  idempotency, `captureException` forwarding with extras,
  `captureException`-throws fallback, and missing-context arg.
  `@sentry/react-native` is mocked at the test-file level only.
- `pnpm check` green locally: `format:check` + `lint` + `typecheck` +
  `test` (219 mobile tests pass — no regressions) + `build`.

Out of scope / explicitly not touched: `apps/web`, `apps/server`,
`docs/react-native-migration.md`, `apps/mobile/src/modules/{finyk,
fizruk,routine}/**`, `apps/mobile/jest.config.js`,
`apps/mobile/tsconfig.json`, root-level deps.

План: `docs/react-native-migration.md` §4 Phase 12 (Monitoring +
Analytics).

## Review & Testing Checklist for Human

Risk: yellow — adds a native-module dep that links into the Expo
native build, though runtime behaviour is fully gated by env.

- [ ] Boot the app locally with **no** `EXPO_PUBLIC_SENTRY_DSN` set and
      confirm the console shows `[observability] sentry disabled (no DSN)`
      and the app renders normally (no Sentry init, no crash).
- [ ] Set `EXPO_PUBLIC_SENTRY_DSN=<your-test-dsn>`, restart the dev
      bundler so the env var is re-inlined, force a crash inside a
      screen wrapped by `ErrorBoundary`, and verify the event lands in
      the configured Sentry project with the `componentStack` in the
      extra context.
- [ ] Run `pnpm --filter @sergeant/mobile typecheck` and
      `pnpm --filter @sergeant/mobile test` locally — both should stay
      green after this merge.
- [ ] If you're about to run an EAS build, double-check that the
      `@sentry/react-native/expo` plugin behaves as expected without
      `SENTRY_AUTH_TOKEN` set (it should skip source-map upload with a
      warning, not fail the build).

### Notes

- Expo SDK 52's `bundledNativeModules.json` pins `@sentry/react-native`
  to `~6.10.0`. Using `~6.3.0` (an older Expo 52 recommendation) is also
  safe but loses bugfixes. If/when the repo bumps to SDK 54 the Sentry
  major will need a bump too (likely to v7+) — not in this PR.
- Split DSN read into `src/lib/observability/env.ts` is a small
  ergonomic concession to `babel-preset-expo`'s
  `transform-inline-environment-variables` plugin, which inlines
  literal `process.env.EXPO_PUBLIC_*` reads at transform time and
  therefore makes runtime env mutations invisible to imported modules
  once transformed. Mocking the separate module sidesteps that cleanly.
- No user-PII capture, no HTTP body breadcrumbs, no `beforeSend` filter,
  no performance tracing — all explicitly out of scope for this
  scaffold-only PR. A follow-up phase can port the web-side
  `beforeSend` cookie stripper if needed.


Link to Devin session: https://app.devin.ai/sessions/0ead2e2facd74a1bb37d7583da669246
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
