### PR TITLE
refactor(settings): прибрати дублікат темної теми з Settings

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -381,8 +381,6 @@ function AppInner() {
           onDismissIos={iosDismiss}
           hubView={ui.hubView}
           onOpenChat={ui.openChat}
-          dark={dark}
-          onToggleDark={toggleDark}
           syncing={sync.syncing}
           onSync={sync.pushAll}
           onPull={sync.pullAll}

--- a/apps/web/src/core/HubSettingsPage.tsx
+++ b/apps/web/src/core/HubSettingsPage.tsx
@@ -32,14 +32,7 @@ const GROUPS = [
   },
 ];
 
-export function HubSettingsPage({
-  dark,
-  onToggleDark,
-  syncing,
-  onSync,
-  onPull,
-  user,
-}) {
+export function HubSettingsPage({ syncing, onSync, onPull, user }) {
   const [tab, setTab] = useState("general");
   const [query, setQuery] = useState("");
   const refs = useRef({});
@@ -52,11 +45,9 @@ export function HubSettingsPage({
         id: "general",
         title: "Інтерфейс і синхронізація",
         keywords:
-          "загальні тема темна світла мова інтерфейс синхронізація акаунт sync cloud backup",
+          "загальні мова інтерфейс синхронізація акаунт sync cloud backup",
         render: () => (
           <GeneralSection
-            dark={dark}
-            onToggleDark={onToggleDark}
             syncing={syncing}
             onSync={onSync}
             onPull={onPull}
@@ -111,7 +102,7 @@ export function HubSettingsPage({
         render: () => <ExperimentalSection />,
       },
     ],
-    [dark, onToggleDark, syncing, onSync, onPull, user],
+    [syncing, onSync, onPull, user],
   );
 
   const q = query.trim().toLowerCase();

--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -37,8 +37,6 @@ export function HubMainContent({
   onDismissIos,
   hubView,
   onOpenChat,
-  dark,
-  onToggleDark,
   syncing,
   onSync,
   onPull,
@@ -180,8 +178,6 @@ export function HubMainContent({
         {hubView === "settings" && (
           <ErrorBoundary key="settings" fallback={HubSectionFallback}>
             <HubSettingsPage
-              dark={dark}
-              onToggleDark={onToggleDark}
               syncing={syncing}
               onSync={onSync}
               onPull={onPull}

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ChangeEvent } from "react";
+import { useCallback, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
@@ -78,8 +78,6 @@ function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
 }
 
 export interface GeneralSectionProps {
-  dark: boolean;
-  onToggleDark: (event: ChangeEvent<HTMLInputElement>) => void;
   syncing: boolean;
   onSync: () => void;
   onPull: () => void;
@@ -87,8 +85,6 @@ export interface GeneralSectionProps {
 }
 
 export function GeneralSection({
-  dark,
-  onToggleDark,
   syncing,
   onSync,
   onPull,
@@ -146,7 +142,6 @@ export function GeneralSection({
 
   return (
     <SettingsGroup title="Загальні" emoji="⚙️">
-      <ToggleRow label="Темна тема" checked={dark} onChange={onToggleDark} />
       <SettingsSubGroup title="Дашборд">
         <ToggleRow
           label="Показувати підказки"


### PR DESCRIPTION
## Summary

Перемикач темної теми був продубльований у двох місцях:
1. **Дропдаун аватарки** (`UserMenuButton`) — швидкий доступ з будь-якої сторінки
2. **Settings → Загальні → «Темна тема»** — ToggleRow у `GeneralSection`

Обидва використовували один `useDarkMode` хук, тому конфліктів не було — але UX-дублювання зайве.

**Рішення:** прибираємо toggle з Settings, залишаємо тільки в дропдауні аватарки (доступний з будь-якої сторінки).

### Що змінено:
- `GeneralSection` — видалено `dark`/`onToggleDark` пропси і `ToggleRow` темної теми
- `HubSettingsPage` — видалено `dark`/`onToggleDark` пропси і прокидання до `GeneralSection`
- `HubMainContent` — видалено `dark`/`onToggleDark` пропси і прокидання до `HubSettingsPage`
- `App.tsx` — видалено прокидання `dark`/`onToggleDark` до `HubMainContent`
- Прибрано «тема темна світла» з keywords пошуку по налаштуваннях

## Review & Testing Checklist for Human

- [ ] Відкрити Settings → Загальні — переконатись що toggle «Темна тема» зник
- [ ] Переключити тему через дропдаун аватарки — має працювати як раніше
- [ ] Для незалогіненого юзера — іконка sun/moon в хедері має працювати

### Notes

Typecheck і lint для `@sergeant/web` проходять без помилок.

Link to Devin session: https://app.devin.ai/sessions/75a4376d952c444595809ffa21935376
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
