### PR TITLE
test(mobile-shell,web): unit tests for Capacitor shell + bearer-token gate

### DIFF
--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -22,7 +22,9 @@
     "build:web": "pnpm --filter @sergeant/web build",
     "build:android": "pnpm build:web && pnpm sync android",
     "build:ios": "pnpm build:web && pnpm sync ios",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@capacitor-mlkit/barcode-scanning": "^7.5.0",
@@ -37,6 +39,8 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^7.4.3",
-    "typescript": "^6.0.3"
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/mobile-shell/src/auth-storage.test.ts
+++ b/apps/mobile-shell/src/auth-storage.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `auth-storage.ts` — тонка обгортка над `@capacitor/preferences`, уся
+ * логіка зводиться до «бери/пиши/прибирай під ключем `auth.bearer`».
+ * Замість реального KV-сховища мокуємо `Preferences` і перевіряємо
+ * саме контракт виклику: правильний ключ, правильний метод.
+ */
+
+const BEARER_KEY = "auth.bearer";
+
+const get =
+  vi.fn<(args: { key: string }) => Promise<{ value: string | null }>>();
+const set = vi.fn<(args: { key: string; value: string }) => Promise<void>>();
+const remove = vi.fn<(args: { key: string }) => Promise<void>>();
+
+vi.mock("@capacitor/preferences", () => ({
+  Preferences: {
+    get: (args: { key: string }) => get(args),
+    set: (args: { key: string; value: string }) => set(args),
+    remove: (args: { key: string }) => remove(args),
+  },
+}));
+
+beforeEach(() => {
+  get.mockReset();
+  set.mockReset();
+  remove.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getBearerToken", () => {
+  it("викликає Preferences.get({ key: 'auth.bearer' }) і повертає value", async () => {
+    get.mockResolvedValue({ value: "jwt-abc" });
+    const { getBearerToken } = await import("./auth-storage.js");
+
+    const result = await getBearerToken();
+
+    expect(result).toBe("jwt-abc");
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith({ key: BEARER_KEY });
+  });
+
+  it("нормалізує `undefined`/відсутній value у `null`", async () => {
+    // @capacitor/preferences повертає `{ value: null }` для відсутнього
+    // ключа, але ми також хочемо бути стійкими до `{ value: undefined }`.
+    get.mockResolvedValue({ value: null });
+    const { getBearerToken } = await import("./auth-storage.js");
+
+    await expect(getBearerToken()).resolves.toBeNull();
+  });
+});
+
+describe("setBearerToken", () => {
+  it("викликає Preferences.set з правильним ключем і переданим value", async () => {
+    set.mockResolvedValue(undefined);
+    const { setBearerToken } = await import("./auth-storage.js");
+
+    await setBearerToken("new-token");
+
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith({ key: BEARER_KEY, value: "new-token" });
+  });
+});
+
+describe("clearBearerToken", () => {
+  it("викликає Preferences.remove({ key: 'auth.bearer' })", async () => {
+    remove.mockResolvedValue(undefined);
+    const { clearBearerToken } = await import("./auth-storage.js");
+
+    await clearBearerToken();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledWith({ key: BEARER_KEY });
+  });
+});

