### PR TITLE
fix(audit): high-severity bugs from static audit

### DIFF
--- a/apps/web/src/core/cloudSync/__tests__/resolver.test.ts
+++ b/apps/web/src/core/cloudSync/__tests__/resolver.test.ts
@@ -118,6 +118,32 @@ describe("resolveInitialSync", () => {
     expect(plan.kind).toBe("merge");
     if (plan.kind === "merge") {
       expect(plan.dirtyMods.sort()).toEqual(["nutrition", "routine"]);
+      expect(plan.skippedDirty).toEqual([]);
+    }
+  });
+
+  it("does NOT apply cloud data for dirty modules (protects unpushed local changes)", () => {
+    const plan = resolveInitialSync({
+      cloud: {
+        // cloud-version новіша, але локально є непушнуті зміни → skip, не apply
+        finyk: { data: { cloud: 1 }, version: 9 },
+        // не dirty → має накотитись з хмари як зазвичай
+        routine: { data: { cloud: 2 }, version: 3 },
+      },
+      hasAnyLocalData: true,
+      migrated: true,
+      userId: "u1",
+      modifiedTimes: { finyk: "2024-01-01T00:00:00.000Z" },
+      getLocalVersion: () => 0,
+      dirtyModules: { finyk: true },
+    });
+    expect(plan.kind).toBe("merge");
+    if (plan.kind === "merge") {
+      expect(plan.applyModules).toEqual([
+        { mod: "routine", data: { cloud: 2 } },
+      ]);
+      expect(plan.skippedDirty).toEqual(["finyk"]);
+      expect(plan.dirtyMods).toEqual(["finyk"]);
     }
   });
 

--- a/apps/web/src/core/cloudSync/conflict/resolver.ts
+++ b/apps/web/src/core/cloudSync/conflict/resolver.ts
@@ -26,6 +26,15 @@ export type InitialSyncPlan =
       applyModules: Array<{ mod: string; data: Record<string, unknown> }>;
       setVersions: Array<{ mod: string; version: number }>;
       dirtyMods: string[];
+      /**
+       * Модулі, де cloud-версія новіша за локальну, але локально лежать
+       * непушнуті зміни (`dirtyModules[mod] === true`). Такі модулі
+       * НЕ накатуємо з хмари, щоб не затерти локальні зміни мовчки —
+       * `applyMerge` потім спробує запушити локальні дані на сервер; LWW-guard
+       * на бекенді (`client_updated_at <= $4`) дасть `conflict`, якщо
+       * cloud-timestamp справді новіший, і UI може показати попередження.
+       */
+      skippedDirty: string[];
     }
   | { kind: "noop" };
 
@@ -77,6 +86,7 @@ export function resolveInitialSync(inputs: ResolveInputs): InitialSyncPlan {
       data: Record<string, unknown>;
     }> = [];
     const setVersions: Array<{ mod: string; version: number }> = [];
