### PR TITLE
fix(stories): автопрогравання сторіс зависає на iOS — додано setInterval fallback

### DIFF
--- a/apps/web/src/core/stories/__tests__/useStoriesAutoplay.test.ts
+++ b/apps/web/src/core/stories/__tests__/useStoriesAutoplay.test.ts
@@ -130,4 +130,45 @@ describe("useStoriesAutoplay", () => {
     expect(result.current).toBe(0);
     raf.restore();
   });
+
+  it("interval fallback advances even when rAF stops firing", () => {
+    // Install fake rAF but never flush it — simulates iOS dropping rAF.
+    const raf = installFakeRaf();
+    const onAdvance = vi.fn();
+    renderHook(() =>
+      useStoriesAutoplay({
+        key: 0,
+        durationMs: 1000,
+        paused: false,
+        onAdvance,
+      }),
+    );
+    // Only advance timers (fires setInterval callbacks via fake timers)
+    // but do NOT flush rAF — simulates rAF being suspended.
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    raf.restore();
+  });
+
+  it("onAdvance is called only once even with both rAF and interval", () => {
+    const raf = installFakeRaf();
+    const onAdvance = vi.fn();
+    renderHook(() =>
+      useStoriesAutoplay({
+        key: 0,
+        durationMs: 1000,
+        paused: false,
+        onAdvance,
+      }),
+    );
+    act(() => {
+      vi.advanceTimersByTime(1100);
+      raf.flush();
+    });
+    // Both rAF and interval had a chance to fire — only one advance.
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    raf.restore();
+  });
 });

