### PR TITLE
feat(finyk): згортання/розгортання транзакцій по днях (web + mobile)

### DIFF
--- a/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.test.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.test.tsx
@@ -108,8 +108,27 @@ function makeRealTx(overrides: Partial<Transaction>): Transaction {
   };
 }
 
+/**
+ * Pre-expand every day in a given year-month so tests authored before
+ * the per-day collapse toggle landed continue to see their seeded rows.
+ * The page's default is "only today is expanded" — seeded dates that
+ * aren't today would otherwise be hidden behind a collapsed header.
+ */
+function expandAllDaysIn(year: number, month: number) {
+  const overrides: Record<string, boolean> = {};
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  for (let d = 1; d <= daysInMonth; d++) {
+    const key = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    overrides[key] = true;
+  }
+  safeWriteLS(STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE, overrides);
+}
+
 beforeEach(() => {
   _getMMKVInstance().clearAll();
+  // Legacy tests seed dates other than FIXED_NOW; pre-expand the whole
+  // month so the day-collapse default doesn't hide their rows.
+  expandAllDaysIn(FIXED_NOW.getFullYear(), FIXED_NOW.getMonth());
 });
 
 describe("TransactionsPage — render", () => {
@@ -568,5 +587,112 @@ describe("TransactionsPage — swipe actions", () => {
     await waitFor(() => {
       expect(screen.getByTestId("finyk-transactions-sheet")).toBeTruthy();
     });
+  });
+});
+
+describe("TransactionsPage — day collapse", () => {
+  // Seed includes today + yesterday so we can assert the default rule
+  // ("today is expanded, yesterday is collapsed") without relying on
+  // the month-wide pre-expansion installed by the global beforeEach.
+  const COLLAPSE_SEED = {
+    manualExpenses: [
+      {
+        id: "me-today",
+        description: "сьогодні-tx",
+        amount: 100,
+        category: "🍴 їжа",
+        date: "2026-04-21T09:00:00.000Z",
+      },
+      {
+        id: "me-yesterday",
+        description: "вчора-tx",
+        amount: 200,
+        category: "🍴 їжа",
+        date: "2026-04-20T09:00:00.000Z",
+      },
+    ],
+  };
+
+  it("expands only today by default; prior days start collapsed", () => {
+    // Reset the month-wide expansion from the global beforeEach so we
+    // can assert the real first-run default.
+    _getMMKVInstance().clearAll();
+    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+
+    // Both day headers render regardless of collapse state.
+    expect(screen.getByTestId("finyk-tx-day-h-2026-04-21")).toBeTruthy();
+    expect(screen.getByTestId("finyk-tx-day-h-2026-04-20")).toBeTruthy();
+
+    // Today's row is visible; yesterday's row is hidden behind the
+    // collapsed header.
+    expect(screen.queryByText("сьогодні-tx")).toBeTruthy();
+    expect(screen.queryByText("вчора-tx")).toBeNull();
+  });
+
+  it("toggles a day expanded when the header is pressed, and persists the choice to MMKV", () => {
+    _getMMKVInstance().clearAll();
+    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+
+    // Precondition: yesterday starts collapsed.
+    expect(screen.queryByText("вчора-tx")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("finyk-tx-day-h-2026-04-20"));
+    expect(screen.getByText("вчора-tx")).toBeTruthy();
+
+    // The override is persisted — MMKV now carries an explicit `true`
+    // for 2026-04-20 that will survive cold starts.
+    const stored = _getMMKVInstance().getString(
+      STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE,
+    );
+    expect(stored).toBeDefined();
+    const parsed = JSON.parse(stored!);
+    expect(parsed["2026-04-20"]).toBe(true);
+  });
+
+  it("collapses today when the user explicitly toggles its header", () => {
+    _getMMKVInstance().clearAll();
+    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+
+    // Precondition: today starts expanded.
+    expect(screen.getByText("сьогодні-tx")).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("finyk-tx-day-h-2026-04-21"));
+    expect(screen.queryByText("сьогодні-tx")).toBeNull();
+
+    const stored = _getMMKVInstance().getString(
+      STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE,
+    );
+    const parsed = JSON.parse(stored!);
+    expect(parsed["2026-04-21"]).toBe(false);
+  });
+
+  it("temporarily ignores the collapsed state when the user types a search query", () => {
+    _getMMKVInstance().clearAll();
+    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+
+    // Precondition: yesterday is hidden (default-collapsed).
+    expect(screen.queryByText("вчора-tx")).toBeNull();
+
+    fireEvent.changeText(
+      screen.getByTestId("finyk-transactions-search"),
+      "вчора",
+    );
+
+    // Match surfaces because searching forces every matching day
+    // expanded (default rule + no explicit override override).
+    expect(screen.getByText("вчора-tx")).toBeTruthy();
+  });
+
+  it("hydrates persisted overrides on mount so prior choices survive a cold start", () => {
+    _getMMKVInstance().clearAll();
+    // Simulate a prior session that explicitly expanded yesterday.
+    safeWriteLS(STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE, {
+      "2026-04-20": true,
+    });
+
+    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+
+    expect(screen.getByText("вчора-tx")).toBeTruthy();
+    expect(screen.getByText("сьогодні-tx")).toBeTruthy();
   });
 });

