### PR TITLE
feat(mobile-shell): Capacitor PoC skeleton in apps/mobile-shell

### DIFF
--- a/apps/mobile-shell/.gitignore
+++ b/apps/mobile-shell/.gitignore
@@ -1,0 +1,15 @@
+# Native build artefacts — генеруються локально / у CI, коммітимо тільки
+# каркас (`android/app/src/main`, `android/build.gradle` тощо).
+android/app/build/
+android/build/
+android/.gradle/
+android/local.properties
+android/capacitor-cordova-android-plugins/
+ios/App/build/
+ios/App/Pods/
+ios/App/App/public/
+ios/DerivedData/
+
+# Capacitor runtime output
+www/
+dist/

--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -1,0 +1,53 @@
+# `@sergeant/mobile-shell` — Capacitor PoC
+
+Тонкий native-shell навколо `@sergeant/web`. Призначення — **PoC-перевірка**:
+чи запускається поточний веб-код у WebView і скільки зусиль треба до шторів.
+Це **не канонічний мобільний клієнт** — повноцінна мобільна апка живе в
+`apps/mobile` (React Native + Expo).
+
+## Швидкий старт (Android)
+
+```bash
+# 1. Перший раз — згенерувати нативний Android-проєкт
+pnpm --filter @sergeant/mobile-shell add:android
+
+# 2. Зібрати веб-бандл (йде в apps/server/dist — див. vite.config.js)
+pnpm build:web
+
+# 3. Скопіювати бандл у нативний проєкт
+pnpm --filter @sergeant/mobile-shell copy
+
+# 4. Відкрити Android Studio для збірки APK/AAB
+pnpm --filter @sergeant/mobile-shell open:android
+```
+
+`pnpm --filter @sergeant/mobile-shell build:android` робить кроки 2+3 разом.
+
+## iOS
+
+Потрібен Mac з Xcode + CocoaPods. Після першого `pnpm --filter
+@sergeant/mobile-shell add:ios` далі так само: `build:web` → `sync ios` →
+`open:ios`.
+
+## Що (навмисно) НЕ зроблено у PoC
+
+- **Push notifications.** `usePushNotifications` у веб-коді використовує
+  Web Push через Service Worker (`PushManager` + VAPID). У native WebView
+  воно не працює на iOS і кульгаво працює на Android. Треба окремий PR з
+  `@capacitor/push-notifications` (FCM + APNs) + розширенням
+  `createPushEndpoints.register` на `platform: "android" | "ios"`.
+- **Auth.** Better Auth зараз через cookie. У native WebView cross-origin
+  cookie крихкі (особливо iOS ITP). Треба окремий PR з bearer-plugin
+  Better Auth + збереженням токена в `@capacitor/preferences` / Keychain.
+- **Barcode scanner.** `BarcodeScanner.tsx` на `getUserMedia`+zxing.
+  Працює у WebView, але UX гірший. Окремим PR — feature-detect і
+  переключення на `@capacitor-community/barcode-scanner`.
+- **Deep links, status bar, splash, safe-area, keyboard avoidance.**
+  Кожне — тонкий плагін `@capacitor/*`, робимо коли підуть реальні фічі.
+
+## Чому окрема директорія, а не окреме репо
+
+`apps/*` вже є workspace, `@sergeant/mobile-shell` автоматично бачить
+`@sergeant/shared`, `@sergeant/api-client` і підʼєднується до turbo/CI
+без кросрепного клею. Видалити експеримент — 1 коміт. Деталі та
+альтернативи — у коментарях PR.

