### PR TITLE
test(mobile): use dynamic TODAY_KEY in routineStore wiring tests

### DIFF
--- a/apps/mobile/src/modules/routine/lib/__tests__/routineStore.test.ts
+++ b/apps/mobile/src/modules/routine/lib/__tests__/routineStore.test.ts
@@ -10,7 +10,7 @@
  * we only assert on the sync wiring, never on real MMKV writes.
  */
 import { act, renderHook } from "@testing-library/react-native";
-import { ROUTINE_STORAGE_KEY } from "@sergeant/routine-domain";
+import { ROUTINE_STORAGE_KEY, dateKeyFromDate } from "@sergeant/routine-domain";
 
 const mockEnqueueChange = jest.fn();
 const mockSafeReadLS = jest.fn();
@@ -56,8 +56,14 @@ function firstHabitId(routine: ReturnType<typeof defaultRoutineState>): string {
  * habit created inside `act()` always has `createdAt = today`. A
  * hard-coded key would silently break on whichever calendar day the
  * CI host happens to run on.
+ *
+ * Must go through `dateKeyFromDate` (the same helper `applyCreateHabit`
+ * uses internally) rather than `toISOString().slice(0, 10)`. The latter
+ * yields the UTC date, which drifts one day ahead of the habit's
+ * local-tz `startDate` in positive-UTC offsets after local midnight but
+ * before UTC midnight (e.g. Europe/Kyiv = UTC+2/+3).
  */
-const TODAY_KEY = new Date().toISOString().slice(0, 10);
+const TODAY_KEY = dateKeyFromDate(new Date());
 
 describe("routineStore — enqueueChange wiring", () => {
   it("setRoutine fires enqueueChange with the routine key", () => {

--- a/apps/mobile/src/modules/routine/lib/__tests__/routineStore.test.ts
+++ b/apps/mobile/src/modules/routine/lib/__tests__/routineStore.test.ts
@@ -49,6 +49,16 @@ function firstHabitId(routine: ReturnType<typeof defaultRoutineState>): string {
   return id;
 }
 
+/**
+ * Today's date-key (`YYYY-MM-DD` in local tz). Use this for any
+ * "toggle a fresh habit for date X" assertion — `habitScheduledOnDate`
+ * rejects dates before `habit.startDate || habit.createdAt`, and a
+ * habit created inside `act()` always has `createdAt = today`. A
+ * hard-coded key would silently break on whichever calendar day the
+ * CI host happens to run on.
+ */
+const TODAY_KEY = new Date().toISOString().slice(0, 10);
+
 describe("routineStore — enqueueChange wiring", () => {
   it("setRoutine fires enqueueChange with the routine key", () => {
     const { result } = renderHook(() => useRoutineStore());
@@ -92,7 +102,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.toggleHabit(habitId, "2026-04-21");
+      result.current.toggleHabit(habitId, TODAY_KEY);
     });
 
     expect(mockEnqueueChange).toHaveBeenCalledWith(ROUTINE_STORAGE_KEY);
@@ -104,7 +114,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.toggleHabit("non-existent-habit", "2026-04-21");
+      result.current.toggleHabit("non-existent-habit", TODAY_KEY);
     });
 
     expect(mockEnqueueChange).not.toHaveBeenCalled();
@@ -115,7 +125,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.bulkMarkDay("2026-04-21");
+      result.current.bulkMarkDay(TODAY_KEY);
     });
 
     expect(mockEnqueueChange).not.toHaveBeenCalled();
@@ -129,7 +139,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.bulkMarkDay("2026-04-21");
+      result.current.bulkMarkDay(TODAY_KEY);
     });
 
     expect(mockEnqueueChange).toHaveBeenCalledWith(ROUTINE_STORAGE_KEY);
@@ -140,7 +150,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.setCompletionNote("missing", "2026-04-21", "note");
+      result.current.setCompletionNote("missing", TODAY_KEY, "note");
     });
 
     expect(mockEnqueueChange).not.toHaveBeenCalled();
@@ -155,7 +165,7 @@ describe("routineStore — enqueueChange wiring", () => {
     mockEnqueueChange.mockClear();
 
     act(() => {
-      result.current.setCompletionNote(id, "2026-04-21", "felt great");
+      result.current.setCompletionNote(id, TODAY_KEY, "felt great");
     });
 
     expect(mockEnqueueChange).toHaveBeenCalledWith(ROUTINE_STORAGE_KEY);


### PR DESCRIPTION
## Summary

Fixes the two `routineStore.test.ts` flakes that have been failing the `check` job on every PR since 2026-04-22 (reported in PR #505 / #508 / #510).

**Root cause.** Two assertions ( `toggleHabit fires enqueueChange after a real state change`, `bulkMarkDay fires enqueueChange when at least one scheduled habit is marked` ) hard-coded `"2026-04-21"` as the date-key they were operating on. The reducer under test does this:

```ts
// packages/routine-domain/src/schedule.ts
const start = habit.startDate || (habit.createdAt ? String(habit.createdAt).slice(0, 10) : dateKey);
if (dateKey < start) return false;
```

A habit created inside `act(() => result.current.createHabit(...))` always has `createdAt = today`. On 2026-04-22 and later, `"2026-04-21" < today` so `habitScheduledOnDate` returns false; the reducer takes the early-return `if (next === prev) return prev` branch; `enqueueChange` is never called; both assertions fail. These tests only worked by accident on the day they were written (2026-04-21) — the bug has been latent ever since.

**Fix.** Compute a single `TODAY_KEY` at top-level (`new Date().toISOString().slice(0, 10)`) and use it everywhere a "toggle / mark / annotate a freshly-created habit" assertion needs a scheduled date. No-op assertions ("toggle a non-existent habit") also get `TODAY_KEY` for consistency — they don't care about scheduling, only about the early-return-on-missing-habit path.

Local run: `pnpm --filter @sergeant/mobile test` → **524 / 524 passed** (was 522 / 524 on main).

## Review & Testing Checklist for Human

- [ ] Confirm the fix approach — I kept the hard-coded `"2026-04-21"` style out entirely and use `new Date().toISOString().slice(0, 10)` inline. If you'd rather freeze time with `jest.useFakeTimers({ now: new Date("2026-04-21") })` at the suite level, I can rework it; that would also fix the two failing tests but slightly changes the semantic (the test asserts "toggling for today fires enqueue" — TODAY_KEY matches that phrasing, frozen clock would instead assert "toggling for a specific date fires enqueue").
- [ ] Sanity-check that nothing else in `apps/mobile` hard-codes 2026-04-2X — I `grep`ped and only this test file has such keys inside `__tests__`; other references are in docs (`docs/ux-audit-2025.md`) or live strings. None of those are timing-sensitive.

### Notes

- No production code changed — this is tests-only.
- The bug wasn't in any reducer logic; `applyToggleHabitCompletion` / `applyMarkAllScheduledHabitsComplete` have correct `habitScheduledOnDate` gating. The tests just drifted.
- All other hard-coded dates in the file (e.g. for `setCompletionNote is a no-op for an unknown habit`) that happened to work even on 2026-04-22+ were also switched to `TODAY_KEY` for consistency — they test early-return branches that don't touch the schedule predicate, so the behaviour is identical.

Link to Devin session: https://app.devin.ai/sessions/f6f827849d2847cbb787145844975436
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated routine store tests to use dynamic date calculation instead of hard-coded dates, improving test reliability and reducing brittleness.

---

**Note:** This release contains internal test improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->