### PR TITLE
feat(web): polish chat header + fix BrandLogo heading a11y

### DIFF
--- a/apps/web/src/core/AuthPage.tsx
+++ b/apps/web/src/core/AuthPage.tsx
@@ -69,7 +69,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
     >
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
-          <BrandLogo size="md" className="justify-center mb-1" />
+          <BrandLogo as="h1" size="md" className="justify-center mb-1" />
           <p className="text-sm text-subtle">
             {mode === "login" ? "Вхід в акаунт" : "Створення акаунту"}
           </p>

--- a/apps/web/src/core/HubChat.tsx
+++ b/apps/web/src/core/HubChat.tsx
@@ -502,21 +502,24 @@ function HubChat({ onClose, initialMessage }) {
         </div>
 
         {/* Header */}
-        <div className="flex items-center justify-between px-4 pb-3 shrink-0 border-b border-line">
-          <div className="flex items-center gap-2.5 min-w-0">
-            <span className="text-2xl leading-none shrink-0" aria-hidden>
-              🤖
-            </span>
+        <div className="flex items-start justify-between gap-3 px-4 pb-3 shrink-0 border-b border-line">
+          <div className="flex items-start gap-3 min-w-0">
+            <div
+              className="w-9 h-9 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0 mt-0.5"
+              aria-hidden
+            >
+              <Icon name="sparkle" size={18} className="text-brand-500" />
+            </div>
             <div className="min-w-0">
               <div
                 id="hub-chat-title"
-                className="text-sm font-semibold text-text"
+                className="text-[15px] font-bold text-text leading-snug"
               >
                 Асистент
               </div>
               <div
                 className={cn(
-                  "text-2xs",
+                  "text-2xs leading-snug mt-0.5",
                   hasData ? "text-subtle" : "text-warning",
                 )}
               >
@@ -524,53 +527,57 @@ function HubChat({ onClose, initialMessage }) {
                   ? "Фінік · Фізрук · Рутина · Харчування"
                   : "Mono не підключено"}
               </div>
-              <div className="text-2xs text-subtle mt-0.5">
-                {contextState.status === "building"
-                  ? "Готую контекст…"
-                  : contextState.status === "ready"
-                    ? "Контекст готовий"
-                    : ""}
-              </div>
-              <div className="text-2xs text-subtle mt-0.5">
-                Сесія: {sessionInfo.historyCount}/10 · ~
-                {Math.round(sessionInfo.chars / 100) / 10}k символів
+              <div className="flex items-center gap-1.5 text-2xs text-subtle mt-1">
+                <span
+                  className={cn(
+                    "inline-block w-1.5 h-1.5 rounded-full",
+                    contextState.status === "ready"
+                      ? "bg-brand-500"
+                      : contextState.status === "building"
+                        ? "bg-warning animate-pulse"
+                        : "bg-line",
+                  )}
+                />
+                <span>
+                  {contextState.status === "building"
+                    ? "Готую контекст…"
+                    : contextState.status === "ready"
+                      ? "Контекст готовий"
+                      : "Очікую"}
+                </span>
+                <span className="text-line">·</span>
+                <span>
+                  {sessionInfo.historyCount}/10 · ~
+                  {Math.round(sessionInfo.chars / 100) / 10}k
+                </span>
               </div>
               <p
                 id="hub-chat-privacy"
-                className="text-2xs text-subtle mt-1 leading-snug max-w-[min(100%,280px)]"
+                className="text-2xs text-muted/70 mt-1 leading-snug max-w-[min(100%,280px)]"
               >
-                Запит і короткий контекст (фінанси, тренування, звички,
-                харчування) відправляються на сервер до AI. Не діліться чужим
-                пристроєм без потреби.
+                Контекст (фінанси, тренування, звички, харчування)
+                відправляється до AI.
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-0.5 shrink-0">
             <button
               type="button"
               onClick={clearChat}
-              className="h-9 px-3 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-xs font-semibold"
-              title="Нова сесія (очистити чат)"
-              aria-label="Нова сесія (очистити чат)"
+              className="h-8 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
+              title="Очистити історію та почати нову сесію"
+              aria-label="Очистити чат"
             >
-              ↻ Нова
-            </button>
-            <button
-              type="button"
-              onClick={clearChat}
-              className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-danger hover:bg-danger/8 transition-colors"
-              title="Очистити чат"
-              aria-label="Очистити історію чату"
-            >
-              <Icon name="trash" size={15} />
+              <Icon name="refresh-cw" size={13} />
+              Новий чат
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+              className="w-8 h-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
               aria-label="Закрити асистента"
             >
-              <Icon name="close" size={18} />
+              <Icon name="close" size={16} />
             </button>
           </div>
         </div>

--- a/apps/web/src/core/ResetPasswordPage.tsx
+++ b/apps/web/src/core/ResetPasswordPage.tsx
@@ -78,7 +78,7 @@ export function ResetPasswordPage() {
     >
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
-          <BrandLogo size="md" className="justify-center mb-1" />
+          <BrandLogo as="h1" size="md" className="justify-center mb-1" />
           <p className="text-sm text-subtle">Новий пароль</p>
         </div>
 

--- a/apps/web/src/core/app/BrandLogo.tsx
+++ b/apps/web/src/core/app/BrandLogo.tsx
@@ -49,27 +49,35 @@ const GRADIENT_STYLE: React.CSSProperties = {
   backgroundClip: "text",
 };
 
+type TagName = "span" | "h1" | "h2" | "h3" | "div";
+
 interface BrandLogoProps {
   /** Extra Tailwind classes for the outer wrapper. */
   className?: string;
   /** Size variant. "lg" is the hub header, "md" is auth/onboarding. */
   size?: "lg" | "md";
+  /** HTML element for the outer wrapper (default "span"). Use "h1" on pages that need a heading landmark. */
+  as?: TagName;
 }
 
-export function BrandLogo({ className, size = "lg" }: BrandLogoProps) {
+export function BrandLogo({
+  className,
+  size = "lg",
+  as: Tag = "span",
+}: BrandLogoProps) {
   const textCls =
     size === "lg"
       ? "text-[26px] leading-none font-extrabold tracking-tight"
       : "text-2xl leading-none font-extrabold tracking-tight";
 
   return (
-    <span
+    <Tag
       className={`inline-flex items-center gap-1.5 select-none text-brand-500 ${className ?? ""}`}
     >
       {CHEVRON_ICON}
       <span className={textCls} style={GRADIENT_STYLE}>
         Sergeant
       </span>
-    </span>
+    </Tag>
   );
 }

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -25,7 +25,7 @@ export function HubHeader({
       className="px-5 pt-10 pb-2 max-w-lg mx-auto w-full flex items-center justify-between"
       style={{ paddingTop: "max(2.5rem, env(safe-area-inset-top))" }}
     >
-      <BrandLogo />
+      <BrandLogo as="h1" />
       <div className="pt-1 flex items-center gap-1">
         <button
           type="button"


### PR DESCRIPTION
## Summary

Дві зміни в одному PR:

### 1. Редизайн шапки чат-панелі асистента
- **Іконка замість емодзі** — `🤖` замінено на стилізований `sparkle` в emerald бейджі (`bg-brand-500/10`)
- **Один «Новий чат» замість двох кнопок** — кнопка «↻ Нова» і кошик (🗑) робили однакову дію `clearChat()`, тому об'єднані в одну чітку кнопку з іконкою `refresh-cw`
- **Статус-індикатор** — зелена крапка = контекст готовий, пульсуюча жовта = будується
- **Компактний рядок сесії** — контекст-статус і лічильник повідомлень в одному рядку замість двох
- **Коротший privacy-текст** — одне речення замість двох

### 2. Accessibility fix для BrandLogo (з Devin Review #677)
- Додано проп `as` (TagName) до `BrandLogo` — дозволяє рендерити як `<h1>`, `<h2>`, тощо
- `HubHeader`, `AuthPage`, `ResetPasswordPage` тепер використовують `as="h1"` — повертає heading landmark для screen readers (WCAG)
- `OnboardingWizard` залишає `<span>` (вже обгорнутий у `<h2>`)

## Review & Testing Checklist for Human
- [ ] Відкрити чат асистента — перевірити що шапка виглядає акуратно (emerald бейдж, sparkle іконка, компактний лейаут)
- [ ] Натиснути «Новий чат» — чат очищується як раніше
- [ ] Перевірити в dark mode — кольори бейджа та статус-крапки коректні
- [ ] Screen reader: перевірити що `<h1>` присутній на сторінках логіна, хабу, скидання паролю

### Notes
- Жодних змін у логіці чату — лише візуальні правки шапки
- `BrandLogo` backward-compatible: без `as` рендерить `<span>` як раніше

Link to Devin session: https://app.devin.ai/sessions/cc7d026fcca649318ee45fadcba99c31
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
