### PR TITLE
ci(mobile-shell-ios): fix Simulator build — raise Podfile to iOS 15.5 + tolerate cap add pod install

### DIFF
--- a/.github/workflows/mobile-shell-android.yml
+++ b/.github/workflows/mobile-shell-android.yml
@@ -65,11 +65,13 @@ jobs:
           node-version: "20"
           cache: pnpm
 
-      # actions/setup-java v4.7.1 — Capacitor 7 / AGP 8 require JDK 17.
+      # actions/setup-java v4.7.1 — Capacitor 7.4 targets Java 21
+      # (`:capacitor-android:compileDebugJavaWithJavac` fails with
+      # "invalid source release: 21" on older JDKs).
       - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install JS deps
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -71,15 +71,30 @@ jobs:
       - name: Build web bundle
         run: pnpm build:web
 
-      - name: Scaffold iOS project (cap add ios)
+      - name: Scaffold iOS project (cap add ios, skip pod install)
         # `ios/` is intentionally uncommitted in the repo — see the
         # "iOS" section of apps/mobile-shell/README.md. `cap add ios`
-        # generates the Xcode project + runs `pod install`.
+        # normally runs `pod install` at the end; we skip it here so
+        # we can bump the Podfile `platform :ios` line _before_ pods
+        # are resolved (GoogleMLKit 7.0 needs iOS 15.5+, which is above
+        # Capacitor's default `14.0`).
         working-directory: apps/mobile-shell
-        run: pnpm exec cap add ios
+        run: pnpm exec cap add ios --no-pod-install
+
+      - name: Raise iOS deployment target in Podfile
+        working-directory: apps/mobile-shell/ios/App
+        # `cap add ios` ships with `platform :ios, '14.0'`. Bump to
+        # 15.5 so `pod install` can resolve GoogleMLKit/BarcodeScanning
+        # 7.0.0 (the transitive dep of @capacitor-mlkit/barcode-scanning).
+        run: |
+          sed -i.bak "s/^platform :ios, '[0-9.]*'/platform :ios, '15.5'/" Podfile
+          diff -u Podfile.bak Podfile || true
+          rm Podfile.bak
 
       - name: Capacitor sync (ios)
         working-directory: apps/mobile-shell
+        # `cap sync ios` runs `pod install` now that the Podfile has
+        # been patched to the right deployment target.
         run: pnpm exec cap sync ios
 
       - name: Build App scheme for iOS Simulator (no signing)

--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -71,15 +71,18 @@ jobs:
       - name: Build web bundle
         run: pnpm build:web
 
-      - name: Scaffold iOS project (cap add ios, skip pod install)
+      - name: Scaffold iOS project (cap add ios)
         # `ios/` is intentionally uncommitted in the repo — see the
         # "iOS" section of apps/mobile-shell/README.md. `cap add ios`
-        # normally runs `pod install` at the end; we skip it here so
-        # we can bump the Podfile `platform :ios` line _before_ pods
-        # are resolved (GoogleMLKit 7.0 needs iOS 15.5+, which is above
-        # Capacitor's default `14.0`).
+        # first scaffolds the Xcode project and _then_ runs `pod install`.
+        # The pod install step fails on the default template because
+        # @capacitor-mlkit/barcode-scanning 7.5 → GoogleMLKit 7.0 needs
+        # iOS ≥15.5 while the template ships `platform :ios, '14.0'`.
+        # The Xcode project + Podfile are already on disk at that point
+        # though, so we swallow the exit code, patch the Podfile, and
+        # run `pod install` ourselves in the next step.
         working-directory: apps/mobile-shell
-        run: pnpm exec cap add ios --no-pod-install
+        run: pnpm exec cap add ios || true
 
       - name: Raise iOS deployment target in Podfile
         working-directory: apps/mobile-shell/ios/App
@@ -87,14 +90,15 @@ jobs:
         # 15.5 so `pod install` can resolve GoogleMLKit/BarcodeScanning
         # 7.0.0 (the transitive dep of @capacitor-mlkit/barcode-scanning).
         run: |
