### PR TITLE
fix(ui): підняти нижні sheet'и над таббаром модуля

### DIFF
--- a/apps/web/src/shared/components/layout/ModuleShell.tsx
+++ b/apps/web/src/shared/components/layout/ModuleShell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -40,8 +40,17 @@ export function ModuleShell({
   className,
   mainClassName,
 }: ModuleShellProps) {
+  // Expose the bottom-nav height as a CSS variable so descendants
+  // (e.g. bottom sheets rendered inside this shell) can lift themselves
+  // above it without having to know whether the current page renders a
+  // nav. Defaults to 0px when no nav is slotted.
+  const shellStyle: CSSProperties = {
+    "--bottom-nav-height": nav ? "60px" : "0px",
+  } as CSSProperties;
+
   return (
     <div
+      style={shellStyle}
       className={cn(
         "h-dvh flex flex-col bg-bg text-text overflow-hidden",
         className,

--- a/apps/web/src/shared/components/ui/Sheet.tsx
+++ b/apps/web/src/shared/components/ui/Sheet.tsx
@@ -24,7 +24,9 @@ import { useDialogFocusTrap } from "../../hooks/useDialogFocusTrap";
  *   - 44×44 close button (WCAG tap target) with <Button variant="ghost" iconOnly>
  *   - focus trap + Escape via useDialogFocusTrap
  *   - overlay-click dismiss
- *   - animated slide-up with safe-area padding (safe-area-pb)
+ *   - animated slide-up with safe-area + bottom-nav margin so the
+ *     panel always clears the module bottom tab bar (see ModuleShell's
+ *     `--bottom-nav-height` CSS variable) and the iOS home indicator
  *   - keyboard-inset-aware margin if kbInsetPx is supplied
  *
  * Callers are still responsible for their own form state, validation,
@@ -90,8 +92,18 @@ export function Sheet({
 
   if (!open) return null;
 
-  const panelStyle: CSSProperties | undefined =
-    kbInsetPx && kbInsetPx > 0 ? { marginBottom: kbInsetPx } : undefined;
+  // Lift the panel above the module bottom nav (set via the
+  // `--bottom-nav-height` CSS variable on ModuleShell) plus the iOS
+  // home-indicator inset. `kbInsetPx` overrides the offset entirely
+  // when the soft keyboard is visible — we want the sheet to hug the
+  // keyboard, not float above where the nav would be.
+  const panelStyle: CSSProperties =
+    kbInsetPx && kbInsetPx > 0
+      ? { marginBottom: kbInsetPx }
+      : {
+          marginBottom:
+            "calc(var(--bottom-nav-height, 0px) + env(safe-area-inset-bottom, 0px))",
+        };
 
   return (
     <div
@@ -114,7 +126,7 @@ export function Sheet({
         onPointerDown={(e) => e.stopPropagation()}
         className={cn(
           "relative w-full max-w-lg bg-panel border-t border-line rounded-t-3xl shadow-soft",
-          "flex flex-col max-h-[90vh] safe-area-pb",
+          "flex flex-col max-h-[90vh]",
           "animate-slide-up",
           panelClassName,
         )}


### PR DESCRIPTION
## Summary

Картка вправи (`ExerciseDetailSheet` у Фізруку) була притиснута до низу viewport, тож кнопка «+ Додати в активне тренування» опинялася під `ModuleBottomNav` і обрізалась таббаром — саме цю проблему показав `Лупа` на скріні.

Фікс:
- `ModuleShell` тепер віддає CSS-змінну `--bottom-nav-height` (60px коли слот `nav` заповнений, 0px коли ні).
- `Sheet` застосовує `margin-bottom: calc(var(--bottom-nav-height, 0px) + env(safe-area-inset-bottom, 0px))` на панель, тому sheet завжди стоїть над таббаром і над home-indicator одночасно.
- Коли активна m-клавіатура (`kbInsetPx`), її оффсет перекриває цю логіку — поведінка з клавіатурою не змінилась.
- Фікс автоматично покриває всі sheet'и на сторінках з bottom nav (Фінік, Фізрук, Рутина, Харчування) без змін у кожному з них окремо; sheet'и в онбордингу/сетапі, де nav не рендериться, залишаються як і були.

Перевірено локально (Chrome responsive 400×906, `#/fizruk/workouts` → активне тренування → відкриття картки вправи): зараз повністю видно «+ Додати в активне тренування», «Закрити», «Копіювати назву», а таббар видно під панеллю.

До:
![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMDViYWQzYmNmY2FiNDdmN2I2MjEzNDNmM2RhZTY4ZGUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMDViYWQzYmNmY2FiNDdmN2I2MjEzNDNmM2RhZTY4ZGUvMmE0ZjNkNTEtY2ZjZC00Y2ZmLTgzNGEtN2Q5ZjY1YjcxNmZjIiwiaWF0IjoxNzc2OTc1NzYxLCJleHAiOjE3Nzc1ODA1NjEsImZpbGVuYW1lIjoic2NyZWVuc2hvdC5wbmcifQ.mMXvHNH8AO7waZltj7wvKijFN1V4BMu1r6wqYvaWBHo)

Після:
![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMDViYWQzYmNmY2FiNDdmN2I2MjEzNDNmM2RhZTY4ZGUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMDViYWQzYmNmY2FiNDdmN2I2MjEzNDNmM2RhZTY4ZGUvNjFhNTA5MzMtYjBjNS00MjI4LWIwOTgtZGJjNWRmN2RmNmE4IiwiaWF0IjoxNzc2OTc1NzYxLCJleHAiOjE3Nzc1ODA1NjEsImZpbGVuYW1lIjoic2NyZWVuc2hvdF9kZjk2MTg2ZmM4ZmM0NjUxYmY0ZWNhNjIzOTE4NjE2Mi5wbmcifQ.v3Gh5BsST2XiRNuP7UeFbAOkTvdgNUFevFiXNXrI-mA)

## Review & Testing Checklist for Human

- [ ] Перевірити на реальному iPhone (PWA/Safari) — відкрити Фізрук → активне тренування → тапнути ℹ️ поруч із вправою в каталозі: кнопка «+ Додати в активне тренування» має бути повністю видима над таббаром.
- [ ] Побіжно пройтись іншими sheet'ами (Фінік ManualExpenseSheet, Рутина HabitDetailSheet, Харчування AddMealSheet): панелі мають стояти на тих самих 60px вище низу, нічого не зламано.
- [ ] Перевірити sheet'и поза модулями (онбордингу `PresetSheet`, `FirstActionSheet`, `/design` showcase) — там `--bottom-nav-height` має лишитись 0px і візуально нічого не зміниться.
- [ ] Sheet з відкритою клавіатурою (наприклад, форма в `ManualExpenseSheet`): `kbInsetPx` має і далі перекривати оффсет і піднімати sheet до клавіатури.

### Notes

Причина, чому таббар "виграє" у iOS Safari, попри `z-100` на sheet і `z-30` на навбарі, ймовірно лежить у специфіці stacking context з `backdrop-filter` (`backdrop-blur-xl` на `ModuleBottomNav`). Цей фікс не намагається перекручувати z-index, а просто фізично розводить панель і таббар, що робить проблему нерелевантною на будь-якому браузері.

Lint / typecheck / `pnpm --filter @sergeant/web test -- --run` (71 test files, 643 tests) — зелені.

Link to Devin session: https://app.devin.ai/sessions/0778f9dbcf8242d09cfba9fc9a52072e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bottom sheet components now properly adjust spacing and positioning relative to the bottom navigation bar
  * Enhanced behavior when using soft keyboard input, with improved spacing calculations to prevent content overlap
  * Refined layout positioning system to maintain consistent alignment across different interaction states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->