### PR TITLE
ci(detox): set SENTRY_DISABLE_AUTO_UPLOAD to unblock Detox iOS/Android builds

### DIFF
--- a/.github/workflows/detox-android.yml
+++ b/.github/workflows/detox-android.yml
@@ -62,6 +62,12 @@ jobs:
       # between the `assembleDebug` and `assembleAndroidTest` passes
       # that Detox triggers via `pnpm e2e:build:android`.
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=-Xmx4g"
+      # `@sentry/react-native` registers a Gradle task that runs
+      # `sentry-cli` to upload source maps. Without SENTRY_ORG /
+      # SENTRY_PROJECT / SENTRY_AUTH_TOKEN (only set on EAS release
+      # lanes) the task aborts the build. Mirror the iOS workflow's
+      # no-op flag so Detox Android builds succeed on CI.
+      SENTRY_DISABLE_AUTO_UPLOAD: "true"
     # Pixel_5_API_34 mirrors the Detox `devices.emulator` avdName in
     # `apps/mobile/.detoxrc.js`, so contributors who run Detox locally
     # against the same AVD see identical behaviour.

--- a/.github/workflows/detox-ios.yml
+++ b/.github/workflows/detox-ios.yml
@@ -48,6 +48,13 @@ jobs:
     env:
       EXPO_PUBLIC_E2E: "1"
       E2E_BUILD: "1"
+      # `@sentry/react-native` injects a `sentry-cli` upload step into
+      # xcodebuild that aborts with `An organization ID or slug is
+      # required` whenever SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN
+      # are unset — which they are on every CI run except EAS release
+      # lanes. Disabling the auto-upload turns the step into an explicit
+      # no-op so Detox can finish building the app.
+      SENTRY_DISABLE_AUTO_UPLOAD: "true"
     steps:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -207,10 +207,12 @@ const buildConfig = (): ExpoConfig => ({
     ],
     // Sentry native plugin — required by `@sentry/react-native` for
     // the iOS/Android native build to link the RNSentry module. Source
-    // maps are only uploaded at EAS build time when `SENTRY_AUTH_TOKEN`
-    // + `SENTRY_ORG` + `SENTRY_PROJECT` are set; otherwise the plugin
-    // no-ops and JS Sentry still initialises via `EXPO_PUBLIC_SENTRY_DSN`
-    // (see `src/lib/observability.ts`).
+    // maps are uploaded at EAS build time when `SENTRY_AUTH_TOKEN`
+    // + `SENTRY_ORG` + `SENTRY_PROJECT` are set; on CI (Detox E2E,
+    // mobile-shell lanes) those env vars are absent, so set
+    // `SENTRY_DISABLE_AUTO_UPLOAD=true` in the workflow to make the
+    // `sentry-cli` build phase a no-op. JS Sentry still initialises
+    // via `EXPO_PUBLIC_SENTRY_DSN` (see `src/lib/observability.ts`).
     "@sentry/react-native/expo",
     // Detox config plugin patches the generated native projects with
     // the Detox instrumentation target. Only registered for dedicated


### PR DESCRIPTION
## Summary

Detox CI (both `detox-ios` on `macos-14` and `detox-android (34)` on `ubuntu-latest`) has been failing / hanging on every PR because the native build aborts long before Detox gets a chance to launch the simulator/emulator. Root cause is in the xcodebuild / Gradle logs:

```
error: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables.
error: An organization ID or slug is required (provide with --org)
Command PhaseScriptExecution emitted errors but did not return a nonzero exit code to indicate failure
detox[76805] E Command failed with exit code = 1
```

`@sentry/react-native/expo` (registered in [`apps/mobile/app.config.ts`](apps/mobile/app.config.ts)) installs a build-phase script on iOS and a Gradle task on Android that runs `sentry-cli` to upload source maps. When `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` are absent — which they are on every CI lane except EAS release builds — the upload hard-errors, failing the xcodebuild / assembleDebug step. The existing comment in `app.config.ts` claimed the plugin "no-ops" in that case; it does not.

This PR sets `SENTRY_DISABLE_AUTO_UPLOAD=true` in the `env:` block of both Detox workflows (same mechanism sentry-cli literally prints in its error message as the remediation). The upload phase becomes an explicit no-op, the native build finishes, and Detox can proceed to the E2E suite. JS Sentry still initialises at runtime via `EXPO_PUBLIC_SENTRY_DSN` — this only disables the build-time source-map upload for CI. EAS release lanes are unaffected because they don't run these workflows.

Also refreshes the `app.config.ts` comment to match reality (hard-error, not no-op) and points readers at the new env flag.

### Changes
- `.github/workflows/detox-ios.yml` — add `SENTRY_DISABLE_AUTO_UPLOAD: "true"` to job-level `env`.
- `.github/workflows/detox-android.yml` — same, alongside existing `GRADLE_OPTS`.
- `apps/mobile/app.config.ts` — rewrite the `@sentry/react-native/expo` plugin comment.

No app code or Detox suite changes.

## Review & Testing Checklist for Human

Risk: **green** — CI-only env flag. Worst case is the native build still fails and we learn something new from the next run's logs.

- [ ] Verify the iOS Detox run on this PR gets past the `Build Detox iOS app` step (previously it failed ~15 min in during `xcodebuild -quiet` on the Sentry `PhaseScriptExecution`). You should see it boot the iPhone 15 simulator and start running the Finyk / Routine smoke suites.
- [ ] Same for the Android Detox run — the `Build Detox Android app` step (`detox build --configuration android.emu.debug`) should complete and hand off to the `android-emulator-runner` script.
- [ ] Sanity-check that **EAS release builds are unaffected**: `eas.json` / EAS build profiles don't source these workflows, and `SENTRY_DISABLE_AUTO_UPLOAD` only scopes to the CI jobs. If you run `eas build` locally or in a release pipeline, source maps should still upload as before.

### Notes

- This is a minimal fix for the sentry-cli build-phase failure only. The `Build iOS Simulator (Debug)` check (the mobile-shell Capacitor workflow) also fails on `main` for a separate reason (CocoaPods can't satisfy `GoogleMLKit/BarcodeScanning (= 7.0.0)` at `platform :ios, '15.5'` and wants a higher deployment target). That's tracked as a follow-up and is intentionally not bundled here.
- If `detox-android` still hangs after the build step — i.e. emulator cold-boot on `android-emulator-runner` — that's a separate infra issue (AVD cache miss, KVM flakiness). Logs after the build stage would make that actionable.

Link to Devin session: https://app.devin.ai/sessions/bca43549a25f4136a1704d8d1aa8c87c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
