### PR TITLE
feat(mobile-shell): Universal Links / App Links HTTPS support

### DIFF
--- a/apps/mobile-shell/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile-shell/android/app/src/main/AndroidManifest.xml
@@ -25,17 +25,45 @@
             </intent-filter>
 
             <!--
-              Deep-link intent-filter для схеми `com.sergeant.shell://<path>`.
+              Custom-scheme deep-link intent-filter для `com.sergeant.shell://<path>`.
               Ловиться в web-коді через `App.addListener('appUrlOpen', ...)`
               (див. `apps/mobile-shell/src/index.ts`). Перевірити через:
                 adb shell am start -a android.intent.action.VIEW \
                   -d 'com.sergeant.shell://home'
+              `autoVerify="false"` — custom scheme не проходить Digital Asset
+              Links перевірку (там тільки http/https), тому явно вимикаємо.
             -->
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="com.sergeant.shell" />
+            </intent-filter>
+
+            <!--
+              HTTPS App Links intent-filter. `autoVerify="true"` + валідний
+              `/.well-known/assetlinks.json` на кожному з hosts-ів нижче дає
+              Android підставу відкривати посилання в app-і БЕЗ chooser-діалогу
+              ("Complete action using…"). Host-и синхронізовані з
+              `DEEP_LINK_HTTPS_HOSTS` в `apps/mobile-shell/src/index.ts` і
+              секцією «prod»-хостів у `docs/mobile.md`.
+
+              Інструкція як згенерувати assetlinks.json і куди покласти —
+              `docs/capacitor-deep-links.md`.
+
+              Перевірити локально:
+                adb shell am start -a android.intent.action.VIEW \
+                  -c android.intent.category.BROWSABLE \
+                  -d 'https://sergeant.vercel.app/scan'
+                adb shell pm get-app-links com.sergeant.shell
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="sergeant.vercel.app" />
+                <data android:host="sergeant.2dmanager.com.ua" />
             </intent-filter>
 
         </activity>

--- a/apps/mobile-shell/src/__tests__/parseDeepLink.test.ts
+++ b/apps/mobile-shell/src/__tests__/parseDeepLink.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
  * будь-яких моків.
  */
 
