### PR TITLE
test(a11y): ignore 'Failed to load resource' network errors so CI passes without backend

### DIFF
--- a/apps/web/tests/a11y/axe.spec.ts
+++ b/apps/web/tests/a11y/axe.spec.ts
@@ -111,12 +111,19 @@ for (const { name, path } of SURFACES) {
     }
 
     // Sanity: SPA bootstrap should not print console errors on these
-    // top-level surfaces in a fresh profile.
+    // top-level surfaces in a fresh profile. Network-level "Failed to
+    // load resource" errors are filtered because the a11y job runs
+    // against `vite preview` with no backend attached — /api/* calls
+    // fail by design. Real JS/React runtime errors are still caught.
     expect(
       consoleErrors.filter(
         (e) =>
           // vite-plugin-pwa registerSW noise in preview mode.
-          !e.includes("workbox") && !e.includes("Service worker"),
+          !e.includes("workbox") &&
+          !e.includes("Service worker") &&
+          // Browser-emitted network failures when /api/* has no
+          // backend to proxy to in CI.
+          !e.includes("Failed to load resource"),
       ),
       `console errors on ${path}:\n${consoleErrors.join("\n")}`,
     ).toEqual([]);


### PR DESCRIPTION
## Summary

Fix pre-existing red CI on `Accessibility (axe-core)`. The job has been failing on every PR (incl. `main` at `20354a3`, see [check-runs API](https://api.github.com/repos/Skords-01/Sergeant/commits/20354a3ec1d1d00fea1f9772f12655a49faf2c08/check-runs)) since the a11y workflow was added in `a46127b` (monorepo migration).

### Root cause

`apps/web/playwright.config.ts` starts `vite preview --port 4173` as its `webServer` — no backend is spun up. `vite preview` still honors `server.proxy` from `vite.config.js` (`/api` → `127.0.0.1:3000`), so every `/api/v1/*` fetch the SPA fires on bootstrap fails with `ECONNREFUSED 127.0.0.1:3000`. The proxy surfaces those failures as HTTP 500 to the browser, which the browser itself logs as `Failed to load resource: the server responded with a status of 500 (Internal Server Error)` console errors.

`tests/a11y/axe.spec.ts` expects zero console errors after axe runs:

```ts
expect(
  consoleErrors.filter(
    (e) => !e.includes("workbox") && !e.includes("Service worker"),
  ),
  `console errors on ${path}:\n${consoleErrors.join("\n")}`,
).toEqual([]);
```

→ The `Failed to load resource` messages are never filtered, so every surface (hub, finyk, fizruk, nutrition, routine) fails the assertion even though axe itself finds zero serious/critical violations.

### Fix

Extend the filter in `tests/a11y/axe.spec.ts` to also drop `Failed to load resource` messages. These are browser-emitted network errors, not SPA bootstrap errors — the original intent of the console check (catch real React/JS runtime errors from module load) is preserved because any uncaught exceptions, React error boundaries, or `console.error` calls from app code still surface.

Intentionally NOT doing any of the following — they're either scope-creep or would mask real failures:

- Mocking `/api/**` with `page.route` — would require knowing the Better Auth session shape to avoid AuthPage redirects, and effectively changes what surfaces axe is snapshotting.
- Spinning up a real backend in CI — the a11y job is purposely a static preview pass (`npm run preview`), adding a DB + API stack triples the job runtime.
- Making the proxy target configurable and silencing it — vite still emits the 500 through the proxy layer.

### Validation

```
$ CI=true pnpm --filter @sergeant/web test:a11y
Running 11 tests using 1 worker
  ✓  1 a11y: hub-root has no serious/critical violations (2.3s)
  ✓  2 a11y: finyk-overview has no serious/critical violations (2.1s)
  ✓  3 a11y: fizruk-dashboard has no serious/critical violations (2.3s)
  ✓  4 a11y: nutrition-dashboard has no serious/critical violations (2.3s)
  ✓  5 a11y: routine-dashboard has no serious/critical violations (2.6s)
  ✓  6 ds-qa: light @ 375px (8.5s)
  ✓  7 ds-qa: light @ 414px (9.9s)
  ✓  8 ds-qa: light @ 768px (8.8s)
  ✓  9 ds-qa: dark @ 375px (8.6s)
  ✓ 10 ds-qa: dark @ 414px (8.6s)
  ✓ 11 ds-qa: dark @ 768px (8.8s)
  11 passed (1.4m)
```

(Locally reproduced the original failure first; confirmed it fails on `main` without the patch with exactly the `Failed to load resource` messages we're now filtering.)

## Review & Testing Checklist for Human

- [ ] Confirm you're happy with filtering `Failed to load resource` wholesale vs. a narrower pattern (e.g. `/api/` path check) — the former is simpler and covers future endpoint shuffles; the latter is more specific but needs maintenance.
- [ ] Decide whether a follow-up should instead swap `vite preview` to serve with a stubbed `/api` so the job can assert hermetic state (bigger change, out of scope here).

### Notes
- Completely unrelated to #532 (docs-only JDK 21 rephrase); that PR's red `Accessibility (axe-core)` will also go green once this lands and that branch is rebased.
- `check` + `CodeRabbit` + `Devin Review` passes were already green on #532, confirming the a11y break is the sole pre-existing regression.

Link to Devin session: https://app.devin.ai/sessions/8b5528b75b714969bc35521ad090cdbf
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite reliability by improving console error filtering to better distinguish between application errors and network-related noise during accessibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->