### PR TITLE
feat(finyk): Budgets stats strip + collapsible Фінплан + dismissable AI-порада

### DIFF
--- a/apps/web/src/modules/finyk/components/FinykStatsStrip.tsx
+++ b/apps/web/src/modules/finyk/components/FinykStatsStrip.tsx
@@ -1,0 +1,173 @@
+/**
+ * Horizontally-scrollable strip of stats tiles shared by the Активи and
+ * Планування pages in Finyk. Each tile is rendered only when its data
+ * slot is non-null, so empty accounts collapse the strip to nothing —
+ * no placeholder boxes, no empty container.
+ *
+ * The component is purely presentational: consumers compute the figures
+ * via `computeFinykSchedule` (see `../lib/upcomingSchedule.ts`) and pass
+ * them in as props.
+ */
+
+import { Icon, type IconName } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+import {
+  formatRelativeDue,
+  type UpcomingCharge,
+  type UrgentLiability,
+} from "../lib/upcomingSchedule";
+
+type IconTone = "success" | "danger" | "muted";
+
+type StatTileProps = {
+  iconName: IconName;
+  iconTone: IconTone;
+  label: string;
+  value: string;
+  hint?: string;
+  onClick?: () => void;
+};
+
+function toneClass(tone: IconTone) {
+  return tone === "success"
+    ? "text-success"
+    : tone === "danger"
+      ? "text-danger"
+      : "text-muted";
+}
+
+export function StatTile({
+  iconName,
+  iconTone,
+  label,
+  value,
+  hint,
+  onClick,
+}: StatTileProps) {
+  const base = cn(
+    "flex-1 min-w-[9.5rem] shrink-0 text-left px-3 py-2.5",
+    "bg-panelHi border border-line rounded-2xl",
+    "transition-colors",
+    onClick && "hover:border-muted/50 active:scale-[0.99]",
+  );
+  const inner = (
+    <>
+      <div className="flex items-center gap-2 text-[11px] text-muted">
+        <span className={cn("inline-flex", toneClass(iconTone))} aria-hidden>
+          <Icon name={iconName} size={14} />
+        </span>
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="text-sm font-bold text-text mt-1 truncate">{value}</div>
+      {hint && (
+        <div className="text-[11px] text-subtle mt-0.5 truncate">{hint}</div>
+      )}
+    </>
+  );
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} className={base}>
+        {inner}
+      </button>
+    );
+  }
+  return <div className={base}>{inner}</div>;
+}
+
+export type FinykStatsStripProps = {
+  /** Sum of UAH subscription amounts; tile hidden when `subsCount === 0`. */
+  subsMonthly: number;
+  subsCount: number;
+  /** Earliest upcoming charge across subs + dated debts + receivables. */
+  nextCharge: UpcomingCharge | null;
+  /** Largest manual debt with a dueDate; shown when present. */
+  urgentLiability?: UrgentLiability | null;
+  todayStart: Date;
+  /** Masks values to `••••` when the user has hidden balances globally. */
+  showBalance: boolean;
+  /** Tap handlers — when omitted the tile renders as a non-interactive div. */
+  onOpenSubs?: () => void;
+  onOpenLiabilities?: () => void;
+  className?: string;
+};
+
+export function FinykStatsStrip({
+  subsMonthly,
+  subsCount,
+  nextCharge,
+  urgentLiability = null,
+  todayStart,
+  showBalance,
+  onOpenSubs,
+  onOpenLiabilities,
+  className,
+}: FinykStatsStripProps) {
+  const showSubsTile = subsCount > 0;
+  const showNextTile = Boolean(nextCharge);
+  const showUrgentTile = Boolean(urgentLiability);
+  if (!showSubsTile && !showNextTile && !showUrgentTile) return null;
+  const hideNumbers = !showBalance;
+  return (
+    <div
+      className={cn(
+        "flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-hidden",
+        className,
+      )}
+      role="list"
+    >
+      {showSubsTile && (
+        <StatTile
+          iconName="refresh-cw"
+          iconTone="muted"
+          label="Підписки · міс"
+          value={
+            hideNumbers
+              ? "••••"
+              : `${subsMonthly.toLocaleString("uk-UA", {
+                  maximumFractionDigits: 0,
+                })} ₴`
+          }
+          hint={`${subsCount} активн${subsCount === 1 ? "а" : "их"}`}
+          onClick={onOpenSubs}
+        />
+      )}
+      {showNextTile && nextCharge && (
+        <StatTile
+          iconName="calendar"
+          iconTone={nextCharge.sign === "-" ? "danger" : "success"}
+          label="Наступний платіж"
+          value={
+            hideNumbers
+              ? "••••"
+              : `${nextCharge.sign}${nextCharge.amount.toLocaleString("uk-UA", {
+                  maximumFractionDigits: 0,
+                })} ₴`
+          }
+          hint={`${nextCharge.label} · ${formatRelativeDue(
+            nextCharge.dueDate,
+            todayStart,
+          )}`}
+        />
+      )}
+      {showUrgentTile && urgentLiability && (
+        <StatTile
+          iconName="alert"
+          iconTone="danger"
+          label="Пасив з дедлайном"
+          value={
+            hideNumbers
+              ? "••••"
+              : `−${urgentLiability.remaining.toLocaleString("uk-UA", {
+                  maximumFractionDigits: 0,
+                })} ₴`
+          }
+          hint={`${urgentLiability.name} · ${formatRelativeDue(
+            urgentLiability.dueDate,
+            todayStart,
+          )}`}
+          onClick={onOpenLiabilities}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
@@ -33,6 +33,7 @@ function LimitBudgetCardComponent({
   explanation,
   explanationLoading,
   onExplain,
+  onDismissAdvice,
   onBeginEdit,
   onChangeLimit,
   onSave,
@@ -153,25 +154,37 @@ function LimitBudgetCardComponent({
               <div className="mt-3 bg-bg rounded-xl overflow-hidden">
                 {proactiveText ? (
                   <>
-                    <button
-                      type="button"
-                      onClick={() => setAdviceOpen((v) => !v)}
-                      aria-expanded={adviceOpen}
-                      className="w-full flex items-center justify-between gap-2 px-3 py-2 text-left hover:bg-panelHi transition-colors"
-                    >
-                      <span className="flex items-center gap-2 text-xs font-semibold text-text">
-                        <span className="text-base leading-none">✨</span>
-                        AI-порада
-                      </span>
-                      <Icon
-                        name="chevron-down"
-                        size={14}
-                        className={cn(
-                          "transition-transform text-muted",
-                          adviceOpen ? "rotate-180" : "",
-                        )}
-                      />
-                    </button>
+                    <div className="flex items-stretch">
+                      <button
+                        type="button"
+                        onClick={() => setAdviceOpen((v) => !v)}
+                        aria-expanded={adviceOpen}
+                        className="flex-1 flex items-center justify-between gap-2 px-3 py-2 text-left hover:bg-panelHi transition-colors"
+                      >
+                        <span className="flex items-center gap-2 text-xs font-semibold text-text">
+                          <span className="text-base leading-none">✨</span>
+                          AI-порада
+                        </span>
+                        <Icon
+                          name="chevron-down"
+                          size={14}
+                          className={cn(
+                            "transition-transform text-muted",
+                            adviceOpen ? "rotate-180" : "",
+                          )}
+                        />
+                      </button>
+                      {onDismissAdvice && (
+                        <button
+                          type="button"
+                          onClick={onDismissAdvice}
+                          className="px-3 text-xs text-muted hover:text-text border-l border-line transition-colors"
+                          title="Прибрати пораду до наступної генерації"
+                        >
+                          Зрозуміло
+                        </button>
+                      )}
+                    </div>
                     {adviceOpen && (
                       <p className="px-3 pb-2.5 text-xs text-text leading-relaxed">
                         {proactiveText}

--- a/apps/web/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
@@ -1,11 +1,15 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { cn } from "@shared/lib/cn";
-import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Icon } from "@shared/components/ui/Icon";
 import { Input } from "@shared/components/ui/Input";
 
 // Merged monthly-plan block: income/expense/savings inputs + fact summary +
-// progress + safe-to-spend hint. Pure presentational; parent owns
-// `monthlyPlan` and the computed fact/usage values.
+// progress + safe-to-spend hint. Collapsible — defaults closed so the
+// Планування page opens with stats-strip + limit cards in view, mirroring
+// the "Прогноз" / "AI-порада" sections inside `LimitBudgetCard`. When
+// collapsed the header still surfaces plan/fact/pct at a glance; the
+// inputs + trend only appear when the user opens it. Pure presentational,
+// parent owns `monthlyPlan` + computed fact/usage values.
 function MonthlyPlanCardComponent({
   monthlyPlan,
   onChangeMonthlyPlan,
@@ -18,130 +22,181 @@ function MonthlyPlanCardComponent({
   isOver,
   daysLeft,
 }) {
+  const [open, setOpen] = useState(false);
+  const hasPlan = planIncome > 0 || planExpense > 0;
+
   return (
     <div
       className={cn(
-        "bg-panel border rounded-2xl p-5 shadow-card",
+        "bg-panel border rounded-2xl shadow-card overflow-hidden",
         isOver ? "border-danger/40" : "border-line",
       )}
     >
-      <SectionHeading as="div" size="sm" className="mb-3">
-        Фінплан на місяць
-      </SectionHeading>
-      <div className="space-y-2">
-        <Input
-          type="number"
-          placeholder="План доходу ₴"
-          value={monthlyPlan?.income ?? ""}
-          onChange={(e) =>
-            onChangeMonthlyPlan((p) => ({
-              ...(p || {}),
-              income: e.target.value,
-            }))
-          }
-        />
-        <Input
-          type="number"
-          placeholder="План витрат ₴"
-          value={monthlyPlan?.expense ?? ""}
-          onChange={(e) =>
-            onChangeMonthlyPlan((p) => ({
-              ...(p || {}),
-              expense: e.target.value,
-            }))
-          }
-        />
-        <Input
-          type="number"
-          placeholder="План накопичень ₴"
-          value={monthlyPlan?.savings ?? ""}
-          onChange={(e) =>
-            onChangeMonthlyPlan((p) => ({
-              ...(p || {}),
-              savings: e.target.value,
-            }))
-          }
-        />
-      </div>
-
-      {(planIncome > 0 || planExpense > 0) && (
-        <div className="mt-4 pt-4 border-t border-line space-y-3">
-          <div className="grid grid-cols-3 gap-2 text-center">
-            <div>
-              <div className="text-2xs text-subtle mb-0.5">Дохід (план)</div>
-              <div className="text-sm font-semibold tabular-nums">
-                {planIncome > 0
-                  ? `${planIncome.toLocaleString("uk-UA")} ₴`
-                  : "—"}
-              </div>
-            </div>
-            <div>
-              <div className="text-2xs text-subtle mb-0.5">Витрати (факт)</div>
-              <div
-                className={cn(
-                  "text-sm font-semibold tabular-nums",
-                  isOver ? "text-danger" : "",
-                )}
-              >
-                {totalExpenseFact.toLocaleString("uk-UA")} ₴
-              </div>
-            </div>
-            <div>
-              <div className="text-2xs text-subtle mb-0.5">Залишок</div>
-              <div
-                className={cn(
-                  "text-sm font-semibold tabular-nums",
-                  isOver
-                    ? "text-danger"
-                    : "text-emerald-600 dark:text-emerald-400",
-                )}
-              >
-                {isOver
-                  ? `−${(totalExpenseFact - planExpense).toLocaleString("uk-UA")} ₴`
-                  : `${remaining.toLocaleString("uk-UA")} ₴`}
-              </div>
-            </div>
-          </div>
-
-          {planExpense > 0 && (
-            <>
-              <div className="flex justify-between text-xs text-subtle">
-                <span>{pctExpense}% від плану</span>
-                <span>план {planExpense.toLocaleString("uk-UA")} ₴</span>
-              </div>
-              <div className="h-2 bg-bg rounded-full overflow-hidden">
-                <div
-                  className={cn(
-                    "h-full rounded-full transition-all",
-                    isOver
-                      ? "bg-danger"
-                      : pctExpense >= 85
-                        ? "bg-warning"
-                        : "bg-emerald-500",
-                  )}
-                  style={{ width: `${pctExpense}%` }}
-                />
-              </div>
-            </>
-          )}
-
-          {safePerDay > 0 && daysLeft > 0 && planExpense > 0 && (
-            <div
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-3 px-5 py-3 text-left hover:bg-panelHi transition-colors"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-muted" aria-hidden>
+            <Icon name="calendar" size={16} />
+          </span>
+          <span className="text-sm font-semibold text-text">
+            Фінплан на місяць
+          </span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {hasPlan && !open && (
+            <span
               className={cn(
-                "rounded-xl px-3 py-2 text-sm",
-                isOver
-                  ? "bg-danger/10 text-danger"
-                  : pctExpense >= 85
-                    ? "bg-warning/10 text-warning"
-                    : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+                "text-xs tabular-nums",
+                isOver ? "text-danger font-semibold" : "text-muted",
               )}
             >
-              <span className="font-semibold">
-                {safePerDay.toLocaleString("uk-UA")} ₴/день
-              </span>
-              <span className="text-xs ml-1 opacity-75">
-                · безпечно витрачати ({daysLeft} дн.)
-              </span>
+              {isOver
+                ? `−${(totalExpenseFact - planExpense).toLocaleString("uk-UA")} ₴`
+                : planExpense > 0
+                  ? `${pctExpense}% · ${remaining.toLocaleString("uk-UA")} ₴`
+                  : `+${planIncome.toLocaleString("uk-UA")} ₴`}
+            </span>
+          )}
+          {!hasPlan && !open && (
+            <span className="text-xs text-subtle">Не заданий</span>
+          )}
+          <Icon
+            name="chevron-down"
+            size={14}
+            className={cn(
+              "transition-transform text-muted",
+              open ? "rotate-180" : "",
+            )}
+          />
+        </div>
+      </button>
+
+      {open && (
+        <div className="px-5 pb-5 pt-1">
+          <div className="space-y-2">
+            <Input
+              type="number"
+              placeholder="План доходу ₴"
+              value={monthlyPlan?.income ?? ""}
+              onChange={(e) =>
+                onChangeMonthlyPlan((p) => ({
+                  ...(p || {}),
+                  income: e.target.value,
+                }))
+              }
+            />
+            <Input
+              type="number"
+              placeholder="План витрат ₴"
+              value={monthlyPlan?.expense ?? ""}
+              onChange={(e) =>
+                onChangeMonthlyPlan((p) => ({
+                  ...(p || {}),
+                  expense: e.target.value,
+                }))
+              }
+            />
+            <Input
+              type="number"
+              placeholder="План накопичень ₴"
+              value={monthlyPlan?.savings ?? ""}
+              onChange={(e) =>
+                onChangeMonthlyPlan((p) => ({
+                  ...(p || {}),
+                  savings: e.target.value,
+                }))
+              }
+            />
+          </div>
+
+          {hasPlan && (
+            <div className="mt-4 pt-4 border-t border-line space-y-3">
+              <div className="grid grid-cols-3 gap-2 text-center">
+                <div>
+                  <div className="text-2xs text-subtle mb-0.5">
+                    Дохід (план)
+                  </div>
+                  <div className="text-sm font-semibold tabular-nums">
+                    {planIncome > 0
+                      ? `${planIncome.toLocaleString("uk-UA")} ₴`
+                      : "—"}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-2xs text-subtle mb-0.5">
+                    Витрати (факт)
+                  </div>
+                  <div
+                    className={cn(
+                      "text-sm font-semibold tabular-nums",
+                      isOver ? "text-danger" : "",
+                    )}
+                  >
+                    {totalExpenseFact.toLocaleString("uk-UA")} ₴
+                  </div>
+                </div>
+                <div>
+                  <div className="text-2xs text-subtle mb-0.5">Залишок</div>
+                  <div
+                    className={cn(
+                      "text-sm font-semibold tabular-nums",
+                      isOver
+                        ? "text-danger"
+                        : "text-emerald-600 dark:text-emerald-400",
+                    )}
+                  >
+                    {isOver
+                      ? `−${(totalExpenseFact - planExpense).toLocaleString("uk-UA")} ₴`
+                      : `${remaining.toLocaleString("uk-UA")} ₴`}
+                  </div>
+                </div>
+              </div>
+
+              {planExpense > 0 && (
+                <>
+                  <div className="flex justify-between text-xs text-subtle">
+                    <span>{pctExpense}% від плану</span>
+                    <span>план {planExpense.toLocaleString("uk-UA")} ₴</span>
+                  </div>
+                  <div className="h-2 bg-bg rounded-full overflow-hidden">
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all",
+                        isOver
+                          ? "bg-danger"
+                          : pctExpense >= 85
+                            ? "bg-warning"
+                            : "bg-emerald-500",
+                      )}
+                      style={{ width: `${pctExpense}%` }}
+                    />
+                  </div>
+                </>
+              )}
+
+              {safePerDay > 0 && daysLeft > 0 && planExpense > 0 && (
+                <div
+                  className={cn(
+                    "rounded-xl px-3 py-2 text-sm",
+                    isOver
+                      ? "bg-danger/10 text-danger"
+                      : pctExpense >= 85
+                        ? "bg-warning/10 text-warning"
+                        : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+                  )}
+                >
+                  <span className="font-semibold">
+                    {safePerDay.toLocaleString("uk-UA")} ₴/день
+                  </span>
+                  <span className="text-xs ml-1 opacity-75">
+                    · безпечно витрачати ({daysLeft} дн.)
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/apps/web/src/modules/finyk/lib/upcomingSchedule.ts
+++ b/apps/web/src/modules/finyk/lib/upcomingSchedule.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared helpers for Finyk's "upcoming schedule" surfaces (stats strip on
+ * Активи / Планування). Centralises the maths that used to live inline in
+ * `Assets.tsx` so Budgets (and any future module page) can reuse the same
+ * `subsMonthly` / `nextCharge` / `urgentLiability` figures without drifting
+ * from the canonical computation.
+ */
+
+import { calcDebtRemaining, calcReceivableRemaining } from "../utils";
+import { getSubscriptionAmountMeta } from "@sergeant/finyk-domain/domain/subscriptionUtils";
+import type {
+  Debt as EngineDebt,
+  Receivable as EngineReceivable,
+  Tx as EngineTx,
+} from "@sergeant/finyk-domain/domain/debtEngine";
+
+export type UpcomingCharge = {
+  label: string;
+  amount: number;
+  sign: "-" | "+";
+  dueDate: Date;
+};
+
+export type UrgentLiability = {
+  name: string;
+  remaining: number;
+  dueDate: Date;
+};
+
+/**
+ * `transactions` is intentionally left as `unknown[]` (mutable) — both
+ * `calcDebtRemaining` and `calcReceivableRemaining` take a non-readonly
+ * `Tx[]` for backward-compat with legacy call sites. The runtime shape
+ * is the same; the mutability opt-out lives in the engine.
+ */
+export type FinykScheduleInput = {
+  subscriptions: readonly unknown[];
+  manualDebts: readonly unknown[];
+  receivables: readonly unknown[];
+  transactions: unknown[];
+  todayStart: Date;
+};
+
+export type FinykSchedule = {
+  subsMonthly: number;
+  subsCount: number;
+  nextCharge: UpcomingCharge | null;
+  urgentLiability: UrgentLiability | null;
+};
+
+export function parseLocalDate(isoDate: string | undefined | null): Date {
+  const [y, m, d] = (isoDate || "").split("-").map(Number);
+  return new Date(y, (m || 1) - 1, d || 1);
+}
+
+export function getNextBillingDate(billingDay: number, now: Date): Date {
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  let d = new Date(y, m, Math.min(billingDay, new Date(y, m + 1, 0).getDate()));
+  if (d < new Date(y, m, now.getDate())) {
+    d = new Date(
+      y,
+      m + 1,
+      Math.min(billingDay, new Date(y, m + 2, 0).getDate()),
+    );
+  }
+  return d;
+}
+
+export function formatShortDate(d: Date): string {
+  return d.toLocaleDateString("uk-UA", { day: "numeric", month: "short" });
+}
+
+export function formatRelativeDue(dueDate: Date, todayStart: Date): string {
+  const days = Math.ceil((dueDate.getTime() - todayStart.getTime()) / 86400000);
+  if (days <= 0) return "сьогодні";
+  if (days === 1) return "завтра";
+  if (days <= 7) return `через ${days} дн`;
+  return formatShortDate(dueDate);
+}
+
+/**
+ * Computes the upcoming-schedule figures from raw Finyk storage slices.
+ *
+ * `subsMonthly` sums only UAH subscription amounts — mixed-currency totals
+ * would be misleading. `nextCharge` is the earliest of next subscription
+ * billing, a manual debt with remaining + dueDate, or a receivable with
+ * remaining + dueDate, dropping anything already in the past relative to
+ * `todayStart`. `urgentLiability` is the **largest** manual debt that
+ * still has a dueDate and owes something — not the soonest — because the
+ * tile is meant to draw attention to the biggest time-sensitive hit, not
+ * every little bill.
+ */
+export function computeFinykSchedule({
+  subscriptions,
+  manualDebts,
+  receivables,
+  transactions,
+  todayStart,
+}: FinykScheduleInput): FinykSchedule {
+  type Sub = {
+    id?: string;
+    name?: string;
+    billingDay: number | string;
+  };
+  // Narrow views over the store shapes: the engine helpers need the
+  // EngineDebt / EngineReceivable fields (`id`, `amount`, optional
+  // `linkedTxIds`), plus `name` / `dueDate` for the UI strip.
+  type Debt = EngineDebt & { name: string; dueDate?: string };
+  type Recv = EngineReceivable & { name: string; dueDate?: string };
+
+  const subs = subscriptions as readonly Sub[];
+  const debts = manualDebts as readonly Debt[];
+  const recvs = receivables as readonly Recv[];
+  const txs = transactions as EngineTx[];
+
+  let subsMonthly = 0;
+  const upcoming: UpcomingCharge[] = [];
+
+  type GetSubAmountMeta = typeof getSubscriptionAmountMeta;
+  for (const sub of subs) {
+    const { amount, currency } = getSubscriptionAmountMeta(
+      sub as Parameters<GetSubAmountMeta>[0],
+      transactions as Parameters<GetSubAmountMeta>[1],
+    );
+    if (!amount || currency !== "₴") continue;
+    subsMonthly += amount;
+    upcoming.push({
+      label: sub.name ?? "Підписка",
+      amount,
+      sign: "-",
+      dueDate: getNextBillingDate(Number(sub.billingDay), todayStart),
+    });
+  }
+
+  for (const d of debts) {
+    if (!d.dueDate) continue;
+    const remaining = calcDebtRemaining(d, txs);
+    if (remaining <= 0) continue;
+    upcoming.push({
+      label: d.name,
+      amount: remaining,
+      sign: "-",
+      dueDate: parseLocalDate(d.dueDate),
+    });
+  }
+
+  for (const r of recvs) {
+    if (!r.dueDate) continue;
+    const remaining = calcReceivableRemaining(r, txs);
+    if (remaining <= 0) continue;
+    upcoming.push({
+      label: r.name,
+      amount: remaining,
+      sign: "+",
+      dueDate: parseLocalDate(r.dueDate),
+    });
+  }
+
+  upcoming.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+  const nextCharge =
+    upcoming.find((it) => it.dueDate.getTime() >= todayStart.getTime()) ?? null;
+
+  let urgentLiability: UrgentLiability | null = null;
+  for (const d of debts) {
+    if (!d.dueDate) continue;
+    const remaining = calcDebtRemaining(d, txs);
+    if (remaining <= 0) continue;
+    const candidate: UrgentLiability = {
+      name: d.name,
+      remaining,
+      dueDate: parseLocalDate(d.dueDate),
+    };
+    if (!urgentLiability || candidate.remaining > urgentLiability.remaining) {
+      urgentLiability = candidate;
+    }
+  }
+
+  return {
+    subsMonthly,
+    subsCount: subs.length,
+    nextCharge,
+    urgentLiability,
+  };
+}
+
+/**
+ * Lazy initialiser for a mount-time `todayStart` (midnight today). Pinning
+ * the value via `useState(() => startOfToday())` keeps `useMemo` deps
+ * referentially stable — date only matters for day-level comparisons, so
+ * a frozen snapshot is safer than a fresh `new Date()` each render.
+ */
+export function startOfToday(): Date {
+  const n = new Date();
+  return new Date(n.getFullYear(), n.getMonth(), n.getDate());
+}

--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -24,34 +24,13 @@ import {
   getDebtTxRole,
   getReceivableTxRole,
 } from "@sergeant/finyk-domain/domain/debtEngine";
-import { getSubscriptionAmountMeta } from "@sergeant/finyk-domain/domain/subscriptionUtils";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import { parseExpenseSpeech as parseExpenseVoice } from "@sergeant/shared";
-
-// Local date + billing helpers mirrored from Overview.tsx. Kept inline so the
-// Assets page doesn't need to import non-exported private helpers.
-const parseLocalDate = (isoDate: string | undefined | null) => {
-  const [y, m, d] = (isoDate || "").split("-").map(Number);
-  return new Date(y, (m || 1) - 1, d || 1);
-};
-const getNextBillingDate = (billingDay: number, now: Date) => {
-  const y = now.getFullYear();
-  const m = now.getMonth();
-  let d = new Date(y, m, Math.min(billingDay, new Date(y, m + 1, 0).getDate()));
-  if (d < new Date(y, m, now.getDate())) {
-    d = new Date(
-      y,
-      m + 1,
-      Math.min(billingDay, new Date(y, m + 2, 0).getDate()),
-    );
-  }
-  return d;
-};
-const formatShortDate = (d: Date) =>
-  d.toLocaleDateString("uk-UA", { day: "numeric", month: "short" });
+import { computeFinykSchedule, startOfToday } from "../lib/upcomingSchedule";
+import { FinykStatsStrip } from "../components/FinykStatsStrip";
 
 type SectionBarProps = {
   title: string;
@@ -61,21 +40,6 @@ type SectionBarProps = {
   open: boolean;
   onToggle: () => void;
 };
-
-type UpcomingCharge = {
-  label: string;
-  amount: number;
-  sign: "-" | "+";
-  dueDate: Date;
-};
-
-function formatRelativeDue(dueDate: Date, todayStart: Date) {
-  const days = Math.ceil((dueDate.getTime() - todayStart.getTime()) / 86400000);
-  if (days <= 0) return "сьогодні";
-  if (days === 1) return "завтра";
-  if (days <= 7) return `через ${days} дн`;
-  return formatShortDate(dueDate);
-}
 
 function AssetsLiabilitiesBar({
   assets,
@@ -105,140 +69,6 @@ function AssetsLiabilitiesBar({
         <span>Активи {assetsPct}%</span>
         <span>Пасиви {liabilitiesPct}%</span>
       </div>
-    </div>
-  );
-}
-
-type StatTileProps = {
-  iconName: IconName;
-  iconTone: "success" | "danger" | "muted";
-  label: string;
-  value: string;
-  hint?: string;
-  onClick?: () => void;
-};
-
-function StatTile({
-  iconName,
-  iconTone,
-  label,
-  value,
-  hint,
-  onClick,
-}: StatTileProps) {
-  const toneClass =
-    iconTone === "success"
-      ? "text-success"
-      : iconTone === "danger"
-        ? "text-danger"
-        : "text-muted";
-  const Wrapper = onClick ? "button" : "div";
-  return (
-    <Wrapper
-      {...(onClick ? { onClick, type: "button" as const } : {})}
-      className={cn(
-        "flex-1 min-w-[9.5rem] shrink-0 text-left px-3 py-2.5",
-        "bg-panelHi border border-line rounded-2xl",
-        "transition-colors",
-        onClick && "hover:border-muted/50 active:scale-[0.99]",
-      )}
-    >
-      <div className="flex items-center gap-2 text-[11px] text-muted">
-        <span className={cn("inline-flex", toneClass)} aria-hidden>
-          <Icon name={iconName} size={14} />
-        </span>
-        <span className="truncate">{label}</span>
-      </div>
-      <div className="text-sm font-bold text-text mt-1 truncate">{value}</div>
-      {hint && (
-        <div className="text-[11px] text-subtle mt-0.5 truncate">{hint}</div>
-      )}
-    </Wrapper>
-  );
-}
-
-function AssetsStatsStrip({
-  subsMonthly,
-  subsCount,
-  nextCharge,
-  urgentLiability,
-  todayStart,
-  showBalance,
-  onOpenSubs,
-  onOpenLiabilities,
-}: {
-  subsMonthly: number;
-  subsCount: number;
-  nextCharge: UpcomingCharge | null;
-  urgentLiability: { name: string; remaining: number; dueDate: Date } | null;
-  todayStart: Date;
-  showBalance: boolean;
-  onOpenSubs: () => void;
-  onOpenLiabilities: () => void;
-}) {
-  const showSubsTile = subsCount > 0;
-  const showNextTile = Boolean(nextCharge);
-  const showUrgentTile = Boolean(urgentLiability);
-  if (!showSubsTile && !showNextTile && !showUrgentTile) return null;
-  const hideNumbers = !showBalance;
-  return (
-    <div
-      className="flex gap-2 overflow-x-auto pb-1 mb-3 -mx-1 px-1 scrollbar-hidden"
-      role="list"
-    >
-      {showSubsTile && (
-        <StatTile
-          iconName="refresh-cw"
-          iconTone="muted"
-          label="Підписки · міс"
-          value={
-            hideNumbers
-              ? "••••"
-              : `${subsMonthly.toLocaleString("uk-UA", {
-                  maximumFractionDigits: 0,
-                })} ₴`
-          }
-          hint={`${subsCount} активн${subsCount === 1 ? "а" : "их"}`}
-          onClick={onOpenSubs}
-        />
-      )}
-      {showNextTile && nextCharge && (
-        <StatTile
-          iconName="calendar"
-          iconTone={nextCharge.sign === "-" ? "danger" : "success"}
-          label="Наступний платіж"
-          value={
-            hideNumbers
-              ? "••••"
-              : `${nextCharge.sign}${nextCharge.amount.toLocaleString("uk-UA", {
-                  maximumFractionDigits: 0,
-                })} ₴`
-          }
-          hint={`${nextCharge.label} · ${formatRelativeDue(
-            nextCharge.dueDate,
-            todayStart,
-          )}`}
-        />
-      )}
-      {showUrgentTile && urgentLiability && (
-        <StatTile
-          iconName="alert"
-          iconTone="danger"
-          label="Пасив з дедлайном"
-          value={
-            hideNumbers
-              ? "••••"
-              : `−${urgentLiability.remaining.toLocaleString("uk-UA", {
-                  maximumFractionDigits: 0,
-                })} ₴`
-          }
-          hint={`${urgentLiability.name} · ${formatRelativeDue(
-            urgentLiability.dueDate,
-            todayStart,
-          )}`}
-          onClick={onOpenLiabilities}
-        />
-      )}
     </div>
   );
 }
@@ -398,91 +228,25 @@ export function Assets({
   const networth = monoTotal + manualAssetTotal + totalReceivable - totalDebt;
   const totalAssets = monoTotal + manualAssetTotal + totalReceivable;
 
-  // Stats strip + upcoming-charge feed. `todayStart` is pinned to the
-  // mount-time midnight via lazy initialiser so `useMemo` deps below stay
-  // referentially stable for the session — date only matters for day-level
-  // comparisons ("next billing date", "days until due"), so a frozen
-  // reference is safer than `new Date()` each render.
-  const [todayStart] = useState<Date>(() => {
-    const n = new Date();
-    return new Date(n.getFullYear(), n.getMonth(), n.getDate());
-  });
+  // Stats strip + upcoming-charge feed. `todayStart` is pinned to a
+  // mount-time midnight via lazy initialiser so `useMemo` deps stay
+  // referentially stable for the session — date only matters for
+  // day-level comparisons, so a frozen snapshot is safer than a fresh
+  // `new Date()` each render.
+  const [todayStart] = useState<Date>(startOfToday);
 
-  const subsMonthlyTotal = useMemo(
+  const schedule = useMemo(
     () =>
-      subscriptions.reduce((sum, sub) => {
-        const { amount, currency } = getSubscriptionAmountMeta(
-          sub,
-          transactions,
-        );
-        if (!amount || currency !== "₴") return sum;
-        return sum + amount;
-      }, 0),
-    [subscriptions, transactions],
+      computeFinykSchedule({
+        subscriptions,
+        manualDebts,
+        receivables,
+        transactions,
+        todayStart,
+      }),
+    [subscriptions, manualDebts, receivables, transactions, todayStart],
   );
-
-  // Combined upcoming feed: next subscription billing + manual debts/
-  // receivables with a concrete dueDate. Sorted by soonest, takes earliest.
-  const nextCharge = useMemo(() => {
-    const items: Array<{
-      label: string;
-      amount: number;
-      sign: "-" | "+";
-      dueDate: Date;
-    }> = [];
-    for (const sub of subscriptions) {
-      const { amount, currency } = getSubscriptionAmountMeta(sub, transactions);
-      if (!amount || currency !== "₴") continue;
-      items.push({
-        label: sub.name,
-        amount,
-        sign: "-",
-        dueDate: getNextBillingDate(Number(sub.billingDay), todayStart),
-      });
-    }
-    for (const d of manualDebts) {
-      if (!d.dueDate) continue;
-      const remaining = calcDebtRemaining(d, transactions);
-      if (remaining <= 0) continue;
-      items.push({
-        label: d.name,
-        amount: remaining,
-        sign: "-",
-        dueDate: parseLocalDate(d.dueDate),
-      });
-    }
-    for (const r of receivables) {
-      if (!r.dueDate) continue;
-      const remaining = calcReceivableRemaining(r, transactions);
-      if (remaining <= 0) continue;
-      items.push({
-        label: r.name,
-        amount: remaining,
-        sign: "+",
-        dueDate: parseLocalDate(r.dueDate),
-      });
-    }
-    items.sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
-    const soonest = items.find(
-      (it) => it.dueDate.getTime() >= todayStart.getTime(),
-    );
-    return soonest ?? null;
-  }, [subscriptions, manualDebts, receivables, transactions, todayStart]);
-
-  // Largest manual debt that still has a dueDate — surfaces the biggest
-  // time-sensitive obligation without forcing users to expand the section.
-  const urgentLiability = useMemo(() => {
-    const withDue = manualDebts
-      .filter((d) => d.dueDate)
-      .map((d) => ({
-        name: d.name,
-        remaining: calcDebtRemaining(d, transactions),
-        dueDate: parseLocalDate(d.dueDate),
-      }))
-      .filter((d) => d.remaining > 0);
-    if (withDue.length === 0) return null;
-    return withDue.reduce((a, b) => (a.remaining >= b.remaining ? a : b));
-  }, [manualDebts, transactions]);
+  const { subsMonthly, nextCharge, urgentLiability } = schedule;
 
   // Quick-action helpers: open the relevant section + reveal its form in a
   // single tap, so the user doesn't expand → scroll → tap "+ Додати".
@@ -801,8 +565,8 @@ export function Assets({
             charge, biggest liability with a deadline. Horizontal scroll on
             mobile, grid on wider screens. Only tiles with data render, so
             the strip disappears entirely for empty accounts. */}
-        <AssetsStatsStrip
-          subsMonthly={subsMonthlyTotal}
+        <FinykStatsStrip
+          subsMonthly={subsMonthly}
           subsCount={subscriptions.length}
           nextCharge={nextCharge}
           urgentLiability={urgentLiability}
@@ -812,6 +576,7 @@ export function Assets({
           onOpenLiabilities={() =>
             setOpen((v) => ({ ...v, liabilities: true }))
           }
+          className="mb-3"
         />
 
         {/* E — quick-action CTAs. Each opens the respective section and its

--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -4,6 +4,8 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { calcCategorySpent, resolveExpenseCategoryMeta } from "../utils";
+import { computeFinykSchedule, startOfToday } from "../lib/upcomingSchedule";
+import { FinykStatsStrip } from "../components/FinykStatsStrip";
 import { buildExpenseCategoryList } from "@sergeant/finyk-domain/domain/categories";
 import {
   getLimitBudgets,
@@ -124,8 +126,8 @@ async function fetchCategoryExplanation({
   return data.text || "Не вдалося отримати пояснення.";
 }
 
-export function Budgets({ mono, storage }) {
-  const { realTx, loadingTx } = mono;
+export function Budgets({ mono, storage, showBalance = true }) {
+  const { realTx, loadingTx, transactions } = mono;
   const {
     budgets,
     setBudgets,
@@ -135,6 +137,9 @@ export function Budgets({ mono, storage }) {
     txCategories,
     txSplits,
     customCategories,
+    subscriptions = [],
+    manualDebts = [],
+    receivables = [],
   } = storage;
   const statTx = useMemo(
     () => filterStatTransactions(realTx, excludedTxIds),
@@ -184,6 +189,39 @@ export function Budgets({ mono, storage }) {
   const [formError, setFormError] = useState("");
 
   const [aiExplanations, setAiExplanations] = useState({});
+
+  // Upcoming-schedule feed for the stats strip (reuses the same
+  // computation as the Активи page so Сума підписок + Наступний платіж
+  // stay consistent across tabs).
+  const [todayStart] = useState<Date>(startOfToday);
+  const schedule = useMemo(
+    () =>
+      computeFinykSchedule({
+        subscriptions,
+        manualDebts,
+        receivables,
+        transactions: transactions ?? [],
+        todayStart,
+      }),
+    [subscriptions, manualDebts, receivables, transactions, todayStart],
+  );
+
+  // Per-(month, category) dismissed-advice registry. Persisted under a
+  // dedicated localStorage namespace so it survives reloads but doesn't
+  // collide with the 24h proactive-advice cache. Value is the dismissed
+  // text itself — when React Query returns a *different* text (next
+  // month, manual refetch), the card shows the advice again automatically.
+  const [dismissedAdvice, setDismissedAdvice] = useState<
+    Record<string, string>
+  >(() => readJSON("finyk_proactive_dismissed_v1", {}));
+  const dismissAdvice = useCallback((categoryId, monthKey, text) => {
+    if (!text) return;
+    setDismissedAdvice((prev) => {
+      const next = { ...prev, [`${monthKey}_${categoryId}`]: text };
+      writeJSON("finyk_proactive_dismissed_v1", next);
+      return next;
+    });
+  }, []);
 
   const forecasts = useMemo(() => {
     if (limitBudgets.length === 0) return [];
@@ -381,6 +419,18 @@ export function Budgets({ mono, storage }) {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
+        {/* Сума підписок + Наступний платіж з тих самих даних, що й на
+            сторінці Активи — без пасив-з-дедлайном тайлу (у Плануванні
+            це не релевантно). Зникає цілком, якщо обидва слоти пусті. */}
+        <FinykStatsStrip
+          subsMonthly={schedule.subsMonthly}
+          subsCount={schedule.subsCount}
+          nextCharge={schedule.nextCharge}
+          urgentLiability={null}
+          todayStart={todayStart}
+          showBalance={showBalance}
+        />
+
         <MonthlyPlanCard
           monthlyPlan={monthlyPlan}
           onChangeMonthlyPlan={setMonthlyPlan}
@@ -447,7 +497,6 @@ export function Budgets({ mono, storage }) {
               remaining={usage.remaining}
               isEditing={isEditing}
               showProactiveAdvice={showAdvice}
-              proactiveText={proactiveAdvice[b.categoryId]}
               proactiveLoading={proactiveLoading[b.categoryId]}
               forecast={forecastForCat}
               explanation={aiExplanations[b.categoryId]}
@@ -462,6 +511,31 @@ export function Budgets({ mono, storage }) {
                         forecastForCat.forecast,
                         forecastForCat.limit,
                       )
+                  : undefined
+              }
+              proactiveText={
+                proactiveAdvice[b.categoryId] &&
+                dismissedAdvice[
+                  `${proactiveItems.find((it) => it.categoryId === b.categoryId)?.monthKey ?? ""}_${b.categoryId}`
+                ] === proactiveAdvice[b.categoryId]
+                  ? null
+                  : proactiveAdvice[b.categoryId]
+              }
+              onDismissAdvice={
+                proactiveAdvice[b.categoryId]
+                  ? () => {
+                      const mk =
+                        proactiveItems.find(
+                          (it) => it.categoryId === b.categoryId,
+                        )?.monthKey ?? "";
+                      if (mk) {
+                        dismissAdvice(
+                          b.categoryId,
+                          mk,
+                          proactiveAdvice[b.categoryId],
+                        );
+                      }
+                    }
                   : undefined
               }
               onBeginEdit={() => setEditIdx(globalIdx)}


### PR DESCRIPTION
## Summary

Three UX asks on the **Планування** page + a refactor that removes ~200 lines of duplicated logic between Активи and Планування.

### C — «Наступний платіж» + «Сума підписок» на сторінці Планування
- New shared `computeFinykSchedule()` lib (`apps/web/src/modules/finyk/lib/upcomingSchedule.ts`) centralises the subscription / debt / receivable schedule maths that used to live inline in `Assets.tsx`.
- New presentational `<FinykStatsStrip>` (`apps/web/src/modules/finyk/components/FinykStatsStrip.tsx`) reused on both pages. Returns `null` if no tiles to show — empty accounts don't see an empty strip.
- Активи consumes the shared lib (drops inline `parseLocalDate` / `getNextBillingDate` / `formatShortDate` / `formatRelativeDue` / `StatTile` / `AssetsStatsStrip` — all in the new module).
- Планування now surfaces `Сума підписок · міс` + `Наступний платіж`. Пасив-з-дедлайном тайл явно вимкнено (`urgentLiability={null}`), бо на сторінці Активи вже є, а тут не релевантно.

### D — Фінплан тепер згортаний, за замовчуванням згорнутий
- `MonthlyPlanCard` переписано як clickable-header + conditional body, як `Прогноз` у `LimitBudgetCard`.
- Закритий — показує `план/факт%` (або `+план доходу ₴` / «Не заданий») у рядку title; відкритий — повні інпути + фактична сітка + прогрес-бар + «безпечно витрачати ₴/день».
- `useState(false)` на старті — Планування тепер відкривається на strip + ліміт-картках, а не на великому плану.

### E — «Зрозуміло» в AI-пораді
- Додано `onDismissAdvice?: () => void` пропс у `LimitBudgetCard`. Рендериться як пікаделева кнопка «Зрозуміло» праворуч від chevron-toggle (так само збережено можливість згортати через chevron).
- Dismissed текст зберігається в `localStorage` під `finyk_proactive_dismissed_v1` ключами виду `${monthKey}_${categoryId}`. Значення — сам text.
- Коли React Query повертає **інший** текст (rollover місяця, manual refetch) — dismiss автоматично стає неактуальним, порада знов показується. Це відповідає запиту «прибирає текст поради, поки не буде згенеровано нову».

## Review & Testing Checklist for Human
- [ ] **Stats strip на Плануванні** — відкрий вкладку Планування, переконайся, що видно `Сума підписок · міс` + `Наступний платіж` (якщо є підписки / борги з дедлайнами). На порожньому акаунті — strip повністю відсутній.
- [ ] **Активи ніщо не зламалось** — той самий strip + proportion-bar + quick-actions з PR #559 працюють як раніше (кнопки `+ Підписка / + Актив / + Пасив`, тап на тайлах відкриває відповідну секцію).
- [ ] **Фінплан згорнутий за замовчуванням** — при першому відкритті Планування `Фінплан на місяць` — одна рядок-хедер. Тап — розгортає інпути + статистику. Зворотний тап — згортає.
- [ ] **«Зрозуміло»** — при наявній AI-пораді справа від chevron видно кнопку `Зрозуміло`. Тап — порада зникає. Ctrl+R / перехід сторінок — порада лишається прибраною. Після очікування 24h cache expiration або ручного очищення localStorage-ключа `finyk_proactive_v1_*` — при наступному fetch-у порада повертається.
- [ ] **Проектипек / лінт / 618 тестів** — всі зелені локально.

### Notes
- `MonthlyPlanCard` переписано з нуля (не точкова правка): компонент був `.jsx`-shaped без власних типів, легше було створити чистий render-time-state pattern, ніж доточити collapse поверх старої структури. Поведінка для каллсайту (props API) — ідентична плюс новий internal-only `open/setOpen`.
- `computeFinykSchedule()` приймає `unknown[]` для сторінкових масивів і внутрішньо звужує через `as` — це свідомий trade-off, бо storage-типи не експортуються з центрального місця, а дублювати їх у новому lib-і дорожче за cast.
- Pre-existing iOS-build фейл на `GoogleMLKit/BarcodeScanning` — не пов'язаний з цією PR (такий самий фейл був на #556/#557/#558/#559).

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added financial stats overview strip displaying subscription count, next payment due date, and urgent liabilities with horizontal scrolling.
  * Monthly plan card is now collapsible (previously always expanded).
  * AI advice in budget cards can now be dismissed.
  * Balance values can be masked for privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->