### PR TITLE
feat(mobile-shell): drop web-push (VAPID) from Capacitor shell bundle via dynamic import

### DIFF
--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -13,13 +13,14 @@ React Native). Співіснують навмисно: `applicationId` у shell
 
 ## Що готово
 
-| Функція                                       | Плагін / PR                                                                                                   |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                             |
-| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                  |
-| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506) |
-| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                   |
-| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                              |
+| Функція                                       | Плагін / PR                                                                                                                                                                                                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                                                                                                                                                                         |
+| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                                                                                                                                                              |
+| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506)                                                                                                                                             |
+| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                                                                                                                                                               |
+| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                                                                                                                                                                          |
+| Push у shell — лише нативний (FCM/APNs)       | `@capacitor/push-notifications` через `@shared/lib/pushNative`. Web Push (VAPID + `PushManager.subscribe`) повністю виключений з shell-бандла через `VITE_TARGET=capacitor` + dynamic `import()` → [#524](https://github.com/Skords-01/Sergeant/pull/524) |
 
 Точка входу native-side — `src/index.ts → initNativeShell()`. Вона
 ідемпотентна (повторні виклики безпечні під HMR / LiveReload) і

--- a/apps/web/src/shared/hooks/usePushNotifications.ts
+++ b/apps/web/src/shared/hooks/usePushNotifications.ts
@@ -13,13 +13,21 @@ import {
 
 const PUSH_SUB_KEY = "hub_push_subscribed";
 
-function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
-  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
-  const rawData = atob(base64);
-  const out = new Uint8Array(new ArrayBuffer(rawData.length));
-  for (let i = 0; i < rawData.length; i++) out[i] = rawData.charCodeAt(i);
-  return out;
+// Весь web-push флоу (`urlBase64ToUint8Array` + `pushManager.subscribe/
+// getSubscription`) ізольований у `./usePushNotifications.webpush.ts`
+// і підтягується динамічним `import()` нижче. У capacitor-білді
+// `import.meta.env.VITE_TARGET === "capacitor"` (інлайниться через
+// `define` у `apps/web/vite.config.js`) => ранній `return` робить увесь
+// web-branch + `import()` мертвим, Rollup DCE викидає цей chunk з
+// shell-бандла повністю. У web-білді chunk емітиться окремо і
+// вантажиться лише коли користувач реально клацне "увімкнути push".
+type WebPushModule = typeof import("./usePushNotifications.webpush");
+let webPushModulePromise: Promise<WebPushModule> | null = null;
+function loadWebPushModule(): Promise<WebPushModule> {
+  if (!webPushModulePromise) {
+    webPushModulePromise = import("./usePushNotifications.webpush");
+  }
+  return webPushModulePromise;
 }
 
 function isWebPushSupported(): boolean {
@@ -144,6 +152,13 @@ export function usePushNotifications(): UsePushNotificationsResult {
         return;
       }
 
+      // Build-time guard: у capacitor-білді `VITE_TARGET` інлайниться у
+      // `"capacitor"` і Rollup викидає все, що нижче, як unreachable —
+      // включно з `import("./usePushNotifications.webpush")`. Runtime
+      // `native`-гілку вище вже обробили, тож сюди у shell не
+      // дістанемось, але явний `return` потрібен саме для DCE.
+      if (import.meta.env.VITE_TARGET === "capacitor") return;
+
       const perm = await Notification.requestPermission();
       setPermission(perm);
       if (perm !== "granted") return;
@@ -159,23 +174,8 @@ export function usePushNotifications(): UsePushNotificationsResult {
       const publicKey = vapid?.publicKey;
       if (!publicKey) throw new Error("VAPID not configured");
 
-      const reg = await navigator.serviceWorker.ready;
-      const sub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(publicKey),
-      });
-
-      // `PushSubscription.toJSON()` повертає `{ endpoint, keys: { p256dh, auth } }`
-      // (RFC 8030). Мапимо у web-варіант `PushRegisterRequest`, щоб
-      // zod-валідація у `createPushEndpoints.register` пройшла без
-      // модифікацій payload.
-      const json = sub.toJSON();
-      const endpoint = json.endpoint;
-      const p256dh = json.keys?.p256dh;
-      const auth = json.keys?.auth;
-      if (!endpoint || !p256dh || !auth) {
-        throw new Error("Push subscription is missing endpoint or keys");
-      }
+      const { subscribeToWebPush } = await loadWebPushModule();
+      const { endpoint, p256dh, auth } = await subscribeToWebPush(publicKey);
       const payload: PushRegisterRequest = {
         platform: "web",
         token: endpoint,
@@ -222,11 +222,18 @@ export function usePushNotifications(): UsePushNotificationsResult {
         return;
       }
 
-      const reg = await navigator.serviceWorker.ready;
-      const sub = await reg.pushManager.getSubscription();
-      if (sub) {
-        const endpoint = sub.endpoint;
-        await sub.unsubscribe();
+      // Аналогічний build-time guard — у capacitor-білді web-гілка мертва
+      // і `loadWebPushModule()` разом з нею DCE-виноситься.
+      if (import.meta.env.VITE_TARGET === "capacitor") {
+        localStorage.removeItem(PUSH_SUB_KEY);
+        setSubscribed(false);
+        queryClient.invalidateQueries({ queryKey: pushKeys.status });
+        return;
+      }
+
+      const { unsubscribeFromWebPush } = await loadWebPushModule();
+      const endpoint = await unsubscribeFromWebPush();
+      if (endpoint) {
         // Серверний анрег — best-effort: якщо сервер недоступний, локально
         // ми все одно розписалися (запис у БД зачистить cron або наступна
         // вдала підписка). Використовуємо уніфікований

--- a/apps/web/src/shared/hooks/usePushNotifications.webpush.ts
+++ b/apps/web/src/shared/hooks/usePushNotifications.webpush.ts
@@ -1,0 +1,78 @@
+// Web Push (VAPID + `PushManager`) — весь код, який:
+//  - використовується лише у веб-рантаймі (Chrome/Firefox/Edge/Safari PWA);
+//  - у Capacitor-shell-і мертвий, бо native WebView ігнорує Service
+//    Worker і push-реєстрація йде через `@capacitor/push-notifications`
+//    (FCM/APNs) у `@shared/lib/pushNative`.
+//
+// Ізоляція у власний модуль дає `usePushNotifications.ts` можливість
+// підтягувати цей шматок через `import()` **лише на веб-білді**. Разом
+// з build-time прапором `VITE_TARGET=capacitor` (див. `vite.config.js`)
+// Rollup DCE-виносить `import("./usePushNotifications.webpush")` з
+// capacitor-білда повністю — і окремий async-chunk у
+// `apps/server/dist/assets/` для shell-а не емітиться.
+
+/**
+ * Конвертує URL-safe base64 (як у VAPID public key) у `Uint8Array` —
+ * формат, який очікує `PushSubscriptionOptions.applicationServerKey`
+ * (`BufferSource`). Окрема функція тримається тут, а не у `@shared/lib`,
+ * щоб не тягнути її у main bundle ні для shell, ні для web (у web вона
+ * вантажиться async-ом разом з рештою web-push флоу).
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const out = new Uint8Array(new ArrayBuffer(rawData.length));
+  for (let i = 0; i < rawData.length; i++) out[i] = rawData.charCodeAt(i);
+  return out;
+}
+
+export interface WebPushSubscriptionPayload {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+/**
+ * Виконує `navigator.serviceWorker.ready` + `pushManager.subscribe()` з
+ * VAPID-ключем і повертає нормалізований payload (`endpoint` +
+ * `keys.{p256dh, auth}`) для `PushRegisterRequest`.
+ *
+ * Кидає, якщо subscription прийшов без endpoint або ключів —
+ * `api.push.register` з `platform: "web"` без них не пройде zod-валідацію.
+ */
+export async function subscribeToWebPush(
+  publicKey: string,
+): Promise<WebPushSubscriptionPayload> {
+  const reg = await navigator.serviceWorker.ready;
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(publicKey),
+  });
+  // `PushSubscription.toJSON()` повертає `{ endpoint, keys: { p256dh, auth } }`
+  // (RFC 8030). Мапимо у `PushRegisterRequest`-форму без зайвих полів.
+  const json = sub.toJSON();
+  const endpoint = json.endpoint;
+  const p256dh = json.keys?.p256dh;
+  const auth = json.keys?.auth;
+  if (!endpoint || !p256dh || !auth) {
+    throw new Error("Push subscription is missing endpoint or keys");
+  }
+  return { endpoint, p256dh, auth };
+}
+
+/**
+ * Шукає активний `PushSubscription` у `pushManager` і, якщо знайдено,
+ * викликає `unsubscribe()`. Повертає `endpoint` розписаної підписки
+ * (або `null`), щоб хук міг послати серверний `api.push.unregister` з
+ * правильним ключем — і тільки після того, як локальний unsubscribe
+ * вже гарантовано пройшов.
+ */
+export async function unsubscribeFromWebPush(): Promise<string | null> {
+  const reg = await navigator.serviceWorker.ready;
+  const sub = await reg.pushManager.getSubscription();
+  if (!sub) return null;
+  const endpoint = sub.endpoint;
+  await sub.unsubscribe();
+  return endpoint;
+}

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -184,7 +184,15 @@ Android-частина (`android/`) закомічена, `applicationId`
   тож `sw.js`, `manifest.webmanifest` і `virtual:pwa-register` chunk
   не потрапляють у `apps/server/dist` при shell-білді. `main.jsx`
   додатково обгорнутий у `!isCapacitor()` runtime guard як defensive
-  net. PWA для веб-деплою (Vercel) — без змін.
+  net. PWA для веб-деплою (Vercel) — без змін. Далі у #526 той же
+  flag використано, щоб виключити і web-push (VAPID +
+  `PushManager.subscribe`) з shell-бандла: web-push helpers винесені
+  в окремий модуль `usePushNotifications.webpush.ts`, який
+  підтягується динамічним `import()` лише на веб-білді; у capacitor
+  native push йде через `@capacitor/push-notifications` і web-гілка
+  DCE-виноситься повністю (`urlBase64ToUint8Array`,
+  `applicationServerKey`, `pushManager.subscribe` у shell-dist
+  відсутні — `grep` перевіряє).
 - `vite.config.js#manualChunks` вже виключає `/node_modules/@capacitor/`
   з `vendor` (див. коментар у конфігу) — це навмисно, бо інакше
   Capacitor-plugin-код їхав би до кожного web-юзера. Підʼєднувати нові


### PR DESCRIPTION
## Summary

Follow-up до [#524](https://github.com/Skords-01/Sergeant/pull/524) (де так само через `VITE_TARGET=capacitor` прапор викинули SW/`vite-plugin-pwa` з shell-бандла). Цей PR розширює той самий паттерн на web-push: VAPID public key + `PushManager.subscribe()` + `urlBase64ToUint8Array` — усе це dead weight у Capacitor-shell-і, бо native push там іде через `@capacitor/push-notifications` (FCM/APNs).

### Підхід: extract → dynamic `import()` → build-time DCE

1. **`usePushNotifications.webpush.ts`** — новий модуль, який експортує:
   - `urlBase64ToUint8Array()` — VAPID-ключ у `BufferSource`;
   - `subscribeToWebPush(publicKey)` — `navigator.serviceWorker.ready` → `pushManager.subscribe()` → повертає `{ endpoint, p256dh, auth }`;
   - `unsubscribeFromWebPush()` — `pushManager.getSubscription()` → `sub.unsubscribe()` → повертає `endpoint` або `null`.
2. **`usePushNotifications.ts`** — усе web-push залізо замінене на:
   ```ts
   if (import.meta.env.VITE_TARGET === "capacitor") return;
   const { subscribeToWebPush } = await loadWebPushModule();
   const { endpoint, p256dh, auth } = await subscribeToWebPush(publicKey);
   // …api.push.register…
   ```
   Той самий build-time гейт у `unsubscribeMutation`. Native-гілка (`if (native) { … }`) не чіпалась — `@capacitor/push-notifications` через `@shared/lib/pushNative` продовжує керувати підпискою у shell-і.

### Поведінка у двох білдах

| Білд                                  | Web-push chunk у `apps/server/dist/assets/`  | `urlBase64ToUint8Array` / `applicationServerKey` / `pushManager.subscribe` у будь-якому chunk |
| ------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
| `pnpm build:web` (web, Vercel)        | `usePushNotifications.webpush-*.js` (~790 B) | **Лише в цьому chunk** — main `index-*.js` чистий. Chunk вантажиться on-demand коли юзер клацне «увімкнути push». |
| `pnpm --filter @sergeant/mobile-shell build:web` (shell) | **Не емітиться взагалі** (`grep -lE "urlBase64ToUint8Array\|applicationServerKey\|pushManager\\.subscribe"` — 0 попадань у всіх js-чанках). | **Відсутні.** Build-time `if (import.meta.env.VITE_TARGET === "capacitor") return` після `define`-заміни у `vite.config.js` робить `import(...)` мертвим, Rollup DCE чистить і `import()`, і цільовий chunk. |

### Розмір `apps/server/dist/assets/` — до/після

Заміри на Node 20.20.2 + pnpm 9.15.1, через `du -b` на сирих файлах:

| Артефакт                           | capacitor-білд до цього PR | capacitor-білд з цим PR | дельта      |
| ---------------------------------- | ------------------------: | ----------------------: | ----------: |
| `apps/server/dist` (всього)        |                 2 362 632 |               2 361 505 | **−1 127 B** |
| `apps/server/dist/assets/index-*.js` (main) |                 330 743 B |               329 616 B | **−1 127 B** |
| `usePushNotifications.webpush-*.js` chunk |                         — |                      — | (не емітиться) |

У web-білді web-push код перенесено з main-bundle-а у окремий lazy-chunk:

| Артефакт                           | web-білд до цього PR | web-білд з цим PR | дельта    |
| ---------------------------------- | -------------------: | ----------------: | --------: |
| `usePushNotifications.webpush-*.js` lazy chunk |                    — |             790 B | +790 B (new, lazy) |
| `assets/index-*.js` (main)         |            329 329 B |         330 789 B | ~+1.5 KB (chunk plumbing overhead) |

Тобто у web main-bundle-і додається ~1.5 KB оверхеду на chunk-ref + promise-обгортку, але web-push код тепер вантажиться **лише коли користувач реально натисне «увімкнути push»** (переважна більшість юзерів цього ніколи не робить). У capacitor-бандлі виграш — 1.1 KB raw (~500 B gzip) і, головне, **повне виключення мертвого web-push коду** (вся гілка з `pushManager.subscribe`, VAPID-конверсією і т.д.).

### Чому `pushApi.getVapidPublic` і `"vapid"` query-key все ще у shell `grep`-і

У capacitor `grep VAPID` показує одне попадання у main index-у — це **не** VAPID-логіка, а:
- рядок `pushKeys.vapid` (query-key `["push", "vapid"]`) у `@shared/lib/queryKeys`;
- closure `queryFn: () => pushApi.getVapidPublic()` у `useQuery`, що не фаєриться (`enabled: supported && !native`).

`useQuery` — hook, його не можна викликати умовно (React rules of hooks), тож closure на `pushApi.getVapidPublic` лишається у графі. Сам метод — тоненький HTTP GET, він уже у `@sergeant/api-client` і так тягнеться для `api.push.register/unregister`, тож це не додає overhead. Справжнє web-push залізо (`pushManager.*`, `urlBase64ToUint8Array`, `applicationServerKey`) повністю викинуте — це й було метою PR.

## Review & Testing Checklist for Human

- [ ] **Web Push — smoke-тест у браузері.** На Vercel preview відкрити налаштування → «Push-сповіщення» → увімкнути. Має пройти перезапит permission-у (якщо ще не granted), DevTools → Network має показати окремий request на `usePushNotifications.webpush-*.js` chunk саме у момент кліку (не при завантаженні сторінки), після цього — успішна реєстрація у `api.push.register` з `platform: "web"`. Unsubscribe так само має відʼєднати push у браузері й послати `api.push.unregister`.
- [ ] **Capacitor shell — native push.** У APK / iOS-simulator (через debug workflow після мерджу #524 workflow-патча) увімкнути «Push-сповіщення». Має відпрацювати native-branch: `subscribeNativePush()` через `@capacitor/push-notifications` → APNs/FCM token → `api.push.register` з `platform: "android" | "ios"`. Web-push гілка не має тригеритись; у `chrome://inspect` DevTools console не має бути запитів за webpush-chunk-ом.
- [ ] (опційно) Після debug APK: `adb pull /data/local/tmp/...` або unzip `.apk` → `assets/public/assets/` — переконатись що там немає `usePushNotifications.webpush-*.js` і жодної лінки на нього у `index-*.js`.

### Notes

- Тести: `pnpm -w lint`, `pnpm -w typecheck`, `pnpm --filter @sergeant/web test` (637 passed) — зелені. `usePushNotifications.test.tsx` (8 тестів — subscribe/unsubscribe для web + native) не потребував змін, бо тестує публічний API хука, а `stubServiceWorker()` з `pushManager.subscribe` / `getSubscription` моками працює і через dynamic-import-ний шлях.
- Жодного compile-time `@capacitor/*` імпорту у `apps/web` не додалось; `isCapacitor()` з `@sergeant/shared` (runtime feature-detect через `window.Capacitor`) — той самий паттерн що у #524.
- `pushKeys.vapid` кеш поведінка не змінилась (`staleTime: Infinity`, `enabled: supported && !native`).
- `.github/workflows/mobile-shell-{android,ios}.yml` цього разу не потребують змін — CI вже білдить shell через `pnpm build:web` (root), який у #524 ще треба перемкнути мейнтейнером окремим patch-ем. До його застосування CI-артефакти shell-а продовжуть містити web-push код, але runtime-поведінка у WebView однакова (web-push branch defensive net через `isCapacitor()` не фаєриться).

Link to Devin session: https://app.devin.ai/sessions/ca59d17a4cbf4cfe86ee39509c001e02
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native push notification support to the mobile shell application.

* **Refactor**
  * Separated web push functionality from native implementation with build-time optimization to reduce mobile bundle size.

* **Documentation**
  * Updated platform documentation to clarify push notification behavior across web and mobile platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->