### PR TITLE
feat(hub/reports): collapsible report cards with persisted state

### DIFF
--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
 import { generateInsights } from "./lib/insightsEngine";
 import {
   calcFinykSpendingByDate,
@@ -259,34 +260,97 @@ function Delta({ cur, prev, higherIsBetter = true }) {
   );
 }
 
-function StatCard({ title, icon, current, prev, unit, higherIsBetter, chart }) {
+function StatCard({
+  title,
+  icon,
+  current,
+  prev,
+  unit,
+  higherIsBetter,
+  chart,
+  storageKey,
+}) {
+  const [collapsed, setCollapsed] = useLocalStorageState<boolean>(
+    storageKey,
+    false,
+    { validate: (v): v is boolean => typeof v === "boolean" },
+  );
+  const formattedCurrent =
+    typeof current === "number" ? current.toLocaleString("uk-UA") : current;
+  const formattedPrev =
+    typeof prev === "number" ? prev.toLocaleString("uk-UA") : prev;
+
   return (
-    <div className="bg-panel border border-line rounded-2xl p-4 space-y-3">
-      <SectionHeading
-        as="div"
-        size="xs"
-        className="flex items-center gap-2 text-muted"
-      >
-        <span className="text-lg">{icon}</span>
-        <span>{title}</span>
-      </SectionHeading>
-      <div className="flex items-baseline gap-2">
-        <span className="text-2xl font-bold text-text">
-          {typeof current === "number"
-            ? current.toLocaleString("uk-UA")
-            : current}
-          {unit}
-        </span>
-        <Delta cur={current} prev={prev} higherIsBetter={higherIsBetter} />
-      </div>
-      {prev !== undefined && (
-        <p className="text-xs text-muted">
-          Минулий:{" "}
-          {typeof prev === "number" ? prev.toLocaleString("uk-UA") : prev}
-          {unit}
-        </p>
+    <div
+      className={cn(
+        "bg-panel border border-line rounded-2xl",
+        collapsed ? "p-3" : "p-4 space-y-3",
       )}
-      {chart}
+    >
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        className={cn(
+          "w-full flex items-center gap-2 text-left rounded-lg",
+          "-m-1 p-1 hover:bg-panelHi transition-colors",
+        )}
+      >
+        <span className="text-lg shrink-0" aria-hidden>
+          {icon}
+        </span>
+        <SectionHeading
+          as="span"
+          size="xs"
+          className="flex-1 min-w-0 text-muted truncate"
+        >
+          {title}
+        </SectionHeading>
+        {collapsed && (
+          <span className="flex items-baseline gap-2 shrink-0">
+            <span className="text-base font-bold text-text">
+              {formattedCurrent}
+              {unit}
+            </span>
+            <Delta cur={current} prev={prev} higherIsBetter={higherIsBetter} />
+          </span>
+        )}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+          className={cn(
+            "shrink-0 text-muted transition-transform",
+            collapsed ? "-rotate-90" : "rotate-0",
+          )}
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      {!collapsed && (
+        <>
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-bold text-text">
+              {formattedCurrent}
+              {unit}
+            </span>
+            <Delta cur={current} prev={prev} higherIsBetter={higherIsBetter} />
+          </div>
+          {prev !== undefined && (
+            <p className="text-xs text-muted">
+              Минулий: {formattedPrev}
+              {unit}
+            </p>
+          )}
+          {chart}
+        </>
+      )}
     </div>
   );
 }
@@ -397,6 +461,7 @@ export function HubReports() {
         <StatCard
           title="Тренування (Фізрук)"
           icon="🏋️"
+          storageKey="hub_reports_collapsed_v1:workouts"
           current={data.workouts.cur.count}
           prev={data.workouts.prev.count}
           unit=" трен."
@@ -414,6 +479,7 @@ export function HubReports() {
         <StatCard
           title="Витрати (Фінік)"
           icon="💳"
+          storageKey="hub_reports_collapsed_v1:spending"
           current={data.spending.cur.total}
           prev={data.spending.prev.total}
           unit=" ₴"
@@ -431,6 +497,7 @@ export function HubReports() {
         <StatCard
           title="Виконання звичок (Рутина)"
           icon="✅"
+          storageKey="hub_reports_collapsed_v1:habits"
           current={data.habits.cur.pct}
           prev={data.habits.prev.pct}
           unit="%"
@@ -449,6 +516,7 @@ export function HubReports() {
         <StatCard
           title="Середньо ккал/день (Харчування)"
           icon="🥗"
+          storageKey="hub_reports_collapsed_v1:kcal"
           current={data.kcal.cur.avg}
           prev={data.kcal.prev.avg}
           unit=" ккал"


### PR DESCRIPTION
## Summary
На вкладці **Звіти** (хаб) кожна картка звіту (`Тренування`, `Витрати`, `Виконання звичок`, `Середньо ккал/день`) займала багато висоти через бар-чарт, і сторінка виглядала як набір великих «модалок». Тепер кожну картку можна згорнути.

**Як працює:**
- Заголовок картки тепер — `<button>`-toggle з chevron-іконкою; клік згортає/розгортає.
- У згорнутому стані: іконка + назва + поточне значення + дельта (`+/- %`) у один рядок. Бар-чарт і рядок `Минулий: …` приховані, паддінги зменшені (`p-3` замість `p-4`).
- У розгорнутому стані — як і раніше.
- Стан кожної картки персистується в `localStorage` (`hub_reports_collapsed_v1:{workouts|spending|habits|kcal}`) через `useLocalStorageState`, тому вибір зберігається між сесіями.
- За замовчуванням усі картки розгорнуті (щоб не ламати звичну поведінку). `aria-expanded` проставляється для доступності.

Зміни обмежені файлом <ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/core/HubReports.tsx" />: компонент `StatCard` отримав згортання + пропс `storageKey`, який проставлений у 4 інстансах у `HubReports`.

## Review & Testing Checklist for Human
- [ ] Відкрити Хаб → вкладка «Звіти», натиснути на заголовок кожної з 4 карток — має згортатись/розгортатись (chevron обертається, чарт зникає, показується компактний підсумок справа)
- [ ] Оновити сторінку — стан згорнутості зберігається для кожної картки окремо
- [ ] Перемикання `Тиждень ↔ Місяць` та навігація `◀ ▶` між періодами не ламають стан згорнутості
- [ ] У згорнутому стані для карток з нульовими значеннями (наприклад `0 трен.` / `-100%`) рядок виглядає адекватно

### Notes
- `pnpm --filter @sergeant/web typecheck` — OK
- `pnpm --filter @sergeant/web lint` — OK
- Не чіпав `Інсайти` та `Підсумок` — вони і так компактні; якщо треба згортати і їх, скажи.


Link to Devin session: https://app.devin.ai/sessions/fef54d4971b54752b30e2ceb70c0c5c9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
