### PR TITLE
docs(capacitor): fix stale markers and outdated TODO items

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -185,7 +185,6 @@ After a successful run:
   PR is safe to merge before secrets land in the repo — the release
   job will just log `::warning::iOS release secrets not configured,
 skipping signed build` and build the unsigned `.app` instead.
-  ||||||| 07ab907
 
 ## Release — Android
 

--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -136,11 +136,15 @@ pnpm --filter @sergeant/mobile-shell open:android
   (`apps/server/src/modules/push.ts → register`) маршрутизує у
   `push_devices` для native-токенів. Залишається лише реальний
   APNs/FCM **send**-pipeline — див. `docs/mobile.md#push-notifications`.
-- **Deep-link навігація у React Router.** `parseDeepLink()` у
+- ~~**Deep-link навігація у React Router.** `parseDeepLink()` у
   `src/index.ts` готовий і `App.addListener('appUrlOpen', ...)`
   викликає callback, але коннект з `useNavigate()` з
-  `@sergeant/web` ще не прокинутий — `options.navigate` наразі
-  падає в fallback `window.location.assign`.
+  `@sergeant/web` ще не прокинутий.~~ **Зроблено**: bridge
+  реалізований через `window.__sergeantShellNavigate` —
+  `ShellDeepLinkBridge` (`apps/web/src/core/app/ShellDeepLinkBridge.tsx`)
+  виставляє navigate-хук після маунту роутера і drain-ить cold-start
+  чергу з `window.__sergeantShellDeepLinkQueue`. Свідомо без
+  `options.navigate`, щоб уникнути out-of-component `history.pushState`.
 - **iOS safe-area + splash race.** CSS `env(safe-area-inset-*)` з
   web-side покриває 99% кейсів, але якщо splash візьметься
   триматись довше 3с (дивись `SplashScreen.hide({ fadeOutDuration })`


### PR DESCRIPTION
- Remove orphaned git merge-conflict marker from MOBILE.md (line 188)
- Mark deep-link React Router navigation as done in mobile-shell README:
  ShellDeepLinkBridge + window.__sergeantShellNavigate is already wired
  up in App.tsx; options.navigate fallback was never the intended path

https://claude.ai/code/session_01TJAfyMxHeLHmi9q4B9DyLs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed stray merge-conflict marker formatting error from iOS release notes documentation.
  * Updated mobile shell README documentation to detail the completion of the deep-link React Router integration. Documents the new shell-to-web bridge navigation system implementation and explains how it handles queued deep links during app cold-start scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->