### PR TITLE
fix(finyk/assets): exclude hidden accounts from displayed debt list

### DIFF
--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -24,6 +24,7 @@ import {
   getDebtTxRole,
   getReceivableTxRole,
 } from "@sergeant/finyk-domain/domain/debtEngine";
+import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
@@ -212,7 +213,13 @@ export function Assets({
     accounts,
     hiddenAccounts,
   );
-  const monoDebtAccounts = accounts.filter((a) => isMonoDebt(a));
+  // Список debt-карток у UI мусить бити узгоджений із `monoTotalDebt`
+  // — інакше схована кредитка не контрибує у борг, але все одно
+  // показується у Liabilities-секції з власним remaining-сумамою.
+  const monoDebtAccounts = filterVisibleAccounts(
+    accounts,
+    hiddenAccounts,
+  ).filter((a) => isMonoDebt(a));
   const manualDebtTotal = manualDebts.reduce(
     (s, d) => s + calcDebtRemaining(d, transactions),
     0,


### PR DESCRIPTION
## Summary

Follow-up до #583, знайдено Devin Review.

У #583 `getMonoTotals()` перейшло на `visible` для розрахунку `debt` — сховану кредитку прибрало з networth. Але прямий виклик у `apps/web/src/modules/finyk/pages/Assets.tsx:215` далі йшов по нефільтрованому масиву:

```ts
const monoDebtAccounts = accounts.filter((a) => isMonoDebt(a));
```

→ сховану кредитку **не рахувало у `totalDebt`**, але **все одно рендерило** як `<DebtCard>` у Liabilities-секції з її власним `remaining`. Це ламало інваріант: summary (`−${totalDebt} ₴`) ≠ сума карток у розкладеному списку.

Фікс: використовуємо `filterVisibleAccounts(accounts, hiddenAccounts)` з `@sergeant/finyk-domain/domain/assets` — тестована nil-safe утиліта (вже використовується у `computeAssetsSummary`), аналогічна inline-фільтру всередині `getMonoTotals`.

<ref_snippet file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/finyk/pages/Assets.tsx" lines="211-222" />

## Review & Testting Checklist for Human

- [ ] На Assets-екрані сховай кредитку з боргом і переконайся, що вона зникла і з summary, і з `<DebtCard>`-списку (до фіксу — зникала тільки з summary).
- [ ] Дебетова картка у мінусі (овердрафт) теж має вести себе узгоджено — її видно у списку коли не схована, і зникає повністю коли схована.

Test plan: відкрий `/finyk/assets`, розгорни Liabilities, натисни hide на кредитці → і `−${totalDebt} ₴` у bar-і, і відповідна `<DebtCard>` мають зникнути одночасно. Unhide → обидва повертаються.

### Notes

Не додаю рендер-тест Assets.tsx — файл великий і без existing-snapshot-у це великий обсяг. Domain-рівень вже покритий регресійними тестами у #583 (`aggregates.test.ts`, `utils.test.ts`). Цей фікс — просто синхронізація UI-glue з уже-правильним domain-обчисленням.

Link to Devin session: https://app.devin.ai/sessions/0643c853dd694e4fa64d64adc0c8c88c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent visibility of hidden accounts in the assets view. Hidden accounts are now properly excluded from debt cards and related debt information displays, ensuring visibility settings are applied consistently throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->