### PR TITLE
fix(mobile): register sucrase TS loader in app.config.ts (follow-up to #499)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,3 +1,19 @@
+// Register a TypeScript `require` hook so `./plugins/*.ts` files that
+// this config imports can be resolved at Expo config-load time. Expo
+// transpiles `app.config.ts` itself via Babel, but follow-on
+// `require()` calls fall through to Node's default resolver — without
+// this register step, `./plugins/withAndroidShortcuts` fails with
+// `Cannot find module` during `expo prebuild` / `expo config` (see
+// `.github/workflows/detox-{ios,android}.yml`).
+//
+// `sucrase/register/ts` is a lightweight TS-only loader (no .tsx /
+// JSX handling) with essentially zero startup cost. Listed as an
+// explicit `devDependency` in `apps/mobile/package.json` so we do
+// not rely on Expo's transitive dependency graph.
+//
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require("sucrase/register/ts");
+
 import type { ExpoConfig } from "expo/config";
 import {
   withAndroidShortcuts,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -74,6 +74,7 @@
     "jest": "^29",
     "jest-expo": "~52.0.0",
     "react-test-renderer": "18.3.1",
+    "sucrase": "^3.35.0",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      sucrase:
+        specifier: ^3.35.0
+        version: 3.35.1
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

Follow-up до [#499](https://github.com/Skords-01/Sergeant/pull/499) — фіксить pre-existing bug, який блокував Detox CI на обох lane-ах (iOS + Android).

**Проблема.** Expo транспілить сам `apps/mobile/app.config.ts` через Babel, але follow-on `require()` виклики всередині нього йдуть через дефолтний Node-резолвер. `app.config.ts` імпортує `./plugins/withAndroidShortcuts.ts` (був доданий в e66a14b), і без TS-register-хука Node не може його знайти:

```
Cannot find module './plugins/withAndroidShortcuts'
  at Object.<anonymous> (.../apps/mobile/app.config.ts:5:29)
  at evalConfig (.../node_modules/@expo/config/build/evalConfig.js:68:47)
```

Через це `pnpm exec expo prebuild --platform android` в job-у `detox-android (34)` [впав exit-code 1 ще на prebuild-кроці](https://github.com/Skords-01/Sergeant/pull/499/checks?check_run_id=72400511114). Той самий шлях був би і в `detox-ios` (#499 CI показав це обом).

**Фікс.**
- Зареєстровано `sucrase/register/ts` в першому рядку `app.config.ts` — легкий TS-only loader без JSX-оверхеду.
- Додано `sucrase@^3.35.0` в `devDependencies` `@sergeant/mobile` → `pnpm-lock.yaml` оновлено (+3 рядки: specifier + resolved version + importer-ref).
- Лок-файл прогнано через `prettier --write` щоб збігався зі стилем, встановленим у `335060d` (double-quotes YAML).

**Rationale for sucrase vs ts-node.** `sucrase/register/ts` стартує ~5× швидше за `ts-node/register/transpile-only`, не валідує типи (що і не потрібно — `pnpm typecheck` уже робить це), і не тягне з собою `typescript` у runtime-граф.

## Review & Testing Checklist for Human

Ризик: **green** — локалізований 3-file фікс, без зміни public API, і лок-файл-diff 3 рядки.

- [ ] Перевірити, що `Accessibility (axe-core)` / інші web-only CI-lane не тригерить `pnpm install` на оновлений `pnpm-lock.yaml` з новим поведінковим сайд-ефектом (`sucrase` — pure JS, без post-install).
- [ ] Дочекатися, поки `detox-android (34)` і `detox-ios` в цьому PR дійдуть принаймні до etapу `pnpm e2e:build:*` — це валідує, що `expo prebuild` більше не падає на `require('./plugins/withAndroidShortcuts')`.

Test plan:
1. Локально пройшли: `expo config --type prebuild` (exit 0), `pnpm --filter @sergeant/mobile lint` / `typecheck` / `test` (78 suites / 520 tests).
2. CI-валідація відбувається через Detox lane-и, додані в #499.

### Notes

- Корінь проблеми датується e66a14b (Phase 10 PR-B), але в CI випливло тільки з #499, бо ані `detox-ios.yml`, ані `detox-android.yml` до цього не тригерилися.
- `withAndroidShortcuts.test.ts` продовжує імпортувати `.ts` напряму через Jest ts-jest transform, без змін.

Link to Devin session: https://app.devin.ai/sessions/b4a471f2b110446686dd54105f444f00
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
