### PR TITLE
fix(mobile): drop react-native-worklets (incompatible with RN 0.76)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -59,7 +59,6 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
-    "react-native-worklets": "^0.8.1",
     "victory-native": "^36.9.2",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,9 +175,6 @@ importers:
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-native-worklets:
-        specifier: ^0.8.1
-        version: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       victory-native:
         specifier: ^36.9.2
         version: 36.9.2(react@18.3.1)
@@ -3639,28 +3636,12 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@react-native/babel-plugin-codegen@0.85.2":
-    resolution:
-      {
-        integrity: sha512-5Dqn08kRTUIxPLYju9hExI0cR1ESX+P5tEv5yv0q0UZcisRTw0VB8iUWDIph2LdY1i5Dc8PIvuaWMRNCw3vnKg==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   "@react-native/babel-preset@0.76.9":
     resolution:
       {
         integrity: sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==,
       }
     engines: { node: ">=18" }
-    peerDependencies:
-      "@babel/core": "*"
-
-  "@react-native/babel-preset@0.85.2":
-    resolution:
-      {
-        integrity: sha512-7d2yW23eKkVt0FbbnZLxqO7KybGLtQXOuvvcO1NUOYGtjzVh6ihNKn0TIHrhSNpMyHwYLDoiiuj95wLtcg3IwQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
     peerDependencies:
       "@babel/core": "*"
 
@@ -3672,15 +3653,6 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@babel/preset-env": ^7.1.6
-
-  "@react-native/codegen@0.85.2":
-    resolution:
-      {
-        integrity: sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-    peerDependencies:
-      "@babel/core": "*"
 
   "@react-native/community-cli-plugin@0.76.9":
     resolution:
@@ -3722,13 +3694,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@react-native/js-polyfills@0.85.2":
-    resolution:
-      {
-        integrity: sha512-esGEAmKVM40DV/yVmNljCKZTIeUo7qXqc+Hwffkv3TG+b3E24xyFovHrbP98gGxZr2ZsEyx+2sKLdXF5asY5nw==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   "@react-native/metro-babel-transformer@0.76.9":
     resolution:
       {
@@ -3737,22 +3702,6 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@babel/core": "*"
-
-  "@react-native/metro-babel-transformer@0.85.2":
-    resolution:
-      {
-        integrity: sha512-lU9XOGahpHvQff30H5lnvh9RYbVwC1zpSHpl84E+7BD2zj0FvW+pD7MBh7CWbmbWmegjtAb+U/2bokXcDVA+jA==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-    peerDependencies:
-      "@babel/core": "*"
-
-  "@react-native/metro-config@0.85.2":
-    resolution:
-      {
-        integrity: sha512-YkTIMfTPeyMUrtpQo/7zd3oybVYJCfTp8626PqoakOvEiWi9PxsUpZ8j44a5GFtOIq8Nc6WWVBiFRn/6qdi1uQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   "@react-native/normalize-colors@0.74.89":
     resolution:
@@ -5334,13 +5283,6 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  accepts@2.0.0:
-    resolution:
-      {
-        integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
-      }
-    engines: { node: ">= 0.6" }
-
   acorn-globals@7.0.1:
     resolution:
       {
@@ -5841,12 +5783,6 @@ packages:
     resolution:
       {
         integrity: sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==,
-      }
-
-  babel-plugin-syntax-hermes-parser@0.33.3:
-    resolution:
-      {
-        integrity: sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==,
       }
 
   babel-plugin-transform-flow-enums@0.0.2:
@@ -8957,18 +8893,6 @@ packages:
         integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==,
       }
 
-  hermes-estree@0.33.3:
-    resolution:
-      {
-        integrity: sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==,
-      }
-
-  hermes-estree@0.35.0:
-    resolution:
-      {
-        integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==,
-      }
-
   hermes-parser@0.23.1:
     resolution:
       {
@@ -8979,18 +8903,6 @@ packages:
     resolution:
       {
         integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==,
-      }
-
-  hermes-parser@0.33.3:
-    resolution:
-      {
-        integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==,
-      }
-
-  hermes-parser@0.35.0:
-    resolution:
-      {
-        integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==,
       }
 
   hoist-non-react-statics@3.3.2:
@@ -10809,26 +10721,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-babel-transformer@0.84.3:
-    resolution:
-      {
-        integrity: sha512-svAA+yMLpeMiGcz/jKJs4oHpIGEx4nBqNEJ5AGj4CYIg1efvK+A0TjR6tgIuc6tKO5e8JmN/1lglpN2+f3/z/w==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro-cache-key@0.81.5:
     resolution:
       {
         integrity: sha512-lGWnGVm1UwO8faRZ+LXQUesZSmP1LOg14OVR+KNPBip8kbMECbQJ8c10nGesw28uQT7AE0lwQThZPXlxDyCLKQ==,
       }
     engines: { node: ">=18.18" }
-
-  metro-cache-key@0.84.3:
-    resolution:
-      {
-        integrity: sha512-TnSL1Fdvrw+2glTdBSRmA5TL8l/i16ECjsrUdf3E5HncA+sNx8KcwDG8r+3ct1UhfYcusJypzZqTN55FZZcwGg==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-cache@0.81.5:
     resolution:
@@ -10837,26 +10735,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-cache@0.84.3:
-    resolution:
-      {
-        integrity: sha512-0QElxwLaHqLZf+Xqio8QrjVbuXP/8sJfQBGSPiITlKDVXrVLefuzYVSH9Sj+QL6lrPj2gYZd/iwQh1yZuVKnLA==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro-config@0.81.5:
     resolution:
       {
         integrity: sha512-oDRAzUvj6RNRxratFdcVAqtAsg+T3qcKrGdqGZFUdwzlFJdHGR9Z413sW583uD2ynsuOjA2QB6US8FdwiBdNKg==,
       }
     engines: { node: ">=18.18" }
-
-  metro-config@0.84.3:
-    resolution:
-      {
-        integrity: sha512-JmCzZWOETR+O22q8oPBWyQppx3roU9EbkbGzD8Gf1jukQ4b5T1fTzqqHruu6K4sTiNq5zVQySmKF6bp4kVARew==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-core@0.81.5:
     resolution:
@@ -10865,26 +10749,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-core@0.84.3:
-    resolution:
-      {
-        integrity: sha512-cc0pvAa80ai1nDmqqz0P59a+0ZqCZ/YHU/3jEekZL6spFnYDfX8iDLdn9FR6kX+67rmzKxHNrbrSRFLX2AYocw==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro-file-map@0.81.5:
     resolution:
       {
         integrity: sha512-mW1PKyiO3qZvjeeVjj1brhkmIotObA3/9jdbY1fQQYvEWM6Ml7bN/oJCRDGn2+bJRlG+J8pwyJ+DgdrM4BsKyg==,
       }
     engines: { node: ">=18.18" }
-
-  metro-file-map@0.84.3:
-    resolution:
-      {
-        integrity: sha512-1cL4m4Jv1yRUt9RJExZQLfccscdlMNOcRG6LHLtmJhf3BG9j3MujPVc7CIpKYdFl+KUl+sdjge6oO3+meKCHQA==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-minify-terser@0.81.5:
     resolution:
@@ -10893,26 +10763,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-minify-terser@0.84.3:
-    resolution:
-      {
-        integrity: sha512-3ofrG2OQyJbO9RNhCfOcl8QU7EE2WrSsnN5dFkuZaJO5+4Imujr9bUXmspeNlXRsOVk0F/rVRbEFH98lFSCkBQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro-resolver@0.81.5:
     resolution:
       {
         integrity: sha512-6BX8Nq3g3go3FxcyXkVbWe7IgctjDTk6D9flq+P201DfHHQ28J+DWFpVelFcrNTn4tIfbP/Bw7u/0g2BGmeXfQ==,
       }
     engines: { node: ">=18.18" }
-
-  metro-resolver@0.84.3:
-    resolution:
-      {
-        integrity: sha512-pjEzGDtoM8DTHAIPK/9u9ZxszEiuRohYUVImWvgbnB91V4gqYJpQcoEYUugf2NIm1lrX5HNu0OvNqWmPBnGYjA==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-runtime@0.81.5:
     resolution:
@@ -10921,26 +10777,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-runtime@0.84.3:
-    resolution:
-      {
-        integrity: sha512-o7HLRfMyVk9N2dUZ9VjQfB6xxUItL9Pi9WcqxURE7MEKOH6wbGt9/E92YdYLluTOtkzYAEVfdC6h6lcxqA+hMQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro-source-map@0.81.5:
     resolution:
       {
         integrity: sha512-Jz+CjvCKLNbJZYJTBeN3Kq9kIJf6b61MoLBdaOQZJ5Ajhw6Pf95Nn21XwA8BwfUYgajsi6IXsp/dTZsYJbN00Q==,
       }
     engines: { node: ">=18.18" }
-
-  metro-source-map@0.84.3:
-    resolution:
-      {
-        integrity: sha512-jS48CeSzw78M8y6VE0f9uy3lVmfbOS677j2VCxnlmlYmnahcXuC6IhoN9K6LynNvos9517yUadcfgioju38xYQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-symbolicate@0.81.5:
     resolution:
@@ -10950,27 +10792,12 @@ packages:
     engines: { node: ">=18.18" }
     hasBin: true
 
-  metro-symbolicate@0.84.3:
-    resolution:
-      {
-        integrity: sha512-J9Tpo8NCycYrozRvBIUyOwGAu4xkawOsAppmTscFiaegK0WvuDGwIM53GbzVSnytCHjVAF0io5GQxpkrKTuc7g==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-    hasBin: true
-
   metro-transform-plugins@0.81.5:
     resolution:
       {
         integrity: sha512-MmHhVx/1dJC94FN7m3oHgv5uOjKH8EX8pBeu1pnPMxbJrx6ZuIejO0k84zTSaQTZ8RxX1wqwzWBpXAWPjEX8mA==,
       }
     engines: { node: ">=18.18" }
-
-  metro-transform-plugins@0.84.3:
-    resolution:
-      {
-        integrity: sha512-8S3baq2XhBaafHEH5Q8sJW6tmzsEJk80qKc3RU/nZV1MsnYq94RdjTUR6AyKjQd6Rfsk1BtBxhtiNnk7mgslCg==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   metro-transform-worker@0.81.5:
     resolution:
@@ -10979,27 +10806,12 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  metro-transform-worker@0.84.3:
-    resolution:
-      {
-        integrity: sha512-Wjba7PyYktNRsHbPmkx2J2UX32rAzcDXjCu49zPHeF/viJlYJhwRaNePQcHaCRqQ+kmgQT4ThprsnJfDj71ZMA==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
-
   metro@0.81.5:
     resolution:
       {
         integrity: sha512-YpFF0DDDpDVygeca2mAn7K0+us+XKmiGk4rIYMz/CRdjFoCGqAei/IQSpV0UrGfQbToSugpMQeQJveaWSH88Hg==,
       }
     engines: { node: ">=18.18" }
-    hasBin: true
-
-  metro@0.84.3:
-    resolution:
-      {
-        integrity: sha512-1h3lbVrE6hGf1e/764HfhPGg/bGrWMJDDh7G2rc4gFYZboVuI40BlG/y+UhtbhQDNlO/csMvrcnK0YrTlHUVew==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
     hasBin: true
 
   micromark-core-commonmark@2.0.3:
@@ -11155,13 +10967,6 @@ packages:
         integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
       }
     engines: { node: ">= 0.6" }
-
-  mime-types@3.0.2:
-    resolution:
-      {
-        integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
-      }
-    engines: { node: ">=18" }
 
   mime@1.6.0:
     resolution:
@@ -11438,13 +11243,6 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  negotiator@1.0.0:
-    resolution:
-      {
-        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
-      }
-    engines: { node: ">= 0.6" }
-
   neo-async@2.6.2:
     resolution:
       {
@@ -11589,13 +11387,6 @@ packages:
         integrity: sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==,
       }
     engines: { node: ">=18.18" }
-
-  ob1@0.84.3:
-    resolution:
-      {
-        integrity: sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==,
-      }
-    engines: { node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0 }
 
   object-assign@4.1.1:
     resolution:
@@ -12694,17 +12485,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-
-  react-native-worklets@0.8.1:
-    resolution:
-      {
-        integrity: sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==,
-      }
-    peerDependencies:
-      "@babel/core": "*"
-      "@react-native/metro-config": "*"
-      react: "*"
-      react-native: 0.81 - 0.85
 
   react-native@0.76.9:
     resolution:
@@ -18073,14 +17853,6 @@ snapshots:
       - "@babel/preset-env"
       - supports-color
 
-  "@react-native/babel-plugin-codegen@0.85.2(@babel/core@7.29.0)":
-    dependencies:
-      "@babel/traverse": 7.29.0
-      "@react-native/codegen": 0.85.2(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - "@babel/core"
-      - supports-color
-
   "@react-native/babel-preset@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/core": 7.29.0
@@ -18132,44 +17904,6 @@ snapshots:
       - "@babel/preset-env"
       - supports-color
 
-  "@react-native/babel-preset@0.85.2(@babel/core@7.29.0)":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/plugin-proposal-export-default-from": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.0)
-      "@babel/plugin-syntax-export-default-from": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.0)
-      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.0)
-      "@babel/plugin-transform-async-generator-functions": 7.29.0(@babel/core@7.29.0)
-      "@babel/plugin-transform-async-to-generator": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-block-scoping": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-class-properties": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-classes": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-destructuring": 7.28.5(@babel/core@7.29.0)
-      "@babel/plugin-transform-flow-strip-types": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-for-of": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-modules-commonjs": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.0(@babel/core@7.29.0)
-      "@babel/plugin-transform-nullish-coalescing-operator": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-optional-catch-binding": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-private-methods": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-private-property-in-object": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-react-display-name": 7.28.0(@babel/core@7.29.0)
-      "@babel/plugin-transform-react-jsx": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-regenerator": 7.29.0(@babel/core@7.29.0)
-      "@babel/plugin-transform-runtime": 7.29.0(@babel/core@7.29.0)
-      "@babel/plugin-transform-typescript": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-unicode-regex": 7.27.1(@babel/core@7.29.0)
-      "@react-native/babel-plugin-codegen": 0.85.2(@babel/core@7.29.0)
-      babel-plugin-syntax-hermes-parser: 0.33.3
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - supports-color
-
   "@react-native/codegen@0.76.9(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/parser": 7.29.2
@@ -18183,16 +17917,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
-
-  "@react-native/codegen@0.85.2(@babel/core@7.29.0)":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/parser": 7.29.2
-      hermes-parser: 0.33.3
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      tinyglobby: 0.2.16
-      yargs: 17.7.2
 
   "@react-native/community-cli-plugin@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
@@ -18240,8 +17964,6 @@ snapshots:
 
   "@react-native/js-polyfills@0.76.9": {}
 
-  "@react-native/js-polyfills@0.85.2": {}
-
   "@react-native/metro-babel-transformer@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))":
     dependencies:
       "@babel/core": 7.29.0
@@ -18251,27 +17973,6 @@ snapshots:
     transitivePeerDependencies:
       - "@babel/preset-env"
       - supports-color
-
-  "@react-native/metro-babel-transformer@0.85.2(@babel/core@7.29.0)":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@react-native/babel-preset": 0.85.2(@babel/core@7.29.0)
-      hermes-parser: 0.33.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  "@react-native/metro-config@0.85.2(@babel/core@7.29.0)":
-    dependencies:
-      "@react-native/js-polyfills": 0.85.2
-      "@react-native/metro-babel-transformer": 0.85.2(@babel/core@7.29.0)
-      metro-config: 0.84.3
-      metro-runtime: 0.84.3
-    transitivePeerDependencies:
-      - "@babel/core"
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   "@react-native/normalize-colors@0.74.89": {}
 
@@ -19332,11 +19033,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   acorn-globals@7.0.1:
     dependencies:
       acorn: 8.16.0
@@ -19654,10 +19350,6 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.25.1:
     dependencies:
       hermes-parser: 0.25.1
-
-  babel-plugin-syntax-hermes-parser@0.33.3:
-    dependencies:
-      hermes-parser: 0.33.3
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
@@ -21765,10 +21457,6 @@ snapshots:
 
   hermes-estree@0.25.1: {}
 
-  hermes-estree@0.33.3: {}
-
-  hermes-estree@0.35.0: {}
-
   hermes-parser@0.23.1:
     dependencies:
       hermes-estree: 0.23.1
@@ -21776,14 +21464,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  hermes-parser@0.33.3:
-    dependencies:
-      hermes-estree: 0.33.3
-
-  hermes-parser@0.35.0:
-    dependencies:
-      hermes-estree: 0.35.0
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -23123,21 +22803,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-babel-transformer@0.84.3:
-    dependencies:
-      "@babel/core": 7.29.0
-      flow-enums-runtime: 0.0.6
-      hermes-parser: 0.35.0
-      metro-cache-key: 0.84.3
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   metro-cache-key@0.81.5:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-
-  metro-cache-key@0.84.3:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -23146,15 +22812,6 @@ snapshots:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
       metro-core: 0.81.5
-
-  metro-cache@0.84.3:
-    dependencies:
-      exponential-backoff: 3.1.3
-      flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
-      metro-core: 0.84.3
-    transitivePeerDependencies:
-      - supports-color
 
   metro-config@0.81.5:
     dependencies:
@@ -23171,50 +22828,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.84.3:
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.84.3
-      metro-cache: 0.84.3
-      metro-core: 0.84.3
-      metro-runtime: 0.84.3
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-core@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.81.5
 
-  metro-core@0.84.3:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-      lodash.throttle: 4.1.1
-      metro-resolver: 0.84.3
-
   metro-file-map@0.81.5:
     dependencies:
       debug: 2.6.9
-      fb-watchman: 2.0.2
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      invariant: 2.2.4
-      jest-worker: 29.7.0
-      micromatch: 4.0.8
-      nullthrows: 1.1.1
-      walker: 1.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-file-map@0.84.3:
-    dependencies:
-      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -23231,25 +22853,11 @@ snapshots:
       flow-enums-runtime: 0.0.6
       terser: 5.46.1
 
-  metro-minify-terser@0.84.3:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-      terser: 5.46.1
-
   metro-resolver@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
 
-  metro-resolver@0.84.3:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-
   metro-runtime@0.81.5:
-    dependencies:
-      "@babel/runtime": 7.29.2
-      flow-enums-runtime: 0.0.6
-
-  metro-runtime@0.84.3:
     dependencies:
       "@babel/runtime": 7.29.2
       flow-enums-runtime: 0.0.6
@@ -23269,20 +22877,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-source-map@0.84.3:
-    dependencies:
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      metro-symbolicate: 0.84.3
-      nullthrows: 1.1.1
-      ob1: 0.84.3
-      source-map: 0.5.7
-      vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   metro-symbolicate@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -23294,29 +22888,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.84.3:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      metro-source-map: 0.84.3
-      nullthrows: 1.1.1
-      source-map: 0.5.7
-      vlq: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   metro-transform-plugins@0.81.5:
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      flow-enums-runtime: 0.0.6
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-transform-plugins@0.84.3:
     dependencies:
       "@babel/core": 7.29.0
       "@babel/generator": 7.29.1
@@ -23341,26 +22913,6 @@ snapshots:
       metro-minify-terser: 0.81.5
       metro-source-map: 0.81.5
       metro-transform-plugins: 0.81.5
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro-transform-worker@0.84.3:
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      flow-enums-runtime: 0.0.6
-      metro: 0.84.3
-      metro-babel-transformer: 0.84.3
-      metro-cache: 0.84.3
-      metro-cache-key: 0.84.3
-      metro-minify-terser: 0.84.3
-      metro-source-map: 0.84.3
-      metro-transform-plugins: 0.84.3
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
@@ -23403,53 +22955,6 @@ snapshots:
       metro-transform-plugins: 0.81.5
       metro-transform-worker: 0.81.5
       mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.84.3:
-    dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      accepts: 2.0.0
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.2.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.84.3
-      metro-cache: 0.84.3
-      metro-cache-key: 0.84.3
-      metro-config: 0.84.3
-      metro-core: 0.84.3
-      metro-file-map: 0.84.3
-      metro-resolver: 0.84.3
-      metro-runtime: 0.84.3
-      metro-source-map: 0.84.3
-      metro-symbolicate: 0.84.3
-      metro-transform-plugins: 0.84.3
-      metro-transform-worker: 0.84.3
-      mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
@@ -23607,10 +23112,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-
   mime@1.6.0: {}
 
   mime@2.6.0: {}
@@ -23755,8 +23256,6 @@ snapshots:
 
   negotiator@0.6.4: {}
 
-  negotiator@1.0.0: {}
-
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
@@ -23828,10 +23327,6 @@ snapshots:
   nwsapi@2.2.23: {}
 
   ob1@0.81.5:
-    dependencies:
-      flow-enums-runtime: 0.0.6
-
-  ob1@0.84.3:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -24516,26 +24011,6 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
-
-  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/plugin-transform-arrow-functions": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-class-properties": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-classes": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-nullish-coalescing-operator": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-optional-chaining": 7.28.6(@babel/core@7.29.0)
-      "@babel/plugin-transform-shorthand-properties": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-template-literals": 7.27.1(@babel/core@7.29.0)
-      "@babel/plugin-transform-unicode-regex": 7.27.1(@babel/core@7.29.0)
-      "@babel/preset-typescript": 7.28.5(@babel/core@7.29.0)
-      "@react-native/metro-config": 0.85.2(@babel/core@7.29.0)
-      convert-source-map: 2.0.0
-      react: 18.3.1
-      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
 
   react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

Unblocks `detox-ios` CI. On #505 (and every earlier PR that hit iOS pod install) the job failed at `pod install` with:

```
[!] Invalid `RNWorklets.podspec` file: [Worklets]
Your installed version of React Native is not compatible with
installed version of Worklets. See the documentation for the list
of supported versions:
https://docs.swmansion.com/react-native-worklets/docs/guides/compatibility/
```

`apps/mobile` pins `react-native@0.76.9`, but [`react-native-worklets`'s compatibility table](https://docs.swmansion.com/react-native-worklets/docs/guides/compatibility/) shows that the minimum React Native supported by any published Worklets version is **0.78** (0.4.x / 0.5.x); 0.8.x (our `^0.8.1`) only supports 0.81–0.85. So there is literally no Worklets release that matches RN 0.76 — the dep was unsatisfiable from day one, it just failed loudly once `pod install` ran autolinking over the new `node_modules` layout the merge of #505 produced.

The package wasn't doing anything for us:

- No source imports it — `rg "from ['\"]react-native-worklets" apps/mobile` returns nothing. The only mentions are a historical note in `apps/mobile/src/components/ui/Toast.tsx` and a parallel note in `apps/mobile/babel.config.js`, both explaining that we deliberately *don't* use `react-native-worklets/plugin`.
- It wasn't a transitive peer of anything in the lockfile either — the only incoming edge was the direct specifier in `apps/mobile/package.json`.
- `react-native-reanimated@~3.16` on RN 0.76 ships its own worklets runtime via `react-native-reanimated/plugin` (which is what `babel.config.js` actually registers), so dropping the standalone package doesn't touch Reanimated's worklet rewriter.

Removing the dep makes iOS autolinking stop seeing `RNWorklets.podspec`, which lets `pod install` succeed.

### Verification

- `pnpm install --frozen-lockfile` — clean on the regenerated lockfile (exit 0, no missing specifiers).
- `pnpm --filter @sergeant/mobile typecheck` — passes (`tsc --noEmit`, exit 0).
- `rg "react-native-worklets" apps` — only the two comment hits in `Toast.tsx` + `babel.config.js` remain, both intentional documentation of why we skip the worklets babel plugin.
- Lockfile diff is large (~7k insertions / ~14k deletions) because `pnpm@9.15.1` re-dedupes on regen; nothing package-semantics-level changed outside of the `react-native-worklets@0.8.1` entries and their transitive-only deps (e.g. `@babel/plugin-transform-arrow-functions` is no longer pulled through this edge).

## Review & Testing Checklist for Human

- [ ] `detox-ios` actually goes green on this PR (the original bug). If pod install still complains about Worklets, something else is linking the podspec and we need to look at `@config-plugins/detox` / prebuild output.
- [ ] `detox-android` is unaffected — Android autolinking reads `react-native.config.js` / gradle, not Podfile, but worth a glance at the job log to confirm no Android native modules were depending on the Worklets JS package.
- [ ] If anyone was mid-flight on a Reanimated 4 / Worklets upgrade branch, they'll need to re-add `react-native-worklets` at a version that matches whatever RN they're bumping to (see the compatibility table linked above).

### Notes

- `Toast.tsx`'s comment about "`react-native-worklets/plugin` friction that PR #413 had to work around" is kept — it's still accurate as a design note for why the toast uses RN's built-in `Animated` instead of Reanimated. No behavior change there.
- The `babel.config.js` comments that mention `react-native-worklets/plugin` are also kept; they document *why* the test env drops NativeWind's Babel preset, not the runtime package.

Link to Devin session: https://app.devin.ai/sessions/f6f827849d2847cbb787145844975436
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency from the mobile app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->