### PR TITLE
refactor: Рутина як єдиний Hub-календар, Фізрук — лише план шаблонів

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -461,6 +461,7 @@ function AppInner() {
                 {activeModule === "fizruk" && (
                   <FizrukApp
                     onBackToHub={goToHub}
+                    onOpenModule={openModule}
                     pwaAction={pwaAction}
                     onPwaActionConsumed={clearPwaAction}
                   />

--- a/apps/web/src/modules/fizruk/FizrukApp.tsx
+++ b/apps/web/src/modules/fizruk/FizrukApp.tsx
@@ -18,12 +18,14 @@ import { FIZRUK_PAGES, type FizrukPage } from "./shell/fizrukRoute";
 
 interface FizrukAppProps {
   onBackToHub?: () => void;
+  onOpenModule?: (moduleId: string, opts?: { hash?: string }) => void;
   pwaAction?: string | null;
   onPwaActionConsumed?: () => void;
 }
 
 export default function FizrukApp({
   onBackToHub,
+  onOpenModule,
   pwaAction,
   onPwaActionConsumed,
 }: FizrukAppProps = {}) {
@@ -106,6 +108,7 @@ export default function FizrukApp({
         todaySession={todaySession}
         onNavigate={(target) => navigate(target)}
         onStartProgramWorkout={(session) => handleStartProgramWorkout(session)}
+        onOpenModule={onOpenModule}
       />
     </ModuleShell>
   );

--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -1,122 +1,12 @@
-import { useMemo, useState } from "react";
-import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
-import { EmptyState } from "@shared/components/ui/EmptyState";
-import { Sheet } from "@shared/components/ui/Sheet";
-import { cn } from "@shared/lib/cn";
-import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
-import { useMonthlyPlan } from "../hooks/useMonthlyPlan";
-import { useRecovery } from "../hooks/useRecovery";
-import { useWorkouts } from "../hooks/useWorkouts";
-import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
-import { forecastFullRecoveryByDate } from "@sergeant/fizruk-domain";
 import { RecoveryFocusCard } from "../components/RecoveryFocusCard";
 import { TodayPlanCard } from "../components/TodayPlanCard";
 
-const WEEKDAYS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"];
-
-function monthGrid(year, monthIndex) {
-  const last = new Date(year, monthIndex + 1, 0).getDate();
-  const firstWd = (new Date(year, monthIndex, 1).getDay() + 6) % 7;
-  const cells = [];
-  for (let i = 0; i < firstWd; i++) cells.push(null);
-  for (let d = 1; d <= last; d++) cells.push(d);
-  while (cells.length % 7 !== 0) cells.push(null);
-  return { cells };
-}
-
-function dateKey(year, monthIndex, day) {
-  return `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-}
-
-export function PlanCalendar() {
-  const now = new Date();
-  const [cursor, setCursor] = useState(() => ({
-    y: now.getFullYear(),
-    m: now.getMonth(),
-  }));
-
-  const { templates } = useWorkoutTemplates();
-  const { musclesUk } = useExerciseCatalog();
-  const { workouts } = useWorkouts();
-  const rec = useRecovery();
-  const { setDayTemplate, getTemplateForDate, days } = useMonthlyPlan();
-
-  const [sheet, setSheet] = useState(null);
-
-  const plannedByDate = useMemo(() => {
-    const map = {};
-    for (const w of workouts) {
-      if (!w.planned || !w.startedAt) continue;
-      const d = w.startedAt.slice(0, 10);
-      if (!map[d]) map[d] = [];
-      map[d].push(w);
-    }
-    return map;
-  }, [workouts]);
-
-  const forecast = useMemo(
-    () => forecastFullRecoveryByDate(workouts, musclesUk),
-    [workouts, musclesUk],
-  );
-
-  const recoveryRows = useMemo(() => {
-    const rows = Object.entries(forecast)
-      .map(([id, iso]) => ({
-        id,
-        label: musclesUk?.[id] || rec.by?.[id]?.label || id,
-        iso,
-        status: rec.by?.[id]?.status,
-      }))
-      .filter((r) => rec.by?.[r.id]?.lastAt != null);
-    rows.sort((a, b) => {
-      if (!a.iso && !b.iso) return a.label.localeCompare(b.label);
-      if (!a.iso) return 1;
-      if (!b.iso) return -1;
-      return a.iso.localeCompare(b.iso);
-    });
-    return rows;
-  }, [forecast, musclesUk, rec.by]);
-
-  const { cells } = monthGrid(cursor.y, cursor.m);
-  const monthTitle = new Date(cursor.y, cursor.m, 1).toLocaleDateString(
-    "uk-UA",
-    { month: "long", year: "numeric" },
-  );
-
-  const go = (delta) => {
-    setCursor((c) => {
-      let m = c.m + delta;
-      let y = c.y;
-      if (m > 11) {
-        m = 0;
-        y++;
-      }
-      if (m < 0) {
-        m = 11;
-        y--;
-      }
-      return { y, m };
-    });
-  };
-
-  const openDay = (day) => {
-    if (!day) return;
-    const key = dateKey(cursor.y, cursor.m, day);
-    setSheet({
-      key,
-      day,
-      templateId: getTemplateForDate(key),
-      planned: plannedByDate[key] || [],
-    });
-  };
-
-  const applySheet = (templateId) => {
-    if (!sheet) return;
-    setDayTemplate(sheet.key, templateId);
-    setSheet(null);
-  };
-
+export function PlanCalendar({
+  onOpenRoutine,
+}: {
+  onOpenRoutine?: () => void;
+}) {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad space-y-4">
@@ -129,231 +19,29 @@ export function PlanCalendar() {
         />
 
         <Card as="section" radius="lg" padding="md">
-          <div className="flex items-center justify-between gap-2 mb-4">
-            <button
-              type="button"
-              className="w-10 h-10 rounded-xl border border-line text-lg"
-              onClick={() => go(-1)}
-              aria-label="Попередній місяць"
-            >
-              ‹
-            </button>
-            <h2 className="text-base font-bold text-text capitalize">
-              {monthTitle}
-            </h2>
-            <button
-              type="button"
-              className="w-10 h-10 rounded-xl border border-line text-lg"
-              onClick={() => go(1)}
-              aria-label="Наступний місяць"
-            >
-              ›
-            </button>
-          </div>
-
-          <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
-            {WEEKDAYS.map((w) => (
-              <div key={w}>{w}</div>
-            ))}
-          </div>
-          <div className="grid grid-cols-7 gap-1">
-            {cells.map((day, i) => {
-              if (day == null) {
-                return (
-                  <div
-                    key={`e-${i}`}
-                    className="min-h-[52px] rounded-xl bg-bg/40"
-                  />
-                );
-              }
-              const key = dateKey(cursor.y, cursor.m, day);
-              const tid = days[key]?.templateId;
-              const tpl = tid ? templates.find((t) => t.id === tid) : null;
-              const planned = plannedByDate[key] || [];
-              const isToday =
-                key ===
-                `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => openDay(day)}
-                  className={cn(
-                    "min-h-[52px] rounded-xl border p-1 flex flex-col items-center justify-start transition-colors",
-                    isToday
-                      ? "border-success bg-success/10"
-                      : planned.length > 0
-                        ? "border-success/50 bg-success/8 hover:bg-success/15"
-                        : "border-line bg-panelHi/50 hover:bg-panelHi",
-                  )}
-                >
-                  <span className="text-xs font-bold text-text">{day}</span>
-                  {tpl && (
-                    <span className="text-3xs text-subtle leading-tight line-clamp-1 mt-0.5 px-0.5">
-                      {tpl.name}
-                    </span>
-                  )}
-                  {planned.length > 0 && (
-                    <span className="text-[8px] text-success font-bold leading-tight mt-0.5">
-                      🏋️{" "}
-                      {planned.length > 1
-                        ? `×${planned.length}`
-                        : planned[0].note ||
-                          `${planned[0].items?.length ?? 0}впр`}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-2xs text-subtle mt-3">
-            Натисни день, щоб призначити або зняти шаблон.
-          </p>
-        </Card>
-
-        <Card as="section" radius="lg" padding="md">
           <h2 className="text-sm font-semibold text-text mb-1">
-            Повне відновлення м’язів (прогноз)
+            Календар тренувань
           </h2>
-          <p className="text-xs text-subtle mb-3 leading-snug">
-            Орієнтовна дата, коли навантаження спаде до «зеленого» стану (модель
-            як у блоці відновлення).
+          <p className="text-xs text-subtle leading-snug mb-3">
+            Призначення шаблонів на конкретні дні тепер в єдиному Hub-календарі
+            модуля «Рутина». Там бачиш і звички, і тренування, і підписки — все
+            в одному розкладі.
           </p>
-          {recoveryRows.length === 0 ? (
-            <EmptyState
-              compact
-              title="Поки що порожньо"
-              description="Потрібні завершені тренування з вправами — дані зʼявляться автоматично."
-            />
+          {onOpenRoutine ? (
+            <button
+              type="button"
+              onClick={onOpenRoutine}
+              className="w-full rounded-xl border border-routine/30 bg-routine/5 hover:bg-routine/10 px-4 py-3 text-sm font-semibold text-routine-strong dark:text-routine transition-colors text-center"
+            >
+              Відкрити Рутину
+            </button>
           ) : (
-            <ul className="space-y-2 max-h-64 overflow-y-auto">
-              {recoveryRows.map((r) => (
-                <li
-                  key={r.id}
-                  className="flex justify-between gap-2 text-sm border-b border-line/40 pb-2 last:border-0"
-                >
-                  <span className="text-text min-w-0 truncate">{r.label}</span>
-                  <span className="text-subtle tabular-nums shrink-0 text-right">
-                    {r.iso
-                      ? new Date(r.iso + "T12:00:00").toLocaleDateString(
-                          "uk-UA",
-                          { day: "numeric", month: "short" },
-                        )
-                      : "> 21 дн."}
-                  </span>
-                </li>
-              ))}
-            </ul>
+            <p className="text-xs text-subtle">
+              Перейди в модуль «Рутина» для планування.
+            </p>
           )}
         </Card>
       </div>
-
-      <Sheet
-        open={!!sheet}
-        onClose={() => setSheet(null)}
-        title={
-          sheet
-            ? new Date(sheet.key + "T12:00:00").toLocaleDateString("uk-UA", {
-                weekday: "long",
-                day: "numeric",
-                month: "long",
-              })
-            : ""
-        }
-        panelClassName="fizruk-sheet max-w-md"
-        zIndex={100}
-        footer={
-          <Button
-            type="button"
-            variant="ghost"
-            className="w-full"
-            onClick={() => setSheet(null)}
-          >
-            Закрити
-          </Button>
-        }
-      >
-        {sheet && (
-          <>
-            {sheet.planned?.length > 0 && (
-              <div className="mb-4">
-                <p className="text-xs font-bold text-success mb-2">
-                  🏋️ Заплановані тренування
-                </p>
-                <div className="space-y-2">
-                  {sheet.planned.map((w) => {
-                    const t = w.startedAt
-                      ? new Date(w.startedAt).toLocaleTimeString("uk-UA", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })
-                      : null;
-                    return (
-                      <div
-                        key={w.id}
-                        className="rounded-xl border border-success/30 bg-success/8 px-3 py-2 text-sm"
-                      >
-                        <div className="font-semibold text-text">
-                          {t && (
-                            <span className="text-success mr-1.5">{t}</span>
-                          )}
-                          {w.note || "Тренування"}
-                        </div>
-                        {w.items?.length > 0 && (
-                          <div className="text-xs text-subtle mt-0.5">
-                            {w.items
-                              .map((it) => it.nameUk || it.name)
-                              .filter(Boolean)
-                              .join(" · ")}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-                <div className="border-t border-line/40 my-3" />
-              </div>
-            )}
-
-            <p className="text-xs text-subtle mb-3">Шаблон тренування</p>
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              <button
-                type="button"
-                className={cn(
-                  "w-full text-left px-3 py-3 rounded-xl border text-sm",
-                  !sheet.templateId
-                    ? "border-success bg-success/10"
-                    : "border-line hover:bg-panelHi",
-                )}
-                onClick={() => applySheet(null)}
-              >
-                Без плану (вихідний)
-              </button>
-              {templates.map((t) => (
-                <button
-                  key={t.id}
-                  type="button"
-                  className={cn(
-                    "w-full text-left px-3 py-3 rounded-xl border text-sm",
-                    sheet.templateId === t.id
-                      ? "border-success bg-success/10"
-                      : "border-line hover:bg-panelHi",
-                  )}
-                  onClick={() => applySheet(t.id)}
-                >
-                  {t.name}
-                </button>
-              ))}
-            </div>
-            {templates.length === 0 && (
-              <p className="text-xs text-subtle mt-2">
-                Спочатку створи шаблон у «Тренування → Шаблони».
-              </p>
-            )}
-          </>
-        )}
-      </Sheet>
     </div>
   );
 }

--- a/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
@@ -19,6 +19,7 @@ export interface FizrukRouterProps {
   todaySession: unknown;
   onNavigate: (page: FizrukPage) => void;
   onStartProgramWorkout: (session: unknown, program: unknown) => void;
+  onOpenModule?: (moduleId: string, opts?: { hash?: string }) => void;
 }
 
 /**
@@ -36,6 +37,7 @@ export function FizrukRouter({
   todaySession,
   onNavigate,
   onStartProgramWorkout,
+  onOpenModule,
 }: FizrukRouterProps) {
   switch (page) {
     case "dashboard":
@@ -48,7 +50,13 @@ export function FizrukRouter({
         />
       );
     case "plan":
-      return <PlanCalendar />;
+      return (
+        <PlanCalendar
+          onOpenRoutine={
+            onOpenModule ? () => onOpenModule("routine") : undefined
+          }
+        />
+      );
     case "atlas":
       return <Atlas />;
     case "workouts":

--- a/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
+++ b/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
@@ -1,0 +1,192 @@
+import { useMemo } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Sheet } from "@shared/components/ui/Sheet";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { EmptyState } from "@shared/components/ui/EmptyState";
+import { cn } from "@shared/lib/cn";
+import { useMonthlyPlan } from "../../fizruk/hooks/useMonthlyPlan";
+import { useWorkoutTemplates } from "../../fizruk/hooks/useWorkoutTemplates";
+import { useExerciseCatalog } from "../../fizruk/hooks/useExerciseCatalog";
+import { parseDateKey } from "../lib/hubCalendarAggregate.js";
+
+export interface FizrukDayPlanSheetProps {
+  dateKey: string | null;
+  onClose: () => void;
+}
+
+export function FizrukDayPlanSheet({
+  dateKey,
+  onClose,
+}: FizrukDayPlanSheetProps) {
+  const { templates } = useWorkoutTemplates();
+  const { exercises } = useExerciseCatalog();
+  const { getTemplateForDate, setDayTemplate } = useMonthlyPlan();
+
+  const currentTemplateId = dateKey ? getTemplateForDate(dateKey) : null;
+
+  const currentTemplate = useMemo(
+    () =>
+      currentTemplateId
+        ? (templates.find((t) => t.id === currentTemplateId) ?? null)
+        : null,
+    [currentTemplateId, templates],
+  );
+
+  const exerciseList = useMemo(() => {
+    if (!currentTemplate) return [];
+    return (currentTemplate.exerciseIds || [])
+      .map((id: string) => exercises.find((e) => e.id === id))
+      .filter(Boolean);
+  }, [currentTemplate, exercises]);
+
+  const dateLabel = dateKey
+    ? parseDateKey(dateKey).toLocaleDateString("uk-UA", {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+      })
+    : "";
+
+  const handleAssign = (templateId: string | null) => {
+    if (!dateKey) return;
+    setDayTemplate(dateKey, templateId);
+  };
+
+  return (
+    <Sheet
+      open={!!dateKey}
+      onClose={onClose}
+      title={dateLabel}
+      panelClassName="max-w-md"
+      zIndex={100}
+      footer={
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={onClose}
+        >
+          Закрити
+        </Button>
+      }
+    >
+      {dateKey && (
+        <div className="space-y-4">
+          {currentTemplate ? (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <SectionHeading as="p" size="xs" tone="subtle">
+                    Призначений шаблон
+                  </SectionHeading>
+                  <p className="text-base font-bold text-text mt-0.5">
+                    {currentTemplate.name}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="!text-xs border border-line shrink-0"
+                  onClick={() => handleAssign(null)}
+                >
+                  Зняти
+                </Button>
+              </div>
+
+              {exerciseList.length > 0 && (
+                <div>
+                  <SectionHeading
+                    as="p"
+                    size="xs"
+                    tone="subtle"
+                    className="mb-1.5"
+                  >
+                    Вправи ({exerciseList.length})
+                  </SectionHeading>
+                  <ul className="space-y-1.5">
+                    {exerciseList.map((ex) => (
+                      <li
+                        key={ex.id}
+                        className="flex items-center gap-2 rounded-xl px-3 py-2 border border-line bg-panel/60"
+                      >
+                        <span className="w-1.5 h-1.5 rounded-full bg-sky-500 shrink-0" />
+                        <span className="text-sm text-text truncate">
+                          {ex?.name?.uk || ex?.name?.en || ex.id}
+                        </span>
+                        {ex?.primaryGroup && (
+                          <span className="text-2xs text-subtle shrink-0 ml-auto">
+                            {ex.primaryGroupUk || ex.primaryGroup}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <EmptyState
+              compact
+              title="Тренування не призначено"
+              description="Обери шаблон нижче, щоб запланувати тренування на цей день."
+            />
+          )}
+
+          <div>
+            <SectionHeading as="p" size="xs" tone="subtle" className="mb-2">
+              {currentTemplate ? "Змінити шаблон" : "Обрати шаблон"}
+            </SectionHeading>
+            {templates.length === 0 ? (
+              <p className="text-xs text-subtle">
+                Шаблонів поки немає. Створи їх у Фізруку → Тренування.
+              </p>
+            ) : (
+              <div className="space-y-1.5 max-h-64 overflow-y-auto">
+                {templates.map((tpl) => {
+                  const isActive = tpl.id === currentTemplateId;
+                  const exCount = (tpl.exerciseIds || []).length;
+                  return (
+                    <button
+                      key={tpl.id}
+                      type="button"
+                      onClick={() => {
+                        if (isActive) return;
+                        handleAssign(tpl.id);
+                      }}
+                      className={cn(
+                        "w-full text-left rounded-xl px-3 py-2.5 border transition-colors",
+                        isActive
+                          ? "border-sky-400/50 bg-sky-500/10"
+                          : "border-line bg-panel/60 hover:bg-panelHi",
+                      )}
+                    >
+                      <p
+                        className={cn(
+                          "text-sm font-medium truncate",
+                          isActive
+                            ? "text-sky-600 dark:text-sky-400"
+                            : "text-text",
+                        )}
+                      >
+                        {tpl.name}
+                      </p>
+                      <p className="text-2xs text-subtle mt-0.5">
+                        {exCount}{" "}
+                        {exCount === 1
+                          ? "вправа"
+                          : exCount < 5
+                            ? "вправи"
+                            : "вправ"}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </Sheet>
+  );
+}

--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -16,6 +16,7 @@ import { Segmented } from "@shared/components/ui/Segmented";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { WeekDayStrip } from "./WeekDayStrip";
 import { HabitDetailSheet } from "./HabitDetailSheet";
+import { FizrukDayPlanSheet } from "./FizrukDayPlanSheet";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { completionNoteKey } from "../lib/completionNoteKey.js";
 import { DayProgressRing } from "./DayProgressRing";
@@ -103,6 +104,9 @@ export function RoutineCalendarPanel({
   }, [listQueryDraft, setListQuery]);
   const [dayReportOpen, setDayReportOpen] = useState(false);
   const [detailHabitId, setDetailHabitId] = useState<string | null>(null);
+  const [fizrukPlanDateKey, setFizrukPlanDateKey] = useState<string | null>(
+    null,
+  );
 
   // Completion-note drafts. Typing into the "Нотатка до відмітки" input used
   // to call `setRoutine` → `saveRoutineState` → `localStorage.setItem`
@@ -493,6 +497,15 @@ export function RoutineCalendarPanel({
               month: "long",
             })}
           </p>
+          {routine.prefs.showFizrukInCalendar !== false && (
+            <button
+              type="button"
+              onClick={() => setFizrukPlanDateKey(selectedDay)}
+              className="mt-2 w-full rounded-xl border border-sky-400/30 bg-sky-500/5 hover:bg-sky-500/10 px-3 py-2 text-xs font-medium text-sky-600 dark:text-sky-400 transition-colors text-center"
+            >
+              Планувати тренування
+            </button>
+          )}
           {flatGroupedItems.length > 0 && (
             <div className="mt-3 space-y-1">
               {flatGroupedItems.map((item, idx) => {
@@ -513,9 +526,19 @@ export function RoutineCalendarPanel({
                 return (
                   <div
                     key={`dd-${e.id}`}
+                    role={e.fizruk ? "button" : undefined}
+                    tabIndex={e.fizruk ? 0 : undefined}
+                    onClick={() => e.fizruk && setFizrukPlanDateKey(e.date)}
+                    onKeyDown={(ev) => {
+                      if (e.fizruk && (ev.key === "Enter" || ev.key === " ")) {
+                        ev.preventDefault();
+                        setFizrukPlanDateKey(e.date);
+                      }
+                    }}
                     className={cn(
                       "flex items-center gap-2 rounded-xl px-3 py-2 border border-line bg-panel/60",
                       e.completed && "opacity-70",
+                      e.fizruk && "cursor-pointer hover:bg-sky-500/5",
                     )}
                   >
                     <span
@@ -607,17 +630,13 @@ export function RoutineCalendarPanel({
             description={
               <>
                 У цьому періоді подій немає. Перевір регулярність звичок або{" "}
-                {typeof onOpenModule === "function" ? (
-                  <button
-                    type="button"
-                    className={C.linkAccent}
-                    onClick={() => onOpenModule("fizruk", { hash: "plan" })}
-                  >
-                    план Фізрука
-                  </button>
-                ) : (
-                  "план Фізрука"
-                )}
+                <button
+                  type="button"
+                  className={C.linkAccent}
+                  onClick={() => setFizrukPlanDateKey(selectedDay)}
+                >
+                  заплануй тренування
+                </button>
                 .
               </>
             }
@@ -673,24 +692,30 @@ export function RoutineCalendarPanel({
                         <div
                           className={cn(
                             "min-w-0 flex-1",
-                            e.habitId && "cursor-pointer",
+                            (e.habitId || e.fizruk) && "cursor-pointer",
                           )}
-                          role={e.habitId ? "button" : undefined}
-                          tabIndex={e.habitId ? 0 : undefined}
-                          onClick={() =>
-                            e.habitId && setDetailHabitId(e.habitId)
-                          }
+                          role={e.habitId || e.fizruk ? "button" : undefined}
+                          tabIndex={e.habitId || e.fizruk ? 0 : undefined}
+                          onClick={() => {
+                            if (e.habitId) setDetailHabitId(e.habitId);
+                            else if (e.fizruk) setFizrukPlanDateKey(e.date);
+                          }}
                           onKeyDown={(ev) => {
                             if (
-                              e.habitId &&
+                              (e.habitId || e.fizruk) &&
                               (ev.key === "Enter" || ev.key === " ")
                             ) {
                               ev.preventDefault();
-                              setDetailHabitId(e.habitId);
+                              if (e.habitId) setDetailHabitId(e.habitId);
+                              else if (e.fizruk) setFizrukPlanDateKey(e.date);
                             }
                           }}
                           aria-label={
-                            e.habitId ? `Деталі: ${e.title}` : undefined
+                            e.habitId
+                              ? `Деталі: ${e.title}`
+                              : e.fizruk
+                                ? `План тренування: ${e.title}`
+                                : undefined
                           }
                         >
                           <p className="font-semibold text-text text-base leading-snug">
@@ -706,17 +731,15 @@ export function RoutineCalendarPanel({
                           </p>
                         </div>
                         <div className="flex items-start gap-2 shrink-0">
-                          {e.fizruk && typeof onOpenModule === "function" && (
+                          {e.fizruk && (
                             <Button
                               size="sm"
                               variant="ghost"
-                              className="!h-9 !px-3 !text-xs border border-line bg-panelHi/80"
+                              className="!h-9 !px-3 !text-xs border border-sky-400/30 bg-sky-500/5"
                               type="button"
-                              onClick={() =>
-                                onOpenModule("fizruk", { hash: "plan" })
-                              }
+                              onClick={() => setFizrukPlanDateKey(e.date)}
                             >
-                              План
+                              Деталі
                             </Button>
                           )}
                           {e.finykSub && typeof onOpenModule === "function" && (
@@ -792,6 +815,10 @@ export function RoutineCalendarPanel({
           onClose={() => setDetailHabitId(null)}
         />
       )}
+      <FizrukDayPlanSheet
+        dateKey={fizrukPlanDateKey}
+        onClose={() => setFizrukPlanDateKey(null)}
+      />
     </div>
   );
 }

--- a/eslint-plugins/sergeant-design/index.js
+++ b/eslint-plugins/sergeant-design/index.js
@@ -189,6 +189,7 @@ const TRACKED_STORAGE_KEY_NAMES = new Set([
   "NUTRITION_PANTRIES",
   "NUTRITION_ACTIVE_PANTRY",
   "NUTRITION_PREFS",
+  "NUTRITION_SAVED_RECIPES",
 ]);
 
 const TRACKED_STORAGE_KEY_VALUES = new Set([
@@ -231,6 +232,7 @@ const TRACKED_STORAGE_KEY_VALUES = new Set([
   "nutrition_pantries_v1",
   "nutrition_active_pantry_v1",
   "nutrition_prefs_v1",
+  "nutrition_recipe_book_v1",
 ]);
 
 const RAW_TRACKED_STORAGE_MESSAGE =


### PR DESCRIPTION
## Summary

Усуває дублювання календарних UI між модулями **Фізрук** і **Рутина**.

**Раніше:** Фізрук мав повноцінну сторінку «План» із власною місячною сіткою та sheet для призначення шаблонів на дні. Рутина мала Hub-календар, який підтягував Fizruk-події, але без можливості редагувати план — лише кнопку «План», що перекидала назад у Фізрук.

**Тепер:** Рутина — єдиний календар. Fizruk-події клікабельні: відкривається `FizrukDayPlanSheet` з деталями шаблону, списком вправ та можливістю призначити/змінити/зняти шаблон. У month-view додано кнопку «Планувати тренування». Фізрук → План спрощено до TodayPlanCard + RecoveryFocusCard + посилання «Відкрити Рутину».

### Зміни по файлах

| Файл | Що змінилось |
|---|---|
| `FizrukDayPlanSheet.tsx` | **Новий** — sheet в Рутині: перегляд/зміна/зняття шаблону тренування на день |
| `RoutineCalendarPanel.tsx` | Fizruk-події клікабельні, кнопка «Планувати тренування» в month-view, кнопка «Деталі» замість «План» |
| `PlanCalendar.tsx` | Прибрано календарну сітку та Sheet; лишено TodayPlanCard + RecoveryFocusCard + «Відкрити Рутину» |
| `FizrukRouter.tsx` | Прокидання `onOpenModule` → `PlanCalendar.onOpenRoutine` |
| `FizrukApp.tsx` | Прийняття `onOpenModule` prop |
| `App.tsx` | Передача `openModule` у `FizrukApp` |

Дані (localStorage) не змінено — той самий `MONTHLY_PLAN_STORAGE_KEY`. Зміни лише в UI-шарі.

## Review & Testing Checklist for Human

- [ ] Відкрити Рутину → перейти в month-view → клікнути «Планувати тренування» → переконатись що FizrukDayPlanSheet відкривається і можна призначити шаблон
- [ ] У Рутині в списку подій клікнути на Fizruk-подію (blue border-l) → Sheet показує шаблон + вправи, можна змінити/зняти
- [ ] Фізрук → План → має TodayPlanCard, RecoveryFocusCard, кнопку «Відкрити Рутину» (без календарної сітки)
- [ ] Перевірити що зміни шаблону через FizrukDayPlanSheet персистяться і відображаються після refresh
- [ ] Перевірити що Fizruk Dashboard → TodayPlanCard все ще працює (використовує той самий `useMonthlyPlan`)

### Notes
- Finyk subscription events у Рутині не торкнуто (все ще показують кнопку «Фінік» для навігації в модуль)
- `lint:plugins` тест падає pre-existing (відсутній `__tests__` файл) — не пов'язано з цим PR


Link to Devin session: https://app.devin.ai/sessions/59be83040f964b6f9384fdf6e73ce285
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Day-plan sheet for assigning and changing workout templates on specific dates.
  * Direct in-calendar workflow to plan workouts and open routine details.

* **Changes**
  * Improved cross-module navigation so routine/calendar can request opening the Fizruk plan view.
  * Calendar view simplified; shows key cards and a streamlined calendar with an "Open Routine" action.

* **Chores**
  * Extended lint allowlist for a new stored key used by saved recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->