### PR TITLE
feat(mobile-shell): native push-notifications via @capacitor/push-notifications

### DIFF
--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -10,7 +10,8 @@
     ".": "./src/index.ts",
     "./platform": "./src/platform.ts",
     "./barcodeNative": "./src/barcodeNative.ts",
-    "./auth-storage": "./src/auth-storage.ts"
+    "./auth-storage": "./src/auth-storage.ts",
+    "./pushNative": "./src/pushNative.ts"
   },
   "scripts": {
     "sync": "cap sync",
@@ -32,6 +33,7 @@
     "@capacitor/ios": "^7.4.3",
     "@capacitor/keyboard": "^7.0.3",
     "@capacitor/preferences": "^7.0.4",
+    "@capacitor/push-notifications": "^7.0.3",
     "@capacitor/splash-screen": "^7.0.3",
     "@capacitor/status-bar": "^7.0.3"
   },

--- a/apps/mobile-shell/src/pushNative.ts
+++ b/apps/mobile-shell/src/pushNative.ts
@@ -1,0 +1,273 @@
+/**
+ * Native push subscription adapter для Capacitor WebView.
+ *
+ * Це єдине місце у workspace, де `@capacitor/push-notifications` і
+ * `@capacitor/preferences` імпортуються **compile-time**. Веб-код
+ * (`apps/web`) ніколи не тягне цей модуль напряму — він доступний
+ * виключно через динамічний `import("@sergeant/mobile-shell/pushNative")`
+ * у гейті `apps/web/src/shared/lib/pushNative.ts`, який в свою чергу
+ * викликається тільки під guard-ом `isCapacitor()`. Завдяки цьому Rollup
+ * виносить FCM/APNs-рантайм у окремий async chunk, який браузерні
+ * користувачі ніколи не завантажують (див. `vite.config.js`, блок
+ * `manualChunks`, catch-all для `@capacitor/*`).
+ *
+ * Чому listener-и треба **явно прибирати** на `unsubscribeNativePush()`:
+ *   - `PushNotifications.addListener("registration", ...)` на Android
+ *     зберігає посилання на JS-callback у нативному Bridge; між сесіями
+ *     WebView (cold-start, HMR у LiveReload) вони акумулюються і
+ *     `register()` починає резолвити resolve-и з попередніх mount-ів.
+ *   - `removeAllListeners()` — офіційний API плагіна (`@since 1.0.0`)
+ *     для очищення, еквівалент web-side `off()`-ів. Після нього
+ *     `unregister()` вже не тригерить фантомні `registration`-колбеки.
+ *
+ * Чому `subscribeNativePush()` сам додає `registration` / `registrationError`
+ * listener-и, а не реєструється глобально у `index.ts`:
+ *   - Ми не хочемо тримати пам'ять під колбеки, поки юзер не натисне
+ *     "увімкнути сповіщення" — це сотні KB нативного bridge-коду на
+ *     iOS, який зайвий без згоди користувача.
+ *   - Listener-и — локальні до одного виклику `register()` (resolve/reject
+ *     Promise-а), після чого їх треба прибрати, щоб не ловити наступний
+ *     `registration` (наприклад, якщо користувач перевідкрив додаток
+ *     і ОС перевидала токен).
+ *
+ * Чому ми кешуємо opaque token у `@capacitor/preferences`:
+ *   - Для `unsubscribeNativePush()` нам треба той самий токен, що ми
+ *     відіслали на сервер, інакше `push_devices` soft-delete не знайде
+ *     запис. Але native-`register()` після першої успішної реєстрації
+ *     може не тригерити `registration` подію повторно — сховище у
+ *     Keychain / EncryptedSharedPreferences є єдиним джерелом правди
+ *     між cold-start-ами WebView.
+ *   - Той же патерн, що у `auth-storage.ts`: namespaced ключ,
+ *     get/set/clear. Веб-сторона синхронно не читає це сховище —
+ *     через `@sergeant/mobile-shell/pushNative` gate.
+ */
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
+import { Preferences } from "@capacitor/preferences";
+import {
+  PushNotifications,
+  type RegistrationError,
+  type Token,
+} from "@capacitor/push-notifications";
+
+/**
+ * Вузький union, симетричний `PushRegisterRequest["platform"]` у
+ * `@sergeant/api-client`. `"web"` тут свідомо відсутній — native-шлях
+ * завжди або iOS, або Android.
+ */
+export type NativePushPlatform = "ios" | "android";
+
+/**
+ * Результат успішної нативної реєстрації push-пристрою. `token` — opaque
+ * APNs hex (iOS) або FCM registration token (Android), сервер трактує
+ * його непрозоро і зберігає у `push_devices` (див. `apps/server/src/routes/push.ts`).
+ */
+export interface NativePushSubscription {
+  platform: NativePushPlatform;
+  token: string;
+}
+
+/**
+ * Ключ у KV-сховищі для останнього отриманого native push-токена.
+ * `push.native.token` — namespaced у тому ж `push.*`-префіксі, що й
+ * майбутні push-налаштування (напр. локальні preference-и відображення).
+ */
+const NATIVE_PUSH_TOKEN_KEY = "push.native.token";
+
+/**
+ * Повертає `"ios"` або `"android"` для native WebView, `null` — якщо
+ * plugin викликано не з native-контексту (захист для тестів / помилкового
+ * прямого імпорту з веба). Рефлектує `Capacitor.getPlatform()`, а не
+ * `process.platform`, щоб робилось виключно на runtime.
+ */
+function detectNativePlatform(): NativePushPlatform | null {
+  const platform = Capacitor.getPlatform();
+  if (platform === "ios" || platform === "android") return platform;
+  return null;
+}
+
+/**
+ * Знімає всі push-listener-и, ігноруючи помилки плагіна. Спільна утиліта
+ * для `subscribeNativePush` (clean-up перед новою реєстрацією, щоб старі
+ * resolve-и з попередніх спроб не злетіли на поточний Promise) і для
+ * `unsubscribeNativePush`.
+ */
+async function safeRemoveAllListeners(): Promise<void> {
+  try {
+    await PushNotifications.removeAllListeners();
+  } catch {
+    // Плагін на web-платформі кидає "not implemented" — це ок: ми
+    // явно не очікуємо, що нас викличуть поза native, але на
+    // мокнутому рантаймі (unit-test) не хочемо валити flow.
+  }
+}
+
+/**
+ * Запитує дозвіл на push, реєструє пристрій в FCM (Android) / APNs (iOS)
+ * і резолвиться, коли плагін повідомить `"registration"` з токеном.
+ *
+ * Поведінка:
+ *   1. `requestPermissions()` — якщо юзер відмовив, повертаємо
+ *      rejection з `"push-permission-denied"`. Calling-hook мапить це
+ *      у UI-повідомлення (без toast-а з тех. помилкою).
+ *   2. Ставимо одноразові listener-и на `"registration"` і
+ *      `"registrationError"` (resolve/reject першого спрацьованого),
+ *      після resolve/reject прибираємо ОБИДВА, щоб не реагувати на
+ *      повторні події ОС.
+ *   3. `register()` — дозволяє плагіну почати реєстрацію у FCM/APNs.
+ *   4. На resolve зберігаємо token у `@capacitor/preferences`, щоб
+ *      `unsubscribeNativePush()` потім знав, який токен слати на
+ *      `/api/v1/push/unregister`.
+ *
+ * НЕ використовує `Notification.requestPermission()` / Service Worker —
+ * native-гілка повністю ортогональна до Web Push, і SW-реєстрації у
+ * WebView на iOS взагалі немає.
+ */
+export async function subscribeNativePush(): Promise<NativePushSubscription> {
+  const platform = detectNativePlatform();
+  if (!platform) {
+    throw new Error("push-native-unavailable");
+  }
+
+  const permission = await PushNotifications.requestPermissions();
+  if (permission.receive !== "granted") {
+    throw new Error("push-permission-denied");
+  }
+
+  // Очищаємо хвости попередніх реєстрацій — на Android listener-и
+  // персистяться між mount-ами WebView і можуть резолвити наш Promise
+  // старим токеном ще до того, як `register()` зробить нову ітерацію.
+  await safeRemoveAllListeners();
+
+  const token = await new Promise<string>((resolve, reject) => {
+    let registrationHandle: PluginListenerHandle | undefined;
+    let errorHandle: PluginListenerHandle | undefined;
+    let settled = false;
+
+    const cleanup = async (): Promise<void> => {
+      try {
+        await registrationHandle?.remove();
+      } catch {
+        // handle.remove() може бути недоступним у старіших версіях
+        // плагіна — fallback на global removeAllListeners().
+      }
+      try {
+        await errorHandle?.remove();
+      } catch {
+        /* noop — див. коментар вище */
+      }
+      await safeRemoveAllListeners();
+    };
+
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      void cleanup().finally(fn);
+    };
+
+    void PushNotifications.addListener("registration", (t: Token) => {
+      settle(() => {
+        if (typeof t.value === "string" && t.value.length > 0) {
+          resolve(t.value);
+        } else {
+          reject(new Error("push-registration-empty-token"));
+        }
+      });
+    })
+      .then((h) => {
+        registrationHandle = h;
+      })
+      .catch((err) => {
+        settle(() => reject(err as Error));
+      });
+
+    void PushNotifications.addListener(
+      "registrationError",
+      (e: RegistrationError) => {
+        settle(() => reject(new Error(e.error || "push-registration-error")));
+      },
+    )
+      .then((h) => {
+        errorHandle = h;
+      })
+      .catch((err) => {
+        settle(() => reject(err as Error));
+      });
+
+    // `register()` повертає одразу; реальний результат приходить через
+    // listener вище. Якщо саме цей виклик провалився синхронно —
+    // мапимо це у reject Promise-а.
+    void PushNotifications.register().catch((err: unknown) => {
+      settle(() =>
+        reject(err instanceof Error ? err : new Error("push-register-failed")),
+      );
+    });
+  });
+
+  await setStoredNativePushToken(token);
+  return { platform, token };
+}
+
+/**
+ * Знімає push-реєстрацію: прибирає listener-и, викликає `unregister()`
+ * (на Android чистить FCM token у Firebase, на iOS — APNs registration),
+ * чистить локальний кеш токена. Мовчки ковтає будь-які помилки
+ * (idempotent): якщо плагін недоступний або вже без реєстрації, UI все
+ * одно має перейти у стан "виключено".
+ *
+ * Повертає кешований токен (який був в `@capacitor/preferences` до
+ * чистки), щоб calling-hook міг відправити `/api/v1/push/unregister`
+ * з правильним ідентифікатором.
+ */
+export async function unsubscribeNativePush(): Promise<string | null> {
+  const cached = await getStoredNativePushToken();
+
+  await safeRemoveAllListeners();
+
+  try {
+    await PushNotifications.unregister();
+  } catch {
+    // На web-платформі або у тестах плагін кидає "not implemented";
+    // не критично — state-вихід все одно проганяємо, щоб UI не застряг
+    // у "увімкнено" після fail-у native-шару.
+  }
+
+  await clearStoredNativePushToken();
+  return cached;
+}
+
+/**
+ * Читає збережений native push-токен або `null`, якщо ще не
+ * реєструвалися (або після `clearStoredNativePushToken`).
+ */
+export async function getStoredNativePushToken(): Promise<string | null> {
+  try {
+    const { value } = await Preferences.get({ key: NATIVE_PUSH_TOKEN_KEY });
+    return value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Зберігає останній отриманий native push-токен у безпечне сховище
+ * (Keychain iOS / EncryptedSharedPreferences Android).
+ */
+export async function setStoredNativePushToken(token: string): Promise<void> {
+  try {
+    await Preferences.set({ key: NATIVE_PUSH_TOKEN_KEY, value: token });
+  } catch {
+    // Збій збереження не ламає user-flow: у найгіршому випадку
+    // на наступному unsubscribe ми просто не матимемо опорного
+    // токена і серверний запис буде почищено cron-ом неактивних.
+  }
+}
+
+/** Видаляє кешований native push-токен (на `unsubscribe` або 401 з сервера). */
+export async function clearStoredNativePushToken(): Promise<void> {
+  try {
+    await Preferences.remove({ key: NATIVE_PUSH_TOKEN_KEY });
+  } catch {
+    // Symmetric з set: fallback — токен перезапишеться при наступній
+    // успішній реєстрації.
+  }
+}

--- a/apps/web/src/shared/hooks/usePushNotifications.test.tsx
+++ b/apps/web/src/shared/hooks/usePushNotifications.test.tsx
@@ -32,8 +32,47 @@ vi.mock("@shared/api", async () => {
   };
 });
 
+// Mock `@sergeant/shared` tо контролювати `isCapacitor()` / `getPlatform()`
+// per-test — інакше native-гілку не перевіриш у jsdom без реального
+// Capacitor-рантайму.
+vi.mock("@sergeant/shared", async () => {
+  const actual =
+    await vi.importActual<typeof import("@sergeant/shared")>(
+      "@sergeant/shared",
+    );
+  return {
+    ...actual,
+    isCapacitor: vi.fn(() => false),
+    getPlatform: vi.fn(() => "web"),
+  };
+});
+
+// Mock native push gate — у юніт-тестах не тягнемо `@sergeant/mobile-shell`
+// (workspace-лінк є, але плагін сам кине "not implemented" у jsdom).
+vi.mock("@shared/lib/pushNative", () => ({
+  subscribeNativePush: vi.fn(),
+  unsubscribeNativePush: vi.fn(),
+  getStoredNativePushToken: vi.fn(),
+}));
+
 import { usePushNotifications } from "./usePushNotifications.js";
 import { pushApi } from "@shared/api";
+import { getPlatform, isCapacitor } from "@sergeant/shared";
+import {
+  getStoredNativePushToken,
+  subscribeNativePush,
+  unsubscribeNativePush,
+} from "@shared/lib/pushNative";
+
+const isCapacitorMock = isCapacitor as unknown as ReturnType<typeof vi.fn>;
+const getPlatformMock = getPlatform as unknown as ReturnType<typeof vi.fn>;
+const subscribeNativePushMock = subscribeNativePush as unknown as ReturnType<
+  typeof vi.fn
+>;
+const unsubscribeNativePushMock =
+  unsubscribeNativePush as unknown as ReturnType<typeof vi.fn>;
+const getStoredNativePushTokenMock =
+  getStoredNativePushToken as unknown as ReturnType<typeof vi.fn>;
 
 const getVapidPublicMock = pushApi.getVapidPublic as unknown as ReturnType<
   typeof vi.fn
@@ -158,6 +197,8 @@ describe("usePushNotifications — subscribe via api.push.register", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    isCapacitorMock.mockReturnValue(false);
+    getPlatformMock.mockReturnValue("web");
     getVapidPublicMock.mockResolvedValue({ publicKey: "AAAA" });
     legacyUnsubscribeMock.mockResolvedValue({ ok: true });
   });
