### PR TITLE
fix(fizruk): persist reminder dedup + cleanup submit-success timer

### DIFF
--- a/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
+++ b/apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts
@@ -2,6 +2,14 @@ import { useEffect, useRef } from "react";
 
 const LAST_KEY = "fizruk_last_reminder_notif_day";
 
+function readLastFiredDay(): string | null {
+  try {
+    return localStorage.getItem(LAST_KEY);
+  } catch {
+    return null;
+  }
+}
+
 export function sendFizrukStateToSW(state) {
   try {
     if (!("serviceWorker" in navigator) || !navigator.serviceWorker.controller)
@@ -24,7 +32,10 @@ export function useFizrukWorkoutReminder({
   reminderEnabled,
   days,
 }) {
-  const firedRef = useRef(null);
+  // Seed from localStorage so that remount within the same day (e.g. after
+  // HMR, route change, or the user navigating away and back) does not
+  // re-fire today's notification.
+  const firedRef = useRef<string | null>(readLastFiredDay());
 
   useEffect(() => {
     sendFizrukStateToSW({

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Label } from "@shared/components/ui/FormField";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
@@ -63,6 +63,18 @@ export function Body({ onOpenMeasurements }) {
     note: "",
   });
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const submitSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    return () => {
+      if (submitSuccessTimerRef.current) {
+        clearTimeout(submitSuccessTimerRef.current);
+        submitSuccessTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -82,7 +94,13 @@ export function Body({ onOpenMeasurements }) {
       note: "",
     });
     setSubmitSuccess(true);
-    setTimeout(() => setSubmitSuccess(false), 2000);
+    if (submitSuccessTimerRef.current) {
+      clearTimeout(submitSuccessTimerRef.current);
+    }
+    submitSuccessTimerRef.current = setTimeout(() => {
+      setSubmitSuccess(false);
+      submitSuccessTimerRef.current = null;
+    }, 2000);
   };
 
   const weightData = useMemo(() => {


### PR DESCRIPTION
## Summary

Два дрібні фікси в модулі **fizruk**:

1. **`useFizrukWorkoutReminder` — денний dedup, що переживає перемонтування.**
   Раніше `firedRef` ініціалізувався як `null` на кожен монтаж, а `LAST_KEY` (`fizruk_last_reminder_notif_day`) писався в localStorage, але **ніде не читався** — тобто, по суті, був мертвим кодом. У результаті, якщо на момент «цільової» хвилини користувач виходив з модуля і повертався, нагадування могло виконатися повторно, а `LAST_KEY` жодного ефекту не мав.
   Тепер `firedRef` ініціалізується з localStorage, так що повторний монтаж у межах того самого дня не перезапускає нагадування. Поведінка за першого запуску не змінилася.

2. **`Body.tsx` — cleanup 2-сек таймера `submitSuccess` на unmount.**
   `setTimeout` без cleanup міг викликати `setSubmitSuccess(false)` на розмонтованому компоненті (React-warning + зайва робота). Тепер таймер тримається в `ref`, скидається на новий submit і в ефекті-cleanup.

## Review & Testing Checklist for Human

- [ ] Увімкнути reminder у Fizruk з часом на найближчу хвилину; переконатись, що нотифікація спрацьовує один раз. Після уходу з модуля і повернення в межах того самого дня — повторного нотифіку не має бути.
- [ ] Submit форми у `Body` — зелена «✓ Збережено» пропадає через 2 с (як раніше), без помилок у консолі, зокрема після швидкого перемикання сторінок одразу після submit.

### Notes

`pnpm lint`, `pnpm typecheck`, `pnpm test` (618/618) — чисто.

Зачіпає лише 2 файли у `apps/web/src/modules/fizruk`.

Link to Devin session: https://app.devin.ai/sessions/e6452873ebab40e29145190f4267a305
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed duplicate workout reminder notifications appearing when navigating between pages or refreshing the browser
- The app now properly maintains reminder history across sessions to prevent unnecessary repeated alerts
- Enhanced success feedback to reliably clear completion states and eliminate stale notifications that linger after interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->