### PR TITLE
feat(web): Capacitor-aware observability — Sentry tags + web-vitals guard

### DIFF
--- a/apps/web/src/core/sentry.test.ts
+++ b/apps/web/src/core/sentry.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Smoke + shape тест навколо `initSentry()`:
+ *   1. Після успішного init Sentry отримує два теги — `platform` і
+ *      `is_capacitor` — з `@sergeant/shared`. Це потрібно для тріажу
+ *      native-specific багів у RUM.
+ *   2. Без `VITE_SENTRY_DSN` — повний no-op, жодного тегу.
+ *
+ * `@sentry/react` повністю замокано, щоб не тягнути справжній SDK і не
+ * робити мережевих запитів у jsdom. `@sergeant/shared` замокано частково
+ * (importActual + override) — так само, як у `bearerToken.test.ts`.
+ */
+
+const sentryInit = vi.fn();
+const setTag = vi.fn();
+const browserTracingIntegration = vi.fn(() => ({ name: "tracing" }));
+const replayIntegration = vi.fn(() => ({ name: "replay" }));
+const captureException = vi.fn();
+
+vi.mock("@sentry/react", () => ({
+  init: sentryInit,
+  setTag,
+  browserTracingIntegration,
+  replayIntegration,
+  captureException,
+}));
+
+const isCapacitorMock = vi.fn<() => boolean>();
+const getPlatformMock = vi.fn<() => "ios" | "android" | "web">();
+
+vi.mock("@sergeant/shared", async () => {
+  const actual =
+    await vi.importActual<typeof import("@sergeant/shared")>(
+      "@sergeant/shared",
+    );
+  return {
+    ...actual,
+    isCapacitor: () => isCapacitorMock(),
+    getPlatform: () => getPlatformMock(),
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  sentryInit.mockReset();
+  setTag.mockReset();
+  browserTracingIntegration.mockClear();
+  replayIntegration.mockClear();
+  captureException.mockReset();
+  isCapacitorMock.mockReset().mockReturnValue(false);
+  getPlatformMock.mockReset().mockReturnValue("web");
+  vi.stubEnv("VITE_SENTRY_DSN", "https://public@sentry.example/1");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("initSentry", () => {
+  it("тегує platform='web' і is_capacitor='false' у браузері", async () => {
+    const { initSentry } = await import("./sentry");
+    await initSentry();
+
+    expect(sentryInit).toHaveBeenCalledTimes(1);
+    expect(setTag).toHaveBeenCalledWith("platform", "web");
+    expect(setTag).toHaveBeenCalledWith("is_capacitor", "false");
+  });
+
+  it("тегує реальну натив-платформу в Capacitor WebView", async () => {
+    isCapacitorMock.mockReturnValue(true);
+    getPlatformMock.mockReturnValue("ios");
+
+    const { initSentry } = await import("./sentry");
+    await initSentry();
+
+    expect(sentryInit).toHaveBeenCalledTimes(1);
+    expect(setTag).toHaveBeenCalledWith("platform", "ios");
+    expect(setTag).toHaveBeenCalledWith("is_capacitor", "true");
+  });
+
+  it("без VITE_SENTRY_DSN — no-op, жодних тегів", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+
+    const { initSentry } = await import("./sentry");
+    await initSentry();
+
+    expect(sentryInit).not.toHaveBeenCalled();
+    expect(setTag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/core/sentry.ts
+++ b/apps/web/src/core/sentry.ts
@@ -1,3 +1,5 @@
+import { getPlatform, isCapacitor } from "@sergeant/shared";
+
 let initialized = false;
 let sentryModule = null;
 
@@ -53,6 +55,11 @@ export async function initSentry() {
       return event;
     },
   });
+
+  // Теги для тріажу: відрізнити події з нативного Capacitor WebView від
+  // браузерних (native-specific баги: inset, кукі, keyboard resize тощо).
+  mod.setTag("platform", getPlatform());
+  mod.setTag("is_capacitor", String(isCapacitor()));
 
   initialized = true;
 }

--- a/apps/web/src/core/webVitals.test.ts
+++ b/apps/web/src/core/webVitals.test.ts
@@ -130,3 +130,57 @@ describe("webVitals.flush", () => {
     expect(payload.metrics[1]).toMatchObject({ name: "CLS", value: 0.1235 });
   });
 });
+
+describe("initWebVitals under Capacitor", () => {
+  afterEach(() => {
+    vi.doUnmock("@sergeant/shared");
+    vi.doUnmock("web-vitals");
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("skips init: does not load web-vitals nor wire lifecycle", async () => {
+    vi.resetModules();
+
+    vi.doMock("@sergeant/shared", async () => {
+      const actual =
+        await vi.importActual<typeof import("@sergeant/shared")>(
+          "@sergeant/shared",
+        );
+      return { ...actual, isCapacitor: () => true };
+    });
+
+    const onLCP = vi.fn();
+    const onINP = vi.fn();
+    const onCLS = vi.fn();
+    const onFCP = vi.fn();
+    const onTTFB = vi.fn();
+    vi.doMock("web-vitals", () => ({ onLCP, onINP, onCLS, onFCP, onTTFB }));
+
+    const docAdd = vi.spyOn(document, "addEventListener");
+    const winAdd = vi.spyOn(window, "addEventListener");
+
+    const mod = await import("./webVitals");
+    mod.__resetForTests();
+    await mod.initWebVitals();
+
+    // None of the `web-vitals` collectors must be registered.
+    expect(onLCP).not.toHaveBeenCalled();
+    expect(onINP).not.toHaveBeenCalled();
+    expect(onCLS).not.toHaveBeenCalled();
+    expect(onFCP).not.toHaveBeenCalled();
+    expect(onTTFB).not.toHaveBeenCalled();
+
+    // No lifecycle listeners should be wired either.
+    expect(docAdd).not.toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(winAdd).not.toHaveBeenCalledWith(
+      "pagehide",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/web/src/core/webVitals.ts
+++ b/apps/web/src/core/webVitals.ts
@@ -1,4 +1,5 @@
 import { apiUrl } from "@shared/lib/apiUrl";
+import { isCapacitor } from "@sergeant/shared";
 
 /**
  * Збір Core Web Vitals (LCP / INP / CLS / FCP / TTFB) і відправка батчем
@@ -130,6 +131,11 @@ export function enqueue(metric) {
  * web-vitals chunk не потрапив у критичний шлях.
  */
 export async function initWebVitals() {
+  // Core Web Vitals у нативному Capacitor WebView — це шум: cold-start WebView,
+  // відсутність SSR і інший JS engine перекручують LCP/FCP/CLS/INP, отруюючи
+  // RUM-дашборди 'web-like' метриками з мобільного шелла. Тому тут — ранній
+  // return, щоб взагалі не тягнути `web-vitals` chunk у native-бандл.
+  if (isCapacitor()) return;
   // Guard проти подвійної ініціалізації (Vite HMR, повторний виклик з іншої
   // entry-точки тощо). Без нього `onLCP(enqueue)` реєструється двічі і кожне
   // `web_vitals_*` спостереження дублюється — отруює baseline, який цей


### PR DESCRIPTION
## Summary

Робить observability в `apps/web` Capacitor-aware:

1. **Sentry теги** — `apps/web/src/core/sentry.ts` після `mod.init({...})` викликає
   `mod.setTag('platform', getPlatform())` і `mod.setTag('is_capacitor', String(isCapacitor()))`.
   - `platform` ∈ `'ios' | 'android' | 'web'`, `is_capacitor` ∈ `'true' | 'false'`.
   - Тегування йде з `@sergeant/shared` (DOM-free, без compile-time dep на `@capacitor/core`),
     тож web-бандл не тягне нічого зайвого.
   - Lazy-init `import("@sentry/react")` і публічний API `initSentry()` — без змін.
   - Тріаж native-specific багів у RUM (inset, кукі, keyboard resize) тепер через фільтр по тегу.

2. **Web-vitals guard** — `apps/web/src/core/webVitals.ts` у `initWebVitals()` додав ранній
   `if (isCapacitor()) return;` *перед* `await import("web-vitals")`.
   - У native Capacitor WebView LCP/FCP/CLS/INP сильно перекручені (cold-start WebView,
     відсутність SSR, інший JS engine) — засмічують RUM 'web-like' метриками з мобільного шелла.
   - Ранній return → `web-vitals` chunk взагалі не підтягується у нативі, жоден
     `on{LCP,INP,CLS,FCP,TTFB}` collector не реєструється, і visibilitychange/pagehide
     слухачі не вішаються.
   - Існуючий `initialized` guard, SSR/jsdom guards і `VITE_WEB_VITALS_ENDPOINT=0` kill-switch
     лишились на місці. Контракт `initWebVitals()` — без змін.

3. **Тести**:
   - `apps/web/src/core/webVitals.test.ts` — новий describe `"initWebVitals under Capacitor"`.
     Через `vi.doMock("@sergeant/shared", ... isCapacitor: () => true)` і
     `vi.doMock("web-vitals", ...)` перевіряє, що жоден з `onLCP/onINP/onCLS/onFCP/onTTFB` не
     зареєстровано і жоден listener (`visibilitychange`, `pagehide`) не вішається.
   - `apps/web/src/core/sentry.test.ts` — новий файл. Мокає `@sentry/react` (init, setTag,
     integrations) і частково `@sergeant/shared`. 3 кейси:
     1) web → `setTag('platform', 'web')` + `setTag('is_capacitor', 'false')`;
     2) Capacitor iOS → `setTag('platform', 'ios')` + `setTag('is_capacitor', 'true')`;
     3) без `VITE_SENTRY_DSN` → повний no-op, жодних тегів.

Жодних нових залежностей. `apps/mobile-shell/**`, `apps/server/**`, `apps/mobile/**`,
`.github/workflows/**` не зачеплені.

## Review & Testing Checklist for Human

- [ ] `apps/web/src/core/sentry.ts`: після `mod.init` ідуть саме два `setTag` і лише потім
      `initialized = true` — щоб повторний виклик не перекинув тегування у `.mockReset` під
      Vitest-hot-reload тощо.
- [ ] Пересвідчитись у Sentry UI (staging): нові events мають `platform` і `is_capacitor`
      теги; запит `is_capacitor:true` повертає події з native WebView, а `platform:web` —
      з браузера.
- [ ] Подивитись у Vite build output для native-shell-цільового бандла (або аналітично —
      `pnpm -w build:analyze`), що `web-vitals` chunk не потрапляє у критичний native шлях
      (у пакунку web-вантажень його можна тримати — ранній return спрацьовує в runtime).
- [ ] Прогнати `pnpm --filter @sergeant/web test` — 637 тестів, серед них 7 для `webVitals`
      і 3 нові для `sentry`.

### Notes

- Форма тегу `is_capacitor` — строка (`'true'`/`'false'`), бо `setTag` value: `string`.
- `@sentry/react` повністю замокано у `sentry.test.ts` — жодних мережевих викликів,
  тест сфокусований на формі контракту (які теги і з якими значеннями виставляються).
- Монорепозиторний `pnpm -w lint` і `pnpm -w test` мають pre-existing failures у
  `eslint-plugins/sergeant-design/__tests__` і `@sergeant/mobile` — підтвердив, що вони
  існують на `main` без моїх змін.


Link to Devin session: https://app.devin.ai/sessions/fdd786eb4366400e8752f8a248ff7353
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
