### PR TITLE
feat(web): central '+' FAB in Routine bottom nav opens habit dialog

### DIFF
--- a/apps/web/src/core/settings/RoutineSection.tsx
+++ b/apps/web/src/core/settings/RoutineSection.tsx
@@ -1,40 +1,25 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
-import { hapticSuccess } from "@shared/lib/haptic";
 import { showUndoToast } from "@shared/lib/undoToast";
 import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
 import {
   applyRoutineBackupPayload,
-  createHabit,
   deleteHabit,
   loadRoutineState,
   restoreHabit,
   snapshotHabit,
-  updateHabit,
 } from "../../modules/routine/lib/routineStorage.js";
-import { dateKeyFromDate } from "../../modules/routine/lib/hubCalendarAggregate.js";
 import { ROUTINE_THEME as C } from "../../modules/routine/lib/routineConstants.js";
-import {
-  emptyHabitDraft,
-  habitDraftToPatch,
-  normalizeReminderTimes,
-  routineTodayDate,
-} from "../../modules/routine/lib/routineDraftUtils.js";
 import { HabitDetailSheet } from "../../modules/routine/components/HabitDetailSheet";
+import { HabitQuickCreateDialog } from "../../modules/routine/components/HabitQuickCreateDialog";
 import { RoutineBackupSection } from "../../modules/routine/components/RoutineBackupSection";
