### PR TITLE
fix(auth): синхронізувати minLength пароля в ResetPasswordPage (6 → 10)

### DIFF
--- a/apps/web/src/core/ResetPasswordPage.tsx
+++ b/apps/web/src/core/ResetPasswordPage.tsx
@@ -34,9 +34,9 @@ export function ResetPasswordPage() {
       );
       return;
     }
-    if (password.length < 6) {
+    if (password.length < 10) {
       setStatus("error");
-      setMessage("Пароль має бути мінімум 6 символів.");
+      setMessage("Пароль має бути мінімум 10 символів.");
       return;
     }
     if (password !== confirm) {
@@ -114,9 +114,9 @@ export function ResetPasswordPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                minLength={6}
+                minLength={10}
                 className={INPUT_CLS}
-                placeholder="Мінімум 6 символів"
+                placeholder="Мінімум 10 символів"
                 autoComplete="new-password"
               />
             </div>
@@ -134,7 +134,7 @@ export function ResetPasswordPage() {
                 value={confirm}
                 onChange={(e) => setConfirm(e.target.value)}
                 required
-                minLength={6}
+                minLength={10}
                 className={INPUT_CLS}
                 placeholder="Введи пароль ще раз"
                 autoComplete="new-password"


### PR DESCRIPTION
## Summary\n\nПродовження PR #617 — `ResetPasswordPage.tsx` залишився з `minLength={6}`, тоді як сервер вимагає `minPasswordLength: 10`. Юзер, що скидав пароль, міг ввести 6-9 символів, пройти клієнтську валідацію, але отримати серверну помилку.\n\n**Зміни (5 місць):**\n- `password.length < 6` → `password.length < 10` (JS-валідація)\n- Повідомлення помилки: «Мінімум 6 символів» → «Мінімум 10 символів»\n- `minLength={6}` → `minLength={10}` на полі нового пароля\n- Placeholder: «Мінімум 6 символів» → «Мінімум 10 символів»\n- `minLength={6}` → `minLength={10}` на полі підтвердження\n\n## Review & Testing Checklist for Human\n\n- [ ] Відкрити `/reset-password?token=test` → перевірити placeholder «Мінімум 10 символів»\n- [ ] Ввести пароль 6-9 символів → має показати «Пароль має бути мінімум 10 символів»\n\n### Notes\n\n- Знайдено Devin Review на PR #617\n- Тепер усі клієнтські сторінки (AuthPage, ResetPasswordPage, mobile sign-up) синхронізовані з серверним `minPasswordLength: 10`

Link to Devin session: https://app.devin.ai/sessions/630b1819153e4f8d87791b88b1e10dab
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
