### PR TITLE
feat(fizruk): dashboard KPI strip + recent workouts list

### DIFF
--- a/apps/web/src/modules/fizruk/components/dashboard/KpiRow.test.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/KpiRow.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type { DashboardKpis } from "@sergeant/fizruk-domain/domain";
+
+import { KpiRow } from "./KpiRow";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeKpis(overrides: Partial<DashboardKpis> = {}): DashboardKpis {
+  return {
+    streakDays: 0,
+    weeklyWorkoutsCount: 0,
+    weeklyVolumeKg: 0,
+    totalCompletedCount: 0,
+    avgDurationSec: 0,
+    latestWorkoutIso: null,
+    weightChangeKg: null,
+    weightWindowDays: 30,
+    ...overrides,
+  };
+}
+
+describe("KpiRow", () => {
+  it("renders zero-state placeholders when the user has no data yet", () => {
+    render(<KpiRow kpis={makeKpis()} />);
+    expect(screen.getByText("0 днів")).toBeDefined();
+    expect(screen.getByText("0 кг")).toBeDefined();
+    expect(screen.getByText("Додай заміри")).toBeDefined();
+    expect(screen.getByText("Почни сьогодні або вчора")).toBeDefined();
+  });
+
+  it("pluralises the streak, weekly volume, and workouts count", () => {
+    render(
+      <KpiRow
+        kpis={makeKpis({
+          streakDays: 3,
+          weeklyWorkoutsCount: 4,
+          weeklyVolumeKg: 10000,
+        })}
+      />,
+    );
+    expect(screen.getByText("3 дні")).toBeDefined();
+    expect(screen.getByText("4 тренування")).toBeDefined();
+    // 10000 kg → 10 т (rounded as whole tonnes once >= 10)
+    expect(screen.getByText("10 т")).toBeDefined();
+  });
+
+  it("keeps sub-tonne volume formatted in kg", () => {
+    render(
+      <KpiRow
+        kpis={makeKpis({
+          streakDays: 1,
+          weeklyWorkoutsCount: 1,
+          weeklyVolumeKg: 420,
+        })}
+      />,
+    );
+    expect(screen.getByText("1 день")).toBeDefined();
+    expect(screen.getByText("1 тренування")).toBeDefined();
+    expect(screen.getByText("420 кг")).toBeDefined();
+  });
+
+  it("formats a negative weight delta as positive tone", () => {
+    render(<KpiRow kpis={makeKpis({ weightChangeKg: -1.4 })} />);
+    // −1.4 → displays rounded to 1 decimal, with minus sign
+    const node = screen.getByText("−1.4 кг");
+    expect(node.className).toContain("text-success");
+  });
+
+  it("formats a positive weight delta as negative tone", () => {
+    render(<KpiRow kpis={makeKpis({ weightChangeKg: 2 })} />);
+    const node = screen.getByText("+2 кг");
+    expect(node.className).toContain("text-danger");
+  });
+
+  it("shows the dash placeholder when no weight samples are available", () => {
+    render(<KpiRow kpis={makeKpis({ weightChangeKg: null })} />);
+    expect(screen.getByText("—")).toBeDefined();
+  });
+
+  it("uses the correct Ukrainian 11/12/14 plural forms", () => {
+    const { rerender } = render(<KpiRow kpis={makeKpis({ streakDays: 11 })} />);
+    expect(screen.getByText("11 днів")).toBeDefined();
+    rerender(<KpiRow kpis={makeKpis({ streakDays: 21 })} />);
+    expect(screen.getByText("21 день")).toBeDefined();
+    rerender(<KpiRow kpis={makeKpis({ streakDays: 22 })} />);
+    expect(screen.getByText("22 дні")).toBeDefined();
+  });
+});

