### PR TITLE
chore(mobile-shell): tighten Capacitor config on Android

### DIFF
--- a/apps/mobile-shell/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-shell/android/app/src/main/AndroidManifest.xml
@@ -2,12 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="false">
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/apps/mobile-shell/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/mobile-shell/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Disallow cleartext HTTP traffic app-wide. The shell loads
+  `apps/server/dist` via `https`-scheme (see `capacitor.config.ts`
+  → `server.androidScheme`) and talks to `apps/server` over HTTPS,
+  so there is no legitimate need for cleartext connections.
+
+  This mirrors `android:usesCleartextTraffic="false"` in the
+  manifest — the XML form is authoritative for Android 7.0+
+  (API 24) when both are present, while the attribute still
+  protects older devices.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/apps/mobile-shell/capacitor.config.ts
+++ b/apps/mobile-shell/capacitor.config.ts
@@ -22,7 +22,48 @@ const config: CapacitorConfig = {
   appName: "Sergeant Shell",
   webDir: "../server/dist",
   server: {
+    // Native WebView звертається до `apps/server` через HTTPS; ніяких
+    // dev-only `server.url` / `cleartext: true` у production-config-у
+    // тримати не можна — вони б ефективно робили cleartext-режим і
+    // ламали б `android:usesCleartextTraffic="false"` у маніфесті.
     androidScheme: "https",
+  },
+  android: {
+    // Паралельно до `android:usesCleartextTraffic="false"` та
+    // `@xml/network_security_config` — захист від ситуації, коли
+    // WebView завантажить https-сторінку, яка мікс-контент тягне http-
+    // ресурс. Тримаємо явний `false`, хоча це і default у Capacitor 7.
+    allowMixedContent: false,
+  },
+  plugins: {
+    SplashScreen: {
+      // `launchAutoHide: false` віддає керування хайдом splash-а коду у
+      // `initNativeShell()` (`SplashScreen.hide({ fadeOutDuration })`)
+      // — інакше дефолтний auto-hide після 500 ms створює flash між
+      // OS-splash і першим React-рендером. `launchShowDuration` — це
+      // failsafe на випадок, якщо runtime-код ніколи не дійде до
+      // `hide()` (bootstrap-помилка ще до маунту React).
+      launchAutoHide: false,
+      launchShowDuration: 3000,
+      // Збігається з web `--c-bg` (light-тема, #fdf9f3). Покриває
+      // області, де `splash.png` не розтягується до країв (wide /
+      // short екрани), щоб не було білої смуги.
+      backgroundColor: "#fdf9f3",
+      androidSplashResourceName: "splash",
+      androidScaleType: "CENTER_CROP",
+      showSpinner: false,
+      splashFullScreen: true,
+      splashImmersive: true,
+    },
+    StatusBar: {
+      // Не дозволяємо WebView-контенту рендеритись під status-bar-ом —
+      // BottomNav / safe-area плиток web-сайду на iOS рахується без
+      // offset-а під notch. Runtime-код у `initNativeShell()` дальше
+      // перевизначає стиль/колір у залежності від dark/light-теми.
+      overlaysWebView: false,
+      style: "DEFAULT",
+      backgroundColor: "#fdf9f3",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Focused audit/tightening of `apps/mobile-shell`'s native Capacitor configuration. iOS is intentionally out of scope (no `ios/` project committed — see `apps/mobile-shell/README.md` § "iOS"). All changes are confined to the Android side of the shell and to `capacitor.config.ts`; no changes to web or server code.

### Audit checklist — before / after

**Changed:**

- [x] **1. App identifiers — reviewed, consistent.** `capacitor.config.ts` `appId`, `AndroidManifest` is implicit via `applicationId`, `android/app/build.gradle` `namespace` / `applicationId`, and `res/values/strings.xml` `package_name` + `custom_url_scheme` are **all `com.sergeant.shell`**. Left as-is.
- [x] **2. Permissions / usage strings (Android) — reviewed, no changes.** Manifest declares only `INTERNET` + `CAMERA` (explicit for `@capacitor-mlkit/barcode-scanning`), plus non-required `camera` / `camera.autofocus` features. `POST_NOTIFICATIONS` is contributed by `@capacitor/push-notifications`' plugin manifest via manifest-merger, so no duplicate declaration here. Left as-is.
- [x] **3. Deep links — reviewed, consistent.** `com.sergeant.shell://` scheme is the same across `src/index.ts`' `DEEP_LINK_SCHEME`, `AndroidManifest.xml` intent-filter, and `res/values/strings.xml` `custom_url_scheme`. Intent-filter correctly carries `android:autoVerify="false"` (custom scheme, not an App Link). Left as-is.
- [x] **4a. Network security — Android cleartext.**
  - Before: no explicit `android:usesCleartextTraffic` flag, no `networkSecurityConfig` XML.
  - After: `android:usesCleartextTraffic="false"` **+** new `res/xml/network_security_config.xml` with `<base-config cleartextTrafficPermitted="false"/>` referenced via `android:networkSecurityConfig="@xml/network_security_config"`. Defense-in-depth on top of `server.androidScheme: "https"` — if someone later adds a `server.url` pointing at `http://…`, WebView will still refuse cleartext.
- [x] **4b. Network security — mixed content.**
  - Before: no explicit value in `capacitor.config.ts`.
  - After: `android.allowMixedContent: false` (explicit; same as current default, documents intent).
- [x] **5a. Splash screen config.**
  - Before: no `plugins.SplashScreen` in `capacitor.config.ts`; runtime code in `initNativeShell()` calls `SplashScreen.hide({ fadeOutDuration: 250 })`, but Capacitor's default `launchAutoHide: true` already hides after 500 ms → race / white flash before React mounts (the exact tuning concern flagged in `README.md` § "Що НЕ зроблено" → "iOS safe-area + splash race").
  - After: `plugins.SplashScreen = { launchAutoHide: false, launchShowDuration: 3000, backgroundColor: "#fdf9f3" /* web --c-bg light */, androidSplashResourceName: "splash", androidScaleType: "CENTER_CROP", showSpinner: false, splashFullScreen: true, splashImmersive: true }`. Explicit hide() in runtime code is now authoritative; `launchShowDuration` is a failsafe in case bootstrap crashes before React mounts.
- [x] **5b. StatusBar config.**
  - Before: no `plugins.StatusBar` — relied entirely on runtime `initNativeShell()`.
  - After: `plugins.StatusBar = { overlaysWebView: false, style: "DEFAULT", backgroundColor: "#fdf9f3" }`. Neutral compile-time defaults; runtime still switches style/backgroundColor between dark/light in `initNativeShell()` (see `src/index.ts:92-96`).
- [x] **7. Server config in `capacitor.config.ts` — reviewed.**
  - Before: `server: { androidScheme: "https" }`. No `server.url`, no `cleartext: true`. **Already production-safe.** Added a clarifying comment so no one re-introduces dev-only fields without noticing they'd break the cleartext-false posture.
- [x] **8a. `allowBackup` (security smell).**
  - Before: `android:allowBackup="true"` (Capacitor template default).
  - After: `android:allowBackup="false"`. Bearer auth tokens are persisted via `@capacitor/preferences` (→ EncryptedSharedPreferences / Keychain, see `src/auth-storage.ts`), and the FCM/APNs token is cached in the same preferences store (`src/pushNative.ts` → `NATIVE_PUSH_TOKEN_KEY`). Leaving backup on would let `adb backup` / auto-backup ship those to Google Drive.

**Reviewed, not changed (reason):**

- **6. SDK levels.** `variables.gradle`: `minSdkVersion=23`, `compileSdkVersion=35`, `targetSdkVersion=35`; AGP `8.7.2`; `capacitor.build.gradle` → Java 21. All match Capacitor 7.4.x's current requirements (min 23, compile/target 35). No change.
- **iOS Info.plist / AppDelegate / Assets.xcassets / ATS / CFBundleURLTypes.** `apps/mobile-shell/ios/` is **not committed** (`README.md` explicitly documents `cap add ios` is blocked on a Mac runner). There is no `ios/` tree to audit or tighten; deferring to a follow-up once the native iOS project lands.
- **FileProvider paths (`res/xml/file_paths.xml`).** Grants `external-path` + `cache-path` both at `.` which is overly broad, but matches the Capacitor-generated default and may be depended on by first-party plugins (e.g. file-sharing via `@capacitor/share` if added later). Narrowing without a concrete consumer risks silent plugin breakage; flagging but leaving as-is.
- **`res/layout/activity_main.xml`.** Contains a `WebView` stub that isn't actually used — Capacitor's `BridgeActivity` inflates its own layout. Harmless template leftover; leaving to avoid mystery diff in a "tighten config" PR.
- **Android `POST_NOTIFICATIONS` / `VIBRATE` permissions.** Contributed by `@capacitor/push-notifications` v7's plugin manifest via manifest-merger; duplicating them in the app manifest would only add noise.
- **Deep-link scheme value.** Verified consistent across code + strings + manifest as `com.sergeant.shell://`. Not changed.

## Review & Testing Checklist for Human

Risk: yellow (config-only, no code paths changed, but two of the changes — `allowBackup=false` and `usesCleartextTraffic=false` — are observable at runtime on a device).

- [ ] Rebuild the Android shell end-to-end and install on a device:
      `pnpm build:web && pnpm --filter @sergeant/mobile-shell sync android && pnpm --filter @sergeant/mobile-shell open:android` → Run → confirm the app boots, loads the web bundle, status bar colour matches `#fdf9f3` in light mode / `#171412` in dark mode (runtime still takes over), and the splash fades out via `initNativeShell()` without a white flash.
- [ ] Verify deep link still opens the app: `adb shell am start -a android.intent.action.VIEW -d 'com.sergeant.shell://home'` → app comes to foreground, `parseDeepLink` listener in `src/index.ts` fires as before.
- [ ] Confirm no plain-HTTP resource needed. The server endpoint (`VITE_API_BASE_URL` / the prod server) must be HTTPS; if any asset/chunk is loaded over `http://…` the WebView will now block it (`net::ERR_CLEARTEXT_NOT_PERMITTED`). `Sergeant` already uses HTTPS everywhere, but worth smoke-testing Monobank webhook flows, push endpoints, etc.
- [ ] Accept that `adb backup -f …` will no longer produce a payload — this is intentional (bearer tokens + FCM token should not be exfiltrated via backup).

### Notes

- No changes to `apps/web`, `apps/server`, `apps/mobile` (Expo), or any shared package. The PR is strictly `apps/mobile-shell/**`.
- Existing `apps/mobile-shell` vitest suite (32 tests across `src/index.test.ts` / `src/auth-storage.test.ts` / `src/platform.test.ts`) still passes locally. Typecheck (`tsc -p tsconfig.json --noEmit`) clean.
- iOS-side audit items from the original checklist (Info.plist `NS*UsageDescription`, `CFBundleURLTypes`, `AppDelegate` URL scheme handling, `Assets.xcassets` splash/icons, ATS, deployment target) are **not covered** — they need a committed `ios/` project, which currently doesn't exist per `apps/mobile-shell/README.md`. Recommend revisiting in the PR that lands `cap add ios`.


---

[Devin session](https://app.devin.ai/sessions/e6ff9cf517fc4e5cb6717e83fda1b8a3) · Requested by Вася (@Skords-01 · steppupa@gmail.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enforced HTTPS-only connections and disabled cleartext traffic for enhanced protection.
  * Disabled app backup functionality.

* **Style**
  * Customized splash screen appearance with updated display duration, colors, and sizing.
  * Enhanced status bar styling and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->