### PR TITLE
feat(shared): useLocalStorageState&lt;T&gt; хук + міграція 6 hotspot-станів

### DIFF
--- a/apps/web/src/core/TodayFocusCard.tsx
+++ b/apps/web/src/core/TodayFocusCard.tsx
@@ -12,6 +12,7 @@ import {
   getModulePrimaryAction,
 } from "@shared/lib/moduleQuickActions";
 import { generateRecommendations } from "./lib/recommendationEngine.js";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 
 // Reuse the same dismissed-map key HubRecommendations used so user
 // dismissals remain stable across the redesign.
@@ -64,30 +65,15 @@ function readJSON(key: string) {
   }
 }
 
-function loadDismissed(): Record<string, number> {
-  try {
-    const raw = localStorage.getItem(DISMISSED_KEY);
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
-}
-
-function saveDismissed(map: Record<string, number>) {
-  try {
-    localStorage.setItem(DISMISSED_KEY, JSON.stringify(map));
-  } catch {
-    /* noop */
-  }
-}
-
 /**
  * Hook that exposes the current dashboard focus (= top recommendation) plus
  * the rest of the visible recommendations, sharing dismiss state with the
  * unified insights panel.
  */
 export function useDashboardFocus() {
-  const [dismissed, setDismissed] = useState(loadDismissed);
+  const [dismissed, setDismissed] = useLocalStorageState<
+    Record<string, number>
+  >(DISMISSED_KEY, {});
   const [, setTick] = useState(0);
 
   useEffect(() => {
@@ -102,13 +88,12 @@ export function useDashboardFocus() {
     [recs, dismissed],
   );
 
-  const dismiss = useCallback((id: string) => {
-    setDismissed((prev) => {
-      const next = { ...prev, [id]: Date.now() };
-      saveDismissed(next);
-      return next;
-    });
-  }, []);
+  const dismiss = useCallback(
+    (id: string) => {
+      setDismissed((prev) => ({ ...prev, [id]: Date.now() }));
+    },
+    [setDismissed],
+  );
 
   return {
     focus: visible[0] || null,

--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -34,6 +34,7 @@ import { MonthlyPlanCard } from "../components/budgets/MonthlyPlanCard.jsx";
 import { PlanFactCard } from "../components/budgets/PlanFactCard.jsx";
 import { AddBudgetForm } from "../components/budgets/AddBudgetForm.jsx";
 import { readJSON, writeJSON } from "../lib/finykStorage.js";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 // ─── React Query integration for AI chat lookups ──────────────────────────
@@ -190,41 +191,39 @@ export function Budgets({ mono, storage, showBalance = true }) {
   // collide with the 24h proactive-advice cache. Value is the dismissed
   // text itself — when React Query returns a *different* text (next
   // month, manual refetch), the card shows the advice again automatically.
-  const [dismissedAdvice, setDismissedAdvice] = useState<
+  const [dismissedAdvice, setDismissedAdvice] = useLocalStorageState<
     Record<string, string>
-  >(() => readJSON("finyk_proactive_dismissed_v1", {}));
+  >("finyk_proactive_dismissed_v1", {});
 
   // Collapsible state for Limits / Goals sections. Default closed per
   // product feedback (списком із можливістю згорнути, згорнуто за замовчуванням).
   // Persist last choice to localStorage so the user's open/closed pref
   // survives reloads and tab switches; still resets to closed only on
   // first ever visit.
-  const [limitsOpen, setLimitsOpen] = useState<boolean>(() =>
-    readJSON("finyk_budgets_limits_open_v1", false),
+  const [limitsOpen, setLimitsOpen] = useLocalStorageState<boolean>(
+    "finyk_budgets_limits_open_v1",
+    false,
   );
-  const [goalsOpen, setGoalsOpen] = useState<boolean>(() =>
-    readJSON("finyk_budgets_goals_open_v1", false),
+  const [goalsOpen, setGoalsOpen] = useLocalStorageState<boolean>(
+    "finyk_budgets_goals_open_v1",
+    false,
   );
   const toggleLimits = useCallback(() => {
-    setLimitsOpen((v) => {
-      writeJSON("finyk_budgets_limits_open_v1", !v);
-      return !v;
-    });
-  }, []);
+    setLimitsOpen((v) => !v);
+  }, [setLimitsOpen]);
   const toggleGoals = useCallback(() => {
-    setGoalsOpen((v) => {
-      writeJSON("finyk_budgets_goals_open_v1", !v);
-      return !v;
-    });
-  }, []);
-  const dismissAdvice = useCallback((categoryId, monthKey, text) => {
-    if (!text) return;
-    setDismissedAdvice((prev) => {
-      const next = { ...prev, [`${monthKey}_${categoryId}`]: text };
-      writeJSON("finyk_proactive_dismissed_v1", next);
-      return next;
-    });
-  }, []);
+    setGoalsOpen((v) => !v);
+  }, [setGoalsOpen]);
+  const dismissAdvice = useCallback(
+    (categoryId, monthKey, text) => {
+      if (!text) return;
+      setDismissedAdvice((prev) => ({
+        ...prev,
+        [`${monthKey}_${categoryId}`]: text,
+      }));
+    },
+    [setDismissedAdvice],
+  );
 
   // At-risk advice fires for any limit where current usage ≥ 80% of limit
   // (see `shouldShowProactiveAdvice`). We key items by `(monthKey,

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
 import { workoutDurationSec } from "@sergeant/fizruk-domain";
 import { ACTIVE_WORKOUT_KEY } from "@sergeant/fizruk-domain";
 import { Card } from "@shared/components/ui/Card";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
 
@@ -35,13 +36,11 @@ export function Dashboard({
 
   const [recoveryOpen, setRecoveryOpen] = useState(false);
 
-  const [selectedTemplateId, setSelectedTemplateId] = useState(() => {
-    try {
-      return localStorage.getItem(SELECTED_TEMPLATE_KEY) || "";
-    } catch {
-      return "";
-    }
-  });
+  const [selectedTemplateId, setSelectedTemplateId] = useLocalStorageState(
+    SELECTED_TEMPLATE_KEY,
+    "",
+    { raw: true },
+  );
   const [planConfirmOpen, setPlanConfirmOpen] = useState(false);
   const [pendingPicks, setPendingPicks] = useState(null);
 
@@ -53,13 +52,8 @@ export function Dashboard({
   useEffect(() => {
     if (selectedTemplateId) return;
     const first = templates[0]?.id;
-    if (first) {
-      setSelectedTemplateId(first);
-      try {
-        localStorage.setItem(SELECTED_TEMPLATE_KEY, first);
-      } catch {}
-    }
-  }, [templates, selectedTemplateId]);
+    if (first) setSelectedTemplateId(first);
+  }, [templates, selectedTemplateId, setSelectedTemplateId]);
 
   const statusByMuscle = (() => {
     const map = (id) => {

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -12,6 +12,7 @@ import {
 import { addDays, startOfIsoWeek } from "./lib/weekUtils.js";
 import { maxActiveStreak, completionRateForRange } from "./lib/streaks.js";
 import { useRoutineReminders } from "./hooks/useRoutineReminders";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 import {
   buildHubCalendarEvents,
   countEventsByDate,
@@ -185,18 +186,14 @@ export default function RoutineApp({
 
   useRoutineReminders(routine);
 
-  const [mainTab, setMainTab] = useState<RoutineMainTab>(() => {
-    try {
-      const v = localStorage.getItem(STORAGE_KEYS.ROUTINE_MAIN_TAB);
-      if (v === "calendar" || v === "stats") return v;
-    } catch {}
-    return "calendar";
-  });
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEYS.ROUTINE_MAIN_TAB, mainTab);
-    } catch {}
-  }, [mainTab]);
+  const [mainTab, setMainTab] = useLocalStorageState<RoutineMainTab>(
+    STORAGE_KEYS.ROUTINE_MAIN_TAB,
+    "calendar",
+    {
+      raw: true,
+      validate: (v): v is RoutineMainTab => v === "calendar" || v === "stats",
+    },
+  );
   const [timeMode, setTimeMode] = useState<RoutineTimeMode>("today");
   const now = todayDate();
   const [monthCursor, setMonthCursor] = useState<MonthCursor>(() => ({

--- a/apps/web/src/shared/hooks/useLocalStorageState.test.ts
+++ b/apps/web/src/shared/hooks/useLocalStorageState.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLocalStorageState } from "./useLocalStorageState.js";
+
+describe("useLocalStorageState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value when the key is missing from storage", () => {
+    const { result } = renderHook(() =>
+      useLocalStorageState<number>("ls:missing", 42),
+    );
+    expect(result.current[0]).toBe(42);
+  });
+
+  it("reads the stored value synchronously on first render", () => {
+    localStorage.setItem("ls:seed", JSON.stringify({ n: 7 }));
+    const { result } = renderHook(() =>
+      useLocalStorageState<{ n: number }>("ls:seed", { n: 0 }),
+    );
+    expect(result.current[0]).toEqual({ n: 7 });
+  });
+
+  it("writes updates back to storage", () => {
+    const { result } = renderHook(() =>
+      useLocalStorageState<string>("ls:write", "a"),
+    );
+    act(() => {
+      result.current[1]("b");
+    });
+    expect(result.current[0]).toBe("b");
+    expect(localStorage.getItem("ls:write")).toBe(JSON.stringify("b"));
+  });
+
+  it("supports updater functions like useState", () => {
+    const { result } = renderHook(() =>
+      useLocalStorageState<number>("ls:updater", 1),
+    );
+    act(() => {
+      result.current[1]((prev) => prev + 10);
+    });
+    expect(result.current[0]).toBe(11);
+    expect(localStorage.getItem("ls:updater")).toBe(JSON.stringify(11));
+  });
+
+  it("falls back to initial when the stored value fails validation", () => {
+    localStorage.setItem("ls:validate", JSON.stringify({ bogus: true }));
+    const isNumber = (x: unknown): x is number => typeof x === "number";
+    const { result } = renderHook(() =>
+      useLocalStorageState<number>("ls:validate", 5, { validate: isNumber }),
+    );
+    expect(result.current[0]).toBe(5);
+  });
+
+  it("falls back to initial on malformed JSON", () => {
+    localStorage.setItem("ls:bad", "{not json");
+    const { result } = renderHook(() =>
+      useLocalStorageState<string>("ls:bad", "safe"),
+    );
+    expect(result.current[0]).toBe("safe");
+  });
+
+  it("accepts a lazy initial (evaluated once)", () => {
+    const init = vi.fn(() => ({ count: 3 }));
+    const { rerender } = renderHook(() =>
+      useLocalStorageState<{ count: number }>("ls:lazy", init),
+    );
+    rerender();
+    rerender();
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it("debounces writes when `debounceMs` is set", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useLocalStorageState<number>("ls:debounce", 0, { debounceMs: 300 }),
+    );
+    // Mount does not write (initial value is a seed, not a user write).
+    expect(localStorage.getItem("ls:debounce")).toBeNull();
+
+    act(() => {
+      result.current[1](1);
+    });
+    // Value is in-memory immediately, but not yet flushed.
+    expect(result.current[0]).toBe(1);
+    expect(localStorage.getItem("ls:debounce")).toBeNull();
+
+    act(() => {
+      result.current[1](2);
+    });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    // Still not committed (debounce reset by the second write).
+    expect(localStorage.getItem("ls:debounce")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(localStorage.getItem("ls:debounce")).toBe(JSON.stringify(2));
+  });
+
+  it("re-reads storage when the key changes", () => {
+    localStorage.setItem("ls:a", JSON.stringify("A"));
+    localStorage.setItem("ls:b", JSON.stringify("B"));
+    const { result, rerender } = renderHook(
+      ({ k }) => useLocalStorageState<string>(k, "fallback"),
+      { initialProps: { k: "ls:a" } },
+    );
+    expect(result.current[0]).toBe("A");
+    rerender({ k: "ls:b" });
+    expect(result.current[0]).toBe("B");
+  });
+
+  it("stores raw strings without JSON-encoding when `raw: true`", () => {
+    localStorage.setItem("ls:raw", "calendar");
+    const { result } = renderHook(() =>
+      useLocalStorageState<"calendar" | "stats">("ls:raw", "calendar", {
+        raw: true,
+        validate: (v): v is "calendar" | "stats" =>
+          v === "calendar" || v === "stats",
+      }),
+    );
+    // Reads the bare string (not `"\"calendar\""`).
+    expect(result.current[0]).toBe("calendar");
+
+    act(() => {
+      result.current[1]("stats");
+    });
+    // Write is also bare — preserves backwards compatibility with
+    // legacy keys that were never JSON-encoded.
+    expect(localStorage.getItem("ls:raw")).toBe("stats");
+  });
+
+  it("supports custom serializer / deserializer", () => {
+    const serialize = (v: Date) => v.toISOString();
+    const deserialize = (raw: string) => new Date(raw);
+    const { result } = renderHook(() =>
+      useLocalStorageState<Date>("ls:date", new Date("2024-01-01T00:00:00Z"), {
+        serialize,
+        deserialize,
+      }),
+    );
+    act(() => {
+      result.current[1](new Date("2025-06-15T10:20:30Z"));
+    });
+    expect(localStorage.getItem("ls:date")).toBe("2025-06-15T10:20:30.000Z");
+  });
+});

--- a/apps/web/src/shared/hooks/useLocalStorageState.ts
+++ b/apps/web/src/shared/hooks/useLocalStorageState.ts
@@ -1,0 +1,176 @@
+/**
+ * `useLocalStorageState<T>` — `useState`-like hook with localStorage persistence.
+ *
+ * Replaces the very common pattern of:
+ *   const [v, setV] = useState<T>(() => readJSON(key, fallback));
+ *   useEffect(() => writeJSON(key, v), [key, v]);
+ *
+ * The hook:
+ *  - reads synchronously in the state initializer so there is no first-paint
+ *    flicker from `undefined → stored value`;
+ *  - swallows storage errors (quota, private mode, disabled) via the shared
+ *    `safeReadLS` / `safeWriteLS` helpers;
+ *  - optionally validates the stored value with a type guard and falls back
+ *    to `initialValue` if the stored shape is unexpected;
+ *  - optionally debounces writes (useful for large payloads written many
+ *    times per second, e.g. a budgets list the user is dragging);
+ *  - does not subscribe to cross-tab `storage` events by default — most
+ *    call sites are user-owned UI state, and opting in via a listener is
+ *    still available by reading `safeReadLS` on focus/visibility if needed.
+ *
+ * Signature matches `useState<T>` as closely as possible so swapping in is
+ * mechanical.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import { safeReadLS } from "@shared/lib/storage.js";
+
+export interface UseLocalStorageStateOptions<T> {
+  /**
+   * Runtime shape guard. Called with the raw parsed value from storage;
+   * should return `true` when the value is structurally compatible with
+   * `T`. If absent, any parsed value is accepted.
+   */
+  validate?: (raw: unknown) => raw is T;
+  /**
+   * Debounce window (ms) between the last `setValue` call and the actual
+   * localStorage write. Use for hot paths that update many times per frame
+   * (drag/resize, typing). 0 / undefined means write immediately inside
+   * the effect.
+   */
+  debounceMs?: number;
+  /**
+   * Store the value as a raw string (no JSON.parse / JSON.stringify).
+   * Shortcut for `serialize: (v) => v`, `deserialize: (raw) => raw`.
+   * Useful for legacy keys that were written as bare strings (e.g.
+   * "calendar" / "stats" rather than `"\"calendar\""`) — switching to
+   * JSON would silently invalidate every existing user's preference.
+   * Only meaningful when `T` is `string`.
+   */
+  raw?: boolean;
+  /**
+   * Custom serializer. Defaults to `JSON.stringify`.
+   */
+  serialize?: (value: T) => string;
+  /**
+   * Custom deserializer. Defaults to `JSON.parse`. Can return anything —
+   * the result is narrowed by `validate` (if provided) or trusted as `T`.
+   */
+  deserialize?: (raw: string) => unknown;
+}
+
+function resolveInitial<T>(initial: T | (() => T)): T {
+  return typeof initial === "function" ? (initial as () => T)() : initial;
+}
+
+export function useLocalStorageState<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UseLocalStorageStateOptions<T> = {},
+): [T, Dispatch<SetStateAction<T>>] {
+  const { validate, debounceMs, raw, serialize, deserialize } = options;
+  const effectiveSerialize =
+    serialize ?? (raw ? (v: T) => String(v) : undefined);
+  const effectiveDeserialize =
+    deserialize ?? (raw ? (r: string) => r : undefined);
+
+  // Stable ref for the latest options so the read/write effects don't
+  // re-subscribe on every render if the caller inlines an options object.
+  const optionsRef = useRef({
+    validate,
+    serialize: effectiveSerialize,
+    deserialize: effectiveDeserialize,
+  });
+  optionsRef.current = {
+    validate,
+    serialize: effectiveSerialize,
+    deserialize: effectiveDeserialize,
+  };
+
+  const [value, setValue] = useState<T>(() => {
+    const fallback = resolveInitial(initialValue);
+    if (typeof localStorage === "undefined") return fallback;
+    try {
+      const storedRaw = localStorage.getItem(key);
+      if (storedRaw === null) return fallback;
+      const parsed = effectiveDeserialize
+        ? effectiveDeserialize(storedRaw)
+        : JSON.parse(storedRaw);
+      if (validate && !validate(parsed)) return fallback;
+      return (parsed ?? fallback) as T;
+    } catch {
+      // `safeReadLS` handles this too but we need the raw path above so a
+      // custom deserializer can own the parsing. Fall through to fallback.
+      return safeReadLS<T>(key, fallback) ?? fallback;
+    }
+  });
+
+  // Track the key the last write was for — if `key` changes between
+  // renders we re-initialize state from the new slot on the next read.
+  const lastKeyRef = useRef(key);
+  useEffect(() => {
+    if (lastKeyRef.current === key) return;
+    lastKeyRef.current = key;
+    if (typeof localStorage === "undefined") return;
+    try {
+      const raw = localStorage.getItem(key);
+      const { deserialize: d, validate: v } = optionsRef.current;
+      if (raw === null) {
+        setValue(resolveInitial(initialValue));
+        return;
+      }
+      const parsed = d ? d(raw) : JSON.parse(raw);
+      if (v && !v(parsed)) {
+        setValue(resolveInitial(initialValue));
+        return;
+      }
+      setValue((parsed ?? resolveInitial(initialValue)) as T);
+    } catch {
+      setValue(resolveInitial(initialValue));
+    }
+    // Intentionally depend only on `key` — `initialValue` by design is a
+    // seed and changing it after mount should not re-initialise state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  // Skip the write on the very first render: `value` was just read from
+  // storage (or is the seeded initial for a missing key), so writing it
+  // back is either a no-op or an unwanted side-effect on first paint.
+  // Subsequent `setValue` calls go through this effect normally.
+  const isFirstWriteRef = useRef(true);
+  useEffect(() => {
+    if (typeof localStorage === "undefined") return undefined;
+    if (isFirstWriteRef.current) {
+      isFirstWriteRef.current = false;
+      return undefined;
+    }
+    const write = () => {
+      const { serialize: s } = optionsRef.current;
+      try {
+        const raw = s ? s(value) : JSON.stringify(value);
+        localStorage.setItem(key, raw);
+      } catch {
+        /* quota / private mode — best-effort */
+      }
+    };
+    if (!debounceMs || debounceMs <= 0) {
+      write();
+      return undefined;
+    }
+    const id = setTimeout(write, debounceMs);
+    return () => clearTimeout(id);
+  }, [key, value, debounceMs]);
+
+  const setStable = useCallback<Dispatch<SetStateAction<T>>>((next) => {
+    setValue(next);
+  }, []);
+
+  return [value, setStable];
+}


### PR DESCRIPTION
## Summary

Пункт 3 з тех-боргу веба — ввести `useLocalStorageState<T>` поверх існуючих storage-хелперів і перевести найчастіші місця, де `useState` + `useEffect` вручну синхронізуються з `localStorage`.

### Новий хук: <ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/shared/hooks/useLocalStorageState.ts" />

API максимально близький до `useState<T>`:

```ts
const [value, setValue] = useLocalStorageState<T>(
  key,
  initialValue,        // або () => T — lazy seed
  options?: {
    validate?: (raw: unknown) => raw is T;   // shape-guard
    debounceMs?: number;                     // для гарячих оновлень
    raw?: boolean;                           // без JSON-обгортки (legacy keys)
    serialize?: (value: T) => string;
    deserialize?: (raw: string) => unknown;
  }
): [T, Dispatch<SetStateAction<T>>]
```

Ключові властивості:
- Синхронне читання з LS у ініціалізаторі — без «блимання» при першому рендері.
- Мовчазна обробка помилок LS (quota, private mode, Safari ITP) — best-effort.
- `validate` — type-guard на збережене значення; при невідповідності падаємо на `initialValue`.
- `debounceMs` — якщо значення оновлюється часто (drag, typing), запис у LS відкладається.
- `raw: true` — зберігає bare-string, щоб не зламати легасі-ключі, які ніколи не були в JSON (напр. `"calendar"` vs `"\"calendar\""`).
- Не пише при першому монтуванні (seed ≠ user write), щоб не затирати LS дефолтами.
- Перечитує LS при зміні `key` між рендерами.

Покриття: <ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/shared/hooks/useLocalStorageState.test.ts" /> — 11 тестів (initial, read, write, updater, validate, malformed, lazy init, debounce, key change, raw, custom (de)serializer).

### Міграції (6 станів у 4 файлах)

1. **<ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/finyk/pages/Budgets.tsx" />**: `dismissedAdvice`, `limitsOpen`, `goalsOpen` — прибрано `readJSON`/`writeJSON` і ручний дубль стану через сет.
2. **<ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/routine/RoutineApp.tsx" />**: `mainTab` (`"calendar" \| "stats"`) — переведено з `raw: true` + `validate`, щоб не зламати юзерів, у яких у LS лежить bare-string.
3. **<ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/fizruk/pages/Dashboard.tsx" />**: `selectedTemplateId` — так само `raw: true`; прибрано окремий `localStorage.setItem` з useEffect-а (хук сам синкає).
4. **<ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/core/TodayFocusCard.tsx" />**: `dismissed` у `useDashboardFocus` — видалено локальні `loadDismissed`/`saveDismissed`, `saveDismissed(next)` всередині `setDismissed` тепер дублюється хуком.

Результат:
- мінус 75 рядків рукописного синку LS ↔ React state,
- жоден ключ LS не змінює формат (backwards-compatible по значеннях),
- lint + typecheck зелені, тести 629/629 зелені (+11 нових).

## Review & Testing Checklist for Human

- [ ] Відкрий «Плани та бюджети»: секції «Ліміти» і «Цілі» повинні залишатись згорнутими за замовчуванням, відкритий стан — пам'ятатись між reload.
- [ ] Проактивна порада: натисни «✕ Приховати» → після перезавантаження порада не повинна повертатись для того ж місяця.
- [ ] Routine: переключи «Сьогодні/Календар/Статистика» → `mainTab` повинен зберігатись між reload (значення в LS — bare `"calendar"` / `"stats"`, без лапок).
- [ ] Fizruk → Dashboard: вибір шаблону тренування повинен зберігатись між reload (значення в LS — raw id без лапок).
- [ ] Hub Dashboard: dismiss фокус-карти → після перезавантаження прихована залишається прихованою (ключ `hub_recs_dismissed_v1` — JSON-мапа).

### Notes

- `raw: true` додано спеціально для легасі-ключів: `STORAGE_KEYS.ROUTINE_MAIN_TAB` і `fizruk_selected_template_id_v1` зберігались як bare-strings. Перевід на JSON для існуючих користувачів означав би тихо «забути» їх вибір.
- `useStorage.ts` у finyk свідомо не мігровано в цьому PR: там ще debounced-write + shape-check на масив/об'єкт, це окрема сесія.
- Хук свідомо не підписується на крос-табний `storage`-event — жодна з мігрованих зон цього не потребувала, а зайві re-render'и під час фонових write'ів — незрозумілий виграш.


Link to Devin session: https://app.devin.ai/sessions/34adb7ca3b0b42d9bf0eb07a2ddf0d79
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified local storage management across the application by consolidating disparate persistence patterns into a shared utility framework. This improves code consistency, reduces duplication, and enhances maintainability while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->