### PR TITLE
fix(fizruk): hide active-workout banner when pointer is stale

### DIFF
--- a/apps/web/src/shared/hooks/useActiveFizrukWorkout.test.ts
+++ b/apps/web/src/shared/hooks/useActiveFizrukWorkout.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useActiveFizrukWorkout } from "./useActiveFizrukWorkout";
+
+const ACTIVE_KEY = "fizruk_active_workout_id_v1";
+const WORKOUTS_KEY = "fizruk_workouts_v1";
+
+function seedWorkouts(
+  workouts: Array<{ id: string; endedAt: string | null }>,
+  { legacyArray = false }: { legacyArray?: boolean } = {},
+) {
+  const payload = legacyArray ? workouts : { schemaVersion: 1, workouts };
+  localStorage.setItem(WORKOUTS_KEY, JSON.stringify(payload));
+}
+
+describe("useActiveFizrukWorkout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null when no active id is persisted", () => {
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the active id when the referenced workout exists and is in progress", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    seedWorkouts([{ id: "w-1", endedAt: null }]);
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBe("w-1");
+  });
+
+  it("treats the pointer as stale when the referenced workout is missing and clears the key", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-gone");
+    seedWorkouts([{ id: "w-other", endedAt: null }]);
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBeNull();
+    expect(localStorage.getItem(ACTIVE_KEY)).toBeNull();
+  });
+
+  it("treats the pointer as stale when the referenced workout is already ended and clears the key", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    seedWorkouts([{ id: "w-1", endedAt: "2026-04-20T10:00:00Z" }]);
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBeNull();
+    expect(localStorage.getItem(ACTIVE_KEY)).toBeNull();
+  });
+
+  it("clears the pointer when there are no workouts persisted at all", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBeNull();
+    expect(localStorage.getItem(ACTIVE_KEY)).toBeNull();
+  });
+
+  it("accepts the legacy plain-array workouts shape", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    seedWorkouts([{ id: "w-1", endedAt: null }], { legacyArray: true });
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBe("w-1");
+  });
+
+  it("keeps the pointer when the workouts JSON is corrupt (fail-open)", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    localStorage.setItem(WORKOUTS_KEY, "{not valid json");
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBe("w-1");
+    // Key is preserved because we cannot prove it's stale.
+    expect(localStorage.getItem(ACTIVE_KEY)).toBe("w-1");
+  });
+
+  it("picks up a same-tab write via the polling fallback", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBeNull();
+
+    act(() => {
+      localStorage.setItem(ACTIVE_KEY, "w-late");
+      seedWorkouts([{ id: "w-late", endedAt: null }]);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(result.current).toBe("w-late");
+  });
+
+  it("reacts to another tab ending the workout (storage event re-validates)", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    seedWorkouts([{ id: "w-1", endedAt: null }]);
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBe("w-1");
+
+    act(() => {
+      // Simulate the other tab flipping endedAt on the workouts list.
+      seedWorkouts([{ id: "w-1", endedAt: "2026-04-20T12:00:00Z" }]);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: WORKOUTS_KEY,
+          newValue: localStorage.getItem(WORKOUTS_KEY),
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBeNull();
+    expect(localStorage.getItem(ACTIVE_KEY)).toBeNull();
+  });
+
+  it("reacts to a logout that clears storage entirely", () => {
+    localStorage.setItem(ACTIVE_KEY, "w-1");
+    seedWorkouts([{ id: "w-1", endedAt: null }]);
+    const { result } = renderHook(() => useActiveFizrukWorkout());
+    expect(result.current).toBe("w-1");
+
+    act(() => {
+      localStorage.clear();
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: null,
+          storageArea: localStorage,
+        }),
+      );
+    });
+    expect(result.current).toBeNull();
+  });
+});

--- a/apps/web/src/shared/hooks/useActiveFizrukWorkout.ts
+++ b/apps/web/src/shared/hooks/useActiveFizrukWorkout.ts
@@ -8,6 +8,20 @@ import { useEffect, useState } from "react";
  * CTAs) need to see that signal so they can offer a "Повернутися до
  * тренування" shortcut without pulling in the whole `useWorkouts` API.
  *
