### PR TITLE
feat(nutrition-domain): extract pure storage-core (Phase 7 / PR 2)

### DIFF
--- a/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
@@ -1,167 +1,78 @@
-import type { PantryItem } from "./pantryTextParser.js";
+/**
+ * Web I/O-адаптер для модуля Харчування: prefs, pantries, log.
+ *
+ * Pure-логіка (normalize/default/mutation-хелпери + типи + LS-ключі) живе
+ * у `@sergeant/nutrition-domain` і спільна з `apps/mobile`. Тут лишаються
+ * лише `load*`/`persist*` поверх `createModuleStorage` і реекспорти
+ * старої поверхні цього модуля, щоб існуючі `../lib/nutritionStorage.js`
+ * імпорти всередині `apps/web` не довелось переписувати.
+ */
 import {
-  macrosHasAnyValue,
-  macrosToTotals,
-  normalizeMacrosNullable,
-  type Macros,
-  type NullableMacros,
-} from "./macros.js";
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  defaultNutritionPrefs,
+  makeDefaultPantry,
+  normalizeNutritionLog,
+  normalizeNutritionPrefs,
+  normalizePantries,
+  type NutritionLog,
+  type NutritionPrefs,
+  type Pantry,
+} from "@sergeant/nutrition-domain";
+
 import { nutritionStorage } from "./nutritionStorageInstance.js";
-import {
-  isMealTypeId,
-  labelForMealType,
-  mealTypeFromLabel,
-  type MealTypeId,
-} from "./mealTypes.js";
 
-export const NUTRITION_PANTRIES_KEY = "nutrition_pantries_v1";
-export const NUTRITION_ACTIVE_PANTRY_KEY = "nutrition_active_pantry_v1";
-export const NUTRITION_PREFS_KEY = "nutrition_prefs_v1";
-export const NUTRITION_LOG_KEY = "nutrition_log_v1";
+export {
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  addDaysISODate,
+  addLogEntry,
+  defaultNutritionPrefs,
+  duplicatePreviousDayMeals,
+  estimateLogBytes,
+  getDayMacros,
+  getDaySummary,
+  getMacrosForDateRange,
+  makeDefaultPantry,
+  mergeNutritionLogs,
+  normalizeMeal,
+  normalizeNutritionLog,
+  normalizePantries,
+  removeLogEntry,
+  searchMealsByName,
+  trimLogOldestDays,
+  updateLogEntry,
+  updatePantry,
+} from "@sergeant/nutrition-domain";
+export { toLocalISODate } from "@sergeant/shared";
+export type {
+  DaySummary,
+  MacrosRow,
+  Meal,
+  MealMacroSource,
+  MealSearchResult,
+  MealSource,
+  MealTemplate,
+  NutritionDay,
+  NutritionGoal,
+  NutritionLog,
+  NutritionLogLike,
+  NutritionPrefs,
+  Pantry,
+} from "@sergeant/nutrition-domain";
 
