### PR TITLE
feat(fizruk): drop module-level settings drawer

### DIFF
--- a/apps/web/src/modules/fizruk/FizrukApp.tsx
+++ b/apps/web/src/modules/fizruk/FizrukApp.tsx
@@ -1,13 +1,7 @@
-import { useState } from "react";
-import {
-  ModuleShell,
-  ModuleSettingsDrawer,
-  StorageErrorBanner,
-} from "@shared/components/layout";
+import { ModuleShell, StorageErrorBanner } from "@shared/components/layout";
 import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import { useHashRoute } from "@shared/hooks/useHashRoute";
 import { usePwaAction } from "@shared/hooks/usePwaAction";
-import { WorkoutBackupBar } from "./components/workouts/WorkoutBackupBar";
 import { useExerciseCatalog } from "./hooks/useExerciseCatalog";
 import { useFizrukProgramStart } from "./hooks/useFizrukProgramStart";
 import { useFizrukWorkoutReminder } from "./hooks/useFizrukWorkoutReminder";
@@ -39,7 +33,6 @@ export default function FizrukApp({
   });
   const exerciseId =
     page === "exercise" && segments[0] ? segments[0] : undefined;
-  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const monthlyPlan = useMonthlyPlan();
   const {
@@ -82,17 +75,7 @@ export default function FizrukApp({
           activeProgram={activeProgram}
           onBackToHub={onBackToHub}
           onBackToDashboard={() => navigate("dashboard")}
-          onOpenSettings={() => setSettingsOpen(true)}
         />
-      }
-      overlays={
-        <ModuleSettingsDrawer
-          open={settingsOpen}
-          onClose={() => setSettingsOpen(false)}
-          title="Дані й резервні копії"
-        >
-          <WorkoutBackupBar className="border-0 bg-transparent p-0" />
-        </ModuleSettingsDrawer>
       }
       banner={
         <StorageErrorBanner

--- a/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
@@ -2,7 +2,6 @@ import {
   ModuleHeader,
   ModuleHeaderBackButton,
   ModuleHeaderChevronButton,
-  ModuleHeaderIconButton,
 } from "@shared/components/layout";
 import { cn } from "@shared/lib/cn";
 import type { FizrukPage } from "./fizrukRoute";
@@ -16,7 +15,6 @@ export interface FizrukHeaderProps {
   activeProgram?: ActiveProgramHeaderView | null;
   onBackToHub?: () => void;
   onBackToDashboard: () => void;
-  onOpenSettings: () => void;
 }
 
 function titleFor(page: FizrukPage): string {
@@ -83,36 +81,20 @@ function DumbbellBadge() {
   );
 }
 
-function SettingsIcon() {
-  return (
-    <svg
-      width="22"
-      height="22"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.65"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
-  );
-}
-
 export function FizrukHeader({
   page,
   activeProgram,
   onBackToHub,
   onBackToDashboard,
-  onOpenSettings,
 }: FizrukHeaderProps) {
   const isAtlas = page === "atlas";
   const isExercise = page === "exercise";
   const showChevronBack = isAtlas || isExercise;
 
+  // Module-level settings drawer was dropped per user request — all
+  // Fizruk settings (backup, reminders, data reset) now live in the
+  // Hub-wide Settings screen. The header no longer owns a gear icon,
+  // so the right slot is left empty.
   let left = null;
   if (showChevronBack) {
     left = <ModuleHeaderChevronButton onClick={onBackToDashboard} />;
@@ -122,19 +104,9 @@ export function FizrukHeader({
     left = <DumbbellBadge />;
   }
 
-  const right = (
-    <ModuleHeaderIconButton
-      onClick={onOpenSettings}
-      ariaLabel="Налаштування даних"
-    >
-      <SettingsIcon />
-    </ModuleHeaderIconButton>
-  );
-
   return (
     <ModuleHeader
       left={left}
-      right={right}
       title={titleFor(page)}
       eyebrow={showChevronBack ? undefined : "ОСОБИСТИЙ ЖУРНАЛ"}
       subtitle={showChevronBack ? undefined : subtitleFor(page, activeProgram)}


### PR DESCRIPTION
## Summary

Follow-up to #594. User asked `та взагалі прибери налаштування в модулі. Вони ж у нас винесені в налаштування у хабі` — so the in-module gear icon + `Дані й резервні копії` drawer inside Fizruk are gone. The Hub-wide Settings screen (`apps/web/src/core/settings/FizrukSection.tsx`) already hosts the backup bar + rest-timer + other Fizruk preferences, so the duplicate was pure noise.

**Changes:**
- `apps/web/src/modules/fizruk/shell/FizrukHeader.tsx` — removed the `ModuleHeaderIconButton`, inline `SettingsIcon` SVG, the `onOpenSettings` prop, and the `ModuleHeaderIconButton` import. Right header slot is now empty (the eyebrow + title + subtitle center still render correctly).
- `apps/web/src/modules/fizruk/FizrukApp.tsx` — dropped the `settingsOpen` `useState`, the `ModuleSettingsDrawer` overlay, and the unused `WorkoutBackupBar` import. `ModuleSettingsDrawer` was the only consumer here.
- `WorkoutBackupBar` (the file itself) is **untouched** — it still renders from `FizrukSection` inside Hub Settings, which is where the user expects to find these controls.

## Review & Testing Checklist for Human
- [ ] Open Fizruk on web (any page: Today / Workouts / Plan / Programs / Body / Atlas / Exercise). The top-right gear icon is gone; no settings drawer opens from the module.
- [ ] Go to Хаб → Налаштування → розділ Фізрук. Backup (Експорт JSON — import removed in #594) and other Fizruk options are still there.
- [ ] No console warnings about missing `onOpenSettings` prop or dangling overlay in `ModuleShell`.

### Notes
- Part of the same user session as #589 / #592 / #593 / #594; separate branch per earlier agreement.
- Mobile Fizruk module has no equivalent in-module settings drawer today, so no RN changes are needed.


Link to Devin session: https://app.devin.ai/sessions/ccdc0083117b4e018c3b7b0685eade65
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the settings drawer from the module interface.
  * Settings gear icon removed from the header.
  * Settings are now accessed through the hub-wide Settings screen instead of the module header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->