### PR TITLE
feat(onboarding): Phase 2 — module checklists, celebrations, permissions

### DIFF
--- a/apps/mobile/src/core/OnboardingWizard.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.tsx
@@ -426,6 +426,46 @@ function GoalsStep({
                 </View>
               );
             }
+            if (q.type === "slider" && q.slider) {
+              const currentNum = (goals[goalKey] as number | null) ?? null;
+              const s = q.slider;
+              const presets = [
+                s.min,
+                Math.round((s.min + s.max) / 3),
+                Math.round(((s.min + s.max) * 2) / 3),
+                s.max,
+              ];
+              return (
+                <View key={q.id} className="gap-1.5">
+                  <Text className="text-sm font-semibold text-stone-900">
+                    {q.title}
+                  </Text>
+                  <View className="flex-row flex-wrap gap-2">
+                    {presets.map((preset) => (
+                      <Pressable
+                        key={preset}
+                        onPress={() => {
+                          hapticTap();
+                          onSetGoal(goalKey, preset);
+                        }}
+                        className={cx(
+                          "rounded-xl border px-3.5 py-2",
+                          "active:opacity-70",
+                          currentNum === preset
+                            ? "border-brand-500/60 bg-brand-500/10"
+                            : "border-cream-300 bg-cream-50",
+                        )}
+                      >
+                        <Text className="text-sm font-medium text-stone-900">
+                          {preset.toLocaleString("uk-UA")}
+                          {s.unit ? ` ${s.unit}` : ""}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              );
+            }
             return null;
           })}
         </View>

