### PR TITLE
fix(ui): restore readable active chips & buttons in dark mode

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -449,7 +449,7 @@ function TxRowImpl({
               className={cn(
                 "text-xs px-3 py-2 rounded-xl border transition-colors min-h-[34px]",
                 c.id === cat.id
-                  ? "bg-text text-white border-text"
+                  ? "bg-text text-bg border-text"
                   : "border-line text-subtle hover:border-muted hover:text-text",
               )}
             >

--- a/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
@@ -42,7 +42,7 @@ function AddBudgetFormComponent({
           className={cn(
             "flex-1 py-2 text-sm font-semibold rounded-xl border transition-colors",
             formType === "limit"
-              ? "bg-primary border-primary text-white"
+              ? "bg-primary border-primary text-bg"
               : "border-line text-subtle",
           )}
         >

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -615,8 +615,8 @@ export function Transactions({
                 className={cn(
                   "text-xs px-4 py-2 rounded-full border transition-colors min-h-[36px] font-medium",
                   filter === f.id
-                    ? "bg-primary border-primary text-white shadow-sm"
-                    : "bg-panelHi border-line/60 text-muted hover:text-text hover:border-line",
+                    ? "bg-primary border-primary text-bg shadow-sm"
+                    : "bg-panelHi border-line text-text hover:border-muted",
                 )}
               >
                 {f.label}

--- a/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
@@ -69,7 +69,7 @@ export function BodyAtlas({ statusByMuscle, height = 320, showLegend = true }) {
             className={cn(
               "text-xs px-3 py-2 rounded-full border transition-colors",
               view === "anterior"
-                ? "bg-text text-white border-text"
+                ? "bg-text text-bg border-text"
                 : "border-line text-subtle hover:text-text",
             )}
             onClick={() => setView("anterior")}
@@ -80,7 +80,7 @@ export function BodyAtlas({ statusByMuscle, height = 320, showLegend = true }) {
             className={cn(
               "text-xs px-3 py-2 rounded-full border transition-colors",
               view === "posterior"
-                ? "bg-text text-white border-text"
+                ? "bg-text text-bg border-text"
                 : "border-line text-subtle hover:text-text",
             )}
             onClick={() => setView("posterior")}

--- a/apps/web/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/AddExerciseSheet.tsx
@@ -115,7 +115,7 @@ export function AddExerciseSheet({
                   className={cn(
                     "text-xs px-3 py-2.5 min-h-[44px] rounded-full border transition-colors",
                     active
-                      ? "bg-text text-white border-text"
+                      ? "bg-text text-bg border-text"
                       : "border-line bg-bg text-muted hover:border-muted hover:text-text",
                   )}
                   aria-pressed={active}
@@ -139,7 +139,7 @@ export function AddExerciseSheet({
                 className={cn(
                   "text-xs px-3 py-2 min-h-[44px] rounded-full border transition-colors",
                   (form.musclesPrimary || []).includes(id)
-                    ? "bg-primary border-primary text-white"
+                    ? "bg-primary border-primary text-bg"
                     : "border-line bg-bg text-muted hover:border-muted hover:text-text",
                 )}
                 onClick={() =>

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -55,7 +55,7 @@ export function WorkoutFinishSheets({
                     className={cn(
                       "min-w-[44px] min-h-[44px] rounded-xl border text-sm font-semibold transition-colors",
                       finishFlash.energy === n
-                        ? "bg-text text-white border-text"
+                        ? "bg-text text-bg border-text"
                         : "border-line bg-bg text-muted hover:border-muted",
                     )}
                     onClick={() =>
@@ -80,7 +80,7 @@ export function WorkoutFinishSheets({
                     className={cn(
                       "min-w-[44px] min-h-[44px] rounded-xl border text-sm font-semibold transition-colors",
                       finishFlash.mood === n
-                        ? "bg-text text-white border-text"
+                        ? "bg-text text-bg border-text"
                         : "border-line bg-bg text-muted hover:border-muted",
                     )}
                     onClick={() =>

--- a/apps/web/src/shared/components/ui/InputDialog.tsx
+++ b/apps/web/src/shared/components/ui/InputDialog.tsx
@@ -129,7 +129,7 @@ export function InputDialog({
         <div className="flex flex-col gap-2">
           <Button
             type="submit"
-            className="w-full h-12 !bg-primary !text-white border-0"
+            className="w-full h-12 !bg-primary !text-bg border-0"
           >
             {confirmLabel}
           </Button>

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -5,7 +5,7 @@ const VARIANT: Record<ToastType, string> = {
   success: "bg-brand-700 text-white",
   error: "bg-danger text-white",
   warning: "bg-warning text-white",
-  info: "bg-primary text-white",
+  info: "bg-primary text-bg",
 };
 
 const ICON_WRAP: Record<ToastType, string> = {


### PR DESCRIPTION
## Summary

У темній темі `--c-primary` і `--c-text` обидва резолвяться у теплий білий (`#faf7f1`), тож усюди, де активний стан використовував `bg-primary text-white` або `bg-text text-white`, виходив білий текст на майже-білому фоні — чіпс/кнопка ставали нечитабельними (як на скриншоті з ФІНІК → Операції: активний чіпс «Доходи» зливається).

Переводжу всі такі активні стани на `text-bg` — цей токен уже мапиться інверсно до `primary`/`text` у обох темах (світла: тепла слонова кістка, темна: теплий темний), і так робить вся решта кодової бази (`ChatMessage`, `ChatInput`, `WeeklyDigestCard`, `TodayFocusCard`, `ModuleErrorBoundary`). Контраст активного стану тепер AAA у обох темах.

Заодно трохи підсилив неактивні чіпси фільтрів у `Transactions.tsx` — `text-muted` → `text-text`, `border-line/60` → `border-line` — щоб у темному режимі вони читались впевнено, а не блякло.

### Затронуті місця (усі зміни — суто класи Tailwind, без логіки)

- `modules/finyk/pages/Transactions.tsx` — чіпси фільтра (Всі / Витрати / Доходи / Кредитна / категорії) — той самий, що на скриншоті
- `modules/finyk/components/budgets/AddBudgetForm.tsx` — таби «Ліміт / Ціль»
- `modules/finyk/components/TxRow.tsx` — пікер категорії в рядку транзакції
- `modules/fizruk/components/workouts/AddExerciseSheet.tsx` — чіпси екіпіровки та основних мʼязів
- `modules/fizruk/components/workouts/WorkoutFinishSheets.tsx` — оцінки енергії та настрою 1–5
- `modules/fizruk/components/BodyAtlas.tsx` — перемикач «Спереду / Ззаду»
- `shared/components/ui/Toast.tsx` — варіант `info`
- `shared/components/ui/InputDialog.tsx` — кнопка підтвердження

## Review & Testing Checklist for Human

- [ ] Увімкнути темну тему, відкрити ФІНІК → Операції, пройтись по чіпсах фільтра — активний і неактивні мають чітко читатись
- [ ] Перевірити бюджет-форму (ФІНІК → план/бюджети) — таби «Ліміт / Ціль»
- [ ] Перевірити пікер категорії при редагуванні транзакції (довгий тап по рядку)
- [ ] Відкрити ФІЗРУК → додавання вправи → почіпати чіпси екіпіровки й мʼязів; після тренування — екран «Завершити» з оцінками
- [ ] Перевірити, що у світлій темі активні чіпси досі мають темний фон + світлий текст (жодних регресій)

### Notes

- Використано існуючий у кодбазі патерн `bg-primary text-bg` / `bg-text text-bg` замість введення нового токена
- Жодних змін у design-tokens / CSS-змінних — бо наявні токени вже задають правильну інверсну семантику, просто не скрізь використовувались послідовно
- Інші конкретно-кольорові кнопки (`bg-danger text-white`, `bg-brand-700 text-white`, модульні `bg-finyk text-white` тощо) залишаються з `text-white` — там фон завжди кольоровий у обох темах, тож проблеми немає

Link to Devin session: https://app.devin.ai/sessions/11dd7b7be1cb403c819d3c196b182845
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling across multiple UI components for improved visual consistency, including category pickers, toggle buttons, filter chips, option buttons, and dialog elements in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->