### PR TITLE
docs: launch-readiness status for web / native / capacitor-shell

### DIFF
--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -1,68 +1,111 @@
-# `@sergeant/mobile-shell` — Capacitor PoC
+# `@sergeant/mobile-shell` — Capacitor shell
 
-Тонкий native-shell навколо `@sergeant/web`. Призначення — **PoC-перевірка**:
-чи запускається поточний веб-код у WebView і скільки зусиль треба до шторів.
-Це **не канонічний мобільний клієнт** — повноцінна мобільна апка живе в
-`apps/mobile` (React Native + Expo).
+Тонкий native-shell навколо `@sergeant/web`. Спочатку задумувався як PoC
+(«чи запуститься поточний веб-код у WebView»), але зараз доріс до MVP:
+bearer-auth, нативний barcode-сканер і UX-поліш (status bar, splash,
+keyboard, deep links) вже закомічені і перевірені у білдах.
+
+Канонічний мобільний клієнт усе ще живе в `apps/mobile` (Expo +
+React Native). Співіснують навмисно: `applicationId` у shell —
+`com.sergeant.shell`, у RN-апці — `com.sergeant.app`.
+
+Короткий статус-репорт по всіх трьох поверхнях — `docs/platforms.md`.
+
+## Що готово
+
+| Функція                                       | Плагін / PR                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                             |
+| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                  |
+| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506) |
+| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                              |
+
+Точка входу native-side — `src/index.ts → initNativeShell()`. Вона
+ідемпотентна (повторні виклики безпечні під HMR / LiveReload) і
+кожен плагін огорнутий try/catch, щоб помилка в одному не заблокувала
+інші.
+
+Web-side інтеграції:
+
+- `apps/web/src/shared/lib/platform.ts` → `isCapacitor()` — runtime-guard
+  **без compile-time залежності** від `@capacitor/core`. Всі native-import-и
+  у web йдуть за цим guard-ом через dynamic `import()`.
+- `apps/web/src/shared/lib/bearerToken.ts` — єдина точка читання/запису
+  bearer-токена з `@sergeant/mobile-shell/auth-storage`.
+- `apps/web/vite.config.js#manualChunks` навмисно виключає
+  `/node_modules/@capacitor/` з `vendor`, щоб Capacitor-плагіни їхали
+  тільки в async-чанки, що підвантажуються динамічним імпортом. При
+  додаванні нового `@capacitor/*` плагіна — оновлювати коментар, але
+  сам виняток уже покриває майбутні пакети без змін.
 
 ## Швидкий старт (Android)
 
-### Варіант А — скачати готовий APK з CI (без Android SDK локально)
+### Варіант А — скачати готовий APK з CI
 
-> **TODO (окремо)**: GitHub Actions workflow для автоматичної збірки APK
-> готовий, але його треба додати вручну — Devin OAuth app не має
-> `workflow` scope, тож файл `.github/workflows/mobile-shell-android.yml`
-> має закомітити мейнтейнер. Текст воркфлоу прикріплений у PR-описі.
-> Після додавання кожен push у PR, що чіпає `apps/mobile-shell/**` або
-> `apps/web/**`, буде білдити debug-APK і виливати як GitHub Actions
-> artifact.
+> **TODO (окремо):** GitHub Actions workflow для автоматичної збірки
+> debug-APK ще треба додати. Devin OAuth app не має `workflow` scope,
+> тож файл `.github/workflows/mobile-shell-android.yml` має закомітити
+> мейнтейнер вручну (або людський акаунт з репо-admin). Після цього
+> кожен push у PR, що чіпає `apps/mobile-shell/**` або `apps/web/**`,
+> буде білдити debug-APK і виливати як GitHub Actions artifact.
 
 ### Варіант Б — локальна збірка
 
 Потрібен Android SDK (через Android Studio або `sdkmanager`).
 
 ```bash
-# 1. Зібрати веб-бандл (йде в apps/server/dist — див. vite.config.js)
+# 1. Зібрати веб-бандл (йде в apps/server/dist — див. vite.config.js).
 pnpm build:web
 
-# 2. Скопіювати бандл у нативний проєкт
+# 2. Скопіювати бандл у нативний проєкт.
 pnpm --filter @sergeant/mobile-shell copy
 
-# 3. Відкрити Android Studio для збірки APK/AAB
+# 3. Відкрити Android Studio для збірки APK/AAB.
 pnpm --filter @sergeant/mobile-shell open:android
 ```
 
