### PR TITLE
fix(hub): equal-width module cards + restore chevron logo

### DIFF
--- a/apps/web/src/core/HubDashboard.tsx
+++ b/apps/web/src/core/HubDashboard.tsx
@@ -414,7 +414,7 @@ const BentoCard = memo(function BentoCard({
       type="button"
       onClick={onClick}
       className={cn(
-        "group relative flex flex-col rounded-3xl border border-line p-3.5",
+        "group relative flex flex-col w-full rounded-3xl border border-line p-3.5",
         "shadow-card transition-all duration-200 text-left",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
         "active:scale-[0.98]",
@@ -542,7 +542,7 @@ const SortableCard = memo(function SortableCard({
   if (!cfg) return null;
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} className="min-w-0">
       <BentoCard
         config={cfg}
         onClick={handleClick}

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -4,6 +4,39 @@ import { DarkModeToggle } from "./DarkModeToggle.jsx";
 import { UserMenuButton } from "./UserMenuButton.jsx";
 import type { User } from "@sergeant/shared";
 
+const CHEVRON_ICON = (
+  <svg
+    viewBox="0 0 18 18"
+    width={18}
+    height={18}
+    fill="none"
+    aria-hidden="true"
+    className="shrink-0"
+  >
+    <path
+      d="M3 6.5 L9 3 L15 6.5"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3 10.5 L9 7 L15 10.5"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3 14.5 L9 11 L15 14.5"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const ICON_BUTTON_CLS =
   "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
@@ -83,6 +116,9 @@ export function HubHeader({
       style={{ paddingTop: "max(2.5rem, env(safe-area-inset-top))" }}
     >
       <div className="min-w-0">
+        <div className="flex items-center gap-1.5 text-brand-500 mb-0.5">
+          {CHEVRON_ICON}
+        </div>
         <h1 className="text-2xl font-bold text-text leading-tight truncate">
           {greeting.text} <span aria-hidden>{greeting.emoji}</span>
         </h1>


### PR DESCRIPTION
## Summary

Fixes two visual issues from the dashboard overhaul (#680):

1. **Module cards disproportionate** — BentoCard `<button>` was missing `w-full`, causing cards to shrink to content width instead of filling grid cells equally. Also added `min-w-0` on the SortableCard wrapper div to prevent grid blowout.

2. **Chevron logo missing** — Restored the sergeant chevron SVG insignia above the greeting text in HubHeader. The chevron now sits in brand emerald above "Доброго ранку ☀️".

## Review & Testing Checklist for Human
- [ ] Verify 2×2 module cards are equal width on mobile (375px viewport)
- [ ] Confirm chevron icon is visible above the greeting in the header

### Notes
Follow-up to #680. No logic changes — purely visual fixes.

Link to Devin session: https://app.devin.ai/sessions/2c622ba3027a4685ac4101d34e45bab4
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chevron icon to the header greeting area with brand color styling.

* **Style**
  * Enhanced card and grid layout behavior to ensure proper width management and prevent overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->