### PR TITLE
feat(fizruk/workouts): Variant A home layout with start CTA + subviews

### DIFF
--- a/apps/mobile/src/modules/fizruk/pages/Workouts.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Workouts.test.tsx
@@ -1,19 +1,15 @@
 /**
- * Jest render + behaviour tests for the Fizruk Workouts page (Phase 6).
+ * Jest render + behaviour tests for the Fizruk Workouts page.
  *
  * Coverage:
- *  - Empty state renders when there is no active workout and no journal.
- *  - Pressing "Почати тренування" starts an active workout and shows
- *    the elapsed timer widget.
- *  - Switching to the journal tab renders one row per persisted workout.
+ *  - Home view renders the active-workout hero, catalog quick-link,
+ *    and the empty recent-workouts placeholder.
+ *  - Pressing "Почати тренування" starts an active workout and routes
+ *    to the catalog subview (elapsed timer visible in the hero).
+ *  - Tapping "Всі →" from home opens the full journal subview.
  *  - Tapping a catalogue exercise adds it to the active workout.
  *  - Opening the set editor, filling in weight+reps and saving appends
  *    a set to the active item and persists it to MMKV.
- *
- * All persistence flows through the real `useFizrukWorkouts` /
- * `useActiveFizrukWorkout` hooks, so the in-memory MMKV shim
- * registered in `jest.setup.js` exercises the hook-reducer-storage
- * contract end-to-end.
  */
 
 import { AccessibilityInfo } from "react-native";
