### PR TITLE
fizruk(web): surface Progress page via bottom nav

### DIFF
--- a/apps/web/src/modules/fizruk/shell/fizrukNav.tsx
+++ b/apps/web/src/modules/fizruk/shell/fizrukNav.tsx
@@ -13,7 +13,10 @@ const NAV_SVG_PROPS = {
 };
 
 export interface FizrukNavItem extends ModuleBottomNavItem {
-  id: Extract<FizrukPage, "dashboard" | "workouts" | "plan" | "body">;
+  id: Extract<
+    FizrukPage,
+    "dashboard" | "workouts" | "plan" | "progress" | "body"
+  >;
 }
 
 export const FIZRUK_NAV: readonly FizrukNavItem[] = [
@@ -45,6 +48,16 @@ export const FIZRUK_NAV: readonly FizrukNavItem[] = [
         <line x1="16" y1="2" x2="16" y2="6" />
         <line x1="8" y1="2" x2="8" y2="6" />
         <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+    ),
+  },
+  {
+    id: "progress",
+    label: "Прогрес",
+    icon: (
+      <svg {...NAV_SVG_PROPS}>
+        <polyline points="3 17 9 11 13 15 21 7" />
+        <polyline points="15 7 21 7 21 13" />
       </svg>
     ),
   },


### PR DESCRIPTION
## Summary

Додає пункт **«Прогрес»** у нижній навбар ФІЗРУКА на вебі, щоб уже існуюча сторінка `Progress` (аналітика тренувань, тренди ваги/жиру, обʼєм по мʼязах, PR-борд, самопочуття, експорт JSON/CSV) стала доступною з UI.

До цієї зміни `progress` був зареєстрований у `FIZRUK_PAGES` і рендерився через `FizrukRouter`, але не було жодного лінка/тайла — ні в навбарі, ні на Dashboard. Тому відкрити сторінку можна було лише вручну через хеш `#/fizruk/progress`.

Порядок табів: `Сьогодні · Тренування · План · Прогрес · Тіло` (5 пунктів; `ModuleBottomNav` використовує `flex-1`, тому додатковий таб лягає без змін у спільному компоненті).

Іконка — лінійний тренд вгору зі стрілочкою, щоб візуально відрізнятись від іконки «Статистика» в інших модулях.

## Review & Testing Checklist for Human

- [ ] Відкрити ФІЗРУК у браузері — переконатись, що в нижньому навбарі зʼявився пункт «Прогрес» між «План» і «Тіло», і тап по ньому веде на сторінку з графіками.
- [ ] Перевірити, що активний стан таба (підсвітка + pill зверху) відпрацьовує на `progress` так само, як на інших табах.
- [ ] Переконатись, що на вузьких екранах (iPhone SE ~320px) 5 табів усе ще вміщаються без обрізання лейблів.

### Notes

- Мобільний ФІЗРУК не чіпав — там аналітика лежить на Dashboard `QuickLinksRow` (`fizrukDashboardQuickLinkCoverage`) і вже покрита.
- Сам контент `Progress.tsx` не змінювався.
- Коментар у `ModuleBottomNav.tsx` («4 tabs») залишив як є — це опис канонічного кейсу, не інваріант; флекс сам обробляє N табів. Якщо хочеш — окремим дрібним PR підрівняю.

Link to Devin session: https://app.devin.ai/sessions/cbd105dc56a846578b2d0bbe5b0731da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Progress" navigation option to the main menu, providing users with a dedicated section for accessing and reviewing fitness metrics and progress data. The new page is now integrated into the navigation structure for convenient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->