### PR TITLE
fix(finyk): tx filter chips — tinted fill instead of pale outline in dark mode

### DIFF
--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -613,10 +613,10 @@ export function Transactions({
                 key={f.id}
                 onClick={() => setFilter(f.id)}
                 className={cn(
-                  "text-xs px-4 py-2 rounded-full border transition-colors min-h-[36px]",
+                  "text-xs px-4 py-2 rounded-full border transition-colors min-h-[36px] font-medium",
                   filter === f.id
-                    ? "bg-primary border-primary text-white"
-                    : "bg-transparent border-line text-subtle hover:border-muted hover:text-muted",
+                    ? "bg-primary border-primary text-white shadow-sm"
+                    : "bg-panelHi border-line/60 text-muted hover:text-text hover:border-line",
                 )}
               >
                 {f.label}


### PR DESCRIPTION
## Summary

Користувач на скрінах (https://app.devin.ai/attachments/8fc87088-3b95-42be-ae84-4131e925ae55) показав, що фільтр-чіпси на сторінці Операції («Всі / Витрати / Доходи / 💳 Кредитна / Борги / …категорії») виглядають «білими» в dark mode — це через `bg-transparent border-line text-subtle` стиль: порожні chip-и з чітким warm-бежевим бордером (`--c-line: #524a41`) контрастують з темним фоном і читаються як «outlined pill», а не частина інтерфейсу.

Замінив на заливку: `bg-panelHi border-line/60 text-muted` — тонкий панель-тінт, м'якший бордер, `text-muted` (#b4aea9) замість `text-subtle` (#878079) для кращої читабельності ярликів. На hover — `text-text` (full white). Активний чіпс лишився `bg-primary text-white`, додав `shadow-sm` щоб трохи підняти його від tinted неактивних.

### Зміна

```tsx
// Було
filter === f.id
  ? "bg-primary border-primary text-white"
  : "bg-transparent border-line text-subtle hover:border-muted hover:text-muted"

// Стало
filter === f.id
  ? "bg-primary border-primary text-white shadow-sm"
  : "bg-panelHi border-line/60 text-muted hover:text-text hover:border-line"
```
(+ `font-medium` на обидва стани для ваги тексту)

## Review & Testing Checklist for Human
- [ ] **Dark-mode Операції**: неактивні чіпси мають легку заливку панелі, не читаються як pale outlined рамки. Активний чіпс — білий на зеленому з м'якою тінню.
- [ ] **Light-mode Операції**: `bg-panelHi` = світло-бежевий фон, `text-muted` = темно-сірий — комфортно контрастує з білим активним чіпсом.
- [ ] **Hover стан** на desktop: колір тексту темніє до `text-text`, бордер трохи підсилюється.
- [ ] **Горизонтальний скрол** працює як раніше (довгий список чіпсів при багатьох категоріях у витратах).

### Notes
- Той самий паттерн заливки вже використовується в іншому chip-ряду (`ManualExpenseSheet`).
- Pre-existing iOS build fail (`GoogleMLKit/BarcodeScanning`) — не пов'язаний.

Link to Devin session: https://app.devin.ai/sessions/907c3d9700af45659c38dfb5208301c6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated transaction filter chip styling with enhanced typography (medium font weight)
  * Refined active state appearance with subtle shadow effects
  * Improved inactive state styling with updated visual treatment and hover interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->