-`pnpm --filter @sergeant/mobile-shell build:android` робить кроки 1+2 разом.
+`pnpm --filter @sergeant/mobile-shell build:android` робить кроки 1+2
+разом.
 
-`android/` вже закомічено (згенеровано `cap add android`). Якщо знадобиться
-перегенерувати з нуля — спочатку видалити директорію, потім
+`android/` уже закомічено (згенеровано `cap add android`). Якщо
+потрібно перегенерувати з нуля — спочатку видалити директорію, потім
 `pnpm --filter @sergeant/mobile-shell add:android`.
 
 ## iOS
 
-Потрібен Mac з Xcode + CocoaPods. Після першого `pnpm --filter
-@sergeant/mobile-shell add:ios` далі так само: `build:web` → `sync ios` →
-`open:ios`.
+`ios/` **не** закомічено — потрібен Mac з Xcode + CocoaPods для
+першого `pnpm --filter @sergeant/mobile-shell add:ios`. Після цього —
+`build:web` → `pnpm --filter @sergeant/mobile-shell sync ios` →
+`open:ios`. Release pipeline на iOS (TestFlight) ще не
+налаштований — блокує відсутність macOS runner-а у CI.
 
-## Що (навмисно) НЕ зроблено у PoC
+## Що НЕ зроблено
 
-- **Push notifications.** `usePushNotifications` у веб-коді використовує
-  Web Push через Service Worker (`PushManager` + VAPID). У native WebView
-  воно не працює на iOS і кульгаво працює на Android. Треба окремий PR з
-  `@capacitor/push-notifications` (FCM + APNs) + розширенням
-  `createPushEndpoints.register` на `platform: "android" | "ios"`.
-- **Auth.** Better Auth зараз через cookie. У native WebView cross-origin
-  cookie крихкі (особливо iOS ITP). Треба окремий PR з bearer-plugin
-  Better Auth + збереженням токена в `@capacitor/preferences` / Keychain.
-- **Barcode scanner.** `BarcodeScanner.tsx` на `getUserMedia`+zxing.
-  Працює у WebView, але UX гірший. Окремим PR — feature-detect і
-  переключення на `@capacitor-community/barcode-scanner`.
-- **Deep links, status bar, splash, safe-area, keyboard avoidance.**
-  Кожне — тонкий плагін `@capacitor/*`, робимо коли підуть реальні фічі.
+- **GitHub Actions APK workflow** (див. TODO вище).
+- **iOS native project** — `cap add ios` чекає на Mac.
+- **Native push notifications.** `usePushNotifications` у web тримає
+  Web Push через Service Worker + VAPID. На iOS у WebView воно
+  працює лише з 16.4+ і тільки якщо web уже установлено як PWA на
+  home-screen; на Android працює, але «крихко». Power-move —
+  окремий PR з `@capacitor/push-notifications` (FCM + APNs) і
+  розширенням `createPushEndpoints.register` на нові
+  `platform: "android" | "ios"`.
+- **Deep-link навігація у React Router.** `parseDeepLink()` у
+  `src/index.ts` готовий і `App.addListener('appUrlOpen', ...)`
+  викликає callback, але коннект з `useNavigate()` з
+  `@sergeant/web` ще не прокинутий — `options.navigate` наразі
+  падає в fallback `window.location.assign`.
+- **iOS safe-area + splash race.** CSS `env(safe-area-inset-*)` з
+  web-side покриває 99% кейсів, але якщо splash візьметься
+  триматись довше 3с (дивись `SplashScreen.hide({ fadeOutDuration })`
+  у `initNativeShell`), користувач може побачити блимання статус-бару.
+  Кандидат на тюнінг у debug-білді.
 
 ## Чому окрема директорія, а не окреме репо
 
