### PR TITLE
fix(fizruk): resume CTA lands on log view + restore axe fix lost in merge

### DIFF
--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -393,13 +393,20 @@ function EmptyState({
           : "У тебе ще немає шаблонів. Створи свій перший або обери програму."}
       </p>
       <div className="mt-6 flex flex-col gap-3">
-        <Button
-          variant="fizruk"
-          className="w-full h-12 min-h-[44px]"
+        {/*
+          Primary CTA uses the raw `bg-fizruk-strong` surface (teal-600,
+          #0d9488) rather than the `variant="fizruk"` default (teal-500,
+          #14b8a6). The latter ships contrast 2.48:1 against white text —
+          below WCAG AA — and so the axe-core check flags it. teal-600 +
+          white clears 4.5:1 comfortably.
+        */}
+        <button
+          type="button"
+          className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white transition-all active:scale-[0.98]"
           onClick={onOpenTemplates}
         >
           {primaryLabel}
-        </Button>
+        </button>
         <Button
           variant="fizruk-soft"
           className="w-full h-12 min-h-[44px]"

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -317,6 +317,17 @@ export function Dashboard({
   ]);
 
   const openWorkoutsTab = () => {
+    // `Workouts` defaults to the `home` view and only switches to the
+    // journal/log when the `fizruk_workouts_mode` hint is primed in
+    // sessionStorage (see `apps/web/src/modules/fizruk/pages/Workouts.tsx`).
+    // When the hero CTA resumes an active session we want the user to
+    // land directly on the log — one extra tap is a real UX regression
+    // otherwise.
+    try {
+      sessionStorage.setItem("fizruk_workouts_mode", "log");
+    } catch {
+      /* non-fatal: default view is still reachable */
+    }
     window.location.hash = "#workouts";
   };
   const openTemplates = () => {


### PR DESCRIPTION
## Summary

Follow-up до #599. Два маленькі фікси, обидва — наслідки того, що #599 змерджили до того, як я встиг допушити останні дві правки.

**1. `openWorkoutsTab` не виставляв `fizruk_workouts_mode = "log"`**

Devin Review справедливо відмітив: новий active-state CTA «Продовжити» приводив користувача на головний екран «Тренування», а не одразу в журнал активної сесії. `Workouts` дефолтиться на `home` view і перемикається у `log` лише коли в `sessionStorage` виставлено `fizruk_workouts_mode` — усі інші entry-point до активної сесії (`Dashboard.startWorkoutFromPlan`, `useFizrukProgramStart`) роблять цей `setItem(..., "log")`. Мій `openWorkoutsTab` цього не робив — CTA вів на generic hub і вимагав додатковий тап. Фікс — один `setItem` перед `window.location.hash = "#workouts"`.

**2. Empty-state CTA не проходив WCAG AA (axe-core regression)**

У першій ітерації #599 я використав `<Button variant="fizruk">` для primary CTA empty-стану — він ship-иться з `bg-fizruk` (`#14b8a6` / teal-500) + `text-white`, що дає 2.48:1 контрасту (нижче 4.5:1 AA-floor). Я локально запустив axe, виявив порушення і запушив фікс (`93315f4`), але PR #599 встигли змерджити зі snapshot-ом до цього коміту — тож на `main` повернулась axe-регресія (і вона зловила `main` цього PR теж). Cherry-pick того ж фіксу сюди: переходимо на той самий `bg-fizruk-strong` (teal-600 / `#0d9488`) pattern, який уже використовують усі інші CTA hero.

## Review & Testing Checklist for Human

- [ ] **Active-state CTA**: запусти тренування (з «Плану на сьогодні» чи «Швидкого старту»), повернись у «Сьогодні» → hero показує «Тренування триває» з живим таймером → клік по «Продовжити» одразу відкриває журнал активного тренування (таймер + підходи), а не generic home-view з вибором шаблонів.
- [ ] **Empty-state CTA**: якщо у тебе немає шаблонів і немає плану, hero показує «Обери шаблон або заплануй день». Кнопка «Створити шаблон» має бути темного teal-кольору (teal-600), не блідого teal-500 — і читабельна на око з білим текстом.
- [ ] CI: `Accessibility (axe-core)` має бути зелений на цьому PR (на main axe зараз падає через regression з #599 — цей PR її виправить).

### Notes

- Зміни ізольовані в `apps/web/src/modules/fizruk/pages/Dashboard.tsx` (+11/−1) і `apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx` (+11/−4).
- Локально: `pnpm --filter web typecheck` ✓, `pnpm --filter web lint` ✓, `prettier --check` ✓, `playwright test a11y --grep fizruk-dashboard` ✓ (з `apps/web` директорії, щоб dev-server стартував коректно).
- Vercel preview падає з `Deployment rate limited — retry in 24 hours` — це org-level ліміт, не стосується коду (див. https://vercel.com/skords-01s-projects?upgradeToPro=build-rate-limit).
- iOS Simulator build продовжує падати з pre-existing CocoaPods issue на `main` (GoogleMLKit/BarcodeScanning 7.0.0 vs `@capacitor-mlkit/barcode-scanning@7.5.0`) — окрема проблема.

Link to Devin session: https://app.devin.ai/sessions/17a7683df87743398402ebcd6f8cba28
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