+    const skippedDirty: string[] = [];
     for (const [mod, payload] of Object.entries(cloud)) {
       if (!payload?.data) continue;
       const localVersion = userId ? getLocalVersion(userId, mod) : 0;
@@ -84,18 +94,34 @@ export function resolveInitialSync(inputs: ResolveInputs): InitialSyncPlan {
       const localModified = parseDateSafe(modifiedTimes[mod]);
       const cloudModified = parseDateSafe(payload.serverUpdatedAt);
 
-      if (
+      const cloudWins =
         cloudVersion > localVersion ||
-        (cloudModified && localModified && cloudModified > localModified)
-      ) {
-        applyModules.push({ mod, data: payload.data });
+        (cloudModified && localModified && cloudModified > localModified);
+
+      if (cloudWins) {
+        // Не затираємо локальні непушнуті зміни: модуль у dirtyModules
+        // пошлеться окремо через `applyMerge` і бекендовий LWW-guard
+        // (`client_updated_at <= $4`) самостійно вирішить, чия версія свіжіша.
+        // Без цього skip, `applyModuleData(cloud)` затирав би локальні зміни
+        // ще ДО push-у, і наступний push вже ніс би втрачений (cloud-)стан.
+        if (inputs.dirtyModules[mod]) {
+          skippedDirty.push(mod);
+        } else {
+          applyModules.push({ mod, data: payload.data });
+        }
       }
       if (userId && payload.version) {
         setVersions.push({ mod, version: payload.version });
       }
     }
     const dirtyMods = Object.keys(inputs.dirtyModules);
-    return { kind: "merge", applyModules, setVersions, dirtyMods };
+    return {
+      kind: "merge",
+      applyModules,
+      setVersions,
+      dirtyMods,
+      skippedDirty,
+    };
   }
 
   return { kind: "noop" };

--- a/apps/web/src/core/cloudSync/engine/initialSync.ts
+++ b/apps/web/src/core/cloudSync/engine/initialSync.ts
@@ -43,14 +43,27 @@ async function applyMerge(
     applyModules: Array<{ mod: string; data: Record<string, unknown> }>;
     setVersions: Array<{ mod: string; version: number }>;
     dirtyMods: string[];
+    skippedDirty: string[];
   },
   userId: UserId,
 ): Promise<void> {
   for (const { mod, data } of plan.applyModules) applyModuleData(mod, data);
   if (userId) {
     for (const { mod, version } of plan.setVersions) {
+      // Не підтягуємо cloud-version для модулів, чиї cloud-дані ми зараз
+      // свідомо пропустили через локальні непушнуті зміни (`skippedDirty`).
+      // Інакше наступний push не побачить різниці й проковтне conflict.
+      if (plan.skippedDirty.includes(mod)) continue;
       setModuleVersion(userId, mod, version);
     }
+  }
+  if (plan.skippedDirty.length > 0) {
+    // Мʼяке логування для тріажу — щоб було видно, що initialSync НЕ накотив
+    // cloud на ці модулі. Pushу нижче уже обробить їх як звичайні dirty-мод-и.
+    console.warn(
+      "[cloudSync] initialSync: skipped cloud apply for dirty modules",
+      plan.skippedDirty,
+    );
   }
   if (plan.dirtyMods.length === 0) return;
   const modules = buildModulesPayload(plan.dirtyMods, getModuleModifiedTimes());

--- a/packages/api-client/src/endpoints/mono.ts
+++ b/packages/api-client/src/endpoints/mono.ts
@@ -80,7 +80,34 @@ export interface MonoEndpoints {
   ) => Promise<MonoStatementEntry[]>;
 }
 