--- a/apps/web/src/core/stories/hooks/useStoriesAutoplay.ts
+++ b/apps/web/src/core/stories/hooks/useStoriesAutoplay.ts
@@ -13,10 +13,13 @@ interface Options {
  * while `paused` is true, and calls `onAdvance` at 100%.
  *
  * Uses requestAnimationFrame with wall-clock deltas so the progress bar
- * stays in sync with real time across frame drops. When the tab is
- * hidden the browser stops calling rAF entirely, so we rebase the start
- * time on `visibilitychange` — preventing the progress bar from jumping
- * on resume.
+ * stays in sync with real time across frame drops. A secondary
+ * `setInterval` guard advances progress on platforms where the browser
+ * throttles or pauses rAF callbacks (iOS Safari standalone-PWA, low
+ * power mode, WKWebView in Capacitor). When the tab is hidden the
+ * browser stops calling rAF entirely, so we rebase the start time on
+ * `visibilitychange` and re-schedule a rAF — preventing the progress
+ * bar from jumping or stalling on resume.
  */
 export function useStoriesAutoplay({
   key,
@@ -41,28 +44,54 @@ export function useStoriesAutoplay({
 
     let rafId: number | null = null;
     let cancelled = false;
+    let advanced = false;
     // Mutable so visibilitychange can rebase without restarting the loop.
     const state = { startTs: performance.now(), lastProgress: 0 };
 
-    const tick = (now: number) => {
-      if (cancelled) return;
+    const doAdvance = () => {
+      if (advanced || cancelled) return;
+      advanced = true;
+      setProgress(100);
+      onAdvanceRef.current();
+    };
+
+    const update = (now: number) => {
+      if (cancelled || advanced) return;
       const pct = Math.min(100, ((now - state.startTs) / durationMs) * 100);
       state.lastProgress = pct;
       setProgress(pct);
       if (pct >= 100) {
-        onAdvanceRef.current();
-        return;
+        doAdvance();
       }
-      rafId = window.requestAnimationFrame(tick);
+    };
+
+    const tick = (now: number) => {
+      if (cancelled || advanced) return;
+      update(now);
+      if (!cancelled && !advanced) {
+        rafId = window.requestAnimationFrame(tick);
+      }
     };
     rafId = window.requestAnimationFrame(tick);
 
+    // Fallback: setInterval catches platforms where rAF silently stops
+    // (iOS Safari PWA, WKWebView, low-power mode). Runs at ~250ms — not
+    // visually smooth, but enough to keep the progress bar moving and
+    // guarantee the slide advances on time.
+    const intervalId = window.setInterval(() => {
+      update(performance.now());
+    }, 250);
+
     const onVisibility = () => {
-      if (document.visibilityState === "visible") {
+      if (document.visibilityState === "visible" && !cancelled && !advanced) {
         // Rebase startTs so we resume from the last observed progress
         // rather than crediting hidden-tab time to the current slide.
         state.startTs =
           performance.now() - (state.lastProgress / 100) * durationMs;
+        // Re-kick rAF — some browsers drop the pending callback when the
+        // page was hidden; the interval guard covers the gap in between.
+        if (rafId !== null) window.cancelAnimationFrame(rafId);
+        rafId = window.requestAnimationFrame(tick);
       }
     };
     document.addEventListener("visibilitychange", onVisibility);
@@ -70,6 +99,7 @@ export function useStoriesAutoplay({
     return () => {
       cancelled = true;
       if (rafId !== null) window.cancelAnimationFrame(rafId);
+      window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [key, durationMs, paused]);

--- a/apps/web/src/core/stories/hooks/useStoriesAutoplay.ts
+++ b/apps/web/src/core/stories/hooks/useStoriesAutoplay.ts
@@ -79,6 +79,7 @@ export function useStoriesAutoplay({
     // visually smooth, but enough to keep the progress bar moving and
     // guarantee the slide advances on time.
     const intervalId = window.setInterval(() => {
+      if (document.visibilityState === "hidden") return;
       update(performance.now());
     }, 250);
 

--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -257,7 +257,7 @@ function ActiveState({
           aria-label="Повернутись до активного тренування"
         >
           <span
-            className="shrink-0 w-11 h-11 rounded-full bg-white/20 flex items-center justify-center"
+            className="shrink-0 w-11 h-11 rounded-full bg-white/15 flex items-center justify-center"
             aria-hidden
           >
             <PlayIcon />


### PR DESCRIPTION
## Summary

Сторіс зависають і не рухаються автоматично (прогрес-бар не наповнюється), якщо не тапати.

**Причина:** `useStoriesAutoplay` покладався виключно на `requestAnimationFrame` для прогресу 0→100%. На iOS Safari (standalone PWA, WKWebView у Capacitor, Low Power Mode) браузер може мовчки призупинити або зупинити rAF-колбеки, через що прогрес-бар зависає посередині.

**Рішення:**
- Додано `setInterval` (250ms) як fallback поруч з rAF — використовує ті ж wall-clock дельти для обчислення прогресу
- Прапорець `advanced` запобігає подвійному виклику `onAdvance`
- На `visibilitychange` → `visible` тепер перезапускаємо rAF-петлю (раніше лише перебазовували `startTs`)
- 2 нових тести: fallback працює коли rAF не стріляє; `onAdvance` викликається тільки раз коли обидва механізми спрацьовують

**Додатково:** повернуто `bg-white/15` на play-icon в ActiveState HeroCard (випадкова зміна в PR #614).

## Review & Testing Checklist for Human

- [ ] Відкрити дайджест → "Переглянути як сторіс" на iOS (PWA або Capacitor) — прогрес-бар має рухатись і сторіс автоматично переключатись кожні ~6.5с
- [ ] Тест hold-to-pause: зажати палець на сторіс — прогрес має зупинитись, відпустити — продовжитись
- [ ] Тест тап: тап праворуч → наступна, тап ліворуч → попередня
- [ ] Тест swipe down → закриття сторіс

### Notes

- setInterval (250ms) менш плавний ніж rAF (60fps), але на iOS коли rAF працює — він домінує і інтервал є no-op. Коли rAF зависає — інтервал підхоплює прогрес з незначною "ступінчастістю"
- `bg-white/15` на play-icon — тепер узгоджено з TodayState (обидва `bg-white/15`)

Link to Devin session: https://app.devin.ai/sessions/630b1819153e4f8d87791b88b1e10dab
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stories autoplay reliability and robustness. The autoplay feature now maintains consistent playback even when animation frame callbacks are throttled or suspended on certain devices, ensuring smooth and uninterrupted playback across all platforms and network conditions.
* **Style**
  * Refined hero card play button styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->