+ * The active-id key is the single source of truth for "is there a session
+ * to resume?", but it can end up stale in several real-world paths:
+ *   - cloud-sync pulls in the completed session from another device but
+ *     this device's active-id key was never cleared,
+ *   - the workouts list gets wiped (FIZRUK_RESET_KEYS, manual reset, demo
+ *     data cleanup) while the active-id key was missed,
+ *   - a workout was ended through a non-UI path (hub chat `finish_workout`
+ *     failing mid-write, cross-tab race) without clearing the active-id,
+ *   - the referenced workout was deleted.
+ * In all of those the banner would keep blinking "Тренування триває" even
+ * though there is nothing to return to — this hook therefore validates the
+ * pointer against `fizruk_workouts_v1` and treats it as `null` (and clears
+ * the stale key) if the workout is missing or already has `endedAt`.
+ *
  * Listens to `storage` events so that when the user ends a workout in
  * another tab the banner disappears immediately, not on next navigation.
  *
@@ -16,30 +30,100 @@ import { useEffect, useState } from "react";
  * setActiveWorkoutId dispatches via the effect that writes the key).
  */
 const ACTIVE_WORKOUT_KEY = "fizruk_active_workout_id_v1";
+const WORKOUTS_KEY = "fizruk_workouts_v1";
 