+/**
+ * Monobank Personal API обмежує `/personal/statement/{acc}/{from}/{to}` 500
+ * транзакціями за запит — повертає останні 500 у діапазоні у зворотному
+ * хронологічному порядку. Активні користувачі з >500 tx/міс мовчки отримували
+ * обрізану виписку. Пагінуємо тут: запит за сторінкою (from, prevTo), далі
+ * зсуваємо `prevTo := min(time) - 1` і повторюємо, поки сторінка повна.
+ *
+ * Safety cap — 20 сторінок (~10 000 tx) — практично неосяжно навіть для
+ * бізнес-акаунтів, і стримує rate-limit (1 req/60 s/per token) від
+ * нескінченного циклу при зламаному API.
+ */
+const MONO_STATEMENT_PAGE_SIZE = 500;
+const MONO_STATEMENT_MAX_PAGES = 20;
+
 export function createMonoEndpoints(http: HttpClient): MonoEndpoints {
+  const fetchStatementPage = (
+    token: string,
+    accId: string,
+    from: number,
+    to: number,
+    signal?: AbortSignal,
+  ) =>
+    http.get<MonoStatementEntry[]>("/api/mono", {
+      query: { path: `/personal/statement/${accId}/${from}/${to}` },
+      headers: { "X-Token": token },
+      signal,
+    });
+
   return {
     clientInfo: (token, opts) =>
       http.get<MonoClientInfo>("/api/mono", {
@@ -88,11 +115,37 @@ export function createMonoEndpoints(http: HttpClient): MonoEndpoints {
         headers: { "X-Token": token },
         signal: opts?.signal,
       }),
-    statement: (token, accId, from, to, opts) =>
-      http.get<MonoStatementEntry[]>("/api/mono", {
-        query: { path: `/personal/statement/${accId}/${from}/${to}` },
-        headers: { "X-Token": token },
-        signal: opts?.signal,
-      }),
+    statement: async (token, accId, from, to, opts) => {
+      const all: MonoStatementEntry[] = [];
+      const seen = new Set<string>();
+      let pageTo = to;
+      for (let page = 0; page < MONO_STATEMENT_MAX_PAGES; page++) {
+        const rows = await fetchStatementPage(
+          token,
+          accId,
+          from,
+          pageTo,
+          opts?.signal,
+        );
+        if (!Array.isArray(rows) || rows.length === 0) break;
+        let oldest = Number.POSITIVE_INFINITY;
+        for (const r of rows) {
+          if (r?.id && !seen.has(r.id)) {
+            seen.add(r.id);
+            all.push(r);
+          }
+          if (typeof r?.time === "number" && r.time < oldest) oldest = r.time;
+        }
+        if (rows.length < MONO_STATEMENT_PAGE_SIZE) break;
+        if (!Number.isFinite(oldest)) break;
+        // Зсуваємо `to` на секунду раніше за найстарішу tx поточної сторінки,
+        // щоб Mono повернуло наступну «порцію» без перекриття (seen-Set усе одно
+        // страхує, якщо кілька tx поділяють ту саму секунду).
+        const nextTo = oldest - 1;
+        if (nextTo <= from) break;
+        pageTo = nextTo;
+      }
+      return all;
+    },
   };
 }

--- a/packages/finyk-domain/package.json
+++ b/packages/finyk-domain/package.json
@@ -10,6 +10,7 @@
     "./backup": "./src/backup.ts",
     "./constants": "./src/constants.ts",
     "./domain": "./src/domain/index.ts",
+    "./domain/assets": "./src/domain/assets/index.ts",
     "./domain/*": "./src/domain/*.ts",
     "./lib": "./src/lib/index.ts",
     "./lib/*": "./src/lib/*.ts",


### PR DESCRIPTION
## Summary

Виправлення 5 знахідок зі статичного аудиту (4 High + 1 Medium), що реально впливають на дані/гроші.

### 1. `getMonoTotals` — приховані рахунки тепер виключаються і з `debt`, не лише з `balance` (`packages/finyk-domain/src/lib/accounts.ts`)
Раніше `balance` рахувався по `visible`, а `debt` — по всіх `accounts`. Якщо користувач ховав кредитку, її баланс зникав із networth, але її борг усе одно зменшував його. Тепер обидві компоненти використовують `visible`.

### 2. `SyncPushSchema.clientUpdatedAt` — обовʼязкове (`packages/shared/src/schemas/api.ts`, `apps/server/src/modules/sync.ts`)
Було `optional`. Якщо клієнт не слав timestamp, сервер fallback-ав на `new Date()` (NOW), а upsert-ний LWW-guard `WHERE client_updated_at <= $4` при цьому завжди проходив → чужі (паралельні) push-и мовчки перезаписувалися. Тепер поле required (zod `ClientUpdatedAt`), додатковий guard в handler-ах відкидає невалідні дати як `400`. Всі наші клієнти (web/mobile) і так завжди шлють — див. `buildPayload.ts`.

### 3. Дебетовий овердрафт тепер рахується як debt (`packages/finyk-domain/src/lib/accounts.ts`)
`isMonoDebt` повертав `false`, коли `creditLimit=0` і `balance<0`, тому гілка `if (acc.balance < 0)` у `getMonoDebt` була мертвою. Тепер `isMonoDebt` повертає `true` і для дебет-овердрафту, і `getMonoTotals` коректно включає такі рахунки у сумарний борг.

### 4. `resolveInitialSync` — не затирає локальні непушнуті зміни (`apps/web/src/core/cloudSync/conflict/resolver.ts`, `engine/initialSync.ts`)
Merge-гілка `cloudVersion > localVersion` накочувала cloud-дані поверх `applyModuleData(...)` навіть коли модуль був у `dirtyModules` (тобто мав локальні непушнуті зміни). Наступний `push-all` далі ніс уже затертий (=cloud) стан → локальні зміни втрачалися. Тепер:
- додано `skippedDirty: string[]` у merge-plan;
- для модулів у `dirtyModules` cloud-дані **не** застосовуються і cloud-`version` **не** підтягується;
- `applyMerge` логує `skippedDirty`, а наступний push-all довантажує локальні зміни через LWW-guard на бекенді, який і вирішить хто переможе.

### 5. Monobank statement — прозора пагінація (`packages/api-client/src/endpoints/mono.ts`)
Monobank повертає максимум 500 tx за один запит; користувачі з >500 tx/міс мовчки отримували обрізану виписку. `monoApi.statement` тепер циклить сторінки: `pageTo := min(time) - 1`, доки сторінка повна, з safety-cap на 20 сторінок (~10 000 tx) і дедупом за `tx.id`. Прозоро для всіх call-сайтів (`useMonoStatements`, `useMonobank.fetchMonth`, `api-client/react/hooks`).

### Перевірки
- `pnpm typecheck` — всі 13 пакетів ✓
- `pnpm test` — 70 файлів / 630 тестів ✓ (оновлено `utils.test.ts`, `resolver.test.ts` під нову поведінку; додано новий тест, що доводить skip-dirty-protection)
- `pnpm lint` — ✓
- `pnpm format:check` — ✓

## Review & Testing Checklist for Human

- [ ] **Мобільний клієнт шле `clientUpdatedAt` у push/push-all** (перевірити `apps/mobile/src/sync/engine/buildPayload.ts` → існуючі старі мобільні білди без поля тепер отримають `400`. Якщо є живі старі інсталяції — продумати soft-fallback).
- [ ] **Monobank rate-limit при пагінації**: для акаунтів із >500 tx/міс тепер 2+ HTTP-виклики підряд. Перевірити, що server-side proxy (`apps/server/src/modules/mono.ts`) має власний rate-limit/breaker і не падає на 429.
- [ ] **initialSync merge після цього PR**: акаунт, що стартує з `dirtyModules=true` і новішою cloud-version, більше не адоптить cloud у локал до push-у. Перевірити, що UI не очікує мгновенного «підхоплення» cloud-версії у цьому edge-case.
- [ ] Перевірити, що `Assets.tsx` тепер відображає дебет-овердрафт у блоці liabilities (він попадає у `monoDebtAccounts = accounts.filter(isMonoDebt)`).
- [ ] Пройти ручний smoke: підключити Monobank → ховати кредитку з боргом → переконатися, що networth і `totalDebt` на `Assets`/`Overview` обидва зменшуються одночасно (раніше баланс зникав, а борг — ні).

### Notes
- Жодна міграція БД не потрібна — зміни суто на рівні схем/логіки.
- Схема `SyncPushAllSchema.modules` тепер вимагає `clientUpdatedAt` і per-module. Тест `sync.test.ts` не потребує оновлень — всі існуючі сценарії вже слали поле.
- Commit: `4070be7`.


Link to Devin session: https://app.devin.ai/sessions/859ef60685f942bc94d37932a57a32ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cloud synchronization to better handle conflicts when modules have unsaved local changes—these changes are now safely preserved instead of being overwritten.
  * Improved statement data retrieval with pagination support for more reliable data access.

* **Tests**
  * Added comprehensive test coverage for cloud sync conflict resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->