@@ -233,6 +274,8 @@ describe("usePushNotifications — unsubscribe via api.push.unregister", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    isCapacitorMock.mockReturnValue(false);
+    getPlatformMock.mockReturnValue("web");
     getVapidPublicMock.mockResolvedValue({ publicKey: "AAAA" });
   });
 
@@ -308,6 +351,189 @@ describe("usePushNotifications — unsubscribe via api.push.unregister", () => {
 
     expect(unregisterMock).not.toHaveBeenCalled();
     // Локальний стан все одно чиститься, щоб UI не лишився «увімкненим».
+    expect(localStorage.getItem("hub_push_subscribed")).toBeNull();
+    expect(result.current.subscribed).toBe(false);
+  });
+});
+
+describe("usePushNotifications — native Capacitor branch", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    // Native-контекст: `isCapacitor()` → true. Web Push API (navigator.serviceWorker,
+    // Notification.requestPermission) НЕ підміняємо навмисно — щоб зафіксувати, що
+    // native-гілка до них не дотикається (інакше jsdom впаде на `await navigator.serviceWorker.ready`).
+    isCapacitorMock.mockReturnValue(true);
+    // `pushApi.getVapidPublic` не має викликатись у native — кидаємо reject,
+    // щоб випадковий `useQuery` не проскочив тихо.
+    getVapidPublicMock.mockRejectedValue(
+      new Error("VAPID must not be fetched on native"),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("android: реєструє `{ platform: 'android', token }` без `keys` і не торкається Web Push API", async () => {
+    getPlatformMock.mockReturnValue("android");
+    subscribeNativePushMock.mockResolvedValue({
+      platform: "android",
+      token: "fcm-token-abc",
+    });
+
+    const notificationRequestSpy = vi.fn();
+    Object.defineProperty(globalThis, "Notification", {
+      configurable: true,
+      writable: true,
+      value: {
+        permission: "default",
+        requestPermission: notificationRequestSpy,
+      },
+    });
+    const serviceWorkerReadySpy = vi.fn();
+    Object.defineProperty(globalThis.navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        get ready() {
+          serviceWorkerReadySpy();
+          return Promise.reject(
+            new Error("serviceWorker must not be accessed on native"),
+          );
+        },
+      },
+    });
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "android" });
+    const apiClient = makeApiClientWithMocks(registerMock);
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    // `supported` має бути true навіть без Web Push API (capacitor-гейт).
+    expect(result.current.supported).toBe(true);
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = registerMock.mock.calls[0][0];
+    expect(payload).toEqual({ platform: "android", token: "fcm-token-abc" });
+    expect(() => PushRegisterRequestSchema.parse(payload)).not.toThrow();
+
+    expect(subscribeNativePushMock).toHaveBeenCalledTimes(1);
+    // Web-Push side-effects MUST NOT бути тригернуті у native-гілці.
+    expect(notificationRequestSpy).not.toHaveBeenCalled();
+    expect(serviceWorkerReadySpy).not.toHaveBeenCalled();
+    expect(getVapidPublicMock).not.toHaveBeenCalled();
+
+    expect(localStorage.getItem("hub_push_subscribed")).toBe("1");
+    expect(result.current.subscribed).toBe(true);
+  });
+
+  it("ios: реєструє `{ platform: 'ios', token }` без `keys`", async () => {
+    getPlatformMock.mockReturnValue("ios");
+    subscribeNativePushMock.mockResolvedValue({
+      platform: "ios",
+      token: "apns-deadbeef",
+    });
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "ios" });
+    const apiClient = makeApiClientWithMocks(registerMock);
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = registerMock.mock.calls[0][0];
+    expect(payload).toEqual({ platform: "ios", token: "apns-deadbeef" });
+    expect(() => PushRegisterRequestSchema.parse(payload)).not.toThrow();
+    expect(result.current.subscribed).toBe(true);
+  });
+
+  it("unsubscribe на native шле `{ platform, token }` і НЕ ходить у navigator.serviceWorker", async () => {
+    getPlatformMock.mockReturnValue("android");
+    getStoredNativePushTokenMock.mockResolvedValue("fcm-token-abc");
+    unsubscribeNativePushMock.mockResolvedValue("fcm-token-abc");
+
+    const serviceWorkerReadySpy = vi.fn();
+    Object.defineProperty(globalThis.navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        get ready() {
+          serviceWorkerReadySpy();
+          return Promise.reject(
+            new Error("serviceWorker must not be accessed on native"),
+          );
+        },
+      },
+    });
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "android" });
+    const unregisterMock = makeUnregisterMock({
+      ok: true,
+      platform: "android",
+    });
+    const apiClient = makeApiClientWithMocks(registerMock, unregisterMock);
+
+    localStorage.setItem("hub_push_subscribed", "1");
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    await act(async () => {
+      await result.current.unsubscribe();
+    });
+
+    await waitFor(() => {
+      expect(unregisterMock).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = unregisterMock.mock.calls[0][0];
+    expect(payload).toEqual({ platform: "android", token: "fcm-token-abc" });
+    expect(() => PushUnregisterRequestSchema.parse(payload)).not.toThrow();
+    expect(unsubscribeNativePushMock).toHaveBeenCalledTimes(1);
+    expect(serviceWorkerReadySpy).not.toHaveBeenCalled();
+    expect(legacyUnsubscribeMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem("hub_push_subscribed")).toBeNull();
+    expect(result.current.subscribed).toBe(false);
+  });
+
+  it("unsubscribe без кешованого токена все одно очищає локальний стан", async () => {
+    getPlatformMock.mockReturnValue("ios");
+    getStoredNativePushTokenMock.mockResolvedValue(null);
+    unsubscribeNativePushMock.mockResolvedValue(null);
+
+    const registerMock = makeRegisterMock({ ok: true, platform: "ios" });
+    const unregisterMock = makeUnregisterMock({ ok: true, platform: "ios" });
+    const apiClient = makeApiClientWithMocks(registerMock, unregisterMock);
+
+    localStorage.setItem("hub_push_subscribed", "1");
+
+    const { result } = renderHook(() => usePushNotifications(), {
+      wrapper: makeWrapper(apiClient),
+    });
+
+    await act(async () => {
+      await result.current.unsubscribe();
+    });
+
+    // Без токена сервер анрегнути нічим — але UI все одно має піти у "вимкнено".
+    expect(unregisterMock).not.toHaveBeenCalled();
     expect(localStorage.getItem("hub_push_subscribed")).toBeNull();
     expect(result.current.subscribed).toBe(false);
   });