-import {
-  HabitForm,
-  type HabitFormErrors,
-} from "../../modules/routine/components/settings/HabitForm";
 import { TagsSection } from "../../modules/routine/components/settings/TagsSection";
 import { CategoriesSection } from "../../modules/routine/components/settings/CategoriesSection";
 import { ActiveHabitsSection } from "../../modules/routine/components/settings/ActiveHabitsSection";
 import { ArchivedHabitsSection } from "../../modules/routine/components/settings/ArchivedHabitsSection";
 import type {
   CategoryDraft,
-  Habit,
-  HabitDraft,
   PendingHabitDeletion,
 } from "../../modules/routine/lib/types";
 import {
@@ -51,7 +36,6 @@ export function RoutineSection() {
   const toast = useToast();
   const { routine, setRoutine, updatePref } = useRoutineState();
 
-  const [habitDraft, setHabitDraft] = useState<HabitDraft>(emptyHabitDraft);
   const [tagDraft, setTagDraft] = useState<string>("");
   const [catDraft, setCatDraft] = useState<CategoryDraft>({
     name: "",
@@ -59,87 +43,15 @@ export function RoutineSection() {
   });
 
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDialogFocusTick, setEditDialogFocusTick] = useState(0);
   const [detailHabitId, setDetailHabitId] = useState<string | null>(null);
   const [deleteHabitPending, setDeleteHabitPending] =
     useState<PendingHabitDeletion | null>(null);
   const [importConfirm, setImportConfirm] = useState<ImportConfirmState | null>(
     null,
   );
-  const [habitErrors, setHabitErrors] = useState<HabitFormErrors>({});
 
-  // Clear field errors as soon as the user edits the relevant field so the
-  // red border doesn't linger once they start fixing the input. Mirrors
-  // behaviour in `HabitQuickCreateDialog` — keeps validation feedback
-  // consistent between the two hosts of `HabitForm`.
-  useEffect(() => {
-    if (habitErrors.name && habitDraft.name.trim()) {
-      setHabitErrors((e) => ({ ...e, name: undefined }));
-    }
-  }, [habitDraft.name, habitErrors.name]);
-  useEffect(() => {
-    if (
-      habitErrors.weekdays &&
-      Array.isArray(habitDraft.weekdays) &&
-      habitDraft.weekdays.length > 0
-    ) {
-      setHabitErrors((e) => ({ ...e, weekdays: undefined }));
-    }
-  }, [habitDraft.weekdays, habitErrors.weekdays]);
-
-  const loadHabitIntoDraft = (h: Habit) => {
-    const times = normalizeReminderTimes(h);
-    setHabitDraft({
-      name: h.name || "",
-      emoji: h.emoji || "✓",
-      tagIds: h.tagIds || [],
-      categoryId: h.categoryId || null,
-      recurrence: h.recurrence || "daily",
-      startDate: h.startDate || dateKeyFromDate(routineTodayDate()),
-      endDate: h.endDate || "",
-      timeOfDay: h.timeOfDay || "",
-      reminderTimes: times,
-      weekdays:
-        Array.isArray(h.weekdays) && h.weekdays.length
-          ? h.weekdays
-          : [0, 1, 2, 3, 4, 5, 6],
-    });
-  };
-
-  const cancelEdit = () => {
-    setEditingId(null);
-    setHabitDraft(emptyHabitDraft());
-    setHabitErrors({});
-  };
-
-  const saveHabit = () => {
-    const patch = habitDraftToPatch(habitDraft);
-    const nextErrors: HabitFormErrors = {};
-    if (!patch.name) {
-      nextErrors.name = "Додай назву звички.";
-    }
-    if (
-      patch.recurrence === "weekly" &&
-      (!patch.weekdays || patch.weekdays.length === 0)
-    ) {
-      nextErrors.weekdays = "Обери хоча б один день тижня.";
-    }
-    if (nextErrors.name || nextErrors.weekdays) {
-      setHabitErrors(nextErrors);
-      return;
-    }
-    setHabitErrors({});
-    if (editingId) {
-      setRoutine((s) => updateHabit(s, editingId, patch));
-      hapticSuccess();
-      toast.success("Звичку оновлено.");
-      cancelEdit();
-    } else {
-      setRoutine((s) => createHabit(s, patch));
-      hapticSuccess();
-      toast.success("Звичку створено.");
-      setHabitDraft(emptyHabitDraft());
-    }
-  };
+  const closeEditDialog = () => setEditingId(null);
 
   return (
     <SettingsGroup title="Рутина" emoji="✅">
@@ -160,15 +72,10 @@ export function RoutineSection() {
 
       <SettingsSubGroup title="Звички">
         <div className="space-y-4">
-          <HabitForm
-            routine={routine}
-            habitDraft={habitDraft}
-            setHabitDraft={setHabitDraft}
-            editingId={editingId}
-            onSave={saveHabit}
-            onCancel={cancelEdit}
-            errors={habitErrors}
-          />
+          <p className="text-xs text-muted">
+            Нові звички додаються через кнопку «+» в центрі нижньої навігації
+            «Рутини». Тут можна редагувати, архівувати й видаляти наявні.
+          </p>
 
           <ActiveHabitsSection
             routine={routine}
@@ -176,10 +83,10 @@ export function RoutineSection() {
             editingId={editingId}
             onEdit={(h) => {
               setEditingId(h.id);
-              loadHabitIntoDraft(h);
+              setEditDialogFocusTick((t) => t + 1);
             }}
             onCancelEditIf={(id) => {
-              if (editingId === id) cancelEdit();
+              if (editingId === id) closeEditDialog();
             }}
             onOpenDetails={(id) => setDetailHabitId(id)}
             onRequestDelete={(pending) => setDeleteHabitPending(pending)}
@@ -218,6 +125,15 @@ export function RoutineSection() {
         />
       </SettingsSubGroup>
 
+      <HabitQuickCreateDialog
+        open={!!editingId}
+        routine={routine}
+        setRoutine={setRoutine}
+        onClose={closeEditDialog}
+        editingId={editingId}
+        focusTick={editDialogFocusTick}
+      />
+
       <ConfirmDialog
         open={!!deleteHabitPending}
         title={
@@ -239,7 +155,9 @@ export function RoutineSection() {
               snapshot = snapshotHabit(s, pending.id);
               return deleteHabit(s, pending.id);
             });
-            if (!pending.archived && editingId === pending.id) cancelEdit();
+            if (!pending.archived && editingId === pending.id) {
+              closeEditDialog();
+            }
             if (snapshot) {
               showUndoToast(toast, {
                 msg: `Видалено звичку «${pending.name}»`,

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -683,7 +683,14 @@ export default function RoutineApp({
         </main>
       </div>
 
-      <RoutineBottomNav mainTab={mainTab} onSelectTab={setMainTab} />
+      <RoutineBottomNav
+        mainTab={mainTab}
+        onSelectTab={setMainTab}
+        onAddHabit={() => {
+          setQuickAddHabitOpen(true);
+          setQuickAddFocusTick((t) => t + 1);
+        }}
+      />
 
       <HabitQuickCreateDialog
         open={quickAddHabitOpen}

--- a/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -3,13 +3,16 @@ import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticSuccess } from "@shared/lib/haptic";
 import { cn } from "@shared/lib/cn";
-import { createHabit } from "../lib/routineStorage.js";
+import { createHabit, updateHabit } from "../lib/routineStorage.js";
 import {
   emptyHabitDraft,
   habitDraftToPatch,
+  normalizeReminderTimes,
+  routineTodayDate,
 } from "../lib/routineDraftUtils.js";
+import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
 import { HabitForm, type HabitFormErrors } from "./settings/HabitForm";
-import type { HabitDraft, RoutineState } from "../lib/types";
+import type { Habit, HabitDraft, RoutineState } from "../lib/types";
 import type { Dispatch, SetStateAction } from "react";
 
 export interface HabitQuickCreateDialogProps {
@@ -18,29 +21,50 @@ export interface HabitQuickCreateDialogProps {
   setRoutine: Dispatch<SetStateAction<RoutineState>>;
   onClose: () => void;
   /**
+   * When set, the dialog is in edit mode for the given habit:
+   * the draft is seeded from the habit, the title switches to
+   * "Редагувати звичку", and save calls `updateHabit`.
+   */
+  editingId?: string | null;
+  /**
    * Bumped by the parent every time the dialog is opened via an external
-   * trigger (PWA `add_habit` action, FTUX hero CTA, etc.) so the habit
-   * form re-focuses its name input even if the user reopens the dialog
-   * after closing it.
+   * trigger (central FAB, PWA `add_habit` action, FTUX hero CTA, etc.)
+   * so the habit form re-focuses its name input even if the user
+   * reopens the dialog after closing it.
    */
   focusTick?: number;
 }
 
+function habitToDraft(habit: Habit): HabitDraft {
+  return {
+    name: habit.name || "",
+    emoji: habit.emoji || "✓",
+    tagIds: habit.tagIds || [],
+    categoryId: habit.categoryId || null,
+    recurrence: habit.recurrence || "daily",
+    startDate: habit.startDate || dateKeyFromDate(routineTodayDate()),
+    endDate: habit.endDate || "",
+    timeOfDay: habit.timeOfDay || "",
+    reminderTimes: normalizeReminderTimes(habit),
+    weekdays:
+      Array.isArray(habit.weekdays) && habit.weekdays.length
+        ? habit.weekdays
+        : [0, 1, 2, 3, 4, 5, 6],
+  };
+}
+
 /**
- * Lightweight "quick-create" sheet for a habit. Rendered on top of the
- * current Routine view (usually the Calendar) so that hitting the
- * `add_habit` PWA shortcut no longer yanks the user into the Settings
- * tab — see audit note S0.2.
- *
- * The dialog owns its own draft state; when the user saves we hand the
- * patch off to `createHabit` and close. Editing an existing habit is
- * still done inside the Settings tab's richer `HabitForm` host.
+ * Bottom-sheet dialog for creating or editing a habit. Rendered on top
+ * of the current view so that adding / editing a habit never yanks the
+ * user into a different tab. Uses the same rich `HabitForm` as the
+ * settings surface, so fields and validation stay in sync.
  */
 export function HabitQuickCreateDialog({
   open,
   routine,
   setRoutine,
   onClose,
+  editingId,
   focusTick,
 }: HabitQuickCreateDialogProps) {
   const ref = useRef<HTMLDivElement>(null);
@@ -50,15 +74,23 @@ export function HabitQuickCreateDialog({
   const [internalFocusTick, setInternalFocusTick] = useState(0);
   const [errors, setErrors] = useState<HabitFormErrors>({});
 
-  // Reset the draft and re-fire the focus tick each time the dialog
-  // opens. Keeps reopens feeling like a fresh entry point instead of
-  // carrying stale input.
+  // Seed the draft every time the dialog opens. In create mode we reset
+  // to an empty draft so reopens feel fresh; in edit mode we load the
+  // current habit so the form reflects its latest persisted state.
   useEffect(() => {
     if (!open) return;
-    setDraft(emptyHabitDraft());
+    if (editingId) {
+      const habit = routine.habits.find((h) => h.id === editingId);
+      setDraft(habit ? habitToDraft(habit) : emptyHabitDraft());
+    } else {
+      setDraft(emptyHabitDraft());
+    }
     setErrors({});
     setInternalFocusTick((t) => t + 1);
-  }, [open, focusTick]);
+    // Depend on `editingId` + `focusTick` — not `routine`, otherwise the
+    // draft resets on every keystroke-driven routine update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, editingId, focusTick]);
 
   // Clear field errors as soon as the user touches the relevant field
   // so the red border doesn't linger once they start fixing the input.
@@ -96,11 +128,19 @@ export function HabitQuickCreateDialog({
       return;
     }
     setErrors({});
-    setRoutine((s) => createHabit(s, patch));
-    hapticSuccess();
-    toast.success("Звичку створено.");
+    if (editingId) {
+      setRoutine((s) => updateHabit(s, editingId, patch));
+      hapticSuccess();
+      toast.success("Звичку оновлено.");
+    } else {
+      setRoutine((s) => createHabit(s, patch));
+      hapticSuccess();
+      toast.success("Звичку створено.");
+    }
     onClose();
   };
+
+  const title = editingId ? "Редагувати звичку" : "Нова звичка";
 
   return (
     <div
@@ -129,7 +169,7 @@ export function HabitQuickCreateDialog({
             id="habit-quick-create-title"
             className="text-base font-bold text-text"
           >
-            Нова звичка
+            {title}
           </h2>
           <button
             type="button"
@@ -157,7 +197,7 @@ export function HabitQuickCreateDialog({
             routine={routine}
             habitDraft={draft}
             setHabitDraft={setDraft}
-            editingId={null}
+            editingId={editingId ?? null}
             onSave={handleSave}
             onCancel={onClose}
             focusTick={internalFocusTick}

--- a/apps/web/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/apps/web/src/modules/routine/components/RoutineBottomNav.tsx
@@ -62,20 +62,55 @@ const NAV: readonly RoutineNavItem[] = [
 export interface RoutineBottomNavProps {
   mainTab: RoutineMainTab;
   onSelectTab: (tab: RoutineMainTab) => void;
+  onAddHabit?: () => void;
 }
 
 export function RoutineBottomNav({
   mainTab,
   onSelectTab,
+  onAddHabit,
 }: RoutineBottomNavProps) {
   return (
-    <ModuleBottomNav
-      items={NAV}
-      activeId={mainTab}
-      onChange={(id) => onSelectTab(id as RoutineMainTab)}
-      module="routine"
-      role="tablist"
-      ariaLabel="Розділи Рутини"
-    />
+    <div className="relative shrink-0">
+      <ModuleBottomNav
+        items={NAV}
+        activeId={mainTab}
+        onChange={(id) => onSelectTab(id as RoutineMainTab)}
+        module="routine"
+        role="tablist"
+        ariaLabel="Розділи Рутини"
+      />
+      {onAddHabit && (
+        <button
+          type="button"
+          onClick={onAddHabit}
+          aria-label="Додати звичку"
+          className={[
+            "absolute left-1/2 -translate-x-1/2 -top-6",
+            "w-14 h-14 rounded-full z-40",
+            "bg-gradient-to-br from-coral-400 to-coral-500 text-white",
+            "shadow-float border-4 border-bg",
+            "flex items-center justify-center",
+            "transition-transform duration-150 active:scale-95 hover:scale-[1.04]",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
+          ].join(" ")}
+        >
+          <svg
+            width="26"
+            height="26"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

У центрі нижньої навігації «Рутини» тепер є кругла кнопка «+», яка відкриває повноцінний діалог створення звички (той самий `HabitForm` зі всіма полями, що раніше жили в налаштуваннях). Саму форму створення прибрано з Hub Settings → Рутина.

**Що змінилось:**
- `RoutineBottomNav` отримав опційний проп `onAddHabit`. Коли він заданий, по центру навігації з’являється піднята кругла кнопка «+» (шрифтовим розміром 14×14, обведена `border-bg` для ефекту «вирізу»).
- `RoutineApp` передає `onAddHabit`, який відкриває `HabitQuickCreateDialog` і піднімає `focusTick` (щоб input назви фокусився при кожному відкритті).
- `HabitQuickCreateDialog` тепер уміє не тільки створення, а й редагування через опційний проп `editingId`: якщо він заданий — драфт сідується з існуючої звички, заголовок стає «Редагувати звичку», а зберігання йде через `updateHabit`.
- Hub Settings → Рутина → Звички більше не рендерить інлайн `HabitForm`. Замість неї — підказка «Нові звички додаються через кнопку «+»…» + існуючий список активних/архівних звичок. Коли користувач клікає «Редагувати» в списку, відкривається той самий діалог у режимі `editingId`. Таким чином створення та редагування використовують один і той самий UI.

## Review & Testing Checklist for Human

- [ ] Перевірити, що по центру нижньої навігації «Рутини» видна кругла кнопка «+», і кнопки Календар / Статистика не перекриті.
- [ ] Тап по «+» відкриває діалог «Нова звичка» з усіма полями (назва, емоджі, теги, категорія, регулярність, дні тижня для «По тижню», пресети нагадувань, «Більше опцій» з датами/часом).
- [ ] Збереження звички з діалогу: вона зʼявляється в календарі й у списку активних у Hub Settings.
- [ ] Hub Settings → Рутина → Звички: натиснути «Редагувати» на активній звичці → відкривається той самий діалог з заголовком «Редагувати звичку» і пресідженими полями. Збереження оновлює звичку.
- [ ] Empty-state у календарі Рутини («Почни з однієї звички») так само відкриває діалог (як в попередньому PR).
- [ ] PWA `add_habit` shortcut продовжує відкривати діалог (той самий `quickAddHabitOpen` state).

### Notes

- Локально пройшли: `pnpm --filter @sergeant/web typecheck`, `pnpm --filter @sergeant/web lint`, `pnpm --filter @sergeant/web test -- --run` (618/618).
- Мобільний застосунок не зачіпаю — у `apps/mobile` інша архітектура.


Link to Devin session: https://app.devin.ai/sessions/618790101aac4b50b46ab2f3756461d7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated dialog interface for creating and editing habits with improved focus management and input handling.
  * Introduced "Add Habit" button in the bottom navigation for quick and convenient habit creation.

* **Refactor**
  * Consolidated habit creation and editing workflows into a unified dialog component, simplifying overall state management and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->