--- a/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
@@ -29,7 +29,7 @@
  *  - Date-range bottom-sheet picker beyond the month nav (covered by
  *    `setRange` on the filter hook — UI can be added later).
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Pressable,
   RefreshControl,
@@ -69,6 +69,8 @@ import {
   type FinykTxFilterState,
   type ManualExpenseRecord,
 } from "@/modules/finyk/lib/transactionsStore";
+import { STORAGE_KEYS } from "@sergeant/shared";
+import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -84,8 +86,38 @@ const BASE_FILTERS: FilterChip[] = [
 ];
 
 type FeedItem =
-  | { kind: "header"; key: string; label: string; total: number; count: number }
+  | {
+      kind: "header";
+      key: string;
+      dayKey: string;
+      label: string;
+      total: number;
+      count: number;
+      collapsed: boolean;
+    }
   | { kind: "tx"; key: string; tx: Transaction };
+
+/** Sparse per-day override map. Missing entries fall back to the
+ *  default rule ("today is expanded, rest collapsed"); explicit
+ *  booleans survive across cold starts. */
+type DayCollapseMap = Record<string, boolean>;
+
+const DAY_COLLAPSE_KEY = STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE;
+
+function readDayCollapse(): DayCollapseMap {
+  const v = safeReadLS<DayCollapseMap | null>(DAY_COLLAPSE_KEY, null);
+  if (v && typeof v === "object" && !Array.isArray(v)) return v;
+  return {};
+}
+
+function isDayExpanded(
+  overrides: DayCollapseMap,
+  key: string,
+  todayKey: string,
+): boolean {
+  const o = overrides[key];
+  return o === undefined ? key === todayKey : !!o;
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -107,6 +139,10 @@ function getMonthBounds(
 
 function dayKeyFromTime(timeSec: number): string {
   const d = new Date(timeSec * 1000);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function dayKeyFromDate(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
@@ -261,6 +297,46 @@ export function TransactionsPage({
 
   const searchLower = search.trim().toLowerCase();
 
+  // Per-day collapse/expand state. Persisted as a sparse override map;
+  // missing entries fall back to the default "only today is expanded"
+  // rule. Live-syncs with other MMKV writers (e.g. another screen that
+  // flips the same flag) via the MMKV value listener.
+  const todayDayKey = useMemo(() => dayKeyFromDate(now), [now]);
+  const [dayOverrides, setDayOverrides] = useState<DayCollapseMap>(() =>
+    readDayCollapse(),
+  );
+  useEffect(() => {
+    const mmkv = _getMMKVInstance();
+    const sub = mmkv.addOnValueChangedListener((changedKey) => {
+      if (changedKey === DAY_COLLAPSE_KEY) {
+        setDayOverrides(readDayCollapse());
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  const toggleDay = useCallback(
+    (dayKey: string) => {
+      setDayOverrides((prev) => {
+        const expanded = isDayExpanded(prev, dayKey, todayDayKey);
+        const next: DayCollapseMap = { ...prev, [dayKey]: !expanded };
+        safeWriteLS(DAY_COLLAPSE_KEY, next);
+        return next;
+      });
+    },
+    [todayDayKey],
+  );
+
+  // When any filter / search is active, collapsed days would hide
+  // matches — force every day expanded so nothing looks "missing". The
+  // persisted override is untouched; clearing filters restores it.
+  const filtersActive =
+    filters.filter !== "all" ||
+    filters.accountIds.length > 0 ||
+    filters.range.startMs != null ||
+    filters.range.endMs != null ||
+    !!searchLower;
+
   // Full list of expense categories (built-ins + user customs) used by
   // the category-filter picker. Mirrors the same merger the web feed
   // uses, so the chip set on mobile and the filter the user picks below
@@ -354,56 +430,54 @@ export function TransactionsPage({
   ]);
 
   // Build the day-grouped flat array consumed by FlashList: each day
-  // contributes a `header` row (label + signed total) followed by its
-  // tx rows.
+  // contributes a `header` row (label + signed total), optionally
+  // followed by its tx rows. When a day is collapsed the header is
+  // still emitted — only the tx rows are suppressed so the user can tap
+  // the header to expand.
   const feed = useMemo<FeedItem[]>(() => {
+    // First pass: compute per-day totals across the full filtered set so
+    // the collapsed-header summary stays accurate regardless of whether
+    // the rows are actually emitted below.
+    const totals = new Map<string, { total: number; count: number }>();
+    for (const t of filtered) {
+      const k = dayKeyFromTime(t.time || 0);
+      const acc = totals.get(k);
+      if (acc) {
+        acc.total += Number(t.amount || 0);
+        acc.count += 1;
+      } else {
+        totals.set(k, { total: Number(t.amount || 0), count: 1 });
+      }
+    }
+
     const out: FeedItem[] = [];
     let currentKey = "";
-    let groupStart = -1;
+    let currentCollapsed = false;
     for (let i = 0; i < filtered.length; i++) {
       const t = filtered[i]!;
       const k = dayKeyFromTime(t.time || 0);
       if (k !== currentKey) {
-        if (groupStart >= 0) {
-          // Patch the just-finished header with totals. The right bound
-          // is `out.length` (everything pushed so far for the previous
-          // day), NOT `i` — `i` indexes into `filtered`, while
-          // `finishGroup` walks `out` which also contains header rows.
-          finishGroup(out, groupStart, out.length);
-        }
-        groupStart = out.length;
+        const expanded =
+          filtersActive || isDayExpanded(dayOverrides, k, todayDayKey);
+        currentCollapsed = !expanded;
+        const summary = totals.get(k) ?? { total: 0, count: 0 };
         out.push({
           kind: "header",
           key: `h-${k}`,
+          dayKey: k,
           label: formatDayLabel(k, now),
-          total: 0,
-          count: 0,
+          total: summary.total,
+          count: summary.count,
+          collapsed: currentCollapsed,
         });
         currentKey = k;
       }
-      out.push({ kind: "tx", key: `t-${t.id}`, tx: t });
-    }
-    if (groupStart >= 0) {
-      finishGroup(out, groupStart, out.length);
-    }
-    return out;
-  }, [filtered, now]);
-
-  function finishGroup(out: FeedItem[], headerIdx: number, end: number) {
-    const header = out[headerIdx];
-    if (!header || header.kind !== "header") return;
-    let sum = 0;
-    let count = 0;
-    for (let j = headerIdx + 1; j < end; j++) {
-      const item = out[j];
-      if (item?.kind === "tx") {
-        sum += Number(item.tx.amount || 0);
-        count += 1;
+      if (!currentCollapsed) {
+        out.push({ kind: "tx", key: `t-${t.id}`, tx: t });
       }
     }
-    header.total = sum;
-    header.count = count;
-  }
+    return out;
+  }, [filtered, now, dayOverrides, todayDayKey, filtersActive]);
 
   // ── Handlers ────────────────────────────────────────────────────────
   const openAddSheet = useCallback(() => {
@@ -480,14 +554,33 @@ export function TransactionsPage({
         const totalText =
           item.count === 0 ? "" : `${sign}${fmtAmt(item.total, CURRENCY.UAH)}`;
         return (
-          <View
-            className="flex-row items-center justify-between bg-cream-100/80 px-4 py-2 border-b border-cream-300"
+          <Pressable
+            onPress={() => toggleDay(item.dayKey)}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: !item.collapsed }}
+            accessibilityLabel={`${item.collapsed ? "Розгорнути" : "Згорнути"} ${item.label}`}
+            className="flex-row items-center justify-between bg-cream-100/80 px-4 py-2 border-b border-cream-300 active:opacity-70"
             testID={`finyk-tx-day-${item.key}`}
           >
-            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
-            <Text className="text-xs font-semibold uppercase tracking-wide text-stone-500">
-              {item.label}
-            </Text>
+            <View className="flex-row items-center flex-1 min-w-0">
+              <Text
+                className="text-stone-500 mr-2 text-xs"
+                style={{ width: 10 }}
+                accessibilityElementsHidden
+                importantForAccessibility="no"
+              >
+                {item.collapsed ? "▸" : "▾"}
+              </Text>
+              {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
+              <Text className="text-xs font-semibold uppercase tracking-wide text-stone-500 flex-shrink">
+                {item.label}
+              </Text>
+              {item.count > 0 ? (
+                <Text className="text-[10px] font-normal text-stone-400 ml-2">
+                  · {item.count}
+                </Text>
+              ) : null}
+            </View>
             {totalText ? (
               <Text
                 className={
@@ -500,7 +593,7 @@ export function TransactionsPage({
                 {totalText}
               </Text>
             ) : null}
-          </View>
+          </Pressable>
         );
       }
       const tx = item.tx;
@@ -537,6 +630,7 @@ export function TransactionsPage({
       handleSwipeRight,
       hiddenTxIdSet,
       openEditSheet,
+      toggleDay,
       txCategories,
       txSplits,
     ],

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { GroupedVirtuoso } from "react-virtuoso";
 import { TxListItem } from "../components/TxListItem";
-import { getCategory, getIncomeCategory } from "../utils";
+import { getCategory, getIncomeCategory, fmtAmt } from "../utils";
 import { manualExpenseToTransaction } from "@sergeant/finyk-domain/domain/transactions";
-import { mergeExpenseCategoryDefinitions } from "../constants";
+import { mergeExpenseCategoryDefinitions, CURRENCY } from "../constants";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { Icon } from "@shared/components/ui/Icon";
@@ -12,12 +12,41 @@ import { cn } from "@shared/lib/cn";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
+import { STORAGE_KEYS } from "@sergeant/shared";
 
 const now = new Date();
+const DAY_COLLAPSE_KEY = STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE;
 
 function dayKeyFromTx(ts) {
   const d = new Date(ts * 1000);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function readDayCollapse() {
+  try {
+    const raw = localStorage.getItem(DAY_COLLAPSE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function writeDayCollapse(v) {
+  try {
+    localStorage.setItem(DAY_COLLAPSE_KEY, JSON.stringify(v));
+  } catch {
+    /* quota / private-mode — drop silently */
+  }
+}
+
+function isDayExpanded(overrides, key, todayKey) {
+  const o = overrides[key];
+  return o === undefined ? key === todayKey : !!o;
 }
 
 function formatStickyDayLabel(key) {
@@ -338,15 +367,78 @@ export function Transactions({
     return groups;
   }, [filtered]);
 
+  // Per-day totals (signed amount in cents, item count). Cheap enough to
+  // compute during grouping, but kept separate so the collapsed-header
+  // summary doesn't force us to touch the hot grouping loop.
+  const daySummaries = useMemo(() => {
+    const map = {};
+    for (const g of groupedByDate) {
+      let total = 0;
+      for (const t of g.items) total += Number(t.amount || 0);
+      map[g.key] = { total, count: g.items.length };
+    }
+    return map;
+  }, [groupedByDate]);
+
+  // Day collapse/expand state. Persisted as a sparse override map:
+  // absence → default rule (only "today" is expanded). Explicit boolean
+  // overrides the default and survives across sessions.
+  const todayDayKey = useMemo(
+    () => dayKeyFromTx(Math.floor(Date.now() / 1000)),
+    [],
+  );
+  const [dayOverrides, setDayOverrides] = useState(() => readDayCollapse());
+
+  // Sync with other tabs: another Finyk tab toggling the same day should
+  // immediately reflect here, matching how the rest of the module treats
+  // localStorage as the single source of truth.
+  useEffect(() => {
+    function onStorage(e) {
+      if (e.key !== DAY_COLLAPSE_KEY) return;
+      setDayOverrides(readDayCollapse());
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const toggleDay = useCallback(
+    (key) => {
+      setDayOverrides((prev) => {
+        const expanded = isDayExpanded(prev, key, todayDayKey);
+        const next = { ...prev, [key]: !expanded };
+        writeDayCollapse(next);
+        return next;
+      });
+    },
+    [todayDayKey],
+  );
+
+  // When the user has narrowed down by a filter chip, collapsing days
+  // would hide matches — temporarily render every day fully expanded so
+  // nothing looks "missing". The persisted override is untouched;
+  // clearing the filter restores the prior state.
+  const ignoreCollapse = filter !== "all";
+
+  const collapsedKeys = useMemo(() => {
+    const s = new Set();
+    if (ignoreCollapse) return s;
+    for (const g of groupedByDate) {
+      if (!isDayExpanded(dayOverrides, g.key, todayDayKey)) s.add(g.key);
+    }
+    return s;
+  }, [groupedByDate, dayOverrides, todayDayKey, ignoreCollapse]);
+
   const groupCounts = useMemo(
-    () => groupedByDate.map((g) => g.items.length),
-    [groupedByDate],
+    () =>
+      groupedByDate.map((g) => (collapsedKeys.has(g.key) ? 0 : g.items.length)),
+    [groupedByDate, collapsedKeys],
   );
 
   // GroupedVirtuoso передає глобальний (плоский) індекс — будуємо плоский масив
   const flatItems = useMemo(
-    () => groupedByDate.flatMap((g) => g.items),
-    [groupedByDate],
+    () =>
+      groupedByDate.flatMap((g) => (collapsedKeys.has(g.key) ? [] : g.items)),
+    [groupedByDate, collapsedKeys],
   );
 
   const syncColor =
@@ -569,14 +661,62 @@ export function Transactions({
               customScrollParent={scrollParent}
               groupCounts={groupCounts}
               increaseViewportBy={{ top: 400, bottom: 400 }}
-              groupContent={(groupIndex) => (
-                <div
-                  className="px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-xs font-semibold text-subtle tracking-wide"
-                  role="presentation"
-                >
-                  {formatStickyDayLabel(groupedByDate[groupIndex].key)}
-                </div>
-              )}
+              groupContent={(groupIndex) => {
+                const group = groupedByDate[groupIndex];
+                if (!group) return null;
+                const key = group.key;
+                const collapsed = collapsedKeys.has(key);
+                const summary = daySummaries[key] ?? { total: 0, count: 0 };
+                const showTotal = showBalance && summary.count > 0;
+                const sign = summary.total > 0 ? "+" : "";
+                const label = formatStickyDayLabel(key);
+                return (
+                  <button
+                    type="button"
+                    onClick={() => toggleDay(key)}
+                    aria-expanded={!collapsed}
+                    aria-label={`${collapsed ? "Розгорнути" : "Згорнути"} ${label}`}
+                    className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-xs font-semibold text-subtle tracking-wide hover:text-text hover:bg-panelHi transition-colors"
+                  >
+                    <span className="flex items-center gap-2 min-w-0">
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.4"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden
+                        className="shrink-0 motion-safe:transition-transform motion-safe:duration-150"
+                        style={{
+                          transform: collapsed
+                            ? "rotate(-90deg)"
+                            : "rotate(0deg)",
+                        }}
+                      >
+                        <polyline points="6 9 12 15 18 9" />
+                      </svg>
+                      <span className="truncate">{label}</span>
+                      <span className="shrink-0 text-[10px] font-normal text-subtle/70 normal-case tabular-nums">
+                        · {summary.count}
+                      </span>
+                    </span>
+                    {showTotal && (
+                      <span
+                        className={cn(
+                          "shrink-0 tabular-nums",
+                          summary.total > 0 ? "text-success" : "text-text",
+                        )}
+                      >
+                        {sign}
+                        {fmtAmt(summary.total, CURRENCY.UAH)}
+                      </span>
+                    )}
+                  </button>
+                );
+              }}
               itemContent={(index) => {
                 const t = flatItems[index];
                 if (!t) return null;

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -58,6 +58,12 @@ export const STORAGE_KEYS = {
   FINYK_CUSTOM_CATS: "finyk_custom_cats_v1",
   FINYK_MANUAL_EXPENSES: "finyk_manual_expenses_v1",
   FINYK_TX_FILTERS: "finyk_tx_filters_v1",
+  // Per-day collapse state for the Transactions screen. Map of
+  // `YYYY-MM-DD` day keys → boolean (true = expanded, false = collapsed).
+  // Missing entries fall back to the default "only today is expanded"
+  // rule; explicit entries always win so user toggles persist across
+  // sessions. UI-only — intentionally excluded from cloud sync.
+  FINYK_TX_DAY_COLLAPSE: "finyk_tx_day_collapse_v1",
 
   // ─── Fizruk ───────────────────────────────────────────────────────────
   FIZRUK_WORKOUTS: "fizruk_workouts_v1",


### PR DESCRIPTION
## Summary

Додає можливість згортати/розгортати групи транзакцій по днях у розділі «Операції» Фініка — окремо на web і mobile.

**Поведінка**
- Тап по хедеру дня перемикає стан згорнуто/розгорнуто. Хедер показує шеврон (`▾`/`▸` на mobile, обертання SVG на web) + назву дня + `· count` + сумарну суму за день (якщо увімкнено показ балансу на web).
- **Дефолт:** сьогодні розгорнуто, всі інші дні згорнуті. Застосовується лише коли у користувача немає явного вибору для конкретного дня.
- **Пошук / фільтри:** коли активний пошук або будь-який фільтр (чіп категорії/витрати/доходи/кредитна/діапазон дат/акаунти), стан згорнутих днів тимчасово ігнорується — всі збіги видимі. Збережений вибір не стирається; після очищення пошуку/фільтрів все повертається як було.
- **Персистентність:** sparse override map `{"YYYY-MM-DD": boolean}` під ключем `finyk_tx_day_collapse_v1`. Web — `localStorage` + `storage`-event синхронізація між вкладками. Mobile — MMKV + `addOnValueChangedListener` для крос-скрін синхронізації. UI-only, навмисно не синкається в хмару.

**Технічні деталі**
- Web (`GroupedVirtuoso`): новий `daySummaries` useMemo для per-day total/count; `groupCounts[i] = 0` для згорнутих днів → віртуалізація не ламається; `flatItems` не містить tx-рядки для згорнутих днів. Хедер тепер `<button>` для a11y (`aria-expanded`).
- Mobile (`FlashList`): one-pass pre-computation підсумків + другий прохід який пропускає tx-рядки для згорнутих днів. Хедер — `Pressable` з `accessibilityState={{expanded}}`.
- Ключ `FINYK_TX_DAY_COLLAPSE` доданий у `packages/shared/src/lib/storageKeys.ts` з коментарем про semantics (sparse map + default rule + UI-only).

## Review & Testing Checklist for Human

- [ ] Mobile: відкрити «Операції» — тільки сьогодні розгорнуто, попередні дні схлопнуті з чевроном `▸`. Після тапу — chevron стає `▾`, рядки з'являються.
- [ ] Mobile: вибір на будь-якому дні переживає swipe-to-refresh та перезапуск застосунку (MMKV). Зворотній бік — повторний тап знову складає.
- [ ] Mobile: ввести пошук — всі дні що містять збіги, тимчасово видимі; очистити пошук — усе повертається до збережених станів.
- [ ] Web: відкрити `/finyk` → «Операції». Перевірити той самий сценарій: default (сьогодні розгорнуто), тап по хедеру, чеврон повертається, підсумок за день справа від хедера (при увімкненому show-balance).
- [ ] Web: відкрити Фінік у двох вкладках — тап в одній вкладці одразу ж змінює стан у іншій (через storage event).
- [ ] Web: при активному фільтрі чи пошуку згорнутий стан не ховає збіги.

### Notes

- Не додав кнопок «Згорнути всі / Розгорнути всі» в тулбар — у цій ітерації тільки тап по хедерах. Можна додати в окремому PR якщо буде попит.
- Попередні тести `TransactionsPage.test.tsx` (mobile) оперували даними на 2026-04-15 і 2026-04-12 при `now=2026-04-21`, тобто з новим дефолтом їхні рядки були б приховані. Додав `expandAllDaysIn()` helper в `beforeEach`, щоб не переписувати 15 існуючих тест-кейсів, і окремий `describe("day collapse", …)` блок з 5 нових тестів спеціально для цієї фічі.
- Node 22 → pre-existing `lint:plugins` помилка (`node --test <dir>` вимагає explicit glob на Node 22). Мої зміни проходять `pnpm --filter {web,mobile,shared} lint` та `pnpm typecheck` чисто.


Link to Devin session: https://app.devin.ai/sessions/4cd727fbbca242919dc8e8c2ac9108cb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
