### PR TITLE
fix(finyk/budgets): rename "бюджет" to "ліміт" in add-budget button

### DIFF
--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -585,7 +585,7 @@ export function Budgets({ mono, storage, showBalance = true }) {
             onClick={() => setShowForm(true)}
             className="w-full py-3 text-sm text-muted border border-dashed border-line rounded-xl hover:border-primary hover:text-primary transition-colors"
           >
-            + Додати бюджет або ціль
+            + Додати ліміт або ціль
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
На сторінці Планування (ФІНІК → Budgets) секції вже називаються **ЛІМІТИ** та **ЦІЛІ НАКОПИЧЕННЯ**, але CTA-кнопка для додавання нового елемента використовувала термін «бюджет» — `+ Додати бюджет або ціль`. Це створювало плутанину з двома паралельними термінами для одного поняття.

Перейменовано кнопку на `+ Додати ліміт або ціль`, щоб термінологія на сторінці була узгодженою.

Змінено лише один user-facing рядок у <ref_snippet file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/finyk/pages/Budgets.tsx" lines="588-588" />. Внутрішні коментарі, назви змінних/файлів, AI-промпти та інші місця з «бюджет» (де йдеться про загальну концепцію бюджетування) не чіпав.

## Review & Testing Checklist for Human
- [ ] Відкрити ФІНІК → вкладка «Планування» і перевірити, що кнопка тепер показує `+ Додати ліміт або ціль`
- [ ] Переконатись, що натискання кнопки як і раніше відкриває форму додавання (ліміт/ціль)

### Notes
- `pnpm --filter @sergeant/web typecheck` — OK
- `pnpm --filter @sergeant/web lint` — OK


Link to Devin session: https://app.devin.ai/sessions/fef54d4971b54752b30e2ceb70c0c5c9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button text label in the Budgets interface for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->