### PR TITLE
feat(mobile-shell): deep-link bridge до React Router через namespaced window-ключі

### DIFF
--- a/apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts
+++ b/apps/mobile-shell/src/__tests__/deepLinkBridge.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Тести deep-link bridge: як `initNativeShell()` передає parsed-path у
+ * web-шар. Три сценарії preference-у:
+ *   1. `options.navigate` (явний callback) — має бути single source of
+ *      truth, shell не ліз у `window.*` bridge.
+ *   2. `window.__sergeantShellNavigate` (React-встановлений bridge) —
+ *      викликається, якщо options.navigate відсутній.
+ *   3. Буферизація в `window.__sergeantShellDeepLinkQueue` — cold start,
+ *      коли ні callback, ні bridge ще не встановлені.
+ *
+ * Покриваємо також resilience: якщо bridge-виклик кидає, shell лише
+ * warn-ає у console — listener `appUrlOpen` повинен лишитись живим.
+ */
+
+type CapacitorMocks = {
+  StatusBar: {
+    setStyle: ReturnType<typeof vi.fn>;
+    setBackgroundColor: ReturnType<typeof vi.fn>;
+  };
+  SplashScreen: { hide: ReturnType<typeof vi.fn> };
+  Keyboard: { setResizeMode: ReturnType<typeof vi.fn> };
+  App: {
+    addListener: ReturnType<typeof vi.fn>;
+    exitApp: ReturnType<typeof vi.fn>;
+  };
+};
+
+type UrlOpenCallback = (event: { url: string }) => void;
+
+type BridgeWindow = Window & {
+  __sergeantShellNavigate?: (path: string) => void;
+  __sergeantShellDeepLinkQueue?: string[];
+};
+
+function installCapacitorMocks(): CapacitorMocks {
+  const StatusBar = {
+    setStyle: vi.fn().mockResolvedValue(undefined),
+    setBackgroundColor: vi.fn().mockResolvedValue(undefined),
+  };
+  const SplashScreen = { hide: vi.fn().mockResolvedValue(undefined) };
+  const Keyboard = { setResizeMode: vi.fn().mockResolvedValue(undefined) };
+  const App = {
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+    exitApp: vi.fn().mockResolvedValue(undefined),
+  };
+
+  vi.doMock("@capacitor/status-bar", () => ({
+    StatusBar,
+    Style: { Dark: "DARK", Light: "LIGHT", Default: "DEFAULT" },
+  }));
+  vi.doMock("@capacitor/splash-screen", () => ({ SplashScreen }));
+  vi.doMock("@capacitor/keyboard", () => ({
+    Keyboard,
+    KeyboardResize: {
+      Body: "body",
+      Ionic: "ionic",
+      Native: "native",
+      None: "none",
+    },
+  }));
+  vi.doMock("@capacitor/app", () => ({ App }));
+
+  return { StatusBar, SplashScreen, Keyboard, App };
+}
+
+async function captureUrlOpenCallback(
+  mocks: CapacitorMocks,
+  options: { navigate?: (path: string) => void } = {},
+): Promise<UrlOpenCallback> {
+  const { initNativeShell } = await import("../index.js");
+  await initNativeShell(options);
+
+  const call = mocks.App.addListener.mock.calls.find(
+    ([event]) => event === "appUrlOpen",
+  );
+  expect(call?.[0]).toBe("appUrlOpen");
+  const cb = call?.[1] as UrlOpenCallback;
+  expect(typeof cb).toBe("function");
+  return cb;
+}
+
+function resetBridgeGlobals(): void {
+  const w = window as BridgeWindow;
+  delete w.__sergeantShellNavigate;
+  delete w.__sergeantShellDeepLinkQueue;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  resetBridgeGlobals();
+});
+
+afterEach(() => {
+  vi.doUnmock("@capacitor/status-bar");
+  vi.doUnmock("@capacitor/splash-screen");
+  vi.doUnmock("@capacitor/keyboard");
+  vi.doUnmock("@capacitor/app");
+  vi.restoreAllMocks();
+  resetBridgeGlobals();
+});
+
+describe("deep-link bridge — preference order", () => {
+  it("`options.navigate` має пріоритет над `window.__sergeantShellNavigate`", async () => {
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+    const bridgeNav = vi.fn();
+    w.__sergeantShellNavigate = bridgeNav;
+
+    const optionsNav = vi.fn();
+    const cb = await captureUrlOpenCallback(mocks, { navigate: optionsNav });
+    cb({ url: "com.sergeant.shell://settings" });
+
+    expect(optionsNav).toHaveBeenCalledTimes(1);
+    expect(optionsNav).toHaveBeenCalledWith("/settings");
+    expect(bridgeNav).not.toHaveBeenCalled();
+  });
+
+  it("`window.__sergeantShellNavigate` викликається, якщо `options.navigate` відсутній", async () => {
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+    const bridgeNav = vi.fn();
+    w.__sergeantShellNavigate = bridgeNav;
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://nutrition/scan" });
+
+    expect(bridgeNav).toHaveBeenCalledTimes(1);
+    expect(bridgeNav).toHaveBeenCalledWith("/nutrition/scan");
+    // Черга не використовується, коли bridge уже встановлений.
+    expect(w.__sergeantShellDeepLinkQueue).toBeUndefined();
+  });
+
+  it("без bridge — path потрапляє у `__sergeantShellDeepLinkQueue`", async () => {
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://finyk" });
+
+    expect(w.__sergeantShellDeepLinkQueue).toEqual(["/finyk"]);
+  });
+
+  it("множинні cold-start події акумулюються у черзі (FIFO)", async () => {
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://finyk" });
+    cb({ url: "com.sergeant.shell://fizruk" });
+    cb({ url: "com.sergeant.shell://routine#today" });
+
+    expect(w.__sergeantShellDeepLinkQueue).toEqual([
+      "/finyk",
+      "/fizruk",
+      "/routine#today",
+    ]);
+  });
+
+  it("коли bridge встановлюється ПІСЛЯ кількох подій, черга не очищається shell-ем (це робить web)", async () => {
+    // Shell — чесний producer: він тільки пише у чергу. Консьюмер
+    // (web ShellDeepLinkBridge) — єдиний, хто її drain-ить. Так ми
+    // не гонимося з React-render-ом і не програємо події двічі.
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://finyk" });
+    cb({ url: "com.sergeant.shell://fizruk" });
+
+    // Тепер web «встановлюється».
+    const bridgeNav = vi.fn();
+    w.__sergeantShellNavigate = bridgeNav;
+
+    // Чергу shell НЕ чистить — це контракт.
+    expect(w.__sergeantShellDeepLinkQueue).toEqual(["/finyk", "/fizruk"]);
+
+    // Нова подія ПІСЛЯ install-у — йде напряму у bridge, минаючи чергу.
+    cb({ url: "com.sergeant.shell://routine" });
+    expect(bridgeNav).toHaveBeenCalledWith("/routine");
+    expect(w.__sergeantShellDeepLinkQueue).toEqual(["/finyk", "/fizruk"]);
+  });
+});
+
+describe("deep-link bridge — відкидання чужих URL", () => {
+  it("чужа схема (https://…) НЕ попадає ні в navigate, ні в чергу", async () => {
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+    const bridgeNav = vi.fn();
+    w.__sergeantShellNavigate = bridgeNav;
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "https://sergeant.app/home" });
+    cb({ url: "javascript:alert(1)" });
+
+    expect(bridgeNav).not.toHaveBeenCalled();
+    expect(w.__sergeantShellDeepLinkQueue).toBeUndefined();
+  });
+});
+
+describe("deep-link bridge — resilience", () => {
+  it("якщо `options.navigate` кидає — shell ловить, warn-ає, і не падає", async () => {
+    const mocks = installCapacitorMocks();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const navigate = vi.fn(() => {
+      throw new Error("boom");
+    });
+
+    const cb = await captureUrlOpenCallback(mocks, { navigate });
+    expect(() => cb({ url: "com.sergeant.shell://home" })).not.toThrow();
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArg = String(warnSpy.mock.calls[0]?.[0]);
+    expect(warnArg).toContain("options.navigate");
+  });
+
+  it("якщо `window.__sergeantShellNavigate` кидає — shell warn-ає і НЕ фоллбеч-ить у чергу (подія вже «доставлена»)", async () => {
+    const mocks = installCapacitorMocks();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const w = window as BridgeWindow;
+    w.__sergeantShellNavigate = vi.fn(() => {
+      throw new Error("router-err");
+    });
+
+    const cb = await captureUrlOpenCallback(mocks);
+    expect(() => cb({ url: "com.sergeant.shell://settings" })).not.toThrow();
+
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArg = String(warnSpy.mock.calls[0]?.[0]);
+    expect(warnArg).toContain("__sergeantShellNavigate");
+    // Черга лишається undefined — ми не дублюємо у fallback, бо
+    // напівдоставлена подія (виняток вже ПІСЛЯ виклику) виглядає для
+    // shell-а як доставлена. Повторювати її у чергу → ризик подвійної
+    // навігації при наступному install-і bridge-а.
+    expect(w.__sergeantShellDeepLinkQueue).toBeUndefined();
+  });
+
+  it("існуюча (preserved) черга не перезаписується — pushes акумулюються", async () => {
+    // Страхуємось від бажання ненароком зробити `w.queue = [path]`,
+    // яке стирало б раніше накопичені cold-start події.
+    const mocks = installCapacitorMocks();
+    const w = window as BridgeWindow;
+    w.__sergeantShellDeepLinkQueue = ["/prev"];
+
+    const cb = await captureUrlOpenCallback(mocks);
+    cb({ url: "com.sergeant.shell://home" });
+
+    expect(w.__sergeantShellDeepLinkQueue).toEqual(["/prev", "/home"]);
+  });
+});

