### PR TITLE
feat(server): Redis-based global rate limiting with in-memory fallback

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "@sergeant/shared": "workspace:*",
     "better-auth": "^1.6.4",
     "express": "^4.22.1",
+    "ioredis": "^5.6.1",
     "google-auth-library": "^10.6.2",
     "helmet": "^8.1.0",
     "pg": "^8.20.0",

--- a/apps/server/src/http/rateLimit.test.ts
+++ b/apps/server/src/http/rateLimit.test.ts
@@ -11,7 +11,18 @@ vi.mock("../obs/metrics.js", async () => {
   };
 });
 
-import { getIp, checkRateLimit } from "./rateLimit.js";
+const redisEvalMock = vi.fn();
+vi.mock("../lib/redis.js", () => ({
+  getRedis: vi.fn(() => null),
+}));
+
+import {
+  getIp,
+  checkRateLimit,
+  checkRateLimitRedis,
+  rateLimitExpress,
+} from "./rateLimit.js";
+import { getRedis } from "../lib/redis.js";
 
 function asReq(partial: Partial<Request> & Record<string, unknown>): Request {
   return partial as unknown as Request;
@@ -197,5 +208,127 @@ describe("checkRateLimit", () => {
     const blocked = checkRateLimit(req, { key, limit: 1, windowMs: 100 });
     expect(blocked.ok).toBe(false);
     expect(blocked.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("checkRateLimitRedis", () => {
+  function makeReq(ip: string): Request {
+    return { ip, headers: {} } as unknown as Request;
+  }
+
+  it("returns ok=true when count is within limit", async () => {
+    const fakRedis = { eval: vi.fn().mockResolvedValue([1, 4800]) } as never;
+    const result = await checkRateLimitRedis(fakRedis, makeReq("1.2.3.4"), {
+      key: "test:redis",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(result.resetMs).toBe(4800);
+    expect(result.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns ok=false when count exceeds limit", async () => {
+    const fakRedis = { eval: vi.fn().mockResolvedValue([6, 3000]) } as never;
+    const result = await checkRateLimitRedis(fakRedis, makeReq("1.2.3.4"), {
+      key: "test:redis:block",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.resetMs).toBe(3000);
+  });
+
+  it("retryAfterSec is at least 1 second when pttl is very small", async () => {
+    const fakRedis = { eval: vi.fn().mockResolvedValue([2, 50]) } as never;
+    const result = await checkRateLimitRedis(fakRedis, makeReq("1.2.3.4"), {
+      key: "test:redis:retry",
+      limit: 1,
+      windowMs: 100,
+    });
+    expect(result.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("rateLimitExpress — Redis path", () => {
+  function makeReq(ip: string): Request {
+    return { ip, headers: {} } as unknown as Request;
+  }
+
+  beforeEach(() => {
+    vi.mocked(getRedis).mockReturnValue(null);
+    redisEvalMock.mockReset();
+  });
+
+  it("uses Redis when getRedis() returns a client", async () => {
+    const fakeRedis = { eval: redisEvalMock.mockResolvedValue([1, 4900]) };
+    vi.mocked(getRedis).mockReturnValue(fakeRedis as never);
+
+    const middleware = rateLimitExpress({
+      key: "mw:redis",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    const req = makeReq("10.0.0.1");
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as never;
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(redisEvalMock).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to in-memory when Redis eval throws", async () => {
+    const fakeRedis = {
+      eval: redisEvalMock.mockRejectedValue(new Error("ECONNREFUSED")),
+    };
+    vi.mocked(getRedis).mockReturnValue(fakeRedis as never);
+
+    const middleware = rateLimitExpress({
+      key: "mw:fallback",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    const req = makeReq("10.0.0.2");
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as never;
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    // fallback to in-memory: next() must still be called despite Redis failure
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("uses in-memory when getRedis() returns null", async () => {
+    vi.mocked(getRedis).mockReturnValue(null);
+
+    const middleware = rateLimitExpress({
+      key: "mw:nuls",
+      limit: 5,
+      windowMs: 5_000,
+    });
+    const req = makeReq("10.0.0.3");
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as never;
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(redisEvalMock).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/src/http/rateLimit.ts
+++ b/apps/server/src/http/rateLimit.ts
@@ -1,5 +1,7 @@
 import type { Request, RequestHandler } from "express";
+import type Redis from "ioredis";
 import { rateLimitHitsTotal } from "../obs/metrics.js";
+import { getRedis } from "../lib/redis.js";
 
 type Outcome = "allowed" | "blocked";
 
@@ -101,6 +103,56 @@ export function rateLimitSubject(req: Request): string {
   return `ip:${getIp(req)}`;
 }
 
+// Lua script: atomically INCR, set EXPIRE on first hit, return [count, pttl].
+const LUA_INCR_EXPIRE = `
+local c = redis.call('INCR', KEYS[1])
+if c == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return {c, ttl}
+`;
+
+/**
+ * Fixed-window rate-limit check backed by Redis (global across replicas).
+ * Falls back to in-memory via {@link checkRateLimit} if Redis throws.
+ */
+export async function checkRateLimitRedis(
+  redis: Redis,
+  req: Request,
+  { key, limit, windowMs }: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const subject = rateLimitSubject(req);
+  const k = `rl:${key}:${subject}`;
+  const windowSecs = Math.max(1, Math.ceil(windowMs / 1000));
+
+  const result = (await redis.eval(
+    LUA_INCR_EXPIRE,
+    1,
+    k,
+    String(windowSecs),
+  )) as [number, number];
+  const count = result[0];
+  const pttlMs = Math.max(0, result[1]);
+
+  if (count > limit) {
+    recordRateLimit(key, "blocked");
+    return {
+      ok: false,
+      remaining: 0,
+      resetMs: pttlMs,
+      retryAfterSec: Math.max(1, Math.ceil(pttlMs / 1000)),
+    };
+  }
+  recordRateLimit(key, "allowed");
+  return {
+    ok: true,
+    remaining: Math.max(0, limit - count),
+    resetMs: pttlMs,
+    retryAfterSec: Math.max(1, Math.ceil(pttlMs / 1000)),
+  };
+}
+
 /**
  * Fixed-window rate-limit check (in-memory, per-process).
  */
@@ -149,8 +201,19 @@ export function rateLimitExpress({
   limit,
   windowMs,
 }: RateLimitOptions): RequestHandler {
-  return (req, res, next) => {
-    const rl = checkRateLimit(req, { key, limit, windowMs });
+  return async (req, res, next) => {
+    const redis = getRedis();
+    let rl: RateLimitResult;
+    if (redis) {
+      try {
+        rl = await checkRateLimitRedis(redis, req, { key, limit, windowMs });
+      } catch {
+        // Redis unavailable — fall back to per-process in-memory limiter.
+        rl = checkRateLimit(req, { key, limit, windowMs });
+      }
+    } else {
+      rl = checkRateLimit(req, { key, limit, windowMs });
+    }
     try {
       res.setHeader("X-RateLimit-Remaining", String(rl.remaining));
     } catch {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import type { Server } from "http";
 import { createApp } from "./app.js";
 import { config } from "./config.js";
 import { pool } from "./db.js";
+import { connectRedis, disconnectRedis } from "./lib/redis.js";
 import { logger, serializeError } from "./obs/logger.js";
 import {
   startPoolSampler,
@@ -35,6 +36,7 @@ const app = createApp({
 });
 
 startPoolSampler(pool);
+connectRedis();
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Graceful shutdown
@@ -124,6 +126,13 @@ async function shutdown(reason: string, exitCode: number): Promise<void> {
         msg: "pg_pool_end_error",
         err: serializeError(err, { includeStack: false }),
       });
+    }
+
+    try {
+      await disconnectRedis();
+      logger.info({ msg: "redis_disconnected" });
+    } catch {
+      /* ignore on shutdown */
     }
 
     try {

--- a/apps/server/src/lib/redis.ts
+++ b/apps/server/src/lib/redis.ts
@@ -1,0 +1,42 @@
+import Redis from "ioredis";
+import { logger } from "../obs/logger.js";
+
+let _client: Redis | null = null;
+
+export function getRedis(): Redis | null {
+  return _client;
+}
+
+/**
+ * Creates a Redis client from REDIS_URL if set.
+ * Rate limiting falls back to in-memory when Redis is unavailable.
+ */
+export function connectRedis(): void {
+  const url = process.env.REDIS_URL;
+  if (!url) return;
+
+  const client = new Redis(url, {
+    // Fail fast per-command so the in-memory fallback kicks in quickly
+    // instead of queuing commands behind a stalled connection.
+    maxRetriesPerRequest: 0,
+    enableOfflineQueue: false,
+    lazyConnect: false,
+  });
+
+  client.on("connect", () => logger.info({ msg: "redis_connected" }));
+  client.on("error", (err: Error) =>
+    logger.warn({ msg: "redis_error", err: err.message }),
+  );
+
+  _client = client;
+}
+
+export async function disconnectRedis(): Promise<void> {
+  if (!_client) return;
+  try {
+    await _client.quit();
+  } catch {
+    /* ignore on shutdown */
+  }
+  _client = null;
+}

--- a/apps/server/src/routes/push.ts
+++ b/apps/server/src/routes/push.ts
@@ -72,8 +72,8 @@ export function createPushRouter(): Router {
   // Свій, вужчий rate-limit (1 req / 5 s / user) поверх загального push-бакета:
   // `rateLimitSubject` після `requireSession` дасть `u:<userId>`, тож ліміт
   // per-user, а не per-IP (мобільний LTE/CGN не має «скинути» стан).
-  // TODO: після сесії 5A замінити in-memory Map (див. `http/rateLimit.ts`) на
-  // redis-based limiter — зараз ріже лише per-process на Railway.
+  // `rateLimitExpress` використовує Redis коли REDIS_URL встановлений,
+  // інакше — in-memory fallback per-process.
   r.post(
     "/api/push/test",
     requireSession(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.10.1
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -3004,6 +3007,12 @@ packages:
         integrity: sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==,
       }
     engines: { node: ">=16.0.0" }
+
+  "@ioredis/commands@1.5.1":
+    resolution:
+      {
+        integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==,
+      }
 
   "@isaacs/cliui@8.0.2":
     resolution:
@@ -6546,6 +6555,13 @@ packages:
       }
     engines: { node: ">=6" }
 
+  cluster-key-slot@1.1.2:
+    resolution:
+      {
+        integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==,
+      }
+    engines: { node: ">=0.10.0" }
+
   co@4.6.0:
     resolution:
       {
@@ -7251,6 +7267,13 @@ packages:
         integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
       }
     engines: { node: ">=0.4.0" }
+
+  denque@2.1.0:
+    resolution:
+      {
+        integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==,
+      }
+    engines: { node: ">=0.10" }
 
   depd@2.0.0:
     resolution:
@@ -9204,6 +9227,13 @@ packages:
         integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==,
       }
 
+  ioredis@5.10.1:
+    resolution:
+      {
+        integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==,
+      }
+    engines: { node: ">=12.22.0" }
+
   ip-regex@2.1.0:
     resolution:
       {
@@ -10453,10 +10483,22 @@ packages:
         integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
       }
 
+  lodash.defaults@4.2.0:
+    resolution:
+      {
+        integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==,
+      }
+
   lodash.includes@4.3.0:
     resolution:
       {
         integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==,
+      }
+
+  lodash.isarguments@3.1.0:
+    resolution:
+      {
+        integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==,
       }
 
   lodash.isboolean@3.0.3:
@@ -12684,6 +12726,20 @@ packages:
       }
     engines: { node: ">=8" }
 
+  redis-errors@1.2.0:
+    resolution:
+      {
+        integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==,
+      }
+    engines: { node: ">=4" }
+
+  redis-parser@3.0.0:
+    resolution:
+      {
+        integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==,
+      }
+    engines: { node: ">=4" }
+
   reflect.getprototypeof@1.0.10:
     resolution:
       {
@@ -13525,6 +13581,12 @@ packages:
         integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==,
       }
     engines: { node: ">=6" }
+
+  standard-as-callback@2.1.0:
+    resolution:
+      {
+        integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==,
+      }
 
   statuses@1.5.0:
     resolution:
@@ -17308,6 +17370,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@ioredis/commands@1.5.1": {}
+
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -19829,6 +19893,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -20202,6 +20268,8 @@ snapshots:
       delaunator: 4.0.1
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -21654,6 +21722,20 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  ioredis@5.10.1:
+    dependencies:
+      "@ioredis/commands": 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-regex@2.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -22633,7 +22715,11 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -24207,6 +24293,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -24716,6 +24808,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
 


### PR DESCRIPTION
Replace per-process in-memory rate limiter with Redis when REDIS_URL is
set. rateLimitExpress now uses a Lua-script-backed fixed-window check
(atomic INCR + conditional EXPIRE) against Redis, falling back to the
existing in-memory Map when Redis is unavailable or throws. Adds
connectRedis/disconnectRedis lifecycle hooks to the server entrypoint
and covers the Redis path with new vitest cases.

https://claude.ai/code/session_01DCY3VXcDN9kvMAjAKbjWD8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting now supports Redis-backed implementation when `REDIS_URL` is configured, with automatic fallback to in-memory rate limiting if Redis is unavailable or errors occur.
  * Server establishes and gracefully closes Redis connections during startup and shutdown.

* **Tests**
  * Added comprehensive tests for Redis-backed rate limiting functionality and fallback behavior.

* **Documentation**
  * Updated rate limiting documentation to reflect Redis support and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->