### PR TITLE
refactor(fizruk): move Today's plan & recovery atlas to Plan tab, drop PhotoProgress from Body

### DIFF
--- a/apps/web/src/modules/fizruk/components/RecoveryFocusCard.tsx
+++ b/apps/web/src/modules/fizruk/components/RecoveryFocusCard.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { BodyAtlas } from "./BodyAtlas";
+import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
+import { useRecovery } from "../hooks/useRecovery";
+
+function mapMuscleId(id: string | undefined | null): string | null {
+  if (!id) return null;
+  if (id === "pectoralis_major" || id === "pectoralis_minor") return "chest";
+  if (id === "latissimus_dorsi") return "upper-back";
+  if (id === "rhomboids" || id === "upper_back") return "upper-back";
+  if (id === "erector_spinae") return "lower-back";
+  if (id === "trapezius") return "trapezius";
+  if (id === "biceps") return "biceps";
+  if (id === "triceps") return "triceps";
+  if (id === "forearms") return "forearm";
+  if (id === "front_deltoid") return "front-deltoids";
+  if (id === "rear_deltoid") return "back-deltoids";
+  if (id === "rectus_abdominis") return "abs";
+  if (id === "obliques") return "obliques";
+  if (id === "quadriceps") return "quadriceps";
+  if (id === "hamstrings") return "hamstring";
+  if (id === "calves") return "calves";
+  if (id === "adductors") return "adductor";
+  if (id === "abductors") return "abductors";
+  if (id === "gluteus_maximus" || id === "gluteus_medius") return "gluteal";
+  if (id === "neck") return "neck";
+  return null;
+}
+
+function worstStatus(a: string, b: string): string {
+  if (a === "red" || b === "red") return "red";
+  if (a === "yellow" || b === "yellow") return "yellow";
+  return "green";
+}
+
+export function RecoveryFocusCard({
+  onOpenAtlas,
+}: {
+  onOpenAtlas?: () => void;
+}) {
+  const rec = useRecovery();
+  const { musclesUk } = useExerciseCatalog();
+  const [open, setOpen] = useState(false);
+
+  const statusByMuscle = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const m of Object.values(rec.by || {})) {
+      const key = mapMuscleId(m.id);
+      if (!key) continue;
+      out[key] = out[key] ? worstStatus(out[key], m.status) : m.status;
+    }
+    return out;
+  }, [rec.by]);
+
+  const focus = useMemo(
+    () =>
+      (rec.ready || []).slice(0, 4).map((m) => ({
+        id: m.id,
+        label: musclesUk?.[m.id] || m.label || m.id,
+        daysSince: m.daysSince,
+      })),
+    [rec.ready, musclesUk],
+  );
+
+  const avoid = useMemo(
+    () =>
+      (rec.avoid || []).slice(0, 4).map((m) => ({
+        id: m.id,
+        label: musclesUk?.[m.id] || m.label || m.id,
+      })),
+    [rec.avoid, musclesUk],
+  );
+
+  return (
+    <Card as="section" radius="lg" aria-label="Відновлення та фокус тренування">
+      <div className="flex items-start justify-between gap-2">
+        <button
+          type="button"
+          className="min-w-0 flex-1 text-left flex items-start gap-2 rounded-xl -m-1 p-1 hover:bg-panelHi/80 transition-colors"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+        >
+          <div className="min-w-0 flex-1">
+            <h2 className="text-base font-semibold text-text">
+              Відновлення й фокус
+            </h2>
+            <p className="text-xs text-subtle mt-1 leading-snug">
+              Колір на силуеті — готовність груп; чіпи — пріоритет після
+              відпочинку.
+            </p>
+          </div>
+          <span
+            className="text-lg leading-none text-muted shrink-0 mt-0.5"
+            aria-hidden
+          >
+            {open ? "▾" : "▸"}
+          </span>
+        </button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 min-h-[40px] px-3 text-xs shrink-0"
+          onClick={() => onOpenAtlas?.()}
+          aria-label="Відкрити атлас мʼязів"
+        >
+          Атлас
+        </Button>
+      </div>
+
+      {open && (
+        <>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-subtle mb-3 mt-3">
+            <span className="inline-flex items-center gap-1">
+              <span className="w-2 h-2 rounded-full bg-success" /> готово
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <span className="w-2 h-2 rounded-full bg-warning" /> краще
+              почекати
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <span className="w-2 h-2 rounded-full bg-danger" /> рано
+            </span>
+          </div>
+
+          {rec.wellbeingMult > 1.1 && (
+            <div className="mb-3 px-3 py-2 rounded-xl bg-warning/10 border border-warning/25 flex items-start gap-2">
+              <span className="text-base shrink-0" aria-hidden>
+                😴
+              </span>
+              <p className="text-xs text-warning leading-snug">
+                {rec.wellbeingMult >= 1.3
+                  ? "Поганий сон або дуже низька енергія — відновлення значно сповільнене."
+                  : "Недостатній сон або низька енергія — відновлення сповільнене."}{" "}
+                М{"'"}язи потребують більше часу перед наступним навантаженням.
+              </p>
+            </div>
+          )}
+
+          <BodyAtlas
+            statusByMuscle={statusByMuscle}
+            height={120}
+            showLegend={false}
+          />
+
+          <div className="mt-4 pt-3 border-t border-line">
+            <SectionHeading as="p" size="xs" className="mb-2">
+              Пріоритет після відпочинку
+            </SectionHeading>
+            <div className="flex flex-wrap gap-2">
+              {focus.map((m) => (
+                <span
+                  key={m.id}
+                  className="px-2.5 py-1 bg-success/10 text-success text-xs rounded-full font-medium border border-success/15"
+                >
+                  {m.label}
+                  {m.daysSince == null ? "" : ` · ${m.daysSince}д без`}
+                </span>
+              ))}
+              {focus.length === 0 && (
+                <span className="text-xs text-subtle">
+                  Додай завершені тренування — зʼявиться пріоритет груп.
+                </span>
+              )}
+            </div>
+            {avoid.length > 0 && (
+              <p className="text-xs text-muted mt-3 leading-relaxed">
+                <span className="font-semibold text-warning">Почекати:</span>{" "}
+                {avoid.map((x) => x.label).join(", ")}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
+++ b/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { Sheet } from "@shared/components/ui/Sheet";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import {
+  ACTIVE_WORKOUT_KEY,
+  recoveryConflictsForExercise,
+} from "@sergeant/fizruk-domain";
+import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
+import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
+import { useRecovery } from "../hooks/useRecovery";
+import { useWorkouts } from "../hooks/useWorkouts";
+import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
+
+const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
+
+export function TodayPlanCard({
+  onOpenCalendar,
+}: {
+  onOpenCalendar?: () => void;
+}) {
+  const rec = useRecovery();
+  const { exercises, primaryGroupsUk } = useExerciseCatalog();
+  const { templates, markTemplateUsed } = useWorkoutTemplates();
+  const monthlyPlan = useMonthlyPlan();
+  const { workouts, createWorkout, addItem } = useWorkouts();
+
+  const [selectedTemplateId, setSelectedTemplateId] = useLocalStorageState(
+    SELECTED_TEMPLATE_KEY,
+    "",
+    { raw: true },
+  );
+  const [planConfirmOpen, setPlanConfirmOpen] = useState(false);
+  const [pendingPicks, setPendingPicks] = useState<unknown[] | null>(null);
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (selectedTemplateId) return;
+    const first = templates[0]?.id;
+    if (first) setSelectedTemplateId(first);
+  }, [templates, selectedTemplateId, setSelectedTemplateId]);
+
+  const effectiveTemplateId = monthlyPlan.todayTemplateId || selectedTemplateId;
+
+  const plan = useMemo(() => {
+    const tpl = templates.find((t) => t.id === effectiveTemplateId);
+    const picked = tpl
+      ? tpl.exerciseIds
+          .map((id) => exercises.find((e) => e.id === id))
+          .filter(Boolean)
+      : [];
+    return { picked, templateName: tpl?.name || "" };
+  }, [effectiveTemplateId, templates, exercises]);
+
+  const closePlanConfirm = () => {
+    setPlanConfirmOpen(false);
+    setPendingPicks(null);
+    setPendingTemplateId(null);
+  };
+
+  const startWorkoutFromPlan = (picks, templateId) => {
+    const w = createWorkout();
+    for (const ex of picks) {
+      const isCardio = ex.primaryGroup === "cardio";
+      addItem(w.id, {
+        exerciseId: ex.id,
+        nameUk: ex?.name?.uk || ex?.name?.en,
+        primaryGroup: ex.primaryGroup,
+        musclesPrimary: ex?.muscles?.primary || [],
+        musclesSecondary: ex?.muscles?.secondary || [],
+        type: isCardio ? "distance" : "strength",
+        sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
+        durationSec: 0,
+        distanceM: isCardio ? 0 : 0,
+      });
+    }
+    if (templateId) markTemplateUsed(templateId);
+    try {
+      localStorage.setItem(ACTIVE_WORKOUT_KEY, w.id);
+    } catch {}
+    try {
+      sessionStorage.setItem("fizruk_workouts_mode", "log");
+    } catch {}
+    window.location.hash = "#workouts";
+  };
+
+  const tryStartPlan = (picks: unknown[], templateId?: string | null) => {
+    if (!picks?.length) return;
+    const risky = picks.some(
+      (ex) => recoveryConflictsForExercise(ex, rec.by).hasWarning,
+    );
+    if (risky) {
+      setPendingPicks(picks);
+      setPendingTemplateId(templateId || null);
+      setPlanConfirmOpen(true);
+      return;
+    }
+    setPendingPicks(null);
+    setPendingTemplateId(null);
+    startWorkoutFromPlan(picks, templateId);
+  };
+
+  return (
+    <>
+      <Card radius="lg" padding="lg">
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <div className="text-xs font-medium text-subtle">
+            План на сьогодні
+          </div>
+          {onOpenCalendar && (
+            <button
+              type="button"
+              className="text-xs font-semibold text-primary hover:underline shrink-0"
+              onClick={onOpenCalendar}
+            >
+              Календар
+            </button>
+          )}
+        </div>
+        {monthlyPlan.todayTemplateId && (
+          <p className="text-xs text-success/90 mb-2">
+            Шаблон з місячного плану на сьогодні.
+          </p>
+        )}
+        <div className="rounded-2xl border border-line bg-panelHi px-3">
+          <SectionHeading as="div" size="xs" className="pt-2">
+            Мій шаблон
+          </SectionHeading>
+          <select
+            className="input-focus-fizruk w-full min-h-[44px] bg-transparent text-sm text-text rounded-xl"
+            value={selectedTemplateId}
+            onChange={(e) => {
+              const v = e.target.value;
+              setSelectedTemplateId(v);
+              try {
+                localStorage.setItem(SELECTED_TEMPLATE_KEY, v);
+              } catch {}
+            }}
+            aria-label="Обрати збережений шаблон тренування"
+          >
+            {templates.length === 0 ? (
+              <option value="">— немає шаблонів —</option>
+            ) : (
+              templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+
+        {templates.length === 0 && (
+          <div className="mt-3 text-sm text-subtle text-center py-2">
+            Створи шаблон у розділі{" "}
+            <button
+              type="button"
+              className="font-semibold text-text underline"
+              onClick={() => {
+                try {
+                  sessionStorage.setItem("fizruk_workouts_mode", "templates");
+                } catch {}
+                window.location.hash = "#workouts";
+              }}
+            >
+              Тренування → Шаблони
+            </button>
+          </div>
+        )}
+
+        {!workouts?.length ? (
+          <div className="text-sm text-subtle text-center py-4">
+            Додай перше тренування, щоб статистика була точнішою
+          </div>
+        ) : null}
+
+        <div className="mt-4">
+          <div className="text-xs text-subtle mb-2">
+            Вправи з шаблону
+            {plan.templateName ? ` «${plan.templateName}»` : ""}:
+          </div>
+          {plan.picked.length ? (
+            <div className="space-y-2">
+              {plan.picked.map((ex) => (
+                <button
+                  key={ex.id}
+                  type="button"
+                  className="w-full text-left border border-line rounded-2xl p-3 min-h-[44px] bg-bg hover:bg-panelHi transition-colors"
+                  onClick={() => {
+                    window.location.hash = `#exercise/${ex.id}`;
+                  }}
+                >
+                  <div className="text-sm font-semibold text-text truncate">
+                    {ex?.name?.uk || ex?.name?.en}
+                  </div>
+                  <div className="text-xs text-subtle mt-0.5">
+                    {primaryGroupsUk?.[ex.primaryGroup] || ex.primaryGroup}
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-subtle text-center py-6">
+              {templates.length
+                ? "У шаблоні немає вправ або вправи видалені з каталогу"
+                : "Обери або створи шаблон"}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <Button
+            className="flex-1 h-12 min-h-[44px]"
+            onClick={() => tryStartPlan(plan.picked, effectiveTemplateId)}
+            disabled={!plan.picked.length}
+          >
+            Стартувати тренування
+          </Button>
+          <Button
+            variant="ghost"
+            className="h-12 min-h-[44px] px-4"
+            onClick={() => {
+              window.location.hash = "#workouts";
+            }}
+          >
+            Журнал
+          </Button>
+        </div>
+      </Card>
+
+      <Sheet
+        open={planConfirmOpen}
+        onClose={closePlanConfirm}
+        title="Увага"
+        panelClassName="fizruk-sheet max-w-4xl"
+        zIndex={100}
+        footer={
+          <div className="flex gap-2">
+            <Button
+              variant="ghost"
+              className="flex-1 h-12 min-h-[44px]"
+              onClick={closePlanConfirm}
+            >
+              Скасувати
+            </Button>
+            <Button
+              className="flex-1 h-12 min-h-[44px]"
+              onClick={() => {
+                const picks = pendingPicks?.length ? pendingPicks : plan.picked;
+                const templateId = pendingTemplateId;
+                closePlanConfirm();
+                startWorkoutFromPlan(picks, templateId);
+              }}
+            >
+              Продовжити
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm text-subtle leading-relaxed">
+          У цьому шаблоні є вправи на мʼязи, які ще відновлюються. Продовжити
+          старт тренування?
+        </p>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -7,7 +7,6 @@ import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
 import { Card } from "@shared/components/ui/Card";
 import { MiniLineChart } from "../components/MiniLineChart";
-import { PhotoProgress } from "../components/PhotoProgress";
 
 /**
  * Trend cards on this page used to be always-expanded, which meant four
@@ -542,8 +541,6 @@ export function Body({ onOpenMeasurements }) {
               </CollapsibleTrendCard>
             );
           })}
-
-        <PhotoProgress />
 
         {entries.length > 0 && (
           <Card as="section" radius="lg" aria-label="Журнал записів">

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -1,14 +1,13 @@
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useMeasurements } from "../hooks/useMeasurements";
 import { useRecovery } from "../hooks/useRecovery";
 import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
-import { BodyAtlas } from "../components/BodyAtlas";
 import { HeroCard, type HeroCardState } from "../components/dashboard/HeroCard";
 import { KpiRow } from "../components/dashboard/KpiRow";
 import { RecentWorkoutsSection } from "../components/dashboard/RecentWorkoutsSection";
@@ -22,12 +21,8 @@ import {
 } from "@sergeant/fizruk-domain/domain";
 import { Card } from "@shared/components/ui/Card";
 import { useActiveFizrukWorkout } from "@shared/hooks/useActiveFizrukWorkout";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
-
-const SELECTED_TEMPLATE_KEY = "fizruk_selected_template_id_v1";
 
 export function Dashboard({
-  onOpenAtlas,
   onOpenPrograms,
   activeProgram,
   todaySession,
@@ -40,99 +35,20 @@ export function Dashboard({
   });
   const rec = useRecovery();
   const { workouts, createWorkout, addItem } = useWorkouts();
-  const { exercises, primaryGroupsUk, musclesUk } = useExerciseCatalog();
+  const { exercises } = useExerciseCatalog();
   const { templates, recentlyUsed, markTemplateUsed } = useWorkoutTemplates();
   const monthlyPlan = useMonthlyPlan();
   const { entries: measurements } = useMeasurements();
 
-  const [recoveryOpen, setRecoveryOpen] = useState(false);
-
-  const [selectedTemplateId, setSelectedTemplateId] = useLocalStorageState(
-    SELECTED_TEMPLATE_KEY,
-    "",
-    { raw: true },
-  );
   const [planConfirmOpen, setPlanConfirmOpen] = useState(false);
   const [pendingPicks, setPendingPicks] = useState(null);
+  const [pendingTemplateId, setPendingTemplateId] = useState(null);
 
   const closePlanConfirm = () => {
     setPlanConfirmOpen(false);
     setPendingPicks(null);
+    setPendingTemplateId(null);
   };
-
-  useEffect(() => {
-    if (selectedTemplateId) return;
-    const first = templates[0]?.id;
-    if (first) setSelectedTemplateId(first);
-  }, [templates, selectedTemplateId, setSelectedTemplateId]);
-
-  const statusByMuscle = (() => {
-    const map = (id) => {
-      if (!id) return null;
-      if (id === "pectoralis_major" || id === "pectoralis_minor")
-        return "chest";
-      if (id === "latissimus_dorsi") return "upper-back";
-      if (id === "rhomboids" || id === "upper_back") return "upper-back";
-      if (id === "erector_spinae") return "lower-back";
-      if (id === "trapezius") return "trapezius";
-      if (id === "biceps") return "biceps";
-      if (id === "triceps") return "triceps";
-      if (id === "forearms") return "forearm";
-      if (id === "front_deltoid") return "front-deltoids";
-      if (id === "rear_deltoid") return "back-deltoids";
-      if (id === "rectus_abdominis") return "abs";
-      if (id === "obliques") return "obliques";
-      if (id === "quadriceps") return "quadriceps";
-      if (id === "hamstrings") return "hamstring";
-      if (id === "calves") return "calves";
-      if (id === "adductors") return "adductor";
-      if (id === "abductors") return "abductors";
-      if (id === "gluteus_maximus" || id === "gluteus_medius") return "gluteal";
-      if (id === "neck") return "neck";
-      return null;
-    };
-    const worst = (a, b) =>
-      a === "red" || b === "red"
-        ? "red"
-        : a === "yellow" || b === "yellow"
-          ? "yellow"
-          : "green";
-    const out = {};
-    for (const m of Object.values(rec.by || {})) {
-      const key = map(m.id);
-      if (!key) continue;
-      out[key] = out[key] ? worst(out[key], m.status) : m.status;
-    }
-    return out;
-  })();
-
-  const effectiveTemplateId = monthlyPlan.todayTemplateId || selectedTemplateId;
-
-  const plan = useMemo(() => {
-    const tpl = templates.find((t) => t.id === effectiveTemplateId);
-    const picked = tpl
-      ? tpl.exerciseIds
-          .map((id) => exercises.find((e) => e.id === id))
-          .filter(Boolean)
-      : [];
-
-    const focus = (rec.ready || []).slice(0, 4).map((m) => ({
-      id: m.id,
-      label: musclesUk?.[m.id] || m.label || m.id,
-      daysSince: m.daysSince,
-    }));
-    const avoid = (rec.avoid || [])
-      .slice(0, 4)
-      .map((m) => ({ id: m.id, label: musclesUk?.[m.id] || m.label || m.id }));
-    return { picked, focus, avoid, templateName: tpl?.name || "" };
-  }, [
-    effectiveTemplateId,
-    templates,
-    exercises,
-    rec.ready,
-    rec.avoid,
-    musclesUk,
-  ]);
 
   const avgDurationSec = useMemo(() => {
     const done = (workouts || []).filter((w) => w.endedAt);
@@ -173,8 +89,6 @@ export function Dashboard({
     } catch {}
     window.location.hash = "#workouts";
   };
-
-  const [pendingTemplateId, setPendingTemplateId] = useState(null);
 
   const tryStartPlan = (picks: unknown[], templateId?: string | null) => {
     if (!picks?.length) return;
@@ -480,240 +394,6 @@ export function Dashboard({
           </Card>
         )}
 
-        <Card
-          as="section"
-          radius="lg"
-          aria-label="Відновлення та фокус тренування"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <button
-              type="button"
-              className="min-w-0 flex-1 text-left flex items-start gap-2 rounded-xl -m-1 p-1 hover:bg-panelHi/80 transition-colors"
-              onClick={() => setRecoveryOpen((o) => !o)}
-              aria-expanded={recoveryOpen}
-            >
-              <div className="min-w-0 flex-1">
-                <h2 className="text-base font-semibold text-text">
-                  Відновлення й фокус
-                </h2>
-                <p className="text-xs text-subtle mt-1 leading-snug">
-                  Колір на силуеті — готовність груп; чіпи — пріоритет після
-                  відпочинку.
-                </p>
-              </div>
-              <span
-                className="text-lg leading-none text-muted shrink-0 mt-0.5"
-                aria-hidden
-              >
-                {recoveryOpen ? "▾" : "▸"}
-              </span>
-            </button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-9 min-h-[40px] px-3 text-xs shrink-0"
-              onClick={() => onOpenAtlas?.()}
-              aria-label="Відкрити атлас мʼязів"
-            >
-              Атлас
-            </Button>
-          </div>
-
-          {recoveryOpen && (
-            <>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-subtle mb-3 mt-3">
-                <span className="inline-flex items-center gap-1">
-                  <span className="w-2 h-2 rounded-full bg-success" /> готово
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <span className="w-2 h-2 rounded-full bg-warning" /> краще
-                  почекати
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <span className="w-2 h-2 rounded-full bg-danger" /> рано
-                </span>
-              </div>
-
-              {rec.wellbeingMult > 1.1 && (
-                <div className="mb-3 px-3 py-2 rounded-xl bg-warning/10 border border-warning/25 flex items-start gap-2">
-                  <span className="text-base shrink-0" aria-hidden>
-                    😴
-                  </span>
-                  <p className="text-xs text-warning leading-snug">
-                    {rec.wellbeingMult >= 1.3
-                      ? "Поганий сон або дуже низька енергія — відновлення значно сповільнене."
-                      : "Недостатній сон або низька енергія — відновлення сповільнене."}{" "}
-                    М{"'"}язи потребують більше часу перед наступним
-                    навантаженням.
-                  </p>
-                </div>
-              )}
-
-              <BodyAtlas
-                statusByMuscle={statusByMuscle}
-                height={120}
-                showLegend={false}
-              />
-
-              <div className="mt-4 pt-3 border-t border-line">
-                <SectionHeading as="p" size="xs" className="mb-2">
-                  Пріоритет після відпочинку
-                </SectionHeading>
-                <div className="flex flex-wrap gap-2">
-                  {(plan.focus || []).map((m) => (
-                    <span
-                      key={m.id}
-                      className="px-2.5 py-1 bg-success/10 text-success text-xs rounded-full font-medium border border-success/15"
-                    >
-                      {m.label}
-                      {m.daysSince == null ? "" : ` · ${m.daysSince}д без`}
-                    </span>
-                  ))}
-                  {(plan.focus || []).length === 0 && (
-                    <span className="text-xs text-subtle">
-                      Додай завершені тренування — зʼявиться пріоритет груп.
-                    </span>
-                  )}
-                </div>
-                {(plan.avoid || []).length > 0 && (
-                  <p className="text-xs text-muted mt-3 leading-relaxed">
-                    <span className="font-semibold text-warning">
-                      Почекати:
-                    </span>{" "}
-                    {plan.avoid.map((x) => x.label).join(", ")}
-                  </p>
-                )}
-              </div>
-            </>
-          )}
-        </Card>
-
-        <Card radius="lg" padding="lg">
-          <div className="flex items-center justify-between gap-2 mb-3">
-            <div className="text-xs font-medium text-subtle">
-              План на сьогодні
-            </div>
-            <button
-              type="button"
-              className="text-xs font-semibold text-primary hover:underline shrink-0"
-              onClick={() => {
-                window.location.hash = "#plan";
-              }}
-            >
-              Календар
-            </button>
-          </div>
-          {monthlyPlan.todayTemplateId && (
-            <p className="text-xs text-success/90 mb-2">
-              Шаблон з місячного плану на сьогодні.
-            </p>
-          )}
-          <div className="rounded-2xl border border-line bg-panelHi px-3">
-            <SectionHeading as="div" size="xs" className="pt-2">
-              Мій шаблон
-            </SectionHeading>
-            <select
-              className="input-focus-fizruk w-full min-h-[44px] bg-transparent text-sm text-text rounded-xl"
-              value={selectedTemplateId}
-              onChange={(e) => {
-                const v = e.target.value;
-                setSelectedTemplateId(v);
-                try {
-                  localStorage.setItem(SELECTED_TEMPLATE_KEY, v);
-                } catch {}
-              }}
-              aria-label="Обрати збережений шаблон тренування"
-            >
-              {templates.length === 0 ? (
-                <option value="">— немає шаблонів —</option>
-              ) : (
-                templates.map((t) => (
-                  <option key={t.id} value={t.id}>
-                    {t.name}
-                  </option>
-                ))
-              )}
-            </select>
-          </div>
-
-          {templates.length === 0 && (
-            <div className="mt-3 text-sm text-subtle text-center py-2">
-              Створи шаблон у розділі{" "}
-              <button
-                type="button"
-                className="font-semibold text-text underline"
-                onClick={() => {
-                  try {
-                    sessionStorage.setItem("fizruk_workouts_mode", "templates");
-                  } catch {}
-                  window.location.hash = "#workouts";
-                }}
-              >
-                Тренування → Шаблони
-              </button>
-            </div>
-          )}
-
-          {!workouts?.length ? (
-            <div className="text-sm text-subtle text-center py-4">
-              Додай перше тренування, щоб статистика була точнішою
-            </div>
-          ) : null}
-
-          <div className="mt-4">
-            <div className="text-xs text-subtle mb-2">
-              Вправи з шаблону
-              {plan.templateName ? ` «${plan.templateName}»` : ""}:
-            </div>
-            {plan.picked.length ? (
-              <div className="space-y-2">
-                {plan.picked.map((ex) => (
-                  <button
-                    key={ex.id}
-                    type="button"
-                    className="w-full text-left border border-line rounded-2xl p-3 min-h-[44px] bg-bg hover:bg-panelHi transition-colors"
-                    onClick={() => {
-                      window.location.hash = `#exercise/${ex.id}`;
-                    }}
-                  >
-                    <div className="text-sm font-semibold text-text truncate">
-                      {ex?.name?.uk || ex?.name?.en}
-                    </div>
-                    <div className="text-xs text-subtle mt-0.5">
-                      {primaryGroupsUk?.[ex.primaryGroup] || ex.primaryGroup}
-                    </div>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <div className="text-sm text-subtle text-center py-6">
-                {templates.length
-                  ? "У шаблоні немає вправ або вправи видалені з каталогу"
-                  : "Обери або створи шаблон"}
-              </div>
-            )}
-          </div>
-
-          <div className="mt-3 flex gap-2">
-            <Button
-              className="flex-1 h-12 min-h-[44px]"
-              onClick={() => tryStartPlan(plan.picked)}
-              disabled={!plan.picked.length}
-            >
-              Стартувати тренування
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-12 min-h-[44px] px-4"
-              onClick={() => {
-                window.location.hash = "#workouts";
-              }}
-            >
-              Журнал
-            </Button>
-          </div>
-        </Card>
-
         <RecentWorkoutsSection
           recent={recentWorkouts}
           onSeeAll={openWorkoutsTab}
@@ -738,10 +418,10 @@ export function Dashboard({
             <Button
               className="flex-1 h-12 min-h-[44px]"
               onClick={() => {
-                const picks = pendingPicks?.length ? pendingPicks : plan.picked;
+                const picks = pendingPicks ?? [];
+                const templateId = pendingTemplateId;
                 closePlanConfirm();
-                startWorkoutFromPlan(picks, pendingTemplateId);
-                setPendingTemplateId(null);
+                startWorkoutFromPlan(picks, templateId);
               }}
             >
               Продовжити

--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -10,6 +10,8 @@ import { useRecovery } from "../hooks/useRecovery";
 import { useWorkouts } from "../hooks/useWorkouts";
 import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
 import { forecastFullRecoveryByDate } from "@sergeant/fizruk-domain";
+import { RecoveryFocusCard } from "../components/RecoveryFocusCard";
+import { TodayPlanCard } from "../components/TodayPlanCard";
 
 const WEEKDAYS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
 
@@ -118,6 +120,14 @@ export function PlanCalendar() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
+        <TodayPlanCard />
+
+        <RecoveryFocusCard
+          onOpenAtlas={() => {
+            window.location.hash = "#atlas";
+          }}
+        />
+
         <Card as="section" radius="lg" padding="md">
           <div className="flex items-center justify-between gap-2 mb-4">
             <button

--- a/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
@@ -41,7 +41,6 @@ export function FizrukRouter({
     case "dashboard":
       return (
         <Dashboard
-          onOpenAtlas={() => onNavigate("atlas")}
           onOpenPrograms={() => onNavigate("programs")}
           activeProgram={activeProgram}
           todaySession={todaySession}


### PR DESCRIPTION
## Summary

За проханням користувача переніс кілька блоків у Фізруку:

- **Тіло (Фізрук)** — прибрано блок «Фото прогресу».
- **Дашборд (перша вкладка Фізруку)** — прибрано картки «План на сьогодні» та «Відновлення й фокус» (з атласом мʼязів).
- **План (календарна вкладка Фізруку)** — ці дві картки тепер рендеряться тут, над календарем.

Щоб уникнути повторення логіки, ці блоки винесено в окремі самодостатні компоненти:

- `apps/web/src/modules/fizruk/components/TodayPlanCard.tsx` — містить власний `Sheet` з попередженням про ризикові мʼязи і власний стан вибраного шаблону (`SELECTED_TEMPLATE_KEY` зберігається як і раніше, тож вибраний шаблон користувача не губиться).
- `apps/web/src/modules/fizruk/components/RecoveryFocusCard.tsx` — інкапсулює `statusByMuscle`-маппінг і приймає колбек `onOpenAtlas` (з Plan-сторінки прокидуємо `window.location.hash = "#atlas"`).

Дашборд-Sheet, що відкривається з «Швидкого старту», залишено на місці — він і раніше завжди виставляв `pendingPicks`, тож прибрано недосяжний `plan.picked`-фолбек у `onClick` «Продовжити». Пропа `onOpenAtlas` з `Dashboard` та `FizrukRouter` прибрана як мертвий код — окрема сторінка `Atlas` як була в хедер-меню, так і залишилась.

## Review & Testing Checklist for Human

- [ ] На вкладці **Фізрук → План** перевір, що зверху зʼявились «План на сьогодні» і «Відновлення й фокус» (з атласом), і що кнопка «Атлас» у правому куті відновлення веде на сторінку Atlas.
- [ ] На вкладці **Фізрук → Дашборд** перевір, що «Швидкий старт» усе ще стартує тренування та що при ризикових мʼязах зʼявляється попередження (Sheet «Увага»).
- [ ] На вкладці **Фізрук → Тіло** перевір, що блок «Фото прогресу» зник, а решта (трендові графіки, журнал) працює.
- [ ] Вибраний шаблон у «План на сьогодні» зберігається між перезавантаженнями (localStorage ключ `fizruk_selected_template_id_v1`).

### Notes

- Тести (`pnpm --filter @sergeant/web test`), лінт і typecheck зелені локально.
- `pnpm lint:plugins` падав у локальному середовищі через несумісність Node 22 vs Node 20 (той самий фейл на `main`) — у CI має бути Node 20, тож не чіпав.


Link to Devin session: https://app.devin.ai/sessions/c3ef2a73f27e4cbd90d952b76cba3490
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Recovery Focus Card displaying muscle group priorities with body visualization and focus/avoid recommendations.
  * Added Today Plan Card showing scheduled workout with quick-start and journal access.

* **Refactor**
  * Restructured workout planning workflow and dashboard layout.
  * Relocated recovery and focus components to Plan Calendar page.

* **Bug Fixes**
  * Removed Photo Progress display from Body page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->