--- a/apps/mobile-shell/src/__tests__/parseDeepLink.test.ts
+++ b/apps/mobile-shell/src/__tests__/parseDeepLink.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Розширене покриття `parseDeepLink()` — edge-кейси, які `src/index.test.ts`
+ * не тестує (trailing slash, multi-segment paths, URL-encoded chars,
+ * empty / root paths тощо). Крадькома від нативного Capacitor-рантайму:
+ * сама функція не тягне `@capacitor/app`, тому тест живе в node-env без
+ * будь-яких моків.
+ */
+
+import { parseDeepLink } from "../index.js";
+
+describe("parseDeepLink — розширені edge-кейси", () => {
+  describe("валідні варіанти", () => {
+    it.each([
+      ["com.sergeant.shell://home", "/home"],
+      ["com.sergeant.shell:///home", "/home"],
+      ["com.sergeant.shell://nutrition/scan", "/nutrition/scan"],
+      [
+        "com.sergeant.shell://finyk/transactions/123",
+        "/finyk/transactions/123",
+      ],
+    ])("витягає path з %s → %s", (url, expected) => {
+      expect(parseDeepLink(url)).toBe(expected);
+    });
+
+    it("зберігає trailing slash як окремий сегмент (`/home/`)", () => {
+      // React Router трактує `/home` і `/home/` трохи по-різному
+      // (trailing slash → матч по `children` префіксу у деяких
+      // конфігураціях). Навмисно НЕ стрипаємо — не наша справа
+      // інтерпретувати, це робота роутера на web-стороні.
+      expect(parseDeepLink("com.sergeant.shell://home/")).toBe("/home/");
+    });
+
+    it("зберігає query string як є", () => {
+      expect(parseDeepLink("com.sergeant.shell://search?q=protein")).toBe(
+        "/search?q=protein",
+      );
+    });
+
+    it("зберігає кілька query-параметрів", () => {
+      expect(
+        parseDeepLink("com.sergeant.shell://search?q=protein&sort=date&n=5"),
+      ).toBe("/search?q=protein&sort=date&n=5");
+    });
+
+    it("зберігає URL-encoded символи у query без повторного декодування", () => {
+      // Якщо b щось деклогодилось, `?q=hello world` ламав би парсер
+      // query-string React Router-а на пробілі.
+      expect(parseDeepLink("com.sergeant.shell://search?q=hello%20world")).toBe(
+        "/search?q=hello%20world",
+      );
+    });
+
+    it("зберігає fragment (`#frag`)", () => {
+      expect(parseDeepLink("com.sergeant.shell://routine#habits")).toBe(
+        "/routine#habits",
+      );
+    });
+
+    it("зберігає fragment разом з query (`?x=1#frag`)", () => {
+      expect(parseDeepLink("com.sergeant.shell://routine?x=1#habits")).toBe(
+        "/routine?x=1#habits",
+      );
+    });
+
+    it("віддає `/` для порожнього path-у (`com.sergeant.shell://`)", () => {
+      // Android `am start -d com.sergeant.shell://` технічно валідний —
+      // трактуємо як «відкрий home».
+      expect(parseDeepLink("com.sergeant.shell://")).toBe("/");
+    });
+
+    it("нормалізує потрійний слеш (`com.sergeant.shell:///`) у `/`", () => {
+      expect(parseDeepLink("com.sergeant.shell:///")).toBe("/");
+    });
+
+    it("зберігає тільки query без path (`?x=1`)", () => {
+      expect(parseDeepLink("com.sergeant.shell://?x=1")).toBe("/?x=1");
+    });
+
+    it("зберігає тільки fragment без path (`#frag`)", () => {
+      expect(parseDeepLink("com.sergeant.shell://#frag")).toBe("/#frag");
+    });
+  });
+
+  describe("відхилення чужих URL (повертає `null`)", () => {
+    it.each([
+      "https://sergeant.app/home",
+      "http://sergeant.app/home",
+      "foo://home",
+      "com.sergeant.app://home", // RN bundle id — навмисно інший
+      "com.sergeant.shel://home", // typo в схемі
+      "com.sergeant.shells://home", // надлишкова `s`
+      "COM.SERGEANT.SHELL://home", // case-sensitive
+      "//com.sergeant.shell://home", // префіксний noise
+      " com.sergeant.shell://home", // leading whitespace
+      "",
+      "about:blank",
+      "javascript:alert(1)", // захист від injection через intent
+    ])("повертає `null` для `%s`", (url) => {
+      expect(parseDeepLink(url)).toBeNull();
+    });
+  });
+});

