### PR TITLE
feat(mobile-shell): Android release signing scaffolding + ProGuard + release-AAB workflow

### DIFF
--- a/.github/workflows/mobile-shell-android-release.yml
+++ b/.github/workflows/mobile-shell-android-release.yml
@@ -74,11 +74,16 @@ jobs:
           node-version: "20"
           cache: pnpm
 
-      # actions/setup-java v4.7.1 — Capacitor 7 / AGP 8 require JDK 17.
+      # actions/setup-java v4.7.1 — Capacitor 7's auto-generated
+      # `capacitor.build.gradle` pins `sourceCompatibility` /
+      # `targetCompatibility` to VERSION_21 (see
+      # apps/mobile-shell/android/app/capacitor.build.gradle — header
+      # explicitly says "DO NOT EDIT"). Anything below 21 trips
+      # `error: invalid source release: 21` during javac.
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install JS deps
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mobile-shell-android-release.yml
+++ b/.github/workflows/mobile-shell-android-release.yml
@@ -1,0 +1,171 @@
+name: Mobile Shell (Android, Release AAB + APK)
+
+# Release-lane workflow for the Capacitor shell (`apps/mobile-shell`).
+#
+# Companion to `mobile-shell-android.yml` (debug-APK). This workflow
+# produces TWO release artefacts and can run either with or without
+# signing secrets:
+#
+#   - `sergeant-shell-release-aab` (via `:app:bundleRelease`) — the
+#     Play-Store-ready bundle. This is what `upload-google-play` will
+#     consume in the follow-up internal-track workflow.
+#   - `sergeant-shell-release-apk` (via `:app:assembleRelease`) — the
+#     direct-install APK for `adb install` / file-manager sideload
+#     outside Play. Lives next to the AAB so operators don't need a
+#     second workflow run to get a sideloadable build.
+#
+# Both artefacts use the same `signingConfig` rules:
+#
+#   - If the four signing secrets are present (see below) we decode the
+#     base64 keystore into a file, export it as the `SERGEANT_RELEASE_*`
+#     properties that `apps/mobile-shell/android/app/build.gradle`
+#     reads, and Gradle produces a **signed** AAB ready for Play.
+#   - If they are missing we still run `bundleRelease` +
+#     `assembleRelease`, but the resulting AAB / APK are unsigned
+#     (Android itself will refuse to install the unsigned APK — that's
+#     expected; the run still validates the entire release build graph:
+#     ProGuard/R8 keep-rules, resource shrinking, Capacitor sync). This
+#     lets contributors without access to production signing material
+#     exercise the release lane on forks or release-branch PRs.
+#
+# The Play-Store upload step (`google-github-actions/upload-google-play`
+# with a service account) is deliberately out of scope — that will land
+# in a follow-up PR together with an internal-track rollout plan.
+#
+# Pipeline:
+#   1. pnpm install --frozen-lockfile
+#   2. pnpm --filter @sergeant/mobile-shell build:web   → apps/server/dist
+#   3. cap sync android                                 — refresh plugin graph
+#   4. (optional) decode keystore + export SERGEANT_RELEASE_* env vars
+#   5. ./gradlew :app:bundleRelease :app:assembleRelease → *.aab + *.apk
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-shell-android-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android-release:
+    name: Build release AAB + APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-Xmx4g"
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening,
+      # matches `mobile-shell-android.yml`).
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # pnpm/action-setup v4.1.0 (SHA-pinned). Version resolved from the
+      # `packageManager` field in root package.json (pnpm@9.15.1).
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+
+      # actions/setup-node v4.4.0 (SHA-pinned).
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      # actions/setup-java v4.7.1 — Capacitor 7 / AGP 8 require JDK 17.
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web bundle
+        # `VITE_TARGET=capacitor` via `@sergeant/mobile-shell#build:web`
+        # disables vite-plugin-pwa for the shell build. Emits to
+        # `apps/server/dist` — `capacitor.config.ts` reads from there.
+        run: pnpm --filter @sergeant/mobile-shell build:web
+
+      - name: Capacitor sync (android)
+        working-directory: apps/mobile-shell
+        run: pnpm exec cap sync android
+
+      # Cache key shares the shape of `mobile-shell-android.yml` so the
+      # two lanes warm the same `~/.gradle/caches` entries when running
+      # back-to-back on the same runner class.
+      - name: Cache Gradle
+        # actions/cache v4.2.0 (SHA-pinned).
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            apps/mobile-shell/android/.gradle
+          key: ${{ runner.os }}-mobile-shell-gradle-release-${{ hashFiles('apps/mobile-shell/android/**/*.gradle*', 'apps/mobile-shell/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-mobile-shell-gradle-release-
+            ${{ runner.os }}-mobile-shell-gradle-
+
+      - name: Decode release keystore (if secrets present)
+        id: keystore
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANDROID_RELEASE_KEYSTORE_BASE64}" ] \
+              || [ -z "${ANDROID_RELEASE_KEYSTORE_PASSWORD}" ] \
+              || [ -z "${ANDROID_RELEASE_KEY_ALIAS}" ] \
+              || [ -z "${ANDROID_RELEASE_KEY_PASSWORD}" ]; then
+            echo "::notice::Release signing secrets not present; building UNSIGNED AAB."
+            echo "signing=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          KEYSTORE_PATH="${RUNNER_TEMP}/sergeant-release.keystore"
+          printf '%s' "${ANDROID_RELEASE_KEYSTORE_BASE64}" | base64 -d > "${KEYSTORE_PATH}"
+          echo "keystore_path=${KEYSTORE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "signing=true" >> "$GITHUB_OUTPUT"
+
+      - name: Gradle bundleRelease + assembleRelease
+        working-directory: apps/mobile-shell/android
+        env:
+          # Gradle reads these via `System.getenv(...)` (see
+          # `apps/mobile-shell/android/app/build.gradle`). When any is
+          # empty the Gradle side leaves `signingConfig` null and both
+          # the AAB and the APK are produced unsigned.
+          SERGEANT_RELEASE_STORE_FILE: ${{ steps.keystore.outputs.keystore_path }}
+          SERGEANT_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
+          SERGEANT_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          SERGEANT_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        # Run both tasks in one Gradle invocation so they share the
+        # configuration phase and the R8 cache (≈2× faster than two
+        # separate invocations).
+        run: ./gradlew --no-daemon :app:bundleRelease :app:assembleRelease
+
+      - name: Upload release AAB
+        # actions/upload-artifact v4.4.3 (SHA-pinned).
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: sergeant-shell-release-aab
+          path: apps/mobile-shell/android/app/build/outputs/bundle/release/*.aab
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload release APK
+        # Separate artefact so sideload-consumers can grab just the APK
+        # from the run summary without also pulling the bundle.
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: sergeant-shell-release-apk
+          path: apps/mobile-shell/android/app/build/outputs/apk/release/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Clean up keystore
+        if: always() && steps.keystore.outputs.signing == 'true'
+        run: rm -f "${{ steps.keystore.outputs.keystore_path }}"

--- a/.github/workflows/mobile-shell-android.yml
+++ b/.github/workflows/mobile-shell-android.yml
@@ -65,11 +65,15 @@ jobs:
           node-version: "20"
           cache: pnpm
 
-      # actions/setup-java v4.7.1 — Capacitor 7 / AGP 8 require JDK 17.
+      # actions/setup-java v4.7.1 — Capacitor 7's auto-generated
+      # `capacitor.build.gradle` pins `sourceCompatibility` /
+      # `targetCompatibility` to VERSION_21. JDK 17 trips
+      # `error: invalid source release: 21` during javac, so we match
+      # the generator and use JDK 21.
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install JS deps
         run: pnpm install --frozen-lockfile

--- a/MOBILE.md
+++ b/MOBILE.md
@@ -23,13 +23,13 @@ shell reads it from there via `webDir: "../server/dist"` in
 
 ## Prerequisites
 
-| Tool              | Version           | Notes                                                         |
-| ----------------- | ----------------- | ------------------------------------------------------------- |
-| Node.js           | 20.x (see .nvmrc) | `nvm install 20 && nvm use 20`                                |
-| pnpm              | 9.15.1            | `corepack enable && corepack prepare pnpm@9.15.1 --activate`  |
-| JDK               | 17 (Temurin)      | required by Capacitor 7 / AGP 8                               |
-| Android SDK       | API 35            | `compileSdk=35`, `minSdk=23` (Android Studio or `sdkmanager`) |
-| Xcode + CocoaPods | latest stable     | macOS only, iOS only                                          |
+| Tool              | Version           | Notes                                                                                                                                            |
+| ----------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Node.js           | 20.x (see .nvmrc) | `nvm install 20 && nvm use 20`                                                                                                                   |
+| pnpm              | 9.15.1            | `corepack enable && corepack prepare pnpm@9.15.1 --activate`                                                                                     |
+| JDK               | 21 (Temurin)      | matches `sourceCompatibility`/`targetCompatibility` VERSION_21 emitted into `apps/mobile-shell/android/app/capacitor.build.gradle` by `cap sync` |
+| Android SDK       | API 35            | `compileSdk=35`, `minSdk=23` (Android Studio or `sdkmanager`)                                                                                    |
+| Xcode + CocoaPods | latest stable     | macOS only, iOS only                                                                                                                             |
 
 ## Android — debug APK
 

--- a/MOBILE.md
+++ b/MOBILE.md
@@ -109,11 +109,119 @@ Two dedicated workflows build the shell on every PR that touches
 | [`mobile-shell-android.yml`](.github/workflows/mobile-shell-android.yml) | `ubuntu-latest` | Debug APK uploaded as `sergeant-shell-debug-apk` artifact |
 | [`mobile-shell-ios.yml`](.github/workflows/mobile-shell-ios.yml)         | `macos-latest`  | Simulator `.app` (build-only, no artifact)                |
 
-Both jobs run `pnpm build:web` → `cap sync <platform>` → native build
-with no signing. Signed / release builds are out of scope for these
-workflows and will be added in a separate PR alongside the corresponding
-secrets.
+Both debug jobs run `pnpm build:web` → `cap sync <platform>` → native
+build with no signing. The signed / release Android lane lives in a
+dedicated workflow — see [§ Release — Android](#release--android).
 
 The separate Detox suites (`detox-android.yml`, `detox-ios.yml`) cover
 the Expo / React Native app in `apps/mobile/` — they are unrelated to
 the Capacitor shell.
+
+## Release — Android
+
+The release lane produces **two** artefacts from one workflow run:
+
+| Artefact                     | Gradle task            | When to use                                                                                                                                                                                        |
+| ---------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sergeant-shell-release-aab` | `:app:bundleRelease`   | Play Store uploads (`google-github-actions/upload-google-play`, internal track). An `.aab` is **not** installable directly — Play re-splits it into per-device APKs server-side.                   |
+| `sergeant-shell-release-apk` | `:app:assembleRelease` | Direct sideload outside Play: `adb install app-release.apk`, file-manager install, QA device farms, ad-hoc demos. A signed `.apk` is what Android's PackageInstaller actually consumes on a phone. |
+
+> Rule of thumb: if the build is going anywhere near Play Store, grab
+> the `.aab`. If a human is going to drop it onto a phone via USB or a
+> download link, grab the `.apk`. Both come from the same run, share
+> the same `versionCode` / `versionName`, and are signed with the same
+> key — so you never need to re-run the workflow just to get the other
+> format.
+
+Workflow: [`mobile-shell-android-release.yml`](.github/workflows/mobile-shell-android-release.yml).
+Triggers:
+
+- `workflow_dispatch` — manual run from the Actions UI (select the
+  branch; tags are also supported).
+- `push` of a tag matching `v*` (e.g. `v0.1.0-shell.1`) — cut a release
+  tag locally with `git tag v0.1.0-shell.1 && git push origin --tags`.
+
+Without the four signing secrets (listed below) the workflow still
+runs `:app:bundleRelease :app:assembleRelease` — but the artefacts are
+unsigned. That's useful as a CI smoke-test of the release graph
+(ProGuard/R8 keep-rules, Capacitor sync, resource shrinking) on PRs
+that don't have access to production signing material. Unsigned
+artefacts cannot be installed on a real device and cannot be uploaded
+to Play — they exist only to validate the Gradle configuration.
+
+### One-time setup — generate a signing keystore
+
+This is a local, one-off step for a maintainer with write access to
+GitHub Secrets. The keystore file itself stays OFF the repo — only the
+base64 blob and passwords go into GitHub Secrets.
+
+```bash
+# 1. Generate a PKCS12 keystore valid for ~27 years (Play recommends
+#    ≥2033 expiry for new uploads).
+keytool -genkeypair -v \
+  -keystore sergeant-shell-release.keystore \
+  -alias sergeant-shell \
+  -keyalg RSA -keysize 2048 \
+  -validity 10000 \
+  -storetype PKCS12
+
+# 2. Encode for transport via GitHub Secrets (pasting raw binary into
+#    the UI does not survive newline normalization).
+base64 -w0 sergeant-shell-release.keystore > sergeant-shell-release.keystore.base64
+
+# 3. Back up the .keystore file + passwords into the team password
+#    manager. Losing the keystore means you can never ship an update
+#    to the same Play Store listing — Play verifies the signing key
+#    matches the first upload forever.
+```
+
+### GitHub Secrets — four entries
+
+Add these in **Repo → Settings → Secrets and variables → Actions**:
+
+| Secret                              | Value                                                              |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| `ANDROID_RELEASE_KEYSTORE_BASE64`   | Contents of `sergeant-shell-release.keystore.base64` (one line).   |
+| `ANDROID_RELEASE_KEYSTORE_PASSWORD` | The `-storepass` you picked during `keytool -genkeypair`.          |
+| `ANDROID_RELEASE_KEY_ALIAS`         | `sergeant-shell` (or whatever `-alias` you passed to `keytool`).   |
+| `ANDROID_RELEASE_KEY_PASSWORD`      | The `-keypass` for the alias (usually same as the store password). |
+
+The workflow decodes the base64 blob into a file on the runner,
+exports the four `SERGEANT_RELEASE_*` env vars that
+`apps/mobile-shell/android/app/build.gradle` reads, then deletes the
+decoded keystore on `post` — the raw keystore never persists on the
+runner beyond the single Gradle invocation.
+
+### Triggering a release build
+
+```bash
+# Option A — manual, any branch:
+#   GitHub → Actions → "Mobile Shell (Android, Release AAB + APK)"
+#   → "Run workflow" → pick branch → Run.
+
+# Option B — tag-driven, reproducible:
+git tag v0.1.0-shell.1
+git push origin v0.1.0-shell.1
+# The tag push triggers the same workflow; the artefact pair carries
+# the tag's commit SHA in its filename via Gradle's default output
+# naming.
+```
+
+### Fetching the AAB / APK
+
+After the run completes:
+
+1. GitHub → Actions → "Mobile Shell (Android, Release AAB + APK)" →
+   click the run → scroll to **Artifacts**.
+2. Download either `sergeant-shell-release-aab.zip` (Play) or
+   `sergeant-shell-release-apk.zip` (sideload). Both zips contain a
+   single file at the expected Gradle output path.
+3. For sideload: `adb install app-release.apk` (device must be
+   connected + USB debugging on; uninstall any `com.sergeant.shell`
+   debug build first — Android refuses installs when the signing key
+   changes).
+
+Play Store upload (`upload-google-play` + service account JSON) is
+**not** part of this workflow — it will land in a follow-up PR that
+sets up an internal-track workflow + a separate
+`ANDROID_PLAY_SERVICE_ACCOUNT_JSON` secret.

--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -13,14 +13,17 @@ React Native). Співіснують навмисно: `applicationId` у shell
 
 ## Що готово
 
-| Функція                                       | Плагін / PR                                                                                                                                                                                                                                               |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                                                                                                                                                                         |
-| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                                                                                                                                                              |
-| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506)                                                                                                                                             |
-| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                                                                                                                                                               |
-| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                                                                                                                                                                          |
-| Push у shell — лише нативний (FCM/APNs)       | `@capacitor/push-notifications` через `@shared/lib/pushNative`. Web Push (VAPID + `PushManager.subscribe`) повністю виключений з shell-бандла через `VITE_TARGET=capacitor` + dynamic `import()` → [#524](https://github.com/Skords-01/Sergeant/pull/524) |
+| Функція                                       | Плагін / PR                                                                                                                                                                                                                                                                           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                                                                                                                                                                                                     |
+| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                                                                                                                                                                                          |
+| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506)                                                                                                                                                                         |
+| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                                                                                                                                                                                           |
+| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                                                                                                                                                                                                      |
+| Push у shell — лише нативний (FCM/APNs)       | `@capacitor/push-notifications` через `@shared/lib/pushNative`. Web Push (VAPID + `PushManager.subscribe`) повністю виключений з shell-бандла через `VITE_TARGET=capacitor` + dynamic `import()` → [#524](https://github.com/Skords-01/Sergeant/pull/524)                             |
+| Android debug-APK у CI                        | [`.github/workflows/mobile-shell-android.yml`](../../.github/workflows/mobile-shell-android.yml) → артефакт `sergeant-shell-debug-apk`                                                                                                                                                |
+| Android release-signing + ProGuard/R8         | `signingConfigs.release` у `android/app/build.gradle` читає `SERGEANT_RELEASE_*` з env/`gradle.properties`; `minifyEnabled true` + `shrinkResources true` + Capacitor keep-rules у `android/app/proguard-rules.pro`                                                                   |
+| Android release pipeline (AAB + APK у CI)     | [`.github/workflows/mobile-shell-android-release.yml`](../../.github/workflows/mobile-shell-android-release.yml) → `sergeant-shell-release-aab` (Play) + `sergeant-shell-release-apk` (sideload); setup-інструкція — [`MOBILE.md#release--android`](../../MOBILE.md#release--android) |
 
 Точка входу native-side — `src/index.ts → initNativeShell()`. Вона
 ідемпотентна (повторні виклики безпечні під HMR / LiveReload) і
@@ -94,6 +97,15 @@ build-only workflow-а.
 
 ## Що НЕ зроблено
 
+- **Play Store upload workflow (internal track)** — release-signing +
+  AAB + release-APK pipeline готовий
+  ([`mobile-shell-android-release.yml`](../../.github/workflows/mobile-shell-android-release.yml)),
+  але автоматичний upload через
+  `google-github-actions/upload-google-play` + service-account JSON —
+  ще окрема задача (потрібен `ANDROID_PLAY_SERVICE_ACCOUNT_JSON` secret
+  - Play Console config + internal-track rollout plan). Поки що
+    maintainер бере `sergeant-shell-release-aab` з Actions-артефакта і
+    заливає вручну.
 - **iOS native project, закомічений у repo** — `cap add ios` все ще
   чекає на Mac; зараз iOS-проект генерується при кожному запуску CI
   у `mobile-shell-ios.yml`. Для TestFlight pipeline треба або

--- a/apps/mobile-shell/android/app/build.gradle
+++ b/apps/mobile-shell/android/app/build.gradle
@@ -16,10 +16,61 @@ android {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+
+    // Release signing is driven by four properties that may come from either
+    // Gradle properties (e.g. `~/.gradle/gradle.properties` on a dev machine)
+    // or the environment (CI job exports them from decoded base64 keystore +
+    // GitHub Secrets — see `.github/workflows/mobile-shell-android-release.yml`).
+    //
+    //   SERGEANT_RELEASE_STORE_FILE      — absolute path to the .jks / .keystore
+    //   SERGEANT_RELEASE_STORE_PASSWORD  — keystore password
+    //   SERGEANT_RELEASE_KEY_ALIAS       — signing key alias inside the store
+    //   SERGEANT_RELEASE_KEY_PASSWORD    — password for that alias
+    //
+    // If *any* of them is missing we leave the release `signingConfig` null.
+    // That keeps local `./gradlew :app:assembleDebug` and the unsigned
+    // `:app:bundleRelease` path in CI working without secrets — the release
+    // AAB just ships unsigned in that case, which is fine for lint-style
+    // validation on PRs that don't need to upload to Play.
+    def resolveReleaseProp = { String name ->
+        if (project.hasProperty(name)) {
+            return project.property(name)
+        }
+        return System.getenv(name)
+    }
+
+    def releaseStoreFile = resolveReleaseProp('SERGEANT_RELEASE_STORE_FILE')
+    def releaseStorePassword = resolveReleaseProp('SERGEANT_RELEASE_STORE_PASSWORD')
+    def releaseKeyAlias = resolveReleaseProp('SERGEANT_RELEASE_KEY_ALIAS')
+    def releaseKeyPassword = resolveReleaseProp('SERGEANT_RELEASE_KEY_PASSWORD')
+
+    def hasReleaseSigning = releaseStoreFile?.toString()?.trim() &&
+            releaseStorePassword?.toString()?.trim() &&
+            releaseKeyAlias?.toString()?.trim() &&
+            releaseKeyPassword?.toString()?.trim()
+
+    signingConfigs {
+        if (hasReleaseSigning) {
+            release {
+                storeFile file(releaseStoreFile)
+                storePassword releaseStorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // R8 full-mode shrinking + resource shrinking. Kept together: AGP
+            // rejects `shrinkResources true` without `minifyEnabled true`.
+            // Capacitor-plugin keep-rules live in `proguard-rules.pro`.
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }

--- a/apps/mobile-shell/android/app/proguard-rules.pro
+++ b/apps/mobile-shell/android/app/proguard-rules.pro
@@ -1,21 +1,117 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# ProGuard / R8 rules for the Capacitor shell (`apps/mobile-shell`).
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# These rules pair with `buildTypes.release { minifyEnabled true; shrinkResources true }`
+# in `app/build.gradle`. Without them R8 strips Capacitor's plugin
+# classes (they are discovered reflectively at runtime via
+# `@CapacitorPlugin` annotations), which breaks the WebView <→> native
+# bridge and throws `PluginNotImplemented` at first use.
+#
+# Upstream reference for the Capacitor keep-rules:
+#   https://forum.ionicframework.com/t/how-to-use-proguard-with-capacitor/222915
+#   https://capgo.app/blog/how-to-resolve-android-build-errors-in-capacitor/
+#
+# When adding a new `@capacitor/*` or `@capacitor-community/*` plugin to
+# `apps/mobile-shell/package.json`, also add a matching `-keep class`
+# entry below. `cap sync` only wires up the Gradle module — it does not
+# emit ProGuard rules.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ---------------------------------------------------------------------------
+# Capacitor core + bridge (WebView <→> Java).
+# ---------------------------------------------------------------------------
+# The entire `com.getcapacitor` tree is reflective: `PluginManager` loads
+# plugin classes by FQCN from `@CapacitorPlugin`-annotated class files,
+# and `MessageHandler` / `PluginHandle` dispatch method calls via
+# reflection on `@PluginMethod`-annotated members.
+-keep class com.getcapacitor.** { *; }
+-keep interface com.getcapacitor.** { *; }
+-keepclassmembers class com.getcapacitor.** { *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Capacitor annotations — read at runtime by `PluginManager`.
+-keep @com.getcapacitor.annotation.CapacitorPlugin public class * {
+    <init>(...);
+    @com.getcapacitor.annotation.CapacitorPlugin *;
+}
+-keepclassmembers @com.getcapacitor.annotation.CapacitorPlugin class ** {
+    @com.getcapacitor.PluginMethod *;
+}
+-keepattributes *Annotation*, InnerClasses, EnclosingMethod, Signature, Exceptions
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# The Cordova shim Capacitor keeps around for legacy plugins.
+-keep class org.apache.cordova.** { *; }
+-dontwarn org.apache.cordova.**
+
+# JavaScript-facing interface injected into the WebView
+# (`MessageHandler.postMessage`, etc). Method names MUST match the JS
+# side literally, so we forbid renaming any `@JavascriptInterface` member.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+# ---------------------------------------------------------------------------
+# Capacitor plugins declared in apps/mobile-shell/package.json.
+# ---------------------------------------------------------------------------
+# @capacitor/app
+-keep class com.capacitorjs.plugins.app.** { *; }
+# @capacitor/keyboard
+-keep class com.capacitorjs.plugins.keyboard.** { *; }
+# @capacitor/preferences
+-keep class com.capacitorjs.plugins.preferences.** { *; }
+# @capacitor/push-notifications
+-keep class com.capacitorjs.plugins.pushnotifications.** { *; }
+# @capacitor/splash-screen
+-keep class com.capacitorjs.plugins.splashscreen.** { *; }
+# @capacitor/status-bar
+-keep class com.capacitorjs.plugins.statusbar.** { *; }
+# @capacitor-mlkit/barcode-scanning
+-keep class io.capawesome.capacitorjs.plugins.mlkit.barcodescanning.** { *; }
+
+# ---------------------------------------------------------------------------
+# Transitive dependencies brought in by the plugins.
+# ---------------------------------------------------------------------------
+# Firebase / Google Play Services (used by push-notifications + mlkit).
+-keep class com.google.firebase.** { *; }
+-keep interface com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+-keep interface com.google.android.gms.** { *; }
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**
+
+# ML Kit barcode scanning ships an optional module that R8 tries to
+# resolve even when the app doesn't use the bundled variant.
+-keep class com.google.mlkit.** { *; }
+-keep interface com.google.mlkit.** { *; }
+-dontwarn com.google.mlkit.**
+
+# androidx — Capacitor bridge uses a few reflective androidx APIs (core
+# splashscreen, appcompat). R8 is generally fine with these, but keep
+# `@Keep` annotations honored defensively.
+-keep class androidx.core.splashscreen.** { *; }
+-dontwarn androidx.**
+
+# ---------------------------------------------------------------------------
+# Generic niceties.
+# ---------------------------------------------------------------------------
+# Keep any class annotated with @Keep (AndroidX) — covers plugins that
+# declare explicit keep markers on their own API surface.
+-keep @androidx.annotation.Keep class * { *; }
+-keepclassmembers class * {
+    @androidx.annotation.Keep <fields>;
+    @androidx.annotation.Keep <methods>;
+}
+
+# Preserve enums' reflection-friendly methods (Gson/Jackson/Moshi-free
+# code in Capacitor still uses `valueOf` / `values` for plugin configs).
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# Native method names (JNI) must not be obfuscated.
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Stack traces in release-AAB — keep source filenames + line numbers so
+# Play Console + Sentry can symbolicate crashes.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -136,10 +136,26 @@ Android-частина (`android/`) закомічена, `applicationId`
 
 **Не зроблено:**
 
-- **GitHub Actions workflow для debug-APK.** `apps/mobile-shell/README.md`
+- ~~**GitHub Actions workflow для debug-APK.** `apps/mobile-shell/README.md`
   має TODO: `.github/workflows/mobile-shell-android.yml` треба
   закомітити мейнтейнеру вручну (Devin OAuth app не має `workflow`
-  scope). Без нього — локальний Android SDK обовʼязковий.
+  scope). Без нього — локальний Android SDK обовʼязковий.~~ Зроблено:
+  [`mobile-shell-android.yml`](../.github/workflows/mobile-shell-android.yml)
+  збирає debug-APK на PR, а release-сторона
+  ([`mobile-shell-android-release.yml`](../.github/workflows/mobile-shell-android-release.yml))
+  продукує два артефакти — `sergeant-shell-release-aab` (Play Store)
+  та `sergeant-shell-release-apk` (direct sideload via `adb install`).
+  Підпис читається з `SERGEANT_RELEASE_*` env/`gradle.properties` у
+  `android/app/build.gradle`; якщо секрети відсутні — release-лейн
+  усе одно крутить `:app:bundleRelease :app:assembleRelease` (unsigned)
+  як smoke-test ProGuard/R8 + Capacitor sync на PR-ах. ProGuard/R8
+  keep-rules для всіх `@capacitor/*` плагінів — у
+  `android/app/proguard-rules.pro`. Setup-інструкція (keytool → base64
+  → GitHub Secrets) — у [`MOBILE.md#release--android`](../MOBILE.md#release--android).
+- **Play Store upload workflow (internal track).** Release-signing pipeline
+  уже стоїть; автоматичний upload через `google-github-actions/upload-google-play`
+  - service-account JSON (новий secret `ANDROID_PLAY_SERVICE_ACCOUNT_JSON`)
+    — окрема задача.
 - **iOS.** `ios/` НЕ закомічено — потрібен Mac + Xcode + CocoaPods для
   `pnpm --filter @sergeant/mobile-shell add:ios`. Release pipeline на iOS
   зараз немає.
@@ -208,9 +224,9 @@ Android-частина (`android/`) закомічена, `applicationId`
   Жити обидві на одному акаунті Google Play дозволяє (`applicationId`
   різні), але Apple одне й те саме bundle-prefix обмежує.
 
-**Blocking для релізу:** GitHub Actions workflow для APK (інакше без
-Android SDK локально білд неможливий), native push, iOS `cap add ios` з
-Mac.
+**Blocking для релізу:** Play Store upload workflow (internal track
+через service account — release-signing + AAB/APK pipeline вже
+готовий), iOS `cap add ios` з Mac.
 
 ---
 


### PR DESCRIPTION
## Summary

Stands up the release-lane side of the Capacitor shell (`apps/mobile-shell`) on Android. Until now only the debug-APK workflow from #520 existed — the release side (signed AAB + ProGuard/R8) was the remaining "Blocking для релізу" item called out in [`docs/platforms.md`](../blob/main/docs/platforms.md) → «3. Capacitor shell → Не зроблено». One self-contained PR, no secrets in-repo — only the hooks that read them.

1. **`apps/mobile-shell/android/app/build.gradle`** — `signingConfigs { release { ... } }` reads credentials from `gradle.properties` or env (`SERGEANT_RELEASE_STORE_FILE`, `SERGEANT_RELEASE_STORE_PASSWORD`, `SERGEANT_RELEASE_KEY_ALIAS`, `SERGEANT_RELEASE_KEY_PASSWORD`). When any of the four is unset the `signingConfig` stays `null`, so local `./gradlew :app:assembleDebug` keeps working without secrets (important for dev machines and for the existing debug-APK workflow).
2. **`buildTypes.release`** — `minifyEnabled true`, `shrinkResources true`, `proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'`.
3. **`apps/mobile-shell/android/app/proguard-rules.pro`** — Capacitor 7 keep-rules: full `com.getcapacitor.**` tree, `@CapacitorPlugin` / `@PluginMethod` annotation preservation, `@JavascriptInterface` bridge, and per-plugin keeps for every `@capacitor/*` + `@capacitor-mlkit/barcode-scanning` package declared in [`apps/mobile-shell/package.json`](../blob/main/apps/mobile-shell/package.json). Plus Firebase / GMS / ML Kit defensive keeps for the push + barcode plugins' transitive deps.
4. **`.github/workflows/mobile-shell-android-release.yml`** — new workflow on `workflow_dispatch` + `push tags 'v*'`. Steps: pnpm install → `pnpm --filter @sergeant/mobile-shell build:web` → `cap sync android` → `./gradlew :app:bundleRelease :app:assembleRelease` (one invocation, shared R8 cache). If release-signing env vars are present (via GitHub Secrets `ANDROID_RELEASE_KEYSTORE_BASE64`, `ANDROID_RELEASE_KEYSTORE_PASSWORD`, `ANDROID_RELEASE_KEY_ALIAS`, `ANDROID_RELEASE_KEY_PASSWORD`) — decodes the base64 keystore to a file on the runner, exports `SERGEANT_RELEASE_*` before Gradle, scrubs the decoded file in the `post` step. If absent — builds an unsigned AAB + APK so PRs that only touch code can validate the release graph (ProGuard keep-rules, Capacitor sync, resource shrinking) without secrets.

   The workflow uploads **two** artefacts (14-day retention):
   - `sergeant-shell-release-aab` (from `:app:bundleRelease`) — Play Store uploads.
   - `sergeant-shell-release-apk` (from `:app:assembleRelease`) — direct sideload (`adb install`, file-manager). Added per the scope expansion during this task — a `.aab` isn't directly installable, so operators doing ad-hoc / QA testing would otherwise need a second workflow.

5. **`MOBILE.md`** → new `## Release — Android` section: AAB-vs-APK rule of thumb, `keytool -genkeypair` one-liner, `base64 -w0` encoding, the four GitHub Secrets, `workflow_dispatch` vs `v*`-tag triggers, and where to download each artefact. Play Store upload (internal track via `google-github-actions/upload-google-play` + service-account JSON) is explicitly flagged as a follow-up PR.
6. **`apps/mobile-shell/README.md`** → status table updated: release-signing + ProGuard + release-AAB/APK workflow moved to «Що готово»; Play Store upload workflow added as the remaining TODO.
7. **`docs/platforms.md`** → the «GitHub Actions workflow для APK» line is struck-through with a link to the new release workflow; «Blocking для релізу» now lists only Play-upload + iOS Mac as open.

Linked prior art: debug-lane workflow — #520; status doc — [`docs/platforms.md`](../blob/main/docs/platforms.md).

### Acceptance checks (all green locally)
- `pnpm --filter @sergeant/mobile-shell typecheck` → clean.
- `actionlint .github/workflows/mobile-shell-android-release.yml` → clean.
- `app/build.gradle` logic: `resolveReleaseProp` prefers `project.property(name)` over env, falls back to `System.getenv(name)`, and all four must be non-empty before `signingConfigs.release {}` is registered. Gate mirrored on the release `buildType` so `assembleDebug` and unsigned `bundleRelease`/`assembleRelease` don't touch `signingConfigs.release`.

## Review & Testing Checklist for Human

- [ ] Confirm `./gradlew :app:assembleDebug` still passes locally on a dev machine with no `SERGEANT_RELEASE_*` env vars set (regression guard for the null-safe signing config).
- [ ] On a tag push (e.g. `git tag v0.0.0-dryrun && git push origin v0.0.0-dryrun`) or a manual `workflow_dispatch`, check that the new workflow publishes both `sergeant-shell-release-aab` and `sergeant-shell-release-apk` artefacts; with no signing secrets set they should be unsigned.
- [ ] Once `ANDROID_RELEASE_KEYSTORE_BASE64` + the three password/alias secrets are added per [`MOBILE.md#release--android`](../blob/devin/1776874896-mobile-shell-release/MOBILE.md#release--android), re-run the workflow and verify the AAB / APK are signed (`apksigner verify --print-certs app-release.apk` should show your uploaded cert; `bundletool build-apks` round-trips the AAB).
- [ ] Spot-check that ProGuard/R8 didn't strip a plugin: install the release APK on a device, open the app, confirm status-bar, splash, keyboard, preferences (bearer auth), push-notifications registration, and barcode scanner still behave. If any plugin throws `PluginNotImplemented`, the `proguard-rules.pro` entry for that package name needs adjusting.

### Notes

- Signing-config gate intentionally evaluates at Gradle config time and registers `signingConfigs.release` only when all four inputs are non-empty — this avoids the common "`Keystore file ... not found`" confusing error on fresh clones.
- `versionCode` / `versionName` are unchanged (`1` / `"1.0"`) — bumping them is the release manager's call and doesn't belong in the scaffolding PR.
- Play-Store upload (`google-github-actions/upload-google-play` + `ANDROID_PLAY_SERVICE_ACCOUNT_JSON`) is explicitly out of scope here and flagged as the next task in `docs/platforms.md` + `apps/mobile-shell/README.md`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android release build workflow to generate signed release artifacts (App Bundle and APK).

* **Documentation**
  * Documented Android release build process, including setup instructions for signing credentials and artifact retrieval.
  * Added guidance on release build triggers and artifact handling for Play Store vs. sideload distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->