### PR TITLE
fix(licenses): flag empty THIRD_PARTY_LICENSES.md as stale

### DIFF
--- a/scripts/generate-licenses.mjs
+++ b/scripts/generate-licenses.mjs
@@ -262,14 +262,20 @@ function cmdCheck() {
 
   const expected = render(entries);
   let actual = "";
+  let fileRead = false;
   try {
     actual = readFileSync(outPath, "utf8");
+    fileRead = true;
   } catch {
     errors.push(
       `  ${outPath} is missing; run \`pnpm licenses:gen\` and commit the result`,
     );
   }
-  if (actual && actual !== expected) {
+  // `fileRead` (not `actual`) is the guard: an existing-but-empty SBOM
+  // file (e.g. truncated to 0 bytes) must still be flagged as stale —
+  // Devin Review caught the earlier `if (actual && …)` version silently
+  // passing in that case.
+  if (fileRead && actual !== expected) {
     errors.push(
       `  ${outPath} is out-of-date; run \`pnpm licenses:gen\` and commit the diff`,
     );


### PR DESCRIPTION
## Summary

Addresses [Devin Review feedback](https://github.com/Skords-01/Sergeant/pull/517#discussion_r3124287519) on #517.

The staleness branch in `cmdCheck` was guarded by `if (actual && actual !== expected)`. If `THIRD_PARTY_LICENSES.md` exists but is empty (e.g. truncated to 0 bytes by a bad rebase or editor crash), `readFileSync` succeeds — so the `catch` block does NOT fire — but `actual` is `""`, which is falsy, so the `&&` short-circuits and the "out-of-date" error is never pushed. The check reports `OK` even though the committed content doesn't match `expected`.

Fix: use an explicit `fileRead` flag to distinguish "read failed" from "read produced empty string". An empty file is now correctly flagged as stale. Inline comment added so the guard doesn't get "simplified" back to the buggy form.

Verified locally by truncating `THIRD_PARTY_LICENSES.md` to 0 bytes and running `pnpm licenses:check`:

```
License policy check failed (865 shipped packages):
  …/THIRD_PARTY_LICENSES.md is out-of-date; run `pnpm licenses:gen` and commit the diff
ELIFECYCLE  Command failed with exit code 1.
```

After restoring the file, `pnpm licenses:check` returns `OK` again.

## Review & Testing Checklist for Human

- [ ] Run `pnpm licenses:check` locally — should still pass.
- [ ] (Optional) Simulate the bug: `: > THIRD_PARTY_LICENSES.md && pnpm licenses:check` — should now fail with the "out-of-date" message. Restore with `git checkout THIRD_PARTY_LICENSES.md` when done.

### Notes

- Single-file change in `scripts/generate-licenses.mjs`, ~6 lines. No workflow or runtime code touched.

Link to Devin session: https://app.devin.ai/sessions/f6f827849d2847cbb787145844975436
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
