### PR TITLE
feat(finyk): declutter ManualExpenseSheet — merge amount chips, inline merchant hints, collapse categories

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useId, useMemo } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Label } from "@shared/components/ui/FormField";
-import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import {
@@ -68,26 +67,27 @@ function stripEmoji(label) {
 }
 
 // Amount suggestion pills. Defaults give a first-run user sane round
-// values; once the user has spending history we show personalised
-// «Часте» amounts (from top merchants’ average spend) separately
-// from the «Швидко» round-number defaults, so the user can tell
-// which suggestion is based on their own history and which is a
-// generic shortcut.
+// values; personalised «часті» amounts (from top merchants’ average
+// spend) are merged into the same row and rendered first, marked with
+// a small dot so the user can still tell which suggestion is based on
+// their own history. One row instead of two separately-labelled rows
+// cuts visual chrome without hiding the personalised shortcuts.
 const DEFAULT_AMOUNTS = [50, 100, 200, 500];
+const MAX_AMOUNT_CHIPS = 6;
 
 function buildAmountSuggestions(frequentMerchants) {
-  const frequent = [];
+  const frequentRaw = [];
   for (const m of frequentMerchants || []) {
     if (!m || typeof m.total !== "number" || !m.count) continue;
     const avg = Math.round(m.total / m.count);
-    if (avg > 0 && !frequent.includes(avg)) frequent.push(avg);
-    if (frequent.length >= 3) break;
+    if (avg > 0 && !frequentRaw.includes(avg)) frequentRaw.push(avg);
+    if (frequentRaw.length >= 3) break;
   }
-  const quick = DEFAULT_AMOUNTS.filter((v) => !frequent.includes(v)).slice(
-    0,
-    4,
+  const frequent = frequentRaw.map((v) => ({ value: v, personal: true }));
+  const quick = DEFAULT_AMOUNTS.filter((v) => !frequentRaw.includes(v)).map(
+    (v) => ({ value: v, personal: false }),
   );
-  return { frequent, quick };
+  return [...frequent, ...quick].slice(0, MAX_AMOUNT_CHIPS);
 }
 
 // Сортує доступні підписи категорій за персональною частотою, зберігаючи
@@ -203,11 +203,32 @@ export function ManualExpenseSheet({
     [frequentCategories],
   );
 
-  const { frequent: frequentAmounts, quick: quickAmounts } = useMemo(
+  // Top-N категорії для згорнутого стану. Якщо обрана категорія випадає
+  // за межі top-N — підтягуємо її у видимий ряд, щоб активний чип завжди
+  // залишався видимим і не плутав користувача при відкритті аркуша.
+  const CATEGORY_COLLAPSED_COUNT = 6;
+  const [categoriesExpanded, setCategoriesExpanded] = useState(false);
+  const visibleCategories = useMemo(() => {
+    if (categoriesExpanded) return sortedCategories;
+    const base = sortedCategories.slice(0, CATEGORY_COLLAPSED_COUNT);
+    if (form.category && !base.includes(form.category)) {
+      return [form.category, ...base].slice(0, CATEGORY_COLLAPSED_COUNT);
+    }
+    return base;
+  }, [sortedCategories, categoriesExpanded, form.category]);
+  const hasHiddenCategories =
+    sortedCategories.length > CATEGORY_COLLAPSED_COUNT;
+
+  const amountSuggestions = useMemo(
     () => buildAmountSuggestions(frequentMerchants),
     [frequentMerchants],
   );
-  // Ховаємо зі списку пропозицій мерчанта, якого вже введено у полі description.
+
+  // Список мерчант-пропозицій, що рендериться інлайн під полем «Назва»
+  // замість окремої секції «Нещодавнє». Ховаємо мерчанта, якого вже
+  // введено як опис. Видимість регулюється через `showMerchantHints`
+  // нижче — показуємо лише поки поле порожнє або у фокусі, щоб не
+  // перевантажувати аркуш, коли користувач уже обрав назву.
   const merchantSuggestions = useMemo(() => {
     if (!frequentMerchants.length) return [];
     const currentKey = (form.description || "")
@@ -217,6 +238,10 @@ export function ManualExpenseSheet({
       .filter((m) => m.name && m.name.toLocaleLowerCase("uk-UA") !== currentKey)
       .slice(0, 5);
   }, [frequentMerchants, form.description]);
+  const [descFocused, setDescFocused] = useState(false);
+  const showMerchantHints =
+    merchantSuggestions.length > 0 &&
+    (descFocused || form.description.trim() === "");
 
   if (!open) return null;
 
@@ -276,54 +301,39 @@ export function ManualExpenseSheet({
         <div className="flex gap-2 items-end">
           <div className="flex-1">
             <Label htmlFor={amountId}>Сума ₴</Label>
-            {(frequentAmounts.length > 0 || quickAmounts.length > 0) && (
-              <div className="space-y-1.5 mb-2">
-                {frequentAmounts.length > 0 && (
-                  <div
-                    className="flex flex-wrap items-center gap-1.5"
-                    role="group"
-                    aria-label="Часті суми"
+            {amountSuggestions.length > 0 && (
+              <div
+                className="flex flex-wrap items-center gap-1.5 mb-2"
+                role="group"
+                aria-label="Швидкі суми"
+              >
+                {amountSuggestions.map(({ value, personal }) => (
+                  <button
+                    key={`${personal ? "f" : "q"}-${value}`}
+                    type="button"
+                    onClick={() =>
+                      setForm((f) => ({ ...f, amount: String(value) }))
+                    }
+                    className={
+                      personal
+                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
+                        : "px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
+                    }
+                    aria-label={
+                      personal
+                        ? `${value.toLocaleString("uk-UA")} ₴ — часта сума`
+                        : `${value.toLocaleString("uk-UA")} ₴`
+                    }
                   >
-                    <SectionHeading as="span" size="xs" tone="subtle">
-                      Часте
-                    </SectionHeading>
-                    {frequentAmounts.map((v) => (
-                      <button
-                        key={`f-${v}`}
-                        type="button"
-                        onClick={() =>
-                          setForm((f) => ({ ...f, amount: String(v) }))
-                        }
-                        className="px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
-                      >
-                        {v.toLocaleString("uk-UA")} ₴
-                      </button>
-                    ))}
-                  </div>
-                )}
-                {quickAmounts.length > 0 && (
-                  <div
-                    className="flex flex-wrap items-center gap-1.5"
-                    role="group"
-                    aria-label="Швидкі суми"
-                  >
-                    <SectionHeading as="span" size="xs" tone="subtle">
-                      Швидко
-                    </SectionHeading>
-                    {quickAmounts.map((v) => (
-                      <button
-                        key={`q-${v}`}
-                        type="button"
-                        onClick={() =>
-                          setForm((f) => ({ ...f, amount: String(v) }))
-                        }
-                        className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
-                      >
-                        {v.toLocaleString("uk-UA")} ₴
-                      </button>
-                    ))}
-                  </div>
-                )}
+                    {personal ? (
+                      <span
+                        aria-hidden
+                        className="w-1.5 h-1.5 rounded-full bg-emerald-500"
+                      />
+                    ) : null}
+                    {value.toLocaleString("uk-UA")} ₴
+                  </button>
+                ))}
               </div>
             )}
             <Input
@@ -381,7 +391,47 @@ export function ManualExpenseSheet({
             onChange={(e) =>
               setForm((f) => ({ ...f, description: e.target.value }))
             }
+            onFocus={() => setDescFocused(true)}
+            onBlur={() => setDescFocused(false)}
+            aria-controls={
+              showMerchantHints ? `${formId}-merchants` : undefined
+            }
+            aria-autocomplete="list"
           />
+          {showMerchantHints && (
+            <div
+              id={`${formId}-merchants`}
+              className="flex flex-wrap gap-1.5 mt-2"
+              role="group"
+              aria-label="Нещодавні мерчанти"
+            >
+              {merchantSuggestions.map((m) => (
+                <button
+                  key={m.key}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() =>
+                    setForm((f) => {
+                      const next = { ...f, description: m.name };
+                      // Якщо є впевнений підпис manual-категорії для цього
+                      // мерчанта — підставляємо його, щоб економити тапи.
+                      const suggested =
+                        m.suggestedManualCategory &&
+                        CATEGORIES.includes(m.suggestedManualCategory)
+                          ? m.suggestedManualCategory
+                          : null;
+                      if (suggested) next.category = suggested;
+                      return next;
+                    })
+                  }
+                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
+                  title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
+                >
+                  {m.name}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Date is "today" 95%+ of the time — the always-visible picker
@@ -409,47 +459,6 @@ export function ManualExpenseSheet({
           </button>
         )}
 
-        {merchantSuggestions.length > 0 && (
-          <div
-            className="flex flex-wrap gap-1.5 -mt-1"
-            role="group"
-            aria-label="Нещодавні мерчанти"
-          >
-            <SectionHeading
-              as="span"
-              size="xs"
-              tone="subtle"
-              className="w-full"
-            >
-              Нещодавнє
-            </SectionHeading>
-            {merchantSuggestions.map((m) => (
-              <button
-                key={m.key}
-                type="button"
-                onClick={() =>
-                  setForm((f) => {
-                    const next = { ...f, description: m.name };
-                    // Якщо є впевнений підпис manual-категорії для цього
-                    // мерчанта — підставляємо його, щоб економити тапи.
-                    const suggested =
-                      m.suggestedManualCategory &&
-                      CATEGORIES.includes(m.suggestedManualCategory)
-                        ? m.suggestedManualCategory
-                        : null;
-                    if (suggested) next.category = suggested;
-                    return next;
-                  })
-                }
-                className="px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors"
-                title={`${m.count} разів · ${m.total.toLocaleString("uk-UA")} ₴`}
-              >
-                {m.name}
-              </button>
-            ))}
-          </div>
-        )}
-
         <div>
           <div
             id={catLabelId}
@@ -463,9 +472,10 @@ export function ManualExpenseSheet({
             role="group"
             aria-labelledby={catLabelId}
           >
-            {sortedCategories.map((cat) => (
+            {visibleCategories.map((cat) => (
               <button
                 key={cat}
+                type="button"
                 onClick={() => setForm((f) => ({ ...f, category: cat }))}
                 className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 ease-smooth active:scale-95 ${
                   form.category === cat
@@ -476,6 +486,16 @@ export function ManualExpenseSheet({
                 {cat}
               </button>
             ))}
+            {hasHiddenCategories && (
+              <button
+                type="button"
+                onClick={() => setCategoriesExpanded((v) => !v)}
+                aria-expanded={categoriesExpanded}
+                className="px-3 py-1.5 rounded-full text-xs font-medium border border-line bg-panel text-muted hover:text-text hover:border-muted/50 hover:bg-panelHi transition-all duration-150 ease-smooth active:scale-95"
+              >
+                {categoriesExpanded ? "Менше ▴" : "Більше ▾"}
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Попередня версія арку­ша «Додати витрату» мала чотири окремі ряди чипсів (**ЧАСТЕ**, **ШВИДКО**, **НЕЩОДАВНЄ**, **КАТЕГОРІЯ**) плюс usual поля Сума/Назва — користувач скаржився, що це виглядає перенасиченим шумом. Цей PR вичищає structure без втрати функціональності:

### Зміни

1. **Одноразовий amount-ряд замість двох.** `Часте` + `Швидко` тепер рендеряться в один flex-wrap-ряд (до 6 чипсів), без окремих `SectionHeading`-лейблів. Персональні суми зберігають emerald-тонування та отримують додатковий маленький emerald-дот як візуальний маркер того, що значення побудовано з твоєї історії трат; решта чипсів — нейтральні панельні.
2. **Inline-autocomplete для нещодавніх мерчантів.** Секція «Нещодавнє» більше не займає власний ряд під датою. Чипси мерчантів з'являються прямо під інпутом «Назва» і показуються лише коли поле порожнє або у фокусі — тобто доки користувач насправді вибирає ім'я. Щойно description не пустий і фокус пішов, hints ховаються. У мерчант-кнопках `onMouseDown` запобігає передчасному blur перед кліком.
3. **Категорії top-6 + «Більше ▾».** Замість усіх 13 чипсів одразу показуються 6 найактуальніших (сортованих за персональною частотою). Якщо обрана категорія не потрапила в top-6, її примусово показано у видимому ряду, щоб активний стан не зникав. Чип «Більше ▾» розгортає повний список («Менше ▴» згортає назад). `aria-expanded` проставлено для screen reader'ів.
4. `SectionHeading` більше не імпортується (прибрано невикористаний імпорт).

### Що НЕ змінилось

- Логіка побудови `frequent` сум із `frequentMerchants` (ті самі top-3 середніх значень).
- Мапа категорій, legacy-upgrade, `sortCategoriesByFrequency` — без змін.
- `onSave` payload, валідація суми, підстановка категорії при виборі мерчанта — без змін.
- Поведінка поля «Дата» («Не сьогодні?» посилання) — без змін.

## Review & Testing Checklist for Human

- [ ] На мобільному (375-414 px) відкрити «Додати витрату» з Фінік → переконатися, що висота арку­ша відчутно менша, і суми не розбиті на дві підписані секції
- [ ] Тапнути у «Назва» → мають з'явитись чипси недавніх мерчантів; почати друкувати → чипси зникають; очистити поле → знову з'являються
- [ ] Клік по мерчант-чипу підставляє назву і не закриває хінти до того, як поле отримало value (на iOS Safari зокрема — через `onMouseDown preventDefault` логіка має працювати)
- [ ] Категорії: стандартно 6 чипсів + «Більше ▾»; після «Більше ▾» — усі 13 + «Менше ▴». Обрана категорія, якщо виходить за top-6, все одно видна у згорнутому стані
- [ ] Edit існуючої витрати: initial-категорія підтягується коректно, навіть якщо вона поза top-6

### Test plan

1. `pnpm --filter @sergeant/web dev` → Фінік → «+» (add expense) на 375 px viewport
2. Диктант: натиснути «Сказати» → сказати «500 гривень на каву» → мають підставитись сума та опис (логіка незмінна, просто перевірка що нічого не поламалось)
3. Edit: зайти в list of transactions → Edit → категорія підтягується; amount-чипи персональні + дефолтні без лейблів

### Notes

- `pnpm --filter @sergeant/web lint` ✅
- `pnpm --filter @sergeant/web typecheck` ✅
- Зміна **суто візуальна/UX**; модель даних, storage shape і analytics payload не торкаються.
- Mobile app (`apps/mobile/src/modules/finyk/components/ManualExpenseSheet.tsx`) — не зачіпав у цьому PR: там інший код і є unit-тести (`ManualExpenseSheet.test.tsx`). Якщо хочеш, зроблю окремий PR для мобілки за тим же патерном.


Link to Devin session: https://app.devin.ai/sessions/15aa55658b7e42d0b96a9b7b4ca9c171
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsible category list displays your most-used categories by default with an expand option to view all available categories
  * Merchant suggestions now appear inline below the expense name input field for quick selection

* **UI Improvements**
  * Amount suggestions consolidated into a single list with visual indicators marking personalized suggestions
  * Reorganized expense entry form layout for improved usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->