### PR TITLE
feat(fizruk-mobile): Programs page (full port)

### DIFF
--- a/apps/mobile/src/modules/fizruk/components/programs/ProgramCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/programs/ProgramCard.tsx
@@ -1,0 +1,136 @@
+/**
+ * `ProgramCard` — single catalogue row on the Fizruk Programs screen.
+ *
+ * A small presentational component extracted from
+ * `pages/Programs.tsx` so both the visual card and the button-state
+ * logic can be exercised in isolation by jest snapshots and
+ * interaction tests. Keeps no state of its own — the active-program
+ * id is lifted up to `usePrograms`.
+ *
+ * Layout mirrors the web `ProgramCard` (see
+ * `apps/web/src/modules/fizruk/pages/Programs.tsx` lines 54-150) with
+ * the RN-native differences noted in `ui/Button.tsx` (no hover,
+ * Pressable press-feedback instead of hover-scale).
+ */
+
+import type { TrainingProgramDef } from "@sergeant/fizruk-domain/domain";
+import { formatProgramCadence } from "@sergeant/fizruk-domain/domain";
+import { Text, View } from "react-native";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+/** `0 = Mon … 6 = Sun`, matching the domain weekday index. */
+const DAY_LABELS: readonly string[] = [
+  "Пн",
+  "Вт",
+  "Ср",
+  "Чт",
+  "Пт",
+  "Сб",
+  "Нд",
+];
+
+export interface ProgramCardProps {
+  program: TrainingProgramDef;
+  /** `true` when this program is the currently-active one. */
+  active: boolean;
+  /** 0-indexed Monday-first weekday to highlight in the mini-calendar. */
+  todayIndex: number;
+  onActivate: (id: string) => void;
+  onDeactivate: () => void;
+  testID?: string;
+}
+
+export function ProgramCard({
+  program,
+  active,
+  todayIndex,
+  onActivate,
+  onDeactivate,
+  testID,
+}: ProgramCardProps) {
+  return (
+    <Card
+      variant={active ? "fizruk-soft" : "default"}
+      radius="lg"
+      padding="lg"
+      testID={testID}
+    >
+      <View className="gap-3">
+        <View className="gap-1.5">
+          <View className="flex-row items-center gap-2 flex-wrap">
+            <Text className="text-base font-bold text-stone-900 flex-1">
+              {program.name}
+            </Text>
+            {active ? (
+              <View
+                className="px-2 py-0.5 rounded-full bg-teal-100 border border-teal-300"
+                testID={testID ? `${testID}-active-badge` : undefined}
+              >
+                <Text className="text-[10px] font-bold text-teal-800">
+                  Активна
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          <Text className="text-xs text-stone-500">
+            {formatProgramCadence(program)}
+          </Text>
+          <Text className="text-sm text-stone-700 leading-snug">
+            {program.description}
+          </Text>
+        </View>
+
+        <View className="flex-row items-center gap-1.5">
+          {DAY_LABELS.map((label, i) => {
+            const hasSession = program.schedule.some((s) => s.day - 1 === i);
+            const isToday = i === todayIndex;
+            const bg = hasSession
+              ? isToday && active
+                ? "bg-teal-600"
+                : "bg-teal-100"
+              : "bg-cream-200/60";
+            const text = hasSession
+              ? isToday && active
+                ? "text-white"
+                : "text-teal-800"
+              : "text-stone-400";
+            return (
+              <View
+                key={`${program.id}-d${i}`}
+                className={`flex-1 items-center justify-center py-1 rounded ${bg}`}
+              >
+                <Text className={`text-[10px] font-bold ${text}`}>{label}</Text>
+              </View>
+            );
+          })}
+        </View>
+
+        <View className="flex-row gap-2">
+          {active ? (
+            <Button
+              variant="secondary"
+              size="md"
+              onPress={onDeactivate}
+              className="flex-1"
+              testID={testID ? `${testID}-deactivate` : undefined}
+            >
+              Деактивувати
+            </Button>
+          ) : (
+            <Button
+              variant="fizruk"
+              size="md"
+              onPress={() => onActivate(program.id)}
+              className="flex-1"
+              testID={testID ? `${testID}-activate` : undefined}
+            >
+              Активувати
+            </Button>
+          )}
+        </View>
+      </View>
+    </Card>
+  );
+}

--- a/apps/mobile/src/modules/fizruk/components/programs/TodaySessionCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/programs/TodaySessionCard.tsx
@@ -1,0 +1,110 @@
+/**
+ * `TodaySessionCard` — the "Сьогоднішня сесія" hero card on the
+ * Fizruk Programs screen.
+ *
+ * Branches across three states:
+ *  1. No active program → muted empty-state nudging activation.
+ *  2. Active program, today is a rest day → "Сьогодні — вихідний".
+ *  3. Active program + scheduled session today → session title +
+ *     "Почати" button that wires into `useActiveFizrukWorkout`.
+ *
+ * The component is purely presentational — the hosting page is
+ * responsible for starting the workout when `onStart` fires.
+ */
+
+import type {
+  TodayProgramSession,
+  TrainingProgramDef,
+} from "@sergeant/fizruk-domain/domain";
+import { Text, View } from "react-native";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+export interface TodaySessionCardProps {
+  activeProgram: TrainingProgramDef | null;
+  todaySession: TodayProgramSession | null;
+  onStart: (session: TodayProgramSession) => void;
+  testID?: string;
+}
+
+export function TodaySessionCard({
+  activeProgram,
+  todaySession,
+  onStart,
+  testID = "today-session-card",
+}: TodaySessionCardProps) {
+  if (!activeProgram) {
+    return (
+      <Card variant="default" radius="lg" padding="lg" testID={testID}>
+        <View className="gap-1.5">
+          <Text className="text-xs font-semibold text-stone-500">
+            Сьогоднішня сесія
+          </Text>
+          <Text
+            className="text-base font-semibold text-stone-900"
+            testID={`${testID}-empty`}
+          >
+            Активуй програму, щоб побачити план на сьогодні
+          </Text>
+          <Text className="text-sm text-stone-500 leading-snug">
+            Обери програму нижче — її сесії автоматично з&apos;являтимуться тут
+            за днем тижня.
+          </Text>
+        </View>
+      </Card>
+    );
+  }
+
+  if (!todaySession) {
+    return (
+      <Card variant="fizruk-soft" radius="lg" padding="lg" testID={testID}>
+        <View className="gap-1.5">
+          <Text className="text-xs font-semibold text-teal-700">
+            {activeProgram.name}
+          </Text>
+          <Text
+            className="text-base font-semibold text-stone-900"
+            testID={`${testID}-rest`}
+          >
+            Сьогодні — вихідний
+          </Text>
+          <Text className="text-sm text-stone-600 leading-snug">
+            Наступна сесія — згідно графіка програми. Відпочинок — частина
+            прогресу.
+          </Text>
+        </View>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="fizruk" radius="xl" padding="lg" testID={testID}>
+      <View className="gap-3">
+        <View className="gap-1">
+          <Text className="text-xs font-semibold text-teal-100">
+            Сьогоднішня сесія
+          </Text>
+          <Text
+            className="text-lg font-bold text-white"
+            testID={`${testID}-title`}
+          >
+            {todaySession.session.name}
+          </Text>
+          <Text className="text-sm text-teal-100">
+            {activeProgram.name} · {todaySession.session.exerciseIds.length}{" "}
+            вправ
+          </Text>
+        </View>
+        <Button
+          variant="secondary"
+          size="lg"
+          onPress={() => onStart(todaySession)}
+          testID={`${testID}-start`}
+        >
+          Почати
+        </Button>
+      </View>
+    </Card>
+  );
+}

--- a/apps/mobile/src/modules/fizruk/components/programs/index.ts
+++ b/apps/mobile/src/modules/fizruk/components/programs/index.ts
@@ -1,0 +1,5 @@
+export { ProgramCard, type ProgramCardProps } from "./ProgramCard";
+export {
+  TodaySessionCard,
+  type TodaySessionCardProps,
+} from "./TodaySessionCard";

--- a/apps/mobile/src/modules/fizruk/hooks/usePrograms.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/usePrograms.ts
@@ -1,0 +1,139 @@
+/**
+ * `usePrograms` — mobile hook for the Fizruk **Programs** screen
+ * (Phase 6 · PR-F).
+ *
+ * Mirrors the public surface of the web hook at
+ * `apps/web/src/modules/fizruk/hooks/useTrainingProgram.ts` — a
+ * read-only list of catalogue entries plus an active-program slot
+ * that can be activated / deactivated / toggled. The active-program
+ * id is persisted in the shared MMKV slot
+ * `STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM` so the same CloudSync entry
+ * the web app writes to is reused verbatim.
+ *
+ * All pure logic (catalogue, today-session resolution, state
+ * normalisation) lives in `@sergeant/fizruk-domain/domain/programs`
+ * and is covered by vitest in isolation. This file is a thin React
+ * shim around those selectors + MMKV.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  PROGRAM_CATALOGUE,
+  defaultActiveProgramState,
+  normalizeActiveProgramState,
+  resolveActiveProgram,
+  resolveTodaySession,
+  type ActiveProgramState,
+  type TodayProgramSession,
+  type TrainingProgramDef,
+} from "@sergeant/fizruk-domain/domain";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
+
+const STORAGE_KEY = STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM;
+
+export interface UseProgramsResult {
+  /** Full built-in catalogue, in display order. */
+  programs: readonly TrainingProgramDef[];
+  /** Persisted active-program id, or `null` if none is active. */
+  activeProgramId: string | null;
+  /** Resolved active program (catalogue entry), or `null` if none is active. */
+  activeProgram: TrainingProgramDef | null;
+  /**
+   * Today's session for the active program (or `null` on a rest day
+   * / when no program is active). Derived from the current system
+   * clock — refreshes whenever `activeProgramId` changes or the
+   * consumer remounts.
+   */
+  todaySession: TodayProgramSession | null;
+  /** Activate a program by id. */
+  activateProgram: (id: string) => void;
+  /** Clear the active program slot. */
+  deactivateProgram: () => void;
+  /** Flip the active slot: activate if inactive, deactivate otherwise. */
+  toggleProgram: (id: string) => void;
+}
+
+/**
+ * Reads the persisted active-program id from MMKV, reacts to
+ * cross-consumer writes (e.g. a parallel-ported web hook running in
+ * the same process during Expo dev), and exposes imperative
+ * activate/deactivate handlers.
+ */
+export function usePrograms(
+  /**
+   * Override the catalogue (test seam). Defaults to the package's
+   * canonical built-in list.
+   */
+  catalogue: readonly TrainingProgramDef[] = PROGRAM_CATALOGUE,
+  /** Override for unit tests — defaults to the real wall clock. */
+  now: () => Date = () => new Date(),
+): UseProgramsResult {
+  const [state, setState] = useState<ActiveProgramState>(() =>
+    normalizeActiveProgramState(safeReadLS<unknown>(STORAGE_KEY, null)),
+  );
+
+  // React to out-of-band writes to the same MMKV slot so the page
+  // re-renders if anything else in the app touches this key.
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey !== STORAGE_KEY) return;
+      setState(
+        normalizeActiveProgramState(safeReadLS<unknown>(STORAGE_KEY, null)),
+      );
+    });
+    return () => sub.remove();
+  }, []);
+
+  const persist = useCallback((next: ActiveProgramState) => {
+    setState(next);
+    safeWriteLS(STORAGE_KEY, next);
+  }, []);
+
+  const activateProgram = useCallback(
+    (id: string) => {
+      const exists = catalogue.some((p) => p.id === id);
+      if (!exists) return;
+      persist({ activeProgramId: id });
+    },
+    [catalogue, persist],
+  );
+
+  const deactivateProgram = useCallback(() => {
+    persist(defaultActiveProgramState());
+  }, [persist]);
+
+  const toggleProgram = useCallback(
+    (id: string) => {
+      if (state.activeProgramId === id) {
+        deactivateProgram();
+      } else {
+        activateProgram(id);
+      }
+    },
+    [state.activeProgramId, activateProgram, deactivateProgram],
+  );
+
+  const activeProgram = useMemo(
+    () => resolveActiveProgram(state.activeProgramId, catalogue),
+    [state.activeProgramId, catalogue],
+  );
+
+  const todaySession = useMemo(
+    () => resolveTodaySession(activeProgram, now()),
+    [activeProgram, now],
+  );
+
+  return {
+    programs: catalogue,
+    activeProgramId: state.activeProgramId,
+    activeProgram,
+    todaySession,
+    activateProgram,
+    deactivateProgram,
+    toggleProgram,
+  };
+}

