### PR TITLE
feat(nutrition/menu): move «План на тиждень + покупки» from Recipes tab to Plan-on-day tab

### DIFF
--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -552,6 +552,10 @@ export default function NutritionApp({
                     fetchDayPlan={() => fetchDayPlan(null)}
                     regenMeal={(mealType) => fetchDayPlan(mealType)}
                     addMealToLog={addMealFromPlan}
+                    weekPlan={weekPlan}
+                    weekPlanRaw={weekPlanRaw}
+                    weekPlanBusy={weekPlanBusy}
+                    fetchWeekPlan={fetchWeekPlan}
                   />
                 ) : (
                   <RecipesCard
@@ -566,10 +570,6 @@ export default function NutritionApp({
                     err={err}
                     fmtMacro={fmtMacro}
                     recipeCacheEntry={recipeCacheEntry}
-                    weekPlan={weekPlan}
-                    weekPlanRaw={weekPlanRaw}
-                    weekPlanBusy={weekPlanBusy}
-                    fetchWeekPlan={fetchWeekPlan}
                     addMealToLog={wrappedSaveMeal}
                   />
                 )}

--- a/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
+++ b/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
@@ -226,6 +226,10 @@ export function DailyPlanCard({
   fetchDayPlan,
   regenMeal,
   addMealToLog,
+  weekPlan,
+  weekPlanRaw,
+  weekPlanBusy,
+  fetchWeekPlan,
 }) {
   const [showManual, setShowManual] = useState(false);
 
@@ -426,22 +430,84 @@ export function DailyPlanCard({
           )}
         </div>
 
-        <button
-          type="button"
-          onClick={fetchDayPlan}
-          disabled={busy || dayPlanBusy}
-          className={cn(
-            "w-full h-11 rounded-2xl text-sm font-semibold",
-            "bg-nutrition-strong text-white hover:bg-nutrition-hover disabled:opacity-50 transition-colors",
+        <div className="grid gap-2">
+          <button
+            type="button"
+            onClick={fetchDayPlan}
+            disabled={busy || dayPlanBusy}
+            className={cn(
+              "w-full h-11 rounded-2xl text-sm font-semibold",
+              "bg-nutrition-strong text-white hover:bg-nutrition-hover disabled:opacity-50 transition-colors",
+            )}
+          >
+            {dayPlanBusy ? "Генерую план…" : "Згенерувати денний план"}
+          </button>
+          {typeof fetchWeekPlan === "function" && (
+            <button
+              type="button"
+              onClick={fetchWeekPlan}
+              disabled={busy || weekPlanBusy}
+              className={cn(
+                "w-full h-11 rounded-2xl text-sm font-semibold border border-nutrition/40",
+                "text-nutrition-strong dark:text-nutrition hover:bg-nutrition/10 disabled:opacity-50 transition-colors",
+              )}
+            >
+              {weekPlanBusy ? "…" : "План на тиждень + покупки"}
+            </button>
           )}
-        >
-          {dayPlanBusy ? "Генерую план…" : "Згенерувати денний план"}
-        </button>
+        </div>
 
         {pantryItems?.length === 0 && (
           <div className="text-xs text-subtle text-center -mt-2">
             Додай продукти на склад — AI врахує їх у плані
           </div>
+        )}
+
+        {weekPlan?.days?.length > 0 && (
+          <div className="rounded-2xl border border-line bg-panel p-4 space-y-3">
+            <div className="text-sm font-semibold text-text">Тижневий план</div>
+            {weekPlan.days.map((d, i) => (
+              <div
+                key={i}
+                className="text-sm border-b border-line/40 pb-2 last:border-0"
+              >
+                <div className="font-semibold text-nutrition-strong dark:text-nutrition">
+                  {d.label}
+                </div>
+                {d.note && (
+                  <div className="text-xs text-subtle mt-0.5">{d.note}</div>
+                )}
+                {Array.isArray(d.meals) && d.meals.length > 0 && (
+                  <ul className="list-disc pl-4 mt-1 text-xs text-text space-y-0.5">
+                    {d.meals.map((line, j) => (
+                      <li key={j}>{line}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+            {weekPlan.shoppingList?.length > 0 && (
+              <div>
+                <div className="text-xs text-subtle mb-1">Список покупок</div>
+                <ul className="list-disc pl-4 text-sm text-text space-y-0.5">
+                  {weekPlan.shoppingList.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {weekPlanRaw && (!weekPlan?.days || weekPlan.days.length === 0) && (
+          <details className="rounded-2xl border border-line bg-bg p-3">
+            <summary className="cursor-pointer text-xs text-muted">
+              Діагностика плану (raw)
+            </summary>
+            <pre className="mt-2 whitespace-pre-wrap text-xs text-subtle max-h-48 overflow-auto">
+              {weekPlanRaw}
+            </pre>
+          </details>
         )}
 
         {sortedMeals.length > 0 && (

--- a/apps/web/src/modules/nutrition/components/RecipesCard.tsx
+++ b/apps/web/src/modules/nutrition/components/RecipesCard.tsx
@@ -47,10 +47,6 @@ export function RecipesCard({
   err,
   fmtMacro,
   recipeCacheEntry,
-  weekPlan,
-  weekPlanRaw,
-  weekPlanBusy,
-  fetchWeekPlan,
   addMealToLog,
 }) {
   const [saved, setSaved] = useState([]);
@@ -372,79 +368,17 @@ export function RecipesCard({
             />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <button
-              type="button"
-              onClick={recommendRecipes}
-              disabled={busy}
-              className={cn(
-                "w-full h-11 rounded-2xl text-sm font-semibold",
-                "bg-nutrition-strong text-white hover:bg-nutrition-hover disabled:opacity-50",
-              )}
-            >
-              Запропонувати рецепти
-            </button>
-            <button
-              type="button"
-              onClick={fetchWeekPlan}
-              disabled={busy || weekPlanBusy}
-              className={cn(
-                "w-full h-11 rounded-2xl text-sm font-semibold border border-nutrition/40",
-                "text-nutrition-strong dark:text-nutrition hover:bg-nutrition/10 disabled:opacity-50",
-              )}
-            >
-              {weekPlanBusy ? "…" : "План на тиждень + покупки"}
-            </button>
-          </div>
-
-          {weekPlan?.days?.length > 0 && (
-            <div className="rounded-2xl border border-line bg-panel p-4 space-y-3">
-              <div className="text-sm font-semibold text-text">
-                Тижневий план
-              </div>
-              {weekPlan.days.map((d, i) => (
-                <div
-                  key={i}
-                  className="text-sm border-b border-line/40 pb-2 last:border-0"
-                >
-                  <div className="font-semibold text-nutrition-strong dark:text-nutrition">
-                    {d.label}
-                  </div>
-                  {d.note && (
-                    <div className="text-xs text-subtle mt-0.5">{d.note}</div>
-                  )}
-                  {Array.isArray(d.meals) && d.meals.length > 0 && (
-                    <ul className="list-disc pl-4 mt-1 text-xs text-text space-y-0.5">
-                      {d.meals.map((line, j) => (
-                        <li key={j}>{line}</li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              ))}
-              {weekPlan.shoppingList?.length > 0 && (
-                <div>
-                  <div className="text-xs text-subtle mb-1">Список покупок</div>
-                  <ul className="list-disc pl-4 text-sm text-text space-y-0.5">
-                    {weekPlan.shoppingList.map((s, i) => (
-                      <li key={i}>{s}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-          )}
-
-          {weekPlanRaw && (!weekPlan?.days || weekPlan.days.length === 0) && (
-            <details className="rounded-2xl border border-line bg-bg p-3">
-              <summary className="cursor-pointer text-xs text-muted">
-                Діагностика плану (raw)
-              </summary>
-              <pre className="mt-2 whitespace-pre-wrap text-xs text-subtle max-h-48 overflow-auto">
-                {weekPlanRaw}
-              </pre>
-            </details>
-          )}
+          <button
+            type="button"
+            onClick={recommendRecipes}
+            disabled={busy}
+            className={cn(
+              "w-full h-11 rounded-2xl text-sm font-semibold",
+              "bg-nutrition-strong text-white hover:bg-nutrition-hover disabled:opacity-50",
+            )}
+          >
+            Запропонувати рецепти
+          </button>
 
           {recipes.length > 0 && (
             <div className="grid gap-3">


### PR DESCRIPTION
## Summary
Юзер помітив, що кнопка «План на тиждень + покупки» живе на табі **Рецепти**, хоча за змістом це планування, а не рецепт-генератор. Переніс CTA і рендер тижневого плану (+ shopping list + raw-діагностика) у таб **План на день**.

Зміни:
- `DailyPlanCard` тепер приймає `weekPlan`, `weekPlanRaw`, `weekPlanBusy`, `fetchWeekPlan`. Кнопка «План на тиждень + покупки» з'являється під «Згенерувати денний план» (stacked, щоб не конкурувати з primary CTA; рендериться тільки якщо передали `fetchWeekPlan`). Рендер тижневого плану та shopping-list-у переїхав одразу над «Ваш план на сьогодні».
- `RecipesCard` — прибраний grid-cols-2 з парою кнопок, залишилась одна «Запропонувати рецепти». Рендер weekPlan/weekPlanRaw видалений, пропси `weekPlan`, `weekPlanRaw`, `weekPlanBusy`, `fetchWeekPlan` більше не приймаються.
- `NutritionApp` — 4 week-plan пропси переставлені з `<RecipesCard>` на `<DailyPlanCard>`, без змін у джерелі (`useNutritionRemoteActions` / `useNutritionUiState`).

Логіка генерації плану (`fetchWeekPlan` в `useNutritionRemoteActions`) і state (`weekPlan`/`weekPlanRaw`/`weekPlanBusy`) не змінилися — це чисто UI-move.

## Review & Testing Checklist for Human
- [ ] Харчування → Меню → «План на день»: з'явилась друга кнопка «План на тиждень + покупки» під «Згенерувати денний план»; тисни — отримай тижневий план + shopping list.
- [ ] Харчування → Меню → «Рецепти»: залишилась одна велика кнопка «Запропонувати рецепти», тижневого плану там більше немає.
- [ ] Спот-чек, що `fetchWeekPlan` все ще працює (той самий ендпоінт, просто викликається з іншого місця).

### Notes
- Lint і typecheck pass локально.
- Week-plan button спеціально рендериться conditional на `typeof fetchWeekPlan === "function"` — щоб `DailyPlanCard` лишився придатним для use-case-ів без week-plan (якщо колись знадобиться).

Link to Devin session: https://app.devin.ai/sessions/da9b499010aa408da318d915119b233a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Weekly plan generation and shopping list functionality are now available in the Daily Plan section for streamlined meal planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->