### PR TITLE
feat(mobile): Phase 10 PR-B — Android app shortcuts + iOS quick actions

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,4 +1,8 @@
 import type { ExpoConfig } from "expo/config";
+import {
+  withAndroidShortcuts,
+  type AndroidShortcutItem,
+} from "./plugins/withAndroidShortcuts";
 
 /**
  * Dynamic Expo config.
@@ -9,7 +13,99 @@ import type { ExpoConfig } from "expo/config";
  */
 const updatesUrl = process.env.EXPO_PUBLIC_EAS_UPDATES_URL;
 
-const config = (): ExpoConfig => ({
+const ANDROID_PACKAGE = "com.sergeant.app";
+
+/**
+ * Static Android app shortcuts (long-press on the launcher icon).
+ *
+ * Each shortcut fires a `sergeant://…` deep link which is consumed by
+ * the existing `useDeepLinks` runtime shim. No UI code here: the
+ * shortcut → intent → `Linking.getInitialURL()` chain is pure config.
+ *
+ * Labels are kept in Ukrainian to match the app's primary locale.
+ * Phase 10 PR-B does not yet ship dedicated monochrome shortcut
+ * icons; we fall back to the launcher mipmap until a follow-up PR
+ * adds `@drawable/ic_shortcut_*` assets.
+ */
+const ANDROID_APP_SHORTCUTS: AndroidShortcutItem[] = [
+  {
+    id: "add_expense",
+    shortLabel: "Витрата",
+    longLabel: "Додати витрату",
+    intent: {
+      action: "android.intent.action.VIEW",
+      data: "sergeant://finance/tx/new",
+      targetPackage: ANDROID_PACKAGE,
+    },
+  },
+  {
+    id: "open_today",
+    shortLabel: "Сьогодні",
+    longLabel: "Рутина на сьогодні",
+    intent: {
+      action: "android.intent.action.VIEW",
+      data: "sergeant://routine",
+      targetPackage: ANDROID_PACKAGE,
+    },
+  },
+  {
+    id: "start_workout",
+    shortLabel: "Тренування",
+    longLabel: "Почати тренування",
+    intent: {
+      action: "android.intent.action.VIEW",
+      data: "sergeant://workout/new",
+      targetPackage: ANDROID_PACKAGE,
+    },
+  },
+];
+
+/**
+ * iOS quick actions (3D-Touch / long-press home icon).
+ *
+ * Expo merges `ios.infoPlist.UIApplicationShortcutItems` straight into
+ * the generated Info.plist, so this needs no plugin. The URL is sent
+ * through `Linking` when the user taps a quick action, and then
+ * consumed by `useDeepLinks`.
+ *
+ * Ordering matches the Android set above so the two platforms stay
+ * in sync.
+ *
+ * `UIApplicationShortcutItemIconType` uses built-in system icons so
+ * PR-B does not pull in any new art assets. A follow-up can swap
+ * `UIApplicationShortcutItemIconFile` in once monochrome icons exist.
+ */
+const IOS_SHORTCUT_ITEMS = [
+  {
+    UIApplicationShortcutItemType: `${ANDROID_PACKAGE}.add_expense`,
+    UIApplicationShortcutItemTitle: "Витрата",
+    UIApplicationShortcutItemSubtitle: "Додати витрату",
+    UIApplicationShortcutItemIconType: "UIApplicationShortcutIconTypeAdd",
+    UIApplicationShortcutItemUserInfo: {
+      url: "sergeant://finance/tx/new",
+    },
+  },
+  {
+    UIApplicationShortcutItemType: `${ANDROID_PACKAGE}.open_today`,
+    UIApplicationShortcutItemTitle: "Сьогодні",
+    UIApplicationShortcutItemSubtitle: "Рутина на сьогодні",
+    UIApplicationShortcutItemIconType: "UIApplicationShortcutIconTypeDate",
+    UIApplicationShortcutItemUserInfo: {
+      url: "sergeant://routine",
+    },
+  },
+  {
+    UIApplicationShortcutItemType: `${ANDROID_PACKAGE}.start_workout`,
+    UIApplicationShortcutItemTitle: "Тренування",
+    UIApplicationShortcutItemSubtitle: "Почати тренування",
+    UIApplicationShortcutItemIconType: "UIApplicationShortcutIconTypePlay",
+    UIApplicationShortcutItemUserInfo: {
+      url: "sergeant://workout/new",
+    },
+  },
+];
+
+const buildConfig = (): ExpoConfig => ({
   name: "Sergeant",
   slug: "sergeant",
   version: "0.1.0",
@@ -28,9 +124,10 @@ const config = (): ExpoConfig => ({
   assetBundlePatterns: ["**/*"],
   ios: {
     supportsTablet: true,
-    bundleIdentifier: "com.sergeant.app",
+    bundleIdentifier: ANDROID_PACKAGE,
     infoPlist: {
       UIBackgroundModes: ["remote-notification"],
+      UIApplicationShortcutItems: IOS_SHORTCUT_ITEMS,
     },
   },
   android: {
@@ -38,7 +135,7 @@ const config = (): ExpoConfig => ({
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#0b0d10",
     },
-    package: "com.sergeant.app",
+    package: ANDROID_PACKAGE,
     // Registers `sergeant://…` as an app link. Expo Router's
     // file-based routes handle the specific deep-link targets; this
     // manifest entry is what tells Android that our app is the default
@@ -94,5 +191,15 @@ const config = (): ExpoConfig => ({
     },
   },
 });
+
+/**
+ * Apply inline config plugins. The `plugins` array above only accepts
+ * published plugin module paths (`string | [string, ...]`) per Expo's
+ * TypeScript type, whereas our local `withAndroidShortcuts` plugin is
+ * a function reference. Applying it here wraps the base config with
+ * the mod registrations so Expo's prebuild pipeline picks them up.
+ */
+const config = (): ExpoConfig =>
+  withAndroidShortcuts(buildConfig(), ANDROID_APP_SHORTCUTS) as ExpoConfig;
 
 export default config;

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -8,7 +8,10 @@
  */
 module.exports = {
   preset: "jest-expo",
-  testMatch: ["<rootDir>/src/**/*.test.{ts,tsx}"],
+  testMatch: [
+    "<rootDir>/src/**/*.test.{ts,tsx}",
+    "<rootDir>/plugins/**/*.test.{ts,tsx}",
+  ],
   setupFiles: ["<rootDir>/jest.setup.js"],
   // `@sergeant/*-domain` packages use NodeNext `.js`-extension imports
   // inside their TS source (required so they compile cleanly under the

--- a/apps/mobile/plugins/withAndroidShortcuts.test.ts
+++ b/apps/mobile/plugins/withAndroidShortcuts.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure tests for the `shortcuts.xml` builder.
+ *
+ * We verify only the string output — the actual plugin body
+ * (`withAndroidManifest` / `withStringsXml` / `withDangerousMod`) is
+ * exercised by `expo prebuild` at native-build time and doesn't lend
+ * itself to meaningful unit testing without a full Expo config fixture.
+ * The builder itself is pure, so we pin its output shape here so that
+ * future tweaks to the XML surface are intentional.
+ */
+import {
+  buildShortcutsXml,
+  shortcutStringKeys,
+  type AndroidShortcutItem,
+} from "./withAndroidShortcuts";
+
+function makeShortcut(
+  overrides: Partial<AndroidShortcutItem> = {},
+): AndroidShortcutItem {
+  return {
+    id: "add_expense",
+    shortLabel: "Додати",
+    longLabel: "Додати витрату",
+    intent: {
+      action: "android.intent.action.VIEW",
+      data: "sergeant://finance/tx/new",
+      targetPackage: "com.sergeant.app",
+    },
+    ...overrides,
+  };
+}
+
+describe("shortcutStringKeys", () => {
+  it("prefixes the string-resource ids with the shortcut id", () => {
+    expect(shortcutStringKeys(makeShortcut({ id: "open_today" }))).toEqual({
+      shortLabelKey: "shortcut_open_today_short",
+      longLabelKey: "shortcut_open_today_long",
+    });
+  });
+});
+
+describe("buildShortcutsXml", () => {
+  it("emits a single <shortcut> block pointing at the deep link", () => {
+    const xml = buildShortcutsXml([makeShortcut()]);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(xml).toContain(
+      '<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">',
+    );
+    expect(xml).toContain('android:shortcutId="add_expense"');
+    expect(xml).toContain(
+      'android:shortcutShortLabel="@string/shortcut_add_expense_short"',
+    );
+    expect(xml).toContain(
+      'android:shortcutLongLabel="@string/shortcut_add_expense_long"',
+    );
+    expect(xml).toContain('android:data="sergeant://finance/tx/new"');
+    expect(xml).toContain('android:targetPackage="com.sergeant.app"');
+    expect(xml).toContain('android:action="android.intent.action.VIEW"');
+  });
+
+  it("defaults the icon to the launcher mipmap", () => {
+    const xml = buildShortcutsXml([makeShortcut()]);
+    expect(xml).toContain('android:icon="@mipmap/ic_launcher"');
+  });
+
+  it("honours a custom icon resource", () => {
+    const xml = buildShortcutsXml([
+      makeShortcut({ iconResource: "@drawable/ic_shortcut_add" }),
+    ]);
+    expect(xml).toContain('android:icon="@drawable/ic_shortcut_add"');
+    expect(xml).not.toContain('android:icon="@mipmap/ic_launcher"');
+  });
+
+  it("embeds the optional targetClass when provided", () => {
+    const xml = buildShortcutsXml([
+      makeShortcut({
+        intent: {
+          action: "android.intent.action.VIEW",
+          data: "sergeant://routine",
+          targetPackage: "com.sergeant.app",
+          targetClass: "com.sergeant.app.MainActivity",
+        },
+      }),
+    ]);
+    expect(xml).toContain(
+      'android:targetClass="com.sergeant.app.MainActivity"',
+    );
+  });
+
+  it("omits targetClass when not provided", () => {
+    const xml = buildShortcutsXml([makeShortcut()]);
+    expect(xml).not.toContain("android:targetClass");
+  });
+
+  it("emits multiple <shortcut> blocks preserving order", () => {
+    const xml = buildShortcutsXml([
+      makeShortcut({ id: "add_expense" }),
+      makeShortcut({
+        id: "open_today",
+        shortLabel: "Сьогодні",
+        longLabel: "Рутина — сьогодні",
+        intent: {
+          action: "android.intent.action.VIEW",
+          data: "sergeant://routine",
+          targetPackage: "com.sergeant.app",
+        },
+      }),
+      makeShortcut({
+        id: "start_workout",
+        shortLabel: "Тренування",
+        longLabel: "Почати тренування",
+        intent: {
+          action: "android.intent.action.VIEW",
+          data: "sergeant://workout/new",
+          targetPackage: "com.sergeant.app",
+        },
+      }),
+    ]);
+
+    const matches = xml.match(/<shortcut\s/g) ?? [];
+    expect(matches).toHaveLength(3);
+
+    const addIdx = xml.indexOf('android:shortcutId="add_expense"');
+    const todayIdx = xml.indexOf('android:shortcutId="open_today"');
+    const workoutIdx = xml.indexOf('android:shortcutId="start_workout"');
+    expect(addIdx).toBeGreaterThan(0);
+    expect(todayIdx).toBeGreaterThan(addIdx);
+    expect(workoutIdx).toBeGreaterThan(todayIdx);
+  });
+
+  it("escapes special characters in attribute values", () => {
+    const xml = buildShortcutsXml([
+      makeShortcut({
+        id: "quirky",
+        intent: {
+          action: "android.intent.action.VIEW",
+          // Contrived but exercises the ampersand escape path.
+          data: 'sergeant://finance?tag="ops"&amp=1',
+          targetPackage: "com.sergeant.app",
+        },
+      }),
+    ]);
+
+    expect(xml).toContain(
+      'android:data="sergeant://finance?tag=&quot;ops&quot;&amp;amp=1"',
+    );
+    expect(xml).not.toContain('data="sergeant://finance?tag="ops"&amp=1"');
+  });
+});

--- a/apps/mobile/plugins/withAndroidShortcuts.ts
+++ b/apps/mobile/plugins/withAndroidShortcuts.ts
@@ -1,0 +1,205 @@
+/**
+ * Inline config plugin: Android static app shortcuts.
+ *
+ * Android app shortcuts are declared via an XML resource
+ * (`res/xml/shortcuts.xml`) referenced from the launcher `<activity>`
+ * through a `<meta-data android:name="android.app.shortcuts" />` entry.
+ * All user-visible strings must be string resources (raw-string
+ * attributes are ignored by the launcher for localisation reasons),
+ * so we also merge entries into `res/values/strings.xml`.
+ *
+ * Why a local plugin and not `expo-quick-actions`?
+ *   - The migration plan (`docs/react-native-migration.md` Phase 10)
+ *     explicitly forbids adding new runtime deps for this step.
+ *   - Static shortcuts don't need a runtime module — they are purely
+ *     manifest-level: tapping one fires the app's existing deep-link
+ *     intent filter (`sergeant://…`) which `useDeepLinks` already
+ *     consumes (see `src/lib/useDeepLinks.ts`).
+ *
+ * iOS quick actions are wired separately in `app.config.ts` via
+ * `ios.infoPlist.UIApplicationShortcutItems` — Expo merges that key
+ * straight into the generated Info.plist, no plugin needed.
+ *
+ * The builders `buildShortcutsXml` / `shortcutStringKeys` are pure and
+ * exported for unit testing.
+ */
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  withAndroidManifest,
+  withDangerousMod,
+  withStringsXml,
+} from "@expo/config-plugins";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * `@expo/config-plugins` types the activity node without `meta-data`
+ * even though xml2js keeps arbitrary child elements. We widen the
+ * type locally so TypeScript lets us append the shortcuts resource
+ * reference without resorting to `any`.
+ */
+type ManifestMetaDataEntry = {
+  $: Record<string, string>;
+};
+type ActivityWithMetaData = {
+  $: Record<string, string | undefined>;
+  "meta-data"?: ManifestMetaDataEntry[];
+};
+
+export type AndroidShortcutIntent = {
+  /** Fully-qualified intent action, e.g. "android.intent.action.VIEW". */
+  action: string;
+  /** Deep-link URI to dispatch, e.g. "sergeant://routine". */
+  data: string;
+  /** App package that should receive the intent, e.g. "com.sergeant.app". */
+  targetPackage: string;
+  /** Optional activity class name. Defaults to MainActivity. */
+  targetClass?: string;
+};
+
+export type AndroidShortcutItem = {
+  /** Stable shortcut id. Must be unique within the shortcut set. */
+  id: string;
+  /** Localised short label (<= 10 chars recommended by AOSP). */
+  shortLabel: string;
+  /** Localised long label (<= 25 chars recommended). */
+  longLabel: string;
+  /**
+   * Drawable resource reference. Defaults to the launcher icon.
+   * Kept as `@mipmap/ic_launcher` for PR-B so no new art asset is
+   * required; a follow-up PR can swap in per-action monochrome icons.
+   */
+  iconResource?: string;
+  /** Intent dispatched when the shortcut is tapped. */
+  intent: AndroidShortcutIntent;
+};
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function shortcutStringKeys(shortcut: AndroidShortcutItem): {
+  shortLabelKey: string;
+  longLabelKey: string;
+} {
+  return {
+    shortLabelKey: `shortcut_${shortcut.id}_short`,
+    longLabelKey: `shortcut_${shortcut.id}_long`,
+  };
+}
+
+export function buildShortcutsXml(items: AndroidShortcutItem[]): string {
+  const entries = items
+    .map((item) => {
+      const { shortLabelKey, longLabelKey } = shortcutStringKeys(item);
+      const icon = item.iconResource ?? "@mipmap/ic_launcher";
+      const targetClassAttr = item.intent.targetClass
+        ? `\n      android:targetClass="${escapeXmlAttr(item.intent.targetClass)}"`
+        : "";
+      return `  <shortcut
+    android:shortcutId="${escapeXmlAttr(item.id)}"
+    android:enabled="true"
+    android:icon="${escapeXmlAttr(icon)}"
+    android:shortcutShortLabel="@string/${shortLabelKey}"
+    android:shortcutLongLabel="@string/${longLabelKey}">
+    <intent
+      android:action="${escapeXmlAttr(item.intent.action)}"
+      android:targetPackage="${escapeXmlAttr(item.intent.targetPackage)}"${targetClassAttr}
+      android:data="${escapeXmlAttr(item.intent.data)}" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>`;
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+${entries}
+</shortcuts>
+`;
+}
+
+export const withAndroidShortcuts: ConfigPlugin<AndroidShortcutItem[]> = (
+  config,
+  shortcuts,
+) => {
+  // 1. Merge localisable labels into res/values/strings.xml.
+  config = withStringsXml(config, (cfg) => {
+    cfg.modResults = AndroidConfig.Strings.setStringItem(
+      shortcuts.flatMap((shortcut) => {
+        const { shortLabelKey, longLabelKey } = shortcutStringKeys(shortcut);
+        return [
+          {
+            $: { name: shortLabelKey, translatable: "false" },
+            _: shortcut.shortLabel,
+          },
+          {
+            $: { name: longLabelKey, translatable: "false" },
+            _: shortcut.longLabel,
+          },
+        ];
+      }),
+      cfg.modResults,
+    );
+    return cfg;
+  });
+
+  // 2. Reference the shortcuts xml resource from MainActivity.
+  config = withAndroidManifest(config, (cfg) => {
+    const app = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      cfg.modResults,
+    );
+    const rawActivity = app.activity?.find((a) =>
+      a.$["android:name"]?.endsWith(".MainActivity"),
+    );
+    if (!rawActivity) return cfg;
+
+    const mainActivity = rawActivity as unknown as ActivityWithMetaData;
+    const existing: ManifestMetaDataEntry[] = mainActivity["meta-data"] ?? [];
+    // Deduplicate previous runs of the plugin.
+    const filtered = existing.filter(
+      (entry) => entry.$["android:name"] !== "android.app.shortcuts",
+    );
+    filtered.push({
+      $: {
+        "android:name": "android.app.shortcuts",
+        "android:resource": "@xml/shortcuts",
+      },
+    });
+    mainActivity["meta-data"] = filtered;
+    return cfg;
+  });
+
+  // 3. Write res/xml/shortcuts.xml. We use `withDangerousMod` because
+  //    there is no dedicated helper for arbitrary xml resources and
+  //    the file lives outside AndroidManifest / strings.xml.
+  config = withDangerousMod(config, [
+    "android",
+    async (cfg) => {
+      const xmlDir = path.join(
+        cfg.modRequest.platformProjectRoot,
+        "app",
+        "src",
+        "main",
+        "res",
+        "xml",
+      );
+      fs.mkdirSync(xmlDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(xmlDir, "shortcuts.xml"),
+        buildShortcutsXml(shortcuts),
+        "utf8",
+      );
+      return cfg;
+    },
+  ]);
+
+  return config;
+};
+
+export default withAndroidShortcuts;

--- a/docs/react-native-migration.md
+++ b/docs/react-native-migration.md
@@ -666,7 +666,7 @@ Mobile: `expo-router` v4 (file-based, зверху React Navigation).
 вже піднятий (auth-модалка + tabs). Всередині кожного табу —
 Stack-навігатор, файли під `app/(tabs)/<module>/*`.
 
-**Phase 10 (deep links) — PR-A, 🔵 In progress.** Pure-хелпер
+**Phase 10 (deep links) — PR-A ✅ + PR-B 🔵, In progress.** Pure-хелпер
 `apps/mobile/src/lib/deepLinks.ts` парсить/будує всі `sergeant://…`
 схеми з таблиці у `docs/mobile.md` і повертає `Href` для
 expo-router через discriminated-union `SergeantDeepLink`. Runtime-шар —
@@ -686,8 +686,28 @@ universal links (`https://sergeant.2dmanager.com.ua` +
 `auth/callback`) рендерять спільний `DeepLinkPlaceholder`
 («Скоро» + primary-CTA + повернення на хаб), доки відповідні фази
 (Phase 6 Fizruk, Phase 7 Nutrition) не підтягнуть реальні екрани.
-Android shortcuts + iOS quick actions — окремий PR-B; smoke-test
-скрипт для deep links — PR-C.
+
+**PR-B — Android app shortcuts + iOS quick actions.** Додає три
+статичних шорткати: «Витрата» → `sergeant://finance/tx/new`,
+«Сьогодні» → `sergeant://routine`, «Тренування» →
+`sergeant://workout/new`. На Android локальний config-плагін
+`apps/mobile/plugins/withAndroidShortcuts.ts` генерує
+`android/app/src/main/res/xml/shortcuts.xml`, зливає localizable
+лейбли у `res/values/strings.xml` через
+`AndroidConfig.Strings.setStringItem`, і реєструє
+`<meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>`
+у `MainActivity` через `withAndroidManifest`. На iOS плагін не
+потрібен — Expo зливає `ios.infoPlist.UIApplicationShortcutItems`
+прямо у згенерований `Info.plist`. Лейбли та порядок однакові на
+обох платформах; іконки беремо дефолтні (`@mipmap/ic_launcher` на
+Android, `UIApplicationShortcutIconTypeAdd/Date/Play` на iOS), щоб
+PR-B не тягнув нових асетів. Тап шортката фаєрить `sergeant://…`
+intent, який іде через уже протестований `useDeepLinks` pipeline —
+жодного нового runtime-коду не додано. Pure `buildShortcutsXml` /
+`shortcutStringKeys` мають unit-тести, решта плагіна — декларативні
+моди, що виконуються під час `expo prebuild`.
+
+Smoke-test скрипт для deep links — окремий PR-C (опційно).
 
 ### 6.4 Push-нотифікації
 


### PR DESCRIPTION
## Summary

Phase 10 PR-B — static app shortcuts on both platforms, layered on top of the deep-link pipeline that landed in [#488](https://github.com/Skords-01/Sergeant/pull/488). Plan row: [`docs/react-native-migration.md` §4 Phase 10](../blob/main/docs/react-native-migration.md), [§6.3 Навігація](../blob/main/docs/react-native-migration.md#63-навігація). Scheme table: [`docs/mobile.md` §2](../blob/main/docs/mobile.md).

**Zero new runtime deps, zero JS code.** Every shortcut dispatches an existing `sergeant://…` intent that `useDeepLinks` already consumes — this PR is pure manifest wiring.

### Shortcuts shipped

Same three shortcuts on both platforms, same order, same deep links:

| Label (uk) | Deep link |
| --- | --- |
| Витрата / Додати витрату | `sergeant://finance/tx/new` |
| Сьогодні / Рутина на сьогодні | `sergeant://routine` |
| Тренування / Почати тренування | `sergeant://workout/new` |

### What this PR does

**1. `apps/mobile/plugins/withAndroidShortcuts.ts`** — local, inline Expo config plugin:
- `withStringsXml` merges localisable `shortcut_<id>_short` / `shortcut_<id>_long` entries into `android/app/src/main/res/values/strings.xml` via `AndroidConfig.Strings.setStringItem` (Android requires `@string/…` references for shortcut labels — raw strings are silently ignored by the launcher).
- `withAndroidManifest` registers `<meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>` on `MainActivity` (dedupes previous plugin runs).
- `withDangerousMod` writes `android/app/src/main/res/xml/shortcuts.xml` — a pure build from `buildShortcutsXml(items)`.
- `buildShortcutsXml` and `shortcutStringKeys` are pure helpers exported for tests.

**2. `apps/mobile/app.config.ts`**:
- Declares `ANDROID_APP_SHORTCUTS` (3 items) and `IOS_SHORTCUT_ITEMS` (3 items, identical set). Shared `ANDROID_PACKAGE` constant (`com.sergeant.app`) replaces the string literals the file used for `ios.bundleIdentifier` / `android.package` / iOS shortcut types.
- iOS quick actions go straight into `ios.infoPlist.UIApplicationShortcutItems` (Expo merges that key into the generated `Info.plist` — no plugin needed). Icons use system types (`UIApplicationShortcutIconTypeAdd` / `Date` / `Play`) so we don't ship new art assets.
- Android side applies the plugin imperatively:
  ```ts
  const config = (): ExpoConfig =>
    withAndroidShortcuts(buildConfig(), ANDROID_APP_SHORTCUTS) as ExpoConfig;
  ```
  (Imperative application because `ExpoConfig.plugins` is typed as `string | [string, ...]` — a raw function reference trips the type.)

**3. `apps/mobile/plugins/withAndroidShortcuts.test.ts`** — 8 unit tests covering `buildShortcutsXml` / `shortcutStringKeys`: default icon fallback, custom icon, optional `targetClass`, order preservation across 3 shortcuts, XML attribute escaping, and the string-resource key convention.

**4. `apps/mobile/jest.config.js`** — adds `<rootDir>/plugins/**/*.test.{ts,tsx}` to `testMatch` so the plugin tests run in the mobile package's suite.

**5. `docs/react-native-migration.md`** — §6.3 progress note extended with a PR-B paragraph describing the plugin architecture, platform parity, and the deferred monochrome shortcut icons. Phase 10 status bumped to `PR-A ✅ + PR-B 🔵`.

### What this PR explicitly does NOT do

- No new runtime dependencies. `@expo/config-plugins` is already a transitive dep of `expo`, `expo-quick-actions` was deliberately avoided.
- No new JS/UI surface — shortcuts trigger intents, which route through the **already-tested** `useDeepLinks` hook (from [#488](https://github.com/Skords-01/Sergeant/pull/488)).
- No new art assets (monochrome shortcut icons deferred to a follow-up; launcher mipmap / iOS system icons used as fallback).
- No web changes — shortcuts are mobile-only.
- No changes to `AndroidManifest.xml` / `Info.plist` / `android/` / `ios/` directly: all edits flow through the Expo config-plugin pipeline and land at prebuild.

### Local verification

- `pnpm --filter @sergeant/mobile lint` — clean.
- `pnpm --filter @sergeant/mobile typecheck` — clean.
- `pnpm --filter @sergeant/mobile test` — **493 tests** across **75 suites** pass (was 485/74 on main; +8 new plugin tests).
- `pnpm --filter @sergeant/mobile check-build-config` — green.
- `pnpm exec tsx -e …` confirms the evaluated `ExpoConfig` has `ios.infoPlist.UIApplicationShortcutItems.length === 3` with the expected deep-link URLs, and `android.intentFilters.length === 1` (the `sergeant://` filter from PR-A). Android shortcuts themselves are registered as Expo mods and materialise on `expo prebuild`.

UI-based testing isn't applicable: static shortcuts are native manifest entries that only appear on a device launcher after a native build (EAS / `expo prebuild`). The tap-through path (shortcut → `sergeant://…` → `useDeepLinks`) is already covered by PR-A's hook tests.

## Review & Testing Checklist for Human

- [ ] On your next EAS build (or local `expo prebuild && expo run:android`), long-press the app icon on the launcher and verify all three shortcuts appear in the expected order, render the Ukrainian labels, and each one deep-links to the correct destination (`finance/tx/new` placeholder, routine tab, `workout/new` placeholder).
- [ ] Same check on iOS: long-press the app icon on the home screen, verify three quick actions show with the correct system icons (Add / Date / Play) and open the right deep-link targets.
- [ ] Sanity-check the Android prebuild output: after `expo prebuild --platform android`, confirm `android/app/src/main/res/xml/shortcuts.xml` exists with three `<shortcut>` blocks, `android/app/src/main/res/values/strings.xml` has the `shortcut_*_short` / `shortcut_*_long` entries, and `MainActivity` in `AndroidManifest.xml` has the new `<meta-data android:name="android.app.shortcuts" …/>` line.

### Notes

- Monochrome shortcut icons (`@drawable/ic_shortcut_add` / `ic_shortcut_today` / `ic_shortcut_workout` on Android, `UIApplicationShortcutItemIconFile` on iOS) are deliberately deferred to a follow-up PR so this change stays asset-free.
- If in the future we ever want to broadcast *dynamic* shortcuts (recently-used routines, most-common transactions, etc.), that's the point at which we'd pull in `expo-quick-actions` or write a small native bridge — static manifest shortcuts don't cover that case. This PR intentionally ships only static shortcuts.
- Follow-up PR-C (optional): small `scripts/test-deep-links.ts` smoke script + extended parser edge cases.


Link to Devin session: https://app.devin.ai/sessions/44c3c6b866d24d0793ca20302c7c7b8d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