--- a/apps/mobile/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/mobile/src/core/onboarding/ModuleChecklist.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import {
+  MODULE_CHECKLISTS,
+  getChecklistState,
+  markChecklistStepDone,
+  markChecklistSeen,
+  dismissChecklist,
+  isChecklistVisible,
+  type DashboardModuleId,
+  type KVStore,
+  hapticTap,
+} from "@sergeant/shared";
+
+import {
+  safeReadLS as mmkvGet,
+  safeRemoveLS as mmkvRemove,
+  safeWriteLS as mmkvWrite,
+} from "@/lib/storage";
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+const mmkvStore: KVStore = {
+  getString(key) {
+    try {
+      return mmkvGet(key) ?? null;
+    } catch {
+      return null;
+    }
+  },
+  setString(key, value) {
+    try {
+      mmkvWrite(key, value);
+    } catch {
+      /* noop */
+    }
+  },
+  remove(key) {
+    try {
+      mmkvRemove(key);
+    } catch {
+      /* noop */
+    }
+  },
+};
+
+export function ModuleChecklist({
+  moduleId,
+  onAction,
+}: {
+  moduleId: DashboardModuleId;
+  onAction?: (action: string) => void;
+}) {
+  const [visible, setVisible] = useState(() =>
+    isChecklistVisible(mmkvStore, moduleId),
+  );
+  const [state, setState] = useState(() =>
+    getChecklistState(mmkvStore, moduleId),
+  );
+
+  const def = MODULE_CHECKLISTS[moduleId];
+  const completed = useMemo(
+    () =>
+      state.completedSteps.filter((s) =>
+        def.steps.some((step) => step.id === s),
+      ).length,
+    [state.completedSteps, def.steps],
+  );
+  const total = def.steps.length;
+
+  useEffect(() => {
+    if (!visible) return;
+    markChecklistSeen(mmkvStore, moduleId);
+  }, [visible, moduleId]);
+
+  const handleStepDone = useCallback(
+    (stepId: string) => {
+      hapticTap();
+      const next = markChecklistStepDone(mmkvStore, moduleId, stepId);
+      setState(next);
+      if (next.completedSteps.length >= def.steps.length) {
+        setVisible(false);
+      }
+    },
+    [moduleId, def.steps.length],
+  );
+
+  const handleDismiss = useCallback(() => {
+    dismissChecklist(mmkvStore, moduleId);
+    setVisible(false);
+  }, [moduleId]);
+
+  if (!visible) return null;
+
+  return (
+    <View className="rounded-2xl border border-cream-200 bg-cream-50 p-4">
+      <View className="mb-3 flex-row items-center justify-between">
+        <Text className="text-sm font-bold text-stone-900">
+          {def.title}{" "}
+          <Text className="text-xs font-normal text-stone-400">
+            ({completed}/{total})
+          </Text>
+        </Text>
+        <Pressable
+          onPress={handleDismiss}
+          hitSlop={12}
+          accessibilityLabel="Сховати чекліст"
+        >
+          <Text className="text-xs text-stone-400">✕</Text>
+        </Pressable>
+      </View>
+
+      <View className="gap-1.5">
+        {def.steps.map((step) => {
+          const done = state.completedSteps.includes(step.id);
+          return (
+            <Pressable
+              key={step.id}
+              onPress={() => {
+                if (!done) {
+                  handleStepDone(step.id);
+                  if (step.action) onAction?.(step.action);
+                }
+              }}
+              disabled={done}
+              className={cx(
+                "flex-row items-center gap-2.5 rounded-xl px-3 py-2",
+                !done && "active:opacity-70",
+              )}
+            >
+              <View
+                className={cx(
+                  "h-5 w-5 items-center justify-center rounded-full border",
+                  done
+                    ? "border-brand-500 bg-brand-500"
+                    : "border-cream-300 bg-white",
+                )}
+              >
+                {done && (
+                  <Text className="text-[10px] font-bold text-white">✓</Text>
+                )}
+              </View>
+              <Text
+                className={cx(
+                  "flex-1 text-sm",
+                  done ? "text-stone-400 line-through" : "text-stone-900",
+                )}
+              >
+                {step.label}
+              </Text>
+              {!done && step.action && (
+                <Text className="text-xs text-stone-400">›</Text>
+              )}
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/apps/web/src/core/OnboardingWizard.tsx
+++ b/apps/web/src/core/OnboardingWizard.tsx
@@ -418,10 +418,7 @@ function GoalsStep({
                   question={q}
                   value={(goals[goalKey] as string | null) ?? null}
                   onChange={(v) => {
-                    onSetGoal(
-                      goalKey,
-                      q.id === "fizruk_weekly" ? Number(v) : v,
-                    );
+                    onSetGoal(goalKey, v);
                     trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
                       module: q.module,
                       goalType: q.id,
@@ -572,7 +569,12 @@ export function OnboardingWizard({
           }
         },
       },
-      state.goals,
+      {
+        ...state.goals,
+        fizrukWeeklyGoal: state.goals.fizrukWeeklyGoal
+          ? Number(state.goals.fizrukWeeklyGoal)
+          : null,
+      },
     );
 
     // Track completion

--- a/apps/web/src/core/onboarding/CelebrationOverlay.tsx
+++ b/apps/web/src/core/onboarding/CelebrationOverlay.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import { getTimeToValueMs } from "./vibePicks.js";
+
+/**
+ * Confetti particle rendered by the celebration overlay.
+ * Uses CSS keyframes for falling animation — no external lib needed.
+ */
+function ConfettiParticle({ delay, left }: { delay: number; left: number }) {
+  const colors = [
+    "bg-brand-500",
+    "bg-yellow-400",
+    "bg-emerald-400",
+    "bg-rose-400",
+    "bg-sky-400",
+    "bg-purple-400",
+  ];
+  const color = colors[Math.floor(Math.random() * colors.length)];
+  const size = 4 + Math.random() * 6;
+  const rotation = Math.random() * 360;
+
+  return (
+    <span
+      className={cn(color, "absolute rounded-sm opacity-0")}
+      style={{
+        width: size,
+        height: size * 0.6,
+        left: `${left}%`,
+        top: -10,
+        transform: `rotate(${rotation}deg)`,
+        animation: `confetti-fall 2.5s ${delay}s ease-out forwards`,
+      }}
+      aria-hidden
+    />
+  );
+}
+
+function buildCelebrrationCopy(ttvMs: number | null): {
+  title: string;
+  subtitle: string;
+} {
+  if (ttvMs != null && ttvMs < 60000) {
+    const sec = Math.max(1, Math.round(ttvMs / 1000));
+    return {
+      title: `${sec} сек — і це вже твої дані!`,
+      subtitle: "Перший запис є. Що далі?",
+    };
+  }
+  return {
+    title: "Це вже твої дані!",
+    subtitle: "Перший запис є. Що далі?",
+  };
+}
+
+/**
+ * Enriched celebration shown after the user's first real entry.
+ * Replaces the simple toast from Phase 1 with confetti + an
+ * actionable card suggesting the next module to try.
+ */
+export function CelebrationOverlay({
+  onDismiss,
+  nextModuleLabel,
+  onNextModule,
+}: {
+  onDismiss: () => void;
+  nextModuleLabel?: string;
+  onNextModule?: () => void;
+}) {
+  const [show, setShow] = useState(false);
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    requestAnimationFrame(() => setShow(true));
+    trackEvent(ANALYTICS_EVENTS.CELEBRATION_SHOWN, { type: "first_entry" });
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setShow(false);
+    setTimeout(onDismiss, 300);
+  }, [onDismiss]);
+
+  const ttvMs = getTimeToValueMs();
+  const copy = buildCelebrrationCopy(ttvMs);
+
+  const particles = useRef(
+    Array.from({ length: 40 }, (_, i) => ({
+      id: i,
+      delay: Math.random() * 0.8,
+      left: Math.random() * 100,
+    })),
+  );
+
+  return (
+    <>
+      {/* Confetti keyframes injected once */}
+      <style>{`
+        @keyframes confetti-fall {
+          0% { opacity: 1; transform: translateY(0) rotate(0deg); }
+          100% { opacity: 0; transform: translateY(85vh) rotate(720deg); }
+        }
+      `}</style>
+
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        className={cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm transition-opacity duration-300",
+          show ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
+        onClick={handleDismiss}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") handleDismiss();
+        }}
+        role="dialog"
+        aria-label="Вітаємо з першим записом"
+      >
+        {/* Confetti layer */}
+        <div className="absolute inset-0 overflow-hidden pointer-events-none">
+          {particles.current.map((p) => (
+            <ConfettiParticle key={p.id} delay={p.delay} left={p.left} />
+          ))}
+        </div>
+
+        {/* Card */}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        <div
+          className={cn(
+            "relative bg-panel rounded-3xl shadow-xl p-6 max-w-sm w-full mx-4 space-y-4 text-center transition-transform duration-300",
+            show ? "scale-100" : "scale-90",
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="w-16 h-16 mx-auto rounded-2xl bg-brand-500/10 flex items-center justify-center">
+            <Icon
+              name="party-popper"
+              size={32}
+              className="text-brand-600 dark:text-brand-400"
+            />
+          </div>
+          <h2 className="text-xl font-bold text-text">{copy.title}</h2>
+          <p className="text-sm text-muted">{copy.subtitle}</p>
+
+          <div className="space-y-2 pt-2">
+            {nextModuleLabel && onNextModule && (
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full"
+                onClick={() => {
+                  onNextModule();
+                  handleDismiss();
+                }}
+              >
+                Спробувати {nextModuleLabel}
+                <Icon name="chevron-right" size={16} />
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full text-muted"
+              onClick={handleDismiss}
+            >
+              На дашборд
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/web/src/core/onboarding/ModuleChecklist.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+import {
+  MODULE_CHECKLISTS,
+  getChecklistState,
+  markChecklistStepDone,
+  markChecklistSeen,
+  dismissChecklist,
+  isChecklistVisible,
+  type DashboardModuleId,
+  type KVStore,
+} from "@sergeant/shared";
+
+const localStorageStore: KVStore = {
+  getString: (k) => {
+    try {
+      return localStorage.getItem(k);
+    } catch {
+      return null;
+    }
+  },
+  setString: (k, v) => {
+    try {
+      localStorage.setItem(k, v);
+    } catch {
+      /* noop */
+    }
+  },
+  remove: (k) => {
+    try {
+      localStorage.removeItem(k);
+    } catch {
+      /* noop */
+    }
+  },
+};
+
+export function ModuleChecklist({
+  moduleId,
+  onAction,
+}: {
+  moduleId: DashboardModuleId;
+  onAction?: (action: string) => void;
+}) {
+  const [visible, setVisible] = useState(() =>
+    isChecklistVisible(localStorageStore, moduleId),
+  );
+  const [state, setState] = useState(() =>
+    getChecklistState(localStorageStore, moduleId),
+  );
+
+  const def = MODULE_CHECKLISTS[moduleId];
+  const completed = useMemo(
+    () =>
+      state.completedSteps.filter((s) =>
+        def.steps.some((step) => step.id === s),
+      ).length,
+    [state.completedSteps, def.steps],
+  );
+  const total = def.steps.length;
+
+  useEffect(() => {
+    if (!visible) return;
+    markChecklistSeen(localStorageStore, moduleId);
+    trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_SHOWN, {
+      module: moduleId,
+      completed,
+      total,
+    });
+  }, [visible, moduleId, completed, total]);
+
+  const handleStepDone = useCallback(
+    (stepId: string) => {
+      const next = markChecklistStepDone(localStorageStore, moduleId, stepId);
+      setState(next);
+      trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_STEP_DONE, {
+        module: moduleId,
+        step: stepId,
+      });
+      if (next.completedSteps.length >= def.steps.length) {
+        setVisible(false);
+      }
+    },
+    [moduleId, def.steps.length],
+  );
+
+  const handleDismiss = useCallback(() => {
+    dismissChecklist(localStorageStore, moduleId);
+    setVisible(false);
+    trackEvent(ANALYTICS_EVENTS.MODULE_CHECKLIST_DISMISSED, {
+      module: moduleId,
+      completedSteps: state.completedSteps.length,
+    });
+  }, [moduleId, state.completedSteps.length]);
+
+  if (!visible) return null;
+
+  return (
+    <section
+      className="bg-panel border border-line rounded-2xl p-4 shadow-card space-y-3"
+      aria-label={def.title}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-sm font-bold text-text">
+            {def.title}{" "}
+            <span className="text-xs font-normal text-muted">
+              ({completed}/{total})
+            </span>
+          </h3>
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          iconOnly
+          onClick={handleDismiss}
+          aria-label="Сховати чекліст"
+          className="shrink-0 -mt-1 -mr-1 text-muted hover:text-text"
+        >
+          <Icon name="close" size={14} />
+        </Button>
+      </div>
+
+      <div className="space-y-1.5">
+        {def.steps.map((step) => {
+          const done = state.completedSteps.includes(step.id);
+          return (
+            <button
+              key={step.id}
+              type="button"
+              onClick={() => {
+                if (!done) {
+                  handleStepDone(step.id);
+                  if (step.action) onAction?.(step.action);
+                }
+              }}
+              disabled={done}
+              className={cn(
+                "w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-left text-sm transition-all",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+                done
+                  ? "text-muted line-through opacity-60"
+                  : "text-text hover:bg-brand-500/5 hover:border-brand-500/20 border border-transparent",
+              )}
+            >
+              <span
+                className={cn(
+                  "shrink-0 w-5 h-5 rounded-full flex items-center justify-center border",
+                  done
+                    ? "bg-brand-500 border-brand-500 text-white"
+                    : "border-line bg-panel",
+                )}
+              >
+                {done && <Icon name="check" size={12} strokeWidth={3} />}
+              </span>
+              <span className="flex-1">{step.label}</span>
+              {!done && step.action && (
+                <Icon name="chevron-right" size={14} className="text-muted" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/core/onboarding/PermissionsPrompt.tsx
+++ b/apps/web/src/core/onboarding/PermissionsPrompt.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
+
+// ---------------------------------------------------------------------------
+// Permission types & config
+// ---------------------------------------------------------------------------
+
+export type PermissionType = "push" | "camera" | "microphone";
+
+interface PermissionConfig {
+  icon: string;
+  title: string;
+  description: string;
+  storageKey: string;
+}
+
+const PERMISSION_CONFIG: Record<PermissionType, PermissionConfig> = {
+  push: {
+    icon: "bell",
+    title: "Нагадування",
+    description: "Хочеш нагадування про звички та цілі?",
+    storageKey: "permission_push_asked_v1",
+  },
+  camera: {
+    icon: "camera",
+    title: "Камера",
+    description: "Для AI-аналізу їжі по фото.",
+    storageKey: "permission_camera_asked_v1",
+  },
+  microphone: {
+    icon: "mic",
+    title: "Мікрофон",
+    description: "Для голосового вводу витрат.",
+    storageKey: "permission_microphone_asked_v1",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+function wasAsked(type: PermissionType): boolean {
+  try {
+    return localStorage.getItem(PERMISSION_CONFIG[type].storageKey) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markAsked(type: PermissionType): void {
+  try {
+    localStorage.setItem(PERMISSION_CONFIG[type].storageKey, "1");
+  } catch {
+    /* noop */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook: permission gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the next permission to request (one at a time), or null
+ * if all relevant permissions have been asked.
+ */
+export function useNextPermission(
+  activeModules: string[],
+): PermissionType | null {
+  const [next, setNext] = useState<PermissionType | null>(null);
+
+  useEffect(() => {
+    const queue: PermissionType[] = [];
+    if (activeModules.includes("routine") && !wasAsked("push")) {
+      queue.push("push");
+    }
+    if (activeModules.includes("nutrition") && !wasAsked("camera")) {
+      queue.push("camera");
+    }
+    if (!wasAsked("microphone")) {
+      queue.push("microphone");
+    }
+    setNext(queue[0] ?? null);
+  }, [activeModules]);
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PermissionsPrompt({
+  type,
+  onGranted,
+  onDismiss,
+}: {
+  type: PermissionType;
+  onGranted?: () => void;
+  onDismiss?: () => void;
+}) {
+  const config = PERMISSION_CONFIG[type];
+
+  const requestPermission = useCallback(async () => {
+    trackEvent(ANALYTICS_EVENTS.PERMISSION_REQUESTED, { type });
+    markAsked(type);
+
+    try {
+      if (type === "push" && "Notification" in window) {
+        const result = await Notification.requestPermission();
+        if (result === "granted") {
+          trackEvent(ANALYTICS_EVENTS.PERMISSION_GRANTED, { type });
+          onGranted?.();
+        } else {
+          trackEvent(ANALYTICS_EVENTS.PERMISSION_DENIED, { type });
+        }
+      } else if (
+        (type === "camera" || type === "microphone") &&
+        navigator.mediaDevices
+      ) {
+        const constraints =
+          type === "camera" ? { video: true } : { audio: true };
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        stream.getTracks().forEach((t) => t.stop());
+        trackEvent(ANALYTICS_EVENTS.PERMISSION_GRANTED, { type });
+        onGranted?.();
+      }
+    } catch {
+      trackEvent(ANALYTICS_EVENTS.PERMISSION_DENIED, { type });
+    }
+
+    onDismiss?.();
+  }, [type, onGranted, onDismiss]);
+
+  const handleLater = useCallback(() => {
+    markAsked(type);
+    trackEvent(ANALYTICS_EVENTS.PERMISSION_DENIED, { type, deferred: true });
+    onDismiss?.();
+  }, [type, onDismiss]);
+
+  return (
+    <section
+      className={cn(
+        "bg-panel border border-line rounded-2xl p-4 shadow-card",
+        "flex items-start gap-3",
+      )}
+      aria-label={config.title}
+    >
+      <div className="shrink-0 w-10 h-10 rounded-xl bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center">
+        <Icon name={config.icon} size={20} />
+      </div>
+      <div className="min-w-0 flex-1 space-y-2">
+        <div>
+          <h3 className="text-sm font-bold text-text">{config.title}</h3>
+          <p className="text-xs text-muted mt-0.5">{config.description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="primary" size="xs" onClick={requestPermission}>
+            Дозволити
+          </Button>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={handleLater}
+            className="text-muted"
+          >
+            Пізніше
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,9 @@ export * from "./lib/onboardingGoals";
 // Reset helpers for Settings ("Restart onboarding").
 export * from "./lib/onboardingReset";
 
+// Module onboarding checklists (Phase 2 — activation).
+export * from "./lib/moduleChecklist";
+
 // First-real-entry detection shared between web and mobile.
 export * from "./lib/firstRealEntry";
 

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -39,6 +39,19 @@ export const ANALYTICS_EVENTS = Object.freeze({
   AUTH_PROMPT_DISMISSED: "auth_prompt_dismissed",
   AUTH_AFTER_VALUE: "auth_after_value",
 
+  // Module checklists (Phase 2 — activation)
+  MODULE_CHECKLIST_SHOWN: "module_checklist_shown",
+  MODULE_CHECKLIST_STEP_DONE: "module_checklist_step_done",
+  MODULE_CHECKLIST_DISMISSED: "module_checklist_dismissed",
+
+  // Permissions (Phase 2 — contextual prompts)
+  PERMISSION_REQUESTED: "permission_requested",
+  PERMISSION_GRANTED: "permission_granted",
+  PERMISSION_DENIED: "permission_denied",
+
+  // Celebrations (Phase 2 — enriched feedback)
+  CELEBRATION_SHOWN: "celebration_shown",
+
   // Hints / tips system
   HINT_SHOWN: "hint_shown",
   HINT_CLICKED: "hint_clicked",

--- a/packages/shared/src/lib/moduleChecklist.test.ts
+++ b/packages/shared/src/lib/moduleChecklist.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMemoryKVStore } from "./kvStore";
+import {
+  MODULE_CHECKLISTS,
+  getChecklistState,
+  saveChecklistState,
+  markChecklistStepDone,
+  dismissChecklist,
+  markChecklistSeen,
+  isChecklistVisible,
+  getChecklistProgress,
+  resetAllChecklists,
+} from "./moduleChecklist";
+
+describe("moduleChecklist — definitions", () => {
+  it("defines checklists for all 4 modules", () => {
+    const ids = Object.keys(MODULE_CHECKLISTS);
+    expect(ids).toEqual(
+      expect.arrayContaining(["finyk", "fizruk", "routine", "nutrition"]),
+    );
+    expect(ids).toHaveLength(4);
+  });
+
+  it("each definition has at least 3 steps", () => {
+    for (const def of Object.values(MODULE_CHECKLISTS)) {
+      expect(def.steps.length).toBeGreaterThanOrEqual(3);
+      for (const step of def.steps) {
+        expect(typeof step.id).toBe("string");
+        expect(typeof step.label).toBe("string");
+      }
+    }
+  });
+});
+
+describe("moduleChecklist — storage", () => {
+  let store: ReturnType<typeof createMemoryKVStore>;
+
+  beforeEach(() => {
+    store = createMemoryKVStore();
+  });
+
+  it("returns empty state for fresh store", () => {
+    const state = getChecklistState(store, "finyk");
+    expect(state.completedSteps).toEqual([]);
+    expect(state.dismissed).toBe(false);
+    expect(state.firstSeenAt).toBeNull();
+  });
+
+  it("round-trips valid state", () => {
+    const original = {
+      completedSteps: ["add_expense", "set_budget"],
+      dismissed: false,
+      firstSeenAt: "2026-01-01T00:00:00.000Z",
+    };
+    saveChecklistState(store, "finyk", original);
+    const loaded = getChecklistState(store, "finyk");
+    expect(loaded).toEqual(original);
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    store.setString("finyk_checklist_v1", "not-json");
+    const state = getChecklistState(store, "finyk");
+    expect(state.completedSteps).toEqual([]);
+    expect(state.dismissed).toBe(false);
+  });
+});
+
+describe("moduleChecklist — mutations", () => {
+  let store: ReturnType<typeof createMemoryKVStore>;
+
+  beforeEach(() => {
+    store = createMemoryKVStore();
+  });
+
+  it("markChecklistStepDone adds step to completedSteps", () => {
+    const state = markChecklistStepDone(store, "finyk", "add_expense");
+    expect(state.completedSteps).toContain("add_expense");
+  });
+
+  it("markChecklistStepDone is idempotent", () => {
+    markChecklistStepDone(store, "finyk", "add_expense");
+    const state = markChecklistStepDone(store, "finyk", "add_expense");
+    expect(
+      state.completedSteps.filter((s) => s === "add_expense"),
+    ).toHaveLength(1);
+  });
+
+  it("dismissChecklist sets dismissed flag", () => {
+    const state = dismissChecklist(store, "routine");
+    expect(state.dismissed).toBe(true);
+  });
+
+  it("markChecklistSeen sets firstSeenAt", () => {
+    const state = markChecklistSeen(store, "fizruk");
+    expect(state.firstSeenAt).toBeTruthy();
+  });
+
+  it("markChecklistSeen does not overwrite existing timestamp", () => {
+    const first = markChecklistSeen(store, "fizruk");
+    const second = markChecklistSeen(store, "fizruk");
+    expect(second.firstSeenAt).toBe(first.firstSeenAt);
+  });
+});
+
+describe("moduleChecklist — visibility", () => {
+  let store: ReturnType<typeof createMemoryKVStore>;
+
+  beforeEach(() => {
+    store = createMemoryKVStore();
+  });
+
+  it("visible by default", () => {
+    expect(isChecklistVisible(store, "finyk")).toBe(true);
+  });
+
+  it("hidden when dismissed", () => {
+    dismissChecklist(store, "finyk");
+    expect(isChecklistVisible(store, "finyk")).toBe(false);
+  });
+
+  it("hidden when all steps completed", () => {
+    const def = MODULE_CHECKLISTS.finyk;
+    for (const step of def.steps) {
+      markChecklistStepDone(store, "finyk", step.id);
+    }
+    expect(isChecklistVisible(store, "finyk")).toBe(false);
+  });
+
+  it("hidden after 7 days", () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    saveChecklistState(store, "finyk", {
+      completedSteps: [],
+      dismissed: false,
+      firstSeenAt: eightDaysAgo,
+    });
+    expect(isChecklistVisible(store, "finyk")).toBe(false);
+  });
+
+  it("still visible within 7 days", () => {
+    const threeDaysAgo = new Date(
+      Date.now() - 3 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    saveChecklistState(store, "finyk", {
+      completedSteps: [],
+      dismissed: false,
+      firstSeenAt: threeDaysAgo,
+    });
+    expect(isChecklistVisible(store, "finyk")).toBe(true);
+  });
+});
+
+describe("moduleChecklist — progress", () => {
+  let store: ReturnType<typeof createMemoryKVStore>;
+
+  beforeEach(() => {
+    store = createMemoryKVStore();
+  });
+
+  it("returns 0/N for fresh store", () => {
+    const progress = getChecklistProgress(store, "routine");
+    expect(progress.completed).toBe(0);
+    expect(progress.total).toBe(MODULE_CHECKLISTS.routine.steps.length);
+  });
+
+  it("counts only valid step ids", () => {
+    markChecklistStepDone(store, "routine", "create_habit");
+    markChecklistStepDone(store, "routine", "bogus_step");
+    const progress = getChecklistProgress(store, "routine");
+    expect(progress.completed).toBe(1);
+  });
+});
+
+describe("moduleChecklist — reset", () => {
+  it("resetAllChecklists clears all modules", () => {
+    const store = createMemoryKVStore();
+    markChecklistStepDone(store, "finyk", "add_expense");
+    markChecklistStepDone(store, "routine", "create_habit");
+    resetAllChecklists(store);
+    expect(getChecklistState(store, "finyk").completedSteps).toEqual([]);
+    expect(getChecklistState(store, "routine").completedSteps).toEqual([]);
+  });
+});

--- a/packages/shared/src/lib/moduleChecklist.ts
+++ b/packages/shared/src/lib/moduleChecklist.ts
@@ -1,0 +1,238 @@
+/**
+ * Module onboarding checklists — shared, DOM-free logic.
+ *
+ * Each module has 3–4 actionable steps that guide the user from first
+ * entry to "aha-moment". State is persisted per-module via KVStore so
+ * progress survives restarts. The checklist is visible for the first
+ * 7 days (or until all steps are completed / dismissed).
+ */
+
+import type { DashboardModuleId } from "./dashboard";
+import { readJSON, writeJSON, type KVStore } from "./kvStore";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChecklistStep {
+  id: string;
+  label: string;
+  /** Optional deep-link action hint (e.g. "add_expense", "open_analytics"). */
+  action?: string;
+}
+
+export interface ChecklistDefinition {
+  moduleId: DashboardModuleId;
+  title: string;
+  steps: ChecklistStep[];
+}
+
+export interface ChecklistState {
+  completedSteps: string[];
+  dismissed: boolean;
+  /** ISO timestamp of first checklist view. */
+  firstSeenAt: string | null;
+}
+
+const EMPTY_STATE: ChecklistState = {
+  completedSteps: [],
+  dismissed: false,
+  firstSeenAt: null,
+};
+
+// ---------------------------------------------------------------------------
+// Checklist definitions per module
+// ---------------------------------------------------------------------------
+
+export const MODULE_CHECKLISTS: Record<DashboardModuleId, ChecklistDefinition> =
+  {
+    finyk: {
+      moduleId: "finyk",
+      title: "Фінік: Перші кроки",
+      steps: [
+        {
+          id: "add_expense",
+          label: "Додати першу витрату",
+          action: "add_expense",
+        },
+        { id: "set_budget", label: "Встановити бюджет", action: "set_budget" },
+        {
+          id: "connect_bank",
+          label: "Підключити Monobank",
+          action: "connect_bank",
+        },
+        {
+          id: "view_analytics",
+          label: "Переглянути аналітику",
+          action: "view_analytics",
+        },
+      ],
+    },
+    fizruk: {
+      moduleId: "fizruk",
+      title: "Фізрук: Перші кроки",
+      steps: [
+        {
+          id: "start_workout",
+          label: "Розпочати тренування",
+          action: "start_workout",
+        },
+        { id: "complete_workout", label: "Завершити тренування" },
+        { id: "set_program", label: "Обрати програму", action: "set_program" },
+        {
+          id: "check_progress",
+          label: "Переглянути прогрес",
+          action: "check_progress",
+        },
+      ],
+    },
+    routine: {
+      moduleId: "routine",
+      title: "Рутина: Перші кроки",
+      steps: [
+        {
+          id: "create_habit",
+          label: "Створити першу звичку",
+          action: "create_habit",
+        },
+        { id: "complete_habit", label: "Відмітити виконання" },
+        { id: "three_day_streak", label: "Стрік 3 дні" },
+      ],
+    },
+    nutrition: {
+      moduleId: "nutrition",
+      title: "Харчування: Перші кроки",
+      steps: [
+        { id: "log_meal", label: "Залогати прийом їжі", action: "log_meal" },
+        {
+          id: "photo_analysis",
+          label: "Спробувати фото-аналіз",
+          action: "photo_analysis",
+        },
+        {
+          id: "daily_plan",
+          label: "Переглянути денний план",
+          action: "daily_plan",
+        },
+      ],
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+function storageKey(moduleId: DashboardModuleId): string {
+  return `${moduleId}_checklist_v1`;
+}
+
+export function getChecklistState(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+): ChecklistState {
+  const data = readJSON<ChecklistState>(store, storageKey(moduleId));
+  if (!data || typeof data !== "object") return { ...EMPTY_STATE };
+  return {
+    completedSteps: Array.isArray(data.completedSteps)
+      ? data.completedSteps.filter((s): s is string => typeof s === "string")
+      : [],
+    dismissed: typeof data.dismissed === "boolean" ? data.dismissed : false,
+    firstSeenAt: typeof data.firstSeenAt === "string" ? data.firstSeenAt : null,
+  };
+}
+
+export function saveChecklistState(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+  state: ChecklistState,
+): void {
+  writeJSON(store, storageKey(moduleId), state);
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+export function markChecklistStepDone(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+  stepId: string,
+): ChecklistState {
+  const state = getChecklistState(store, moduleId);
+  if (!state.completedSteps.includes(stepId)) {
+    state.completedSteps = [...state.completedSteps, stepId];
+  }
+  saveChecklistState(store, moduleId, state);
+  return state;
+}
+
+export function dismissChecklist(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+): ChecklistState {
+  const state = getChecklistState(store, moduleId);
+  state.dismissed = true;
+  saveChecklistState(store, moduleId, state);
+  return state;
+}
+
+export function markChecklistSeen(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+): ChecklistState {
+  const state = getChecklistState(store, moduleId);
+  if (!state.firstSeenAt) {
+    state.firstSeenAt = new Date().toISOString();
+    saveChecklistState(store, moduleId, state);
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Derived helpers
+// ---------------------------------------------------------------------------
+
+/** Max age (in ms) before checklist auto-hides. */
+const CHECKLIST_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export function isChecklistVisible(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+): boolean {
+  const def = MODULE_CHECKLISTS[moduleId];
+  const state = getChecklistState(store, moduleId);
+  if (state.dismissed) return false;
+  if (state.completedSteps.length >= def.steps.length) return false;
+  if (state.firstSeenAt) {
+    const age = Date.now() - new Date(state.firstSeenAt).getTime();
+    if (age > CHECKLIST_MAX_AGE_MS) return false;
+  }
+  return true;
+}
+
+export function getChecklistProgress(
+  store: KVStore,
+  moduleId: DashboardModuleId,
+): { completed: number; total: number } {
+  const def = MODULE_CHECKLISTS[moduleId];
+  const state = getChecklistState(store, moduleId);
+  return {
+    completed: state.completedSteps.filter((s) =>
+      def.steps.some((step) => step.id === s),
+    ).length,
+    total: def.steps.length,
+  };
+}
+
+/** Reset all checklists (used in onboarding reset). */
+export function resetAllChecklists(store: KVStore): void {
+  const moduleIds: DashboardModuleId[] = [
+    "finyk",
+    "fizruk",
+    "routine",
+    "nutrition",
+  ];
+  for (const id of moduleIds) {
+    store.remove(storageKey(id));
+  }
+}

--- a/packages/shared/src/lib/onboardingReset.ts
+++ b/packages/shared/src/lib/onboardingReset.ts
@@ -17,6 +17,7 @@ import {
   SOFT_AUTH_DISMISSED_KEY,
 } from "./vibePicks";
 import { clearAllHintsState } from "./hints";
+import { resetAllChecklists } from "./moduleChecklist";
 
 export function resetOnboardingState(store: KVStore): void {
   clearOnboardingDone(store);
@@ -28,4 +29,5 @@ export function resetOnboardingState(store: KVStore): void {
   store.remove(TTV_MS_KEY);
   store.remove(SOFT_AUTH_DISMISSED_KEY);
   clearAllHintsState(store);
+  resetAllChecklists(store);
 }


### PR DESCRIPTION
## Summary

Phase 2 of the onboarding rebuild (activation layer). Includes fixes for 2 Phase 1 defects found by Devin Review + all Phase 2 features.

### Phase 1 Bug Fixes
- **Web fizruk radio highlight**: radio buttons never showed selected state due to `Number(v)` creating a type mismatch with string option values. Fix: store as string throughout, convert to number only at save time.
- **Mobile slider questions**: `finyk_budget` (type: slider) was silently dropped — the render loop only handled `type === "radio"`. Fix: added preset-button renderer for slider-type questions.

### Phase 2 Features

**Shared (`@sergeant/shared`)**
- `moduleChecklist.ts` — types, storage, definitions for all 4 modules (3–4 steps each), 7-day auto-hide, dismiss, progress tracking
- 7 new analytics events: `module_checklist_shown/step_done/dismissed`, `permission_requested/granted/denied`, `celebration_shown`
- `onboardingReset` now clears checklists on restart
- 18 new tests (211 total, all passing)

**Web**
- `ModuleChecklist.tsx` — inline checklist with step completion, action callbacks, analytics, dismiss
- `CelebrationOverlay.tsx` — confetti animation + card with time-to-value copy and next-module CTA (replaces simple toast)
- `PermissionsPrompt.tsx` — contextual one-at-a-time permission requests (push/camera/mic) with `useNextPermission` hook

**Mobile**
- `ModuleChecklist.tsx` — RN-adapted checklist with haptic feedback

## Review & Testing Checklist for Human

- [ ] Verify fizruk radio buttons now highlight correctly on web
- [ ] On mobile, select only Finyk module and verify the budget question appears on Goals step
- [ ] Test ModuleChecklist component renders in a module view and steps can be checked off
- [ ] Verify CelebrationOverlay confetti animation + card appears after first real entry
- [ ] Test PermissionsPrompt shows one permission at a time in correct context
- [ ] Confirm checklist auto-hides after 7 days or when all steps completed
- [ ] Run `pnpm test` — all 211 tests should pass

### Notes
- CelebrationOverlay and PermissionsPrompt are standalone components ready to be wired into HubDashboard / module views.
- Module checklist definitions can be extended per module as the product evolves.
- The mobile ModuleChecklist uses the same shared storage/logic, just different UI primitives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