--- a/apps/web/src/shared/hooks/usePushNotifications.ts
+++ b/apps/web/src/shared/hooks/usePushNotifications.ts
@@ -2,8 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePushRegister, usePushUnregister } from "@sergeant/api-client/react";
 import type { PushRegisterRequest } from "@sergeant/api-client";
+import { getPlatform, isCapacitor } from "@sergeant/shared";
 import { isApiError, pushApi } from "@shared/api";
 import { pushKeys } from "@shared/lib/queryKeys";
+import {
+  getStoredNativePushToken,
+  subscribeNativePush,
+  unsubscribeNativePush,
+} from "@shared/lib/pushNative";
 
 const PUSH_SUB_KEY = "hub_push_subscribed";
 
@@ -16,13 +22,34 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   return out;
 }
 
-function isPushSupported(): boolean {
+function isWebPushSupported(): boolean {
   return (
     typeof window !== "undefined" &&
     "serviceWorker" in navigator &&
     "PushManager" in window &&
     "Notification" in window
   );
+}
+
+/**
+ * Високорівневий feature-detect для UI-тоглу: на native WebView (Capacitor)
+ * ми завжди показуємо перемикач — дозволи й токен отримуються через
+ * `@capacitor/push-notifications` незалежно від наявності Web Push API.
+ * На вебі тримаємо старий detect (SW + PushManager + Notification).
+ */
+function isPushSupported(): boolean {
+  return isCapacitor() || isWebPushSupported();
+}
+
+/**
+ * Читає `Notification.permission` лише коли Notification API справді
+ * доступне. На Capacitor-only WebView глобалу може не бути — у такому
+ * разі `"default"` сигналізує UI, що реальний стан буде відомий у
+ * мідл-процесі `subscribe()` (native permission prompt плагіна).
+ */
+function readInitialPermission(): NotificationPermission {
+  if (typeof Notification === "undefined") return "default";
+  return Notification.permission;
 }
 
 export interface UsePushNotificationsResult {
@@ -53,6 +80,7 @@ export interface UsePushNotificationsResult {
  */
 export function usePushNotifications(): UsePushNotificationsResult {
   const supported = isPushSupported();
+  const native = isCapacitor();
   const queryClient = useQueryClient();
   // `usePushRegister`/`usePushUnregister` — канонічні хуки уніфікованого
   // push-API (`@sergeant/api-client`). Вони задають `mutationKey`
@@ -61,9 +89,10 @@ export function usePushNotifications(): UsePushNotificationsResult {
   const pushRegister = usePushRegister();
   const pushUnregister = usePushUnregister();
 
-  const [permission, setPermission] = useState<NotificationPermission>(
-    supported ? Notification.permission : "denied",
-  );
+  const [permission, setPermission] = useState<NotificationPermission>(() => {
+    if (!supported) return "denied";
+    return readInitialPermission();
+  });
   const [subscribed, setSubscribed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(PUSH_SUB_KEY) === "1";
@@ -73,16 +102,22 @@ export function usePushNotifications(): UsePushNotificationsResult {
   });
 
   useEffect(() => {
-    if (!supported) return;
+    // Native-гілка тримає permission-стан всередині плагіна — читати
+    // `Notification.permission` у WebView некоректно (web API тут може
+    // взагалі не відображати APNs/FCM-дозвіл).
+    if (!supported || native) return;
+    if (typeof Notification === "undefined") return;
     setPermission(Notification.permission);
-  }, [supported]);
+  }, [supported, native]);
 
   // Prefetch VAPID на маунт — коли користувач натисне "увімкнути",
   // ключ вже буде в кеші й ми одразу підемо у pushManager.subscribe.
+  // Native-гілка VAPID не використовує (FCM/APNs token-и opaque), тож
+  // ранній похід за ключем був би зайвим мережевим трафіком у shell-і.
   const vapidQuery = useQuery({
     queryKey: pushKeys.vapid,
     queryFn: () => pushApi.getVapidPublic(),
-    enabled: supported,
+    enabled: supported && !native,
     staleTime: Infinity,
     gcTime: Infinity,
   });
@@ -90,6 +125,24 @@ export function usePushNotifications(): UsePushNotificationsResult {
   const subscribeMutation = useMutation({
     mutationFn: async (): Promise<void> => {
       if (!supported) return;
+
+      // Native-гілка: `@capacitor/push-notifications` сам керує
+      // дозволом/реєстрацією у FCM/APNs, Web Push API (SW + VAPID) тут
+      // не чіпаємо.
+      if (native) {
+        const result = await subscribeNativePush();
+        if (!result) return;
+        setPermission("granted");
+        const payload: PushRegisterRequest = {
+          platform: result.platform,
+          token: result.token,
+        };
+        await pushRegister.mutateAsync(payload);
+        localStorage.setItem(PUSH_SUB_KEY, "1");
+        setSubscribed(true);
+        queryClient.invalidateQueries({ queryKey: pushKeys.status });
+        return;
+      }
 
       const perm = await Notification.requestPermission();
       setPermission(perm);
@@ -145,6 +198,29 @@ export function usePushNotifications(): UsePushNotificationsResult {
   const unsubscribeMutation = useMutation({
     mutationFn: async (): Promise<void> => {
       if (!supported) return;
+
+      // Native-гілка: беремо кешований токен (якщо користувач уже
+      // реєструвався у попередній сесії — `pushManager` у WebView
+      // до нього не дотягнеться), прибираємо listener-и + викликаємо
+      // `unregister()` через native gate, потім шлемо серверний
+      // анрег. Web Push гілку сюди не тягнемо.
+      if (native) {
+        const cachedBefore = await getStoredNativePushToken();
+        const cleared = await unsubscribeNativePush();
+        const token = cleared ?? cachedBefore;
+        // `getPlatform()` з `@sergeant/shared` повертає `"ios"`|`"android"`|`"web"`;
+        // ми вже у `native`-гілці, тож web тут не трапляється, але підстраховуємось
+        // fallback-ом на `android` (основний target FCM-реєстрацій).
+        const detected = getPlatform();
+        const platform = detected === "ios" ? "ios" : "android";
+        if (token) {
+          await pushUnregister.mutateAsync({ platform, token }).catch(() => {});
+        }
+        localStorage.removeItem(PUSH_SUB_KEY);
+        setSubscribed(false);
+        queryClient.invalidateQueries({ queryKey: pushKeys.status });
+        return;
+      }
 
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.getSubscription();

--- a/apps/web/src/shared/lib/pushNative.ts
+++ b/apps/web/src/shared/lib/pushNative.ts
@@ -1,0 +1,99 @@
+/**
+ * Dynamic-import гейт до native push-адаптера з `@sergeant/mobile-shell`.
+ *
+ * Дзеркало `apps/web/src/shared/lib/bearerToken.ts`: той самий патерн
+ * code-split + `isCapacitor()` + try/catch fallback. Навіщо:
+ *
+ *   1. **Bundle hygiene.** `@capacitor/push-notifications` (і транзитивно
+ *      `@capacitor/core`) не потрібні браузерному користувачу — Vite
+ *      кладе цю гілку в окремий async chunk, який ніколи не
+ *      завантажується у звичайному браузерному сеансі.
+ *   2. **Single source of truth.** `usePushNotifications` — єдиний
+ *      споживач — завжди ходить через цей хелпер і не знає про
+ *      `@sergeant/mobile-shell/pushNative` напряму.
+ *   3. **Resilience.** Якщо workspace-лінк з якихось причин зламався
+ *      (напр. у тест-білді без `@sergeant/mobile-shell` у графі),
+ *      `subscribeNativePush()` повертає `null` і calling-hook
+ *      лишається у web-гілці замість кидати на маунті.
+ *
+ * Реальний модуль — `apps/mobile-shell/src/pushNative.ts`.
+ */
+import { isCapacitor } from "@sergeant/shared";
+
+export type NativePushPlatform = "ios" | "android";
+
+export interface NativePushSubscription {
+  platform: NativePushPlatform;
+  token: string;
+}
+
+/**
+ * Internal module shape, повернутий `import("@sergeant/mobile-shell/pushNative")`.
+ * Навмисно тримаємо `unknown`-сумісну сигнатуру: якщо версії розійдуться,
+ * `loadPushNative()` поверне `null`, а не дасть TS-помилку в рантаймі.
+ */
+type PushNativeModule = {
+  subscribeNativePush: () => Promise<NativePushSubscription>;
+  unsubscribeNativePush: () => Promise<string | null>;
+  getStoredNativePushToken: () => Promise<string | null>;
+};
+
+async function loadPushNative(): Promise<PushNativeModule | null> {
+  if (!isCapacitor()) return null;
+  try {
+    const mod = (await import("@sergeant/mobile-shell/pushNative")) as
+      | PushNativeModule
+      | { default?: PushNativeModule };
+    if ("subscribeNativePush" in mod) return mod as PushNativeModule;
+    return mod.default ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Запускає native push-реєстрацію (FCM на Android, APNs на iOS). Поза
+ * Capacitor завжди `null` (код не завантажується і не виконується).
+ * Помилки всередині native-шару (відмова в permission, збій плагіна)
+ * пробігають далі — calling-hook вирішує, чи показувати toast.
+ */
+export async function subscribeNativePush(): Promise<NativePushSubscription | null> {
+  const mod = await loadPushNative();
+  if (!mod) return null;
+  return mod.subscribeNativePush();
+}
+
+/**
+ * Знімає native push-реєстрацію. Повертає кешований токен (той, що був
+ * відправлений у `register`), щоб calling-hook міг прогнати
+ * `/api/v1/push/unregister` з правильним ідентифікатором. Поза
+ * Capacitor — `null`, без маунту native-плагіна.
+ */
+export async function unsubscribeNativePush(): Promise<string | null> {
+  const mod = await loadPushNative();
+  if (!mod) return null;
+  try {
+    return await mod.unsubscribeNativePush();
+  } catch {
+    // `unsubscribeNativePush` сам проковтує помилки; якщо щось все ж
+    // піднялось — повертаємо null і дозволяємо calling-hook
+    // все одно очистити локальний стейт (UX важливіший за перфект-sync).
+    return null;
+  }
+}
+
+/**
+ * Читає останній native push-токен зі сховища `@capacitor/preferences`,
+ * не запускаючи registration flow. Використовується, щоб на `unsubscribe`
+ * без попереднього маунту `subscribe`-а (наприклад, після cold-start-а
+ * апки) все одно мати що надіслати на сервер.
+ */
+export async function getStoredNativePushToken(): Promise<string | null> {
+  const mod = await loadPushNative();
+  if (!mod) return null;
+  try {
+    return await mod.getStoredNativePushToken();
+  } catch {
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       "@capacitor/preferences":
         specifier: ^7.0.4
         version: 7.0.4(@capacitor/core@7.6.2)
+      "@capacitor/push-notifications":
+        specifier: ^7.0.3
+        version: 7.0.6(@capacitor/core@7.6.2)
       "@capacitor/splash-screen":
         specifier: ^7.0.3
         version: 7.0.5(@capacitor/core@7.6.2)
@@ -2002,6 +2005,14 @@ packages:
     resolution:
       {
         integrity: sha512-TJhkwaI2RCs/iDC9PjNczZV4h6JM4gUtTuKMeFdy0OwGgFEHf4TrtW2mFMc1TnPDalYQ91p9NT+UKgiJs9/xtg==,
+      }
+    peerDependencies:
+      "@capacitor/core": ">=7.0.0"
+
+  "@capacitor/push-notifications@7.0.6":
+    resolution:
+      {
+        integrity: sha512-zAhbHpdbc15ImuVGgoFwUZsKI+jjGxy/oO5mgfYKUx8Xl2OskndzhL79PYsCPjyGLbqUR9NRUZJthV9auVT3nw==,
       }
     peerDependencies:
       "@capacitor/core": ">=7.0.0"
@@ -16589,6 +16600,10 @@ snapshots:
       "@capacitor/core": 7.6.2
 
   "@capacitor/preferences@7.0.4(@capacitor/core@7.6.2)":
+    dependencies:
+      "@capacitor/core": 7.6.2
+
+  "@capacitor/push-notifications@7.0.6(@capacitor/core@7.6.2)":
     dependencies:
       "@capacitor/core": 7.6.2
 


### PR DESCRIPTION
## Summary

Реалізовано native push-нотифікації для Capacitor-шелла `apps/mobile-shell` через `@capacitor/push-notifications` (FCM на Android, APNs на iOS). Web Push гілка у `apps/web` лишається без змін — хук `usePushNotifications` отримав розвилку `isCapacitor()`, а контракт `UsePushNotificationsResult` не мінявся, тож `PushNotificationToggle.tsx` правити не треба.

### Що додано / змінено

- **`apps/mobile-shell/package.json`** — `@capacitor/push-notifications: ^7.0.3` (резолвиться у `7.0.6` під `@capacitor/core@7.6.2`, версія узгоджена зі всіма іншими `@capacitor/*` плагінами у проєкті через `pnpm-lock.yaml`). Додано `./pushNative` у `exports`.
- **`apps/mobile-shell/src/pushNative.ts`** (новий) — static-імпорт плагіна (`@capacitor/push-notifications`, `@capacitor/preferences`, `Capacitor.getPlatform()` з `@capacitor/core`):
  - `subscribeNativePush(): Promise<{ platform: 'ios'|'android'; token: string }>` — `requestPermissions()` → одноразові listener-и на `registration` / `registrationError` → `register()`. Після resolve прибирає listener-и (інакше на Android вони акумулюються між mount-ами WebView і резолвлять наступний Promise старим токеном). Токен зберігає у `@capacitor/preferences` (`push.native.token`) для наступного `unsubscribe`.
  - `unsubscribeNativePush(): Promise<string | null>` — idempotent: `removeAllListeners()` + `unregister()` у try/catch-ах, потім `clearStoredNativePushToken()`, повертає кешований токен calling-хуку.
  - `get/set/clearStoredNativePushToken` — той самий pattern, що `auth-storage.ts` (namespaced ключ, try/catch на fail Preferences).
  - Повний JSDoc пояснює: чому static-імпорт плагіна, як веб-side тягне це через dynamic import, чому listeners треба прибирати на unsubscribe, навіщо кешувати opaque токен.
- **`apps/web/src/shared/lib/pushNative.ts`** (новий) — dynamic-import gate, дзеркало `bearerToken.ts`:
  - `subscribeNativePush()` / `unsubscribeNativePush()` / `getStoredNativePushToken()` — кожен під guard-ом `isCapacitor()`, try/catch на резолві модуля з fallback-ом на `null`. Веб ніколи не тягне плагін у bundle.
- **`apps/web/src/shared/hooks/usePushNotifications.ts`** — розвилка `native = isCapacitor()` на початку `subscribeMutation.mutationFn` / `unsubscribeMutation.mutationFn`:
  - **subscribe (native):** `subscribeNativePush()` → `pushRegister.mutateAsync({ platform, token })` БЕЗ `keys`, `localStorage[PUSH_SUB_KEY]='1'`, `setSubscribed(true)`, invalidate `pushKeys.status`. **НЕ викликає** `Notification.requestPermission()`, **НЕ чіпає** `navigator.serviceWorker`.
  - **unsubscribe (native):** `getStoredNativePushToken()` → `unsubscribeNativePush()` → `pushUnregister.mutateAsync({ platform, token })` (якщо токен був), локальний стан чиститься завжди.
  - `supported = isCapacitor() || isPushSupported()` — на native WebView тогл показуємо навіть без Web Push API.
  - `permission` useEffect не читає `Notification.permission` у native-гілці (плагін керує дозволом сам, Web API може взагалі не відображати APNs/FCM-стан).
  - VAPID `useQuery` `enabled: supported && !native` — щоб у shell-і не робити зайвий мережевий похід за публічним ключем, якого native не використовує.
- **`apps/web/src/shared/hooks/usePushNotifications.test.tsx`** — 4 нових тест-кейси у новому `describe("native Capacitor branch")`:
  1. `android: register({ platform: 'android', token })` без `keys`; перевірка, що `Notification.requestPermission`, `navigator.serviceWorker.ready`, `pushApi.getVapidPublic` **НЕ викликались**.
  2. `ios: register({ platform: 'ios', token })` без `keys`.
  3. `unsubscribe` на native шле `{ platform, token }` через `api.push.unregister` і НЕ торкається `navigator.serviceWorker`.
  4. `unsubscribe` без кешованого токена — сервер не чіпаємо, але локальний стан все одно чистимо.
  
  Мок-інфраструктура: `vi.mock("@sergeant/shared")` (контрольовані `isCapacitor` / `getPlatform`) + `vi.mock("@shared/lib/pushNative")`. Існуючі web-тести отримали явні `mockReturnValue(false)` у `beforeEach`, щоб native-мок не протікав між describe-блоками.

### Capacitor-плагіни додано

- `@capacitor/push-notifications@^7.0.3` → резолвиться `7.0.6`, peer `@capacitor/core: >=7.0.0` задовольняється наявним `7.6.2`.

Інші залежності не чіпав. Сервер (`apps/server/src/routes/push.ts`), схеми (`packages/shared/src/schemas/api.ts`, `packages/api-client/src/endpoints/push.ts`), RN-апка (`apps/mobile/**`), workflow-и (`.github/workflows/**`) — усе незмінне за скоупом з промпту.

### Чому Web Push гілку лишив без змін

Існуючий flow з Service Worker + `PushManager` + VAPID працює і тестується для `platform: "web"` (сервер приймає обидва формати через `PushRegisterSchema` discriminated union). Native-гілка ортогональна і вмикається виключно guard-ом `isCapacitor()`. `PushNotificationToggle.tsx` не потребує змін — той самий `UsePushNotificationsResult`.

### Як тестував

- `pnpm -w typecheck` — усі 12 workspace-ів проходять.
- `pnpm -w lint` — проходить (плюс `lint:imports` / `lint:plugins`).
- `pnpm --filter @sergeant/web test -- usePushNotifications` — 8 тестів зелені (4 старих web + 4 нові native).
- `pnpm -w test` — усі зелені, крім 2 pre-existing фейлів у `@sergeant/mobile#test` (`routineStore.test.ts`) — відтворюються на `main` без моїх змін; це RN-апка, яка явно поза скоупом цього PR.

### Unit-тест для `apps/mobile-shell`

`apps/mobile-shell` зараз не має тестового runner-а (немає сусідніх `*.test.*` / `vitest.config.*` у пакеті; `package.json` містить лише `typecheck` і `cap sync` скрипти). Додавати інфраструктуру на один smoke-тест вважаю поза скоупом цього PR — тому native-шар покритий опосередковано через мок у web-тестах. Додати прямий unit-тест зручно буде разом з майбутнім loader-ом тестів у mobile-shell.

## Review & Testing Checklist for Human

- [ ] **Реальна реєстрація на Android** — запустити `pnpm --filter @sergeant/mobile-shell build:android`, відкрити у Android Studio, увімкнути тогл у UI, перевірити що у лог-ах FCM token приходить і відправляється на сервер як `{ platform: 'android', token }` (без `keys`).
- [ ] **Реальна реєстрація на iOS** — те саме на iOS-девайсі / симуляторі з APNs-certificates; потрібен реальний Apple Developer profile з `Push Notifications` capability.
- [ ] Перевірити, що після `unsubscribe` і повторного `subscribe` listener-и не дублюються (у native лог не має бути зайвих `registration`-подій на один тап).
- [ ] Перевірити, що у веб-бандлі (`apps/server/dist`) `@capacitor/push-notifications` НЕ приходить eager-ом (має бути async chunk разом з іншими Capacitor-плагінами; `vite.config.js` `manualChunks` вже підготовлений).

### Notes

- Lockfile: `pnpm install --frozen-lockfile` проходить.
- Контракт `PushRegisterSchema` / `PushUnregisterSchema` у `@sergeant/shared` підтримує `platform: 'ios'|'android'` з `token` без `keys` — використано як є.
- Pre-commit (`lint-staged`) відпрацював на комміті — усі файли відформатовані.

Link to Devin session: https://app.devin.ai/sessions/dbb9e58f0c464491a0ce6825b1ff9d72
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
