### PR TITLE
docs(platforms,mobile-shell): strike outdated push platform-disambiguation bullets (ship-docs for #512)

### DIFF
--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -97,13 +97,22 @@ build-only workflow-а.
   чекає на Mac; зараз iOS-проект генерується при кожному запуску CI
   у `mobile-shell-ios.yml`. Для TestFlight pipeline треба або
   закомітити `ios/`, або додати macOS-крок з кешем Pods.
-- **Native push notifications.** `usePushNotifications` у web тримає
+- ~~**Native push notifications.** `usePushNotifications` у web тримає
   Web Push через Service Worker + VAPID. На iOS у WebView воно
   працює лише з 16.4+ і тільки якщо web уже установлено як PWA на
   home-screen; на Android працює, але «крихко». Power-move —
   окремий PR з `@capacitor/push-notifications` (FCM + APNs) і
   розширенням `createPushEndpoints.register` на нові
-  `platform: "android" | "ios"`.
+  `platform: "android" | "ios"`.~~ **Зроблено** у
+  [#512](https://github.com/Skords-01/Sergeant/pull/512):
+  `@capacitor/push-notifications` закомічено, `subscribeNativePush()`
+  у `src/pushNative.ts` тягне APNs/FCM токен і резолвить
+  `{ platform, token }`, а `createPushEndpoints.register`
+  (`packages/api-client/src/endpoints/push.ts`) — discriminated union
+  на `platform: "web" | "ios" | "android"`, серверний handler
+  (`apps/server/src/modules/push.ts → register`) маршрутизує у
+  `push_devices` для native-токенів. Залишається лише реальний
+  APNs/FCM **send**-pipeline — див. `docs/mobile.md#push-notifications`.
 - **Deep-link навігація у React Router.** `parseDeepLink()` у
   `src/index.ts` готовий і `App.addListener('appUrlOpen', ...)`
   викликає callback, але коннект з `useNavigate()` з

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -143,11 +143,23 @@ Android-частина (`android/`) закомічена, `applicationId`
 - **iOS.** `ios/` НЕ закомічено — потрібен Mac + Xcode + CocoaPods для
   `pnpm --filter @sergeant/mobile-shell add:ios`. Release pipeline на iOS
   зараз немає.
-- **Native push.** `usePushNotifications` у web користується Service
+- ~~**Native push.** `usePushNotifications` у web користується Service
   Worker-ом + VAPID — у WebView це працює кульгаво (iOS тільки 16.4+,
   Android — лише якщо PWA установлено). Повний fix — окремий PR з
   `@capacitor/push-notifications` (FCM + APNs) і розширенням
-  `createPushEndpoints.register` на `platform: "android" | "ios"`.
+  `createPushEndpoints.register` на `platform: "android" | "ios"`.~~
+  **Зроблено** у [#512](https://github.com/Skords-01/Sergeant/pull/512):
+  `@capacitor/push-notifications` реєструє APNs/FCM-токен через
+  `subscribeNativePush()` (див. `apps/mobile-shell/src/pushNative.ts`),
+  а `POST /api/v1/push/register` (і його зодівський валідатор
+  `PushRegisterSchema` у `packages/shared/src/schemas/api.ts`) —
+  discriminated union на `platform: "web" | "ios" | "android"`,
+  native-гілка робить upsert у `push_devices (platform, token)` з
+  CHECK-constraint-ом на enum (`apps/server/src/migrations/006_push_devices.sql`).
+  Web-клієнт (`usePushNotifications`) і RN-клієнт (`registerPush`)
+  шлють `platform` явно. Актуальне «не зроблено» — лише реальна
+  APNs/FCM **send**-гілка (див. RN-секцію, пункт про
+  «iOS/Android native push-send path»).
 - ~~**Deep links.** `parseDeepLink()` в `src/index.ts` є, але
   `App.addListener('appUrlOpen', ...)` ще не звʼязаний з React Router
   всередині `apps/web` — треба exported `navigate()` прокинути.~~ Готово:


### PR DESCRIPTION
## Summary

Docs-only PR. Викреслює застарілі TODO-пункти про розрізнення `platform`
у push-реєстрації з `docs/platforms.md` (секція «Capacitor shell / Не
зроблено») і `apps/mobile-shell/README.md` — уся імплементація (shell
через `@capacitor/push-notifications`, zod discriminated union на
`platform: "web" | "ios" | "android"` у `PushRegisterSchema`, колонка
`push_devices.platform` з `NOT NULL` + CHECK-constraint-ом, server
handler, що маршрутизує web vs native у потрібну таблицю, web/RN
клієнти, що шлють `platform` явно, і unit-тести на ios/android/web/400)
вже на `main` після [#512](https://github.com/Skords-01/Sergeant/pull/512)
(commit `a7b081e` + попередні session-4c/5a/5b).

Без змін у коді / міграціях / тестах — тільки викреслення (`~~ ~~`) і
відсилка на #512, щоб читач docs не думав, що TODO ще висить.

## Review & Testing Checklist for Human

- [ ] Подивитися, що рендер `docs/platforms.md` у GitHub показує
      викреслений старий буллет + «Зроблено у #512» нижче — і те саме
      у `apps/mobile-shell/README.md`. Strikethrough має працювати у
      GitHub-flavored Markdown без додаткових плагінів.
- [ ] Переконатися, що формулювання «Залишається лише реальний
      APNs/FCM **send**-pipeline» не суперечить актуальному статусу
      send-гілки: у RN-секції `docs/platforms.md` (рядок про
      «iOS/Android native push-send path») цей пункт залишено
      незачепленим, бо `docs/mobile.md#push-notifications` і
      `apps/server/src/push/send.ts` — окрема тема.

### Notes

- Міграція не генерується: репо не використовує Drizzle/Prisma, а raw
  SQL через `apps/server/migrate.mjs` + `apps/server/src/migrations/*.sql`;
  колонка `platform` вже є у `006_push_devices.sql` (NOT NULL + CHECK).
- Unit-тести на ендпоінт `POST /api/v1/push/register` для ios/android,
  web (503 vapid-guard з валідним payload), і невалідної платформи
  (`windows-phone` → 400) вже є в
  `apps/server/src/routes/apiV1.test.ts` (`describe POST /api/v1/push/register`).
- Shell (`apps/mobile-shell/src/pushNative.ts`) вже детектить
  `Capacitor.getPlatform()` і відкидає `"web"` з native gate; сам
  register-виклик з shell-а йде через web-гілку
  `apps/web/src/shared/hooks/usePushNotifications.ts`, яка теж уже шле
  `platform` явно (native та web гілки).
- `pnpm format:check` — passing локально. `pnpm -w lint` на node 22 у
  середовищі падає на pre-existing проблемі в `lint:plugins`
  (`node --test` на директорії) — це відтворюється і на чистому `main`,
  до моїх змін не стосується; CI на node 20.x (див. `engines.node`).


Link to Devin session: https://app.devin.ai/sessions/bf2e646d7e6a47daa4b94f6ffcf86293
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
