### PR TITLE
fix(reports): скидання виділення стовпчика при зміні періоду

### DIFF
--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -522,6 +522,7 @@ export function HubReports() {
           higherIsBetter={true}
           chart={
             <BarChart
+              key={`${period}-${offset}`}
               data={data.workouts.cur.daily}
               dates={dates}
               colorClass="bg-sky-500"
@@ -540,6 +541,7 @@ export function HubReports() {
           higherIsBetter={false}
           chart={
             <BarChart
+              key={`${period}-${offset}`}
               data={data.spending.cur.daily}
               dates={dates}
               colorClass="bg-emerald-500"
@@ -558,6 +560,7 @@ export function HubReports() {
           higherIsBetter={true}
           chart={
             <BarChart
+              key={`${period}-${offset}`}
               data={data.habits.cur.daily}
               dates={dates}
               colorClass="bg-orange-500"
@@ -577,6 +580,7 @@ export function HubReports() {
           higherIsBetter={true}
           chart={
             <BarChart
+              key={`${period}-${offset}`}
               data={data.kcal.cur.daily}
               dates={dates}
               colorClass="bg-lime-500"


### PR DESCRIPTION
## Summary

Фікс бага з PR #665: при перемиканні між «Тиждень» / «Місяць» або навігації між періодами, `selected` індекс стовпчика не скидався. Якщо користувач обрав стовпчик №25 у місячному вигляді (31 день), а потім перемикнувся на тижневий (7 днів), `selected` залишався 25 → `dates[25]` та `vals[25]` = `undefined` → тултіп показував `NaN.NaN: NaN`.

**Рішення:** додано `key={period-offset}` до всіх 4 інстансів `BarChart`, що змушує React перемонтувати компонент і скинути стан при зміні періоду або навігації.

## Review & Testing Checklist for Human
- [ ] Обрати стовпчик у місячному вигляді → перемикнути на «Тиждень» → тултіп не повинен показувати NaN

### Notes
- Виявлено Devin Review на PR #665

Link to Devin session: https://app.devin.ai/sessions/c49c7ab4dd754f5e892d668cae1636a7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
