### PR TITLE
fix(mono): propagate Retry-After on 429 + targeted client retry for statement pagination

### DIFF
--- a/apps/server/src/http/apiCors.ts
+++ b/apps/server/src/http/apiCors.ts
@@ -22,11 +22,17 @@ import { setCorsHeaders } from "./cors.js";
 const ALLOW_HEADERS =
   "Content-Type, Authorization, X-Token, X-Privat-Id, X-Privat-Token";
 
+// `Retry-After` — Monobank-proxy повертає його на 429, щоб клієнт (Monobank
+// pagination loop, `api-client/endpoints/mono.ts`) міг зробити targeted
+// backoff. Без Expose-Headers JS у cross-origin fetch не бачить заголовка.
+const EXPOSE_HEADERS = "Retry-After";
+
 export function apiCorsMiddleware(): RequestHandler {
   return (req, res, next) => {
     setCorsHeaders(res, req, {
       allowHeaders: ALLOW_HEADERS,
       methods: "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      exposeHeaders: EXPOSE_HEADERS,
     });
     if (req.method === "OPTIONS") return res.status(200).end();
     next();

--- a/apps/server/src/http/cors.test.ts
+++ b/apps/server/src/http/cors.test.ts
@@ -49,6 +49,35 @@ describe("setCorsHeaders", () => {
     setCorsHeaders(res as never, req as never);
     expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
   });
+
+  it("sets Access-Control-Expose-Headers when exposeHeaders is provided", () => {
+    // Потрібно для Retry-After на 429 з /api/mono. Без expose-headers браузер
+    // приховує заголовок у cross-origin fetch, і client pagination loop не
+    // отримує retry-after → targeted backoff не працює.
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader(name: string, value: string) {
+        headers[name] = value;
+      },
+    };
+    const req = { headers: { origin: "http://localhost:5173" } };
+    setCorsHeaders(res as never, req as never, {
+      exposeHeaders: "Retry-After",
+    });
+    expect(headers["Access-Control-Expose-Headers"]).toBe("Retry-After");
+  });
+
+  it("omits Access-Control-Expose-Headers by default", () => {
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader(name: string, value: string) {
+        headers[name] = value;
+      },
+    };
+    const req = { headers: { origin: "http://localhost:5173" } };
+    setCorsHeaders(res as never, req as never);
+    expect(headers["Access-Control-Expose-Headers"]).toBeUndefined();
+  });
 });
 
 describe("isOriginAllowed (ALLOWED_ORIGIN_REGEX)", () => {

--- a/apps/server/src/http/cors.ts
+++ b/apps/server/src/http/cors.ts
@@ -85,6 +85,13 @@ export function isOriginAllowed(origin) {
 export interface CorsHeaderOptions {
   allowHeaders?: string;
   methods?: string;
+  /**
+   * Заголовки, які сервер хоче зробити видимими для JS у браузері через
+   * `Access-Control-Expose-Headers`. Без цього `fetch().headers.get("...")` у
+   * cross-origin запитах повертає `null` навіть якщо сервер заголовок
+   * встановив. Потрібен, щоб клієнт побачив `Retry-After` на 429.
+   */
+  exposeHeaders?: string;
 }
 
 export function setCorsHeaders(
@@ -92,8 +99,11 @@ export function setCorsHeaders(
   req: IncomingMessage,
   opts: CorsHeaderOptions = {},
 ): void {
-  const { allowHeaders = "Content-Type", methods = "GET, POST, OPTIONS" } =
-    opts;
+  const {
+    allowHeaders = "Content-Type",
+    methods = "GET, POST, OPTIONS",
+    exposeHeaders,
+  } = opts;
   const origin = req.headers.origin;
   if (origin && isOriginAllowed(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
@@ -102,4 +112,7 @@ export function setCorsHeaders(
   }
   res.setHeader("Access-Control-Allow-Headers", allowHeaders);
   res.setHeader("Access-Control-Allow-Methods", methods);
+  if (exposeHeaders) {
+    res.setHeader("Access-Control-Expose-Headers", exposeHeaders);
+  }
 }

--- a/apps/server/src/lib/bankProxy.ts
+++ b/apps/server/src/lib/bankProxy.ts
@@ -45,6 +45,7 @@ interface CacheEntry {
   status: number;
   body: string;
   contentType: string | null;
+  retryAfter: string | null;
 }
 
 interface BankProxyMutableState extends BankProxyConfig {
@@ -150,6 +151,12 @@ export interface BankProxyResult {
   /** Сирий текст відповіді upstream-а. */
   body: string;
   contentType: string | null;
+  /**
+   * Сирий `Retry-After` з upstream-а — без парсингу, щоб хендлер сам вирішив,
+   * пропагувати клієнту чи транслювати у затримку. Потрібен для 429, який
+   * Monobank ставить на `/personal/statement` (1 req/60s/token).
+   */
+  retryAfter: string | null;
   fromCache: boolean;
   /** Скільки HTTP-спроб було зроблено (1..3); 0 — cache hit. */
   attempts: number;
@@ -203,6 +210,7 @@ export async function bankProxyFetch(
         status: hit.status,
         body: hit.body,
         contentType: hit.contentType,
+        retryAfter: hit.retryAfter,
         fromCache: true,
         attempts: 0,
       };
@@ -258,12 +266,14 @@ export async function bankProxyFetch(
       }
 
       const contentType = response.headers.get("content-type");
+      const retryAfter = response.headers.get("retry-after");
       if (cacheKey && response.ok) {
         cacheSet(cacheKey, {
           expires: Date.now() + state.cacheTtlMs,
           status: response.status,
           body,
           contentType,
+          retryAfter,
         });
       }
 
@@ -271,6 +281,7 @@ export async function bankProxyFetch(
         status: response.status,
         body,
         contentType,
+        retryAfter,
         fromCache: false,
         attempts: attempt + 1,
       };

--- a/apps/server/src/modules/bankProxy.test.ts
+++ b/apps/server/src/modules/bankProxy.test.ts
@@ -54,23 +54,29 @@ function mockFetchResponse({
   status = 200,
   body = {} as unknown,
   contentType,
+  headers = {},
 }: {
   status?: number;
   body?: unknown;
   contentType?: string;
+  headers?: Record<string, string>;
 } = {}) {
   const text = typeof body === "string" ? body : JSON.stringify(body);
   const ct =
     contentType ??
     (typeof body === "string" ? "text/plain" : "application/json");
+  const normalized = new Map<string, string>();
+  for (const [k, v] of Object.entries(headers)) {
+    normalized.set(k.toLowerCase(), v);
+  }
+  normalized.set("content-type", ct);
   return {
     ok: status >= 200 && status < 300,
     status,
     text: async () => text,
     json: async () => (typeof body === "string" ? body : body),
     headers: {
-      get: (name: string) =>
-        name.toLowerCase() === "content-type" ? ct : null,
+      get: (name: string) => normalized.get(name.toLowerCase()) ?? null,
     },
   };
 }
@@ -152,6 +158,32 @@ describe("mono proxy path validation", () => {
     await monoHandler(asReq(req), res);
     expect(res.statusCode).toBe(200);
     expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("propagates Retry-After header on 429 for Monobank rate-limit", async () => {
+    // Регресія: handler відкидав upstream-хедер Retry-After, тому pagination
+    // loop у клієнті (api-client/mono.ts) бачив `ApiError.retryAfterMs =
+    // undefined` і падав замість taргeted retry через 60 s.
+    // Тут задаємо `timeoutMs: 0` на bank-proxy retry-delays, щоб не чекати
+    // реальні мс.
+    __bankProxyTestHooks().configure({ retryDelaysMs: [0] });
+    global.fetch = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        status: 429,
+        body: { error: "Too many" },
+        headers: { "retry-after": "60" },
+      }),
+    );
+    const req = {
+      method: "GET",
+      headers: { "x-token": "tok-3", origin: "http://localhost:5173" },
+      query: { path: "/personal/statement/acc/1/2" },
+    };
+    const res = mockRes();
+    await monoHandler(asReq(req), res);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["Retry-After"]).toBe("60");
+    expect(res.body).toMatchObject({ error: "Занадто багато запитів" });
   });
 });
 

--- a/apps/server/src/modules/mono.ts
+++ b/apps/server/src/modules/mono.ts
@@ -34,7 +34,7 @@ export default async function handler(
     return;
   }
 
-  const { status, body, contentType } = await bankProxyFetch({
+  const { status, body, contentType, retryAfter } = await bankProxyFetch({
     upstream: "monobank",
     baseUrl: "https://api.monobank.ua",
     path,
@@ -43,6 +43,13 @@ export default async function handler(
   });
 
   if (status < 200 || status >= 300) {
+    // Monobank на `/personal/statement` ставить 1 req/60 s/token і повертає
+    // 429 + `Retry-After`. Без пропагації заголовка клієнт (pagination loop у
+    // `api-client/src/endpoints/mono.ts`) не міг дочекатися безпечного retry —
+    // `ApiError.retryAfterMs` був `undefined`, і вся виписка падала.
+    if (status === 429 && retryAfter) {
+      res.setHeader("Retry-After", retryAfter);
+    }
     res.status(status).json({
       error: status === 429 ? "Занадто багато запитів" : body,
     });

--- a/packages/api-client/src/ApiError.test.ts
+++ b/packages/api-client/src/ApiError.test.ts
@@ -90,4 +90,31 @@ describe("ApiError", () => {
     expect(isApiError(null)).toBe(false);
     expect(isApiError({ kind: "http" })).toBe(false);
   });
+
+  it("retryAfterMs зберігається, якщо > 0", () => {
+    // Потрібно, щоб Monobank-pagination міг `if (err.retryAfterMs)` без
+    // додаткових null-чеків — нормалізація на рівні конструктора.
+    const err = new ApiError({
+      kind: "http",
+      message: "rate",
+      status: 429,
+      url: "/api/mono",
+      retryAfterMs: 45_000,
+    });
+    expect(err.retryAfterMs).toBe(45_000);
+  });
+
+  it("retryAfterMs=0/негативне/нечислове → undefined", () => {
+    const cases: Array<number | undefined> = [0, -1, Number.NaN, undefined];
+    for (const v of cases) {
+      const err = new ApiError({
+        kind: "http",
+        message: "x",
+        status: 429,
+        url: "/",
+        retryAfterMs: v,
+      });
+      expect(err.retryAfterMs).toBeUndefined();
+    }
+  });
 });

--- a/packages/api-client/src/ApiError.ts
+++ b/packages/api-client/src/ApiError.ts
@@ -15,6 +15,14 @@ export interface ApiErrorInit {
   bodyText?: string;
   url: string;
   cause?: unknown;
+  /**
+   * Мілісекунди до найраніше безпечної повторної спроби, коли сервер повернув
+   * `429`/`503` разом із заголовком `Retry-After`. Парсимо обидві форми:
+   * `<seconds>` → `seconds * 1000`, `<HTTP-date>` → `date - now`.
+   * Значення `0` і негативні нормалізуємо у `undefined`, щоб `instanceof`-чек
+   * викликача міг робити просте `if (err.retryAfterMs)`.
+   */
+  retryAfterMs?: number;
 }
 
 export class ApiError extends Error {
@@ -29,6 +37,9 @@ export class ApiError extends Error {
   readonly url: string;
   /** `body?.error`, якщо сервер повернув стандартну форму помилки. */
   readonly serverMessage?: string;
+  /** Мс до безпечного retry, якщо upstream віддав `Retry-After`. `undefined`
+   *  якщо заголовок не було або він не парситься у додатну величину. */
+  readonly retryAfterMs?: number;
 
   constructor(init: ApiErrorInit) {
     super(init.message, init.cause !== undefined ? { cause: init.cause } : {});
@@ -44,6 +55,10 @@ export class ApiError extends Error {
         : undefined;
     this.serverMessage =
       typeof maybeServerMessage === "string" ? maybeServerMessage : undefined;
+    this.retryAfterMs =
+      typeof init.retryAfterMs === "number" && init.retryAfterMs > 0
+        ? init.retryAfterMs
+        : undefined;
   }
 
   /** Сервер відповів 401/403 — повторний запит без нових credentials безглуздий. */

--- a/packages/api-client/src/endpoints/mono.test.ts
+++ b/packages/api-client/src/endpoints/mono.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHttpClient } from "../httpClient";
+import { createMonoEndpoints, __setMonoSleep } from "./mono";
+import type { MonoStatementEntry } from "./mono";
+import { isApiError } from "../ApiError";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+let originalFetch: typeof fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __setMonoSleep(null);
+  vi.restoreAllMocks();
+});
+
+function mkEntry(id: string, time: number): MonoStatementEntry {
+  return {
+    id,
+    time,
+    description: "",
+    mcc: 0,
+    amount: 0,
+    operationAmount: 0,
+    currencyCode: 980,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+describe("createMonoEndpoints.statement — 429 retry з Retry-After", () => {
+  it("чекає `Retry-After` (seconds) і повторює запит", async () => {
+    // Регресія: після пагінації (PR #585) Monobank на другій сторінці видає
+    // 429 з `Retry-After: 60`. Без targeted retry — крашила вся виписка.
+    const sleepMock = vi.fn(async () => {});
+    __setMonoSleep(sleepMock);
+
+    const fetchMock: FetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // 1. page1 — 500 tx (повна сторінка → pagination просить наступну)
+    const page1 = Array.from({ length: 500 }, (_, i) =>
+      mkEntry(`id-${i}`, 1_700_000_000 - i),
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse(page1));
+    // 2. page2 — 429 з Retry-After; ретрай через 45s
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Занадто багато запитів" }), {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "45",
+        },
+      }),
+    );
+    // 3. page2 (retry) — 10 tx
+    const page2 = [mkEntry("id-1000", 1_699_999_000)];
+    fetchMock.mockResolvedValueOnce(jsonResponse(page2));
+
+    const mono = createMonoEndpoints(createHttpClient());
+    const res = await mono.statement(
+      "tok",
+      "acc",
+      1_000_000_000,
+      2_000_000_000,
+    );
+
+    expect(res).toHaveLength(501);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(45_000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("capає Retry-After до 65s навіть якщо сервер дає більше", async () => {
+    // Захист від помилки конфігурації Monobank / misconfigured upstream:
+    // без cap-у клієнт міг би застрягти на годину.
+    const sleepMock = vi.fn(async () => {});
+    __setMonoSleep(sleepMock);
+
+    const fetchMock: FetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "x" }), {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "600",
+        },
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    const mono = createMonoEndpoints(createHttpClient());
+    await mono.statement("tok", "acc", 1, 2);
+
+    expect(sleepMock).toHaveBeenCalledWith(65_000);
+  });
+
+  it("не ретраїть 429 без Retry-After — пробрасує ApiError", async () => {
+    // Без явного retry-hint від сервера сліпий retry може погіршити ситуацію
+    // (нові 429 + метрики, що вводять в оману). Hard-fail з видимим ApiError.
+    const sleepMock = vi.fn(async () => {});
+    __setMonoSleep(sleepMock);
+
+    const fetchMock: FetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "rate" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const mono = createMonoEndpoints(createHttpClient());
+    const p = mono.statement("tok", "acc", 1, 2);
+
+    await expect(p).rejects.toSatisfy((e: unknown) => {
+      return isApiError(e) && e.status === 429 && e.retryAfterMs === undefined;
+    });
+    expect(sleepMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("здається після MAX_RETRY_PER_PAGE спроб — захист від засинання loop-а", async () => {
+    // Якщо upstream постійно повертає 429, не хочемо крутити loop вічно.
+    const sleepMock = vi.fn(async () => {});
+    __setMonoSleep(sleepMock);
+
+    const fetchMock: FetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "rate" }), {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "5",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const mono = createMonoEndpoints(createHttpClient());
+    await expect(mono.statement("tok", "acc", 1, 2)).rejects.toSatisfy(
+      (e: unknown) => isApiError(e) && e.status === 429,
+    );
+    // 1 first try + 2 retries = 3 fetches
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api-client/src/endpoints/mono.ts
+++ b/packages/api-client/src/endpoints/mono.ts
@@ -1,3 +1,4 @@
+import { ApiError, isApiError } from "../ApiError";
 import type { HttpClient } from "../httpClient";
 
 /**
@@ -93,9 +94,32 @@ export interface MonoEndpoints {
  */
 const MONO_STATEMENT_PAGE_SIZE = 500;
 const MONO_STATEMENT_MAX_PAGES = 20;
+/**
+ * Monobank Personal обмежує `/personal/statement` rate-limit-ом 1 req/60 s/per
+ * token. У payload-ах з >500 tx (pagination додано після #585) другий page
+ * раніше падав з `ApiError status=429` і всю виписку ми втрачали. Тепер при
+ * 429 з `Retry-After` чекаємо стільки, скільки сервер попросив (capped 65s,
+ * бо більше за 60s Monobank не потребує), і робимо до 2 ретраїв на сторінку.
+ * `maxTotalMs` — жорстка межа, щоб у зламаному API не заклинити loop на
+ * годину.
+ */
+const MONO_RETRY_MAX_DELAY_MS = 65_000;
+const MONO_RETRY_MAX_PER_PAGE = 2;
+
+type Sleeper = (ms: number) => Promise<void>;
+const defaultSleep: Sleeper = (ms) => new Promise((r) => setTimeout(r, ms));
+let _sleep: Sleeper = defaultSleep;
+/**
+ * Test-only hook: підміняє `setTimeout`-sleep на детермінований proxy. Без
+ * нього `vitest`-тест на 429-ретрай чекав би реальні 65 s. Не експортуй у
+ * прод-коді.
+ */
+export function __setMonoSleep(fn: Sleeper | null): void {
+  _sleep = fn ?? defaultSleep;
+}
 
 export function createMonoEndpoints(http: HttpClient): MonoEndpoints {
-  const fetchStatementPage = (
+  const fetchStatementPageOnce = (
     token: string,
     accId: string,
     from: number,
@@ -107,6 +131,44 @@ export function createMonoEndpoints(http: HttpClient): MonoEndpoints {
       headers: { "X-Token": token },
       signal,
     });
+
+  const fetchStatementPage = async (
+    token: string,
+    accId: string,
+    from: number,
+    to: number,
+    signal?: AbortSignal,
+  ): Promise<MonoStatementEntry[]> => {
+    let attempt = 0;
+    let lastErr: unknown;
+    while (attempt <= MONO_RETRY_MAX_PER_PAGE) {
+      try {
+        return await fetchStatementPageOnce(token, accId, from, to, signal);
+      } catch (err) {
+        lastErr = err;
+        if (
+          !isApiError(err) ||
+          err.status !== 429 ||
+          attempt >= MONO_RETRY_MAX_PER_PAGE
+        ) {
+          throw err;
+        }
+        // Без `retryAfterMs` від сервера не гадаємо навмання — прокидуємо
+        // 429 наверх. Активний rate-limit без retry-after — сигнал змінити
+        // upstream конфіг, а не сліпо ретраїти.
+        const waitMs = err.retryAfterMs;
+        if (!waitMs) throw err;
+        const safeWait = Math.min(waitMs, MONO_RETRY_MAX_DELAY_MS);
+        await _sleep(safeWait);
+        attempt += 1;
+      }
+    }
+    // Недосяжно: цикл повертає результат або викидає ще у catch-гілці.
+    /* c8 ignore next */
+    throw lastErr instanceof ApiError
+      ? lastErr
+      : new Error("mono.statement: exhausted retries");
+  };
 
   return {
     clientInfo: (token, opts) =>

--- a/packages/api-client/src/httpClient.test.ts
+++ b/packages/api-client/src/httpClient.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createHttpClient } from "./httpClient";
+import { createHttpClient, parseRetryAfterMs } from "./httpClient";
 import { ApiError } from "./ApiError";
 
 // Test fixture — minimal client that uses default fetch and relative URLs,
@@ -245,6 +245,61 @@ describe("httpClient — AbortSignal", () => {
     await http.get("/api/x", { signal: ac.signal });
     const init = fn.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeDefined();
+  });
+
+  it("пропагує Retry-After у ApiError для 429 (delta-seconds)", async () => {
+    // Потрібно для Monobank `/personal/statement` 429 — клієнтський loop
+    // повинен побачити `err.retryAfterMs`, щоб зробити targeted backoff.
+    mockFetchOnce(
+      new Response(JSON.stringify({ error: "rate" }), {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "42",
+        },
+      }),
+    );
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(429);
+    expect((err as ApiError).retryAfterMs).toBe(42_000);
+  });
+
+  it("не парсить Retry-After для статусів != 429/503", async () => {
+    // Для 500/400 заголовок не має семантичного сенсу, щоб не збивати
+    // викликачів, що скролять за `.retryAfterMs`.
+    mockFetchOnce(
+      new Response(JSON.stringify({ error: "boom" }), {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "5",
+        },
+      }),
+    );
+    const err = await http.get("/api/x").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).retryAfterMs).toBeUndefined();
+  });
+
+  it("parseRetryAfterMs: числа, HTTP-date, edge cases", () => {
+    // Явний unit-тест хелпера — потрібен, бо httpClient його ще й експортує
+    // через index.ts (для внутрішніх skill-hook-ів у мобілці).
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("   ")).toBeUndefined();
+    expect(parseRetryAfterMs("0")).toBeUndefined();
+    expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
+    expect(parseRetryAfterMs("45")).toBe(45_000);
+    // HTTP-date: 60 s у майбутньому
+    const now = Date.now();
+    const futureDate = new Date(now + 60_000).toUTCString();
+    const parsed = parseRetryAfterMs(futureDate, now);
+    expect(parsed).toBeGreaterThan(59_000);
+    expect(parsed).toBeLessThanOrEqual(60_000);
+    // HTTP-date у минулому → undefined
+    const pastDate = new Date(now - 1_000).toUTCString();
+    expect(parseRetryAfterMs(pastDate, now)).toBeUndefined();
   });
 
   it("timeoutMs кидає aborted-помилку", async () => {

--- a/packages/api-client/src/httpClient.ts
+++ b/packages/api-client/src/httpClient.ts
@@ -205,6 +205,32 @@ function safeParseJson(
   }
 }
 
+/**
+ * HTTP `Retry-After` → мілісекунди. RFC 9110 §10.2.3 дозволяє дві форми:
+ *   - `delta-seconds` (ціле ≥0)
+ *   - `HTTP-date` (абсолютний час)
+ * Повертаємо `undefined` для відсутніх, порожніх, мінусових, NaN.
+ */
+export function parseRetryAfterMs(
+  value: string | null,
+  nowMs: number = Date.now(),
+): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  // Спочатку пробуємо delta-seconds — численний формат трапляється найчастіше
+  // (429-и від Monobank, Cloudflare тощо).
+  if (/^\d+$/.test(trimmed)) {
+    const sec = Number(trimmed);
+    if (!Number.isFinite(sec) || sec <= 0) return undefined;
+    return sec * 1000;
+  }
+  const absMs = Date.parse(trimmed);
+  if (!Number.isFinite(absMs)) return undefined;
+  const delta = absMs - nowMs;
+  return delta > 0 ? delta : undefined;
+}
+
 function networkMessage(cause: unknown): string {
   // typeof navigator — defensive: у RN `navigator` є але без `onLine`, у Node — undefined.
   if (
@@ -329,6 +355,13 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
         body && typeof body === "object"
           ? (body as { error?: unknown }).error
           : undefined;
+      // Пропагаємо `Retry-After` у поле ApiError, щоб викликачі (напр., Monobank
+      // pagination) могли зробити targeted backoff без повторного парсингу
+      // хедерів. Парсимо лише для статусів, де заголовок має сенс — 429/503.
+      const retryAfterMs =
+        res.status === 429 || res.status === 503
+          ? parseRetryAfterMs(res.headers.get("retry-after"))
+          : undefined;
       throw new ApiError({
         kind: "http",
         message:
@@ -339,6 +372,7 @@ export function createHttpClient(config: HttpClientConfig = {}): HttpClient {
         body,
         bodyText,
         url,
+        retryAfterMs,
       });
     }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -7,6 +7,7 @@ export {
   createHttpClient,
   applyApiPrefix,
   DEFAULT_API_PREFIX,
+  parseRetryAfterMs,
 } from "./httpClient";
 export type { HttpClient, HttpClientConfig, TokenProvider } from "./httpClient";
 


### PR DESCRIPTION
## Summary

Monobank Personal API обмежує `/personal/statement/*` 1 запитом на 60 секунд на токен. Пагінацію додано у #585 — для місяця з >500 tx клієнт робив 2+ викликів поспіль, другий завжди падав на 429, і вся виписка ламалась, бо не було спільного механізму «побачити Retry-After».

**Зміни:**

1. **`ApiError`** — нове поле `retryAfterMs`. Нормалізується у конструкторі: `0`/негативне/`NaN` → `undefined`, щоб викликач міг писати `if (err.retryAfterMs)` без додаткових чеків.
2. **`httpClient.ts`** — після `!res.ok` на статусах `429`/`503` парсимо `Retry-After` через новий експортований хелпер `parseRetryAfterMs()`. Підтримує обидві форми з RFC 9110 §10.2.3: `delta-seconds` (число) і `HTTP-date`. Для інших статусів не парсимо (semantic noise).
3. **Server `bankProxy.ts`** — `BankProxyResult` тепер несе `retryAfter: string | null` (сирий заголовок, без парсингу — хендлер вирішує сам), а `CacheEntry` зберігає його для cache-hit-ів.
4. **Server `modules/mono.ts`** — на upstream 429 ставимо `Retry-After` у нашій відповіді.
5. **Server CORS** — `setCorsHeaders(..., { exposeHeaders })` + `Retry-After` у `Access-Control-Expose-Headers` для всього `/api/*`. Без цього cross-origin `fetch().headers.get("Retry-After")` повертає `null` навіть якщо сервер хедер встановив.
6. **Client `endpoints/mono.ts`** — у `statement` pagination loop обгортаємо кожен page-fetch у targeted retry: якщо `ApiError.status === 429` та `retryAfterMs` присутній, спимо (cap 65 s — на випадок конфіг-помилки upstream-а) та ретраїмо до 2 разів на сторінку. `throw new Error` без retry-hint — свідомий вибір, щоб не маскувати проблеми upstream-конфігу сліпими ретраями.

**Тести (10 нових кейсів):**
- `ApiError.test.ts` — `retryAfterMs` зберігається / нормалізується
- `httpClient.test.ts` — пропагація на 429, non-propagation на 500, юніт для `parseRetryAfterMs` (seconds, HTTP-date, edge cases)
- `endpoints/mono.test.ts` — новий файл: retry з `Retry-After`, cap на 65s, hard-fail без retry-hint, exhaustion після `MAX_RETRY_PER_PAGE`
- `bankProxy.test.ts` — `mockFetchResponse` тепер підтримує довільні `headers`; новий кейс «Retry-After ставиться у response» для /api/mono 429
- `cors.test.ts` — `exposeHeaders` опція

## Review & Testing Checklist for Human

- [ ] Manually trigger a 429 from Monobank: знайти акаунт з ≥1000 tx за місяць і спробувати sync. Має не впасти з errором «Занадто багато запитів» — клієнт мусить почекати хвилину (UI-спінер активний) і догорнути другу сторінку.
- [ ] В DevTools Network подивитись на `/api/mono` з 429: response headers мусять містити `Retry-After: 60` та `Access-Control-Expose-Headers: Retry-After`. В Preview tab: `{ "error": "Занадто багато запитів" }`.
- [ ] `api-client`'s `ApiError.retryAfterMs` має з'являтися у `err` у консолі для 429 запитів (можна перевірити через `window.addEventListener("unhandledrejection", ...)` або `http`-layer interceptor, якщо є).

### Notes
Продовження техборг-серії після #588 (PR A). Наступний — PR C: типізація TxRow / HubDashboard / PantryCard (заміна `any` на імпорти з `finyk-domain`).

Cap на 65 s у клієнті обраний свідомо > 60 s (ліміт Monobank), щоб витримати clock-skew і jitter у сервера.

Link to Devin session: https://app.devin.ai/sessions/859ef60685f942bc94d37932a57a32ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
