### PR TITLE
feat(routine-mobile): useRoutineReminders via expo-notifications

### DIFF
--- a/apps/mobile/src/modules/routine/RoutineApp.tsx
+++ b/apps/mobile/src/modules/routine/RoutineApp.tsx
@@ -52,6 +52,8 @@ import {
   RoutineBottomNav,
   type RoutineMainTab,
 } from "./components/RoutineBottomNav";
+import { useRoutineReminders } from "./hooks/useRoutineReminders";
+import { useRoutineStore } from "./lib/routineStore";
 import { Calendar } from "./pages/Calendar";
 import { HabitsPage } from "./pages/Habits/HabitsPage";
 import { HeatmapPage } from "./pages/Heatmap/HeatmapPage";
@@ -78,6 +80,15 @@ function readPersistedTab(): RoutineMainTab {
 
 function RoutineShell() {
   const [mainTab, setMainTab] = useState<RoutineMainTab>(readPersistedTab);
+
+  // Subscribe to the routine store so the reminder scheduler sees
+  // live habit edits without us re-reading MMKV on every change.
+  // The hook itself only fires schedule/cancel work when permission
+  // is `granted` — on first mount it only calls
+  // `Notifications.getPermissionsAsync()`, never the permission
+  // prompt (see `useRoutineReminders.ts`).
+  const { routine } = useRoutineStore();
+  useRoutineReminders(routine);
 
   const handleSelectTab = useCallback((next: RoutineMainTab) => {
     setMainTab(next);

--- a/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
+++ b/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
@@ -1,0 +1,360 @@
+/**
+ * Render-layer tests for `useRoutineReminders`.
+ *
+ * Covers the five scenarios called out by the Phase 5 / PR 6 spec:
+ *
+ *  1. Permission not-yet-requested — the hook reports `undetermined`
+ *     and never schedules anything on mount.
+ *  2. Grant path — after `requestPermission()` resolves to `granted`,
+ *     the hook schedules one `Notifications.scheduleNotificationAsync`
+ *     call per habit × weekday × reminder time.
+ *  3. Deny path — after `requestPermission()` resolves to `denied`,
+ *     no scheduling happens and `permission` flips to "denied".
+ *  4. Cancel on habit delete — removing a habit from the list cancels
+ *     the previously-scheduled notification ids for that habit.
+ *  5. Re-schedule on reminder toggle — flipping `reminderTimes` on an
+ *     existing habit calls cancel + schedule for the new times.
+ */
+
+import { act, render, waitFor } from "@testing-library/react-native";
+import { useEffect } from "react";
+import { Text } from "react-native";
+
+import { _getMMKVInstance } from "@/lib/storage";
+import {
+  defaultRoutineState,
+  type Habit,
+  type RoutineState,
+} from "@sergeant/routine-domain";
+
+jest.mock("expo-notifications", () => {
+  const getPermissionsAsync = jest.fn();
+  const requestPermissionsAsync = jest.fn();
+  const scheduleNotificationAsync = jest.fn();
+  const cancelScheduledNotificationAsync = jest.fn();
+  return {
+    __esModule: true,
+    IosAuthorizationStatus: { PROVISIONAL: 3 },
+    getPermissionsAsync,
+    requestPermissionsAsync,
+    scheduleNotificationAsync,
+    cancelScheduledNotificationAsync,
+  };
+});
+
+import * as Notifications from "expo-notifications";
+
+import {
+  SCHEDULED_MAP_KEY,
+  useRoutineReminders,
+  type UseRoutineRemindersApi,
+} from "./useRoutineReminders";
+
+const mockedGetPerms = Notifications.getPermissionsAsync as jest.Mock;
+const mockedRequestPerms = Notifications.requestPermissionsAsync as jest.Mock;
+const mockedSchedule = Notifications.scheduleNotificationAsync as jest.Mock;
+const mockedCancel =
+  Notifications.cancelScheduledNotificationAsync as jest.Mock;
+
+function makeHabit(overrides: Partial<Habit> & { id: string }): Habit {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? "Habit",
+    emoji: overrides.emoji ?? "✓",
+    recurrence: overrides.recurrence ?? "daily",
+    reminderTimes: overrides.reminderTimes ?? ["08:00"],
+    weekdays: overrides.weekdays,
+    archived: overrides.archived,
+  };
+}
+
+function makeState(habits: Habit[]): RoutineState {
+  const base = defaultRoutineState();
+  return {
+    ...base,
+    habits,
+    prefs: { ...base.prefs, routineRemindersEnabled: true },
+  };
+}
+
+interface HarnessProps {
+  state: RoutineState;
+  onApi?: (api: UseRoutineRemindersApi) => void;
+}
+
+function Harness({ state, onApi }: HarnessProps) {
+  const api = useRoutineReminders(state);
+  useEffect(() => {
+    onApi?.(api);
+  }, [api, onApi]);
+  return <Text testID="permission">{api.permission}</Text>;
+}
+
+/**
+ * Let every pending microtask + the 250ms debounce timer settle.
+ *
+ * Two passes: the first drains microtasks (so state updates from
+ * `getPermissionsAsync` / `requestPermissionsAsync` commit and the
+ * debounce effect queues its setTimeout); the second advances past
+ * the 250ms debounce and drains the reschedule's async work.
+ */
+async function flushScheduler(): Promise<void> {
+  // Multiple passes: microtasks need to settle before the debounce
+  // timer is queued, and again after it fires (each `reschedule` awaits
+  // an async chain of cancel→schedule calls).
+  for (let round = 0; round < 3; round++) {
+    await act(async () => {
+      for (let i = 0; i < 8; i++) {
+        await Promise.resolve();
+      }
+      jest.advanceTimersByTime(260);
+      for (let i = 0; i < 8; i++) {
+        await Promise.resolve();
+      }
+    });
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  _getMMKVInstance().clearAll();
+  mockedGetPerms.mockReset();
+  mockedRequestPerms.mockReset();
+  mockedSchedule.mockReset();
+  mockedCancel.mockReset();
+
+  mockedGetPerms.mockResolvedValue({ granted: false, status: "undetermined" });
+  mockedRequestPerms.mockResolvedValue({
+    granted: false,
+    status: "undetermined",
+  });
+
+  let seq = 0;
+  mockedSchedule.mockImplementation(async () => `notif-${++seq}`);
+  mockedCancel.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("useRoutineReminders", () => {
+  it("reports 'undetermined' and does not schedule on mount when permission is not yet requested", async () => {
+    const state = makeState([makeHabit({ id: "h1", name: "Drink water" })]);
+
+    const { getByTestId } = render(<Harness state={state} />);
+
+    await waitFor(() => {
+      expect(getByTestId("permission").props.children).toBe("undetermined");
+    });
+
+    // No schedule call fires until permission is explicitly granted.
+    await flushScheduler();
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    // Nothing persisted either.
+    expect(_getMMKVInstance().getString(SCHEDULED_MAP_KEY)).toBeUndefined();
+  });
+
+  it("schedules weekly notifications after permission is granted via requestPermission()", async () => {
+    const state = makeState([
+      makeHabit({
+        id: "h1",
+        name: "Drink water",
+        recurrence: "weekly",
+        weekdays: [0, 2], // Mon, Wed in routine's 0=Mon convention.
+        reminderTimes: ["08:00", "20:30"],
+      }),
+    ]);
+
+    let api: UseRoutineRemindersApi | null = null;
+    render(<Harness state={state} onApi={(a) => (api = a)} />);
+
+    // Later calls to getPermissionsAsync (inside requestPermission) reflect
+    // the "undetermined" state up until the native prompt resolves.
+    mockedGetPerms.mockResolvedValue({
+      granted: false,
+      status: "undetermined",
+    });
+    mockedRequestPerms.mockResolvedValueOnce({
+      granted: true,
+      status: "granted",
+    });
+
+    // Flush the initial getPermissionsAsync from mount.
+    await flushScheduler();
+
+    await act(async () => {
+      await api!.requestPermission();
+    });
+    await flushScheduler();
+
+    // 2 weekdays × 2 times = 4 scheduled notifications.
+    expect(mockedSchedule).toHaveBeenCalledTimes(4);
+
+    // Sanity-check one of the schedule payloads — routine Mon (0)
+    // should map to Expo weekday 2 at 08:00.
+    const firstCall = mockedSchedule.mock.calls.find(
+      ([arg]) => arg?.trigger?.weekday === 2 && arg?.trigger?.hour === 8,
+    );
+    expect(firstCall).toBeTruthy();
+    expect(firstCall![0].trigger).toMatchObject({
+      weekday: 2,
+      hour: 8,
+      minute: 0,
+      repeats: true,
+    });
+    expect(firstCall![0].content).toMatchObject({
+      title: "✓ Drink water",
+    });
+
+    // Persisted map contains 4 ids under the single habit.
+    const persisted = _getMMKVInstance().getString(SCHEDULED_MAP_KEY);
+    expect(persisted).toBeTruthy();
+    expect(JSON.parse(persisted as string)).toEqual({
+      h1: ["notif-1", "notif-2", "notif-3", "notif-4"],
+    });
+  });
+
+  it("does not schedule when the user denies the permission prompt", async () => {
+    const state = makeState([makeHabit({ id: "h1", name: "Drink water" })]);
+
+    let api: UseRoutineRemindersApi | null = null;
+    const { getByTestId } = render(
+      <Harness state={state} onApi={(a) => (api = a)} />,
+    );
+    await flushScheduler();
+
+    mockedRequestPerms.mockResolvedValueOnce({
+      granted: false,
+      status: "denied",
+    });
+
+    await act(async () => {
+      await api!.requestPermission();
+    });
+    await flushScheduler();
+
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(getByTestId("permission").props.children).toBe("denied");
+  });
+
+  it("cancels previously-scheduled reminders when a habit is removed from the list", async () => {
+    const initial = makeState([
+      makeHabit({
+        id: "h1",
+        recurrence: "daily",
+        reminderTimes: ["08:00"],
+      }),
+      makeHabit({
+        id: "h2",
+        recurrence: "daily",
+        reminderTimes: ["09:00"],
+      }),
+    ]);
+
+    mockedGetPerms.mockResolvedValue({
+      granted: true,
+      status: "granted",
+    });
+
+    let api: UseRoutineRemindersApi | null = null;
+    const { rerender } = render(
+      <Harness state={initial} onApi={(a) => (api = a)} />,
+    );
+    await flushScheduler();
+
+    // Each habit fires on 7 weekdays × 1 time = 7 schedules → 14 total.
+    expect(mockedSchedule).toHaveBeenCalledTimes(14);
+    const firstScheduleCount = mockedSchedule.mock.calls.length;
+    mockedCancel.mockClear();
+
+    // Drop h1, keep h2 with the same reminder times.
+    const afterDelete = makeState([
+      makeHabit({
+        id: "h2",
+        recurrence: "daily",
+        reminderTimes: ["09:00"],
+      }),
+    ]);
+
+    rerender(<Harness state={afterDelete} onApi={(a) => (api = a)} />);
+    await flushScheduler();
+
+    // All previous ids (14) were cancelled before rescheduling.
+    expect(mockedCancel).toHaveBeenCalledTimes(firstScheduleCount);
+    // h2 was re-scheduled for 7 weekdays.
+    expect(mockedSchedule.mock.calls.length).toBe(firstScheduleCount + 7);
+
+    // Persisted map drops h1 entirely.
+    const persisted = JSON.parse(
+      _getMMKVInstance().getString(SCHEDULED_MAP_KEY) as string,
+    );
+    expect(Object.keys(persisted)).toEqual(["h2"]);
+    expect(api!.permission).toBe("granted");
+  });
+
+  it("re-schedules when `reminderTimes` toggles on an existing habit", async () => {
+    const initial = makeState([
+      makeHabit({
+        id: "h1",
+        recurrence: "daily",
+        reminderTimes: ["08:00"],
+      }),
+    ]);
+
+    mockedGetPerms.mockResolvedValue({
+      granted: true,
+      status: "granted",
+    });
+
+    const { rerender } = render(<Harness state={initial} />);
+    await flushScheduler();
+
+    expect(mockedSchedule).toHaveBeenCalledTimes(7); // one per weekday
+    const initialCount = mockedSchedule.mock.calls.length;
+    mockedCancel.mockClear();
+
+    // Flip from a single time to two times on the same habit.
+    const toggled = makeState([
+      makeHabit({
+        id: "h1",
+        recurrence: "daily",
+        reminderTimes: ["08:00", "20:00"],
+      }),
+    ]);
+
+    rerender(<Harness state={toggled} />);
+    await flushScheduler();
+
+    // Previous 7 ids cancelled, new 14 ids scheduled (7 weekdays × 2 times).
+    expect(mockedCancel).toHaveBeenCalledTimes(initialCount);
+    expect(mockedSchedule.mock.calls.length).toBe(initialCount + 14);
+  });
+
+  it("survives when `expo-notifications.requestPermissionsAsync` is not a function (non-Expo env)", async () => {
+    // Exercise the Phase-5 requirement: the hook must not throw if the
+    // module surface is incomplete (e.g. bare RN test runner).
+    const module = Notifications as unknown as Record<string, unknown>;
+    const originalRequest = module.requestPermissionsAsync;
+    module.requestPermissionsAsync = undefined;
+
+    try {
+      const state = makeState([
+        makeHabit({ id: "h1", reminderTimes: ["08:00"] }),
+      ]);
+      let api: UseRoutineRemindersApi | null = null;
+      render(<Harness state={state} onApi={(a) => (api = a)} />);
+      await flushScheduler();
+
+      await act(async () => {
+        await api!.requestPermission();
+      });
+      await flushScheduler();
+
+      // Nothing scheduled, nothing persisted, no throw.
+      expect(mockedSchedule).not.toHaveBeenCalled();
+    } finally {
+      module.requestPermissionsAsync = originalRequest;
+    }
+  });
+});

--- a/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
+++ b/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
@@ -16,7 +16,7 @@
  *     existing habit calls cancel + schedule for the new times.
  */
 
-import { act, render, waitFor } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 import { useEffect } from "react";
 import { Text } from "react-native";
 
@@ -144,12 +144,14 @@ describe("useRoutineReminders", () => {
 
     const { getByTestId } = render(<Harness state={state} />);
 
-    await waitFor(() => {
-      expect(getByTestId("permission").props.children).toBe("undetermined");
-    });
+    // Flush initial `getPermissionsAsync` microtasks + debounce window.
+    // Using `waitFor` here would burn the 5s Jest timeout on CI since
+    // fake timers + polling don't advance each other automatically.
+    await flushScheduler();
+
+    expect(getByTestId("permission").props.children).toBe("undetermined");
 
     // No schedule call fires until permission is explicitly granted.
-    await flushScheduler();
     expect(mockedSchedule).not.toHaveBeenCalled();
     // Nothing persisted either.
     expect(_getMMKVInstance().getString(SCHEDULED_MAP_KEY)).toBeUndefined();

--- a/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
+++ b/apps/mobile/src/modules/routine/hooks/useRoutineReminders.test.tsx
@@ -99,24 +99,28 @@ function Harness({ state, onApi }: HarnessProps) {
  * the 250ms debounce and drains the reschedule's async work.
  */
 async function flushScheduler(): Promise<void> {
-  // Multiple passes: microtasks need to settle before the debounce
-  // timer is queued, and again after it fires (each `reschedule` awaits
-  // an async chain of cancel→schedule calls).
+  // Several passes of `advanceTimersByTimeAsync` + microtask drain.
+  // The hook's state machine has two "settling" stages per externally
+  // observable change:
+  //   (a) `getPermissionsAsync` / `requestPermissionsAsync` resolves
+  //       → `setPermissionState` → React re-render;
+  //   (b) the debounce effect sees the new deps and queues a fresh
+  //       `setTimeout(250)`;
+  // so each observable change costs one timer advance plus a batch of
+  // microtask drains. Three passes are plenty for our test cases.
   for (let round = 0; round < 3; round++) {
     await act(async () => {
-      for (let i = 0; i < 8; i++) {
-        await Promise.resolve();
-      }
-      jest.advanceTimersByTime(260);
-      for (let i = 0; i < 8; i++) {
-        await Promise.resolve();
-      }
+      await jest.advanceTimersByTimeAsync(300);
     });
   }
 }
 
+// CI runners are noticeably slower than local machines — give every
+// test a generous budget for mounting react-native + expo mocks.
+jest.setTimeout(20_000);
+
 beforeEach(() => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ doNotFake: ["nextTick"] });
   _getMMKVInstance().clearAll();
   mockedGetPerms.mockReset();
   mockedRequestPerms.mockReset();

--- a/apps/mobile/src/modules/routine/hooks/useRoutineReminders.ts
+++ b/apps/mobile/src/modules/routine/hooks/useRoutineReminders.ts
@@ -1,0 +1,368 @@
+/**
+ * Sergeant Routine — `useRoutineReminders` hook (React Native).
+ *
+ * Mobile port of
+ * `apps/web/src/modules/routine/hooks/useRoutineReminders.ts`, but
+ * retargeted at `expo-notifications` weekly triggers so the scheduler
+ * survives the app being backgrounded / killed — the web SW shim that
+ * hand-rolls `setTimeout` doesn't make sense on native.
+ *
+ * Scope of this cut (Phase 5 / PR 6 — Reminders):
+ *
+ *  - Iterates `RoutineState.habits` and schedules one repeating weekly
+ *    notification per habit × routine weekday × reminder "HH:MM".
+ *    Skips archived habits and habits without any `reminderTimes`.
+ *  - Maps routine's 0=Mon..6=Sun convention to Expo's 1=Sun..7=Sat via
+ *    `routineWeekdayToExpoWeekday` / `computeTriggerForHabitWeekday`
+ *    from `@sergeant/routine-domain/domain/reminders`. Pure helpers
+ *    are unit-tested separately on the package side.
+ *  - Persists `habitId -> scheduledNotificationId[]` into MMKV under
+ *    `routine/reminders/scheduled` (`SCHEDULED_MAP_KEY`) so we can
+ *    cancel previously-scheduled notifications before re-scheduling
+ *    (or on habit delete / archive). MMKV-backed so reschedule across
+ *    cold starts does not leak duplicate notifications.
+ *  - Debounces re-scheduling on habit-list changes (250ms).
+ *  - Lazy permission model: the hook does NOT prompt the system on
+ *    mount. It reads the current status via `getPermissionsAsync`.
+ *    Callers (e.g. a "Дозволити" button in settings, or HabitForm's
+ *    "reminder on" toggle) invoke `requestPermission()` to actually
+ *    open the native prompt.
+ *  - Gracefully no-ops if `expo-notifications` is not available (Jest
+ *    / SSR), or if permission is `denied` / `undetermined`.
+ *
+ * Exposed API:
+ *   {
+ *     permission: 'granted' | 'denied' | 'undetermined',
+ *     requestPermission(): Promise<void>,
+ *     reschedule(): Promise<void>,
+ *     cancelAll(): Promise<void>,
+ *   }
+ *
+ * Intentional differences from the web hook:
+ *  - No per-minute polling / idempotency localStorage keys. Expo's
+ *    weekly trigger handles the "fire once per week at this time"
+ *    contract for us.
+ *  - No completion-aware filtering. An Expo trigger cannot be
+ *    conditionally cancelled based on "has the user already tapped the
+ *    habit today" — that would require the notification action handler
+ *    to poll live state. For Phase 5 we accept an occasional already-
+ *    completed ping; a future iteration can layer
+ *    `Notifications.dismissNotificationAsync` via an
+ *    `addNotificationReceivedListener` hook.
+ *  - `monthly` / `once` recurrences are skipped. Expo's weekly cron
+ *    trigger cannot encode them; the pure adapter
+ *    `habitActiveRoutineWeekdays` returns `[]` for those and we emit
+ *    zero reminders.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Notifications from "expo-notifications";
+
+import {
+  computeTriggerForHabitWeekday,
+  habitActiveRoutineWeekdays,
+  normalizeReminderTimes,
+  parseReminderTime,
+  type Habit,
+  type RoutineState,
+} from "@sergeant/routine-domain";
+
+import { safeReadLS, safeWriteLS } from "@/lib/storage";
+
+/** MMKV slot holding `habitId -> scheduledNotificationId[]` (JSON). */
+export const SCHEDULED_MAP_KEY = "routine/reminders/scheduled";
+
+/** Debounce window for re-scheduling on habit-list changes. */
+const RESCHEDULE_DEBOUNCE_MS = 250;
+
+export type RoutineReminderPermission = "granted" | "denied" | "undetermined";
+
+export interface UseRoutineRemindersApi {
+  /** Current notification permission state (tri-state — no `unsupported`). */
+  permission: RoutineReminderPermission;
+  /**
+   * Ask the OS for notification permission (iOS / Android 13+).
+   * No-op if permission is already `granted`. After the call
+   * completes, `permission` is refreshed and — if granted — reminders
+   * are immediately re-scheduled.
+   */
+  requestPermission: () => Promise<void>;
+  /** Cancel + re-schedule all reminders from the current state. */
+  reschedule: () => Promise<void>;
+  /** Cancel every reminder we own and clear the MMKV map. */
+  cancelAll: () => Promise<void>;
+}
+
+/** Shape persisted under `SCHEDULED_MAP_KEY`. */
+type ScheduledMap = Record<string, string[]>;
+
+/**
+ * Read the habit→notification-id map from MMKV. Defensive — any
+ * malformed persisted value degrades to an empty map rather than
+ * throwing out of the hook.
+ */
+function readScheduledMap(): ScheduledMap {
+  const raw = safeReadLS<unknown>(SCHEDULED_MAP_KEY, null);
+  if (!raw || typeof raw !== "object") return {};
+  const out: ScheduledMap = {};
+  for (const [habitId, value] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    if (!Array.isArray(value)) continue;
+    const ids = value.filter((v): v is string => typeof v === "string");
+    if (ids.length > 0) out[habitId] = ids;
+  }
+  return out;
+}
+
+function writeScheduledMap(next: ScheduledMap): void {
+  safeWriteLS(SCHEDULED_MAP_KEY, next);
+}
+
+/**
+ * Map an `expo-notifications` permission response to our tri-state.
+ * iOS `provisional` authorisation counts as `granted` — matches
+ * `registerPush.ensurePermissions` and `NotificationsSection`.
+ */
+function toPermission(
+  perm: Notifications.NotificationPermissionsStatus | null | undefined,
+): RoutineReminderPermission {
+  if (!perm) return "undetermined";
+  if (perm.granted) return "granted";
+  const iosProv =
+    perm.ios?.status === Notifications.IosAuthorizationStatus?.PROVISIONAL;
+  if (iosProv) return "granted";
+  if (perm.status === "denied") return "denied";
+  return "undetermined";
+}
+
+/**
+ * Is the `expo-notifications` module actually wired up? Jest mocks
+ * the full surface, but a bare-metal RN test or SSR path might import
+ * the package without the native methods attached — the hook must not
+ * crash in that case (per the Phase 5 requirements).
+ */
+function hasNotificationsModule(): boolean {
+  return (
+    typeof Notifications !== "undefined" &&
+    typeof Notifications.getPermissionsAsync === "function"
+  );
+}
+
+/**
+ * Cancel a list of scheduled notification ids, swallowing per-id
+ * failures (Expo throws if the id no longer exists, e.g. after the
+ * user cleared system notifications).
+ */
+async function cancelIds(ids: readonly string[]): Promise<void> {
+  for (const id of ids) {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(id);
+    } catch {
+      /* noop — already gone or platform error */
+    }
+  }
+}
+
+/**
+ * Schedule every reminder described by a habit, returning the list of
+ * newly-created notification ids. Skips silently when there is no
+ * scheduling work to do for the habit (archived, no times, no active
+ * weekdays) — the caller uses an empty array as a signal that the
+ * habit should be removed from the MMKV map.
+ */
+async function scheduleHabit(h: Habit): Promise<string[]> {
+  const times = normalizeReminderTimes(h);
+  if (times.length === 0) return [];
+  const routineWeekdays = habitActiveRoutineWeekdays(h);
+  if (routineWeekdays.length === 0) return [];
+
+  const out: string[] = [];
+  const title = `${h.emoji || "✓"} ${h.name}`;
+
+  for (const rw of routineWeekdays) {
+    for (const hm of times) {
+      const { hour, minute } = parseReminderTime(hm);
+      const trigger = computeTriggerForHabitWeekday(rw, hour, minute);
+      try {
+        const id = await Notifications.scheduleNotificationAsync({
+          content: {
+            title,
+            body: "Нагадування про звичку",
+            data: { habitId: h.id, routineWeekday: rw, time: hm },
+          },
+          // `expo-notifications` accepts the weekly trigger shape
+          // produced by `computeTriggerForHabitWeekday`. The cast
+          // keeps the call strictly typed without us re-declaring
+          // Expo's union.
+          trigger: trigger as unknown as Notifications.NotificationTriggerInput,
+        });
+        if (typeof id === "string") out.push(id);
+      } catch {
+        /* noop — individual schedule failures shouldn't abort the rest */
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Cancel all reminders currently tracked in the MMKV map, clear the
+ * map, and return the cleared map (empty) for the caller to adopt.
+ */
+async function cancelAllInternal(): Promise<ScheduledMap> {
+  const current = readScheduledMap();
+  const allIds = Object.values(current).flat();
+  await cancelIds(allIds);
+  writeScheduledMap({});
+  return {};
+}
+
+/**
+ * `useRoutineReminders` — wires the routine state into
+ * `expo-notifications` weekly triggers.
+ *
+ * Mount the hook once at the top of `RoutineApp` (inside the
+ * component, via `useEffect` — never at module scope, per the
+ * Phase 5 constraints). Consumers outside the tree (e.g. HabitForm's
+ * "reminder on" toggle) can call `reschedule()` / `requestPermission()`
+ * by getting the return value from a shared provider in a follow-up
+ * PR.
+ */
+export function useRoutineReminders(
+  routine: RoutineState,
+): UseRoutineRemindersApi {
+  const [permission, setPermission] =
+    useState<RoutineReminderPermission>("undetermined");
+  const routineRef = useRef<RoutineState>(routine);
+  const permissionRef = useRef<RoutineReminderPermission>(permission);
+  const rescheduleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rescheduleInFlightRef = useRef<Promise<void> | null>(null);
+
+  routineRef.current = routine;
+  permissionRef.current = permission;
+
+  // --- perform the real schedule/cancel work -----------------------------
+  const performReschedule = useCallback(async (): Promise<void> => {
+    if (!hasNotificationsModule()) return;
+    if (permissionRef.current !== "granted") {
+      // If permission was revoked between scheduling calls, wipe any
+      // stale ids so cancelAll isn't called on no-ops forever.
+      const prev = readScheduledMap();
+      if (Object.keys(prev).length > 0) {
+        await cancelIds(Object.values(prev).flat());
+        writeScheduledMap({});
+      }
+      return;
+    }
+
+    const prev = readScheduledMap();
+    // Cancel everything we previously owned — simpler and less
+    // error-prone than diffing habit-by-habit. The cost is O(N)
+    // native calls per reschedule, which is fine for the single-
+    // digit habit counts we actually see.
+    await cancelIds(Object.values(prev).flat());
+
+    const next: ScheduledMap = {};
+    const habits = routineRef.current.habits;
+    for (const h of habits) {
+      if (h.archived) continue;
+      const ids = await scheduleHabit(h);
+      if (ids.length > 0) next[h.id] = ids;
+    }
+    writeScheduledMap(next);
+  }, []);
+
+  const reschedule = useCallback(async (): Promise<void> => {
+    // Collapse overlapping callers onto a single in-flight promise so
+    // rapid draft toggles don't race the native scheduler.
+    if (rescheduleInFlightRef.current) {
+      return rescheduleInFlightRef.current;
+    }
+    const p = performReschedule().finally(() => {
+      rescheduleInFlightRef.current = null;
+    });
+    rescheduleInFlightRef.current = p;
+    return p;
+  }, [performReschedule]);
+
+  const cancelAll = useCallback(async (): Promise<void> => {
+    if (!hasNotificationsModule()) return;
+    await cancelAllInternal();
+  }, []);
+
+  const refreshPermission =
+    useCallback(async (): Promise<RoutineReminderPermission> => {
+      if (!hasNotificationsModule()) {
+        setPermission("undetermined");
+        return "undetermined";
+      }
+      try {
+        const perm = await Notifications.getPermissionsAsync();
+        const next = toPermission(perm);
+        setPermission(next);
+        return next;
+      } catch {
+        setPermission("undetermined");
+        return "undetermined";
+      }
+    }, []);
+
+  const requestPermission = useCallback(async (): Promise<void> => {
+    if (!hasNotificationsModule()) return;
+    try {
+      const current = await Notifications.getPermissionsAsync();
+      let next = toPermission(current);
+      if (next !== "granted") {
+        if (typeof Notifications.requestPermissionsAsync !== "function") {
+          // No-op in non-Expo environments (Phase 5 requirement).
+          setPermission(next);
+          return;
+        }
+        const asked = await Notifications.requestPermissionsAsync();
+        next = toPermission(asked);
+      }
+      setPermission(next);
+      // Rescheduling is driven by the `[permission, routine.habits]`
+      // effect below — flipping `permission` to "granted" triggers
+      // a debounced reschedule without us calling it synchronously
+      // here. Keeping the two paths in a single place makes it easier
+      // to reason about "at most one in-flight reschedule per change".
+    } catch {
+      setPermission("undetermined");
+    }
+  }, []);
+
+  // --- initial mount: read current permission --------------------------
+  //
+  // We deliberately do NOT call `reschedule()` here — flipping
+  // `permission` to "granted" (when the user had already authorised in
+  // a previous launch) schedules the reminder through the debounced
+  // auto-reschedule effect below. This keeps the "what causes a
+  // reschedule?" contract narrowed to a single place.
+  useEffect(() => {
+    void refreshPermission();
+    // `refreshPermission` is stable (no deps).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- debounced auto-reschedule on habit / prefs changes ----------------
+  useEffect(() => {
+    if (permission !== "granted") return undefined;
+    if (rescheduleTimerRef.current) {
+      clearTimeout(rescheduleTimerRef.current);
+    }
+    rescheduleTimerRef.current = setTimeout(() => {
+      void reschedule();
+    }, RESCHEDULE_DEBOUNCE_MS);
+    return () => {
+      if (rescheduleTimerRef.current) {
+        clearTimeout(rescheduleTimerRef.current);
+        rescheduleTimerRef.current = null;
+      }
+    };
+  }, [routine.habits, permission, reschedule]);
+
+  return { permission, requestPermission, reschedule, cancelAll };
+}

--- a/packages/routine-domain/src/domain/reminders/index.ts
+++ b/packages/routine-domain/src/domain/reminders/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public surface of the Routine reminder-trigger module.
+ *
+ * Re-exported from `@sergeant/routine-domain` so both `apps/web` and
+ * `apps/mobile` import weekday/trigger helpers via the same entry
+ * point as other routine-domain surfaces.
+ */
+
+export * from "./weekday.js";

--- a/packages/routine-domain/src/domain/reminders/weekday.test.ts
+++ b/packages/routine-domain/src/domain/reminders/weekday.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for pure routine reminder weekday / trigger helpers.
+ *
+ * These must cover the full 0=Mon..6=Sun → Expo 1=Sun..7=Sat mapping
+ * table plus the edge cases the mobile adapter relies on (NaN, out-of-
+ * range weekday, invalid "HH:MM", non-weekly recurrences).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  clampHour,
+  clampMinute,
+  computeTriggerForHabitWeekday,
+  habitActiveRoutineWeekdays,
+  normalizeRoutineWeekday,
+  parseReminderTime,
+  routineWeekdayToExpoWeekday,
+} from "./weekday.js";
+
+describe("routineWeekdayToExpoWeekday", () => {
+  it("maps Monday (0) to Expo 2", () => {
+    expect(routineWeekdayToExpoWeekday(0)).toBe(2);
+  });
+
+  it("maps Tuesday (1) to Expo 3", () => {
+    expect(routineWeekdayToExpoWeekday(1)).toBe(3);
+  });
+
+  it("maps Wednesday (2) to Expo 4", () => {
+    expect(routineWeekdayToExpoWeekday(2)).toBe(4);
+  });
+
+  it("maps Thursday (3) to Expo 5", () => {
+    expect(routineWeekdayToExpoWeekday(3)).toBe(5);
+  });
+
+  it("maps Friday (4) to Expo 6", () => {
+    expect(routineWeekdayToExpoWeekday(4)).toBe(6);
+  });
+
+  it("maps Saturday (5) to Expo 7", () => {
+    expect(routineWeekdayToExpoWeekday(5)).toBe(7);
+  });
+
+  it("maps Sunday (6) to Expo 1 (wrap)", () => {
+    expect(routineWeekdayToExpoWeekday(6)).toBe(1);
+  });
+
+  it("clamps out-of-range inputs to Monday (Expo 2)", () => {
+    expect(routineWeekdayToExpoWeekday(-1)).toBe(2);
+    expect(routineWeekdayToExpoWeekday(7)).toBe(2);
+    expect(routineWeekdayToExpoWeekday(99)).toBe(2);
+  });
+
+  it("clamps NaN / Infinity to Monday (Expo 2)", () => {
+    expect(routineWeekdayToExpoWeekday(Number.NaN)).toBe(2);
+    expect(routineWeekdayToExpoWeekday(Number.POSITIVE_INFINITY)).toBe(2);
+  });
+
+  it("truncates fractional weekdays", () => {
+    // 3.9 truncates to 3 (Thu) → Expo 5.
+    expect(routineWeekdayToExpoWeekday(3.9)).toBe(5);
+  });
+});
+
+describe("normalizeRoutineWeekday", () => {
+  it("passes valid routine weekdays through unchanged", () => {
+    for (let i = 0; i <= 6; i++) {
+      expect(normalizeRoutineWeekday(i)).toBe(i);
+    }
+  });
+
+  it("clamps negative / out-of-range to 0 (Mon)", () => {
+    expect(normalizeRoutineWeekday(-3)).toBe(0);
+    expect(normalizeRoutineWeekday(12)).toBe(0);
+  });
+});
+
+describe("clampHour / clampMinute", () => {
+  it("clampHour keeps 0..23 and defaults out-of-range to 0", () => {
+    expect(clampHour(0)).toBe(0);
+    expect(clampHour(23)).toBe(23);
+    expect(clampHour(24)).toBe(0);
+    expect(clampHour(-1)).toBe(0);
+    expect(clampHour(Number.NaN)).toBe(0);
+  });
+
+  it("clampMinute keeps 0..59 and defaults out-of-range to 0", () => {
+    expect(clampMinute(0)).toBe(0);
+    expect(clampMinute(59)).toBe(59);
+    expect(clampMinute(60)).toBe(0);
+    expect(clampMinute(-5)).toBe(0);
+    expect(clampMinute(Number.NaN)).toBe(0);
+  });
+});
+
+describe("parseReminderTime", () => {
+  it("parses a valid HH:MM", () => {
+    expect(parseReminderTime("08:30")).toEqual({ hour: 8, minute: 30 });
+    expect(parseReminderTime("23:59")).toEqual({ hour: 23, minute: 59 });
+    expect(parseReminderTime("00:00")).toEqual({ hour: 0, minute: 0 });
+  });
+
+  it("falls back to 00:00 for malformed / nullish input", () => {
+    expect(parseReminderTime(undefined)).toEqual({ hour: 0, minute: 0 });
+    expect(parseReminderTime(null)).toEqual({ hour: 0, minute: 0 });
+    expect(parseReminderTime("")).toEqual({ hour: 0, minute: 0 });
+    expect(parseReminderTime("8:30")).toEqual({ hour: 0, minute: 0 });
+    expect(parseReminderTime("08:3")).toEqual({ hour: 0, minute: 0 });
+    expect(parseReminderTime("noon")).toEqual({ hour: 0, minute: 0 });
+  });
+
+  it("clamps parsed-but-out-of-range values", () => {
+    // Parser matches /^\d{2}:\d{2}$/, so a shape-valid but logically
+    // invalid string ("99:99") still falls through to the clamp path.
+    expect(parseReminderTime("99:99")).toEqual({ hour: 0, minute: 0 });
+  });
+});
+
+describe("computeTriggerForHabitWeekday", () => {
+  it("returns the Expo weekly trigger shape", () => {
+    expect(computeTriggerForHabitWeekday(0, 8, 30)).toEqual({
+      weekday: 2,
+      hour: 8,
+      minute: 30,
+      repeats: true,
+    });
+  });
+
+  it("clamps hour/minute and weekday defensively", () => {
+    expect(computeTriggerForHabitWeekday(99, 99, 99)).toEqual({
+      weekday: 2, // routineWeekday 99 → Mon → Expo 2
+      hour: 0,
+      minute: 0,
+      repeats: true,
+    });
+  });
+
+  it("preserves Sunday → Expo 1 mapping", () => {
+    expect(computeTriggerForHabitWeekday(6, 20, 0)).toEqual({
+      weekday: 1,
+      hour: 20,
+      minute: 0,
+      repeats: true,
+    });
+  });
+});
+
+describe("habitActiveRoutineWeekdays", () => {
+  it("expands 'daily' to all 7 routine weekdays", () => {
+    expect(habitActiveRoutineWeekdays({ recurrence: "daily" })).toEqual([
+      0, 1, 2, 3, 4, 5, 6,
+    ]);
+  });
+
+  it("expands 'weekdays' to Mon..Fri (0..4)", () => {
+    expect(habitActiveRoutineWeekdays({ recurrence: "weekdays" })).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+  });
+
+  it("returns the habit.weekdays set for 'weekly'", () => {
+    expect(
+      habitActiveRoutineWeekdays({
+        recurrence: "weekly",
+        weekdays: [2, 4, 6],
+      }),
+    ).toEqual([2, 4, 6]);
+  });
+
+  it("de-dupes / sorts / drops invalid entries for 'weekly'", () => {
+    expect(
+      habitActiveRoutineWeekdays({
+        recurrence: "weekly",
+        // @ts-expect-error — exercise the defensive filter for non-number entries.
+        weekdays: [5, 5, 2, "1", 9, -1, 0],
+      }),
+    ).toEqual([0, 2, 5]);
+  });
+
+  it("returns [] for monthly / once / unknown", () => {
+    expect(habitActiveRoutineWeekdays({ recurrence: "monthly" })).toEqual([]);
+    expect(habitActiveRoutineWeekdays({ recurrence: "once" })).toEqual([]);
+    expect(
+      habitActiveRoutineWeekdays({ recurrence: "some-unknown-value" }),
+    ).toEqual([]);
+  });
+
+  it("returns [] for an archived habit regardless of recurrence", () => {
+    expect(
+      habitActiveRoutineWeekdays({ recurrence: "daily", archived: true }),
+    ).toEqual([]);
+  });
+
+  it("defaults recurrence=undefined to 'daily' (all weekdays)", () => {
+    expect(habitActiveRoutineWeekdays({})).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+});

--- a/packages/routine-domain/src/domain/reminders/weekday.ts
+++ b/packages/routine-domain/src/domain/reminders/weekday.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure weekday / trigger helpers for routine reminders.
+ *
+ * Mobile's `useRoutineReminders` hook feeds `Notifications.scheduleNotificationAsync`
+ * with Expo's weekly cron-ish trigger:
+ *   `{ weekday, hour, minute, repeats: true }`
+ * where `weekday` uses Expo's 1..7 scale (1=Sunday, 2=Monday, …, 7=Saturday).
+ *
+ * Routine's own weekday convention is 0..6 with **0 = Monday** (mirrors the
+ * ISO-8601-ish weekly grid used by the habit editor / `WeekdayPicker`).
+ *
+ * These helpers are DOM-free and Expo-free so both platform adapters
+ * (web's service worker, mobile's expo-notifications) can share the
+ * exact same mapping logic.
+ */
+
+import type { Habit } from "../../types.js";
+
+/**
+ * Range-check a routine weekday (0=Mon..6=Sun).
+ *
+ * Out-of-range inputs are clamped to Monday so malformed persisted
+ * state cannot crash downstream Expo calls (RN's native scheduler
+ * throws on an out-of-range weekday).
+ */
+export function normalizeRoutineWeekday(rw: number): number {
+  if (!Number.isFinite(rw)) return 0;
+  const i = Math.trunc(rw);
+  if (i < 0 || i > 6) return 0;
+  return i;
+}
+
+/**
+ * Convert routine-module weekday (0=Mon..6=Sun) to Expo's weekday
+ * scale (1=Sun..7=Sat).
+ *
+ * Mapping:
+ *   Mon (0) → 2, Tue (1) → 3, Wed (2) → 4, Thu (3) → 5,
+ *   Fri (4) → 6, Sat (5) → 7, Sun (6) → 1.
+ */
+export function routineWeekdayToExpoWeekday(rw: number): number {
+  const safe = normalizeRoutineWeekday(rw);
+  // 0→2, 1→3, 2→4, 3→5, 4→6, 5→7, 6→1.
+  return safe === 6 ? 1 : safe + 2;
+}
+
+/** Clamp hour into the 0..23 range. Out-of-range values fall back to 0. */
+export function clampHour(h: number): number {
+  if (!Number.isFinite(h)) return 0;
+  const n = Math.trunc(h);
+  if (n < 0 || n > 23) return 0;
+  return n;
+}
+
+/** Clamp minute into the 0..59 range. Out-of-range values fall back to 0. */
+export function clampMinute(m: number): number {
+  if (!Number.isFinite(m)) return 0;
+  const n = Math.trunc(m);
+  if (n < 0 || n > 59) return 0;
+  return n;
+}
+
+/**
+ * Parse a "HH:MM" reminder-time string into `{ hour, minute }`.
+ *
+ * Invalid strings (undefined, wrong shape, NaN parts) collapse to
+ * `{ hour: 0, minute: 0 }` — same defensive contract as the rest of
+ * the routine-domain pure helpers.
+ */
+export function parseReminderTime(hm: string | undefined | null): {
+  hour: number;
+  minute: number;
+} {
+  if (typeof hm !== "string" || !/^\d{2}:\d{2}$/.test(hm)) {
+    return { hour: 0, minute: 0 };
+  }
+  const [rawH, rawM] = hm.split(":");
+  return { hour: clampHour(Number(rawH)), minute: clampMinute(Number(rawM)) };
+}
+
+/**
+ * Expo weekly-repeating trigger descriptor.
+ *
+ * Intentionally narrow (no `channelId`, no `seconds`) — the hook
+ * spreads this into the actual `Notifications.scheduleNotificationAsync`
+ * call so extra platform-specific fields can be layered on top.
+ */
+export interface ExpoWeeklyTrigger {
+  /** Expo weekday (1=Sun..7=Sat). */
+  weekday: number;
+  /** Local wall-clock hour (0..23). */
+  hour: number;
+  /** Local wall-clock minute (0..59). */
+  minute: number;
+  /** Always `true` — we want week-after-week repetition. */
+  repeats: true;
+}
+
+/**
+ * Build an Expo weekly trigger for a habit firing on the given routine
+ * weekday at `HH:MM`.
+ */
+export function computeTriggerForHabitWeekday(
+  routineWeekday: number,
+  hour: number,
+  minute: number,
+): ExpoWeeklyTrigger {
+  return {
+    weekday: routineWeekdayToExpoWeekday(routineWeekday),
+    hour: clampHour(hour),
+    minute: clampMinute(minute),
+    repeats: true,
+  };
+}
+
+/** Every day of the week (Mon..Sun) — used for `daily` recurrence. */
+const EVERY_WEEKDAY = [0, 1, 2, 3, 4, 5, 6];
+
+/** Monday..Friday in routine's 0=Mon convention. */
+const WORK_WEEKDAYS = [0, 1, 2, 3, 4];
+
+/**
+ * Resolve which routine weekdays (0=Mon..6=Sun) a habit is scheduled
+ * to recur on for reminder scheduling purposes.
+ *
+ * Non-weekly recurrences (`monthly`, `once`) return an empty list —
+ * Expo's `{ weekday, hour, minute, repeats: true }` trigger cannot
+ * encode "N-th of the month" or "one-shot" semantics, so mobile
+ * simply skips them. Those reminders are still honoured by the
+ * web adapter via `buildReminderSchedule` which operates on raw
+ * dates.
+ */
+export function habitActiveRoutineWeekdays(
+  h: Pick<Habit, "recurrence" | "weekdays" | "archived">,
+): number[] {
+  if (h.archived) return [];
+  const rec = (h.recurrence as string) || "daily";
+  if (rec === "daily") return [...EVERY_WEEKDAY];
+  if (rec === "weekdays") return [...WORK_WEEKDAYS];
+  if (rec === "weekly") {
+    if (!Array.isArray(h.weekdays)) return [];
+    const uniq = new Set<number>();
+    for (const raw of h.weekdays) {
+      if (typeof raw !== "number") continue;
+      if (!Number.isFinite(raw)) continue;
+      const n = Math.trunc(raw);
+      if (n < 0 || n > 6) continue;
+      uniq.add(n);
+    }
+    return Array.from(uniq).sort((a, b) => a - b);
+  }
+  // `monthly` / `once` / unknown — weekly trigger cannot express it.
+  return [];
+}

--- a/packages/routine-domain/src/index.ts
+++ b/packages/routine-domain/src/index.ts
@@ -30,3 +30,4 @@ export * from "./calendarEvents.js";
 export * from "./calendarGrid.js";
 export * from "./reminders.js";
 export * from "./domain/heatmap/index.js";
+export * from "./domain/reminders/index.js";


### PR DESCRIPTION
## Summary

Phase 5 / PR 6 of the React Native migration — ports `useRoutineReminders` from web's browser-`Notification`-API shim onto mobile's native `expo-notifications` weekly-trigger scheduler.

**New pure helpers in `@sergeant/routine-domain` (`src/domain/reminders/*`)**
- `routineWeekdayToExpoWeekday(rw)` — maps routine's 0=Mon..6=Sun to Expo's 1=Sun..7=Sat.
- `computeTriggerForHabitWeekday(rw, hour, minute)` — returns the `{ weekday, hour, minute, repeats: true }` Expo trigger.
- `habitActiveRoutineWeekdays(habit)` — expands `daily` / `weekdays` / `weekly` (with `habit.weekdays`) into a sorted list of routine weekdays; returns `[]` for `monthly` / `once` / archived (Expo's weekly trigger cannot encode those).
- Defensive helpers: `normalizeRoutineWeekday`, `clampHour`, `clampMinute`, `parseReminderTime`.
- 27 vitest cases cover the full mapping table plus edge cases (NaN, out-of-range weekday, malformed `HH:MM`, de-dup/sort/drop of invalid `weekdays` entries, archived, unknown recurrence).

**New mobile hook `apps/mobile/src/modules/routine/hooks/useRoutineReminders.ts`**
- Lazy permission model — never prompts on mount, only reads `Notifications.getPermissionsAsync()`. Callers invoke `requestPermission()` to open the native dialog (e.g. a settings button, or `HabitForm`'s reminder toggle in a follow-up PR).
- Debounces re-scheduling on habit-list changes (250ms) and collapses overlapping `reschedule()` callers onto a single in-flight promise so rapid draft toggles don't race the native scheduler.
- Persists `habitId -> scheduledNotificationId[]` into MMKV under `routine/reminders/scheduled` (`SCHEDULED_MAP_KEY`) so cold-start rescheduling cancels previously-owned notifications instead of leaking duplicates.
- Maps iOS `provisional` authorisation to `granted` (matches `registerPush.ensurePermissions` / `NotificationsSection`).
- Gracefully no-ops when `expo-notifications` is absent (Jest/SSR/bare-RN test runners) or when permission is `denied` / `undetermined`.
- Exposed API: `{ permission: 'granted' | 'denied' | 'undetermined', requestPermission, reschedule, cancelAll }`.

**Wiring in `RoutineApp.tsx`**
- `RoutineShell` now subscribes to the routine store and calls `useRoutineReminders(routine)` once. No auto permission prompt — scheduling only runs if the OS has already granted permission in a previous launch.

**Jest tests `useRoutineReminders.test.tsx`**
1. Permission not-yet-requested → `undetermined` and nothing scheduled.
2. Grant path → 2 weekdays × 2 times = 4 `scheduleNotificationAsync` calls, persisted map `{ h1: ["notif-1"..."notif-4"] }`, first call confirms Mon→Expo 2 at 08:00.
3. Deny path → `denied` status, zero schedules.
4. Habit delete → previous ids cancelled, re-scheduled only for remaining habit, persisted map drops the deleted id.
5. `reminderTimes` toggle → cancel all + re-schedule at new cardinality.
6. Non-Expo env (`requestPermissionsAsync` undefined) → no throw, no schedules.

### Intentional differences from the web hook

- No per-minute polling or idempotency localStorage keys — Expo's weekly trigger handles the "fire once per week at this time" contract natively.
- No completion-aware filtering (an Expo trigger can't be conditionally cancelled by live state). Phase 5 accepts an occasional already-completed ping; a future iteration can layer `addNotificationReceivedListener` + `dismissNotificationAsync`.
- `monthly` / `once` recurrences skipped — `habitActiveRoutineWeekdays` returns `[]`.

### Out of scope (per task constraints)

- `expo-device` NOT added — `expo-notifications` alone provides everything the hook needs for permission + scheduling on both iOS/Android.
- No changes to `pages/Calendar.tsx`, `pages/Habits/**`, `pages/Heatmap/**`, `lib/routineStore.ts`, `components/HabitHeatmap.tsx`, `jest.config.js`, `tsconfig.json`, `package.json`, `apps/web/**`, `docs/react-native-migration.md`.
- `HabitForm` does NOT yet call `reschedule()` after toggling `reminderEnabled` — that's a trivial follow-up that can ride in a PR which imports the hook's return value via a shared provider; doing it here would require touching the forbidden `pages/Habits/**` files.

## Review & Testing Checklist for Human

- [ ] Confirm the weekday mapping (Mon=0→Expo 2 … Sun=6→Expo 1) matches the UI expectations — a single off-by-one here means reminders fire on the wrong day for an entire week.
- [ ] On a physical iOS / Android device, grant notification permission, add a habit with a reminder a few minutes into the future (edit the hook or set the system clock forward), background the app, confirm the notification fires.
- [ ] Delete the habit while permission is granted → verify via `npx expo start` + `Notifications.getAllScheduledNotificationsAsync()` logs (or just `console.log(_getMMKVInstance().getString("routine/reminders/scheduled"))`) that the id list for that habit is gone.

### Notes

- The `routine/reminders/scheduled` MMKV slot is new — first-launch users on the released app will see an empty map, which is the safe default (nothing to cancel). No migration needed.
- The hook depends on the existing `useRoutineStore` subscription inside `RoutineShell`. If a future refactor moves the store out of `RoutineShell`, re-wire `useRoutineReminders(routine)` accordingly (or lift it into a provider near the routine route).

Link to Devin session: https://app.devin.ai/sessions/2330e55cf6cb4a9b84599592068afef8
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reminder notifications for routines. The app now schedules notifications based on habits and reminder times, automatically adjusts reminders when routines are modified, and manages notification permissions on your behalf.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->