### PR TITLE
fix(finyk,sync): hidden-account debt, debit overdraft, required clientUpdatedAt

### DIFF
--- a/apps/server/src/modules/sync.test.ts
+++ b/apps/server/src/modules/sync.test.ts
@@ -445,6 +445,22 @@ describe("syncPush (singular) — contract tests", () => {
     expect(pool.query).not.toHaveBeenCalled();
   });
 
+  it("missing clientUpdatedAt → 400 (раніше мовчки перезаписував чужі push-и)", async () => {
+    const res = makeRes();
+    await syncPush(makeReq({ module: "finyk", data: { balance: 100 } }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "clientUpdatedAt" }),
+      ]),
+    );
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(syncOperationsTotal.inc.mock.calls.map(([l]) => l)).toContainEqual(
+      expect.objectContaining({ op: "push", outcome: "invalid" }),
+    );
+  });
+
   it("blob > MAX_BLOB_SIZE → 413 + outcome='too_large'", async () => {
     const huge = "x".repeat(MAX_BLOB_SIZE);
     const res = makeRes();

--- a/apps/server/src/modules/sync.ts
+++ b/apps/server/src/modules/sync.ts
@@ -157,7 +157,10 @@ export async function syncPush(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const clientTs = clientUpdatedAt ? new Date(clientUpdatedAt) : new Date();
+  // `clientUpdatedAt` — required у `SyncPushSchema`, тому fallback на
+  // `new Date()` прибрано: раніше він мовчки переписував свіжіший серверний
+  // запис, бо `client_updated_at <= NOW()` завжди true.
+  const clientTs = new Date(clientUpdatedAt);
 
   try {
     // EXPLAIN ANALYZE (типовий plan):
@@ -378,7 +381,9 @@ export async function syncPushAll(req: Request, res: Response): Promise<void> {
         results[mod] = { ok: false, error: "Too large" };
         continue;
       }
-      const clientTs = clientUpdatedAt ? new Date(clientUpdatedAt) : new Date();
+      // `clientUpdatedAt` — required у `SyncPushAllSchema`; fallback на
+      // `new Date()` прибрано з тієї ж причини, що й у `syncPush` вище.
+      const clientTs = new Date(clientUpdatedAt);
       const r = await client.query<ModuleDataUpsertRow>(
         `INSERT INTO module_data (user_id, module, data, client_updated_at, version)
          VALUES ($1, $2, $3, $4, 1)

--- a/packages/finyk-domain/src/domain/assets/aggregates.test.ts
+++ b/packages/finyk-domain/src/domain/assets/aggregates.test.ts
@@ -225,6 +225,55 @@ describe("assets — computeAssetsSummary", () => {
     expect(summary.totalAssets).toBe(400);
   });
 
+  it("виключає сховану кредитку і з debt, не лише з balance (regression)", () => {
+    // Раніше `getMonoTotals` фільтрував `visible` для balance, але debt
+    // рахував по всіх accounts → сховану кредитку виводило з UI, а її
+    // борг усе одно тягнувся у networth. Тут — кредитка з боргом 700₴,
+    // прихована → totalLiabilities має бути 0.
+    const accounts: MonoAccount[] = [
+      { id: "cash", balance: 500_00, currencyCode: 980 },
+      {
+        id: "hidden-credit",
+        balance: 300_00,
+        creditLimit: 1000_00,
+        currencyCode: 980,
+      },
+    ];
+    const summary = computeAssetsSummary({
+      accounts,
+      hiddenAccounts: ["hidden-credit"],
+      manualAssets: [],
+      manualDebts: [],
+      receivables: [],
+      transactions: [],
+    });
+    expect(summary.monoBalance).toBe(500);
+    expect(summary.monoDebt).toBe(0);
+    expect(summary.totalLiabilities).toBe(0);
+    expect(summary.networth).toBe(500);
+  });
+
+  it("дебетова картка у мінусі рахується як debt (regression)", () => {
+    // Раніше `isMonoDebt` повертав false для `creditLimit=0`, тож
+    // овердрафтна дебетка (balance<0) мовчки не йшла у networth.
+    const accounts: MonoAccount[] = [
+      { id: "cash", balance: 300_00, currencyCode: 980 },
+      { id: "overdraft", balance: -150_00, currencyCode: 980 },
+    ];
+    const summary = computeAssetsSummary({
+      accounts,
+      hiddenAccounts: [],
+      manualAssets: [],
+      manualDebts: [],
+      receivables: [],
+      transactions: [],
+    });
+    expect(summary.monoBalance).toBe(300);
+    expect(summary.monoDebt).toBe(150);
+    expect(summary.totalLiabilities).toBe(150);
+    expect(summary.networth).toBe(150);
+  });
+
   it("враховує лінковані платежі при підсумку боргів", () => {
     const manualDebts: AssetsDebt[] = [
       { id: "d1", amount: 0, totalAmount: 500, linkedTxIds: ["p1"] },

--- a/packages/finyk-domain/src/lib/accounts.ts
+++ b/packages/finyk-domain/src/lib/accounts.ts
@@ -17,7 +17,12 @@ export function getMonoDebt(acc: MonoAccount): number {
 
 export function isMonoDebt(acc: MonoAccount): boolean {
   const creditLimit = acc.creditLimit ?? 0;
-  return creditLimit > 0 && creditLimit - acc.balance > 0;
+  if (creditLimit > 0) return creditLimit - acc.balance > 0;
+  // Дебетова картка у мінусі (овердрафт / реверс комісії) — теж борг.
+  // До фіксу ця гілка `getMonoDebt` була недосяжна з `getMonoTotals`,
+  // бо `isMonoDebt` вимагав `creditLimit > 0`, і від'ємні дебетові
+  // баланси мовчки не йшли у networth.
+  return acc.balance < 0;
 }
 
 export function daysUntil(day: number): number {
@@ -47,7 +52,10 @@ export function getMonoTotals(
         a.currencyCode === (CURRENCY.UAH as number),
     )
     .reduce((sum, a) => sum + a.balance / 100, 0);
-  const debt = accounts
+  // Приховані рахунки виключаємо і з balance, і з debt —
+  // інакше при схованій кредитці `networth = balance - debt` займає
+  // її борг, а сама кредитка не видна у списку.
+  const debt = visible
     .filter((a) => isMonoDebt(a))
     .reduce((sum, a) => sum + getMonoDebt(a), 0);
   return { balance, debt };

--- a/packages/finyk-domain/src/utils.test.ts
+++ b/packages/finyk-domain/src/utils.test.ts
@@ -174,8 +174,12 @@ describe("isMonoDebt", () => {
   it("true коли є заборгованість по кредитці", () => {
     expect(isMonoDebt({ creditLimit: 500000, balance: 200000 })).toBe(true);
   });
-  it("false коли ліміт=0", () => {
-    expect(isMonoDebt({ creditLimit: 0, balance: -100000 })).toBe(false);
+  it("true коли дебетова картка у мінусі (овердрафт/реверс)", () => {
+    expect(isMonoDebt({ creditLimit: 0, balance: -100000 })).toBe(true);
+  });
+  it("false коли дебетова картка у плюсі", () => {
+    expect(isMonoDebt({ creditLimit: 0, balance: 100000 })).toBe(false);
+    expect(isMonoDebt({ creditLimit: 0, balance: 0 })).toBe(false);
   });
   it("false коли ліміт вичерпано/погашено", () => {
     expect(isMonoDebt({ creditLimit: 500000, balance: 500000 })).toBe(false);
@@ -350,9 +354,10 @@ describe("getMonoTotals", () => {
     expect(res).toHaveProperty("balance");
     expect(res).toHaveProperty("debt");
     expect(res.balance).toBe(1000);
-    expect(res.debt).toBe(3000);
+    // a2 — дебетова картка у мінусі (-500 UAH), a3 — кредитка (-3000 UAH).
+    expect(res.debt).toBe(3500);
   });
-  it("пропускає приховані рахунки", () => {
+  it("пропускає приховані рахунки (і з balance, і з debt)", () => {
     const accounts = [
       {
         id: "a1",
@@ -368,9 +373,21 @@ describe("getMonoTotals", () => {
         creditLimit: 0,
         currencyCode: CURRENCY.UAH,
       },
+      {
+        id: "a3",
+        type: "black",
+        balance: 0,
+        creditLimit: 500000,
+        currencyCode: CURRENCY.UAH,
+      },
     ];
     const visible = getMonoTotals(accounts, []);
-    const hidden = getMonoTotals(accounts, ["a2"]);
-    expect(hidden.balance).toBeLessThan(visible.balance);
+    const hiddenBalance = getMonoTotals(accounts, ["a2"]);
+    expect(hiddenBalance.balance).toBeLessThan(visible.balance);
+    // Regression: схована кредитка має випадати і з debt —
+    // раніше `debt` рахувався по всіх рахунках, ігноруючи `hiddenAccountIds`.
+    const hiddenDebt = getMonoTotals(accounts, ["a3"]);
+    expect(hiddenDebt.debt).toBe(0);
+    expect(visible.debt).toBe(5000);
   });
 });

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -357,6 +357,14 @@ export const CoachMemoryPostSchema = z.object({
 // єдина SSOT — той Set; тут лише back-compat перелік для 400 з деталями поля.
 const SyncModuleEnum = z.enum(["finyk", "fizruk", "routine", "nutrition"]);
 
+// `clientUpdatedAt` — обов'язковий last-write-wins guard. Без нього
+// `module_data.client_updated_at <= $4` зі сторожовою умовою у
+// `syncPush`/`syncPushAll` завжди матчить (handler підставляв `new Date()`),
+// тому push старого клієнта мовчки перезаписував свіжіший запис з іншого
+// пристрою. Тепер клієнт, що не надсилає поле, отримує 400 замість
+// тихої втрати даних.
+const ClientUpdatedAtSchema = z.union([z.string(), z.number(), z.date()]);
+
 export const SyncPushSchema = z.object({
   module: SyncModuleEnum,
   // Клієнт може слати будь-який JSON всередині `data` (зашифрований blob),
@@ -364,7 +372,7 @@ export const SyncPushSchema = z.object({
   data: z.unknown().refine((v) => v !== undefined && v !== null, {
     message: "Missing data",
   }),
-  clientUpdatedAt: z.union([z.string(), z.number(), z.date()]).optional(),
+  clientUpdatedAt: ClientUpdatedAtSchema,
 });
 
 export const SyncPullSchema = z.object({
@@ -376,7 +384,7 @@ export const SyncPushAllSchema = z.object({
     z.string(),
     z.object({
       data: z.unknown(),
-      clientUpdatedAt: z.union([z.string(), z.number(), z.date()]).optional(),
+      clientUpdatedAt: ClientUpdatedAtSchema,
     }),
   ),
 });


### PR DESCRIPTION
## Summary

Три High-severity фікси логічних хиб, знайдених у статичному аудиті:

### 1. `getMonoTotals()` — сховані рахунки пропускалися з balance, але НЕ з debt
`packages/finyk-domain/src/lib/accounts.ts`

До фіксу `balance` рахувався по `visible`, а `debt` — по всіх `accounts`, ігноруючи `hiddenAccountIds`. При схованій кредитці `networth = balance − debt` віднімав її борг, а самої кредитки у списку не було → завищені `totalLiabilities`, перекошений Assets-екран. Тепер debt теж рахується по `visible`.

### 2. `isMonoDebt()` — дебетова картка у мінусі (овердрафт/реверс) не йшла у borg
`packages/finyk-domain/src/lib/accounts.ts`

`getMonoDebt` має гілку `if (balance < 0) return Math.abs(balance) / 100`, але вона була **недосяжна** з `getMonoTotals`: `isMonoDebt` вимагав `creditLimit > 0`, тому дебетка з мінусом мовчки не рахувалася як debt. Тепер `isMonoDebt` повертає true і для `creditLimit=0 && balance<0`.

### 3. `SyncPushSchema.clientUpdatedAt` — optional → required
`packages/shared/src/schemas/api.ts` + handler `apps/server/src/modules/sync.ts`

Клієнт без `clientUpdatedAt` обходив last-write-wins guard: handler підставляв `new Date()` → `WHERE module_data.client_updated_at <= NOW()` завжди матчило → push мовчки переписував свіжіший запис з іншого пристрою. Інфіковані клієнти не повідомлялися про конфлікт, дані іншого девайсу губилися без сліду.

Верифіковано, що всі внутрішні клієнти (web/mobile/`@sergeant/api-client`) завжди шлють `clientUpdatedAt` — `buildPayload.ts` стемпить його з `modifiedTimes[mod] || new Date().toISOString()`. Тобто це не ламає жоден наявний клієнт, але тепер валідація повертає 400 + `{ path: "clientUpdatedAt" }` для випадкових зовнішніх споживачів, що відправляли payload без поля.

Fallback `clientUpdatedAt ? new Date(clientUpdatedAt) : new Date()` прибрано в обох handler-ах (`syncPush`, `syncPushAll`) — поле тепер гарантовано присутнє після zod-парсу.

## Review & Testing Checklist for Human

- [ ] Переконайся, що на Assets-екрані при схованій кредитці `totalLiabilities` тепер 0 (а не 700₴ або скільки там борг був).
- [ ] Якщо у когось є дебетова картка в овердрафті — її борг тепер з'явиться у networth. Подумай, чи це очікувана поведінка у твоєму UX (може варто показати окремий label типу "овердрафт").
- [ ] Перевір, що нічого, що шле на `/api/sync/push` або `/api/sync/push-all`, не забуло `clientUpdatedAt`. Зокрема — будь-які зовнішні скрипти чи mobile-збірки, що можуть ще не оновитися.
- [ ] CI має пройти, але перевір також вручну метрику `sync_operations_total{outcome="invalid"}` — раптом ми зараз ловимо реальних клієнтів без поля.

Test plan: запусти web, створи локальні зміни, увійди з іншого пристрою/браузера з чистим локал-сторейджем, зроби зміни й там, зайди назад на першому → fresh timestamp має виграти, старіший push має отримати `conflict: true` (як і раніше), але тепер без поля взагалі сервер відкине.

### Notes

Фікси навмисно окремі комміти-по-темі залишились в одному (попросили один PR). Якщо захочеш split — можу винести #3 в окремий PR.

Знайдено під час аудиту `Skords-01/Sergeant` — повний звіт із 20 знахідками (5 High, 7 Medium, 8 Low) я надіслав окремо перед цим PR-ом.

Link to Devin session: https://app.devin.ai/sessions/0643c853dd694e4fa64d64adc0c8c88c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync push requests now properly validate the timestamp field as required; missing values return a validation error instead of silently defaulting to the current time.
  * Hidden accounts are now correctly excluded from debt and liability calculations.
  * Negative account balances on debit accounts are now properly recognized and counted as debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->