--- a/apps/mobile-shell/src/index.test.ts
+++ b/apps/mobile-shell/src/index.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Для `initNativeShell()` ми тестуємо лише композицію: що кожен з чотирьох
+ * Capacitor-плагінів був викликаний з правильними аргументами, що помилка
+ * одного не ламає інші, що виклик ідемпотентний і що `appUrlOpen` listener
+ * коректно маршрутизує deep-link. Реальний native-рантайм тут не потрібен.
+ *
+ * Мокуємо через `vi.doMock` (не `vi.mock`) — чистимо й перевстановлюємо
+ * моки в `beforeEach`, а модуль імпортуємо динамічно після налаштування
+ * моків. Це дозволяє скинути module-level `initialized` прапор між тестами
+ * через `vi.resetModules()`.
+ */
+
+type CapacitorMocks = {
+  StatusBar: {
+    setStyle: ReturnType<typeof vi.fn>;
+    setBackgroundColor: ReturnType<typeof vi.fn>;
+  };
+  SplashScreen: { hide: ReturnType<typeof vi.fn> };
+  Keyboard: { setResizeMode: ReturnType<typeof vi.fn> };
+  App: { addListener: ReturnType<typeof vi.fn> };
+};
+
+type UrlOpenCallback = (event: { url: string }) => void;
+
+function installCapacitorMocks(): CapacitorMocks {
+  const StatusBar = {
+    setStyle: vi.fn().mockResolvedValue(undefined),
+    setBackgroundColor: vi.fn().mockResolvedValue(undefined),
+  };
+  const SplashScreen = { hide: vi.fn().mockResolvedValue(undefined) };
+  const Keyboard = { setResizeMode: vi.fn().mockResolvedValue(undefined) };
+  const App = {
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  };
+
+  vi.doMock("@capacitor/status-bar", () => ({
+    StatusBar,
+    Style: { Dark: "DARK", Light: "LIGHT", Default: "DEFAULT" },
+  }));
+  vi.doMock("@capacitor/splash-screen", () => ({ SplashScreen }));
+  vi.doMock("@capacitor/keyboard", () => ({
+    Keyboard,
+    KeyboardResize: {
+      Body: "body",
+      Ionic: "ionic",
+      Native: "native",
+      None: "none",
+    },
+  }));
+  vi.doMock("@capacitor/app", () => ({ App }));
+
+  return { StatusBar, SplashScreen, Keyboard, App };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  document.documentElement.classList.remove("dark");
+});
+
+afterEach(() => {
+  vi.doUnmock("@capacitor/status-bar");
+  vi.doUnmock("@capacitor/splash-screen");
+  vi.doUnmock("@capacitor/keyboard");
+  vi.doUnmock("@capacitor/app");
+  vi.restoreAllMocks();
+});
+
+describe("parseDeepLink", () => {
+  it("повертає `/home` для `com.sergeant.shell://home`", async () => {
+    installCapacitorMocks();
+    const { parseDeepLink } = await import("./index.js");
+    expect(parseDeepLink("com.sergeant.shell://home")).toBe("/home");
+  });
+
+  it("зберігає query+hash: `/home?x=1#frag`", async () => {
+    installCapacitorMocks();
+    const { parseDeepLink } = await import("./index.js");
+    expect(parseDeepLink("com.sergeant.shell://home?x=1#frag")).toBe(
+      "/home?x=1#frag",
+    );
+  });
+
+  it("нормалізує `com.sergeant.shell:///home` → `/home` (не дублює ведучий `/`)", async () => {
+    installCapacitorMocks();
+    const { parseDeepLink } = await import("./index.js");
+    expect(parseDeepLink("com.sergeant.shell:///home")).toBe("/home");
+  });
+
+  it.each([
+    "https://sergeant.app/home",
+    "foo://home",
+    "",
+    "com.sergeant.shel://home", // очепятка в схемі
+  ])("повертає null для `%s`", async (url) => {
+    installCapacitorMocks();
+    const { parseDeepLink } = await import("./index.js");
+    expect(parseDeepLink(url)).toBeNull();
+  });
+});
+
+describe("initNativeShell — композиція плагінів", () => {
+  it("викликає StatusBar + SplashScreen + Keyboard + App.addListener з правильними аргументами (light-тема)", async () => {
+    const mocks = installCapacitorMocks();
+    const { initNativeShell } = await import("./index.js");
+
+    await initNativeShell();
+
+    expect(mocks.StatusBar.setStyle).toHaveBeenCalledTimes(1);
+    expect(mocks.StatusBar.setStyle).toHaveBeenCalledWith({ style: "LIGHT" });
+    expect(mocks.StatusBar.setBackgroundColor).toHaveBeenCalledTimes(1);
+    expect(mocks.StatusBar.setBackgroundColor).toHaveBeenCalledWith({
+      color: "#fdf9f3",
+    });
+    expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
+    expect(mocks.SplashScreen.hide).toHaveBeenCalledWith({
+      fadeOutDuration: 250,
+    });
+    expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
+    expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledWith({ mode: "body" });
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledWith(
+      "appUrlOpen",
+      expect.any(Function),
+    );
+  });
+
+  it("у dark-темі застосовує dark style + #171412 background", async () => {
+    const mocks = installCapacitorMocks();
+    document.documentElement.classList.add("dark");
+
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell();
+
+    expect(mocks.StatusBar.setStyle).toHaveBeenCalledWith({ style: "DARK" });
+    expect(mocks.StatusBar.setBackgroundColor).toHaveBeenCalledWith({
+      color: "#171412",
+    });
+  });
+});
+
+describe("initNativeShell — ідемпотентність", () => {
+  it("другий і третій виклики — no-op (лічильники моків не зростають)", async () => {
+    const mocks = installCapacitorMocks();
+    const { initNativeShell } = await import("./index.js");
+
+    await initNativeShell();
+    await initNativeShell();
+    await initNativeShell();
+
+    expect(mocks.StatusBar.setStyle).toHaveBeenCalledTimes(1);
+    expect(mocks.StatusBar.setBackgroundColor).toHaveBeenCalledTimes(1);
+    expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
+    expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("initNativeShell — ізоляція помилок", () => {
+  it("якщо StatusBar падає, SplashScreen/Keyboard/App все одно викликаються", async () => {
+    const mocks = installCapacitorMocks();
+    mocks.StatusBar.setStyle.mockRejectedValueOnce(new Error("boom"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell();
+
+    expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
+    expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    // StatusBar warn-повідомлення вилетіло — інакше користувач побачив би
+    // лише «мовчки не спрацювало».
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArg = warnSpy.mock.calls[0]?.[0];
+    expect(String(warnArg)).toContain("StatusBar");
+  });
+
+  it("якщо SplashScreen.hide падає, App.addListener все одно реєструється", async () => {
+    const mocks = installCapacitorMocks();
+    mocks.SplashScreen.hide.mockRejectedValueOnce(new Error("boom"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell();
+
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("initNativeShell — deep-link listener", () => {
+  async function captureUrlOpenCallback(
+    mocks: CapacitorMocks,
+    options: { navigate?: (path: string) => void } = {},
+  ): Promise<UrlOpenCallback> {
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell(options);
+
+    const call = mocks.App.addListener.mock.calls[0];
+    expect(call?.[0]).toBe("appUrlOpen");
+    const cb = call?.[1] as UrlOpenCallback;
+    expect(typeof cb).toBe("function");
+    return cb;
+  }
+
+  it("викликає options.navigate з витягнутим шляхом", async () => {
+    const mocks = installCapacitorMocks();
+    const navigate = vi.fn();
+
+    const cb = await captureUrlOpenCallback(mocks, { navigate });
+    cb({ url: "com.sergeant.shell://settings" });
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/settings");
+  });
+
+  it("НЕ викликає navigate для чужого URL (https://…)", async () => {
+    const mocks = installCapacitorMocks();
+    const navigate = vi.fn();
+
+    const cb = await captureUrlOpenCallback(mocks, { navigate });
+    cb({ url: "https://example.com" });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("без options.navigate — fallback на window.location.assign", async () => {
+    const mocks = installCapacitorMocks();
+    const assign = vi.fn();
+    // `window.location.assign` у jsdom не конфігурується точково, тому
+    // підміняємо весь `window.location` — цього достатньо для тесту.
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign },
+    });
+
+    try {
+      const cb = await captureUrlOpenCallback(mocks);
+      cb({ url: "com.sergeant.shell://home" });
+
+      expect(assign).toHaveBeenCalledTimes(1);
+      expect(assign).toHaveBeenCalledWith("/home");
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+});

--- a/apps/mobile-shell/src/platform.test.ts
+++ b/apps/mobile-shell/src/platform.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Тонка обгортка над `@capacitor/core`.Capacitor — весь тест зводиться до
+ * того, щоб `isCapacitor()` чесно проксі-викликав `isNativePlatform()`, а
+ * `getPlatform()` нормалізував `getPlatform()` до вузького union-а
+ * `'web' | 'ios' | 'android'` (усе, що не `ios`/`android` → `web`).
+ */
+
+const isNativePlatform = vi.fn<() => boolean>();
+const getPlatform = vi.fn<() => string>();
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => isNativePlatform(),
+    getPlatform: () => getPlatform(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  isNativePlatform.mockReset();
+  getPlatform.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isCapacitor", () => {
+  it("повертає true, коли Capacitor.isNativePlatform() = true", async () => {
+    isNativePlatform.mockReturnValue(true);
+    const mod = await import("./platform.js");
+    expect(mod.isCapacitor()).toBe(true);
+    expect(isNativePlatform).toHaveBeenCalledTimes(1);
+  });
+
+  it("повертає false, коли Capacitor.isNativePlatform() = false", async () => {
+    isNativePlatform.mockReturnValue(false);
+    const mod = await import("./platform.js");
+    expect(mod.isCapacitor()).toBe(false);
+  });
+});
+
+describe("getPlatform", () => {
+  it.each([
+    ["ios", "ios"],
+    ["android", "android"],
+  ] as const)(
+    "проксі-викликає Capacitor.getPlatform() і повертає %s як %s",
+    async (input, expected) => {
+      getPlatform.mockReturnValue(input);
+      const mod = await import("./platform.js");
+      expect(mod.getPlatform()).toBe(expected);
+    },
+  );
+
+  it.each(["web", "windows", "macos", "", "unknown"])(
+    "нормалізує невідоме значення (%s) у 'web'",
+    async (input) => {
+      getPlatform.mockReturnValue(input);
+      const mod = await import("./platform.js");
+      expect(mod.getPlatform()).toBe("web");
+    },
+  );
+});

--- a/apps/mobile-shell/vitest.config.ts
+++ b/apps/mobile-shell/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/apps/web/src/shared/lib/bearerToken.test.ts
+++ b/apps/web/src/shared/lib/bearerToken.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `bearerToken.ts` — це гейт навколо `@sergeant/mobile-shell/auth-storage`:
+ *   1. Поза Capacitor (`isCapacitor()=false`) усі три функції — no-op,
+ *      ніякого динамічного імпорту взагалі.
+ *   2. У Capacitor — делегує до нативного сховища.
+ *   3. Якщо динамічний імпорт падає (наприклад, виявилось, що shell не
+ *      залінкований у білд) — `getBearerToken` повертає `null`,
+ *      `set`/`clear` — тихі no-op. Помилка не пропагує.
+ *   4. Якщо модуль резолвиться, але окремий метод кидає — такий самий
+ *      резилієнс.
+ *
+ * Тести побудовані на `vi.doMock` + `vi.resetModules()`, щоб кожен
+ * сценарій отримував свіжий модуль з новою конфігурацією моків (інакше
+ * `vi.mock` кешувався б між тестами).
+ */
+
+const isCapacitorMock = vi.fn<() => boolean>();
+
+// `@sergeant/shared` — єдине, що `bearerToken.ts` імпортує статично.
+// Мокуємо тільки `isCapacitor` — решту експорту лишаємо актуальною через
+// `importActual`, щоб випадкові транзитивні імпорти не ламались.
+vi.mock("@sergeant/shared", async () => {
+  const actual =
+    await vi.importActual<typeof import("@sergeant/shared")>(
+      "@sergeant/shared",
+    );
+  return { ...actual, isCapacitor: () => isCapacitorMock() };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  isCapacitorMock.mockReset();
+});
+
+afterEach(() => {
+  vi.doUnmock("@sergeant/mobile-shell/auth-storage");
+  vi.restoreAllMocks();
+});
+
+describe("поза Capacitor — все no-op", () => {
+  beforeEach(() => {
+    isCapacitorMock.mockReturnValue(false);
+  });
+
+  it("getBearerToken повертає null і НЕ підтягує auth-storage модуль", async () => {
+    // Якщо модуль всередині `loadStorage()` все-таки почне резолвитись,
+    // мок кине і ми побачимо це у звіті.
+    const importSpy = vi.fn(async () => {
+      throw new Error("dynamic import should not be called in web branch");
+    });
+    vi.doMock("@sergeant/mobile-shell/auth-storage", importSpy);
+
+    const { getBearerToken } = await import("./bearerToken.js");
+    await expect(getBearerToken()).resolves.toBeNull();
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it("setBearerToken — тихий no-op, не кидає, не викликає storage", async () => {
+    const setSpy = vi.fn();
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: setSpy,
+      clearBearerToken: vi.fn(),
+    }));
+
+    const { setBearerToken } = await import("./bearerToken.js");
+    await expect(setBearerToken("x")).resolves.toBeUndefined();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("clearBearerToken — тихий no-op, не кидає, не викликає storage", async () => {
+    const clearSpy = vi.fn();
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: vi.fn(),
+      clearBearerToken: clearSpy,
+    }));
+
+    const { clearBearerToken } = await import("./bearerToken.js");
+    await expect(clearBearerToken()).resolves.toBeUndefined();
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("у Capacitor — делегує до auth-storage", () => {
+  beforeEach(() => {
+    isCapacitorMock.mockReturnValue(true);
+  });
+
+  it("getBearerToken делегує до storage.getBearerToken", async () => {
+    const storageGet = vi.fn(async () => "tok-42");
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: storageGet,
+      setBearerToken: vi.fn(),
+      clearBearerToken: vi.fn(),
+    }));
+
+    const { getBearerToken } = await import("./bearerToken.js");
+    await expect(getBearerToken()).resolves.toBe("tok-42");
+    expect(storageGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("setBearerToken делегує до storage.setBearerToken з тим самим токеном", async () => {
+    const storageSet = vi.fn(async () => undefined);
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: storageSet,
+      clearBearerToken: vi.fn(),
+    }));
+
+    const { setBearerToken } = await import("./bearerToken.js");
+    await setBearerToken("jwt-xyz");
+    expect(storageSet).toHaveBeenCalledTimes(1);
+    expect(storageSet).toHaveBeenCalledWith("jwt-xyz");
+  });
+
+  it("clearBearerToken делегує до storage.clearBearerToken", async () => {
+    const storageClear = vi.fn(async () => undefined);
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: vi.fn(),
+      clearBearerToken: storageClear,
+    }));
+
+    const { clearBearerToken } = await import("./bearerToken.js");
+    await clearBearerToken();
+    expect(storageClear).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("резилієнс: dynamic import падає", () => {
+  beforeEach(() => {
+    isCapacitorMock.mockReturnValue(true);
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => {
+      throw new Error("module resolve failure");
+    });
+  });
+
+  it("getBearerToken повертає null, не кидає", async () => {
+    const { getBearerToken } = await import("./bearerToken.js");
+    await expect(getBearerToken()).resolves.toBeNull();
+  });
+
+  it("setBearerToken — тихий no-op, не кидає", async () => {
+    const { setBearerToken } = await import("./bearerToken.js");
+    await expect(setBearerToken("x")).resolves.toBeUndefined();
+  });
+
+  it("clearBearerToken — тихий no-op, не кидає", async () => {
+    const { clearBearerToken } = await import("./bearerToken.js");
+    await expect(clearBearerToken()).resolves.toBeUndefined();
+  });
+});
+
+describe("резилієнс: модуль резолвиться, але окремий метод кидає", () => {
+  beforeEach(() => {
+    isCapacitorMock.mockReturnValue(true);
+  });
+
+  it("getBearerToken ловить помилку storage і повертає null", async () => {
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(async () => {
+        throw new Error("keychain unavailable");
+      }),
+      setBearerToken: vi.fn(),
+      clearBearerToken: vi.fn(),
+    }));
+
+    const { getBearerToken } = await import("./bearerToken.js");
+    await expect(getBearerToken()).resolves.toBeNull();
+  });
+
+  it("setBearerToken ловить помилку storage і тихо завершується", async () => {
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+      clearBearerToken: vi.fn(),
+    }));
+
+    const { setBearerToken } = await import("./bearerToken.js");
+    await expect(setBearerToken("x")).resolves.toBeUndefined();
+  });
+
+  it("clearBearerToken ловить помилку storage і тихо завершується", async () => {
+    vi.doMock("@sergeant/mobile-shell/auth-storage", () => ({
+      getBearerToken: vi.fn(),
+      setBearerToken: vi.fn(),
+      clearBearerToken: vi.fn(async () => {
+        throw new Error("keychain locked");
+      }),
+    }));
+
+    const { clearBearerToken } = await import("./bearerToken.js");
+    await expect(clearBearerToken()).resolves.toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,9 +255,15 @@ importers:
       "@capacitor/cli":
         specifier: ^7.4.3
         version: 7.6.2
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.2.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@1.21.7)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/server:
     dependencies:


### PR DESCRIPTION
## Summary

Додає Vitest unit-тести до свіжододаних mobile-shell модулів (PR-и #502-#506), які раніше не мали окремих тест-файлів. Жодних змін у runtime-коді (`index.ts`, `bearerToken.ts`, `platform.ts`, `auth-storage.ts`) — тільки тести + мінімальний Vitest setup для `@sergeant/mobile-shell`.

### Нові тест-файли

- **`apps/mobile-shell/src/index.test.ts`** — `parseDeepLink()` (щасливі шляхи, query+hash збереження, нормалізація подвійного слеша, чужі схеми → `null`) + `initNativeShell()` (композиція всіх 4 плагінів із правильними аргументами, light/dark-тема, ідемпотентність після 2-3 викликів, ізоляція помилок одного плагіна, deep-link listener із `options.navigate` / fallback на `window.location.assign`).
- **`apps/web/src/shared/lib/bearerToken.test.ts`** — поза Capacitor усі три функції — no-op і не підтягують shell-модуль; у Capacitor — делегація до `@sergeant/mobile-shell/auth-storage`; резилієнс на падіння dynamic-import-у та на падіння окремого методу сховища (`getBearerToken → null`, set/clear — тихі no-op).
- **`apps/mobile-shell/src/auth-storage.test.ts`** — `@capacitor/preferences` змокано; перевіряємо що `get`/`set`/`remove` викликаються з ключем `auth.bearer` і переданим значенням.
- **`apps/mobile-shell/src/platform.test.ts`** — `@capacitor/core` Capacitor змокано; `isCapacitor()` проксі-викликає `isNativePlatform()`, `getPlatform()` нормалізує невідомі значення (`web`, `windows`, `""`, ...) у `'web'`.

### Інфраструктура

`apps/mobile-shell` раніше не мав тестового runner-а:

- `apps/mobile-shell/package.json`: додано `test` + `test:watch` скрипти, devDeps `vitest@^3.0.0` і `jsdom@^29.0.2` (збігаються з іншими пакетами).
- `apps/mobile-shell/vitest.config.ts`: мінімальний конфіг з `environment: "node"` + `passWithNoTests: true` за взірцем `packages/shared/vitest.config.ts`; `index.test.ts` оголошує `// @vitest-environment jsdom` локально (він один потребує `document`/`window`).
- Існуючий `tsconfig.json` уже покриває `src/**/*.ts`, тож окремого `tsconfig.test.json` не знадобилося.

Турбо-pipeline `pnpm -w test` автоматично підхоплює новий `test` скрипт, і `pnpm --filter @sergeant/mobile-shell test` локально проходить 28/28 (index: 15, auth-storage: 4, platform: 9). `apps/web` bearerToken-тест проходить 12/12.

## Review & Testing Checklist for Human

- [ ] Перевір, що `pnpm -w test` локально зелений для двох пакетів, які торкнулися: `@sergeant/mobile-shell` і `@sergeant/web` (NB: `@sergeant/mobile` має 2 прекс-існуючі флакі-тести у `routineStore.test.ts`, не повʼязані з цим PR — відтворюються на чистому `main`).
- [ ] Перевір, що `pnpm -w typecheck` і `pnpm -w lint` лишаються зеленими — конфіг `types: []` у `apps/mobile-shell/tsconfig.json` не тягне vitest globals, бо тести імпортують `describe/it/expect/vi` явно з `"vitest"`.
- [ ] Окремо перевір `initNativeShell` idempotence-тест: він спирається на module-level `initialized` прапор, тому в тесті використано `vi.resetModules()` + динамічний `await import("./index.js")` у кожному `it()` — якщо хтось прибере `vi.resetModules()`, тести на композицію/ідемпотентність почнуть інтерферувати.

### Notes

- Під час написання знайшов один дрібний нюанс runtime-коду: у `parseDeepLink()` подвійний слеш `com.sergeant.shell:///home` нормалізується коректно (`rest.startsWith("/")` не дублює ведучий `/`). Тест зафіксовує цю інваріанту.
- Не правив `.github/workflows/**`, `apps/server/**`, `apps/mobile/**` згідно скоупу.
- В `index.test.ts` тест на `window.location.assign` fallback підміняє весь `window.location` через `Object.defineProperty(window, "location", ...)` з наступним відновленням — jsdom не дозволяє локальне перевизначення `.assign` (non-configurable property).


Link to Devin session: https://app.devin.ai/sessions/e7142bb663da4f3eb3b9cda6b7440c92
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
