### PR TITLE
test(profile): тести ProfilePage + buildSlides, фікси Devin Review

### DIFF
--- a/apps/web/src/core/ProfilePage.test.tsx
+++ b/apps/web/src/core/ProfilePage.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const updateUserMock = vi.fn(async () => ({ error: null }));
+const changePasswordMock = vi.fn(async () => ({ error: null }));
+const listSessionsMock = vi.fn(async () => ({ data: [] }));
+const revokeSessionMock = vi.fn(async () => ({ error: null }));
+const deleteUserMock = vi.fn(async () => ({ error: null }));
+const signOutMock = vi.fn(async () => undefined);
+
+vi.mock("./authClient.js", () => ({
+  updateUser: (...args: unknown[]) => updateUserMock(...args),
+  changePassword: (...args: unknown[]) => changePasswordMock(...args),
+  listSessions: () => listSessionsMock(),
+  revokeSession: (...args: unknown[]) => revokeSessionMock(...args),
+  deleteUser: (...args: unknown[]) => deleteUserMock(...args),
+  signOut: () => signOutMock(),
+}));
+
+const useOnlineStatusMock = vi.fn(() => true);
+vi.mock("@shared/hooks/useOnlineStatus", () => ({
+  useOnlineStatus: () => useOnlineStatusMock(),
+}));
+
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+vi.mock("@shared/hooks/useToast", () => ({
+  useToast: () => ({ success: toastSuccessMock, error: toastErrorMock }),
+}));
+
+const mockUser = {
+  id: "u-1",
+  email: "test@example.com",
+  name: "Тест",
+  image: null as string | null,
+  emailVerified: true,
+};
+const refreshMock = vi.fn(async () => undefined);
+const logoutMock = vi.fn(async () => undefined);
+
+vi.mock("./AuthContext.jsx", () => ({
+  useAuth: () => ({
+    user: mockUser,
+    logout: logoutMock,
+    refresh: refreshMock,
+    isLoading: false,
+    status: "authenticated",
+  }),
+}));
+
+import { ProfilePage } from "./ProfilePage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ProfilePage />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    useOnlineStatusMock.mockReturnValue(true);
+    mockUser.image = null;
+    mockUser.name = "Тест";
+    mockUser.emailVerified = true;
+  });
+
+  describe("rendering", () => {
+    it("shows user name and email", () => {
+      renderPage();
+      expect(screen.getByText("Тест")).toBeInTheDocument();
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    });
+
+    it("shows verified badge when emailVerified is true", () => {
+      renderPage();
+      const badges = screen.getAllByText("Підтверджено");
+      expect(badges.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("hides verified badge when emailVerified is false", () => {
+      mockUser.emailVerified = false;
+      renderPage();
+      expect(screen.queryByText("Підтверджено")).not.toBeInTheDocument();
+    });
+
+    it("shows initial letter when no avatar image", () => {
+      renderPage();
+      const avatarBtns = screen.getAllByLabelText("Змінити аватар");
+      expect(within(avatarBtns[0]).getByText("Т")).toBeInTheDocument();
+    });
+
+    it("shows avatar image when user.image is set", () => {
+      mockUser.image = "data:image/webp;base64,abc";
+      renderPage();
+      const avatarBtns = screen.getAllByLabelText("Змінити аватар");
+      const img = avatarBtns[0].querySelector("img");
+      expect(img).toBeTruthy();
+      expect(img!.getAttribute("src")).toBe("data:image/webp;base64,abc");
+    });
+
+    it("shows remove photo link when avatar is set", () => {
+      mockUser.image = "data:image/webp;base64,abc";
+      renderPage();
+      const links = screen.getAllByText("Видалити фото");
+      expect(links.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("hides remove photo link when no avatar", () => {
+      renderPage();
+      expect(screen.queryByText("Видалити фото")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("offline UX", () => {
+    it("shows offline warning banner when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      expect(
+        screen.getByText(
+          "Ви офлайн — редагування профілю тимчасово недоступне",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("hides offline warning banner when online", () => {
+      useOnlineStatusMock.mockReturnValue(true);
+      renderPage();
+      expect(
+        screen.queryByText(
+          "Ви офлайн — редагування профілю тимчасово недоступне",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it("disables save name button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const saveBtns = screen.getAllByRole("button", { name: "Зберегти" });
+      expect(saveBtns[0]).toBeDisabled();
+    });
+
+    it("disables change password button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const changeBtn = screen.getByRole("button", {
+        name: "Змінити пароль",
+      });
+      expect(changeBtn).toBeDisabled();
+    });
+
+    it("disables delete account button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const deleteBtn = screen.getByRole("button", {
+        name: "Видалити акаунт",
+      });
+      expect(deleteBtn).toBeDisabled();
+    });
+
+    it("disables avatar upload button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const avatarBtns = screen.getAllByLabelText("Змінити аватар");
+      expect(avatarBtns[0]).toBeDisabled();
+    });
+  });
+
+  describe("sessions section", () => {
+    it("calls listSessions on mount when online", () => {
+      useOnlineStatusMock.mockReturnValue(true);
+      renderPage();
+      expect(listSessionsMock).toHaveBeenCalled();
+    });
+
+    it("does NOT call listSessions when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      expect(listSessionsMock).not.toHaveBeenCalled();
+    });
+
+    it("disables refresh button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const refreshBtn = screen.getByRole("button", { name: "Оновити" });
+      expect(refreshBtn).toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/core/ProfilePage.tsx
+++ b/apps/web/src/core/ProfilePage.tsx
@@ -172,11 +172,9 @@ function PersonalInfoSection({
               )}
             >
               {uploadingAvatar ? (
-                <Icon
-                  name="refresh-cw"
-                  size={18}
-                  className="text-white animate-spin"
-                />
+                <span className="inline-block animate-spin">
+                  <Icon name="refresh-cw" size={18} className="text-white" />
+                </span>
               ) : (
                 <Icon name="upload" size={18} className="text-white" />
               )}
@@ -431,7 +429,12 @@ function SessionsSection({ online }: { online: boolean }) {
           <Icon name="refresh-cw" size={18} className="text-muted" />
           <span className="text-sm font-semibold text-text">Активні сесії</span>
         </div>
-        <Button variant="ghost" size="xs" onClick={load} disabled={loading}>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={load}
+          disabled={loading || !online}
+        >
           Оновити
         </Button>
       </div>

--- a/apps/web/src/core/stories/__tests__/buildSlides.test.ts
+++ b/apps/web/src/core/stories/__tests__/buildSlides.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../useWeeklyDigest", () => ({
+  aggregateFinyk: vi.fn(() => null),
+  aggregateFizruk: vi.fn(() => null),
+  aggregateNutrition: vi.fn(() => null),
+  aggregateRoutine: vi.fn(() => null),
+}));
+
+import { buildSlides } from "../buildSlides";
+import {
+  aggregateFinyk,
+  aggregateFizruk,
+  aggregateNutrition,
+  aggregateRoutine,
+} from "../../useWeeklyDigest";
+
+const mFinyk = vi.mocked(aggregateFinyk);
+const mFizruk = vi.mocked(aggregateFizruk);
+const mNutrition = vi.mocked(aggregateNutrition);
+const mRoutine = vi.mocked(aggregateRoutine);
+
+describe("buildSlides", () => {
+  it("always includes intro slide", () => {
+    const slides = buildSlides(null, "2026-W17", "21–27 квітня");
+    expect(slides[0].kind).toBe("intro");
+    expect(slides[0].weekRange).toBe("21–27 квітня");
+  });
+
+  it("skips module slides when no aggregates and no digest data", () => {
+    const slides = buildSlides(null, "2026-W17", undefined);
+    expect(slides).toHaveLength(1);
+    expect(slides[0].kind).toBe("intro");
+  });
+
+  it("adds finyk slide when aggregate has txCount > 0", () => {
+    mFinyk.mockReturnValueOnce({ txCount: 5 } as ReturnType<
+      typeof aggregateFinyk
+    >);
+    const slides = buildSlides(null, "2026-W17", undefined);
+    const finykSlide = slides.find((s) => s.kind === "finyk");
+    expect(finykSlide).toBeDefined();
+    expect(finykSlide!.label).toBe("Фінанси");
+    expect(finykSlide!.agg).toEqual({ txCount: 5 });
+  });
+
+  it("adds finyk slide when digest.finyk is present even without aggregate", () => {
+    const slides = buildSlides(
+      { finyk: { summary: "Good week" } },
+      "2026-W17",
+      undefined,
+    );
+    const finykSlide = slides.find((s) => s.kind === "finyk");
+    expect(finykSlide).toBeDefined();
+    expect(finykSlide!.ai).toEqual({ summary: "Good week" });
+  });
+
+  it("adds fizruk slide when aggregate has workoutsCount > 0", () => {
+    mFizruk.mockReturnValueOnce({ workoutsCount: 3 } as ReturnType<
+      typeof aggregateFizruk
+    >);
+    const slides = buildSlides(null, "2026-W17", undefined);
+    const fizrukSlide = slides.find((s) => s.kind === "fizruk");
+    expect(fizrukSlide).toBeDefined();
+    expect(fizrukSlide!.label).toBe("Тренування");
+  });
+
+  it("adds nutrition slide when aggregate has daysLogged > 0", () => {
+    mNutrition.mockReturnValueOnce({ daysLogged: 2 } as ReturnType<
+      typeof aggregateNutrition
+    >);
+    const slides = buildSlides(null, "2026-W17", undefined);
+    const nutritionSlide = slides.find((s) => s.kind === "nutrition");
+    expect(nutritionSlide).toBeDefined();
+    expect(nutritionSlide!.label).toBe("Харчування");
+  });
+
+  it("adds routine slide when aggregate has habitCount > 0", () => {
+    mRoutine.mockReturnValueOnce({ habitCount: 4 } as ReturnType<
+      typeof aggregateRoutine
+    >);
+    const slides = buildSlides(null, "2026-W17", undefined);
+    const routineSlide = slides.find((s) => s.kind === "routine");
+    expect(routineSlide).toBeDefined();
+    expect(routineSlide!.label).toBe("Звички");
+  });
+
+  it("adds overall slide when overallRecommendations is non-empty", () => {
+    const slides = buildSlides(
+      { overallRecommendations: ["Drink more water"] },
+      "2026-W17",
+      undefined,
+    );
+    const overallSlide = slides.find((s) => s.kind === "overall");
+    expect(overallSlide).toBeDefined();
+    expect(overallSlide!.recommendations).toEqual(["Drink more water"]);
+  });
+
+  it("skips overall slide when overallRecommendations is empty", () => {
+    const slides = buildSlides(
+      { overallRecommendations: [] },
+      "2026-W17",
+      undefined,
+    );
+    expect(slides.find((s) => s.kind === "overall")).toBeUndefined();
+  });
+
+  it("carries weekRange to every slide", () => {
+    mFinyk.mockReturnValueOnce({ txCount: 1 } as ReturnType<
+      typeof aggregateFinyk
+    >);
+    const slides = buildSlides(null, "2026-W17", "21–27 квітня");
+    for (const slide of slides) {
+      expect(slide.weekRange).toBe("21–27 квітня");
+    }
+  });
+
+  it("builds all slides in correct order when all modules have data", () => {
+    mFinyk.mockReturnValueOnce({ txCount: 1 } as ReturnType<
+      typeof aggregateFinyk
+    >);
+    mFizruk.mockReturnValueOnce({ workoutsCount: 1 } as ReturnType<
+      typeof aggregateFizruk
+    >);
+    mNutrition.mockReturnValueOnce({ daysLogged: 1 } as ReturnType<
+      typeof aggregateNutrition
+    >);
+    mRoutine.mockReturnValueOnce({ habitCount: 1 } as ReturnType<
+      typeof aggregateRoutine
+    >);
+    const slides = buildSlides(
+      { overallRecommendations: ["tip"] },
+      "2026-W17",
+      undefined,
+    );
+    const kinds = slides.map((s) => s.kind);
+    expect(kinds).toEqual([
+      "intro",
+      "finyk",
+      "fizruk",
+      "nutrition",
+      "routine",
+      "overall",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Тести для нової сторінки `/profile` (PR #624) + фікси знайдені Devin Review після мержу:

### Тести (27 нових тестів)
- **ProfilePage.test.tsx** (16 тестів): рендеринг (ім'я, email, аватар, бейдж верифікації), offline UX (банер, disabled кнопки), секція сесій
- **buildSlides.test.ts** (11 тестів): побудова слайдів Weekly Digest — кожен модуль, порядок, weekRange, порожній стан

### Фікси з Devin Review (#624)
- **Кнопка «Оновити» в секції сесій** — тепер `disabled` коли offline (раніше клік мовчки нічого не робив)
- **animate-spin на SVG** — обгорнуто `<Icon>` в `<span>` per AGENTS.md Rule 6.1 (аналогічно `Spinner.tsx`)

## Review & Testing Checklist for Human

- [ ] Переконатися що всі 696 тестів проходять: `pnpm --filter @sergeant/web test`
- [ ] На `/profile` в офлайні — кнопка «Оновити» в секції сесій має бути disabled (не клікабельна)
- [ ] При завантаженні аватара — спінер крутиться плавно (не глітчить як SVG)

### Notes

- Тест-покриття: 74 → 76 файлів, 669 → 696 тестів
- Фікси стосуються коду з PR #624 який вже в main

Link to Devin session: https://app.devin.ai/sessions/675de84a49f44f1fbfae6ce1548fb16d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