--- a/apps/mobile-shell/src/index.test.ts
+++ b/apps/mobile-shell/src/index.test.ts
@@ -234,28 +234,27 @@ describe("initNativeShell — deep-link listener", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("без options.navigate — fallback на window.location.assign", async () => {
+  it("без options.navigate і без `window.__sergeantShellNavigate` — буферизує у `window.__sergeantShellDeepLinkQueue`", async () => {
+    // Нова семантика: замість `window.location.assign(path)` (повний
+    // reload, втрата state) shell акуратно штовхає path у чергу і чекає,
+    // поки React-шар виставить bridge. Веб при маунті роутера drain-ить
+    // чергу — див. `apps/web/src/core/app/ShellDeepLinkBridge.tsx`.
     const mocks = installCapacitorMocks();
-    const assign = vi.fn();
-    // `window.location.assign` у jsdom не конфігурується точково, тому
-    // підміняємо весь `window.location` — цього достатньо для тесту.
-    const originalLocation = window.location;
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: { ...originalLocation, assign },
-    });
+    const w = window as Window & {
+      __sergeantShellNavigate?: (path: string) => void;
+      __sergeantShellDeepLinkQueue?: string[];
+    };
+    delete w.__sergeantShellNavigate;
+    delete w.__sergeantShellDeepLinkQueue;
 
     try {
       const cb = await captureUrlOpenCallback(mocks);
       cb({ url: "com.sergeant.shell://home" });
 
-      expect(assign).toHaveBeenCalledTimes(1);
-      expect(assign).toHaveBeenCalledWith("/home");
+      expect(w.__sergeantShellDeepLinkQueue).toEqual(["/home"]);
     } finally {
-      Object.defineProperty(window, "location", {
-        configurable: true,
-        value: originalLocation,
-      });
+      delete w.__sergeantShellNavigate;
+      delete w.__sergeantShellDeepLinkQueue;
     }
   });
 });