--- a/apps/mobile/src/modules/fizruk/pages/Programs.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Programs.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Jest render + behaviour tests for the Fizruk Programs page
+ * (Phase 6 · PR-F).
+ *
+ * Coverage:
+ *  - Empty-state hero card when no program is active AND catalogue is
+ *    non-empty (activation nudge).
+ *  - Full catalogue renders one `ProgramCard` per built-in program
+ *    with an "Активувати" CTA.
+ *  - Activate → card flips to "Деактивувати"; pressing it clears the
+ *    slot back to the empty hero state.
+ *  - Hero "Сьогоднішня сесія" renders when today's weekday is in the
+ *    active program's schedule; falls back to "Сьогодні — вихідний"
+ *    on a rest day.
+ *  - Pressing "Почати" writes a program-* id into the shared active
+ *    workout MMKV slot (`FIZRUK_ACTIVE_WORKOUT`).
+ *  - Empty-catalogue edge case shows the `-empty` catalogue slot.
+ */
+
+import { AccessibilityInfo } from "react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance, safeWriteLS } from "@/lib/storage";
+
+import { Programs } from "./Programs";
+
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock("expo-keep-awake", () => ({
+  __esModule: true,
+  activateKeepAwakeAsync: jest.fn(() => Promise.resolve()),
+  deactivateKeepAwake: jest.fn(),
+}));
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+  jest
+    .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+    .mockResolvedValue(false);
+  jest
+    .spyOn(AccessibilityInfo, "addEventListener")
+    .mockImplementation(() => ({ remove: () => {} }) as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("Fizruk Programs page (mobile)", () => {
+  it("renders the empty hero state and every built-in program card", () => {
+    render(<Programs />);
+
+    // Hero card nudges activation when no program is active.
+    expect(screen.getByTestId("fizruk-programs-today-empty")).toBeTruthy();
+
+    // Catalogue list is rendered with one card per canonical program.
+    expect(screen.getByTestId("fizruk-programs-list")).toBeTruthy();
+    for (const id of ["ppl", "upper_lower", "full_body", "starting_strength"]) {
+      expect(screen.getByTestId(`fizruk-programs-card-${id}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(`fizruk-programs-card-${id}-activate`),
+      ).toBeTruthy();
+    }
+  });
+
+  it("activating a program toggles its CTA and flips the active-program slot", () => {
+    render(<Programs />);
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("fizruk-programs-card-ppl-activate"));
+    });
+
+    // MMKV persisted the active id.
+    const raw = _getMMKVInstance().getString(
+      STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM,
+    );
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw ?? "null") as {
+      activeProgramId: string | null;
+    };
+    expect(parsed?.activeProgramId).toBe("ppl");
+
+    // Card now renders a Деактивувати control.
+    expect(
+      screen.getByTestId("fizruk-programs-card-ppl-deactivate"),
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId("fizruk-programs-card-ppl-active-badge"),
+    ).toBeTruthy();
+
+    act(() => {
+      fireEvent.press(
+        screen.getByTestId("fizruk-programs-card-ppl-deactivate"),
+      );
+    });
+
+    // Back to the empty hero state + Активувати CTA.
+    expect(screen.getByTestId("fizruk-programs-today-empty")).toBeTruthy();
+    expect(
+      screen.getByTestId("fizruk-programs-card-ppl-activate"),
+    ).toBeTruthy();
+  });
+
+  it("shows the planned session hero when the active program schedules today", () => {
+    // PPL schedules a Push session on day 1 (Monday).
+    const monday = new Date("2026-04-20T12:00:00Z");
+    jest.useFakeTimers().setSystemTime(monday);
+    safeWriteLS(STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM, {
+      activeProgramId: "ppl",
+    });
+
+    render(<Programs />);
+
+    expect(screen.getByTestId("fizruk-programs-today-title")).toBeTruthy();
+    expect(screen.getByText("Push Day")).toBeTruthy();
+    expect(screen.getByTestId("fizruk-programs-today-start")).toBeTruthy();
+
+    jest.useRealTimers();
+  });
+
+  it("shows the rest-day hero when the active program has no session today", () => {
+    // PPL schedules days 1-6 (Mon-Sat). Use a Sunday.
+    const sunday = new Date("2026-04-26T12:00:00Z");
+    jest.useFakeTimers().setSystemTime(sunday);
+    safeWriteLS(STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM, {
+      activeProgramId: "ppl",
+    });
+
+    render(<Programs />);
+
+    expect(screen.getByTestId("fizruk-programs-today-rest")).toBeTruthy();
+    expect(screen.queryByTestId("fizruk-programs-today-start")).toBeNull();
+
+    jest.useRealTimers();
+  });
+
+  it("wires the 'Почати' button into the shared active-workout MMKV slot", () => {
+    const monday = new Date("2026-04-20T12:00:00Z");
+    jest.useFakeTimers().setSystemTime(monday);
+    safeWriteLS(STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM, {
+      activeProgramId: "ppl",
+    });
+
+    render(<Programs />);
+
+    expect(
+      _getMMKVInstance().getString(STORAGE_KEYS.FIZRUK_ACTIVE_WORKOUT),
+    ).toBeUndefined();
+
+    act(() => {
+      fireEvent.press(screen.getByTestId("fizruk-programs-today-start"));
+    });
+
+    const id = _getMMKVInstance().getString(STORAGE_KEYS.FIZRUK_ACTIVE_WORKOUT);
+    expect(id).toBeTruthy();
+    expect(id).toMatch(/^program-ppl-push-/);
+
+    jest.useRealTimers();
+  });
+});

--- a/apps/mobile/src/modules/fizruk/pages/Programs.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Programs.tsx
@@ -1,26 +1,125 @@
 /**
- * Fizruk / Programs page — mobile placeholder (Phase 6 / PR-1).
+ * Fizruk / Programs page — mobile (Phase 6 · PR-F).
  *
- * Web counterpart: `apps/web/src/modules/fizruk/pages/Programs.tsx` (231 LOC).
- * Training-program catalogue + active-program controls. Lands alongside
- * the Dashboard port in a follow-up Phase 6 PR.
+ * Web counterpart: `apps/web/src/modules/fizruk/pages/Programs.tsx`
+ * (231 LOC). Full port of the training-program catalogue:
+ *
+ *  - Top "Сьогоднішня сесія" hero card — shows the scheduled session
+ *    for the active program on today's weekday, a rest-day fallback,
+ *    or an empty state nudging activation.
+ *  - Scrollable catalogue of `ProgramCard`s, one per built-in program.
+ *    Each card shows name, cadence (days/week · duration), description,
+ *    a mini weekday strip, and an Активувати / Деактивувати control.
+ *  - When the user taps "Почати" on the hero card we mint a new
+ *    active-workout id via `useActiveFizrukWorkout` so the shared
+ *    timer + `RestTimerOverlay` picks it up — same path the web page
+ *    takes via `handleStartProgramWorkout` (minus the workout-CRUD
+ *    layer, which still lives in the web inline state and lands with
+ *    a later PR).
+ *
+ * Pure logic — catalogue, today-session resolution, cadence
+ * formatters — lives in `@sergeant/fizruk-domain/domain/programs`
+ * and is covered by vitest in isolation.
  */
 
-import { PagePlaceholder } from "./PagePlaceholder";
+import type { TodayProgramSession } from "@sergeant/fizruk-domain/domain";
+import { weekdayIndex } from "@sergeant/fizruk-domain/domain";
+import { useCallback, useMemo } from "react";
+import { ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-export function Programs() {
+import { ProgramCard, TodaySessionCard } from "../components/programs";
+import { useActiveFizrukWorkout } from "../hooks/useActiveFizrukWorkout";
+import { usePrograms } from "../hooks/usePrograms";
+
+export interface ProgramsProps {
+  /** Optional root testID — sub-ids derive from it. */
+  testID?: string;
+}
+
+export function Programs({ testID = "fizruk-programs" }: ProgramsProps) {
+  const {
+    programs,
+    activeProgramId,
+    activeProgram,
+    todaySession,
+    activateProgram,
+    deactivateProgram,
+  } = usePrograms();
+
+  const { setActiveWorkoutId } = useActiveFizrukWorkout();
+
+  const todayIndex = useMemo(() => weekdayIndex(), []);
+
+  const handleStart = useCallback(
+    (session: TodayProgramSession) => {
+      // Mint a stable id per start so the shared timer / overlay can
+      // pick it up. Workout-CRUD (sets / items / groups) still lives
+      // in the legacy web inline state and lands in a follow-up PR.
+      setActiveWorkoutId(
+        `program-${session.programId}-${session.schedule.sessionKey}-${Date.now()}`,
+      );
+    },
+    [setActiveWorkoutId],
+  );
+
   return (
-    <PagePlaceholder
-      title="Програми"
-      description="Каталог готових програм тренувань, активація / деактивація, сьогоднішня сесія з активної програми."
-      plannedFeatures={[
-        "Каталог програм (pure з `@sergeant/fizruk-domain`)",
-        "Активація / деактивація з persistence у MMKV",
-        "Сьогоднішня сесія з активної програми → кнопка «Почати»",
-        "Інтеграція з таймером активного тренування",
-      ]}
-      phaseHint="Фаза 6 · PR-F — Programs + active-workout"
-    />
+    <SafeAreaView
+      className="flex-1 bg-cream-50"
+      edges={["top"]}
+      testID={testID}
+    >
+      <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
+        <Text className="text-[22px]">🗓️</Text>
+        <Text className="text-[22px] font-bold text-stone-900 flex-1">
+          Програми
+        </Text>
+      </View>
+      <Text className="px-4 text-sm text-stone-600 leading-snug mb-3">
+        Готові програми тренувань. Активуй одну — сьогоднішня сесія
+        з&apos;явиться вгорі з кнопкою «Почати».
+      </Text>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120, gap: 14 }}
+      >
+        <TodaySessionCard
+          activeProgram={activeProgram}
+          todaySession={todaySession}
+          onStart={handleStart}
+          testID={`${testID}-today`}
+        />
+
+        {programs.length === 0 ? (
+          <View
+            className="items-center justify-center py-10"
+            testID={`${testID}-empty`}
+          >
+            <Text className="text-sm text-stone-500">
+              Каталог порожній — спробуй пізніше.
+            </Text>
+          </View>
+        ) : (
+          <View className="gap-3" testID={`${testID}-list`}>
+            <Text className="text-sm font-semibold text-stone-900">
+              Каталог програм
+            </Text>
+            {programs.map((program) => (
+              <ProgramCard
+                key={program.id}
+                program={program}
+                active={program.id === activeProgramId}
+                todayIndex={todayIndex}
+                onActivate={activateProgram}
+                onDeactivate={deactivateProgram}
+                testID={`${testID}-card-${program.id}`}
+              />
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/packages/fizruk-domain/src/constants.ts
+++ b/packages/fizruk-domain/src/constants.ts
@@ -11,6 +11,7 @@ export const MEASUREMENTS_STORAGE_KEY = "fizruk_measurements_v1";
 export const TEMPLATES_STORAGE_KEY = "fizruk_workout_templates_v1";
 export const SELECTED_TEMPLATE_STORAGE_KEY = "fizruk_selected_template_id_v1";
 export const ACTIVE_WORKOUT_KEY = "fizruk_active_workout_id_v1";
+export const ACTIVE_PROGRAM_KEY = "fizruk_active_program_id_v1";
 export const PLAN_TEMPLATE_STORAGE_KEY = "fizruk_plan_template_v1";
 export const MONTHLY_PLAN_STORAGE_KEY = "fizruk_monthly_plan_v1";
 

--- a/packages/fizruk-domain/src/domain/index.ts
+++ b/packages/fizruk-domain/src/domain/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./progress/index.js";
 export * from "./measurements/index.js";
+export * from "./programs/index.js";

--- a/packages/fizruk-domain/src/domain/programs/catalogue.ts
+++ b/packages/fizruk-domain/src/domain/programs/catalogue.ts
@@ -1,0 +1,210 @@
+/**
+ * Built-in Fizruk training programs.
+ *
+ * Strictly-typed canonical source — `lib/trainingPrograms.ts` re-exports
+ * these symbols for backwards compatibility with the web module while
+ * the mobile port consumes the strict types directly.
+ *
+ * Exercise IDs correspond to entries in `data/exercises.gymup.json`.
+ * `progressionKg` — kg to add per session for compound lifts.
+ */
+
+import type { TrainingProgramDef } from "./types.js";
+
+export const PROGRAM_CATALOGUE: readonly TrainingProgramDef[] = [
+  {
+    id: "ppl",
+    name: "Push Pull Legs",
+    description:
+      "Класична 6-денна програма. Push (груди/плечі/трицепс), Pull (спина/біцепс), Legs (ноги/сідниці). Відмінно для середнього рівня.",
+    days: 6,
+    durationWeeks: 8,
+    schedule: [
+      { day: 1, sessionKey: "push", name: "Push — Груди, плечі, трицепс" },
+      { day: 2, sessionKey: "pull", name: "Pull — Спина, біцепс" },
+      { day: 3, sessionKey: "legs", name: "Legs — Ноги, сідниці" },
+      { day: 4, sessionKey: "push", name: "Push — Груди, плечі, трицепс" },
+      { day: 5, sessionKey: "pull", name: "Pull — Спина, біцепс" },
+      { day: 6, sessionKey: "legs", name: "Legs — Ноги, сідниці" },
+    ],
+    sessions: {
+      push: {
+        name: "Push Day",
+        exerciseIds: [
+          "bench_press_barbell",
+          "overhead_press_barbell",
+          "incline_bench_press",
+          "lateral_raise",
+          "tricep_pushdown",
+          "overhead_tricep_extension",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 90,
+      },
+      pull: {
+        name: "Pull Day",
+        exerciseIds: [
+          "deadlift",
+          "pullup",
+          "barbell_row",
+          "cable_face_pull",
+          "bicep_curl_barbell",
+          "hammer_curl",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 90,
+      },
+      legs: {
+        name: "Leg Day",
+        exerciseIds: [
+          "squat_barbell",
+          "romanian_deadlift",
+          "leg_press",
+          "leg_curl",
+          "leg_extension",
+          "calf_raise_standing",
+        ],
+        progressionKg: 5,
+        defaultRestSec: 120,
+      },
+    },
+  },
+  {
+    id: "upper_lower",
+    name: "Upper / Lower",
+    description:
+      "4-денна програма: два тренування на верх тіла та два на низ. Оптимальна частота для кожної групи. Підходить для початківців та середнього рівня.",
+    days: 4,
+    durationWeeks: 8,
+    schedule: [
+      { day: 1, sessionKey: "upper_a", name: "Upper A — Верх тіла (сила)" },
+      { day: 2, sessionKey: "lower_a", name: "Lower A — Низ тіла (сила)" },
+      { day: 4, sessionKey: "upper_b", name: "Upper B — Верх тіла (об'єм)" },
+      { day: 5, sessionKey: "lower_b", name: "Lower B — Низ тіла (об'єм)" },
+    ],
+    sessions: {
+      upper_a: {
+        name: "Upper A (сила)",
+        exerciseIds: [
+          "bench_press_barbell",
+          "barbell_row",
+          "overhead_press_barbell",
+          "pullup",
+          "bicep_curl_barbell",
+          "tricep_pushdown",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 90,
+      },
+      lower_a: {
+        name: "Lower A (сила)",
+        exerciseIds: [
+          "squat_barbell",
+          "romanian_deadlift",
+          "leg_press",
+          "leg_curl",
+          "calf_raise_standing",
+        ],
+        progressionKg: 5,
+        defaultRestSec: 120,
+      },
+      upper_b: {
+        name: "Upper B (об'єм)",
+        exerciseIds: [
+          "incline_bench_press",
+          "cable_seated_row",
+          "lateral_raise",
+          "cable_face_pull",
+          "bicep_curl_dumbbell",
+          "overhead_tricep_extension",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 75,
+      },
+      lower_b: {
+        name: "Lower B (об'єм)",
+        exerciseIds: [
+          "deadlift",
+          "leg_press",
+          "leg_extension",
+          "leg_curl",
+          "calf_raise_standing",
+        ],
+        progressionKg: 5,
+        defaultRestSec: 90,
+      },
+    },
+  },
+  {
+    id: "full_body",
+    name: "Full Body 3×тиждень",
+    description:
+      "Три повних тренування тіла на тиждень (Пн/Ср/Пт). Ідеально для початківців та тих, хто має обмежений час. Максимальна частота стимуляції м'язів.",
+    days: 3,
+    durationWeeks: 6,
+    schedule: [
+      { day: 1, sessionKey: "full_a", name: "Full Body A" },
+      { day: 3, sessionKey: "full_b", name: "Full Body B" },
+      { day: 5, sessionKey: "full_a", name: "Full Body A" },
+    ],
+    sessions: {
+      full_a: {
+        name: "Full Body A",
+        exerciseIds: [
+          "squat_barbell",
+          "bench_press_barbell",
+          "barbell_row",
+          "overhead_press_barbell",
+          "deadlift",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 90,
+      },
+      full_b: {
+        name: "Full Body B",
+        exerciseIds: [
+          "deadlift",
+          "incline_bench_press",
+          "pullup",
+          "lateral_raise",
+          "squat_barbell",
+        ],
+        progressionKg: 2.5,
+        defaultRestSec: 90,
+      },
+    },
+  },
+  {
+    id: "starting_strength",
+    name: "Лінійна прогресія",
+    description:
+      "3-денна програма на основі базових багатосуглобових рухів. Щотренування +2.5 кг на штанзі. Найкраще для новачків — швидкий набір сили.",
+    days: 3,
+    durationWeeks: 12,
+    schedule: [
+      { day: 1, sessionKey: "ss_a", name: "Workout A" },
+      { day: 3, sessionKey: "ss_b", name: "Workout B" },
+      { day: 5, sessionKey: "ss_a", name: "Workout A" },
+    ],
+    sessions: {
+      ss_a: {
+        name: "Workout A",
+        exerciseIds: ["squat_barbell", "bench_press_barbell", "deadlift"],
+        progressionKg: 2.5,
+        defaultRestSec: 180,
+      },
+      ss_b: {
+        name: "Workout B",
+        exerciseIds: ["squat_barbell", "overhead_press_barbell", "deadlift"],
+        progressionKg: 2.5,
+        defaultRestSec: 180,
+      },
+    },
+  },
+];
+
+/**
+ * Back-compat alias used by existing web consumers
+ * (`import { BUILTIN_PROGRAMS } from "@sergeant/fizruk-domain"`).
+ */
+export const BUILTIN_PROGRAMS = PROGRAM_CATALOGUE;

--- a/packages/fizruk-domain/src/domain/programs/format.ts
+++ b/packages/fizruk-domain/src/domain/programs/format.ts
@@ -1,0 +1,50 @@
+/**
+ * Locale-aware labels for training-program cards.
+ *
+ * Pure / string-only so they compile cleanly for RN + web with no
+ * Intl dependencies. Ukrainian plural rules are hand-rolled (the
+ * built-in `Intl.PluralRules` would work too but pulls in extra
+ * polyfill weight on Hermes).
+ */
+
+import type { TrainingProgramDef } from "./types.js";
+
+/**
+ * Ukrainian plural category for a non-negative integer.
+ * `one` → 1, 21, 31 …
+ * `few` → 2–4, 22–24 …
+ * `many` → everything else.
+ */
+export function ukPluralCategory(n: number): "one" | "few" | "many" {
+  const abs = Math.abs(Math.trunc(n));
+  const mod10 = abs % 10;
+  const mod100 = abs % 100;
+  if (mod10 === 1 && mod100 !== 11) return "one";
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return "few";
+  return "many";
+}
+
+/** "1 тиждень" / "3 тижні" / "8 тижнів". Clamps non-finite input to 0. */
+export function formatDurationWeeks(weeks: number): string {
+  const safe = Number.isFinite(weeks) ? Math.max(0, Math.trunc(weeks)) : 0;
+  const forms = { one: "тиждень", few: "тижні", many: "тижнів" } as const;
+  return `${safe} ${forms[ukPluralCategory(safe)]}`;
+}
+
+/**
+ * Frequency label — "6 дн/тиждень". Uses the program's `days`
+ * directly (matches the web catalogue) so the card copy stays stable
+ * across platforms.
+ */
+export function formatFrequency(program: TrainingProgramDef): string {
+  const n = Number.isFinite(program.days) ? Math.max(0, program.days) : 0;
+  return `${n} дн/тиждень`;
+}
+
+/**
+ * Combined "частота · тривалість" line for the program card.
+ * Example: `"6 дн/тиждень · 8 тижнів"`.
+ */
+export function formatProgramCadence(program: TrainingProgramDef): string {
+  return `${formatFrequency(program)} · ${formatDurationWeeks(program.durationWeeks)}`;
+}

--- a/packages/fizruk-domain/src/domain/programs/index.ts
+++ b/packages/fizruk-domain/src/domain/programs/index.ts
@@ -1,0 +1,17 @@
+/**
+ * `@sergeant/fizruk-domain/domain/programs` — pure types, selectors,
+ * resolvers, and formatters backing the Fizruk Programs screen.
+ *
+ * Everything in this module is platform-neutral: no DOM, no MMKV, no
+ * `Date`-global stubs. Apps wrap the selectors in their own
+ * persistence hooks (`apps/mobile/src/modules/fizruk/hooks/usePrograms`
+ * for mobile, `apps/web/src/modules/fizruk/hooks/useTrainingProgram`
+ * on web).
+ */
+
+export * from "./types.js";
+export * from "./catalogue.js";
+export * from "./selectors.js";
+export * from "./today.js";
+export * from "./state.js";
+export * from "./format.js";

--- a/packages/fizruk-domain/src/domain/programs/programs.test.ts
+++ b/packages/fizruk-domain/src/domain/programs/programs.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Vitest coverage for `@sergeant/fizruk-domain/domain/programs`.
+ *
+ * Exercised helpers:
+ *  - catalogue integrity (shape + session-key cross-refs)
+ *  - `findProgramById` / `resolveActiveProgram`
+ *  - `weekdayIndex`, `getProgramScheduleForDay`,
+ *    `getProgramSessionForDay`, `resolveTodaySession`
+ *  - `normalizeActiveProgramState`
+ *  - `formatDurationWeeks`, `formatFrequency`, `formatProgramCadence`,
+ *    `ukPluralCategory`
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PROGRAM_CATALOGUE,
+  defaultActiveProgramState,
+  findProgramById,
+  formatDurationWeeks,
+  formatFrequency,
+  formatProgramCadence,
+  getProgramScheduleForDay,
+  getProgramSessionForDay,
+  normalizeActiveProgramState,
+  resolveActiveProgram,
+  resolveTodaySession,
+  ukPluralCategory,
+  weekdayIndex,
+  type TrainingProgramDef,
+} from "./index.js";
+
+describe("PROGRAM_CATALOGUE", () => {
+  it("exposes at least the four built-in programs", () => {
+    expect(PROGRAM_CATALOGUE.length).toBeGreaterThanOrEqual(4);
+    const ids = PROGRAM_CATALOGUE.map((p) => p.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "ppl",
+        "upper_lower",
+        "full_body",
+        "starting_strength",
+      ]),
+    );
+  });
+
+  it("every schedule entry references a session key that exists on the program", () => {
+    for (const program of PROGRAM_CATALOGUE) {
+      for (const slot of program.schedule) {
+        expect(program.sessions[slot.sessionKey]).toBeDefined();
+        expect(slot.day).toBeGreaterThanOrEqual(1);
+        expect(slot.day).toBeLessThanOrEqual(7);
+      }
+    }
+  });
+
+  it("program.days equals schedule length", () => {
+    for (const program of PROGRAM_CATALOGUE) {
+      expect(program.days).toBe(program.schedule.length);
+    }
+  });
+});
+
+describe("findProgramById / resolveActiveProgram", () => {
+  it("returns the catalogue entry by id", () => {
+    const prog = findProgramById("ppl");
+    expect(prog?.id).toBe("ppl");
+    expect(prog?.days).toBe(6);
+  });
+
+  it("returns null for unknown id, empty string, or null", () => {
+    expect(findProgramById("does-not-exist")).toBeNull();
+    expect(findProgramById("")).toBeNull();
+    expect(findProgramById(null)).toBeNull();
+    expect(findProgramById(undefined)).toBeNull();
+  });
+
+  it("resolveActiveProgram is the same as findProgramById against a custom catalogue", () => {
+    const fake: TrainingProgramDef = {
+      id: "fake",
+      name: "Fake",
+      description: "",
+      days: 1,
+      durationWeeks: 1,
+      schedule: [{ day: 1, sessionKey: "x", name: "X" }],
+      sessions: {
+        x: {
+          name: "X",
+          exerciseIds: ["a"],
+          progressionKg: 0,
+          defaultRestSec: 60,
+        },
+      },
+    };
+    expect(resolveActiveProgram("fake", [fake])?.id).toBe("fake");
+    expect(resolveActiveProgram("ppl", [fake])).toBeNull();
+  });
+});
+
+describe("weekdayIndex", () => {
+  it("maps JS Date getDay (Sun=0) to Monday-first 0-indexed", () => {
+    // 2026-04-20 is a Monday.
+    expect(weekdayIndex(new Date("2026-04-20T12:00:00Z"))).toBe(0);
+    // 2026-04-26 is a Sunday.
+    expect(weekdayIndex(new Date("2026-04-26T12:00:00Z"))).toBe(6);
+    // 2026-04-22 is a Wednesday.
+    expect(weekdayIndex(new Date("2026-04-22T12:00:00Z"))).toBe(2);
+  });
+});
+
+describe("getProgramScheduleForDay", () => {
+  const ppl = PROGRAM_CATALOGUE.find((p) => p.id === "ppl")!;
+
+  it("returns the schedule slot when the program trains that day", () => {
+    const mon = getProgramScheduleForDay(ppl, 0);
+    expect(mon?.sessionKey).toBe("push");
+    const tue = getProgramScheduleForDay(ppl, 1);
+    expect(tue?.sessionKey).toBe("pull");
+  });
+
+  it("returns null for rest days", () => {
+    // PPL schedules Mon–Sat (days 1-6), Sunday (index 6) is a rest day.
+    expect(getProgramScheduleForDay(ppl, 6)).toBeNull();
+  });
+
+  it("returns null for null program or out-of-range day index", () => {
+    expect(getProgramScheduleForDay(null, 0)).toBeNull();
+    expect(getProgramScheduleForDay(ppl, -1)).toBeNull();
+    expect(getProgramScheduleForDay(ppl, 7)).toBeNull();
+    expect(getProgramScheduleForDay(ppl, Number.NaN)).toBeNull();
+  });
+});
+
+describe("getProgramSessionForDay", () => {
+  const ppl = PROGRAM_CATALOGUE.find((p) => p.id === "ppl")!;
+
+  it("resolves the session definition for a training day", () => {
+    const push = getProgramSessionForDay(ppl, 0);
+    expect(push?.name).toBe("Push Day");
+    expect(push?.exerciseIds.length).toBeGreaterThan(0);
+  });
+
+  it("returns null for a rest day", () => {
+    expect(getProgramSessionForDay(ppl, 6)).toBeNull();
+  });
+});
+
+describe("resolveTodaySession", () => {
+  const ppl = PROGRAM_CATALOGUE.find((p) => p.id === "ppl")!;
+
+  it("returns the {programId, schedule, session} triple for a training day", () => {
+    // 2026-04-21 is a Tuesday → ppl schedules pull.
+    const result = resolveTodaySession(ppl, new Date("2026-04-21T12:00:00Z"));
+    expect(result?.programId).toBe("ppl");
+    expect(result?.schedule.sessionKey).toBe("pull");
+    expect(result?.session.name).toBe("Pull Day");
+  });
+
+  it("returns null on a rest day", () => {
+    // 2026-04-26 is a Sunday (index 6). PPL's schedule covers days 1-6.
+    expect(
+      resolveTodaySession(ppl, new Date("2026-04-26T12:00:00Z")),
+    ).toBeNull();
+  });
+
+  it("returns null when the program is null", () => {
+    expect(resolveTodaySession(null)).toBeNull();
+  });
+
+  it("returns null when a session key is missing from sessions map", () => {
+    const broken: TrainingProgramDef = {
+      id: "broken",
+      name: "Broken",
+      description: "",
+      days: 1,
+      durationWeeks: 1,
+      schedule: [{ day: 1, sessionKey: "ghost", name: "Ghost" }],
+      sessions: {},
+    };
+    expect(
+      resolveTodaySession(broken, new Date("2026-04-20T12:00:00Z")),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeActiveProgramState", () => {
+  it("returns the default state for null / undefined input", () => {
+    expect(normalizeActiveProgramState(null)).toEqual(
+      defaultActiveProgramState(),
+    );
+    expect(normalizeActiveProgramState(undefined)).toEqual({
+      activeProgramId: null,
+    });
+  });
+
+  it("accepts a bare string id (legacy web format)", () => {
+    expect(normalizeActiveProgramState("ppl")).toEqual({
+      activeProgramId: "ppl",
+    });
+  });
+
+  it("treats an empty or whitespace string as 'no active program'", () => {
+    expect(normalizeActiveProgramState("")).toEqual({ activeProgramId: null });
+    expect(normalizeActiveProgramState("   ")).toEqual({
+      activeProgramId: null,
+    });
+  });
+
+  it("accepts the object form `{ activeProgramId }`", () => {
+    expect(
+      normalizeActiveProgramState({ activeProgramId: "full_body" }),
+    ).toEqual({
+      activeProgramId: "full_body",
+    });
+  });
+
+  it("falls back to default on malformed input", () => {
+    expect(normalizeActiveProgramState({ activeProgramId: 42 })).toEqual({
+      activeProgramId: null,
+    });
+    expect(normalizeActiveProgramState([])).toEqual({
+      activeProgramId: null,
+    });
+    expect(normalizeActiveProgramState(true)).toEqual({
+      activeProgramId: null,
+    });
+  });
+});
+
+describe("formatDurationWeeks", () => {
+  it("uses the 'one' plural form for 1, 21, 31, …", () => {
+    expect(formatDurationWeeks(1)).toBe("1 тиждень");
+    expect(formatDurationWeeks(21)).toBe("21 тиждень");
+    expect(formatDurationWeeks(31)).toBe("31 тиждень");
+  });
+
+  it("uses the 'few' plural form for 2–4, 22–24, …", () => {
+    expect(formatDurationWeeks(2)).toBe("2 тижні");
+    expect(formatDurationWeeks(3)).toBe("3 тижні");
+    expect(formatDurationWeeks(24)).toBe("24 тижні");
+  });
+
+  it("uses the 'many' plural form for 5–20, 11–14, 25+, …", () => {
+    expect(formatDurationWeeks(5)).toBe("5 тижнів");
+    expect(formatDurationWeeks(8)).toBe("8 тижнів");
+    expect(formatDurationWeeks(11)).toBe("11 тижнів");
+    expect(formatDurationWeeks(25)).toBe("25 тижнів");
+  });
+
+  it("clamps non-finite input to 0", () => {
+    expect(formatDurationWeeks(Number.NaN)).toBe("0 тижнів");
+    expect(formatDurationWeeks(-3)).toBe("0 тижнів");
+    expect(formatDurationWeeks(Number.POSITIVE_INFINITY)).toBe("0 тижнів");
+  });
+});
+
+describe("formatFrequency / formatProgramCadence", () => {
+  const ppl = PROGRAM_CATALOGUE.find((p) => p.id === "ppl")!;
+  const startingStrength = PROGRAM_CATALOGUE.find(
+    (p) => p.id === "starting_strength",
+  )!;
+
+  it("formats days-per-week", () => {
+    expect(formatFrequency(ppl)).toBe("6 дн/тиждень");
+    expect(formatFrequency(startingStrength)).toBe("3 дн/тиждень");
+  });
+
+  it("combines frequency + duration for the card line", () => {
+    expect(formatProgramCadence(ppl)).toBe("6 дн/тиждень · 8 тижнів");
+    expect(formatProgramCadence(startingStrength)).toBe(
+      "3 дн/тиждень · 12 тижнів",
+    );
+  });
+});
+
+describe("ukPluralCategory", () => {
+  it("agrees with the Ukrainian plural rules over a range of small integers", () => {
+    expect(ukPluralCategory(0)).toBe("many");
+    expect(ukPluralCategory(1)).toBe("one");
+    expect(ukPluralCategory(4)).toBe("few");
+    expect(ukPluralCategory(11)).toBe("many");
+    expect(ukPluralCategory(12)).toBe("many");
+    expect(ukPluralCategory(14)).toBe("many");
+    expect(ukPluralCategory(21)).toBe("one");
+    expect(ukPluralCategory(22)).toBe("few");
+    expect(ukPluralCategory(25)).toBe("many");
+  });
+});

--- a/packages/fizruk-domain/src/domain/programs/selectors.ts
+++ b/packages/fizruk-domain/src/domain/programs/selectors.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure selectors over the built-in program catalogue.
+ *
+ * These are the functions the mobile + web hooks call to look up the
+ * active program from a (catalogue, persisted-id) pair. Kept tiny and
+ * single-purpose so they compose cleanly in `useMemo` bodies.
+ */
+
+import { PROGRAM_CATALOGUE } from "./catalogue.js";
+import type { TrainingProgramDef } from "./types.js";
+
+/**
+ * Look up a program by id within `catalogue`. Returns `null` when the
+ * id is absent or empty. Defaults to the built-in {@link PROGRAM_CATALOGUE}
+ * so callers that use the canonical catalogue don't have to pass it
+ * explicitly.
+ */
+export function findProgramById(
+  id: string | null | undefined,
+  catalogue: readonly TrainingProgramDef[] = PROGRAM_CATALOGUE,
+): TrainingProgramDef | null {
+  if (typeof id !== "string" || id === "") return null;
+  return catalogue.find((p) => p.id === id) ?? null;
+}
+
+/**
+ * Resolve the currently-active program from a persisted
+ * `activeProgramId`. Identical semantics to
+ * {@link findProgramById}, kept as a distinct named export so
+ * selector-style call sites stay self-documenting.
+ */
+export function resolveActiveProgram(
+  activeProgramId: string | null | undefined,
+  catalogue: readonly TrainingProgramDef[] = PROGRAM_CATALOGUE,
+): TrainingProgramDef | null {
+  return findProgramById(activeProgramId, catalogue);
+}

--- a/packages/fizruk-domain/src/domain/programs/state.ts
+++ b/packages/fizruk-domain/src/domain/programs/state.ts
@@ -1,0 +1,46 @@
+/**
+ * Load / normalise helpers for the persisted
+ * {@link ActiveProgramState}.
+ *
+ * Pure — no `localStorage`, no MMKV, no `window`. Apps hand in whatever
+ * `JSON.parse(raw)` produced (or `null` on a fresh install) and we
+ * return a safe state, ready to consume.
+ */
+
+import type { ActiveProgramState } from "./types.js";
+
+/** Blank state for a fresh install (no program activated yet). */
+export function defaultActiveProgramState(): ActiveProgramState {
+  return { activeProgramId: null };
+}
+
+/**
+ * Normalise arbitrary JSON (parsed MMKV / localStorage payload) into
+ * an {@link ActiveProgramState}.
+ *
+ * Accepted shapes:
+ *  - `null` / `undefined` → default state.
+ *  - A plain string id (legacy web format, stored directly under
+ *    `fizruk_active_program_id_v1` without JSON wrapping).
+ *  - An object with `{ activeProgramId: string | null }`.
+ *
+ * Unknown or malformed input returns the default — callers can always
+ * trust the result.
+ */
+export function normalizeActiveProgramState(raw: unknown): ActiveProgramState {
+  if (raw == null) return defaultActiveProgramState();
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return {
+      activeProgramId: trimmed.length > 0 ? trimmed : null,
+    };
+  }
+  if (typeof raw === "object") {
+    const src = raw as Record<string, unknown>;
+    const id = src.activeProgramId;
+    if (typeof id === "string" && id !== "") {
+      return { activeProgramId: id };
+    }
+  }
+  return defaultActiveProgramState();
+}

--- a/packages/fizruk-domain/src/domain/programs/today.ts
+++ b/packages/fizruk-domain/src/domain/programs/today.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure "today's session" resolver for the Fizruk Programs screen.
+ *
+ * All three helpers here accept a `now` seam so unit tests can freeze
+ * the clock without stubbing `Date` globally.
+ */
+
+import type {
+  ProgramScheduleEntry,
+  ProgramSessionDef,
+  TodayProgramSession,
+  TrainingProgramDef,
+  WeekdayIndex,
+} from "./types.js";
+
+/**
+ * Monday-first 0-indexed weekday (`0 = Mon … 6 = Sun`). Accepts a
+ * `now` seam for testing.
+ */
+export function weekdayIndex(now: Date = new Date()): WeekdayIndex {
+  return ((now.getDay() + 6) % 7) as WeekdayIndex;
+}
+
+/**
+ * Schedule entry for a given `(program, weekdayIndex)` pair, or
+ * `null` when the program has no session on that day.
+ *
+ * `dayIndex` follows the canonical {@link WeekdayIndex} convention
+ * (`0 = Mon … 6 = Sun`) — convert JS `Date#getDay()` via
+ * {@link weekdayIndex} first.
+ */
+export function getProgramScheduleForDay(
+  program: TrainingProgramDef | null | undefined,
+  dayIndex: number,
+): ProgramScheduleEntry | null {
+  if (!program) return null;
+  if (!Number.isFinite(dayIndex) || dayIndex < 0 || dayIndex > 6) return null;
+  const found = program.schedule.find((s) => s.day - 1 === dayIndex);
+  return found ?? null;
+}
+
+/**
+ * Session definition for a given `(program, weekdayIndex)`, or `null`
+ * when there is no session today or the session key is missing from
+ * {@link TrainingProgramDef.sessions}.
+ */
+export function getProgramSessionForDay(
+  program: TrainingProgramDef | null | undefined,
+  dayIndex: number,
+): ProgramSessionDef | null {
+  const schedule = getProgramScheduleForDay(program, dayIndex);
+  if (!schedule || !program) return null;
+  return program.sessions[schedule.sessionKey] ?? null;
+}
+
+/**
+ * Resolve the "today's session" triple for an active program. Returns
+ * `null` when no program is active, when today is a rest day, or when
+ * the scheduled session key is missing from the program definition.
+ */
+export function resolveTodaySession(
+  program: TrainingProgramDef | null | undefined,
+  now: Date = new Date(),
+): TodayProgramSession | null {
+  if (!program) return null;
+  const idx = weekdayIndex(now);
+  const schedule = getProgramScheduleForDay(program, idx);
+  if (!schedule) return null;
+  const session = program.sessions[schedule.sessionKey];
+  if (!session) return null;
+  return { programId: program.id, schedule, session };
+}

--- a/packages/fizruk-domain/src/domain/programs/types.ts
+++ b/packages/fizruk-domain/src/domain/programs/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared domain types for the Fizruk **Programs** screen.
+ *
+ * Platform-neutral — consumed by `apps/web` (port in a follow-up) and
+ * `apps/mobile`. The shapes describe the built-in training-program
+ * catalogue plus the small persisted slice
+ * (`ActiveProgramState`) that tracks the user's currently-active
+ * program id.
+ *
+ * Weekday convention mirrors the web page: day numbers in the schedule
+ * are 1-based (`1 = Monday … 7 = Sunday`) so the JSON payload lines up
+ * with how humans write a split. The "today" resolver converts
+ * JavaScript's Sunday-first `Date#getDay()` to this Monday-first
+ * 0-indexed space via `(d.getDay() + 6) % 7` and then matches
+ * `schedule.day - 1 === weekdayIndex`.
+ */
+
+/** 1 = Mon … 7 = Sun — matches the web catalogue exactly. */
+export type ProgramScheduleDay = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/** Canonical monday-first 0-indexed weekday (`0 = Mon … 6 = Sun`). */
+export type WeekdayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** A single planned session slot inside a program's weekly schedule. */
+export interface ProgramScheduleEntry {
+  /** Day of week — 1 = Mon … 7 = Sun. */
+  readonly day: ProgramScheduleDay;
+  /** Session key into {@link TrainingProgramDef.sessions}. */
+  readonly sessionKey: string;
+  /** Localised human-readable title (e.g. "Push — Груди, плечі, трицепс"). */
+  readonly name: string;
+}
+
+/** Definition of a single program session (one day of the split). */
+export interface ProgramSessionDef {
+  readonly name: string;
+  readonly exerciseIds: readonly string[];
+  /** Weight increment (kg) to add per session for compound lifts. */
+  readonly progressionKg: number;
+  /** Default rest between sets, in seconds. */
+  readonly defaultRestSec: number;
+}
+
+/**
+ * Full definition of a built-in training program.
+ *
+ * `durationWeeks` is the nominal plan length (e.g. "8 тижнів"); the
+ * catalogue is evergreen — a program can be re-started indefinitely —
+ * but we surface the length so the card can show a weekly cadence
+ * ("6 дн/тиждень · 8 тижнів").
+ */
+export interface TrainingProgramDef {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  /** Training days per week (length of `schedule`). */
+  readonly days: number;
+  /** Nominal plan length, in weeks. */
+  readonly durationWeeks: number;
+  readonly schedule: readonly ProgramScheduleEntry[];
+  readonly sessions: Readonly<Record<string, ProgramSessionDef>>;
+}
+
+/**
+ * Persisted slice tracking which program is currently active. Callers
+ * load this from MMKV / localStorage via
+ * {@link import("./state.js").normalizeActiveProgramState} and write
+ * it back on activate / deactivate.
+ */
+export interface ActiveProgramState {
+  readonly activeProgramId: string | null;
+}
+
+/**
+ * Resolved "today's planned session" — when an active program exists
+ * *and* its schedule has an entry for today's weekday.
+ */
+export interface TodayProgramSession {
+  readonly programId: string;
+  readonly schedule: ProgramScheduleEntry;
+  readonly session: ProgramSessionDef;
+}

--- a/packages/fizruk-domain/src/lib/trainingPrograms.ts
+++ b/packages/fizruk-domain/src/lib/trainingPrograms.ts
@@ -1,212 +1,55 @@
 /**
- * Built-in training programs for Fizruk.
- * Each program defines a weekly schedule with session keys and exercise IDs.
- * All exercise IDs correspond to entries in exercises.gymup.json.
- * progressionKg: how many kg to add per session for compound lifts.
+ * Back-compat shim for the legacy `lib/trainingPrograms` surface.
+ *
+ * The canonical source for the training-program catalogue + resolvers
+ * lives in {@link import("../domain/programs/index.js")}. This file
+ * preserves the two loose-typed helpers that `apps/web` has depended
+ * on since the pre-Phase-6 era:
+ *
+ *  - `getTodaySession(program)` — returns the **schedule entry**
+ *    (`{ day, sessionKey, name }`) for today or `null` on a rest
+ *    day. New mobile / web code should prefer
+ *    {@link import("../domain/programs/today.js").resolveTodaySession}
+ *    which returns the fully-resolved `{ programId, schedule, session }`
+ *    triple.
+ *  - `getDefaultRestSec(primaryGroup)` — unrelated rest-default
+ *    helper that historically lived in this file; kept here to avoid
+ *    churn in callers.
+ *
+ * `BUILTIN_PROGRAMS` and `getProgramScheduleForDay` are re-exported
+ * directly from `domain/programs` via the top-level package barrel —
+ * consumers should import them from `@sergeant/fizruk-domain` without
+ * reaching for `/lib/`.
  */
 
-export const BUILTIN_PROGRAMS = [
-  {
-    id: "ppl",
-    name: "Push Pull Legs",
-    description:
-      "Класична 6-денна програма. Push (груди/плечі/трицепс), Pull (спина/біцепс), Legs (ноги/сідниці). Відмінно для середнього рівня.",
-    days: 6,
-    schedule: [
-      { day: 1, sessionKey: "push", name: "Push — Груди, плечі, трицепс" },
-      { day: 2, sessionKey: "pull", name: "Pull — Спина, біцепс" },
-      { day: 3, sessionKey: "legs", name: "Legs — Ноги, сідниці" },
-      { day: 4, sessionKey: "push", name: "Push — Груди, плечі, трицепс" },
-      { day: 5, sessionKey: "pull", name: "Pull — Спина, біцепс" },
-      { day: 6, sessionKey: "legs", name: "Legs — Ноги, сідниці" },
-    ],
-    sessions: {
-      push: {
-        name: "Push Day",
-        exerciseIds: [
-          "bench_press_barbell",
-          "overhead_press_barbell",
-          "incline_bench_press",
-          "lateral_raise",
-          "tricep_pushdown",
-          "overhead_tricep_extension",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 90,
-      },
-      pull: {
-        name: "Pull Day",
-        exerciseIds: [
-          "deadlift",
-          "pullup",
-          "barbell_row",
-          "cable_face_pull",
-          "bicep_curl_barbell",
-          "hammer_curl",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 90,
-      },
-      legs: {
-        name: "Leg Day",
-        exerciseIds: [
-          "squat_barbell",
-          "romanian_deadlift",
-          "leg_press",
-          "leg_curl",
-          "leg_extension",
-          "calf_raise_standing",
-        ],
-        progressionKg: 5,
-        defaultRestSec: 120,
-      },
-    },
-  },
-  {
-    id: "upper_lower",
-    name: "Upper / Lower",
-    description:
-      "4-денна програма: два тренування на верх тіла та два на низ. Оптимальна частота для кожної групи. Підходить для початківців та середнього рівня.",
-    days: 4,
-    schedule: [
-      { day: 1, sessionKey: "upper_a", name: "Upper A — Верх тіла (сила)" },
-      { day: 2, sessionKey: "lower_a", name: "Lower A — Низ тіла (сила)" },
-      { day: 4, sessionKey: "upper_b", name: "Upper B — Верх тіла (об'єм)" },
-      { day: 5, sessionKey: "lower_b", name: "Lower B — Низ тіла (об'єм)" },
-    ],
-    sessions: {
-      upper_a: {
-        name: "Upper A (сила)",
-        exerciseIds: [
-          "bench_press_barbell",
-          "barbell_row",
-          "overhead_press_barbell",
-          "pullup",
-          "bicep_curl_barbell",
-          "tricep_pushdown",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 90,
-      },
-      lower_a: {
-        name: "Lower A (сила)",
-        exerciseIds: [
-          "squat_barbell",
-          "romanian_deadlift",
-          "leg_press",
-          "leg_curl",
-          "calf_raise_standing",
-        ],
-        progressionKg: 5,
-        defaultRestSec: 120,
-      },
-      upper_b: {
-        name: "Upper B (об'єм)",
-        exerciseIds: [
-          "incline_bench_press",
-          "cable_seated_row",
-          "lateral_raise",
-          "cable_face_pull",
-          "bicep_curl_dumbbell",
-          "overhead_tricep_extension",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 75,
-      },
-      lower_b: {
-        name: "Lower B (об'єм)",
-        exerciseIds: [
-          "deadlift",
-          "leg_press",
-          "leg_extension",
-          "leg_curl",
-          "calf_raise_standing",
-        ],
-        progressionKg: 5,
-        defaultRestSec: 90,
-      },
-    },
-  },
-  {
-    id: "full_body",
-    name: "Full Body 3×тиждень",
-    description:
-      "Три повних тренування тіла на тиждень (Пн/Ср/Пт). Ідеально для початківців та тих, хто має обмежений час. Максимальна частота стимуляції м'язів.",
-    days: 3,
-    schedule: [
-      { day: 1, sessionKey: "full_a", name: "Full Body A" },
-      { day: 3, sessionKey: "full_b", name: "Full Body B" },
-      { day: 5, sessionKey: "full_a", name: "Full Body A" },
-    ],
-    sessions: {
-      full_a: {
-        name: "Full Body A",
-        exerciseIds: [
-          "squat_barbell",
-          "bench_press_barbell",
-          "barbell_row",
-          "overhead_press_barbell",
-          "deadlift",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 90,
-      },
-      full_b: {
-        name: "Full Body B",
-        exerciseIds: [
-          "deadlift",
-          "incline_bench_press",
-          "pullup",
-          "lateral_raise",
-          "squat_barbell",
-        ],
-        progressionKg: 2.5,
-        defaultRestSec: 90,
-      },
-    },
-  },
-  {
-    id: "starting_strength",
-    name: "Лінійна прогресія",
-    description:
-      "3-денна програма на основі базових багатосуглобових рухів. Щотренування +2.5 кг на штанзі. Найкраще для новачків — швидкий набір сили.",
-    days: 3,
-    schedule: [
-      { day: 1, sessionKey: "ss_a", name: "Workout A" },
-      { day: 3, sessionKey: "ss_b", name: "Workout B" },
-      { day: 5, sessionKey: "ss_a", name: "Workout A" },
-    ],
-    sessions: {
-      ss_a: {
-        name: "Workout A",
-        exerciseIds: ["squat_barbell", "bench_press_barbell", "deadlift"],
-        progressionKg: 2.5,
-        defaultRestSec: 180,
-      },
-      ss_b: {
-        name: "Workout B",
-        exerciseIds: ["squat_barbell", "overhead_press_barbell", "deadlift"],
-        progressionKg: 2.5,
-        defaultRestSec: 180,
-      },
-    },
-  },
-];
+import {
+  getProgramScheduleForDay,
+  weekdayIndex,
+  type ProgramScheduleEntry,
+  type TrainingProgramDef,
+} from "../domain/programs/index.js";
 
-/** Get the session for a given program and day index (0=Mon…6=Sun). */
-export function getProgramSessionForDay(program, dayIndex) {
-  if (!program) return null;
-  return program.schedule.find((s) => s.day - 1 === dayIndex) || null;
+/**
+ * Schedule entry for today (based on the current system clock) or
+ * `null` on a rest day. Maintains the legacy signature — callers that
+ * need the fully-resolved `{ programId, schedule, session }` triple
+ * should use `resolveTodaySession` from `domain/programs`.
+ */
+export function getTodaySession(
+  program: TrainingProgramDef | null | undefined,
+): ProgramScheduleEntry | null {
+  return getProgramScheduleForDay(program, weekdayIndex());
 }
 
-/** Get today's session (based on current weekday). */
-export function getTodaySession(program) {
-  if (!program) return null;
-  const dayIndex = (new Date().getDay() + 6) % 7;
-  return getProgramSessionForDay(program, dayIndex);
-}
-
-export function getDefaultRestSec(primaryGroup) {
+/**
+ * Heuristic default rest duration, in seconds, for a given
+ * `primaryGroup` tag from the exercise catalogue. Kept here for
+ * backwards compatibility — the restrictions screen owns the
+ * user-editable version under `fizruk_rest_settings_v1`.
+ */
+export function getDefaultRestSec(
+  primaryGroup: string | null | undefined,
+): number {
   if (!primaryGroup) return 90;
   const compound = ["chest", "back", "legs", "glutes", "full_body"];
   const isolation = ["shoulders", "arms", "core"];

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -68,6 +68,7 @@ export const STORAGE_KEYS = {
   FIZRUK_MEASUREMENTS: "fizruk_measurements_v1",
   FIZRUK_SELECTED_TEMPLATE: "fizruk_selected_template_id_v1",
   FIZRUK_ACTIVE_WORKOUT: "fizruk_active_workout_id_v1",
+  FIZRUK_ACTIVE_PROGRAM: "fizruk_active_program_id_v1",
   FIZRUK_DAILY_LOG: "fizruk_daily_log_v1",
   FIZRUK_REST_SETTINGS: "fizruk_rest_settings_v1",
 


### PR DESCRIPTION
## Summary

Full mobile port of the Fizruk **Programs** page — Phase 6 · PR-F of the React Native migration (`docs/react-native-migration.md` §4).

Replaces the 27-LOC placeholder at `apps/mobile/src/modules/fizruk/pages/Programs.tsx` with a complete catalogue screen that mirrors the web counterpart (`apps/web/src/modules/fizruk/pages/Programs.tsx`, 231 LOC), plus a reusable pure-domain module shared with web.

### What lands

- **New pure module** `@sergeant/fizruk-domain/domain/programs/*` (7 files, 28 vitest cases):
  - `types.ts` — strict `TrainingProgramDef`, `ActiveProgramState`, `TodayProgramSession`, `ProgramScheduleEntry`, `ProgramSessionDef`, `WeekdayIndex`, `ProgramScheduleDay`. Weekday convention documented (1 = Mon … 7 = Sun in schedules; `weekdayIndex` converts JS `getDay()` to 0-indexed Monday-first).
  - `catalogue.ts` — canonical `PROGRAM_CATALOGUE` with the four built-in programs (`ppl`, `upper_lower`, `full_body`, `starting_strength`) + strict types + new `durationWeeks` field.
  - `selectors.ts` — `findProgramById`, `resolveActiveProgram`.
  - `today.ts` — `weekdayIndex`, `getProgramScheduleForDay`, `getProgramSessionForDay`, `resolveTodaySession`.
  - `state.ts` — `normalizeActiveProgramState` (handles legacy string format + object form), `defaultActiveProgramState`.
  - `format.ts` — Ukrainian-pluralised `formatDurationWeeks`, `formatFrequency`, `formatProgramCadence`, plus `ukPluralCategory`.
  - `index.ts` — barrel export. Wired into `src/domain/index.ts`.
- **Back-compat**: `src/lib/trainingPrograms.ts` now re-exports `BUILTIN_PROGRAMS` via the new canonical source and keeps `getTodaySession` (schedule-entry flavour) / `getDefaultRestSec` so web consumers (`apps/web/src/modules/fizruk/**`) compile unchanged.
- **Mobile MMKV hook** `apps/mobile/src/modules/fizruk/hooks/usePrograms.ts` — list + activate / deactivate / toggle, persisted under the shared `STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM` slot (new entry in `packages/shared/src/lib/storageKeys.ts` + `packages/fizruk-domain/src/constants.ts`). Subscribes to MMKV value-change events so out-of-band writes re-render the page.
- **Mobile page** `apps/mobile/src/modules/fizruk/pages/Programs.tsx` — `SafeAreaView` + `ScrollView` layout with:
  - Top `TodaySessionCard` (`components/programs/TodaySessionCard.tsx`) with three states: no-active empty state, rest-day fallback (`Сьогодні — вихідний`), active branded card with session name + `Почати` CTA.
  - Scrollable `ProgramCard` list (`components/programs/ProgramCard.tsx`) with name, cadence (`6 дн/тиждень · 8 тижнів`), description, mini weekday strip, and `Активувати` / `Деактивувати` control.
  - `Почати` wires into `useActiveFizrukWorkout` — mints a stable `program-<id>-<sessionKey>-<ts>` active-workout id so the existing shared timer + `RestTimerOverlay` from PR-B picks it up.
- **Route wrapper** `apps/mobile/app/(tabs)/fizruk/programs.tsx` — already landed in #450, confirmed still points at the new page.
- **Test coverage**
  - Vitest (`packages/fizruk-domain/src/domain/programs/programs.test.ts`): 28 cases across catalogue integrity, selectors, `weekdayIndex`, schedule / session resolvers, `resolveTodaySession` (including rest-day / missing-session / null-program edge cases), `normalizeActiveProgramState` (legacy string, object, malformed, whitespace), `formatDurationWeeks` Ukrainian plural rules (`one` / `few` / `many`), `formatFrequency`, `formatProgramCadence`, `ukPluralCategory`.
  - Jest (`apps/mobile/src/modules/fizruk/pages/Programs.test.tsx`): 5 cases — empty hero + every built-in card rendered with `Активувати` CTA, activate → MMKV write + `Деактивувати` flip → deactivate → back to empty hero, planned-session hero on a scheduled Monday (PPL · Push Day), rest-day hero on a Sunday, and `Почати` wiring writing a `program-*` id into `FIZRUK_ACTIVE_WORKOUT`.

### Why this shape

The web page mixed data, persistence, and presentation in one file. By extracting the pure slice into `@sergeant/fizruk-domain/domain/programs` we keep mobile + (future) web-refactor consumers on a single source of truth, keep all non-React logic unit-testable with vitest in isolation, and avoid any bundled `Date` / MMKV / DOM dependency in the shared package. The mobile hook is a thin MMKV wrapper around those selectors — same pattern as `useMeasurements` (#470) and `useMonthlyPlan` (#464).

### Files NOT touched (per brief)

- `apps/web/**` — only ported from. `lib/trainingPrograms.ts` stays back-compat so web compiles unchanged (verified by `pnpm build` on web).
- `apps/mobile/src/modules/routine/**`, `apps/mobile/src/modules/finyk/**`.
- Stable fizruk pages: `Progress.tsx`, `PlanCalendar.tsx`, `Measurements.tsx`, `Dashboard.tsx`, `Workouts.tsx`, `Atlas.tsx`, `Body.tsx`, `Exercise.tsx`.
- Stable fizruk components: `BodyAtlas.tsx`, `RestTimerOverlay.tsx`, `components/progress/**`, `components/measurements/**`.
- `docs/react-native-migration.md`.
- `apps/mobile/jest.config.js`, `apps/mobile/tsconfig.json`, `apps/mobile/package.json` — no changes needed.
- No new root-level dependencies.

## Review & Testing Checklist for Human

- [ ] Open the Fizruk → `Програми` tab on a real device: catalogue renders four cards, cadence label reads correctly for each, mini weekday strip highlights the right days.
- [ ] Tap `Активувати` on one program — badge + `Деактивувати` appear, hero card on top populates (or shows `Сьогодні — вихідний` on a rest day). Tap `Деактивувати` — hero card reverts to the activation nudge.
- [ ] On a training day, tap `Почати` — the shared rest-timer-enabled workout state should engage (`useActiveFizrukWorkout` flips; pre-existing `RestTimerOverlay` path unchanged).
- [ ] Kill + relaunch the app after activating — the active program should persist (MMKV key `fizruk_active_program_id_v1`).
- [ ] Smoke-check the web build in dev: `BUILTIN_PROGRAMS` / `getTodaySession` still wired to the web page unchanged (same storage key `fizruk_active_program_id_v1`, so web & mobile share CloudSync slot).

### Notes

- `pnpm check` passes locally (format, lint, typecheck, 28 new vitest + 5 new jest cases, web + mobile build).
- Storage key added: `STORAGE_KEYS.FIZRUK_ACTIVE_PROGRAM` + `ACTIVE_PROGRAM_KEY` (matches legacy web key `fizruk_active_program_id_v1`).
- No touchpoints on workout-CRUD; full Workouts port still lands in a later phase.


Link to Devin session: https://app.devin.ai/sessions/547d3946041a43ef91d4444aba51f0e1
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
