### PR TITLE
docs(mobile-shell): bump required JDK from 17 to 21 in MOBILE.md (Capacitor 7.6+)

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -23,13 +23,13 @@ shell reads it from there via `webDir: "../server/dist"` in
 
 ## Prerequisites
 
-| Tool              | Version           | Notes                                                                                                                                            |
-| ----------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Node.js           | 20.x (see .nvmrc) | `nvm install 20 && nvm use 20`                                                                                                                   |
-| pnpm              | 9.15.1            | `corepack enable && corepack prepare pnpm@9.15.1 --activate`                                                                                     |
-| JDK               | 21 (Temurin)      | matches `sourceCompatibility`/`targetCompatibility` VERSION_21 emitted into `apps/mobile-shell/android/app/capacitor.build.gradle` by `cap sync` |
-| Android SDK       | API 35            | `compileSdk=35`, `minSdk=23` (Android Studio or `sdkmanager`)                                                                                    |
-| Xcode + CocoaPods | latest stable     | macOS only, iOS only                                                                                                                             |
+| Tool              | Version           | Notes                                                         |
+| ----------------- | ----------------- | ------------------------------------------------------------- |
+| Node.js           | 20.x (see .nvmrc) | `nvm install 20 && nvm use 20`                                |
+| pnpm              | 9.15.1            | `corepack enable && corepack prepare pnpm@9.15.1 --activate`  |
+| JDK               | 21 (Temurin)      | required by Capacitor 7.6+ (compiles to VERSION_21) / AGP 8   |
+| Android SDK       | API 35            | `compileSdk=35`, `minSdk=23` (Android Studio or `sdkmanager`) |
+| Xcode + CocoaPods | latest stable     | macOS only, iOS only                                          |
 
 ## Android — debug APK
 


### PR DESCRIPTION
## Summary

Doc-only follow-up to #521 (Capacitor bump 7.4.3 → 7.6.2).

After #521, Capacitor's auto-generated `apps/mobile-shell/android/app/capacitor.build.gradle` pins `sourceCompatibility` / `targetCompatibility` to `VERSION_21`. Anything below JDK 21 now trips `error: invalid source release: 21` during `:capacitor-android:compileDebugJavaWithJavac`.

CI is already on JDK 21 (`actions/setup-java` with `java-version: "21"` in both `.github/workflows/mobile-shell-android.yml` and `.github/workflows/mobile-shell-android-release.yml` — the latter was bumped in #529 when the JDK row in MOBILE.md also got updated to `21 (Temurin)`). This PR only rephrases the `Notes` column of the JDK row in the Prerequisites table so local operators see the same rationale CI uses (Capacitor 7.6+ compiling to VERSION_21 / AGP 8) and not the prior `cap sync`-flavored note.

### What changed
- `MOBILE.md` — Prerequisites table, JDK row Notes column: `matches sourceCompatibility/targetCompatibility VERSION_21 emitted into apps/mobile-shell/android/app/capacitor.build.gradle by cap sync` → `required by Capacitor 7.6+ (compiles to VERSION_21) / AGP 8`. Prettier reflowed the table padding during lint-staged.

### What was intentionally NOT changed
- `apps/mobile-shell/android/**`, `capacitor.config.ts`, any gradle file — untouched.
- `.github/workflows/detox-android.yml` still uses JDK 17; that's the Expo / React Native lane (`apps/mobile`) and not in scope here.
- `.github/workflows/mobile-shell-android.yml` — a one-line comment still references `JDK 17 trips` on line 70. It was intended to be rephrased to `Anything below 21 trips` in this PR, but Devin's GitHub App lacks the `workflow` OAuth scope and the push was rejected. The comment is inside the `mobile-shell-android` debug workflow only (release workflow already uses the `Anything below 21` wording). Happy to land it separately if you want.

### Scope check
Other stale references searched for and verified absent:
- `grep -rn 'java-version' .github/workflows/ apps/ docs/` → only `17` hit is `detox-android.yml` (out of scope).
- `grep -rn 'JDK 17\|JDK17\|Java 17\|Temurin 17' .` → only hits are the two workflow files noted above.
- `apps/mobile-shell/README.md`, `docs/platforms.md`, `docs/mobile.md` — no Capacitor-JDK-17 references.

## Review & Testing Checklist for Human

- [ ] Confirm the rephrased Notes cell reads well in the rendered MOBILE.md table (GitHub preview).
- [ ] Decide whether the leftover `JDK 17 trips` comment in `.github/workflows/mobile-shell-android.yml:70` should also be rephrased (Devin couldn't push `workflow` changes — would need a manual commit or a re-run with `workflow` scope).
- [ ] Sanity-check that `detox-android.yml` staying on JDK 17 is still the desired state for the Expo SDK 52 lane.

### Notes
- Related: #521 (Capacitor 7.4.3 → 7.6.2), #529 (bumped Android JDK to 21 for debug + release workflows — which is the commit that had already updated the JDK row in `MOBILE.md` from `17` to `21`; this PR only refines the wording of the Notes column).
- CI impact: none expected — single-line doc change, no workflow / build inputs touched.

Link to Devin session: https://app.devin.ai/sessions/8b5528b75b714969bc35521ad090cdbf
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted Prerequisites table in mobile development documentation for improved readability.
  * Clarified JDK 21 requirements documentation for Capacitor and Android Gradle Plugin compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->