### PR TITLE
feat(hub/today-focus): refine quick-add chips to match Hub theme

### DIFF
--- a/apps/web/src/core/TodayFocusCard.tsx
+++ b/apps/web/src/core/TodayFocusCard.tsx
@@ -144,18 +144,32 @@ const QUICK_ADD_CHIPS: QuickAddChip[] = (
   return { module: mod, label: a.shortLabel, action: a.action };
 });
 
-// Chip surfaces use saturated-accent-at-low-opacity in dark mode so they
-// blend with the warm dark panel instead of glowing as acidic pastel
-// (matches the `Badge`/`Tabs`/`Segmented` pattern already used across the
-// app). Light-mode surfaces stay on the soft pastel tokens.
-const MODULE_CHIP_CLASS: Record<HubModuleId, string> = {
-  finyk: "bg-finyk-soft text-finyk-strong dark:bg-finyk/15 dark:text-finyk",
-  fizruk:
-    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk/15 dark:text-fizruk",
-  routine:
-    "bg-routine-surface text-routine-strong dark:bg-routine/15 dark:text-routine",
-  nutrition:
-    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition",
+// Refined chip language: neutral panel base (matches the cream module rows
+// below) + a tinted «bubble» with a module-coloured plus, so the chips
+// visually echo the module list's icon-square pattern instead of looking
+// like loose candy pastels.
+const MODULE_CHIP_ACCENT: Record<
+  HubModuleId,
+  { bubble: string; hoverBorder: string }
+> = {
+  finyk: {
+    bubble: "bg-finyk-soft text-finyk dark:bg-finyk/20 dark:text-finyk",
+    hoverBorder: "hover:border-finyk/40 hover:bg-finyk-soft/40",
+  },
+  fizruk: {
+    bubble: "bg-fizruk-soft text-fizruk dark:bg-fizruk/20 dark:text-fizruk",
+    hoverBorder: "hover:border-fizruk/40 hover:bg-fizruk-soft/40",
+  },
+  routine: {
+    bubble:
+      "bg-routine-surface text-routine dark:bg-routine/20 dark:text-routine",
+    hoverBorder: "hover:border-routine/40 hover:bg-routine-surface/40",
+  },
+  nutrition: {
+    bubble:
+      "bg-nutrition-soft text-nutrition dark:bg-nutrition/20 dark:text-nutrition",
+    hoverBorder: "hover:border-nutrition/40 hover:bg-nutrition-soft/40",
+  },
 };
 
 /**
@@ -202,21 +216,34 @@ function EmptyFocus() {
       </p>
 
       <div className="mt-3 flex flex-wrap gap-2">
-        {QUICK_ADD_CHIPS.map((chip) => (
-          <button
-            key={chip.module}
-            type="button"
-            onClick={() => openHubModuleWithAction(chip.module, chip.action)}
-            className={cn(
-              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
-              "text-xs font-semibold",
-              "hover:brightness-110 active:scale-[0.98] transition-all",
-              MODULE_CHIP_CLASS[chip.module],
-            )}
-          >
-            {chip.label}
-          </button>
-        ))}
+        {QUICK_ADD_CHIPS.map((chip) => {
+          const accent = MODULE_CHIP_ACCENT[chip.module];
+          const name = chip.label.replace(/^\+\s*/, "");
+          return (
+            <button
+              key={chip.module}
+              type="button"
+              onClick={() => openHubModuleWithAction(chip.module, chip.action)}
+              className={cn(
+                "group inline-flex items-center gap-1.5 pl-1 pr-3 py-1 rounded-full",
+                "bg-panel border border-line text-xs font-semibold text-text",
+                "shadow-sm transition-all active:scale-[0.98]",
+                accent.hoverBorder,
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "inline-flex items-center justify-center w-5 h-5 rounded-full",
+                  accent.bubble,
+                )}
+              >
+                <Icon name="plus" size={12} strokeWidth={2.5} />
+              </span>
+              {name}
+            </button>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
На скріншоті юзера 4 quick-add-чипи у «Що зафіксуємо?» (`+ Витрата`, `+ Їжа`, `+ Звичка`, `+ Тренування`) виглядали як окремі кольорові цукерки на теплому cream-фоні — різні пастелі, без структури, без перегукування з рядками модулів нижче.

Переробив їх на єдину «panel-chip» мову:
- база — `bg-panel` + `border border-line` (як у module-row-ів) + `shadow-sm`;
- модульний акцент винесений у круглу «bubble» зліва — той самий патерн, що й іконки модулів у списку нижче (`bg-{module}-soft text-{module}`), тільки 5×5 з іконкою `plus` замість svg-гліфа модуля;
- лейбл — нейтральний `text-text`, без пастельної заливки;
- hover тепер м'яко підсвічує границю і фон у модульний акцент (`hover:border-{module}/40 hover:bg-{module}-soft/40`) замість `brightness-110`, який на соковитих пастелях виглядав кислим;
- dark-mode відтінки через `dark:bg-{module}/20`, щоб bubble не світився.

Видалив `MODULE_CHIP_CLASS`, додав `MODULE_CHIP_ACCENT` з `{ bubble, hoverBorder }`. Знятий префікс `"+ "` із `chip.label` при рендері — тепер плюс живе в bubble, а не в тексті.

Дія (`openHubModuleWithAction`), порядок модулів, іконка/a11y (`aria-hidden`) — без змін.

## Review & Testing Checklist for Human
- [ ] На Головній (без активної recommendation) чипи у «Що зафіксуємо?» тепер виглядають як панелі з кольоровою «+»-bubble зліва — перевір light і dark режими.
- [ ] Тап по кожному чипу все ще відкриває відповідний модуль з правильним PWA-intent-ом (Фінік → add_expense, Харчування → add_meal, Рутина → add_habit, Фізрук → start_workout).
- [ ] Спот-чек, що hover/active/focus стани зчитуються (особливо на мобільному — `active:scale-[0.98]` + зміна border).

### Notes
- Перевір на Vercel-preview-у: https://github.com/Skords-01/Sergeant/pull нижче буде лінк від Vercel-боту.
- `MODULE_CHIP_CLASS` більше ніде не імпортувався — безпечно видалений.
- Lint, typecheck pass локально.

Link to Devin session: https://app.devin.ai/sessions/da9b499010aa408da318d915119b233a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
