### PR TITLE
fix: показувати лоадер на /profile під час завантаження auth

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -260,7 +260,10 @@ function AppInner() {
   }
 
   if (onProfileRoute) {
-    if (!authLoading && !user) {
+    if (authLoading) {
+      return <PageLoader />;
+    }
+    if (!user) {
       return <RedirectTo to={SIGN_IN_PATH} />;
     }
     return (

--- a/apps/web/src/core/ProfilePage.tsx
+++ b/apps/web/src/core/ProfilePage.tsx
@@ -479,11 +479,7 @@ export function ProfilePage() {
   const { user, logout, refresh } = useAuth();
 
   if (!user) {
-    return (
-      <div className="min-h-dvh bg-bg flex items-center justify-center">
-        <p className="text-muted">Увійдіть, щоб переглянути профіль.</p>
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary

Виправляє race condition на сторінці `/profile` під час початкового завантаження авторизації (auth hydration).

**Проблема:** Коли авторизований користувач переходить напряму на `/profile` (через закладку, deep link або оновлення сторінки), `authLoading = true` і `user = null`. Попередня перевірка `!authLoading && !user` пропускала рендер `<ProfilePage />`, який показував оманливе повідомлення «Увійдіть, щоб переглянути профіль» — хоча користувач залогінений, просто сесія ще не завантажилась.

**Виправлення:**
- `App.tsx`: Додано явну перевірку `authLoading` → показуємо `<PageLoader />` поки сесія завантажується (аналогічно до роуту `/sign-in`)
- `ProfilePage.tsx`: Прибрано оманливе повідомлення, замінено на `return null` як safety fallback

## Review & Testing Checklist for Human

- [ ] Відкрити `/profile` напряму в новій вкладці (або оновити сторінку на `/profile`) — має показати лоадер, потім профіль
- [ ] Відкрити `/profile` без логіну — редірект на `/sign-in`

### Notes

Фікс за рекомендацією Devin Review на PR #620.

Link to Devin session: https://app.devin.ai/sessions/675de84a49f44f1fbfae6ce1548fb16d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile page authentication handling to display a loading indicator while verifying authentication status, preventing premature redirects.
  * Updated profile page to show a blank state instead of a sign-in placeholder when authentication is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->