### PR TITLE
feat: restore standalone CoachInsightCard on dashboard, wire showCoach pref

### DIFF
--- a/apps/web/src/core/CoachInsightCard.tsx
+++ b/apps/web/src/core/CoachInsightCard.tsx
@@ -1,0 +1,111 @@
+import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+
+interface CoachInsightCardProps {
+  insight: string | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+  onOpenChat?: (context?: string) => void;
+}
+
+export function CoachInsightCard({
+  insight,
+  loading,
+  error,
+  onRefresh,
+  onOpenChat,
+}: CoachInsightCardProps) {
+  const handleDiscuss = () => {
+    if (typeof onOpenChat === "function") {
+      const coachContext = insight
+        ? `[Коуч-контекст]\nПерсональне повідомлення дня:\n"${insight}"\n\nЯ хочу обговорити цей інсайт або отримати більше порад.`
+        : "[Коуч-контекст]\nЯ хочу поговорити з персональним коучем.";
+      onOpenChat(coachContext);
+    }
+  };
+
+  return (
+    <Card
+      variant="default"
+      radius="lg"
+      padding="none"
+      className="overflow-hidden"
+    >
+      <div
+        className={cn(
+          "px-4 py-3.5 border-l-[4px] border-violet-500",
+          "bg-gradient-to-r from-violet-500/[0.06] to-transparent",
+          "dark:from-violet-500/[0.10]",
+        )}
+      >
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 w-8 h-8 rounded-full bg-violet-500/15 flex items-center justify-center text-sm">
+            <span aria-hidden>🤖</span>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2 mb-1">
+              <SectionHeading
+                as="span"
+                size="xs"
+                className="text-violet-600 dark:text-violet-400"
+              >
+                Коуч
+              </SectionHeading>
+              <Button
+                variant="ghost"
+                size="xs"
+                iconOnly
+                onClick={onRefresh}
+                disabled={loading}
+                aria-label="Оновити повідомлення коуча"
+                className={cn(
+                  "text-muted hover:text-text -mr-1",
+                  loading && "animate-spin",
+                )}
+              >
+                <Icon name="refresh-cw" size={14} />
+              </Button>
+            </div>
+
+            {loading && !insight && (
+              <p className="text-sm text-muted animate-pulse">
+                Коуч готує повідомлення…
+              </p>
+            )}
+
+            {error && !insight && (
+              <p className="text-sm text-danger">{error}</p>
+            )}
+
+            {insight && (
+              <p className="text-sm text-text leading-relaxed">{insight}</p>
+            )}
+
+            {!loading && !error && !insight && (
+              <p className="text-sm text-muted">Коуч аналізує твої дані…</p>
+            )}
+
+            {onOpenChat && (
+              <div className="mt-2.5">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleDiscuss}
+                  className="font-semibold"
+                >
+                  <Icon name="message-circle" size={14} />
+                  Обговорити
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/core/HubDashboard.tsx
+++ b/apps/web/src/core/HubDashboard.tsx
@@ -30,6 +30,8 @@ import { HubInsightsPanel } from "./HubInsightsPanel.jsx";
 import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
 import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
 import { useCoachInsight } from "./useCoachInsight.js";
+import { CoachInsightCard } from "./CoachInsightCard.jsx";
+import { useHubPref } from "./settings/hubPrefs.js";
 import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
 import { FirstActionHeroCard } from "./onboarding/FirstActionSheet.jsx";
 import { detectFirstRealEntry } from "./onboarding/firstRealEntry.js";
@@ -565,11 +567,14 @@ export function HubDashboard({
 
   const { focus, rest, dismiss } = useDashboardFocus();
 
-  // Coach insight підʼєднується на рівні дашборду і передається в NextCard
-  // як inline italic-рядок. Раніше він жив у `HubInsightsPanel` і
-  // змушував секцію авто-розкриватись — зараз інсайт стоїть поруч із
-  // фокусом, без окремого місця у списку.
-  const { insight: coachInsightText } = useCoachInsight();
+  // Coach insight — standalone card on the dashboard + inline in TodayFocusCard.
+  const [showCoach] = useHubPref<boolean>("showCoach", true);
+  const {
+    insight: coachInsightText,
+    loading: coachLoading,
+    error: coachError,
+    refresh: coachRefresh,
+  } = useCoachInsight();
 
   // ─────────────────────────────────────────────────────────────────────
   // «Є сигнал?» мапа — які модулі мають видиму рекомендацію. Використовується
@@ -680,6 +685,15 @@ export function HubDashboard({
       )}
 
       {hero}
+
+      {showCoach !== false && (
+        <CoachInsightCard
+          insight={coachInsightText}
+          loading={coachLoading}
+          error={coachError}
+          onRefresh={coachRefresh}
+        />
+      )}
 
       {activeNudge && !reengagement.show && (
         <DailyNudge


### PR DESCRIPTION
## Summary

Картка AI-коуча (`CoachInsightCard`) була видалена як "dead code" у коміті `ab282df9`, але перемикач "Показувати AI-коуч" у налаштуваннях залишився. В результаті: галочка є, а коуча на дашборді немає.

**Що зроблено:**
1. Створено новий `CoachInsightCard.tsx` — standalone картка коуча з дизайном під поточну систему (Card, Button, Icon, SectionHeading)
2. У `HubDashboard.tsx` підключено `useHubPref("showCoach")` — тепер перемикач у налаштуваннях реально контролює показ картки
3. Картка відображається після hero-секції на дашборді

**Що показує картка:**
- Іконка + заголовок "Коуч"
- Текст інсайту від AI (або лоадер / помилка / заглушка)
- Кнопка оновлення (refresh)
- Кнопка "Обговорити" (з'явиться, коли `onOpenChat` буде пробраковано)

## Review & Testing Checklist for Human
- [ ] Увімкнути "Показувати AI-коуч" у налаштуваннях → перевірити, що картка з'являється на дашборді
- [ ] Вимкнути "Показувати AI-коуч" → перевірити, що картка зникає
- [ ] Натиснути кнопку оновлення на картці → перевірити, що інсайт оновлюється
- [ ] Перевірити, що картка коректно виглядає в dark mode

### Notes
- `onOpenChat` поки не прокинуто в картку, тому кнопка "Обговорити" не показується. Це можна додати окремим PR якщо потрібно.
- Інлайн-інсайт у `TodayFocusCard` залишився без змін.

Link to Devin session: https://app.devin.ai/sessions/38e14d0e88bc4de8b280b4ba56d8f781
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
