### PR TITLE
docs(migration): закрити серію HubDashboard (PR-1/PR-2/PR-3)

### DIFF
--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -264,10 +264,14 @@ isReduceMotionEnabled()` (WCAG 2.3.3 parity).
     доступний у наступному релізі» (Better Auth sheet на mobile ще не
     зведено в навігацію — TODO). Тести: 64 vitest-кейси для shared
     (>=80% branch); 22 jest-expo кейси на картки + one-hero rule в
-    `HubDashboard.test.tsx`. Не входить у PR-2 (плановано окремо):
-    quick-stats preview у `StatusRow` (`*_quick_stats` LocalStorage
-    readers — PR-3), `HubInsightsPanel` (colapse з Coach-рекомендаціями —
-    PR-3), `WeeklyDigestFooter` — PR-3.
+    `HubDashboard.test.tsx`. Продовження серії (приземлилося окремо у
+    PR-3 ✅ PR [#482](https://github.com/Skords-01/Sergeant/pull/482)):
+    quick-stats preview у `StatusRow` (`*_quick_stats` MMKV readers),
+    `HubInsightsPanel` (collapsible панель із Coach-рекомендаціями) і
+    `WeeklyDigestFooter`. `rest`-рекомендації з `useDashboardFocus`
+    тепер фідять `HubInsightsPanel` (спільна dismiss-мапа
+    `hub_recs_dismissed_v1`), тож one-hero правило та secondary-панель
+    працюють від одного джерела recs.
 - `apps/mobile/src/core/dashboard/{HubDashboard,DraggableDashboard,StatusRow,useDashboardOrder,dashboardModuleConfig}.tsx`
   - `packages/shared/src/lib/dashboard.ts`
     — `HubDashboard` PR-1 (Phase 2 / Hub-core, PR [#480](https://github.com/Skords-01/Sergeant/pull/480)).
@@ -309,12 +313,15 @@ isReduceMotionEnabled()` (WCAG 2.3.3 parity).
     через яку `pnpm/action-setup` падав). `pnpm-lock.yaml` додано у
     `.prettierignore`. Без нових runtime-deps поверх уже наявних
     `react-native-gesture-handler` + `react-native-reanimated` +
-    `expo-haptics`. Не входить у PR-1 (плановано окремо):
-    `TodayFocusCard` / `FirstActionHeroCard` / `SoftAuthPromptCard`
-    (hero-шар — PR-2), quick-stats preview у `StatusRow`
-    (`*_quick_stats` LocalStorage readers — PR-3), `HubInsightsPanel`
-    (colapse з Coach-рекомендаціями — PR-3), `WeeklyDigestFooter` —
-    PR-3.
+    `expo-haptics`. Продовження серії (приземлилося окремо):
+    `TodayFocusCard` / `FirstActionHeroCard` / `SoftAuthPromptCard` —
+    hero-шар, PR-2 ✅ PR [#483](https://github.com/Skords-01/Sergeant/pull/483);
+    quick-stats preview у `StatusRow` (`*_quick_stats` MMKV readers),
+    `HubInsightsPanel` (collapsible панель із Coach-рекомендаціями) і
+    `WeeklyDigestFooter` — PR-3 ✅ PR [#482](https://github.com/Skords-01/Sergeant/pull/482).
+    Трьома PR-ами серія `HubDashboard` на mobile закрита — далі по Hub-
+    core Phase 2 йдуть `OnboardingWizard`, `HubChat`, `HubSearch`,
+    `HubReports`.
 - `packages/finyk-domain/src/storageKeys.ts` і
   `packages/finyk-domain/src/backup.ts` — PR2 Фази 4 (pure domain
   extract). `FINYK_STORAGE_KEYS`, `FINYK_MANUAL_ONLY_KEY` та мапа


### PR DESCRIPTION
## Summary

Мінорний апдейт `docs/react-native-migration.md` — закриваємо прогрес-трекер серії `HubDashboard`. PR-2 (#483, hero-шар) і PR-3 (#482, quick-stats preview + `HubInsightsPanel` + `WeeklyDigestFooter`) замержені; у §2.2 ще стояли forward-looking абзаци в описах PR-1 і PR-2, що перелічували ці пункти як «плановано окремо». Перепаковую їх у минулий час і додаю прямі посилання на замержені PR-и, щоб наступний читач не думав, що це все ще у беклозі.

Без змін у коді — лише доку.

## Review & Testing Checklist for Human

Risk: **green** — тільки markdown, жодного коду чи залежностей.

- [ ] Відкрий `docs/react-native-migration.md` §2.2 та переконайся, що після блоків PR-1 та PR-2 більше немає «Не входить у PR-X (плановано окремо)» — замість цього стоять лінки на #482 і #483 з коротким описом, що серія закрита.

### Notes

- Snapshot-таблиця Phase 2 (row #33) та Phased-plan-таблиця (row #497) вже містили посилання на обидва PR — їх не чіпав, щоб не створювати merge-hazard із наступними апдейтами тих самих довгих рядків.
- Серію `HubDashboard` на mobile вважаємо закритою; далі по Hub-core йдуть `OnboardingWizard`, `HubChat`, `HubSearch`, `HubReports`.

Link to Devin session: https://app.devin.ai/sessions/4c5a1f4bd9464ebabaa4b7f0e7527a9a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
