### PR TITLE
fix(nutrition): correct day-plan payload shape to match server schema

### DIFF
--- a/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.test.tsx
@@ -158,7 +158,7 @@ describe("useNutritionRemoteActions", () => {
       expect(spies.setRecipesTried).toHaveBeenCalledWith(true);
       expect(apiRecommendRecipes).toHaveBeenCalledWith(
         expect.objectContaining({
-          items: expect.any(Array),
+          pantry: expect.any(Array),
           preferences: expect.objectContaining({
             goal: "balanced",
             locale: "uk-UA",
@@ -287,6 +287,43 @@ describe("useNutritionRemoteActions", () => {
         expect(spies.setErr).toHaveBeenCalledWith(
           "Не вдалося отримати план харчування",
         ),
+      );
+    });
+
+    it("posts `pantry` (not `items`) and omits regenerateMealType when no regen target", async () => {
+      // Matches server DayPlanSchema: expects `pantry: [...]` and
+      // `regenerateMealType` as a valid enum value or absent — not `null`.
+      apiFetchDayPlan.mockResolvedValueOnce({ plan: { meals: [] } });
+      const { result } = makeHarness();
+      act(() => {
+        result.current.fetchDayPlan();
+      });
+      await waitFor(() => expect(apiFetchDayPlan).toHaveBeenCalled());
+      const body = apiFetchDayPlan.mock.calls.at(-1)?.[0];
+      expect(body).toEqual(
+        expect.objectContaining({
+          pantry: expect.any(Array),
+          targets: expect.any(Object),
+          locale: "uk-UA",
+        }),
+      );
+      expect(body).not.toHaveProperty("items");
+      expect(body).not.toHaveProperty("regenerateMealType");
+    });
+
+    it("includes regenerateMealType when regenerating a specific meal", async () => {
+      apiFetchDayPlan.mockResolvedValueOnce({ plan: { meals: [] } });
+      const { result } = makeHarness();
+      act(() => {
+        result.current.fetchDayPlan("lunch");
+      });
+      await waitFor(() => expect(apiFetchDayPlan).toHaveBeenCalled());
+      const body = apiFetchDayPlan.mock.calls.at(-1)?.[0];
+      expect(body).toEqual(
+        expect.objectContaining({
+          pantry: expect.any(Array),
+          regenerateMealType: "lunch",
+        }),
       );
     });
   });

--- a/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
@@ -223,7 +223,7 @@ export function useNutritionRemoteActions({
       if (items.length === 0)
         throw new Error("Дай хоча б 2–3 продукти для рецептів.");
       return nutritionApi.recommendRecipes({
-        items: items.slice(0, 40),
+        pantry: items.slice(0, 40),
         preferences: {
           goal: prefs.goal,
           servings: toNumber(prefs.servings, 1),
@@ -274,7 +274,7 @@ export function useNutritionRemoteActions({
       const items = pantry.effectiveItems;
       if (items.length === 0) throw new Error("Додай продукти на склад.");
       return nutritionApi.weekPlan({
-        items: items.slice(0, 50),
+        pantry: items.slice(0, 50),
         preferences: { goal: prefs.goal },
         locale: "uk-UA",
       });
@@ -368,14 +368,14 @@ export function useNutritionRemoteActions({
     mutationFn: (regenerateMealType: string | null | undefined) =>
       nutritionApi
         .dayPlan({
-          items: pantry.effectiveItems.slice(0, 50),
+          pantry: pantry.effectiveItems.slice(0, 50),
           targets: {
             kcal: prefs.dailyTargetKcal,
             protein_g: prefs.dailyTargetProtein_g,
             fat_g: prefs.dailyTargetFat_g,
             carbs_g: prefs.dailyTargetCarbs_g,
           },
-          regenerateMealType: regenerateMealType || null,
+          ...(regenerateMealType ? { regenerateMealType } : {}),
           locale: "uk-UA",
         })
         .then((data) => {


### PR DESCRIPTION
## Summary
Кнопка **«Згенерувати денний план»** (ФІНІК → Харчування → Мій раціон) падала з помилкою `Некоректні дані запиту` через невідповідність між payload-ом клієнта і zod-схемою сервера.

**Корінь проблеми (`useNutritionRemoteActions.ts`):**

1. Клієнт слав `regenerateMealType: regenerateMealType || null` для кожного виклику. При звичайній генерації це `null`, але `DayPlanSchema` (див. <ref_file file="/home/ubuntu/repos/Sergeant/packages/shared/src/schemas/api.ts" />) описує поле як `z.enum([...]).optional()` — тобто дозволяє лише значення з enum або `undefined`, але **не `null`**. Це й провокувало 400 `Некоректні дані запиту`.

2. Паралельний тихий баг: клієнт слав список комори як `items: [...]`, а сервер (як і всі інші nutrition-ендпойнти) читає `pantry: [...]`. Zod-схема просто викидала невідоме поле, через що AI генерував план без урахування реальних продуктів користувача. Та сама невідповідність існувала у `recommendRecipes` і `weekPlan` — теж полагоджено.

**Фікс (клієнтська сторона):**
- `items` → `pantry` у трьох викликах `nutritionApi.dayPlan / weekPlan / recommendRecipes`
- `regenerateMealType` додається до payload-а лише якщо це truthy рядок (інакше поле взагалі не йде в запит)

Додав два регресійні тести в <ref_file file="/home/ubuntu/repos/Sergeant/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.test.tsx" />, які фіксують форму payload-а для `fetchDayPlan()` (без регенерації) та `fetchDayPlan("lunch")` (з регенерацією).

## Review & Testing Checklist for Human
- [ ] Відкрити Харчування → Мій раціон → обрати пресет/цілі → натиснути «Згенерувати денний план» — має згенеруватись план без помилки `Некоректні дані запиту`
- [ ] Переконатись, що AI-план тепер реально враховує продукти зі складу (наприклад, додати в «Дім» 3-4 специфічні продукти й згенерувати план — вони мають зʼявлятись в інгредієнтах/описі страв)
- [ ] Натиснути «↻ Замінити» на окремому прийомі їжі — має згенеруватись заміна саме для цього типу (`regenerateMealType` включається тільки для цього кейсу)
- [ ] Перевірити, що рекомендація рецептів і тижневий план теж коректно приймають продукти зі складу

### Notes
- `pnpm --filter @sergeant/web test useNutritionRemoteActions` — 14/14 passed
- `pnpm --filter @sergeant/web typecheck` — OK
- `pnpm --filter @sergeant/web lint` — OK
- Серверну схему не чіпав: зміна контракту на сервері (приймати `items` або `null` для `regenerateMealType`) лише приховувала б помилку. Правильна сторона для виправлення — клієнт.


Link to Devin session: https://app.devin.ai/sessions/fef54d4971b54752b30e2ceb70c0c5c9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
