### PR TITLE
fix: category_breakdown key + mark_debt_paid partial payments; document exhaustive-deps

### DIFF
--- a/apps/mobile/src/modules/finyk/lib/budgetsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/budgetsStore.ts
@@ -110,6 +110,7 @@ export function useFinykBudgetsStore(
     if (seed.budgets) safeWriteLS(KEY_BUDGETS, seed.budgets);
     if (seed.monthlyPlan) safeWriteLS(KEY_MONTHLY_PLAN, seed.monthlyPlan);
     if (seed.subscriptions) safeWriteLS(KEY_SUBS, seed.subscriptions);
+    // Mount-only: `seed` is expected to be stable (from parent context).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/mobile/src/modules/finyk/lib/transactionsStore.ts
+++ b/apps/mobile/src/modules/finyk/lib/transactionsStore.ts
@@ -245,6 +245,7 @@ export function useFinykTransactionsStore(
       };
       safeWriteLS(KEY_TX_CACHE, snapshot);
     }
+    // Mount-only: `seed` is expected to be stable (from parent context).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/web/src/core/HubSearch.tsx
+++ b/apps/web/src/core/HubSearch.tsx
@@ -403,6 +403,7 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
+    // `openHit`/`commitQuery` are stable callbacks; `setActiveIdx` is a setter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flat, activeIdx, onClose, query]);
 

--- a/apps/web/src/core/hooks/useHubNavigation.ts
+++ b/apps/web/src/core/hooks/useHubNavigation.ts
@@ -73,6 +73,8 @@ export function useHubNavigation(): HubNavigation {
       setModuleAnimClass(mod ? "module-enter" : "hub-enter");
       setActiveModule(mod);
     }
+    // `activeModule` is read but also set — adding it would loop.
+    // Setters (`setActiveModule`, `setModuleAnimClass`) are stable.
   }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { activeModule, openModule, goToHub, moduleAnimClass };

--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -281,7 +281,7 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       } | null>("finyk_tx_cache", null);
       const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
       const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
-      const catMap = ls<Record<string, string>>("finyk_cat_overrides", {});
+      const catMap = ls<Record<string, string>>("finyk_tx_cats", {});
       const expenses = (txCache?.txs || []).filter((t) => {
         if (hiddenTxIds.includes(t.id || "")) return false;
         const ts = (t.time || 0) * 1000;

--- a/apps/web/src/core/lib/chatActions/finykActions.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.ts
@@ -271,7 +271,15 @@ export function handleFinykAction(action: ChatAction): string | undefined {
       });
       lsSet("finyk_manual_expenses_v1", manualExpenses);
       debt.linkedTxIds = [...(debt.linkedTxIds || []), txId];
-      const totalPaid = payAmount;
+      const prevPaid = debt.linkedTxIds
+        .filter((lid) => lid !== txId)
+        .reduce((sum, lid) => {
+          const linked = manualExpenses.find(
+            (e: { id: string }) => e.id === lid,
+          );
+          return sum + (linked ? Math.abs(Number(linked.amount) || 0) : 0);
+        }, 0);
+      const totalPaid = prevPaid + payAmount;
       const closed = totalPaid >= Number(debt.totalAmount);
       if (closed) {
         debts.splice(idx, 1);

--- a/apps/web/src/core/settings/hubPrefs.ts
+++ b/apps/web/src/core/settings/hubPrefs.ts
@@ -49,6 +49,8 @@ export function useHubPref<T>(
     };
     window.addEventListener("storage", handler);
     return () => window.removeEventListener("storage", handler);
+    // `read`/`setValue` excluded — `read` is stable for a given `key`,
+    // `setValue` is a React setter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -239,6 +239,8 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     if (!isCurrentMonth && !historyCache[monthKey]) {
       ensureMonth(year, month, monthKey);
     }
+    // `ensureMonth`/`historyCache` excluded — `ensureMonth` is redefined
+    // each render and `historyCache` changes after fetch, both would loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [year, month, isCurrentMonth, monthKey]);
 
@@ -246,6 +248,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
     if (!historyCache[prevKey]) {
       ensureMonth(prevYear, prevMonth, prevKey);
     }
+    // `ensureMonth`/`historyCache` excluded — same reason as above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prevYear, prevMonth, prevKey]);
 

--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -132,6 +132,7 @@ export default function NutritionApp({
         window.clearTimeout(fallback);
       };
     }
+    // `photo.fileRef` is a stable ref; `setPhotoCardForceOpen` is a setter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [log, onPwaActionConsumed, pwaAction]);
 

--- a/apps/web/src/modules/nutrition/components/meal-sheet/useFoodSearch.ts
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/useFoodSearch.ts
@@ -79,6 +79,7 @@ export function useFoodSearch(foodQuery: string): UseFoodSearchResult {
   // the fetch-effect; restore it explicitly here.
   useEffect(() => {
     if (foodErr) setFoodErr("");
+    // `foodErr` excluded: including it would loop (effect clears it).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trimmed]);
 


### PR DESCRIPTION
## Summary

**Bug fixes** (pre-existing in original `hubChatActions.ts`, surfaced by Devin Review on #672):

1. **`category_breakdown` used wrong storage key** — `finyk_cat_overrides` doesn't exist anywhere in the codebase. Fixed to `finyk_tx_cats` (used by all other finyk code). User-assigned category overrides were completely ignored in breakdowns.

2. **`mark_debt_paid` ignored previous partial payments** — `totalPaid = payAmount` only considered the current payment, so a 5000₴ debt paid in two installments (2000 + 3000) could never close. Now sums all linked transaction amounts before comparing to `totalAmount`.

**Documentation** — audited all 28 `react-hooks/exhaustive-deps` suppressions. All are intentional. Added justification comments to 10 that were undocumented (loop prevention, mount-only effects, stable refs/setters).

## Review & Testing Checklist for Human

- [ ] Test `category_breakdown` in chat: ask AI for category breakdown — verify it shows user-assigned categories (not just original ones)
- [ ] Test `mark_debt_paid` with partial payments: create a debt, make 2+ partial payments, verify debt closes when sum >= totalAmount
- [ ] Spot-check justification comments make sense (e.g. `useHubNavigation.ts`, `Analytics.tsx`, `hubPrefs.ts`)

### Notes
- All 704 tests pass. TypeScript and build succeed.
- The bug fixes are behavioral changes in chat actions — recommend manual testing via the HubChat AI interface.

Link to Devin session: https://app.devin.ai/sessions/18f995d0da4d43e6b0ccbccba9f2d8a0
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
