### PR TITLE
fix(nutrition): keep native scanner result alive across re-renders

### DIFF
--- a/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
+++ b/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
@@ -20,38 +20,51 @@ interface BarcodeScannerProps {
 
 function NativeBarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   const toast = useToast();
-  const firedRef = useRef(false);
+
+  // Stash the latest callbacks + toast API in refs so the native-scan
+  // effect can read them without listing any of them in its dependency
+  // array. The ML Kit modal is asynchronous; if we depended on
+  // `onClose` / `onDetected` / `toast`, a transient re-render (for
+  // example when an unrelated toast auto-dismisses and the `ToastContext`
+  // value changes identity, or when the parent passes inline arrow
+  // callbacks — `NutritionOverlays.tsx` does exactly that) would run the
+  // effect's cleanup and flip `cancelled = true`, silently dropping the
+  // scan result when `scanBarcodeNative()` later resolves.
+  const onDetectedRef = useRef(onDetected);
+  const onCloseRef = useRef(onClose);
+  const toastRef = useRef(toast);
+  onDetectedRef.current = onDetected;
+  onCloseRef.current = onClose;
+  toastRef.current = toast;
 
   useEffect(() => {
-    if (firedRef.current) return;
-    firedRef.current = true;
     let cancelled = false;
     (async () => {
       try {
         const result: BarcodeResult | null = await scanBarcodeNative();
         if (cancelled) return;
         if (result?.code) {
-          onDetected(result.code);
+          onDetectedRef.current(result.code);
         } else {
-          onClose();
+          onCloseRef.current();
         }
       } catch (err) {
         if (cancelled) return;
         const msg = (err as Error)?.message ?? "";
         if (msg === "camera-permission-denied") {
-          toast.error(
+          toastRef.current.error(
             "Потрібен дозвіл на камеру. Увімкни його в налаштуваннях додатку.",
           );
         } else {
-          toast.error("Сканер недоступний. Введи код вручну.");
+          toastRef.current.error("Сканер недоступний. Введи код вручну.");
         }
-        onClose();
+        onCloseRef.current();
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [onDetected, onClose, toast]);
+  }, []);
 
   // ML Kit presents its own full-screen scanner UI; no DOM is required,
   // but we keep an accessible live region so screen-reader users know


### PR DESCRIPTION
## Summary

Follow-up to #504. Devin Review caught a real concurrency bug in `NativeBarcodeScanner`: while the ML Kit modal is open, any unrelated re-render (toast auto-dismiss, parent inline callback, etc.) fires the effect cleanup, flips `cancelled = true`, and the eventual `scanBarcodeNative()` result is silently dropped.

Root cause: the `useEffect` listed `[onDetected, onClose, toast]` as deps. `useToast()` memoizes `ToastContextValue` on `{ api, toasts }`, so every `show` / `dismiss` in the app — including the 3.5 s auto-dismiss of an unrelated info toast — produces a new context value identity and re-renders any consumer. `NutritionOverlays.tsx:81` also passes `onClose` as an inline arrow, so the parent re-rendering for any reason alone is enough to cancel the pending scan.

Fix: stash `onDetected`, `onClose`, and `toast` in refs, run the effect once with an empty dep array, and read the latest callbacks from the refs. Cleanup now only fires on real unmount. The `firedRef` guard becomes unnecessary and is removed.

## Review & Testing Checklist for Human

- [ ] **Needs device verification.** On Android, open Nutrition → barcode scanner. While the ML Kit modal is on screen, trigger an unrelated toast on the underlying page (e.g. save a meal, which shows a success toast); after it auto-dismisses, scan a code. The scan result should propagate (before this PR it would be dropped).
- [ ] Regression check browser flow: `pnpm --filter @sergeant/web dev`, open Nutrition, confirm the existing bottom-sheet `<video>` scanner behaves identically.
- [ ] Sanity-check the permission-denied path still surfaces the existing toast on Android after a cold install + deny.

### Notes

- Pure behavior fix; no new dependencies, no API changes, no bundle impact. `scanBarcodeNative` / `useBarcodeScanner` / `useWebScanner` are unchanged.
- Pre-existing on `main`, unrelated: `docs/react-native-migration.md` formatting drift was already fixed in #504; `detox-ios` CI fails on main due to `react-native-worklets` / RN version drift.


Link to Devin session: https://app.devin.ai/sessions/84100c99d62d4142a2e18d17eb15f9e7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
