### PR TITLE
ci(mobile-shell-ios): fix Simulator build — raise Podfile to iOS 15.5 + tolerate cap add pod install

### DIFF
--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -74,12 +74,31 @@ jobs:
       - name: Scaffold iOS project (cap add ios)
         # `ios/` is intentionally uncommitted in the repo — see the
         # "iOS" section of apps/mobile-shell/README.md. `cap add ios`
-        # generates the Xcode project + runs `pod install`.
+        # first scaffolds the Xcode project and _then_ runs `pod install`.
+        # The pod install step fails on the default template because
+        # @capacitor-mlkit/barcode-scanning 7.5 → GoogleMLKit 7.0 needs
+        # iOS ≥ 15.5 while the template ships `platform :ios, '14.0'`.
+        # The Xcode project + Podfile are already on disk at that point
+        # though, so we swallow the exit code, patch the Podfile, and
+        # run `pod install` ourselves in the next step via `cap sync ios`.
         working-directory: apps/mobile-shell
-        run: pnpm exec cap add ios
+        run: pnpm exec cap add ios || true
+
+      - name: Raise iOS deployment target in Podfile
+        working-directory: apps/mobile-shell/ios/App
+        # Bump `platform :ios, 'X'` from the Capacitor template default to
+        # 15.5 so `pod install` can resolve GoogleMLKit/BarcodeScanning
+        # 7.0.0 (the transitive dep of @capacitor-mlkit/barcode-scanning).
+        run: |
+          test -f Podfile || { echo "Podfile missing — cap add ios did not scaffold"; exit 1; }
+          sed -i.bak "s/^platform :ios, '[0-9.]*'/platform :ios, '15.5'/" Podfile
+          diff -u Podfile.bak Podfile || true
+          rm Podfile.bak
 
       - name: Capacitor sync (ios)
         working-directory: apps/mobile-shell
+        # `cap sync ios` now runs `pod install` against the patched
+        # Podfile and refreshes the plugin graph / web assets.
         run: pnpm exec cap sync ios
 
       - name: Build App scheme for iOS Simulator (no signing)


### PR DESCRIPTION
## Summary

Розблоковує `Build iOS Simulator (Debug)` CI-джоб (`.github/workflows/mobile-shell-ios.yml`), який падав на кожному PR, що зачіпав `apps/web/**` / `apps/mobile-shell/**` / `apps/server/**` / `packages/**`.

Причина падіння:

```
[!] CocoaPods could not find compatible versions for pod "GoogleMLKit/BarcodeScanning":
    CapacitorMlkitBarcodeScanning (from `@capacitor-mlkit/barcode-scanning`) was resolved to 7.5.0, which depends on
    GoogleMLKit/BarcodeScanning (= 7.0.0)
Specs satisfying the `GoogleMLKit/BarcodeScanning (= 7.0.0)` dependency were found, but they required a higher minimum deployment target.
```

Capacitor iOS template ставить `platform :ios, '14.0'`, а `@capacitor-mlkit/barcode-scanning@7.5` → `GoogleMLKit/BarcodeScanning@7.0` вимагає iOS ≥ 15.5.

### Що змінено в workflow

1. `pnpm exec cap add ios || true` — толеруємо падіння трейлінгового `pod install` всередині CLI (у Capacitor 7.x нема `--no-pod-install` флага).
2. Новий крок **Raise iOS deployment target in Podfile** — `sed` підіймає `platform :ios, '14.0'` → `'15.5'` у щойно згенерованому `ios/App/Podfile`.
3. `pnpm exec cap sync ios` далі заново ганяє `pod install` уже проти пропатченого Podfile — `GoogleMLKit/BarcodeScanning 7.0` резолвиться без проблем.

Ці зміни вже існували в комітках `94a9bf0` + `0250e43` на старій гілці `devin/1776866494-mobile-shell-ci`, але та гілка ~31 PR позаду main і змерджити її напряму не виходить (див. #602, який я зараз закрию).

Жодних продовольчих змін у рантайм-коді. Android-джоб не чіпаю — JDK 21 уже в main.

## Review & Testing Checklist for Human

Risk: **yellow** — лише workflow file, але iOS ≥ 15.5 стає нашим ефективним deployment floor для Capacitor-shell.

- [ ] Переконатись, що `Build iOS Simulator (Debug)` зеленіє на цьому PR.
- [ ] Перевірити, що iOS 15.5 ок як floor (збігається з вимогою Google MLKit; iOS 15 зараз покриває ~99% активних пристроїв за статистикою Apple).
- [ ] Після мержу перезапустити CI на #598 (fizruk progress nav) — там має також позеленіти iOS.

### Notes

- Після мержу закрию вручну stale-PR #602 (той самий фікс, але на древній гілці з конфліктами).
- Vercel preview окрема історія — там build rate limit на акаунті, не код.

Link to Devin session: https://app.devin.ai/sessions/cbd105dc56a846578b2d0bbe5b0731da
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS mobile shell build process to properly resolve required dependencies by updating the minimum iOS deployment target to version 15.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->