### PR TITLE
refactor(hub): замінити add-speed-dial FAB на AI-assistant FAB

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -339,12 +339,14 @@ function AppInner() {
           inFtuxSession={inFtuxSession}
         />
 
-        {/* Primary quick-add surface for the hub. AI chat moved to the
-            header — see `HubHeader` / `HubHeaderWithProps` (`onOpenChat`).
-            Hidden during the FTUX session so the only add-surface in view is
-            the `FirstActionHeroCard` → `PresetSheet` one-tap path; the FAB
-            returns the moment the first real entry lands. */}
-        <HubFloatingActions hidden={inFtuxSession} />
+        {/* Thumb-reach entry to the AI assistant. Module quick-add is
+            handled above by `TodayFocusCard`'s chips (+ Витрата / + Їжа /
+            + Звичка / + Тренування), so a separate add-speed-dial FAB
+            would be a pure duplicate. Hidden during the FTUX session so
+            the only interactive surface in view is the FirstActionHero
+            → PresetSheet one-tap path; the FAB returns the moment the
+            first real entry lands. */}
+        <HubFloatingActions hidden={inFtuxSession} onOpenChat={ui.openChat} />
 
         {/* Persistent shortcut back to an in-progress Fizruk workout.
             Hidden during FTUX so the splash stays single-CTA; otherwise

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -1,157 +1,51 @@
-import { useEffect, useRef, useState } from "react";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
-import { openHubModuleWithAction } from "@shared/lib/hubNav";
 
 /**
- * Cross-module "+ Додати" speed dial. Tapping the primary FAB reveals 4
- * contextual add actions — the shortest path from the hub to a real entry
- * in any module. Replaces the previous AI-chat-only FAB; the AI assistant
- * now lives in the header (see `HubHeader`).
- */
-const ACTIONS = [
-  {
-    id: "expense",
-    icon: "credit-card",
-    label: "Витрата",
-    accent: "text-finyk bg-finyk-soft",
-    run: () => openHubModuleWithAction("finyk", "add_expense"),
-  },
-  {
-    id: "meal",
-    icon: "utensils",
-    label: "Прийом їжі",
-    accent: "text-nutrition bg-nutrition-soft",
-    run: () => openHubModuleWithAction("nutrition", "add_meal"),
-  },
-  {
-    id: "habit",
-    icon: "check",
-    label: "Звичка",
-    accent: "text-routine bg-routine-soft",
-    run: () => openHubModuleWithAction("routine", "add_habit"),
-  },
-  {
-    id: "workout",
-    icon: "dumbbell",
-    label: "Тренування",
-    accent: "text-fizruk bg-fizruk-soft",
-    run: () => openHubModuleWithAction("fizruk", "start_workout"),
-  },
-];
-
-/**
+ * Thumb-reach entry point to the AI assistant. A single FAB that opens
+ * the hub chat — the primary add surface is `TodayFocusCard`
+ * (`+ Витрата / + Їжа / + Звичка / + Тренування` chips), which already
+ * covers every module's quick-add path and made the previous
+ * add-speed-dial FAB a pure duplicate.
+ *
+ * The header also exposes an AI chat sparkle icon (`HubHeader`
+ * `onOpenChat`); having both is intentional — same action, two
+ * reach zones (top-right on desktop, bottom-right thumb zone on mobile).
+ *
  * @param {object} props
- * @param {boolean} [props.hidden=false] - When true the FAB is not rendered
- *   at all. Used during the FTUX session so the only add-surface in view is
- *   `FirstActionHeroCard` → `PresetSheet` (the one-tap "real entry" path).
- *   The generic FAB would otherwise bypass that flow and drop the user into
- *   a full manual AddSheet, defeating the 30-second promise.
+ * @param {boolean} [props.hidden=false] - When true the FAB is not
+ *   rendered at all. Used during the FTUX session so the only
+ *   interactive surface in view is `FirstActionHeroCard` → `PresetSheet`
+ *   (the one-tap "real entry" path). A chat FAB would otherwise pull
+ *   users into a conversational flow before they've logged anything.
+ * @param {() => void} props.onOpenChat - Opens the hub AI chat panel.
+ *   Shared with `HubHeader` so both entry points resolve to the same
+ *   `ui.openChat()`.
  */
-export function HubFloatingActions({ hidden = false }) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef(null);
-
-  // Collapse the speed-dial the moment we're hidden so reopening after FTUX
-  // doesn't flash a stale open state.
-  useEffect(() => {
-    if (hidden) setOpen(false);
-  }, [hidden]);
-
-  // Click-outside + Escape close. Matches the ambient dismissal pattern
-  // used by the rest of the hub's popovers.
-  useEffect(() => {
-    if (!open) return;
-    const onDocDown = (e) => {
-      if (rootRef.current && !rootRef.current.contains(e.target)) {
-        setOpen(false);
-      }
-    };
-    const onKey = (e) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onDocDown);
-    document.addEventListener("touchstart", onDocDown, { passive: true });
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocDown);
-      document.removeEventListener("touchstart", onDocDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  const runAction = (action) => {
-    setOpen(false);
-    action.run();
-  };
-
-  if (hidden) return null;
+export function HubFloatingActions({ hidden = false, onOpenChat }) {
+  if (hidden || !onOpenChat) return null;
 
   return (
     <div
-      ref={rootRef}
       className="fixed right-5 z-40 flex flex-col items-end gap-2 pointer-events-none"
       style={{ bottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))" }}
     >
-      {open && (
-        <div
-          role="menu"
-          aria-label="Швидке додавання"
-          className="pointer-events-auto flex flex-col items-end gap-2 animate-fade-in"
-        >
-          {ACTIONS.map((a) => (
-            <button
-              key={a.id}
-              type="button"
-              role="menuitem"
-              onClick={() => runAction(a)}
-              className="group flex items-center gap-3 pl-3 pr-2 h-11 rounded-full bg-panel border border-line shadow-card hover:shadow-float transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
-            >
-              <span className="text-sm font-medium text-text whitespace-nowrap">
-                {a.label}
-              </span>
-              <span
-                className={cn(
-                  "w-8 h-8 rounded-full flex items-center justify-center",
-                  a.accent,
-                )}
-                aria-hidden
-              >
-                <Icon name={a.icon} size={16} strokeWidth={2} />
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* S5 / S14: extended FAB pill — shows an always-visible "Додати"
-          label on first paint so the primary action isn't just a blue
-          circle users have to guess at (especially on touch, where the
-          `title` tooltip never appears). Collapses to an icon-only
-          rotated × when the speed-dial is open. */}
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-haspopup="menu"
-        aria-label={open ? "Закрити меню додавання" : "Додати"}
-        title={open ? "Закрити" : "Додати"}
+        onClick={onOpenChat}
+        aria-label="Відкрити AI-асистента"
+        title="Асистент"
         className={cn(
-          "pointer-events-auto h-14 flex items-center justify-center gap-2 rounded-full bg-brand-500 text-white shadow-float hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-          open ? "w-14" : "pl-4 pr-5",
+          "pointer-events-auto h-14 pl-4 pr-5 flex items-center justify-center gap-2 rounded-full",
+          "bg-brand-500 text-white shadow-float",
+          "hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-all",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         )}
       >
-        <Icon
-          name="plus"
-          size={26}
-          strokeWidth={2.5}
-          className={cn("transition-transform", open && "rotate-45")}
-        />
-        {!open && (
-          <span className="text-sm font-semibold whitespace-nowrap">
-            Додати
-          </span>
-        )}
+        <Icon name="sparkle" size={22} strokeWidth={2.2} />
+        <span className="text-sm font-semibold whitespace-nowrap">
+          Асистент
+        </span>
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

На дашборді Hub-а користувач бачив два паралельних шляхи для швидкого додавання запису:

1. **`TodayFocusCard`** → `EmptyFocus` showed чотири quick-add чипси: `+ Витрата / + Їжа / + Звичка / + Тренування`.
2. **`HubFloatingActions`** — speed-dial FAB, який розкривався в 4 дії: `Витрата / Прийом їжі / Звичка / Тренування`.

Обидві поверхні викликали той самий `openHubModuleWithAction(module, action)` з `@shared/lib/hubNav`, тож фактично пропонували один і той же набір дій з трохи різними написами й іконками. Репорт [від dmytro.s.stakhov](https://app.devin.ai/sessions/bca43549a25f4136a1704d8d1aa8c87c) — «картка Зафіксуємо і FAB роблять дубль» — був абсолютно коректним.

### Що змінилось

- [`apps/web/src/core/app/HubFloatingActions.tsx`](apps/web/src/core/app/HubFloatingActions.tsx): повна заміна. Замість speed-dial з чотирма add-діями тепер один thumb-reach FAB `Асистент`, який відкриває Hub AI chat через `ui.openChat()` — той самий handler, що вже підключено до sparkle-іконки в `HubHeader`. Видалено local state (`open`), click-outside + Escape слухачі, `ACTIONS` масив — все стало непотрібним.
- [`apps/web/src/core/App.tsx`](apps/web/src/core/App.tsx): прокидаю `onOpenChat={ui.openChat}` у `HubFloatingActions` і переписую сусідній коментар, щоб майбутні читачі не шукали чому FAB не має add-дій.

### Що НЕ змінилось

- **Module quick-add** — `TodayFocusCard.EmptyFocus` чипси лишаються primary add surface: `QUICK_ADD_CHIPS` з `MODULE_PRIMARY_ACTION` → `openHubModuleWithAction(...)` працює без змін.
- **Header sparkle icon** — `HubHeader.onOpenChat` лишається. Два entry-point'и для одного chat-handler'а це не плутанина (обидва роблять рівно одне й те саме), зате покриваємо і top-right десктопний річ, і bottom-right мобільний thumb-zone.
- **FTUX guard** — `<HubFloatingActions hidden={inFtuxSession} />` працює як раніше; під час first-time onboarding FAB ховається, щоб єдиною CTA в кадрі лишалась `FirstActionHeroCard → PresetSheet`.
- `hubNav`, `openHubModuleWithAction`, `MODULE_PRIMARY_ACTION` — не зачеплено.

### Скрін до/після

**До:** TodayFocusCard `+ Витрата / + Їжа / + Звичка / + Тренування` + FAB speed-dial відкривається з тим самим набором.

**Після:** TodayFocusCard chips лишаються, FAB — один `Асистент`-пілл, який відкриває чат.

## Review & Testing Checklist for Human

Risk: **green** — локалізована UI-заміна одного компонента; бізнес-логіка не зачеплена, всі 618 vitest-тестів проходять, `pnpm lint` і `tsc --noEmit` чисті.

- [ ] Відкрити дашборд без рекомендацій (EmptyFocus state) — чотири quick-add чипси мають лишитись, і кожен має відкривати свій модуль з правильним preset/action. FAB праворуч-знизу тепер відкриває `HubChat`, не add-sheet.
- [ ] Відкрити дашборд з активним `focus` rec — primary CTA в hero картці працює як раніше, FAB `Асистент` поруч не заважає.
- [ ] FTUX (перший захід, user === null, ще немає реальних записів): FAB схований, сплеш-первинна дія лишається єдиною CTA.

### Notes

- Якщо потім захочете прибрати й header-sparkle, залишивши chat тільки в FAB — це one-liner у `HubHeader`, але я це не робив у цьому PR, щоб не розширювати scope і щоб десктопний top-bar entry-point лишився.
- Альтернатива, яку я розглянув і відкинув: тримати add-FAB, але ховати його коли рендериться EmptyFocus (conditional duplication). Це додає прихованої логіки і розбиває консистентність розташування FAB між станами дашборду, тож вибрав простішу заміну.

Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
