### PR TITLE
feat(profile): fix issues & add improvements to ProfilePage

### DIFF
--- a/apps/web/src/core/ProfilePage.test.tsx
+++ b/apps/web/src/core/ProfilePage.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -11,6 +17,9 @@ const listSessionsMock = vi.fn<() => Promise<{ data: unknown[] }>>();
 const revokeSessionMock = vi.fn<(d: unknown) => Promise<{ error: null }>>();
 const deleteUserMock = vi.fn<(d: unknown) => Promise<{ error: null }>>();
 const signOutMock = vi.fn<() => Promise<void>>();
+const sendVerificationEmailMock =
+  vi.fn<(d: unknown) => Promise<{ error: null }>>();
+const changeEmailMock = vi.fn<(d: unknown) => Promise<{ error: null }>>();
 
 updateUserMock.mockResolvedValue({ error: null });
 changePasswordMock.mockResolvedValue({ error: null });
@@ -18,6 +27,8 @@ listSessionsMock.mockResolvedValue({ data: [] });
 revokeSessionMock.mockResolvedValue({ error: null });
 deleteUserMock.mockResolvedValue({ error: null });
 signOutMock.mockResolvedValue(undefined);
+sendVerificationEmailMock.mockResolvedValue({ error: null });
+changeEmailMock.mockResolvedValue({ error: null });
 
 vi.mock("./authClient.js", () => ({
   updateUser: (data: unknown) => updateUserMock(data),
@@ -26,6 +37,8 @@ vi.mock("./authClient.js", () => ({
   revokeSession: (data: unknown) => revokeSessionMock(data),
   deleteUser: (data: unknown) => deleteUserMock(data),
   signOut: () => signOutMock(),
+  sendVerificationEmail: (data: unknown) => sendVerificationEmailMock(data),
+  changeEmail: (data: unknown) => changeEmailMock(data),
 }));
 
 const useOnlineStatusMock = vi.fn(() => true);
@@ -85,7 +98,8 @@ describe("ProfilePage", () => {
     it("shows user name and email", () => {
       renderPage();
       expect(screen.getByText("Тест")).toBeInTheDocument();
-      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+      const emails = screen.getAllByText("test@example.com");
+      expect(emails.length).toBeGreaterThanOrEqual(1);
     });
 
     it("shows verified badge when emailVerified is true", () => {
@@ -125,6 +139,37 @@ describe("ProfilePage", () => {
     it("hides remove photo link when no avatar", () => {
       renderPage();
       expect(screen.queryByText("Видалити фото")).not.toBeInTheDocument();
+    });
+
+    it("shows email verification banner when emailVerified is false", () => {
+      mockUser.emailVerified = false;
+      renderPage();
+      expect(screen.getByText("Email не підтверджено")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Надіслати лист" }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides email verification banner when emailVerified is true", () => {
+      renderPage();
+      expect(
+        screen.queryByText("Email не підтверджено"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows avatar removal confirm when clicking remove photo", () => {
+      mockUser.image = "data:image/webp;base64,abc";
+      renderPage();
+      const links = screen.getAllByText("Видалити фото");
+      fireEvent.click(links[0]);
+      expect(screen.getByText("Видалити?")).toBeInTheDocument();
+    });
+
+    it("shows change email button", () => {
+      renderPage();
+      expect(
+        screen.getByRole("button", { name: "Змінити" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -179,6 +224,21 @@ describe("ProfilePage", () => {
       renderPage();
       const avatarBtns = screen.getAllByLabelText("Змінити аватар");
       expect(avatarBtns[0]).toBeDisabled();
+    });
+
+    it("disables email verification button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      mockUser.emailVerified = false;
+      renderPage();
+      const btn = screen.getByRole("button", { name: "Надіслати лист" });
+      expect(btn).toBeDisabled();
+    });
+
+    it("disables change email button when offline", () => {
+      useOnlineStatusMock.mockReturnValue(false);
+      renderPage();
+      const btn = screen.getByRole("button", { name: "Змінити" });
+      expect(btn).toBeDisabled();
     });
   });
 

--- a/apps/web/src/core/ProfilePage.tsx
+++ b/apps/web/src/core/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { Input } from "@shared/components/ui/Input";
 import { useToast } from "@shared/hooks/useToast";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { useAuth } from "./AuthContext.jsx";
+import { STORAGE_KEYS } from "@sergeant/shared";
 import {
   updateUser,
   changePassword,
@@ -15,6 +16,8 @@ import {
   revokeSession,
   deleteUser,
   signOut,
+  sendVerificationEmail,
+  changeEmail,
   type SessionItem,
 } from "./authClient.js";
 
@@ -75,6 +78,11 @@ function PersonalInfoSection({
   const [name, setName] = useState(user.name ?? "");
   const [saving, setSaving] = useState(false);
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
+  const [confirmRemoveAvatar, setConfirmRemoveAvatar] = useState(false);
+  const [sendingVerification, setSendingVerification] = useState(false);
+  const [editingEmail, setEditingEmail] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [savingEmail, setSavingEmail] = useState(false);
   const dirty = name.trim() !== (user.name ?? "");
 
   useEffect(() => {
@@ -116,6 +124,7 @@ function PersonalInfoSection({
   };
 
   const handleRemoveAvatar = async () => {
+    setConfirmRemoveAvatar(false);
     setUploadingAvatar(true);
     const res = await updateUser({ image: null });
     setUploadingAvatar(false);
@@ -123,6 +132,36 @@ function PersonalInfoSection({
       toast.error(res.error.message ?? "Не вдалося видалити аватар");
     } else {
       toast.success("Аватар видалено");
+      await onRefresh();
+    }
+  };
+
+  const handleSendVerification = async () => {
+    if (!user.email) return;
+    setSendingVerification(true);
+    const res = await sendVerificationEmail({ email: user.email });
+    setSendingVerification(false);
+    if (res.error) {
+      toast.error(
+        res.error.message ?? "Не вдалося надіслати лист підтвердження",
+      );
+    } else {
+      toast.success("Лист підтвердження надіслано");
+    }
+  };
+
+  const handleChangeEmail = async () => {
+    const trimmed = newEmail.trim();
+    if (!trimmed) return;
+    setSavingEmail(true);
+    const res = await changeEmail({ newEmail: trimmed });
+    setSavingEmail(false);
+    if (res.error) {
+      toast.error(res.error.message ?? "Не вдалося змінити email");
+    } else {
+      toast.success("Лист підтвердження нового email надіслано");
+      setEditingEmail(false);
+      setNewEmail("");
       await onRefresh();
     }
   };
@@ -200,18 +239,58 @@ function PersonalInfoSection({
                 </span>
               )}
             </div>
-            {user.image && (
+            {user.image && !confirmRemoveAvatar && (
               <button
                 type="button"
                 className="text-xs text-muted hover:text-danger transition-colors mt-1"
                 disabled={!online || uploadingAvatar}
-                onClick={handleRemoveAvatar}
+                onClick={() => setConfirmRemoveAvatar(true)}
               >
                 Видалити фото
               </button>
             )}
+            {user.image && confirmRemoveAvatar && (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-danger font-medium">
+                  Видалити?
+                </span>
+                <button
+                  type="button"
+                  className="text-xs font-semibold text-danger hover:text-danger/80 transition-colors"
+                  onClick={handleRemoveAvatar}
+                >
+                  Так
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-muted hover:text-text transition-colors"
+                  onClick={() => setConfirmRemoveAvatar(false)}
+                >
+                  Ні
+                </button>
+              </div>
+            )}
           </div>
         </div>
+
+        {/* Email verification / change */}
+        {!user.emailVerified && user.email && (
+          <div className="flex items-center gap-2 rounded-xl bg-warning/10 border border-warning/30 px-3 py-2.5">
+            <Icon name="alert" size={14} className="text-warning shrink-0" />
+            <p className="text-xs text-warning font-medium flex-1">
+              Email не підтверджено
+            </p>
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={!online || sendingVerification}
+              loading={sendingVerification}
+              onClick={handleSendVerification}
+            >
+              Надіслати лист
+            </Button>
+          </div>
+        )}
 
         {/* Edit name */}
         <div className="space-y-2">
@@ -241,6 +320,68 @@ function PersonalInfoSection({
               Зберегти
             </Button>
           </div>
+        </div>
+
+        {/* Edit email */}
+        <div className="space-y-2">
+          <label
+            htmlFor="profile-email"
+            className="block text-xs font-medium text-muted"
+          >
+            Email
+          </label>
+          {!editingEmail ? (
+            <div className="flex items-center gap-2">
+              <p className="text-sm text-text flex-1 truncate">{user.email}</p>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={!online}
+                onClick={() => {
+                  setEditingEmail(true);
+                  setNewEmail(user.email ?? "");
+                }}
+              >
+                Змінити
+              </Button>
+            </div>
+          ) : (
+            <div className="flex gap-2">
+              <Input
+                id="profile-email"
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                placeholder="Новий email"
+                autoComplete="email"
+                className="flex-1"
+              />
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={
+                  !newEmail.trim() ||
+                  newEmail.trim() === user.email ||
+                  savingEmail ||
+                  !online
+                }
+                loading={savingEmail}
+                onClick={handleChangeEmail}
+              >
+                Зберегти
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setEditingEmail(false);
+                  setNewEmail("");
+                }}
+              >
+                Скасувати
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </Card>
@@ -619,7 +760,7 @@ interface MemoryEntry {
   createdAt: string;
 }
 
-const PROFILE_KEY = "hub_user_profile_v1";
+const PROFILE_KEY = STORAGE_KEYS.USER_PROFILE;
 
 const CATEGORY_META: Record<string, { label: string; emoji: string }> = {
   allergy: { label: "Алергії", emoji: "🚫" },
@@ -635,6 +776,8 @@ const MEMORY_ONBOARDING_PROMPT =
   "Привіт! Давай заповнимо мій профіль. Задай мені по черзі кілька запитань: 1) Чи є в мене алергії або обмеження в їжі? 2) Яка моя дієта чи стиль харчування? 3) Яка моя основна ціль (схуднути, набрати масу, підтримка)? 4) Скільки разів на тиждень я тренуюсь і де? 5) Чи є щось ще важливе про моє здоров'я? Запам'ятай кожну відповідь через remember.";
 
 function MemoryBankSection() {
+  const toast = useToast();
+  const importRef = useRef<HTMLInputElement>(null);
   const [entries, setEntries] = useState<MemoryEntry[]>(() => {
     try {
       const raw = localStorage.getItem(PROFILE_KEY);
@@ -663,6 +806,64 @@ function MemoryBankSection() {
     window.dispatchEvent(new CustomEvent("hub:openChat", { detail: prompt }));
   }, [entries.length]);
 
+  const handleExport = useCallback(() => {
+    const json = JSON.stringify(entries, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `sergeant-memory-bank-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Експорт завершено");
+  }, [entries, toast]);
+
+  const handleImport = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      if (importRef.current) importRef.current.value = "";
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(reader.result as string);
+          if (!Array.isArray(parsed)) {
+            toast.error("Невалідний формат файлу");
+            return;
+          }
+          const valid = parsed.filter(
+            (item: unknown) =>
+              typeof item === "object" &&
+              item !== null &&
+              "id" in item &&
+              "fact" in item,
+          ) as MemoryEntry[];
+          if (valid.length === 0) {
+            toast.error("Файл не містить валідних записів");
+            return;
+          }
+          const existingIds = new Set(entries.map((ent) => ent.id));
+          const merged = [
+            ...entries,
+            ...valid.filter((v) => !existingIds.has(v.id)),
+          ];
+          setEntries(merged);
+          try {
+            localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
+          } catch {}
+          const added = merged.length - entries.length;
+          toast.success(
+            `Імпортовано ${added} ${added === 1 ? "запис" : added < 5 ? "записи" : "записів"}`,
+          );
+        } catch {
+          toast.error("Не вдалося прочитати файл");
+        }
+      };
+      reader.readAsText(file);
+    },
+    [entries, toast],
+  );
+
   const grouped = useMemo(() => {
     const map: Record<string, MemoryEntry[]> = {};
     for (const e of entries) {
@@ -671,6 +872,13 @@ function MemoryBankSection() {
       map[cat].push(e);
     }
     return map;
+  }, [entries]);
+
+  const storageSize = useMemo(() => {
+    if (entries.length === 0) return "0 B";
+    const bytes = new Blob([JSON.stringify(entries)]).size;
+    if (bytes < 1024) return `${bytes} B`;
+    return `${(bytes / 1024).toFixed(1)} KB`;
   }, [entries]);
 
   const isEmpty = entries.length === 0;
@@ -687,6 +895,8 @@ function MemoryBankSection() {
             : entries.length < 5
               ? "записи"
               : "записів"}
+          {" \u00b7 "}
+          {storageSize}
         </span>
       </div>
 
@@ -701,10 +911,27 @@ function MemoryBankSection() {
               ШІ задасть кілька запитань щоб дізнатися про ваші алергії, цілі,
               уподобання та рівень активності
             </p>
-            <Button variant="primary" size="sm" onClick={openMemoryChat}>
-              <Icon name="sparkle" size={14} className="mr-1.5" />
-              Заповнити профіль
-            </Button>
+            <div className="flex items-center justify-center gap-2">
+              <Button variant="primary" size="sm" onClick={openMemoryChat}>
+                <Icon name="sparkle" size={14} className="mr-1.5" />
+                Заповнити профіль
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => importRef.current?.click()}
+              >
+                <Icon name="upload" size={14} className="mr-1.5" />
+                Імпорт
+              </Button>
+            </div>
+            <input
+              ref={importRef}
+              type="file"
+              accept=".json"
+              className="hidden"
+              onChange={handleImport}
+            />
           </div>
         ) : (
           <div className="space-y-3">
@@ -739,14 +966,39 @@ function MemoryBankSection() {
               );
             })}
 
-            <button
-              type="button"
-              onClick={openMemoryChat}
-              className="w-full mt-2 py-2.5 rounded-xl border border-dashed border-line text-sm text-muted hover:text-text hover:border-muted transition-colors flex items-center justify-center gap-1.5"
-            >
-              <Icon name="plus" size={14} />
-              Додати інфо
-            </button>
+            <div className="flex gap-2 mt-2">
+              <button
+                type="button"
+                onClick={openMemoryChat}
+                className="flex-1 py-2.5 rounded-xl border border-dashed border-line text-sm text-muted hover:text-text hover:border-muted transition-colors flex items-center justify-center gap-1.5"
+              >
+                <Icon name="plus" size={14} />
+                Додати інфо
+              </button>
+              <button
+                type="button"
+                onClick={handleExport}
+                className="py-2.5 px-3 rounded-xl border border-line text-sm text-muted hover:text-text hover:border-muted transition-colors flex items-center justify-center gap-1.5"
+                aria-label="Експорт пам'яті"
+              >
+                <Icon name="download" size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={() => importRef.current?.click()}
+                className="py-2.5 px-3 rounded-xl border border-line text-sm text-muted hover:text-text hover:border-muted transition-colors flex items-center justify-center gap-1.5"
+                aria-label="Імпорт пам'яті"
+              >
+                <Icon name="upload" size={14} />
+              </button>
+            </div>
+            <input
+              ref={importRef}
+              type="file"
+              accept=".json"
+              className="hidden"
+              onChange={handleImport}
+            />
           </div>
         )}
       </div>

--- a/apps/web/src/core/authClient.ts
+++ b/apps/web/src/core/authClient.ts
@@ -97,6 +97,14 @@ const authClient = createAuthClient({
     password?: string;
     token?: string;
   }) => Promise<AuthResult>;
+  sendVerificationEmail: (args: {
+    email: string;
+    callbackURL?: string;
+  }) => Promise<AuthResult>;
+  changeEmail: (args: {
+    newEmail: string;
+    callbackURL?: string;
+  }) => Promise<AuthResult>;
 };
 
 type PasswordResetResult = {
@@ -142,6 +150,8 @@ const {
   revokeSession,
   revokeSessions,
   deleteUser,
+  sendVerificationEmail,
+  changeEmail,
 } = typedAuthClient;
 
 type SignOutFn = typeof rawSignOut;
@@ -176,6 +186,8 @@ export {
   revokeSession,
   revokeSessions,
   deleteUser,
+  sendVerificationEmail,
+  changeEmail,
 };
 
 export type { AuthResult, SessionItem };

--- a/apps/web/src/core/cloudSync/config.ts
+++ b/apps/web/src/core/cloudSync/config.ts
@@ -53,6 +53,9 @@ export const SYNC_MODULES = {
       STORAGE_KEYS.NUTRITION_PREFS,
     ],
   },
+  profile: {
+    keys: [STORAGE_KEYS.USER_PROFILE],
+  },
 } as const;
 
 export type ModuleName = keyof typeof SYNC_MODULES;

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -15,6 +15,7 @@ export const STORAGE_KEYS = {
   ONBOARDING_DONE: "hub_onboarding_done_v1",
   DASHBOARD_ORDER: "hub_dashboard_order_v1",
   HUB_PREFS: "hub_prefs_v1",
+  USER_PROFILE: "hub_user_profile_v1",
 
   // Hub quick-stats previews rendered on the dashboard
   FINYK_QUICK_STATS: "finyk_quick_stats",


### PR DESCRIPTION
## Summary

Виправлення проблем та додавання покращень до сторінки профілю користувача:

### Виправлені проблеми
1. **Memory Bank не синхронізувався між пристроями** — `hub_user_profile_v1` тепер додано до `SYNC_MODULES` як модуль `profile`, і дані пам'яті ШІ синхронізуються через cloudSync нарівні з finyk/fizruk/routine/nutrition.
2. **Немає підтвердження при видаленні аватара** — додано inline-confirm діалог («Видалити? Так / Ні») замість негайного видалення.
3. **Email не підтверджено — немає кнопки повторної відправки** — додано банер з кнопкою «Надіслати лист» для непідтверджених email адрес.
4. **Неможливо змінити email** — додано інлайн-редактор email з кнопкою «Змінити».

### Нові покращення
5. **Export/Import Memory Bank** — кнопки експорту (JSON-файл) та імпорту з дедуплікацією за ID.
6. **Розмір Memory Bank** — показується кількість записів + розмір даних (наприклад, «5 записів · 1.2 KB»).
7. **`STORAGE_KEYS.USER_PROFILE`** — замість магічного рядка `"hub_user_profile_v1"` використовується централізована константа.
8. **`sendVerificationEmail` та `changeEmail`** — експортовані з `authClient.ts` для використання в UI.

### Змінені файли
- `packages/shared/src/lib/storageKeys.ts` — додано `USER_PROFILE`
- `apps/web/src/core/cloudSync/config.ts` — додано модуль `profile` до `SYNC_MODULES`
- `apps/web/src/core/authClient.ts` — додано типи та експорт `sendVerificationEmail`, `changeEmail`
- `apps/web/src/core/ProfilePage.tsx` — всі UI зміни
- `apps/web/src/core/ProfilePage.test.tsx` — 22 тести (6 нових), всі проходять

## Review & Testing Checklist for Human
- [ ] **Cloud Sync Memory Bank**: увійти на двох пристроях, додати запис у Memory Bank на одному → перевірити що з'являється на іншому після sync
- [ ] **Email verification**: зареєструвати нового юзера без верифікації email → перевірити банер «Email не підтверджено» та кнопку «Надіслати лист»
- [ ] **Change email**: натиснути «Змінити» біля email → ввести новий → перевірити що приходить лист підтвердження (потребує `changeEmail` endpoint в Better Auth — якщо сервер не підтримує, кнопка поверне помилку)
- [ ] **Avatar confirm**: завантажити аватар → натиснути «Видалити фото» → перевірити що з'являється «Видалити? Так / Ні»
- [ ] **Memory Bank export/import**: додати записи → натиснути export → перевірити JSON файл → очистити localStorage → натиснути import → перевірити відновлення

### Notes
- `changeEmail` залежить від наявності відповідного endpoint в Better Auth. Якщо endpoint не налаштовано на сервері — кнопка «Змінити» покаже toast з помилкою. Це безпечна деградація.
- Аватар як base64 в PostgreSQL — задокументований tech debt для майбутнього масштабування (міграція в S3/R2), але не в цьому PR.

Link to Devin session: https://app.devin.ai/sessions/315b9c411fb84906a0e95cc23743ab27
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email verification workflow with send verification email button and status banner
  * Email change functionality with validation and error handling
  * Avatar deletion confirmation dialog
  * Memory Bank import/export with JSON file support and storage size display

* **Tests**
  * Updated test coverage for new email verification, email change, and offline profile flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->