### PR TITLE
fix(vercel): point outputDirectory to apps/server/dist

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "corepack enable && corepack prepare pnpm@9.15.1 --activate && pnpm install --frozen-lockfile",
   "buildCommand": "pnpm --filter @sergeant/web build",
-  "outputDirectory": "apps/web/dist",
+  "outputDirectory": "apps/server/dist",
   "headers": [
     {
       "source": "/index.html",


### PR DESCRIPTION
## Summary

Preview deployments були зафейлені з помилкою:

> Build Failed — No Output Directory named "dist" found after the Build completed. Update `vercel.json#outputDirectory` to ensure the correct output directory is generated.

Причина — розсинхрон між конфігом Vite та `vercel.json`:

- `apps/web/vite.config.js` білдить у `"../server/dist"` (monorepo-convention: веб-артефакт лежить поруч з Express-сервером для статик-сервінгу в non-Vercel оточенні).
- `vercel.json#outputDirectory` досі був `"apps/web/dist"`, тому Vercel після успішного білду не знаходив артефакт і рипортив Build Failed.

Фікс — один рядок: `"outputDirectory": "apps/server/dist"`. `buildCommand`, `installCommand` і решта не чіпаються.

## Review & Testing Checklist for Human

- [ ] Дочекатись Vercel preview deploy на цьому PR — має стати green з робочим preview URL (перший реальний preview за останню добу, якщо ліміт free-плану вже відпустив).
- [ ] Відкрити preview URL і прокликати ключові екрани (Auth, Hub, Finyk, Fizruk) — перевірити що статик + SPA rewrites (`/((?!api/).*) → /index.html`) нічого не зламали.

### Notes

- Не зачіпає інші PR-и окрім того, що вони тепер зможуть деплоїтись.
- Не чіпав `buildCommand` навмисно — `pnpm --filter @sergeant/web build` і далі коректний, він інвокує Vite, який пише в `apps/server/dist` через свій `outDir`.

Link to Devin session: https://app.devin.ai/sessions/f6f827849d2847cbb787145844975436
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->