### PR TITLE
fix(web): improve dark mode contrast for brand accents and module hero surfaces

### DIFF
--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -298,7 +298,9 @@ function InsightCard({ emoji, title, stat, detail }) {
       <div className="min-w-0 flex-1 space-y-1">
         <p className="text-sm text-text leading-snug">{title}</p>
         <div className="flex items-baseline gap-2 flex-wrap">
-          <span className="text-lg font-bold text-brand-600">{stat}</span>
+          <span className="text-lg font-bold text-brand-600 dark:text-brand-400">
+            {stat}
+          </span>
           {detail && (
             <span className="text-xs text-muted truncate">{detail}</span>
           )}

--- a/apps/web/src/core/OnboardingWizard.tsx
+++ b/apps/web/src/core/OnboardingWizard.tsx
@@ -86,7 +86,9 @@ function VibeChipRow({ picks, togglePick }) {
               <span
                 className={cn(
                   "shrink-0 w-8 h-8 rounded-lg flex items-center justify-center",
-                  active ? "bg-brand-500/15 text-brand-600" : "bg-panelHi",
+                  active
+                    ? "bg-brand-500/15 text-brand-600 dark:text-brand-400"
+                    : "bg-panelHi",
                 )}
                 aria-hidden
               >
@@ -120,7 +122,7 @@ function SplashStep({ picks, togglePick, onContinue }) {
   const hasPicks = picks.length > 0;
   return (
     <div className="flex flex-col items-center text-center space-y-5">
-      <div className="w-20 h-20 rounded-3xl bg-brand-500/10 text-brand-600 flex items-center justify-center">
+      <div className="w-20 h-20 rounded-3xl bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center">
         <Icon name="sparkle" size={40} strokeWidth={1.8} aria-hidden />
       </div>
       <div>

--- a/apps/web/src/core/app/MigrationPrompt.tsx
+++ b/apps/web/src/core/app/MigrationPrompt.tsx
@@ -12,7 +12,7 @@ export function MigrationPrompt({ onUpload, onSkip, syncing }) {
         className="max-w-sm w-full space-y-5"
       >
         <div className="text-center space-y-2">
-          <div className="w-14 h-14 mx-auto bg-brand-500/10 rounded-2xl flex items-center justify-center text-brand-600">
+          <div className="w-14 h-14 mx-auto bg-brand-500/10 rounded-2xl flex items-center justify-center text-brand-600 dark:text-brand-400">
             <Icon name="upload" size={28} strokeWidth={1.8} />
           </div>
           <h2 className="text-xl font-bold text-text">

--- a/apps/web/src/core/onboarding/FirstActionSheet.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.tsx
@@ -188,7 +188,11 @@ export function FirstActionHeroCard({ onDismiss }) {
                 {primary.desc}
               </div>
             </div>
-            <Icon name="chevron-right" size={18} className="text-brand-600" />
+            <Icon
+              name="chevron-right"
+              size={18}
+              className="text-brand-600 dark:text-brand-400"
+            />
           </div>
         </button>
 

--- a/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
+++ b/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
@@ -35,7 +35,7 @@ export function SoftAuthPromptCard({ onOpenAuth, onDismiss }) {
       )}
     >
       <div className="flex items-start gap-3">
-        <div className="w-10 h-10 shrink-0 rounded-2xl bg-brand-500/15 text-brand-600 flex items-center justify-center">
+        <div className="w-10 h-10 shrink-0 rounded-2xl bg-brand-500/15 text-brand-600 dark:text-brand-400 flex items-center justify-center">
           <Icon name="cloud-check" size={20} aria-hidden />
         </div>
         <div className="min-w-0 flex-1">

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -575,7 +575,7 @@ export default function App({
               </button>
             ) : null}
             <div
-              className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 border border-emerald-500/15"
+              className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
               aria-hidden
             >
               <svg

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -322,7 +322,7 @@ export function ManualExpenseSheet({
                     }
                     className={
                       personal
-                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
+                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
                         : "px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
                     }
                     aria-label={

--- a/apps/web/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
@@ -91,7 +91,9 @@ function MonthlyPlanCardComponent({
               <div
                 className={cn(
                   "text-sm font-semibold tabular-nums",
-                  isOver ? "text-danger" : "text-emerald-600",
+                  isOver
+                    ? "text-danger"
+                    : "text-emerald-600 dark:text-emerald-400",
                 )}
               >
                 {isOver
@@ -131,7 +133,7 @@ function MonthlyPlanCardComponent({
                   ? "bg-danger/10 text-danger"
                   : pctExpense >= 85
                     ? "bg-warning/10 text-warning"
-                    : "bg-emerald-500/10 text-emerald-700",
+                    : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
               )}
             >
               <span className="font-semibold">

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -172,7 +172,7 @@ const ComparisonRow = memo(function ComparisonRow({
               good === null
                 ? "text-muted"
                 : good
-                  ? "text-emerald-600"
+                  ? "text-emerald-600 dark:text-emerald-400"
                   : "text-danger",
             )}
           >
@@ -336,7 +336,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
               </div>
               <div className="text-center">
                 <div className="text-2xs text-subtle mb-1">Дохід</div>
-                <div className="text-sm font-bold tabular-nums text-emerald-600">
+                <div className="text-sm font-bold tabular-nums text-emerald-600 dark:text-emerald-400">
                   {summary.income.toLocaleString("uk-UA")} ₴
                 </div>
               </div>
@@ -345,7 +345,9 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
                 <div
                   className={cn(
                     "text-sm font-bold tabular-nums",
-                    summary.balance >= 0 ? "text-emerald-600" : "text-danger",
+                    summary.balance >= 0
+                      ? "text-emerald-600 dark:text-emerald-400"
+                      : "text-danger",
                   )}
                 >
                   {summary.balance >= 0 ? "+" : ""}

--- a/apps/web/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/web/src/modules/fizruk/pages/Atlas.tsx
@@ -50,7 +50,7 @@ export function Atlas() {
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-3">
         <section
-          className="rounded-3xl p-5 border border-line/20 bg-hero-teal"
+          className="rounded-3xl p-5 border border-line/20 bg-hero-teal dark:border-teal-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
           aria-label="Атлас мʼязів"
         >
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -262,7 +262,7 @@ export function Dashboard({
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
         <section
-          className="rounded-3xl p-6 overflow-hidden bg-hero-teal"
+          className="rounded-3xl p-6 overflow-hidden bg-hero-teal dark:bg-panel dark:border dark:border-teal-800/30 dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
           aria-label="Привітання"
         >
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -50,7 +50,7 @@ const variants: Record<ButtonVariant, string> = {
   destructive:
     "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
-    "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 active:scale-[0.98]",
+    "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
 
   // Module-specific branded buttons
   finyk:

--- a/apps/web/src/shared/components/ui/Card.tsx
+++ b/apps/web/src/shared/components/ui/Card.tsx
@@ -80,13 +80,13 @@ const variants: Record<CardVariant, string> = {
 
   // Soft module cards (less prominent)
   "finyk-soft":
-    "rounded-2xl border border-brand-100 bg-brand-50/50 backdrop-blur-sm",
+    "rounded-2xl border border-brand-100 bg-brand-50/50 backdrop-blur-sm dark:border-brand-500/20 dark:bg-brand-500/10",
   "fizruk-soft":
-    "rounded-2xl border border-teal-100 bg-teal-50/50 backdrop-blur-sm",
+    "rounded-2xl border border-teal-100 bg-teal-50/50 backdrop-blur-sm dark:border-teal-500/20 dark:bg-teal-500/10",
   "routine-soft":
-    "rounded-2xl border border-coral-100 bg-coral-50/50 backdrop-blur-sm",
+    "rounded-2xl border border-coral-100 bg-coral-50/50 backdrop-blur-sm dark:border-coral-500/20 dark:bg-coral-500/10",
   "nutrition-soft":
-    "rounded-2xl border border-lime-100 bg-lime-50/50 backdrop-blur-sm",
+    "rounded-2xl border border-lime-100 bg-lime-50/50 backdrop-blur-sm dark:border-lime-500/20 dark:bg-lime-500/10",
 };
 
 const paddings: Record<CardPadding, string> = {

--- a/apps/web/src/shared/components/ui/Stat.tsx
+++ b/apps/web/src/shared/components/ui/Stat.tsx
@@ -37,7 +37,7 @@ const toneClass: Record<StatTone, string> = {
   finyk: "text-finyk",
   fizruk: "text-fizruk",
   routine: "text-coral-500",
-  nutrition: "text-lime-600",
+  nutrition: "text-lime-600 dark:text-lime-400",
 };
 
 const valueSize: Record<StatSize, string> = {


### PR DESCRIPTION
## Summary

Покращую читабельність нічного режиму: деякі елементи використовували `text-brand-600` / `text-emerald-600` / `text-emerald-700` без `dark:`-варіантів, через що темно-зелений текст ставав нерозбірливим на темному фоні. Також два hero-блоки у Фізруку (`Dashboard`, `Atlas`) використовували пастельний світлий градієнт `bg-hero-teal` у всіх режимах — у нічному він «вибивався» дуже світлою плямою на темному UI. Софт-варіанти `Card` (`finyk-soft`/`fizruk-soft`/`routine-soft`/`nutrition-soft`) і `success` варіант `Button` також не мали темних відповідників.

### Що саме змінено

**Акценти (text / icon), додано `dark:text-*-400`:**
- `OnboardingWizard` — активний чіп модуля + splash-icon
- `onboarding/FirstActionSheet` — chevron на primary CTA
- `onboarding/SoftAuthPromptCard` — іконка cloud-check
- `app/MigrationPrompt` — іконка upload
- `HubReports` — stat у InsightCard
- `finyk/pages/Analytics` — позитивна дельта, дохід, баланс
- `finyk/FinykApp` — іконка банківської картки в header
- `finyk/components/budgets/MonthlyPlanCard` — «Залишок» + safe-per-day pill
- `finyk/components/ManualExpenseSheet` — персональна сума-пілл

**Компоненти дизайн-системи:**
- `shared/components/ui/Button` — `success` варіант тепер має коректний темний стан (`dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30`) замість майже-білого `bg-brand-50`
- `shared/components/ui/Card` — `*-soft` варіанти (`finyk-soft`, `fizruk-soft`, `routine-soft`, `nutrition-soft`) тепер мають `dark:` фон/бордер замість світлих пастельних
- `shared/components/ui/Stat` — тон `nutrition` отримав `dark:text-lime-400`

**Hero-секції, що дзеркалять патерн із `Card`:**
- `fizruk/pages/Dashboard` та `fizruk/pages/Atlas` — під темною темою `bg-hero-teal` замінюється на `bg-panel` з ледь помітним teal-градієнтом

### Що НЕ змінено
- Семантичні токени в `index.css` (WCAG-calibrовані) і палітру в `design-tokens` не чіпав.
- Stories-слайди (overlay поверх кольорового фону) — там `bg-white/15` і `text-white` коректні в обох режимах.

## Review & Testing Checklist for Human

- [ ] Увімкнути нічний режим через хедер і пройтись по: Dashboard (hub), Finyk → Analytics / Budgets / Manual expense, Fizruk → Dashboard / Atlas, Onboarding wizard (для нового юзера), Migration prompt, Reports. Переконатися, що акцентний текст/іконки тепер читабельні.
- [ ] Ручно перевірити `success` варіант кнопки у нічному режимі (не має бути майже-білого прямокутника).
- [ ] Перевірити, що `Card` варіанти `*-soft` у світлій темі виглядають як раніше (змін не передбачалось).

### Notes
- Всі зміни — cosmetic / Tailwind-класи; логіки не змінено.
- `pnpm --filter @sergeant/web lint` ✅, `typecheck` ✅, `test` ✅ (617/617).


Link to Devin session: https://app.devin.ai/sessions/476206d3021c4e3abc0652d6f6d7bb55
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode support across the application with improved color contrast and visual distinction of UI elements
  * Updated styling for buttons, cards, and icons to provide a more polished and cohesive dark theme appearance
  * Refined color schemes on analytics pages, onboarding flows, and core features to ensure consistent light and dark mode experiences throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->