### PR TITLE
feat(mobile/nutrition): MMKV storage adapter (Phase 7 / PR 3)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -28,6 +28,7 @@
     "@sergeant/design-tokens": "workspace:*",
     "@sergeant/finyk-domain": "workspace:^",
     "@sergeant/fizruk-domain": "workspace:*",
+    "@sergeant/nutrition-domain": "workspace:*",
     "@sergeant/routine-domain": "workspace:*",
     "@sergeant/shared": "workspace:*",
     "@shopify/flash-list": "1.7.3",

--- a/apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts
+++ b/apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Phase 7 / PR 3 — mobile nutrition storage foundation.
+ *
+ * Verifies that every `load*` / `save*` helper in `nutritionStore.ts`
+ * routes through `safeReadLS` / `safeWriteLS` (→ MMKV) and delegates
+ * normalization to `@sergeant/nutrition-domain`. Storage primitives
+ * are mocked so the suite stays pure — we never touch real MMKV.
+ */
+const mockSafeReadLS = jest.fn();
+const mockSafeReadStringLS = jest.fn();
+const mockSafeWriteLS = jest.fn();
+
+jest.mock("@/lib/storage", () => ({
+  safeReadLS: (...args: unknown[]) => mockSafeReadLS(...args),
+  safeReadStringLS: (...args: unknown[]) => mockSafeReadStringLS(...args),
+  safeWriteLS: (...args: unknown[]) => mockSafeWriteLS(...args),
+}));
+
+import {
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  SHOPPING_LIST_KEY,
+  WATER_LOG_KEY,
+} from "@sergeant/nutrition-domain";
+import {
+  loadActivePantryId,
+  loadNutritionLog,
+  loadNutritionPrefs,
+  loadPantries,
+  loadShoppingList,
+  loadWaterLog,
+  saveActivePantryId,
+  saveNutritionLog,
+  saveNutritionPrefs,
+  savePantries,
+  saveShoppingList,
+  saveWaterLog,
+} from "../nutritionStore";
+
+beforeEach(() => {
+  mockSafeReadLS.mockReset().mockReturnValue(null);
+  mockSafeReadStringLS.mockReset().mockReturnValue(null);
+  mockSafeWriteLS.mockReset().mockReturnValue(true);
+});
+
+describe("mobile nutritionStore — log", () => {
+  it("loadNutritionLog normalises missing data into an empty log", () => {
+    const out = loadNutritionLog();
+    expect(mockSafeReadLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, null);
+    expect(out).toEqual({});
+  });
+
+  it("loadNutritionLog normalises one well-formed day", () => {
+    mockSafeReadLS.mockReturnValueOnce({
+      "2024-01-15": {
+        meals: [{ id: "m1", name: "Сніданок", mealType: "breakfast" }],
+      },
+    });
+    const out = loadNutritionLog();
+    expect(out["2024-01-15"].meals).toHaveLength(1);
+    expect(out["2024-01-15"].meals[0].id).toBe("m1");
+  });
+
+  it("saveNutritionLog writes to the canonical key", () => {
+    saveNutritionLog({ "2024-01-15": { meals: [] } });
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, {
+      "2024-01-15": { meals: [] },
+    });
+  });
+
+  it("saveNutritionLog with null writes an empty object (not null)", () => {
+    saveNutritionLog(null);
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_LOG_KEY, {});
+  });
+});
+
+describe("mobile nutritionStore — prefs", () => {
+  it("loadNutritionPrefs returns defaults for missing input", () => {
+    const out = loadNutritionPrefs();
+    expect(mockSafeReadLS).toHaveBeenCalledWith(NUTRITION_PREFS_KEY, null);
+    expect(out.goal).toBe("balanced");
+    expect(out.waterGoalMl).toBe(2000);
+  });
+
+  it("loadNutritionPrefs normalises custom water goal", () => {
+    mockSafeReadLS.mockReturnValueOnce({ waterGoalMl: 2500 });
+    expect(loadNutritionPrefs().waterGoalMl).toBe(2500);
+  });
+
+  it("saveNutritionPrefs persists provided prefs", () => {
+    const prefs = { goal: "cut" } as Parameters<typeof saveNutritionPrefs>[0];
+    saveNutritionPrefs(prefs);
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_PREFS_KEY, prefs);
+  });
+});
+
+describe("mobile nutritionStore — pantries", () => {
+  it("loadActivePantryId defaults to `home` when nothing is stored", () => {
+    expect(loadActivePantryId()).toBe("home");
+    expect(mockSafeReadStringLS).toHaveBeenCalledWith(
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      null,
+    );
+  });
+
+  it("loadActivePantryId returns stored id", () => {
+    mockSafeReadStringLS.mockReturnValueOnce("work");
+    expect(loadActivePantryId()).toBe("work");
+  });
+
+  it("saveActivePantryId persists under the active key", () => {
+    saveActivePantryId("work");
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      "work",
+    );
+  });
+
+  it("loadPantries seeds the default pantry on first launch", () => {
+    const out = loadPantries();
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("home");
+    // Seeded default also writes the active pointer.
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      "home",
+    );
+  });
+
+  it("loadPantries normalises existing pantries", () => {
+    mockSafeReadLS.mockReturnValueOnce([
+      { id: "home", name: "Дім", items: [], text: "" },
+      { id: "work", name: "Робота", items: [], text: "" },
+    ]);
+    const out = loadPantries();
+    expect(out.map((p) => p.id)).toEqual(["home", "work"]);
+  });
+
+  it("savePantries writes pantries + optional active id", () => {
+    savePantries([{ id: "home", name: "Дім", items: [], text: "" }], "home");
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(NUTRITION_PANTRIES_KEY, [
+      { id: "home", name: "Дім", items: [], text: "" },
+    ]);
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(
+      NUTRITION_ACTIVE_PANTRY_KEY,
+      "home",
+    );
+  });
+
+  it("savePantries skips active-id write when none provided", () => {
+    savePantries([{ id: "home", name: "Дім", items: [], text: "" }]);
+    const writtenKeys = mockSafeWriteLS.mock.calls.map((c) => c[0]);
+    expect(writtenKeys).toContain(NUTRITION_PANTRIES_KEY);
+    expect(writtenKeys).not.toContain(NUTRITION_ACTIVE_PANTRY_KEY);
+  });
+});
+
+describe("mobile nutritionStore — water", () => {
+  it("loadWaterLog returns an empty object on missing data", () => {
+    expect(loadWaterLog()).toEqual({});
+    expect(mockSafeReadLS).toHaveBeenCalledWith(WATER_LOG_KEY, null);
+  });
+
+  it("loadWaterLog keeps only positive ISO-date entries", () => {
+    mockSafeReadLS.mockReturnValueOnce({
+      "2024-01-15": 1500,
+      "not-a-date": 999,
+      "2024-01-16": -5,
+    });
+    expect(loadWaterLog()).toEqual({ "2024-01-15": 1500 });
+  });
+
+  it("saveWaterLog normalises before persisting", () => {
+    saveWaterLog({ "2024-01-15": 1500, "bad-key": 1 });
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(WATER_LOG_KEY, {
+      "2024-01-15": 1500,
+    });
+  });
+});
+
+describe("mobile nutritionStore — shopping list", () => {
+  it("loadShoppingList returns empty categories on missing data", () => {
+    expect(loadShoppingList()).toEqual({ categories: [] });
+    expect(mockSafeReadLS).toHaveBeenCalledWith(SHOPPING_LIST_KEY, null);
+  });
+
+  it("loadShoppingList normalises categories + items", () => {
+    mockSafeReadLS.mockReturnValueOnce({
+      categories: [
+        {
+          name: "Овочі",
+          items: [
+            { id: "a", name: "Морква" },
+            { id: "b", name: "" },
+          ],
+        },
+      ],
+    });
+    const out = loadShoppingList();
+    expect(out.categories).toHaveLength(1);
+    expect(out.categories[0].items).toHaveLength(1);
+    expect(out.categories[0].items[0].name).toBe("Морква");
+  });
+
+  it("saveShoppingList normalises before persisting", () => {
+    saveShoppingList({ categories: [] });
+    expect(mockSafeWriteLS).toHaveBeenCalledWith(SHOPPING_LIST_KEY, {
+      categories: [],
+    });
+  });
+});

