### PR TITLE
fix(finyk): inline «Хаб» back button into module header so it no longer overlaps ФІНІК title

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -375,37 +375,6 @@ function AppInner() {
           requirement: switching modules mid-set must not bury the
           workout. */}
       {activeModule !== "fizruk" && <ActiveWorkoutBanner />}
-      {/* Finyk has no in-module header of its own, so we provide a
-          floating back-to-hub pill here. Fizruk, Routine and Nutrition
-          render their own inline "← Хаб" button inside the module header
-          for consistency — see #S0.5. */}
-      {activeModule === "finyk" && (
-        <div className="shrink-0 absolute top-0 left-0 z-50 p-2 safe-area-pt-8">
-          <button
-            type="button"
-            onClick={goToHub}
-            className="h-11 min-h-[44px] pl-2 pr-3 flex items-center gap-1.5 rounded-2xl bg-panel/90 backdrop-blur-md border border-line text-muted hover:text-text shadow-card transition-colors"
-            title="До хабу"
-            aria-label="До хабу"
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M15 18l-6-6 6-6" />
-            </svg>
-            <span className="text-sm font-semibold">Хаб</span>
-          </button>
-        </div>
-      )}
-
       <Suspense fallback={<PageLoader />}>
         {/* Skip-link target. We render `<main>` by default so every screen
             exposes a `main` landmark for AT users. One exception: the

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -543,7 +543,37 @@ export default function App({
       {/* Header */}
       <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
         <div className="flex h-14 items-center justify-between px-4 sm:px-5 gap-3">
-          <div className="flex items-center gap-2.5 min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
+            {typeof onBackToHub === "function" ? (
+              <button
+                type="button"
+                onClick={onBackToHub}
+                className={cn(
+                  "shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5",
+                  "flex items-center justify-center rounded-xl",
+                  "text-muted hover:text-text transition-all duration-200",
+                  "border border-line bg-panel/80 hover:bg-panelHi",
+                  "active:scale-95",
+                )}
+                aria-label="До хабу"
+                title="До хабу"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden
+                >
+                  <path d="M15 18l-6-6 6-6" />
+                </svg>
+                <span className="text-sm font-semibold">Хаб</span>
+              </button>
+            ) : null}
             <div
               className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 border border-emerald-500/15"
               aria-hidden


### PR DESCRIPTION
## Summary

На сторінках модуля **ФІНІК** плаваюча пігулка «← Хаб» (абсолютне позиціювання у лівому верхньому куті) перекривала перші символи заголовка «ФІНІК» — на скріншоті користувача видно лише «…НІК».

Інші модулі (Фізрук, Рутина, Харчування) вже давно рендерять «← Хаб» **усередині власного рядка хедера** (див. `NutritionHeader`). Для Фінік же в `core/App.tsx` залишалася окрема floating-пігулка (`absolute top-0 left-0 z-50`), яка накладалася на вбудований хедер модуля.

Цей PR переносить кнопку «Хаб» всередину рядка Finyk-хедера — так само, як це реалізовано в Харчуванні — і прибирає зайву floating-пігулку з `core/App.tsx`. Візуальний стиль (rounded-xl пігулка з chevron + лейблом «Хаб») збережено, щоб нічого не змінилося для користувача на рівні «вигляду» самої кнопки — змінилося лише її **місце** в DOM.

### Що змінилося
- `apps/web/src/modules/finyk/FinykApp.tsx` — додано inline-кнопку «← Хаб» перед іконкою/назвою модуля в header-рядку. Використовується існуюча prop `onBackToHub`, яку Finyk вже приймає.
- `apps/web/src/core/App.tsx` — видалено floating back-to-hub блок для `activeModule === "finyk"` (разом із супутнім коментарем, який був вже неактуальний).

## Review & Testing Checklist for Human

- [ ] На мобільному (375-414 px ширина) відкрити ФІНІК → пересвідчитись, що заголовок «ФІНІК» повністю видно й не перекривається кнопкою «Хаб»
- [ ] Клік по «← Хаб» у Фінік коректно повертає до хабу (та сама `goToHub`, що й раніше)
- [ ] Перевірити інші модулі (Фізрук, Рутина, Харчування) — їхня поведінка не змінена, бо floating-пігулка рендерилась тільки для `finyk`
- [ ] Swipe-назад / back-жест у PWA досі працює (не залежить від цієї кнопки, але варто глянути)

### Notes

- `pnpm typecheck` ✅
- `pnpm --filter @sergeant/web lint` ✅
- `pnpm prettier --write` — файли вже у відформатованому стані
- Коментар у `core/App.tsx`, який пояснював «Finyk has no in-module header of its own…», видалено разом із блоком — тепер Finyk має інлайн-кнопку в своєму хедері, як і інші модулі, тож пояснення більше не актуальне.


Link to Devin session: https://app.devin.ai/sessions/15aa55658b7e42d0b96a9b7b4ca9c171
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
