### PR TITLE
feat(mobile-shell): Android hardware Back → web-history traversal

### DIFF
--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -18,6 +18,7 @@ React Native). Співіснують навмисно: `applicationId` у shell
 | Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                             |
 | Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                  |
 | Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506) |
+| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                   |
 | Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                              |
 
 Точка входу native-side — `src/index.ts → initNativeShell()`. Вона

--- a/apps/mobile-shell/src/index.test.ts
+++ b/apps/mobile-shell/src/index.test.ts
@@ -20,10 +20,14 @@ type CapacitorMocks = {
   };
   SplashScreen: { hide: ReturnType<typeof vi.fn> };
   Keyboard: { setResizeMode: ReturnType<typeof vi.fn> };
-  App: { addListener: ReturnType<typeof vi.fn> };
+  App: {
+    addListener: ReturnType<typeof vi.fn>;
+    exitApp: ReturnType<typeof vi.fn>;
+  };
 };
 
 type UrlOpenCallback = (event: { url: string }) => void;
+type BackButtonCallback = (event: { canGoBack: boolean }) => void;
 
 function installCapacitorMocks(): CapacitorMocks {
   const StatusBar = {
@@ -34,6 +38,7 @@ function installCapacitorMocks(): CapacitorMocks {
   const Keyboard = { setResizeMode: vi.fn().mockResolvedValue(undefined) };
   const App = {
     addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+    exitApp: vi.fn().mockResolvedValue(undefined),
   };
 
   vi.doMock("@capacitor/status-bar", () => ({
@@ -120,9 +125,13 @@ describe("initNativeShell — композиція плагінів", () => {
     });
     expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
     expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledWith({ mode: "body" });
-    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(2);
     expect(mocks.App.addListener).toHaveBeenCalledWith(
       "appUrlOpen",
+      expect.any(Function),
+    );
+    expect(mocks.App.addListener).toHaveBeenCalledWith(
+      "backButton",
       expect.any(Function),
     );
   });
@@ -154,7 +163,7 @@ describe("initNativeShell — ідемпотентність", () => {
     expect(mocks.StatusBar.setBackgroundColor).toHaveBeenCalledTimes(1);
     expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
     expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
-    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -169,7 +178,7 @@ describe("initNativeShell — ізоляція помилок", () => {
 
     expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
     expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
-    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(2);
     // StatusBar warn-повідомлення вилетіло — інакше користувач побачив би
     // лише «мовчки не спрацювало».
     expect(warnSpy).toHaveBeenCalled();
@@ -185,7 +194,7 @@ describe("initNativeShell — ізоляція помилок", () => {
     const { initNativeShell } = await import("./index.js");
     await initNativeShell();
 
-    expect(mocks.App.addListener).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -248,5 +257,81 @@ describe("initNativeShell — deep-link listener", () => {
         value: originalLocation,
       });
     }
+  });
+});
+
+describe("initNativeShell — backButton listener", () => {
+  async function captureBackButtonCallback(
+    mocks: CapacitorMocks,
+  ): Promise<BackButtonCallback> {
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell();
+
+    const call = mocks.App.addListener.mock.calls.find(
+      ([event]) => event === "backButton",
+    );
+    expect(call?.[0]).toBe("backButton");
+    const cb = call?.[1] as BackButtonCallback;
+    expect(typeof cb).toBe("function");
+    return cb;
+  }
+
+  it("реєструє listener на 'backButton' (симетрично до 'appUrlOpen')", async () => {
+    const mocks = installCapacitorMocks();
+    const { initNativeShell } = await import("./index.js");
+
+    await initNativeShell();
+
+    expect(mocks.App.addListener).toHaveBeenCalledWith(
+      "backButton",
+      expect.any(Function),
+    );
+  });
+
+  it("коли canGoBack=true → window.history.back(), App.exitApp — НЕ викликається", async () => {
+    const mocks = installCapacitorMocks();
+    const historyBackSpy = vi
+      .spyOn(window.history, "back")
+      .mockImplementation(() => {});
+
+    const cb = await captureBackButtonCallback(mocks);
+    cb({ canGoBack: true });
+
+    expect(historyBackSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.App.exitApp).not.toHaveBeenCalled();
+  });
+
+  it("коли canGoBack=false → App.exitApp(), window.history.back — НЕ викликається", async () => {
+    const mocks = installCapacitorMocks();
+    const historyBackSpy = vi
+      .spyOn(window.history, "back")
+      .mockImplementation(() => {});
+
+    const cb = await captureBackButtonCallback(mocks);
+    cb({ canGoBack: false });
+
+    expect(mocks.App.exitApp).toHaveBeenCalledTimes(1);
+    expect(historyBackSpy).not.toHaveBeenCalled();
+  });
+
+  it("якщо addListener('backButton') падає — інші плагін-ініти НЕ ламаються", async () => {
+    const mocks = installCapacitorMocks();
+    // `appUrlOpen` реєструється першим виклик — хай резолвиться, а другий
+    // (`backButton`) хай падає. Це повторює шаблон resilience-тестів вище.
+    mocks.App.addListener
+      .mockResolvedValueOnce({ remove: vi.fn() })
+      .mockRejectedValueOnce(new Error("boom"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { initNativeShell } = await import("./index.js");
+    await initNativeShell();
+
+    expect(mocks.StatusBar.setStyle).toHaveBeenCalledTimes(1);
+    expect(mocks.SplashScreen.hide).toHaveBeenCalledTimes(1);
+    expect(mocks.Keyboard.setResizeMode).toHaveBeenCalledTimes(1);
+    expect(mocks.App.addListener).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArgs = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warnArgs.some((m) => m.includes("backButton"))).toBe(true);
   });
 });

--- a/apps/mobile-shell/src/index.ts
+++ b/apps/mobile-shell/src/index.ts
@@ -130,4 +130,25 @@ export async function initNativeShell(
   } catch (err) {
     console.warn("[mobile-shell] App.addListener('appUrlOpen') failed", err);
   }
+
+  try {
+    // Апаратна кнопка "Назад" на Android: Capacitor default — `App.exitApp()`
+    // на першому ж натисканні, що для SPA виглядає як «апка раптом закрилась».
+    // Очікувана Android UX — пройтись назад по web-history, і лише коли
+    // стек порожній — вийти. Свідомо використовуємо `window.history.back()`,
+    // а не `options.navigate` хук: back-button — це pure history traversal
+    // (React Router сам слухає `popstate`), тоді як `navigate()` робить
+    // `push` і плутає з deep-link кейсом, де URL «прибігає збоку» ззовні.
+    await App.addListener("backButton", ({ canGoBack }) => {
+      if (canGoBack) {
+        if (typeof window !== "undefined") {
+          window.history.back();
+        }
+      } else {
+        void App.exitApp();
+      }
+    });
+  } catch (err) {
+    console.warn("[mobile-shell] App.addListener('backButton') failed", err);
+  }
 }


### PR DESCRIPTION
## Summary

Capacitor default на Android — натиснення апаратної кнопки «Назад» одразу викликає `App.exitApp()`. Для SPA це виглядає як «апка раптом закрилася» після того, як користувач зайшов на 2-3 екрани вглиб. Очікувана Android-UX — пройтись назад по web-history і лише коли стек порожній — вийти.

Додано симетричний listener до вже існуючого `appUrlOpen` у `initNativeShell()`:

- `apps/mobile-shell/src/index.ts`: нове `App.addListener("backButton", ({ canGoBack }) => …)` усередині `try/catch` з `console.warn` (ідентичний патерн до сусідніх блоків), під вже наявним `initialized` ідемпотент-гардом. Поведінка: `canGoBack === true` → `window.history.back()`, інакше → `App.exitApp()`. Використовуємо `window.history.back()` навмисно, а не `options.navigate` хук: back-button — це pure history traversal (React Router сам слухає `popstate`), тоді як `navigate()` робить `push` і плутає з deep-link кейсом, де URL «прибігає збоку» ззовні.
- `apps/mobile-shell/src/index.test.ts`: новий `describe('initNativeShell — backButton listener')` з 4 кейсами за тим самим патерном моків `vi.doMock('@capacitor/app', …)`:
  1. listener реєструється з подією `'backButton'`.
  2. `canGoBack=true` → `window.history.back` викликається, `App.exitApp` — ні.
  3. `canGoBack=false` → `App.exitApp` викликається, `window.history.back` — ні.
  4. якщо `addListener('backButton')` падає — StatusBar/Splash/Keyboard/appUrlOpen-ініти НЕ ламаються (як у існуючих resilience-тестах).
  Також оновлено лічильники `App.addListener` у існуючих тестах з 1 → 2, бо плагін тепер реєструє 2 listener-и.
- `apps/mobile-shell/README.md`: додано рядок у таблицю «Що готово».

Жодних нових dependency — `@capacitor/app` вже був підключений для `appUrlOpen`. Не чіпав `apps/web/**`, `.github/workflows/**`, не рефакторив існуючий `initNativeShell` — тільки додавання.

## Review & Testing Checklist for Human

- [ ] На реальному Android-білді: відкрити апку → перейти на вкладений екран (напр. Фінік → транзакція) → натиснути апаратну кнопку «Back»: очікується повернення назад по history, а не вихід з апки.
- [ ] На головному екрані (коли web-history порожній / лише один запис) натиснути «Back»: очікується вихід з апки (`App.exitApp()`) — як і раніше.
- [ ] Переконатись, що iOS (де апаратної Back-кнопки немає) не змінив поведінку: `backButton` event просто не випускатиметься, це no-op.

### Notes

- `pnpm -w typecheck` — зелене.
- `pnpm --filter @sergeant/mobile-shell test` — 32/32 тести зелені (з них 19 у `index.test.ts`, включно з 4 новими для `backButton`).
- `pnpm -w test` має pre-existing failure у `@sergeant/mobile#test` (`routineStore.test.ts`, 2 кейси) — це не пов’язано з цим PR, відтворюється на `main` без моїх змін. Так само `pnpm -w lint` падає на `lint:plugins` через Node 22 vs `node --test <dir>` — але CI на Node 20, там це зелене.

Link to Devin session: https://app.devin.ai/sessions/1635450d624042cb8d1284412d432397
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
