### PR TITLE
fix(nutrition): persist reminder dedup + cleanup transient timers

### DIFF
--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { NutritionHeader } from "./components/NutritionHeader.jsx";
 import { NutritionBottomNav } from "./components/NutritionBottomNav.jsx";
 import { SubTabs } from "./components/SubTabs.jsx";
@@ -71,6 +71,32 @@ export default function NutritionApp({
   // "Аналіз фото страви" disclosure open and pop the native file picker
   // on the next frame — no extra "Звідки страва?" detour.
   const [photoCardForceOpen, setPhotoCardForceOpen] = useState(false);
+
+  // Shared bucket for short-lived one-shot timers scheduled from imperative
+  // click / route handlers (file picker fallbacks, "Add meal" sheet open).
+  // We need to clear them on unmount so late setState / click() calls
+  // don't touch a torn-down component.
+  const transientTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(
+    new Set(),
+  );
+  const scheduleTransient = useCallback(
+    (cb: () => void, delayMs: number): ReturnType<typeof setTimeout> => {
+      const id = setTimeout(() => {
+        transientTimersRef.current.delete(id);
+        cb();
+      }, delayMs);
+      transientTimersRef.current.add(id);
+      return id;
+    },
+    [],
+  );
+  useEffect(() => {
+    const timers = transientTimersRef.current;
+    return () => {
+      for (const id of timers) clearTimeout(id);
+      timers.clear();
+    };
+  }, []);
 
   useEffect(() => {
     if (pwaAction === "add_meal") {
@@ -223,7 +249,7 @@ export default function NutritionApp({
         /* noop — picker may be blocked without a user gesture */
       }
     });
-    window.setTimeout(() => {
+    scheduleTransient(() => {
       cancelAnimationFrame(raf);
       try {
         photo.fileRef.current?.click();
@@ -360,7 +386,7 @@ export default function NutritionApp({
                   onAddMeal={() => {
                     log.setSelectedDate(todayISODate());
                     setActivePageAndHash("log");
-                    setTimeout(() => {
+                    scheduleTransient(() => {
                       log.setAddMealPhotoResult(null);
                       log.setAddMealSheetOpen(true);
                     }, 80);

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -66,6 +66,22 @@ export function useNutritionLog() {
     );
   }, [nutritionLog]);
 
+  // Flush scheduled thumbnail deletes on unmount. The 6 s grace window
+  // exists to allow `handleRestoreMeal` to cancel the delete, but that
+  // handler only exists while the hook is alive — once we unmount the
+  // undo path is gone, so we cancel the timers and delete immediately
+  // instead of letting the raw `setTimeout` fire on a torn-down hook.
+  useEffect(() => {
+    const pending = pendingThumbDeletesRef.current;
+    return () => {
+      for (const [id, timer] of pending) {
+        clearTimeout(timer);
+        void deleteMealThumbnail(id);
+      }
+      pending.clear();
+    };
+  }, []);
+
   // Coach insight and weekly digest both derive from the nutrition log.
   // Invalidate them whenever the log changes so the next mount / user
   // refresh regenerates with the latest context. `staleTime: Infinity`

--- a/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
@@ -6,8 +6,29 @@ export interface NutritionReminderPrefs {
   reminderHour?: number | null;
 }
 
+const LAST_NOTIFY_KEY_STORAGE = "nutrition_last_reminder_notif_key";
+
+function readLastNotifyKey(): string {
+  try {
+    return localStorage.getItem(LAST_NOTIFY_KEY_STORAGE) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeLastNotifyKey(key: string): void {
+  try {
+    localStorage.setItem(LAST_NOTIFY_KEY_STORAGE, key);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function useNutritionReminders(prefs: NutritionReminderPrefs): void {
-  const lastNotifyKeyRef = useRef<string>("");
+  // Seed from localStorage so a remount within the same reminder window
+  // (e.g. navigating away from nutrition and back) does not re-fire the
+  // same day's notification.
+  const lastNotifyKeyRef = useRef<string>(readLastNotifyKey());
 
   useEffect(() => {
     try {
@@ -40,6 +61,7 @@ export function useNutritionReminders(prefs: NutritionReminderPrefs): void {
       const key = `${todayISODate()}-${target}`;
       if (lastNotifyKeyRef.current === key) return;
       lastNotifyKeyRef.current = key;
+      writeLastNotifyKey(key);
       try {
         if ("serviceWorker" in navigator) {
           navigator.serviceWorker.ready


### PR DESCRIPTION
## Summary

Три фікси в модулі **nutrition** з однієї категорії — «`setTimeout` живе довше за компонент/хук».

1. **`useNutritionReminders` — dedup, що переживає перемонтування.**
   `lastNotifyKeyRef` раніше ініціалізувався як `""` на кожен mount, тому при поверненні в модуль у межах reminder-години нагадування могло надіслатися повторно. Тепер ключ персиститься в localStorage (`nutrition_last_reminder_notif_key`) і читається при старті хука.

2. **`NutritionApp` — cleanup двох транзитивних `setTimeout`ів.**
   - 80 ms fallback після `requestAnimationFrame` для file-picker (S13).
   - 80 ms затримка перед відкриттям AddMeal sheet з OverviewTab.
   Обидва не очищалися на unmount. Додав невеликий `scheduleTransient` helper — timers кладуться в `Set` у ref і всі скидаються на unmount.

3. **`useNutritionLog` — flush `pendingThumbDeletesRef` на unmount.**
   6-секундний grace-таймер між видаленням meal і `deleteMealThumbnail` існує лише для того, щоб `handleRestoreMeal` міг його скасувати. Після unmount хука undo-шлях недоступний, тому на cleanup я скасовую таймер і виконую `deleteMealThumbnail` одразу — замість того, щоб raw `setTimeout` спрацював на вже розібраному хуці.

**Водяний трекер** (`WaterTrackerCard`) уже має коректний cleanup — у ньому нічого не змінюю.

## Review & Testing Checklist for Human

- [ ] Nutrition: увімкнути нагадування на найближчу годину, отримати нотифікацію → вийти з модуля та повернутись у межах тієї ж години → повторного нагадування не має бути; після перезавантаження сторінки теж.
- [ ] «Додати прийом» з OverviewTab → аркуш відкривається як раніше; при швидкому виході з nutrition одразу після натискання — без React-warning у консолі.
- [ ] Видалити прийом → натиснути «Повернути» у межах 6 с → прийом повертається; фото на місці. Якщо вийти з модуля до натискання «Повернути» — фото коректно зникає з IDB (не лишається orphan).

### Notes

`pnpm lint`, `pnpm typecheck`, `pnpm test` (618/618) — чисто.

Зачіпає 3 файли: `hooks/useNutritionReminders.ts`, `hooks/useNutritionLog.ts`, `NutritionApp.tsx`.

Link to Devin session: https://app.devin.ai/sessions/e6452873ebab40e29145190f4267a305
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