--- a/apps/mobile-shell/capacitor.config.ts
+++ b/apps/mobile-shell/capacitor.config.ts
@@ -1,0 +1,29 @@
+import type { CapacitorConfig } from "@capacitor/cli";
+
+/**
+ * Capacitor shell над `@sergeant/web`.
+ *
+ * `webDir` вказує на існуючий артефакт Vite-білду, який лежить у
+ * `apps/server/dist` (див. `apps/web/vite.config.js` → `build.outDir`).
+ * Це дозволяє переюзати готовий production-бандл без копіювання.
+ *
+ * `appId` свідомо відрізняється від RN-апки (`com.sergeant.app`, див.
+ * `apps/mobile/app.config.ts`), щоб PoC-shell і канонічна RN-апка могли
+ * жити на одному пристрої пліч-о-пліч без колізії.
+ *
+ * Призначення PoC:
+ *   - довести, що поточний веб-код запускається у WebView «з коробки»;
+ *   - дати вимір «скільки саме зусиль треба», не чіпаючи `apps/web`.
+ * Production-рішення (native push, bearer-auth, barcode scanner) —
+ * окремими PR-ами після того, як shell стартує.
+ */
+const config: CapacitorConfig = {
+  appId: "com.sergeant.shell",
+  appName: "Sergeant Shell",
+  webDir: "../server/dist",
+  server: {
+    androidScheme: "https",
+  },
+};
+
+export default config;

