### PR TITLE
fix(web): address 4 code review issues

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -111,7 +111,7 @@ const RESET_PASSWORD_PATH = "/reset-password";
 // Tiny effect-only component so the redirect is a declarative render,
 // not a `navigate()` call in the middle of AppInner — keeps the render
 // phase free of side effects and avoids the React warning.
-function RedirectTo({ to }) {
+function RedirectTo({ to }: { to: string }) {
   const navigate = useNavigate();
   useEffect(() => {
     navigate(to, { replace: true });

--- a/apps/web/src/core/HubDashboard.tsx
+++ b/apps/web/src/core/HubDashboard.tsx
@@ -3,18 +3,25 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type ReactNode,
 } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
-import { safeReadLS, safeWriteLS, safeRemoveLS } from "@shared/lib/storage.js";
+import {
+  safeReadLS,
+  safeReadStringLS,
+  safeWriteLS,
+  safeRemoveLS,
+} from "@shared/lib/storage.js";
 import {
   DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
   STORAGE_KEYS,
   normalizeDashboardOrder,
+  selectModulePreview,
+  type ModulePreview,
+  type User,
 } from "@sergeant/shared";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { getModulePrimaryAction } from "@shared/lib/moduleQuickActions";
@@ -75,19 +82,6 @@ const saveOrder = saveDashboardOrder;
 // ═══════════════════════════════════════════════════════════════════════════
 // MODULE CONFIGURATIONS — calm accent-only styling
 // ═══════════════════════════════════════════════════════════════════════════
-/**
- * Preview — легка read-model картки модуля для `StatusRow`. Поля опційні:
- * окремі модулі (напр. finyk) не показують progress, а нутрішн показує.
- * Раніше `StatusRow`-props були `any`; будь-яка зміна shape-у preview чи
- * конфігу проходила без помилки TS.
- */
-interface ModulePreview {
-  main?: string | null;
-  sub?: string | null;
-  /** 0..100. Рендериться тільки коли `hasGoal && progress > 0`. */
-  progress?: number;
-}
-
 interface ModuleConfig {
   icon: ReactNode;
   label: string;
@@ -124,23 +118,11 @@ const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     accentClass: "bg-finyk",
     description: "Транзакції та бюджети",
     hasGoal: false,
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("finyk_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.todaySpent
-              ? `${stats.todaySpent.toLocaleString()} грн`
-              : null,
-            sub: stats.budgetLeft
-              ? `Залишок: ${stats.budgetLeft.toLocaleString()}`
-              : null,
-          };
-        }
-      } catch {}
-      return { main: null, sub: null };
-    },
+    getPreview: () =>
+      selectModulePreview(
+        "finyk",
+        safeReadStringLS(STORAGE_KEYS.FINYK_QUICK_STATS),
+      ),
   },
   fizruk: {
     icon: (
@@ -165,19 +147,11 @@ const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     accentClass: "bg-fizruk",
     description: "Тренування та прогрес",
     hasGoal: false,
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("fizruk_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.weekWorkouts ? `${stats.weekWorkouts} трен.` : null,
-            sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
-          };
-        }
-      } catch {}
-      return { main: null, sub: null };
-    },
+    getPreview: () =>
+      selectModulePreview(
+        "fizruk",
+        safeReadStringLS(STORAGE_KEYS.FIZRUK_QUICK_STATS),
+      ),
   },
   routine: {
     icon: (
@@ -201,25 +175,11 @@ const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     accentClass: "bg-routine",
     description: "Звички та щоденні цілі",
     hasGoal: true,
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("routine_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main:
-              stats.todayDone !== undefined
-                ? `${stats.todayDone}/${stats.todayTotal}`
-                : null,
-            sub: stats.streak ? `Серія: ${stats.streak} днів` : null,
-            progress: stats.todayTotal
-              ? (stats.todayDone / stats.todayTotal) * 100
-              : 0,
-          };
-        }
-      } catch {}
-      return { main: null, sub: null, progress: 0 };
-    },
+    getPreview: () =>
+      selectModulePreview(
+        "routine",
+        safeReadStringLS(STORAGE_KEYS.ROUTINE_QUICK_STATS),
+      ),
   },
   nutrition: {
     icon: (
@@ -244,22 +204,11 @@ const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     accentClass: "bg-nutrition",
     description: "КБЖВ та раціон",
     hasGoal: true,
-    getPreview: () => {
-      try {
-        const data = localStorage.getItem("nutrition_quick_stats");
-        if (data) {
-          const stats = JSON.parse(data);
-          return {
-            main: stats.todayCal ? `${stats.todayCal} ккал` : null,
-            sub: stats.calGoal ? `Ціль: ${stats.calGoal} ккал` : null,
-            progress: stats.calGoal
-              ? (stats.todayCal / stats.calGoal) * 100
-              : 0,
-          };
-        }
-      } catch {}
-      return { main: null, sub: null, progress: 0 };
-    },
+    getPreview: () =>
+      selectModulePreview(
+        "nutrition",
+        safeReadStringLS(STORAGE_KEYS.NUTRITION_QUICK_STATS),
+      ),
   },
 };
 
