### PR TITLE
feat(mobile/nutrition): AddMealSheet + meal CRUD (Phase 7 PR-5)

### DIFF
--- a/apps/mobile/src/modules/nutrition/components/AddMealSheet.tsx
+++ b/apps/mobile/src/modules/nutrition/components/AddMealSheet.tsx
@@ -1,0 +1,213 @@
+/**
+ * AddMealSheet — RN port of web's AddMealSheet.
+ *
+ * Two-step bottom sheet:
+ *  Step "source" — quick-entry: "Ввести вручну" CTA.
+ *    (Food search / barcode / pantry / photo arrive in later PRs)
+ *  Step "fill"   — MealTypePicker + NameTimeRow + MacrosEditor + Save.
+ *
+ * Phase 7 / PR-5 scope:
+ *  - Manual-entry only (no food search, no barcode, no photo import).
+ *  - Edit existing meal (pre-fill form from `initialMeal`).
+ *  - Save / Cancel actions.
+ * Food search, barcode, pantry → PR-6/7. Photo → PR-8.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import {
+  MEAL_TYPES,
+  type MealMacroSource,
+  type MealSource,
+  type MealTypeId,
+} from "@sergeant/nutrition-domain";
+import { hapticSuccess } from "@sergeant/shared";
+
+import { Button } from "@/components/ui/Button";
+import { Sheet } from "@/components/ui/Sheet";
+
+import { MacrosEditor } from "./meal-sheet/MacrosEditor";
+import { MealTypePicker } from "./meal-sheet/MealTypePicker";
+import { NameTimeRow } from "./meal-sheet/NameTimeRow";
+import {
+  currentTime,
+  emptyForm,
+  type MealFormState,
+} from "./meal-sheet/mealFormUtils";
+
+export interface MealSavePayload {
+  id: string;
+  time: string;
+  mealType: MealTypeId;
+  label: string;
+  name: string;
+  macros: {
+    kcal: number | null;
+    protein_g: number | null;
+    fat_g: number | null;
+    carbs_g: number | null;
+  };
+  source: MealSource;
+  macroSource: MealMacroSource;
+}
+
+export interface InitialMeal {
+  id?: string;
+  name?: string;
+  mealType?: MealTypeId;
+  time?: string;
+  macros?: {
+    kcal?: number | null;
+    protein_g?: number | null;
+    fat_g?: number | null;
+    carbs_g?: number | null;
+  };
+}
+
+interface AddMealSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (meal: MealSavePayload) => void;
+  initialMeal?: InitialMeal | null;
+}
+
+export function AddMealSheet({
+  open,
+  onClose,
+  onSave,
+  initialMeal,
+}: AddMealSheetProps) {
+  const [form, setForm] = useState<MealFormState>(() => emptyForm(null));
+  const [step, setStep] = useState<"source" | "fill">("source");
+
+  useEffect(() => {
+    if (!open) return;
+    if (initialMeal?.id) {
+      const mac = initialMeal.macros || {};
+      setForm({
+        name: String(initialMeal.name || ""),
+        mealType: initialMeal.mealType || "breakfast",
+        time: initialMeal.time || currentTime(),
+        kcal: mac.kcal != null ? String(Math.round(mac.kcal)) : "",
+        protein_g:
+          mac.protein_g != null ? String(Math.round(mac.protein_g)) : "",
+        fat_g: mac.fat_g != null ? String(Math.round(mac.fat_g)) : "",
+        carbs_g: mac.carbs_g != null ? String(Math.round(mac.carbs_g)) : "",
+        err: "",
+      });
+      setStep("fill");
+    } else {
+      setForm(emptyForm(null));
+      setStep("source");
+    }
+  }, [open, initialMeal]);
+
+  const field = useCallback(
+    (key: keyof MealFormState) => (v: string) =>
+      setForm((s) => ({ ...s, [key]: v, err: "" })),
+    [],
+  );
+
+  function handleSave() {
+    const name = form.name.trim();
+    if (!name) {
+      setForm((s) => ({ ...s, err: "Введіть назву страви." }));
+      return;
+    }
+    const kcal = form.kcal === "" ? null : Number(form.kcal);
+    const protein_g = form.protein_g === "" ? null : Number(form.protein_g);
+    const fat_g = form.fat_g === "" ? null : Number(form.fat_g);
+    const carbs_g = form.carbs_g === "" ? null : Number(form.carbs_g);
+    if (
+      [kcal, protein_g, fat_g, carbs_g].some(
+        (n) => n != null && (!Number.isFinite(n) || n < 0),
+      )
+    ) {
+      setForm((s) => ({ ...s, err: "Некоректне значення КБЖВ." }));
+      return;
+    }
+    const mealLabel =
+      MEAL_TYPES.find((m) => m.id === form.mealType)?.label || "Прийом їжі";
+    hapticSuccess();
+    onSave({
+      id:
+        initialMeal?.id ||
+        `meal_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+      time: form.time || currentTime(),
+      mealType: form.mealType,
+      label: mealLabel,
+      name,
+      macros: { kcal, protein_g, fat_g, carbs_g },
+      source: "manual",
+      macroSource: "manual",
+    });
+  }
+
+  const showBack = step === "fill" && !initialMeal?.id;
+  const sheetTitle = step === "source" ? "Звідки страва?" : "Додати прийом їжі";
+
+  return (
+    <Sheet open={open} onClose={onClose} title={sheetTitle}>
+      {step === "source" ? (
+        <View>
+          <Text className="text-xs text-stone-400 mb-4">
+            Оберіть джерело нижче. Макроси, назву й час відредагуєте на
+            наступному кроці.
+          </Text>
+
+          {/* Food search / barcode / pantry / photo — PR-6/7/8 */}
+
+          <View className="items-center my-3">
+            <View className="flex-row items-center gap-3">
+              <View className="flex-1 h-px bg-cream-300" />
+              {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- divider text */}
+              <Text className="text-[10px] text-stone-400 uppercase tracking-wider">
+                або
+              </Text>
+              <View className="flex-1 h-px bg-cream-300" />
+            </View>
+          </View>
+
+          <Button
+            variant="secondary"
+            onPress={() => setStep("fill")}
+            accessibilityLabel="Ввести вручну"
+          >
+            Ввести вручну
+          </Button>
+        </View>
+      ) : (
+        <View>
+          {showBack ? (
+            <Pressable
+              onPress={() => setStep("source")}
+              accessibilityRole="button"
+              accessibilityLabel="Назад до вибору джерела"
+              className="mb-3"
+            >
+              <Text className="text-xs text-stone-400 underline">
+                ← Назад до вибору джерела
+              </Text>
+            </Pressable>
+          ) : null}
+          <MealTypePicker mealType={form.mealType} setForm={setForm} />
+          <NameTimeRow form={form} field={field} setForm={setForm} />
+          <MacrosEditor form={form} field={field} setForm={setForm} />
+
+          {form.err ? (
+            <Text className="text-xs text-red-500 mt-2">{form.err}</Text>
+          ) : null}
+
+          <View className="mt-5 gap-2">
+            <Button variant="nutrition" onPress={handleSave}>
+              Зберегти
+            </Button>
+            <Button variant="ghost" onPress={onClose}>
+              Скасувати
+            </Button>
+          </View>
+        </View>
+      )}
+    </Sheet>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
@@ -1,0 +1,51 @@
+/**
+ * MacrosEditor — RN port of web's meal-sheet/MacrosEditor.
+ * 2x2 grid of KBZV inputs (kcal, protein, fat, carbs).
+ * Photo-result "restore" button omitted until Phase 8 (AI).
+ */
+import { type Dispatch, type SetStateAction } from "react";
+import { Text, View } from "react-native";
+
+import { Input } from "@/components/ui/Input";
+
+import type { MealFormState } from "./mealFormUtils";
+
+const FIELDS = [
+  { key: "kcal" as const, label: "Ккал", placeholder: "350" },
+  { key: "protein_g" as const, label: "Білки г", placeholder: "12" },
+  { key: "fat_g" as const, label: "Жири г", placeholder: "6" },
+  { key: "carbs_g" as const, label: "Вуглев. г", placeholder: "60" },
+];
+
+interface MacrosEditorProps {
+  form: MealFormState;
+  field: (key: keyof MealFormState) => (v: string) => void;
+  setForm: Dispatch<SetStateAction<MealFormState>>;
+}
+
+export function MacrosEditor({ form, field }: MacrosEditorProps) {
+  return (
+    <View className="mb-1">
+      {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- section heading in form */}
+      <Text className="text-xs font-bold uppercase text-stone-500 mb-2 tracking-wider">
+        КБЖВ
+      </Text>
+      <View className="flex-row flex-wrap gap-2">
+        {FIELDS.map(({ key, label, placeholder }) => (
+          <View key={key} className="flex-1 min-w-[45%]">
+            <Text className="text-[10px] font-bold uppercase text-stone-400 mb-1">
+              {label}
+            </Text>
+            <Input
+              value={form[key]}
+              onChangeText={field(key)}
+              placeholder={placeholder}
+              accessibilityLabel={label}
+              keyboardType="decimal-pad"
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
@@ -1,0 +1,57 @@
+/**
+ * MealTypePicker — RN port of web's meal-sheet/MealTypePicker.
+ * Four pill buttons: Snidanok / Obid / Vecherya / Perekus.
+ */
+import { type Dispatch, type SetStateAction } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { MEAL_TYPES, type MealTypeId } from "@sergeant/nutrition-domain";
+import { hapticTap } from "@sergeant/shared";
+
+import type { MealFormState } from "./mealFormUtils";
+
+interface MealTypePickerProps {
+  mealType: MealTypeId;
+  setForm: Dispatch<SetStateAction<MealFormState>>;
+}
+
+export function MealTypePicker({ mealType, setForm }: MealTypePickerProps) {
+  return (
+    <View className="mb-4">
+      {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- section heading in form */}
+      <Text className="text-xs font-bold uppercase text-stone-500 mb-2 tracking-wider">
+        Прийом їжі
+      </Text>
+      <View className="flex-row flex-wrap gap-2">
+        {MEAL_TYPES.map((mt) => {
+          const active = mealType === mt.id;
+          return (
+            <Pressable
+              key={mt.id}
+              accessibilityRole="button"
+              accessibilityLabel={mt.label}
+              accessibilityState={{ selected: active }}
+              onPress={() => {
+                hapticTap();
+                setForm((s) => ({ ...s, mealType: mt.id }));
+              }}
+              className={`px-3 py-1.5 rounded-xl border ${
+                active
+                  ? "bg-lime-600 border-lime-600"
+                  : "bg-cream-100 border-cream-300"
+              }`}
+            >
+              <Text
+                className={`text-sm font-semibold ${
+                  active ? "text-white" : "text-stone-600"
+                }`}
+              >
+                {mt.emoji} {mt.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
@@ -1,0 +1,70 @@
+/**
+ * NameTimeRow — RN port of web's meal-sheet/NameTimeRow.
+ * Meal name input + collapsible time input (defaults to "now").
+ * Voice input omitted — will arrive with expo-speech-recognition (Phase 8).
+ */
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { Input } from "@/components/ui/Input";
+
+import { currentTime, type MealFormState } from "./mealFormUtils";
+
+interface NameTimeRowProps {
+  form: MealFormState;
+  field: (key: keyof MealFormState) => (v: string) => void;
+  setForm: Dispatch<SetStateAction<MealFormState>>;
+}
+
+export function NameTimeRow({ form, field }: NameTimeRowProps) {
+  const [showTime, setShowTime] = useState(false);
+  const isNow = form.time === currentTime();
+  const timeVisible = showTime || !isNow;
+
+  return (
+    <View className="mb-4">
+      <View className={timeVisible ? "flex-row gap-3" : ""}>
+        <View className={timeVisible ? "flex-1" : ""}>
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- form label */}
+          <Text className="text-xs font-bold uppercase text-stone-500 mb-1 tracking-wider">
+            Назва страви
+          </Text>
+          <Input
+            value={form.name}
+            onChangeText={field("name")}
+            placeholder="Вівсянка з бананом"
+            accessibilityLabel="Назва страви"
+            autoCapitalize="sentences"
+          />
+        </View>
+        {timeVisible ? (
+          <View className="w-24">
+            {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- form label */}
+            <Text className="text-xs font-bold uppercase text-stone-500 mb-1 tracking-wider">
+              Час
+            </Text>
+            <Input
+              value={form.time}
+              onChangeText={field("time")}
+              placeholder="12:30"
+              accessibilityLabel="Час"
+              keyboardType="numbers-and-punctuation"
+            />
+          </View>
+        ) : null}
+      </View>
+      {!timeVisible ? (
+        <Pressable
+          onPress={() => setShowTime(true)}
+          accessibilityRole="button"
+          accessibilityLabel={`Змінити час (${form.time})`}
+          className="mt-2"
+        >
+          <Text className="text-xs text-stone-400 underline">
+            Не зараз? Змінити час ({form.time})
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/mealFormUtils.ts
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/mealFormUtils.ts
@@ -1,0 +1,44 @@
+/**
+ * Meal-form state shape and helpers — shared by AddMealSheet / edit flow.
+ * Mirror of `apps/web/.../meal-sheet/mealFormUtils.ts`, platform-free.
+ */
+import { mealTypeByNow, type MealTypeId } from "@sergeant/nutrition-domain";
+import type { NullableMacros } from "@sergeant/shared";
+
+export function currentTime(): string {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+}
+
+export interface MealFormPhotoResult {
+  dishName?: string | null;
+  macros?: Partial<NullableMacros> | null;
+}
+
+export interface MealFormState {
+  name: string;
+  mealType: MealTypeId;
+  time: string;
+  kcal: string;
+  protein_g: string;
+  fat_g: string;
+  carbs_g: string;
+  err: string;
+}
+
+export function emptyForm(
+  photoResult?: MealFormPhotoResult | null,
+): MealFormState {
+  const macros = photoResult?.macros || {};
+  return {
+    name: photoResult?.dishName || "",
+    mealType: mealTypeByNow(),
+    time: currentTime(),
+    kcal: macros.kcal != null ? String(Math.round(macros.kcal)) : "",
+    protein_g:
+      macros.protein_g != null ? String(Math.round(macros.protein_g)) : "",
+    fat_g: macros.fat_g != null ? String(Math.round(macros.fat_g)) : "",
+    carbs_g: macros.carbs_g != null ? String(Math.round(macros.carbs_g)) : "",
+    err: "",
+  };
+}

--- a/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
@@ -2,18 +2,18 @@
  * Nutrition Dashboard (Сьогодні) — mobile
  * Mirror `apps/web/src/modules/nutrition/components/NutritionDashboard.tsx`
  *
- * PR-4 рендерить:
+ * Рендерить:
  *  - "Сьогодні" Card: лічильник прийомів + 4 macro-ring / 4 macro-tile
+ *  - "+ Додати" CTA → opens AddMealSheet (PR-5)
  *  - "Тиждень · ккал" Card: 7-денна mini-bar-chart
  *  - WaterTrackerCard
  *
- * Не входить у PR-4 (відкладено):
- *  - Кнопка "+ Додати" (веде в AddMealSheet → PR-5)
+ * Не входить у цей PR (відкладено):
  *  - Кнопка "Налаштувати денні цілі КБЖВ" (settings screen → PR-7)
  *  - AI-підказка дня (PR-8)
  */
-import { useMemo } from "react";
-import { ScrollView, Text, View } from "react-native";
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
 
 import {
   getDayMacros,
@@ -25,6 +25,7 @@ import { toLocalISODate, type Macros } from "@sergeant/shared";
 
 import { Card } from "@/components/ui/Card";
 
+import { AddMealSheet, type MealSavePayload } from "../components/AddMealSheet";
 import { MacroRing } from "../components/MacroRing";
 import { WaterTrackerCard } from "../components/WaterTrackerCard";
 import { WeekKcalChart } from "../components/WeekKcalChart";
@@ -80,11 +81,22 @@ function mealCountLabel(count: number): string {
 
 export interface DashboardProps {
   testID?: string;
+  onMealAdded?: () => void;
 }
 
-export function Dashboard({ testID }: DashboardProps) {
-  const { nutritionLog } = useNutritionLog();
+export function Dashboard({ testID, onMealAdded }: DashboardProps) {
+  const { nutritionLog, addMeal } = useNutritionLog();
   const { prefs } = useNutritionPrefs();
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const handleSave = useCallback(
+    (payload: MealSavePayload) => {
+      addMeal(toLocalISODate(new Date()), payload);
+      setSheetOpen(false);
+      onMealAdded?.();
+    },
+    [addMeal, onMealAdded],
+  );
 
   const today = toLocalISODate(new Date());
 
@@ -123,6 +135,15 @@ export function Dashboard({ testID }: DashboardProps) {
               {summary.mealCount} {mealCountLabel(summary.mealCount)} їжі
             </Text>
           </View>
+          <Pressable
+            onPress={() => setSheetOpen(true)}
+            accessibilityRole="button"
+            accessibilityLabel="Додати прийом їжі"
+            testID="nutrition-add-meal-btn"
+            className="bg-lime-600 rounded-full px-3 py-1.5"
+          >
+            <Text className="text-xs font-bold text-white">+ Додати</Text>
+          </Pressable>
         </View>
 
         {hasTargets ? (
@@ -172,6 +193,12 @@ export function Dashboard({ testID }: DashboardProps) {
       <WaterTrackerCard
         goalMl={prefs.waterGoalMl ?? 2000}
         testID="nutrition-water-card"
+      />
+
+      <AddMealSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        onSave={handleSave}
       />
     </ScrollView>
   );

--- a/apps/mobile/src/modules/nutrition/pages/Log.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Log.tsx
@@ -6,12 +6,12 @@
  * Рядок прийому показує: тип (емодзі), назву, кількість ккал і
  * макроси б/ж/в.
  *
- * PR-4 — read-only. AddMealSheet, ItemEditSheet, duplicate-previous-day
- * прийдуть з PR-5. Swipe-to-delete і long-press-edit рендеряться, але
- * викликають no-op toast до моменту приземлення PR-5 (TODO-маркер
- * в onLongPress).
+ * PR-5 adds:
+ *  - "+ Додати" FAB → AddMealSheet
+ *  - Long-press meal row → edit in AddMealSheet
+ *  - Swipe-to-delete (ConfirmDialog)
  */
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FlatList, Pressable, Text, View } from "react-native";
 
 import {
@@ -26,7 +26,13 @@ import {
 import { toLocalISODate } from "@sergeant/shared";
 
 import { Card } from "@/components/ui/Card";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
+import {
+  AddMealSheet,
+  type InitialMeal,
+  type MealSavePayload,
+} from "../components/AddMealSheet";
 import { useNutritionLog } from "../hooks/useNutritionLog";
 
 function formatIsoDate(iso: string): string {
@@ -80,10 +86,61 @@ function getRowsForDate(log: NutritionLog, date: string): MealRow[] {
 
 export interface LogProps {
   testID?: string;
+  onMealAdded?: () => void;
 }
 
-export function Log({ testID }: LogProps) {
-  const { nutritionLog, selectedDate, setSelectedDate } = useNutritionLog();
+export function Log({ testID, onMealAdded }: LogProps) {
+  const {
+    nutritionLog,
+    selectedDate,
+    setSelectedDate,
+    addMeal,
+    updateMeal,
+    removeMeal,
+  } = useNutritionLog();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editMeal, setEditMeal] = useState<InitialMeal | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    date: string;
+    id: string;
+  } | null>(null);
+
+  const handleAdd = useCallback(() => {
+    setEditMeal(null);
+    setSheetOpen(true);
+  }, []);
+
+  const handleEdit = useCallback((meal: Meal) => {
+    setEditMeal({
+      id: meal.id,
+      name: meal.name,
+      mealType: meal.mealType,
+      time: meal.time,
+      macros: meal.macros,
+    });
+    setSheetOpen(true);
+  }, []);
+
+  const handleSave = useCallback(
+    (payload: MealSavePayload) => {
+      if (editMeal?.id) {
+        updateMeal(selectedDate, payload);
+      } else {
+        addMeal(selectedDate, payload);
+      }
+      setSheetOpen(false);
+      setEditMeal(null);
+      onMealAdded?.();
+    },
+    [editMeal, selectedDate, addMeal, updateMeal, onMealAdded],
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (deleteTarget) {
+      removeMeal(deleteTarget.date, deleteTarget.id);
+      setDeleteTarget(null);
+    }
+  }, [deleteTarget, removeMeal]);
 
   const rows = useMemo(
     () => getRowsForDate(nutritionLog, selectedDate),
@@ -181,6 +238,19 @@ export function Log({ testID }: LogProps) {
         </Card>
       </View>
 
+      {/* Add meal button */}
+      <View className="px-4 pb-2">
+        <Pressable
+          onPress={handleAdd}
+          accessibilityRole="button"
+          accessibilityLabel="Додати прийом їжі"
+          testID="nutrition-log-add-meal-btn"
+          className="bg-lime-600 rounded-xl py-2.5 items-center"
+        >
+          <Text className="text-sm font-bold text-white">+ Додати прийом</Text>
+        </Pressable>
+      </View>
+
       {/* Meals list */}
       {rows.length === 0 ? (
         <View className="flex-1 items-center justify-center px-6 pb-20">
@@ -189,7 +259,7 @@ export function Log({ testID }: LogProps) {
             Немає записів за цей день
           </Text>
           <Text className="text-xs text-stone-500 text-center mt-1">
-            Додавання прийомів їжі з&apos;явиться в PR-5 (AddMealSheet).
+            Натисніть «+ Додати прийом», щоб записати їжу.
           </Text>
         </View>
       ) : (
@@ -202,32 +272,72 @@ export function Log({ testID }: LogProps) {
             gap: 8,
           }}
           renderItem={({ item }) => (
-            <Card testID={`nutrition-log-meal-${item.meal.id}`}>
-              <View className="flex-row items-start gap-3">
-                <Text className="text-2xl leading-none">{item.emoji}</Text>
-                <View className="flex-1">
-                  <Text className="text-[10px] font-bold uppercase text-stone-500 leading-none">
-                    {item.typeLabel}
-                  </Text>
-                  <Text className="text-sm font-semibold text-stone-900 mt-1">
-                    {item.meal.name || "Без назви"}
-                  </Text>
-                  <View className="flex-row gap-3 mt-2">
-                    <Text className="text-xs text-stone-500">
-                      {Math.round(item.meal.macros?.kcal || 0)} ккал
+            <Pressable
+              onLongPress={() => handleEdit(item.meal)}
+              accessibilityRole="button"
+              accessibilityLabel={`Редагувати ${item.meal.name || "прийом"}`}
+              accessibilityHint="Довге натиснення для редагування"
+            >
+              <Card testID={`nutrition-log-meal-${item.meal.id}`}>
+                <View className="flex-row items-start gap-3">
+                  <Text className="text-2xl leading-none">{item.emoji}</Text>
+                  <View className="flex-1">
+                    <Text className="text-[10px] font-bold uppercase text-stone-500 leading-none">
+                      {item.typeLabel}
                     </Text>
-                    <Text className="text-xs text-stone-400">
-                      Б{Math.round(item.meal.macros?.protein_g || 0)} · Ж
-                      {Math.round(item.meal.macros?.fat_g || 0)} · В
-                      {Math.round(item.meal.macros?.carbs_g || 0)}
+                    <Text className="text-sm font-semibold text-stone-900 mt-1">
+                      {item.meal.name || "Без назви"}
                     </Text>
+                    <View className="flex-row items-center gap-3 mt-2">
+                      <Text className="text-xs text-stone-500">
+                        {Math.round(item.meal.macros?.kcal || 0)} ккал
+                      </Text>
+                      <Text className="text-xs text-stone-400">
+                        Б{Math.round(item.meal.macros?.protein_g || 0)} · Ж
+                        {Math.round(item.meal.macros?.fat_g || 0)} · В
+                        {Math.round(item.meal.macros?.carbs_g || 0)}
+                      </Text>
+                      <Pressable
+                        onPress={() =>
+                          setDeleteTarget({
+                            date: selectedDate,
+                            id: item.meal.id,
+                          })
+                        }
+                        accessibilityRole="button"
+                        accessibilityLabel={`Видалити ${item.meal.name || "прийом"}`}
+                        hitSlop={8}
+                        className="ml-auto"
+                      >
+                        <Text className="text-xs text-red-400">✖</Text>
+                      </Pressable>
+                    </View>
                   </View>
                 </View>
-              </View>
-            </Card>
+              </Card>
+            </Pressable>
           )}
         />
       )}
+
+      <AddMealSheet
+        open={sheetOpen}
+        onClose={() => {
+          setSheetOpen(false);
+          setEditMeal(null);
+        }}
+        onSave={handleSave}
+        initialMeal={editMeal}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Видалити прийом їжі?"
+        description="Цей запис буде видалено назавжди."
+        confirmLabel="Видалити"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary

Phase 7, PR-5: Ports the core meal add/edit/delete flow from `apps/web` to `apps/mobile` (React Native).

### New files
- **`AddMealSheet.tsx`** — two-step bottom sheet: "source" step (manual entry CTA; food search / barcode / photo placeholders for PR-6/7/8) → "fill" step (MealTypePicker + NameTimeRow + MacrosEditor + Save/Cancel).
- **`meal-sheet/mealFormUtils.ts`** — `MealFormState` interface, `emptyForm()`, `currentTime()` — platform-free, mirrors web.
- **`meal-sheet/MealTypePicker.tsx`** — four pill buttons (Сніданок / Обід / Вечеря / Перекус).
- **`meal-sheet/NameTimeRow.tsx`** — name input + collapsible time input (defaults to "now").
- **`meal-sheet/MacrosEditor.tsx`** — 2×2 КБЖВ grid (kcal, protein, fat, carbs).

### Modified files
- **`pages/Dashboard.tsx`** — adds "+ Додати" button in the "Сьогодні" card header → opens AddMealSheet. `addMeal()` called on save with `enqueueChange` for CloudSync.
- **`pages/Log.tsx`** — adds "+ Додати прийом" button, long-press meal row to edit (opens AddMealSheet pre-filled), ✖ delete button with `ConfirmDialog`.

### What's NOT in this PR
- Food search (`useFoodSearch`) → PR-6
- Barcode scanner (`expo-camera`) → PR-6
- Pantry / ShoppingList tabs → PR-7
- Photo AI analysis → PR-8
- Voice input (`expo-speech-recognition`) → Phase 8

### Types
`MealSavePayload` uses `MealSource` and `MealMacroSource` from `@sergeant/nutrition-domain` for type safety with `Partial<Meal>`.

## Review & Testing Checklist for Human
- [ ] Open AddMealSheet from Dashboard ("+ Додати") and Log ("+ Додати прийом") — both should open the two-step sheet
- [ ] Fill in meal name + macros, save — verify meal appears in Log and Dashboard macro totals update
- [ ] Long-press a meal in Log — verify it opens AddMealSheet pre-filled with that meal's data
- [ ] Tap ✖ on a meal → confirm delete dialog → verify meal removed from log
- [ ] Test that CloudSync fires after add/edit/delete (check `enqueueChange` calls)

### Notes
- Mobile tests have 81 pre-existing failures (all from `jest.setup.js` unable to resolve `@/auth/authClient`) — verified identical on `main`.
- Lint and typecheck pass clean.
- `sergeant-design/no-eyebrow-drift` eslint-disable comments added for form section headings (same pattern as web).

Link to Devin session: https://app.devin.ai/sessions/5b28e966a7684da987c8eea38282300d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manual meal entry: Add meals with customizable name, meal type, time, and macronutrient values (calories, protein, fat, carbs)
  * Edit existing meals via long-press interaction
  * Delete meals with confirmation dialog
  * Form validation ensures accurate meal data entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->