### PR TITLE
feat(onboarding): multi-step wizard v2 — welcome, modules, goals

### DIFF
--- a/apps/mobile/src/core/OnboardingWizard.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.tsx
@@ -1,31 +1,26 @@
 /**
- * Mobile port of `apps/web/src/core/OnboardingWizard.tsx` (285 LOC).
+ * Mobile multi-step onboarding wizard (v2).
  *
- * Keeps full parity with the web flow — single-step splash, default
- * "all four modules" selection, empty-picks fallback in `finish()` —
- * and reuses the shared pure domain (`@sergeant/shared/lib/onboarding`
- * + `vibePicks` + `firstRealEntry`) so both platforms cannot drift on
- * key constants, chip taxonomy or done-flag rules.
+ * 3 steps: Welcome → Module selection → Goal-setting → Hub.
+ *
+ * Keeps full parity with the web flow and reuses the shared pure domain
+ * (`@sergeant/shared/lib/onboarding` + `vibePicks` + `onboardingGoals`)
+ * so both platforms cannot drift on key constants, step taxonomy or
+ * done-flag rules.
  *
  * Platform-specific behaviour:
- *  - Haptics via the shared adapter (`expo-haptics` registered in
- *    `apps/mobile/app/_layout.tsx`): `tap` on chip toggle, `success`
- *    on finish. Calls are no-ops when the user has Reduce Motion on
- *    AND the platform is iOS (haptics follow Reduce Motion there).
+ *  - Haptics via the shared adapter (`expo-haptics`): `tap` on chip
+ *    toggle, `success` on finish.
  *  - Respects `AccessibilityInfo.isReduceMotionEnabled()` for the
- *    enter animation: when motion is reduced the card fades in
- *    instantly; otherwise it uses RN's default modal slide-up.
- *  - Progress is persisted through the shared `KVStore` adapter that
- *    wraps the mobile storage helpers (no direct MMKV writes).
- *
- * Wiring: `app/(tabs)/_layout.tsx` checks `shouldShowOnboarding` on
- * mount and renders this wizard full-screen before any tabs paint.
+ *    enter animation.
+ *  - Progress is persisted through the shared `KVStore` adapter.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import {
   AccessibilityInfo,
   Modal,
+  Pressable,
   SafeAreaView,
   Text,
   View,
@@ -34,13 +29,23 @@ import {
 import {
   ALL_MODULES,
   buildFinalPicks,
+  DASHBOARD_MODULE_LABELS,
   hapticSuccess,
+  hapticTap,
   markFirstActionPending,
   markFirstActionStartedAt,
   markOnboardingDone,
+  ONBOARDING_MODULE_DESCRIPTIONS,
+  ONBOARDING_STEPS,
+  ONBOARDING_VIBE_TEASERS,
   saveVibePicks,
   type DashboardModuleId,
   type KVStore,
+  type OnboardingStepId,
+  EMPTY_GOALS,
+  getGoalQuestions,
+  saveOnboardingGoals,
+  type OnboardingGoals,
 } from "@sergeant/shared";
 
 import {
@@ -49,14 +54,8 @@ import {
   safeWriteLS as mmkvWrite,
 } from "@/lib/storage";
 
-import { SplashStep } from "./onboarding/SplashStep";
+import { Button } from "@/components/ui/Button";
 
-/**
- * Mobile `KVStore` adapter backed by the shared MMKV helpers. Mirrors
- * the pattern already used in `core/dashboard/SoftAuthPromptCard.tsx`
- * so every shared helper on mobile talks to the same underlying
- * `sergeant.mobile.v1` instance.
- */
 const mmkvStore: KVStore = {
   getString(key) {
     try {
@@ -83,11 +82,6 @@ const mmkvStore: KVStore = {
   },
 };
 
-/**
- * Exported for callers that need to talk to onboarding KV state from
- * the same adapter without touching MMKV directly (e.g. the tab
- * layout that reads `shouldShowOnboarding` on mount).
- */
 export function getOnboardingStore(): KVStore {
   return mmkvStore;
 }
@@ -98,25 +92,64 @@ export interface OnboardingFinishOptions {
 }
 
 export interface OnboardingWizardProps {
-  /**
-   * Called after `saveVibePicks` + `markFirstActionStartedAt` +
-   * `markFirstActionPending` + `markOnboardingDone` all fire.
-   * Matches the web signature: first arg is a `startModuleId` which
-   * is always `null` from the splash path, second arg carries the
-   * intent + normalised picks.
-   */
   onDone: (
     startModuleId: DashboardModuleId | null,
     opts: OnboardingFinishOptions,
   ) => void;
-  /**
-   * "modal" wraps the splash in an RN `Modal` that covers the tab
-   * bar; "fullPage" drops the Modal chrome so a parent route can
-   * own the frame (e.g. a future `/welcome` screen). Defaults to
-   * `modal` so callers get the same behaviour as the web OnboardingWizard.
-   */
   variant?: "modal" | "fullPage";
 }
+
+// ---------------------------------------------------------------------------
+// Wizard state
+// ---------------------------------------------------------------------------
+
+interface WizardState {
+  step: OnboardingStepId;
+  picks: DashboardModuleId[];
+  goals: OnboardingGoals;
+}
+
+type WizardAction =
+  | { type: "NEXT" }
+  | { type: "BACK" }
+  | { type: "TOGGLE_PICK"; id: DashboardModuleId }
+  | { type: "SET_GOAL"; key: keyof OnboardingGoals; value: unknown };
+
+function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "NEXT": {
+      const idx = ONBOARDING_STEPS.indexOf(state.step);
+      if (idx < ONBOARDING_STEPS.length - 1) {
+        return { ...state, step: ONBOARDING_STEPS[idx + 1] };
+      }
+      return state;
+    }
+    case "BACK": {
+      const idx = ONBOARDING_STEPS.indexOf(state.step);
+      if (idx > 0) {
+        return { ...state, step: ONBOARDING_STEPS[idx - 1] };
+      }
+      return state;
+    }
+    case "TOGGLE_PICK": {
+      const picks = state.picks.includes(action.id)
+        ? state.picks.filter((p) => p !== action.id)
+        : [...state.picks, action.id];
+      return { ...state, picks };
+    }
+    case "SET_GOAL":
+      return {
+        ...state,
+        goals: { ...state.goals, [action.key]: action.value },
+      };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function useReduceMotion(): boolean {
   const [reduceMotion, setReduceMotion] = useState(false);
@@ -126,9 +159,7 @@ function useReduceMotion(): boolean {
       .then((enabled) => {
         if (mounted) setReduceMotion(enabled);
       })
-      .catch(() => {
-        /* unsupported — default to motion-on */
-      });
+      .catch(() => {});
     const sub = AccessibilityInfo.addEventListener(
       "reduceMotionChanged",
       (enabled) => setReduceMotion(enabled),
@@ -141,39 +172,355 @@ function useReduceMotion(): boolean {
   return reduceMotion;
 }
 
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+const CHIP_GLYPH: Record<DashboardModuleId, string> = {
+  finyk: "💰",
+  fizruk: "🏋",
+  routine: "✅",
+  nutrition: "🍽",
+};
+
+// ---------------------------------------------------------------------------
+// Step indicator
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current, total }: { current: number; total: number }) {
+  return (
+    <View className="flex-row items-center justify-center gap-1.5">
+      {Array.from({ length: total }, (_, i) => (
+        <View
+          key={i}
+          className={cx(
+            "rounded-full",
+            i === current
+              ? "h-1.5 w-6 bg-brand-500"
+              : "h-1.5 w-1.5 bg-stone-300",
+          )}
+        />
+      ))}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Welcome
+// ---------------------------------------------------------------------------
+
+function WelcomeStep({ onContinue }: { onContinue: () => void }) {
+  return (
+    <View className="items-center gap-5">
+      <View className="h-20 w-20 items-center justify-center rounded-3xl bg-brand-500/10">
+        <Text className="text-4xl">✨</Text>
+      </View>
+      <View className="items-center gap-2">
+        <Text className="text-center text-2xl font-bold text-stone-900">
+          Привіт. Це Sergeant.
+        </Text>
+        <Text className="text-center text-sm leading-relaxed text-stone-500">
+          Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.
+        </Text>
+      </View>
+      <View className="flex-row items-center gap-3">
+        <Text className="text-xs text-stone-400">📶 Офлайн</Text>
+        <Text className="text-xs text-stone-400">🔒 Локально</Text>
+        <Text className="text-xs text-stone-400">⚡ ~30 сек</Text>
+      </View>
+      <Button
+        variant="primary"
+        size="lg"
+        onPress={onContinue}
+        testID="onboarding-next-welcome"
+        className="w-full"
+      >
+        Далі
+      </Button>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Module selection
+// ---------------------------------------------------------------------------
+
+function ModulesStep({
+  picks,
+  togglePick,
+  onContinue,
+  onBack,
+}: {
+  picks: DashboardModuleId[];
+  togglePick: (id: DashboardModuleId) => void;
+  onContinue: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <View className="items-center gap-4">
+      <View className="items-center gap-1">
+        <Text className="text-center text-xl font-bold text-stone-900">
+          Що тобі важливо?
+        </Text>
+        <Text className="text-center text-xs text-stone-500">
+          Обери модулі — решту легко додати потім.
+        </Text>
+      </View>
+      <View className="w-full gap-2">
+        {ALL_MODULES.map((id) => {
+          const active = picks.includes(id);
+          return (
+            <Pressable
+              key={id}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={DASHBOARD_MODULE_LABELS[id]}
+              testID={`onboarding-module-${id}`}
+              onPress={() => {
+                hapticTap();
+                togglePick(id);
+              }}
+              className={cx(
+                "w-full flex-row items-start gap-3 rounded-2xl border p-3.5",
+                "active:opacity-70",
+                active
+                  ? "border-brand-500/60 bg-brand-500/10"
+                  : "border-cream-300 bg-cream-50",
+              )}
+            >
+              {active && (
+                <View className="absolute right-2.5 top-2.5 h-5 w-5 items-center justify-center rounded-full bg-brand-500">
+                  <Text className="text-xs text-white">✓</Text>
+                </View>
+              )}
+              <View
+                className={cx(
+                  "h-10 w-10 shrink-0 items-center justify-center rounded-xl",
+                  active ? "bg-brand-500/15" : "bg-cream-100",
+                )}
+              >
+                <Text className="text-lg">{CHIP_GLYPH[id]}</Text>
+              </View>
+              <View className="min-w-0 flex-1 pr-4">
+                <Text className="text-sm font-bold leading-tight text-stone-900">
+                  {DASHBOARD_MODULE_LABELS[id]}
+                </Text>
+                <Text className="mt-0.5 text-xs leading-snug text-stone-500">
+                  {ONBOARDING_MODULE_DESCRIPTIONS[id]}
+                </Text>
+                <Text className="mt-1 text-[11px] leading-tight text-stone-400">
+                  {ONBOARDING_VIBE_TEASERS[id]}
+                </Text>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+      <View className="w-full flex-row gap-2">
+        <Pressable
+          onPress={onBack}
+          className="items-center justify-center rounded-xl px-4 py-3 active:opacity-70"
+          testID="onboarding-back-modules"
+        >
+          <Text className="text-sm text-stone-500">←</Text>
+        </Pressable>
+        <Button
+          variant="primary"
+          size="lg"
+          onPress={onContinue}
+          testID="onboarding-next-modules"
+          className="flex-1"
+        >
+          Далі
+        </Button>
+      </View>
+      {picks.length === 0 && (
+        <Text className="text-center text-[11px] text-stone-500">
+          Без вибору — всі 4 модулі.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Goals
+// ---------------------------------------------------------------------------
+
+const GOAL_KEY_MAP: Record<string, keyof OnboardingGoals> = {
+  finyk_budget: "finykBudget",
+  fizruk_weekly: "fizrukWeeklyGoal",
+  routine_first_habit: "routineFirstHabit",
+  nutrition_goal: "nutritionGoal",
+};
+
+function GoalsStep({
+  picks,
+  goals,
+  onSetGoal,
+  onFinish,
+  onBack,
+}: {
+  picks: DashboardModuleId[];
+  goals: OnboardingGoals;
+  onSetGoal: (key: keyof OnboardingGoals, value: unknown) => void;
+  onFinish: () => void;
+  onBack: () => void;
+}) {
+  const questions = useMemo(() => getGoalQuestions(picks), [picks]);
+  const hasQuestions = questions.length > 0;
+
+  return (
+    <View className="items-center gap-4">
+      <View className="items-center gap-1">
+        <Text className="text-center text-xl font-bold text-stone-900">
+          {hasQuestions ? "Твої цілі" : "Готово!"}
+        </Text>
+        <Text className="text-center text-xs text-stone-500">
+          {hasQuestions
+            ? "Необов'язково — можна пропустити."
+            : "Налаштуй деталі потім у кожному модулі."}
+        </Text>
+      </View>
+
+      {hasQuestions && (
+        <View className="w-full gap-4">
+          {questions.map((q) => {
+            const goalKey = GOAL_KEY_MAP[q.id];
+            if (q.type === "radio" && q.options) {
+              const currentVal = (goals[goalKey] as string | null) ?? null;
+              return (
+                <View key={q.id} className="gap-1.5">
+                  <Text className="text-sm font-semibold text-stone-900">
+                    {q.title}
+                  </Text>
+                  <View className="flex-row flex-wrap gap-2">
+                    {q.options.map((opt) => (
+                      <Pressable
+                        key={opt.value}
+                        onPress={() => {
+                          hapticTap();
+                          onSetGoal(
+                            goalKey,
+                            q.id === "fizruk_weekly"
+                              ? Number(opt.value)
+                              : opt.value,
+                          );
+                        }}
+                        className={cx(
+                          "rounded-xl border px-3.5 py-2",
+                          "active:opacity-70",
+                          currentVal === opt.value ||
+                            (q.id === "fizruk_weekly" &&
+                              goals[goalKey] === Number(opt.value))
+                            ? "border-brand-500/60 bg-brand-500/10"
+                            : "border-cream-300 bg-cream-50",
+                        )}
+                      >
+                        <Text className="text-sm font-medium text-stone-900">
+                          {opt.label}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              );
+            }
+            return null;
+          })}
+        </View>
+      )}
+
+      <View className="w-full flex-row gap-2">
+        <Pressable
+          onPress={onBack}
+          className="items-center justify-center rounded-xl px-4 py-3 active:opacity-70"
+          testID="onboarding-back-goals"
+        >
+          <Text className="text-sm text-stone-500">←</Text>
+        </Pressable>
+        <Button
+          variant="primary"
+          size="lg"
+          onPress={onFinish}
+          testID="onboarding-finish"
+          className="flex-1"
+        >
+          Заповни мій хаб
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main wizard
+// ---------------------------------------------------------------------------
+
 export function OnboardingWizard({
   onDone,
   variant = "modal",
 }: OnboardingWizardProps) {
-  // Default to "all four modules active" — matches the web lazy-path:
-  // one tap finishes onboarding with every module visible on the hub.
-  const [picks, setPicks] = useState<DashboardModuleId[]>(() => [
-    ...ALL_MODULES,
-  ]);
+  const [state, dispatch] = useReducer(wizardReducer, {
+    step: "welcome",
+    picks: [...ALL_MODULES],
+    goals: { ...EMPTY_GOALS },
+  });
   const reduceMotion = useReduceMotion();
 
   const togglePick = useCallback((id: DashboardModuleId) => {
-    setPicks((prev) =>
-      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
-    );
+    dispatch({ type: "TOGGLE_PICK", id });
+  }, []);
+
+  const setGoal = useCallback((key: keyof OnboardingGoals, value: unknown) => {
+    dispatch({ type: "SET_GOAL", key, value });
+  }, []);
+
+  const handleNext = useCallback(() => {
+    dispatch({ type: "NEXT" });
+  }, []);
+
+  const handleBack = useCallback(() => {
+    dispatch({ type: "BACK" });
   }, []);
 
   const finish = useCallback(() => {
-    const chosen = buildFinalPicks(picks, ALL_MODULES);
+    const chosen = buildFinalPicks(state.picks, ALL_MODULES);
     saveVibePicks(mmkvStore, chosen);
+    saveOnboardingGoals(mmkvStore, state.goals);
     markFirstActionStartedAt(mmkvStore);
     markFirstActionPending(mmkvStore);
     markOnboardingDone(mmkvStore);
     hapticSuccess();
     onDone(null, { intent: "vibe_empty", picks: chosen });
-  }, [onDone, picks]);
+  }, [onDone, state.picks, state.goals]);
+
+  const stepIdx = ONBOARDING_STEPS.indexOf(state.step);
 
   const content = (
     <View
       testID="onboarding-splash-card"
-      className="w-full max-w-sm rounded-3xl border border-cream-300 bg-cream-50 p-6"
+      className="w-full max-w-sm rounded-3xl border border-cream-300 bg-cream-50 p-6 gap-4"
     >
-      <SplashStep picks={picks} togglePick={togglePick} onContinue={finish} />
+      <StepIndicator current={stepIdx} total={ONBOARDING_STEPS.length} />
+      {state.step === "welcome" && <WelcomeStep onContinue={handleNext} />}
+      {state.step === "modules" && (
+        <ModulesStep
+          picks={state.picks}
+          togglePick={togglePick}
+          onContinue={handleNext}
+          onBack={handleBack}
+        />
+      )}
+      {state.step === "goals" && (
+        <GoalsStep
+          picks={state.picks}
+          goals={state.goals}
+          onSetGoal={setGoal}
+          onFinish={finish}
+          onBack={handleBack}
+        />
+      )}
     </View>
   );
 
@@ -201,8 +548,6 @@ export function OnboardingWizard({
       testID="onboarding-wizard"
     >
       <View className="flex-1 items-center justify-end bg-black/60 p-4">
-        {/* Stretch the card to the sheet-style bottom layout on phones;
-            pb-6 adds a little breathing room above the home indicator. */}
         <View className="w-full max-w-sm pb-6">
           <Text accessibilityRole="header" className="sr-only">
             Вітальний екран

--- a/apps/web/src/core/OnboardingWizard.tsx
+++ b/apps/web/src/core/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
@@ -14,185 +14,573 @@ import {
   shouldShowOnboarding as sharedShouldShowOnboarding,
 } from "./onboarding/onboardingGate.js";
 import { MODULE_LABELS } from "@shared/lib/moduleLabels";
+import {
+  ONBOARDING_MODULE_DESCRIPTIONS,
+  ONBOARDING_STEPS,
+  ONBOARDING_VIBE_ICONS,
+  ONBOARDING_VIBE_TEASERS,
+  type OnboardingStepId,
+} from "@sergeant/shared";
+import {
+  EMPTY_GOALS,
+  getGoalQuestions,
+  saveOnboardingGoals,
+  type GoalQuestion,
+  type OnboardingGoals,
+} from "@sergeant/shared";
 
 // Re-exported so `App.tsx` and any legacy call-site keep importing
-// `shouldShowOnboarding` straight from this file — the thin web
-// adapter in `./onboarding/onboardingGate.ts` holds the real
-// implementation on top of the shared helper.
+// `shouldShowOnboarding` straight from this file.
 export function shouldShowOnboarding() {
   return sharedShouldShowOnboarding();
 }
 
-// Module chips shown inline on the splash — the single source of truth
-// for module taxonomy on this screen. Labels read from `MODULE_LABELS`
-// so цей splash, hub-header і module bottom-nav усі показують одне й те
-// ж бренд-ім'я («Фінік», а не «Гроші»). Раніше splash використовував
-// аспіраційні слова («Гроші / Тіло / Їжа»), а потім модулі — бренд, і
-// користувач не був певен що це одне й те ж. Бренд виграє, бо його й
-// так видно на кожному внутрішньому екрані; аспіраційний опис живе в
-// `teaser` ряду нижче.
-//
-// Keys match `ALL_MODULES` so picks feed straight into `saveVibePicks`.
-const VIBE_CHIPS = [
-  {
-    id: "finyk",
-    icon: "credit-card",
-    label: MODULE_LABELS.finyk,
-    teaser: "−320₴ / тиждень",
-  },
-  {
-    id: "fizruk",
-    icon: "dumbbell",
-    label: MODULE_LABELS.fizruk,
-    teaser: "5 трен. за 14 днів",
-  },
-  {
-    id: "routine",
-    icon: "check",
-    label: MODULE_LABELS.routine,
-    teaser: "стрік «вода» 7 днів",
-  },
-  {
-    id: "nutrition",
-    icon: "utensils",
-    label: MODULE_LABELS.nutrition,
-    teaser: "сніданок · 420 ккал",
-  },
-];
+// ---------------------------------------------------------------------------
+// Wizard state
+// ---------------------------------------------------------------------------
 
-function VibeChipRow({ picks, togglePick }) {
+interface WizardState {
+  step: OnboardingStepId;
+  picks: string[];
+  goals: OnboardingGoals;
+  stepStartedAt: number;
+}
+
+type WizardAction =
+  | { type: "NEXT" }
+  | { type: "BACK" }
+  | { type: "TOGGLE_PICK"; id: string }
+  | { type: "SET_GOAL"; key: keyof OnboardingGoals; value: unknown };
+
+function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case "NEXT": {
+      const idx = ONBOARDING_STEPS.indexOf(state.step);
+      if (idx < ONBOARDING_STEPS.length - 1) {
+        return {
+          ...state,
+          step: ONBOARDING_STEPS[idx + 1],
+          stepStartedAt: Date.now(),
+        };
+      }
+      return state;
+    }
+    case "BACK": {
+      const idx = ONBOARDING_STEPS.indexOf(state.step);
+      if (idx > 0) {
+        return {
+          ...state,
+          step: ONBOARDING_STEPS[idx - 1],
+          stepStartedAt: Date.now(),
+        };
+      }
+      return state;
+    }
+    case "TOGGLE_PICK": {
+      const picks = state.picks.includes(action.id)
+        ? state.picks.filter((p) => p !== action.id)
+        : [...state.picks, action.id];
+      return { ...state, picks };
+    }
+    case "SET_GOAL":
+      return {
+        ...state,
+        goals: { ...state.goals, [action.key]: action.value },
+      };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step indicator (3 dots)
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current, total }: { current: number; total: number }) {
   return (
-    <div className="w-full space-y-2">
-      <p className="text-[11px] text-muted text-center">
-        Зніми зайве — решту легко додати потім.
-      </p>
-      <div className="grid grid-cols-2 gap-2">
-        {VIBE_CHIPS.map((chip) => {
-          const active = picks.includes(chip.id);
-          return (
-            <button
-              key={chip.id}
-              type="button"
-              onClick={() => togglePick(chip.id)}
-              aria-pressed={active}
-              className={cn(
-                "flex items-center gap-2.5 px-3 py-2.5 rounded-xl border text-left transition-[background-color,border-color,color,opacity]",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
-                active
-                  ? "border-brand-500/60 bg-brand-500/10 text-text shadow-card"
-                  : "border-line bg-panel text-muted hover:border-brand-500/40",
-              )}
-            >
-              <span
-                className={cn(
-                  "shrink-0 w-8 h-8 rounded-lg flex items-center justify-center",
-                  active
-                    ? "bg-brand-500/15 text-brand-600 dark:text-brand-400"
-                    : "bg-panelHi",
-                )}
-                aria-hidden
-              >
-                <Icon name={chip.icon} size={16} strokeWidth={2} />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block text-sm font-semibold text-text leading-tight truncate">
-                  {chip.label}
-                </span>
-                <span className="block text-[11px] text-muted leading-tight truncate">
-                  {chip.teaser}
-                </span>
-              </span>
-            </button>
-          );
-        })}
-      </div>
+    <div className="flex items-center justify-center gap-1.5" aria-hidden>
+      {Array.from({ length: total }, (_, i) => (
+        <span
+          key={i}
+          className={cn(
+            "rounded-full transition-all duration-300",
+            i === current
+              ? "w-6 h-1.5 bg-brand-500"
+              : "w-1.5 h-1.5 bg-muted/30",
+          )}
+        />
+      ))}
     </div>
   );
 }
 
-// Single-step splash. Value prop, static preview and the vibe picker live
-// in the same view so the user spends one screen — not two — before they
-// see their populated hub. CTA stays enabled only while at least one
-// module is picked; all four default to active so the lazy path is
-// "tap → done".
-function SplashStep({ picks, togglePick, onContinue }) {
-  // Zero-picks used to disable the CTA. That gate punished users who deselected
-  // every chip to see what happens — `finish()` already falls back to
-  // ALL_MODULES, so we let the tap through and surface a gentle hint instead.
-  const hasPicks = picks.length > 0;
+// ---------------------------------------------------------------------------
+// Step 1: Welcome
+// ---------------------------------------------------------------------------
+
+function WelcomeStep({ onContinue }: { onContinue: () => void }) {
   return (
-    <div className="flex flex-col items-center text-center space-y-5">
+    <div className="flex flex-col items-center text-center space-y-6">
       <div className="w-20 h-20 rounded-3xl bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center">
         <Icon name="sparkle" size={40} strokeWidth={1.8} aria-hidden />
       </div>
-      <div>
-        <h2 className="text-2xl font-bold text-text">
-          Твоє життя — один екран.
-        </h2>
-        <p className="text-sm text-muted mt-2 leading-relaxed">
-          Гроші, тіло, звички, їжа. Офлайн. ~5 секунд на перший запис.
+      <div className="space-y-2">
+        <h2 className="text-2xl font-bold text-text">Привіт. Це Sergeant.</h2>
+        <p className="text-sm text-muted leading-relaxed max-w-xs mx-auto">
+          Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно. Через
+          хвилину побачиш свій хаб.
         </p>
       </div>
-      <VibeChipRow picks={picks} togglePick={togglePick} />
+      <div className="flex items-center gap-3 text-xs text-muted">
+        <span className="flex items-center gap-1">
+          <Icon name="wifi-off" size={14} aria-hidden />
+          Офлайн
+        </span>
+        <span className="flex items-center gap-1">
+          <Icon name="lock" size={14} aria-hidden />
+          Локально
+        </span>
+        <span className="flex items-center gap-1">
+          <Icon name="zap" size={14} aria-hidden />
+          ~30 сек
+        </span>
+      </div>
+      <Button
+        type="button"
+        onClick={onContinue}
+        variant="primary"
+        size="lg"
+        className="w-full"
+      >
+        Далі
+        <Icon name="chevron-right" size={16} />
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Module selection (ModuleCards)
+// ---------------------------------------------------------------------------
+
+const MODULE_CARDS = ALL_MODULES.map((id) => ({
+  id,
+  icon: ONBOARDING_VIBE_ICONS[id],
+  label: MODULE_LABELS[id],
+  teaser: ONBOARDING_VIBE_TEASERS[id],
+  description: ONBOARDING_MODULE_DESCRIPTIONS[id],
+}));
+
+function ModuleCard({
+  card,
+  active,
+  onToggle,
+}: {
+  card: (typeof MODULE_CARDS)[number];
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={cn(
+        "relative w-full text-left p-3.5 rounded-2xl border transition-all duration-200",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+        active
+          ? "border-brand-500/60 bg-brand-500/8 shadow-card"
+          : "border-line bg-panel hover:border-brand-500/30",
+      )}
+    >
+      {active && (
+        <span className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-500 text-white flex items-center justify-center">
+          <Icon name="check" size={12} strokeWidth={3} />
+        </span>
+      )}
+      <div className="flex items-start gap-3">
+        <span
+          className={cn(
+            "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
+            active
+              ? "bg-brand-500/15 text-brand-600 dark:text-brand-400"
+              : "bg-panelHi text-muted",
+          )}
+          aria-hidden
+        >
+          <Icon name={card.icon} size={20} strokeWidth={2} />
+        </span>
+        <div className="min-w-0 flex-1 pr-4">
+          <span className="block text-sm font-bold text-text leading-tight">
+            {card.label}
+          </span>
+          <span className="block text-xs text-muted mt-0.5 leading-snug">
+            {card.description}
+          </span>
+          <span className="block text-[11px] text-subtle mt-1 leading-tight">
+            {card.teaser}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function ModulesStep({
+  picks,
+  togglePick,
+  onContinue,
+  onBack,
+}: {
+  picks: string[];
+  togglePick: (id: string) => void;
+  onContinue: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center text-center space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-xl font-bold text-text">Що тобі важливо?</h2>
+        <p className="text-xs text-muted">
+          Обери модулі — решту легко додати потім.
+        </p>
+      </div>
       <div className="w-full space-y-2">
+        {MODULE_CARDS.map((card) => (
+          <ModuleCard
+            key={card.id}
+            card={card}
+            active={picks.includes(card.id)}
+            onToggle={() => togglePick(card.id)}
+          />
+        ))}
+      </div>
+      <div className="w-full flex gap-2">
+        <Button
+          type="button"
+          onClick={onBack}
+          variant="ghost"
+          size="lg"
+          className="w-auto px-4"
+        >
+          <Icon name="chevron-left" size={16} />
+        </Button>
         <Button
           type="button"
           onClick={onContinue}
           variant="primary"
           size="lg"
-          className="w-full"
+          className="flex-1"
         >
-          Заповни мій хаб
+          Далі
           <Icon name="chevron-right" size={16} />
         </Button>
-        {!hasPicks && (
-          <p className="text-[11px] text-muted">
-            Без вибору — всі 4 модулі. Налаштуєш потім.
-          </p>
-        )}
       </div>
-      <p className="text-[11px] text-subtle leading-relaxed">
-        Усе локально. Синхрон — коли сам захочеш.
-      </p>
+      {picks.length === 0 && (
+        <p className="text-[11px] text-muted">Без вибору — всі 4 модулі.</p>
+      )}
     </div>
   );
 }
 
-/**
- * Onboarding splash. Renders the same single-step content either as a
- * modal overlay (default, for legacy callers) or inline inside a larger
- * layout when a parent already owns the page chrome.
- *
- * The `fullPage` variant is used by the `/welcome` route so the splash
- * becomes a URL-addressable cold-start surface with the populated hub
- * peeking through behind it, instead of a dialog that hovers over an
- * empty page.
- *
- * @param {object} props
- * @param {(startModuleId: string | null, opts?: { intent: string, picks: string[] }) => void} props.onDone
- * @param {"modal" | "fullPage"} [props.variant="modal"]
- */
-export function OnboardingWizard({ onDone, variant = "modal" }) {
-  // Single-step flow: default to "all four modules active" so the lazy
-  // path is one tap. The vibe picker is still a real choice — motivated
-  // users can deselect what they don't want before tapping the primary
-  // CTA. Previously the default was `[]`, which forced every user through
-  // an explicit-selection gate and added ~6 s to the time-to-value.
-  const [picks, setPicks] = useState(() => [...ALL_MODULES]);
+// ---------------------------------------------------------------------------
+// Step 3: Goal-setting
+// ---------------------------------------------------------------------------
 
+function GoalRadioGroup({
+  question,
+  value,
+  onChange,
+}: {
+  question: GoalQuestion;
+  value: string | null;
+  onChange: (v: string) => void;
+}) {
+  if (!question.options) return null;
+  return (
+    <div className="space-y-1.5">
+      <p className="text-sm font-semibold text-text text-left">
+        {question.title}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {question.options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "px-3.5 py-2 rounded-xl border text-sm font-medium transition-all duration-150",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+              value === opt.value
+                ? "border-brand-500/60 bg-brand-500/10 text-brand-700 dark:text-brand-300"
+                : "border-line bg-panel text-text hover:border-brand-500/30",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GoalSlider({
+  question,
+  value,
+  onChange,
+}: {
+  question: GoalQuestion;
+  value: number | null;
+  onChange: (v: number) => void;
+}) {
+  const s = question.slider;
+  if (!s) return null;
+  const current = value ?? Math.round((s.min + s.max) / 2);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between">
+        <p className="text-sm font-semibold text-text text-left">
+          {question.title}
+        </p>
+        <span className="text-sm font-bold text-brand-600 dark:text-brand-400 tabular-nums">
+          {current.toLocaleString("uk-UA")}
+          {s.unit}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={s.min}
+        max={s.max}
+        step={s.step}
+        value={current}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-brand-500"
+      />
+      <div className="flex justify-between text-[11px] text-muted">
+        <span>
+          {s.min.toLocaleString("uk-UA")}
+          {s.unit}
+        </span>
+        <span>
+          {s.max.toLocaleString("uk-UA")}
+          {s.unit}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** Map question id → OnboardingGoals key. */
+const GOAL_KEY_MAP: Record<string, keyof OnboardingGoals> = {
+  finyk_budget: "finykBudget",
+  fizruk_weekly: "fizrukWeeklyGoal",
+  routine_first_habit: "routineFirstHabit",
+  nutrition_goal: "nutritionGoal",
+};
+
+function GoalsStep({
+  picks,
+  goals,
+  onSetGoal,
+  onFinish,
+  onBack,
+}: {
+  picks: string[];
+  goals: OnboardingGoals;
+  onSetGoal: (key: keyof OnboardingGoals, value: unknown) => void;
+  onFinish: () => void;
+  onBack: () => void;
+}) {
+  const questions = useMemo(() => getGoalQuestions(picks as never[]), [picks]);
+  const hasQuestions = questions.length > 0;
+
+  return (
+    <div className="flex flex-col items-center text-center space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-xl font-bold text-text">
+          {hasQuestions ? "Твої цілі" : "Готово!"}
+        </h2>
+        <p className="text-xs text-muted">
+          {hasQuestions
+            ? "Необов'язково — можна пропустити."
+            : "Налаштуй деталі потім у кожному модулі."}
+        </p>
+      </div>
+
+      {hasQuestions && (
+        <div className="w-full space-y-4 text-left">
+          {questions.map((q) => {
+            const goalKey = GOAL_KEY_MAP[q.id];
+            if (q.type === "radio") {
+              return (
+                <GoalRadioGroup
+                  key={q.id}
+                  question={q}
+                  value={(goals[goalKey] as string | null) ?? null}
+                  onChange={(v) => {
+                    onSetGoal(
+                      goalKey,
+                      q.id === "fizruk_weekly" ? Number(v) : v,
+                    );
+                    trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
+                      module: q.module,
+                      goalType: q.id,
+                      value: v,
+                    });
+                  }}
+                />
+              );
+            }
+            return (
+              <GoalSlider
+                key={q.id}
+                question={q}
+                value={(goals[goalKey] as number | null) ?? null}
+                onChange={(v) => {
+                  onSetGoal(goalKey, v);
+                  trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
+                    module: q.module,
+                    goalType: q.id,
+                    value: v,
+                  });
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <div className="w-full flex gap-2">
+        <Button
+          type="button"
+          onClick={onBack}
+          variant="ghost"
+          size="lg"
+          className="w-auto px-4"
+        >
+          <Icon name="chevron-left" size={16} />
+        </Button>
+        <Button
+          type="button"
+          onClick={onFinish}
+          variant="primary"
+          size="lg"
+          className="flex-1"
+        >
+          Заповни мій хаб
+          <Icon name="chevron-right" size={16} />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main wizard
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-step onboarding wizard (v2).
+ *
+ * 3 steps: Welcome → Module selection → Goal-setting → Hub.
+ *
+ * Renders as a modal overlay (default) or inline card (`fullPage`
+ * variant) inside the `/welcome` route.
+ */
+export function OnboardingWizard({
+  onDone,
+  variant = "modal",
+}: {
+  onDone: (
+    startModuleId: string | null,
+    opts?: { intent: string; picks: string[] },
+  ) => void;
+  variant?: "modal" | "fullPage";
+}) {
+  const [state, dispatch] = useReducer(wizardReducer, {
+    step: "welcome",
+    picks: [...ALL_MODULES],
+    goals: { ...EMPTY_GOALS },
+    stepStartedAt: Date.now(),
+  });
+
+  // Track wizard start
   useEffect(() => {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "welcome" });
   }, []);
 
-  const togglePick = (id) => {
-    setPicks((prev) =>
-      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
-    );
-  };
+  // Track step views
+  const trackStepTransition = useCallback(
+    (fromStep: OnboardingStepId, toStep: OnboardingStepId) => {
+      const duration = Date.now() - state.stepStartedAt;
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+        step: fromStep,
+        durationMs: duration,
+      });
+      trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: toStep });
+    },
+    [state.stepStartedAt],
+  );
 
-  const finish = () => {
-    const chosen = picks.length > 0 ? picks : [...ALL_MODULES];
-    saveVibePicks(chosen);
+  const handleNext = useCallback(() => {
+    const idx = ONBOARDING_STEPS.indexOf(state.step);
+    if (idx < ONBOARDING_STEPS.length - 1) {
+      trackStepTransition(state.step, ONBOARDING_STEPS[idx + 1]);
+    }
+    dispatch({ type: "NEXT" });
+  }, [state.step, trackStepTransition]);
+
+  const handleBack = useCallback(() => {
+    dispatch({ type: "BACK" });
+  }, []);
+
+  const togglePick = useCallback((id: string) => {
+    dispatch({ type: "TOGGLE_PICK", id });
+  }, []);
+
+  const setGoal = useCallback((key: keyof OnboardingGoals, value: unknown) => {
+    dispatch({ type: "SET_GOAL", key, value });
+  }, []);
+
+  const finish = useCallback(() => {
+    const chosen = state.picks.length > 0 ? state.picks : [...ALL_MODULES];
+    saveVibePicks(chosen as never[]);
+
+    // Persist goals
+    saveOnboardingGoals(
+      {
+        getString: (k) => {
+          try {
+            return localStorage.getItem(k);
+          } catch {
+            return null;
+          }
+        },
+        setString: (k, v) => {
+          try {
+            localStorage.setItem(k, v);
+          } catch {
+            /* noop */
+          }
+        },
+        remove: (k) => {
+          try {
+            localStorage.removeItem(k);
+          } catch {
+            /* noop */
+          }
+        },
+      },
+      state.goals,
+    );
+
+    // Track completion
+    const duration = Date.now() - state.stepStartedAt;
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+      step: "goals",
+      durationMs: duration,
+    });
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_VIBE_PICKED, {
       picks: chosen,
       picksCount: chosen.length,
@@ -200,28 +588,45 @@ export function OnboardingWizard({ onDone, variant = "modal" }) {
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
       intent: "vibe_empty",
       picksCount: chosen.length,
+      hasGoals: Object.values(state.goals).some((v) => v !== null),
     });
+
     markFirstActionStartedAt();
     markFirstActionPending();
     markOnboardingDone();
-    // Stay on the hub dashboard — the FirstActionHeroCard appears on top
-    // of the empty module rows a tick later via the
-    // `first_action_pending` flag and walks the user to their first real
-    // entry (no more fake demo numbers on fresh accounts).
     onDone(null, { intent: "vibe_empty", picks: chosen });
-  };
+  }, [state.picks, state.goals, state.stepStartedAt, onDone]);
+
+  const stepIdx = ONBOARDING_STEPS.indexOf(state.step);
 
   const content = (
-    <SplashStep picks={picks} togglePick={togglePick} onContinue={finish} />
+    <div className="space-y-4">
+      <StepIndicator current={stepIdx} total={ONBOARDING_STEPS.length} />
+      {state.step === "welcome" && <WelcomeStep onContinue={handleNext} />}
+      {state.step === "modules" && (
+        <ModulesStep
+          picks={state.picks}
+          togglePick={togglePick}
+          onContinue={handleNext}
+          onBack={handleBack}
+        />
+      )}
+      {state.step === "goals" && (
+        <GoalsStep
+          picks={state.picks}
+          goals={state.goals}
+          onSetGoal={setGoal}
+          onFinish={finish}
+          onBack={handleBack}
+        />
+      )}
+    </div>
   );
 
   if (variant === "fullPage") {
-    // Parent (`WelcomeScreen`) owns the full-page frame + peek backdrop.
-    // We render just the card so the splash can share the same viewport
-    // with a blurred hub preview without a modal dialog wrapper.
     return (
       <div
-        className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-5 animate-onboarding-enter"
+        className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 animate-onboarding-enter"
         aria-label="Вітальний екран"
       >
         {content}
@@ -237,7 +642,7 @@ export function OnboardingWizard({ onDone, variant = "modal" }) {
       aria-label="Вітальний екран"
     >
       <div className="absolute inset-0 bg-bg/80 backdrop-blur-md" />
-      <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 space-y-5 animate-onboarding-enter">
+      <div className="relative w-full max-w-sm bg-panel border border-line rounded-3xl shadow-float p-6 animate-onboarding-enter">
         {content}
       </div>
     </div>

--- a/apps/web/src/core/onboarding/FirstActionSheet.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.tsx
@@ -6,6 +6,31 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
 import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
 import { PresetSheet, getPresetModule } from "./PresetSheet.jsx";
+import { getOnboardingGoals } from "@sergeant/shared";
+
+const localStorageStore = {
+  getString: (k: string) => {
+    try {
+      return localStorage.getItem(k);
+    } catch {
+      return null;
+    }
+  },
+  setString: (k: string, v: string) => {
+    try {
+      localStorage.setItem(k, v);
+    } catch {
+      /* noop */
+    }
+  },
+  remove: (k: string) => {
+    try {
+      localStorage.removeItem(k);
+    } catch {
+      /* noop */
+    }
+  },
+};
 
 /**
  * Per-module "one tap to your first real entry" copy. Tapping a row
@@ -70,6 +95,39 @@ function pickPrimary(picks) {
  * row now makes the default choice for them (highest-priority pick) and
  * only reveals the alternatives if they tap "Інший модуль".
  */
+/**
+ * Goal-aware contextual descriptions. If the user set a goal during
+ * onboarding, the first-action card reflects it, making the CTA feel
+ * more personal than the generic static copy.
+ */
+function getGoalAwareDesc(moduleId: string, fallback: string): string {
+  const goals = getOnboardingGoals(localStorageStore);
+  if (moduleId === "finyk" && goals.finykBudget) {
+    return `Встанови бюджет ${goals.finykBudget.toLocaleString("uk-UA")}₴ — додай першу витрату.`;
+  }
+  if (moduleId === "fizruk" && goals.fizrukWeeklyGoal) {
+    return `${goals.fizrukWeeklyGoal}× на тиждень — починай із розминки.`;
+  }
+  if (moduleId === "routine" && goals.routineFirstHabit) {
+    const habitLabels: Record<string, string> = {
+      water: "«Пити воду»",
+      exercise: "«Зарядка»",
+      reading: "«Читання»",
+    };
+    const label = habitLabels[goals.routineFirstHabit] ?? "свою звичку";
+    return `Створи ${label} — стрік почнеться сьогодні.`;
+  }
+  if (moduleId === "nutrition" && goals.nutritionGoal) {
+    const goalLabels: Record<string, string> = {
+      lose: "Схуднути",
+      gain: "Набрати масу",
+      maintain: "Підтримка",
+    };
+    return `${goalLabels[goals.nutritionGoal]} — залогай перший прийом їжі.`;
+  }
+  return fallback;
+}
+
 export function FirstActionHeroCard({ onDismiss }) {
   const picks = useMemo(() => {
     const raw = getVibePicks();
@@ -185,7 +243,7 @@ export function FirstActionHeroCard({ onDismiss }) {
             <div className="min-w-0 flex-1">
               <div className="text-sm font-bold text-text">{primary.title}</div>
               <div className="text-xs text-muted mt-0.5 truncate">
-                {primary.desc}
+                {getGoalAwareDesc(primaryId, primary.desc)}
               </div>
             </div>
             <Icon

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,9 @@ export * from "./lib/vibePicks";
 // Onboarding gate helpers (first-launch detection, done flag, splash taxonomy).
 export * from "./lib/onboarding";
 
+// Onboarding goal-setting (multi-step v2).
+export * from "./lib/onboardingGoals";
+
 // Reset helpers for Settings ("Restart onboarding").
 export * from "./lib/onboardingReset";
 

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -5,10 +5,14 @@
  * names to whatever sink it adopts later without drifting on strings.
  */
 export const ANALYTICS_EVENTS = Object.freeze({
-  // Onboarding splash
+  // Onboarding wizard (multi-step v2)
   ONBOARDING_STARTED: "onboarding_started",
   ONBOARDING_COMPLETED: "onboarding_completed",
   ONBOARDING_VIBE_PICKED: "onboarding_vibe_picked",
+  ONBOARDING_STEP_VIEWED: "onboarding_step_viewed",
+  ONBOARDING_STEP_COMPLETED: "onboarding_step_completed",
+  ONBOARDING_GOAL_SET: "onboarding_goal_set",
+  ONBOARDING_SKIPPED: "onboarding_skipped",
 
   // Finyk / activation
   EXPENSE_ADDED: "expense_added",

--- a/packages/shared/src/lib/onboarding.test.ts
+++ b/packages/shared/src/lib/onboarding.test.ts
@@ -5,6 +5,9 @@ import { createMemoryKVStore } from "./kvStore";
 import {
   ONBOARDING_DONE_KEY,
   ONBOARDING_EXISTING_DATA_SOURCES,
+  ONBOARDING_MODULE_DESCRIPTIONS,
+  ONBOARDING_STEP_COUNT,
+  ONBOARDING_STEPS,
   ONBOARDING_VIBE_CHIP_ORDER,
   ONBOARDING_VIBE_ICONS,
   ONBOARDING_VIBE_TEASERS,
@@ -174,5 +177,23 @@ describe("onboarding — buildFinalPicks", () => {
       "routine",
       "finyk",
     ]);
+  });
+});
+
+describe("onboarding — multi-step v2 types", () => {
+  it("has exactly 3 steps", () => {
+    expect(ONBOARDING_STEP_COUNT).toBe(3);
+    expect(ONBOARDING_STEPS).toHaveLength(3);
+  });
+
+  it("steps are welcome → modules → goals", () => {
+    expect(ONBOARDING_STEPS).toEqual(["welcome", "modules", "goals"]);
+  });
+
+  it("module descriptions cover every module id", () => {
+    for (const id of DASHBOARD_MODULE_IDS) {
+      expect(typeof ONBOARDING_MODULE_DESCRIPTIONS[id]).toBe("string");
+      expect(ONBOARDING_MODULE_DESCRIPTIONS[id].length).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/shared/src/lib/onboarding.ts
+++ b/packages/shared/src/lib/onboarding.ts
@@ -20,6 +20,36 @@ import { type DashboardModuleId, DASHBOARD_MODULE_IDS } from "./dashboard";
 import { readJSON, type KVStore } from "./kvStore";
 import { ALL_MODULES, sanitizePicks } from "./vibePicks";
 
+// ---------------------------------------------------------------------------
+// Multi-step wizard types (v2)
+// ---------------------------------------------------------------------------
+
+/** Wizard step identifiers. */
+export type OnboardingStepId = "welcome" | "modules" | "goals";
+
+/** Total number of wizard steps. */
+export const ONBOARDING_STEP_COUNT = 3 as const;
+
+/** Ordered step sequence rendered by the wizard. */
+export const ONBOARDING_STEPS: readonly OnboardingStepId[] = [
+  "welcome",
+  "modules",
+  "goals",
+];
+
+/**
+ * Module descriptions shown on step 2 (ModuleCards). Longer than the
+ * teaser line — explains what the module *does* rather than a stat
+ * preview.
+ */
+export const ONBOARDING_MODULE_DESCRIPTIONS: Record<DashboardModuleId, string> =
+  {
+    finyk: "Контроль витрат, Monobank-синхронізація, бюджети та тренди",
+    fizruk: "Тренування з таймером, програми, прогрес і виміри тіла",
+    routine: "Звички зі стріками, хітмеп, статистика та нагадування",
+    nutrition: "Фото → AI-аналіз калорій, сканер штрихкодів, денний план",
+  };
+
 /** MMKV / localStorage key used to record that onboarding has finished. */
 export const ONBOARDING_DONE_KEY = "hub_onboarding_done_v1";
 

--- a/packages/shared/src/lib/onboardingGoals.test.ts
+++ b/packages/shared/src/lib/onboardingGoals.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { createMemoryKVStore } from "./kvStore";
+import {
+  EMPTY_GOALS,
+  ONBOARDING_GOALS_KEY,
+  getGoalQuestions,
+  getOnboardingGoals,
+  saveOnboardingGoals,
+  type OnboardingGoals,
+} from "./onboardingGoals";
+
+describe("onboardingGoals — storage", () => {
+  it("returns EMPTY_GOALS from a fresh store", () => {
+    const store = createMemoryKVStore();
+    expect(getOnboardingGoals(store)).toEqual(EMPTY_GOALS);
+  });
+
+  it("round-trips valid goals", () => {
+    const store = createMemoryKVStore();
+    const goals: OnboardingGoals = {
+      finykBudget: 15000,
+      fizrukWeeklyGoal: 3,
+      routineFirstHabit: "water",
+      nutritionGoal: "lose",
+    };
+    saveOnboardingGoals(store, goals);
+    expect(getOnboardingGoals(store)).toEqual(goals);
+  });
+
+  it("normalises invalid values to null", () => {
+    const store = createMemoryKVStore({
+      [ONBOARDING_GOALS_KEY]: JSON.stringify({
+        finykBudget: -100,
+        fizrukWeeklyGoal: 0,
+        routineFirstHabit: "",
+        nutritionGoal: "invalid",
+      }),
+    });
+    expect(getOnboardingGoals(store)).toEqual(EMPTY_GOALS);
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    const store = createMemoryKVStore({
+      [ONBOARDING_GOALS_KEY]: "not-json",
+    });
+    expect(getOnboardingGoals(store)).toEqual(EMPTY_GOALS);
+  });
+
+  it("handles non-object JSON gracefully", () => {
+    const store = createMemoryKVStore({
+      [ONBOARDING_GOALS_KEY]: JSON.stringify("string"),
+    });
+    expect(getOnboardingGoals(store)).toEqual(EMPTY_GOALS);
+  });
+
+  it("accepts valid nutritionGoal values", () => {
+    for (const goal of ["lose", "gain", "maintain"] as const) {
+      const store = createMemoryKVStore();
+      saveOnboardingGoals(store, { ...EMPTY_GOALS, nutritionGoal: goal });
+      expect(getOnboardingGoals(store).nutritionGoal).toBe(goal);
+    }
+  });
+});
+
+describe("onboardingGoals — getGoalQuestions", () => {
+  it("returns no questions for empty picks", () => {
+    expect(getGoalQuestions([])).toEqual([]);
+  });
+
+  it("returns questions ordered by friction priority", () => {
+    const questions = getGoalQuestions([
+      "finyk",
+      "fizruk",
+      "routine",
+      "nutrition",
+    ]);
+    expect(questions[0].module).toBe("routine");
+    expect(questions[1].module).toBe("finyk");
+    expect(questions[2].module).toBe("nutrition");
+  });
+
+  it("caps at maxQuestions", () => {
+    const questions = getGoalQuestions(
+      ["finyk", "fizruk", "routine", "nutrition"],
+      2,
+    );
+    expect(questions).toHaveLength(2);
+  });
+
+  it("only returns questions for picked modules", () => {
+    const questions = getGoalQuestions(["finyk"]);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].module).toBe("finyk");
+  });
+
+  it("includes correct question types", () => {
+    const questions = getGoalQuestions([
+      "finyk",
+      "fizruk",
+      "routine",
+      "nutrition",
+    ]);
+    const finykQ = questions.find((q) => q.module === "finyk");
+    expect(finykQ?.type).toBe("slider");
+    const routineQ = questions.find((q) => q.module === "routine");
+    expect(routineQ?.type).toBe("radio");
+  });
+});

--- a/packages/shared/src/lib/onboardingGoals.ts
+++ b/packages/shared/src/lib/onboardingGoals.ts
@@ -1,0 +1,168 @@
+/**
+ * Onboarding goal-setting — DOM-free helpers.
+ *
+ * Phase 1 of the onboarding v2 rebuild: after the user picks which
+ * modules they care about (vibe picks), we ask 1–2 contextual
+ * questions so the hub starts personalised. The questions, storage
+ * keys and validation rules live here; platform adapters bind them
+ * to the appropriate `KVStore`.
+ *
+ * Each goal question is module-scoped. The wizard renders only
+ * questions for modules the user selected as vibe picks. If
+ * the user skips the goal step, all values stay `null` and the app
+ * falls back to sensible defaults (same as pre-v2 behaviour).
+ */
+
+import type { DashboardModuleId } from "./dashboard";
+import { readJSON, writeJSON, type KVStore } from "./kvStore";
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+export const ONBOARDING_GOALS_KEY = "hub_onboarding_goals_v1";
+
+export interface OnboardingGoals {
+  /** Monthly spending target in UAH (Finyk). */
+  finykBudget: number | null;
+  /** Weekly training target (Fizruk). */
+  fizrukWeeklyGoal: number | null;
+  /** First habit preset id (Routine). */
+  routineFirstHabit: string | null;
+  /** Nutrition objective (Nutrition). */
+  nutritionGoal: "lose" | "gain" | "maintain" | null;
+}
+
+export const EMPTY_GOALS: Readonly<OnboardingGoals> = Object.freeze({
+  finykBudget: null,
+  fizrukWeeklyGoal: null,
+  routineFirstHabit: null,
+  nutritionGoal: null,
+});
+
+export function saveOnboardingGoals(
+  store: KVStore,
+  goals: OnboardingGoals,
+): void {
+  writeJSON(store, ONBOARDING_GOALS_KEY, goals);
+}
+
+export function getOnboardingGoals(store: KVStore): OnboardingGoals {
+  const raw = readJSON<Partial<OnboardingGoals>>(store, ONBOARDING_GOALS_KEY);
+  if (!raw || typeof raw !== "object") return { ...EMPTY_GOALS };
+  return {
+    finykBudget:
+      typeof raw.finykBudget === "number" && raw.finykBudget > 0
+        ? raw.finykBudget
+        : null,
+    fizrukWeeklyGoal:
+      typeof raw.fizrukWeeklyGoal === "number" && raw.fizrukWeeklyGoal > 0
+        ? raw.fizrukWeeklyGoal
+        : null,
+    routineFirstHabit:
+      typeof raw.routineFirstHabit === "string" &&
+      raw.routineFirstHabit.length > 0
+        ? raw.routineFirstHabit
+        : null,
+    nutritionGoal:
+      raw.nutritionGoal === "lose" ||
+      raw.nutritionGoal === "gain" ||
+      raw.nutritionGoal === "maintain"
+        ? raw.nutritionGoal
+        : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Question definitions
+// ---------------------------------------------------------------------------
+
+export type GoalQuestionId =
+  | "finyk_budget"
+  | "fizruk_weekly"
+  | "routine_first_habit"
+  | "nutrition_goal";
+
+export interface GoalQuestionOption {
+  value: string;
+  label: string;
+}
+
+export interface GoalQuestion {
+  id: GoalQuestionId;
+  module: DashboardModuleId;
+  title: string;
+  type: "radio" | "slider";
+  options?: readonly GoalQuestionOption[];
+  /** Slider min/max/step/unit — only for type === "slider". */
+  slider?: { min: number; max: number; step: number; unit: string };
+}
+
+/** Display order: lowest-friction first. */
+const PRIORITY: readonly DashboardModuleId[] = [
+  "routine",
+  "finyk",
+  "nutrition",
+  "fizruk",
+];
+
+const ALL_QUESTIONS: readonly GoalQuestion[] = [
+  {
+    id: "routine_first_habit",
+    module: "routine",
+    title: "Яка звичка перша?",
+    type: "radio",
+    options: [
+      { value: "water", label: "Пити воду" },
+      { value: "exercise", label: "Зарядка" },
+      { value: "reading", label: "Читання" },
+      { value: "custom", label: "Своя" },
+    ],
+  },
+  {
+    id: "finyk_budget",
+    module: "finyk",
+    title: "Скільки хочеш витрачати на місяць?",
+    type: "slider",
+    slider: { min: 5000, max: 50000, step: 1000, unit: "₴" },
+  },
+  {
+    id: "nutrition_goal",
+    module: "nutrition",
+    title: "Яка ціль харчування?",
+    type: "radio",
+    options: [
+      { value: "lose", label: "Схуднути" },
+      { value: "gain", label: "Набрати масу" },
+      { value: "maintain", label: "Підтримка" },
+    ],
+  },
+  {
+    id: "fizruk_weekly",
+    module: "fizruk",
+    title: "Скільки тренувань на тиждень?",
+    type: "radio",
+    options: [
+      { value: "2", label: "2" },
+      { value: "3", label: "3" },
+      { value: "4", label: "4" },
+      { value: "5", label: "5" },
+      { value: "6", label: "6" },
+    ],
+  },
+];
+
+/**
+ * Return questions relevant to the user's module picks, ordered by
+ * friction priority (routine first, fizruk last). Caps at `maxQuestions`
+ * so the wizard never shows more than 2–3 questions.
+ */
+export function getGoalQuestions(
+  picks: readonly DashboardModuleId[],
+  maxQuestions = 3,
+): GoalQuestion[] {
+  const pickSet = new Set(picks);
+  return PRIORITY.filter((m) => pickSet.has(m))
+    .flatMap((m) => ALL_QUESTIONS.filter((q) => q.module === m))
+    .slice(0, maxQuestions);
+}

--- a/packages/shared/src/lib/onboardingReset.ts
+++ b/packages/shared/src/lib/onboardingReset.ts
@@ -7,6 +7,7 @@
  */
 import { type KVStore } from "./kvStore";
 import { clearOnboardingDone } from "./onboarding";
+import { ONBOARDING_GOALS_KEY } from "./onboardingGoals";
 import {
   FIRST_ACTION_PENDING_KEY,
   FIRST_ACTION_STARTED_AT_KEY,
@@ -20,6 +21,7 @@ import { clearAllHintsState } from "./hints";
 export function resetOnboardingState(store: KVStore): void {
   clearOnboardingDone(store);
   store.remove(VIBE_PICKS_KEY);
+  store.remove(ONBOARDING_GOALS_KEY);
   store.remove(FIRST_ACTION_PENDING_KEY);
   store.remove(FIRST_ACTION_STARTED_AT_KEY);
   store.remove(FIRST_REAL_ENTRY_KEY);
@@ -27,4 +29,3 @@ export function resetOnboardingState(store: KVStore): void {
   store.remove(SOFT_AUTH_DISMISSED_KEY);
   clearAllHintsState(store);
 }
-


### PR DESCRIPTION
## Summary

Phase 1 MVP перебудови онбордингу згідно з [планом покращення](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMWQ1MGNhMzRhYjIzNDllNzk0NGMyNWNiNzI1M2ZjOTciLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMWQ1MGNhMzRhYjIzNDllNzk0NGMyNWNiNzI1M2ZjOTcvZWZjOGVlOTgtNjBiMS00MDU4LWE3MGUtYWQ3ZDdlNWU1NWRhIiwiaWF0IjoxNzc3MDYyODMzLCJleHAiOjE3Nzc2Njc2MzMsImZpbGVuYW1lIjoib25ib2FyZGluZy1pbXByb3ZlbWVudC1wbGFuLm1kIn0.ISerU8YYWsPEkj4-CLIm8mRHjbCqYzMRZlggrVnYC1U).

Замість одного splash-екрану тепер **3-кроковий wizard**:

1. **Welcome** — привітання з value prop + значки офлайн/локально/~30 сек
2. **Modules** — ModuleCards (замість маленьких chips) з описом та прев'ю кожного модуля
3. **Goals** — персоналізовані запитання залежно від обраних модулів (бюджет, к-ть тренувань, перша звичка, ціль харчування)

**Shared (`@sergeant/shared`):**
- `onboardingGoals.ts` — types, questions, storage, `getGoalQuestions()`
- `ONBOARDING_STEPS`, `ONBOARDING_MODULE_DESCRIPTIONS`, `OnboardingStepId`
- 4 нових analytics events: `step_viewed`, `step_completed`, `goal_set`, `skipped`
- `onboardingReset` тепер також очищує goals
- 11 нових тестів для goals module + тести для нових step types

**Web:**
- `OnboardingWizard.tsx` — `useReducer`-based 3-step wizard зі StepIndicator
- `FirstActionSheet.tsx` — goal-aware контекстні описи (якщо юзер встановив бюджет → desc адаптується)

**Mobile:**
- Повна парність з web: 3-step wizard, ModuleCards з emoji, goal-setting з haptic feedback

## Review & Testing Checklist for Human

- [ ] **Перевірити wizard flow на web**: скинути онбординг (Налаштування → Перезапустити онбординг), пройти всі 3 кроки, переконатись що goals зберігаються і FirstActionHeroCard показує goal-aware copy
- [ ] **Перевірити mobile wizard**: запустити на емуляторі/девайсі, пройти 3 кроки, переконатись що haptics спрацьовують і goals зберігаються через MMKV
- [ ] **Перевірити back navigation**: кнопка «назад» на кожному кроці повертає на попередній крок зі збереженням стану
- [ ] **Перевірити skip flow**: пропустити goals крок → переконатись що fallback до default поведінки працює коректно
- [ ] **Перевірити analytics**: в console/network переконатись що `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_goal_set` трекаються

### Notes
- Старі `SplashStep.tsx` і `VibeChipRow.tsx` на mobile залишились як мертвий код — можна прибрати в окремому cleanup PR
- Goals slider (finyk budget) на mobile не імплементований (тільки radio questions) — доробити в Phase 2
- Все shared-first: логіка в `packages/shared`, platform adapters мінімальні

Link to Devin session: https://app.devin.ai/sessions/2feca57444f041838580e262936bb013
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