--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sergeant/mobile-shell",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Capacitor shell that wraps @sergeant/web into a native Android/iOS app.",
+  "scripts": {
+    "sync": "cap sync",
+    "copy": "cap copy",
+    "open:android": "cap open android",
+    "open:ios": "cap open ios",
+    "add:android": "cap add android",
+    "add:ios": "cap add ios",
+    "build:web": "pnpm --filter @sergeant/web build",
+    "build:android": "pnpm build:web && pnpm sync android",
+    "build:ios": "pnpm build:web && pnpm sync ios",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@capacitor/android": "^7.4.3",
+    "@capacitor/core": "^7.4.3",
+    "@capacitor/ios": "^7.4.3"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^7.4.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/mobile-shell/src/platform.ts
+++ b/apps/mobile-shell/src/platform.ts
@@ -1,0 +1,27 @@
+/**
+ * Runtime-детектор Capacitor-оточення.
+ *
+ * Експортуємо звідси, а не з `apps/web`, щоб веб не мав compile-time
+ * залежності на `@capacitor/core` (і щоб bundle залишався чистим для
+ * браузерного деплою). Веб може імпортувати цей файл через
+ * `@sergeant/mobile-shell/platform` тільки якщо shell буде підключений
+ * як dependency — зараз це не так, shell споживає веб-білд як
+ * статичний артефакт.
+ *
+ * Для веба feature-detect-у native-середовища достатньо перевірки на
+ * глобальний `window.Capacitor` (впорскується native-runtime при
+ * завантаженні WebView), що дублюємо нижче — саме цей варіант і
+ * раджу використовувати в `apps/web` у будь-якій гілці, що хоче
+ * гілкуватися `if (isCapacitor()) { nativeImpl() } else { webImpl() }`.
+ */
+
+import { Capacitor } from "@capacitor/core";
+
+export function isCapacitor(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
+export function getPlatform(): "web" | "ios" | "android" {
+  const p = Capacitor.getPlatform();
+  return p === "ios" || p === "android" ? p : "web";
+}

--- a/apps/mobile-shell/tsconfig.json
+++ b/apps/mobile-shell/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "types": []
+  },
+  "include": ["capacitor.config.ts", "src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,25 @@ importers:
         specifier: ~5.9.0
         version: 5.9.3
 
+  apps/mobile-shell:
+    dependencies:
+      "@capacitor/android":
+        specifier: ^7.4.3
+        version: 7.6.2(@capacitor/core@7.6.2)
+      "@capacitor/core":
+        specifier: ^7.4.3
+        version: 7.6.2
+      "@capacitor/ios":
+        specifier: ^7.4.3
+        version: 7.6.2(@capacitor/core@7.6.2)
+    devDependencies:
+      "@capacitor/cli":
+        specifier: ^7.4.3
+        version: 7.6.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/server:
     dependencies:
       "@better-auth/expo":
@@ -1904,6 +1923,36 @@ packages:
       }
     hasBin: true
 
+  "@capacitor/android@7.6.2":
+    resolution:
+      {
+        integrity: sha512-zRIn10uTPbOQaFVRqkTGKwrrDypmn3L3I/x4XZSVLiCYt3zs8MUCPoqrMudNvOD+s6nQ5m0cX4GW8JRpMxKOkQ==,
+      }
+    peerDependencies:
+      "@capacitor/core": ^7.6.0
+
+  "@capacitor/cli@7.6.2":
+    resolution:
+      {
+        integrity: sha512-uPm+GDVhdWrM/DBWZ/L6c8uBVaEcge4MAXhqrIJWSkwad/9vNoVfUjtHaVgXxPE1g399PhlGm4kU8U7Qdfmwow==,
+      }
+    engines: { node: ">=20.0.0" }
+    hasBin: true
+
+  "@capacitor/core@7.6.2":
+    resolution:
+      {
+        integrity: sha512-8HRKEUlYpCOeRec8bCHZwEA4o/E2q5dhHSd0v/Cr6+ume08fZY/gniF+ZCKF+6DO0T/nRaBeNRQn6Up+45J1mg==,
+      }
+
+  "@capacitor/ios@7.6.2":
+    resolution:
+      {
+        integrity: sha512-TZOXn7ZSEMsetrIEb8EHT4X9Nwsed1itqMwe+z5QOCDvm9XZ7i2YsjnrinUC1ZOIgva9IE2l+azus7qOpQ0aCg==,
+      }
+    peerDependencies:
+      "@capacitor/core": ^7.6.0
+
   "@colors/colors@1.6.0":
     resolution:
       {
@@ -2789,6 +2838,62 @@ packages:
         integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==,
       }
 
+  "@ionic/cli-framework-output@2.2.8":
+    resolution:
+      {
+        integrity: sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-array@2.1.6":
+    resolution:
+      {
+        integrity: sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-fs@3.1.7":
+    resolution:
+      {
+        integrity: sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-object@2.1.6":
+    resolution:
+      {
+        integrity: sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-process@2.1.12":
+    resolution:
+      {
+        integrity: sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-stream@3.1.7":
+    resolution:
+      {
+        integrity: sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-subprocess@3.0.1":
+    resolution:
+      {
+        integrity: sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@ionic/utils-terminal@2.3.5":
+    resolution:
+      {
+        integrity: sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==,
+      }
+    engines: { node: ">=16.0.0" }
+
   "@isaacs/cliui@8.0.2":
     resolution:
       {
@@ -2802,6 +2907,13 @@ packages:
         integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==,
       }
     engines: { node: ">=18" }
+
+  "@isaacs/fs-minipass@4.0.1":
+    resolution:
+      {
+        integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
+      }
+    engines: { node: ">=18.0.0" }
 
   "@isaacs/ttlcache@1.4.1":
     resolution:
@@ -4536,6 +4648,12 @@ packages:
         integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==,
       }
 
+  "@types/fs-extra@8.1.5":
+    resolution:
+      {
+        integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==,
+      }
+
   "@types/graceful-fs@4.1.9":
     resolution:
       {
@@ -4716,6 +4834,12 @@ packages:
     resolution:
       {
         integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==,
+      }
+
+  "@types/slice-ansi@4.0.0":
+    resolution:
+      {
+        integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==,
       }
 
   "@types/stack-utils@2.0.3":
@@ -5489,6 +5613,13 @@ packages:
       }
     engines: { node: ">=4" }
 
+  astral-regex@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+      }
+    engines: { node: ">=8" }
+
   async-function@1.0.0:
     resolution:
       {
@@ -5953,6 +6084,12 @@ packages:
         integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==,
       }
 
+  buffer-crc32@0.2.13:
+    resolution:
+      {
+        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
+      }
+
   buffer-equal-constant-time@1.0.1:
     resolution:
       {
@@ -6235,6 +6372,13 @@ packages:
         integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==,
       }
     engines: { node: ">=10" }
+
+  chownr@3.0.0:
+    resolution:
+      {
+        integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
+      }
+    engines: { node: ">=18" }
 
   chrome-launcher@0.15.2:
     resolution:
@@ -7270,6 +7414,13 @@ packages:
         integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==,
       }
 
+  elementtree@0.1.7:
+    resolution:
+      {
+        integrity: sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==,
+      }
+    engines: { node: ">= 0.4.0" }
+
   emittery@0.13.1:
     resolution:
       {
@@ -7355,6 +7506,13 @@ packages:
         integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==,
       }
     engines: { node: ">=8" }
+
+  env-paths@2.2.1:
+    resolution:
+      {
+        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
+      }
+    engines: { node: ">=6" }
 
   environment@1.1.0:
     resolution:
@@ -8088,6 +8246,12 @@ packages:
         integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==,
       }
 
+  fd-slicer@1.1.0:
+    resolution:
+      {
+        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
+      }
+
   fdir@6.5.0:
     resolution:
       {
@@ -8545,6 +8709,13 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution:
+      {
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   glob@6.0.4:
     resolution:
       {
@@ -8960,6 +9131,13 @@ packages:
       {
         integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
       }
+
+  ini@4.1.3:
+    resolution:
+      {
+        integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
   inline-style-parser@0.2.7:
     resolution:
@@ -10037,6 +10215,13 @@ packages:
       }
     engines: { node: ">=6" }
 
+  kleur@4.1.5:
+    resolution:
+      {
+        integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==,
+      }
+    engines: { node: ">=6" }
+
   kuler@2.0.0:
     resolution:
       {
@@ -11045,6 +11230,13 @@ packages:
       }
     engines: { node: ">= 8" }
 
+  minizlib@3.1.0:
+    resolution:
+      {
+        integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==,
+      }
+    engines: { node: ">= 18" }
+
   mkdirp@0.5.6:
     resolution:
       {
@@ -11129,6 +11321,14 @@ packages:
         integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==,
       }
     engines: { node: ^20.0.0 || >=22.0.0 }
+
+  native-run@2.0.3:
+    resolution:
+      {
+        integrity: sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==,
+      }
+    engines: { node: ">=16.0.0" }
+    hasBin: true
 
   nativewind@4.2.3:
     resolution:
@@ -11700,6 +11900,12 @@ packages:
         integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
       }
     engines: { node: ">= 14.16" }
+
+  pend@1.2.0:
+    resolution:
+      {
+        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
+      }
 
   pg-cloudflare@1.3.0:
     resolution:
@@ -12816,6 +13022,14 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rimraf@6.1.3:
+    resolution:
+      {
+        integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==,
+      }
+    engines: { node: 20 || >=22 }
+    hasBin: true
+
   rollup-plugin-visualizer@7.0.1:
     resolution:
       {
@@ -12923,6 +13137,12 @@ packages:
     resolution:
       {
         integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==,
+      }
+
+  sax@1.1.4:
+    resolution:
+      {
+        integrity: sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==,
       }
 
   sax@1.6.0:
@@ -13225,6 +13445,13 @@ packages:
         integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==,
       }
     engines: { node: ">=14.16" }
+
+  slice-ansi@4.0.0:
+    resolution:
+      {
+        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+      }
+    engines: { node: ">=10" }
 
   slice-ansi@5.0.0:
     resolution:
@@ -13780,6 +14007,13 @@ packages:
     engines: { node: ">=10" }
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  tar@7.5.13:
+    resolution:
+      {
+        integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==,
+      }
+    engines: { node: ">=18" }
+
   tdigest@0.1.2:
     resolution:
       {
@@ -13891,6 +14125,12 @@ packages:
     resolution:
       {
         integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==,
+      }
+
+  through2@4.0.2:
+    resolution:
+      {
+        integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==,
       }
 
   tinybench@2.9.0:
@@ -14019,6 +14259,13 @@ packages:
         integrity: sha512-TOgFolKG8JFY+9d5EohGWMvwvteRafcyfPWWNIqcuD1W/FUvxWcy2MSCZ/beYHM63oYPHYHCd3tkbgCctHVP7w==,
       }
     engines: { node: ">=12.0.0" }
+
+  tree-kill@1.2.2:
+    resolution:
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution:
@@ -14350,6 +14597,13 @@ packages:
         integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
       }
     engines: { node: ">= 0.8" }
+
+  untildify@4.0.0:
+    resolution:
+      {
+        integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==,
+      }
+    engines: { node: ">=8" }
 
   upath@1.2.0:
     resolution:
@@ -15283,6 +15537,13 @@ packages:
       }
     engines: { node: ">=4.0.0" }
 
+  xml2js@0.6.2:
+    resolution:
+      {
+        integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==,
+      }
+    engines: { node: ">=4.0.0" }
+
   xmlbuilder@11.0.1:
     resolution:
       {
@@ -15336,6 +15597,13 @@ packages:
         integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
       }
 
+  yallist@5.0.0:
+    resolution:
+      {
+        integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
+      }
+    engines: { node: ">=18" }
+
   yaml@2.8.3:
     resolution:
       {
@@ -15378,6 +15646,12 @@ packages:
         integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==,
       }
     engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
+
+  yauzl@2.10.0:
+    resolution:
+      {
+        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+      }
 
   yocto-queue@0.1.0:
     resolution:
@@ -16416,6 +16690,40 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  "@capacitor/android@7.6.2(@capacitor/core@7.6.2)":
+    dependencies:
+      "@capacitor/core": 7.6.2
+
+  "@capacitor/cli@7.6.2":
+    dependencies:
+      "@ionic/cli-framework-output": 2.2.8
+      "@ionic/utils-subprocess": 3.0.1
+      "@ionic/utils-terminal": 2.3.5
+      commander: 12.1.0
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 11.3.4
+      kleur: 4.1.5
+      native-run: 2.0.3
+      open: 8.4.2
+      plist: 3.1.0
+      prompts: 2.4.2
+      rimraf: 6.1.3
+      semver: 7.7.4
+      tar: 7.5.13
+      tslib: 2.8.1
+      xml2js: 0.6.2
+    transitivePeerDependencies:
+      - supports-color
+
+  "@capacitor/core@7.6.2":
+    dependencies:
+      tslib: 2.8.1
+
+  "@capacitor/ios@7.6.2(@capacitor/core@7.6.2)":
+    dependencies:
+      "@capacitor/core": 7.6.2
+
   "@colors/colors@1.6.0": {}
 
   "@config-plugins/detox@9.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))":
@@ -17002,6 +17310,82 @@ snapshots:
 
   "@ide/backoff@1.0.0": {}
 
+  "@ionic/cli-framework-output@2.2.8":
+    dependencies:
+      "@ionic/utils-terminal": 2.3.5
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-array@2.1.6":
+    dependencies:
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-fs@3.1.7":
+    dependencies:
+      "@types/fs-extra": 8.1.5
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-object@2.1.6":
+    dependencies:
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-process@2.1.12":
+    dependencies:
+      "@ionic/utils-object": 2.1.6
+      "@ionic/utils-terminal": 2.3.5
+      debug: 4.4.3
+      signal-exit: 3.0.7
+      tree-kill: 1.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-stream@3.1.7":
+    dependencies:
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-subprocess@3.0.1":
+    dependencies:
+      "@ionic/utils-array": 2.1.6
+      "@ionic/utils-fs": 3.1.7
+      "@ionic/utils-process": 2.1.12
+      "@ionic/utils-stream": 3.1.7
+      "@ionic/utils-terminal": 2.3.5
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@ionic/utils-terminal@2.3.5":
+    dependencies:
+      "@types/slice-ansi": 4.0.0
+      debug: 4.4.3
+      signal-exit: 3.0.7
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      tslib: 2.8.1
+      untildify: 4.0.0
+      wrap-ansi: 7.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -17012,6 +17396,10 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   "@isaacs/cliui@9.0.0": {}
+
+  "@isaacs/fs-minipass@4.0.1":
+    dependencies:
+      minipass: 7.1.3
 
   "@isaacs/ttlcache@1.4.1": {}
 
@@ -18414,6 +18802,10 @@ snapshots:
       "@types/qs": 6.15.0
       "@types/serve-static": 1.15.10
 
+  "@types/fs-extra@8.1.5":
+    dependencies:
+      "@types/node": 25.6.0
+
   "@types/graceful-fs@4.1.9":
     dependencies:
       "@types/node": 25.6.0
@@ -18520,6 +18912,8 @@ snapshots:
       "@types/send": 0.17.6
 
   "@types/shimmer@1.2.0": {}
+
+  "@types/slice-ansi@4.0.0": {}
 
   "@types/stack-utils@2.0.3": {}
 
@@ -19058,6 +19452,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  astral-regex@2.0.0: {}
+
   async-function@1.0.0: {}
 
   async-limiter@1.0.1: {}
@@ -19358,6 +19754,8 @@ snapshots:
       buffer-alloc-unsafe: 1.1.0
       buffer-fill: 1.0.0
 
+  buffer-crc32@0.2.13: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-fill@1.0.0: {}
@@ -19525,6 +19923,8 @@ snapshots:
       fsevents: 2.3.3
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chrome-launcher@0.15.2:
     dependencies:
@@ -20116,6 +20516,10 @@ snapshots:
 
   electron-to-chromium@1.5.340: {}
 
+  elementtree@0.1.7:
+    dependencies:
+      sax: 1.1.4
+
   emittery@0.13.1: {}
 
   emoji-regex@10.6.0: {}
@@ -20146,6 +20550,8 @@ snapshots:
   entities@8.0.0: {}
 
   env-editor@0.4.2: {}
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
@@ -20852,6 +21258,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -21136,6 +21546,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@6.0.4:
     dependencies:
       inflight: 1.0.6
@@ -21389,6 +21805,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@4.1.3: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -22277,6 +22695,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  kleur@4.1.5: {}
+
   kuler@2.0.0: {}
 
   kysely@0.28.16: {}
@@ -23154,6 +23574,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -23195,6 +23619,22 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.3.0: {}
+
+  native-run@2.0.3:
+    dependencies:
+      "@ionic/utils-fs": 3.1.7
+      "@ionic/utils-terminal": 2.3.5
+      bplist-parser: 0.3.2
+      debug: 4.4.3
+      elementtree: 0.1.7
+      ini: 4.1.3
+      plist: 3.1.0
+      split2: 4.2.0
+      through2: 4.0.2
+      tslib: 2.8.1
+      yauzl: 2.10.0
+    transitivePeerDependencies:
+      - supports-color
 
   nativewind@4.2.3(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -23523,6 +23963,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pend@1.2.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -24295,6 +24737,11 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
+
   rollup-plugin-visualizer@7.0.1(rollup@2.80.0):
     dependencies:
       open: 11.0.0
@@ -24380,6 +24827,8 @@ snapshots:
   sanitize-filename@1.6.4:
     dependencies:
       truncate-utf8-bytes: 1.0.2
+
+  sax@1.1.4: {}
 
   sax@1.6.0: {}
 
@@ -24559,6 +25008,12 @@ snapshots:
   slash@3.0.0: {}
 
   slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   slice-ansi@5.0.0:
     dependencies:
@@ -24917,6 +25372,14 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  tar@7.5.13:
+    dependencies:
+      "@isaacs/fs-minipass": 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
@@ -24988,6 +25451,10 @@ snapshots:
 
   throat@5.0.0: {}
 
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -25047,6 +25514,8 @@ snapshots:
   trace-event-lib@1.4.1:
     dependencies:
       browser-process-hrtime: 1.0.0
+
+  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -25233,6 +25702,8 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  untildify@4.0.0: {}
 
   upath@1.2.0: {}
 
@@ -26040,6 +26511,11 @@ snapshots:
       sax: 1.6.0
       xmlbuilder: 11.0.1
 
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@14.0.0: {}
@@ -26055,6 +26531,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 
@@ -26087,6 +26565,11 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Додає workspace-пакет `@sergeant/mobile-shell`, який обгортає існуючий веб-бандл `@sergeant/web` у Capacitor-based native shell (Android/iOS). Це **PoC-скелет**, а не канонічна мобільна апка — канонічна живе в `apps/mobile` (React Native + Expo) і паралельно мігрується (Phase 6).

Мета PR — відповісти на питання "наскільки складно обгорнути веб у Capacitor?" **кодом, а не оцінкою**: з цією гілкою будь-хто локально може за 3 команди отримати Android APK з поточного веб-коду.

### Що всередині
- `apps/mobile-shell/capacitor.config.ts` — `webDir: "../server/dist"` (напряму бере артефакт `apps/web` → `apps/server/dist`, який уже створює `vite.config.js`). Нульове копіювання.
- `apps/mobile-shell/package.json` — `@capacitor/{core,cli,android,ios}@^7.4.3`. `appId: com.sergeant.shell` свідомо відрізняється від RN-апки (`com.sergeant.app`), щоб PoC і канонічна апка могли жити поруч на одному пристрої.
- `apps/mobile-shell/src/platform.ts` — runtime-детектор Capacitor-середовища. Наразі не споживається вебом (shell завантажує готовий білд як статичний артефакт), але задокументовано, як `apps/web` може гілкувати логіку `if (isCapacitor()) { nativeImpl() } else { webImpl() }` без compile-time залежності на `@capacitor/core`.
- `apps/mobile-shell/README.md` — 3 команди щоб отримати Android APK + явно перелічені **три фічі, які у PoC НЕ зроблено** (native push, bearer-auth, native barcode scanner). Кожна з них — окремий наступний PR.

### Що навмисно НЕ зроблено
- Нативні проєкти `android/` та `ios/` **не закоммічено**. На практиці Capacitor рекомендує їх коммітити, але для PoC-скелета краще дати людині згенерувати з потрібним package-name/signing-конфігом: `pnpm --filter @sergeant/mobile-shell add:android`.
- Web Push → native push не переключений. У <ref_file file="apps/web/src/shared/hooks/usePushNotifications.ts" /> зараз `PushManager` + VAPID через SW, що в native WebView кульгаве (iOS) / не працює (Android без `@capacitor/push-notifications`).
- Cookie-сесія Better Auth не переведена на bearer. У WebView cross-origin cookie крихкі; треба bearer-plugin + `@capacitor/preferences`.
- `BarcodeScanner.tsx` (getUserMedia+zxing) не переключений на `@capacitor-community/barcode-scanner`.

Деталі + оцінку 5–8 робочих днів до сабміту в сторах — у README і в мотиваційному коментарі PR.

## Review & Testing Checklist for Human

- [ ] Прокликати `pnpm install --frozen-lockfile` на чистому клоні (хочу пересвідчитись, що `pnpm-lock.yaml` resolve-ниться детерміністично після додавання 4 Capacitor пакетів).
- [ ] `pnpm --filter @sergeant/mobile-shell add:android` → відкрити `apps/mobile-shell/android` в Android Studio → зібрати debug APK → перевірити, що апка стартує, логін проходить, навігація працює. (iOS — на Mac окремо.)
- [ ] Прийняти стратегічне рішення: мержимо цей shell у main як паралельну опцію, лишаємо гілку як довідковий PoC без мержу, чи фокусуємось лише на RN-міграції. README і коментарі PR написані з припущенням "паралельна опція"; якщо рішення інше — перед мержем це краще зафіксувати в `docs/`.

**Test plan**:
1. Зібрати веб: `pnpm build:web` → пересвідчитись, що `apps/server/dist/index.html` існує.
2. `pnpm --filter @sergeant/mobile-shell add:android` (один раз).
3. `pnpm --filter @sergeant/mobile-shell build:android` → Android Studio → Run on emulator.
4. В емуляторі: увійти за існуючим акаунтом, перейти по модулях (Фінік / Фізрук / Харчування / Routine). Очікувано **НЕ працюватиме**: web push і barcode scanner (це задокументовано у README).

### Notes
- CI `check` job: `pnpm check` = `format:check && lint && typecheck && test && build`. Формат, типи, білд мого пакета прогнано локально. Лінт моєї директорії проходить (турбо підхоплює новий workspace автоматично). Єдина річ, яку локально не відтворити — `lint:plugins` падає на Node 22 (CI-версія — Node 20, там ок; ми тут про передіснуючу поведінку, не про мій PR).
- License-policy checker у <ref_snippet file=".github/workflows/ci.yml" lines="43-49" /> має explicit allowlist sergeant-пакетів. `@sergeant/mobile-shell` наразі додавати туди **не треба** — checker у `--production` режимі не доходить до workspace-пакетів, що не є транзитивними prod-depами root-а (поточний стан). Якщо CI покаже інше — додам окремим коммітом у цей PR.
- Draft свідомо: це питання "нам цей напрям взагалі потрібен?" до PR-ревʼю, а не "готово до мержу".

Link to Devin session: https://app.devin.ai/sessions/26d40dd3f7ea42b9afcbef09d6c6fb8c
Requested by: @Skords-01