### PR TITLE
feat(fizruk/body): make trend charts collapsible

### DIFF
--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -16,6 +16,14 @@
 
 require("react-native-gesture-handler/jestSetup");
 
+// `@react-native-async-storage/async-storage` ships a hand-rolled
+// CommonJS mock — register it here so any component that reads/writes
+// persisted UI state (e.g. the collapsible Body trend cards) works in
+// tests without pulling in the real TurboModule.
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
+);
+
 // `@/auth/authClient` re-exports Better Auth's React client, which is
 // shipped as an ESM-only bundle. jest-expo's default transform list
 // does not include `better-auth/*`, so any test that indirectly

--- a/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
@@ -7,8 +7,9 @@
  * the already-shipped `TrendChart` from `../progress` rather than
  * pulling in a second chart renderer.
  */
-import { memo } from "react";
-import { Text, View } from "react-native";
+import { memo, useCallback, useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import {
   buildMeasurementSeries,
@@ -18,6 +19,8 @@ import {
 } from "@sergeant/fizruk-domain/domain";
 
 import { TrendChart } from "../progress/TrendChart";
+
+const TREND_OPEN_KEY_PREFIX = "fizruk:body:trend-open:";
 
 export interface BodyTrendCardProps {
   /** Card heading shown above the chart (e.g. "Динаміка ваги"). */
@@ -67,26 +70,107 @@ const BodyTrendCardImpl = function BodyTrendCard({
     limit,
   );
   const rootTestID = testID ?? `fizruk-body-trend-${field}`;
+  const storageKey = `${TREND_OPEN_KEY_PREFIX}${field}`;
+
+  // Start collapsed so the Body screen reads as a compact list of
+  // trends at first load — the user can expand any one to inspect the
+  // chart. The choice is persisted in AsyncStorage per-field so it
+  // survives app restarts, matching the web counterpart.
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(storageKey)
+      .then((v) => {
+        if (!cancelled && v === "1") setOpen(true);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKey]);
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      AsyncStorage.setItem(storageKey, next ? "1" : "0").catch(() => {
+        /* ignore */
+      });
+      return next;
+    });
+  }, [storageKey]);
+
+  // When collapsed, show a latest-value + delta teaser next to the
+  // title so the card still communicates the most important signal
+  // without opening the chart. Uses the same logic as TrendChart.
+  const validPoints = series
+    .map((p) => (p.value != null ? Number(p.value) : null))
+    .filter((v): v is number => v != null && Number.isFinite(v));
+  const latest =
+    validPoints.length > 0 ? validPoints[validPoints.length - 1] : null;
+  const first = validPoints.length > 0 ? validPoints[0] : null;
+  const delta = latest != null && first != null ? latest - first : null;
 
   return (
     <View
-      className="rounded-2xl bg-cream-50 border border-cream-200 p-4"
+      className="rounded-2xl bg-cream-50 border border-cream-200"
       testID={rootTestID}
       accessibilityLabel={`Динаміка: ${metricLabel}`}
     >
-      <View className="flex-row items-baseline justify-between mb-2">
-        <Text className="text-sm font-semibold text-stone-900">{title}</Text>
-        <Text className="text-[11px] text-stone-500">
-          {`останні ${limit ?? 8}`}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${open ? "Згорнути" : "Розгорнути"}: ${title}`}
+        accessibilityState={{ expanded: open }}
+        onPress={toggle}
+        className="flex-row items-center gap-3 px-4 py-3"
+        testID={`${rootTestID}-toggle`}
+      >
+        <View className="flex-1 min-w-0">
+          <Text className="text-sm font-semibold text-stone-900">{title}</Text>
+        </View>
+        {latest != null ? (
+          <View className="flex-row items-baseline gap-2 shrink-0">
+            <Text className="text-sm font-semibold text-stone-900 tabular-nums">
+              {`${latest.toFixed(0)}${unit}`}
+            </Text>
+            {delta != null && delta !== 0 ? (
+              <Text
+                className={
+                  delta > 0
+                    ? "text-[11px] font-semibold text-amber-700 tabular-nums"
+                    : "text-[11px] font-semibold text-emerald-700 tabular-nums"
+                }
+              >
+                {`${delta > 0 ? "+" : ""}${delta.toFixed(1)}${unit}`}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+        <Text
+          className={`text-stone-500 ${open ? "rotate-180" : ""}`}
+          accessibilityElementsHidden
+        >
+          ▾
         </Text>
-      </View>
-      <TrendChart
-        series={series}
-        strokeColor={strokeColor}
-        unit={unit}
-        metricLabel={metricLabel}
-        testIDPrefix={rootTestID}
-      />
+      </Pressable>
+      {open ? (
+        <View className="px-4 pb-4">
+          <View className="flex-row items-baseline justify-end mb-2">
+            <Text className="text-[11px] text-stone-500">
+              {`останні ${limit ?? 8}`}
+            </Text>
+          </View>
+          <TrendChart
+            series={series}
+            strokeColor={strokeColor}
+            unit={unit}
+            metricLabel={metricLabel}
+            testIDPrefix={rootTestID}
+          />
+        </View>
+      ) : null}
     </View>
   );
 };

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Label } from "@shared/components/ui/FormField";
 import { subtleNavButtonClass } from "@shared/components/ui/buttonPresets";
@@ -7,6 +8,147 @@ import { useDailyLog } from "../hooks/useDailyLog";
 import { Card } from "@shared/components/ui/Card";
 import { MiniLineChart } from "../components/MiniLineChart";
 import { PhotoProgress } from "../components/PhotoProgress";
+
+/**
+ * Trend cards on this page used to be always-expanded, which meant four
+ * ~180px-tall charts stacked one after another — on mobile Safari that
+ * pushed the useful summary + input form far off-screen. The user asked
+ * for them to be collapsible, so each chart card is now wrapped in
+ * `CollapsibleTrendCard`:
+ *
+ *  - Default: collapsed, showing only the title + a latest-value +
+ *    delta teaser, so the page reads as a compact list at first load.
+ *  - Tap/click the header to toggle. Per-card open state is persisted
+ *    in localStorage under `fizruk:body:trend-open:<key>` so the user's
+ *    choice survives reloads.
+ */
+const TREND_STORAGE_PREFIX = "fizruk:body:trend-open:";
+
+function readTrendOpen(key: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(TREND_STORAGE_PREFIX + key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function CollapsibleTrendCard({
+  storageKey,
+  title,
+  latestValue,
+  latestUnit,
+  delta,
+  ariaLabel,
+  children,
+}: {
+  storageKey: string;
+  title: string;
+  latestValue: number | null;
+  latestUnit: string;
+  delta: number | null;
+  ariaLabel: string;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState<boolean>(() => readTrendOpen(storageKey));
+  const contentId = `trend-card-content-${storageKey}`;
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.setItem(
+            TREND_STORAGE_PREFIX + storageKey,
+            next ? "1" : "0",
+          );
+        } catch {
+          /* ignore quota / disabled storage */
+        }
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  const deltaClass =
+    delta == null || delta === 0
+      ? "text-muted"
+      : delta > 0
+        ? "text-warning"
+        : "text-success";
+  const deltaLabel =
+    delta == null
+      ? ""
+      : `${delta > 0 ? "+" : ""}${delta.toFixed(1)} ${latestUnit}`;
+
+  return (
+    <Card as="section" radius="lg" padding="none" aria-label={ariaLabel}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-controls={contentId}
+        className={cn(
+          "w-full flex items-center gap-3 px-4 py-3 text-left",
+          "rounded-2xl transition-colors",
+          "hover:bg-panelHi/40",
+        )}
+      >
+        <div className="flex-1 min-w-0">
+          <SectionHeading as="h2" size="sm" className="!mb-0">
+            {title}
+          </SectionHeading>
+        </div>
+        {latestValue != null && (
+          <div className="flex items-baseline gap-2 shrink-0">
+            <span className="text-sm font-semibold tabular-nums text-text">
+              {latestValue} {latestUnit}
+            </span>
+            {delta != null && delta !== 0 && (
+              <span className={cn("text-xs font-semibold", deltaClass)}>
+                {deltaLabel}
+              </span>
+            )}
+          </div>
+        )}
+        <span
+          aria-hidden
+          className={cn(
+            "inline-block w-4 text-muted transition-transform shrink-0",
+            open ? "rotate-180" : "rotate-0",
+          )}
+        >
+          ▾
+        </span>
+      </button>
+      {open && (
+        <div id={contentId} className="px-4 pb-4 pt-1">
+          {children}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function lastValidValue<T extends { value: number | null }>(
+  data: readonly T[],
+): number | null {
+  for (let i = data.length - 1; i >= 0; i--) {
+    const v = data[i].value;
+    if (v != null && Number.isFinite(Number(v))) return Number(v);
+  }
+  return null;
+}
+
+function firstValidValue<T extends { value: number | null }>(
+  data: readonly T[],
+): number | null {
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i].value;
+    if (v != null && Number.isFinite(Number(v))) return Number(v);
+  }
+  return null;
+}
 
 const ENERGY_LABELS = [
   "",
@@ -335,61 +477,71 @@ export function Body({ onOpenMeasurements }) {
           </form>
         </Card>
 
-        {weightData.length >= 2 && (
-          <Card as="section" radius="lg" aria-label="Динаміка ваги">
-            <SectionHeading as="h2" size="sm" className="mb-3">
-              Динаміка ваги
-            </SectionHeading>
-            <MiniLineChart
-              data={weightData}
-              unit="кг"
-              color="rgb(22 163 74)"
-              metricLabel="вагу"
-            />
-          </Card>
-        )}
-
-        {sleepData.length >= 2 && (
-          <Card as="section" radius="lg" aria-label="Динаміка сну">
-            <SectionHeading as="h2" size="sm" className="mb-3">
-              Сон
-            </SectionHeading>
-            <MiniLineChart
-              data={sleepData}
-              unit="год"
-              color="rgb(99 102 241)"
-              metricLabel="сон"
-            />
-          </Card>
-        )}
-
-        {energyData.length >= 2 && (
-          <Card as="section" radius="lg" aria-label="Динаміка енергії">
-            <SectionHeading as="h2" size="sm" className="mb-3">
-              Рівень енергії
-            </SectionHeading>
-            <MiniLineChart
-              data={energyData}
-              unit="/5"
-              color="rgb(245 158 11)"
-              metricLabel="рівень енергії"
-            />
-          </Card>
-        )}
-
-        {moodData.length >= 2 && (
-          <Card as="section" radius="lg" aria-label="Динаміка настрою">
-            <SectionHeading as="h2" size="sm" className="mb-3">
-              Настрій
-            </SectionHeading>
-            <MiniLineChart
-              data={moodData}
-              unit="/5"
-              color="rgb(236 72 153)"
-              metricLabel="настрій"
-            />
-          </Card>
-        )}
+        {(
+          [
+            {
+              storageKey: "weight",
+              title: "Динаміка ваги",
+              ariaLabel: "Динаміка ваги",
+              data: weightData,
+              unit: "кг",
+              color: "rgb(22 163 74)",
+              metricLabel: "вагу",
+            },
+            {
+              storageKey: "sleep",
+              title: "Сон",
+              ariaLabel: "Динаміка сну",
+              data: sleepData,
+              unit: "год",
+              color: "rgb(99 102 241)",
+              metricLabel: "сон",
+            },
+            {
+              storageKey: "energy",
+              title: "Рівень енергії",
+              ariaLabel: "Динаміка енергії",
+              data: energyData,
+              unit: "/5",
+              color: "rgb(245 158 11)",
+              metricLabel: "рівень енергії",
+            },
+            {
+              storageKey: "mood",
+              title: "Настрій",
+              ariaLabel: "Динаміка настрою",
+              data: moodData,
+              unit: "/5",
+              color: "rgb(236 72 153)",
+              metricLabel: "настрій",
+            },
+          ] as const
+        )
+          .filter((card) => card.data.length >= 2)
+          .map((card) => {
+            const latest = lastValidValue(card.data);
+            const first = firstValidValue(card.data);
+            const delta =
+              latest != null && first != null ? latest - first : null;
+            return (
+              <CollapsibleTrendCard
+                key={card.storageKey}
+                storageKey={card.storageKey}
+                title={card.title}
+                ariaLabel={card.ariaLabel}
+                latestValue={latest}
+                latestUnit={card.unit}
+                delta={delta}
+              >
+                <MiniLineChart
+                  data={card.data}
+                  unit={card.unit}
+                  color={card.color}
+                  metricLabel={card.metricLabel}
+                />
+              </CollapsibleTrendCard>
+            );
+          })}
 
         <PhotoProgress />
 


### PR DESCRIPTION
## Summary

Feedback from the screenshot: Fizruk → Тіло has four trend charts stacked — Вага / Сон / Рівень енергії / Настрій — each ~180px tall. On an iPhone viewport that pushed the "Записати сьогодні" input form and summary tiles far below the fold; user asked `зроби ці графіки згорнутими`.

**Behavior change:**
- Each of the four chart cards is now **collapsible**, **collapsed by default**.
- Header row shows `Title · latest value + signed delta · chevron`, so the most actionable number stays visible without expanding (e.g. `Сон · 8 год +1.0 год`).
- Tapping/clicking the header toggles the chart. The chevron rotates `0° → 180°`.
- Per-card open state persists:
  - **web**: `localStorage` under `fizruk:body:trend-open:<key>`
  - **mobile**: `AsyncStorage` under the same key scheme
- No impact on measurement storage, entry form, photo progress, or the summary tiles.

**Files:**
- `apps/web/src/modules/fizruk/pages/Body.tsx` — new local `CollapsibleTrendCard` helper + `readTrendOpen` / `lastValidValue` / `firstValidValue`. The 4 static `<Card><MiniLineChart/></Card>` blocks were collapsed into a single `.filter().map()` over a typed array.
- `apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx` — converted from a plain card into a `Pressable`-headed collapsible. Chart only mounts when `open`. `AsyncStorage` persistence with an unmount cancel flag. Root `testID` (`fizruk-body-trend-<field>`) unchanged so existing `Body.test.tsx` keeps passing.
- `apps/mobile/jest.setup.js` — registered the upstream `@react-native-async-storage/async-storage/jest/async-storage-mock` so any component touching AsyncStorage runs clean in jest-expo.

## Review & Testing Checklist for Human
- [ ] **web**: Go to Фізрук → Тіло. The four chart cards should be collapsed on first load, each showing only the title, last value, signed Δ delta, and a down chevron. Tap a header → card expands and the chart renders; tap again → collapses. Refresh the page — per-card open state is remembered.
- [ ] **mobile**: Same page on the native build. Chevron rotates, `accessibilityState.expanded` is set so VoiceOver announces "expanded/collapsed". Quit & relaunch — open state survives per field.
- [ ] **delta color sanity**: negative delta renders green (progress for metrics like weight going down — matches existing MiniLineChart convention), positive renders amber, zero is hidden from the teaser.
- [ ] **a11y**: `aria-expanded` / `aria-controls` wiring on web; `accessibilityLabel` on mobile reads `Згорнути: …` / `Розгорнути: …` depending on state.

### Notes
- Internals of `<MiniLineChart>` (web) and `<TrendChart>` (mobile) are unchanged — this PR only touches the card chrome that wraps them.
- Same user session as #589 / #592; separate branch per the earlier agreement.


Link to Devin session: https://app.devin.ai/sessions/ccdc0083117b4e018c3b7b0685eade65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trend cards now support collapsible/expandable behavior with a compact teaser view when collapsed, displaying the latest value and change
  * Card expanded/collapsed state is persisted across sessions

* **Tests**
  * Added mock configuration for async storage in the test environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->