### PR TITLE
fix(routine/habit-form): tidy quick-create dialog layout

### DIFF
--- a/apps/web/src/modules/routine/components/settings/HabitForm.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitForm.tsx
@@ -11,6 +11,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
+import type { ReactNode } from "react";
 import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
 import {
   ROUTINE_THEME as C,
@@ -149,8 +150,24 @@ export function HabitForm({
     }
   }, [focusTick]);
 
+  // When embedded in a dialog (HabitQuickCreateDialog) we skip the outer
+  // Card chrome — the dialog already provides the bordered, rounded
+  // container. Nesting another Card here visually duplicates the "flash
+  // card" around the form (noticed on mobile Safari where it looked like
+  // two stacked panels) and eats ~32px of horizontal padding.
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    hideHeading ? (
+      <section ref={sectionRef} className="space-y-4">
+        {children}
+      </section>
+    ) : (
+      <Card as="section" ref={sectionRef} radius="lg" className="space-y-3">
+        {children}
+      </Card>
+    );
+
   return (
-    <Card as="section" ref={sectionRef} radius="lg" className="space-y-3">
+    <Wrapper>
       {!hideHeading && (
         <SectionHeading as="h2" size="sm">
           {editingId ? "Редагувати звичку" : "Нова звичка"}
@@ -158,17 +175,17 @@ export function HabitForm({
       )}
 
       <div>
-        <div className="flex gap-2 items-stretch">
-          <div className="relative" ref={emojiWrapRef}>
+        <div className="flex gap-2 items-center">
+          <div className="relative shrink-0" ref={emojiWrapRef}>
             <button
               type="button"
               onClick={() => setShowEmojiPicker((v) => !v)}
               aria-label="Обрати емодзі"
               aria-expanded={showEmojiPicker}
               className={cn(
-                "routine-touch-field w-16 h-full shrink-0 flex items-center justify-center",
-                "rounded-2xl border border-line bg-panel text-xl",
-                "hover:bg-panelHi transition-colors",
+                "routine-touch-field w-12 shrink-0 flex items-center justify-center",
+                "rounded-2xl border border-line bg-panelHi text-xl",
+                "hover:bg-panel transition-colors",
               )}
             >
               <span aria-hidden>{habitDraft.emoji || "✓"}</span>
@@ -414,25 +431,33 @@ export function HabitForm({
         </div>
       )}
 
-      <div className="flex flex-col gap-2">
-        <Button
-          type="button"
-          className={cn("w-full font-bold", C.primary)}
-          onClick={onSave}
-        >
-          {editingId ? "Зберегти зміни" : "Додати звичку"}
-        </Button>
+      <div
+        className={cn(
+          "flex gap-2",
+          // Inside the quick-create dialog the sheet already has an "X"
+          // close in the top-right, so the Cancel button would be
+          // redundant. Stretch the primary save button to fill the row.
+          editingId ? "flex-row" : "flex-col",
+        )}
+      >
         {editingId && (
           <Button
             type="button"
             variant="ghost"
-            className="w-full border border-line"
+            className="flex-1 border border-line"
             onClick={onCancel}
           >
             Скасувати
           </Button>
         )}
+        <Button
+          type="button"
+          className={cn("flex-1", C.primary)}
+          onClick={onSave}
+        >
+          {editingId ? "Зберегти зміни" : "Додати звичку"}
+        </Button>
       </div>
-    </Card>
+    </Wrapper>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the reported "Поля вилазять за блоки. Форма непропорційна до флеш картки" issue on the **Нова звичка** / **Редагувати звичку** bottom-sheet dialog in the Routine module.

### Root cause
`HabitQuickCreateDialog` already renders the sheet as a bordered, rounded container with its own padding. Inside it we rendered `HabitForm` whose outer element was **also** a `Card` with `bg-panel + border + shadow + p-4`. The result was two concentric "flash cards" inside the same sheet — wasted ~32px of horizontal room (double padding) and the inner border looked like the form was floating inside a card inside a card.

On top of that the top input row used `items-stretch` + `h-full` on the emoji chip, so the chip stretched taller than the name `Input`, leaving the mic button visually floating at a third height.

### What I changed (single file)
- `HabitForm.tsx`:
  - When `hideHeading` is `true` (the dialog case) render the form contents inside a plain `<section className="space-y-4">` instead of a `<Card>`. The settings-page usage (`hideHeading=false`) still gets the `<Card>` treatment.
  - Top row switches from `items-stretch` to `items-center`; emoji chip is now a fixed `w-12 routine-touch-field` (44px tall, matching `Input` and the mic button). Chip color is `bg-panelHi` so it reads as an inline action, not a second card.
  - Primary CTA drops the `w-full + font-bold` combo. In **edit** mode it now shares a `flex-row` with Cancel; in **create** mode it's the single button in the row (no duplicate Cancel because the sheet already has an `X` close top-right).

### Before / After (visual expectation on iPhone Safari)
- Before: `| sheet | card | form | card | sheet |` padding stack — ~52px total padding ate into a 360px viewport.
- After: `| sheet | form | sheet |` — ~32px total padding, fields actually hit the form edges, emoji + input + mic sit on the same baseline.

## Review & Testing Checklist for Human
- [ ] **Create mode:** Open Рутина → central "+" → Нова звичка. Emoji chip, name input and mic button should be exactly the same height on one line, no inner bordered card. "Додати звичку" should be a single full-row coral button at the bottom.
- [ ] **Edit mode:** Open any existing habit → edit. Two buttons in a row at bottom: ghost `Скасувати` on the left + coral `Зберегти зміни` on the right, both 50/50 width.
- [ ] **Settings page:** Navigate to Рутина → ⚙ Налаштування → звички. The form there still has its heading ("Нова звичка / Редагувати звичку") and the bordered `<Card>` frame — not affected by this fix.
- [ ] **Mobile Safari viewport ≤ 375px:** no horizontal overflow, fields don't clip into the sheet edges.

### Notes
- Follow-up from PR #589 (Fizruk Workouts) — same user session, separate concern so landed on a separate branch.
- No behavioural / validation changes; purely the chrome/layout. Existing tests (if any covered layout) would still pass because the form structure + testIDs are unchanged.


Link to Devin session: https://app.devin.ai/sessions/ccdc0083117b4e018c3b7b0685eade65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & UI Improvements**
  * Enhanced form layout with improved input alignment and spacing
  * Refined emoji picker button styling for better visual presentation
  * Restructured action button area with improved organization and responsive behavior
  * Optimized dialog chrome handling to eliminate redundant padding
  * Improved form state-specific layout adjustments for create and edit modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->