-`apps/*` вже є workspace, `@sergeant/mobile-shell` автоматично бачить
-`@sergeant/shared`, `@sergeant/api-client` і підʼєднується до turbo/CI
-без кросрепного клею. Видалити експеримент — 1 коміт. Деталі та
-альтернативи — у коментарях PR.
+`apps/*` — це вже pnpm workspace, тож `@sergeant/mobile-shell`
+автоматично бачить `@sergeant/shared`, `@sergeant/api-client`,
+`@sergeant/mobile-shell/auth-storage` і підключений до turbo/CI без
+кросрепного клею. Видалити експеримент — один коміт. Деталі та
+альтернативи — у обговореннях [PR #503](https://github.com/Skords-01/Sergeant/pull/503)
+(перший скафолд shell-а).

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -6,17 +6,40 @@
 
 ## Статус
 
-**Фаза 0 (цей PR) — скафолд.** Піднятий Expo-проєкт з:
+**Internal dev-client** — готово до `eas build --profile development` і
+установки на фізичний пристрій / симулятор, але ще не для store.
 
-- Expo Router (tabs + (auth) модалка);
-- Better Auth Expo-клієнт (bearer токен у `expo-secure-store`, див.
-  `docs/mobile.md`);
-- спільні пакети підключені через `metro.config.js` (monorepo-resolver);
-- заглушкові екрани для 4 модулів: Фінік, Фізрук, Рутина, Харчування.
+Портовано з `apps/web` у `src/modules/`:
 
-**Далі:** окремими PR-ами порт модулів з `apps/web` на нативні екрани
-(View/Text/FlashList, AsyncStorage/SecureStore, expo-speech замість Web
-Speech, expo-barcode-scanner замість ZXing тощо).
+- **ФІНІК** — pages (Overview, Transactions, Analytics, Budgets,
+  Assets), components, hooks, lib + `__tests__`.
+- **ФІЗРУК** — pages, components (workouts, programs, body, progress,
+  measurements, exercise, dashboard), hooks + `__tests__`.
+- **Рутина** — pages (Habits, Heatmap), components, hooks, lib + `__tests__`.
+
+Інфраструктура готова:
+
+- Expo Router (tabs + (auth) модалка), `app.config.ts` з
+  `bundleIdentifier` / `androidPackage` = `com.sergeant.app`;
+- Better Auth Expo-клієнт (bearer у `expo-secure-store`, `docs/mobile.md`);
+- `PushRegistrar` шле native APNs/FCM токен у `POST /api/v1/push/register`
+  з ідемпотентним кешем у `AsyncStorage`;
+- CloudSync + MMKV-офлайн-черга + React Query warm-start (фаза 3);
+- Detox e2e конфіги для iOS і Android у CI (поки smoke-build, реальні
+  сценарії треба дописати).
+
+**Не зроблено:**
+
+- **Харчування (Phase 7)** — лише `ModuleStub` + `DeepLinkPlaceholder`
+  на `scan.tsx` / `recipe/[id].tsx`. Потрібно портувати ~30 компонентів
+  з `apps/web/src/modules/nutrition`, замінити ZXing на `expo-camera` і
+  localStorage на MMKV для комори/списку покупок.
+- **Native push-send pipeline** (APNs через `node-apn`, FCM HTTP v1) —
+  сервер зараз тільки реєструє токени; відправка — окрема задача.
+- **Voice / Speech** — `expo-speech` + STT ще не підключено.
+- **Store-listing** (іконки, privacy manifest iOS, data safety Android).
+
+Повний статус-репорт по всіх трьох поверхнях — `docs/platforms.md`.
 
 ## Запуск
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,182 @@
+# Статус трьох поверхонь — web / native / capacitor-shell
+
+Короткий репорт «що готово до запуску, що треба доробити» по трьох
+варіантах Sergeant-а. Живе поруч з `docs/mobile.md` (API-контракт) і
+`docs/react-native-migration.md` (роадмап порту web → RN).
+
+| Поверхня                       | Де живе             | Технології                 | Реліз-готовність                             |
+| ------------------------------ | ------------------- | -------------------------- | -------------------------------------------- |
+| **Web / PWA** (канонічна апка) | `apps/web`          | React 19 + Vite + PWA      | **Production** (live)                        |
+| **Native RN** (iOS / Android)  | `apps/mobile`       | Expo SDK 52 + Expo Router  | **Internal dev-client**                      |
+| **Capacitor shell** (WebView)  | `apps/mobile-shell` | Capacitor 7 + Android Java | **MVP** (Android closer, iOS blocked on Mac) |
+
+Сервер (`apps/server`) — спільний для всіх трьох, деплой на Railway,
+`/api/v1/*` з Better Auth (cookies для web, bearer для native/shell).
+Конкретний статус сервера тримати тут не будемо — він просто `Production`,
+деталі у `docs/api-v1.md` і `docs/backend-tech-debt.md`.
+
+---
+
+## 1. Web / PWA — `apps/web`
+
+**Що є:** всі чотири модулі (Фінік, Фізрук, Рутина, Харчування) і весь
+Hub-функціонал (AuthContext, HubSearch, HubChat, HubReports,
+OnboardingWizard, WeeklyDigestCard, CoachInsight, VoiceMicButton,
+HubRecommendations, HubSettingsPage), PWA з SW + Web Push через VAPID,
+офлайн-черга через `useCloudSync`. Build artefact — `apps/server/dist`,
+деплой Vercel (статика) → Railway (`/api/*`). Це **головна продакшн-точка**
+Sergeant-а.
+
+**CI:** `ci.yml` (lint + typecheck + vitest + web build),
+`detox-android.yml` / `detox-ios.yml` — це для `apps/mobile`, не для web.
+Preview-деплої на Vercel тепер працюють коректно після fix
+`vercel.json#outputDirectory → apps/server/dist` ([#508](https://github.com/Skords-01/Sergeant/pull/508)).
+
+**Що варто покращити:**
+
+- Два pre-existing flake-и у `src/modules/routine/lib/__tests__/routineStore.test.ts`
+  (`mockEnqueueChange` не отримує `"hub_routine_v1"`). Падають і на main
+  без нових змін — треба окремий PR з фіксом очікувань або заміною
+  stub-а `enqueueChange`.
+- Bundle hygiene: `vendor-zxing` (411kB) і `vendor` (345kB) лишаються
+  великими. У WebView (shell) вони підвантажуються eager — кандидати на
+  lazy-chunk за feature flag.
+- Web push тримає VAPID-keys і `webpush.sendNotification`; APNs/FCM для
+  RN/shell — окремо (див. native секцію).
+- `THIRD_PARTY_LICENSES.md` треба регенерувати при наступному upgrad-і
+  залежностей (не автоматизовано).
+
+**Blocking для релізу:** немає. Запускається як є.
+
+---
+
+## 2. Native RN — `apps/mobile`
+
+**Що є:** Expo Router скафолд (tabs + (auth) модалка), Better Auth
+bearer на SecureStore, `PushRegistrar` з native APNs/FCM токеном,
+CloudSync + MMKV-офлайн-черга + React Query warm-start, і **три з
+чотирьох** модулів портовані повністю з `apps/web`:
+
+- `src/modules/finyk/*` — pages (Overview, Transactions, Analytics,
+  Budgets, Assets), components, hooks, lib + `__tests__`.
+- `src/modules/fizruk/*` — pages, components (workouts, programs, body,
+  progress, measurements, exercise, dashboard), hooks + `__tests__`.
+- `src/modules/routine/*` — pages (Habits, Heatmap), components,
+  hooks, lib + `__tests__`.
+
+**Не зроблено:**
+
+- **Nutrition (Phase 7)** — лише `ModuleStub` + deep-link
+  `DeepLinkPlaceholder` на `scan.tsx` / `recipe/[id].tsx`. Потрібно
+  портувати ~30 компонентів з `apps/web/src/modules/nutrition`,
+  замінити ZXing на `expo-camera` для сканера, AsyncStorage замість
+  `localStorage` для комори/списку покупок.
+- **iOS/Android native push-send path** — сервер зараз тільки реєструє
+  токени у `push_devices`, реальна відправка через APNs (node-apn) / FCM
+  HTTP v1 — окрема задача (див. `docs/mobile.md#push-notifications`).
+- **Voice / Speech** — web використовує Web Speech API; для RN треба
+  `expo-speech` + платформний STT (iOS Speech framework / Android
+  `SpeechRecognizer`). Не початок.
+- **App Store / Play метадані** — `app.config.ts` тримає bundle id
+  `com.sergeant.app`, але store-listing + іконки + privacy manifest
+  (iOS) + data safety form (Android) ще не зібрано.
+- Два Detox конфіги в CI (`detox-ios.yml`, `detox-android.yml`) — наразі
+  тільки smoke-build; реальні e2e-сценарії (login → hub → module) не
+  дописані.
+
+**Що варто покращити:**
+
+- `react-native-worklets` знято з deps ([#509](https://github.com/Skords-01/Sergeant/pull/509)) —
+  був ^0.8.1 несумісний з RN 0.76 і ламав iOS `pod install`. Після
+  апгрейду RN (0.76 → 0.78+) можна повернути пакет за compatibility-таблицею
+  Software Mansion ([docs](https://docs.swmansion.com/react-native-worklets/docs/guides/compatibility/)).
+- Не забути згенерувати `google-services.json` для FCM і покласти
+  його як EAS secret (`GOOGLE_SERVICES_JSON`, type: `file`). Без нього
+  Android-push не стартує (`docs/mobile.md`).
+- На фізичному iOS-девайсі потрібен `development-device` EAS-профіль
+  без `ios.simulator: true` — зараз є тільки simulator-build у
+  `development`.
+
+**Blocking для релізу:** Nutrition-порт (фундамент value prop),
+реальний push-send pipeline, store-listing. До цього — тільки
+internal dev-client.
+
+---
+
+## 3. Capacitor shell — `apps/mobile-shell`
+
+**Що є:** тонкий WebView-обгортка над `apps/web` build. `webDir`
+вказує напряму в `apps/server/dist`, тому жодного копіювання — sync
+бере готовий Vite-артефакт. Закомічені native-плагіни:
+
+- `@capacitor/preferences` — bearer-token storage (Keychain / EncryptedSharedPreferences) [#505](https://github.com/Skords-01/Sergeant/pull/505)
+- `@capacitor/status-bar`, `@capacitor/splash-screen`, `@capacitor/keyboard`, `@capacitor/app` — native UX polish [#506](https://github.com/Skords-01/Sergeant/pull/506)
+- `@capacitor-mlkit/barcode-scanning` — заміна ZXing у WebView [#504](https://github.com/Skords-01/Sergeant/pull/504)
+
+`apps/mobile-shell/src/index.ts` → `initNativeShell()` налаштовує
+status-bar / splash / keyboard / deep-links ідемпотентно. Auth через
+bearer у `auth-storage.ts`, barcode через `barcodeNative.ts` — обидва
+підключаються у `apps/web` динамічним `import()` за guard-ом
+`isCapacitor()` (див. `apps/web/src/shared/lib/platform.ts`).
+
+Android-частина (`android/`) закомічена, `applicationId`
+= `com.sergeant.shell` (навмисно різний з `com.sergeant.app` RN-апки,
+щоби могли співіснувати на одному девайсі).
+
+**Не зроблено:**
+
+- **GitHub Actions workflow для debug-APK.** `apps/mobile-shell/README.md`
+  має TODO: `.github/workflows/mobile-shell-android.yml` треба
+  закомітити мейнтейнеру вручну (Devin OAuth app не має `workflow`
+  scope). Без нього — локальний Android SDK обовʼязковий.
+- **iOS.** `ios/` НЕ закомічено — потрібен Mac + Xcode + CocoaPods для
+  `pnpm --filter @sergeant/mobile-shell add:ios`. Release pipeline на iOS
+  зараз немає.
+- **Native push.** `usePushNotifications` у web користується Service
+  Worker-ом + VAPID — у WebView це працює кульгаво (iOS тільки 16.4+,
+  Android — лише якщо PWA установлено). Повний fix — окремий PR з
+  `@capacitor/push-notifications` (FCM + APNs) і розширенням
+  `createPushEndpoints.register` на `platform: "android" | "ios"`.
+- **Deep links.** `parseDeepLink()` в `src/index.ts` є, але
+  `App.addListener('appUrlOpen', ...)` ще не звʼязаний з React Router
+  всередині `apps/web` — треба exported `navigate()` прокинути.
+- **Safe-area / keyboard avoidance** на iOS усе ще покладаються на
+  CSS `env(safe-area-inset-*)` — працює, але не 100% якщо splash
+  тримається довше за `hide()`.
+
+**Що варто покращити:**
+
+- Bundle size у WebView: сам `apps/web` build важить ~1.2MB gzipped,
+  і перший cold-start через asset-extract довгий. Можна додати
+  `capacitor.config.ts → server.cleartext: false` + виключити service
+  worker з shell-бандла (зараз `sw.js` реєструється намарно — native
+  layer його ігнорує, але код все одно вантажиться).
+- `vite.config.js#manualChunks` вже виключає `/node_modules/@capacitor/`
+  з `vendor` (див. коментар у конфігу) — це навмисно, бо інакше
+  Capacitor-plugin-код їхав би до кожного web-юзера. Підʼєднувати нові
+  plugin-и — оновлювати той коментар ([пр. #505](https://github.com/Skords-01/Sergeant/pull/505)).
+- Split-brain з `apps/mobile`: якщо RN-апка реліз-готова раніше за shell
+  (або навпаки), треба визначитись з product-side, яку постити на store.
+  Жити обидві на одному акаунті Google Play дозволяє (`applicationId`
+  різні), але Apple одне й те саме bundle-prefix обмежує.
+
+**Blocking для релізу:** GitHub Actions workflow для APK (інакше без
+Android SDK локально білд неможливий), native push, iOS `cap add ios` з
+Mac.
+
+---
+
+## Пріоритетна черга (суб'єктивно)
+
+1. **Web + мобільний shell (Android)** — найшвидший шлях до «в руках
+   користувача»: web уже live, shell потребує тільки workflow-файл і
+   підпис APK. **2–3 PR-и.**
+2. **Native RN Nutrition-порт** — найдорожчий шматок (Phase 7),
+   блокує справжній App Store / Play реліз. **4–6 PR-ів.**
+3. **Native push-send (APNs + FCM)** — потрібно для будь-якого з двох
+   native-шляхів. **1–2 PR-и на сервер + 1 клієнт.**
+4. **iOS shell** — потрібен Mac у CI (EAS / GitHub Actions macOS
+   runner), досі заблоковано відсутністю Xcode-env.
+5. **Detox e2e coverage** — зараз білди-smoke; треба реальні сценарії
+   sign-in → module → sign-out, інакше `detox-*` job-и дають false
+   confidence.


### PR DESCRIPTION
## Summary

Adds a consolidated status report for the three Sergeant surfaces and refreshes two README files that had drifted from reality.

**New — `docs/platforms.md`**

A single-page status table + per-surface breakdown (what's in, what's missing, what blocks release) for:

- `apps/web` — **Production**, live on Vercel + Railway; only open items are two pre-existing routine-store flakes and bundle-size tuning.
- `apps/mobile` (Expo RN) — **Internal dev-client**; Finyk / Fizruk / Routine fully ported with tests, Nutrition (Phase 7) still stubbed, native push-send pipeline (APNs + FCM) not yet wired on the server side.
- `apps/mobile-shell` (Capacitor) — **MVP**; bearer-auth ([#505](https://github.com/Skords-01/Sergeant/pull/505)), native barcode scanner ([#504](https://github.com/Skords-01/Sergeant/pull/504)) and status-bar/splash/keyboard/app ([#506](https://github.com/Skords-01/Sergeant/pull/506)) all shipped. Android-closer: a GitHub Actions workflow for debug-APK still needs a maintainer push (Devin OAuth app has no `workflow` scope). iOS blocked on someone running `cap add ios` on a Mac.

Ends with a subjective priority queue (web + Android shell → RN Nutrition port → native push send → iOS shell → real Detox scenarios).

**Refresh — `apps/mobile-shell/README.md`**

Old README framed the package as a "PoC" with auth / native scanner / UX polish all listed as TODO. All three have shipped — rewritten the "Що зроблено" table to point at the PRs, kept the GitHub Actions workflow TODO since that one's still outstanding, clarified Android vs iOS state (iOS `cap add ios` not committed), moved deep-link navigation + iOS safe-area/splash race into "Що НЕ зроблено".

**Refresh — `apps/mobile/README.md` "Статус" section**

Old copy still said "Фаза 0 — скафолд". Replaced with: three of four modules fully ported (Finyk / Fizruk / Routine), full CloudSync + MMKV offline queue, PushRegistrar wired to `/api/v1/push/register`, Detox smoke builds in CI. Nutrition (Phase 7) still stubbed with `ModuleStub` + `DeepLinkPlaceholder`; native push-send pipeline, voice/speech, and store metadata are the other open buckets.

No source code touched — docs-only PR.

## Review & Testing Checklist for Human

- [ ] Sanity-check my "what's shipped" claims for `apps/mobile-shell` match your mental model — I based the three-PR roll-up (#504 / #505 / #506) on the current `android/` tree and `apps/mobile-shell/package.json` dependencies, not on a live build. If #504 ended up differently than the scanner wiring I described, the mobile-shell README needs a tweak.
- [ ] Confirm `apps/mobile` module coverage (Finyk / Fizruk / Routine ported, Nutrition stubbed) — I read it off `ls apps/mobile/src/modules/` + the Expo-router tree under `app/(tabs)/`, so it's a structural check rather than a feature-parity audit.
- [ ] If you disagree with the priority queue at the bottom of `docs/platforms.md` (web+Android shell first, then RN Nutrition, then native push, then iOS, then Detox), push back — that section is opinionated and not derived from any repo artefact.

### Notes

- Kept the GitHub Actions workflow TODO in `apps/mobile-shell/README.md` verbatim — Devin OAuth app still lacks the `workflow` scope, so this can't land via a Devin PR.
- All three docs files link back to `docs/platforms.md` so a reader landing on any of them gets to the full picture in one hop.
- Did not touch `apps/mobile/docs/mobile.md` (EAS build guide) — still accurate, and it's a different abstraction layer than `docs/platforms.md`.

Link to Devin session: https://app.devin.ai/sessions/f6f827849d2847cbb787145844975436
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