-function readId(): string | null {
+/**
+ * Accepts both the current `{ schemaVersion, workouts }` envelope and the
+ * legacy plain-array shape — mirrors `parseWorkoutsFromStorage` in the
+ * fizruk-domain package. Inlined here so the hook stays in `shared/` and
+ * doesn't pull in the fizruk package.
+ */
+function readActiveId(): string | null {
+  let id: string | null;
   try {
-    return localStorage.getItem(ACTIVE_WORKOUT_KEY) || null;
+    id = localStorage.getItem(ACTIVE_WORKOUT_KEY) || null;
   } catch {
     return null;
+  }
+  if (!id) return null;
+
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(WORKOUTS_KEY);
+  } catch {
+    // If we can't read the workouts list we have no way to validate —
+    // fall back to the optimistic behaviour (show the banner) rather than
+    // hiding a legitimately active session.
+    return id;
+  }
+  if (!raw) {
+    // No workouts persisted at all → the active-id is definitely stale.
+    // Clear it so subsequent reads from any tab see the correct state.
+    clearStaleActiveId();
+    return null;
+  }
+
+  let list: unknown;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) list = parsed;
+    else if (
+      parsed &&
+      Array.isArray((parsed as { workouts?: unknown }).workouts)
+    )
+      list = (parsed as { workouts: unknown[] }).workouts;
+    else list = [];
+  } catch {
+    // Corrupt JSON — same reasoning as the read failure above: don't
+    // hide a potentially active session on parse error.
+    return id;
+  }
+
+  if (!Array.isArray(list)) return id;
+  const match = (list as Array<{ id?: unknown; endedAt?: unknown }>).find(
+    (w) => w && w.id === id,
+  );
+  if (!match) {
+    clearStaleActiveId();
+    return null;
+  }
+  if (match.endedAt) {
+    clearStaleActiveId();
+    return null;
+  }
+  return id;
+}
+
+function clearStaleActiveId(): void {
+  try {
+    localStorage.removeItem(ACTIVE_WORKOUT_KEY);
+  } catch {
+    /* best-effort cleanup */
   }
 }
 
 export function useActiveFizrukWorkout(): string | null {
-  const [id, setId] = useState<string | null>(() => readId());
+  const [id, setId] = useState<string | null>(() => readActiveId());
 
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
       // e.key === null means storage was cleared entirely (logout, sync).
-      if (e.key === ACTIVE_WORKOUT_KEY || e.key === null) {
-        setId(readId());
+      // Also re-validate when the workouts list changes — a finish flow
+      // elsewhere may have flipped `endedAt` without touching the pointer.
+      if (
+        e.key === ACTIVE_WORKOUT_KEY ||
+        e.key === WORKOUTS_KEY ||
+        e.key === null
+      ) {
+        setId(readActiveId());
       }
     };
     // Poll every 1.5s as a fallback — storage events don't fire in the
     // same tab, and Fizruk writes via localStorage.setItem in an effect.
-    // The cost (1 localStorage.getItem per 1.5s) is negligible.
+    // The cost (1-2 localStorage.getItem + JSON.parse per 1.5s) is
+    // negligible compared to keeping a zombie "Тренування триває" pill.
     const poll = setInterval(() => {
-      const next = readId();
+      const next = readActiveId();
       setId((prev) => (prev === next ? prev : next));
     }, 1500);
     window.addEventListener("storage", onStorage);


### PR DESCRIPTION
## Summary

У хабі інколи світиться pill «Тренування триває», хоча активного тренування немає (скриншот у повідомленні користувача).

Причина: `useActiveFizrukWorkout` (що живить `ActiveWorkoutBanner`) читав тільки ключ `fizruk_active_workout_id_v1` у localStorage — без перевірки, чи це тренування взагалі існує та чи не завершене. Через це банер «застрявав» у кількох реальних сценаріях:

- cloud-sync підтягнув завершену сесію з іншого пристрою, але локальний `fizruk_active_workout_id_v1` ніхто не очистив,
- список тренувань очистили (FIZRUK_RESET_KEYS, ручний reset, демо-клінап) і pointer залишився ні на що,
- workout завершився через не-UI-шлях (hub chat `finish_workout`, що зафейлився мід-write, cross-tab race) без очищення pointer,
- тренування, на яке вказує pointer, видалили.

Фікс: в `useActiveFizrukWorkout` тепер перевіряємо pointer проти `fizruk_workouts_v1` (приймаємо обидва формати — `{ schemaVersion, workouts }` та legacy plain-array). Якщо тренування не знайдене або в нього вже є `endedAt` — повертаємо `null` і чистимо застарілий ключ. Додатково реагуємо на cross-tab `storage`-події для ключа workouts, щоб при завершенні сесії в іншій вкладці pill зникав миттєво, а не на наступному polling-тіку.

Побічних змін у Фізруку немає — його власний стан `activeWorkoutId` у `apps/web/src/modules/fizruk/pages/Workouts.tsx` працює як і раніше. Мобільний app не зачеплений.

## Review & Testing Checklist for Human

- [ ] Відкрити хаб, впевнитись що банер `Тренування триває` НЕ показується, коли немає активної сесії (можна додатково в DevTools: `localStorage.setItem('fizruk_active_workout_id_v1', 'w-bogus')` — банер має ЗНИКНУТИ після ~1.5с поллінгу, а ключ — видалитись).
- [ ] Запустити реальне тренування у Фізруку, повернутись у хаб — банер має зʼявитись. Завершити тренування — банер має зникнути.
- [ ] Edge-кейс з двома вкладками: у tab A активна сесія → в tab B завершити її (або виставити `endedAt`) → у tab A pill має зникнути через `storage`-подію.

### Notes

- Валідаційний парсер `fizruk_workouts_v1` інлайнений у хуку, щоб пакет `apps/web/src/shared/hooks` не тягнув `@sergeant/fizruk-domain` — це зберігає поточне шарування. Формат віддзеркалює `parseWorkoutsFromStorage` з fizruk-domain.
- Fail-open на corrupt JSON / read-errors — краще показати pill на зайву секунду, ніж приховати справжню активну сесію.

Link to Devin session: https://app.devin.ai/sessions/17a7683df87743398402ebcd6f8cba28
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test suite for active workout tracking, including cross-tab scenarios and edge cases

* **Bug Fixes**
  * Enhanced validation of active workout references against saved workout data
  * Improved synchronization of workout state across browser tabs
  * Strengthened cleanup behavior during logout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->