### PR TITLE
fix(finyk): reset categoriesExpanded + descFocused when ManualExpenseSheet reopens

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -191,6 +191,12 @@ export function ManualExpenseSheet({
         });
       }
       setError("");
+      // UI-only state (категорії розгорнуті / фокус у полі Назва) зберігається
+      // між відкриттями, бо компонент змонтований постійно (FinykApp тримає
+      // його як always-rendered). Скидаємо до дефолтів, щоб новий «Додати
+      // витрату» не успадковував стан попереднього відкриття.
+      setCategoriesExpanded(false);
+      setDescFocused(false);
     }
     // frequentCategories/initialCategory/initialDescription лише задають
     // стартовий стан при відкритті — навмисно не реагуємо на їхні


### PR DESCRIPTION
## Summary

Follow-up fix на Devin Review comment до PR #540: UI-only state-и `categoriesExpanded` і `descFocused`, додані в редизайні, не скидалися при повторному відкритті аркуша «Додати витрату».

`ManualExpenseSheet` рендериться завжди (родич `FinykApp` тримає його змонтованим); рядок `if (!open) return null` лише прибирає DOM, але не демонтує React-компонент, тож state-и переживають close → open цикл. `useEffect([open, initialExpense])` скидав `form` та `error`, а два нові UI-state-и — ні. У результаті, якщо користувач розгорнув категорії («Більше ▾»), закрив аркуш і відкрив знову для нової витрати — категорії залишалися розгорнутими, що не збігається з поведінкою інших станів форми.

### Fix
У тому ж `useEffect` блоці `if (open)` додано:
- `setCategoriesExpanded(false)` — новий аркуш відкривається у top-6 режимі.
- `setDescFocused(false)` — стартовий фокус-стан. (У нормі `onFocus`/`onBlur` інпута все одно перепишуть цей прапор, але reset усуває edge-кейси, коли аркуш закрився поки поле «Назва» було сфокусоване.)

Додано коментар, який пояснює, чому ці setter-и тут (бо компонент завжди змонтований).

## Review & Testing Checklist for Human

- [ ] Відкрити «Додати витрату» → натиснути «Більше ▾» → закрити аркуш → відкрити знову: категорії мають бути згорнуті (top-6 + «Більше ▾»)
- [ ] Відкрити аркуш, не торкаючись нічого — поведінка має бути ідентична до попередньої (сумі-чипи, merchant-hints, категорії top-6)
- [ ] Edit existing expense → потім Add new → категорія не «липне» від попереднього редагування

### Notes

- `pnpm --filter @sergeant/web lint` ✅
- `pnpm --filter @sergeant/web typecheck` ✅
- Purely state-reset fix; рендер/розмітку не чіпав.
- Devin Review також згадав ще 4 findings, але вони доступні лише на app.devin.ai/review і я не зміг їх витягти з цієї сесії. Якщо їх теж треба пофіксити — дай знати посилання/текст, зроблю окремим PR.


Link to Devin session: https://app.devin.ai/sessions/15aa55658b7e42d0b96a9b7b4ca9c171
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
