### PR TITLE
fix(server): add createRequire banner to esbuild ESM bundles

### DIFF
--- a/apps/server/build.mjs
+++ b/apps/server/build.mjs
@@ -14,6 +14,14 @@ const base = {
   // the bundle self-contained avoids Node ESM ".js extension" pitfalls in
   // internal workspace packages (e.g. @sergeant/shared).
   packages: "bundle",
+  // `pg` (and other native deps) use CJS `require()` for Node built-ins
+  // like `events`, `net`, `tls`, etc. When esbuild emits ESM, the
+  // generated `__require` shim throws "Dynamic require of … is not
+  // supported" for built-ins. Injecting `createRequire` restores a real
+  // `require` function that Node can resolve.
+  banner: {
+    js: 'import{createRequire}from"module";const require=createRequire(import.meta.url);',
+  },
 };
 
 await build({


### PR DESCRIPTION
## Summary

Fixes 7 consecutive failed Railway deployments caused by `Error: Dynamic require of "events" is not supported` in `dist-server/migrate.js`.

**Root cause:** `build.mjs` uses esbuild with `format: "esm"` + `packages: "bundle"`, which bundles the `pg` library. `pg` internally uses CJS `require()` for Node.js built-ins (`events`, `net`, `tls`, etc.). esbuild's generated `__require` shim throws at runtime because ESM doesn't support dynamic requires of built-in modules.

**Fix:** Add a `banner` to the esbuild config that injects `createRequire` from Node's `module` package, restoring a real `require` function that can resolve built-in modules in the ESM output.

```js
banner: {
  js: 'import{createRequire}from"module";const require=createRequire(import.meta.url);',
},
```

Verified locally: `pnpm build` succeeds, `node dist-server/migrate.js` no longer throws the dynamic require error, and `node dist-server/index.js` starts normally.

## Review & Testing Checklist for Human

- [ ] Merge and verify that the next Railway deployment succeeds (pre-deploy `db:migrate` should pass without the `Dynamic require` error)
- [ ] Confirm the API starts and responds on `https://sergeant-production.up.railway.app`

### Notes

**Other runtime warnings found in Railway logs (not addressed in this PR):**
1. **`vapid_email_missing`** — `VAPID_EMAIL` env var not set on Railway → push notifications return 503. Fix: set `VAPID_EMAIL=mailto:your@email.com` in Railway env vars.
2. **`Invalid origin` from Better Auth** — Vercel preview URL `https://sergeant-git-cursor-sw-debug-controls-skords-01s-projects.vercel.app` not in `trustedOrigins`. Fix: add it to `ALLOWED_ORIGINS` env var on Railway, or add a wildcard pattern for Vercel previews in `getTrustedOrigins()`.
3. **HTTP 401 warnings on `/api/me`, `/api/coach/*`** — normal unauthenticated requests, not actionable.

---
Devin session: https://app.devin.ai/sessions/c3582318a1ff412abc673bd8fdaf4acd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server module resolution to ensure proper handling of Node.js built-in dependencies at runtime, enhancing compatibility and stability of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->