### PR TITLE
feat(fizruk): split arms/legs into muscle subgroups, add exercises, equipment filter

### DIFF
--- a/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
@@ -18,6 +18,8 @@ import { Pressable, ScrollView, Text, View } from "react-native";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
 
+const EMPTY_RECORD: Record<string, string> = {};
+
 export interface ExerciseCatalogSectionProps {
   exercises: readonly WorkoutExerciseCatalogEntry[];
   primaryGroupsUk?: Record<string, string>;
@@ -223,8 +225,8 @@ function ExerciseRow({
 
 export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
   exercises,
-  primaryGroupsUk = {},
-  equipmentUk = {},
+  primaryGroupsUk = EMPTY_RECORD,
+  equipmentUk = EMPTY_RECORD,
   onPickExercise,
   onInspectExercise,
   query: controlledQuery,

--- a/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/Input";
 export interface ExerciseCatalogSectionProps {
   exercises: readonly WorkoutExerciseCatalogEntry[];
   primaryGroupsUk?: Record<string, string>;
+  equipmentUk?: Record<string, string>;
   onPickExercise?(ex: WorkoutExerciseCatalogEntry): void;
   /** Long-press handler — typically navigates to the exercise detail page. */
   onInspectExercise?(ex: WorkoutExerciseCatalogEntry): void;
@@ -32,6 +33,8 @@ export interface ExerciseCatalogSectionProps {
   onQueryChange?(next: string): void;
   primaryGroup?: string | null;
   onPrimaryGroupChange?(next: string | null): void;
+  equipment?: readonly string[];
+  onEquipmentChange?(next: string[]): void;
   /** Optional root testID — sub-ids derive from it. */
   testID?: string;
 }
@@ -47,8 +50,6 @@ function PrimaryGroupChips({
   onChange(next: string | null): void;
   testID: string;
 }) {
-  // Canonical ordering — fall back to alphabetical for groups that
-  // aren't in the canonical list (e.g. user-imported data).
   const knownOrder = [...PRIMARY_GROUP_ORDER];
   const allKeys = Object.keys(groupsUk);
   const extras = allKeys.filter((k) => !knownOrder.includes(k)).sort();
@@ -78,6 +79,62 @@ function PrimaryGroupChips({
         />
       ))}
     </ScrollView>
+  );
+}
+
+function EquipmentChips({
+  equipmentUk,
+  selected,
+  onChange,
+  testID,
+}: {
+  equipmentUk: Record<string, string>;
+  selected: readonly string[];
+  onChange(next: string[]): void;
+  testID: string;
+}) {
+  const ids = Object.keys(equipmentUk);
+  if (ids.length === 0) return null;
+
+  const toggle = (id: string) => {
+    const arr = [...selected];
+    const idx = arr.indexOf(id);
+    if (idx >= 0) arr.splice(idx, 1);
+    else arr.push(id);
+    onChange(arr);
+  };
+
+  return (
+    <View className="gap-1">
+      <Text className="text-xs font-semibold text-stone-500 px-1">
+        Обладнання
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ gap: 8, paddingVertical: 2 }}
+        testID={testID}
+      >
+        {ids.map((id) => (
+          <Chip
+            key={id}
+            label={equipmentUk[id] ?? id}
+            active={selected.includes(id)}
+            onPress={() => toggle(id)}
+            testID={`${testID}-${id}`}
+          />
+        ))}
+        {selected.length > 0 && (
+          <Chip
+            label="Скинути"
+            active={false}
+            onPress={() => onChange([])}
+            testID={`${testID}-reset`}
+          />
+        )}
+      </ScrollView>
+    </View>
   );
 }
 
