### PR TITLE
feat(mobile/nutrition): Dashboard + Log + Water UI shell (Phase 7 / PR 4)

### DIFF
--- a/apps/mobile/app/(tabs)/nutrition/index.tsx
+++ b/apps/mobile/app/(tabs)/nutrition/index.tsx
@@ -1,18 +1,5 @@
-import { ModuleStub } from "@/components/ModuleStub";
+import { NutritionApp } from "@/modules/nutrition/NutritionApp";
 
 export default function NutritionTab() {
-  return (
-    <ModuleStub
-      title="Харчування"
-      description="Лог їжі, AI-аналіз фото, сканер штрихкодів, денний план, вода."
-      plannedFeatures={[
-        "Щоденник їжі",
-        "Фото → AI-аналіз макросів",
-        "Сканер штрихкодів (OFF + USDA + UPCitemdb)",
-        "Денний план і денний підрахунок",
-        "Список покупок, комора, рецепти",
-        "Трекер води",
-      ]}
-    />
-  );
+  return <NutritionApp />;
 }

--- a/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
+++ b/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Render tests for the Nutrition module shell (Phase 7 PR 4).
+ *
+ * Covers:
+ *  - Default tab is "Сьогодні" (dashboard);
+ *  - Tapping bottom-nav switches між Dashboard / Log / Water;
+ *  - Selected tab is written до MMKV під ключем
+ *    `STORAGE_KEYS.NUTRITION_MAIN_TAB` у raw-string форматі (web parity);
+ *  - An existing persisted tab is picked up on first mount;
+ *  - Legacy / malformed persisted value falls back to "dashboard".
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+
+import { NutritionApp } from "./NutritionApp";
+
+// Унікальний рядок в Dashboard card ("Сьогодні").
+const DASHBOARD_MARKER = "Сьогодні";
+// Унікальний heading у Water сторінці.
+const WATER_MARKER = "Щоденний трекер";
+// Log: empty-state headline (немає записів при чистому MMKV).
+const LOG_EMPTY_MARKER = "Немає записів за цей день";
+
+beforeEach(() => {
+  _getMMKVInstance().clearAll();
+});
+
+describe("NutritionApp shell", () => {
+  it("renders the Dashboard screen by default", () => {
+    const { getAllByText } = render(<NutritionApp />);
+    // 1 — у Dashboard Card title, 1 — у bottom-nav label "Сьогодні".
+    expect(getAllByText(DASHBOARD_MARKER).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("switches to the Log screen when the Journal tab is pressed", () => {
+    const { getByTestId, getByText } = render(<NutritionApp />);
+
+    fireEvent.press(getByTestId("nutrition-bottom-nav-log"));
+
+    expect(getByText(LOG_EMPTY_MARKER)).toBeTruthy();
+  });
+
+  it("switches to the Water screen when the Water tab is pressed", () => {
+    const { getByTestId, getByText } = render(<NutritionApp />);
+
+    fireEvent.press(getByTestId("nutrition-bottom-nav-water"));
+
+    expect(getByText(WATER_MARKER)).toBeTruthy();
+  });
+
+  it("writes the selected tab to MMKV under NUTRITION_MAIN_TAB", () => {
+    const { getByTestId } = render(<NutritionApp />);
+
+    fireEvent.press(getByTestId("nutrition-bottom-nav-log"));
+
+    const raw = _getMMKVInstance().getString(STORAGE_KEYS.NUTRITION_MAIN_TAB);
+    expect(raw).toBe("log");
+  });
+
+  it("picks up a persisted tab from MMKV on first mount", () => {
+    _getMMKVInstance().set(STORAGE_KEYS.NUTRITION_MAIN_TAB, "water");
+
+    const { getByText } = render(<NutritionApp />);
+
+    expect(getByText(WATER_MARKER)).toBeTruthy();
+  });
+
+  it("falls back to dashboard when the persisted value is malformed", () => {
+    _getMMKVInstance().set(STORAGE_KEYS.NUTRITION_MAIN_TAB, "garbage");
+
+    const { getAllByText } = render(<NutritionApp />);
+
+    expect(getAllByText(DASHBOARD_MARKER).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/mobile/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/mobile/src/modules/nutrition/NutritionApp.tsx
@@ -1,0 +1,111 @@
+/**
+ * Sergeant Nutrition — NutritionApp shell (React Native, first cut)
+ *
+ * Mobile port of `apps/web/src/modules/nutrition/NutritionApp.tsx` (581 LOC).
+ *
+ * Scope of PR-4:
+ *  - Замінює `ModuleStub` на реальну shell-обгортку з
+ *    `ModuleErrorBoundary` (моdule-name = "Харчування") + bottom-nav з
+ *    трьома вкладками (`dashboard` / `log` / `water`).
+ *  - Вкладка "Сьогодні" (`dashboard`) → `pages/Dashboard.tsx` (macros +
+ *    week-bar + water).
+ *  - Вкладка "Журнал" (`log`) → `pages/Log.tsx` — read-only список
+ *    прийомів за вибрану дату з date-switcher.
+ *  - Вкладка "Вода" (`water`) → `pages/Water.tsx` — дубль водного картка
+ *    для швидкого доступу.
+ *
+ * Що навмисно відсутнє у PR-4 (чекає наступні PR-и):
+ *  - AddMealSheet / ItemEditSheet — PR-5. Дотик на "Сьогодні → +Додати" та
+ *    длинне натискання в журналі в цьому PR залишаються без дії; простір
+ *    під них зарезервовано у Dashboard/Log коментарями.
+ *  - Barcode scanner — PR-6 (`apps/mobile/app/(tabs)/nutrition/scan.tsx`
+ *    ще рендерить stub-деф-скрін; він перехопить контроль коли в
+ *    sheet-і з'явиться кнопка "Сканер").
+ *  - Pantry / ShoppingList — PR-7. Вкладки в bottom-nav додадуться коли
+ *    логіка приземлиться.
+ *  - AI-фічі (photo analyze / day plan / recipes) — PR-8.
+ *  - Reminders / cloud backup — PR-9.
+ *
+ * Persistence:
+ *  - Активна вкладка зберігається у MMKV за ключем
+ *    `STORAGE_KEYS.NUTRITION_MAIN_TAB` (raw string, as зроблено у Routine).
+ */
+import { useCallback, useState } from "react";
+import { View } from "react-native";
+
+import { STORAGE_KEYS } from "@sergeant/shared";
+import { router } from "expo-router";
+
+import ModuleErrorBoundary from "@/core/ModuleErrorBoundary";
+import { safeReadStringLS, safeWriteLS } from "@/lib/storage";
+
+import {
+  NutritionBottomNav,
+  type NutritionMainTab,
+} from "./components/NutritionBottomNav";
+import { Dashboard } from "./pages/Dashboard";
+import { Log } from "./pages/Log";
+import { Water } from "./pages/Water";
+
+const TAB_PERSIST_KEY = STORAGE_KEYS.NUTRITION_MAIN_TAB;
+
+function isNutritionMainTab(value: unknown): value is NutritionMainTab {
+  return value === "dashboard" || value === "log" || value === "water";
+}
+
+function readPersistedTab(): NutritionMainTab {
+  const raw = safeReadStringLS(TAB_PERSIST_KEY);
+  return isNutritionMainTab(raw) ? raw : "dashboard";
+}
+
+function NutritionShell() {
+  const [mainTab, setMainTab] = useState<NutritionMainTab>(readPersistedTab);
+
+  const handleSelectTab = useCallback((next: NutritionMainTab) => {
+    setMainTab(next);
+    safeWriteLS(TAB_PERSIST_KEY, next);
+  }, []);
+
+  return (
+    <View className="flex-1 bg-cream-50" testID="nutrition-shell">
+      <View className="flex-1">
+        {mainTab === "dashboard" ? (
+          <Dashboard testID="nutrition-dashboard" />
+        ) : null}
+        {mainTab === "log" ? <Log testID="nutrition-log" /> : null}
+        {mainTab === "water" ? <Water testID="nutrition-water" /> : null}
+      </View>
+
+      <NutritionBottomNav
+        mainTab={mainTab}
+        onSelectTab={handleSelectTab}
+        testID="nutrition-bottom-nav"
+      />
+    </View>
+  );
+}
+
+/**
+ * NutritionApp — public entry для модуля Харчування (mobile).
+ *
+ * Wrap у `ModuleErrorBoundary` — якщо краш в будь-якій вкладці, він
+ * ізольований у Nutrition-табі. `onBackToHub` веде на Hub-таб (`/`)
+ * через `expo-router` — mirror web-поведінки.
+ */
+export function NutritionApp() {
+  const handleBackToHub = useCallback(() => {
+    try {
+      router.replace("/");
+    } catch {
+      /* noop — best-effort navigation after module crash */
+    }
+  }, []);
+
+  return (
+    <ModuleErrorBoundary moduleName="Харчування" onBackToHub={handleBackToHub}>
+      <NutritionShell />
+    </ModuleErrorBoundary>
+  );
+}
+
+export default NutritionApp;

--- a/apps/mobile/src/modules/nutrition/components/MacroRing.tsx
+++ b/apps/mobile/src/modules/nutrition/components/MacroRing.tsx
@@ -1,0 +1,89 @@
+/**
+ * Кільце прогресу для макросу (кілокалорії / білки / жири / вуглеводи).
+ *
+ * Web-версія рендерить такі кільця інлайн у `NutritionDashboard.tsx`
+ * через SVG. На native використовуємо `react-native-svg` — візуально
+ * зберігаємо той самий ринг +90° counterclockwise start і закруглений
+ * stroke-cap.
+ */
+import { View, Text } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+
+export interface MacroRingProps {
+  /** Поточне значення (відображається в центрі). */
+  value: number;
+  /** Цільове значення; якщо ≤ 0 — кільце малюється без fill-сегмента. */
+  target: number;
+  /** Колір активного сегмента (за замовчуванням — помаранчевий ккал). */
+  color?: string;
+  /** Діаметр у px. Дефолт 56 (як на web). */
+  size?: number;
+  /** Товщина stroke у px. Дефолт 5. */
+  stroke?: number;
+  label: string;
+  /** Unit-suffix над targets (`г` / порожньо для ккал). */
+  unit?: string;
+}
+
+export function MacroRing({
+  value,
+  target,
+  color = "#f97316",
+  size = 56,
+  stroke = 5,
+  label,
+  unit,
+}: MacroRingProps) {
+  const r = (size - stroke) / 2;
+  const circ = 2 * Math.PI * r;
+  const percent = target > 0 ? Math.min(100, (value / target) * 100) : 0;
+  const dash = (percent / 100) * circ;
+
+  return (
+    <View className="items-center gap-1">
+      <View style={{ width: size, height: size }}>
+        <Svg
+          width={size}
+          height={size}
+          // -90° rotation щоб segment стартував згори
+          style={{ transform: [{ rotate: "-90deg" }] }}
+        >
+          <Circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            stroke="#e7e5e4"
+            strokeWidth={stroke}
+          />
+          {target > 0 ? (
+            <Circle
+              cx={size / 2}
+              cy={size / 2}
+              r={r}
+              fill="none"
+              stroke={color}
+              strokeWidth={stroke}
+              strokeLinecap="round"
+              strokeDasharray={`${dash} ${circ}`}
+            />
+          ) : null}
+        </Svg>
+        <View className="absolute inset-0 items-center justify-center">
+          <Text className="text-xs font-bold text-stone-900 leading-none">
+            {Math.round(value)}
+          </Text>
+        </View>
+      </View>
+      <Text className="text-[10px] font-semibold text-stone-500 leading-none">
+        {label}
+      </Text>
+      {target > 0 ? (
+        <Text className="text-[9px] text-stone-400 leading-none">
+          / {target}
+          {unit || ""}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/NutritionBottomNav.tsx
+++ b/apps/mobile/src/modules/nutrition/components/NutritionBottomNav.tsx
@@ -1,0 +1,81 @@
+/**
+ * Sergeant Nutrition — NutritionBottomNav (React Native)
+ *
+ * Three-tab segmented control для модуля Харчування (mobile). Патерн
+ * 1:1 з `RoutineBottomNav` — інлайн buttons з емодзі, 44×44 min tap
+ * targets, a11y tablist/tab roles.
+ *
+ * Phase 7 / PR 4 рендерить лише 3 вкладки — Dashboard / Log / Water.
+ * AddMeal, Pantry, Shopping list, Recipes — це наступні PR-и, і вони
+ * приєднаються сюди як нові пункти (або як sub-tabs всередині Log).
+ */
+import { Pressable, Text, View } from "react-native";
+
+import { hapticTap } from "@sergeant/shared";
+
+export type NutritionMainTab = "dashboard" | "log" | "water";
+
+interface NavItem {
+  id: NutritionMainTab;
+  label: string;
+  emoji: string;
+}
+
+const NAV: readonly NavItem[] = [
+  { id: "dashboard", label: "Сьогодні", emoji: "🍽️" },
+  { id: "log", label: "Журнал", emoji: "📒" },
+  { id: "water", label: "Вода", emoji: "💧" },
+];
+
+export interface NutritionBottomNavProps {
+  mainTab: NutritionMainTab;
+  onSelectTab: (tab: NutritionMainTab) => void;
+  testID?: string;
+}
+
+export function NutritionBottomNav({
+  mainTab,
+  onSelectTab,
+  testID,
+}: NutritionBottomNavProps) {
+  return (
+    <View
+      accessibilityRole="tablist"
+      accessibilityLabel="Розділи Харчування"
+      testID={testID}
+      className="flex-row items-stretch border-t border-cream-300 bg-cream-50"
+    >
+      {NAV.map((item) => {
+        const selected = item.id === mainTab;
+        return (
+          <Pressable
+            key={item.id}
+            accessibilityRole="tab"
+            accessibilityState={{ selected }}
+            accessibilityLabel={item.label}
+            testID={testID ? `${testID}-${item.id}` : undefined}
+            onPress={() => {
+              if (selected) return;
+              hapticTap();
+              onSelectTab(item.id);
+            }}
+            className="flex-1 items-center justify-center py-2 min-h-[56px]"
+          >
+            <Text
+              className={`text-xl ${selected ? "opacity-100" : "opacity-60"}`}
+            >
+              {item.emoji}
+            </Text>
+            <Text
+              className={`text-[11px] mt-0.5 ${
+                selected ? "text-coral-700 font-semibold" : "text-stone-500"
+              }`}
+            >
+              {item.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/WaterTrackerCard.tsx
+++ b/apps/mobile/src/modules/nutrition/components/WaterTrackerCard.tsx
@@ -1,0 +1,135 @@
+/**
+ * Water tracker card — mobile port
+ * web: apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
+ *
+ * Рендерить секцію "Вода": поточне ml, progress-bar, 4 quick-add
+ * кнопки (200 / 300 / 500 / 750 ml), reset з confirm-tap.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { hapticTap } from "@sergeant/shared";
+
+import { Card } from "@/components/ui/Card";
+
+import { useWaterTracker } from "../hooks/useWaterTracker";
+
+const QUICK_ML = [200, 300, 500, 750] as const;
+
+function fmt(ml: number): string {
+  return ml >= 1000 ? `${(ml / 1000).toFixed(1)} л` : `${ml} мл`;
+}
+
+export interface WaterTrackerCardProps {
+  goalMl?: number;
+  testID?: string;
+}
+
+export function WaterTrackerCard({
+  goalMl = 2000,
+  testID,
+}: WaterTrackerCardProps) {
+  const { todayMl, add, reset } = useWaterTracker();
+  const [resetPending, setResetPending] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const pct = goalMl > 0 ? Math.min(100, (todayMl / goalMl) * 100) : 0;
+  const done = todayMl >= goalMl && goalMl > 0;
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleResetPress = () => {
+    if (resetPending) {
+      if (resetTimerRef.current !== null) {
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+      reset();
+      setResetPending(false);
+      return;
+    }
+    if (resetTimerRef.current !== null) {
+      clearTimeout(resetTimerRef.current);
+    }
+    setResetPending(true);
+    resetTimerRef.current = setTimeout(() => {
+      setResetPending(false);
+      resetTimerRef.current = null;
+    }, 2500);
+  };
+
+  return (
+    <Card testID={testID}>
+      <View className="flex-row items-center justify-between mb-3">
+        <View className="flex-row items-center gap-2">
+          <Text className="text-lg leading-none">💧</Text>
+          <View>
+            <Text className="text-sm font-semibold text-stone-900 leading-none">
+              Вода
+            </Text>
+            <Text className="text-xs text-stone-500 mt-0.5">
+              {fmt(todayMl)}
+              {goalMl > 0 ? ` / ${fmt(goalMl)}` : ""}
+              {done ? " ✓" : ""}
+            </Text>
+          </View>
+        </View>
+        {todayMl > 0 ? (
+          <Pressable
+            onPress={handleResetPress}
+            accessibilityRole="button"
+            accessibilityLabel={
+              resetPending
+                ? "Підтвердити скидання води за сьогодні"
+                : "Скинути воду за сьогодні"
+            }
+            testID={testID ? `${testID}-reset` : undefined}
+            className="px-2 py-1 rounded-lg"
+          >
+            <Text className="text-xs text-stone-500">
+              {resetPending ? "Скинути?" : "↺"}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {goalMl > 0 ? (
+        <View className="h-2 bg-stone-200 rounded-full overflow-hidden mb-3">
+          <View
+            style={{ width: `${pct}%` }}
+            className={`h-full rounded-full ${
+              done ? "bg-lime-500" : "bg-sky-500"
+            }`}
+          />
+        </View>
+      ) : null}
+
+      <View className="flex-row gap-1.5">
+        {QUICK_ML.map((ml) => (
+          <Pressable
+            key={ml}
+            accessibilityRole="button"
+            accessibilityLabel={`Додати ${ml} мл води`}
+            testID={testID ? `${testID}-add-${ml}` : undefined}
+            onPress={() => {
+              hapticTap();
+              add(ml);
+            }}
+            className="flex-1 h-9 rounded-xl items-center justify-center bg-sky-500/10 border border-sky-500/20"
+          >
+            <Text className="text-xs font-semibold text-sky-700">
+              +{ml < 1000 ? ml : `${ml / 1000}л`}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </Card>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/WeekKcalChart.tsx
+++ b/apps/mobile/src/modules/nutrition/components/WeekKcalChart.tsx
@@ -1,0 +1,65 @@
+/**
+ * 7-денна mini-bar-chart ккал. Mirror web `MiniBar` з
+ * `NutritionDashboard.tsx`. Сегмент для "сьогодні" підсвічується
+ * bg-nutrition full, інші — bg-nutrition/30.
+ */
+import { Text, View } from "react-native";
+
+import type { MacrosRow } from "@sergeant/nutrition-domain";
+
+const DAY_LABELS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"] as const;
+const CHART_HEIGHT = 48;
+
+export interface WeekKcalChartProps {
+  rows: MacrosRow[];
+  targetKcal: number;
+  todayIso: string;
+}
+
+export function WeekKcalChart({
+  rows,
+  targetKcal,
+  todayIso,
+}: WeekKcalChartProps) {
+  const max = Math.max(targetKcal || 1, ...rows.map((r) => r.kcal || 0));
+
+  return (
+    <View className="flex-row items-end gap-1 h-16">
+      {rows.map((r) => {
+        const ratio = max > 0 ? r.kcal / max : 0;
+        const height = Math.max(3, ratio * CHART_HEIGHT);
+        const isToday = r.date === todayIso;
+        const [y, m, d] = r.date.split("-").map(Number);
+        const dt = new Date(y, m - 1, d);
+        const label = DAY_LABELS[(dt.getDay() + 6) % 7];
+        return (
+          <View key={r.date} className="flex-1 items-center gap-0.5">
+            <View
+              style={{ height: CHART_HEIGHT, justifyContent: "flex-end" }}
+              className="w-full items-center"
+            >
+              <View
+                style={{
+                  height,
+                  width: 18,
+                  borderTopLeftRadius: 4,
+                  borderTopRightRadius: 4,
+                }}
+                className={isToday ? "bg-lime-500" : "bg-lime-500/30"}
+              />
+            </View>
+            <Text
+              className={
+                isToday
+                  ? "text-[9px] leading-none text-stone-900 font-bold"
+                  : "text-[9px] leading-none text-stone-400"
+              }
+            >
+              {label}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -1,0 +1,106 @@
+/**
+ * `useNutritionLog` — MMKV-backed React hook над журналом прийомів їжі
+ * для mobile. Mirror `apps/web/src/modules/nutrition/hooks/useNutritionLog.ts`
+ * але без photo-thumbnail-GC, query-invalidation і storage-error-banner
+ * (ті блоки специфічні для web або прилітають у пізніших PR-ах).
+ *
+ * Action-surface цього PR-а (PR-4 — read-only UI):
+ * - `log` + `selectedDate` + `setSelectedDate`
+ * - мутатори (`addMeal`, `removeMeal`, `updateMeal`) повертають void;
+ *   після мутації викликається `enqueueChange` для cloud-sync push.
+ *
+ * AddMealSheet / PhotoAnalyze / AI-фічі — PR-5+.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  addLogEntry,
+  normalizeNutritionLog,
+  removeLogEntry,
+  updateLogEntry,
+  type Meal,
+  type NutritionLog,
+} from "@sergeant/nutrition-domain";
+import { STORAGE_KEYS, toLocalISODate } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+import { enqueueChange } from "@/sync/enqueue";
+
+import { loadNutritionLog, saveNutritionLog } from "../lib/nutritionStore";
+
+export interface UseNutritionLogResult {
+  nutritionLog: NutritionLog;
+  selectedDate: string;
+  setSelectedDate: (date: string) => void;
+  addMeal: (date: string, meal: Partial<Meal>) => void;
+  removeMeal: (date: string, id: string) => void;
+  updateMeal: (date: string, meal: Partial<Meal>) => void;
+  /** Примусове перечитання з MMKV (після фонового sync-pull). */
+  refresh: () => void;
+}
+
+export function useNutritionLog(): UseNutritionLogResult {
+  const [nutritionLog, setNutritionLog] = useState<NutritionLog>(() =>
+    loadNutritionLog(),
+  );
+  const [selectedDate, setSelectedDate] = useState<string>(() =>
+    toLocalISODate(new Date()),
+  );
+
+  // Тримаємо в ref найсвіжіший стан, щоб обробник підписки MMKV
+  // порівнював із фактичним значенням, а не з snapshot-ом замикання.
+  const logRef = useRef(nutritionLog);
+  useEffect(() => {
+    logRef.current = nutritionLog;
+  }, [nutritionLog]);
+
+  const refresh = useCallback(() => {
+    setNutritionLog(loadNutritionLog());
+  }, []);
+
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey === STORAGE_KEYS.NUTRITION_LOG) refresh();
+    });
+    return () => sub.remove();
+  }, [refresh]);
+
+  const commit = useCallback((next: NutritionLog) => {
+    const normalized = normalizeNutritionLog(next);
+    setNutritionLog(normalized);
+    saveNutritionLog(normalized);
+    enqueueChange(STORAGE_KEYS.NUTRITION_LOG);
+  }, []);
+
+  const addMeal = useCallback(
+    (date: string, meal: Partial<Meal>) => {
+      commit(addLogEntry(logRef.current, date, meal));
+    },
+    [commit],
+  );
+
+  const removeMeal = useCallback(
+    (date: string, id: string) => {
+      commit(removeLogEntry(logRef.current, date, id));
+    },
+    [commit],
+  );
+
+  const updateMeal = useCallback(
+    (date: string, meal: Partial<Meal>) => {
+      commit(updateLogEntry(logRef.current, date, meal));
+    },
+    [commit],
+  );
+
+  return {
+    nutritionLog,
+    selectedDate,
+    setSelectedDate,
+    addMeal,
+    removeMeal,
+    updateMeal,
+    refresh,
+  };
+}

--- a/apps/mobile/src/modules/nutrition/hooks/useNutritionPrefs.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useNutritionPrefs.ts
@@ -1,0 +1,65 @@
+/**
+ * `useNutritionPrefs` — MMKV-backed read/write hook для nutrition prefs
+ * (денні цілі КБЖВ, водна ціль, reminder-опції).
+ *
+ * PR-4 використовує це лише для читання (денні targets у Dashboard).
+ * Запис prefs-форми через реальний settings-екран прилітає з PR-7/8.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { type NutritionPrefs } from "@sergeant/nutrition-domain";
+import { STORAGE_KEYS } from "@sergeant/shared";
+
+import { _getMMKVInstance } from "@/lib/storage";
+import { enqueueChange } from "@/sync/enqueue";
+
+import { loadNutritionPrefs, saveNutritionPrefs } from "../lib/nutritionStore";
+
+export interface UseNutritionPrefsResult {
+  prefs: NutritionPrefs;
+  setPrefs: (next: NutritionPrefs) => void;
+  updatePrefs: (patch: Partial<NutritionPrefs>) => void;
+}
+
+export function useNutritionPrefs(): UseNutritionPrefsResult {
+  const [prefs, setPrefsState] = useState<NutritionPrefs>(() =>
+    loadNutritionPrefs(),
+  );
+
+  const prefsRef = useRef(prefs);
+  useEffect(() => {
+    prefsRef.current = prefs;
+  }, [prefs]);
+
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey === STORAGE_KEYS.NUTRITION_PREFS) {
+        setPrefsState(loadNutritionPrefs());
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  const commit = useCallback((next: NutritionPrefs) => {
+    setPrefsState(next);
+    saveNutritionPrefs(next);
+    enqueueChange(STORAGE_KEYS.NUTRITION_PREFS);
+  }, []);
+
+  const setPrefs = useCallback(
+    (next: NutritionPrefs) => {
+      commit(next);
+    },
+    [commit],
+  );
+
+  const updatePrefs = useCallback(
+    (patch: Partial<NutritionPrefs>) => {
+      commit({ ...prefsRef.current, ...patch });
+    },
+    [commit],
+  );
+
+  return { prefs, setPrefs, updatePrefs };
+}

--- a/apps/mobile/src/modules/nutrition/hooks/useWaterTracker.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useWaterTracker.ts
@@ -1,0 +1,60 @@
+/**
+ * `useWaterTracker` — MMKV-backed React hook для щоденного трекера води.
+ * Mirror `apps/web/src/modules/nutrition/hooks/useWaterTracker.ts`.
+ *
+ * Вся чиста логіка (`addWaterMl` / `getTodayWaterMl` / `resetTodayWater`)
+ * живе у `@sergeant/nutrition-domain` → web і native отримують ту саму
+ * семантику.
+ *
+ * Water key не входить до `SYNC_MODULES.nutrition` на mobile, бо web
+ * історично також не синкає воду (див.
+ * `apps/web/src/core/cloudSync/config.ts`). Це свідомо — вода суто
+ * локальний трекер. Якщо передумаємо, достатньо буде додати
+ * `WATER_LOG_KEY` у конфіг і викликати `enqueueChange(WATER_LOG_KEY)`
+ * після commit.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  addWaterMl,
+  getTodayWaterMl,
+  resetTodayWater,
+  type WaterLog,
+} from "@sergeant/nutrition-domain";
+
+import { loadWaterLog, saveWaterLog } from "../lib/nutritionStore";
+
+export interface UseWaterTrackerResult {
+  todayMl: number;
+  add: (ml: number) => void;
+  reset: () => void;
+}
+
+export function useWaterTracker(): UseWaterTrackerResult {
+  const [log, setLog] = useState<WaterLog>(() => loadWaterLog());
+
+  const logRef = useRef(log);
+  useEffect(() => {
+    logRef.current = log;
+  }, [log]);
+
+  const commit = useCallback((next: WaterLog) => {
+    setLog(next);
+    saveWaterLog(next);
+  }, []);
+
+  const todayMl = getTodayWaterMl(log);
+
+  const add = useCallback(
+    (ml: number) => {
+      commit(addWaterMl(logRef.current, ml));
+    },
+    [commit],
+  );
+
+  const reset = useCallback(() => {
+    commit(resetTodayWater(logRef.current));
+  }, [commit]);
+
+  return { todayMl, add, reset };
+}

--- a/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
@@ -1,0 +1,178 @@
+/**
+ * Nutrition Dashboard (Сьогодні) — mobile
+ * Mirror `apps/web/src/modules/nutrition/components/NutritionDashboard.tsx`
+ *
+ * PR-4 рендерить:
+ *  - "Сьогодні" Card: лічильник прийомів + 4 macro-ring / 4 macro-tile
+ *  - "Тиждень · ккал" Card: 7-денна mini-bar-chart
+ *  - WaterTrackerCard
+ *
+ * Не входить у PR-4 (відкладено):
+ *  - Кнопка "+ Додати" (веде в AddMealSheet → PR-5)
+ *  - Кнопка "Налаштувати денні цілі КБЖВ" (settings screen → PR-7)
+ *  - AI-підказка дня (PR-8)
+ */
+import { useMemo } from "react";
+import { ScrollView, Text, View } from "react-native";
+
+import {
+  getDayMacros,
+  getDaySummary,
+  getMacrosForDateRange,
+  type NutritionPrefs,
+} from "@sergeant/nutrition-domain";
+import { toLocalISODate, type Macros } from "@sergeant/shared";
+
+import { Card } from "@/components/ui/Card";
+
+import { MacroRing } from "../components/MacroRing";
+import { WaterTrackerCard } from "../components/WaterTrackerCard";
+import { WeekKcalChart } from "../components/WeekKcalChart";
+import { useNutritionLog } from "../hooks/useNutritionLog";
+import { useNutritionPrefs } from "../hooks/useNutritionPrefs";
+
+type MacroKey = "kcal" | "protein_g" | "fat_g" | "carbs_g";
+
+interface MacroDef {
+  key: MacroKey;
+  label: string;
+  color: string;
+  prefKey: keyof NutritionPrefs;
+  unit: string;
+}
+
+const MACRO_DEFS: readonly MacroDef[] = [
+  {
+    key: "kcal",
+    label: "Ккал",
+    color: "#f97316",
+    prefKey: "dailyTargetKcal",
+    unit: "",
+  },
+  {
+    key: "protein_g",
+    label: "Білки",
+    color: "#3b82f6",
+    prefKey: "dailyTargetProtein_g",
+    unit: "г",
+  },
+  {
+    key: "fat_g",
+    label: "Жири",
+    color: "#eab308",
+    prefKey: "dailyTargetFat_g",
+    unit: "г",
+  },
+  {
+    key: "carbs_g",
+    label: "Вуглев.",
+    color: "#22c55e",
+    prefKey: "dailyTargetCarbs_g",
+    unit: "г",
+  },
+] as const;
+
+function mealCountLabel(count: number): string {
+  if (count === 1) return "прийом";
+  if (count >= 2 && count <= 4) return "прийоми";
+  return "прийомів";
+}
+
+export interface DashboardProps {
+  testID?: string;
+}
+
+export function Dashboard({ testID }: DashboardProps) {
+  const { nutritionLog } = useNutritionLog();
+  const { prefs } = useNutritionPrefs();
+
+  const today = toLocalISODate(new Date());
+
+  const macros: Macros = useMemo(
+    () => getDayMacros(nutritionLog, today),
+    [nutritionLog, today],
+  );
+  const summary = useMemo(
+    () => getDaySummary(nutritionLog, today),
+    [nutritionLog, today],
+  );
+  const weekRows = useMemo(
+    () => getMacrosForDateRange(nutritionLog, today, 7),
+    [nutritionLog, today],
+  );
+
+  const hasTargets =
+    (prefs.dailyTargetKcal || 0) > 0 ||
+    (prefs.dailyTargetProtein_g || 0) > 0 ||
+    (prefs.dailyTargetFat_g || 0) > 0 ||
+    (prefs.dailyTargetCarbs_g || 0) > 0;
+
+  return (
+    <ScrollView
+      testID={testID}
+      className="flex-1 bg-cream-50"
+      contentContainerStyle={{ padding: 16, gap: 12 }}
+    >
+      <Card testID="nutrition-today-card">
+        <View className="flex-row items-center justify-between mb-3">
+          <View>
+            <Text className="text-sm font-semibold text-stone-900 leading-none">
+              Сьогодні
+            </Text>
+            <Text className="text-xs text-stone-500 mt-1">
+              {summary.mealCount} {mealCountLabel(summary.mealCount)} їжі
+            </Text>
+          </View>
+        </View>
+
+        {hasTargets ? (
+          <View className="flex-row justify-around">
+            {MACRO_DEFS.map((m) => (
+              <MacroRing
+                key={m.key}
+                value={macros[m.key] || 0}
+                target={Number(prefs[m.prefKey]) || 0}
+                color={m.color}
+                label={m.label}
+                unit={m.unit}
+              />
+            ))}
+          </View>
+        ) : (
+          <View className="flex-row gap-2">
+            {MACRO_DEFS.map((m) => (
+              <View
+                key={m.key}
+                className="flex-1 rounded-xl border border-lime-500/20 bg-lime-500/10 px-2 py-2.5 items-center"
+              >
+                <Text className="text-[10px] font-bold uppercase text-lime-700 leading-none mb-1">
+                  {m.label}
+                </Text>
+                <Text className="text-sm font-extrabold text-stone-900 leading-none">
+                  {Math.round(macros[m.key] || 0)}
+                  {m.unit ? ` ${m.unit}` : ""}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </Card>
+
+      <Card testID="nutrition-week-card">
+        <Text className="text-sm font-semibold text-stone-900 mb-2 leading-none">
+          Тиждень · ккал
+        </Text>
+        <WeekKcalChart
+          rows={weekRows}
+          targetKcal={prefs.dailyTargetKcal || 0}
+          todayIso={today}
+        />
+      </Card>
+
+      <WaterTrackerCard
+        goalMl={prefs.waterGoalMl ?? 2000}
+        testID="nutrition-water-card"
+      />
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/pages/Log.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Log.tsx
@@ -1,0 +1,233 @@
+/**
+ * Nutrition Log (Журнал) — mobile
+ *
+ * Читає MMKV-nutrition-log та показує прийоми їжі за вибрану дату
+ * (today за замовчуванням). Стрілки ← / → для переключення днів.
+ * Рядок прийому показує: тип (емодзі), назву, кількість ккал і
+ * макроси б/ж/в.
+ *
+ * PR-4 — read-only. AddMealSheet, ItemEditSheet, duplicate-previous-day
+ * прийдуть з PR-5. Swipe-to-delete і long-press-edit рендеряться, але
+ * викликають no-op toast до моменту приземлення PR-5 (TODO-маркер
+ * в onLongPress).
+ */
+import { useMemo } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
+
+import {
+  addDaysISODate,
+  getDayMacros,
+  labelForMealType,
+  MEAL_META,
+  MEAL_ORDER,
+  type Meal,
+  type NutritionLog,
+} from "@sergeant/nutrition-domain";
+import { toLocalISODate } from "@sergeant/shared";
+
+import { Card } from "@/components/ui/Card";
+
+import { useNutritionLog } from "../hooks/useNutritionLog";
+
+function formatIsoDate(iso: string): string {
+  const today = toLocalISODate(new Date());
+  const yesterday = addDaysISODate(today, -1);
+  const tomorrow = addDaysISODate(today, 1);
+  if (iso === today) return "Сьогодні";
+  if (iso === yesterday) return "Вчора";
+  if (iso === tomorrow) return "Завтра";
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  const months = [
+    "січ",
+    "лют",
+    "бер",
+    "квіт",
+    "трав",
+    "черв",
+    "лип",
+    "сер",
+    "вер",
+    "жовт",
+    "лист",
+    "груд",
+  ];
+  return `${dt.getDate()} ${months[dt.getMonth()]}`;
+}
+
+interface MealRow {
+  meal: Meal;
+  emoji: string;
+  typeLabel: string;
+}
+
+function getRowsForDate(log: NutritionLog, date: string): MealRow[] {
+  const day = log?.[date];
+  if (!day || !Array.isArray(day.meals)) return [];
+  const copy: Meal[] = day.meals.slice();
+  copy.sort((a, b) => {
+    const ai = MEAL_ORDER.indexOf(a.mealType);
+    const bi = MEAL_ORDER.indexOf(b.mealType);
+    if (ai !== bi) return ai - bi;
+    return (a.time || "").localeCompare(b.time || "");
+  });
+  return copy.map((meal) => ({
+    meal,
+    emoji: MEAL_META[meal.mealType]?.emoji ?? "🍽️",
+    typeLabel: labelForMealType(meal.mealType),
+  }));
+}
+
+export interface LogProps {
+  testID?: string;
+}
+
+export function Log({ testID }: LogProps) {
+  const { nutritionLog, selectedDate, setSelectedDate } = useNutritionLog();
+
+  const rows = useMemo(
+    () => getRowsForDate(nutritionLog, selectedDate),
+    [nutritionLog, selectedDate],
+  );
+
+  const macros = useMemo(
+    () => getDayMacros(nutritionLog, selectedDate),
+    [nutritionLog, selectedDate],
+  );
+
+  const goPrev = () => setSelectedDate(addDaysISODate(selectedDate, -1));
+  const goNext = () => setSelectedDate(addDaysISODate(selectedDate, 1));
+  const goToday = () => setSelectedDate(toLocalISODate(new Date()));
+
+  const isToday = selectedDate === toLocalISODate(new Date());
+
+  return (
+    <View testID={testID} className="flex-1 bg-cream-50">
+      {/* Date switcher */}
+      <View className="flex-row items-center justify-between px-4 pt-3 pb-2">
+        <Pressable
+          onPress={goPrev}
+          accessibilityRole="button"
+          accessibilityLabel="Попередній день"
+          testID="nutrition-log-prev-day"
+          className="w-10 h-10 items-center justify-center rounded-full"
+        >
+          <Text className="text-xl text-stone-600">‹</Text>
+        </Pressable>
+        <Pressable
+          onPress={goToday}
+          accessibilityRole="button"
+          accessibilityLabel="Повернутись на сьогодні"
+          testID="nutrition-log-today"
+          className="flex-1 items-center"
+        >
+          <Text className="text-sm font-bold text-stone-900">
+            {formatIsoDate(selectedDate)}
+          </Text>
+          {!isToday ? (
+            <Text className="text-[10px] text-stone-400 mt-0.5">
+              {selectedDate}
+            </Text>
+          ) : null}
+        </Pressable>
+        <Pressable
+          onPress={goNext}
+          accessibilityRole="button"
+          accessibilityLabel="Наступний день"
+          testID="nutrition-log-next-day"
+          className="w-10 h-10 items-center justify-center rounded-full"
+        >
+          <Text className="text-xl text-stone-600">›</Text>
+        </Pressable>
+      </View>
+
+      {/* Macro summary */}
+      <View className="px-4 pb-3">
+        <Card>
+          <View className="flex-row justify-around py-1">
+            <View className="items-center">
+              <Text className="text-[10px] font-bold uppercase text-stone-500">
+                Ккал
+              </Text>
+              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+                {Math.round(macros.kcal)}
+              </Text>
+            </View>
+            <View className="items-center">
+              <Text className="text-[10px] font-bold uppercase text-stone-500">
+                Б
+              </Text>
+              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+                {Math.round(macros.protein_g)} г
+              </Text>
+            </View>
+            <View className="items-center">
+              <Text className="text-[10px] font-bold uppercase text-stone-500">
+                Ж
+              </Text>
+              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+                {Math.round(macros.fat_g)} г
+              </Text>
+            </View>
+            <View className="items-center">
+              <Text className="text-[10px] font-bold uppercase text-stone-500">
+                В
+              </Text>
+              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+                {Math.round(macros.carbs_g)} г
+              </Text>
+            </View>
+          </View>
+        </Card>
+      </View>
+
+      {/* Meals list */}
+      {rows.length === 0 ? (
+        <View className="flex-1 items-center justify-center px-6 pb-20">
+          <Text className="text-5xl mb-3">🍽️</Text>
+          <Text className="text-sm font-semibold text-stone-900 text-center">
+            Немає записів за цей день
+          </Text>
+          <Text className="text-xs text-stone-500 text-center mt-1">
+            Додавання прийомів їжі з&apos;явиться в PR-5 (AddMealSheet).
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={rows}
+          keyExtractor={(r) => r.meal.id}
+          contentContainerStyle={{
+            paddingHorizontal: 16,
+            paddingBottom: 24,
+            gap: 8,
+          }}
+          renderItem={({ item }) => (
+            <Card testID={`nutrition-log-meal-${item.meal.id}`}>
+              <View className="flex-row items-start gap-3">
+                <Text className="text-2xl leading-none">{item.emoji}</Text>
+                <View className="flex-1">
+                  <Text className="text-[10px] font-bold uppercase text-stone-500 leading-none">
+                    {item.typeLabel}
+                  </Text>
+                  <Text className="text-sm font-semibold text-stone-900 mt-1">
+                    {item.meal.name || "Без назви"}
+                  </Text>
+                  <View className="flex-row gap-3 mt-2">
+                    <Text className="text-xs text-stone-500">
+                      {Math.round(item.meal.macros?.kcal || 0)} ккал
+                    </Text>
+                    <Text className="text-xs text-stone-400">
+                      Б{Math.round(item.meal.macros?.protein_g || 0)} · Ж
+                      {Math.round(item.meal.macros?.fat_g || 0)} · В
+                      {Math.round(item.meal.macros?.carbs_g || 0)}
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </Card>
+          )}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/pages/Water.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Water.tsx
@@ -1,0 +1,42 @@
+/**
+ * Water tab сторінка — обгортка над `WaterTrackerCard` з отриманням
+ * `goalMl` з MMKV-prefs. Відповідник web-варіанта, де WaterTrackerCard
+ * рендериться в Dashboard-секції — на mobile ми дублюємо його ж
+ * окремою вкладкою, щоб швидкий доступ з bottom-nav був натиском одного
+ * таба.
+ */
+import { ScrollView, Text, View } from "react-native";
+
+import { useNutritionPrefs } from "../hooks/useNutritionPrefs";
+import { WaterTrackerCard } from "../components/WaterTrackerCard";
+
+export interface WaterProps {
+  testID?: string;
+}
+
+export function Water({ testID }: WaterProps) {
+  const { prefs } = useNutritionPrefs();
+  const goalMl = prefs.waterGoalMl ?? 2000;
+
+  return (
+    <ScrollView
+      testID={testID}
+      className="flex-1 bg-cream-50"
+      contentContainerStyle={{ padding: 16, gap: 12 }}
+    >
+      <View>
+        <Text className="text-xs text-stone-500 mb-1 leading-none">
+          Щоденний трекер
+        </Text>
+        <Text className="text-lg font-bold text-stone-900 leading-none">
+          Вода
+        </Text>
+      </View>
+      <WaterTrackerCard goalMl={goalMl} testID="nutrition-water-card" />
+      <Text className="text-[11px] text-stone-400 leading-snug">
+        Підрахунок скидається опівночі локального часу. Зміна денної цілі
+        доступна у налаштуваннях харчування — з&apos;явиться в PR-7.
+      </Text>
+    </ScrollView>
+  );
+}

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
   LAST_MODULE: "hub_last_module",
   ROUTINE: "hub_routine_v1",
   ROUTINE_MAIN_TAB: "hub_routine_main_tab_v1",
+  NUTRITION_MAIN_TAB: "hub_nutrition_main_tab_v1",
   ONBOARDING_DONE: "hub_onboarding_done_v1",
   DASHBOARD_ORDER: "hub_dashboard_order_v1",
   HUB_PREFS: "hub_prefs_v1",


### PR DESCRIPTION
## Summary

**Base: #536** (Phase 7 / PR 3). Після мержу PR-3 ця гілка автоматично перебазується на `main`.

Четвертий крок **Phase 7**. `ModuleStub` у табі `(tabs)/nutrition` замінено на реальний `NutritionApp` — перший UI-cut модуля Харчування на native. Вся бізнес-логіка (`getDayMacros`, `getDaySummary`, `getMacrosForDateRange`, `addWaterMl`, `MEAL_META/ORDER`, `labelForMealType`) спільна з web через `@sergeant/nutrition-domain` — зміни у цих хелперах автоматично прилітають на обидві платформи.

**Що всередині:**

Shell + навігація:
- `NutritionApp.tsx` — `ModuleErrorBoundary` (moduleName=`"Харчування"`) + 3-табовий bottom-nav. Активна вкладка зберігається в MMKV під новим ключем `STORAGE_KEYS.NUTRITION_MAIN_TAB` як raw-string (web parity з `ROUTINE_MAIN_TAB`).
- `components/NutritionBottomNav.tsx` — три таби: «Сьогодні» / «Журнал» / «Вода». Патерн 1:1 з `RoutineBottomNav` (44×44 tap-targets, a11y `tablist/tab`, `hapticTap`).

Вкладка «Сьогодні» (`pages/Dashboard.tsx`):
- Card «Сьогодні» з лічильником прийомів (коректна pluralization: прийом / прийоми / прийомів).
- 4 `MacroRing`-и (`components/MacroRing.tsx`, react-native-svg) коли хоч один `dailyTarget*` > 0. Інакше — 4 плитки з поточними значеннями.
- Card «Тиждень · ккал» з 7-денним mini-bar-chart (`components/WeekKcalChart.tsx`).
- `WaterTrackerCard` з `goalMl` з prefs.

Вкладка «Журнал» (`pages/Log.tsx`):
- Стрілки ← / → для переключення дат + «Сьогодні»/«Вчора»/«Завтра» labels.
- Macro-summary Card (Ккал / Б / Ж / В).
- `FlatList` прийомів їжі, відсортованих за `MEAL_ORDER` → `meal.time`.
- Empty-state коли немає записів (копі пояснює, що додавання буде у PR-5).

Вкладка «Вода» (`pages/Water.tsx`): дубль `WaterTrackerCard` як окремий швидкий доступ з bottom-nav.

Хуки:
- `hooks/useNutritionLog.ts` — MMKV-backed state з listener на `NUTRITION_LOG`, `enqueueChange` після мутацій (cloud-sync wiring готове до PR-5).
- `hooks/useWaterTracker.ts` — mirror web shape (`todayMl` / `add` / `reset`).
- `hooks/useNutritionPrefs.ts` — MMKV listener на `NUTRITION_PREFS`, `enqueueChange` після updates.

Shared: `STORAGE_KEYS.NUTRITION_MAIN_TAB = "hub_nutrition_main_tab_v1"`.

Тести: `NutritionApp.test.tsx` — 6 тестів (default tab, switch до Log/Water через testID, MMKV persist, picks persisted tab, fallback на malformed).

**Що НЕ входить у PR-4:** AddMealSheet / ItemEditSheet → PR-5. Barcode scanner → PR-6. Pantry / Shopping List → PR-7. AI-фічі → PR-8. Reminders / cloud backup → PR-9.

## Review & Testing Checklist for Human

Ризик: **🟡 medium** — вперше реальний UI у модулі Харчування на native, перша поверхня з MMKV-seeded macro-ring SVG і FlatList.

- [ ] Візуально порівняти Dashboard з web-еквівалентом (`apps/web/src/modules/nutrition/components/NutritionDashboard.tsx`) — 4 рінги та bar-chart повинні виглядати схоже з тими самими кольорами.
- [ ] Empty-state Журналу при чистому MMKV: «Немає записів за цей день» + пояснення про PR-5.
- [ ] Double-tap reset води: перший тап показує «Скинути?» (2.5s таймер), другий фактично скидає.
- [ ] Активна вкладка зберігається у MMKV і відновлюється після холодного старту.

### Test plan

```
pnpm install
pnpm turbo run test typecheck lint \
  --filter @sergeant/nutrition-domain \
  --filter @sergeant/mobile \
  --filter @sergeant/shared
```

У мене: 9/9 turbo tasks green, +6 нових тестів `NutritionApp`, +20 тестів PR-3 `nutritionStore`, не зламано існуючі 544 mobile / 617 web / 20 domain.

### Notes

- Після мержу PR-3 гілку треба буде ребейзнути на main (повинно пройти без конфліктів — PR-4 не чіпає файли з PR-3).
- Запропоную протестувати Dashboard/Log/Water на емуляторі після того, як CI стане зелений — це перший реальний UI-cut модуля Харчування на native.

Link to Devin session: https://app.devin.ai/sessions/4705a3c258bd489aaa1be96776dd2321
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
