### PR TITLE
fix(hub): FAB opens chat reliably; remove duplicate header chat icon

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -294,7 +294,6 @@ function AppInner() {
 
         <HubHeader
           onOpenSearch={() => ui.setSearchOpen(true)}
-          onOpenChat={() => ui.openChat()}
           user={user}
           syncing={sync.syncing}
           lastSync={sync.lastSync}

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -8,9 +8,8 @@ import { cn } from "@shared/lib/cn";
  * covers every module's quick-add path and made the previous
  * add-speed-dial FAB a pure duplicate.
  *
- * The header also exposes an AI chat sparkle icon (`HubHeader`
- * `onOpenChat`); having both is intentional — same action, two
- * reach zones (top-right on desktop, bottom-right thumb zone on mobile).
+ * This is the only chat entry point in the hub chrome; the header no
+ * longer duplicates the action next to search/dark-mode.
  *
  * @param {object} props
  * @param {boolean} [props.hidden=false] - When true the FAB is not
@@ -18,9 +17,8 @@ import { cn } from "@shared/lib/cn";
  *   interactive surface in view is `FirstActionHeroCard` → `PresetSheet`
  *   (the one-tap "real entry" path). A chat FAB would otherwise pull
  *   users into a conversational flow before they've logged anything.
- * @param {() => void} props.onOpenChat - Opens the hub AI chat panel.
- *   Shared with `HubHeader` so both entry points resolve to the same
- *   `ui.openChat()`.
+ * @param {() => void} props.onOpenChat - Opens the hub AI chat panel
+ *   (resolves to `ui.openChat()`).
  */
 export function HubFloatingActions({ hidden = false, onOpenChat }) {
   if (hidden || !onOpenChat) return null;
@@ -32,7 +30,7 @@ export function HubFloatingActions({ hidden = false, onOpenChat }) {
     >
       <button
         type="button"
-        onClick={onOpenChat}
+        onClick={() => onOpenChat()}
         aria-label="Відкрити AI-асистента"
         title="Асистент"
         className={cn(

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -7,7 +7,6 @@ const ICON_BUTTON_CLS =
 
 export function HubHeader({
   onOpenSearch,
-  onOpenChat,
   user,
   syncing,
   lastSync,
@@ -27,17 +26,6 @@ export function HubHeader({
     >
       <h1 className="text-3xl font-bold text-text tracking-tight">Sergeant</h1>
       <div className="pt-1 flex items-center gap-1">
-        {onOpenChat && (
-          <button
-            type="button"
-            onClick={onOpenChat}
-            aria-label="Відкрити AI-асистента"
-            title="Асистент"
-            className={ICON_BUTTON_CLS}
-          >
-            <Icon name="sparkle" size={20} />
-          </button>
-        )}
         <button
           type="button"
           onClick={onOpenSearch}


### PR DESCRIPTION
## Summary

Після PR #555, який замінив add-speed-dial FAB на кнопку AI-асистента, FAB «Асистент» перестав коректно відкривати чат. Причина — `<button onClick={onOpenChat}>`: React передавав `SyntheticEvent` як перший аргумент у `ui.openChat(message?)`. Подія зберігалась як `chatInitialMessage`, а `HubChat` у ефекті робив `setInput(initialMessage)`, тобто клав об'єкт події в `<input value>` замість рядка — панель відкривалась у поламаному стані.

Одночасно користувач попросив прибрати дублюючу кнопку чату у шапці (біля пошуку та нічного режиму), залишивши FAB як єдину точку входу в чат.

## Changes
- `apps/web/src/core/app/HubFloatingActions.tsx` — `onClick={() => onOpenChat()}` (нульовий виклик без події). Оновлено JSDoc (більше немає дубля в шапці).
- `apps/web/src/core/app/HubHeader.tsx` — прибрано sparkle-кнопку «Асистент» і проп `onOpenChat`.
- `apps/web/src/core/App.tsx` — прибрано передачу `onOpenChat` у `HubHeader`. FAB і далі використовує `ui.openChat`.

## Review & Testing Checklist for Human
- [ ] Тап по FAB «Асистент» відкриває чат і інпут порожній (не містить `[object Object]`).
- [ ] У шапці біля пошуку та нічного режиму більше немає іконки чату; FAB — єдиний вхід у чат з хаб-оболонки.
- [ ] FAB і далі прихований під час FTUX-сесії (до першого реального запису).
- [ ] Відкриття чату через голосовий ввід / інші виклики `ui.openChat("текст")` з заздалегідь заповненим повідомленням продовжує працювати (якщо такі точки входу використовуються).

### Notes
`ui.openChat(message?: string | null)` приймає опціональний рядок. Прямий `onClick={onOpenChat}` полонив цю сигнатуру подією — безпечніше завжди обгортати в `() => onOpenChat()` там, де початкове повідомлення не потрібне.

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated chat entry point—AI assistant button is now accessible exclusively through the floating action button instead of the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->