@@ -167,17 +224,23 @@ function ExerciseRow({
 export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
   exercises,
   primaryGroupsUk = {},
+  equipmentUk = {},
   onPickExercise,
   onInspectExercise,
   query: controlledQuery,
   onQueryChange,
   primaryGroup: controlledPrimaryGroup,
   onPrimaryGroupChange,
+  equipment: controlledEquipment,
+  onEquipmentChange,
   testID = "fizruk-workouts-catalog",
 }: ExerciseCatalogSectionProps) {
   const [uncontrolledQuery, setUncontrolledQuery] = useState("");
   const [uncontrolledGroup, setUncontrolledGroup] = useState<string | null>(
     null,
+  );
+  const [uncontrolledEquipment, setUncontrolledEquipment] = useState<string[]>(
+    [],
   );
 
   const query = controlledQuery ?? uncontrolledQuery;
@@ -185,6 +248,7 @@ export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
     controlledPrimaryGroup === undefined
       ? uncontrolledGroup
       : controlledPrimaryGroup;
+  const equipment = controlledEquipment ?? uncontrolledEquipment;
 
   const handleQueryChange = useCallback(
     (next: string) => {
@@ -202,14 +266,23 @@ export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
     [onPrimaryGroupChange],
   );
 
+  const handleEquipmentChange = useCallback(
+    (next: string[]) => {
+      if (onEquipmentChange) onEquipmentChange(next);
+      else setUncontrolledEquipment(next);
+    },
+    [onEquipmentChange],
+  );
+
   const groups = useMemo(
     () =>
       buildExerciseCatalogGroups(exercises, {
         query,
         primaryGroup,
+        equipment: equipment.length > 0 ? equipment : null,
         primaryGroupsUk,
       }),
-    [exercises, query, primaryGroup, primaryGroupsUk],
+    [exercises, query, primaryGroup, equipment, primaryGroupsUk],
   );
 
   return (
@@ -227,6 +300,12 @@ export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
         selected={primaryGroup ?? null}
         onChange={handlePrimaryGroupChange}
         testID={`${testID}-chips`}
+      />
+      <EquipmentChips
+        equipmentUk={equipmentUk}
+        selected={equipment}
+        onChange={handleEquipmentChange}
+        testID={`${testID}-equipment`}
       />
 
       {groups.length === 0 ? (

--- a/apps/web/src/core/onboarding/seedDemoData.ts
+++ b/apps/web/src/core/onboarding/seedDemoData.ts
@@ -454,8 +454,8 @@ function seedFizruk(): void {
           exerciseId: "squat",
           nameUk: "Присідання зі штангою",
           primaryGroup: "quadriceps",
-          musclesPrimary: ["quads"],
-          musclesSecondary: ["glutes", "core"],
+          musclesPrimary: ["quadriceps"],
+          musclesSecondary: ["gluteus_maximus", "rectus_abdominis"],
           type: "strength",
           sets: [
             { weightKg: 60, reps: 10 },

--- a/apps/web/src/core/onboarding/seedDemoData.ts
+++ b/apps/web/src/core/onboarding/seedDemoData.ts
@@ -453,7 +453,7 @@ function seedFizruk(): void {
           id: shortId("demo_wi", 1),
           exerciseId: "squat",
           nameUk: "Присідання зі штангою",
-          primaryGroup: "legs",
+          primaryGroup: "quadriceps",
           musclesPrimary: ["quads"],
           musclesSecondary: ["glutes", "core"],
           type: "strength",

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx
@@ -3,10 +3,18 @@ import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
 import { Card } from "@shared/components/ui/Card";
 
+function toggleArr(arr, value) {
+  const a = Array.isArray(arr) ? arr : [];
+  return a.includes(value) ? a.filter((x) => x !== value) : [...a, value];
+}
+
 export function WorkoutCatalogSection({
   mode,
   q,
   setQ,
+  equipmentFilter,
+  setEquipmentFilter,
+  equipmentUk,
   grouped,
   open,
   setOpen,
@@ -33,6 +41,48 @@ export function WorkoutCatalogSection({
           </button>
         )}
       </div>
+
+      {equipmentUk && Object.keys(equipmentUk).length > 0 && (
+        <div className="mb-3">
+          <div className="text-xs font-semibold text-subtle mb-1.5">
+            Обладнання
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(equipmentUk as Record<string, string>).map(
+              ([id, label]) => {
+                const active = (equipmentFilter || []).includes(id);
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() =>
+                      setEquipmentFilter(toggleArr(equipmentFilter, id))
+                    }
+                    className={cn(
+                      "text-xs px-3 py-1.5 rounded-full border transition-colors",
+                      active
+                        ? "bg-text text-bg border-text"
+                        : "border-line bg-bg text-muted hover:border-muted hover:text-text",
+                    )}
+                    aria-pressed={active}
+                  >
+                    {label}
+                  </button>
+                );
+              },
+            )}
+            {(equipmentFilter || []).length > 0 && (
+              <button
+                type="button"
+                onClick={() => setEquipmentFilter([])}
+                className="text-xs px-3 py-1.5 rounded-full border border-line text-muted hover:text-text hover:border-muted transition-colors"
+              >
+                Скинути
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {mode === "log" && (
         <p className="text-xs text-subtle mb-2 leading-relaxed">

--- a/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
+++ b/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
@@ -20,6 +20,7 @@ export function useExerciseCatalog() {
   const [customExercises, setCustomExercises] = useState([]);
 
   const primaryGroupsUk = FizrukData.PRIMARY_GROUPS_UK;
+  const equipmentUk = FizrukData.EQUIPMENT_UK;
   const musclesUk = FizrukData.MUSCLES_UK;
   const musclesByPrimaryGroup = FizrukData.MUSCLES_BY_PRIMARY_GROUP;
 
@@ -101,6 +102,7 @@ export function useExerciseCatalog() {
     exercises,
     search,
     primaryGroupsUk,
+    equipmentUk,
     musclesUk,
     musclesByPrimaryGroup,
     addExercise,

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -82,6 +82,7 @@ export function Workouts() {
     exercises,
     search,
     primaryGroupsUk,
+    equipmentUk,
     musclesUk,
     musclesByPrimaryGroup,
     addExercise,
@@ -103,6 +104,7 @@ export function Workouts() {
   } = useWorkouts();
   const templateApi = useWorkoutTemplates();
   const [q, setQ] = useState("");
+  const [equipmentFilter, setEquipmentFilter] = useState<string[]>([]);
   const [selected, setSelected] = useState(null);
   const [open, setOpen] = useState(() => ({}));
   const [addOpen, setAddOpen] = useState(false);
@@ -361,20 +363,27 @@ export function Workouts() {
   }, [workouts, activeWorkoutId]);
 
   const grouped = useMemo(() => {
+    const eqSet = equipmentFilter.length > 0 ? new Set(equipmentFilter) : null;
+    const pool = eqSet
+      ? list.filter((ex) => (ex.equipment ?? []).some((e) => eqSet.has(e)))
+      : list;
     const m = new Map();
-    for (const ex of list) {
+    for (const ex of pool) {
       const gid = ex.primaryGroup || "full_body";
       if (!m.has(gid)) m.set(gid, []);
       m.get(gid).push(ex);
     }
-    // stable group order (common first)
     const order = [
       "chest",
       "back",
       "shoulders",
-      "arms",
+      "biceps",
+      "triceps",
+      "forearms",
       "core",
-      "legs",
+      "quadriceps",
+      "hamstrings",
+      "calves",
       "glutes",
       "full_body",
       "cardio",
@@ -393,7 +402,7 @@ export function Workouts() {
       items: items.slice(0, 80),
       total: items.length,
     }));
-  }, [list, primaryGroupsUk]);
+  }, [list, equipmentFilter, primaryGroupsUk]);
 
   const finishedCount = useMemo(
     () => (workouts || []).filter((w) => w.endedAt).length,
@@ -542,6 +551,9 @@ export function Workouts() {
             mode={mode}
             q={q}
             setQ={setQ}
+            equipmentFilter={equipmentFilter}
+            setEquipmentFilter={setEquipmentFilter}
+            equipmentUk={equipmentUk}
             grouped={grouped}
             open={open}
             setOpen={setOpen}

--- a/packages/fizruk-domain/src/data/bodyAtlas.ts
+++ b/packages/fizruk-domain/src/data/bodyAtlas.ts
@@ -127,6 +127,7 @@ export function mapDomainMuscleToAtlas(
     case "trapezius":
       return "trapezius";
     case "biceps":
+    case "brachialis":
       return "biceps";
     case "triceps":
       return "triceps";

--- a/packages/fizruk-domain/src/data/exercises.gymup.json
+++ b/packages/fizruk-domain/src/data/exercises.gymup.json
@@ -9,12 +9,27 @@
       "chest": "Груди",
       "back": "Спина",
       "shoulders": "Плечі",
-      "arms": "Руки",
+      "biceps": "Біцепс",
+      "triceps": "Трицепс",
+      "forearms": "Передпліччя",
       "core": "Прес",
-      "legs": "Ноги",
+      "quadriceps": "Квадрицепс",
+      "hamstrings": "Задня поверхня стегна",
+      "calves": "Ікри",
       "glutes": "Сідниці",
       "cardio": "Кардіо",
       "full_body": "Все тіло"
+    },
+    "equipmentUk": {
+      "barbell": "Штанга",
+      "dumbbell": "Гантелі",
+      "kettlebell": "Гиря",
+      "cable": "Блок/трос",
+      "machine": "Тренажер",
+      "bodyweight": "Власна вага",
+      "band": "Еспандер/резинка",
+      "bench": "Лава",
+      "other": "Інше"
     },
     "musclesUk": {
       "pectoralis_major": "Великий грудний",
@@ -31,6 +46,7 @@
       "biceps": "Біцепс",
       "triceps": "Трицепс",
       "forearms": "Передпліччя",
+      "brachialis": "Плечовий м'яз",
       "rectus_abdominis": "Прямий м'яз живота",
       "obliques": "Косі м'язи живота",
       "quadriceps": "Квадрицепс",
@@ -67,9 +83,13 @@
         "trapezius",
         "triceps"
       ],
-      "arms": ["biceps", "triceps", "forearms"],
-      "core": ["rectus_abdominis", "obliques"],
-      "legs": ["quadriceps", "hamstrings", "calves", "adductors", "abductors"],
+      "biceps": ["biceps", "brachialis", "forearms"],
+      "triceps": ["triceps", "forearms"],
+      "forearms": ["forearms", "biceps"],
+      "core": ["rectus_abdominis", "obliques", "erector_spinae"],
+      "quadriceps": ["quadriceps", "adductors", "abductors"],
+      "hamstrings": ["hamstrings", "gluteus_maximus"],
+      "calves": ["calves"],
       "glutes": ["gluteus_maximus", "gluteus_medius", "hamstrings"],
       "cardio": [],
       "full_body": [
@@ -117,11 +137,50 @@
       "equipment": ["barbell", "bench"]
     },
     {
+      "id": "incline_dumbbell_press",
+      "name": {
+        "uk": "Жим гантелей на похилій лаві",
+        "en": "Incline Dumbbell Press"
+      },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major", "front_deltoid"],
+        "secondary": ["triceps"]
+      },
+      "equipment": ["dumbbell", "bench"]
+    },
+    {
+      "id": "decline_bench_press",
+      "name": {
+        "uk": "Жим штанги на лаві з від'ємним нахилом",
+        "en": "Decline Bench Press"
+      },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major", "pectoralis_minor"],
+        "secondary": ["triceps", "front_deltoid"]
+      },
+      "equipment": ["barbell", "bench"]
+    },
+    {
       "id": "dumbbell_flyes",
       "name": { "uk": "Розводка гантелей лежачи", "en": "Dumbbell Flyes" },
       "primaryGroup": "chest",
       "muscles": {
         "primary": ["pectoralis_major", "pectoralis_minor"],
+        "secondary": ["front_deltoid", "serratus_anterior"]
+      },
+      "equipment": ["dumbbell", "bench"]
+    },
+    {
+      "id": "incline_dumbbell_flyes",
+      "name": {
+        "uk": "Розводка гантелей на похилій лаві",
+        "en": "Incline Dumbbell Flyes"
+      },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major"],
         "secondary": ["front_deltoid", "serratus_anterior"]
       },
       "equipment": ["dumbbell", "bench"]
@@ -147,6 +206,19 @@
       "equipment": ["bodyweight"]
     },
     {
+      "id": "diamond_pushup",
+      "name": {
+        "uk": "Віджимання з вузькою постановкою рук",
+        "en": "Diamond Push-up"
+      },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major", "triceps"],
+        "secondary": ["front_deltoid"]
+      },
+      "equipment": ["bodyweight"]
+    },
+    {
       "id": "dips_chest",
       "name": {
         "uk": "Віджимання на брусах (акцент груди)",
@@ -159,6 +231,37 @@
       },
       "equipment": ["bodyweight"]
     },
+    {
+      "id": "cable_crossover",
+      "name": { "uk": "Зведення рук на блоці", "en": "Cable Crossover" },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major", "pectoralis_minor"],
+        "secondary": ["front_deltoid", "serratus_anterior"]
+      },
+      "equipment": ["cable"]
+    },
+    {
+      "id": "machine_chest_press",
+      "name": { "uk": "Жим у тренажері (груди)", "en": "Machine Chest Press" },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major"],
+        "secondary": ["triceps", "front_deltoid"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "pec_deck",
+      "name": { "uk": "Зведення рук у тренажері (пек-дек)", "en": "Pec Deck" },
+      "primaryGroup": "chest",
+      "muscles": {
+        "primary": ["pectoralis_major", "pectoralis_minor"],
+        "secondary": ["front_deltoid"]
+      },
+      "equipment": ["machine"]
+    },
+
     {
       "id": "pullup",
       "name": {
@@ -229,6 +332,19 @@
       "equipment": ["cable", "machine"]
     },
     {
+      "id": "close_grip_lat_pulldown",
+      "name": {
+        "uk": "Тяга верхнього блоку вузьким хватом",
+        "en": "Close-grip Lat Pulldown"
+      },
+      "primaryGroup": "back",
+      "muscles": {
+        "primary": ["latissimus_dorsi", "biceps"],
+        "secondary": ["rhomboids", "rear_deltoid"]
+      },
+      "equipment": ["cable", "machine"]
+    },
+    {
       "id": "cable_seated_row",
       "name": { "uk": "Тяга нижнього блоку сидячи", "en": "Seated Cable Row" },
       "primaryGroup": "back",
@@ -237,6 +353,16 @@
         "secondary": ["biceps", "rear_deltoid", "forearms"]
       },
       "equipment": ["cable", "machine"]
+    },
+    {
+      "id": "t_bar_row",
+      "name": { "uk": "Тяга T-грифа", "en": "T-bar Row" },
+      "primaryGroup": "back",
+      "muscles": {
+        "primary": ["latissimus_dorsi", "rhomboids"],
+        "secondary": ["biceps", "rear_deltoid", "trapezius"]
+      },
+      "equipment": ["barbell", "machine"]
     },
     {
       "id": "hyperextension",
@@ -248,6 +374,40 @@
       },
       "equipment": ["machine", "bodyweight"]
     },
+    {
+      "id": "inverted_row",
+      "name": { "uk": "Горизонтальні підтягування", "en": "Inverted Row" },
+      "primaryGroup": "back",
+      "muscles": {
+        "primary": ["latissimus_dorsi", "rhomboids", "upper_back"],
+        "secondary": ["biceps", "rear_deltoid"]
+      },
+      "equipment": ["bodyweight"]
+    },
+    {
+      "id": "straight_arm_pulldown",
+      "name": {
+        "uk": "Тяга прямими руками (блок)",
+        "en": "Straight-arm Pulldown"
+      },
+      "primaryGroup": "back",
+      "muscles": {
+        "primary": ["latissimus_dorsi"],
+        "secondary": ["rear_deltoid", "triceps"]
+      },
+      "equipment": ["cable"]
+    },
+    {
+      "id": "machine_row",
+      "name": { "uk": "Тяга в тренажері (горизонт.)", "en": "Machine Row" },
+      "primaryGroup": "back",
+      "muscles": {
+        "primary": ["latissimus_dorsi", "rhomboids"],
+        "secondary": ["biceps", "rear_deltoid"]
+      },
+      "equipment": ["machine"]
+    },
+
     {
       "id": "overhead_press_barbell",
       "name": { "uk": "Жим штанги стоячи", "en": "Barbell Overhead Press" },
@@ -269,6 +429,19 @@
       "equipment": ["dumbbell"]
     },
     {
+      "id": "seated_dumbbell_press",
+      "name": {
+        "uk": "Жим гантелей сидячи",
+        "en": "Seated Dumbbell Press"
+      },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["front_deltoid", "lateral_deltoid"],
+        "secondary": ["triceps", "trapezius"]
+      },
+      "equipment": ["dumbbell", "bench"]
+    },
+    {
       "id": "arnold_press",
       "name": { "uk": "Жим Арнольда", "en": "Arnold Press" },
       "primaryGroup": "shoulders",
@@ -287,6 +460,19 @@
         "secondary": ["front_deltoid", "trapezius"]
       },
       "equipment": ["dumbbell"]
+    },
+    {
+      "id": "cable_lateral_raise",
+      "name": {
+        "uk": "Підйом через сторони на блоці",
+        "en": "Cable Lateral Raise"
+      },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["lateral_deltoid"],
+        "secondary": ["front_deltoid", "trapezius"]
+      },
+      "equipment": ["cable"]
     },
     {
       "id": "front_raise",
@@ -322,19 +508,66 @@
       "equipment": ["barbell", "dumbbell"]
     },
     {
+      "id": "cable_face_pull",
+      "name": { "uk": "Тяга на обличчя (блок)", "en": "Face Pull" },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["rear_deltoid"],
+        "secondary": ["rhomboids", "trapezius", "upper_back"]
+      },
+      "equipment": ["cable", "machine"]
+    },
+    {
+      "id": "shrugs",
+      "name": { "uk": "Шраги зі штангою", "en": "Barbell Shrugs" },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["trapezius"],
+        "secondary": ["neck", "forearms"]
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+    {
+      "id": "machine_shoulder_press",
+      "name": {
+        "uk": "Жим у тренажері (плечі)",
+        "en": "Machine Shoulder Press"
+      },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["front_deltoid", "lateral_deltoid"],
+        "secondary": ["triceps"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "band_pull_apart",
+      "name": { "uk": "Розведення рук із резинкою", "en": "Band Pull-apart" },
+      "primaryGroup": "shoulders",
+      "muscles": {
+        "primary": ["rear_deltoid"],
+        "secondary": ["rhomboids", "upper_back"]
+      },
+      "equipment": ["band"]
+    },
+
+    {
       "id": "bicep_curl_barbell",
       "name": { "uk": "Згинання рук зі штангою", "en": "Barbell Bicep Curl" },
-      "primaryGroup": "arms",
+      "primaryGroup": "biceps",
       "muscles": {
         "primary": ["biceps"],
-        "secondary": ["forearms", "front_deltoid"]
+        "secondary": ["forearms", "brachialis"]
       },
       "equipment": ["barbell"]
     },
     {
       "id": "bicep_curl_dumbbell",
-      "name": { "uk": "Згинання рук з гантелями", "en": "Dumbbell Bicep Curl" },
-      "primaryGroup": "arms",
+      "name": {
+        "uk": "Згинання рук з гантелями",
+        "en": "Dumbbell Bicep Curl"
+      },
+      "primaryGroup": "biceps",
       "muscles": {
         "primary": ["biceps"],
         "secondary": ["forearms"]
@@ -344,17 +577,91 @@
     {
       "id": "hammer_curl",
       "name": { "uk": "Молоткоподібні згинання", "en": "Hammer Curl" },
-      "primaryGroup": "arms",
+      "primaryGroup": "biceps",
       "muscles": {
-        "primary": ["biceps", "forearms"],
-        "secondary": ["front_deltoid"]
+        "primary": ["biceps", "brachialis"],
+        "secondary": ["forearms"]
       },
       "equipment": ["dumbbell"]
     },
     {
+      "id": "concentration_curl",
+      "name": { "uk": "Концентроване згинання", "en": "Concentration Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["dumbbell"]
+    },
+    {
+      "id": "preacher_curl",
+      "name": { "uk": "Згинання на лаві Скотта", "en": "Preacher Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps", "brachialis"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["barbell", "dumbbell", "bench"]
+    },
+    {
+      "id": "cable_curl",
+      "name": { "uk": "Згинання рук на блоці", "en": "Cable Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["cable"]
+    },
+    {
+      "id": "incline_dumbbell_curl",
+      "name": {
+        "uk": "Згинання рук з гантелями на похилій лаві",
+        "en": "Incline Dumbbell Curl"
+      },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["dumbbell", "bench"]
+    },
+    {
+      "id": "spider_curl",
+      "name": { "uk": "Спайдер-згинання", "en": "Spider Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps"],
+        "secondary": ["brachialis"]
+      },
+      "equipment": ["barbell", "dumbbell", "bench"]
+    },
+    {
+      "id": "ez_bar_curl",
+      "name": { "uk": "Згинання рук із EZ-грифом", "en": "EZ-bar Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps", "brachialis"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["barbell"]
+    },
+    {
+      "id": "band_bicep_curl",
+      "name": { "uk": "Згинання рук з резинкою", "en": "Band Bicep Curl" },
+      "primaryGroup": "biceps",
+      "muscles": {
+        "primary": ["biceps"],
+        "secondary": ["forearms"]
+      },
+      "equipment": ["band"]
+    },
+
+    {
       "id": "tricep_pushdown",
       "name": { "uk": "Розгинання рук на блоці", "en": "Tricep Pushdown" },
-      "primaryGroup": "arms",
+      "primaryGroup": "triceps",
       "muscles": {
         "primary": ["triceps"],
         "secondary": []
@@ -364,7 +671,7 @@
     {
       "id": "skull_crusher",
       "name": { "uk": "Французький жим лежачи", "en": "Skull Crusher" },
-      "primaryGroup": "arms",
+      "primaryGroup": "triceps",
       "muscles": {
         "primary": ["triceps"],
         "secondary": []
@@ -377,13 +684,129 @@
         "uk": "Віджимання на брусах (акцент трицепс)",
         "en": "Tricep Dips"
       },
-      "primaryGroup": "arms",
+      "primaryGroup": "triceps",
       "muscles": {
         "primary": ["triceps"],
         "secondary": ["pectoralis_major", "front_deltoid"]
       },
       "equipment": ["bodyweight"]
     },
+    {
+      "id": "overhead_tricep_extension",
+      "name": {
+        "uk": "Розгинання рук з гантеллю над головою",
+        "en": "Overhead Tricep Extension"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": []
+      },
+      "equipment": ["dumbbell", "cable"]
+    },
+    {
+      "id": "close_grip_bench_press",
+      "name": {
+        "uk": "Жим штанги вузьким хватом",
+        "en": "Close-grip Bench Press"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": ["pectoralis_major", "front_deltoid"]
+      },
+      "equipment": ["barbell", "bench"]
+    },
+    {
+      "id": "tricep_kickback",
+      "name": {
+        "uk": "Відведення руки з гантеллю назад",
+        "en": "Tricep Kickback"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": []
+      },
+      "equipment": ["dumbbell"]
+    },
+    {
+      "id": "rope_pushdown",
+      "name": {
+        "uk": "Розгинання рук на блоці з канатом",
+        "en": "Rope Pushdown"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": []
+      },
+      "equipment": ["cable"]
+    },
+    {
+      "id": "bench_dips",
+      "name": {
+        "uk": "Зворотні віджимання від лави",
+        "en": "Bench Dips"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": ["front_deltoid", "pectoralis_major"]
+      },
+      "equipment": ["bench", "bodyweight"]
+    },
+    {
+      "id": "band_tricep_pushdown",
+      "name": {
+        "uk": "Розгинання рук із резинкою",
+        "en": "Band Tricep Pushdown"
+      },
+      "primaryGroup": "triceps",
+      "muscles": {
+        "primary": ["triceps"],
+        "secondary": []
+      },
+      "equipment": ["band"]
+    },
+
+    {
+      "id": "wrist_curl",
+      "name": { "uk": "Згинання зап'ястя", "en": "Wrist Curl" },
+      "primaryGroup": "forearms",
+      "muscles": {
+        "primary": ["forearms"],
+        "secondary": []
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+    {
+      "id": "reverse_wrist_curl",
+      "name": {
+        "uk": "Розгинання зап'ястя",
+        "en": "Reverse Wrist Curl"
+      },
+      "primaryGroup": "forearms",
+      "muscles": {
+        "primary": ["forearms"],
+        "secondary": []
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+    {
+      "id": "reverse_curl",
+      "name": {
+        "uk": "Згинання рук зворотнім хватом",
+        "en": "Reverse Curl"
+      },
+      "primaryGroup": "forearms",
+      "muscles": {
+        "primary": ["forearms", "brachialis"],
+        "secondary": ["biceps"]
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+
     {
       "id": "crunch",
       "name": { "uk": "Скручування", "en": "Crunch" },
@@ -445,9 +868,40 @@
       "equipment": ["bodyweight"]
     },
     {
+      "id": "side_plank",
+      "name": { "uk": "Бокова планка", "en": "Side Plank" },
+      "primaryGroup": "core",
+      "muscles": {
+        "primary": ["obliques"],
+        "secondary": ["rectus_abdominis", "gluteus_medius"]
+      },
+      "equipment": ["bodyweight"]
+    },
+    {
+      "id": "ab_wheel_rollout",
+      "name": { "uk": "Розкатка з роликом", "en": "Ab Wheel Rollout" },
+      "primaryGroup": "core",
+      "muscles": {
+        "primary": ["rectus_abdominis"],
+        "secondary": ["obliques", "erector_spinae", "latissimus_dorsi"]
+      },
+      "equipment": ["other"]
+    },
+    {
+      "id": "cable_woodchop",
+      "name": { "uk": "Дроворуб (блок)", "en": "Cable Woodchop" },
+      "primaryGroup": "core",
+      "muscles": {
+        "primary": ["obliques"],
+        "secondary": ["rectus_abdominis"]
+      },
+      "equipment": ["cable"]
+    },
+
+    {
       "id": "squat_barbell",
       "name": { "uk": "Присідання зі штангою", "en": "Barbell Back Squat" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps", "gluteus_maximus"],
         "secondary": ["hamstrings", "erector_spinae", "adductors", "calves"]
@@ -455,9 +909,22 @@
       "equipment": ["barbell"]
     },
     {
+      "id": "front_squat",
+      "name": {
+        "uk": "Фронтальне присідання",
+        "en": "Front Squat"
+      },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps"],
+        "secondary": ["gluteus_maximus", "erector_spinae"]
+      },
+      "equipment": ["barbell"]
+    },
+    {
       "id": "squat_goblet",
       "name": { "uk": "Присідання з гирею (goblet)", "en": "Goblet Squat" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps", "gluteus_maximus"],
         "secondary": ["hamstrings", "adductors", "erector_spinae"]
@@ -467,7 +934,7 @@
     {
       "id": "squat_bodyweight",
       "name": { "uk": "Присідання (власна вага)", "en": "Bodyweight Squat" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps", "gluteus_maximus"],
         "secondary": ["hamstrings", "calves"]
@@ -477,7 +944,7 @@
     {
       "id": "leg_press",
       "name": { "uk": "Жим ногами в тренажері", "en": "Leg Press" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps", "gluteus_maximus"],
         "secondary": ["hamstrings", "calves"]
@@ -487,7 +954,7 @@
     {
       "id": "leg_extension",
       "name": { "uk": "Розгинання ніг у тренажері", "en": "Leg Extension" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps"],
         "secondary": []
@@ -495,19 +962,9 @@
       "equipment": ["machine"]
     },
     {
-      "id": "leg_curl",
-      "name": { "uk": "Згинання ніг у тренажері", "en": "Leg Curl" },
-      "primaryGroup": "legs",
-      "muscles": {
-        "primary": ["hamstrings"],
-        "secondary": ["calves"]
-      },
-      "equipment": ["machine"]
-    },
-    {
       "id": "lunge",
       "name": { "uk": "Випади з гантелями", "en": "Dumbbell Lunge" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["quadriceps", "gluteus_maximus"],
         "secondary": ["hamstrings", "calves", "adductors"]
@@ -517,7 +974,7 @@
     {
       "id": "reverse_lunge",
       "name": { "uk": "Зворотні випади", "en": "Reverse Lunge" },
-      "primaryGroup": "legs",
+      "primaryGroup": "quadriceps",
       "muscles": {
         "primary": ["gluteus_maximus", "quadriceps"],
         "secondary": ["hamstrings", "calves"]
@@ -525,9 +982,156 @@
       "equipment": ["bodyweight", "dumbbell"]
     },
     {
+      "id": "walking_lunge",
+      "name": { "uk": "Випади у ходьбі", "en": "Walking Lunge" },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps", "gluteus_maximus"],
+        "secondary": ["hamstrings", "calves"]
+      },
+      "equipment": ["bodyweight", "dumbbell"]
+    },
+    {
+      "id": "bulgarian_split_squat",
+      "name": {
+        "uk": "Болгарські випади",
+        "en": "Bulgarian Split Squat"
+      },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps", "gluteus_maximus"],
+        "secondary": ["hamstrings", "adductors"]
+      },
+      "equipment": ["dumbbell", "bench"]
+    },
+    {
+      "id": "hack_squat",
+      "name": { "uk": "Гак-присідання", "en": "Hack Squat" },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps"],
+        "secondary": ["gluteus_maximus", "calves"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "sissy_squat",
+      "name": { "uk": "Сіссі-присідання", "en": "Sissy Squat" },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps"],
+        "secondary": []
+      },
+      "equipment": ["bodyweight"]
+    },
+    {
+      "id": "step_up",
+      "name": { "uk": "Зашагування на платформу", "en": "Step-up" },
+      "primaryGroup": "quadriceps",
+      "muscles": {
+        "primary": ["quadriceps", "gluteus_maximus"],
+        "secondary": ["hamstrings", "calves"]
+      },
+      "equipment": ["bodyweight", "dumbbell"]
+    },
+
+    {
+      "id": "leg_curl",
+      "name": { "uk": "Згинання ніг у тренажері", "en": "Leg Curl" },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings"],
+        "secondary": ["calves"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "romanian_deadlift",
+      "name": { "uk": "Румунська тяга", "en": "Romanian Deadlift" },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings", "gluteus_maximus"],
+        "secondary": ["erector_spinae", "calves"]
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+    {
+      "id": "stiff_leg_deadlift",
+      "name": {
+        "uk": "Тяга на прямих ногах",
+        "en": "Stiff-leg Deadlift"
+      },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings", "erector_spinae"],
+        "secondary": ["gluteus_maximus"]
+      },
+      "equipment": ["barbell", "dumbbell"]
+    },
+    {
+      "id": "good_morning",
+      "name": { "uk": "Доброго ранку (Good Morning)", "en": "Good Morning" },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings", "erector_spinae"],
+        "secondary": ["gluteus_maximus"]
+      },
+      "equipment": ["barbell"]
+    },
+    {
+      "id": "nordic_curl",
+      "name": { "uk": "Нордичне згинання", "en": "Nordic Hamstring Curl" },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings"],
+        "secondary": ["calves"]
+      },
+      "equipment": ["bodyweight"]
+    },
+    {
+      "id": "single_leg_deadlift",
+      "name": {
+        "uk": "Румунська тяга на одній нозі",
+        "en": "Single-leg Deadlift"
+      },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings", "gluteus_maximus"],
+        "secondary": ["erector_spinae"]
+      },
+      "equipment": ["dumbbell", "kettlebell"]
+    },
+    {
+      "id": "kettlebell_swing",
+      "name": { "uk": "Свінг з гирею", "en": "Kettlebell Swing" },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings", "gluteus_maximus"],
+        "secondary": ["erector_spinae", "quadriceps"]
+      },
+      "equipment": ["kettlebell"]
+    },
+    {
+      "id": "band_leg_curl",
+      "name": {
+        "uk": "Згинання ніг із резинкою",
+        "en": "Band Leg Curl"
+      },
+      "primaryGroup": "hamstrings",
+      "muscles": {
+        "primary": ["hamstrings"],
+        "secondary": ["calves"]
+      },
+      "equipment": ["band"]
+    },
+
+    {
       "id": "calf_raise_standing",
-      "name": { "uk": "Підйоми на носки стоячи", "en": "Standing Calf Raise" },
-      "primaryGroup": "legs",
+      "name": {
+        "uk": "Підйоми на носки стоячи",
+        "en": "Standing Calf Raise"
+      },
+      "primaryGroup": "calves",
       "muscles": {
         "primary": ["calves"],
         "secondary": []
@@ -537,13 +1141,40 @@
     {
       "id": "calf_raise_seated",
       "name": { "uk": "Підйоми на носки сидячи", "en": "Seated Calf Raise" },
-      "primaryGroup": "legs",
+      "primaryGroup": "calves",
       "muscles": {
         "primary": ["calves"],
         "secondary": []
       },
       "equipment": ["machine"]
     },
+    {
+      "id": "donkey_calf_raise",
+      "name": {
+        "uk": "Підйоми на носки «ослик»",
+        "en": "Donkey Calf Raise"
+      },
+      "primaryGroup": "calves",
+      "muscles": {
+        "primary": ["calves"],
+        "secondary": []
+      },
+      "equipment": ["machine", "bodyweight"]
+    },
+    {
+      "id": "single_leg_calf_raise",
+      "name": {
+        "uk": "Підйом на носок однією ногою",
+        "en": "Single-leg Calf Raise"
+      },
+      "primaryGroup": "calves",
+      "muscles": {
+        "primary": ["calves"],
+        "secondary": []
+      },
+      "equipment": ["bodyweight", "dumbbell"]
+    },
+
     {
       "id": "hip_thrust",
       "name": { "uk": "Ягідний місток зі штангою", "en": "Barbell Hip Thrust" },
@@ -597,6 +1228,46 @@
       },
       "equipment": ["machine"]
     },
+    {
+      "id": "adductor_machine",
+      "name": {
+        "uk": "Зведення стегна в тренажері",
+        "en": "Hip Adduction Machine"
+      },
+      "primaryGroup": "glutes",
+      "muscles": {
+        "primary": ["adductors"],
+        "secondary": ["gluteus_medius"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "banded_clamshell",
+      "name": {
+        "uk": "Розведення ніг лежачи з резинкою",
+        "en": "Banded Clamshell"
+      },
+      "primaryGroup": "glutes",
+      "muscles": {
+        "primary": ["gluteus_medius"],
+        "secondary": ["gluteus_maximus"]
+      },
+      "equipment": ["band"]
+    },
+    {
+      "id": "single_leg_hip_thrust",
+      "name": {
+        "uk": "Ягідний місток на одній нозі",
+        "en": "Single-leg Hip Thrust"
+      },
+      "primaryGroup": "glutes",
+      "muscles": {
+        "primary": ["gluteus_maximus"],
+        "secondary": ["hamstrings"]
+      },
+      "equipment": ["bench", "bodyweight"]
+    },
+
     {
       "id": "running",
       "name": { "uk": "Біг", "en": "Running" },
@@ -653,6 +1324,37 @@
       "equipment": ["other"]
     },
     {
+      "id": "rowing_machine",
+      "name": { "uk": "Веслувальний тренажер", "en": "Rowing Machine" },
+      "primaryGroup": "cardio",
+      "muscles": {
+        "primary": ["latissimus_dorsi", "quadriceps"],
+        "secondary": ["biceps", "hamstrings", "erector_spinae"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "stairclimber",
+      "name": { "uk": "Сходовий тренажер", "en": "Stair Climber" },
+      "primaryGroup": "cardio",
+      "muscles": {
+        "primary": ["quadriceps", "gluteus_maximus"],
+        "secondary": ["calves", "hamstrings"]
+      },
+      "equipment": ["machine"]
+    },
+    {
+      "id": "battle_ropes",
+      "name": { "uk": "Канатні хвилі (Battle Ropes)", "en": "Battle Ropes" },
+      "primaryGroup": "cardio",
+      "muscles": {
+        "primary": ["front_deltoid", "forearms"],
+        "secondary": ["rectus_abdominis", "quadriceps"]
+      },
+      "equipment": ["other"]
+    },
+
+    {
       "id": "deadlift",
       "name": { "uk": "Становая тяга", "en": "Deadlift" },
       "primaryGroup": "full_body",
@@ -708,77 +1410,39 @@
       "equipment": ["barbell", "dumbbell"]
     },
     {
-      "id": "cable_face_pull",
-      "name": { "uk": "Тяга на обличчя (блок)", "en": "Face Pull" },
-      "primaryGroup": "shoulders",
+      "id": "snatch",
+      "name": { "uk": "Ривок штанги", "en": "Snatch" },
+      "primaryGroup": "full_body",
       "muscles": {
-        "primary": ["rear_deltoid"],
-        "secondary": ["rhomboids", "trapezius", "upper_back"]
+        "primary": [
+          "quadriceps",
+          "gluteus_maximus",
+          "front_deltoid",
+          "trapezius"
+        ],
+        "secondary": ["hamstrings", "erector_spinae", "triceps"]
       },
-      "equipment": ["cable", "machine"]
+      "equipment": ["barbell"]
     },
     {
-      "id": "shrugs",
-      "name": { "uk": "Шраги зі штангою", "en": "Barbell Shrugs" },
-      "primaryGroup": "shoulders",
+      "id": "man_maker",
+      "name": { "uk": "Мен-мейкер", "en": "Man Maker" },
+      "primaryGroup": "full_body",
       "muscles": {
-        "primary": ["trapezius"],
-        "secondary": ["neck", "forearms"]
-      },
-      "equipment": ["barbell", "dumbbell"]
-    },
-    {
-      "id": "cable_crossover",
-      "name": { "uk": "Зведення рук на блоці", "en": "Cable Crossover" },
-      "primaryGroup": "chest",
-      "muscles": {
-        "primary": ["pectoralis_major", "pectoralis_minor"],
-        "secondary": ["front_deltoid", "serratus_anterior"]
-      },
-      "equipment": ["cable"]
-    },
-    {
-      "id": "concentration_curl",
-      "name": { "uk": "Концентроване згинання", "en": "Concentration Curl" },
-      "primaryGroup": "arms",
-      "muscles": {
-        "primary": ["biceps"],
-        "secondary": ["forearms"]
+        "primary": [
+          "pectoralis_major",
+          "quadriceps",
+          "front_deltoid",
+          "latissimus_dorsi"
+        ],
+        "secondary": [
+          "triceps",
+          "gluteus_maximus",
+          "rectus_abdominis",
+          "biceps"
+        ]
       },
       "equipment": ["dumbbell"]
-    },
-    {
-      "id": "overhead_tricep_extension",
-      "name": {
-        "uk": "Розгинання рук з гантеллю над головою",
-        "en": "Overhead Tricep Extension"
-      },
-      "primaryGroup": "arms",
-      "muscles": {
-        "primary": ["triceps"],
-        "secondary": []
-      },
-      "equipment": ["dumbbell", "cable"]
-    },
-    {
-      "id": "t_bar_row",
-      "name": { "uk": "Тяга T-грифа", "en": "T-bar Row" },
-      "primaryGroup": "back",
-      "muscles": {
-        "primary": ["latissimus_dorsi", "rhomboids"],
-        "secondary": ["biceps", "rear_deltoid", "trapezius"]
-      },
-      "equipment": ["barbell", "machine"]
-    },
-    {
-      "id": "romanian_deadlift",
-      "name": { "uk": "Румунська тяга", "en": "Romanian Deadlift" },
-      "primaryGroup": "legs",
-      "muscles": {
-        "primary": ["hamstrings", "gluteus_maximus"],
-        "secondary": ["erector_spinae", "calves"]
-      },
-      "equipment": ["barbell", "dumbbell"]
     }
   ]
 }

--- a/packages/fizruk-domain/src/data/index.ts
+++ b/packages/fizruk-domain/src/data/index.ts
@@ -22,6 +22,7 @@ export interface ExerciseCatalog {
   source?: { name?: string; notes?: string };
   labels?: {
     primaryGroupsUk?: Record<string, string>;
+    equipmentUk?: Record<string, string>;
     musclesUk?: Record<string, string>;
     musclesByPrimaryGroup?: Record<string, string[]>;
   };
@@ -56,6 +57,10 @@ export const EXERCISES: RawExerciseDef[] = Array.isArray(
 /** Мапа українських назв primary-груп. */
 export const PRIMARY_GROUPS_UK: Record<string, string> =
   EXERCISE_CATALOG.labels?.primaryGroupsUk || {};
+
+/** Мапа українських назв обладнання. */
+export const EQUIPMENT_UK: Record<string, string> =
+  EXERCISE_CATALOG.labels?.equipmentUk || {};
 
 /** Мапа українських назв м'язів. */
 export const MUSCLES_UK: Record<string, string> =

--- a/packages/fizruk-domain/src/domain/workouts/catalog.test.ts
+++ b/packages/fizruk-domain/src/domain/workouts/catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildExerciseCatalogGroups,
   exerciseDisplayName,
+  filterExercisesByEquipment,
   filterExercisesByPrimaryGroup,
   filterExercisesBySearch,
   groupExercisesByPrimary,
@@ -18,24 +19,28 @@ const POOL: WorkoutExerciseCatalogEntry[] = [
     primaryGroupUk: "Груди",
     muscles: { primary: ["pectoralis_major"], secondary: ["triceps"] },
     aliases: ["bench", "жим лежачи"],
+    equipment: ["barbell", "bench"],
   },
   {
     id: "pushup",
     name: { uk: "Віджимання", en: "Push-up" },
     primaryGroup: "chest",
     muscles: { primary: ["pectoralis_major"] },
+    equipment: ["bodyweight"],
   },
   {
     id: "squat",
     name: { uk: "Присідання зі штангою", en: "Back Squat" },
-    primaryGroup: "legs",
+    primaryGroup: "quadriceps",
     muscles: { primary: ["quadriceps"] },
+    equipment: ["barbell"],
   },
   {
     id: "deadlift",
     name: { uk: "Тяга", en: "Deadlift" },
     primaryGroup: "back",
     muscles: { primary: ["erector_spinae"] },
+    equipment: ["barbell"],
   },
   {
     id: "mystery",
@@ -93,7 +98,11 @@ describe("filterExercisesByPrimaryGroup", () => {
 describe("groupExercisesByPrimary", () => {
   it("sorts buckets in the canonical order", () => {
     const groups = groupExercisesByPrimary(POOL, {
-      primaryGroupsUk: { chest: "Груди", legs: "Ноги", back: "Спина" },
+      primaryGroupsUk: {
+        chest: "Груди",
+        quadriceps: "Квадрицепс",
+        back: "Спина",
+      },
     });
     const orderIndex = (id: string) => PRIMARY_GROUP_ORDER.indexOf(id);
     const orderedKnown = groups
@@ -141,6 +150,25 @@ describe("buildExerciseCatalogGroups", () => {
 
   it("copes with an empty pool", () => {
     expect(buildExerciseCatalogGroups([])).toEqual([]);
+  });
+});
+
+describe("filterExercisesByEquipment", () => {
+  it("filters by one equipment tag", () => {
+    expect(
+      filterExercisesByEquipment(POOL, ["barbell"]).map((x) => x.id),
+    ).toEqual(["bench", "squat", "deadlift"]);
+  });
+
+  it("filters by multiple equipment tags (OR logic)", () => {
+    expect(
+      filterExercisesByEquipment(POOL, ["bodyweight"]).map((x) => x.id),
+    ).toEqual(["pushup"]);
+  });
+
+  it("returns all when equipmentIds is null or empty", () => {
+    expect(filterExercisesByEquipment(POOL, null)).toHaveLength(POOL.length);
+    expect(filterExercisesByEquipment(POOL, [])).toHaveLength(POOL.length);
   });
 });
 

--- a/packages/fizruk-domain/src/domain/workouts/catalog.ts
+++ b/packages/fizruk-domain/src/domain/workouts/catalog.ts
@@ -21,9 +21,13 @@ export const PRIMARY_GROUP_ORDER: readonly string[] = [
   "chest",
   "back",
   "shoulders",
-  "arms",
+  "biceps",
+  "triceps",
+  "forearms",
   "core",
-  "legs",
+  "quadriceps",
+  "hamstrings",
+  "calves",
   "glutes",
   "full_body",
   "cardio",
@@ -138,20 +142,42 @@ export function groupExercisesByPrimary(
 }
 
 /**
- * Composite helper — apply search + primary-group filter, then
- * bucket the result. Matches the single memo the web page builds.
+ * Narrow the pool to exercises that include at least one of the given
+ * equipment tags. Empty / null `equipmentIds` disables the filter.
+ */
+export function filterExercisesByEquipment(
+  exercises: readonly WorkoutExerciseCatalogEntry[],
+  equipmentIds: readonly string[] | null | undefined,
+): WorkoutExerciseCatalogEntry[] {
+  if (!equipmentIds || equipmentIds.length === 0) return exercises.slice();
+  const set = new Set(equipmentIds);
+  return exercises.filter((ex) =>
+    (ex?.equipment ?? []).some((e) => set.has(e)),
+  );
+}
+
+/**
+ * Composite helper — apply search + primary-group + equipment filter,
+ * then bucket the result. Matches the single memo the web page builds.
  */
 export function buildExerciseCatalogGroups(
   exercises: readonly WorkoutExerciseCatalogEntry[],
   options: {
     query?: string;
     primaryGroup?: string | null;
+    equipment?: readonly string[] | null;
     primaryGroupsUk?: Record<string, string>;
   } = {},
 ): WorkoutCatalogGroup[] {
-  const { query = "", primaryGroup = null, primaryGroupsUk = {} } = options;
+  const {
+    query = "",
+    primaryGroup = null,
+    equipment = null,
+    primaryGroupsUk = {},
+  } = options;
   const bySearch = filterExercisesBySearch(exercises, query);
-  const filtered = filterExercisesByPrimaryGroup(bySearch, primaryGroup);
+  const byGroup = filterExercisesByPrimaryGroup(bySearch, primaryGroup);
+  const filtered = filterExercisesByEquipment(byGroup, equipment);
   return groupExercisesByPrimary(filtered, {
     primaryGroupsUk,
     totalsBy: exercises,

--- a/packages/fizruk-domain/src/domain/workouts/exerciseDetail.test.ts
+++ b/packages/fizruk-domain/src/domain/workouts/exerciseDetail.test.ts
@@ -32,7 +32,7 @@ function strength(
     id,
     exerciseId,
     nameUk: exerciseId,
-    primaryGroup: "legs",
+    primaryGroup: "quadriceps",
     musclesPrimary: [],
     musclesSecondary: [],
     type: "strength",

--- a/packages/fizruk-domain/src/lib/restSettings.ts
+++ b/packages/fizruk-domain/src/lib/restSettings.ts
@@ -25,7 +25,14 @@ export const REST_CATEGORY_LABELS: Record<keyof typeof REST_DEFAULTS, string> =
     cardio: "Кардіо",
   };
 
-const ISOLATION_GROUPS = ["shoulders", "arms", "core"];
+const ISOLATION_GROUPS = [
+  "shoulders",
+  "biceps",
+  "triceps",
+  "forearms",
+  "core",
+  "calves",
+];
 const CARDIO_GROUPS = ["cardio"];
 
 export type RestCategory = keyof typeof REST_DEFAULTS;

--- a/packages/fizruk-domain/src/lib/trainingPrograms.ts
+++ b/packages/fizruk-domain/src/lib/trainingPrograms.ts
@@ -51,8 +51,22 @@ export function getDefaultRestSec(
   primaryGroup: string | null | undefined,
 ): number {
   if (!primaryGroup) return 90;
-  const compound = ["chest", "back", "legs", "glutes", "full_body"];
-  const isolation = ["shoulders", "arms", "core"];
+  const compound = [
+    "chest",
+    "back",
+    "quadriceps",
+    "hamstrings",
+    "glutes",
+    "full_body",
+  ];
+  const isolation = [
+    "shoulders",
+    "biceps",
+    "triceps",
+    "forearms",
+    "core",
+    "calves",
+  ];
   if (compound.includes(primaryGroup)) return 90;
   if (isolation.includes(primaryGroup)) return 60;
   return 30;


### PR DESCRIPTION
## Summary

Розділив групу «руки» на біцепс / трицепс / передпліччя, групу «ноги» на квадрицепс / задню поверхню стегна / ікри. Додав ~50 нових вправ (загалом ~120). Додав фільтр по обладнанню (штанга, гантелі, тренажер тощо) — чіпи-кнопки у веб- та мобільному каталозі.

### What changed

**Data (`exercises.gymup.json`)**
- `primaryGroupsUk`: replaced `arms` → `biceps`, `triceps`, `forearms`; replaced `legs` → `quadriceps`, `hamstrings`, `calves`
- Added `equipmentUk` labels section
- Added `brachialis` to `musclesUk`
- Updated `musclesByPrimaryGroup` for all new groups
- Added ~50 new exercises across all groups (total ~120)

**Domain layer (`fizruk-domain`)**
- `catalog.ts`: updated `PRIMARY_GROUP_ORDER`, added `filterExercisesByEquipment()`; `buildExerciseCatalogGroups()` now accepts `equipment` filter option
- `data/index.ts`: exported `EQUIPMENT_UK`, updated `ExerciseCatalog` interface
- `bodyAtlas.ts`: mapped `brachialis` → `biceps`
- `restSettings.ts` / `trainingPrograms.ts`: updated compound/isolation group lists
- Tests updated for new groups + new `filterExercisesByEquipment` tests

**Web UI**
- `WorkoutCatalogSection.tsx`: added equipment filter chips (toggle, reset)
- `Workouts.tsx`: added `equipmentFilter` state, passes to catalog section, filters in `grouped` memo
- `useExerciseCatalog.ts`: exposes `equipmentUk`
- `seedDemoData.ts`: updated demo exercise primaryGroup `legs` → `quadriceps`

**Mobile UI**
- `ExerciseCatalogSection.tsx`: added `EquipmentChips` component, `equipmentUk` prop, equipment filter state

## Review & Testing Checklist for Human

- [ ] Відкрий каталог вправ і перевір що групи біцепс/трицепс/квадрицепс/задня поверхня стегна/ікри відображаються коректно замість «руки» та «ноги»
- [ ] Обери фільтр «Гантелі» — переконайся що показуються тільки вправи з гантелями
- [ ] Обери декілька фільтрів обладнання одночасно та натисни «Скинути» — перевір що скидається
- [ ] Перевір що існуючі тренування (якщо є записані з `primaryGroup: "arms"` або `"legs"`) відображаються коректно (backward compat — old data may show as uncategorized)

### Notes

- Old user workouts stored in localStorage with `primaryGroup: "arms"` or `"legs"` will still render but may appear in an "unknown" group bucket since those IDs no longer exist in `primaryGroupsUk`. This is by design — old data is not migrated.
- The `lint:plugins` step has a pre-existing failure in `eslint-plugins/sergeant-design/__tests__` unrelated to this PR.


Link to Devin session: https://app.devin.ai/sessions/06297020bffd448a8342a0d4ceb34706
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment multi-select filters added to exercise and workout catalogs
  * Ukrainian equipment names included
  * Expanded exercise catalog with many new entries and finer muscle-group classifications

* **Improvements**
  * Muscle groups reorganized (biceps, triceps, forearms, quadriceps, hamstrings, calves) with updated rest recommendations
  * Minor demo data and mapping updates to align classifications and labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->