### PR TITLE
fix(finyk): bump low-contrast text across dark mode

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -230,7 +230,7 @@ function TxRowImpl({
               {hideAmount ? "••••" : fmtAmt(tx.amount, CURRENCY.UAH)}
             </div>
             {tx.currencyCode !== CURRENCY.UAH && tx.operationAmount && (
-              <div className="text-2xs text-subtle/70 tabular-nums">
+              <div className="text-2xs text-muted tabular-nums">
                 {hideAmount
                   ? "••••"
                   : fmtAmt(tx.operationAmount, tx.currencyCode)}

--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -484,7 +484,7 @@ export function Overview({
         {realTx.length > 0 && (
           <button
             onClick={() => onNavigate("transactions")}
-            className="w-full py-4 text-sm font-medium text-subtle/70 border border-line/40 border-dashed rounded-2xl hover:border-muted/50 hover:text-muted transition-colors min-h-[52px]"
+            className="w-full py-4 text-sm font-medium text-muted border border-line/60 border-dashed rounded-2xl hover:border-muted hover:text-text transition-colors min-h-[52px]"
           >
             Усі операції ({realTx.length}) →
           </button>

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -679,7 +679,7 @@ export function Transactions({
                     onClick={() => toggleDay(key)}
                     aria-expanded={!collapsed}
                     aria-label={`${collapsed ? "Розгорнути" : "Згорнути"} ${label}`}
-                    className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-xs font-semibold text-subtle tracking-wide hover:text-text hover:bg-panelHi transition-colors"
+                    className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-bg/95 backdrop-blur-sm border-b border-line text-xs font-semibold text-text tracking-wide hover:bg-panelHi transition-colors"
                   >
                     <span className="flex items-center gap-2 min-w-0">
                       <svg
@@ -702,7 +702,7 @@ export function Transactions({
                         <polyline points="6 9 12 15 18 9" />
                       </svg>
                       <span className="truncate">{label}</span>
-                      <span className="shrink-0 text-[10px] font-normal text-subtle/70 normal-case tabular-nums">
+                      <span className="shrink-0 text-[10px] font-semibold text-muted normal-case tabular-nums">
                         · {summary.count}
                       </span>
                     </span>

--- a/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
@@ -45,11 +45,9 @@ const MonthPulseCardImpl = function MonthPulseCard({
       <div className="flex items-start justify-between gap-3 mb-4">
         <div>
           <div className="text-xs font-medium text-subtle">Місяць</div>
-          <p className="text-xs text-subtle/80 mt-0.5 capitalize">
-            {dateLabel}
-          </p>
+          <p className="text-xs text-muted mt-0.5 capitalize">{dateLabel}</p>
         </div>
-        <span className="text-xs text-subtle/60 shrink-0 text-right tabular-nums">
+        <span className="text-xs text-muted shrink-0 text-right tabular-nums">
           {Math.max(0, daysInMonth - daysPassed)} дн. залишилось
         </span>
       </div>
@@ -87,7 +85,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
       </div>
 
       <div className="mt-4 space-y-1.5">
-        <div className="flex justify-between text-xs text-subtle/70">
+        <div className="flex justify-between text-xs text-muted">
           <span>Витрати від доходу</span>
           <span>{showBalance ? `${Math.round(spendPct)}%` : "—"}</span>
         </div>
@@ -100,7 +98,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
             style={{ width: showBalance ? `${spendPct}%` : "0%" }}
           />
         </div>
-        <div className="flex justify-between text-xs text-subtle/70">
+        <div className="flex justify-between text-xs text-muted">
           <span>
             {showBalance
               ? `Залишок: ${monthBalance >= 0 ? "+" : "−"}${Math.abs(monthBalance).toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
@@ -121,7 +119,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
           <div className="text-xs font-medium text-subtle">
             Факт і прогноз витрат
           </div>
-          <p className="text-xs text-subtle/80 leading-snug">
+          <p className="text-xs text-muted leading-snug">
             За {daysPassed}{" "}
             {daysPassed === 1 ? "день" : daysPassed < 5 ? "дні" : "дн."} · факт{" "}
             <span className="font-semibold text-text tabular-nums">
@@ -144,7 +142,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
               style={{ width: `${forecastTrendPct}%` }}
             />
           </div>
-          <div className="flex justify-between text-xs text-subtle/70">
+          <div className="flex justify-between text-xs text-muted">
             <span>{forecastTrendPct}% від прогнозу за темпом</span>
           </div>
         </div>
@@ -153,9 +151,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
       <div className="mt-4 pt-4 border-t border-line">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-medium text-subtle">Фінпульс</span>
-          <span className="text-xs text-subtle/60">
-            цільова витрата на день
-          </span>
+          <span className="text-xs text-muted">цільова витрата на день</span>
         </div>
         <div
           className={cn(
@@ -180,7 +176,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
         <div className={cn("text-sm mt-0.5", color)}>{statusText}</div>
         {(recurringOutThisMonth > 0 || recurringInThisMonth > 0) &&
           showBalance && (
-            <div className="text-xs text-subtle/70 mt-2 leading-relaxed">
+            <div className="text-xs text-muted mt-2 leading-relaxed">
               Враховано планових: −
               {recurringOutThisMonth.toLocaleString("uk-UA", {
                 maximumFractionDigits: 0,

--- a/apps/web/src/modules/finyk/pages/overview/NetworthSection.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/NetworthSection.tsx
@@ -20,7 +20,7 @@ const NetworthSectionImpl = function NetworthSection({ networthHistory }) {
           <span className="text-xs font-medium text-subtle">
             Динаміка нетворсу
           </span>
-          <span className="text-xs text-subtle/60">
+          <span className="text-xs text-muted">
             {networthHistory.length} міс.
           </span>
         </div>

--- a/apps/web/src/modules/finyk/pages/overview/PlanFactCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/PlanFactCard.tsx
@@ -22,7 +22,7 @@ const PlanFactCardImpl = function PlanFactCard({
       <div className="text-xs font-medium text-subtle mb-3">План / Факт</div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">
-          <div className="text-xs text-subtle/60 mb-1">План</div>
+          <div className="text-xs text-muted mb-1">План</div>
           <div className="text-sm text-muted tabular-nums">
             +{planIncome.toLocaleString("uk-UA")} ₴
           </div>
@@ -34,7 +34,7 @@ const PlanFactCardImpl = function PlanFactCard({
           </div>
         </div>
         <div className="space-y-1.5">
-          <div className="text-xs text-subtle/60 mb-1">Факт</div>
+          <div className="text-xs text-muted mb-1">Факт</div>
           <div className="text-sm text-success tabular-nums">
             +{income.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
           </div>


### PR DESCRIPTION
Day headers on Transactions were text-subtle (already dim) without font-weight help; count label was text-subtle/70 — essentially illegible in dark mode. Also audited the rest of Finyk and replaced opacity-reduced text-subtle/60-80 with text-muted where text was primary content (not decorative).

- Transactions day-header: text-subtle → text-text (bright), count text-subtle/70 → text-muted + font-semibold.
- TxRow secondary currency amount: text-subtle/70 → text-muted.
- MonthPulseCard: 7 instances of text-subtle/60|70|80 → text-muted (date label, days-left, 'Витрати від доходу', forecast, 'Фінпульс' target, recurring totals).
- PlanFactCard: 'План' / 'Факт' labels text-subtle/60 → text-muted.
- NetworthSection: month count text-subtle/60 → text-muted.
- Overview: 'Усі операції' CTA text-subtle/70 → text-muted, border /40 → /60, hover now flips to text-text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
