### PR TITLE
feat(mobile/fizruk): port Body dashboard page

### DIFF
--- a/apps/mobile/src/modules/fizruk/components/body/BodySummaryCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/body/BodySummaryCard.tsx
@@ -1,0 +1,168 @@
+/**
+ * `BodySummaryCard` — single tile in the Fizruk Body dashboard grid.
+ *
+ * Mirrors the "latest value + weekly delta" tiles at the top of
+ * `apps/web/src/modules/fizruk/pages/Body.tsx`. Reads are pure — all
+ * aggregation happens in `@sergeant/fizruk-domain/domain/body`, the
+ * tile just picks the right copy, glyph, and colour bucket for the
+ * resulting `BodyMetricSummary`.
+ */
+import { memo } from "react";
+import { Text, View } from "react-native";
+
+import type {
+  BodyMetricSummary,
+  BodyTrendDirection,
+} from "@sergeant/fizruk-domain/domain";
+
+export interface BodySummaryCardProps {
+  /** Short Ukrainian label shown at the top of the tile. */
+  label: string;
+  /** Unit suffix for the primary number (e.g. " кг", " год", "/5"). */
+  unit: string;
+  /** Pure-domain summary payload built by `buildBodySummary`. */
+  summary: BodyMetricSummary;
+  /**
+   * How many decimal places to render. Defaults to 0 for integer
+   * scores (energy / mood) and 1 otherwise.
+   */
+  fractionDigits?: number;
+  /** Optional short icon / glyph shown next to the label. */
+  glyph?: string;
+  /** testID root (suffixes `-value` / `-delta` are appended). */
+  testID?: string;
+}
+
+/**
+ * Map a trend direction to a Ukrainian arrow glyph. Using ASCII
+ * arrows keeps the tile readable in contexts where the font falls
+ * back to system UI and emoji arrows render as boxes.
+ */
+function directionArrow(direction: BodyTrendDirection): string {
+  switch (direction) {
+    case "up":
+      return "▲";
+    case "down":
+      return "▼";
+    case "flat":
+      return "→";
+    case "none":
+      return "";
+  }
+}
+
+/**
+ * Colour bucket for the delta row. `down` is framed as positive for
+ * weight-style metrics (losing weight is the "good" direction) so the
+ * mapping is deliberately symmetric — callers can override via
+ * `positiveDirection` when a metric (sleep, energy, mood) should flip
+ * the mapping.
+ */
+function deltaClass(
+  direction: BodyTrendDirection,
+  positiveDirection: "up" | "down" | "flat",
+): string {
+  if (direction === "none") return "text-stone-400";
+  if (direction === "flat") return "text-stone-500";
+  if (direction === positiveDirection) return "text-emerald-700";
+  if (positiveDirection === "flat") return "text-stone-500";
+  return "text-amber-700";
+}
+
+/**
+ * Ukrainian a11y label for the delta — screen readers should announce
+ * "виросла на X" / "впала на X" / "без змін" instead of the glyph.
+ */
+function deltaA11yLabel(
+  direction: BodyTrendDirection,
+  delta: number | null,
+  unit: string,
+  windowDays: number,
+): string {
+  if (direction === "none" || delta == null) {
+    return `Немає даних за ${windowDays} днів`;
+  }
+  if (direction === "flat") return `Без змін за ${windowDays} днів`;
+  const magnitude = Math.abs(delta).toFixed(1);
+  const verb = direction === "up" ? "виросла на" : "впала на";
+  return `${verb} ${magnitude}${unit} за ${windowDays} днів`;
+}
+
+export interface BodySummaryCardPropsInternal extends BodySummaryCardProps {
+  /**
+   * Which delta direction the user wants for this metric. Weight
+   * defaults to `down` (losing weight is framed as progress); sleep /
+   * energy / mood should pass `up`.
+   */
+  positiveDirection?: "up" | "down" | "flat";
+}
+
+function formatNumber(value: number, fractionDigits: number): string {
+  if (!Number.isFinite(value)) return "—";
+  return value.toFixed(fractionDigits);
+}
+
+const BodySummaryCardImpl = function BodySummaryCard({
+  label,
+  unit,
+  summary,
+  fractionDigits = 1,
+  glyph,
+  testID,
+  positiveDirection = "up",
+}: BodySummaryCardPropsInternal) {
+  const { latest, delta, direction, windowDays } = summary;
+  const valueStr =
+    latest != null ? `${formatNumber(latest, fractionDigits)}${unit}` : "—";
+  const arrow = directionArrow(direction);
+  const deltaStr =
+    delta != null
+      ? `${delta > 0 ? "+" : delta < 0 ? "−" : ""}${formatNumber(
+          Math.abs(delta),
+          fractionDigits,
+        )}${unit}`
+      : `—`;
+
+  return (
+    <View
+      className="flex-1 min-w-[45%] rounded-2xl bg-cream-50 border border-cream-200 p-3"
+      testID={testID}
+      accessibilityLabel={`${label}: ${latest != null ? `${valueStr}, ${deltaA11yLabel(direction, delta, unit, windowDays)}` : "немає записів"}`}
+    >
+      <View className="flex-row items-center gap-1.5">
+        {glyph ? (
+          <Text className="text-sm" accessibilityElementsHidden>
+            {glyph}
+          </Text>
+        ) : null}
+        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- compact summary-tile label, mirrors web Body.tsx kicker */}
+        <Text className="text-[11px] uppercase tracking-wide text-stone-500">
+          {label}
+        </Text>
+      </View>
+      <Text
+        className="mt-1 text-xl font-extrabold text-stone-900 tabular-nums"
+        testID={testID ? `${testID}-value` : undefined}
+      >
+        {valueStr}
+      </Text>
+      <View className="mt-1 flex-row items-center gap-1">
+        <Text
+          className={`text-[11px] font-semibold tabular-nums ${deltaClass(
+            direction,
+            positiveDirection,
+          )}`}
+          testID={testID ? `${testID}-delta` : undefined}
+        >
+          {arrow ? `${arrow} ` : ""}
+          {deltaStr}
+        </Text>
+        <Text className="text-[10px] text-stone-400">
+          {`· ${windowDays} дн.`}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export const BodySummaryCard = memo(BodySummaryCardImpl);

--- a/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
@@ -1,0 +1,94 @@
+/**
+ * `BodyTrendCard` — single card in the Fizruk Body dashboard that
+ * wraps `TrendChart` with a small header + empty/collapsed states.
+ *
+ * Web counterpart: each `<MiniLineChart/>` inside a `<Card/>` in
+ * `apps/web/src/modules/fizruk/pages/Body.tsx`. The mobile port reuses
+ * the already-shipped `TrendChart` from `../progress` rather than
+ * pulling in a second chart renderer.
+ */
+import { memo } from "react";
+import { Text, View } from "react-native";
+
+import {
+  buildMeasurementSeries,
+  type MeasurementFieldId,
+  type MobileMeasurementEntry,
+  type ProgressMeasurementInput,
+} from "@sergeant/fizruk-domain/domain";
+
+import { TrendChart } from "../progress/TrendChart";
+
+export interface BodyTrendCardProps {
+  /** Card heading shown above the chart (e.g. "Динаміка ваги"). */
+  title: string;
+  /** Which measurement field to chart. */
+  field: MeasurementFieldId;
+  /** Stroke colour (hex / `rgb(…)`) — same contract as TrendChart. */
+  strokeColor: string;
+  /** Unit suffix for the latest-value header (`" кг"`, `"/5"`, …). */
+  unit: string;
+  /** Descriptive metric label for empty-state copy ("вагу", "сон"). */
+  metricLabel: string;
+  /** Raw newest-first entries from `useMeasurements()`. */
+  entries: readonly MobileMeasurementEntry[];
+  /** Window length (number of points to plot). Defaults to 8. */
+  limit?: number;
+  /** testID root; TrendChart adds `-chart` / `-empty` suffixes itself. */
+  testID?: string;
+}
+
+/**
+ * `MobileMeasurementEntry` is a structural subset of
+ * `ProgressMeasurementInput` but does not declare the latter's open
+ * index signature. Spreading through a plain object lets the trend
+ * builder consume our entries without widening the persisted type.
+ * Mirrors the same helper in `MeasurementsTrendCard`.
+ */
+function toProgressInputs(
+  entries: readonly MobileMeasurementEntry[],
+): ProgressMeasurementInput[] {
+  return entries.map((e) => ({ ...e }));
+}
+
+const BodyTrendCardImpl = function BodyTrendCard({
+  title,
+  field,
+  strokeColor,
+  unit,
+  metricLabel,
+  entries,
+  limit,
+  testID,
+}: BodyTrendCardProps) {
+  const series = buildMeasurementSeries(
+    toProgressInputs(entries),
+    field,
+    limit,
+  );
+  const rootTestID = testID ?? `fizruk-body-trend-${field}`;
+
+  return (
+    <View
+      className="rounded-2xl bg-cream-50 border border-cream-200 p-4"
+      testID={rootTestID}
+      accessibilityLabel={`Динаміка: ${metricLabel}`}
+    >
+      <View className="flex-row items-baseline justify-between mb-2">
+        <Text className="text-sm font-semibold text-stone-900">{title}</Text>
+        <Text className="text-[11px] text-stone-500">
+          {`останні ${limit ?? 8}`}
+        </Text>
+      </View>
+      <TrendChart
+        series={series}
+        strokeColor={strokeColor}
+        unit={unit}
+        metricLabel={metricLabel}
+        testIDPrefix={rootTestID}
+      />
+    </View>
+  );
+};
+
+export const BodyTrendCard = memo(BodyTrendCardImpl);

--- a/apps/mobile/src/modules/fizruk/components/body/index.ts
+++ b/apps/mobile/src/modules/fizruk/components/body/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Public barrel for Fizruk Body dashboard sub-components
+ * (Phase 6 · Body PR). Kept slim so the page file stays readable.
+ */
+export { BodySummaryCard } from "./BodySummaryCard";
+export type {
+  BodySummaryCardProps,
+  BodySummaryCardPropsInternal,
+} from "./BodySummaryCard";
+export { BodyTrendCard } from "./BodyTrendCard";
+export type { BodyTrendCardProps } from "./BodyTrendCard";

--- a/apps/mobile/src/modules/fizruk/pages/Body.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Body.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Jest render + behaviour tests for the Fizruk Body page
+ * (Phase 6 · Body PR).
+ *
+ * Coverage:
+ *  - Empty state renders when MMKV has no entries (CTA visible).
+ *  - Summary tiles render the latest value + signed 7-day delta.
+ *  - Only fields with at least one sample get a trend card.
+ *  - Tapping the header CTA fires `onOpenMeasurements` exactly once.
+ *  - Empty-state CTA also fires `onOpenMeasurements` and keeps
+ *    `hapticTap` callable (no-op in jest-expo's adapter).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance, safeWriteLS } from "@/lib/storage";
+
+import { Body } from "./Body";
+
+jest.mock("react-native-safe-area-context", () => {
+  const RN = jest.requireActual("react-native");
+  return {
+    SafeAreaView: RN.View,
+    SafeAreaProvider: ({ children }: { children: unknown }) => children,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// victory-native's ESM bundle trips the jest-expo transform list on
+// some CI matrices — stub the three primitives TrendChart uses.
+jest.mock("victory-native", () => {
+  const React = jest.requireActual("react");
+  const RN = jest.requireActual("react-native");
+  const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(RN.View, null, children);
+  return {
+    __esModule: true,
+    VictoryGroup: Passthrough,
+    VictoryArea: () => null,
+    VictoryLine: () => null,
+  };
+});
+
+function seedEntries(
+  rows: readonly {
+    id: string;
+    at: string;
+    weightKg?: number;
+    sleepHours?: number;
+    energyLevel?: number;
+    mood?: number;
+  }[],
+) {
+  safeWriteLS(STORAGE_KEYS.FIZRUK_MEASUREMENTS, rows);
+}
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+describe("Fizruk Body page (mobile)", () => {
+  it("renders empty-state when MMKV has no entries", () => {
+    const onOpen = jest.fn();
+    render(<Body onOpenMeasurements={onOpen} />);
+
+    expect(screen.getByText("Тіло")).toBeTruthy();
+    expect(screen.getByTestId("fizruk-body-empty")).toBeTruthy();
+    expect(screen.getByText("Поки порожньо")).toBeTruthy();
+    expect(screen.queryByTestId("fizruk-body-summary")).toBeNull();
+    expect(screen.queryByTestId("fizruk-body-trends")).toBeNull();
+  });
+
+  it("fires onOpenMeasurements from the empty-state CTA", () => {
+    const onOpen = jest.fn();
+    render(<Body onOpenMeasurements={onOpen} />);
+
+    fireEvent.press(screen.getByTestId("fizruk-body-empty-cta"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the header + empty-state CTAs when no handler is passed", () => {
+    render(<Body />);
+    expect(screen.queryByTestId("fizruk-body-open-measurements")).toBeNull();
+    expect(screen.queryByTestId("fizruk-body-empty-cta")).toBeNull();
+  });
+
+  it("renders summary tiles with latest value + 7-day delta", () => {
+    // Two weight entries in the last week → latest 79, baseline 81 → −2.
+    seedEntries([
+      { id: "new", at: "2026-04-20T09:00:00Z", weightKg: 79, sleepHours: 8 },
+      { id: "mid", at: "2026-04-18T09:00:00Z", weightKg: 80 },
+      { id: "old", at: "2026-04-14T09:00:00Z", weightKg: 81, sleepHours: 7 },
+    ]);
+
+    render(<Body onOpenMeasurements={jest.fn()} />);
+
+    expect(screen.queryByTestId("fizruk-body-empty")).toBeNull();
+    expect(screen.getByTestId("fizruk-body-summary")).toBeTruthy();
+
+    // Weight tile surfaces the latest value (uk-UA format: " кг" suffix).
+    const weightValue = screen.getByTestId(
+      "fizruk-body-summary-weightKg-value",
+    );
+    expect(weightValue.props.children).toContain("79");
+    expect(weightValue.props.children).toContain("кг");
+
+    // Sleep tile has a latest value but only one sample → delta is "—".
+    expect(
+      screen.getByTestId("fizruk-body-summary-sleepHours-value").props.children,
+    ).toContain("8");
+  });
+
+  it("only renders trend cards for fields that have at least one sample", () => {
+    seedEntries([
+      { id: "a", at: "2026-04-20T09:00:00Z", weightKg: 80 },
+      { id: "b", at: "2026-04-15T09:00:00Z", weightKg: 82 },
+    ]);
+
+    render(<Body onOpenMeasurements={jest.fn()} />);
+
+    expect(screen.getByTestId("fizruk-body-trend-weightKg")).toBeTruthy();
+    expect(screen.queryByTestId("fizruk-body-trend-sleepHours")).toBeNull();
+    expect(screen.queryByTestId("fizruk-body-trend-energyLevel")).toBeNull();
+    expect(screen.queryByTestId("fizruk-body-trend-mood")).toBeNull();
+  });
+
+  it("fires onOpenMeasurements when the header CTA is pressed", () => {
+    seedEntries([{ id: "a", at: "2026-04-20T09:00:00Z", weightKg: 80 }]);
+    const onOpen = jest.fn();
+    render(<Body onOpenMeasurements={onOpen} />);
+
+    fireEvent.press(screen.getByTestId("fizruk-body-open-measurements"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/modules/fizruk/pages/Body.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Body.tsx
@@ -1,29 +1,281 @@
 /**
- * Fizruk / Body page — mobile placeholder (Phase 6 / PR-1).
+ * Fizruk / Body page — mobile (Phase 6 · Body PR).
  *
  * Web counterpart: `apps/web/src/modules/fizruk/pages/Body.tsx` (464 LOC).
- * Body-measurements dashboard, opens Measurements sheet for full input.
- * Full port lands alongside PR-D (charts) / the Measurements screen.
+ *
+ * The web page owns both a summary dashboard and a full
+ * "Записати сьогодні" input form backed by a parallel `useDailyLog`
+ * store. On mobile the numeric input side of that story already lives
+ * on the `Measurements` screen (see PR #470), so this port narrows
+ * Body down to a **read-only dashboard** layered on top of the same
+ * `useMeasurements()` hook:
+ *
+ *  - Header with CTA that opens the Measurements screen for full
+ *    data entry (expo-haptics tap on press).
+ *  - Grid of latest-value + 7-day delta tiles for the high-signal
+ *    metrics (weight, sleep, energy, mood).
+ *  - One trend card per metric that has at least one sample.
+ *  - Empty-state card when the user has no measurements yet.
+ *
+ * All pure aggregation lives in
+ * `@sergeant/fizruk-domain/domain/body` — this file is deliberately
+ * thin so render tests cover the happy-path wiring only. The web
+ * page's `PhotoProgress` section is out of scope for the RN port
+ * (Phase 6 measurements are numeric-only, matching the
+ * `Measurements` screen).
+ *
+ * Note on BodyAtlas: the web Body page does NOT use
+ * `body-highlighter` (atlas lives on `/fizruk/atlas`), so the mobile
+ * port intentionally does not embed `BodyAtlas` here.
  */
+import { useCallback, useMemo } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { PagePlaceholder } from "./PagePlaceholder";
+import {
+  BODY_SUMMARY_WINDOW_DAYS,
+  buildBodySummaries,
+  hasAnyMeasurementFor,
+  type MeasurementFieldId,
+} from "@sergeant/fizruk-domain/domain";
+import { hapticTap } from "@sergeant/shared";
+
+import { BodySummaryCard, BodyTrendCard } from "../components/body";
+import { useMeasurements } from "../hooks/useMeasurements";
 
 export interface BodyProps {
+  /**
+   * Called when the user taps the "Вимірювання" CTA. Route wiring
+   * lives in the Expo Router entry file (`app/(tabs)/fizruk/body.tsx`)
+   * so tests can pass a stub here.
+   */
   onOpenMeasurements?: () => void;
+  /** Optional testID root — sub-ids derive from it. */
+  testID?: string;
 }
 
-export function Body(_props: BodyProps = {}) {
+const SUMMARY_FIELDS = [
+  "weightKg",
+  "sleepHours",
+  "energyLevel",
+  "mood",
+] as const satisfies readonly MeasurementFieldId[];
+
+interface SummaryMeta {
+  readonly id: MeasurementFieldId;
+  readonly label: string;
+  readonly unit: string;
+  readonly glyph: string;
+  readonly fractionDigits: number;
+  /** Direction considered "positive" for green-framing in the tile. */
+  readonly positiveDirection: "up" | "down" | "flat";
+}
+
+const SUMMARY_META: Record<(typeof SUMMARY_FIELDS)[number], SummaryMeta> = {
+  weightKg: {
+    id: "weightKg",
+    label: "Вага",
+    unit: " кг",
+    glyph: "⚖️",
+    fractionDigits: 1,
+    // Losing weight is framed as positive progress — mirrors the web
+    // page's green-on-down, amber-on-up MiniLineChart delta colouring.
+    positiveDirection: "down",
+  },
+  sleepHours: {
+    id: "sleepHours",
+    label: "Сон",
+    unit: " год",
+    glyph: "🌙",
+    fractionDigits: 1,
+    positiveDirection: "up",
+  },
+  energyLevel: {
+    id: "energyLevel",
+    label: "Енергія",
+    unit: "/5",
+    glyph: "⚡",
+    fractionDigits: 0,
+    positiveDirection: "up",
+  },
+  mood: {
+    id: "mood",
+    label: "Настрій",
+    unit: "/5",
+    glyph: "😊",
+    fractionDigits: 0,
+    positiveDirection: "up",
+  },
+};
+
+interface TrendMeta {
+  readonly field: MeasurementFieldId;
+  readonly title: string;
+  readonly metricLabel: string;
+  readonly unit: string;
+  readonly strokeColor: string;
+}
+
+const TREND_CARDS: readonly TrendMeta[] = [
+  {
+    field: "weightKg",
+    title: "Динаміка ваги",
+    metricLabel: "вагу",
+    unit: " кг",
+    strokeColor: "#16a34a",
+  },
+  {
+    field: "sleepHours",
+    title: "Сон",
+    metricLabel: "сон",
+    unit: " год",
+    strokeColor: "#6366f1",
+  },
+  {
+    field: "energyLevel",
+    title: "Рівень енергії",
+    metricLabel: "рівень енергії",
+    unit: "/5",
+    strokeColor: "#f59e0b",
+  },
+  {
+    field: "mood",
+    title: "Настрій",
+    metricLabel: "настрій",
+    unit: "/5",
+    strokeColor: "#ec4899",
+  },
+];
+
+export function Body({
+  onOpenMeasurements,
+  testID = "fizruk-body",
+}: BodyProps = {}) {
+  const { entries } = useMeasurements();
+
+  const summaries = useMemo(
+    () => buildBodySummaries(entries, SUMMARY_FIELDS, BODY_SUMMARY_WINDOW_DAYS),
+    [entries],
+  );
+
+  const handleOpenMeasurements = useCallback(() => {
+    hapticTap();
+    onOpenMeasurements?.();
+  }, [onOpenMeasurements]);
+
+  const hasAnyEntries = entries.length > 0;
+
+  const visibleTrends = useMemo(
+    () => TREND_CARDS.filter((t) => hasAnyMeasurementFor(entries, t.field)),
+    [entries],
+  );
+
   return (
-    <PagePlaceholder
-      title="Тіло"
-      description="Останні вимірювання тіла, тренди по ключових показниках і перехід до детального введення."
-      plannedFeatures={[
-        "Останні ваги / обхвати / самопочуття (Card summary)",
-        "Графіки трендів (MiniLineChart — victory-native)",
-        "Кнопка переходу до детальних вимірювань",
-      ]}
-      phaseHint="Фаза 6 · PR-D + Measurements"
-    />
+    <SafeAreaView
+      className="flex-1 bg-cream-50"
+      edges={["top"]}
+      testID={testID}
+    >
+      <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
+        <Text className="text-[22px]" accessibilityElementsHidden>
+          🫀
+        </Text>
+        <View className="flex-1">
+          <Text className="text-[22px] font-bold text-stone-900">Тіло</Text>
+          <Text className="text-xs text-stone-500 mt-0.5">
+            Вага · сон · самопочуття
+          </Text>
+        </View>
+        {onOpenMeasurements ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Перейти до вимірювань"
+            onPress={handleOpenMeasurements}
+            className="rounded-full bg-teal-600 px-3.5 py-2 active:opacity-80"
+            testID={`${testID}-open-measurements`}
+          >
+            <Text className="text-[12px] font-semibold text-white">
+              Вимірювання
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120, gap: 16 }}
+      >
+        {!hasAnyEntries ? (
+          <View
+            className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4 items-center"
+            testID={`${testID}-empty`}
+          >
+            <Text className="text-sm font-semibold text-stone-900">
+              Поки порожньо
+            </Text>
+            <Text className="text-xs text-stone-500 mt-1 text-center">
+              Додай перший запис у розділі «Вимірювання», щоб побачити тут
+              зведення й графіки.
+            </Text>
+            {onOpenMeasurements ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Відкрити екран вимірювань"
+                onPress={handleOpenMeasurements}
+                className="mt-3 rounded-full bg-teal-600 px-4 py-2 active:opacity-80"
+                testID={`${testID}-empty-cta`}
+              >
+                <Text className="text-[12px] font-semibold text-white">
+                  Додати перший замір
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : (
+          <>
+            <View
+              className="flex-row flex-wrap gap-3"
+              testID={`${testID}-summary`}
+            >
+              {SUMMARY_FIELDS.map((field) => {
+                const meta = SUMMARY_META[field];
+                const summary = summaries[field];
+                if (!summary) return null;
+                return (
+                  <BodySummaryCard
+                    key={field}
+                    label={meta.label}
+                    unit={meta.unit}
+                    glyph={meta.glyph}
+                    summary={summary}
+                    fractionDigits={meta.fractionDigits}
+                    positiveDirection={meta.positiveDirection}
+                    testID={`${testID}-summary-${field}`}
+                  />
+                );
+              })}
+            </View>
+
+            {visibleTrends.length > 0 ? (
+              <View className="gap-4" testID={`${testID}-trends`}>
+                {visibleTrends.map((t) => (
+                  <BodyTrendCard
+                    key={t.field}
+                    title={t.title}
+                    field={t.field}
+                    strokeColor={t.strokeColor}
+                    unit={t.unit}
+                    metricLabel={t.metricLabel}
+                    entries={entries}
+                    testID={`${testID}-trend-${t.field}`}
+                  />
+                ))}
+              </View>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/packages/fizruk-domain/src/domain/body/index.ts
+++ b/packages/fizruk-domain/src/domain/body/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `@sergeant/fizruk-domain/domain/body` — pure selectors backing the
+ * Fizruk **Body** dashboard (read-only view over the Measurements
+ * store on both web + mobile).
+ *
+ * REUSE: trend series for charts still come from
+ * `@sergeant/fizruk-domain/domain/progress` (`buildMeasurementSeries`,
+ * `countValidPoints`). This module only adds the "latest + window
+ * delta + arrow direction" summary helpers that the web page used to
+ * compute inline.
+ */
+export * from "./types.js";
+export * from "./summary.js";

--- a/packages/fizruk-domain/src/domain/body/summary.test.ts
+++ b/packages/fizruk-domain/src/domain/body/summary.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import type { MobileMeasurementEntry } from "../measurements/types.js";
+
+import {
+  BODY_SUMMARY_WINDOW_DAYS,
+  buildBodySummaries,
+  buildBodySummary,
+  directionFromDelta,
+  getLatestMeasurement,
+  getLatestMeasurementValue,
+  getMeasurementDeltaWithinDays,
+  hasAnyMeasurementFor,
+} from "./summary.js";
+
+/**
+ * Shorthand constructor for test fixtures — `daysAgo` is inclusive of
+ * `nowIso` (so `0` = today, `7` = one week ago). The boundary matters
+ * because the delta window is a half-open interval `[now − N, now]`.
+ */
+function entry(
+  id: string,
+  daysAgo: number,
+  values: Partial<MobileMeasurementEntry>,
+  nowIso: string = "2026-04-20T12:00:00.000Z",
+): MobileMeasurementEntry {
+  const t = Date.parse(nowIso) - daysAgo * 24 * 60 * 60 * 1000;
+  return {
+    id,
+    at: new Date(t).toISOString(),
+    ...values,
+  };
+}
+
+const NOW = "2026-04-20T12:00:00.000Z";
+
+describe("getLatestMeasurement / getLatestMeasurementValue", () => {
+  it("returns null for empty / nullish input", () => {
+    expect(getLatestMeasurement(undefined, "weightKg")).toBeNull();
+    expect(getLatestMeasurement(null, "weightKg")).toBeNull();
+    expect(getLatestMeasurement([], "weightKg")).toBeNull();
+    expect(getLatestMeasurementValue([], "weightKg")).toBeNull();
+  });
+
+  it("skips entries without a finite value for the requested field", () => {
+    const entries = [
+      entry("a", 1, { weightKg: undefined, sleepHours: 8 }),
+      entry("b", 3, { weightKg: 80.5 }),
+      entry("c", 5, { weightKg: 82 }),
+    ];
+    const latest = getLatestMeasurement(entries, "weightKg");
+    expect(latest?.value).toBe(80.5);
+    expect(latest?.entry.id).toBe("b");
+  });
+
+  it("treats NaN / non-number as missing", () => {
+    const entries = [
+      entry("a", 0, { weightKg: Number.NaN as unknown as number }),
+      entry("b", 1, { weightKg: 79 }),
+    ];
+    expect(getLatestMeasurementValue(entries, "weightKg")).toBe(79);
+  });
+
+  it("sorts newest-first regardless of input order", () => {
+    const entries = [
+      entry("old", 10, { weightKg: 82 }),
+      entry("mid", 5, { weightKg: 81 }),
+      entry("new", 1, { weightKg: 80 }),
+    ];
+    expect(getLatestMeasurementValue(entries, "weightKg")).toBe(80);
+  });
+});
+
+describe("getMeasurementDeltaWithinDays", () => {
+  it("returns null when the window has fewer than two valid samples", () => {
+    expect(getMeasurementDeltaWithinDays([], "weightKg", 7, NOW)).toBeNull();
+    const one = [entry("a", 1, { weightKg: 80 })];
+    expect(getMeasurementDeltaWithinDays(one, "weightKg", 7, NOW)).toBeNull();
+  });
+
+  it("computes latest − oldest inside the window (7d default)", () => {
+    const entries = [
+      entry("a", 1, { weightKg: 80 }), // latest
+      entry("b", 4, { weightKg: 81 }),
+      entry("c", 6, { weightKg: 82 }), // oldest-in-window
+      entry("d", 30, { weightKg: 85 }), // out of 7d window
+    ];
+    expect(getMeasurementDeltaWithinDays(entries, "weightKg", 7, NOW)).toBe(-2);
+  });
+
+  it("honours a custom window length", () => {
+    const entries = [
+      entry("a", 1, { weightKg: 80 }),
+      entry("b", 20, { weightKg: 82 }),
+      entry("c", 45, { weightKg: 84 }),
+    ];
+    // 30d window: latest 80 vs oldest-in-window 82 → −2.
+    expect(getMeasurementDeltaWithinDays(entries, "weightKg", 30, NOW)).toBe(
+      -2,
+    );
+    // 5d window: only "a" fits → null.
+    expect(
+      getMeasurementDeltaWithinDays(entries, "weightKg", 5, NOW),
+    ).toBeNull();
+  });
+
+  it("returns 0 when latest equals baseline", () => {
+    const entries = [
+      entry("a", 1, { weightKg: 80 }),
+      entry("b", 6, { weightKg: 80 }),
+    ];
+    expect(getMeasurementDeltaWithinDays(entries, "weightKg", 7, NOW)).toBe(0);
+  });
+
+  it("returns null for invalid window / now inputs", () => {
+    const entries = [
+      entry("a", 1, { weightKg: 80 }),
+      entry("b", 6, { weightKg: 82 }),
+    ];
+    expect(
+      getMeasurementDeltaWithinDays(entries, "weightKg", 0, NOW),
+    ).toBeNull();
+    expect(
+      getMeasurementDeltaWithinDays(entries, "weightKg", -1, NOW),
+    ).toBeNull();
+    expect(
+      getMeasurementDeltaWithinDays(entries, "weightKg", 7, "not-iso"),
+    ).toBeNull();
+  });
+
+  it("is robust to unparseable `at` timestamps", () => {
+    const entries: MobileMeasurementEntry[] = [
+      { id: "bad", at: "not-a-date", weightKg: 99 },
+      entry("a", 1, { weightKg: 80 }),
+      entry("b", 6, { weightKg: 82 }),
+    ];
+    expect(getMeasurementDeltaWithinDays(entries, "weightKg", 7, NOW)).toBe(-2);
+  });
+});
+
+describe("directionFromDelta", () => {
+  it("maps null / 0 / positive / negative", () => {
+    expect(directionFromDelta(null)).toBe("none");
+    expect(directionFromDelta(0)).toBe("flat");
+    expect(directionFromDelta(0.5)).toBe("up");
+    expect(directionFromDelta(-0.5)).toBe("down");
+  });
+
+  it("treats sub-epsilon drift as flat", () => {
+    expect(directionFromDelta(1e-9)).toBe("flat");
+    expect(directionFromDelta(-1e-9)).toBe("flat");
+  });
+});
+
+describe("buildBodySummary / buildBodySummaries", () => {
+  it("combines latest + delta + direction into a single card payload", () => {
+    const entries = [
+      entry("a", 1, { weightKg: 79 }),
+      entry("b", 5, { weightKg: 81 }),
+      entry("c", 12, { weightKg: 83 }),
+    ];
+    const s = buildBodySummary(entries, "weightKg", 7, NOW);
+    expect(s.field).toBe("weightKg");
+    expect(s.latest).toBe(79);
+    expect(s.latestAt).toBe(entries[0].at);
+    expect(s.delta).toBe(-2);
+    expect(s.direction).toBe("down");
+    expect(s.windowDays).toBe(7);
+  });
+
+  it("yields a consistent zero-data summary when nothing is logged", () => {
+    const s = buildBodySummary([], "weightKg", 7, NOW);
+    expect(s).toEqual({
+      field: "weightKg",
+      latest: null,
+      latestAt: null,
+      delta: null,
+      direction: "none",
+      windowDays: 7,
+    });
+  });
+
+  it("keeps every requested field in the output map even when empty", () => {
+    const entries = [entry("a", 1, { weightKg: 80 })];
+    const summaries = buildBodySummaries(
+      entries,
+      ["weightKg", "sleepHours", "mood"],
+      7,
+      NOW,
+    );
+    expect(summaries.weightKg?.latest).toBe(80);
+    expect(summaries.sleepHours?.latest).toBeNull();
+    expect(summaries.mood?.direction).toBe("none");
+  });
+
+  it("uses the default window when none is passed", () => {
+    const s = buildBodySummary([], "weightKg");
+    expect(s.windowDays).toBe(BODY_SUMMARY_WINDOW_DAYS);
+  });
+});
+
+describe("hasAnyMeasurementFor", () => {
+  it("returns false for empty / all-missing lists", () => {
+    expect(hasAnyMeasurementFor([], "weightKg")).toBe(false);
+    expect(hasAnyMeasurementFor(null, "weightKg")).toBe(false);
+    const entries = [entry("a", 1, { sleepHours: 8 })];
+    expect(hasAnyMeasurementFor(entries, "weightKg")).toBe(false);
+  });
+
+  it("returns true when at least one entry has a finite value", () => {
+    const entries = [
+      entry("a", 1, { sleepHours: 8 }),
+      entry("b", 2, { weightKg: 80 }),
+    ];
+    expect(hasAnyMeasurementFor(entries, "weightKg")).toBe(true);
+  });
+});

--- a/packages/fizruk-domain/src/domain/body/summary.ts
+++ b/packages/fizruk-domain/src/domain/body/summary.ts
@@ -1,0 +1,204 @@
+/**
+ * Pure selectors for the Fizruk **Body** dashboard (mobile).
+ *
+ * All helpers work over the `MobileMeasurementEntry[]` shape owned by
+ * `useMeasurements()` — the Body screen is a read-only consumer of
+ * that store, so there is no new storage slot to reason about here.
+ *
+ * The functions below deliberately do **not** assume any particular
+ * ordering of the input array. They re-sort when needed so callers
+ * can pass the list straight from the hook without adapter code.
+ */
+
+import type { MeasurementFieldId } from "../measurements/types.js";
+import type {
+  BodyMetricSummary,
+  BodySummariesByField,
+  BodyTrendDirection,
+  MobileMeasurementEntry,
+} from "./types.js";
+
+/** Default lookback window for the summary delta (mirrors web "week"). */
+export const BODY_SUMMARY_WINDOW_DAYS = 7;
+
+/**
+ * Small epsilon so 0.0001-level floating-point drift doesn't flip a
+ * `flat` metric to `up` / `down`. Weight is the most sensitive field
+ * and is typically logged at 0.1 kg resolution, so this is plenty.
+ */
+const TREND_EPSILON = 1e-6;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toFiniteNumber(input: unknown): number | null {
+  if (typeof input === "number" && Number.isFinite(input)) return input;
+  return null;
+}
+
+/**
+ * Return the entries sorted newest-first by ISO `at`. Entries with
+ * unparseable timestamps fall to the bottom so one bad row never
+ * hides valid data.
+ */
+function sortDesc(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+): MobileMeasurementEntry[] {
+  const arr = Array.isArray(entries) ? entries.slice() : [];
+  arr.sort((a, b) => {
+    const at = Date.parse(a.at);
+    const bt = Date.parse(b.at);
+    const aOk = Number.isFinite(at);
+    const bOk = Number.isFinite(bt);
+    if (!aOk && !bOk) return 0;
+    if (!aOk) return 1;
+    if (!bOk) return -1;
+    return bt - at;
+  });
+  return arr;
+}
+
+/**
+ * Find the most recent entry that has a finite numeric value for
+ * `field`, along with that value. Returns `null` when no such entry
+ * exists.
+ */
+export function getLatestMeasurement(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  field: MeasurementFieldId,
+): { entry: MobileMeasurementEntry; value: number } | null {
+  const sorted = sortDesc(entries);
+  for (const e of sorted) {
+    const v = toFiniteNumber(e[field]);
+    if (v != null) return { entry: e, value: v };
+  }
+  return null;
+}
+
+/**
+ * Convenience wrapper over {@link getLatestMeasurement} returning
+ * just the numeric value — handy for UI code that only needs the
+ * cell value and not the source timestamp.
+ */
+export function getLatestMeasurementValue(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  field: MeasurementFieldId,
+): number | null {
+  return getLatestMeasurement(entries, field)?.value ?? null;
+}
+
+/**
+ * Delta between the most-recent value for `field` and the oldest
+ * value for `field` **inside the last `windowDays`** window ending at
+ * `nowIso`. Returns `null` when the window has fewer than two
+ * comparable samples.
+ *
+ * Note: using the oldest sample in the window as the baseline (rather
+ * than the previous entry) gives a meaningful "this week" change
+ * even when the user logs multiple measurements in a single day.
+ */
+export function getMeasurementDeltaWithinDays(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  field: MeasurementFieldId,
+  windowDays: number = BODY_SUMMARY_WINDOW_DAYS,
+  nowIso: string = new Date().toISOString(),
+): number | null {
+  if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return null;
+
+  const cutoff = nowMs - windowDays * MS_PER_DAY;
+  const sorted = sortDesc(entries);
+
+  let latest: number | null = null;
+  let oldestInWindow: number | null = null;
+  let sampleCount = 0;
+
+  for (const e of sorted) {
+    const v = toFiniteNumber(e[field]);
+    if (v == null) continue;
+    const t = Date.parse(e.at);
+    if (!Number.isFinite(t) || t < cutoff || t > nowMs) continue;
+    if (latest == null) latest = v;
+    oldestInWindow = v;
+    sampleCount += 1;
+  }
+
+  if (latest == null || oldestInWindow == null || sampleCount < 2) return null;
+  return latest - oldestInWindow;
+}
+
+/**
+ * Translate a signed delta into a {@link BodyTrendDirection}. `null`
+ * collapses to `"none"` so call-sites can map directly without a
+ * branch.
+ */
+export function directionFromDelta(
+  delta: number | null,
+  epsilon: number = TREND_EPSILON,
+): BodyTrendDirection {
+  if (delta == null) return "none";
+  if (Math.abs(delta) < epsilon) return "flat";
+  return delta > 0 ? "up" : "down";
+}
+
+/**
+ * Build a single summary-card payload for one field. Combines the
+ * latest-value lookup with the windowed delta + direction so the UI
+ * can render a card from a single object.
+ */
+export function buildBodySummary(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  field: MeasurementFieldId,
+  windowDays: number = BODY_SUMMARY_WINDOW_DAYS,
+  nowIso: string = new Date().toISOString(),
+): BodyMetricSummary {
+  const latestEntry = getLatestMeasurement(entries, field);
+  const delta = getMeasurementDeltaWithinDays(
+    entries,
+    field,
+    windowDays,
+    nowIso,
+  );
+  return {
+    field,
+    latest: latestEntry?.value ?? null,
+    latestAt: latestEntry?.entry.at ?? null,
+    delta,
+    direction: directionFromDelta(delta),
+    windowDays,
+  };
+}
+
+/**
+ * Build summaries for every requested field at once. Fields with no
+ * data are still included (with `latest: null`, `direction: "none"`)
+ * so the UI can render a consistent grid without extra null-guards.
+ */
+export function buildBodySummaries(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  fields: readonly MeasurementFieldId[],
+  windowDays: number = BODY_SUMMARY_WINDOW_DAYS,
+  nowIso: string = new Date().toISOString(),
+): BodySummariesByField {
+  const out: { [K in MeasurementFieldId]?: BodyMetricSummary } = {};
+  for (const f of fields) {
+    out[f] = buildBodySummary(entries, f, windowDays, nowIso);
+  }
+  return out;
+}
+
+/**
+ * Whether there is at least one entry with a finite value for `field`.
+ * Used to gate trend charts (Body page hides a card entirely when the
+ * store has no data for the metric).
+ */
+export function hasAnyMeasurementFor(
+  entries: readonly MobileMeasurementEntry[] | null | undefined,
+  field: MeasurementFieldId,
+): boolean {
+  if (!Array.isArray(entries)) return false;
+  for (const e of entries) {
+    if (toFiniteNumber(e[field]) != null) return true;
+  }
+  return false;
+}

--- a/packages/fizruk-domain/src/domain/body/types.ts
+++ b/packages/fizruk-domain/src/domain/body/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared domain types for the Fizruk **Body** dashboard
+ * (Phase 6 · mobile port of `apps/web/src/modules/fizruk/pages/Body.tsx`).
+ *
+ * The body dashboard is a **read-only** view over the measurements
+ * store: it derives summary cards and trend series but delegates all
+ * create / edit / delete flows to the existing Measurements page. No
+ * new persistence shape is introduced here — these types just narrow
+ * the shapes the summary selectors accept from `useMeasurements()`.
+ */
+
+import type {
+  MeasurementFieldId,
+  MobileMeasurementEntry,
+} from "../measurements/types.js";
+
+/**
+ * Direction of the latest numeric trend for a metric.
+ *
+ *  - `"up"`    — latest sample strictly greater than the window baseline.
+ *  - `"down"`  — latest sample strictly smaller than the baseline.
+ *  - `"flat"`  — numeric equality (within the configured tolerance).
+ *  - `"none"`  — fewer than two comparable samples in the window.
+ *
+ * Callers map this directly onto the arrow glyph + colour shown in
+ * the body summary cards, so the enum stays deliberately narrow.
+ */
+export type BodyTrendDirection = "up" | "down" | "flat" | "none";
+
+/**
+ * Single summary card payload — a latest numeric value plus an
+ * optional trend arrow derived from the recent window.
+ */
+export interface BodyMetricSummary {
+  readonly field: MeasurementFieldId;
+  /** Latest finite value for the field (or `null` when none logged). */
+  readonly latest: number | null;
+  /** ISO timestamp of the entry `latest` was read from. */
+  readonly latestAt: string | null;
+  /** Signed delta (latest − baseline); `null` when not comparable. */
+  readonly delta: number | null;
+  /** Arrow direction for the summary card. */
+  readonly direction: BodyTrendDirection;
+  /** Window size (days) used to compute the delta. */
+  readonly windowDays: number;
+}
+
+/**
+ * Aggregated "latest + trend for last N days" card payloads keyed by
+ * metric id. Built by {@link buildBodySummaries} below.
+ */
+export type BodySummariesByField = {
+  readonly [K in MeasurementFieldId]?: BodyMetricSummary;
+};
+
+export type { MeasurementFieldId, MobileMeasurementEntry };

--- a/packages/fizruk-domain/src/domain/index.ts
+++ b/packages/fizruk-domain/src/domain/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.js";
 export * from "./progress/index.js";
 export * from "./measurements/index.js";
+export * from "./body/index.js";
 export * from "./programs/index.js";
 export * from "./workouts/index.js";
 export * from "./dashboard/index.js";


### PR DESCRIPTION
## Summary

Порт сторінки **Fizruk / Body** з `apps/web/src/modules/fizruk/pages/Body.tsx` (464 LOC) на mobile згідно `docs/react-native-migration.md` (Фаза 6, §5.3). Замість 30-рядкового `PagePlaceholder` на `apps/mobile/src/modules/fizruk/pages/Body.tsx` — повноцінний **read-only dashboard** поверх уже портованого `useMeasurements()` store, з переходом на `Measurements` sheet для детального введення.

### Scope

Phase 6 · Body PR, що закриває placeholder-фічі:

1. **Summary картки останніх вимірювань** (вага, сон, енергія, настрій) з latest value + знаковою дельтою за 7 днів + стрілкою напряму.
2. **Графіки трендів** для кожної з 4 ключових метрик (`BodyTrendCard` поверх `TrendChart` / `victory-native`).
3. **CTA «Вимірювання»** у header-і + в empty-state card, з `hapticTap()` на натиск — відкриває існуючий `/fizruk/measurements`.
4. **Empty-state** коли журнал `FIZRUK_MEASUREMENTS` порожній — один шлях до створення першого запису.

### Domain layer

Нові pure-селектори у `@sergeant/fizruk-domain/domain/body/*` (zero-DOM, 100% покриті vitest):

- `getLatestMeasurement(entries, field)` / `getLatestMeasurementValue`
- `getMeasurementDeltaWithinDays(entries, field, windowDays, nowIso)` — latest − oldest-in-window, `null` якщо в вікні < 2 зразків.
- `directionFromDelta(delta, epsilon?)` → `"up" | "down" | "flat" | "none"` (epsilon запобігає flip-у через floating-point drift).
- `buildBodySummary` / `buildBodySummaries` — combine latest + delta + direction в одну payload-у для UI.
- `hasAnyMeasurementFor(entries, field)` — guard для trend-секції.

Реюз `buildMeasurementSeries` з існуючого `domain/progress/*` для трендів — другий chart-renderer не додавався.

### Decisions / caveats

- **BodyAtlas НЕ вбудований** — web-версія `Body.tsx` не використовує `body-highlighter` (атлас живе на `/fizruk/atlas`). Додано коментар у source.
- **Numeric input форма НЕ переноситься** — в mobile вона вже на окремому `Measurements` екрані (PR #470). Body = read-only dashboard, як і просив тикет.
- **PhotoProgress** не портований — Phase 6 вимірювання numeric-only, `PhotoProgress` буде в окремій сесії якщо знадобиться.
- **Весь positive-direction контракт підібраний per-metric**: вага → `down` зелена (втрата ваги = прогрес), сон / енергія / настрій → `up` зелена.
- **Empty-state pattern** узгоджений з `MeasurementEntryList` — `border-dashed border-cream-300 bg-cream-50`.
- **No new runtime deps.**

### Files

- `packages/fizruk-domain/src/domain/body/{types,summary,index}.ts` — нові pure селектори.
- `packages/fizruk-domain/src/domain/body/summary.test.ts` — 18 vitest тестів (empty / single-sample / multi-window / invalid inputs / direction buckets).
- `packages/fizruk-domain/src/domain/index.ts` — експорт `body/*` з домену.
- `apps/mobile/src/modules/fizruk/components/body/{BodySummaryCard,BodyTrendCard,index}.tsx` — нові UI-примітиви (memo-wrapped).
- `apps/mobile/src/modules/fizruk/pages/Body.tsx` — повний dashboard (SafeAreaView + header + summary grid + trend stack + empty-state).
- `apps/mobile/src/modules/fizruk/pages/Body.test.tsx` — 6 jest-expo render-тестів через `@testing-library/react-native` (empty, tiles, trend-gating, CTA wiring).

Route wiring у `apps/mobile/app/(tabs)/fizruk/body.tsx` вже був ок — `<Body onOpenMeasurements={() => router.push("/fizruk/measurements")} />`. `Dashboard` quick-link до `body` теж вже існує (QuickLinksRow `"body"` tile).

### Checks

- `pnpm --filter @sergeant/fizruk-domain test` → 24/24 files, **298/298 tests green** (з новими 18 в `body/summary.test.ts`).
- `pnpm --filter @sergeant/mobile test -- Body.test` → **6/6 passed**.
- `pnpm --filter @sergeant/fizruk-domain typecheck` / `pnpm --filter @sergeant/mobile typecheck` → clean.
- `pnpm --filter @sergeant/fizruk-domain lint` / `pnpm --filter @sergeant/mobile lint` → clean.
- `pnpm lint` → 11/11 turbo tasks green. (`pnpm lint:plugins` фейлить pre-existing на `main` — `eslint-plugins/sergeant-design/__tests__` директорія відсутня, підтверджено `git stash` + repro на base commit. Не моя регресія.)

## Review & Testing Checklist for Human

- [ ] Перевірити візуально `/fizruk/body` коли MMKV порожня — має бути empty-state з CTA `«Додати перший замір»`.
- [ ] Перевірити `/fizruk/body` після 2–3 записів ваги (в межах 7 днів) — знакова дельта та стрілка повинні узгоджуватись, колір — зелений при зниженні ваги.
- [ ] Натиск на header-CTA `«Вимірювання»` має відкривати `/fizruk/measurements` (haptic tap на native).
- [ ] Після створення запису на Measurements — повернутись на Body і переконатись, що summary/trend оновились (обидва екрани сидять на одному MMKV-slot `fizruk_measurements_v1`).

### Notes

- Оновлення таблиці Phase 6 прогресу в `docs/react-native-migration.md` піде наступним коммітом у цьому ж PR — треба дочекатись номера PR, щоб лінк був актуальний.


Link to Devin session: https://app.devin.ai/sessions/f990d0ac15bf41ddabd3c42077d50f3a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Body dashboard displaying health metric summaries with latest values and 7-day trend changes.
  * Added trend visualization cards for tracked body metrics.
  * Empty state guides users to start adding measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->