--- a/apps/mobile-shell/src/index.ts
+++ b/apps/mobile-shell/src/index.ts
@@ -4,14 +4,21 @@
  * Цей модуль — єдине місце, де **compile-time** імпортуються рантайм-плагіни
  * `@capacitor/status-bar`, `@capacitor/splash-screen`, `@capacitor/keyboard`,
  * `@capacitor/app`. Браузерні користувачі це дерево ніколи не тягнуть — веб
- * (`apps/web`) імпортує цей файл **динамічно** і лише якщо
- * `isCapacitor()` (див. `apps/web/src/shared/lib/platform.ts`). Vite через
- * це виносить плагіни в окремий chunk, і точка входу бандлу лишається
- * вільною від Capacitor-runtime.
+ * (`apps/web`) імпортує цей файл **динамічно** і лише якщо `isCapacitor()`
+ * (див. `packages/shared/src/lib/platform.ts`). Vite через це виносить
+ * плагіни в окремий chunk, і точка входу бандлу лишається вільною від
+ * Capacitor-runtime.
  *
  * `initNativeShell()` ідемпотентний — друге-трете викликання мовчки
  * ігнорується, щоби HMR у Capacitor LiveReload не дублював listener-и
  * (`App.addListener('appUrlOpen', ...)` інакше зростає на кожному ре-імпорті).
