### PR TITLE
feat(reports): додано підписи дат та тултіп при натисканні на стовпчик BarChart

### DIFF
--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -201,41 +201,95 @@ function BarChart({
   maxValue?: number;
   unit?: string;
 }) {
+  const [selected, setSelected] = useState<number | null>(null);
   const vals = dates.map((d) => data[d] ?? 0);
   const max = maxValue || Math.max(...vals, 1);
   const hasData = vals.some((v) => v > 0);
+  const isWeek = dates.length <= 7;
 
   if (!hasData) {
     return (
-      <div className="h-20 flex items-center justify-center text-xs text-muted">
+      <div className="h-24 flex items-center justify-center text-xs text-muted">
         Немає даних
       </div>
     );
   }
 
+  function labelStep(count: number) {
+    if (count <= 7) return 1;
+    if (count <= 15) return 2;
+    return Math.ceil(count / 8);
+  }
+  const step = labelStep(dates.length);
+
+  function formatLabel(dateStr: string) {
+    const d = new Date(dateStr + "T00:00:00");
+    if (isWeek) {
+      const dayNames = ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"];
+      return dayNames[d.getDay()];
+    }
+    return String(d.getDate());
+  }
+
+  function formatTooltip(dateStr: string, value: number) {
+    const d = new Date(dateStr + "T00:00:00");
+    const day = String(d.getDate()).padStart(2, "0");
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    return `${day}.${month}: ${value.toLocaleString("uk-UA")}${unit}`;
+  }
+
   return (
-    <div className="flex items-end gap-0.5 h-20" aria-label="Графік">
-      {vals.map((v, i) => {
-        const pct = Math.max(0, Math.min(100, (v / max) * 100));
-        const isToday = dates[i] === localDateKey();
-        return (
-          <div
-            key={dates[i]}
-            className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full"
-            title={`${dates[i]}: ${v}${unit}`}
-          >
-            <div
+    <div>
+      {selected !== null && (
+        <div className="text-xs text-center text-text font-medium mb-1 h-4">
+          {formatTooltip(dates[selected], vals[selected])}
+        </div>
+      )}
+      {selected === null && <div className="h-4 mb-1" />}
+      <div className="flex items-end gap-0.5 h-20" aria-label="Графік">
+        {vals.map((v, i) => {
+          const pct = Math.max(0, Math.min(100, (v / max) * 100));
+          const isToday = dates[i] === localDateKey();
+          const isSelected = selected === i;
+          return (
+            <button
+              key={dates[i]}
+              type="button"
+              className="flex-1 flex flex-col items-center justify-end gap-0.5 h-full appearance-none bg-transparent border-0 p-0 cursor-pointer"
+              onClick={() => setSelected(isSelected ? null : i)}
+            >
+              <div
+                className={cn(
+                  "w-full rounded-t-sm transition-[height,background-color,opacity]",
+                  colorClass,
+                  (isToday || isSelected) && "opacity-100",
+                  !isToday && !isSelected && "opacity-60",
+                )}
+                style={{
+                  height: `${pct}%`,
+                  minHeight: v > 0 ? "2px" : "0",
+                }}
+              />
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex gap-0.5 mt-1">
+        {dates.map((d, i) => {
+          const show = i % step === 0 || i === dates.length - 1;
+          return (
+            <span
+              key={d}
               className={cn(
-                "w-full rounded-t-sm transition-[height,background-color,opacity]",
-                colorClass,
-                isToday && "opacity-100",
-                !isToday && "opacity-60",
+                "flex-1 text-center text-[10px] leading-tight",
+                selected === i ? "text-text font-medium" : "text-muted",
               )}
-              style={{ height: `${pct}%`, minHeight: v > 0 ? "2px" : "0" }}
-            />
-          </div>
-        );
-      })}
+            >
+              {show ? formatLabel(d) : ""}
+            </span>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Графіки у вкладці «Звіти» не показували підписи дат на осі X та не мали тултіпів при натисканні на стовпчик (HTML `title` не працює на мобільних пристроях).

**Зміни:**
- **Підписи дат під графіком:** у тижневому вигляді — дні тижня (Пн, Вт, Ср…), у місячному — числа місяця з розумним кроком (кожне N-те число), щоб не було занадто тісно
- **Тап/клік тултіп:** натискання на стовпчик показує дату та значення зверху графіка (формат `ДД.ММ: значення`)
- **Виділення:** обраний стовпчик підсвічується повною opacity
- **Accessibility:** замінено `div` на `button` для стовпчиків, щоб вони були доступні з клавіатури

## Review & Testing Checklist for Human
- [ ] Відкрити вкладку «Звіти» на мобільному (PWA) → перевірити, що під кожним графіком є підписи дат
- [ ] Натиснути на стовпчик → перевірити, що зверху з'являється тултіп з датою та значенням
- [ ] Переключити між «Тиждень» та «Місяць» → підписи мають змінюватися (дні тижня vs числа)
- [ ] Натиснути на обраний стовпчик ще раз → тултіп має зникнути

### Notes
- Lint та typecheck для `@sergeant/web` проходять без помилок
- Існуючий failing test у `eslint-plugins/sergeant-design/__tests__` не пов'язаний з цими змінами

Link to Devin session: https://app.devin.ai/sessions/c49c7ab4dd754f5e892d668cae1636a7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Bar chart interaction: click individual bars to view detailed metrics and values displayed in an interactive tooltip
- Smart x-axis labels: date labels intelligently adapt their format and display density based on the time period shown
- Visual selection feedback: the selected bar is prominently highlighted and emphasized for easy identification
- Enhanced empty state presentation for better visual balance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->