### PR TITLE
fix(finyk): auto-open forecast section when overLimit flips false→true

### DIFF
--- a/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
@@ -1,4 +1,4 @@
-import { memo, Suspense, useEffect, useRef, useState } from "react";
+import { memo, Suspense, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { Icon } from "@shared/components/ui/Icon";
@@ -47,21 +47,23 @@ function LimitBudgetCardComponent({
   const [forecastOpen, setForecastOpen] = useState(
     Boolean(forecast?.overLimit),
   );
-  // `useState` фіксує initial value лише при першому монтажі. Без цього
-  // ефекту картка, яка монтувалась у безпечному стані, лишалась би
-  // згорнутою після того як прогноз перейшов у перевищення — напр. коли
-  // користувач опускає ліміт інлайн-редактором або надходить нова
-  // транзакція. Авто-розкриваємо секцію лише на переході `false → true`,
-  // щоб не перевідкривати її після того, як користувач свідомо її
-  // згорнув при вже перевищеному прогнозі.
-  const prevOverLimitRef = useRef(Boolean(forecast?.overLimit));
-  useEffect(() => {
-    const nextOverLimit = Boolean(forecast?.overLimit);
-    if (nextOverLimit && !prevOverLimitRef.current) {
+  // Авто-розкриваємо секцію лише на переході `overLimit: false → true`
+  // (напр. користувач опускає ліміт інлайн-редактором, нова транзакція
+  // виводить проєкцію за стелю). `useState` запам'ятовує initial value
+  // тільки при першому монтажі, тож стежимо за попереднім значенням
+  // окремим state і оновлюємо його під час рендеру — render-time
+  // state adjustment за React docs (you-might-not-need-an-effect),
+  // без зайвого ре-рендеру через `useEffect`. Свідоме згортання
+  // користувачем вже-перевищеної секції лишається недоторканим, поки
+  // `overLimit` не впаде назад у `false` і не стрельне знову.
+  const nextOverLimit = Boolean(forecast?.overLimit);
+  const [prevOverLimit, setPrevOverLimit] = useState(nextOverLimit);
+  if (nextOverLimit !== prevOverLimit) {
+    setPrevOverLimit(nextOverLimit);
+    if (nextOverLimit) {
       setForecastOpen(true);
     }
-    prevOverLimitRef.current = nextOverLimit;
-  }, [forecast?.overLimit]);
+  }
   const [explanationOpen, setExplanationOpen] = useState(true);
 
   return (

--- a/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
@@ -1,4 +1,4 @@
-import { memo, Suspense, useState } from "react";
+import { memo, Suspense, useEffect, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { Icon } from "@shared/components/ui/Icon";
@@ -47,6 +47,21 @@ function LimitBudgetCardComponent({
   const [forecastOpen, setForecastOpen] = useState(
     Boolean(forecast?.overLimit),
   );
+  // `useState` фіксує initial value лише при першому монтажі. Без цього
+  // ефекту картка, яка монтувалась у безпечному стані, лишалась би
+  // згорнутою після того як прогноз перейшов у перевищення — напр. коли
+  // користувач опускає ліміт інлайн-редактором або надходить нова
+  // транзакція. Авто-розкриваємо секцію лише на переході `false → true`,
+  // щоб не перевідкривати її після того, як користувач свідомо її
+  // згорнув при вже перевищеному прогнозі.
+  const prevOverLimitRef = useRef(Boolean(forecast?.overLimit));
+  useEffect(() => {
+    const nextOverLimit = Boolean(forecast?.overLimit);
+    if (nextOverLimit && !prevOverLimitRef.current) {
+      setForecastOpen(true);
+    }
+    prevOverLimitRef.current = nextOverLimit;
+  }, [forecast?.overLimit]);
   const [explanationOpen, setExplanationOpen] = useState(true);
 
   return (


### PR DESCRIPTION
## Summary

Фолоу-ап до #557. Devin Review (коментар [#3129373559](https://github.com/Skords-01/Sergeant/pull/557#discussion_r3129373559)) справедливо вказав, що `LimitBudgetCard` ініціалізував `forecastOpen` через `useState(Boolean(forecast?.overLimit))` — а `useState` читає initial value лише при першому монтажі. Якщо прогноз переходить у перевищення **після** монтажу (напр., користувач опускає ліміт інлайн-редактором з 10 000 ₴ до 5 000 ₴, або нова транзакція виводить проєкцію за стелю), картка перерендериться з тим самим `key` (`b.id`), і React збереже старий `false` — попередження лишиться за згорнутим рядком, що суперечить контракту «відкрито за замовчуванням при перевищенні».

Трекаю попередній `overLimit` у `useRef` і авто-відкриваю секцію лише на переході `false → true`. Якщо користувач свідомо згорнув вже перевищену секцію — це рішення зберігається, поки `overLimit` не впаде назад у `false` і не стрельне знову.

## Changes
- `apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx` — додано `useEffect` + `useRef<boolean>` для авто-розкриття `forecastOpen` на false→true; імпорт оновлено (`useEffect`, `useRef`).

## Review & Testing Checklist for Human
- [ ] Прогноз у межах ліміту → рядок згорнутий. Ввести транзакцій стільки, щоб проєкція перейшла за ліміт → секція автоматично розгортається з `⚠️ Перевищення …` без ремонту картки.
- [ ] Прогноз перевищено, користувач свідомо згортає секцію → повторний ренедер з тим самим `overLimit: true` не перевідкриває її.
- [ ] Якщо прогноз падає назад у безпечну зону, а потім знову переходить у перевищення — секція автоматично розгортається на другому переході.

### Notes
Альтернатива через `useEffect(() => setForecastOpen(forecast?.overLimit), [forecast?.overLimit])` стирала б вибір користувача щоразу, коли проп ре-ідентифікується. Варіант із `useRef` + перевіркою переходу явно описує семантику.

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget cards now auto-expand only when forecast limits transition from OK to exceeded, and will remain closed if the user manually collapsed them afterward. The component also tracks prior forecast state to avoid repeatedly forcing the forecast open once the user has toggled it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->