### PR TITLE
fix(nav): посилання «Скільки витратив на їжу» тепер відкриває аналітику, а не огляд Фініка

### DIFF
--- a/apps/web/src/core/hooks/useHubNavigation.ts
+++ b/apps/web/src/core/hooks/useHubNavigation.ts
@@ -47,10 +47,12 @@ export function useHubNavigation(): HubNavigation {
       const typedId = nextId as HubModuleId;
       const isSame = typedId === activeModule;
 
+      let hashStr = "";
       try {
         const raw = opts.hash != null ? String(opts.hash).trim() : "";
         if (raw) {
-          window.location.hash = raw.startsWith("#") ? raw : `#${raw}`;
+          hashStr = raw.startsWith("#") ? raw : `#${raw}`;
+          window.location.hash = hashStr;
         } else if (!isSame) {
           window.location.hash = "";
         }
@@ -60,7 +62,7 @@ export function useHubNavigation(): HubNavigation {
 
       setModuleAnimClass("module-enter");
       setActiveModule(typedId);
-      navigate(`/?module=${typedId}`, { replace: false });
+      navigate(`/?module=${typedId}${hashStr}`, { replace: false });
     },
     [activeModule, navigate],
   );


### PR DESCRIPTION
## Summary

Посилання «💸 Скільки витратив на їжу цього місяця?» зі сторінки «Покупки» (Харчування) вело на дефолтну сторінку Фініка (Огляд), а не на Аналітику, де видно розбивку по категоріях.

**Причина:** `openHubModule("finyk", "/analytics")` спочатку ставив `window.location.hash = "#/analytics"`, але потім `navigate('/?module=finyk')` (React Router v7) створював нову location з порожнім hash, перезатираючи щойно встановлений hash. В результаті FinykApp відкривався на дефолтній сторінці (overview).

**Виправлення:** hash тепер включається в URL при виклику `navigate()`:
```js
navigate(`/?module=${typedId}${hashStr}`, { replace: false });
```

Це виправляє deep linking для **всіх** модулів, не лише для Фініка. `window.location.hash` також залишається для `hashchange` event (коли модуль вже змонтований).

## Review & Testing Checklist for Human
- [ ] Відкрити Харчування → Склад → Покупки → натиснути «💸 Скільки витратив на їжу цього місяця?» → має відкритися Фінік на вкладці **Аналітика** (де видно категорії), а НЕ на Огляді
- [ ] Перевірити інші deep links: натиснути банер активного тренування → має відкритися Фізрук на вкладці Тренування

### Notes
- Цей баг стосувався всіх `openHubModule(...)` викликів з hash параметром, не лише посилання на їжу

Link to Devin session: https://app.devin.ai/sessions/c49c7ab4dd754f5e892d668cae1636a7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