+ *
+ * Deep-link bridge: `appUrlOpen` парситься через `parseDeepLink()` і
+ * диспатчиться у web-шар БЕЗ compile-time залежності — через namespaced
+ * `window.__sergeantShellNavigate` (виставляється React-компонентом після
+ * маунту роутера) з буфером `window.__sergeantShellDeepLinkQueue` для
+ * cold-start сценарію, коли native-подія прилетіла ДО того, як веб встиг
+ * зареєструвати bridge. Web-сторона програє буфер при install-і.
  */
 
 import { App, type URLOpenListenerEvent } from "@capacitor/app";
@@ -31,10 +38,71 @@ export interface InitNativeShellOptions {
   /**
    * Хук навігації з web-side (зазвичай обгортка над React Router
    * `navigate()`). Викликається з відносним шляхом, витягнутим з
-   * `com.sergeant.shell://<path>`. Якщо не передано — використовується
-   * повний `window.location.assign(...)` як fallback.
+   * `com.sergeant.shell://<path>`. Якщо не передано — deep-link
+   * диспатчиться через window-bridge (`__sergeantShellNavigate`) з
+   * буферизацією у `__sergeantShellDeepLinkQueue` для cold-start.
    */
   navigate?: (path: string) => void;
+}
+
+/**
+ * Ключ на `window`, який виставляє React-компонент веб-шару (`useNavigate()`
+ * обгортка) після маунту роутера. Shell викликає його, щоби програмно
+ * навігувати по React Router без full-reload.
+ */
+const SHELL_NAVIGATE_KEY = "__sergeantShellNavigate" as const;
+
+/**
+ * Буфер deep-link шляхів, що прилетіли ДО того, як web-шар встиг виставити
+ * `__sergeantShellNavigate` (cold start через deep link). Веб при install-і
+ * drain-ить цей масив і програє накопичені шляхи через React Router.
+ */
+const SHELL_QUEUE_KEY = "__sergeantShellDeepLinkQueue" as const;
+
+type DeepLinkBridgeWindow = Window & {
+  [SHELL_NAVIGATE_KEY]?: (path: string) => void;
+  [SHELL_QUEUE_KEY]?: string[];
+};
+
+/**
+ * Диспатчер deep-link шляху у web-сторону. Порядок preference:
+ *   1. `options.navigate(path)` — явно переданий callback (тестова ін'єкція
+ *      або legacy-caller, що сам тримає навігаційний хук).
+ *   2. `window.__sergeantShellNavigate(path)` — bridge, який виставляє
+ *      React-layout після маунту роутера.
+ *   3. Буферизація у `window.__sergeantShellDeepLinkQueue`, якщо bridge ще
+ *      не встановлений (cold-start) — веб drain-ить чергу при install-і.
+ *
+ * Помилки виклику navigate не шкодять shell — залоговане попередження, але
+ * подія все одно проковтнута (не падає з listener-у `appUrlOpen`).
+ */
+function dispatchDeepLink(path: string, options: InitNativeShellOptions): void {
+  if (options.navigate) {
+    try {
+      options.navigate(path);
+    } catch (err) {
+      console.warn("[mobile-shell] options.navigate failed", err);
+    }
+    return;
+  }
+
+  if (typeof window === "undefined") return;
+  const w = window as DeepLinkBridgeWindow;
+
+  const bridgeNavigate = w[SHELL_NAVIGATE_KEY];
+  if (typeof bridgeNavigate === "function") {
+    try {
+      bridgeNavigate(path);
+    } catch (err) {
+      console.warn("[mobile-shell] window.__sergeantShellNavigate failed", err);
+    }
+    return;
+  }
+
+  if (!Array.isArray(w[SHELL_QUEUE_KEY])) {
+    w[SHELL_QUEUE_KEY] = [];
+  }
+  w[SHELL_QUEUE_KEY]!.push(path);
 }
 
 let initialized = false;
