### PR TITLE
feat(fizruk/settings): drop workout backup import buttons

### DIFF
--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx
@@ -1,43 +1,24 @@
-import { useRef, useState } from "react";
 import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
-import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
-import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
-import {
-  applyFizrukBackupPayload,
-  buildFizrukBackupPayload,
-} from "../../lib/fizrukStorage";
+import { buildFizrukBackupPayload } from "../../lib/fizrukStorage";
 
+/**
+ * Export-only variant of the Fizruk backup bar. The import flows
+ * ("Імпорт (додати)" / "Імпорт (замінити)") were removed on user
+ * request — keeping a one-way export button lets the user take a
+ * snapshot of their workouts/exercises/journal without exposing a
+ * destructive replace action from the Settings screen. The underlying
+ * `applyFizrukBackupPayload` helper stays in `fizrukStorage.ts` in
+ * case we want to restore the import surface later.
+ */
 export function WorkoutBackupBar({ className }) {
-  const fileRef = useRef(null);
-  const fileReplaceRef = useRef(null);
-  const toast = useToast();
-  const [confirmReplace, setConfirmReplace] = useState(false);
-
   const exportJson = async () => {
     const payload = buildFizrukBackupPayload();
     await downloadJson(
       `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`,
       payload,
     );
-  };
-
-  const runImport = (e, replace) => {
-    const f = e.target.files?.[0];
-    if (!f) return;
-    const r = new FileReader();
-    r.onload = () => {
-      try {
-        const data = JSON.parse(String(r.result));
-        applyFizrukBackupPayload(data, { replace });
-        window.location.reload();
-      } catch (err) {
-        toast.error((err as Error)?.message || "Не вдалось імпортувати файл");
-      }
-      e.target.value = "";
-    };
-    r.readAsText(f);
   };
 
   return (
@@ -48,7 +29,7 @@ export function WorkoutBackupBar({ className }) {
       )}
     >
       <p className="font-semibold text-text leading-snug">
-        Резервна копія та імпорт даних Фізрука (тренування, вправи, журнал).
+        Резервна копія даних Фізрука (тренування, вправи, журнал).
       </p>
       <div className="flex flex-wrap items-center gap-2">
         <Button
@@ -60,52 +41,7 @@ export function WorkoutBackupBar({ className }) {
         >
           Експорт JSON
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-9 min-h-[44px]"
-          type="button"
-          onClick={() => fileRef.current?.click()}
-        >
-          Імпорт (додати)
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-9 min-h-[44px] text-warning"
-          type="button"
-          onClick={() => setConfirmReplace(true)}
-        >
-          Імпорт (замінити)
-        </Button>
       </div>
-      <input
-        ref={fileRef}
-        type="file"
-        accept="application/json,.json"
-        className="hidden"
-        onChange={(e) => runImport(e, false)}
-      />
-      <input
-        ref={fileReplaceRef}
-        type="file"
-        accept="application/json,.json"
-        className="hidden"
-        onChange={(e) => runImport(e, true)}
-      />
-      <ConfirmDialog
-        open={confirmReplace}
-        title="Замінити всі дані Фізрука?"
-        description="Поточні тренування та власні вправи буде замінено даними з файлу. Цю дію неможливо відмінити."
-        confirmLabel="Замінити"
-        cancelLabel="Скасувати"
-        danger
-        onConfirm={() => {
-          setConfirmReplace(false);
-          fileReplaceRef.current?.click();
-        }}
-        onCancel={() => setConfirmReplace(false)}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

User asked `Прибери оце імпорт з модуля фізрука` pointing at the **«Дані й резервні копії»** card in Fizruk settings. Removed both import flows (`Імпорт (додати)` + the destructive `Імпорт (замінити)`); only `Експорт JSON` remains.

- `apps/web/src/modules/fizruk/components/workouts/WorkoutBackupBar.tsx` slimmed down to a single Export button. Dropped the two hidden `<input type="file">`s, the `ConfirmDialog`, `useToast`, `useRef`, `useState`, and the `runImport` handler.
- Copy updated: `Резервна копія та імпорт даних…` → `Резервна копія даних…` so the label matches the new surface.
- `applyFizrukBackupPayload` helper in `fizrukStorage.ts` is deliberately **left in place** — it's dead on the UI side now but cheap to keep, and it means we can restore the import surface later without re-implementing the parser.
- No mobile counterpart exists yet (the mobile Fizruk Settings screen comments note this is a planned port), so no RN changes are needed.

## Review & Testing Checklist for Human
- [ ] Web · Налаштування → Фізрук · «Дані й резервні копії»: card now shows only `Експорт JSON`, no Import buttons, no confirm dialog.
- [ ] Web · `/fizruk` Settings modal (FizrukApp) same — one Export button.
- [ ] `Експорт JSON` still downloads `fizruk-backup-YYYY-MM-DD.json` with workouts / exercises / journal payload (unchanged code path).

### Notes
- Same user session as #589 / #592 / #593, separate branch as requested.
- If import is needed again later, wiring it back only requires reverting the JSX in this file — the underlying `applyFizrukBackupPayload` storage helper is untouched.


Link to Devin session: https://app.devin.ai/sessions/ccdc0083117b4e018c3b7b0685eade65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