@@ -479,7 +428,13 @@ function useMondayAutoDigest() {
 // WEEKLY DIGEST FOOTER — тихий лінк у нижньому ряду. Fresh-dot показується,
 // коли live-digest за цей тиждень існує.
 // ═══════════════════════════════════════════════════════════════════════════
-function WeeklyDigestFooter({ onExpand, fresh }) {
+function WeeklyDigestFooter({
+  onExpand,
+  fresh,
+}: {
+  onExpand: () => void;
+  fresh: boolean;
+}) {
   return (
     <button
       type="button"
@@ -507,12 +462,19 @@ function WeeklyDigestFooter({ onExpand, fresh }) {
 // ═══════════════════════════════════════════════════════════════════════════
 // MAIN HUB DASHBOARD
 // ═══════════════════════════════════════════════════════════════════════════
+interface HubDashboardProps {
+  onOpenModule: (module: string) => void;
+  onOpenChat?: () => void;
+  user: User | null;
+  onShowAuth: () => void;
+}
+
 export function HubDashboard({
   onOpenModule,
   onOpenChat: _onOpenChat,
   user,
   onShowAuth,
-}) {
+}: HubDashboardProps) {
   const [order, setOrder] = useState(loadOrder);
   useMondayAutoDigest();
 
@@ -532,15 +494,13 @@ export function HubDashboard({
   const hasRealEntry = detectFirstRealEntry();
   useFirstEntryCelebration(hasRealEntry);
   // Record today's session on mount so the proactive nudge actually
-  // accumulates days; scoped to once-per-mount via ref to avoid
-  // double-counting if the component re-renders. `-1` is used as the
-  // "uninitialized" marker because `recordSessionDay()` / `getSessionDays()`
-  // return `0` from their localStorage-unavailable catch path, which would
-  // otherwise re-fire the guard on every render.
-  const sessionDaysRef = useRef<number>(-1);
-  if (sessionDaysRef.current === -1) {
-    sessionDaysRef.current = recordSessionDay() || getSessionDays();
-  }
+  // accumulates days. Using state + effect instead of a ref guard in the
+  // render body — the ref pattern caused a localStorage write during the
+  // render phase, which React Strict Mode can double-invoke.
+  const [sessionDays, setSessionDays] = useState(-1);
+  useEffect(() => {
+    setSessionDays(recordSessionDay() || getSessionDays());
+  }, []);
   const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
   const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
     isSoftAuthDismissed(),
@@ -549,8 +509,7 @@ export function HubDashboard({
     !user &&
     !softAuthDismissed &&
     typeof onShowAuth === "function" &&
-    (hasRealEntry ||
-      sessionDaysRef.current >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
+    (hasRealEntry || sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
 
   const { focus, rest, dismiss } = useDashboardFocus();
 

--- a/apps/web/src/core/cloudSync/state/dirtyModules.ts
+++ b/apps/web/src/core/cloudSync/state/dirtyModules.ts
@@ -2,6 +2,19 @@ import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { DIRTY_MODULES_KEY, MODULE_MODIFIED_KEY } from "../config";
 import { emitStatusEvent } from "./events";
 
+// Cross-tab awareness: when another tab marks a module dirty or clears it,
+// emit a status event so this tab's sync hook re-evaluates. The write race
+// (two tabs simultaneously doing read→modify→write) is inherent to
+// localStorage, but its impact is limited — at worst one dirty mark is lost
+// for one sync cycle, and it will be re-marked on the next mutation.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === DIRTY_MODULES_KEY || event.key === MODULE_MODIFIED_KEY) {
+      emitStatusEvent();
+    }
+  });
+}
+
 export function getDirtyModules(): Record<string, true> {
   return safeReadLS<Record<string, true>>(DIRTY_MODULES_KEY, {}) || {};
 }

--- a/apps/web/src/core/lib/insightsEngine.ts
+++ b/apps/web/src/core/lib/insightsEngine.ts
@@ -8,6 +8,8 @@
  *   - Specific per-insight gates are documented below.
  */
 
+import { STORAGE_KEYS } from "@sergeant/shared";
+
 export interface Insight {
   id: string;
   emoji: string;
@@ -57,7 +59,7 @@ function localDateKey(d: Date = new Date()): string {
 }
 
 function parseFizrukWorkouts(): Workout[] {
-  const raw = localStorage.getItem("fizruk_workouts_v1");
+  const raw = localStorage.getItem(STORAGE_KEYS.FIZRUK_WORKOUTS);
   if (!raw) return [];
   try {
     const p = JSON.parse(raw) as Workout[] | { workouts?: Workout[] } | null;
@@ -128,12 +130,17 @@ function workoutDayInsight(): Insight | null {
 function activeWeeksSpendingInsight(): Insight | null {
   const workouts = parseFizrukWorkouts().filter((w) => w.endedAt);
   const raw = safeLS<Transaction[] | { txs?: Transaction[] }>(
-    "finyk_tx_cache",
+    STORAGE_KEYS.FINYK_TX_CACHE,
     [],
   );
   const txs: Transaction[] = Array.isArray(raw) ? raw : (raw?.txs ?? []);
-  const hiddenSet = new Set<string>(safeLS<string[]>("finyk_hidden_txs", []));
-  const txCategories = safeLS<Record<string, string>>("finyk_tx_cats", {});
+  const hiddenSet = new Set<string>(
+    safeLS<string[]>(STORAGE_KEYS.FINYK_HIDDEN_TXS, []),
+  );
+  const txCategories = safeLS<Record<string, string>>(
+    STORAGE_KEYS.FINYK_TX_CATS,
+    {},
+  );
   const transferIds = new Set<string>(
     Object.entries(txCategories)
       .filter(([, v]) => v === "internal_transfer")
@@ -214,7 +221,7 @@ function activeWeeksSpendingInsight(): Insight | null {
  * AND ≥ 4 distinct ISO weeks with any completion.
  */
 function bestHabitMonthInsight(): Insight | null {
-  const state = safeLS<RoutineState | null>("hub_routine_v1", null);
+  const state = safeLS<RoutineState | null>(STORAGE_KEYS.ROUTINE, null);
   if (!state) return null;
 
   const habits = (state.habits || []).filter((h) => !h.archived);
@@ -278,7 +285,7 @@ function bestHabitMonthInsight(): Insight | null {
  */
 function workoutKcalInsight(): Insight | null {
   const workouts = parseFizrukWorkouts().filter((w) => w.endedAt);
-  const log = safeLS<NutritionLog>("nutrition_log_v1", {});
+  const log = safeLS<NutritionLog>(STORAGE_KEYS.NUTRITION_LOG, {});
 
   const workoutDays = new Set<string>(
     workouts.map((w) => localDateKey(new Date(w.startedAt))),
@@ -330,8 +337,8 @@ function workoutKcalInsight(): Insight | null {
  * Requires ≥ 4 weeks with both habit and nutrition data.
  */
 function habitWeeksKcalInsight(): Insight | null {
-  const state = safeLS<RoutineState | null>("hub_routine_v1", null);
-  const log = safeLS<NutritionLog>("nutrition_log_v1", {});
+  const state = safeLS<RoutineState | null>(STORAGE_KEYS.ROUTINE, null);
+  const log = safeLS<NutritionLog>(STORAGE_KEYS.NUTRITION_LOG, {});
 
   if (!state) return null;
   const habits = (state.habits || []).filter((h) => !h.archived);


### PR DESCRIPTION
1. Side effect in render phase (HubDashboard): replace useRef guard that
   wrote to localStorage during render with useState(-1) + useEffect, which
   is safe under React Strict Mode's double-invoke behaviour.

2. Cross-tab localStorage race (dirtyModules): add a StorageEvent listener
   so that when another tab marks a module dirty or clears it, this tab
   re-emits a status event and the sync hook re-evaluates.

3. Hardcoded storage key strings (HubDashboard, insightsEngine): replace
   all literal keys ("finyk_quick_stats", "fizruk_workouts_v1", etc.) with
   STORAGE_KEYS constants from @sergeant/shared.  HubDashboard.getPreview()
   implementations are replaced by selectModulePreview() from the same
   package, removing duplicate formatting logic.

4. Missing TypeScript annotations: add explicit prop types to RedirectTo
   (App.tsx), WeeklyDigestFooter, and HubDashboard (HubDashboardProps).

All 643 tests pass; TypeScript reports no errors.

https://claude.ai/code/session_01R8c3cH8GFbNEvVLyUZMCPZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud sync now synchronizes state across browser tabs.

* **Bug Fixes**
  * Improved reliability of session-day tracking on app load.

* **Refactor**
  * Enhanced type safety across core components and module preview generation.
  * Standardized storage key references throughout the insights engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->