-export type NutritionGoal = string;
-export type MealMacroSource = "manual" | "productDb" | "photoAI" | "recipeAI";
-export type MealSource = "manual" | "photo";
-
-export interface MealTemplate {
-  id: string;
-  name: string;
-  mealType: MealTypeId;
-  macros: NullableMacros;
-}
-
-export interface NutritionPrefs {
-  goal: NutritionGoal;
-  servings: number;
-  timeMinutes: number;
-  exclude: string;
-  dailyTargetKcal: number | null;
-  dailyTargetProtein_g: number | null;
-  dailyTargetFat_g: number | null;
-  dailyTargetCarbs_g: number | null;
-  mealTemplates: MealTemplate[];
-  reminderEnabled: boolean;
-  reminderHour: number;
-  waterGoalMl: number;
-}
-
-export interface Pantry {
-  id: string;
-  name: string;
-  items: PantryItem[];
-  text: string;
-}
-
-export interface Meal {
-  id: string;
-  name: string;
-  time: string;
-  mealType: MealTypeId;
-  label: string;
-  macros: NullableMacros;
-  source: MealSource;
-  macroSource: MealMacroSource;
-  amount_g: number | null;
-  foodId: string | null;
-  demo?: true;
-}
-
-export interface NutritionDay {
-  meals: Meal[];
-}
-
-export type NutritionLog = Record<string, NutritionDay>;
-
-export type NutritionLogLike =
-  | Record<string, { meals?: unknown[] | null } | null | undefined>
-  | null
-  | undefined;
-
-export interface DaySummary extends Macros {
-  date: string;
-  mealCount: number;
-  hasMeals: boolean;
-  hasAnyMacros: boolean;
-}
-
-export function toLocalISODate(d: Date | string | number = new Date()): string {
-  const dt = d instanceof Date ? d : new Date(d);
-  if (Number.isNaN(dt.getTime())) return "1970-01-01";
-  const y = dt.getFullYear();
-  const m = String(dt.getMonth() + 1).padStart(2, "0");
-  const day = String(dt.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function optionalPositiveNumber(v: unknown): number | null {
-  if (v == null || v === "") return null;
-  const n = Number(v);
-  return Number.isFinite(n) && n > 0 ? n : null;
-}
-
-export function defaultNutritionPrefs(): NutritionPrefs {
-  return {
-    goal: "balanced",
-    servings: 1,
-    timeMinutes: 25,
-    exclude: "",
-    dailyTargetKcal: null,
-    dailyTargetProtein_g: null,
-    dailyTargetFat_g: null,
-    dailyTargetCarbs_g: null,
-    mealTemplates: [],
-    reminderEnabled: false,
-    reminderHour: 12,
-    waterGoalMl: 2000,
-  };
-}
+// ─────────────────────────────────────────────
+// I/O wrappers (createModuleStorage / localStorage)
+// ─────────────────────────────────────────────
 
 export function loadNutritionPrefs(
   key: string = NUTRITION_PREFS_KEY,
 ): NutritionPrefs {
-  const p = nutritionStorage.readJSON(key, null) as unknown;
-  if (!p || typeof p !== "object" || Array.isArray(p))
-    return defaultNutritionPrefs();
-  try {
-    const defaults = defaultNutritionPrefs();
-    const raw = p as Record<string, unknown>;
-    const waterGoalMl = optionalPositiveNumber(raw.waterGoalMl);
-    const mealTemplates: MealTemplate[] = Array.isArray(raw.mealTemplates)
-      ? (raw.mealTemplates as unknown[])
-          .filter(
-            (t): t is Record<string, unknown> => !!t && typeof t === "object",
-          )
-          .map((t) => ({
-            id: String(t.id || `tpl_${Date.now()}`),
-            name: String(t.name || "").trim(),
-            mealType: isMealTypeId(t.mealType) ? t.mealType : "snack",
-            macros: normalizeMacros(t.macros),
-          }))
-          .filter((t) => t.name)
-          .slice(0, 40)
-      : [];
-    return {
-      ...defaults,
-      ...(raw as Partial<NutritionPrefs>),
-      servings: raw.servings != null ? Number(raw.servings) || 1 : 1,
-      timeMinutes: raw.timeMinutes != null ? Number(raw.timeMinutes) || 25 : 25,
-      exclude: raw.exclude == null ? "" : String(raw.exclude),
-      goal: raw.goal ? String(raw.goal) : "balanced",
-      dailyTargetKcal: optionalPositiveNumber(raw.dailyTargetKcal),
-      dailyTargetProtein_g: optionalPositiveNumber(raw.dailyTargetProtein_g),
-      dailyTargetFat_g: optionalPositiveNumber(raw.dailyTargetFat_g),
-      dailyTargetCarbs_g: optionalPositiveNumber(raw.dailyTargetCarbs_g),
-      mealTemplates,
-      reminderEnabled: Boolean(raw.reminderEnabled),
-      reminderHour:
-        raw.reminderHour != null && Number.isFinite(Number(raw.reminderHour))
-          ? Math.min(23, Math.max(0, Math.floor(Number(raw.reminderHour))))
-          : 12,
-      waterGoalMl: waterGoalMl != null ? waterGoalMl : defaults.waterGoalMl,
-    };
-  } catch {
-    return defaultNutritionPrefs();
-  }
+  return normalizeNutritionPrefs(nutritionStorage.readJSON(key, null));
 }
 
 export function persistNutritionPrefs(
@@ -169,47 +80,6 @@ export function persistNutritionPrefs(
   key: string = NUTRITION_PREFS_KEY,
 ): boolean {
   return nutritionStorage.writeJSON(key, prefs || defaultNutritionPrefs());
-}
-
-export function makeDefaultPantry(): Pantry {
-  return { id: "home", name: "Дім", items: [], text: "" };
-}
-
-function sanitizePantryItem(raw: unknown): PantryItem | null {
-  if (!raw || typeof raw !== "object") return null;
-  const r = raw as Record<string, unknown>;
-  const name = String(r.name || "").trim();
-  if (!name) return null;
-  const qtyNum = Number(r.qty);
-  const qty = r.qty == null || !Number.isFinite(qtyNum) ? null : qtyNum;
-  return {
-    name,
-    qty,
-    unit: r.unit == null ? null : String(r.unit),
-    notes: r.notes == null ? null : String(r.notes),
-  };
-}
-
-export function normalizePantries(raw: unknown): Pantry[] {
-  if (!Array.isArray(raw)) return [];
-  const out: Pantry[] = [];
-  const seenIds = new Set<string>();
-  for (const p of raw as unknown[]) {
-    if (!p || typeof p !== "object") continue;
-    const rp = p as Record<string, unknown>;
-    let id = rp.id != null ? String(rp.id).trim() : "";
-    if (!id || seenIds.has(id)) id = `p_${Date.now()}_${out.length}`;
-    seenIds.add(id);
-    const name = String(rp.name || "Склад").trim() || "Склад";
-    const items = Array.isArray(rp.items)
-      ? (rp.items as unknown[])
-          .map(sanitizePantryItem)
-          .filter((x): x is PantryItem => x != null)
-      : [];
-    const text = rp.text == null ? "" : String(rp.text);
-    out.push({ id, name, items, text });
-  }
-  return out;
 }
 
 export function loadActivePantryId(
@@ -227,8 +97,9 @@ export function loadPantries(
   const normalized = normalizePantries(parsed);
   if (normalized.length > 0) return normalized;
 
-  // Legacy v0 pantry migration is handled by storageManager (nutrition_001_migrate_legacy_pantry).
-  // By the time this code runs after app boot, the v1 key already has data if any v0 data existed.
+  // Legacy v0 pantry migration is handled by storageManager
+  // (nutrition_001_migrate_legacy_pantry). By the time this code runs after
+  // app boot, the v1 key already has data if any v0 data existed.
   const fallback = makeDefaultPantry();
   nutritionStorage.writeRaw(activeKey, fallback.id);
   return [fallback];
@@ -250,121 +121,6 @@ export function persistPantries(
   return a && b;
 }
 
-export function updatePantry(
-  pantries: Pantry[] | null | undefined,
-  activeId: string | null | undefined,
-  fn: (p: Pantry) => Pantry,
-): Pantry[] {
-  const arr = Array.isArray(pantries) ? pantries : [];
-  const id = String(activeId || "home");
-  const idx = arr.findIndex((p) => p.id === id);
-  if (idx === -1) {
-    const created = fn(makeDefaultPantry());
-    return [created, ...arr];
-  }
-  const next = [...arr];
-  next[idx] = fn(next[idx]);
-  return next;
-}
-
-function normalizeMacros(mac: unknown): NullableMacros {
-  // Backward-compatible export name used across this module:
-  // meals/templates store nullable macros; totals are computed separately.
-  return normalizeMacrosNullable(mac);
-}
-
-export function normalizeMeal(m: unknown, idx: number): Meal {
-  const raw = (m && typeof m === "object" ? m : {}) as Record<string, unknown>;
-  let id = raw.id != null && String(raw.id).trim() ? String(raw.id).trim() : "";
-  if (!id)
-    id = `meal_mig_${Date.now()}_${idx}_${Math.random().toString(36).slice(2, 8)}`;
-
-  const name = raw.name != null ? String(raw.name).trim() : "";
-  const time = raw.time != null ? String(raw.time).trim() : "";
-
-  let mealType: MealTypeId;
-  if (isMealTypeId(raw.mealType)) {
-    mealType = raw.mealType;
-  } else {
-    mealType = mealTypeFromLabel(raw.label);
-  }
-
-  const label =
-    raw.label != null && String(raw.label).trim()
-      ? String(raw.label).trim()
-      : labelForMealType(mealType);
-
-  const macros = normalizeMacros(raw.macros);
-  const source: MealSource =
-    raw.source && String(raw.source) === "photo" ? "photo" : "manual";
-
-  const rawMacroSource =
-    raw.macroSource != null ? String(raw.macroSource).trim() : "";
-  const macroSource: MealMacroSource =
-    rawMacroSource === "manual" ||
-    rawMacroSource === "productDb" ||
-    rawMacroSource === "photoAI" ||
-    rawMacroSource === "recipeAI"
-      ? (rawMacroSource as MealMacroSource)
-      : source === "photo"
-        ? "photoAI"
-        : "manual";
-
-  const amount_g =
-    raw.amount_g != null &&
-    Number.isFinite(Number(raw.amount_g)) &&
-    Number(raw.amount_g) > 0
-      ? Number(raw.amount_g)
-      : null;
-  const foodId =
-    raw.foodId != null && String(raw.foodId).trim()
-      ? String(raw.foodId).trim()
-      : null;
-
-  // Pass the FTUX demo flag through untouched. Seeded meals carry
-  // `demo: true` so cross-module detectors (see `firstRealEntry.js`) can
-  // tell seeded data apart from real entries. Because `useNutritionLog`
-  // immediately persists the normalized log back to localStorage, any
-  // property dropped here is lost on the first module visit — which is
-  // what used to silently re-classify demo meals as real entries and
-  // trip the soft-auth prompt.
-  const out: Meal = {
-    id,
-    name,
-    time,
-    mealType,
-    label,
-    macros,
-    source,
-    macroSource,
-    amount_g,
-    foodId,
-  };
-  if (raw.demo === true) out.demo = true;
-  return out;
-}
-
-export function normalizeNutritionLog(raw: unknown): NutritionLog {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const out: NutritionLog = {};
-  for (const [dateKey, day] of Object.entries(raw as Record<string, unknown>)) {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) continue;
-    const mealsRaw = (day as { meals?: unknown } | null)?.meals;
-    if (!Array.isArray(mealsRaw)) {
-      out[dateKey] = { meals: [] };
-      continue;
-    }
-    out[dateKey] = {
-      meals: mealsRaw.map((m, i) => normalizeMeal(m, i)),
-    };
-  }
-  return out;
-}
-
-// ─────────────────────────────────────────────
-// Nutrition log (журнал прийомів їжі)
-// ─────────────────────────────────────────────
-
 export function loadNutritionLog(
   key: string = NUTRITION_LOG_KEY,
 ): NutritionLog {
@@ -377,199 +133,4 @@ export function persistNutritionLog(
   key: string = NUTRITION_LOG_KEY,
 ): boolean {
   return nutritionStorage.writeJSON(key, log || {});
-}
-
-export function addLogEntry(
-  log: NutritionLog,
-  date: string,
-  meal: unknown,
-): NutritionLog {
-  const normalized = normalizeMeal(meal, 0);
-  const day = log[date] || { meals: [] };
-  return {
-    ...log,
-    [date]: {
-      ...day,
-      meals: [...(Array.isArray(day.meals) ? day.meals : []), normalized],
-    },
-  };
-}
-
-export function removeLogEntry(
-  log: NutritionLog,
-  date: string,
-  id: string,
-): NutritionLog {
-  const day = log[date];
-  if (!day) return log;
-  const meals = (Array.isArray(day.meals) ? day.meals : []).filter(
-    (m) => m.id !== id,
-  );
-  if (meals.length === 0) {
-    const next: NutritionLog = { ...log };
-    delete next[date];
-    return next;
-  }
-  return { ...log, [date]: { ...day, meals } };
-}
-
-export function updateLogEntry(
-  log: NutritionLog,
-  date: string,
-  meal: unknown,
-): NutritionLog {
-  const normalized = normalizeMeal(meal, 0);
-  const day = log[date];
-  if (!day) return log;
-  const prevMeals = Array.isArray(day.meals) ? day.meals : [];
-  const idx = prevMeals.findIndex((m) => m.id === normalized.id);
-  if (idx === -1) return log;
-  const nextMeals = [...prevMeals];
-  nextMeals[idx] = normalized;
-  return { ...log, [date]: { ...day, meals: nextMeals } };
-}
-
-export function getDayMacros(log: NutritionLogLike, date: string): Macros {
-  const day = log?.[date];
-  if (!day || !Array.isArray(day.meals))
-    return { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 };
-  return (day.meals as Meal[]).reduce<Macros>(
-    (acc, m) => {
-      const mac = macrosToTotals(m?.macros);
-      return {
-        kcal: acc.kcal + mac.kcal,
-        protein_g: acc.protein_g + mac.protein_g,
-        fat_g: acc.fat_g + mac.fat_g,
-        carbs_g: acc.carbs_g + mac.carbs_g,
-      };
-    },
-    { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 },
-  );
-}
-
-export function getDaySummary(log: NutritionLogLike, date: string): DaySummary {
-  const day = log?.[date];
-  const meals = (Array.isArray(day?.meals) ? day.meals : []) as Meal[];
-  const totals = getDayMacros(log, date);
-  const hasAnyMacros = meals.some((m) => macrosHasAnyValue(m?.macros));
-  return {
-    date,
-    mealCount: meals.length,
-    hasMeals: meals.length > 0,
-    hasAnyMacros,
-    ...totals,
-  };
-}
-
-export function addDaysISODate(iso: string, deltaDays: number): string {
-  const [y, m, d] = iso.split("-").map(Number);
-  const dt = new Date(y, m - 1, d + deltaDays);
-  return toLocalISODate(dt);
-}
-
-export function duplicatePreviousDayMeals(
-  log: NutritionLog,
-  targetDate: string,
-): NutritionLog {
-  const prev = addDaysISODate(targetDate, -1);
-  const prevDay = log[prev];
-  if (!prevDay || !Array.isArray(prevDay.meals) || prevDay.meals.length === 0)
-    return log;
-  const existing = Array.isArray(log[targetDate]?.meals)
-    ? log[targetDate].meals
-    : [];
-  const startIdx = existing.length;
-  const clones = prevDay.meals.map((m, i) =>
-    normalizeMeal({ ...m, id: undefined, source: "manual" }, startIdx + i),
-  );
-  return {
-    ...log,
-    [targetDate]: { meals: [...existing, ...clones] },
-  };
-}
-
-export function mergeNutritionLogs(
-  base: unknown,
-  incoming: unknown,
-): NutritionLog {
-  const a = normalizeNutritionLog(base);
-  const b = normalizeNutritionLog(incoming);
-  const out: NutritionLog = { ...a };
-  for (const [d, dayB] of Object.entries(b)) {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
-    const mealsB = Array.isArray(dayB?.meals) ? dayB.meals : [];
-    if (mealsB.length === 0) continue;
-    const existing = Array.isArray(out[d]?.meals) ? out[d].meals : [];
-    const merged = [
-      ...existing,
-      ...mealsB.map((m, i) => normalizeMeal(m, existing.length + i)),
-    ];
-    out[d] = { meals: merged };
-  }
-  return out;
-}
-
-export interface MealSearchResult {
-  date: string;
-  meal: Meal;
-}
-
-export function searchMealsByName(
-  log: NutritionLogLike,
-  query: string,
-): MealSearchResult[] {
-  const q = String(query || "")
-    .trim()
-    .toLowerCase();
-  if (!q) return [];
-  const results: MealSearchResult[] = [];
-  for (const [date, day] of Object.entries(log || {})) {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
-    for (const m of (day?.meals || []) as Meal[]) {
-      const n = String(m?.name || "").toLowerCase();
-      if (n.includes(q)) results.push({ date, meal: m });
-    }
-  }
-  return results.sort((a, b) => b.date.localeCompare(a.date));
-}
-
-export interface MacrosRow extends Macros {
-  date: string;
-}
-
-export function getMacrosForDateRange(
-  log: NutritionLogLike,
-  endIso: string,
-  dayCount: number,
-): MacrosRow[] {
-  const rows: MacrosRow[] = [];
-  for (let i = dayCount - 1; i >= 0; i--) {
-    const d = addDaysISODate(endIso, -i);
-    rows.push({ date: d, ...getDayMacros(log, d) });
-  }
-  return rows;
-}
-
-export function estimateLogBytes(log: NutritionLogLike): number {
-  try {
-    return new Blob([JSON.stringify(log || {})]).size;
-  } catch {
-    return 0;
-  }
-}
-
-/** Залишає лише останні `keepCount` календарних днів (за сортуванням дат). */
-export function trimLogOldestDays(
-  log: unknown,
-  keepCount: number,
-): NutritionLog {
-  const normalized = normalizeNutritionLog(log);
-  const dates = Object.keys(normalized)
-    .filter((k) => /^\d{4}-\d{2}-\d{2}$/.test(k))
-    .sort();
-  if (dates.length <= keepCount) return normalized;
-  const drop = dates.slice(0, dates.length - keepCount);
-  const out: NutritionLog = { ...normalized };
-  for (const d of drop) delete out[d];
-  return out;
 }

--- a/apps/web/src/modules/nutrition/lib/shoppingListStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/shoppingListStorage.ts
@@ -1,23 +1,33 @@
+/**
+ * Web I/O-адаптер для списку покупок.
+ *
+ * Pure-логіка (`normalizeShoppingList`, `toggleShoppingItem`,
+ * `removeCheckedItems`, `getCheckedItems`, `getTotalCount`, типи) живе у
+ * `@sergeant/nutrition-domain` і спільна з `apps/mobile`. Тут лишаються
+ * лише load/persist поверх `createModuleStorage`.
+ */
+import {
+  SHOPPING_LIST_KEY,
+  normalizeShoppingList,
+  type ShoppingList,
+} from "@sergeant/nutrition-domain";
+
 import { nutritionStorage } from "./nutritionStorageInstance.js";
 
-export const SHOPPING_LIST_KEY = "nutrition_shopping_list_v1";
-
-export interface ShoppingItem {
-  id: string;
-  name: string;
-  quantity: string;
-  note: string;
-  checked: boolean;
-}
-
-export interface ShoppingCategory {
-  name: string;
-  items: ShoppingItem[];
-}
-
-export interface ShoppingList {
-  categories: ShoppingCategory[];
-}
+export {
+  SHOPPING_LIST_KEY,
+  getCheckedItems,
+  getTotalCount,
+  normalizeShoppingList,
+  removeCheckedItems,
+  toggleShoppingItem,
+} from "@sergeant/nutrition-domain";
+export type {
+  ShoppingCategory,
+  ShoppingItem,
+  ShoppingList,
+  ShoppingListLike,
+} from "@sergeant/nutrition-domain";
 
 export function loadShoppingList(
   key: string = SHOPPING_LIST_KEY,
@@ -31,162 +41,4 @@ export function persistShoppingList(
   key: string = SHOPPING_LIST_KEY,
 ): boolean {
   return nutritionStorage.writeJSON(key, normalizeShoppingList(list));
-}
-
-function normalizeItemKey(name: unknown): string {
-  return String(name || "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ");
-}
-
-function makeItemId(): string {
-  return `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function sanitizeItem(raw: unknown, seenIds: Set<string>): ShoppingItem | null {
-  if (!raw || typeof raw !== "object") return null;
-  const r = raw as Record<string, unknown>;
-  const itemName = String(r.name || "").trim();
-  if (!itemName) return null;
-  let id = r.id != null ? String(r.id).trim() : "";
-  if (!id || seenIds.has(id)) id = makeItemId();
-  while (seenIds.has(id)) id = makeItemId();
-  seenIds.add(id);
-  return {
-    id,
-    name: itemName,
-    quantity: String(r.quantity || "").trim(),
-    note: String(r.note || "").trim(),
-    checked: Boolean(r.checked),
-  };
-}
-
-function mergeItem(existing: ShoppingItem, next: ShoppingItem): ShoppingItem {
-  // Keep first id; prefer checked=true so user progress is not lost on merge.
-  return {
-    ...existing,
-    quantity: existing.quantity || next.quantity,
-    note: existing.note || next.note,
-    checked: existing.checked || next.checked,
-  };
-}
-
-interface CategoryBucket {
-  name: string;
-  items: ShoppingItem[];
-  byKey: Map<string, number>;
-}
-
-export function normalizeShoppingList(raw: unknown): ShoppingList {
-  const obj =
-    raw && typeof raw === "object" && !Array.isArray(raw)
-      ? (raw as Record<string, unknown>)
-      : {};
-  const rawCategories = Array.isArray(obj.categories)
-    ? (obj.categories as unknown[])
-    : [];
-  const seenIds = new Set<string>();
-  const byCategory = new Map<string, CategoryBucket>();
-
-  for (const cat of rawCategories) {
-    if (!cat || typeof cat !== "object") continue;
-    const c = cat as Record<string, unknown>;
-    const name = String(c.name || "Інше").trim() || "Інше";
-    const rawItems = Array.isArray(c.items) ? (c.items as unknown[]) : [];
-
-    const bucket: CategoryBucket = byCategory.get(name) || {
-      name,
-      items: [],
-      byKey: new Map<string, number>(),
-    };
-    for (const rawItem of rawItems) {
-      const item = sanitizeItem(rawItem, seenIds);
-      if (!item) continue;
-      const key = normalizeItemKey(item.name);
-      const existingIdx = bucket.byKey.get(key);
-      if (existingIdx == null) {
-        bucket.byKey.set(key, bucket.items.length);
-        bucket.items.push(item);
-      } else {
-        bucket.items[existingIdx] = mergeItem(bucket.items[existingIdx], item);
-      }
-    }
-    if (bucket.items.length > 0 && !byCategory.has(name)) {
-      byCategory.set(name, bucket);
-    } else if (bucket.items.length > 0) {
-      byCategory.set(name, bucket);
-    }
-  }
-
-  const categories: ShoppingCategory[] = [];
-  for (const { name, items } of byCategory.values()) {
-    if (items.length === 0) continue;
-    categories.push({ name, items });
-  }
-  return { categories };
-}
-
-export interface ShoppingListLike {
-  categories?: Array<{ name?: string; items?: Array<Partial<ShoppingItem>> }>;
-}
-
-export function toggleShoppingItem(
-  list: ShoppingListLike | null | undefined,
-  categoryName: string,
-  itemId: string,
-): ShoppingList {
-  const categories = (list?.categories || []).map((cat) => {
-    if (cat.name !== categoryName) return cat as ShoppingCategory;
-    return {
-      ...(cat as ShoppingCategory),
-      items: (cat.items || []).map((item) =>
-        item.id === itemId
-          ? { ...(item as ShoppingItem), checked: !item.checked }
-          : (item as ShoppingItem),
-      ),
-    };
-  });
-  return { ...(list as ShoppingList), categories };
-}
-
-export function removeCheckedItems(
-  list: ShoppingListLike | null | undefined,
-): ShoppingList {
-  const categories = (list?.categories || [])
-    .map((cat) => ({
-      ...(cat as ShoppingCategory),
-      items: (cat.items || []).filter(
-        (item) => !item.checked,
-      ) as ShoppingItem[],
-    }))
-    .filter((cat) => cat.items.length > 0);
-  return { ...(list as ShoppingList), categories };
-}
-
-export function getCheckedItems(
-  list: ShoppingListLike | null | undefined,
-): ShoppingItem[] {
-  const items: ShoppingItem[] = [];
-  for (const cat of list?.categories || []) {
-    for (const item of cat.items || []) {
-      if (item.checked) items.push(item as ShoppingItem);
-    }
-  }
-  return items;
-}
-
-export function getTotalCount(list: ShoppingListLike | null | undefined): {
-  total: number;
-  checked: number;
-} {
-  let total = 0;
-  let checked = 0;
-  for (const cat of list?.categories || []) {
-    for (const item of cat.items || []) {
-      total++;
-      if (item.checked) checked++;
-    }
-  }
-  return { total, checked };
 }

--- a/apps/web/src/modules/nutrition/lib/waterStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/waterStorage.ts
@@ -1,28 +1,27 @@
-import { toLocalISODate } from "@sergeant/shared";
+/**
+ * Web I/O-адаптер для журналу води.
+ *
+ * Pure-логіка (`normalizeWaterLog`, `addWaterMl`, `getTodayWaterMl`,
+ * `resetTodayWater`, тип `WaterLog`, ключ `WATER_LOG_KEY`) живе у
+ * `@sergeant/nutrition-domain` і спільна з `apps/mobile`. Тут лишаються
+ * лише load/save поверх `createModuleStorage`.
+ */
+import {
+  WATER_LOG_KEY,
+  normalizeWaterLog,
+  type WaterLog,
+} from "@sergeant/nutrition-domain";
+
 import { nutritionStorage } from "./nutritionStorageInstance.js";
 
-export const WATER_LOG_KEY = "nutrition_water_v1";
-
-export type WaterLog = Record<string, number>;
-
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function sanitizeMl(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  return Math.floor(n);
-}
-
-export function normalizeWaterLog(raw: unknown): WaterLog {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const out: WaterLog = {};
-  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-    if (!ISO_DATE_RE.test(k)) continue;
-    const ml = sanitizeMl(v);
-    if (ml > 0) out[k] = ml;
-  }
-  return out;
-}
+export {
+  WATER_LOG_KEY,
+  addWaterMl,
+  getTodayWaterMl,
+  normalizeWaterLog,
+  resetTodayWater,
+} from "@sergeant/nutrition-domain";
+export type { WaterLog } from "@sergeant/nutrition-domain";
 
 export function loadWaterLog(key: string = WATER_LOG_KEY): WaterLog {
   return normalizeWaterLog(nutritionStorage.readJSON(key, {}));
@@ -33,27 +32,4 @@ export function saveWaterLog(
   key: string = WATER_LOG_KEY,
 ): boolean {
   return nutritionStorage.writeJSON(key, normalizeWaterLog(log));
-}
-
-export function getTodayWaterMl(log: unknown): number {
-  if (!log || typeof log !== "object") return 0;
-  const today = toLocalISODate();
-  const n = Number((log as Record<string, unknown>)[today]);
-  return Number.isFinite(n) && n > 0 ? n : 0;
-}
-
-export function addWaterMl(log: unknown, ml: unknown): WaterLog {
-  const delta = sanitizeMl(ml);
-  if (delta <= 0) return normalizeWaterLog(log);
-  const base = normalizeWaterLog(log);
-  const today = toLocalISODate();
-  return { ...base, [today]: (base[today] || 0) + delta };
-}
-
-export function resetTodayWater(log: unknown): WaterLog {
-  const base = normalizeWaterLog(log);
-  const today = toLocalISODate();
-  const { [today]: _removed, ...rest } = base;
-  void _removed;
-  return rest;
 }

--- a/packages/nutrition-domain/package.json
+++ b/packages/nutrition-domain/package.json
@@ -11,8 +11,14 @@
     "./meal-types": "./src/mealTypes.ts",
     "./merge-items": "./src/mergeItems.ts",
     "./nutrition-format": "./src/nutritionFormat.ts",
+    "./nutrition-log": "./src/nutritionLog.ts",
+    "./nutrition-pantries": "./src/nutritionPantries.ts",
+    "./nutrition-prefs": "./src/nutritionPrefs.ts",
+    "./nutrition-types": "./src/nutritionTypes.ts",
     "./pantry-text-parser": "./src/pantryTextParser.ts",
-    "./recipe-ids": "./src/recipeIds.ts"
+    "./recipe-ids": "./src/recipeIds.ts",
+    "./shopping-list": "./src/shoppingList.ts",
+    "./water-log": "./src/waterLog.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/nutrition-domain/src/index.ts
+++ b/packages/nutrition-domain/src/index.ts
@@ -2,15 +2,23 @@
 // бізнес-логіка Харчування, яку споживають `apps/web` і `apps/mobile`
 // без платформних залежностей (`localStorage`, `window`, `document`).
 //
-// Phase 7 / PR 1: перший зріз pure-логіки модуля Харчування —
-// meal-types, pantry-text-parser, merge-items, recipe-ids, food-categories,
-// nutrition-format. Решта шарів (storage, cloud-backup, IndexedDB-recipe-book,
-// stats/day-summary який зараз тісно зв'язаний з localStorage) приходить
-// наступними PR-ами після того, як витягнемо platform-IO за `KVStore`-
-// абстракцію.
+// Phase 7 / PR 1: meal-types, pantry-text-parser, merge-items, recipe-ids,
+// food-categories, nutrition-format.
+// Phase 7 / PR 2: pure core storage shapes + mutations — nutrition-log,
+// water-log, shopping-list, pantries, prefs. `load*`/`persist*` I/O-шари
+// живуть у `apps/web` (createModuleStorage) і пізніше в `apps/mobile`
+// (MMKV) — обидва кладуть ті самі normalize/mutation-функції поверх
+// власного KVStore.
 export * from "./mealTypes.js";
 export * from "./pantryTextParser.js";
 export * from "./mergeItems.js";
 export * from "./recipeIds.js";
 export * from "./foodCategories.js";
 export * from "./nutritionFormat.js";
+
+export * from "./nutritionTypes.js";
+export * from "./nutritionPrefs.js";
+export * from "./nutritionPantries.js";
+export * from "./nutritionLog.js";
+export * from "./waterLog.js";
+export * from "./shoppingList.js";

--- a/packages/nutrition-domain/src/nutritionLog.ts
+++ b/packages/nutrition-domain/src/nutritionLog.ts
@@ -1,0 +1,307 @@
+/**
+ * Pure-операції над журналом прийомів їжі. Без `localStorage`.
+ *
+ * `apps/web/src/modules/nutrition/lib/nutritionStorage.ts` лишається тонким
+ * I/O-адаптером над `createModuleStorage`; `apps/mobile` буде імпортувати
+ * ті самі функції напряму з `@sergeant/nutrition-domain`.
+ */
+import {
+  macrosHasAnyValue,
+  macrosToTotals,
+  normalizeMacrosNullable,
+  toLocalISODate,
+  type Macros,
+  type NullableMacros,
+} from "@sergeant/shared";
+
+import {
+  isMealTypeId,
+  labelForMealType,
+  mealTypeFromLabel,
+} from "./mealTypes.js";
+import type {
+  DaySummary,
+  MacrosRow,
+  Meal,
+  MealMacroSource,
+  MealSearchResult,
+  MealSource,
+  NutritionDay,
+  NutritionLog,
+  NutritionLogLike,
+} from "./nutritionTypes.js";
+
+function normalizeMacros(mac: unknown): NullableMacros {
+  return normalizeMacrosNullable(mac) as NullableMacros;
+}
+
+export function normalizeMeal(m: unknown, idx: number): Meal {
+  const raw = (m && typeof m === "object" ? m : {}) as Record<string, unknown>;
+  let id = raw.id != null && String(raw.id).trim() ? String(raw.id).trim() : "";
+  if (!id)
+    id = `meal_mig_${Date.now()}_${idx}_${Math.random().toString(36).slice(2, 8)}`;
+
+  const name = raw.name != null ? String(raw.name).trim() : "";
+  const time = raw.time != null ? String(raw.time).trim() : "";
+
+  const mealType = isMealTypeId(raw.mealType)
+    ? raw.mealType
+    : mealTypeFromLabel(raw.label);
+
+  const label =
+    raw.label != null && String(raw.label).trim()
+      ? String(raw.label).trim()
+      : labelForMealType(mealType);
+
+  const macros = normalizeMacros(raw.macros);
+  const source: MealSource =
+    raw.source && String(raw.source) === "photo" ? "photo" : "manual";
+
+  const rawMacroSource =
+    raw.macroSource != null ? String(raw.macroSource).trim() : "";
+  const macroSource: MealMacroSource =
+    rawMacroSource === "manual" ||
+    rawMacroSource === "productDb" ||
+    rawMacroSource === "photoAI" ||
+    rawMacroSource === "recipeAI"
+      ? (rawMacroSource as MealMacroSource)
+      : source === "photo"
+        ? "photoAI"
+        : "manual";
+
+  const amount_g =
+    raw.amount_g != null &&
+    Number.isFinite(Number(raw.amount_g)) &&
+    Number(raw.amount_g) > 0
+      ? Number(raw.amount_g)
+      : null;
+  const foodId =
+    raw.foodId != null && String(raw.foodId).trim()
+      ? String(raw.foodId).trim()
+      : null;
+
+  // Pass the FTUX demo flag through untouched. Seeded meals carry
+  // `demo: true` so cross-module detectors (see `firstRealEntry.js`) can
+  // tell seeded data apart from real entries. Because `useNutritionLog`
+  // immediately persists the normalized log back to localStorage, any
+  // property dropped here is lost on the first module visit — which is
+  // what used to silently re-classify demo meals as real entries and
+  // trip the soft-auth prompt.
+  const out: Meal = {
+    id,
+    name,
+    time,
+    mealType,
+    label,
+    macros,
+    source,
+    macroSource,
+    amount_g,
+    foodId,
+  };
+  if (raw.demo === true) out.demo = true;
+  return out;
+}
+
+export function normalizeNutritionLog(raw: unknown): NutritionLog {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: NutritionLog = {};
+  for (const [dateKey, day] of Object.entries(raw as Record<string, unknown>)) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) continue;
+    const mealsRaw = (day as { meals?: unknown } | null)?.meals;
+    if (!Array.isArray(mealsRaw)) {
+      out[dateKey] = { meals: [] };
+      continue;
+    }
+    out[dateKey] = {
+      meals: mealsRaw.map((m, i) => normalizeMeal(m, i)),
+    };
+  }
+  return out;
+}
+
+export function addLogEntry(
+  log: NutritionLog,
+  date: string,
+  meal: unknown,
+): NutritionLog {
+  const normalized = normalizeMeal(meal, 0);
+  const day: NutritionDay = log[date] || { meals: [] };
+  return {
+    ...log,
+    [date]: {
+      ...day,
+      meals: [...(Array.isArray(day.meals) ? day.meals : []), normalized],
+    },
+  };
+}
+
+export function removeLogEntry(
+  log: NutritionLog,
+  date: string,
+  id: string,
+): NutritionLog {
+  const day = log[date];
+  if (!day) return log;
+  const meals = (Array.isArray(day.meals) ? day.meals : []).filter(
+    (m) => m.id !== id,
+  );
+  if (meals.length === 0) {
+    const next: NutritionLog = { ...log };
+    delete next[date];
+    return next;
+  }
+  return { ...log, [date]: { ...day, meals } };
+}
+
+export function updateLogEntry(
+  log: NutritionLog,
+  date: string,
+  meal: unknown,
+): NutritionLog {
+  const normalized = normalizeMeal(meal, 0);
+  const day = log[date];
+  if (!day) return log;
+  const prevMeals = Array.isArray(day.meals) ? day.meals : [];
+  const idx = prevMeals.findIndex((m) => m.id === normalized.id);
+  if (idx === -1) return log;
+  const nextMeals = [...prevMeals];
+  nextMeals[idx] = normalized;
+  return { ...log, [date]: { ...day, meals: nextMeals } };
+}
+
+export function getDayMacros(log: NutritionLogLike, date: string): Macros {
+  const day = log?.[date];
+  if (!day || !Array.isArray(day.meals))
+    return { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 };
+  return (day.meals as Meal[]).reduce<Macros>(
+    (acc, m) => {
+      const mac = macrosToTotals(m?.macros);
+      return {
+        kcal: acc.kcal + mac.kcal,
+        protein_g: acc.protein_g + mac.protein_g,
+        fat_g: acc.fat_g + mac.fat_g,
+        carbs_g: acc.carbs_g + mac.carbs_g,
+      };
+    },
+    { kcal: 0, protein_g: 0, fat_g: 0, carbs_g: 0 },
+  );
+}
+
+export function getDaySummary(log: NutritionLogLike, date: string): DaySummary {
+  const day = log?.[date];
+  const meals = (Array.isArray(day?.meals) ? day.meals : []) as Meal[];
+  const totals = getDayMacros(log, date);
+  const hasAnyMacros = meals.some((m) => macrosHasAnyValue(m?.macros));
+  return {
+    date,
+    mealCount: meals.length,
+    hasMeals: meals.length > 0,
+    hasAnyMacros,
+    ...totals,
+  };
+}
+
+export function addDaysISODate(iso: string, deltaDays: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, m - 1, d + deltaDays);
+  return toLocalISODate(dt);
+}
+
+export function duplicatePreviousDayMeals(
+  log: NutritionLog,
+  targetDate: string,
+): NutritionLog {
+  const prev = addDaysISODate(targetDate, -1);
+  const prevDay = log[prev];
+  if (!prevDay || !Array.isArray(prevDay.meals) || prevDay.meals.length === 0)
+    return log;
+  const existing = Array.isArray(log[targetDate]?.meals)
+    ? log[targetDate].meals
+    : [];
+  const startIdx = existing.length;
+  const clones = prevDay.meals.map((m, i) =>
+    normalizeMeal({ ...m, id: undefined, source: "manual" }, startIdx + i),
+  );
+  return {
+    ...log,
+    [targetDate]: { meals: [...existing, ...clones] },
+  };
+}
+
+export function mergeNutritionLogs(
+  base: unknown,
+  incoming: unknown,
+): NutritionLog {
+  const a = normalizeNutritionLog(base);
+  const b = normalizeNutritionLog(incoming);
+  const out: NutritionLog = { ...a };
+  for (const [d, dayB] of Object.entries(b)) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
+    const mealsB = Array.isArray(dayB?.meals) ? dayB.meals : [];
+    if (mealsB.length === 0) continue;
+    const existing = Array.isArray(out[d]?.meals) ? out[d].meals : [];
+    const merged = [
+      ...existing,
+      ...mealsB.map((m, i) => normalizeMeal(m, existing.length + i)),
+    ];
+    out[d] = { meals: merged };
+  }
+  return out;
+}
+
+export function searchMealsByName(
+  log: NutritionLogLike,
+  query: string,
+): MealSearchResult[] {
+  const q = String(query || "")
+    .trim()
+    .toLowerCase();
+  if (!q) return [];
+  const results: MealSearchResult[] = [];
+  for (const [date, day] of Object.entries(log || {})) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    for (const m of (day?.meals || []) as Meal[]) {
+      const n = String(m?.name || "").toLowerCase();
+      if (n.includes(q)) results.push({ date, meal: m });
+    }
+  }
+  return results.sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export function getMacrosForDateRange(
+  log: NutritionLogLike,
+  endIso: string,
+  dayCount: number,
+): MacrosRow[] {
+  const rows: MacrosRow[] = [];
+  for (let i = dayCount - 1; i >= 0; i--) {
+    const d = addDaysISODate(endIso, -i);
+    rows.push({ date: d, ...getDayMacros(log, d) });
+  }
+  return rows;
+}
+
+export function estimateLogBytes(log: NutritionLogLike): number {
+  try {
+    return new Blob([JSON.stringify(log || {})]).size;
+  } catch {
+    return 0;
+  }
+}
+
+/** Залишає лише останні `keepCount` календарних днів (за сортуванням дат). */
+export function trimLogOldestDays(
+  log: unknown,
+  keepCount: number,
+): NutritionLog {
+  const normalized = normalizeNutritionLog(log);
+  const dates = Object.keys(normalized)
+    .filter((k) => /^\d{4}-\d{2}-\d{2}$/.test(k))
+    .sort();
+  if (dates.length <= keepCount) return normalized;
+  const drop = dates.slice(0, dates.length - keepCount);
+  const out: NutritionLog = { ...normalized };
+  for (const d of drop) delete out[d];
+  return out;
+}

--- a/packages/nutrition-domain/src/nutritionPantries.ts
+++ b/packages/nutrition-domain/src/nutritionPantries.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure-операції над складами (pantries). Без `localStorage`.
+ */
+import type { Pantry } from "./nutritionTypes.js";
+import type { PantryItem } from "./pantryTextParser.js";
+
+export function makeDefaultPantry(): Pantry {
+  return { id: "home", name: "Дім", items: [], text: "" };
+}
+
+function sanitizePantryItem(raw: unknown): PantryItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const name = String(r.name || "").trim();
+  if (!name) return null;
+  const qtyNum = Number(r.qty);
+  const qty = r.qty == null || !Number.isFinite(qtyNum) ? null : qtyNum;
+  return {
+    name,
+    qty,
+    unit: r.unit == null ? null : String(r.unit),
+    notes: r.notes == null ? null : String(r.notes),
+  };
+}
+
+export function normalizePantries(raw: unknown): Pantry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Pantry[] = [];
+  const seenIds = new Set<string>();
+  for (const p of raw as unknown[]) {
+    if (!p || typeof p !== "object") continue;
+    const rp = p as Record<string, unknown>;
+    let id = rp.id != null ? String(rp.id).trim() : "";
+    if (!id || seenIds.has(id)) id = `p_${Date.now()}_${out.length}`;
+    seenIds.add(id);
+    const name = String(rp.name || "Склад").trim() || "Склад";
+    const items = Array.isArray(rp.items)
+      ? (rp.items as unknown[])
+          .map(sanitizePantryItem)
+          .filter((x): x is PantryItem => x != null)
+      : [];
+    const text = rp.text == null ? "" : String(rp.text);
+    out.push({ id, name, items, text });
+  }
+  return out;
+}
+
+export function updatePantry(
+  pantries: Pantry[] | null | undefined,
+  activeId: string | null | undefined,
+  fn: (p: Pantry) => Pantry,
+): Pantry[] {
+  const arr = Array.isArray(pantries) ? pantries : [];
+  const id = String(activeId || "home");
+  const idx = arr.findIndex((p) => p.id === id);
+  if (idx === -1) {
+    const created = fn(makeDefaultPantry());
+    return [created, ...arr];
+  }
+  const next = [...arr];
+  next[idx] = fn(next[idx]);
+  return next;
+}

--- a/packages/nutrition-domain/src/nutritionPrefs.ts
+++ b/packages/nutrition-domain/src/nutritionPrefs.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure-фабрика дефолтних prefs + нормалізація (парсинг) довільного JSON-вводу
+ * у валідний `NutritionPrefs`. `load*`/`persist*` I/O-шар лишається у web.
+ */
+import { normalizeMacrosNullable, type NullableMacros } from "@sergeant/shared";
+
+import { isMealTypeId } from "./mealTypes.js";
+import type { MealTemplate, NutritionPrefs } from "./nutritionTypes.js";
+
+function optionalPositiveNumber(v: unknown): number | null {
+  if (v == null || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function defaultNutritionPrefs(): NutritionPrefs {
+  return {
+    goal: "balanced",
+    servings: 1,
+    timeMinutes: 25,
+    exclude: "",
+    dailyTargetKcal: null,
+    dailyTargetProtein_g: null,
+    dailyTargetFat_g: null,
+    dailyTargetCarbs_g: null,
+    mealTemplates: [],
+    reminderEnabled: false,
+    reminderHour: 12,
+    waterGoalMl: 2000,
+  };
+}
+
+export function normalizeNutritionPrefs(p: unknown): NutritionPrefs {
+  if (!p || typeof p !== "object" || Array.isArray(p))
+    return defaultNutritionPrefs();
+  try {
+    const defaults = defaultNutritionPrefs();
+    const raw = p as Record<string, unknown>;
+    const waterGoalMl = optionalPositiveNumber(raw.waterGoalMl);
+    const mealTemplates: MealTemplate[] = Array.isArray(raw.mealTemplates)
+      ? (raw.mealTemplates as unknown[])
+          .filter(
+            (t): t is Record<string, unknown> => !!t && typeof t === "object",
+          )
+          .map((t) => ({
+            id: String(t.id || `tpl_${Date.now()}`),
+            name: String(t.name || "").trim(),
+            mealType: isMealTypeId(t.mealType) ? t.mealType : "snack",
+            macros: normalizeMacrosNullable(t.macros) as NullableMacros,
+          }))
+          .filter((t) => t.name)
+          .slice(0, 40)
+      : [];
+    return {
+      ...defaults,
+      ...(raw as Partial<NutritionPrefs>),
+      servings: raw.servings != null ? Number(raw.servings) || 1 : 1,
+      timeMinutes: raw.timeMinutes != null ? Number(raw.timeMinutes) || 25 : 25,
+      exclude: raw.exclude == null ? "" : String(raw.exclude),
+      goal: raw.goal ? String(raw.goal) : "balanced",
+      dailyTargetKcal: optionalPositiveNumber(raw.dailyTargetKcal),
+      dailyTargetProtein_g: optionalPositiveNumber(raw.dailyTargetProtein_g),
+      dailyTargetFat_g: optionalPositiveNumber(raw.dailyTargetFat_g),
+      dailyTargetCarbs_g: optionalPositiveNumber(raw.dailyTargetCarbs_g),
+      mealTemplates,
+      reminderEnabled: Boolean(raw.reminderEnabled),
+      reminderHour:
+        raw.reminderHour != null && Number.isFinite(Number(raw.reminderHour))
+          ? Math.min(23, Math.max(0, Math.floor(Number(raw.reminderHour))))
+          : 12,
+      waterGoalMl: waterGoalMl != null ? waterGoalMl : defaults.waterGoalMl,
+    };
+  } catch {
+    return defaultNutritionPrefs();
+  }
+}

--- a/packages/nutrition-domain/src/nutritionTypes.ts
+++ b/packages/nutrition-domain/src/nutritionTypes.ts
@@ -1,0 +1,89 @@
+/**
+ * Спільні типи + LS-ключі модуля Харчування.
+ *
+ * Жодних залежностей на `localStorage` / `window` / `document` — це дозволяє
+ * імпортувати той самий набір з web і з RN, не тягнучи `apps/web`-специфіку.
+ */
+import type { Macros, NullableMacros } from "@sergeant/shared";
+
+import type { MealTypeId } from "./mealTypes.js";
+import type { PantryItem } from "./pantryTextParser.js";
+
+export const NUTRITION_PANTRIES_KEY = "nutrition_pantries_v1";
+export const NUTRITION_ACTIVE_PANTRY_KEY = "nutrition_active_pantry_v1";
+export const NUTRITION_PREFS_KEY = "nutrition_prefs_v1";
+export const NUTRITION_LOG_KEY = "nutrition_log_v1";
+
+export type NutritionGoal = string;
+export type MealMacroSource = "manual" | "productDb" | "photoAI" | "recipeAI";
+export type MealSource = "manual" | "photo";
+
+export interface MealTemplate {
+  id: string;
+  name: string;
+  mealType: MealTypeId;
+  macros: NullableMacros;
+}
+
+export interface NutritionPrefs {
+  goal: NutritionGoal;
+  servings: number;
+  timeMinutes: number;
+  exclude: string;
+  dailyTargetKcal: number | null;
+  dailyTargetProtein_g: number | null;
+  dailyTargetFat_g: number | null;
+  dailyTargetCarbs_g: number | null;
+  mealTemplates: MealTemplate[];
+  reminderEnabled: boolean;
+  reminderHour: number;
+  waterGoalMl: number;
+}
+
+export interface Pantry {
+  id: string;
+  name: string;
+  items: PantryItem[];
+  text: string;
+}
+
+export interface Meal {
+  id: string;
+  name: string;
+  time: string;
+  mealType: MealTypeId;
+  label: string;
+  macros: NullableMacros;
+  source: MealSource;
+  macroSource: MealMacroSource;
+  amount_g: number | null;
+  foodId: string | null;
+  demo?: true;
+}
+
+export interface NutritionDay {
+  meals: Meal[];
+}
+
+export type NutritionLog = Record<string, NutritionDay>;
+
+export type NutritionLogLike =
+  | Record<string, { meals?: unknown[] | null } | null | undefined>
+  | null
+  | undefined;
+
+export interface DaySummary extends Macros {
+  date: string;
+  mealCount: number;
+  hasMeals: boolean;
+  hasAnyMacros: boolean;
+}
+
+export interface MealSearchResult {
+  date: string;
+  meal: Meal;
+}
+
+export interface MacrosRow extends Macros {
+  date: string;
+}

--- a/packages/nutrition-domain/src/shoppingList.ts
+++ b/packages/nutrition-domain/src/shoppingList.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure-helpers для списку покупок (без `localStorage` / `window`).
+ *
+ * `apps/web/src/modules/nutrition/lib/shoppingListStorage.ts` лишається
+ * тонким I/O-адаптером, який бере `createModuleStorage` і ці помічники.
+ */
+
+export const SHOPPING_LIST_KEY = "nutrition_shopping_list_v1";
+
+export interface ShoppingItem {
+  id: string;
+  name: string;
+  quantity: string;
+  note: string;
+  checked: boolean;
+}
+
+export interface ShoppingCategory {
+  name: string;
+  items: ShoppingItem[];
+}
+
+export interface ShoppingList {
+  categories: ShoppingCategory[];
+}
+
+export interface ShoppingListLike {
+  categories?: Array<{ name?: string; items?: Array<Partial<ShoppingItem>> }>;
+}
+
+function normalizeItemKey(name: unknown): string {
+  return String(name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function makeItemId(): string {
+  return `si_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizeItem(raw: unknown, seenIds: Set<string>): ShoppingItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const itemName = String(r.name || "").trim();
+  if (!itemName) return null;
+  let id = r.id != null ? String(r.id).trim() : "";
+  if (!id || seenIds.has(id)) id = makeItemId();
+  while (seenIds.has(id)) id = makeItemId();
+  seenIds.add(id);
+  return {
+    id,
+    name: itemName,
+    quantity: String(r.quantity || "").trim(),
+    note: String(r.note || "").trim(),
+    checked: Boolean(r.checked),
+  };
+}
+
+function mergeItem(existing: ShoppingItem, next: ShoppingItem): ShoppingItem {
+  return {
+    ...existing,
+    quantity: existing.quantity || next.quantity,
+    note: existing.note || next.note,
+    checked: existing.checked || next.checked,
+  };
+}
+
+interface CategoryBucket {
+  name: string;
+  items: ShoppingItem[];
+  byKey: Map<string, number>;
+}
+
+export function normalizeShoppingList(raw: unknown): ShoppingList {
+  const obj =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {};
+  const rawCategories = Array.isArray(obj.categories)
+    ? (obj.categories as unknown[])
+    : [];
+  const seenIds = new Set<string>();
+  const byCategory = new Map<string, CategoryBucket>();
+
+  for (const cat of rawCategories) {
+    if (!cat || typeof cat !== "object") continue;
+    const c = cat as Record<string, unknown>;
+    const name = String(c.name || "Інше").trim() || "Інше";
+    const rawItems = Array.isArray(c.items) ? (c.items as unknown[]) : [];
+
+    const bucket: CategoryBucket = byCategory.get(name) || {
+      name,
+      items: [],
+      byKey: new Map<string, number>(),
+    };
+    for (const rawItem of rawItems) {
+      const item = sanitizeItem(rawItem, seenIds);
+      if (!item) continue;
+      const key = normalizeItemKey(item.name);
+      const existingIdx = bucket.byKey.get(key);
+      if (existingIdx == null) {
+        bucket.byKey.set(key, bucket.items.length);
+        bucket.items.push(item);
+      } else {
+        bucket.items[existingIdx] = mergeItem(bucket.items[existingIdx], item);
+      }
+    }
+    if (bucket.items.length > 0) {
+      byCategory.set(name, bucket);
+    }
+  }
+
+  const categories: ShoppingCategory[] = [];
+  for (const { name, items } of byCategory.values()) {
+    if (items.length === 0) continue;
+    categories.push({ name, items });
+  }
+  return { categories };
+}
+
+export function toggleShoppingItem(
+  list: ShoppingListLike | null | undefined,
+  categoryName: string,
+  itemId: string,
+): ShoppingList {
+  const categories = (list?.categories || []).map((cat) => {
+    if (cat.name !== categoryName) return cat as ShoppingCategory;
+    return {
+      ...(cat as ShoppingCategory),
+      items: (cat.items || []).map((item) =>
+        item.id === itemId
+          ? { ...(item as ShoppingItem), checked: !item.checked }
+          : (item as ShoppingItem),
+      ),
+    };
+  });
+  return { ...(list as ShoppingList), categories };
+}
+
+export function removeCheckedItems(
+  list: ShoppingListLike | null | undefined,
+): ShoppingList {
+  const categories = (list?.categories || [])
+    .map((cat) => ({
+      ...(cat as ShoppingCategory),
+      items: (cat.items || []).filter(
+        (item) => !item.checked,
+      ) as ShoppingItem[],
+    }))
+    .filter((cat) => cat.items.length > 0);
+  return { ...(list as ShoppingList), categories };
+}
+
+export function getCheckedItems(
+  list: ShoppingListLike | null | undefined,
+): ShoppingItem[] {
+  const items: ShoppingItem[] = [];
+  for (const cat of list?.categories || []) {
+    for (const item of cat.items || []) {
+      if (item.checked) items.push(item as ShoppingItem);
+    }
+  }
+  return items;
+}
+
+export function getTotalCount(list: ShoppingListLike | null | undefined): {
+  total: number;
+  checked: number;
+} {
+  let total = 0;
+  let checked = 0;
+  for (const cat of list?.categories || []) {
+    for (const item of cat.items || []) {
+      total++;
+      if (item.checked) checked++;
+    }
+  }
+  return { total, checked };
+}

--- a/packages/nutrition-domain/src/waterLog.ts
+++ b/packages/nutrition-domain/src/waterLog.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure-helpers для журналу води (нема `localStorage` / `window` залежностей).
+ *
+ * `apps/web/src/modules/nutrition/lib/waterStorage.ts` лишається тонким
+ * I/O-адаптером, який бере `createModuleStorage` і ці помічники; `apps/mobile`
+ * буде імпортувати ці ж функції напряму з `@sergeant/nutrition-domain` і
+ * підкладати MMKV-адаптер.
+ */
+import { toLocalISODate } from "@sergeant/shared";
+
+export const WATER_LOG_KEY = "nutrition_water_v1";
+
+export type WaterLog = Record<string, number>;
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function sanitizeMl(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.floor(n);
+}
+
+export function normalizeWaterLog(raw: unknown): WaterLog {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: WaterLog = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (!ISO_DATE_RE.test(k)) continue;
+    const ml = sanitizeMl(v);
+    if (ml > 0) out[k] = ml;
+  }
+  return out;
+}
+
+export function getTodayWaterMl(log: unknown): number {
+  if (!log || typeof log !== "object") return 0;
+  const today = toLocalISODate();
+  const n = Number((log as Record<string, unknown>)[today]);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export function addWaterMl(log: unknown, ml: unknown): WaterLog {
+  const delta = sanitizeMl(ml);
+  if (delta <= 0) return normalizeWaterLog(log);
+  const base = normalizeWaterLog(log);
+  const today = toLocalISODate();
+  return { ...base, [today]: (base[today] || 0) + delta };
+}
+
+export function resetTodayWater(log: unknown): WaterLog {
+  const base = normalizeWaterLog(log);
+  const today = toLocalISODate();
+  const { [today]: _removed, ...rest } = base;
+  void _removed;
+  return rest;
+}


### PR DESCRIPTION
## Summary

Продовжує #534. Другий крок **Phase 7 (Порт Харчування у RN)** — витяг DOM-free частин стораж-шару у `@sergeant/nutrition-domain`, щоб `apps/mobile` зміг побудувати MMKV-адаптер поверх тих самих normalize/mutation-хелперів без копіпасти з `apps/web`.

**Нові pure-модулі у пакеті** (всі без `localStorage` / `window` / `document`):

- `nutritionTypes` — всі спільні типи (`Meal`, `NutritionLog`, `NutritionDay`, `Pantry`, `NutritionPrefs`, `MealTemplate`, `DaySummary`, `MealSearchResult`, `MacrosRow`, `MealMacroSource`, `MealSource`, `NutritionGoal`, `NutritionLogLike`) + константи LS-ключів (`NUTRITION_PANTRIES_KEY`, `NUTRITION_ACTIVE_PANTRY_KEY`, `NUTRITION_PREFS_KEY`, `NUTRITION_LOG_KEY`)
- `nutritionLog` — `normalizeMeal`, `normalizeNutritionLog`, `addLogEntry`, `removeLogEntry`, `updateLogEntry`, `getDayMacros`, `getDaySummary`, `addDaysISODate`, `duplicatePreviousDayMeals`, `mergeNutritionLogs`, `searchMealsByName`, `getMacrosForDateRange`, `estimateLogBytes`, `trimLogOldestDays`
- `nutritionPantries` — `makeDefaultPantry`, `normalizePantries`, `updatePantry`
- `nutritionPrefs` — `defaultNutritionPrefs`, `normalizeNutritionPrefs` (витягнуто pure-частину зі старого `loadNutritionPrefs`)
- `waterLog` — `WATER_LOG_KEY`, `normalizeWaterLog`, `getTodayWaterMl`, `addWaterMl`, `resetTodayWater`, тип `WaterLog`
- `shoppingList` — `SHOPPING_LIST_KEY`, `normalizeShoppingList`, `toggleShoppingItem`, `removeCheckedItems`, `getCheckedItems`, `getTotalCount` + типи

**Web I/O-адаптери стали тонкими** — `apps/web/src/modules/nutrition/lib/{nutritionStorage,waterStorage,shoppingListStorage}.ts` тепер лише `load*`/`persist*`/`save*` поверх `createModuleStorage` + реекспорти. Публічна поверхня НЕ змінилась: існуючі імпорти `../lib/nutritionStorage.js`, `../lib/waterStorage.js`, `../lib/shoppingListStorage.js` (~30 call-sites) продовжують працювати без змін.

**Що НЕ входить у PR-2** (залишено для наступних PR-ів):
- `recipeBook.ts` — IndexedDB, окрема async-абстракція
- `recipeCache.ts`, `mealPhotoStorage.ts` — зв'язані з `createModuleStorage` для невеликих кешів, винесемо разом з AI-фічами (PR-8)
- `nutritionErrors.ts` — залежить від web-only `@shared/lib/friendlyApiError`
- `nutritionStats.ts`, `nutritionDaySummary.ts` — споживають уже витягнуті pure-хелпери, але самі по собі лежать у web і працюють через модуль
- `nutritionCloudBackup.ts`, `nutritionRouter.ts` — platform-coupled
- Тести для нових pure-модулів — існуючі тести у `apps/web/.../{nutritionStorage,waterStorage,shoppingListStorage}.test.ts` вже покривають весь цей код через тонкі load/save wrapper-и; переносити їх у пакет сенсу немає, бо вони специфічно мокають `localStorage`

**Наступний PR-3**: створити `apps/mobile/src/modules/nutrition/lib/` — тонкі storage-адаптери поверх MMKV, які кладуть ті самі domain-хелпери, що тепер живуть у пакеті.

## Review & Testing Checklist for Human

Риск: **🟢 low** — механічний витяг pure-логіки без зміни поведінки. Повністю покрито існуючими тестами (`apps/web/.../{nutritionStorage,waterStorage,shoppingListStorage}.test.ts` ~60 тестів + 20 тестів пакета, всі зелені).

- [ ] Подивитись на тонкі адаптери (`apps/web/src/modules/nutrition/lib/{nutritionStorage,waterStorage,shoppingListStorage}.ts` — кожен зараз ≤ 140 рядків) — переконатись, що нічого з публічного API старого файлу не пропало (особливо `loadPantries`, `persistPantries`, `loadActivePantryId`, `loadNutritionPrefs`, `persistNutritionPrefs`).
- [ ] Перевірити `packages/nutrition-domain/src/nutritionLog.ts` → `normalizeMeal` повністю збігається з web-версією до рядка (зокрема блок FTUX `demo: true` і макро-source fallback).
- [ ] Для спокою можна локально відкрити `/nutrition`-сторінку у web і швидко: додати прийом їжі → додати воду → додати товар у список покупок → refresh — перевірити, що дані зберігаються і перечитуються (це найбільша регрес-зона, хоч тести її покривають).

### Test plan

```
pnpm install
pnpm turbo run test typecheck lint \
  --filter @sergeant/nutrition-domain \
  --filter @sergeant/shared \
  --filter @sergeant/web
```

Очікую 9/9 зелених тасок. У мене дало:
- `@sergeant/nutrition-domain`: 4 файли / 20 тестів ✓
- `@sergeant/web`: 69 файлів / 617 тестів ✓
- всі typecheck/lint чисті

### Notes

- `toLocalISODate` продовжує реекспортуватись з `apps/web/.../nutritionStorage.ts` (тепер реекспорт іде з `@sergeant/shared`, як і давно має бути) — існуючі споживачі не відчують різниці.
- Сценарій «повернути все як було» — один `git revert` цього PR-а плюс revert #534.
- Цей PR зберігає той самий патерн шимів що і #534: замість переписувати всі call-sites одним махом, лишаємо тонкі реекспорти. Переведення споживачів на прямі імпорти з `@sergeant/nutrition-domain` — окремий follow-up.

Link to Devin session: https://app.devin.ai/sessions/4705a3c258bd489aaa1be96776dd2321
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated nutrition-related functions and types into a shared domain package, improving code organization and reducing duplication across storage modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->