### PR TITLE
refactor(modules): unify module headers across Фінік / Фізрук / Рутина / Харчування

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -11,6 +11,10 @@ import { PAGES } from "./constants";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
+import {
+  ModuleHeader,
+  ModuleHeaderBackButton,
+} from "@shared/components/layout";
 import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
@@ -575,42 +579,13 @@ export default function App({
   // ── Main app ──────────────────────────────────────────────────────────
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      {/* Header */}
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
-        <div className="flex h-14 items-center justify-between px-4 sm:px-5 gap-3">
-          <div className="flex items-center gap-2 min-w-0">
-            {typeof onBackToHub === "function" ? (
-              <button
-                type="button"
-                onClick={onBackToHub}
-                className={cn(
-                  "shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5",
-                  "flex items-center justify-center rounded-xl",
-                  "text-muted hover:text-text transition-all duration-200",
-                  "border border-line bg-panel/80 hover:bg-panelHi",
-                  "active:scale-95",
-                )}
-                aria-label="До хабу"
-                title="До хабу"
-              >
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden
-                >
-                  <path d="M15 18l-6-6 6-6" />
-                </svg>
-                <span className="text-sm font-semibold">Хаб</span>
-              </button>
-            ) : null}
+      <ModuleHeader
+        left={
+          typeof onBackToHub === "function" ? (
+            <ModuleHeaderBackButton onClick={onBackToHub} />
+          ) : (
             <div
-              className="shrink-0 w-9 h-9 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
+              className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
               aria-hidden
             >
               <svg
@@ -627,17 +602,16 @@ export default function App({
                 <line x1="2" y1="10" x2="22" y2="10" />
               </svg>
             </div>
-            <div className="min-w-0">
-              <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-                ФІНІК
-              </span>
-              <span className="text-2xs text-subtle font-medium hidden sm:block truncate">
-                Monobank · бюджети
-              </span>
-            </div>
-          </div>
+          )
+        }
+        title="ФІНІК"
+        subtitle="Monobank · бюджети"
+        right={
           <div className="flex items-center gap-2">
-            <div className="flex items-center gap-2 text-xs text-subtle select-none">
+            <div
+              className="flex items-center gap-2 text-xs text-subtle select-none"
+              aria-label={`Стан синхронізації: ${syncTone.text}`}
+            >
               <span className={cn("w-2 h-2 rounded-full", syncTone.dot)} />
               <span className="hidden sm:inline">{syncTone.text}</span>
             </div>
@@ -681,8 +655,8 @@ export default function App({
               )}
             </button>
           </div>
-        </div>
-      </div>
+        }
+      />
 
       {/* Page content */}
       <div

--- a/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
@@ -108,7 +108,6 @@ export function FizrukHeader({
     <ModuleHeader
       left={left}
       title={titleFor(page)}
-      eyebrow={showChevronBack ? undefined : "ОСОБИСТИЙ ЖУРНАЛ"}
       subtitle={showChevronBack ? undefined : subtitleFor(page, activeProgram)}
     />
   );

--- a/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
@@ -1,81 +1,49 @@
+import {
+  ModuleHeader,
+  ModuleHeaderBackButton,
+} from "@shared/components/layout";
 import { cn } from "@shared/lib/cn";
 
-export function NutritionHeader({ busy: _busy, onBackToHub }) {
+function AppleBadge() {
   return (
-    <div className="shrink-0 bg-panel/95 backdrop-blur-xl border-b border-line z-40 relative safe-area-pt">
-      <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
-        {typeof onBackToHub === "function" ? (
-          <button
-            type="button"
-            onClick={onBackToHub}
-            className={cn(
-              "shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5",
-              "flex items-center justify-center rounded-xl",
-              "text-muted hover:text-text transition-all duration-200",
-              "border border-line bg-panel/80 hover:bg-panelHi",
-              "active:scale-95",
-            )}
-            aria-label="До хабу"
-            title="До хабу"
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M15 18l-6-6 6-6" />
-            </svg>
-            <span className="text-sm font-semibold">Хаб</span>
-          </button>
-        ) : (
-          <div
-            className={cn(
-              "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-              "bg-gradient-to-br from-lime-100 to-green-100",
-              "dark:from-lime-900/40 dark:to-green-900/30",
-              "text-lime-600 dark:text-lime-400",
-              "border border-lime-200/60 dark:border-lime-700/30",
-              "shadow-sm",
-            )}
-            aria-hidden
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M4 11c0 6 4 10 8 10s8-4 8-10" />
-              <path d="M12 21V11" />
-              <path d="M7 5c0 2 1 3 2 4M17 5c0 2-1 3-2 4" />
-              <path d="M7 5c0-1 1-2 2-2s2 1 2 2c0 2-2 4-2 6" />
-              <path d="M17 5c0-1-1-2-2-2s-2 1-2 2c0 2 2 4 2 6" />
-            </svg>
-          </div>
-        )}
-
-        <div className="min-w-0 flex-1">
-          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-              Module hero kicker with bespoke light/dark lime tints at
-              text-3xs; mirrors FizrukApp / RoutineApp header kickers. */}
-          <span className="text-3xs text-lime-800 dark:text-lime-400/70 font-bold tracking-widest uppercase block leading-none mb-0.5">
-            ХАРЧУВАННЯ
-          </span>
-          <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-            Мій раціон
-          </span>
-        </div>
-      </div>
+    <div
+      className={cn(
+        "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
+        "bg-gradient-to-br from-lime-100 to-green-100",
+        "dark:from-lime-900/40 dark:to-green-900/30",
+        "text-lime-600 dark:text-lime-400",
+        "border border-lime-200/60 dark:border-lime-700/30",
+        "shadow-sm",
+      )}
+      aria-hidden
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M4 11c0 6 4 10 8 10s8-4 8-10" />
+        <path d="M12 21V11" />
+        <path d="M7 5c0 2 1 3 2 4M17 5c0 2-1 3-2 4" />
+        <path d="M7 5c0-1 1-2 2-2s2 1 2 2c0 2-2 4-2 6" />
+        <path d="M17 5c0-1-1-2-2-2s-2 1-2 2c0 2 2 4 2 6" />
+      </svg>
     </div>
   );
+}
+
+export function NutritionHeader({ busy: _busy, onBackToHub }) {
+  const left =
+    typeof onBackToHub === "function" ? (
+      <ModuleHeaderBackButton onClick={onBackToHub} />
+    ) : (
+      <AppleBadge />
+    );
+
+  return <ModuleHeader left={left} title="ХАРЧУВАННЯ" subtitle="Мій раціон" />;
 }

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Banner } from "@shared/components/ui/Banner";
+import {
+  ModuleHeader,
+  ModuleHeaderBackButton,
+} from "@shared/components/layout";
 import { hapticTap } from "@shared/lib/haptic";
 import {
   loadRoutineState,
@@ -475,31 +479,10 @@ export default function RoutineApp({
 
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
-      <div className="shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt">
-        <div className="flex min-h-[68px] items-center px-4 py-2 sm:px-5 gap-3">
-          {typeof onBackToHub === "function" ? (
-            <button
-              type="button"
-              onClick={onBackToHub}
-              className="shrink-0 h-10 min-h-[40px] -ml-1 pl-2 pr-3 gap-1.5 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors border border-line bg-panel/80"
-              aria-label="До хабу"
-              title="До хабу"
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <path d="M15 18l-6-6 6-6" />
-              </svg>
-              <span className="text-sm font-semibold">Хаб</span>
-            </button>
+      <ModuleHeader
+        left={
+          typeof onBackToHub === "function" ? (
+            <ModuleHeaderBackButton onClick={onBackToHub} />
           ) : (
             <div
               className={cn(
@@ -521,24 +504,11 @@ export default function RoutineApp({
                 <path d="M8 14h.01M12 14h.01M16 14h.01" />
               </svg>
             </div>
-          )}
-          <div className="min-w-0 flex-1">
-            <span
-              className={cn(
-                // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Module hero kicker composed via cn(..., C.eyebrow) with dynamic routine-branded class; SectionHeading can't express the conditional tint.
-                "text-3xs font-bold tracking-widest uppercase block leading-none mb-0.5",
-                C.eyebrow,
-              )}
-            >
-              Hub календар
-            </span>
-            <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-              РУТИНА
-            </span>
-            <span className="text-2xs text-subtle font-medium truncate">
-              Звички · план Фізрука · один розклад
-            </span>
-          </div>
+          )
+        }
+        title="РУТИНА"
+        subtitle="Звички · план Фізрука · один розклад"
+        right={
           <button
             type="button"
             onClick={() => applyTimeMode("today")}
@@ -551,8 +521,8 @@ export default function RoutineApp({
           >
             Сьогодні
           </button>
-        </div>
-      </div>
+        }
+      />
 
       <div className="flex-1 overflow-hidden flex flex-col min-h-0">
         <main


### PR DESCRIPTION
## Summary

Уніфіковано хедери всіх чотирьох модулів під спільний `ModuleHeader` (варіант B — мінімалізм):

- **Без eyebrow** в усіх модулях (прибрано «ОСОБИСТИЙ ЖУРНАЛ», «Hub календар», «ХАРЧУВАННЯ» як кікер).
- **title** = назва модуля великими в усіх: **ФІНІК / ФІЗРУК / РУТИНА / ХАРЧУВАННЯ**.
- **subtitle** = коротка tagline однаковим стилем (`text-2xs text-subtle font-medium truncate`):
  - Фінік: «Monobank · бюджети» (прибрано `hidden sm:block` — тепер видно на всіх розмірах).
  - Фізрук: «Тренування · прогрес».
  - Рутина: «Звички · план Фізрука · один розклад».
  - Харчування: «Мій раціон» (раніше було в title).
- **Висота** уніфікована `min-h-[68px]` (Фінік був `h-14 ≈ 56px`).
- Усі хедери тепер проходять через спільні компоненти `ModuleHeader` + `ModuleHeaderBackButton` замість локальних inline-копій.

Модульні праві кнопки збережено:
- Фінік — sync-dot і eye-toggle (показати/приховати суми).
- Рутина — «Сьогодні».
- Фізрук / Харчування — без правого слота.

Файли:
- `apps/web/src/modules/finyk/FinykApp.tsx` — inline хедер замінено на `ModuleHeader`; додано імпорт із `@shared/components/layout`.
- `apps/web/src/modules/routine/RoutineApp.tsx` — те саме для Рутини.
- `apps/web/src/modules/nutrition/components/NutritionHeader.tsx` — переписано поверх `ModuleHeader`, «ХАРЧУВАННЯ» переїхало з eyebrow у title.
- `apps/web/src/modules/fizruk/shell/FizrukHeader.tsx` — прибрано eyebrow «ОСОБИСТИЙ ЖУРНАЛ».

Локально: `lint` (включно з `lint:plugins` / `lint:imports`), `typecheck`, `test` (665/665) — зелені.

## Review & Testing Checklist for Human

- [ ] Фінік: відкрити `/finyk` → хедер `min-h-[68px]`, title «ФІНІК», під ним «Monobank · бюджети» (має бути видно і на мобілці); sync-dot + око-toggle праворуч працюють.
- [ ] Фізрук: відкрити `/fizruk` → немає рядка «ОСОБИСТИЙ ЖУРНАЛ»; title «ФІЗРУК», subtitle «Тренування · прогрес»; під-сторінки (Atlas/Exercise) так само без eyebrow, з chevron-назад.
- [ ] Рутина: `/routine` → без «Hub календар» зверху; title «РУТИНА», subtitle «Звички · план Фізрука · один розклад»; чип «Сьогодні» праворуч тапається і скролить на сьогодні.
- [ ] Харчування: `/nutrition` → title «ХАРЧУВАННЯ» (раніше було «Мій раціон»), subtitle «Мій раціон»; кнопка «Хаб» повертає до хаба.
- [ ] Темна/світла теми: перевірити контраст title/subtitle.

### Notes

Візуально найпомітніше: у Харчуванні змінилось, що саме написано «жирним» (тепер це назва модуля), а «Мій раціон» — маленьким subtitle. Якщо семантично важливо залишити «Мій раціон» як головний акцент — кажи, поміняю місцями; за варіантом B ми йдемо «назва модуля завжди у title».

Link to Devin session: https://app.devin.ai/sessions/6fdd6c4d288b4638a9b2142d82781c09
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
