### PR TITLE
fix(finyk-analytics): виключити внутрішні перекази з пай-чарта Категорії

### DIFF
--- a/packages/finyk-domain/src/domain/selectors.test.ts
+++ b/packages/finyk-domain/src/domain/selectors.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
+  computeCategorySpendIndex,
   formatComparisonSummary,
+  getCategoryDistribution,
   getCurrentVsPreviousComparison,
+  getMonthlySummary,
 } from "./selectors";
 import type { Transaction } from "./types";
+import { INTERNAL_TRANSFER_ID } from "../constants";
 
 // Minimal tx factory — fills only the fields our aggregation actually reads
 // (`time`, `amount`, `id`) so tests stay readable and focused.
@@ -178,5 +182,51 @@ describe("formatComparisonSummary", () => {
   it("returns no_prev when comparison itself is null", () => {
     const summary = formatComparisonSummary(null);
     expect(summary.direction).toBe("no_prev");
+  });
+});
+
+describe("computeCategorySpendIndex — internal transfers", () => {
+  it("виключає tx, що повністю позначений внутрішнім переказом (через excludedTxIds)", () => {
+    const txs = [
+      tx("t1", "2025-03-05T10:00:00Z", -50000),
+      tx("t2", "2025-03-10T10:00:00Z", -20000),
+    ];
+    const index = computeCategorySpendIndex(txs, {
+      excludedTxIds: new Set(["t2"]),
+      txCategories: { t2: INTERNAL_TRANSFER_ID },
+    });
+    expect(index.totalSpent).toBe(500);
+    expect(index.catSpend[INTERNAL_TRANSFER_ID]).toBeUndefined();
+  });
+
+  it("ігнорує спліт-частку з internal_transfer, узгоджено з getTxStatAmount", () => {
+    const txs = [tx("t1", "2025-03-05T10:00:00Z", -50000)];
+    const splits = {
+      t1: [
+        { amount: 300, categoryId: "food" },
+        { amount: 200, categoryId: INTERNAL_TRANSFER_ID },
+      ],
+    };
+    const index = computeCategorySpendIndex(txs, { txSplits: splits });
+    expect(index.catSpend.food).toBe(300);
+    expect(index.catSpend[INTERNAL_TRANSFER_ID]).toBeUndefined();
+    expect(index.totalSpent).toBe(300);
+  });
+
+  it("пай 'Категорії' збігається з витратами з 'Підсумку місяця' для сплітів з переказом", () => {
+    const txs = [tx("t1", "2025-03-05T10:00:00Z", -50000)];
+    const splits = {
+      t1: [
+        { amount: 300, categoryId: "food" },
+        { amount: 200, categoryId: INTERNAL_TRANSFER_ID },
+      ],
+    };
+    const summary = getMonthlySummary(txs, { txSplits: splits });
+    const distribution = getCategoryDistribution(txs, { txSplits: splits });
+    const distTotal = distribution.reduce((s, c) => s + c.spent, 0);
+    expect(distTotal).toBe(summary.spent);
+    expect(
+      distribution.some((c) => c.categoryId === INTERNAL_TRANSFER_ID),
+    ).toBe(false);
   });
 });

--- a/packages/finyk-domain/src/domain/selectors.ts
+++ b/packages/finyk-domain/src/domain/selectors.ts
@@ -7,6 +7,7 @@ import {
   getCategory,
   resolveExpenseCategoryMeta,
 } from "../utils";
+import { INTERNAL_TRANSFER_ID } from "../constants";
 import type {
   AnalyticsResult,
   Category,
@@ -138,6 +139,10 @@ export function computeCategorySpendIndex(
     if (splits && splits.length > 0) {
       for (const s of splits) {
         if (!s.categoryId || !s.amount) continue;
+        // Внутрішні перекази не є витратою — пропускаємо частку спліту,
+        // узгоджено з `getTxStatAmount`, щоб пай "Категорії" збігався з
+        // "Підсумком місяця".
+        if (s.categoryId === INTERNAL_TRANSFER_ID) continue;
         catSpend[s.categoryId] = (catSpend[s.categoryId] || 0) + s.amount;
         totalSpent += s.amount;
       }


### PR DESCRIPTION
## Summary

Фіксить невідповідність між секцією **"Підсумок місяця"** на Аналітиці (яка правильно не враховує внутрішні перекази) і паєм **"Категорії"** — він показував зелений сегмент *"↔️ Внутрішній переказ"* і тим самим роздував `Всього` у центрі.

Причина: у `computeCategorySpendIndex` (`packages/finyk-domain/src/domain/selectors.ts`) при ітерації сплітів транзакції не фільтрувалась частка з `categoryId === INTERNAL_TRANSFER_ID`. Це розходилось з `getTxStatAmount`, який у підсумку саме цю частку пропускає. Транзакції, категоризовані повністю як `internal_transfer`, і так потрапляли в `excludedTxIds` через `useStorage.excludedTxIds` і виключались — отже, єдиний шлях, яким переказ прокрадався в пай, були спліти (UI у `TxRow` навіть пропонує шаблон спліта з `INTERNAL_TRANSFER_ID` за замовчуванням).

Зміни:
- `computeCategorySpendIndex`: пропускаємо split-частину з `categoryId === INTERNAL_TRANSFER_ID`, узгоджуючи поведінку з `getTxStatAmount`.
- Додані юніт-тести у `selectors.test.ts`:
  - tx повністю позначений як internal_transfer не потрапляє в індекс (регрес);
  - split-частина `internal_transfer` не додається до `catSpend`/`totalSpent`;
  - сума сегментів пая = `summary.spent` для сплітів з переказом (точка злиття з "Підсумком місяця").

Приклад (витрата 500 ₴, split: 300 їжа + 200 переказ):

| | До | Після |
|---|---|---|
| Summary spent | 300 | 300 |
| Pie `Всього` | 500 | 300 |
| Сегмент `↔️ Внутрішній переказ` | 200 (видимий) | відсутній |

## Review & Testing Checklist for Human

- [ ] Відкрити Фінік → Аналітика. Пай **"Категорії"** більше не показує сегмент *"↔️ Внутрішній переказ"*; `Всього` у центрі збігається з `Витрати` з секції **"Підсумок місяця"**.
- [ ] Перевірити, що транзакція зі сплітом, де одна частина — *Внутрішній переказ*, а інша — звичайна категорія, у пай-чарті враховується лише звичайною часткою; сума по категорії і `Всього` змінились відповідно.
- [ ] Транзакція, категоризована цілком як *Внутрішній переказ* (через зміну категорії в рядку), як і раніше не впливає ні на "Підсумок місяця", ні на пай.

### Notes
Поведінка для звичайних (неспліт) транзакцій не змінюється — повне виключення йде через `excludedTxIds` у `useStorage`. Точкова правка вузько в одному селекторі, тести покривають саме цю точку злиття даних.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal transfers were incorrectly included in category spending calculations, resulting in inflated expense totals.
  * Category summaries now accurately exclude internal transfers and align with overall monthly spending totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->