### PR TITLE
fix: show actual expense-to-income percentage when >100%

### DIFF
--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -344,7 +344,8 @@ export function Overview({ mono, storage, onNavigate, showBalance = true }) {
   const dayBudget = expenseLeft / remainingDays;
 
   const monthBalance = income - spent;
-  const spendPct = Math.min(100, income > 0 ? (spent / income) * 100 : 0);
+  const spendPct = income > 0 ? (spent / income) * 100 : 0;
+  const spendBarPct = Math.min(100, spendPct);
   const expenseFromIncomeBarClass =
     spendPct > 75 ? "bg-danger" : spendPct > 50 ? "bg-warning" : "bg-success";
   const showMonthForecast = showBalance && daysPassed > 0 && projectedSpend > 0;
@@ -418,6 +419,7 @@ export function Overview({ mono, storage, onNavigate, showBalance = true }) {
           showMonthForecast={showMonthForecast}
           projectedSpend={projectedSpend}
           spendPct={spendPct}
+          spendBarPct={spendBarPct}
           expenseFromIncomeBarClass={expenseFromIncomeBarClass}
           forecastTrendPct={forecastTrendPct}
           forecastBarClass={forecastBarClass}

--- a/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
@@ -18,6 +18,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
   showMonthForecast,
   projectedSpend,
   spendPct,
+  spendBarPct,
   expenseFromIncomeBarClass,
   forecastTrendPct,
   forecastBarClass,
@@ -95,7 +96,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
               "h-full rounded-full transition-[width,background-color] duration-700",
               expenseFromIncomeBarClass,
             )}
-            style={{ width: showBalance ? `${spendPct}%` : "0%" }}
+            style={{ width: showBalance ? `${spendBarPct}%` : "0%" }}
           />
         </div>
         <div className="flex justify-between text-xs text-muted">


### PR DESCRIPTION
## Summary

Коли витрати перевищують дохід (наприклад, 57 776 ₴ витрат при 53 087 ₴ доходу), у картці «Місяць» на Overview ФІНІК показувалось "100%" замість реального відсотка (~109%).

**Причина:** `Math.min(100, ...)` обрізав `spendPct` і для тексту, і для ширини прогрес-бару.

**Виправлення:** розділено на дві змінні:
- `spendPct` — реальний відсоток (без обмеження) → для відображення тексту
- `spendBarPct` — обмежений до 100% → для ширини CSS прогрес-бару

## Review & Testing Checklist for Human
- [ ] Перевірити, що при витратах > доходу текст показує реальний % (наприклад, 109%)
- [ ] Перевірити, що прогрес-бар при >100% заповнений повністю (не виходить за межі)
- [ ] Перевірити, що при витратах < доходу все працює як раніше

### Notes
Зміни мінімальні — лише 2 файли, 5 рядків додано, 2 видалено.

Link to Devin session: https://app.devin.ai/sessions/38e14d0e88bc4de8b280b4ba56d8f781
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the spending progress bar to accurately display spending that exceeds income. The spending percentage now correctly shows values above 100% when expenses surpass income, providing a more accurate financial overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->