@@ -121,11 +189,7 @@ export async function initNativeShell(
     await App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
       const path = parseDeepLink(event.url);
       if (path == null) return;
-      if (options.navigate) {
-        options.navigate(path);
-      } else if (typeof window !== "undefined") {
-        window.location.assign(path);
-      }
+      dispatchDeepLink(path, options);
     });
   } catch (err) {
     console.warn("[mobile-shell] App.addListener('appUrlOpen') failed", err);

--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -38,6 +38,7 @@ import { hasAnyRealEntry } from "./onboarding/firstRealEntry.js";
 import { useHubNavigation } from "./hooks/useHubNavigation.js";
 import { useHubUIState } from "./hooks/useHubUIState.js";
 import { usePwaActions, type PwaAction } from "./hooks/usePwaActions.js";
+import { ShellDeepLinkBridge } from "./app/ShellDeepLinkBridge";
 
 const AuthPage = lazy(() =>
   import("./AuthPage.jsx").then((m) => ({ default: m.AuthPage })),
@@ -76,6 +77,12 @@ export default function App() {
   return (
     <ToastProvider>
       <ToastContainer />
+      {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
+          рендериться під <BrowserRouter>), але поза AppInner, щоб
+          bridge переживав ранні return-и в AppInner (/sign-in,
+          /reset-password, /design тощо) — deep link може прилетіти у
+          будь-який із цих станів. */}
+      <ShellDeepLinkBridge />
       <ApiClientProvider client={apiClient}>
         <AuthProvider>
           <AppInner />

--- a/apps/web/src/core/app/ShellDeepLinkBridge.tsx
+++ b/apps/web/src/core/app/ShellDeepLinkBridge.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { isCapacitor } from "@sergeant/shared";
+
+/**
+ * Bridge-компонент, який звʼязує Capacitor-shell і React Router через
+ * namespaced window-ключі — без compile-time залежності веб-бандла на
+ * `@capacitor/*`. Після маунту роутера виставляє
+ * `window.__sergeantShellNavigate` (shell використовує його у
+ * `appUrlOpen` handler) і прогає буферизовані deep-link шляхи, що
+ * прилетіли ДО маунту (cold start через `com.sergeant.shell://…`
+ * URL → Capacitor вже встиг пушнути path у
+ * `window.__sergeantShellDeepLinkQueue`, але React Router тоді ще не
+ * існував).
+ *
+ * У браузері рендер no-op: guard `isCapacitor()` скіпає install-логіку,
+ * і всі window-ключі лишаються `undefined`. Компонент повертає `null`
+ * незалежно від плаформи — він лише для side-effect-ів ефекту.
+ *
+ * Маунтиться ВСЕРЕДИНІ `<BrowserRouter>`, інакше `useNavigate()` кине
+ * «useNavigate() may be used only in the context of a <Router>».
+ */
+
+type DeepLinkBridgeWindow = Window & {
+  __sergeantShellNavigate?: (path: string) => void;
+  __sergeantShellDeepLinkQueue?: string[];
+};
+
+export function ShellDeepLinkBridge(): null {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isCapacitor()) return;
+    if (typeof window === "undefined") return;
+    const w = window as DeepLinkBridgeWindow;
+
+    const handler = (path: string): void => {
+      navigate(path);
+    };
+    w.__sergeantShellNavigate = handler;
+
+    // Drain-имо буфер cold-start шляхів одразу після install-у. Масив
+    // міг бути заповнений shell-ем у вікні між `initNativeShell()` і
+    // першим ефектом React-дерева — типовий сценарій при запуску апки
+    // через `com.sergeant.shell://<path>`.
+    const queue = w.__sergeantShellDeepLinkQueue;
+    if (Array.isArray(queue) && queue.length > 0) {
+      const pending = queue.splice(0, queue.length);
+      for (const path of pending) {
+        try {
+          navigate(path);
+        } catch (err) {
+          console.warn("[shell-deep-link] flush navigate failed", err);
+        }
+      }
+    }
+
+    return () => {
+      // Чистимо саме наш handler — якщо хтось інший перевстановив
+      // bridge (наприклад, HMR-перезапуск ефекту), не витираємо новіший.
+      if (w.__sergeantShellNavigate === handler) {
+        delete w.__sergeantShellNavigate;
+      }
+    };
+  }, [navigate]);
+
+  return null;
+}

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -105,18 +105,17 @@ if (typeof window !== "undefined") {
 // Native-shell bootstrap: лише в Capacitor WebView, ніколи у браузері.
 // Dynamic import ⇒ Vite кладе `@sergeant/mobile-shell` та всі `@capacitor/*`
 // плагіни в окремий chunk, тож browser-бандл не тягне їх зовсім.
+//
+// Deep-link bridge підʼєднується НЕ через `options.navigate` (який викликає
+// `history.pushState` out-of-component і плутає React Router з «перший render
+// уже завершився» сценарієм), а через namespaced `window.__sergeantShellNavigate`,
+// який виставляє `<ShellDeepLinkBridge/>` у `core/App.tsx` після маунту
+// роутера. Якщо `appUrlOpen` прилітає ДО маунту (cold start через deep link),
+// shell буферизує path у `window.__sergeantShellDeepLinkQueue` і bridge
+// drain-ить його при install-і.
 if (isCapacitor()) {
   import("@sergeant/mobile-shell")
-    .then(({ initNativeShell }) =>
-      initNativeShell({
-        navigate: (path) => {
-          // React Router слухає `popstate` для оновлення шляху — це канонічний
-          // спосіб програмно навігувати без useNavigate() out-of-component.
-          window.history.pushState(null, "", path);
-          window.dispatchEvent(new PopStateEvent("popstate"));
-        },
-      }),
-    )
+    .then(({ initNativeShell }) => initNativeShell())
     .catch((err) => {
       console.warn("[main] native-shell init failed", err);
     });

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -148,9 +148,14 @@ Android-частина (`android/`) закомічена, `applicationId`
   Android — лише якщо PWA установлено). Повний fix — окремий PR з
   `@capacitor/push-notifications` (FCM + APNs) і розширенням
   `createPushEndpoints.register` на `platform: "android" | "ios"`.
-- **Deep links.** `parseDeepLink()` в `src/index.ts` є, але
+- ~~**Deep links.** `parseDeepLink()` в `src/index.ts` є, але
   `App.addListener('appUrlOpen', ...)` ще не звʼязаний з React Router
-  всередині `apps/web` — треба exported `navigate()` прокинути.
+  всередині `apps/web` — треба exported `navigate()` прокинути.~~ Готово:
+  shell диспатчить parsed path через namespaced
+  `window.__sergeantShellNavigate` (встановлюється
+  `<ShellDeepLinkBridge/>` у `apps/web/src/core/App.tsx` після маунту
+  роутера) з буфером `window.__sergeantShellDeepLinkQueue` для cold-start
+  сценарію (native-подія прилетіла ДО готовності React-шару).
 - **Safe-area / keyboard avoidance** на iOS усе ще покладаються на
   CSS `env(safe-area-inset-*)` — працює, але не 100% якщо splash
   тримається довше за `hide()`.


### PR DESCRIPTION
## Summary

Закриває пункт **Deep links** з [`docs/platforms.md` секція «Capacitor shell / Не зроблено»](https://github.com/Skords-01/Sergeant/blob/main/docs/platforms.md#L151-L153):

> `parseDeepLink()` в `src/index.ts` є, але `App.addListener('appUrlOpen', ...)` ще не звʼязаний з React Router всередині `apps/web` — треба exported `navigate()` прокинути.

Раніше `appUrlOpen` диспатчив parsed path через `options.navigate` хук, який main.jsx робив як `history.pushState` + `popstate` dispatch. Два проблемних місця:

1. **Cold start через deep link** (`com.sergeant.shell://<path>` як launch intent) міг прилітати ДО маунту React Router — подія тихо губилась.
2. `history.pushState` out-of-component обходив React Router замість нормально пройти через `useNavigate()`, що плутало transitions (Suspense boundaries не бачили зміни, deep link на lazy-route інколи рендерив stale component до наступного рендера).

### Що змінилось

**Shell side** (`apps/mobile-shell/src/index.ts`):
- `App.addListener("appUrlOpen", ...)` тепер диспатчить parsed path через `dispatchDeepLink()` з preference: `options.navigate` → `window.__sergeantShellNavigate` → буфер `window.__sergeantShellDeepLinkQueue`.
- Помилки виклику bridge загорнуті у `try/catch` — listener переживає падіння web-шару (як інші плагіни в `initNativeShell()`).
- Прибраний `window.location.assign(path)` fallback (робив full reload, втрачав state) — замість нього acord буферизація у чергу.

**Web side** (`apps/web/src/core/app/ShellDeepLinkBridge.tsx`):
- Новий компонент-sentinel, який монтується всередині `<BrowserRouter>` (`core/App.tsx`), поза `AppInner` — щоб переживати ранні return-и (`/sign-in`, `/reset-password`, `/design` гілки) бо deep link може прилетіти у будь-який стан.
- У `useEffect` виставляє `window.__sergeantShellNavigate = (path) => navigate(path)` та drain-ить `window.__sergeantShellDeepLinkQueue` (cold-start буфер).
- Guard `isCapacitor()` (з `@sergeant/shared/lib/platform`) — у браузері це no-op, ключі лишаються `undefined`.
- Жодного compile-time імпорту `@capacitor/*` у `apps/web` — bridge живе лише на window globals.

**`main.jsx`**: прибрана inline-навігація `history.pushState` з `initNativeShell({ navigate })` — тепер `initNativeShell()` без опцій, bridge приходить через window з React-шару.

**Документація**: `docs/platforms.md` — пункт «Deep links» викреслено зі короткою довідкою куди дивитись.

### Architecture notes

- **Producer/consumer контракт**: shell тільки пише у чергу, web тільки drain-ить. Shell НЕ очищає чергу після install-у bridge — інакше race між «shell щойно побачив, що bridge зʼявився» і «web щойно почав drain» міг би програти одну подію двічі.
- **FIFO буфер** для множинних cold-start подій (Android `am start -d ...` подвійний виклик, або push-notification + deep link одночасно).
- **Сумісність options.navigate** лишається як тестова ін'єкція та legacy caller — пріоритетніша за bridge.

## Review &amp; Testing Checklist for Human

🟡 — зона середнього ризику: точка дотику шар shell ↔ web, зміна runtime-контракту навігації, але unit-тести покривають усі гілки + веб-fallback guard-иться `isCapacitor()`.

- [ ] На реальному Android device / emulator перевірити cold start через `adb shell am start -W -a android.intent.action.VIEW -d "com.sergeant.shell://routine" com.sergeant.shell` — після повного launch користувач має опинитись на `/routine`, а не на home.
- [ ] Warm deep link: з апки у фоні запустити той же `am start` — має переключити route без full reload (перевірити `<Suspense>` fallback-и не мигнули).
- [ ] Web build (не Capacitor) має продовжувати працювати — `apps/server/dist` rebuild-иться і відкривається у браузері без помилок у консолі (bridge-компонент no-op через `isCapacitor()` guard).
- [ ] Backward-compat `options.navigate` тест-кейс — якщо хтось із зовні ще викликає `initNativeShell({ navigate })`, воно має мати пріоритет над window-bridge.

Test plan:
1. `pnpm -w typecheck` — має проходити (12 packages, ~23s).
2. `pnpm --filter @sergeant/mobile-shell test` — 67 тестів (19 у `index.test.ts`, 26 у `parseDeepLink.test.ts`, 9 у `deepLinkBridge.test.ts`, + platform/auth-storage).
3. Запустити `pnpm --filter @sergeant/web dev` → відкрити DevTools → `window.__sergeantShellNavigate` має бути `undefined` (бо isCapacitor()=false у браузері).

### Notes

- `pnpm lint:plugins` (`node --test eslint-plugins/sergeant-design/__tests__/`) падає і на `main`, і на цьому бренчі — це Node 22 vs 20 різниця у `node --test <dir>` behavior, не пов'язано з цим PR.
- Unit-тести навмисно лежать у `apps/mobile-shell/src/__tests__/` як просив task; окремий `parseDeepLink.test.ts` розширює покриття (trailing slash, URL-encoded, multi-segment, leading whitespace, `javascript:` injection), `deepLinkBridge.test.ts` тестує preference order + resilience + FIFO буфер.
- `@capacitor/app` плагін сам буферизує native-side `appUrlOpen` події до JS-listener реєстрації — наша JS-сторона буферизації лише для наступного шару (`initNativeShell()` already called → React bridge still not installed).

Link to Devin session: https://app.devin.ai/sessions/0bc7ee973b0941e99748a3db0467c6dc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deep-link handling is now fully implemented and ready for use.
  * App properly navigates to paths opened via Capacitor shell deep-links.
  * Added cold-start support to buffer and process deep-links during app initialization.

* **Tests**
  * Added comprehensive test coverage for deep-link parsing and dispatch behavior.

* **Documentation**
  * Updated platform documentation to reflect deep-link feature completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->