### PR TITLE
fix(finyk): trim Активи stats strip (move subs/next to Планування) + pass showBalance to Budgets

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -724,7 +724,11 @@ export default function App({
               key="page-budgets"
               title="Не вдалось показати «Планування»"
             >
-              <Budgets mono={mergedMono} storage={storage} />
+              <Budgets
+                mono={mergedMono}
+                storage={storage}
+                showBalance={showBalance}
+              />
             </SectionErrorBoundary>
           )}
           {page === "analytics" && (

--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -235,7 +235,10 @@ export function Assets({
   // `new Date()` each render.
   const [todayStart] = useState<Date>(startOfToday);
 
-  const schedule = useMemo(
+  // На Активи з усього schedule потрібен тільки `urgentLiability` —
+  // інші тайли (`subsMonthly` / `nextCharge`) переїхали на Планування,
+  // щоб не дублювати ту саму інформацію на двох сторінках.
+  const { urgentLiability } = useMemo(
     () =>
       computeFinykSchedule({
         subscriptions,
@@ -246,7 +249,6 @@ export function Assets({
       }),
     [subscriptions, manualDebts, receivables, transactions, todayStart],
   );
-  const { subsMonthly, nextCharge, urgentLiability } = schedule;
 
   // Quick-action helpers: open the relevant section + reveal its form in a
   // single tap, so the user doesn't expand → scroll → tap "+ Додати".
@@ -565,14 +567,16 @@ export function Assets({
             charge, biggest liability with a deadline. Horizontal scroll on
             mobile, grid on wider screens. Only tiles with data render, so
             the strip disappears entirely for empty accounts. */}
+        {/* На сторінці Активи залишаємо тільки «Пасив з дедлайном» —
+            «Сума підписок» + «Наступний платіж» переїхали на Планування
+            (PR #560), тут дублювати не треба. */}
         <FinykStatsStrip
-          subsMonthly={subsMonthly}
-          subsCount={subscriptions.length}
-          nextCharge={nextCharge}
+          subsMonthly={0}
+          subsCount={0}
+          nextCharge={null}
           urgentLiability={urgentLiability}
           todayStart={todayStart}
           showBalance={showBalance}
-          onOpenSubs={() => setOpen((v) => ({ ...v, subscriptions: true }))}
           onOpenLiabilities={() =>
             setOpen((v) => ({ ...v, liabilities: true }))
           }


### PR DESCRIPTION
## Summary

Follow-up to #560. Two fixes:

### 1. Активи stats-strip дублював дані з Планування
У #560 я додав «Сума підписок» + «Наступний платіж» на Планування, але забув прибрати ті самі тайли з Активи — і тепер обидві сторінки показували ідентичні цифри. За скаргою користувача (скрін: https://app.devin.ai/attachments/84986be5-c7fa-44c1-b6d0-6a82c1370b8c) прибрано з Активи, лишено тільки «Пасив з дедлайном» (єдиний тайл, що на Плануванні не має сенсу, бо там інший фокус).

Реалізація: у `Assets.tsx` передаю `subsMonthly={0}`, `subsCount={0}`, `nextCharge={null}` у `<FinykStatsStrip>` — компонент автоматично не рендерить тайл, коли нема даних, тож код-ветки в самому компоненті не треба міняти. Також витягаю з `computeFinykSchedule()` тільки `urgentLiability`.

### 2. `showBalance` не прокидався у `<Budgets>` (Devin Review finding #560)
У #560 я додав `showBalance` пропс у `Budgets.tsx` з дефолтом `true` і прокинув його далі у `<FinykStatsStrip>`. Але в `FinykApp.tsx:727` виклик був `<Budgets mono={mergedMono} storage={storage} />` — без `showBalance`. Результат: коли користувач тапав «сховати баланс», тайли на Плануванні однаково показували реальні суми (витік чутливих даних, які користувач явно сховав).

Виправлено: `FinykApp.tsx` тепер прокидає `showBalance={showBalance}`, так само як це вже робиться для `<Overview>` (line 700), `<Transactions>` (line 712), `<Assets>` (line 746).

## Review & Testing Checklist for Human
- [ ] **Активи stats-strip** — тапни «Активи». На ньому має бути тільки «Пасив з дедлайном» тайл (якщо є борг із dueDate). «Сума підписок» + «Наступний платіж» більше не з'являються.
- [ ] **Планування stats-strip** — тапни «Планування». Тут навпаки має бути «Сума підписок · міс» + «Наступний платіж» (якщо є підписки/борги). Без пасива — він тепер живе тільки на Активи.
- [ ] **Hide balance toggle** — натисни око (сховати баланс). Тайли на **обох** сторінках мають замінити числа на `••••`. До цього PR на Плануванні тайли ігнорували toggle.
- [ ] **618 тестів / typecheck / lint** — всі зелені локально.

### Notes
- Жодних інших змін в `FinykStatsStrip` чи `computeFinykSchedule` — компонент уже коректно ховає тайли без даних. Це точкова правка callsite-ів.
- Pre-existing iOS-build фейл — не пов'язаний.

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Budgets page balance visibility state now synchronizes with the application header toggle for consistent display across the interface
  * Assets page stats display refined: subscription-related metrics including monthly totals and next scheduled charge date have been removed; the shortcut to access subscriptions from this page has been removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->