### PR TITLE
fix(shared): remove duplicate resetOnboardingState export

### DIFF
--- a/packages/shared/src/lib/onboardingReset.ts
+++ b/packages/shared/src/lib/onboardingReset.ts
@@ -11,9 +11,9 @@ import {
   FIRST_ACTION_PENDING_KEY,
   FIRST_ACTION_STARTED_AT_KEY,
   FIRST_REAL_ENTRY_KEY,
-  SOFT_AUTH_DISMISSED_KEY,
   TTV_MS_KEY,
   VIBE_PICKS_KEY,
+  SOFT_AUTH_DISMISSED_KEY,
 } from "./vibePicks";
 import { clearAllHintsState } from "./hints";
 
@@ -25,41 +25,6 @@ export function resetOnboardingState(store: KVStore): void {
   store.remove(FIRST_REAL_ENTRY_KEY);
   store.remove(TTV_MS_KEY);
   store.remove(SOFT_AUTH_DISMISSED_KEY);
-  clearAllHintsState(store);
-}
-
-/**
- * Reset onboarding + FTUX state without wiping the user's actual data.
- *
- * Used by "Restart onboarding" in Settings. This deliberately does NOT
- * remove domain data (finyk/nutrition/etc). It only clears gates and
- * funnel flags so the welcome flow + first-action guidance can re-run.
- */
-import { type KVStore } from "./kvStore";
-import { clearOnboardingDone } from "./onboarding";
-import {
-  FIRST_ACTION_PENDING_KEY,
-  FIRST_ACTION_STARTED_AT_KEY,
-  FIRST_REAL_ENTRY_KEY,
-  TTV_MS_KEY,
-  VIBE_PICKS_KEY,
-  SOFT_AUTH_DISMISSED_KEY,
-} from "./vibePicks";
-import { clearAllHintsState } from "./hints";
-
-export function resetOnboardingState(store: KVStore): void {
-  // Onboarding gate
-  clearOnboardingDone(store);
-
-  // FTUX funnel flags
-  store.remove(VIBE_PICKS_KEY);
-  store.remove(FIRST_ACTION_PENDING_KEY);
-  store.remove(FIRST_ACTION_STARTED_AT_KEY);
-  store.remove(FIRST_REAL_ENTRY_KEY);
-  store.remove(TTV_MS_KEY);
-  store.remove(SOFT_AUTH_DISMISSED_KEY);
-
-  // Hints (optional, but matches the mental model of "fresh start")
   clearAllHintsState(store);
 }
 


### PR DESCRIPTION
Fix Vite build failure caused by duplicated module content.

Made-with: Cursor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
