### PR TITLE
fix(settings): collapse Notifications section by default

### DIFF
--- a/apps/web/src/core/settings/NotificationsSection.tsx
+++ b/apps/web/src/core/settings/NotificationsSection.tsx
@@ -123,7 +123,7 @@ export function NotificationsSection() {
   const permColor = permColors[permStatus] ?? "text-muted";
 
   return (
-    <SettingsGroup title="Сповіщення" emoji="🔔" defaultOpen>
+    <SettingsGroup title="Сповіщення" emoji="🔔">
       <div className="flex items-center justify-between gap-3 p-3 rounded-xl bg-bg border border-line">
         <div>
           <p className="text-sm font-semibold text-text">Push-сповіщення</p>


### PR DESCRIPTION
## Summary

Раніше секція **«Сповіщення» (🔔)** у Hub-налаштуваннях відкривалася розгорнутою за замовчуванням — на відміну від усіх інших секцій (`Загальні`, `AI Звіт тижня`, `Рутина`, `Фізрук`, `Фінік`, `Експериментальне`), які стартують згорнутими.

Прибрано проп `defaultOpen` з кореневого `<SettingsGroup>` у <ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/core/settings/NotificationsSection.tsx" />, щоб секція поводилася так само, як інші — була згорнутою за замовчуванням і відкривалася лише після кліку на заголовок.

Вкладені під-секції (`Звички (Рутина)`, `Тренування (Фізрук)`, `Харчування`) залишено з `defaultOpen`, як було — вони впливають лише після того, як користувач розгорне основну секцію.

## Review & Testing Checklist for Human

- [ ] Відкрити Hub-налаштування → вкладка «Загальні»: секція «🔔 Сповіщення» згорнута (шеврон ▶), як і «⚙️ Загальні» та «📋 AI Звіт тижня».
- [ ] Клік на заголовок секції розгортає її та показує вкладені під-секції з існуючим `defaultOpen`-станом.
- [ ] Пошук за словами «сповіщення / push / нагадування» все одно знаходить секцію (логіка фільтрації у `HubSettingsPage` не змінювалась).

### Notes

- Змінено лише один рядок; ні логіку, ні стилі, ні під-секції не зачіпали.
- `pnpm --filter @sergeant/web typecheck` і `pnpm --filter @sergeant/web lint` проходять локально.

Link to Devin session: https://app.devin.ai/sessions/dff72bf400cc469ba21a4cfdaed96432
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified the default behavior of the Notifications settings section to no longer be automatically expanded when accessing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->