### PR TITLE
chore(web): remove duplicate @sergeant/mobile-shell dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,6 @@
     "@sergeant/nutrition-domain": "workspace:*",
     "@sergeant/routine-domain": "workspace:*",
     "@sergeant/insights": "workspace:*",
-    "@sergeant/mobile-shell": "workspace:*",
     "@sergeant/shared": "workspace:*",
     "@tanstack/react-query": "^5.99.0",
     "@zxing/browser": "^0.1.5",


### PR DESCRIPTION
## Summary

`@sergeant/mobile-shell` був оголошений у `apps/web/package.json` двічі (рядки 25 та 31 на `main`). esbuild/vitest видавали warning `Duplicate key "@sergeant/mobile-shell" in object literal`, pnpm при установці — теж. Обидва посилання вказували на `workspace:*`, тому це чистий cleanup.

## Review & Testing Checklist for Human

- [ ] `pnpm install` проходить без warning про дубльований ключ.
- [ ] `apps/web` досі має `@sergeant/mobile-shell` серед `dependencies` і збірка web не зламалась.

### Notes

Зачіпає лише один рядок у `apps/web/package.json`. `pnpm lint`, `pnpm typecheck` — чисто, lockfile не змінюється (pnpm бере останній ключ, який ми і залишили).

Link to Devin session: https://app.devin.ai/sessions/e6452873ebab40e29145190f4267a305
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
