### PR TITLE
fix(cloudSync): dedupe offlineQueue against retry storms

### DIFF
--- a/apps/web/src/core/cloudSync/queue/offlineQueue.ts
+++ b/apps/web/src/core/cloudSync/queue/offlineQueue.ts
@@ -8,14 +8,54 @@ export function getOfflineQueue(): QueueEntry[] {
   return Array.isArray(q) ? q : [];
 }
 
+function isPushEntryWithModules(entry: unknown): entry is QueuePushEntry {
+  if (!entry || typeof entry !== "object") return false;
+  const e = entry as { type?: unknown; modules?: unknown };
+  return e.type === "push" && !!e.modules && typeof e.modules === "object";
+}
+
+/**
+ * Compare the module payload that would be produced by coalescing `nextModules`
+ * into `prevModules` against `prevModules`. If the coalesce is a structural
+ * no-op (same keys, same payload shape), we skip the localStorage write —
+ * which fires on every `pushDirty` retry attempt against a flaky server —
+ * to avoid thrash and redundant status-event emissions.
+ */
+function coalesceIsNoop(
+  prev: QueuePushEntry["modules"],
+  next: QueuePushEntry["modules"],
+): boolean {
+  try {
+    for (const k of Object.keys(next)) {
+      if (!(k in prev)) return false;
+      if (JSON.stringify(prev[k]) !== JSON.stringify(next[k])) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Append a queue entry. Consecutive `push` entries are coalesced: new module
  * payloads are merged into the last queued push instead of appending a new
  * row. This prevents queue growth and duplicate work on replay when many
  * small changes happen while offline.
+ *
+ * Two additional safeguards:
+ *   - If a `push` entry would be appended but earlier rows already contain
+ *     stranded push entries (e.g. from an older app version or a race),
+ *     those are coalesced into a single push before we decide whether to
+ *     merge or append.
+ *   - If the resulting merge would not change the queue at all (same
+ *     payloads as the last row), we skip the write + event emission —
+ *     useful during retry loops where `pushDirty.catch` keeps re-queueing
+ *     the same payload every backoff.
  */
 export function addToOfflineQueue(entry: Partial<QueuePushEntry>): void {
   let queue = getOfflineQueue();
+  queue = normalizePushEntries(queue);
+
   if (
     entry &&
     entry.type === "push" &&
@@ -24,12 +64,12 @@ export function addToOfflineQueue(entry: Partial<QueuePushEntry>): void {
     queue.length > 0
   ) {
     const last = queue[queue.length - 1];
-    if (
-      last &&
-      last.type === "push" &&
-      last.modules &&
-      typeof last.modules === "object"
-    ) {
+    if (isPushEntryWithModules(last)) {
+      if (coalesceIsNoop(last.modules, entry.modules)) {
+        // Queue already represents the exact same payload — skip the
+        // write so retry storms don't churn localStorage.
+        return;
+      }
       last.modules = { ...last.modules, ...entry.modules };
       last.ts = new Date().toISOString();
       safeWriteLS(OFFLINE_QUEUE_KEY, queue);
@@ -46,6 +86,38 @@ export function addToOfflineQueue(entry: Partial<QueuePushEntry>): void {
   }
   safeWriteLS(OFFLINE_QUEUE_KEY, queue);
   emitStatusEvent();
+}
+
+/**
+ * Collapse any stranded push entries into a single trailing push row. Entries
+ * of unknown types are preserved in place. In current code paths the queue
+ * should already be at most one push row thanks to in-line coalescing, but
+ * we still normalize defensively to heal any state left over from a previous
+ * version, a multi-tab race, or manual localStorage edits.
+ */
+function normalizePushEntries(queue: QueueEntry[]): QueueEntry[] {
+  const pushIndices: number[] = [];
+  for (let i = 0; i < queue.length; i++) {
+    if (isPushEntryWithModules(queue[i])) pushIndices.push(i);
+  }
+  if (pushIndices.length <= 1) return queue;
+  const mergedModules: QueuePushEntry["modules"] = {};
+  let latestTs = "";
+  for (const idx of pushIndices) {
+    const e = queue[idx] as QueuePushEntry;
+    Object.assign(mergedModules, e.modules);
+    if (e.ts && e.ts > latestTs) latestTs = e.ts;
+  }
+  const next: QueueEntry[] = [];
+  for (let i = 0; i < queue.length; i++) {
+    if (!isPushEntryWithModules(queue[i])) next.push(queue[i]);
+  }
+  next.push({
+    type: "push",
+    modules: mergedModules,
+    ts: latestTs || new Date().toISOString(),
+  });
+  return next;
 }
 
 export function clearOfflineQueue(): void {


### PR DESCRIPTION
## Summary

`pushDirty` у `catch`-блоці завжди ре-енквʼює той самий payload, який тільки що впав. Через in-line coalescing черга не росте кількістю рядів, але кожен retry проти нестабільного сервера:

- викликає `safeWriteLS(OFFLINE_QUEUE_KEY, queue)` з фактично ідентичним змістом,
- диспатчить `emitStatusEvent()` → ре-рендер status-панелі.

На серії експоненційних бекоффів (backoff 1s/2s/4s × зовнішній retryAsync) це десятки записів у localStorage та сповіщень за хвилину простоюючого девайсу, при цьому у черзі ніколи нічого нового немає.

**Що змінилось у `apps/web/src/core/cloudSync/queue/offlineQueue.ts`:**

- Додав `coalesceIsNoop(prev, next)` — структурне порівняння `JSON.stringify` полів модулів. Якщо злиття `next` у `prev` не змінить нічого — повертаємо з `addToOfflineQueue` без `safeWriteLS` і без `emitStatusEvent()`.
- Додав `normalizePushEntries(queue)` — якщо в черзі випадково більше ніж один `push`-запис (залишок старої версії, multi-tab race, ручне редагування localStorage), обʼєднуємо їх у єдиний trailing push перед вирішенням про append vs merge. У поточних code paths зазвичай ≤1 push-запис, але тепер ми ще й лікуємо успадкований стан.
- Дрібна декомпозиція: type-guard `isPushEntryWithModules(entry)` замість повторюваних runtime-перевірок.

Існуюча поведінка coalescing (`useCloudSync.hardening.test.ts`) лишилась — merge, idempotent repeats, не-push last, cap на 50 записів тощо.

## Review & Testing Checklist for Human

- [ ] На вкладці Application → Local Storage → `sync_offline_queue_v1` під час симуляції «сервер постійно 500» — черга має залишатися одним стабільним записом і **не переписуватися** при кожному бекоффі (перевір через Chrome DevTools → Storage events).
- [ ] Запустити DevTools throttling = Offline → зробити кілька змін у модулях → повернути online → дані синхронізуються, черга очищується (успішний happy path незмінений).
- [ ] Мульти-tab сценарій: у двох вкладках зробити одночасні зміни в різних модулях → offline → online — фінальний payload містить обидва модулі без дублів.

### Notes

`pnpm lint`, `pnpm typecheck`, `pnpm test` (618/618) — чисто. Зміна тільки в `apps/web/src/core/cloudSync/queue/offlineQueue.ts`; `push.ts` / `replay.ts` / `collectQueued.ts` не чіпалися.

Link to Devin session: https://app.devin.ai/sessions/e6452873ebab40e29145190f4267a305
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
