### PR TITLE
fix(auth): синхронізувати minLength пароля клієнта з сервером (6 → 10)

### DIFF
--- a/apps/web/src/core/AuthPage.tsx
+++ b/apps/web/src/core/AuthPage.tsx
@@ -135,8 +135,10 @@ export function AuthPage({ onContinueWithoutAccount }) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              minLength={6}
-              placeholder="Мінімум 6 символів"
+              minLength={mode === "register" ? 10 : 1}
+              placeholder={
+                mode === "register" ? "Мінімум 10 символів" : "Пароль"
+              }
               autoComplete={
                 mode === "login" ? "current-password" : "new-password"
               }


### PR DESCRIPTION
## Summary

Клієнтська форма реєстрації дозволяла паролі від 6 символів (`minLength={6}`), але сервер вимагає мінімум 10 (`minPasswordLength: 10` в `auth.ts`, NIST SP 800-63B). Юзер міг ввести 6-9 символів, натиснути «Створити», і отримати «Помилка реєстрації» без пояснення чому.

**Зміни:**
- Режим `register`: `minLength={10}`, placeholder «Мінімум 10 символів»
- Режим `login`: `minLength={1}`, placeholder «Пароль» (існуючі акаунти можуть мати старі паролі)

## Review & Testing Checklist for Human

- [ ] Відкрити сторінку реєстрації → перевірити що placeholder показує «Мінімум 10 символів»
- [ ] Спробувати зареєструватись з паролем < 10 символів → браузер має заблокувати сабміт (HTML5 validation)
- [ ] Переключитись на логін → перевірити що placeholder показує «Пароль» і пароль будь-якої довжини приймається

### Notes

- Серверний `minPasswordLength` читається з `process.env.MIN_PASSWORD_LENGTH` з fallback на 10. Якщо env var зміниться — клієнт знову розсинхронізується. В майбутньому варто підтягувати це значення з API.

Link to Devin session: https://app.devin.ai/sessions/630b1819153e4f8d87791b88b1e10dab
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Password validation enhancements**: The password input field now adapts its requirements and labeling based on authentication context. In registration mode, users must meet a 10-character minimum with clear placeholder instructions. In login mode, requirements are relaxed, featuring a simplified generic password label to expedite access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->