### PR TITLE
feat(fizruk): move «Внести проведене заняття» entry-point to Workouts home

### DIFF
--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -207,22 +207,24 @@ export function WorkoutJournalSection({
           <SectionHeading as="div" size="sm">
             Останні тренування
           </SectionHeading>
-          <button
-            type="button"
-            onClick={() => setRetroOpen((o) => !o)}
-            className={compactToolbarButtonClass}
-            aria-expanded={retroOpen}
-            title="Записати заднім числом"
-          >
-            •••
-          </button>
         </div>
 
         {retroOpen && (
           <div className="px-4 py-3 border-b border-line bg-bg space-y-3">
-            <p className="text-xs font-semibold text-text">
-              Записати тренування заднім числом
-            </p>
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-xs font-semibold text-text">
+                Записати тренування заднім числом
+              </p>
+              <button
+                type="button"
+                onClick={() => setRetroOpen(false)}
+                className={compactToolbarButtonClass}
+                aria-label="Закрити"
+                title="Закрити"
+              >
+                ×
+              </button>
+            </div>
             <p className="text-xs text-subtle leading-relaxed">
               Вкажи, коли було тренування, потім додай вправи та заповни
               кг/повтори.

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -470,6 +470,10 @@ export function Workouts() {
             onOpenCatalog={() => setView("catalog")}
             onOpenTemplates={() => setView("templates")}
             onOpenJournal={() => setView("log")}
+            onOpenRetro={() => {
+              setRetroOpen(true);
+              setView("log");
+            }}
           />
         ) : null}
 
@@ -677,6 +681,7 @@ interface WorkoutsHomeProps {
   onOpenCatalog: () => void;
   onOpenTemplates: () => void;
   onOpenJournal: () => void;
+  onOpenRetro: () => void;
 }
 
 function WorkoutsHome({
@@ -689,6 +694,7 @@ function WorkoutsHome({
   onOpenCatalog,
   onOpenTemplates,
   onOpenJournal,
+  onOpenRetro,
 }: WorkoutsHomeProps) {
   const hasActive = !!activeWorkout && !activeWorkout.endedAt;
 
@@ -740,6 +746,14 @@ function WorkoutsHome({
           </div>
         </div>
       )}
+
+      <Button
+        variant="ghost"
+        className="h-11 w-full text-sm"
+        onClick={onOpenRetro}
+      >
+        ✏️ Внести проведене заняття
+      </Button>
 
       <div>
         <div className="flex items-center justify-between px-1 mb-2">


### PR DESCRIPTION
## Summary

Винесено кнопку «Внести проведене заняття» з Журналу у перший слайд сторінки Тренування (там, де «Почати» та «Шаблони»).

Що зроблено:
- `WorkoutsHome` (перший слайд): додано нову ghost-кнопку «✏️ Внести проведене заняття» під hero-блоком. Клік відкриває Журнал і автоматично розгортає retro-форму (дата/час + «Створити й заповнити»).
- `WorkoutJournalSection`: прибрано недоступну «•••» кнопку з заголовка «Останні тренування» — retro-форма тепер вмикається ззовні (з home). Всередині самої форми додано «×» для закриття, щоб користувач не застрягав, якщо вже на сторінці Журналу.

Файли:
- `apps/web/src/modules/fizruk/pages/Workouts.tsx` — новий prop `onOpenRetro` в `WorkoutsHome`, кнопка рендериться завжди на home (і коли немає активного тренування, і коли є).
- `apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx` — прибрано header-toggle, додано inline `×` у retro-формі.

Локально пройшли: `pnpm --filter @sergeant/web lint`, `typecheck`, `test` (665/665).

## Review & Testing Checklist for Human

- [ ] Відкрити `/fizruk/workouts` → на першому слайді (home) під hero є кнопка «✏️ Внести проведене заняття».
- [ ] Натиснути її → відбувається перехід у Журнал, і retro-форма (Дата/Час початку + «Створити й заповнити») вже розгорнута.
- [ ] Заповнити форму й натиснути «Створити й заповнити» → створюється заднє-числове тренування, форма згортається, актив-сесія виставлена на новий workout.
- [ ] Перевірити стан, коли вже є активне тренування: home показує hero «Активне тренування … Відкрити →», і кнопка retro усе одно доступна нижче.
- [ ] Перевірити закриття retro-форми зсередини через «×» (коли user вже у Журналі).

### Notes

Зміни мінімальні та локалізовані в межах модуля Фізрук. Бізнес-логіка retro (`submitRetroWorkout`, стан `retroOpen/retroDate/retroTime`) не змінювалась — лише переміщено точку входу.

Link to Devin session: https://app.devin.ai/sessions/6fdd6c4d288b4638a9b2142d82781c09
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
