### PR TITLE
feat(routine): список подій при натисканні на дату в місячному календарі

### DIFF
--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -493,6 +493,74 @@ export function RoutineCalendarPanel({
               month: "long",
             })}
           </p>
+          {flatGroupedItems.length > 0 && (
+            <div className="mt-3 space-y-1">
+              {flatGroupedItems.map((item, idx) => {
+                if (item.kind === "header") {
+                  return (
+                    <SectionHeading
+                      key={`dh-${item.label}`}
+                      as="p"
+                      size="xs"
+                      tone="subtle"
+                      className={cn(idx > 0 && "mt-2")}
+                    >
+                      {item.label}
+                    </SectionHeading>
+                  );
+                }
+                const e = item.e;
+                return (
+                  <div
+                    key={`dd-${e.id}`}
+                    className={cn(
+                      "flex items-center gap-2 rounded-xl px-3 py-2 border border-line bg-panel/60",
+                      e.completed && "opacity-70",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "w-1.5 h-1.5 rounded-full shrink-0",
+                        e.fizruk
+                          ? "bg-sky-500"
+                          : e.finykSub
+                            ? "bg-emerald-500"
+                            : C.dot,
+                      )}
+                    />
+                    <span className="flex-1 min-w-0 text-sm font-medium text-text truncate">
+                      {e.title}
+                    </span>
+                    <span className="text-2xs text-subtle shrink-0">
+                      {e.subtitle}
+                    </span>
+                    {e.habitId && (
+                      <button
+                        type="button"
+                        onClick={() => onToggleHabit(e.habitId, e.date)}
+                        className={cn(
+                          "w-7 h-7 rounded-lg border flex items-center justify-center text-xs font-bold transition-colors shrink-0",
+                          e.completed
+                            ? C.done
+                            : "border-line hover:bg-panelHi text-muted",
+                        )}
+                        aria-label={
+                          e.completed ? "Скасувати виконання" : "Виконано"
+                        }
+                      >
+                        {e.completed ? "✓" : "○"}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {flatGroupedItems.length === 0 && (
+            <p className="mt-2 text-2xs text-subtle text-center">
+              Подій на цей день немає
+            </p>
+          )}
         </Card>
       )}
 


### PR DESCRIPTION
## Summary

При натисканні на дату в місячному календарі тепер одразу під «Обрано: середа, 22 квітня» з'являється компактний список подій/звичок/планів на цей день.

Раніше при виборі дати в місячному вигляді список подій рендерився нижче карточки календаря — поза видимою областю екрана, і потрібно було скролити вниз. Тепер інформація видна одразу.

**Що показується:**
- Звички з кнопкою toggle (✓/○) для відмітки виконання
- Тренування Фізрука (позначені синьою крапкою)
- Підписки Фініка (позначені зеленою крапкою)
- Групування по типу (Ранок/День/Вечір, Фізрук, Підписки Фініка)
- «Подій на цей день немає» якщо немає подій

## Review & Testing Checklist for Human
- [ ] Відкрити Рутина → Календар → Місяць → натиснути на дату з подіями (●2) → під датою має з'явитись список подій
- [ ] Натиснути toggle кнопку (○) на звичці → звичка відмічається виконаною (✓)
- [ ] Натиснути на дату без подій → має показати «Подій на цей день немає»

### Notes
- Дані для списку беруться з того ж джерела (`grouped`), що й великий список під календарем — жодних нових запитів до сховища

Link to Devin session: https://app.devin.ai/sessions/c49c7ab4dd754f5e892d668cae1636a7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
