### PR TITLE
feat(fizruk/progress): remove standalone JSON import — use Hub shared backup

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { EmptyState } from "@shared/components/ui/EmptyState";
-import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useMeasurements } from "../hooks/useMeasurements";
@@ -13,7 +12,6 @@ import { MiniLineChart } from "../components/MiniLineChart";
 import { WellbeingChart } from "../components/WellbeingChart";
 import { WeeklyVolumeChart } from "../components/WeeklyVolumeChart";
 import {
-  applyFizrukFullBackupPayload,
   buildFizrukFullBackupPayload,
   FIZRUK_RESET_KEYS,
 } from "../lib/fizrukStorage";
@@ -31,12 +29,10 @@ function weekStartMs(d) {
 }
 
 export function Progress() {
-  const toast = useToast();
   const { workouts } = useWorkouts();
   const { entries } = useMeasurements();
   const { exercises, musclesUk } = useExerciseCatalog();
   const { stats: pushupStats, hasData: hasPushupData } = usePushupActivity();
-  const fileRef = useRef(null);
 
   const meas = useMemo(() => {
     const latest = entries?.[0] || null;
@@ -224,25 +220,6 @@ export function Progress() {
       `fizruk-backup-${new Date().toISOString().slice(0, 10)}.json`,
       payload,
     );
-  };
-
-  const importJson = async (file) => {
-    let text;
-    try {
-      text = await file.text();
-    } catch (err) {
-      console.error("[fizruk] importJson: failed to read file", err);
-      throw err;
-    }
-    let parsed;
-    try {
-      parsed = JSON.parse(text);
-    } catch (err) {
-      console.error("[fizruk] importJson: invalid JSON", err);
-      throw new Error("Невірний формат файлу");
-    }
-    applyFizrukFullBackupPayload(parsed);
-    window.location.reload();
   };
 
   const [resetConfirm, setResetConfirm] = useState(false);
@@ -677,35 +654,13 @@ export function Progress() {
           >
             Експорт (backup)
           </button>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              className="h-12 min-h-[44px] rounded-full"
-              variant="ghost"
-              onClick={() => fileRef.current?.click()}
-            >
-              Імпорт
-            </Button>
-            <Button
-              className="h-12 min-h-[44px] rounded-full"
-              variant="ghost"
-              onClick={exportCsv}
-            >
-              CSV
-            </Button>
-          </div>
-          <input
-            ref={fileRef}
-            type="file"
-            accept="application/json"
-            className="hidden"
-            onChange={(e) => {
-              const f = e.target.files?.[0];
-              if (!f) return;
-              importJson(f).catch(() =>
-                toast.error("Не вдалося імпортувати файл"),
-              );
-            }}
-          />
+          <Button
+            className="w-full h-12 min-h-[44px] rounded-full"
+            variant="ghost"
+            onClick={exportCsv}
+          >
+            CSV
+          </Button>
           <div className="mt-3">
             <Button
               variant="danger"


### PR DESCRIPTION
## Summary
Removed the standalone "Імпорт" JSON-upload button from the Fizruk **Прогрес** page, along with its hidden `<input type="file">`, the `importJson` handler, and the now-unused `useRef` / `useToast` / `applyFizrukFullBackupPayload` / `fileRef` / `toast` bindings. Fizruk data is still importable via the shared **Hub backup** in Settings (`HubBackupPanel`), which round-trips the full Fizruk payload through the same `applyFizrukFullBackupPayload` path (`apps/web/src/core/hubBackup.ts`).

Kept on the Прогрес page:
- `Експорт (backup)` — Fizruk-only full JSON export (still useful as a module-scoped snapshot).
- `CSV` — workouts-only tabular export (not duplicated in Hub).
- `Скинути всі дані` — reset.

The `grid-cols-2` row that previously held `Імпорт` + `CSV` is collapsed to a single full-width `CSV` button.

No changes to mobile (`apps/mobile/.../Progress.tsx` — no import UI there), no changes to `fizrukStorage.ts` (`applyFizrukFullBackupPayload` is still exported and consumed by `hubBackup.ts`).

## Review & Testing Checklist for Human
- [ ] Open Фізрук → Прогрес and confirm the "Імпорт" button and file picker are gone; "Експорт (backup)", "CSV" and "Скинути всі дані" still work.
- [ ] Open Налаштування → Hub backup and confirm Import/Export JSON still round-trips Fizruk data (create a workout/measurement → Експорт → Скинути → Імпорт → data returns).
- [ ] Spot-check that no other page was relying on the removed `fileRef`/`toast` on Progress (grep for `fizruk/pages/Progress` references).

### Notes
- Lint, typecheck, and `@sergeant/web` tests all pass locally (665 tests).
- The mobile Progress screen has no import UI to remove.

Link to Devin session: https://app.devin.ai/sessions/da9b499010aa408da318d915119b233a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Removed import functionality from data management; export/backup (JSON and CSV) features remain available.
  * Simplified data management section layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->