--- a/apps/mobile/src/modules/nutrition/lib/nutritionStore.ts
+++ b/apps/mobile/src/modules/nutrition/lib/nutritionStore.ts
@@ -1,0 +1,131 @@
+/**
+ * MMKV-backed storage adapter for the mobile Nutrition module.
+ *
+ * Mirrors the shape of `apps/web/src/modules/nutrition/lib/*Storage.ts`
+ * (Phase 7 / PR 2) but on top of MMKV via `@/lib/storage`. All
+ * normalization / mutation logic is delegated to
+ * `@sergeant/nutrition-domain` so mobile and web share the exact same
+ * `NutritionLog` / `Pantry` / `WaterLog` / `ShoppingList` / `Prefs`
+ * semantics — one domain change, both platforms updated.
+ *
+ * Scope of this file (Phase 7 / PR 3 — Mobile storage foundation):
+ *  - `load*` / `save*` functions for every nutrition LS-key
+ *  - No hooks, no UI, no AI — those ship with the actual RN screens in
+ *    Phase 7 / PR 4+. This PR only stands up the storage plumbing so
+ *    upcoming UI PR-s can `import {load*, save*}` without touching
+ *    MMKV directly.
+ *
+ * Cloud-sync note: writes go through `safeWriteLS` which bypasses the
+ * JS `localStorage` setItem-patch that the web uses to auto-mark
+ * modules dirty. UI layers that need `useCloudSync` parity must either
+ * (a) call `enqueueChange(key)` explicitly, or (b) prefer
+ * `useSyncedStorage` wrappers. See `docs/react-native-migration.md`
+ * § 6.1 and `apps/mobile/src/sync/config.ts` for the full list of
+ * nutrition keys that are already registered in `SYNC_MODULES`.
+ */
+import {
+  NUTRITION_ACTIVE_PANTRY_KEY,
+  NUTRITION_LOG_KEY,
+  NUTRITION_PANTRIES_KEY,
+  NUTRITION_PREFS_KEY,
+  SHOPPING_LIST_KEY,
+  WATER_LOG_KEY,
+  defaultNutritionPrefs,
+  makeDefaultPantry,
+  normalizeNutritionLog,
+  normalizeNutritionPrefs,
+  normalizePantries,
+  normalizeShoppingList,
+  normalizeWaterLog,
+  type NutritionLog,
+  type NutritionPrefs,
+  type Pantry,
+  type ShoppingList,
+  type WaterLog,
+} from "@sergeant/nutrition-domain";
+
+import { safeReadLS, safeReadStringLS, safeWriteLS } from "@/lib/storage";
+
+// ── Log ─────────────────────────────────────────────────────────────
+
+export function loadNutritionLog(): NutritionLog {
+  return normalizeNutritionLog(safeReadLS<unknown>(NUTRITION_LOG_KEY, null));
+}
+
+export function saveNutritionLog(
+  log: NutritionLog | null | undefined,
+): boolean {
+  return safeWriteLS(NUTRITION_LOG_KEY, log || {});
+}
+
+// ── Prefs ───────────────────────────────────────────────────────────
+
+export function loadNutritionPrefs(): NutritionPrefs {
+  return normalizeNutritionPrefs(
+    safeReadLS<unknown>(NUTRITION_PREFS_KEY, null),
+  );
+}
+
+export function saveNutritionPrefs(
+  prefs: NutritionPrefs | null | undefined,
+): boolean {
+  return safeWriteLS(NUTRITION_PREFS_KEY, prefs || defaultNutritionPrefs());
+}
+
+// ── Pantries ────────────────────────────────────────────────────────
+
+export function loadActivePantryId(): string {
+  const v = safeReadStringLS(NUTRITION_ACTIVE_PANTRY_KEY, null);
+  return v ? String(v) : "home";
+}
+
+export function saveActivePantryId(id: string): boolean {
+  return safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, String(id || "home"));
+}
+
+export function loadPantries(): Pantry[] {
+  const parsed = safeReadLS<unknown>(NUTRITION_PANTRIES_KEY, null);
+  const normalized = normalizePantries(parsed);
+  if (normalized.length > 0) return normalized;
+  // No pantries yet — seed with default so the UI has something to
+  // render on first launch. Matches web behaviour (see
+  // `apps/web/src/modules/nutrition/lib/nutritionStorage.ts →
+  // loadPantries`).
+  const fallback = makeDefaultPantry();
+  safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, fallback.id);
+  return [fallback];
+}
+
+export function savePantries(
+  pantries: Pantry[] | null | undefined,
+  activeId?: string | null,
+): boolean {
+  const a = safeWriteLS(
+    NUTRITION_PANTRIES_KEY,
+    Array.isArray(pantries) ? pantries : [],
+  );
+  const b = activeId
+    ? safeWriteLS(NUTRITION_ACTIVE_PANTRY_KEY, String(activeId))
+    : true;
+  return a && b;
+}
+
+// ── Water ───────────────────────────────────────────────────────────
+
+export function loadWaterLog(): WaterLog {
+  return normalizeWaterLog(safeReadLS<unknown>(WATER_LOG_KEY, null));
+}
+
+export function saveWaterLog(log: unknown): boolean {
+  return safeWriteLS(WATER_LOG_KEY, normalizeWaterLog(log));
+}
+
+// ── Shopping list ───────────────────────────────────────────────────
+
+export function loadShoppingList(): ShoppingList {
+  return normalizeShoppingList(safeReadLS<unknown>(SHOPPING_LIST_KEY, null));
+}
+
+export function saveShoppingList(list: unknown): boolean {
+  return safeWriteLS(SHOPPING_LIST_KEY, normalizeShoppingList(list));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       "@sergeant/fizruk-domain":
         specifier: workspace:*
         version: link:../../packages/fizruk-domain
+      "@sergeant/nutrition-domain":
+        specifier: workspace:*
+        version: link:../../packages/nutrition-domain
       "@sergeant/routine-domain":
         specifier: workspace:*
         version: link:../../packages/routine-domain


### PR DESCRIPTION
## Summary

**Base-branch: #535** (Phase 7 / PR 2). Після мержу PR-2 ця гілка автоматично перебазується на `main` і покаже лише commit PR-3.

Третій крок **Phase 7**. Створено MMKV-backed storage-адаптер для модуля Харчування у `apps/mobile`. Усі normalize/default-хелпери йдуть з `@sergeant/nutrition-domain` (PR-2) — отже зміни в доменній логіці тепер автоматично прилітають на web і на native.

**Нові файли:**

- `apps/mobile/src/modules/nutrition/lib/nutritionStore.ts` — шість пар `load*` / `save*`:
  - `loadNutritionLog` / `saveNutritionLog`
  - `loadNutritionPrefs` / `saveNutritionPrefs`
  - `loadPantries` / `savePantries` / `loadActivePantryId` / `saveActivePantryId` (з ідентичним seed-падлоком на `makeDefaultPantry()` як на web)
  - `loadWaterLog` / `saveWaterLog`
  - `loadShoppingList` / `saveShoppingList`
  
  Кожен `load*` — це `safeReadLS` + domain-normalize; `save*` — domain-normalize + `safeWriteLS`. Патерн 1:1 з `apps/mobile/src/modules/routine/lib/routineStore.ts`.

- `apps/mobile/src/modules/nutrition/lib/__tests__/nutritionStore.test.ts` — 20 jest-тестів з мокнутими `@/lib/storage` примітивами.

- `apps/mobile/package.json` — додано `"@sergeant/nutrition-domain": "workspace:*"`.

## Що НЕ входить у PR-3

- **React-хуки** (`useNutritionLog`, `useWaterTracker`, `useShoppingList`, `useNutritionPantries`) — ідуть разом з UI-екранами у PR-4+. `nutritionStore.ts` — суто функціональна поверхня, аналог того, як Phase 5 / PR 2 спочатку дав `loadRoutineState` / `saveRoutineState` без хука.
- **Cloud-sync wiring через `enqueueChange`** — UI-хуки самі викликатимуть `enqueueChange(key)` після `save*`, як уже робить `routineStore`. Нутриційні ключі вже зареєстровані в `apps/mobile/src/sync/config.ts → SYNC_MODULES.nutrition`.
- **UI** — `apps/mobile/src/modules/nutrition/ModuleStub.tsx` поки що лишається stub-ом. PR-4 замінить його на реальний `NutritionApp` з Dashboard + Log + Water.

## Review & Testing Checklist for Human

Ризик: **🟢 low** — чиста додача, web не чіпали взагалі. Якщо PR-2 merge-не-рідко зберігає семантику, PR-3 автоматично коректний.

- [ ] Глянути `nutritionStore.ts` — переконатися, що кожен `load*` викликає `safeReadLS(KEY, null)` + normalize, а `save*` викликає normalize + `safeWriteLS(KEY, ...)`. Жодного прямого імпорту `localStorage` чи `window` тут бути не повинно (це навмисно — MMKV-only).
- [ ] Перевірити, що `loadPantries()` на першому запуску сіє default-pantry (`makeDefaultPantry()`) — якщо користувач видалив MMKV вручну, cipher-keyless MMKV віддає пустий масив, і UI має отримати хоча б один `{id: "home", name: "Дім"}`. Це відповідає web-поведінці.
- [ ] Після merge PR-2: rebase цієї гілки на main (`git rebase origin/main`) — перевірити, що конфлікту немає (не повинно бути, PR-3 не чіпає файли з PR-2).

### Test plan

```
pnpm install
pnpm turbo run test typecheck lint \
  --filter @sergeant/nutrition-domain \
  --filter @sergeant/mobile
```

Очікую 9/9 зелених тасок. У мене:
- `@sergeant/nutrition-domain`: 4 файли / 20 тестів ✓
- `@sergeant/mobile`: 80 файлів / 544 тести ✓ (з +1 новим файлом / +20 тестами PR-3)
- `@sergeant/web`: 69 файлів / 617 тестів ✓ (не чіпали, прогнав для певності)

### Notes

- Далі у Phase 7 / PR 4 планую: ModuleStub -> `NutritionApp` з трьома вкладками (Dashboard / Log / Water) + хуки над цим store.
- PR-3 не потребує UI-тестування (backend plumbing, немає екранів). Повна UI-валідація прийде з PR-4.

Link to Devin session: https://app.devin.ai/sessions/4705a3c258bd489aaa1be96776dd2321
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
