### PR TITLE
fix(finyk/assets): import filterVisibleAccounts from concrete aggrega…

### DIFF
--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -24,7 +24,7 @@ import {
   getDebtTxRole,
   getReceivableTxRole,
 } from "@sergeant/finyk-domain/domain/debtEngine";
-import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets";
+import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets/aggregates";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
 import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";


### PR DESCRIPTION
…tes path

`@sergeant/finyk-domain` exports map `./domain/*` → `./src/domain/*.ts` (файл, не директорія), тож `./domain/assets` не резолвиться у Vite/Rollup, хоч TS moduleResolution це пропускає. Імпорт з конкретного файлу `./domain/assets/aggregates` працює і в TS, і у build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
