### PR TITLE
fix(finyk/analytics): respect txSplits in Top Merchants

### DIFF
--- a/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.tsx
@@ -165,8 +165,8 @@ export function Analytics({ data, now, testID }: AnalyticsProps) {
   );
 
   const topMerchants = useMemo(
-    () => getTopMerchants(currTx, { excludedTxIds }),
-    [currTx, excludedTxIds],
+    () => getTopMerchants(currTx, { excludedTxIds, txSplits }),
+    [currTx, excludedTxIds, txSplits],
   );
 
   const comparison = useMemo(() => {

--- a/apps/web/src/modules/finyk/hooks/useAnalytics.ts
+++ b/apps/web/src/modules/finyk/hooks/useAnalytics.ts
@@ -55,10 +55,13 @@ export function useAnalytics({ mono, storage, monthlyHistory = [] }) {
     [categorySpendIndex, customCategories],
   );
 
-  // Cache: top merchants by total spend. Depends on tx list + excludedTxIds.
+  // Cache: top merchants by total spend. Depends on tx list + excludedTxIds
+  // + txSplits — сплітовані транзакції (напр. оренда з поверненнями) вже
+  // нормалізуються до чистої частки користувача, щоб цифри збігалися з
+  // "Підсумком місяця" та "Категоріями".
   const topMerchants = useMemo(
-    () => getTopMerchants(realTx, { excludedTxIds }),
-    [realTx, excludedTxIds],
+    () => getTopMerchants(realTx, { excludedTxIds, txSplits }),
+    [realTx, excludedTxIds, txSplits],
   );
 
   // Cache: monthly spend/income series for sparkline-style charts.

--- a/packages/finyk-domain/src/domain/selectors.test.ts
+++ b/packages/finyk-domain/src/domain/selectors.test.ts
@@ -5,6 +5,7 @@ import {
   getCategoryDistribution,
   getCurrentVsPreviousComparison,
   getMonthlySummary,
+  getTopMerchants,
 } from "./selectors";
 import type { Transaction } from "./types";
 import { INTERNAL_TRANSFER_ID } from "../constants";
@@ -228,5 +229,91 @@ describe("computeCategorySpendIndex — internal transfers", () => {
     expect(
       distribution.some((c) => c.categoryId === INTERNAL_TRANSFER_ID),
     ).toBe(false);
+  });
+});
+
+describe("getTopMerchants", () => {
+  it("без сплітів агрегує повну суму транзакції по мерчанту", () => {
+    const txs = [
+      tx("a1", "2025-03-05T10:00:00Z", -50000, { description: "АТБ" }),
+      tx("a2", "2025-03-15T10:00:00Z", -30000, { description: "атб  " }),
+      tx("r1", "2025-03-20T10:00:00Z", -100000, { description: "Ранчо" }),
+    ];
+    const merchants = getTopMerchants(txs);
+    expect(merchants[0]).toMatchObject({
+      name: "Ранчо",
+      total: 1000,
+      count: 1,
+    });
+    expect(merchants[1]).toMatchObject({ name: "АТБ", total: 800, count: 2 });
+  });
+
+  it("для сплітованих транзакцій рахує лише чисту частку користувача", () => {
+    // 14 000 ₴ оренда з карти — своя частка 6 000 ₴, повернення від хлопців
+    // трактуються як internal_transfer. У Топ мерчантах має показатись 6 000 ₴,
+    // а не 14 000, щоб цифри збігалися з «Підсумком місяця» та «Категоріями».
+    const txs = [
+      tx("rent", "2025-03-01T10:00:00Z", -1400000, {
+        description: "536354****8294",
+      }),
+      tx("food", "2025-03-05T10:00:00Z", -50000, { description: "АТБ" }),
+    ];
+    const splits = {
+      rent: [
+        { amount: 6000, categoryId: "housing" },
+        { amount: 8000, categoryId: INTERNAL_TRANSFER_ID },
+      ],
+    };
+    const merchants = getTopMerchants(txs, { txSplits: splits });
+    expect(merchants[0]).toMatchObject({
+      name: "536354****8294",
+      total: 6000,
+      count: 1,
+    });
+    expect(merchants[1]).toMatchObject({ name: "АТБ", total: 500, count: 1 });
+  });
+
+  it("пропускає мерчанта, якщо після сплітів чиста частка = 0", () => {
+    // Вся сума транзакції — внутрішній переказ (повністю повернули),
+    // тож такий «мерчант» не має потрапляти в топ.
+    const txs = [
+      tx("t1", "2025-03-01T10:00:00Z", -500000, { description: "Monobank" }),
+      tx("t2", "2025-03-05T10:00:00Z", -10000, { description: "АТБ" }),
+    ];
+    const splits = {
+      t1: [{ amount: 5000, categoryId: INTERNAL_TRANSFER_ID }],
+    };
+    const merchants = getTopMerchants(txs, { txSplits: splits });
+    expect(merchants).toHaveLength(1);
+    expect(merchants[0]?.name).toBe("АТБ");
+  });
+
+  it("сума топ-мерчантів узгоджена з витратами 'Підсумку місяця' для сплітованих витрат", () => {
+    const txs = [
+      tx("rent", "2025-03-01T10:00:00Z", -1400000, { description: "Оренда" }),
+      tx("food", "2025-03-05T10:00:00Z", -50000, { description: "АТБ" }),
+    ];
+    const splits = {
+      rent: [
+        { amount: 6000, categoryId: "housing" },
+        { amount: 8000, categoryId: INTERNAL_TRANSFER_ID },
+      ],
+    };
+    const summary = getMonthlySummary(txs, { txSplits: splits });
+    const merchants = getTopMerchants(txs, { txSplits: splits });
+    const merchantsTotal = merchants.reduce((s, m) => s + m.total, 0);
+    expect(merchantsTotal).toBe(summary.spent);
+  });
+
+  it("поважає excludedTxIds", () => {
+    const txs = [
+      tx("a", "2025-03-01T10:00:00Z", -10000, { description: "АТБ" }),
+      tx("b", "2025-03-02T10:00:00Z", -20000, { description: "Ранчо" }),
+    ];
+    const merchants = getTopMerchants(txs, {
+      excludedTxIds: new Set(["b"]),
+    });
+    expect(merchants).toHaveLength(1);
+    expect(merchants[0]?.name).toBe("АТБ");
   });
 });