--- a/apps/web/src/modules/fizruk/components/dashboard/KpiRow.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/KpiRow.tsx
@@ -1,0 +1,137 @@
+/**
+ * `KpiRow` — dashboard KPI strip (streak / weekly volume / weight Δ).
+ *
+ * Purely presentational: the `DashboardKpis` payload is computed by
+ * `@sergeant/fizruk-domain/domain/dashboard`'s `computeDashboardKpis`,
+ * so the aggregation stays platform-neutral and shared with
+ * `apps/mobile/src/modules/fizruk/components/dashboard/KpiRow.tsx`.
+ *
+ * Three tiles side-by-side on a compact Card. Numbers are formatted
+ * for Ukrainian pluralisation (`1 день` / `2 дні` / `5 днів` and
+ * `1 тренування` / `2 тренування` / `5 тренувань`). Weight delta
+ * swaps tone — a drop is reported as `text-success`, a gain as
+ * `text-danger` — so the strip reads as progress towards a recomp
+ * goal out of the box. (Callers who are bulking can still ignore the
+ * colour and just read the number.)
+ */
+
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import type { DashboardKpis } from "@sergeant/fizruk-domain/domain";
+
+export interface KpiRowProps {
+  readonly kpis: DashboardKpis;
+  readonly className?: string;
+}
+
+type TileTone = "default" | "positive" | "negative";
+
+interface TileProps {
+  readonly label: string;
+  readonly value: string;
+  readonly hint?: string;
+  readonly tone?: TileTone;
+}
+
+const TONE_CLASS: Record<TileTone, string> = {
+  default: "text-text",
+  positive: "text-success",
+  negative: "text-danger",
+};
+
+function Tile({ label, value, hint, tone = "default" }: TileProps) {
+  return (
+    <div className="flex-1 min-w-0 rounded-2xl border border-line bg-panel p-3 flex flex-col">
+      <SectionHeading as="p" size="xs">
+        {label}
+      </SectionHeading>
+      <p
+        className={`mt-1 text-lg font-bold leading-tight truncate ${TONE_CLASS[tone]}`}
+      >
+        {value}
+      </p>
+      {hint ? (
+        <p className="mt-0.5 text-[11px] text-subtle truncate">{hint}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function formatVolumeKg(kg: number): string {
+  if (kg <= 0) return "0 кг";
+  if (kg >= 1000) {
+    const thousands = kg / 1000;
+    const rounded =
+      thousands >= 10 ? Math.round(thousands) : Math.round(thousands * 10) / 10;
+    return `${rounded} т`;
+  }
+  return `${Math.round(kg)} кг`;
+}
+
+function formatWeightDelta(delta: number | null): {
+  readonly value: string;
+  readonly tone: TileTone;
+} {
+  if (delta == null) return { value: "—", tone: "default" };
+  if (delta === 0) return { value: "0 кг", tone: "default" };
+  const sign = delta > 0 ? "+" : "−";
+  const abs = Math.abs(delta);
+  const rounded = Math.round(abs * 10) / 10;
+  return {
+    value: `${sign}${rounded} кг`,
+    tone: delta < 0 ? "positive" : "negative",
+  };
+}
+
+function pluralDays(n: number): string {
+  const mod100 = n % 100;
+  const mod10 = n % 10;
+  if (mod100 >= 11 && mod100 <= 14) return `${n} днів`;
+  if (mod10 === 1) return `${n} день`;
+  if (mod10 >= 2 && mod10 <= 4) return `${n} дні`;
+  return `${n} днів`;
+}
+
+function pluralWorkouts(n: number): string {
+  const mod100 = n % 100;
+  const mod10 = n % 10;
+  if (mod100 >= 11 && mod100 <= 14) return `${n} тренувань`;
+  if (mod10 === 1) return `${n} тренування`;
+  if (mod10 >= 2 && mod10 <= 4) return `${n} тренування`;
+  return `${n} тренувань`;
+}
+
+export function KpiRow({ kpis, className }: KpiRowProps) {
+  const streakLabel =
+    kpis.streakDays > 0 ? pluralDays(kpis.streakDays) : "0 днів";
+  const weeklyLabel = formatVolumeKg(kpis.weeklyVolumeKg);
+  const weeklyHint = pluralWorkouts(kpis.weeklyWorkoutsCount);
+  const delta = formatWeightDelta(kpis.weightChangeKg);
+
+  return (
+    <Card
+      as="section"
+      radius="lg"
+      padding="sm"
+      aria-label="Ключові показники тренувань"
+      className={className}
+    >
+      <div className="flex flex-row gap-2">
+        <Tile
+          label="Серія"
+          value={streakLabel}
+          hint={kpis.streakDays === 0 ? "Почни сьогодні або вчора" : "підряд"}
+        />
+        <Tile label="Цей тиждень" value={weeklyLabel} hint={weeklyHint} />
+        <Tile
+          label={`Вага · ${kpis.weightWindowDays}д`}
+          value={delta.value}
+          hint={kpis.weightChangeKg == null ? "Додай заміри" : "дельта"}
+          tone={delta.tone}
+        />
+      </div>
+    </Card>
+  );
+}
+
+export default KpiRow;

--- a/apps/web/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.test.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DashboardRecentWorkout } from "@sergeant/fizruk-domain/domain";
+
+import { RecentWorkoutsSection } from "./RecentWorkoutsSection";
+
+afterEach(() => {
+  cleanup();
+});
+
+function row(
+  overrides: Partial<DashboardRecentWorkout> = {},
+): DashboardRecentWorkout {
+  return {
+    startedAt: "2026-04-23T09:30:00.000Z",
+    endedAt: "2026-04-23T10:15:00.000Z",
+    durationSec: 45 * 60,
+    itemsCount: 5,
+    tonnageKg: 1200,
+    label: "Понеділок · Груди + трицепс",
+    ...overrides,
+  };
+}
+
+describe("RecentWorkoutsSection", () => {
+  it("shows an empty-state card and hides the 'Усі' link when the list is empty", () => {
+    const onSeeAll = vi.fn();
+    render(<RecentWorkoutsSection recent={[]} onSeeAll={onSeeAll} />);
+    expect(screen.getByText("Ще жодного завершеного тренування")).toBeDefined();
+    expect(screen.queryByLabelText("Усі тренування")).toBeNull();
+  });
+
+  it("renders each recent workout with its label, duration and tonnage", () => {
+    const onSeeAll = vi.fn();
+    const recent = [
+      row({ label: "Ноги", durationSec: 30 * 60, tonnageKg: 850 }),
+      row({
+        startedAt: "2026-04-22T09:30:00.000Z",
+        endedAt: "2026-04-22T11:00:00.000Z",
+        label: "Спина",
+        durationSec: 90 * 60,
+        tonnageKg: 1500,
+      }),
+    ];
+    render(<RecentWorkoutsSection recent={recent} onSeeAll={onSeeAll} />);
+    expect(screen.getByText("Ноги")).toBeDefined();
+    expect(screen.getByText("Спина")).toBeDefined();
+    expect(screen.getByText("850 кг")).toBeDefined();
+    // 90 min → 1 год 30 хв
+    expect(screen.getByText(/1 год 30 хв/)).toBeDefined();
+    expect(screen.getByText("1.5 т")).toBeDefined();
+  });
+
+  it("uses '—' placeholders when duration or tonnage is zero/invalid", () => {
+    const onSeeAll = vi.fn();
+    const recent = [row({ durationSec: 0, tonnageKg: 0 })];
+    render(<RecentWorkoutsSection recent={recent} onSeeAll={onSeeAll} />);
+    // Tonnage renders in its own span → getByText finds it directly.
+    expect(screen.getByText("—")).toBeDefined();
+    // Duration is inside a joined "{date} · —" sentence; match via regex.
+    expect(screen.getByText(/·\s*—$/)).toBeDefined();
+  });
+
+  it("invokes onSeeAll when the 'Усі' pill is clicked", () => {
+    const onSeeAll = vi.fn();
+    render(<RecentWorkoutsSection recent={[row()]} onSeeAll={onSeeAll} />);
+    const btn = screen.getByLabelText("Усі тренування");
+    fireEvent.click(btn);
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.tsx
@@ -1,0 +1,120 @@
+/**
+ * `RecentWorkoutsSection` — bottom-of-dashboard list of the last few
+ * completed workouts. Uses the pure `listRecentCompletedWorkouts`
+ * selector from `@sergeant/fizruk-domain/domain/dashboard` so ordering,
+ * duration and tonnage stay consistent with
+ * `apps/mobile/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.tsx`.
+ *
+ * Collapses gracefully to an empty-state card when there is nothing to
+ * show. The "Усі" pill routes to the Workouts journal (`#workouts` with
+ * `fizruk_workouts_mode=log`) — the same surface the resume-CTA uses.
+ */
+
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import type { DashboardRecentWorkout } from "@sergeant/fizruk-domain/domain";
+
+export interface RecentWorkoutsSectionProps {
+  readonly recent: readonly DashboardRecentWorkout[];
+  readonly onSeeAll: () => void;
+}
+
+function formatDateShort(iso: string | null): string {
+  if (!iso) return "";
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return "";
+  try {
+    return new Date(ms).toLocaleDateString("uk-UA", {
+      day: "numeric",
+      month: "short",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function formatDuration(sec: number): string {
+  if (!Number.isFinite(sec) || sec <= 0) return "—";
+  const mins = Math.round(sec / 60);
+  if (mins < 60) return `${mins} хв`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m === 0 ? `${h} год` : `${h} год ${m} хв`;
+}
+
+function formatTonnage(kg: number): string {
+  if (!Number.isFinite(kg) || kg <= 0) return "—";
+  if (kg >= 1000) {
+    const thousands = kg / 1000;
+    const rounded =
+      thousands >= 10 ? Math.round(thousands) : Math.round(thousands * 10) / 10;
+    return `${rounded} т`;
+  }
+  return `${Math.round(kg)} кг`;
+}
+
+export function RecentWorkoutsSection({
+  recent,
+  onSeeAll,
+}: RecentWorkoutsSectionProps) {
+  return (
+    <Card as="section" radius="lg" aria-label="Останні тренування">
+      <div className="flex items-baseline justify-between gap-2 mb-3">
+        <SectionHeading as="h2" size="sm">
+          Останні тренування
+        </SectionHeading>
+        {recent.length > 0 ? (
+          <button
+            type="button"
+            onClick={onSeeAll}
+            className="text-xs font-semibold text-fizruk-strong hover:underline active:opacity-70"
+            aria-label="Усі тренування"
+          >
+            Усі →
+          </button>
+        ) : null}
+      </div>
+
+      {recent.length === 0 ? (
+        <div
+          className="rounded-2xl border border-dashed border-line p-6 flex flex-col items-center text-center"
+          data-testid="fizruk-dashboard-recent-empty"
+        >
+          <p className="text-sm font-semibold text-text">
+            Ще жодного завершеного тренування
+          </p>
+          <p className="text-xs text-subtle mt-1">
+            Почни сесію — результати з&apos;являться тут автоматично.
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {recent.map((row) => (
+            <li
+              key={`${row.startedAt}-${row.endedAt ?? "na"}`}
+              className="rounded-2xl border border-line bg-bg p-3 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-text truncate">
+                  {row.label}
+                </p>
+                <p className="text-[11px] text-subtle mt-0.5">
+                  {formatDateShort(row.endedAt)} ·{" "}
+                  {formatDuration(row.durationSec)}
+                </p>
+              </div>
+              <div className="flex flex-col items-end shrink-0">
+                <span className="text-sm font-bold text-fizruk-strong">
+                  {formatTonnage(row.tonnageKg)}
+                </span>
+                <span className="text-[10px] text-subtle">тоннаж</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+export default RecentWorkoutsSection;

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -3,16 +3,23 @@ import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { useEffect, useMemo, useState } from "react";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
+import { useMeasurements } from "../hooks/useMeasurements";
 import { useRecovery } from "../hooks/useRecovery";
 import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
 import { BodyAtlas } from "../components/BodyAtlas";
 import { HeroCard, type HeroCardState } from "../components/dashboard/HeroCard";
+import { KpiRow } from "../components/dashboard/KpiRow";
+import { RecentWorkoutsSection } from "../components/dashboard/RecentWorkoutsSection";
 import { recoveryConflictsForExercise } from "@sergeant/fizruk-domain";
 import { workoutDurationSec } from "@sergeant/fizruk-domain";
 import { ACTIVE_WORKOUT_KEY } from "@sergeant/fizruk-domain";
-import { getNextPlanSession } from "@sergeant/fizruk-domain/domain";
+import {
+  computeDashboardKpis,
+  getNextPlanSession,
+  listRecentCompletedWorkouts,
+} from "@sergeant/fizruk-domain/domain";
 import { Card } from "@shared/components/ui/Card";
 import { useActiveFizrukWorkout } from "@shared/hooks/useActiveFizrukWorkout";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
@@ -36,6 +43,7 @@ export function Dashboard({
   const { exercises, primaryGroupsUk, musclesUk } = useExerciseCatalog();
   const { templates, recentlyUsed, markTemplateUsed } = useWorkoutTemplates();
   const monthlyPlan = useMonthlyPlan();
+  const { entries: measurements } = useMeasurements();
 
   const [recoveryOpen, setRecoveryOpen] = useState(false);
 
@@ -281,6 +289,19 @@ export function Dashboard({
     }
   }, [monthlyPlan, templates]);
 
+  const dashboardKpis = useMemo(
+    () =>
+      computeDashboardKpis(workouts || [], {
+        measurements: measurements || [],
+      }),
+    [workouts, measurements],
+  );
+
+  const recentWorkouts = useMemo(
+    () => listRecentCompletedWorkouts(workouts || [], { limit: 3 }),
+    [workouts],
+  );
+
   const heroState: HeroCardState = useMemo(() => {
     if (activeWorkout?.startedAt) {
       return {
@@ -353,6 +374,8 @@ export function Dashboard({
           onOpenTemplates={openTemplates}
           onOpenPrograms={() => onOpenPrograms?.()}
         />
+
+        <KpiRow kpis={dashboardKpis} />
 
         {templates.length > 0 &&
           (() => {
@@ -690,6 +713,11 @@ export function Dashboard({
             </Button>
           </div>
         </Card>
+
+        <RecentWorkoutsSection
+          recent={recentWorkouts}
+          onSeeAll={openWorkoutsTab}
+        />
       </div>
 
       <Sheet


### PR DESCRIPTION
## Summary

Другий PR з редизайну «Сьогодні» (Фізрук). Після #599 hero показує 4 інформативні стани, але решта сторінки так і не повідомляла користувачу жодного реального числа про нього самого. Цей PR — два нові секції, обидві повністю керовані існуючими pure-селекторами з `@sergeant/fizruk-domain`:

**`KpiRow`** — стрічка з трьох плиток під hero:
- **Серія**: поточна кількість днів підряд з ≥1 завершеним тренуванням (дає «grace period» на сьогодні — не показує «0» допоки не закінчиться вчорашній день). Український плюрал: `1 день` / `2 дні` / `5 днів`, з правильною формою для 11-14.
- **Цей тиждень**: сумарний тоннаж Mon-first тижня, автоматично flip у «т» при ≥ 1000 кг (з однією десятою для 1-9.9т і цілими для 10+т), плюс hint з кількістю тренувань.
- **Вага · 30д**: підписана delta між найстарішим і найновішим виміром у вікні. Тонування інвертоване до інтуїції для recomp: **втрата ваги = `text-success`**, приріст = `text-danger`. Якщо замірів менше двох, показує `—` + "Додай заміри".

**`RecentWorkoutsSection`** — карта внизу зі списком трьох останніх завершених тренувань: лейбл (нота або перша назва вправи), дата, тривалість, тоннаж. «Усі →» тригерить той самий `openWorkoutsTab` що і resume-CTA з hero — приземляється на `#workouts` з `fizruk_workouts_mode=log`, тобто одразу у журналі, а не на generic home.

Нічого не дублюється з мобільного — обидва застосунки тепер споживають той самий контракт `computeDashboardKpis` / `listRecentCompletedWorkouts`. Дашборд фізрука на вебі підхопив 30-денну weight-дельту через існуючий `useMeasurements` хук без змін у шарі персистентності.

## Review & Testing Checklist for Human

- [ ] Відкрий «Сьогодні» фізрука. Під hero тепер — 3 плитки (Серія / Цей тиждень / Вага · 30д). Числа мають відповідати: щоденний streak рахується до сьогодні (або до вчора, якщо сьогодні ще без тренування), тижневий тоннаж — сума `weightKg × reps` по всіх strength-сетах від понеділка.
- [ ] Введи два виміри у Measurements (перший важчий, другий легший, обидва в межах 30 днів) — плитка «Вага · 30д» має показати **`−X кг`** у зеленому. Зроби навпаки — має почервоніти. Поки менше двох замірів у вікні — показується `—` + «Додай заміри».
- [ ] Проскролли до низу — карта «Останні тренування» показує ≤3 завершені тренування newest-first, з датою (укр. `23 квіт.`), тривалістю (`45 хв` / `1 год 30 хв`) і тоннажем. Клік «Усі →» веде одразу у журнал.
- [ ] Empty-state: якщо ще немає жодного завершеного тренування, секція показує плейсхолдер «Ще жодного завершеного тренування» без кнопки «Усі».
- [ ] CI: `Accessibility (axe-core) · fizruk-dashboard` має бути зелений — локально passed. 665 web unit-тестів зелені (додав 7 для KpiRow + 4 для RecentWorkoutsSection).

### Notes

- Файли: `apps/web/src/modules/fizruk/components/dashboard/KpiRow.tsx` (+140), `.../RecentWorkoutsSection.tsx` (+130), `.../KpiRow.test.tsx`, `.../RecentWorkoutsSection.test.tsx`, і 3 правки в `apps/web/src/modules/fizruk/pages/Dashboard.tsx` (+24 / −1).
- **Свідомо не чіпаю** «Швидкий старт» / «Програма сьогодні» / «План на сьогодні» / «Відновлення й фокус» — це PR #3 з редизайну (видалити дублі CTA та розкрити «Відновлення»). Хочу щоб цей PR був чистим «додаємо нову інформацію», без видалення існуючого flow.
- Vercel preview може впасти з `Deployment rate limited — retry in 24 hours` (org-level ліміт, не стосується коду).
- iOS Simulator build продовжує падати на `main` через CocoaPods (GoogleMLKit/BarcodeScanning vs `@capacitor-mlkit/barcode-scanning@7.5.0`) — окрема проблема.

Link to Devin session: https://app.devin.ai/sessions/17a7683df87743398402ebcd6f8cba28
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
