### PR TITLE
fix: middleware proxy — use arrayBuffer instead of duplex stream

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,9 @@ export const config = {
   matcher: "/api/:path*",
 };
 
-export default function middleware(request: Request): Response | undefined {
+export default async function middleware(
+  request: Request,
+): Promise<Response | undefined> {
   const backend = process.env.BACKEND_URL;
   if (!backend) return undefined;
 
@@ -27,11 +29,12 @@ export default function middleware(request: Request): Response | undefined {
   headers.set("x-forwarded-host", url.host);
   headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
 
-  return fetch(target, {
+  const hasBody = request.method !== "GET" && request.method !== "HEAD";
+  const body = hasBody ? await request.arrayBuffer() : undefined;
+
+  return fetch(target.toString(), {
     method: request.method,
     headers,
-    body: request.body,
-    // @ts-expect-error — Node fetch supports duplex for streaming bodies
-    duplex: "half",
+    body,
   });
 }


### PR DESCRIPTION
## Summary

Фікс `MIDDLEWARE_INVOCATION_FAILED` — Vercel Edge Runtime не підтримує `duplex: "half"` у `fetch()`. Замість потокового проксі body тепер зчитується як `ArrayBuffer` перед пересиланням на Railway.

Продовження #629.

## Review & Testing Checklist for Human

- [ ] Після мерджу перевірити `curl -X POST https://sergeant.vercel.app/api/auth/sign-up/email` — має проксити на Railway (не 500)
- [ ] Спробувати реєстрацію з Safari iOS

### Notes

- `request.arrayBuffer()` буферизує body, тому SSE/streaming ендпоінти отримають повний body одразу. Для auth endpoints це ОК (маленькі JSON payload-и). AI chat streaming (POST → SSE response) працюватиме нормально, бо стримиться лише відповідь, не запит.

Link to Devin session: https://app.devin.ai/sessions/d29e98896a0d49fcacb212898f818633
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Middleware request handling is now asynchronous, with improved payload processing that conditionally reads request data based on HTTP method for more efficient handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->