### PR TITLE
refactor(routine): remove per-module import from Routine settings

### DIFF
--- a/apps/web/src/core/settings/RoutineSection.tsx
+++ b/apps/web/src/core/settings/RoutineSection.tsx
@@ -4,9 +4,7 @@ import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
 import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
 import {
-  applyRoutineBackupPayload,
   deleteHabit,
-  loadRoutineState,
   restoreHabit,
   snapshotHabit,
 } from "../../modules/routine/lib/routineStorage.js";
@@ -28,10 +26,6 @@ import {
   ToggleRow,
 } from "./SettingsPrimitives.jsx";
 
-interface ImportConfirmState {
-  parsed: unknown;
-}
-
 export function RoutineSection() {
   const toast = useToast();
   const { routine, setRoutine, updatePref } = useRoutineState();
@@ -47,9 +41,6 @@ export function RoutineSection() {
   const [detailHabitId, setDetailHabitId] = useState<string | null>(null);
   const [deleteHabitPending, setDeleteHabitPending] =
     useState<PendingHabitDeletion | null>(null);
-  const [importConfirm, setImportConfirm] = useState<ImportConfirmState | null>(
-    null,
-  );
 
   const closeEditDialog = () => setEditingId(null);
 
@@ -118,11 +109,7 @@ export function RoutineSection() {
       </SettingsSubGroup>
 
       <SettingsSubGroup title="Резервна копія">
-        <RoutineBackupSection
-          theme={C}
-          toast={toast}
-          onImportParsed={(parsed) => setImportConfirm({ parsed })}
-        />
+        <RoutineBackupSection theme={C} />
       </SettingsSubGroup>
 
       <HabitQuickCreateDialog
@@ -168,27 +155,6 @@ export function RoutineSection() {
           setDeleteHabitPending(null);
         }}
         onCancel={() => setDeleteHabitPending(null)}
-      />
-
-      <ConfirmDialog
-        open={!!importConfirm}
-        title="Імпорт резервної копії"
-        description="Імпорт замінить усі поточні дані Рутини (звички, відмітки, відтискання) даними з файлу. Продовжити?"
-        confirmLabel="Імпортувати"
-        danger={false}
-        onConfirm={() => {
-          if (importConfirm?.parsed) {
-            try {
-              applyRoutineBackupPayload(importConfirm.parsed);
-              setRoutine(loadRoutineState());
-              toast.success("Резервну копію імпортовано.");
-            } catch (err) {
-              toast.error(err?.message || "Не вдалося імпортувати файл.");
-            }
-          }
-          setImportConfirm(null);
-        }}
-        onCancel={() => setImportConfirm(null)}
       />
 
       {detailHabitId && (

--- a/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
@@ -1,4 +1,3 @@
-import { useRef, type ChangeEvent } from "react";
 import { downloadJson } from "@sergeant/shared";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
@@ -10,30 +9,19 @@ export interface RoutineBackupTheme {
   primary?: string;
 }
 
-export interface RoutineBackupToast {
-  warning?: (message: string) => void;
-}
-
 export interface RoutineBackupSectionProps {
   theme?: RoutineBackupTheme;
-  toast?: RoutineBackupToast;
-  onImportParsed?: (parsed: unknown) => void;
 }
 
-export function RoutineBackupSection({
-  theme,
-  toast,
-  onImportParsed,
-}: RoutineBackupSectionProps) {
-  const backupRef = useRef<HTMLInputElement | null>(null);
-
+export function RoutineBackupSection({ theme }: RoutineBackupSectionProps) {
   return (
     <Card as="section" radius="lg" padding="md" className="space-y-3">
       <SectionHeading as="h2" size="sm">
         Резервна копія
       </SectionHeading>
       <p className="text-xs text-subtle">
-        Експорт/імпорт JSON для переносу даних між пристроями.
+        Експорт лише даних Рутини у JSON. Для відновлення або перенесення між
+        пристроями використовуй загальний імпорт у «Загальні → Резервна копія».
       </p>
       <div className="flex flex-wrap gap-2">
         <Button
@@ -48,36 +36,6 @@ export function RoutineBackupSection({
         >
           Експорт JSON
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          className="border border-line"
-          onClick={() => backupRef.current?.click()}
-        >
-          Імпорт
-        </Button>
-        <input
-          ref={backupRef}
-          type="file"
-          accept="application/json,.json"
-          className="hidden"
-          onChange={async (e: ChangeEvent<HTMLInputElement>) => {
-            const f = e.target.files?.[0];
-            if (!f) return;
-            try {
-              const text = await f.text();
-              const parsed: unknown = JSON.parse(text);
-              onImportParsed?.(parsed);
-            } catch (err) {
-              const msg =
-                err instanceof Error
-                  ? err.message
-                  : "Не вдалося імпортувати файл.";
-              toast?.warning?.(msg);
-            }
-            e.target.value = "";
-          }}
-        />
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary

В Hub-налаштуваннях (Загальні → Резервна копія) уже є один загальний імпорт даних всього хабу через `HubBackupPanel` (`applyHubBackupPayload`, охоплює Фінік/Фізрук/Рутину й останній модуль). У секції «Рутина → Резервна копія» стояв ще один окремий імпорт, який створював плутанину — два різні діалоги з різною семантикою мерджу.

Видаляю дубль:

- У `RoutineBackupSection`: прибираю кнопку «Імпорт», файловий `<input>` та проп `onImportParsed` / `toast`. Залишаю «Експорт JSON» — він корисний, якщо треба зробити snapshot лише по Рутині (відмітки, відтискання), і оновлюю опис, щоб відсилав до загального імпорту.
- У `core/settings/RoutineSection.tsx`: прибираю `importConfirm` state, `ImportConfirmState` interface, `ConfirmDialog` імпорту та вже непотрібні імпорти `applyRoutineBackupPayload` і `loadRoutineState`.

Код логіки Рутини (`applyRoutineBackupPayload`) і CRUD-функції `routineStorage` не чіпав — `HubBackupPanel` уже викликає їх через `applyHubBackupPayload`.

## Review & Testing Checklist for Human

- [ ] Відкрити Хаб → Налаштування → Модулі → Рутина → «Резервна копія» — має лишитись лише «Експорт JSON» і нова підказка про загальний імпорт
- [ ] Перевірити, що Загальні → Резервна копія (HubBackupPanel) досі приймає бекап, який включає дані Рутини, і після імпорту звички/відмітки підтягуються
- [ ] Переконатись, що кнопка «Експорт JSON» у Рутині досі завантажує файл виду `hub-routine-backup-YYYY-MM-DD.json`

### Notes

- Якщо для Рутини потрібна окрема семантика імпорту (наприклад, merge замість replace), можемо повернути кнопку пізніше — але вона має викликати саме `applyHubBackupPayload` або спільну утиліту, щоб логіка не розїхалась між двома точками входу
- Секції Налаштувань Харчування зараз немає в `HubSettingsPage` взагалі (є тільки General/Notifications/AI/Routine/Fizruk/Finyk/Experimental). Якщо треба — зроблю окремим PR додавання `NutritionSection` (денні KБЖУ-цілі, одиниці води, дефолтний прийом їжі, автопідстановка з комори)

Link to Devin session: https://app.devin.ai/sessions/11dd7b7be1cb403c819d3c196b182845
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
