### PR TITLE
hotfix(finyk/assets): use concrete aggregates path in import (fix broken main build)

### DIFF
--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -24,7 +24,7 @@ import {
   getDebtTxRole,
   getReceivableTxRole,
 } from "@sergeant/finyk-domain/domain/debtEngine";
-import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets";
+import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets/aggregates";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";


### PR DESCRIPTION
## Summary

**Hotfix для main.** #584 було змерджено з broken build: імпорт `@sergeant/finyk-domain/domain/assets` не резолвиться у Vite/Rollup (TS moduleResolution це пропускав, тому локальний typecheck проходив, але `vite build` падає з `Rollup failed to resolve import "@sergeant/finyk-domain/domain/assets"`).

Причина: package exports мапить `"./domain/*": "./src/domain/*.ts"` — тобто чекає **файл**, не директорію. `./domain/assets` → `./src/domain/assets.ts`, якого немає (є `./src/domain/assets/index.ts`).

Фікс: імпорт з конкретного файлу `"@sergeant/finyk-domain/domain/assets/aggregates"` → `./src/domain/assets/aggregates.ts`, який існує і експортує `filterVisibleAccounts`.

<ref_snippet file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/finyk/pages/Assets.tsx" lines="27" />

Локально `pnpm --filter @sergeant/web build` — зелений.

## Review & Testing Checklist for Human

- [ ] Переконайся, що Vercel preview збирається зелено.
- [ ] Паралельно можна (окремим PR) додати `"./domain/assets": "./src/domain/assets/index.ts"` у `packages/finyk-domain/package.json` щоб `./domain/assets` теж працювало як shortcut — не обов'язково, але зменшить шанс повтору.

Test plan: локально `pnpm --filter @sergeant/web build` має пройти. На Vercel preview — зелений Deployment.

### Notes

Мій typecheck у минулій сесії пройшов, бо TS `bundler`/`nodenext` moduleResolution лояльніший ніж Rollup exports-walker. Варто у майбутньому прогонити `pnpm build` перед створенням PR на web.

Link to Devin session: https://app.devin.ai/sessions/0643c853dd694e4fa64d64adc0c8c88c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