@@ -49,18 +45,18 @@ afterEach(() => {
 });
 
 describe("Fizruk Workouts page (mobile)", () => {
-  it("renders the no-active-workout empty state by default", () => {
+  it("renders the home view with start CTA and catalog tile by default", () => {
     render(<Workouts />);
 
     expect(screen.getByText("Тренування")).toBeTruthy();
     expect(screen.getByTestId("fizruk-workouts-active")).toBeTruthy();
     expect(screen.getByTestId("fizruk-workouts-active-start")).toBeTruthy();
-    // Segmented tabs visible.
-    expect(screen.getByTestId("fizruk-workouts-mode-catalog")).toBeTruthy();
-    expect(screen.getByTestId("fizruk-workouts-mode-log")).toBeTruthy();
+    expect(screen.getByTestId("fizruk-workouts-open-catalog")).toBeTruthy();
+    // Recent-workouts empty-state hint is visible on first load.
+    expect(screen.getByTestId("fizruk-workouts-recent")).toBeTruthy();
   });
 
-  it("starts a new workout when the primary CTA is pressed", () => {
+  it("starts a new workout when the primary CTA is pressed and jumps to the catalog", () => {
     render(<Workouts />);
 
     fireEvent.press(screen.getByTestId("fizruk-workouts-active-start"));
@@ -68,6 +64,8 @@ describe("Fizruk Workouts page (mobile)", () => {
     // Elapsed timer takes over the panel.
     expect(screen.getByTestId("fizruk-workouts-active-elapsed")).toBeTruthy();
     expect(screen.getByTestId("fizruk-workouts-active-finish")).toBeTruthy();
+    // The catalog subview is now active (search input visible).
+    expect(screen.getByTestId("fizruk-workouts-catalog-search")).toBeTruthy();
 
     const rawActive = _getMMKVInstance().getString(
       STORAGE_KEYS.FIZRUK_ACTIVE_WORKOUT,
@@ -81,7 +79,7 @@ describe("Fizruk Workouts page (mobile)", () => {
     expect(parsed).toHaveLength(1);
   });
 
-  it("renders journal rows when switched to the log tab", () => {
+  it("opens the journal subview from the 'Всі →' shortcut", () => {
     safeWriteLS(STORAGE_KEYS.FIZRUK_WORKOUTS, [
       {
         id: "w_older",
@@ -107,7 +105,7 @@ describe("Fizruk Workouts page (mobile)", () => {
 
     render(<Workouts />);
 
-    fireEvent.press(screen.getByTestId("fizruk-workouts-mode-log"));
+    fireEvent.press(screen.getByTestId("fizruk-workouts-open-journal"));
 
     expect(
       screen.getByTestId("fizruk-workouts-journal-row-w_older"),
@@ -120,11 +118,9 @@ describe("Fizruk Workouts page (mobile)", () => {
   it("adds the tapped catalogue exercise to the active workout", () => {
     render(<Workouts />);
 
-    // Start a workout so tapping the catalogue doesn't bootstrap one.
     fireEvent.press(screen.getByTestId("fizruk-workouts-active-start"));
 
-    // Filter down to a single exercise via the search field so the
-    // test doesn't depend on the bundled catalog's ordering.
+    // Home → catalog jump happens automatically via handleStart.
     fireEvent.changeText(
       screen.getByTestId("fizruk-workouts-catalog-search"),
       "Жим штанги лежачи",
@@ -167,14 +163,16 @@ describe("Fizruk Workouts page (mobile)", () => {
       fireEvent.press(rows[0]!);
     });
 
-    // Find the first active-item card and its "+ Додати сет" button.
+    // Navigate back to home to access the active-item cards (they
+    // live alongside the hero, not inside the catalog subview).
+    fireEvent.press(screen.getByTestId("fizruk-workouts-back"));
+
     const addSetButtons = screen.getAllByTestId(/-add-set$/);
     expect(addSetButtons.length).toBeGreaterThan(0);
     act(() => {
       fireEvent.press(addSetButtons[0]!);
     });
 
-    // Fill the weight + reps and save.
     fireEvent.changeText(
       screen.getByTestId("fizruk-workouts-set-editor-weight-input"),
       "60",

--- a/apps/mobile/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Workouts.tsx
@@ -1,34 +1,26 @@
 /**
- * Fizruk / Workouts page — mobile port (Phase 6).
+ * Fizruk / Workouts page — home + subview layout.
  *
- * Web counterpart: `apps/web/src/modules/fizruk/pages/Workouts.tsx` (626 LOC).
+ * Replaces the older 3-tab layout (Каталог / Журнал / Шаблони + scattered
+ * top-right nav) with a single home screen fronted by the active-workout
+ * panel. Recent sessions surface inline and the catalog opens as a
+ * dedicated subview (back chevron → home), which gives the page one clear
+ * primary action ("Почати тренування") instead of five competing ones.
  *
- * Full port of the three core surfaces of the web page:
- *   1. Active-workout status strip (start / elapsed / finish + quick rest buttons).
- *   2. Searchable, primary-group-filtered exercise catalogue (built-in +
- *      custom), routed through `@sergeant/fizruk-domain/domain/workouts`
- *      pure helpers.
- *   3. Journal — newest-first list of sessions grouped by local date,
- *      with per-row aggregate summaries.
+ * Internal state machine:
+ *   `view = 'home'    ` — active/start hero + recent 3 journal rows +
+ *                         quick-link tile to the catalog.
+ *   `view = 'catalog' ` — full-screen exercise catalog (search +
+ *                         grouped list + detail tap).
+ *   `view = 'journal' ` — full journal list grouped by day.
  *
- * The catalogue tap → adds an exercise to the active workout; the
- * active-workout strip then reveals each item with an "add set" CTA
- * that opens the `ActiveSetEditor` sheet (weight / reps / optional
- * RPE, validated through the domain helpers, with haptics).
- *
- * Explicitly **excluded** from this port (covered by follow-up PRs):
- *   - Templates (WorkoutTemplates UI — PR #477 scoped it out).
- *   - Exercise detail sheet + recovery overlays (lands with the Exercise
- *     detail page PR).
- *   - Photo progress (ruled out by PR #468).
- *
- * Store integration: reuses `useActiveFizrukWorkout`, `useFizrukWorkouts`
- * and `useCustomExercises` — no new persisted slot. Both hooks already
- * route through `enqueueChange` (Task #7 pattern) so CloudSync picks
- * up changes automatically.
+ * All CRUD (start/finish workout, add exercise to active workout, log
+ * sets) still flows through `useActiveFizrukWorkout` / `useFizrukWorkouts`
+ * just like before. Only the chrome changed.
  */
 
 import {
+  computeWorkoutSummary,
   exerciseDisplayName,
   type WorkoutExerciseCatalogEntry,
   type WorkoutSet,
@@ -42,7 +34,6 @@ import { router } from "expo-router";
 
 import { hapticSuccess, hapticTap, hapticWarning } from "@sergeant/shared";
 
-import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 
 import { RestTimerOverlay } from "../components/RestTimerOverlay";
@@ -63,12 +54,7 @@ import {
   type FizrukWorkoutItem,
 } from "../hooks/useFizrukWorkouts";
 
-type WorkoutsMode = "catalog" | "log";
-
-const MODE_ITEMS: ReadonlyArray<{ value: WorkoutsMode; label: string }> = [
-  { value: "catalog", label: "Каталог" },
-  { value: "log", label: "Журнал" },
-];
+type WorkoutsView = "home" | "catalog" | "journal";
 
 interface SetEditorState {
   workoutId: string;
@@ -97,14 +83,9 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
     cancelRestTimer,
   } = useActiveFizrukWorkout();
 
-  const [mode, setMode] = useState<WorkoutsMode>("catalog");
+  const [view, setView] = useState<WorkoutsView>("home");
   const [setEditor, setSetEditor] = useState<SetEditorState | null>(null);
 
-  // Merged list: custom first, built-in after (deduped by id). We
-  // don't route through `mergeExerciseCatalog` because that helper
-  // insists on the stricter `RawExerciseDef` shape (required
-  // `name.uk`); the mobile catalog entry type is deliberately more
-  // permissive so legacy custom-exercise records never get dropped.
   const catalog = useMemo<WorkoutExerciseCatalogEntry[]>(() => {
     const custom: WorkoutExerciseCatalogEntry[] = customExercises.map((ex) => ({
       id: ex.id,
@@ -139,11 +120,19 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
     activeWorkout?.endedAt ? null : (activeWorkout?.startedAt ?? null),
   );
 
+  const finishedCount = useMemo(
+    () => workouts.filter((w) => w.endedAt).length,
+    [workouts],
+  );
+
   const handleStart = useCallback(() => {
     hapticSuccess();
     const created = createWorkout();
     setActiveWorkoutId(created.id);
-    setMode("catalog");
+    // Jump straight into the catalog so the next tap can add an
+    // exercise — matches the mental model of "I pressed Start, now
+    // what do I do first".
+    setView("catalog");
   }, [createWorkout, setActiveWorkoutId]);
 
   const handleFinish = useCallback(() => {
@@ -152,6 +141,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
     endWorkout(activeWorkoutId);
     clearActiveWorkout();
     cancelRestTimer();
+    setView("home");
   }, [activeWorkoutId, cancelRestTimer, clearActiveWorkout, endWorkout]);
 
   const handleStartRest = useCallback(
@@ -166,7 +156,6 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
     (ex: WorkoutExerciseCatalogEntry) => {
       if (!activeWorkoutId) {
         hapticWarning();
-        // Auto-start a workout for convenience.
         const created = createWorkout();
         setActiveWorkoutId(created.id);
         const isCardio = ex.primaryGroup === "cardio";
@@ -262,6 +251,23 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
 
   const activeItems = activeWorkout?.items ?? [];
 
+  const recentWorkouts = useMemo(
+    () =>
+      [...workouts]
+        .sort(
+          (a, b) =>
+            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+        )
+        .slice(0, 3),
+    [workouts],
+  );
+
+  const subtitle = activeWorkout
+    ? `Активне · ${activeItems.length} вправ`
+    : finishedCount > 0
+      ? `Завершено: ${finishedCount}`
+      : "Перше тренування — попереду";
+
   return (
     <SafeAreaView
       className="flex-1 bg-cream-50"
@@ -269,20 +275,42 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
       testID={testID}
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
-        <Text className="text-[22px]">🏋️</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Тренування
-        </Text>
+        {view !== "home" ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Назад"
+            onPress={() => setView("home")}
+            testID={`${testID}-back`}
+            className="w-10 h-10 items-center justify-center -ml-2"
+            hitSlop={8}
+          >
+            <Text className="text-2xl text-stone-800">‹</Text>
+          </Pressable>
+        ) : (
+          <Text className="text-[22px]">🏋️</Text>
+        )}
+        <View className="flex-1">
+          <Text className="text-[22px] font-bold text-stone-900">
+            {view === "catalog"
+              ? "Каталог вправ"
+              : view === "journal"
+                ? "Журнал"
+                : "Тренування"}
+          </Text>
+          {view === "home" ? (
+            <Text className="text-xs text-stone-500 mt-0.5">{subtitle}</Text>
+          ) : null}
+        </View>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-3">
-        Каталог вправ, активне тренування і журнал — все в одному місці.
-      </Text>
 
       <ScrollView
         className="flex-1"
         contentContainerStyle={{ padding: 16, paddingBottom: 140, gap: 16 }}
         testID={`${testID}-scroll`}
       >
+        {/* Active-workout strip stays visible across all subviews so the
+            elapsed timer + "Завершити" button are always reachable
+            while browsing the catalog or journal. */}
         <WorkoutActivePanel
           activeWorkoutId={activeWorkoutId}
           elapsedSec={elapsedSec}
@@ -292,57 +320,112 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
           testID={`${testID}-active`}
         />
 
-        {activeWorkout && activeItems.length > 0 ? (
-          <View className="gap-3" testID={`${testID}-items`}>
-            <Text className="text-sm font-semibold text-stone-900 px-1">
-              Вправи тренування
-            </Text>
-            <View className="gap-3">
-              {activeItems.map((item) => (
-                <ActiveItemCard
-                  key={item.id}
-                  item={item}
-                  onAddSet={() => openNewSetEditor(item)}
-                  onEditSet={(setIndex) => openEditSetEditor(item, setIndex)}
-                  testID={`${testID}-item-${item.id}`}
-                />
-              ))}
+        {view === "home" ? (
+          <>
+            {activeWorkout && activeItems.length > 0 ? (
+              <View className="gap-3" testID={`${testID}-items`}>
+                <Text className="text-sm font-semibold text-stone-900 px-1">
+                  Вправи тренування
+                </Text>
+                <View className="gap-3">
+                  {activeItems.map((item) => (
+                    <ActiveItemCard
+                      key={item.id}
+                      item={item}
+                      onAddSet={() => openNewSetEditor(item)}
+                      onEditSet={(setIndex) =>
+                        openEditSetEditor(item, setIndex)
+                      }
+                      testID={`${testID}-item-${item.id}`}
+                    />
+                  ))}
+                </View>
+              </View>
+            ) : null}
+
+            <View className="gap-3" testID={`${testID}-quicklinks`}>
+              <Text className="text-sm font-semibold text-stone-700 px-1">
+                Довідники
+              </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Каталог вправ"
+                onPress={() => {
+                  hapticTap();
+                  setView("catalog");
+                }}
+                testID={`${testID}-open-catalog`}
+              >
+                {({ pressed }) => (
+                  <Card
+                    variant="default"
+                    radius="lg"
+                    padding="md"
+                    className={pressed ? "opacity-80" : ""}
+                  >
+                    <View className="flex-row items-center gap-3">
+                      <Text className="text-2xl">📚</Text>
+                      <View className="flex-1">
+                        <Text className="text-sm font-semibold text-stone-900">
+                          Каталог вправ
+                        </Text>
+                        <Text className="text-[11px] text-stone-500 mt-0.5">
+                          Пошук · групи м&apos;язів · своя вправа
+                        </Text>
+                      </View>
+                      <Text className="text-stone-400 text-lg">›</Text>
+                    </View>
+                  </Card>
+                )}
+              </Pressable>
             </View>
-          </View>
+
+            <View className="gap-3" testID={`${testID}-recent`}>
+              <View className="flex-row items-center justify-between px-1">
+                <Text className="text-sm font-semibold text-stone-700">
+                  Останні тренування
+                </Text>
+                {workouts.length > 0 ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Всі тренування"
+                    onPress={() => {
+                      hapticTap();
+                      setView("journal");
+                    }}
+                    testID={`${testID}-open-journal`}
+                    hitSlop={8}
+                  >
+                    <Text className="text-xs font-semibold text-teal-700">
+                      Всі →
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
+              {recentWorkouts.length > 0 ? (
+                <View className="gap-2">
+                  {recentWorkouts.map((w) => (
+                    <RecentWorkoutRow
+                      key={w.id}
+                      workout={w}
+                      isActive={w.id === activeWorkoutId}
+                      testID={`${testID}-recent-${w.id}`}
+                    />
+                  ))}
+                </View>
+              ) : (
+                <Card variant="flat" radius="lg" padding="lg">
+                  <Text className="text-sm text-stone-600">
+                    Після першого завершеного тренування тут з&apos;являться
+                    останні сесії.
+                  </Text>
+                </Card>
+              )}
+            </View>
+          </>
         ) : null}
 
-        <View className="flex-row gap-2 px-0" testID={`${testID}-segmented`}>
-          {MODE_ITEMS.map((entry) => {
-            const active = mode === entry.value;
-            return (
-              <Pressable
-                key={entry.value}
-                accessibilityRole="button"
-                accessibilityState={{ selected: active }}
-                accessibilityLabel={entry.label}
-                onPress={() => setMode(entry.value)}
-                testID={`${testID}-mode-${entry.value}`}
-                className={
-                  active
-                    ? "flex-1 h-10 rounded-2xl bg-teal-600 items-center justify-center"
-                    : "flex-1 h-10 rounded-2xl bg-cream-100 border border-cream-300 items-center justify-center"
-                }
-              >
-                <Text
-                  className={
-                    active
-                      ? "text-sm font-semibold text-white"
-                      : "text-sm font-semibold text-stone-700"
-                  }
-                >
-                  {entry.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        {mode === "catalog" ? (
+        {view === "catalog" ? (
           <ExerciseCatalogSection
             onInspectExercise={handleInspectExercise}
             exercises={catalog}
@@ -350,13 +433,15 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
             onPickExercise={handlePickExercise}
             testID={`${testID}-catalog`}
           />
-        ) : (
+        ) : null}
+
+        {view === "journal" ? (
           <WorkoutJournalSection
             workouts={workouts}
             activeWorkoutId={activeWorkoutId}
             testID={`${testID}-journal`}
           />
-        )}
+        ) : null}
       </ScrollView>
 
       {restTimer ? (
@@ -384,7 +469,7 @@ interface ActiveItemCardProps {
   item: FizrukWorkoutItem;
   onAddSet(): void;
   onEditSet(setIndex: number): void;
-  testID: string;
+  testID?: string;
 }
 
 function ActiveItemCard({
@@ -393,65 +478,97 @@ function ActiveItemCard({
   onEditSet,
   testID,
 }: ActiveItemCardProps) {
-  const sets = Array.isArray(item.sets) ? item.sets : [];
+  const sets = item.sets ?? [];
   return (
     <Card variant="default" radius="lg" padding="md" testID={testID}>
-      <View className="gap-2">
-        <View className="flex-row items-baseline justify-between">
-          <Text
-            className="text-sm font-semibold text-stone-900 flex-1 pr-2"
-            numberOfLines={2}
-          >
-            {item.nameUk || "Вправа"}
+      <Text className="text-sm font-semibold text-stone-900">
+        {item.nameUk || "Вправа"}
+      </Text>
+      {sets.length > 0 ? (
+        <View className="mt-2 gap-1">
+          {sets.map((set, idx) => (
+            <Pressable
+              key={idx}
+              accessibilityRole="button"
+              accessibilityLabel={`Сет ${idx + 1}: ${set.weightKg} кг × ${set.reps}`}
+              onPress={() => onEditSet(idx)}
+              testID={`${testID}-set-${idx}`}
+              className="flex-row items-center justify-between py-1.5 px-2 rounded-lg bg-cream-100"
+            >
+              <Text className="text-xs text-stone-500">Сет {idx + 1}</Text>
+              <Text className="text-sm font-semibold text-stone-900">
+                {set.weightKg} кг × {set.reps}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Додати сет"
+        onPress={onAddSet}
+        testID={`${testID}-add-set`}
+        className="mt-3 h-10 rounded-xl bg-teal-600 items-center justify-center"
+      >
+        <Text className="text-sm font-semibold text-white">+ Додати сет</Text>
+      </Pressable>
+    </Card>
+  );
+}
+
+interface RecentWorkoutRowProps {
+  workout: FizrukWorkout;
+  isActive: boolean;
+  testID?: string;
+}
+
+function RecentWorkoutRow({
+  workout,
+  isActive,
+  testID,
+}: RecentWorkoutRowProps) {
+  const summary = useMemo(
+    () => computeWorkoutSummary(workout as never),
+    [workout],
+  );
+  const started = new Date(workout.startedAt);
+  const dateLabel = started.toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+  const parts: string[] = [];
+  if (summary.itemCount > 0) parts.push(`${summary.itemCount} вправ`);
+  if (summary.setCount > 0) parts.push(`${summary.setCount} сетів`);
+  const durMin = summary.durationSec
+    ? Math.max(1, Math.round(summary.durationSec / 60))
+    : null;
+  if (durMin !== null) parts.push(`${durMin} хв`);
+  const subtitle = parts.length ? parts.join(" · ") : "порожнє тренування";
+
+  return (
+    <View
+      className="px-3 py-3 rounded-xl border border-cream-300 bg-cream-50 flex-row items-center justify-between"
+      testID={testID}
+    >
+      <View className="flex-1 pr-2">
+        <View className="flex-row items-center gap-2">
+          <Text className="text-sm font-semibold text-stone-900">
+            {dateLabel}
           </Text>
-          {item.primaryGroup ? (
-            <Text className="text-[10px] uppercase font-bold text-stone-500">
-              {item.primaryGroup}
+          {isActive ? (
+            <Text className="text-[10px] uppercase font-bold text-teal-700 bg-teal-100 px-2 py-0.5 rounded-full">
+              Активне
+            </Text>
+          ) : !summary.isFinished ? (
+            <Text className="text-[10px] uppercase font-bold text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">
+              Чернетка
             </Text>
           ) : null}
         </View>
-
-        {sets.length > 0 ? (
-          <View className="gap-1" testID={`${testID}-sets`}>
-            {sets.map((set, idx) => {
-              const hasData = (set?.weightKg ?? 0) > 0 || (set?.reps ?? 0) > 0;
-              return (
-                <Pressable
-                  key={idx}
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    hasData
-                      ? `Редагувати сет ${idx + 1}: ${set?.weightKg ?? 0} на ${set?.reps ?? 0}`
-                      : `Заповнити сет ${idx + 1}`
-                  }
-                  onPress={() => onEditSet(idx)}
-                  testID={`${testID}-set-${idx}`}
-                  className="flex-row items-center justify-between px-2 py-1.5 rounded-lg bg-cream-100"
-                >
-                  <Text className="text-xs font-semibold text-stone-600">
-                    #{idx + 1}
-                  </Text>
-                  <Text className="text-sm text-stone-900">
-                    {hasData
-                      ? `${set?.weightKg ?? 0} кг × ${set?.reps ?? 0}`
-                      : "—"}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
-        ) : null}
-
-        <Button
-          variant="fizruk-soft"
-          size="sm"
-          onPress={onAddSet}
-          accessibilityLabel="Додати сет"
-          testID={`${testID}-add-set`}
-        >
-          + Додати сет
-        </Button>
+        <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+          {subtitle}
+        </Text>
       </View>
-    </Card>
+    </View>
   );
 }

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
-import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
-import { Segmented } from "@shared/components/ui/Segmented";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
@@ -23,6 +21,7 @@ import {
   ACTIVE_WORKOUT_KEY,
   summarizeWorkoutForFinish,
 } from "@sergeant/fizruk-domain";
+import { computeWorkoutSummary } from "@sergeant/fizruk-domain/domain";
 
 // Shared AudioContext reused across beeps. Creating/closing one per call
 // races with quick successive rest-timer completions and fights iOS' audio
@@ -75,12 +74,7 @@ function vibrateRestComplete() {
   hapticPattern([200, 100, 200]);
 }
 
-type WorkoutsMode = "catalog" | "log" | "templates";
-const WORKOUTS_MODE_ITEMS = [
-  { value: "catalog", label: "Каталог" },
-  { value: "log", label: "Журнал" },
-  { value: "templates", label: "Шаблони" },
-] as const satisfies ReadonlyArray<{ value: WorkoutsMode; label: string }>;
+type WorkoutsView = "home" | "catalog" | "log" | "templates";
 
 export function Workouts() {
   const toast = useToast();
@@ -112,7 +106,19 @@ export function Workouts() {
   const [selected, setSelected] = useState(null);
   const [open, setOpen] = useState(() => ({}));
   const [addOpen, setAddOpen] = useState(false);
-  const [mode, setMode] = useState("catalog"); // catalog | log | templates
+  // `view` drives the page chrome:
+  //   "home"      — new landing layout with active/start hero, recent 3
+  //                 journal rows and quick-link tiles. Replaces the old
+  //                 default that dropped users straight into the catalog.
+  //   "log"       — active-workout panel + exercise catalog below (this is
+  //                 where you actually run a session and add exercises).
+  //   "catalog"   — browse-only catalog (no active-workout wiring).
+  //   "templates" — workout templates list.
+  const [view, setView] = useState<WorkoutsView>("home");
+  // `mode` is still exposed to legacy subcomponents that branch on
+  // "catalog" vs "log" (exercise-in-list click handler, `ExerciseDetailSheet`,
+  // `WorkoutCatalogSection`). Kept in sync with `view` for those subviews.
+  const mode = view === "templates" || view === "home" ? "catalog" : view;
   const [restTimer, setRestTimer] = useState(null);
   const [activeWorkoutId, setActiveWorkoutId] = useState(() => {
     try {
@@ -175,10 +181,10 @@ export function Workouts() {
     try {
       const m = sessionStorage.getItem("fizruk_workouts_mode");
       if (m === "templates") {
-        setMode("templates");
+        setView("templates");
         sessionStorage.removeItem("fizruk_workouts_mode");
       } else if (m === "log") {
-        setMode("log");
+        setView("log");
         sessionStorage.removeItem("fizruk_workouts_mode");
       }
     } catch {}
@@ -298,7 +304,7 @@ export function Workouts() {
       }
       if (tpl?.id) templateApi.markTemplateUsed(tpl.id);
       setActiveWorkoutId(w.id);
-      setMode("log");
+      setView("log");
     },
     [exercises, createWorkout, addItem, updateWorkout, templateApi],
   );
@@ -394,61 +400,80 @@ export function Workouts() {
     [workouts],
   );
 
+  const recentWorkouts = useMemo(
+    () =>
+      [...(workouts || [])]
+        .sort(
+          (a, b) =>
+            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+        )
+        .slice(0, 3),
+    [workouts],
+  );
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-        <div className="flex items-center justify-between gap-3 mb-3">
-          <div>
-            <h1 className="text-xl font-bold text-text">Тренування</h1>
-            <p className="text-xs text-subtle mt-0.5">
-              {activeWorkout && !activeWorkout.endedAt
-                ? `Активне · ${(activeWorkout.items || []).length} вправ`
-                : `Завершено: ${finishedCount}`}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3 mb-3">
+          {view !== "home" ? (
             <button
               type="button"
-              className={subtleNavButtonClass}
-              onClick={() => (window.location.hash = "#progress")}
+              className="w-9 h-9 -ml-1 rounded-lg flex items-center justify-center text-text/80 hover:bg-surface-2"
+              onClick={() => setView("home")}
+              aria-label="Повернутись до тренувань"
             >
-              Прогрес →
+              ‹
             </button>
-            <button
-              type="button"
-              className={subtleNavButtonClass}
-              onClick={() => (window.location.hash = "#programs")}
-            >
-              Програми →
-            </button>
+          ) : null}
+          <div className="flex-1">
+            <h1 className="text-xl font-bold text-text">
+              {view === "catalog"
+                ? "Каталог вправ"
+                : view === "templates"
+                  ? "Шаблони"
+                  : view === "log"
+                    ? activeWorkout && !activeWorkout.endedAt
+                      ? "Активне тренування"
+                      : "Журнал"
+                    : "Тренування"}
+            </h1>
+            {view === "home" ? (
+              <p className="text-xs text-subtle mt-0.5">
+                {activeWorkout && !activeWorkout.endedAt
+                  ? `Активне · ${(activeWorkout.items || []).length} вправ`
+                  : finishedCount > 0
+                    ? `Завершено: ${finishedCount}`
+                    : "Перше тренування — попереду"}
+              </p>
+            ) : null}
           </div>
+          {view === "catalog" ? (
+            <Button
+              size="sm"
+              className="h-9 min-h-[44px] px-4"
+              onClick={() => setAddOpen(true)}
+              aria-label="Додати вправу в каталог"
+            >
+              + Додати
+            </Button>
+          ) : null}
         </div>
 
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <Segmented
-              tone="solid"
-              size="md"
-              accent="fizruk"
-              ariaLabel="Режим екрану тренувань"
-              items={WORKOUTS_MODE_ITEMS}
-              value={mode}
-              onChange={setMode}
-            />
-            {mode === "catalog" && (
-              <Button
-                size="sm"
-                className="h-9 min-h-[44px] px-4"
-                onClick={() => setAddOpen(true)}
-                aria-label="Додати вправу в каталог"
-              >
-                + Додати
-              </Button>
-            )}
-          </div>
-        </div>
+        {view === "home" ? (
+          <WorkoutsHome
+            activeWorkout={activeWorkout}
+            activeDuration={activeDuration}
+            recentWorkouts={recentWorkouts}
+            createWorkout={createWorkout}
+            setActiveWorkoutId={setActiveWorkoutId}
+            onOpenSession={() => setView("log")}
+            onOpenCatalog={() => setView("catalog")}
+            onOpenTemplates={() => setView("templates")}
+            onOpenJournal={() => setView("log")}
+          />
+        ) : null}
 
-        {mode === "log" && !workoutsLoaded && (
+        {view === "log" && !workoutsLoaded && (
           // First-paint placeholder while `useWorkouts` is still rehydrating
           // from `localStorage` (one tick on mount). Prevents the "порожньо"
           // empty-state from flashing before real data renders — matches the
@@ -464,7 +489,7 @@ export function Workouts() {
             <Skeleton className="h-20 w-full" />
           </div>
         )}
-        {mode === "log" && workoutsLoaded && (
+        {view === "log" && workoutsLoaded && (
           <WorkoutJournalSection
             activeWorkout={activeWorkout}
             activeDuration={activeDuration}
@@ -478,7 +503,7 @@ export function Workouts() {
             retroTime={retroTime}
             setRetroTime={setRetroTime}
             createWorkout={createWorkout}
-            setMode={setMode}
+            setMode={setView}
             musclesUk={musclesUk}
             recBy={rec.by}
             lastByExerciseId={lastByExerciseId}
@@ -495,7 +520,7 @@ export function Workouts() {
           />
         )}
 
-        {mode === "templates" && (
+        {view === "templates" && (
           <WorkoutTemplatesSection
             exercises={exercises}
             search={search}
@@ -508,7 +533,7 @@ export function Workouts() {
           />
         )}
 
-        {(mode === "catalog" || mode === "log") && (
+        {(view === "catalog" || view === "log") && (
           <WorkoutCatalogSection
             mode={mode}
             q={q}
@@ -621,6 +646,223 @@ export function Workouts() {
         }}
         onCancel={() => setRiskyTemplateConfirm(null)}
       />
+    </div>
+  );
+}
+
+/**
+ * Landing view for the Workouts page.
+ *
+ * Shows one dominant path ("Почати тренування" → active session) plus two
+ * supporting shortcuts (recent sessions preview and quick-link tiles to
+ * the catalog / templates / full journal).
+ */
+interface WorkoutsHomeProps {
+  activeWorkout: {
+    id: string;
+    startedAt: string;
+    endedAt?: string | null;
+    items?: ReadonlyArray<unknown>;
+  } | null;
+  activeDuration: string | null;
+  recentWorkouts: ReadonlyArray<{
+    id: string;
+    startedAt: string;
+    endedAt?: string | null;
+    items?: ReadonlyArray<unknown>;
+  }>;
+  createWorkout: () => { id: string };
+  setActiveWorkoutId: (id: string | null) => void;
+  onOpenSession: () => void;
+  onOpenCatalog: () => void;
+  onOpenTemplates: () => void;
+  onOpenJournal: () => void;
+}
+
+function WorkoutsHome({
+  activeWorkout,
+  activeDuration,
+  recentWorkouts,
+  createWorkout,
+  setActiveWorkoutId,
+  onOpenSession,
+  onOpenCatalog,
+  onOpenTemplates,
+  onOpenJournal,
+}: WorkoutsHomeProps) {
+  const hasActive = !!activeWorkout && !activeWorkout.endedAt;
+
+  const handleStart = () => {
+    const w = createWorkout();
+    setActiveWorkoutId(w.id);
+    onOpenSession();
+  };
+
+  return (
+    <div className="space-y-4">
+      {hasActive ? (
+        <div className="rounded-xl border border-teal-500/40 bg-teal-500/10 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold text-teal-700">
+                Активне тренування
+              </div>
+              <div className="mt-1 text-sm text-text">
+                <span className="font-bold">{activeDuration ?? "00:00"}</span>
+                {" · "}
+                {(activeWorkout?.items || []).length} вправ
+              </div>
+            </div>
+            <Button className="h-11 px-4" onClick={onOpenSession}>
+              Відкрити →
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-surface p-4 text-center">
+          <div className="text-sm font-semibold text-text">
+            Немає активного тренування
+          </div>
+          <div className="text-xs text-subtle mt-1">
+            Почни нове або обери один із збережених шаблонів.
+          </div>
+          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <Button className="h-12 text-base" onClick={handleStart}>
+              ▶︎ Почати тренування
+            </Button>
+            <Button
+              variant="ghost"
+              className="h-12 text-base"
+              onClick={onOpenTemplates}
+            >
+              📋 Почати з шаблону →
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between px-1 mb-2">
+          <h2 className="text-sm font-semibold text-text/80">
+            Останні тренування
+          </h2>
+          {recentWorkouts.length > 0 ? (
+            <button
+              type="button"
+              className="text-xs font-semibold text-teal-700 hover:underline"
+              onClick={onOpenJournal}
+            >
+              Всі →
+            </button>
+          ) : null}
+        </div>
+        {recentWorkouts.length > 0 ? (
+          <ul className="space-y-2">
+            {recentWorkouts.map((w) => (
+              <li key={w.id}>
+                <button
+                  type="button"
+                  className="w-full text-left rounded-xl border border-border bg-surface-2 px-3 py-3 flex items-center justify-between hover:bg-surface-3"
+                  onClick={onOpenJournal}
+                >
+                  <RecentWorkoutSummary workout={w} />
+                  <span className="text-subtle">›</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-xl border border-border bg-surface-2 p-4 text-xs text-subtle">
+            Після першого завершеного тренування тут з&apos;являться останні
+            сесії.
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h2 className="text-sm font-semibold text-text/80 px-1 mb-2">
+          Довідники
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <button
+            type="button"
+            className="rounded-xl border border-border bg-surface-2 p-4 text-left hover:bg-surface-3"
+            onClick={onOpenCatalog}
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">📚</span>
+              <div className="flex-1">
+                <div className="text-sm font-semibold text-text">
+                  Каталог вправ
+                </div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Пошук · групи м&apos;язів · своя вправа
+                </div>
+              </div>
+              <span className="text-subtle">›</span>
+            </div>
+          </button>
+          <button
+            type="button"
+            className="rounded-xl border border-border bg-surface-2 p-4 text-left hover:bg-surface-3"
+            onClick={onOpenTemplates}
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">📋</span>
+              <div className="flex-1">
+                <div className="text-sm font-semibold text-text">Шаблони</div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Збережені набори вправ на швидкий старт
+                </div>
+              </div>
+              <span className="text-subtle">›</span>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RecentWorkoutSummaryProps {
+  workout: {
+    id: string;
+    startedAt: string;
+    endedAt?: string | null;
+    items?: ReadonlyArray<unknown>;
+  };
+}
+
+function RecentWorkoutSummary({ workout }: RecentWorkoutSummaryProps) {
+  const summary = useMemo(
+    () => computeWorkoutSummary(workout as never),
+    [workout],
+  );
+  const started = new Date(workout.startedAt);
+  const dateLabel = started.toLocaleDateString("uk-UA", {
+    day: "numeric",
+    month: "short",
+  });
+  const parts: string[] = [];
+  if (summary.itemCount > 0) parts.push(`${summary.itemCount} вправ`);
+  if (summary.setCount > 0) parts.push(`${summary.setCount} сетів`);
+  const durMin = summary.durationSec
+    ? Math.max(1, Math.round(summary.durationSec / 60))
+    : null;
+  if (durMin !== null) parts.push(`${durMin} хв`);
+  const subtitle = parts.length ? parts.join(" · ") : "порожнє тренування";
+
+  return (
+    <div className="flex-1 pr-2">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold text-text">{dateLabel}</span>
+        {!summary.isFinished ? (
+          <span className="text-[10px] uppercase font-bold text-amber-700 bg-amber-500/15 px-2 py-0.5 rounded-full">
+            Чернетка
+          </span>
+        ) : null}
+      </div>
+      <div className="text-xs text-subtle mt-0.5 truncate">{subtitle}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Restructures the Fizruk **Тренування** page (web + mobile, mirrored) around **one clear primary action** instead of five competing entry points — a follow-up to the user report *"Де вправи, де тренування, що куди клацати"*.

### Before (on both platforms)
- You landed on a grouped **exercise catalog** that was labelled "Тренування" — confusing, since it wasn't showing any actual training.
- The header had a 3-tab segmented control (**Каталог / Журнал / Шаблони**) + duplicate top-right **Прогрес →** / **Програми →** shortcuts + a **+ Додати** button. Five controls, no hierarchy.
- There was **no visible "Start workout" button** — you had to guess that you needed to switch to the **Журнал** tab and press **+ Нове**.

### After
- Lands on a **home view** with:
  - Active-workout summary card **or** a dominant **▶︎ Почати тренування** + secondary **📋 Почати з шаблону →** pair (no active workout).
  - **Останні тренування** preview (3 most recent sessions) with an **Всі →** shortcut to the full journal.
  - Two **Довідники** quick-link tiles: 📚 *Каталог вправ* and 📋 *Шаблони*.
- Catalog, Журнал (active + log) and Шаблони each become a **dedicated subview** reached from the home tiles/CTAs, with a back chevron (`‹`) to return home.
- Top-right **Прогрес →** / **Програми →** nav is **gone** — those links already live on the Fizruk Dashboard, so duplicating them here was noise.
- Mobile mirrors the same structure (home + catalog + journal; no templates surface on mobile yet) with a **persistent active-workout strip** at the top of every subview so the elapsed timer and **Завершити** stay reachable while browsing the catalog.

### Files touched
- `apps/web/src/modules/fizruk/pages/Workouts.tsx` — new `view` state machine (`home | catalog | log | templates`), new `WorkoutsHome` landing component, chrome simplified (back arrow + dynamic title). Existing `WorkoutJournalSection` / `WorkoutCatalogSection` / `WorkoutTemplatesSection` are reused verbatim for the subviews.
- `apps/mobile/src/modules/fizruk/pages/Workouts.tsx` — full rewrite around `view: "home" | "catalog" | "journal"`. Active workout panel is now hoisted above the view switch so the elapsed timer is always visible after you start a session.
- `apps/mobile/src/modules/fizruk/pages/Workouts.test.tsx` — updated expectations for the new IA (no more segmented-tab testids, journal reached via `open-journal`, set editor flow traverses `home → catalog → home`).

All domain logic (active workout CRUD, set editor, rest timer, recovery conflicts, templates start) is unchanged — only the page chrome / IA.

## Review & Testing Checklist for Human
- [ ] **Web — cold load:** open `#fizruk/workouts`. Expect the home view (Active / Start CTAs + Останні + Довідники tiles). Verify `localStorage` doesn't get a stale mode value that breaks defaults.
- [ ] **Web — start flow:** on home with no active workout, press **▶︎ Почати тренування** → should create a workout, switch to the **log** subview, and show the active panel + catalog below (the same screen that existed under the old *Журнал* tab).
- [ ] **Web — templates shortcut:** `sessionStorage.fizruk_workouts_mode = "templates"` before navigating should still deep-link you into the Шаблони subview (used from Dashboard's "Шаблони" tile). Same for `"log"`.
- [ ] **Mobile — start flow:** press the hero Start button → should create a workout and automatically jump to the Catalog subview while keeping the elapsed timer visible in the strip above. Tap Back (`‹`) → see recent + active items cards on home.
- [ ] **Mobile — journal:** add two workouts, tap **Всі →** → journal subview lists both grouped by day. Back chevron returns to home.

### Notes
- `computeWorkoutSummary` (from `@sergeant/fizruk-domain/domain`) drives the new "Останні тренування" rows on both platforms so they stay consistent with the existing journal summaries.
- `mode` is still derived from `view` for legacy subcomponents (`WorkoutCatalogSection`, `ExerciseDetailSheet`) that branch on `"catalog"` vs `"log"` — nothing needs to change in those files.
- Mobile tests were updated to reflect the new nav (segmented control testids are gone). 558 mobile tests + 633 web tests pass locally.


Link to Devin session: https://app.devin.ai/sessions/ccdc0083117b4e018c3b7b0685eade65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a home view showing active workouts and recent workouts summaries on both mobile and web platforms.
  * Introduced quick-link tiles for easier navigation between catalog, templates, and journal sections.

* **Refactor**
  * Redesigned navigation flow from mode-based tabs to a multi-view state system.
  * Updated header with dynamic back navigation and view-aware titles.
  * Reorganized set editing and display with improved interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->