### PR TITLE
feat(plan): шаблон за замовчуванням без вибору + кнопка «Запланувати тренування»

### DIFF
--- a/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
+++ b/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
@@ -37,12 +37,6 @@ export function TodayPlanCard({
   const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(
     null,
   );
-
-  useEffect(() => {
-    if (selectedTemplateId) return;
-    const first = templates[0]?.id;
-    if (first) setSelectedTemplateId(first);
-  }, [templates, selectedTemplateId, setSelectedTemplateId]);
 
   const effectiveTemplateId = monthlyPlan.todayTemplateId || selectedTemplateId;
 
@@ -142,15 +136,14 @@ export function TodayPlanCard({
             }}
             aria-label="Обрати збережений шаблон тренування"
           >
-            {templates.length === 0 ? (
-              <option value="">— немає шаблонів —</option>
-            ) : (
-              templates.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name}
-                </option>
-              ))
-            )}
+            <option value="">
+              {templates.length === 0 ? "— немає шаблонів —" : "Оберіть шаблон"}
+            </option>
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name}
+              </option>
+            ))}
           </select>
         </div>
 
@@ -178,39 +171,43 @@ export function TodayPlanCard({
           </div>
         ) : null}
 
-        <div className="mt-4">
-          <div className="text-xs text-subtle mb-2">
-            Вправи з шаблону
-            {plan.templateName ? ` «${plan.templateName}»` : ""}:
+        {effectiveTemplateId ? (
+          <div className="mt-4">
+            <div className="text-xs text-subtle mb-2">
+              Вправи з шаблону
+              {plan.templateName ? ` «${plan.templateName}»` : ""}:
+            </div>
+            {plan.picked.length ? (
+              <div className="space-y-2">
+                {plan.picked.map((ex) => (
+                  <button
+                    key={ex.id}
+                    type="button"
+                    className="w-full text-left border border-line rounded-2xl p-3 min-h-[44px] bg-bg hover:bg-panelHi transition-colors"
+                    onClick={() => {
+                      window.location.hash = `#exercise/${ex.id}`;
+                    }}
+                  >
+                    <div className="text-sm font-semibold text-text truncate">
+                      {ex?.name?.uk || ex?.name?.en}
+                    </div>
+                    <div className="text-xs text-subtle mt-0.5">
+                      {primaryGroupsUk?.[ex.primaryGroup] || ex.primaryGroup}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-subtle text-center py-6">
+                У шаблоні немає вправ або вправи видалені з каталогу
+              </div>
+            )}
           </div>
-          {plan.picked.length ? (
-            <div className="space-y-2">
-              {plan.picked.map((ex) => (
-                <button
-                  key={ex.id}
-                  type="button"
-                  className="w-full text-left border border-line rounded-2xl p-3 min-h-[44px] bg-bg hover:bg-panelHi transition-colors"
-                  onClick={() => {
-                    window.location.hash = `#exercise/${ex.id}`;
-                  }}
-                >
-                  <div className="text-sm font-semibold text-text truncate">
-                    {ex?.name?.uk || ex?.name?.en}
-                  </div>
-                  <div className="text-xs text-subtle mt-0.5">
-                    {primaryGroupsUk?.[ex.primaryGroup] || ex.primaryGroup}
-                  </div>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="text-sm text-subtle text-center py-6">
-              {templates.length
-                ? "У шаблоні немає вправ або вправи видалені з каталогу"
-                : "Обери або створи шаблон"}
-            </div>
-          )}
-        </div>
+        ) : (
+          <div className="mt-4 text-sm text-subtle text-center py-6">
+            Оберіть шаблон, щоб побачити вправи
+          </div>
+        )}
 
         <div className="mt-3 flex gap-2">
           <Button

--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@shared/components/ui/Card";
+import { Button } from "@shared/components/ui/Button";
 import { RecoveryFocusCard } from "../components/RecoveryFocusCard";
 import { TodayPlanCard } from "../components/TodayPlanCard";
 
@@ -18,29 +18,19 @@ export function PlanCalendar({
           }}
         />
 
-        <Card as="section" radius="lg" padding="md">
-          <h2 className="text-sm font-semibold text-text mb-1">
-            Календар тренувань
-          </h2>
-          <p className="text-xs text-subtle leading-snug mb-3">
-            Призначення шаблонів на конкретні дні тепер в єдиному Hub-календарі
-            модуля «Рутина». Там бачиш і звички, і тренування, і підписки — все
-            в одному розкладі.
-          </p>
-          {onOpenRoutine ? (
-            <button
-              type="button"
+        <div className="space-y-2">
+          {onOpenRoutine && (
+            <Button
+              className="w-full h-12 min-h-[44px]"
               onClick={onOpenRoutine}
-              className="w-full rounded-xl border border-routine/30 bg-routine/5 hover:bg-routine/10 px-4 py-3 text-sm font-semibold text-routine-strong dark:text-routine transition-colors text-center"
             >
-              Відкрити Рутину
-            </button>
-          ) : (
-            <p className="text-xs text-subtle">
-              Перейди в модуль «Рутина» для планування.
-            </p>
+              Запланувати тренування
+            </Button>
           )}
-        </Card>
+          <p className="text-xs text-subtle text-center leading-snug">
+            Заплановані тренування відображатимуться у календарі модуля «Рутина»
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Зміни на сторінці **План** у модулі Фізрук:

1. **Шаблон за замовчуванням — placeholder**: Прибрано автовибір першого шаблону. Тепер `<select>` показує «Оберіть шаблон» і не відображає вправи, поки користувач не обере шаблон вручну.

2. **Прибрано блок «Календар тренувань»**: Нижній блок з описом Рутини і кнопкою «Відкрити Рутину» видалено.

3. **Додано кнопку «Запланувати тренування»**: Замість видаленого блоку — кнопка, що відкриває модуль Рутина для планування тренувань у календарі.

4. **Припис про календар**: Під кнопкою — текст «Заплановані тренування відображатимуться у календарі модуля «Рутина»».

**Файли:**
- `apps/web/src/modules/fizruk/components/TodayPlanCard.tsx` — placeholder у select, прибрано useEffect автовибору, вправи приховані без шаблону
- `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx` — видалено Card «Календар тренувань», додано Button + припис

## Review & Testing Checklist for Human
- [ ] Відкрити сторінку **План** — переконатися що select показує «Оберіть шаблон» і вправи не відображаються
- [ ] Обрати шаблон — вправи повинні з'явитися, «Стартувати тренування» активна
- [ ] Перевірити кнопку «Запланувати тренування» — має відкривати модуль Рутина
- [ ] Перевірити що припис про календар Рутини відображається

### Notes
- «Стартувати тренування» і «Журнал» залишились як були
- `RecoveryFocusCard` залишився без змін

Link to Devin session: https://app.devin.ai/sessions/75a4376d952c444595809ffa21935376
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Template selection in the planning interface now requires explicit user selection—the first template is no longer automatically pre-selected.
  * Updated template dropdown prompts for clarity.
  * Refined exercise display behavior to show template selection guidance when needed.
  * Simplified the training calendar interface layout with updated action button text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->