+          test -f Podfile || { echo "Podfile missing — cap add ios did not scaffold"; exit 1; }
           sed -i.bak "s/^platform :ios, '[0-9.]*'/platform :ios, '15.5'/" Podfile
           diff -u Podfile.bak Podfile || true
           rm Podfile.bak
 
       - name: Capacitor sync (ios)
         working-directory: apps/mobile-shell
-        # `cap sync ios` runs `pod install` now that the Podfile has
-        # been patched to the right deployment target.
+        # `cap sync ios` now runs `pod install` against the patched
+        # Podfile and refreshes the plugin graph / web assets.
         run: pnpm exec cap sync ios
 
       - name: Build App scheme for iOS Simulator (no signing)


### PR DESCRIPTION
## Summary

Фіксить `Build iOS Simulator (Debug)` CI-джоб (`.github/workflows/mobile-shell-ios.yml`), який зараз провалюється на кожному PR, що чіпає `apps/web/**` / `apps/mobile-shell/**` / `apps/server/**` / `packages/**`.

Branch **`devin/1776866494-mobile-shell-ci`** — той самий, з якого був змерджений PR #520. Дві follow-up-комітки, які **не потрапили в main**:

- `94a9bf0` — `ci(mobile-shell): bump android JDK to 21, raise iOS Podfile to 15.5`
- `0250e43` — `ci(mobile-shell-ios): tolerate cap add ios pod install failure, patch Podfile in-place`

(Android JDK 21 уже в main через окрему комітку, так що тут ефективно мерджиться лише iOS-частина.)

### Чому iOS джоб падав

```
[!] CocoaPods could not find compatible versions for pod "GoogleMLKit/BarcodeScanning":
    CapacitorMlkitBarcodeScanning (from `@capacitor-mlkit/barcode-scanning`) was resolved to 7.5.0, which depends on
    GoogleMLKit/BarcodeScanning (= 7.0.0)
Specs satisfying the `GoogleMLKit/BarcodeScanning (= 7.0.0)` dependency were found, but they required a higher minimum deployment target.
```

Capacitor iOS template ставить `platform :ios, '14.0'`, а `@capacitor-mlkit/barcode-scanning@7.5` → `GoogleMLKit/BarcodeScanning@7.0` хоче `iOS ≥ 15.5`.

### Як виправлено

У workflow:
1. `cap add ios || true` — толеруємо падіння трейлінгового `pod install` всередині CLI (у Capacitor 7.x нема `--no-pod-install` флага).
2. Новий крок `Raise iOS deployment target in Podfile` — `sed` підіймає `platform :ios` до `15.5`.
3. Далі `cap sync ios` заново ганяє `pod install` уже проти пропатченого Podfile.

## Review & Testing Checklist for Human

Risk: **yellow** — тільки CI-workflow, без змін у рантайм-коді. Однак гілка стара (~31 PR позаду), тож очікувано конфлікти з main навіть якщо workflow-файл не чіпали.

- [ ] Переконатись, що iOS-джоб зеленіє на цьому PR (`Build iOS Simulator (Debug)`).
- [ ] Якщо GitHub покаже конфлікти — найпростіше закрити цей PR і cherry-pick-нути `94a9bf0` + `0250e43` у свіжу гілку з `main`. Я сам цього зробити не можу, бо пушити зміни у `.github/workflows/**` у мене нема `workflow` scope на OAuth-токені — тому переюзовую існуючу гілку.
- [ ] Перевірити, що iOS deployment target `15.5` ок як floor (це збігається з вимогою Google MLKit і буде нашим ефективним floor для barcode scanner).

### Notes

- Цей PR **розблокує iOS CI** для #598 (fizruk: surface Progress in bottom nav) та будь-яких інших відкритих web-PR.
- Android-джоб не чіпаю — JDK 21 уже в main через `8a0aab9`/`f1bc91c` тощо.
- Vercel-чек окрема історія (build rate limit, не код).

Link to Devin session: https://app.devin.ai/sessions/cbd105dc56a846578b2d0bbe5b0731da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