-import { parseDeepLink } from "../index.js";
+import { DEEP_LINK_HTTPS_HOSTS, parseDeepLink } from "../index.js";
 
 describe("parseDeepLink — розширені edge-кейси", () => {
   describe("валідні варіанти", () => {
@@ -85,8 +85,11 @@ describe("parseDeepLink — розширені edge-кейси", () => {
 
   describe("відхилення чужих URL (повертає `null`)", () => {
     it.each([
-      "https://sergeant.app/home",
-      "http://sergeant.app/home",
+      "https://sergeant.app/home", // не наш домен
+      "http://sergeant.vercel.app/home", // http — явно відхиляємо
+      "https://evil.com/home",
+      "https://sergeant.vercel.app.evil.com/home", // suffix-attack
+      "https://evil.com.sergeant.vercel.app@phish.com/home", // userinfo-injection (`host` = phish.com)
       "foo://home",
       "com.sergeant.app://home", // RN bundle id — навмисно інший
       "com.sergeant.shel://home", // typo в схемі
@@ -99,6 +102,95 @@ describe("parseDeepLink — розширені edge-кейси", () => {
       "javascript:alert(1)", // захист від injection через intent
     ])("повертає `null` для `%s`", (url) => {
       expect(parseDeepLink(url)).toBeNull();
+    });
+  });
+
+  describe("HTTPS Universal / App Links", () => {
+    it("експонує список дозволених хостів для синхронізації з manifest / AASA", () => {
+      // Smoke-guard: якщо хтось перейменує чи винесе список, тест-файл
+      // fail-ить відразу і нагадує оновити AndroidManifest + AASA.
+      expect(DEEP_LINK_HTTPS_HOSTS).toEqual([
+        "sergeant.vercel.app",
+        "sergeant.2dmanager.com.ua",
+      ]);
+    });
+
+    it.each([
+      ["https://sergeant.vercel.app/home", "/home"],
+      ["https://sergeant.2dmanager.com.ua/home", "/home"],
+      ["https://sergeant.vercel.app/nutrition/scan", "/nutrition/scan"],
+      [
+        "https://sergeant.2dmanager.com.ua/finyk/transactions/123",
+        "/finyk/transactions/123",
+      ],
+    ])("витягає path з %s → %s", (url, expected) => {
+      expect(parseDeepLink(url)).toBe(expected);
+    });
+
+    it("повертає `/` для кореня HTTPS URL (без path)", () => {
+      expect(parseDeepLink("https://sergeant.vercel.app")).toBe("/");
+      expect(parseDeepLink("https://sergeant.vercel.app/")).toBe("/");
+    });
+
+    it("зберігає trailing slash у HTTPS варіанті (`/home/`)", () => {
+      expect(parseDeepLink("https://sergeant.vercel.app/home/")).toBe("/home/");
+    });
+
+    it("зберігає query-string у HTTPS варіанті", () => {
+      expect(
+        parseDeepLink("https://sergeant.vercel.app/search?q=protein&n=5"),
+      ).toBe("/search?q=protein&n=5");
+    });
+
+    it("зберігає URL-encoded символи у query HTTPS варіанті", () => {
+      expect(
+        parseDeepLink("https://sergeant.vercel.app/search?q=hello%20world"),
+      ).toBe("/search?q=hello%20world");
+    });
+
+    it("зберігає fragment у HTTPS варіанті", () => {
+      expect(
+        parseDeepLink("https://sergeant.2dmanager.com.ua/routine#habits"),
+      ).toBe("/routine#habits");
+    });
+
+    it("приймає host у різному регістрі (case-insensitive)", () => {
+      // Android Intent іноді нормалізує host у lowercase, iOS — нерідко
+      // зберігає original-case. `new URL()` тримає host як є, тож порівняння
+      // обовʼязково має бути case-insensitive (RFC 3986 §3.2.2).
+      expect(parseDeepLink("https://Sergeant.Vercel.App/home")).toBe("/home");
+      expect(parseDeepLink("https://SERGEANT.VERCEL.APP/home")).toBe("/home");
+    });
+
+    it("ігнорує :port як частину host-matching — :443 не губить match", () => {
+      // Default port 443 для https — `new URL().host` повертає без `:443`.
+      expect(parseDeepLink("https://sergeant.vercel.app:443/home")).toBe(
+        "/home",
+      );
+    });
+
+    it("ненаш HTTPS-порт (з non-default) трактуємо як інший host", () => {
+      // `new URL("https://sergeant.vercel.app:8443/x").host` = `sergeant.vercel.app:8443`.
+      // Для App Links це нерелевантно (Android не бʼє по port), але з точки
+      // зору нашого коду — це інший host, strict-reject.
+      expect(parseDeepLink("https://sergeant.vercel.app:8443/home")).toBeNull();
+    });
+
+    it("відхиляє http:// навіть для нашого host (ніяких cleartext deep link-ів)", () => {
+      expect(parseDeepLink("http://sergeant.vercel.app/home")).toBeNull();
+      expect(parseDeepLink("http://sergeant.2dmanager.com.ua/home")).toBeNull();
+    });
+
+    it("відхиляє суб-домени нашого домена як fail-closed", () => {
+      // Якщо колись зʼявиться `api.sergeant.vercel.app` — це має бути
+      // свідомо додано до DEEP_LINK_HTTPS_HOSTS, а не мовчки прийнято.
+      expect(parseDeepLink("https://api.sergeant.vercel.app/home")).toBeNull();
+      expect(parseDeepLink("https://www.sergeant.vercel.app/home")).toBeNull();
+    });
+
+    it("відхиляє malformed URL (invalid constructor input)", () => {
+      expect(parseDeepLink("https://")).toBeNull();
+      expect(parseDeepLink("https:///home")).toBeNull(); // empty host
     });
   });
 });

--- a/apps/mobile-shell/src/index.ts
+++ b/apps/mobile-shell/src/index.ts
@@ -31,8 +31,29 @@ const STATUS_BAR_COLOR_LIGHT = "#fdf9f3";
 /** Колір status bar-а у dark-темі — збігається з `.dark --c-bg` (#171412). */
 const STATUS_BAR_COLOR_DARK = "#171412";
 
-/** Deep-link scheme, оголошений в `AndroidManifest.xml` і `iOS Info.plist`. */
+/** Custom deep-link scheme, оголошений в `AndroidManifest.xml` і `iOS Info.plist`. */
 const DEEP_LINK_SCHEME = "com.sergeant.shell://";
+
+/**
+ * HTTPS-хости, які shell приймає як Universal Links (iOS) / App Links
+ * (Android). Має збігатись з:
+ *   - `<data android:host="..." />` у `AndroidManifest.xml`;
+ *   - `applinks:<host>` в iOS entitlements `com.apple.developer.associated-domains`;
+ *   - `applinks.details[].appIDs` у `/.well-known/apple-app-site-association` цього хоста;
+ *   - `target.package_name` у `/.well-known/assetlinks.json` цього хоста.
+ *
+ * Список синхронізований з `docs/mobile.md` (секція CORS — «prod»-хости):
+ *   - `sergeant.vercel.app` — Vercel-preview і прод-дефолт;
+ *   - `sergeant.2dmanager.com.ua` — кастомний prod-домен.
+ *
+ * Кожен хост валідується строго (case-insensitive host match), без
+ * suffix-wildcard, щоби `sergeant.vercel.app.evil.com` не проходив як
+ * наш deep link.
+ */
+export const DEEP_LINK_HTTPS_HOSTS: readonly string[] = Object.freeze([
+  "sergeant.vercel.app",
+  "sergeant.2dmanager.com.ua",
+]);
 
 export interface InitNativeShellOptions {
   /**
@@ -125,17 +146,62 @@ function isDarkTheme(): boolean {
 }
 
 /**
- * Витягує шлях з `com.sergeant.shell://<path>?q=1#frag` у вигляді, придатному
- * для React Router (`/path?q=1#frag`). Повертає `null`, якщо URL не відповідає
- * нашій схемі — щоби випадково не навігувати на чужий intent.
+ * Витягує шлях з deep-link URL для React Router (`/path?q=1#frag`). Приймає
+ * дві форми:
+ *
+ *   1. **Custom scheme** — `com.sergeant.shell://<path>?q=1#frag`. Історично
+ *      перший спосіб, працює без assetlinks/AASA та без chooser-діалогу
+ *      тільки коли інша апка не зареєструвалась на ту саму схему
+ *      (`com.sergeant.shell` достатньо унікальна).
+ *   2. **HTTPS Universal / App Links** — `https://<host>/<path>?q=1#frag`
+ *      для хостів з `DEEP_LINK_HTTPS_HOSTS`. Потребує валідних
+ *      `.well-known/assetlinks.json` (Android) та
+ *      `.well-known/apple-app-site-association` (iOS) — див.
+ *      `docs/capacitor-deep-links.md`.
+ *
+ * Обидві форми повертають ту саму канонічну React-Router path, щоби
+ * user-facing навігаційна логіка (роутер, analytics, A/B) була єдина.
+ *
+ * Повертає `null` для будь-чого, що не вписується у ці дві форми —
+ * захист від intent-ів чужих апок (`android.intent.action.VIEW` на
+ * невідому схему не повинен навігувати у нашому роутері).
+ *
+ * Host comparison case-insensitive (RFC 3986 §3.2.2), path/query/fragment
+ * зберігаємо «як є» — не URL-decode-имо, щоби параметри з `%20`/`+`
+ * дійшли до web-шару у первинній формі.
  */
 export function parseDeepLink(url: string): string | null {
-  if (!url.startsWith(DEEP_LINK_SCHEME)) return null;
-  const rest = url.slice(DEEP_LINK_SCHEME.length);
-  // `com.sergeant.shell://home` і `com.sergeant.shell:///home` трактуємо
-  // однаково — перша форма частіше генерується Android `am start`.
-  const normalized = rest.startsWith("/") ? rest : `/${rest}`;
-  return normalized;
+  if (typeof url !== "string" || url.length === 0) return null;
+
+  if (url.startsWith(DEEP_LINK_SCHEME)) {
+    const rest = url.slice(DEEP_LINK_SCHEME.length);
+    // `com.sergeant.shell://home` і `com.sergeant.shell:///home` трактуємо
+    // однаково — перша форма частіше генерується Android `am start`.
+    return rest.startsWith("/") ? rest : `/${rest}`;
+  }
+
+  // HTTPS-варіант. Навмисно не приймаємо http:// — App Links / Universal
+  // Links апрувляться тільки на https, і ми не хочемо стрільнути cleartext
+  // deep link навіть у тесті.
+  if (url.startsWith("https://")) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return null;
+    }
+    const hostLower = parsed.host.toLowerCase();
+    const matchesHost = DEEP_LINK_HTTPS_HOSTS.some(
+      (allowed) => allowed.toLowerCase() === hostLower,
+    );
+    if (!matchesHost) return null;
+    // `parsed.pathname` завжди починається з `/` (у т.ч. для кореня);
+    // `parsed.search` і `parsed.hash` вже з лідируючим `?` / `#` або
+    // порожні рядки — об'єднуємо напряму без re-encoding.
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  }
+
+  return null;
 }
 
 /**

--- a/apps/server/src/routes/frontend.ts
+++ b/apps/server/src/routes/frontend.ts
@@ -35,7 +35,25 @@ export function createFrontendMiddleware({
     maxAge: "1y",
     immutable: true,
   });
-  const rootStatic = express.static(distPath, { maxAge: 0 });
+  // `setHeaders` callback для `.well-known/*` — iOS перевіряє
+  // `Content-Type: application/json` при Universal Links handshake; без
+  // цього хендшейк тихо провалюється і посилання відкриваються у Safari
+  // замість app-и. `apple-app-site-association` йде без розширення, тому
+  // express.static за замовчуванням не ставить Content-Type взагалі —
+  // виправляємо вручну. Для `assetlinks.json` розширення вже .json і
+  // Content-Type і так правильний, але duplicate-set нічого не ламає.
+  const rootStatic = express.static(distPath, {
+    maxAge: 0,
+    setHeaders: (res, filePath) => {
+      if (
+        filePath.endsWith("/.well-known/apple-app-site-association") ||
+        filePath.endsWith("\\.well-known\\apple-app-site-association") ||
+        filePath.endsWith("/.well-known/assetlinks.json")
+      ) {
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+      }
+    },
+  });
   const sendIndex: RequestHandler = (_req, res) => {
     res.sendFile(join(distPath, "index.html"));
   };

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["REPLACE_WITH_TEAM_ID.com.sergeant.shell"],
+        "components": [
+          {
+            "/": "/*",
+            "comment": "Усі HTTPS-шляхи на цьому host-і відкриваються в Sergeant Shell як Universal Links."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.sergeant.shell",
+      "sha256_cert_fingerprints": ["REPLACE_WITH_SHA256_FROM_SIGNING_KEYSTORE"]
+    }
+  }
+]

--- a/docs/capacitor-deep-links.md
+++ b/docs/capacitor-deep-links.md
@@ -1,0 +1,237 @@
+# Capacitor deep links — App Links (Android) + Universal Links (iOS)
+
+Цей документ описує HTTPS-варіант deep-лінків для Capacitor-shell-а
+(`apps/mobile-shell`), що доповнює custom scheme
+`com.sergeant.shell://<path>`. HTTPS-посилання з email-ів / push / SMS
+відкриваються в app напряму, без chooser-діалогу «Complete action
+using…» (Android) і без зупинки у Safari (iOS).
+
+## Короткий контракт
+
+- **Custom scheme** (`com.sergeant.shell://scan`) — працював і раніше
+  через `parseDeepLink()` + `App.addListener('appUrlOpen', ...)`; див.
+  `apps/mobile-shell/src/index.ts` і `docs/platforms.md`.
+- **HTTPS App Links / Universal Links** — нова форма, яку `parseDeepLink()`
+  нормалізує до тієї ж React-Router-path. Хости перераховані в константі
+  `DEEP_LINK_HTTPS_HOSTS` у тому ж файлі та мають бути синхронізовані з:
+  - `AndroidManifest.xml` → HTTPS intent-filter з `autoVerify="true"`;
+  - iOS entitlements `com.apple.developer.associated-domains`
+    (`applinks:<host>`) — **коли буде додано `apps/mobile-shell/ios/`**;
+  - `/.well-known/assetlinks.json` (Android DAL);
+  - `/.well-known/apple-app-site-association` (iOS AASA).
+
+Поточні hosts (див. `docs/mobile.md` секція CORS — «prod»):
+
+- `sergeant.vercel.app` — Vercel дефолт;
+- `sergeant.2dmanager.com.ua` — кастомний prod-домен.
+
+## Статичні файли
+
+Файли-шаблони лежать у `apps/web/public/.well-known/`:
+
+- `assetlinks.json` — Android Digital Asset Links;
+- `apple-app-site-association` — iOS (БЕЗ розширення; Content-Type
+  `application/json`).
+
+Vite копіює `apps/web/public/` у `apps/server/dist/` при білді
+(`apps/web/vite.config.js` → `build.outDir`), тому обидва файли
+опиняються у `apps/server/dist/.well-known/`, звідки їх роздає Vercel
+(`vercel.json` → `outputDirectory`).
+
+### Vercel: заголовки та rewrite
+
+У `vercel.json` додано:
+
+- `headers` правило для `/.well-known/apple-app-site-association` і
+  `/.well-known/assetlinks.json` — `Content-Type: application/json` +
+  `Cache-Control: public, max-age=3600`.
+- SPA rewrite `"/((?!api/|\\.well-known/).*)" → "/index.html"` явно
+  **виключає** `.well-known/` — щоб catch-all не відбивав запити на
+  `index.html` навіть гіпотетично (Vercel і так віддає статику раніше
+  за rewrites, але defense-in-depth).
+
+### Express (apps/server) дзеркало
+
+Коли `apps/server` сервує фронт у Replit-режимі, `express.static` з
+`apps/server/src/routes/frontend.ts` має `setHeaders`-callback, який
+ставить `Content-Type: application/json; charset=utf-8` на обидва
+`.well-known`-файли. Без цього iOS AASA-валідатор tiha відхиляв би
+файл (дефолтний Content-Type на файл без розширення — порожній або
+`application/octet-stream`).
+
+## Android App Links — генерація `assetlinks.json`
+
+1. Отримати SHA-256 із release-keystore (для debug-білда — debug
+   keystore у `~/.android/debug.keystore`):
+
+   ```bash
+   keytool -list -v \
+     -keystore <path-to-keystore>.jks \
+     -alias <alias> \
+     -storepass <password>
+   ```
+
+   У виводі знайти рядок `SHA256:` і скопіювати hex (без пробілів,
+   залишивши двокрапки — Google Digital Asset Links приймає обидві
+   форми).
+
+2. Альтернативно — згенерувати JSON-фрагмент онлайн:
+   <https://developers.google.com/digital-asset-links/tools/generator>
+   Вставити `com.sergeant.shell` як package name і SHA-256 зверху.
+
+3. Відредагувати `apps/web/public/.well-known/assetlinks.json`,
+   замінивши `REPLACE_WITH_SHA256_FROM_SIGNING_KEYSTORE` на реальний
+   fingerprint. Якщо релізний і debug-підпис різні — список може
+   містити **обидва** fingerprints:
+
+   ```json
+   "sha256_cert_fingerprints": [
+     "14:6D:E9:83:...release...",
+     "A8:8B:7C:...debug..."
+   ]
+   ```
+
+4. Задеплоїти на всі hosts з `DEEP_LINK_HTTPS_HOSTS`. Файл має
+   віддаватись по `GET https://<host>/.well-known/assetlinks.json` з
+   `Content-Type: application/json` та без редіректу.
+
+5. Перевірити через Google Statement List Tester:
+   <https://developers.google.com/digital-asset-links/tools/generator>
+   → «Check that the statement file is...» внизу сторінки.
+
+### Тест на девайсі
+
+```bash
+# Подивитись, чи Android перевірив domain-verification після встановлення APK:
+adb shell pm get-app-links com.sergeant.shell
+
+# Очікуваний вивід: "Domain verification state" → "verified" для обох hosts.
+
+# Ручний тест відкриття:
+adb shell am start -a android.intent.action.VIEW \
+  -c android.intent.category.BROWSABLE \
+  -d 'https://sergeant.vercel.app/scan'
+
+# Якщо state=none або !verified, форсувати перевірку:
+adb shell pm verify-app-links --re-verify com.sergeant.shell
+```
+
+Посилання з email / SMS / Chrome intent відкриваються в app-і без
+chooser-а тоді й тільки тоді, коли `pm get-app-links` показує
+`verified` для кожного host-а.
+
+## iOS Universal Links (тільки документація)
+
+> **Зараз `apps/mobile-shell/ios/` не закомічено в репо.** Коли
+> `ionic capacitor add ios` відбудеться — нижче checklist, який має
+> виконати maintainer, щоб Universal Links запрацювали.
+
+1. У Xcode відкрити target → Signing & Capabilities → «+ Capability»
+   → **Associated Domains**. Додати для кожного host-а:
+
+   ```
+   applinks:sergeant.vercel.app
+   applinks:sergeant.2dmanager.com.ua
+   ```
+
+   Це додає `com.apple.developer.associated-domains` у
+   `App.entitlements`.
+
+2. Знайти Team ID: Apple Developer portal → Membership → Team ID
+   (формату `ABCDE12345`). У комбінації з bundle id
+   `com.sergeant.shell` отримаємо AppID: `ABCDE12345.com.sergeant.shell`.
+
+3. Відредагувати `apps/web/public/.well-known/apple-app-site-association`,
+   замінивши `REPLACE_WITH_TEAM_ID` на реальний Team ID. Формат:
+
+   ```json
+   {
+     "applinks": {
+       "details": [
+         {
+           "appIDs": ["ABCDE12345.com.sergeant.shell"],
+           "components": [{ "/": "/*" }]
+         }
+       ]
+     }
+   }
+   ```
+
+   Якщо для тих самих hosts у майбутньому будуть різні appIDs (RN
+   `com.sergeant.app` + Capacitor `com.sergeant.shell`), обидва можна
+   перерахувати у `appIDs` — iOS розв'язує колізію по першому
+   entitlement-match.
+
+4. Файл **має називатись саме** `apple-app-site-association` без
+   розширення, віддаватись по HTTPS (не HTTP), без редіректів, з
+   `Content-Type: application/json`. Перевірити:
+
+   ```bash
+   curl -I https://sergeant.vercel.app/.well-known/apple-app-site-association
+   # очікуваний HTTP/2 200 + Content-Type: application/json
+
+   curl https://sergeant.vercel.app/.well-known/apple-app-site-association | jq .
+   ```
+
+5. Після деплою — на реальному iOS-девайсі видалити app, передеплоїти
+   через Xcode / TestFlight, перезапустити. iOS кешує AASA агресивно
+   (до 24 годин); для CI-тестування Apple дозволяє debug-обхід:
+
+   Settings → Developer → **Associated Domains Development** → Enable.
+   Потім у схемі Run додати launch arg:
+
+   ```
+   -com.apple.developer.associated-domains.debug-mode 1
+   ```
+
+6. Тест: будь-яке повідомлення в Messages / Mail з
+   `https://sergeant.vercel.app/<path>` → довгий тап → «Open in
+   Sergeant Shell» має зʼявитись у меню. Тап по банеру на top-і
+   Safari («Open in …») — теж валідний indicator.
+
+## Тестові чек-листи
+
+### Android
+
+- [ ] `apps/web/public/.well-known/assetlinks.json` містить реальний
+      SHA-256 (release + debug) і коректний `package_name`.
+- [ ] Файл сервиться по HTTPS на всіх `DEEP_LINK_HTTPS_HOSTS` з
+      `Content-Type: application/json` і без редіректів.
+- [ ] Після `adb install` і перезапуску app-и
+      `adb shell pm get-app-links com.sergeant.shell` показує
+      `verified` для кожного host-а.
+- [ ] `adb shell am start -a android.intent.action.VIEW -d 'https://sergeant.vercel.app/scan'`
+      відкриває app на `/scan` (а не chooser).
+- [ ] Custom scheme і далі працює:
+      `adb shell am start -d 'com.sergeant.shell://scan'`.
+
+### iOS
+
+- [ ] `apps/web/public/.well-known/apple-app-site-association` містить
+      валідний `<TEAM_ID>.com.sergeant.shell` і правильний
+      components-паттерн.
+- [ ] Файл сервиться БЕЗ розширення, з `Content-Type: application/json`,
+      без редіректів, по всіх hosts-ах.
+- [ ] Xcode Signing & Capabilities показує `applinks:<host>` для
+      обох доменів, entitlement закомічено.
+- [ ] SMS/Mail з `https://sergeant.vercel.app/scan` відкриває app-у
+      напряму (чи через "Open in Sergeant Shell" у long-tap меню).
+- [ ] Custom scheme і далі працює —
+      `xcrun simctl openurl booted 'com.sergeant.shell://scan'`.
+
+## Пов'язані файли
+
+- `apps/mobile-shell/src/index.ts` — `parseDeepLink()` приймає обидві
+  форми; `DEEP_LINK_HTTPS_HOSTS` — строгий allow-list hosts-ів.
+- `apps/mobile-shell/android/app/src/main/AndroidManifest.xml` — два
+  intent-filter-и: custom scheme (autoVerify=false) і HTTPS
+  (autoVerify=true).
+- `apps/web/public/.well-known/assetlinks.json` — Android DAL.
+- `apps/web/public/.well-known/apple-app-site-association` — iOS AASA.
+- `vercel.json` — Content-Type headers + rewrite-exclusion для
+  `/.well-known/`.
+- `apps/server/src/routes/frontend.ts` — Express static mirror з тим
+  самим Content-Type override.
+- `apps/mobile-shell/src/__tests__/parseDeepLink.test.ts` — unit-тести
+  на всі edge-кейси (custom scheme, HTTPS, case-insensitivity,
+  suffix-attack, userinfo-injection тощо).

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -167,7 +167,13 @@ Android-частина (`android/`) закомічена, `applicationId`
   `window.__sergeantShellNavigate` (встановлюється
   `<ShellDeepLinkBridge/>` у `apps/web/src/core/App.tsx` після маунту
   роутера) з буфером `window.__sergeantShellDeepLinkQueue` для cold-start
-  сценарію (native-подія прилетіла ДО готовності React-шару).
+  сценарію (native-подія прилетіла ДО готовності React-шару). HTTPS
+  Universal Links / App Links теж підтримуються — `parseDeepLink()`
+  приймає дозволені hosts (`DEEP_LINK_HTTPS_HOSTS` в
+  `apps/mobile-shell/src/index.ts`), `AndroidManifest.xml` має
+  `autoVerify="true"` intent-filter, у `apps/web/public/.well-known/`
+  лежать шаблони `assetlinks.json` та `apple-app-site-association`.
+  Повний setup-гайд — `docs/capacitor-deep-links.md`.
 - **Safe-area / keyboard avoidance** на iOS усе ще покладаються на
   CSS `env(safe-area-inset-*)` — працює, але не 100% якщо splash
   тримається довше за `hide()`.

--- a/vercel.json
+++ b/vercel.json
@@ -21,11 +21,37 @@
           "value": "public, max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
     }
   ],
   "rewrites": [
     {
-      "source": "/((?!api/).*)",
+      "source": "/((?!api/|\\.well-known/).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary

Follow-up до [#523](https://github.com/Skords-01/Sergeant/pull/523) (React-Router bridge для custom scheme `com.sergeant.shell://`). Додаємо HTTPS-варіант, щоб посилання з email / push / SMS відкривали app напряму, без chooser-діалогу на Android і без зупинки у Safari на iOS.

Закриває пункт «Deep links» у [`docs/platforms.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/platforms.md#L163) у його повній постановці (custom scheme + HTTPS). Повний setup-гайд — новий [`docs/capacitor-deep-links.md`](https://github.com/Skords-01/Sergeant/blob/devin/1776873283-capacitor-universal-links/docs/capacitor-deep-links.md).

**Що змінилось:**

- **`apps/mobile-shell/src/index.ts`** — `parseDeepLink()` приймає дві форми і нормалізує до однієї React-Router path:
  - `com.sergeant.shell://<path>?q=1#frag` — як раніше;
  - `https://<host>/<path>?q=1#frag` для дозволених `DEEP_LINK_HTTPS_HOSTS` (`sergeant.vercel.app`, `sergeant.2dmanager.com.ua` — з prod-секції [`docs/mobile.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/mobile.md#L117)).
  - Case-insensitive host match (RFC 3986 §3.2.2), БЕЗ wildcard / subdomain: `www.sergeant.vercel.app` і `api.sergeant.vercel.app` → `null` (fail-closed).
  - Захист від suffix-attack (`sergeant.vercel.app.evil.com`), userinfo-injection (`@phish.com`), non-default port (`:8443`), `http://` (відхиляємо навіть для нашого host).
  - Парсимо через нативний `new URL()` — без самописного парсера.
- **`AndroidManifest.xml`** — новий HTTPS intent-filter з `autoVerify="true"` + обидва hosts. Старий custom-scheme filter явно `autoVerify="false"` (custom-схема не проходить DAL, це норма).
- **`apps/web/public/.well-known/`** — шаблони:
  - `assetlinks.json` з `package_name: com.sergeant.shell` + placeholder `REPLACE_WITH_SHA256_FROM_SIGNING_KEYSTORE`;
  - `apple-app-site-association` (БЕЗ розширення) з placeholder `REPLACE_WITH_TEAM_ID.com.sergeant.shell` і components `"/": "/*"`.
  - Vite копіює `apps/web/public/` у `apps/server/dist/` (`vite.config.js` → `build.outDir`), звідки Vercel сервить.
- **`vercel.json`** — `Content-Type: application/json` headers для обох `.well-known` файлів (iOS AASA-handshake СУВОРО вимагає цей MIME). SPA rewrite `"/((?!api/|\\.well-known/).*)" → "/index.html"` явно виключає `.well-known/`.
- **`apps/server/src/routes/frontend.ts`** — `setHeaders`-callback у `express.static` дзеркалить Content-Type для Replit/self-host режиму.
- **22 нові unit-тести** у `apps/mobile-shell/src/__tests__/parseDeepLink.test.ts`: HTTPS happy-path на обох hosts, case-insensitivity, port handling (`:443` допускається, `:8443` — reject), subdomain fail-closed, malformed URL, smoke-guard на `DEEP_LINK_HTTPS_HOSTS`.
- **`docs/capacitor-deep-links.md`** — повний setup-гайд (Android DAL з keytool + Statement List Tester, iOS AASA + entitlements + Team ID, `adb pm get-app-links`, чек-листи на обидві платформи).
- **`docs/platforms.md`** — розширено «Готово»-пункт про Deep links з HTTPS-варіантом і крос-лінком на новий doc.

## Review & Testing Checklist for Human

🟡 Середній ризик: критичні місця (host allow-list, Content-Type для AASA) покриті тестами і статичним конфігом, але реальна верифікація пройде тільки на живому девайсі після деплою. Плейсхолдери в `.well-known/` файлах навмисно НЕ заповнені — SHA-256 і Team ID мають бути закомічені maintainer-ом окремо (Devin не повинен знати керстор-паролі).

- [ ] **Maintainer**: згенерувати SHA-256 з release-keystore (+ debug keystore якщо треба), замінити `REPLACE_WITH_SHA256_FROM_SIGNING_KEYSTORE` у `apps/web/public/.well-known/assetlinks.json`. Інструкція — `docs/capacitor-deep-links.md` § «Android App Links — генерація `assetlinks.json`».
- [ ] **Maintainer**: коли `apps/mobile-shell/ios/` додасться — дізнатись Team ID з Apple Developer portal, замінити `REPLACE_WITH_TEAM_ID` у `apple-app-site-association`, додати `applinks:sergeant.vercel.app` + `applinks:sergeant.2dmanager.com.ua` у Xcode Associated Domains. Інструкція — `docs/capacitor-deep-links.md` § «iOS Universal Links».
- [ ] Після деплою на Vercel — перевірити Content-Type:
      ```bash
      curl -sI https://<preview>/.well-known/apple-app-site-association
      curl -sI https://<preview>/.well-known/assetlinks.json
      ```
      Обидва мають повернути `200` + `Content-Type: application/json`.
- [ ] На Android device (після того, як реальний SHA-256 закомічено і деплой прокотився): `adb shell pm get-app-links com.sergeant.shell` → «verified» для обох hosts. Далі `adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d 'https://sergeant.vercel.app/scan'` → app відкривається напряму, без chooser-а. Custom scheme продовжує працювати: `adb shell am start -d 'com.sergeant.shell://scan'`.

**Test plan:**

1. `pnpm --filter @sergeant/mobile-shell test` → 86/86 passed (45 у parseDeepLink.test.ts включно з 22 новими HTTPS-кейсами, 9 у deepLinkBridge.test.ts, 19 у index.test.ts, + platform/auth-storage).
2. `pnpm -w typecheck` → 12/12 packages OK.
3. Vercel preview build — `curl` команди вище.

### Notes

- Native-device тестування неможливе з мого боку (потребує Android emulator з підписаним APK і реальний iOS build). Весь чек-лист з `adb` і `curl` командами — у `docs/capacitor-deep-links.md`.
- CI failures на цьому PR (a11y backend 500, APK Java 21, iOS CocoaPods `dtrace-provider`) — pre-existing на `main`, та сама сигнатура що й у [#522](https://github.com/Skords-01/Sergeant/pull/522) / [#523](https://github.com/Skords-01/Sergeant/pull/523).
- `DEEP_LINK_HTTPS_HOSTS` навмисно експортовано і покрито smoke-guard тестом — щоб майбутні перейменування host-ів синхронно тригерили оновлення AndroidManifest, AASA і assetlinks.json.

Link to Devin session: https://app.devin.ai/sessions/0bc7ee973b0941e99748a3db0467c6dc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended deep-linking support to include HTTPS-based deep links, enabling Universal Links on iOS and App Links on Android for improved app navigation.

* **Documentation**
  * Added comprehensive guide for configuring and validating deep-link functionality across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->