### PR TITLE
fix(sync,cloudSync,logging): clientUpdatedAt NaN-guard + per-module conflict retention + silent-catch logging

### DIFF
--- a/apps/server/src/modules/sync.test.ts
+++ b/apps/server/src/modules/sync.test.ts
@@ -461,6 +461,38 @@ describe("syncPush (singular) — contract tests", () => {
     );
   });
 
+  // Зона «проскакують zod, але крешать хендлер»: `""` / `"garbage"` / `NaN`
+  // раніше проходили union `string|number|date` і ставали `Invalid Date` →
+  // `pg` при серіалізації кидав `RangeError`, і відповідь була 500 замість
+  // чистого 400.
+  it.each<[string, unknown]>([
+    ["empty string", ""],
+    ["non-parseable string", "not a date"],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])(
+    "invalid clientUpdatedAt (%s) → 400 before reaching DB",
+    async (_label, value) => {
+      const res = makeRes();
+      await syncPush(
+        makeReq({
+          module: "finyk",
+          data: { balance: 100 },
+          clientUpdatedAt: value,
+        }),
+        res,
+      );
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toMatchObject({ error: "Некоректні дані запиту" });
+      expect(res.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "clientUpdatedAt" }),
+        ]),
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    },
+  );
+
   it("blob > MAX_BLOB_SIZE → 413 + outcome='too_large'", async () => {
     const huge = "x".repeat(MAX_BLOB_SIZE);
     const res = makeRes();

--- a/apps/web/src/core/cloudSync/engine/initialSync.test.ts
+++ b/apps/web/src/core/cloudSync/engine/initialSync.test.ts
@@ -112,6 +112,71 @@ describe("initialSync return value", () => {
     expect(onSettled).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps conflict modules dirty after a successful merge push", async () => {
+    // Регресія: `applyMerge` викликав `clearAllDirty()` після `syncApi.pushAll`,
+    // ігноруючи per-module `{ ok: true, conflict: true }` → dirty стирався,
+    // наступний pull накатував cloud, і локальні зміни зникали.
+    mockedPullAll.mockResolvedValueOnce({
+      modules: {
+        finyk: {
+          data: { a: 1 },
+          clientUpdatedAt: new Date(Date.now() - 1000).toISOString(),
+          version: 5,
+        },
+      },
+    });
+    // LWW loser: server відкинув push як conflict.
+    mockedPushAll.mockResolvedValueOnce({
+      results: { finyk: { ok: true, conflict: true, version: 5 } },
+    });
+    localStorage.setItem(STORAGE_KEYS.FINYK_BUDGETS, JSON.stringify({ x: 1 }));
+    localStorage.setItem(
+      STORAGE_KEYS.SYNC_DIRTY_MODULES,
+      JSON.stringify({ finyk: true }),
+    );
+    markMigrationDone("u1");
+    const { args, onSuccess, onError } = makeArgs();
+
+    const result = await initialSync(args);
+
+    expect(result).toBe(true);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    // dirty має лишитись — до наступної ітерації push-у.
+    expect(
+      JSON.parse(localStorage.getItem(STORAGE_KEYS.SYNC_DIRTY_MODULES) || "{}"),
+    ).toEqual({ finyk: true });
+  });
+
+  it("clears dirty for non-conflict modules on a successful merge push", async () => {
+    mockedPullAll.mockResolvedValueOnce({
+      modules: {
+        finyk: {
+          data: { a: 1 },
+          clientUpdatedAt: new Date(Date.now() - 1000).toISOString(),
+          version: 5,
+        },
+      },
+    });
+    mockedPushAll.mockResolvedValueOnce({
+      results: { finyk: { ok: true, version: 6 } },
+    });
+    localStorage.setItem(STORAGE_KEYS.FINYK_BUDGETS, JSON.stringify({ x: 1 }));
+    localStorage.setItem(
+      STORAGE_KEYS.SYNC_DIRTY_MODULES,
+      JSON.stringify({ finyk: true }),
+    );
+    markMigrationDone("u1");
+    const { args, onSuccess } = makeArgs();
+
+    await initialSync(args);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.parse(localStorage.getItem(STORAGE_KEYS.SYNC_DIRTY_MODULES) || "{}"),
+    ).toEqual({});
+  });
+
   it("returns false when a merge push fails mid-reconciliation", async () => {
     // Arrange: cloud has some data, local has some dirty data → merge
     // branch. pushAll inside initialSync throws.

--- a/apps/web/src/core/cloudSync/engine/initialSync.ts
+++ b/apps/web/src/core/cloudSync/engine/initialSync.ts
@@ -1,15 +1,21 @@
 import { syncApi } from "@shared/api";
 import { SYNC_MODULES } from "../config";
+import { isModulePushSuccess } from "../conflict/pushSuccess";
 import { resolveInitialSync } from "../conflict/resolver";
 import {
-  clearAllDirty,
+  clearDirtyModule,
   getDirtyModules,
   getModuleModifiedTimes,
 } from "../state/dirtyModules";
 import { isMigrationDone, markMigrationDone } from "../state/migration";
 import { applyModuleData, hasLocalData } from "../state/moduleData";
 import { getModuleVersion, setModuleVersion } from "../state/versions";
-import type { EngineArgs, PullAllModuleBody, PullAllResponse } from "../types";
+import type {
+  EngineArgs,
+  PullAllModuleBody,
+  PullAllResponse,
+  PushAllResponse,
+} from "../types";
 import { buildModulesPayload } from "./buildPayload";
 import { replayOfflineQueue } from "./replay";
 import { retryAsync } from "./retryAsync";
@@ -72,10 +78,31 @@ async function applyMerge(
   // markMigrationDone is skipped — matches pre-refactor behavior where
   // `if (pushRes.ok) clearAllDirty()` combined with the syncApi-throwing
   // transport meant a push failure aborted the whole initialSync.
-  await retryAsync(() => syncApi.pushAll(modules), {
+  const pushResult = (await retryAsync(() => syncApi.pushAll(modules), {
     label: "initialSync.merge",
-  });
-  clearAllDirty();
+  })) as PushAllResponse;
+  // Per-module clear: якщо сервер повернув `{ conflict: true }` (LWW loser),
+  // `clearAllDirty()` мовчки дропав локальний dirty-флаг → наступний pull
+  // накатував cloud, і локальні зміни зникали без попередження. Тепер
+  // очищаємо лише не-conflict модулі, а conflict-модулі лишаються dirty і
+  // будуть перевідправлені разом із наступним push-у (або користувач
+  // побачить попередження через telemetry).
+  const results = pushResult?.results ?? {};
+  const conflicted: string[] = [];
+  for (const mod of Object.keys(modules)) {
+    const r = results[mod];
+    if (isModulePushSuccess(r)) {
+      clearDirtyModule(mod);
+    } else {
+      conflicted.push(mod);
+    }
+  }
+  if (conflicted.length > 0) {
+    console.warn(
+      "[cloudSync] initialSync.merge: server rejected push for modules (kept dirty for retry)",
+      conflicted,
+    );
+  }
 }
 
 /**

--- a/apps/web/src/core/cloudSync/engine/push.test.ts
+++ b/apps/web/src/core/cloudSync/engine/push.test.ts
@@ -204,4 +204,29 @@ describe("pushAll", () => {
     expect(onError).not.toHaveBeenCalled();
     expect(getDirtyModules()).toEqual({});
   });
+
+  it("keeps conflict modules dirty (LWW loser) instead of silently dropping local changes", async () => {
+    // Регресія: `clearAllDirty()` стирав dirty і для `{ ok: true, conflict: true }`,
+    // після чого pull накатував cloud → локальні зміни гинули.
+    markModuleDirty("finyk");
+    markModuleDirty("routine");
+    mockedBuild.mockReturnValueOnce({
+      finyk: { data: { a: 1 }, clientUpdatedAt: "2025-01-01T00:00:00.000Z" },
+      routine: { data: { b: 2 }, clientUpdatedAt: "2025-01-01T00:00:00.000Z" },
+    });
+    mockedPushAllApi.mockResolvedValueOnce({
+      results: {
+        finyk: { ok: true, version: 42 },
+        routine: { ok: true, conflict: true, version: 7 },
+      },
+    });
+
+    const { args, onSuccess, onError } = makeArgs();
+    await pushAll(args);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    // finyk — очищений, routine — лишився dirty до наступного push-у.
+    expect(getDirtyModules()).toEqual({ routine: true });
+  });
 });

--- a/apps/web/src/core/cloudSync/engine/push.ts
+++ b/apps/web/src/core/cloudSync/engine/push.ts
@@ -112,7 +112,26 @@ export async function pushAll(args: PushArgs): Promise<void> {
         if (r?.version) setModuleVersion(user.id, mod, r.version);
       }
     }
-    clearAllDirty();
+    // Per-module clear замість `clearAllDirty()`: інакше при LWW-conflict-і
+    // (`{ ok: true, conflict: true }`) dirty-флаг стирався мовчки, і
+    // наступний pull накатував cloud → локальні зміни гинули. Лишаємо
+    // conflict-модулі dirty для наступної ітерації push-у.
+    const results = result?.results ?? {};
+    const conflicted: string[] = [];
+    for (const mod of Object.keys(modules)) {
+      const r = results[mod];
+      if (isModulePushSuccess(r)) {
+        clearDirtyModule(mod);
+      } else {
+        conflicted.push(mod);
+      }
+    }
+    if (conflicted.length > 0) {
+      console.warn(
+        "[cloudSync] pushAll: server rejected push for modules (kept dirty)",
+        conflicted,
+      );
+    }
     onSuccess(new Date());
   } catch (err) {
     args.onErrorRaw?.(err);

--- a/apps/web/src/core/lib/hubChatActions.ts
+++ b/apps/web/src/core/lib/hubChatActions.ts
@@ -1379,7 +1379,11 @@ export function executeAction(action: ChatAction): string {
                 : null,
           },
         };
-        void saveRecipeToBook(payload).catch(() => {});
+        void saveRecipeToBook(payload).catch((err: unknown) => {
+          // fire-and-forget, але повний silent не хочемо — збої збереження
+          // рецепту у книгу з чату були невидимі для UX/саппорту.
+          console.warn("[hubChat] saveRecipeToBook failed", err);
+        });
         return `Рецепт "${t}" збережено в книгу рецептів.`;
       }
       case "add_to_shopping_list": {

--- a/apps/web/src/core/useWeeklyDigest.ts
+++ b/apps/web/src/core/useWeeklyDigest.ts
@@ -476,7 +476,12 @@ export function useWeeklyDigest(selectedWeekKey?: string) {
               ...(report as object),
             },
           })
-          .catch(() => {});
+          .catch((err: unknown) => {
+            // non-fatal, але без логу не було видно серверних збоїв у
+            // персоналізованому coach-контексті — digest генерувався, а
+            // пам'ять мовчки не оновлювалася.
+            console.warn("[weeklyDigest] coachApi.postMemory failed", err);
+          });
       } catch {
         /* non-fatal */
       }

--- a/apps/web/src/shared/hooks/usePushNotifications.ts
+++ b/apps/web/src/shared/hooks/usePushNotifications.ts
@@ -214,7 +214,16 @@ export function usePushNotifications(): UsePushNotificationsResult {
         const detected = getPlatform();
         const platform = detected === "ios" ? "ios" : "android";
         if (token) {
-          await pushUnregister.mutateAsync({ platform, token }).catch(() => {});
+          await pushUnregister
+            .mutateAsync({ platform, token })
+            .catch((err: unknown) => {
+              // best-effort — локально вже розписалися, але хочемо бачити
+              // серверні збої у Sentry/DevTools замість глухого silent fail.
+              console.warn(
+                "[push] native unregister failed (best-effort)",
+                err,
+              );
+            });
         }
         localStorage.removeItem(PUSH_SUB_KEY);
         setSubscribed(false);
@@ -241,7 +250,9 @@ export function usePushNotifications(): UsePushNotificationsResult {
         // трекається як окрема мутація в devtools.
         await pushUnregister
           .mutateAsync({ platform: "web", endpoint })
-          .catch(() => {});
+          .catch((err: unknown) => {
+            console.warn("[push] web unregister failed (best-effort)", err);
+          });
       }
       localStorage.removeItem(PUSH_SUB_KEY);
       setSubscribed(false);

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -363,7 +363,16 @@ const SyncModuleEnum = z.enum(["finyk", "fizruk", "routine", "nutrition"]);
 // тому push старого клієнта мовчки перезаписував свіжіший запис з іншого
 // пристрою. Тепер клієнт, що не надсилає поле, отримує 400 замість
 // тихої втрати даних.
-const ClientUpdatedAtSchema = z.union([z.string(), z.number(), z.date()]);
+//
+// `.min(1)` / `.finite()` + refine на валідність `new Date(v)` — потрібні,
+// бо інакше `""`, `NaN`, `"garbage"` проходили zod і ставали `Invalid Date`
+// у хендлері: `pg` при серіалізації викидав `RangeError: Invalid time
+// value`, і замість чистого 400 клієнт отримував 500 з внутрішнім стектрейсом.
+const ClientUpdatedAtSchema = z
+  .union([z.string().min(1), z.number().finite(), z.date()])
+  .refine((v) => !Number.isNaN(new Date(v).getTime()), {
+    message: "Invalid date",
+  });
 
 export const SyncPushSchema = z.object({
   module: SyncModuleEnum,


### PR DESCRIPTION
## Summary

Три техборги у сумі:

**1. `ClientUpdatedAtSchema` — NaN/garbage guard (server 400 замість 500)**
`packages/shared/src/schemas/api.ts`. Було `z.union([z.string(), z.number(), z.date()])` — пропускало `""`, `NaN`, `Infinity`, `"not a date"`. У `syncPush`/`syncPushAll` ці значення ставали Invalid Date, `pg` при серіалізації кидав `RangeError: Invalid time value`, клієнт отримував 500 з внутрішнім стектрейсом замість чистого 400. Тепер: `string.min(1) | number.finite() | date` + refine `Number.isFinite(new Date(v).getTime())`. Додав 4 параметризованих `it.each` кейсів у `apps/server/src/modules/sync.test.ts`.

**2. `pushAll` / `initialSync.applyMerge` — LWW conflict-loser більше не дропається мовчки**
`apps/web/src/core/cloudSync/engine/{initialSync,push}.ts`. `syncApi.pushAll` повертає `results[mod] = { ok: true, conflict: true }` для модулів, де server LWW-guard (`client_updated_at <= $4`) відкинув upsert. Хендлер вище викликав `clearAllDirty()` — dirty-флаг стирався навіть для conflict-модулів, і наступний pull накатував cloud-дані поверх локальних (без UI warning). Тепер ітеруємось по відправлених модулях і очищаємо dirty per-module через `isModulePushSuccess(r)` — conflict-модулі лишаються dirty, логуються у console.warn і повторно спробуються на наступному push-у. Покриття: 2 нові тести у `initialSync.test.ts`, 1 у `push.test.ts`.

**3. `.catch(() => {})` у гарячих шляхах тепер логує**
Три точки, де silent swallow міг приховувати реальні збої від саппорту/Sentry:
- `apps/web/src/shared/hooks/usePushNotifications.ts` — native та web push-token unregister
- `apps/web/src/core/useWeeklyDigest.ts` — `coachApi.postMemory` (пам'ять персоналізації)
- `apps/web/src/core/lib/hubChatActions.ts` — `saveRecipeToBook` з chat action

Решта `.catch(() => {fallback})` у reminder-hooks (useFizrukWorkoutReminder, useNutritionReminders) залишив — там catch уже має non-trivial body (fallback Notification), це не silent swallow.

## Review & Testing Checklist for Human

- [ ] Зайти з новим клієнтом (чиста localStorage) у юзера, де на сервері вже є дані; переконатись, що initialSync відпрацьовує як раніше у звичайних сценаріях (adoptCloud та merge без конфліктів).
- [ ] Спровокувати LWW conflict вручну (змінити щось локально, потім з іншого пристрою push новіший timestamp, повернутись на перший пристрій та натиснути "Sync now"): у DevTools має зʼявитись `[cloudSync] pushAll: server rejected push for modules (kept dirty) [...]`, local-зміни не повинні зникнути, модуль лишається dirty.
- [ ] В DevTools Network зробити POST `/api/sync/push` з `clientUpdatedAt: ""` (або `"garbage"`, `NaN`) — перевірити, що відповідь 400 з `details: [{path: "clientUpdatedAt"}]`, а не 500.

### Notes
Продовження техборг-серії після PR #585. Наступні у черзі: #5 Monobank proxy per-token rate-limit, #4 типізація TxRow / HubDashboard / PantryCard (окремі PR).

Link to Devin session: https://app.devin.ai/sessions/859ef60685f942bc94d37932a57a32ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sync timestamp validation to prevent request failures
  * Fixed dirty module state management during sync conflicts—conflicted modules now correctly retained for retry instead of being cleared
  * Improved error visibility: recipe saves, memory posts, and push notification unsubscriptions now log warnings instead of failing silently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->