### PR TITLE
feat(mobile-shell): drop service worker from Capacitor shell bundle via VITE_TARGET=capacitor

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -13,6 +13,14 @@ native Android/iOS app. The web bundle lands in `apps/server/dist` — the
 shell reads it from there via `webDir: "../server/dist"` in
 [`apps/mobile-shell/capacitor.config.ts`](apps/mobile-shell/capacitor.config.ts).
 
+> Shell білдить web-бандл через
+> `pnpm --filter @sergeant/mobile-shell build:web`, який делегує до
+> `@sergeant/web build:capacitor` (`VITE_TARGET=capacitor`). Цей варіант
+> вимикає `vite-plugin-pwa`, тому `sw.js`, `manifest.webmanifest` і
+> `virtual:pwa-register` chunk **не** потрапляють у `apps/server/dist`
+> — native WebView їх все одно ігнорує. Для web-деплою (Vercel) і далі
+> використовується root `pnpm build:web`, PWA поведінка без змін.
+
 ## Prerequisites
 
 | Tool              | Version           | Notes                                                         |
@@ -30,7 +38,11 @@ The `android/` folder is already committed, so no scaffolding is needed.
 ```bash
 # from repo root
 pnpm install --frozen-lockfile
-pnpm build:web                                 # → apps/server/dist
+# `mobile-shell#build:web` делегує до `@sergeant/web build:capacitor`
+# (`VITE_TARGET=capacitor`), який вимикає `vite-plugin-pwa` — shell не
+# тягне `sw.js` / `manifest.webmanifest` / `virtual:pwa-register` chunk.
+# Для чистого web-деплою все ще використовується root `pnpm build:web`.
+pnpm --filter @sergeant/mobile-shell build:web # → apps/server/dist
 pnpm --filter @sergeant/mobile-shell exec cap sync android
 cd apps/mobile-shell/android
 ./gradlew assembleDebug                        # → app/build/outputs/apk/debug/
