### PR TITLE
fix(finyk): tx list — readable account pill + collapse respects filter + collapsed by default

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -172,7 +172,7 @@ function TxRowImpl({
             </span>
           )}
           {!isCreditCard && account && (
-            <span className="text-3xs text-subtle/50 px-1 py-0.5">
+            <span className="text-3xs bg-panelHi text-muted border border-line px-1.5 py-0.5 rounded-full font-medium">
               {accountName}
             </span>
           )}

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -44,9 +44,13 @@ function writeDayCollapse(v) {
   }
 }
 
-function isDayExpanded(overrides, key, todayKey) {
-  const o = overrides[key];
-  return o === undefined ? key === todayKey : !!o;
+// Усі дні згорнуті за замовчуванням; ручне розгортання зберігається
+// в `overrides` і переживає перезавантаження (та міжтабову синхронізацію).
+// `todayKey` лишається в сигнатурі на випадок, якщо колись захочемо
+// повернути логіку "сьогодні завжди відкрите" через feature-toggle,
+// але зараз користувач свідомо попросив згорнуто-за-замовчуванням.
+function isDayExpanded(overrides, key, _todayKey) {
+  return !!overrides[key];
 }
 
 function formatStickyDayLabel(key) {
@@ -413,20 +417,19 @@ export function Transactions({
     [todayDayKey],
   );
 
-  // When the user has narrowed down by a filter chip, collapsing days
-  // would hide matches — temporarily render every day fully expanded so
-  // nothing looks "missing". The persisted override is untouched;
-  // clearing the filter restores the prior state.
-  const ignoreCollapse = filter !== "all";
-
+  // Фільтр-чіпи (Витрати/Доходи/Кредитна/Борг) більше не форсять
+  // розгортання — користувач явно хотів, щоб згортання працювало
+  // навіть під активним фільтром (inbox-style). `groupedByDate` уже
+  // обчислено з відфільтрованого `filtered`, тож у згорнутій групі
+  // лічильник під датою показує кількість саме *відфільтрованих*
+  // транзакцій — нічого не зникає, все одно тап розгортає.
   const collapsedKeys = useMemo(() => {
     const s = new Set();
-    if (ignoreCollapse) return s;
     for (const g of groupedByDate) {
       if (!isDayExpanded(dayOverrides, g.key, todayDayKey)) s.add(g.key);
     }
     return s;
-  }, [groupedByDate, dayOverrides, todayDayKey, ignoreCollapse]);
+  }, [groupedByDate, dayOverrides, todayDayKey]);
 
   const groupCounts = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Три UX-фікси на сторінці Операції за скаргою користувача (скрін: https://app.devin.ai/attachments/f5fe03bc-d36b-464e-b700-60d200a197c8).

### 1. Назва акаунта («Біла») майже невидима в dark-mode
`TxRow` рендерив account name як `text-3xs text-subtle/50 px-1 py-0.5` — `text-subtle` вже приглушений, а `/50` (50% opacity) ще й додатково гасив його до майже непрочитного на темному фоні. Ніякого bg/border теж не було, тож його було важко парсити поряд з іншими пілями-категоріями.

Тепер: `bg-panelHi text-muted border border-line px-1.5 py-0.5 rounded-full font-medium` — такий самий pill-pattern як у «змін.» / «⅔ спліт» / «П24», з повноцінним контрастом і на dark, і на light.

### 2. «Не працюють згортання по датах» коли обрано фільтр
Причина: у `Transactions.tsx` було `const ignoreCollapse = filter !== "all"` + ранній `return s` у `collapsedKeys`. Ідея: якщо користувач включив фільтр, примусово розгорнути всі дні, щоб не ховати матчі. На практиці — тап на заголовок дня нічого не робив, бо override писався в localStorage, але колаб'юз ігнорувався.

Прибрано. `groupedByDate` уже побудовано з `filtered`, отже порожніх груп у цьому списку **нема**. У згорнутій групі лічильник `·N` під датою тепер відображає кількість *відфільтрованих* транзакцій, тап — розгортає тільки матчі.

### 3. «Постав згорнуто за замовчуванням теж»
Було: `isDayExpanded` повертав `true` для `todayKey` навіть без override — тобто сьогодні завжди відкрите. Тепер default — `!!overrides[key]`, тобто всі дні згорнуті, поки користувач явно не тапне. Override живе в `localStorage` (ключ `STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE`) і синхронізується між вкладками через `storage` event — без змін.

## Review & Testing Checklist for Human
- [ ] **Account pill** — у dark-mode тап «Операції». Назва акаунта («Біла» / інша monobank-карта) має бути на чіткому bg-pill з межею, легко читатись. У light-mode — нічого не зламалось.
- [ ] **Колапс з фільтром** — обери чіп «Витрати» (або «Доходи»). Заголовки дат лишаються, лічильник `·N` — кількість *відфільтрованих* за той день. Тап на заголовок — розгортає. Фільтр змінюється — стан згортання зберігається.
- [ ] **Колапс за замовчуванням** — при першому відкритті сторінки всі дні згорнуті (включно з «Сьогодні»). Тап — розгортає. Refresh — стан, який користувач обрав, зберігається.
- [ ] **Кешовані overrides** — якщо користувач розгортав щось до цього PR, його overrides все ще живі в localStorage; тільки той override, який явно був `true`, залишається розгорнутим.
- [ ] **618 тестів / typecheck / lint** — усі зелені локально.

### Notes
- `todayKey` лишився в сигнатурі `isDayExpanded` (як `_todayKey`), бо параметр передається з двох call-sites. Якщо в майбутньому захочемо feature-flag «сьогодні завжди відкрите» — логіка вже там, додай `|| key === todayKey` в поверненні.
- Pre-existing iOS-build fail — не пов'язаний.

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual appearance of account name badges with improved styling, borders, and rounded design.

* **Bug Fixes**
  * Corrected transaction day expansion behavior to properly collapse by default and consistently honor user collapse/expand preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->