### PR TITLE
feat(fizruk): dashboard hero with 4 informative states

### DIFF
--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.test.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import { HeroCard, type HeroCardState } from "./HeroCard";
+
+/**
+ * Default callback prop bag reused across tests — each test only needs
+ * to override the one it's asserting on. Keeps each case focused.
+ */
+function makeCallbacks() {
+  return {
+    onResume: vi.fn(),
+    onStartToday: vi.fn(),
+    onOpenPlan: vi.fn(),
+    onOpenTemplates: vi.fn(),
+    onOpenPrograms: vi.fn(),
+  };
+}
+
+function renderHero(
+  state: HeroCardState,
+  overrides: Record<string, unknown> = {},
+) {
+  const cbs = makeCallbacks();
+  const utils = render(
+    <HeroCard
+      state={state}
+      greeting="Доброго дня"
+      today="середа, 23 квітня"
+      {...cbs}
+      {...overrides}
+    />,
+  );
+  return { ...utils, ...cbs };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("HeroCard · active state", () => {
+  beforeEach(() => {
+    // Freeze the clock so `diffSecFromNow` returns a deterministic elapsed
+    // value no matter when the test runs.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:15:30Z"));
+  });
+
+  it("renders the localized kicker, live elapsed timer and 'Продовжити' CTA", () => {
+    const { onResume } = renderHero({
+      kind: "active",
+      // 65 seconds before the frozen 'now' → expect "1:05".
+      startedAtIso: "2026-04-23T12:14:25Z",
+      itemsCount: 3,
+    });
+
+    expect(screen.getByText(/Доброго дня/i)).toBeInTheDocument();
+    expect(screen.getByText("1:05")).toBeInTheDocument();
+    expect(screen.getByText(/Тренування триває/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 вправ у сесії/i)).toBeInTheDocument();
+
+    const resumeBtn = screen.getByLabelText(
+      /Повернутись до активного тренування/i,
+    );
+    fireEvent.click(resumeBtn);
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("formats the elapsed timer as H:MM:SS past the hour mark", () => {
+    // 65 minutes + 7 seconds before the frozen 'now' → "1:05:07".
+    renderHero({
+      kind: "active",
+      startedAtIso: "2026-04-23T11:10:23Z",
+    });
+    expect(screen.getByText("1:05:07")).toBeInTheDocument();
+  });
+
+  it("shows a generic fallback when itemsCount is zero / missing", () => {
+    renderHero({
+      kind: "active",
+      startedAtIso: "2026-04-23T12:14:25Z",
+      itemsCount: 0,
+    });
+    expect(
+      screen.getByText(/Сесія відкрита — підходи й таймер чекають/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to 0:00 for an unparseable startedAt", () => {
+    renderHero({
+      kind: "active",
+      startedAtIso: "not-a-date",
+    });
+    expect(screen.getByText("0:00")).toBeInTheDocument();
+  });
+});
+
+describe("HeroCard · today state", () => {
+  it("renders the template name, meta and 'Почати' CTA", () => {
+    const { onStartToday } = renderHero({
+      kind: "today",
+      label: "Push A",
+      exerciseCount: 6,
+      estimatedMin: 45,
+      hint: "З місячного плану",
+    });
+
+    expect(screen.getByText(/Сьогоднішнє тренування/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Push A" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/6 вправ · ~45 хв · З місячного плану/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Почати тренування: Push A/i));
+    expect(onStartToday).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits estimate and hint parts when not provided", () => {
+    renderHero({
+      kind: "today",
+      label: "Legs",
+      exerciseCount: 5,
+    });
+    // Only "5 вправ" should appear in the meta line — no " · ".
+    const meta = screen.getByText(/^5 вправ$/i);
+    expect(meta).toBeInTheDocument();
+  });
+});
+
+describe("HeroCard · upcoming state", () => {
+  it("renders days-away + date and wires the 'Відкрити план' CTA", () => {
+    const { onOpenPlan } = renderHero({
+      kind: "upcoming",
+      label: "Push B",
+      daysFromNow: 2,
+      dateKey: "2026-04-25",
+      exerciseCount: 5,
+    });
+
+    expect(screen.getByText(/Наступне тренування/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Push B" })).toBeInTheDocument();
+    expect(screen.getByText(/За 2 дні/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Відкрити план/i }));
+    expect(onOpenPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("pluralises days-away correctly (Ukrainian)", () => {
+    renderHero({
+      kind: "upcoming",
+      label: "X",
+      daysFromNow: 5,
+      dateKey: "2026-05-01",
+      exerciseCount: null,
+    });
+    expect(screen.getByText(/За 5 днів/i)).toBeInTheDocument();
+    cleanup();
+
+    renderHero({
+      kind: "upcoming",
+      label: "Y",
+      daysFromNow: 1,
+      dateKey: "2026-04-24",
+      exerciseCount: null,
+    });
+    expect(screen.getByText(/Завтра/i)).toBeInTheDocument();
+    cleanup();
+
+    renderHero({
+      kind: "upcoming",
+      label: "Z",
+      daysFromNow: 21,
+      dateKey: "2026-05-14",
+      exerciseCount: null,
+    });
+    expect(screen.getByText(/За 21 день/i)).toBeInTheDocument();
+  });
+
+  it("hides exercise count when the catalogue doesn't know the template", () => {
+    renderHero({
+      kind: "upcoming",
+      label: "Mystery",
+      daysFromNow: 3,
+      dateKey: "2026-04-26",
+      exerciseCount: null,
+    });
+    expect(screen.queryByText(/вправ/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("HeroCard · empty state", () => {
+  it("renders 'Обрати шаблон' when the user already has templates", () => {
+    const { onOpenTemplates, onOpenPrograms } = renderHero({
+      kind: "empty",
+      hasTemplates: true,
+    });
+
+    expect(screen.getByText(/План порожній/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Обрати шаблон/i }));
+    expect(onOpenTemplates).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /До програм/i }));
+    expect(onOpenPrograms).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders 'Створити шаблон' when the user has no templates yet", () => {
+    renderHero({
+      kind: "empty",
+      hasTemplates: false,
+    });
+    expect(
+      screen.getByRole("button", { name: /Створити шаблон/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -1,0 +1,461 @@
+/**
+ * Fizruk Dashboard — Hero card (web).
+ *
+ * Mirrors the mobile `apps/mobile/.../HeroCard.tsx` composition, adapted
+ * to the web stack (Tailwind utilities, shared `Button` component, the
+ * existing `bg-hero-teal` dashboard hero surface). Four mutually
+ * exclusive states keep the hero informative instead of always
+ * reading the same marketing slogan:
+ *
+ *   1. `active`   — a workout is open; surface the live elapsed timer
+ *                   and a "Продовжити" CTA so the user can jump back
+ *                   into the session without hunting for it in the
+ *                   journal.
+ *   2. `today`    — the monthly plan / active program schedules a
+ *                   session for today; surface the template name,
+ *                   exercise count, est. duration, and a primary
+ *                   "Почати" CTA.
+ *   3. `upcoming` — the next scheduled session falls in the lookahead
+ *                   window but is not today; surface "За N днів",
+ *                   the date, and a softer "Відкрити план" CTA.
+ *   4. `empty`    — nothing scheduled; nudge the user toward a template
+ *                   or the programs catalogue.
+ *
+ * State selection lives in the Dashboard page (it has all the inputs);
+ * this component stays pure/presentational so it can be storybooked and
+ * unit-tested in isolation.
+ */
+
+import { useEffect, useState, type ReactNode } from "react";
+
+import { Button } from "@shared/components/ui/Button";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+
+/**
+ * Discriminated union for the four hero states. Keeping each state's
+ * inputs explicit (instead of a single optional-everything props bag)
+ * makes it impossible to render e.g. `elapsedSec` on a non-active card
+ * or `daysFromNow` on the empty state.
+ */
+export type HeroCardState =
+  | {
+      readonly kind: "active";
+      /**
+       * ISO timestamp of `workout.startedAt`. The hero ticks a local
+       * 1-second timer off of this so the rest of the Dashboard doesn't
+       * re-render every second just to keep the elapsed counter live.
+       */
+      readonly startedAtIso: string;
+      /** Optional count of exercises already logged in the session. */
+      readonly itemsCount?: number | null;
+    }
+  | {
+      readonly kind: "today";
+      /** Template name (or program session name). */
+      readonly label: string;
+      /** Exercises in the session. */
+      readonly exerciseCount: number;
+      /** Heuristic duration estimate in minutes, or `null` to hide. */
+      readonly estimatedMin?: number | null;
+      /** Context line, e.g. "З місячного плану" or program name. */
+      readonly hint?: string | null;
+    }
+  | {
+      readonly kind: "upcoming";
+      /** Template name of the next scheduled session. */
+      readonly label: string;
+      /** Days from today. `1` = tomorrow. */
+      readonly daysFromNow: number;
+      /** Local `YYYY-MM-DD` date key. */
+      readonly dateKey: string;
+      /** Exercises in the template, or `null` when catalogue doesn't know. */
+      readonly exerciseCount: number | null;
+    }
+  | {
+      readonly kind: "empty";
+      /** When `true`, "Обрати шаблон" opens templates instead of plan. */
+      readonly hasTemplates: boolean;
+    };
+
+export interface HeroCardProps {
+  readonly state: HeroCardState;
+  /** Localized greeting, e.g. "Доброго дня". */
+  readonly greeting: string;
+  /** Localized date label, e.g. "середа, 23 квітня". */
+  readonly today: string;
+  /** Invoked for the primary CTA on the `active` state. */
+  readonly onResume: () => void;
+  /** Invoked for the primary CTA on the `today` state. */
+  readonly onStartToday: () => void;
+  /** Invoked for the primary CTA on the `upcoming` state. */
+  readonly onOpenPlan: () => void;
+  /** Invoked for the empty state's "Обрати шаблон" CTA. */
+  readonly onOpenTemplates: () => void;
+  /** Invoked for the empty state's secondary "Програми" CTA. */
+  readonly onOpenPrograms: () => void;
+}
+
+const HERO_CARD_CLASS =
+  "rounded-3xl p-6 overflow-hidden bg-hero-teal dark:bg-panel dark:border dark:border-teal-800/30 dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]";
+
+function formatElapsed(sec: number): string {
+  if (!Number.isFinite(sec) || sec <= 0) return "0:00";
+  const total = Math.floor(sec);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  }
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/**
+ * Seconds between now and `startedAtIso`. Guarded so malformed ISO
+ * strings (or a future-dated `startedAt` from clock skew) produce `0`
+ * instead of NaN / negatives in the rendered "00:00".
+ */
+function diffSecFromNow(startedAtIso: string): number {
+  const start = Date.parse(startedAtIso);
+  if (!Number.isFinite(start)) return 0;
+  const diffMs = Date.now() - start;
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return 0;
+  return Math.floor(diffMs / 1000);
+}
+
+/**
+ * Ticks a 1-second elapsed counter for the active-workout hero without
+ * pulling the rest of the Dashboard into a 1Hz re-render loop. Returns
+ * `0` on the server / before mount so SSR and first paint stay stable.
+ */
+function useElapsedSec(startedAtIso: string): number {
+  const [sec, setSec] = useState<number>(() => diffSecFromNow(startedAtIso));
+  useEffect(() => {
+    setSec(diffSecFromNow(startedAtIso));
+    const id = setInterval(() => {
+      setSec(diffSecFromNow(startedAtIso));
+    }, 1000);
+    return () => {
+      clearInterval(id);
+    };
+  }, [startedAtIso]);
+  return sec;
+}
+
+function formatDateShort(dateKey: string): string {
+  try {
+    const d = new Date(`${dateKey}T12:00:00`);
+    if (Number.isNaN(d.getTime())) return dateKey;
+    return d.toLocaleDateString("uk-UA", { day: "numeric", month: "long" });
+  } catch {
+    return dateKey;
+  }
+}
+
+/**
+ * Ukrainian pluralization for "N днів / день / дні" etc. Mirrors the
+ * mobile helper so identical dates render identically on both clients.
+ */
+function formatDaysAway(days: number): string {
+  if (days === 0) return "Сьогодні";
+  if (days === 1) return "Завтра";
+  const mod100 = days % 100;
+  const mod10 = days % 10;
+  if (mod100 >= 11 && mod100 <= 14) return `За ${days} днів`;
+  if (mod10 === 1) return `За ${days} день`;
+  if (mod10 >= 2 && mod10 <= 4) return `За ${days} дні`;
+  return `За ${days} днів`;
+}
+
+/**
+ * Renders the `greeting · today` kicker. Shared across all states so
+ * the top of the hero always anchors "when am I".
+ */
+function HeroKicker({
+  greeting,
+  today,
+}: {
+  readonly greeting: string;
+  readonly today: string;
+}) {
+  return (
+    <SectionHeading as="p" size="sm" tone="fizruk">
+      {greeting} · {today}
+    </SectionHeading>
+  );
+}
+
+/**
+ * Secondary eyebrow that labels each state ("Тренування триває", etc.)
+ * Sits directly under the `HeroKicker` and uses the lighter `white/80`
+ * ink so it reads as an overlay label on the teal hero background.
+ */
+function HeroStateLabel({ children }: { readonly children: ReactNode }) {
+  return (
+    <SectionHeading as="p" size="sm" className="mt-3 text-white/80">
+      {children}
+    </SectionHeading>
+  );
+}
+
+/**
+ * "Play" icon that headlines the primary CTA. Inlined (rather than an
+ * `Icon name="play"` call) so the hero stays self-contained and zero
+ * extra import surfaces get dragged in.
+ */
+function PlayIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+function ActiveState({
+  state,
+  greeting,
+  today,
+  onResume,
+}: {
+  readonly state: Extract<HeroCardState, { kind: "active" }>;
+  readonly greeting: string;
+  readonly today: string;
+  readonly onResume: () => void;
+}) {
+  const elapsedSec = useElapsedSec(state.startedAtIso);
+  const meta =
+    state.itemsCount != null && state.itemsCount > 0
+      ? `${state.itemsCount} вправ у сесії`
+      : "Сесія відкрита — підходи й таймер чекають";
+  return (
+    <section className={HERO_CARD_CLASS} aria-label="Активне тренування">
+      <HeroKicker greeting={greeting} today={today} />
+      <HeroStateLabel>Тренування триває</HeroStateLabel>
+      <p
+        className="mt-1 text-hero font-black text-white leading-none tabular-nums"
+        aria-live="polite"
+        aria-label={`Час тренування ${formatElapsed(elapsedSec)}`}
+      >
+        {formatElapsed(elapsedSec)}
+      </p>
+      <p className="mt-2 text-sm text-white/75">{meta}</p>
+      <div className="mt-6">
+        <button
+          type="button"
+          className="w-full py-4 px-5 rounded-2xl bg-fizruk-strong text-white transition-all active:scale-[0.98] flex items-center gap-3 text-left"
+          onClick={onResume}
+          aria-label="Повернутись до активного тренування"
+        >
+          <span
+            className="shrink-0 w-11 h-11 rounded-full bg-white/15 flex items-center justify-center"
+            aria-hidden
+          >
+            <PlayIcon />
+          </span>
+          <span className="min-w-0 flex-1">
+            <SectionHeading as="span" size="xs" className="block text-white/70">
+              Продовжити
+            </SectionHeading>
+            <span className="block text-base font-black leading-tight">
+              Повернутись у сесію
+            </span>
+          </span>
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function TodayState({
+  state,
+  greeting,
+  today,
+  onStartToday,
+}: {
+  readonly state: Extract<HeroCardState, { kind: "today" }>;
+  readonly greeting: string;
+  readonly today: string;
+  readonly onStartToday: () => void;
+}) {
+  const metaParts: string[] = [`${state.exerciseCount} вправ`];
+  if (state.estimatedMin) metaParts.push(`~${state.estimatedMin} хв`);
+  if (state.hint) metaParts.push(state.hint);
+  return (
+    <section className={HERO_CARD_CLASS} aria-label="Сьогоднішнє тренування">
+      <HeroKicker greeting={greeting} today={today} />
+      <HeroStateLabel>Сьогоднішнє тренування</HeroStateLabel>
+      <h1 className="text-hero font-black text-white mt-1 leading-tight truncate">
+        {state.label}
+      </h1>
+      <p className="mt-2 text-sm text-white/75 truncate">
+        {metaParts.join(" · ")}
+      </p>
+      <div className="mt-6">
+        <button
+          type="button"
+          className="w-full py-4 px-5 rounded-2xl bg-fizruk-strong text-white transition-all active:scale-[0.98] flex items-center gap-3 text-left"
+          onClick={onStartToday}
+          aria-label={`Почати тренування: ${state.label}`}
+        >
+          <span
+            className="shrink-0 w-11 h-11 rounded-full bg-white/15 flex items-center justify-center"
+            aria-hidden
+          >
+            <PlayIcon />
+          </span>
+          <span className="min-w-0 flex-1">
+            <SectionHeading as="span" size="xs" className="block text-white/70">
+              Почати
+            </SectionHeading>
+            <span className="block text-base font-black truncate leading-tight">
+              {state.label}
+            </span>
+          </span>
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function UpcomingState({
+  state,
+  greeting,
+  today,
+  onOpenPlan,
+}: {
+  readonly state: Extract<HeroCardState, { kind: "upcoming" }>;
+  readonly greeting: string;
+  readonly today: string;
+  readonly onOpenPlan: () => void;
+}) {
+  const metaParts: string[] = [
+    formatDaysAway(state.daysFromNow),
+    formatDateShort(state.dateKey),
+  ];
+  if (state.exerciseCount != null && state.exerciseCount > 0) {
+    metaParts.push(`${state.exerciseCount} вправ`);
+  }
+  return (
+    <section className={HERO_CARD_CLASS} aria-label="Наступне тренування">
+      <HeroKicker greeting={greeting} today={today} />
+      <HeroStateLabel>Наступне тренування</HeroStateLabel>
+      <h1 className="text-hero font-black text-white mt-1 leading-tight truncate">
+        {state.label}
+      </h1>
+      <p className="mt-2 text-sm text-white/75 truncate">
+        {metaParts.join(" · ")}
+      </p>
+      <div className="mt-6">
+        <Button
+          variant="fizruk-soft"
+          className="w-full h-12 min-h-[44px]"
+          onClick={onOpenPlan}
+          aria-label="Відкрити план тренувань"
+        >
+          Відкрити план
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({
+  state,
+  greeting,
+  today,
+  onOpenTemplates,
+  onOpenPrograms,
+}: {
+  readonly state: Extract<HeroCardState, { kind: "empty" }>;
+  readonly greeting: string;
+  readonly today: string;
+  readonly onOpenTemplates: () => void;
+  readonly onOpenPrograms: () => void;
+}) {
+  const primaryLabel = state.hasTemplates ? "Обрати шаблон" : "Створити шаблон";
+  return (
+    <section className={HERO_CARD_CLASS} aria-label="План на сьогодні порожній">
+      <HeroKicker greeting={greeting} today={today} />
+      <HeroStateLabel>План порожній</HeroStateLabel>
+      <h1 className="text-hero font-black text-white mt-1 leading-tight">
+        Обери шаблон або <br />
+        заплануй день
+      </h1>
+      <p className="mt-2 text-sm text-white/75">
+        {state.hasTemplates
+          ? "Нічого не заплановано — запусти готовий шаблон або відкрий програми."
+          : "У тебе ще немає шаблонів. Створи свій перший або обери програму."}
+      </p>
+      <div className="mt-6 flex flex-col gap-3">
+        <Button
+          variant="fizruk"
+          className="w-full h-12 min-h-[44px]"
+          onClick={onOpenTemplates}
+        >
+          {primaryLabel}
+        </Button>
+        <Button
+          variant="fizruk-soft"
+          className="w-full h-12 min-h-[44px]"
+          onClick={onOpenPrograms}
+        >
+          До програм
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The Dashboard hero. State-driven (see `HeroCardState`) — callers
+ * compute the state from their hooks and pass one of four shapes; the
+ * component renders the right layout.
+ */
+export function HeroCard(props: HeroCardProps) {
+  const { state, greeting, today } = props;
+  switch (state.kind) {
+    case "active":
+      return (
+        <ActiveState
+          state={state}
+          greeting={greeting}
+          today={today}
+          onResume={props.onResume}
+        />
+      );
+    case "today":
+      return (
+        <TodayState
+          state={state}
+          greeting={greeting}
+          today={today}
+          onStartToday={props.onStartToday}
+        />
+      );
+    case "upcoming":
+      return (
+        <UpcomingState
+          state={state}
+          greeting={greeting}
+          today={today}
+          onOpenPlan={props.onOpenPlan}
+        />
+      );
+    case "empty":
+      return (
+        <EmptyState
+          state={state}
+          greeting={greeting}
+          today={today}
+          onOpenTemplates={props.onOpenTemplates}
+          onOpenPrograms={props.onOpenPrograms}
+        />
+      );
+  }
+}

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -8,10 +8,13 @@ import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
 import { BodyAtlas } from "../components/BodyAtlas";
+import { HeroCard, type HeroCardState } from "../components/dashboard/HeroCard";
 import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
 import { workoutDurationSec } from "@sergeant/fizruk-domain";
 import { ACTIVE_WORKOUT_KEY } from "@sergeant/fizruk-domain";
+import { getNextPlanSession } from "@sergeant/fizruk-domain/domain";
 import { Card } from "@shared/components/ui/Card";
+import { useActiveFizrukWorkout } from "@shared/hooks/useActiveFizrukWorkout";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 
 const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
@@ -252,94 +255,93 @@ export function Dashboard({
     tryStartPlan(primaryAction.picks, primaryAction.templateId);
   };
 
+  // ── Hero state resolution ───────────────────────────────────────
+  // Priority: active session > today by program/plan > fallback
+  // template (recentlyUsed) > upcoming scheduled day > empty nudge.
+  // Each branch returns a fully-typed `HeroCardState` so the hero can
+  // decide on layout without re-deriving any data.
+  const activeWorkoutId = useActiveFizrukWorkout();
+  const activeWorkout = useMemo(() => {
+    if (!activeWorkoutId) return null;
+    const w = (workouts || []).find(
+      (it) => it && it.id === activeWorkoutId && !it.endedAt,
+    );
+    return w || null;
+  }, [activeWorkoutId, workouts]);
+
+  const nextPlanSession = useMemo(() => {
+    if (!templates?.length) return null;
+    try {
+      return getNextPlanSession({
+        plan: monthlyPlan,
+        templatesById: templates,
+      });
+    } catch {
+      return null;
+    }
+  }, [monthlyPlan, templates]);
+
+  const heroState: HeroCardState = useMemo(() => {
+    if (activeWorkout?.startedAt) {
+      return {
+        kind: "active",
+        startedAtIso: activeWorkout.startedAt,
+        itemsCount: (activeWorkout.items || []).length,
+      };
+    }
+    if (primaryAction) {
+      return {
+        kind: "today",
+        label: primaryAction.label,
+        exerciseCount: primaryAction.exerciseCount,
+        estimatedMin: estimatedDurationMin,
+        hint: primaryAction.hint,
+      };
+    }
+    if (nextPlanSession && !nextPlanSession.isToday) {
+      return {
+        kind: "upcoming",
+        label: nextPlanSession.templateName,
+        daysFromNow: nextPlanSession.daysFromNow,
+        dateKey: nextPlanSession.dateKey,
+        exerciseCount: nextPlanSession.exerciseCount,
+      };
+    }
+    return { kind: "empty", hasTemplates: (templates?.length || 0) > 0 };
+  }, [
+    activeWorkout,
+    primaryAction,
+    nextPlanSession,
+    templates,
+    estimatedDurationMin,
+  ]);
+
+  const openWorkoutsTab = () => {
+    window.location.hash = "#workouts";
+  };
+  const openTemplates = () => {
+    try {
+      sessionStorage.setItem("fizruk_workouts_mode", "templates");
+    } catch {}
+    window.location.hash = "#workouts";
+  };
+  const openPlan = () => {
+    window.location.hash = "#plan";
+  };
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
-        <section
-          className="rounded-3xl p-6 overflow-hidden bg-hero-teal dark:bg-panel dark:border dark:border-teal-800/30 dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
-          aria-label="Привітання"
-        >
-          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-              Branded fizruk hero kicker above h1 — dynamic greeting string. */}
-          <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
-            {greeting} · {today}
-          </p>
-          <h1 className="text-hero font-black text-white mt-3 leading-tight">
-            Твій прогрес
-            <br />
-            зібраний в одному місці
-          </h1>
-          <div className="mt-6 flex flex-col gap-3">
-            {primaryAction ? (
-              <button
-                type="button"
-                className="w-full py-4 px-5 rounded-2xl bg-fizruk-strong text-white transition-all active:scale-[0.98] flex items-center gap-3 text-left"
-                onClick={handleStartPrimary}
-                aria-label={`Почати: ${primaryAction.label}`}
-              >
-                <span
-                  className="shrink-0 w-11 h-11 rounded-full bg-white/15 flex items-center justify-center"
-                  aria-hidden
-                >
-                  <svg
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <path d="M8 5v14l11-7z" />
-                  </svg>
-                </span>
-                <span className="min-w-0 flex-1">
-                  <SectionHeading
-                    as="span"
-                    size="xs"
-                    className="block text-white/70"
-                  >
-                    Почати
-                  </SectionHeading>
-                  <span className="block text-base font-black truncate leading-tight">
-                    {primaryAction.label}
-                  </span>
-                  <span className="block text-2xs text-white/70 mt-0.5 truncate">
-                    {primaryAction.exerciseCount} вправ
-                    {estimatedDurationMin
-                      ? ` · ~${estimatedDurationMin} хв`
-                      : ""}
-                    {primaryAction.hint ? ` · ${primaryAction.hint}` : ""}
-                  </span>
-                </span>
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white transition-all active:scale-[0.98]"
-                onClick={() => {
-                  try {
-                    sessionStorage.setItem("fizruk_workouts_mode", "templates");
-                  } catch {}
-                  window.location.hash = "#workouts";
-                }}
-                aria-label="Створити перший шаблон"
-              >
-                Створити перший шаблон
-              </button>
-            )}
-            <button
-              type="button"
-              className="w-full py-4 rounded-full font-semibold text-base text-white border border-white/25 transition-colors active:bg-white/10"
-              onClick={() => {
-                try {
-                  sessionStorage.setItem("fizruk_workouts_mode", "templates");
-                } catch {}
-                window.location.hash = "#workouts";
-              }}
-              aria-label="Мої шаблони"
-            >
-              Мої шаблони
-            </button>
-          </div>
-        </section>
+        <HeroCard
+          state={heroState}
+          greeting={greeting}
+          today={today}
+          onResume={openWorkoutsTab}
+          onStartToday={handleStartPrimary}
+          onOpenPlan={openPlan}
+          onOpenTemplates={openTemplates}
+          onOpenPrograms={() => onOpenPrograms?.()}
+        />
 
         {templates.length > 0 &&
           (() => {


### PR DESCRIPTION
## Summary

Перший з запланованої серії PR-ів по редизайну Фізрук / «Сьогодні» (див. переписку з користувачем — pr-proposal у повідомленні). На цій сторінці hero зараз показував статичний маркетинговий заголовок «Твій прогрес зібраний в одному місці» і один і той самий CTA «Почати {шаблон}» незалежно від того, чи є активна сесія, чи щось заплановано, чи взагалі є шаблони. Він був неінформативним у всіх станах, крім одного.

Цей PR замінює hero на `HeroCard` — state-driven компонент у 4 станах:

1. **`active`** — є активна сесія (`useActiveFizrukWorkout()` повертає валідний id, а `workout.endedAt` не виставлений): показуємо лейбл «Тренування триває», живий таймер у форматі `MM:SS` / `H:MM:SS`, підпис «N вправ у сесії», CTA **«Продовжити»** → `#workouts`.
2. **`today`** — є `primaryAction` (активна програма з `todaySession`, або `monthlyPlan.todayTemplateId`, або fallback `recentlyUsed[0]` / `templates[0]`): лейбл «Сьогоднішнє тренування», `{label}`, мета `{N} вправ · ~{minEst} хв · {hint}`, CTA **«Почати: {label}»** (той самий старт-шлях, що й раніше — `handleStartPrimary`).
3. **`upcoming`** — немає нічого на сьогодні, але `getNextPlanSession` з `@sergeant/fizruk-domain/domain/dashboard` повертає сесію на наступні ≤14 днів: «Наступне тренування · {label} · За N дні · {date} · {N} вправ», CTA **«Відкрити план»** (`#plan`).
4. **`empty`** — нічого з вищеперелічених: текст «План порожній — обери шаблон або заплануй день», CTA «{Обрати / Створити} шаблон» + «До програм».

Таймер у стані `active` тікає локально (власний `useElapsedSec` із 1 Гц `setInterval`), тож решта Dashboard не перемальовується щосекунди.

Також прибрав дубль-CTA **«Мої шаблони»** з hero — він вів у той самий екран, що й боттом-нав «Тренування», тож мертвий клік.

Рештa блоків Dashboard (Швидкий старт, Програма, Відновлення й фокус, План на сьогодні) — без змін. Їх я зачеплю в наступних PR-ах (KpiRow / RecentWorkouts / RecentPRs / тримінг «Плану на сьогодні»), мобільна композиція з `apps/mobile/.../Dashboard.tsx` слугує референсом.

## Review & Testing Checklist for Human

- [ ] **Стан `active`**: запусти будь-яке тренування з «Швидкого старту» або «Плану на сьогодні», повернись у «Сьогодні» → hero має показати **живий** таймер (mm:ss), лейбл «Тренування триває» і кнопку «Продовжити», яка відкриває `#workouts`. Через хвилину таймер має показати, скажімо, `2:05`, а не застрягнути на `0:00`.
- [ ] **Стан `today`**: при відсутності активної сесії, з наявними шаблонами/програмою/планом на сьогодні — hero показує назву сесії і `«N вправ · ~XX хв · {З місячного плану | Останнє тренування | activeProgram.name}»`. Кнопка «Почати» запускає ту саму логіку `handleStartPrimary`, що й раніше (plan-confirm sheet для risky recovery все ще виринає).
- [ ] **Стан `upcoming`**: якщо нічого не заплановано на сьогодні (активної програми нема, `monthlyPlan.todayTemplateId === null`, `recentlyUsed` і `templates` порожні) — але в `monthlyPlan.days` є шаблон на завтра / через 2 дні — hero має сказати «За 1 день / За 2 дні · {дата}» і вести в `#plan`. Примітка: через fallback `recentlyUsed[0]` / `templates[0]` в `primaryAction`, цей стан побачиш лише якщо шаблонів нема або вони не у recent.
- [ ] **Стан `empty`**: новий користувач без жодного шаблону → hero показує «Створити шаблон» + «До програм». «Створити шаблон» має відкрити `#workouts` у режимі `templates` (через `sessionStorage.fizruk_workouts_mode`).
- [ ] Темна тема: градієнтний teal з `dark:[background-image:linear-gradient(...)]` зберігається в усіх 4 станах.

### Notes

- Hook `useActiveFizrukWorkout` — той самий, що я підправив у #596, тож активний pointer вже cross-валідується проти `fizruk_workouts_v1`. HeroCard додатково довантажує workout-obj із `useWorkouts()` щоб дістати `startedAt` (для таймера) і `items.length` (для «N вправ у сесії»). Якщо workout раптом зникне зі списку між тиками, стан просто тихо перемкнеться на `today` / `empty`.
- `getNextPlanSession` уже покритий тестами в `packages/fizruk-domain` і вже використовується мобільним додатком — жодних змін у цьому helper-і.
- Додано 11 vitest-тестів для HeroCard (`HeroCard.test.tsx`), що покривають кожен із 4 станів, форматування таймера в `H:MM:SS`, українські множинні форми для «за N днів/день/дні», fallback-поведінку на невалідний `startedAtIso`, та проводку всіх 5 callback-ів.
- Локально пройдено: `pnpm --filter web typecheck` ✓, `pnpm --filter web lint` ✓, `pnpm --filter web test` → 654 tests pass (+11 нових), `pnpm format:check` ✓.
- **Не зачеплено** `apps/mobile` — мобільний Dashboard уже має свій `HeroCard` з цими 4 станами, саме його я зараз переносив на веб.

Link to Devin session: https://app.devin.ai/sessions/17a7683df87743398402ebcd6f8cba28
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