--- a/packages/finyk-domain/src/domain/selectors.ts
+++ b/packages/finyk-domain/src/domain/selectors.ts
@@ -484,6 +484,7 @@ export function getTopMerchants(
 ): MerchantStat[] {
   const {
     excludedTxIds = new Set<string>(),
+    txSplits = {} as TxSplitsMap,
     month = null,
     limit: optsLimit,
   } = typeof opts === "number"
@@ -502,9 +503,16 @@ export function getTopMerchants(
     if (!raw) continue;
     const key = merchantGroupKey(raw);
     if (!key) continue;
+    // Враховуємо лише чисту частку користувача: якщо транзакція сплітована
+    // (напр. оренда з поверненнями від співмешканців), беремо суму не-
+    // internal_transfer частин — узгоджено з `getMonthlySummary` /
+    // `computeCategorySpendIndex`, щоб цифри у "Топ мерчантах" збігалися з
+    // рештою аналітики.
+    const amount = getTxStatAmount(tx, txSplits);
+    if (!(amount > 0)) continue;
     if (!merchants[key]) merchants[key] = { name: raw, count: 0, total: 0 };
     merchants[key].count++;
-    merchants[key].total += Math.abs(tx.amount / 100);
+    merchants[key].total += amount;
   }
 
   return Object.values(merchants)


### PR DESCRIPTION
## Summary

У «Топ мерчантах» на вкладці Аналітика цифри не збігалися з «Підсумком місяця» та «Категоріями», коли транзакція була сплітована (напр. оренда 14 000 ₴ з картки, де моя частина — 6 000 ₴, а решта — повернення від співмешканців через `internal_transfer`-спліти). `getMonthlySummary` / `computeCategorySpendIndex` / `getMonthlySpendSeries` уже всі користувалися `txSplits` через `getTxStatAmount`, а `getTopMerchants` — ні: він брав повний `Math.abs(tx.amount)` і взагалі не приймав `txSplits` у опціях.

Цей PR приводить `getTopMerchants` до тієї самої семантики «чистої частки користувача», що й решта аналітики:

- `packages/finyk-domain/src/domain/selectors.ts` — `TopMerchantsOptions` тепер несе `txSplits`, а агрегація йде через `getTxStatAmount(tx, txSplits)`. Мерчанти з нульовою чистою часткою (повністю повернули або internal-transfer) не потрапляють у топ.
- `apps/web/src/modules/finyk/hooks/useAnalytics.ts` — прокинуто `txSplits` у `getTopMerchants` і додано у залежності `useMemo`.
- `apps/mobile/src/modules/finyk/pages/Analytics/Analytics.tsx` — те ж саме для мобільного екрану Аналітики.
- `packages/finyk-domain/src/domain/selectors.test.ts` — 5 нових кейсів, включно з регресією `merchantsTotal === summary.spent` саме на сценарії сплітованої оренди, що описав репортер.

**Наслідок для юзера:** на скріні репортера картка `536354****8294` показувала 14 000 ₴, хоча його реальна витрата по ній — лише її власна частина. Після PR «Топ мерчанти» покаже саме цю чисту частку, і сума топу збігатиметься з витратами «Підсумку місяця».

## Review & Testing Checklist for Human

- [ ] На реальних даних відкрити «Аналітика → Топ мерчанти» і перевірити, що сплітована оренда показується з чистою часткою користувача (а не повною сумою платежу).
- [ ] Перевірити, що в сумі Σ total по Топ мерчантах тепер ≈ spent у «Підсумку місяця» на сценарії зі сплітами (невеликі розбіжності допустимі через `Math.round` по кожному мерчанту).
- [ ] Переглянути, що мерчант, який повністю повернули (усі спліти = `internal_transfer`), більше не зʼявляється у топі.

### Notes

- `MerchantList` / `useFinykAnalyticsData` на мобільному не чіпали — `txSplits` вже читається з `resolved.txSplits` тим самим шляхом, що й для `getMonthlySummary`, просто тепер цей параметр передається і в `getTopMerchants`.
- Існуючий тест `Analytics.test.tsx` (який не передає `txSplits`) проходить без змін — поведінка для не-сплітованих транзакцій зберігається (`getTxStatAmount` без сплітів повертає `Math.abs(amount)/100`).
- Довгий локальний `pnpm lint` на VM із Node 22 падає на `lint:plugins` (`eslint-plugins/sergeant-design/__tests__` не резолвиться як модуль) — це не повʼязано з цим PR і в CI на Node 20 працює.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced top merchants analytics to accurately account for transaction splits, preventing internal transfers from inflating merchant spending totals and ensuring rankings reflect actual spending patterns.

* **Tests**
  * Added comprehensive test suite validating merchant spending calculations across various transaction split scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->