### PR TITLE
feat(finyk/analytics): toggle to expand «Інше» into all categories

### DIFF
--- a/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.test.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.test.tsx
@@ -166,6 +166,68 @@ describe("Analytics screen (mobile)", () => {
     });
   });
 
+  describe("category donut toggle", () => {
+    // Seven distinct MCC-driven categories so the donut has a non-empty
+    // long tail (> TOP_N = 5) and the "Показати всі" toggle is rendered.
+    const manyCategories: FinykAnalyticsData = {
+      ...emptyData(),
+      realTx: [
+        tx("c1", "2025-05-02T10:00:00Z", "АТБ", -600_00, 5411), // food
+        tx("c2", "2025-05-03T10:00:00Z", "Таксі", -500_00, 4121), // transport
+        tx("c3", "2025-05-04T10:00:00Z", "McDonalds", -400_00, 5812), // restaurant
+        tx("c4", "2025-05-05T10:00:00Z", "Spotify", -300_00, 4899), // subscriptions
+        tx("c5", "2025-05-06T10:00:00Z", "Аптека", -250_00, 5912), // health
+        tx("c6", "2025-05-07T10:00:00Z", "Rozetka", -150_00, 5311), // shopping
+        tx("c7", "2025-05-08T10:00:00Z", "Cinema", -80_00, 7832), // entertainment
+      ],
+    };
+
+    it("renders the toggle collapsed by default with an Інше bucket", () => {
+      render(<Analytics data={manyCategories} now={fixedNow} />);
+      const toggle = screen.getByTestId("finyk-analytics-donut-toggle");
+      expect(toggle).toBeTruthy();
+      // Collapsed legend shows an "Інше" row rolling up the long tail.
+      expect(
+        screen.getByTestId("finyk-analytics-donut-row-_other"),
+      ).toBeTruthy();
+    });
+
+    it("expands the legend to every category when pressed", () => {
+      render(<Analytics data={manyCategories} now={fixedNow} />);
+      const toggle = screen.getByTestId("finyk-analytics-donut-toggle");
+      fireEvent.press(toggle);
+      // The "Інше" row is gone and every real category id has its own row.
+      expect(
+        screen.queryByTestId("finyk-analytics-donut-row-_other"),
+      ).toBeNull();
+      for (const id of [
+        "food",
+        "transport",
+        "restaurant",
+        "subscriptions",
+        "health",
+        "shopping",
+        "entertainment",
+      ]) {
+        expect(
+          screen.getByTestId(`finyk-analytics-donut-row-${id}`),
+        ).toBeTruthy();
+      }
+    });
+
+    it("hides the toggle when there are ≤ TOP_N categories", () => {
+      const fewCategories: FinykAnalyticsData = {
+        ...emptyData(),
+        realTx: [
+          tx("f1", "2025-05-02T10:00:00Z", "АТБ", -300_00, 5411),
+          tx("f2", "2025-05-05T10:00:00Z", "Таксі", -80_00, 4121),
+        ],
+      };
+      render(<Analytics data={fewCategories} now={fixedNow} />);
+      expect(screen.queryByTestId("finyk-analytics-donut-toggle")).toBeNull();
+    });
+  });
+
   describe("month navigation", () => {
     it("stepping back unblocks the next-month button", () => {
       render(<Analytics data={emptyData()} now={new Date(2025, 4, 15)} />);

--- a/apps/mobile/src/modules/finyk/pages/Analytics/CategoryDonut.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/CategoryDonut.tsx
@@ -13,9 +13,15 @@
  * VictoryPie) matches the web implementation byte-for-byte and lets
  * us skip the layout overhead of victory-native for the small (160px)
  * chart this screen renders.
+ *
+ * When there are more than `TOP_N` categories, the legend renders a
+ * «Показати всі / Згорнути» toggle below it. Collapsed view shows the
+ * top N + an "Інше" bucket (default); expanded view replaces the
+ * bucket with every category in `data` so the user can drill into the
+ * long tail without leaving the screen.
  */
-import { memo } from "react";
-import { Text, View } from "react-native";
+import { memo, useState } from "react";
+import { Pressable, Text, View } from "react-native";
 import Svg, { Path, Text as SvgText } from "react-native-svg";
 
 import type { TopCategory } from "@sergeant/finyk-domain/domain";
@@ -95,6 +101,9 @@ const TOP_N = 5;
 const RENDER_MIN_SWEEP = 0.5;
 
 function CategoryDonutComponent({ data, size = 160 }: CategoryDonutProps) {
+  const [showAll, setShowAll] = useState(false);
+  const hasOverflow = (data?.length ?? 0) > TOP_N;
+
   if (!data || data.length === 0) return null;
 
   const cx = size / 2;
@@ -105,22 +114,32 @@ function CategoryDonutComponent({ data, size = 160 }: CategoryDonutProps) {
   const total = data.reduce((s, d) => s + d.spent, 0);
   if (total === 0) return null;
 
-  const top = data.slice(0, TOP_N);
-  const otherSpent = data.slice(TOP_N).reduce((s, d) => s + d.spent, 0);
-  const totalTopPct = top.reduce((s, d) => s + d.pct, 0);
-  const segments: Omit<Arc, "start" | "end">[] =
-    otherSpent > 0
-      ? [
-          ...top,
-          {
-            categoryId: "_other",
-            label: "Інше",
-            spent: otherSpent,
-            pct: Math.max(0, 100 - totalTopPct),
-            color: "#94a3b8",
-          },
-        ]
-      : top;
+  const expanded = showAll && hasOverflow;
+
+  let segments: Omit<Arc, "start" | "end">[];
+  if (expanded) {
+    // Expanded legend replaces the "Інше" bucket with every category
+    // from `data` (the selector caps this at 20 entries — see
+    // `selectCategoryDistributionFromIndex`).
+    segments = data.map((d) => ({ ...d }));
+  } else {
+    const top = data.slice(0, TOP_N);
+    const otherSpent = data.slice(TOP_N).reduce((s, d) => s + d.spent, 0);
+    const totalTopPct = top.reduce((s, d) => s + d.pct, 0);
+    segments =
+      otherSpent > 0
+        ? [
+            ...top,
+            {
+              categoryId: "_other",
+              label: "Інше",
+              spent: otherSpent,
+              pct: Math.max(0, 100 - totalTopPct),
+              color: "#94a3b8",
+            },
+          ]
+        : top;
+  }
 
   let currentAngle = 0;
   const arcs: Arc[] = segments.map((seg) => {
@@ -134,78 +153,92 @@ function CategoryDonutComponent({ data, size = 160 }: CategoryDonutProps) {
   const GAP_DEG = visible.length > 1 ? 1 : 0;
 
   return (
-    <View
-      className="w-full flex-row items-center gap-4"
-      testID="finyk-analytics-donut"
-    >
-      <Svg
-        width={size}
-        height={size}
-        viewBox={`0 0 ${size} ${size}`}
-        accessibilityLabel="Кругова діаграма категорій"
-      >
-        {arcs.map((arc, i) => {
-          const sweep = arc.end - arc.start;
-          if (sweep < RENDER_MIN_SWEEP) return null;
-          const pad = Math.min(GAP_DEG / 2, sweep / 2 - 0.01);
-          const d = describeSector(
-            cx,
-            cy,
-            outerR,
-            innerR,
-            arc.start + pad,
-            arc.end - pad,
-          );
-          return <Path key={arc.categoryId || i} d={d} fill={arc.color} />;
-        })}
-        <SvgText
-          x={cx}
-          y={cy - 4}
-          textAnchor="middle"
-          fontSize="11"
-          fill="#78716c"
-          fontWeight="500"
+    <View className="w-full gap-3" testID="finyk-analytics-donut">
+      <View className="flex-row items-center gap-4">
+        <Svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          accessibilityLabel="Кругова діаграма категорій"
         >
-          Всього
-        </SvgText>
-        <SvgText
-          x={cx}
-          y={cy + 12}
-          textAnchor="middle"
-          fontSize="13"
-          fontWeight="600"
-          fill="#1c1917"
-        >
-          {`${total.toLocaleString("uk-UA")} ₴`}
-        </SvgText>
-      </Svg>
-
-      <View className="flex-1 gap-1.5 min-w-0">
-        {arcs.map((arc) => (
-          <View
-            key={arc.categoryId}
-            className="flex-row items-center gap-2"
-            testID={`finyk-analytics-donut-row-${arc.categoryId}`}
+          {arcs.map((arc, i) => {
+            const sweep = arc.end - arc.start;
+            if (sweep < RENDER_MIN_SWEEP) return null;
+            const pad = Math.min(GAP_DEG / 2, sweep / 2 - 0.01);
+            const d = describeSector(
+              cx,
+              cy,
+              outerR,
+              innerR,
+              arc.start + pad,
+              arc.end - pad,
+            );
+            return <Path key={arc.categoryId || i} d={d} fill={arc.color} />;
+          })}
+          <SvgText
+            x={cx}
+            y={cy - 4}
+            textAnchor="middle"
+            fontSize="11"
+            fill="#78716c"
+            fontWeight="500"
           >
+            Всього
+          </SvgText>
+          <SvgText
+            x={cx}
+            y={cy + 12}
+            textAnchor="middle"
+            fontSize="13"
+            fontWeight="600"
+            fill="#1c1917"
+          >
+            {`${total.toLocaleString("uk-UA")} ₴`}
+          </SvgText>
+        </Svg>
+
+        <View className="flex-1 gap-1.5 min-w-0">
+          {arcs.map((arc) => (
             <View
-              className="w-2.5 h-2.5 rounded-full"
-              style={{ backgroundColor: arc.color }}
-            />
-            <Text
-              className="text-xs text-stone-900 flex-1 min-w-0"
-              numberOfLines={1}
+              key={arc.categoryId}
+              className="flex-row items-center gap-2"
+              testID={`finyk-analytics-donut-row-${arc.categoryId}`}
             >
-              {arc.label}
-            </Text>
-            <Text className="text-xs text-stone-500 tabular-nums">
-              {arc.pct < 1 && arc.pct > 0 ? "<1" : arc.pct}%
-            </Text>
-            <Text className="text-xs font-medium text-stone-900 tabular-nums">
-              {arc.spent.toLocaleString("uk-UA")} ₴
-            </Text>
-          </View>
-        ))}
+              <View
+                className="w-2.5 h-2.5 rounded-full"
+                style={{ backgroundColor: arc.color }}
+              />
+              <Text
+                className="text-xs text-stone-900 flex-1 min-w-0"
+                numberOfLines={1}
+              >
+                {arc.label}
+              </Text>
+              <Text className="text-xs text-stone-500 tabular-nums">
+                {arc.pct < 1 && arc.pct > 0 ? "<1" : arc.pct}%
+              </Text>
+              <Text className="text-xs font-medium text-stone-900 tabular-nums">
+                {arc.spent.toLocaleString("uk-UA")} ₴
+              </Text>
+            </View>
+          ))}
+        </View>
       </View>
+      {hasOverflow ? (
+        <Pressable
+          onPress={() => setShowAll((v) => !v)}
+          accessibilityRole="button"
+          accessibilityLabel={
+            expanded ? "Згорнути категорії" : "Показати всі категорії"
+          }
+          testID="finyk-analytics-donut-toggle"
+          className="self-center px-3 py-1.5 rounded-full border border-cream-300 bg-cream-50 active:opacity-70"
+        >
+          <Text className="text-xs font-medium text-stone-700">
+            {expanded ? "Згорнути ↑" : `Показати всі (${data.length}) ↓`}
+          </Text>
+        </Pressable>
+      ) : null}
     </View>
   );
 }

--- a/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
+++ b/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 
 // Convert a polar angle (0° = 12 o'clock, clockwise) to cartesian coordinates.
@@ -50,10 +50,16 @@ function describeSector(cx, cy, outerR, innerR, startDeg, endDeg) {
   ].join(" ");
 }
 
+const TOP_N = 5;
+
 // Presentational donut chart for category spending. Output is fully
-// derived from props, so `memo` skips redundant re-renders when the
-// parent Analytics page re-renders for unrelated reasons.
+// derived from props + local expand/collapse state, so `memo` skips
+// redundant re-renders when the parent Analytics page re-renders for
+// unrelated reasons.
 function CategoryPieChartComponent({ data = [], size = 160, className }) {
+  const [showAll, setShowAll] = useState(false);
+  const hasOverflow = (data?.length ?? 0) > TOP_N;
+
   if (!data || data.length === 0) return null;
 
   const cx = size / 2;
@@ -65,21 +71,29 @@ function CategoryPieChartComponent({ data = [], size = 160, className }) {
   const total = data.reduce((s, d) => s + d.spent, 0);
   if (total === 0) return null;
 
-  const TOP_N = 5;
-  const top = data.slice(0, TOP_N);
-  const otherSpent = data.slice(TOP_N).reduce((s, d) => s + d.spent, 0);
-  const segments =
-    otherSpent > 0
-      ? [
-          ...top,
-          {
-            categoryId: "_other",
-            label: "Інше",
-            spent: otherSpent,
-            color: "#94a3b8",
-          },
-        ]
-      : top;
+  const expanded = showAll && hasOverflow;
+  let segments;
+  if (expanded) {
+    // Expanded view shows every category returned by the selector
+    // (capped at 20 in `selectCategoryDistributionFromIndex`). Collapsed
+    // view keeps the top N + "Інше" bucket.
+    segments = data;
+  } else {
+    const top = data.slice(0, TOP_N);
+    const otherSpent = data.slice(TOP_N).reduce((s, d) => s + d.spent, 0);
+    segments =
+      otherSpent > 0
+        ? [
+            ...top,
+            {
+              categoryId: "_other",
+              label: "Інше",
+              spent: otherSpent,
+              color: "#94a3b8",
+            },
+          ]
+        : top;
+  }
 
   let currentAngle = 0;
   const arcs = segments.map((seg) => {
@@ -180,6 +194,19 @@ function CategoryPieChartComponent({ data = [], size = 160, className }) {
           ))}
         </div>
       </div>
+      {hasOverflow ? (
+        <div className="mt-3 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setShowAll((v) => !v)}
+            aria-expanded={expanded}
+            data-testid="finyk-analytics-donut-toggle"
+            className="px-3 py-1.5 rounded-full border border-line bg-panelHi text-xs font-medium text-text hover:border-muted/50 transition-colors"
+          >
+            {expanded ? "Згорнути ↑" : `Показати всі (${data.length}) ↓`}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

У Фінік → Аналітика кругова діаграма категорій завжди рендерила лише **топ-5 категорій + одну сіру «Інше» частинку**, яка агрегує всі інші категорії разом. Коли категорій багато, у користувача «Інше» стає найбільшим куском і приховує реальні дані.

Додаю невеликий тогл під легендою діаграми, який при натисканні розгортає легенду і діаграму на **всі категорії** (до 20 — стільки віддає `selectCategoryDistributionFromIndex`). При повторному натисканні — згортає назад до топ-5 + «Інше».

Зміни синхронні для мобілки та вебу, поведінка однакова:

- **Мобілка** — `apps/mobile/src/modules/finyk/pages/Analytics/CategoryDonut.tsx`: додано `useState` + `<Pressable>` під легендою. У згорнутому стані: топ-5 + «Інше» (як раніше). У розгорнутому: всі категорії з `data`. Тогл ховається, якщо категорій ≤ 5.
- **Веб** — `apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx`: симетрична зміна — `useState` + `<button>` з `aria-expanded`, стилі у фірмовій панелі (`border-line`, `bg-panelHi`).
- **Тести (мобілка)** — `Analytics.test.tsx`: +3 тести для тогла (рендер за замовчуванням, розгортання у всі категорії, ховається при ≤ TOP_N).

Дані не чіпав — селектор `selectCategoryDistributionFromIndex` вже віддавав до 20 категорій, просто компонент донату їх обрізав до топ-5.

## Review & Testing Checklist for Human

- [ ] Відкрити ФІНІК → Аналітика на мобілці (де є ≥6 категорій за місяць) і перевірити, що: а) з'являється тогл «Показати всі (N) ↓»; б) натискання розгортає донат і легенду; в) «Згорнути ↑» повертає топ-5 + «Інше».
- [ ] Те саме на вебі — Фінік → Аналітика, секція «Категорії» (`<CategoryPieChart>`).
- [ ] Коли категорій ≤ 5 — тогла немає і «Інше» не показується (уже покрито тестом, але варто перевірити очима).
- [ ] Легенда в розгорнутому режимі не розʼїжджається на вузькому екрані мобілки (truncate + numberOfLines=1 збережено).

### Notes

- «Інше» bucket збережено саме як сіру частинку (`#94a3b8`) з `categoryId: "_other"` — це стабільний testID для скрінів, тож не змінював.
- Тогл рендериться центровано під обома колонками (діаграма + легенда), щоб не зміщувати донат ліворуч.
- Селектор повертає до 20 категорій, тож у розгорнутому режимі легенда може бути довгою, але скролл екрана Аналітики це покриває.


Link to Devin session: https://app.devin.ai/sessions/9f8af802ff2c43deb482efab9abf87fe
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