@@ -60,7 +72,8 @@ under the hood). Requires macOS + Xcode + CocoaPods.
 ```bash
 # from repo root
 pnpm install --frozen-lockfile
-pnpm build:web                                 # → apps/server/dist
+# Capacitor-варіант web-бандла (без `vite-plugin-pwa`).
+pnpm --filter @sergeant/mobile-shell build:web # → apps/server/dist
 
 cd apps/mobile-shell
 pnpm exec cap add ios                          # first time only — scaffolds ios/

--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -56,8 +56,15 @@ PR, що чіпає `apps/mobile-shell/**`, `apps/web/**`, `apps/server/**`
 Потрібен Android SDK (через Android Studio або `sdkmanager`).
 
 ```bash
-# 1. Зібрати веб-бандл (йде в apps/server/dist — див. vite.config.js).
-pnpm build:web
+# 1. Зібрати веб-бандл у shell-варіанті (йде в apps/server/dist — див.
+#    vite.config.js). `@sergeant/mobile-shell#build:web` делегує до
+#    `@sergeant/web build:capacitor` (`VITE_TARGET=capacitor`), який
+#    вимикає `vite-plugin-pwa`: у `apps/server/dist` при цьому не
+#    зʼявляються `sw.js`, `manifest.webmanifest` та
+#    `virtual:pwa-register` chunk — native WebView їх ігнорує, тому у
+#    shell вони були dead weight. Для веб-деплою (Vercel) нічого не
+#    зміниться: там все ще використовується root `pnpm build:web`.
+pnpm --filter @sergeant/mobile-shell build:web
 
 # 2. Скопіювати бандл у нативний проєкт.
 pnpm --filter @sergeant/mobile-shell copy

--- a/apps/mobile-shell/capacitor.config.ts
+++ b/apps/mobile-shell/capacitor.config.ts
@@ -27,6 +27,12 @@ const config: CapacitorConfig = {
     // тримати не можна — вони б ефективно робили cleartext-режим і
     // ламали б `android:usesCleartextTraffic="false"` у маніфесті.
     androidScheme: "https",
+    // Явне `cleartext: false` — belt-and-braces поруч з
+    // `androidScheme: "https"` і `android.allowMixedContent: false`
+    // нижче. Default у Capacitor 7 і так `false`, але фіксуємо явно,
+    // щоб випадкова зміна default-у у мажорному апгрейді Capacitor
+    // не перемкнула shell у cleartext-режим.
+    cleartext: false,
   },
   android: {
     // Паралельно до `android:usesCleartextTraffic="false"` та

--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -20,7 +20,7 @@
     "open:ios": "cap open ios",
     "add:android": "cap add android",
     "add:ios": "cap add ios",
-    "build:web": "pnpm --filter @sergeant/web build",
+    "build:web": "pnpm --filter @sergeant/web build:capacitor",
     "build:android": "pnpm build:web && pnpm sync android",
     "build:ios": "pnpm build:web && pnpm sync ios",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --port 5173 --host 0.0.0.0",
     "build": "vite build",
+    "build:capacitor": "cross-env VITE_TARGET=capacitor vite build",
     "build:analyze": "cross-env ANALYZE=1 vite build",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -122,7 +122,20 @@ if (isCapacitor()) {
     });
 }
 
-if ("serviceWorker" in navigator) {
+// Service worker реєструємо лише у веб-деплої (`apps/web` → Vercel).
+// Capacitor WebView ігнорує SW, тож у shell-варіанті (`VITE_TARGET=capacitor`
+// + runtime `isCapacitor()`) вся ця гілка мертва і Vite-build її DCE-вирізає:
+//   - build-time `import.meta.env.VITE_TARGET !== "capacitor"` падає у `false`
+//     після `define`-заміни у `vite.config.js`, тож Rollup не тягне
+//     `virtual:pwa-register` (якого у capacitor-білді не існує — плагін
+//     `vite-plugin-pwa` там відключений);
+//   - runtime `!isCapacitor()` — defensive net на випадок, якщо дефолтний
+//     web-бандл раптом завантажиться у Capacitor WebView.
+if (
+  import.meta.env.VITE_TARGET !== "capacitor" &&
+  !isCapacitor() &&
+  "serviceWorker" in navigator
+) {
   import("virtual:pwa-register").then(({ registerSW }) => {
     const updateSW = registerSW({
       onNeedRefresh() {

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -14,84 +14,106 @@ export default defineConfig(({ mode }) => {
   // don't litter dist/ with the report in CI.
   const analyze = env.ANALYZE === "1" || process.env.ANALYZE === "1";
 
+  // `VITE_TARGET=capacitor` вмикає build-варіант для Capacitor-shell-а
+  // (`apps/mobile-shell`): native WebView і без того ігнорує
+  // `navigator.serviceWorker.register`, тому `vite-plugin-pwa`,
+  // згенерований `sw.js` і `manifest.webmanifest` — dead weight у
+  // shell-бандлі. Відключаємо плагін повністю, а `main.jsx` під
+  // build-time прапором викидає динамічний `import("virtual:pwa-register")`
+  // через DCE — щоб Rollup не намагався резолвити virtual-модуль, якого
+  // тепер немає у graph-і. Веб-деплой (Vercel) продовжує білдитись як
+  // раніше: без прапора плагін активний, PWA для браузерних юзерів
+  // лишається.
+  const isCapacitorBuild =
+    env.VITE_TARGET === "capacitor" || process.env.VITE_TARGET === "capacitor";
+
   return {
+    define: {
+      // Пробрасуємо значення у клієнтський бандл як статичний літерал,
+      // щоб `main.jsx` міг DCE-вирізати SW-гілку у capacitor-білді.
+      "import.meta.env.VITE_TARGET": JSON.stringify(
+        isCapacitorBuild ? "capacitor" : "web",
+      ),
+    },
     plugins: [
       react(),
-      VitePWA({
-        strategies: "injectManifest",
-        srcDir: "src",
-        filename: "sw.js",
-        registerType: "prompt",
-        includeAssets: [
-          "icon.svg",
-          "icon-192.png",
-          "icon-512.png",
-          "apple-touch-icon.png",
-        ],
-        manifest: {
-          name: "Sergeant — Твій персональний хаб життя",
-          short_name: "Sergeant",
-          description: "Персональний хаб: фінанси, спорт, звички та харчування",
-          start_url: "/",
-          display: "standalone",
-          orientation: "portrait",
-          background_color: "#fdf9f3",
-          theme_color: "#fdf9f3",
-          lang: "uk",
-          shortcuts: [
-            {
-              name: "Додати витрату",
-              short_name: "Витрата",
-              description: "Швидко додати нову витрату у Фінік",
-              url: "/?module=finyk&action=add_expense",
-              icons: [
-                { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
-              ],
-            },
-            {
-              name: "Розпочати тренування",
-              short_name: "Тренування",
-              description: "Розпочати нове тренування у Фізрук",
-              url: "/?module=fizruk&action=start_workout",
-              icons: [
-                { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
-              ],
-            },
-            {
-              name: "Додати прийом їжі",
-              short_name: "Їжа",
-              description: "Записати прийом їжі у Харчування",
-              url: "/?module=nutrition&action=add_meal",
-              icons: [
-                { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
-              ],
-            },
+      !isCapacitorBuild &&
+        VitePWA({
+          strategies: "injectManifest",
+          srcDir: "src",
+          filename: "sw.js",
+          registerType: "prompt",
+          includeAssets: [
+            "icon.svg",
+            "icon-192.png",
+            "icon-512.png",
+            "apple-touch-icon.png",
           ],
-          icons: [
-            {
-              src: "/icon-192.png",
-              sizes: "192x192",
-              type: "image/png",
-              purpose: "any",
-            },
-            {
-              src: "/icon-512.png",
-              sizes: "512x512",
-              type: "image/png",
-              purpose: "any maskable",
-            },
-            {
-              src: "/icon.svg",
-              sizes: "any",
-              type: "image/svg+xml",
-              purpose: "any",
-            },
-          ],
-        },
-        injectManifest: {
-          globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-        },
-      }),
+          manifest: {
+            name: "Sergeant — Твій персональний хаб життя",
+            short_name: "Sergeant",
+            description:
+              "Персональний хаб: фінанси, спорт, звички та харчування",
+            start_url: "/",
+            display: "standalone",
+            orientation: "portrait",
+            background_color: "#fdf9f3",
+            theme_color: "#fdf9f3",
+            lang: "uk",
+            shortcuts: [
+              {
+                name: "Додати витрату",
+                short_name: "Витрата",
+                description: "Швидко додати нову витрату у Фінік",
+                url: "/?module=finyk&action=add_expense",
+                icons: [
+                  { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+                ],
+              },
+              {
+                name: "Розпочати тренування",
+                short_name: "Тренування",
+                description: "Розпочати нове тренування у Фізрук",
+                url: "/?module=fizruk&action=start_workout",
+                icons: [
+                  { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+                ],
+              },
+              {
+                name: "Додати прийом їжі",
+                short_name: "Їжа",
+                description: "Записати прийом їжі у Харчування",
+                url: "/?module=nutrition&action=add_meal",
+                icons: [
+                  { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+                ],
+              },
+            ],
+            icons: [
+              {
+                src: "/icon-192.png",
+                sizes: "192x192",
+                type: "image/png",
+                purpose: "any",
+              },
+              {
+                src: "/icon-512.png",
+                sizes: "512x512",
+                type: "image/png",
+                purpose: "any maskable",
+              },
+              {
+                src: "/icon.svg",
+                sizes: "any",
+                type: "image/svg+xml",
+                purpose: "any",
+              },
+            ],
+          },
+          injectManifest: {
+            globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+          },
+        }),
       analyze &&
         visualizer({
           filename: "dist/bundle-report.html",

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -158,10 +158,16 @@ Android-частина (`android/`) закомічена, `applicationId`
 **Що варто покращити:**
 
 - Bundle size у WebView: сам `apps/web` build важить ~1.2MB gzipped,
-  і перший cold-start через asset-extract довгий. Можна додати
+  і перший cold-start через asset-extract довгий. ~~Можна додати
   `capacitor.config.ts → server.cleartext: false` + виключити service
   worker з shell-бандла (зараз `sw.js` реєструється намарно — native
-  layer його ігнорує, але код все одно вантажиться).
+  layer його ігнорує, але код все одно вантажиться).~~ Зроблено:
+  явний `server.cleartext: false` у `capacitor.config.ts` +
+  `VITE_TARGET=capacitor` build-flag, який вимикає `vite-plugin-pwa`,
+  тож `sw.js`, `manifest.webmanifest` і `virtual:pwa-register` chunk
+  не потрапляють у `apps/server/dist` при shell-білді. `main.jsx`
+  додатково обгорнутий у `!isCapacitor()` runtime guard як defensive
+  net. PWA для веб-деплою (Vercel) — без змін.
 - `vite.config.js#manualChunks` вже виключає `/node_modules/@capacitor/`
   з `vendor` (див. коментар у конфігу) — це навмисно, бо інакше
   Capacitor-plugin-код їхав би до кожного web-юзера. Підʼєднувати нові


### PR DESCRIPTION
## Summary

Capacitor WebView ігнорує `navigator.serviceWorker.register`, тож `vite-plugin-pwa`, згенерований `sw.js`, `manifest.webmanifest` і `virtual:pwa-register` chunk — dead weight у shell-бандлі. Цей PR додає build-варіант для shell-а, який повністю викидає їх з `apps/server/dist`, плюс defensive runtime guard на випадок, якщо дефолтний web-білд раптом завантажиться у Capacitor WebView.

### Підхід (комбінація build-time + runtime)

1. **Build-time прапор `VITE_TARGET=capacitor`** — новий скрипт `apps/web#build:capacitor` (`cross-env VITE_TARGET=capacitor vite build`). У `apps/web/vite.config.js` під цим прапором:
   - `VitePWA` **повністю виключається** з plugin-списку → `sw.js` / `manifest.webmanifest` не генеруються взагалі.
   - `define` інлайнить `import.meta.env.VITE_TARGET` як статичний літерал `"capacitor"`, щоб `main.jsx` міг DCE-вирізати дин. імпорт.
2. **Runtime guard** у `apps/web/src/main.jsx`:
   ```js
   if (
     import.meta.env.VITE_TARGET !== "capacitor" &&
     !isCapacitor() &&
     "serviceWorker" in navigator
   ) {
     import("virtual:pwa-register").then(({ registerSW }) => { ... });
   }
   ```
   - У capacitor-білді `"capacitor" !== "capacitor"` → `false` → Rollup DCE-виносить увесь блок, `virtual:pwa-register` не резолвиться (і плагіна, що його провайдить, все одно нема в graph-і).
   - У веб-білді умова falls back до `!isCapacitor()` runtime-check-у — чистий defensive net.
3. **`apps/mobile-shell#build:web`** тепер делегує до `build:capacitor` (був: `pnpm --filter @sergeant/web build`).
4. **`capacitor.config.ts`**: додав явне `server.cleartext: false` (default у Capacitor 7 і так `false`, але фіксуємо belt-and-braces поруч з `androidScheme: "https"` і `android.allowMixedContent: false`). Це та сама рекомендація з `docs/platforms.md`, тому цей бульєт струкнуто у цьому ж PR.
5. **Документація**: `MOBILE.md`, `apps/mobile-shell/README.md`, `docs/platforms.md` (бульєт відмічений як `~~зроблено~~` зі списком конкретних змін).

### Розмір `apps/server/dist` — до/після

Заміри на цій гілці, Node 20 + pnpm 9.15.1:

| Артефакт                                | web-білд (`pnpm build:web`) | shell-білд (`--filter @sergeant/mobile-shell build:web`) | дельта     |
| --------------------------------------- | --------------------------: | -------------------------------------------------------: | ---------: |
| `apps/server/dist` (всього)             |                  2 403 466B (~2.29 MiB) |                                  2 360 486B (~2.25 MiB)  | **−43 KB** |
| `apps/server/dist/assets` (JS+CSS+img)  |                  2 271 379B |                                                2 263 804B |  −7 575B   |
| `sw.js`                                 |                     33 895B (gzip 11.2KB) |                                                   — **нема** | −33 895B   |
| `manifest.webmanifest`                  |                      1 420B |                                                   — **нема** |  −1 420B   |
| `assets/virtual_pwa-register-*.js`      |                      1 220B (gzip 688B) |                                                   — **нема** |  −1 220B   |
| `assets/vendor-*.js` (workbox-window ін.) |             345 256B (gzip 104.6KB) |                                     339 320B (gzip 102.4KB) |  −5 936B (gzip −2.2KB) |

(Розмір gzip — приблизна оцінка з `gzip -c`. Повні таблиці — у `vite build` output.)

Крім того:
- у shell-dist **51 JS chunk** замість 52;
- `grep -l "registerSW\\|virtual:pwa-register"` у `apps/server/dist/assets/` у shell-білді — нуль попадань (у баз-варіанті — один, у `virtual_pwa-register-*.js`);
- `workbox`-стрічки у vendor-чанку — 0 у shell-білді (2 у web-білді, від `workbox-window`).

### Що **НЕ** ввійшло у цей коміт

`.github/workflows/mobile-shell-android.yml` та `mobile-shell-ios.yml` треба оновити вручну (заміна єдиного step-у `pnpm build:web` → `pnpm --filter @sergeant/mobile-shell build:web`) — **Devin OAuth app не має `workflow` scope** (див. також `docs/platforms.md` п. 3). Готовий патч:

<details>
<summary>Patch for `.github/workflows/mobile-shell-{android,ios}.yml`</summary>

```diff
diff --git a/.github/workflows/mobile-shell-android.yml b/.github/workflows/mobile-shell-android.yml
@@ -74,10 +74,14 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build web bundle
+      - name: Build web bundle (capacitor variant)
+        # `@sergeant/mobile-shell#build:web` делегує до
+        # `@sergeant/web build:capacitor`, який виставляє
+        # `VITE_TARGET=capacitor` і вимикає `vite-plugin-pwa` — щоб
+        # `sw.js` / `manifest.webmanifest` / `virtual:pwa-register`
+        # chunk не потрапляли у shell-бандл (native WebView їх ігнорує).
         # Emits to apps/server/dist (see apps/web/vite.config.js).
         # capacitor.config.ts points `webDir` at this path.
-        run: pnpm build:web
+        run: pnpm --filter @sergeant/mobile-shell build:web
 
diff --git a/.github/workflows/mobile-shell-ios.yml b/.github/workflows/mobile-shell-ios.yml
@@ -68,8 +68,12 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build web bundle
-        run: pnpm build:web
+      - name: Build web bundle (capacitor variant)
+        # `@sergeant/mobile-shell#build:web` делегує до
+        # `@sergeant/web build:capacitor` (`VITE_TARGET=capacitor`),
+        # який вимикає `vite-plugin-pwa` — `sw.js` / manifest /
+        # `virtual:pwa-register` chunk не потрапляють у shell-бандл.
+        run: pnpm --filter @sergeant/mobile-shell build:web
```

</details>

До застосування цього патча CI-workflow-и все ще білдять shell-варіант через звичайний `pnpm build:web` — це працює, але shell-бандл у них продовжує містити `sw.js` і `manifest.webmanifest` як dead weight. Усі локальні команди (MOBILE.md, mobile-shell/README.md) оновлені на нову команду — це важливо для людей, що білдять локально.

## Review & Testing Checklist for Human

- [ ] **Застосуй патч workflow-файлів** (вище у деталях). Після цього `mobile-shell-android.yml` і `mobile-shell-ios.yml` будуть білдити справжній capacitor-варіант без SW. До цього — patch повідомлення у MOBILE.md / README.md і CI можуть розійтись.
- [ ] Перевір веб-деплой на Vercel (preview) — мають бути `sw.js`, `manifest.webmanifest`, PWA install prompt / offline працює як до PR. Підозрілий артефакт: `https://<vercel-preview>/sw.js` має повернути 200.
- [ ] Завантаж debug APK з `sergeant-shell-debug-apk` артефакту (після оновлення workflow) — переконайся, що app стартує, і у DevTools (`chrome://inspect`) `navigator.serviceWorker.getRegistration()` → `undefined` / порожнь список, без реєстрованих SW.
- [ ] (опційно) Візуально порівняй `apps/server/dist` між `pnpm build:web` і `pnpm --filter @sergeant/mobile-shell build:web` — у другому не має бути `sw.js`, `manifest.webmanifest` і `assets/virtual_pwa-register-*.js`.

### Notes

- Тести: `pnpm -w lint`, `pnpm -w typecheck`, `pnpm -w build`, `pnpm --filter @sergeant/web test` (637 passed) і `pnpm --filter @sergeant/mobile-shell test` (32 passed) — усі зелені (Node 20.20.2).
- Жодного compile-time `@capacitor/*` імпорту у `apps/web` не додалось: `isCapacitor()` і далі тягнеться з `@sergeant/shared` (runtime feature-detect через `window.Capacitor`).
- `workbox-*` deps у `apps/web/package.json` залишив — вони все ще потрібні для web-варіанта (`src/sw.js` → `workbox-precaching` / `workbox-routing` / etc.), у shell-білді просто не тягнуться тому, що `sw.js` не компілюється і main bundle ці пакети не імпортує напряму.
- `workbox-window` (єдиний workbox-пакет, що потрапляв у main-bundle через `virtual:pwa-register` → `registerSW`) з shell-бандла зник — звідси ~6 KB shrinkage у `vendor`-чанку.


Link to Devin session: https://app.devin.ai/sessions/ca59d17a4cbf4cfe86ee39509c001e02
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Capacitor-specific build configuration for Android and iOS app deployments.

* **Improvements**
  * Disabled PWA features in mobile builds to optimize native app bundles.
  * Added security hardening for mobile network configuration.

* **Documentation**
  * Updated mobile development guides with new build process instructions and Capacitor-specific build details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->