### PR TITLE
fix(ui): UI/UX audit improvements — Switch toggle, a11y modals, URL tabs, DRY storage, bento backdrop

### DIFF
--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -2,32 +2,14 @@ import { useState, useMemo } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
 import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { safeReadLS } from "@shared/lib/storage";
+import { parseFizrukWorkouts } from "@shared/lib/parseFizrukWorkouts";
 import { generateInsights } from "./lib/insightsEngine";
 import {
   calcFinykSpendingByDate,
   getFinykExcludedTxIdsFromStorage,
   getFinykTxSplitsFromStorage,
 } from "@finyk/utils";
-
-function safeParseLS(key, fallback) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return fallback;
-    return JSON.parse(raw) ?? fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function parseFizrukWorkouts(raw) {
-  if (!raw) return [];
-  try {
-    const p = JSON.parse(raw);
-    if (Array.isArray(p)) return p;
-    if (p && Array.isArray(p.workouts)) return p.workouts;
-  } catch {}
-  return [];
-}
 
 function localDateKey(d = new Date()) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -95,7 +77,7 @@ function useReportData(period, offset) {
     }
 
     function collectSpending(dates) {
-      const txRaw = safeParseLS("finyk_tx_cache", null);
+      const txRaw = safeReadLS("finyk_tx_cache", null);
       const txList = txRaw?.txs ?? txRaw ?? [];
       const excludedTxIds = getFinykExcludedTxIdsFromStorage();
       const txSplits = getFinykTxSplitsFromStorage();
@@ -108,7 +90,7 @@ function useReportData(period, offset) {
     }
 
     function collectHabits(dates) {
-      const state = safeParseLS("hub_routine_v1", null);
+      const state = safeReadLS("hub_routine_v1", null);
       if (!state) return { pct: 0, daily: {} };
       const habits = Array.isArray(state.habits)
         ? state.habits.filter((h) => !h.archived)
@@ -137,7 +119,7 @@ function useReportData(period, offset) {
     }
 
     function collectKcal(dates) {
-      const log = safeParseLS("nutrition_log_v1", {});
+      const log = safeReadLS("nutrition_log_v1", {});
       const dateSet = new Set(dates);
       const daily = {};
       let total = 0;

--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -3,40 +3,42 @@ import { cn } from "@shared/lib/cn";
 import { OnboardingWizard } from "../OnboardingWizard.jsx";
 
 // Static preview of the populated hub that sits behind the splash card on
-// `/welcome`. We intentionally don't render the real `HubDashboard` here
-// — the module rows show numbers that haven't been seeded yet, so a real
-// render would display zero-state copy and break the "look, this is your
-// hub about to happen" illusion. Instead we hand-roll four rows matching
-// `ModuleRow`'s visual rhythm.
-const PEEK_ROWS = [
+// `/welcome`. Renders a 2×2 bento grid matching `HubDashboard`'s module
+// cards so the blurred silhouette under the splash accurately teases the
+// real dashboard layout new users are about to see.
+const PEEK_CARDS = [
   {
     id: "finyk",
-    label: "Фінік",
-    accent: "text-finyk-strong dark:text-finyk bg-finyk-soft",
+    label: "💰 Фінік",
+    cardBg: "bg-finyk-soft/40 dark:bg-finyk/8",
+    iconClass: "bg-finyk-soft text-finyk dark:bg-finyk/15",
     icon: "credit-card",
-    metric: "−320 грн",
+    metric: "−320 ₴",
     sub: "тиждень",
   },
   {
     id: "fizruk",
-    label: "Фізрук",
-    accent: "text-fizruk-strong dark:text-fizruk bg-fizruk-soft",
+    label: "💪 Фізрук",
+    cardBg: "bg-fizruk-soft/40 dark:bg-fizruk/8",
+    iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk/15",
     icon: "dumbbell",
     metric: "5 трен.",
     sub: "14 днів",
   },
   {
     id: "routine",
-    label: "Рутина",
-    accent: "text-routine-strong dark:text-routine bg-routine-surface",
+    label: "✅ Рутина",
+    cardBg: "bg-routine-surface/40 dark:bg-routine/8",
+    iconClass: "bg-routine-surface text-routine dark:bg-routine/15",
     icon: "check",
     metric: "7 днів",
-    sub: "стрік «вода»",
+    sub: "стрік",
   },
   {
     id: "nutrition",
-    label: "Харчування",
-    accent: "text-nutrition-strong dark:text-nutrition bg-nutrition-soft",
+    label: "🥗 Харчування",
+    cardBg: "bg-nutrition-soft/40 dark:bg-nutrition/8",
+    iconClass: "bg-nutrition-soft text-nutrition dark:bg-nutrition/15",
     icon: "utensils",
     metric: "420 ккал",
     sub: "сніданок",
@@ -59,7 +61,7 @@ function PeekBackdrop() {
       {/* Faux hub rendered under a blur so the user perceives the shape
           and accent colors of their about-to-be-populated dashboard, but
           can't read individual numbers well enough to be distracted from
-          the splash copy. */}
+          the splash copy. Uses a 2×2 bento grid matching the real dashboard. */}
       <div
         className="absolute inset-x-0 top-0 pt-[max(2.5rem,env(safe-area-inset-top))] px-5 max-w-lg mx-auto w-full opacity-40 blur-[6px]"
         style={{ filter: "blur(6px) saturate(0.85)" }}
@@ -69,29 +71,35 @@ function PeekBackdrop() {
             <div className="h-6 w-32 rounded-md bg-panelHi" />
             <div className="h-3 w-24 rounded-md bg-panelHi mt-2" />
           </div>
-          <div className="rounded-2xl border border-line bg-panel overflow-hidden divide-y divide-line/60">
-            {PEEK_ROWS.map((row) => (
+          <div className="grid grid-cols-2 gap-3">
+            {PEEK_CARDS.map((card) => (
               <div
-                key={row.id}
-                className="flex items-center gap-3 px-4 py-3 bg-panel"
+                key={card.id}
+                className={cn(
+                  "flex flex-col rounded-3xl border border-line p-3.5 shadow-card",
+                  card.cardBg,
+                )}
               >
                 <div
                   className={cn(
-                    "w-8 h-8 rounded-xl flex items-center justify-center shrink-0",
-                    row.accent,
+                    "w-7 h-7 rounded-lg flex items-center justify-center shrink-0 mb-2",
+                    card.iconClass,
                   )}
                 >
-                  <Icon name={row.icon} size={16} strokeWidth={2} aria-hidden />
+                  <Icon
+                    name={card.icon}
+                    size={16}
+                    strokeWidth={2}
+                    aria-hidden
+                  />
                 </div>
-                <span className="text-xs font-semibold text-text truncate">
-                  {row.label}
+                <span className="text-xs font-semibold text-text">
+                  {card.label}
                 </span>
-                <div className="ml-auto flex items-center gap-2">
-                  <span className="text-sm font-semibold text-text tabular-nums">
-                    {row.metric}
-                  </span>
-                  <span className="text-[11px] text-muted">{row.sub}</span>
-                </div>
+                <span className="text-lg font-bold text-text tabular-nums mt-1">
+                  {card.metric}
+                </span>
+                <span className="text-2xs text-muted mt-0.5">{card.sub}</span>
               </div>
             ))}
           </div>

--- a/apps/web/src/core/hooks/useHubUIState.ts
+++ b/apps/web/src/core/hooks/useHubUIState.ts
@@ -1,6 +1,18 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export type HubView = "dashboard" | "reports" | "settings";
+
+const VALID_VIEWS = new Set<string>(["dashboard", "reports", "settings"]);
+
+function readViewFromURL(): HubView {
+  try {
+    const param = new URLSearchParams(window.location.search).get("tab");
+    if (param && VALID_VIEWS.has(param)) return param as HubView;
+  } catch {
+    /* SSR / non-browser */
+  }
+  return "dashboard";
+}
 
 // Onboarding is now a URL-addressable route (`/welcome`) owned by
 // `AppInner`; it no longer lives in hub UI state. The router handles
@@ -23,7 +35,32 @@ export function useHubUIState(): HubUIState {
     null,
   );
   const [searchOpen, setSearchOpen] = useState(false);
-  const [hubView, setHubView] = useState<HubView>("dashboard");
+  const [hubView, setHubViewRaw] = useState<HubView>(readViewFromURL);
+
+  const setHubView = useCallback((view: HubView) => {
+    setHubViewRaw(view);
+
+    // Sync the tab to URL search params so deep-links and back button work.
+    const url = new URL(window.location.href);
+    if (view === "dashboard") {
+      url.searchParams.delete("tab");
+    } else {
+      url.searchParams.set("tab", view);
+    }
+    window.history.pushState(null, "", url.toString());
+
+    // Scroll to top when switching tabs.
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  // Listen for back/forward navigation.
+  useEffect(() => {
+    const onPopState = () => {
+      setHubViewRaw(readViewFromURL());
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
 
   const openChat = useCallback((message: string | null = null) => {
     setChatInitialMessage(message || null);

--- a/apps/web/src/core/settings/SettingsPrimitives.tsx
+++ b/apps/web/src/core/settings/SettingsPrimitives.tsx
@@ -1,7 +1,9 @@
-import { useState, type ChangeEvent, type ReactNode } from "react";
+import { useRef, useState, type ChangeEvent, type ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Card } from "@shared/components/ui/Card";
+import { Switch } from "@shared/components/ui/Switch";
+import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 
 interface ChevronIconProps {
   expanded: boolean;
@@ -127,12 +129,7 @@ export function ToggleRow({
         )}
       </div>
       <div className="shrink-0 pt-0.5">
-        <input
-          type="checkbox"
-          className="w-5 h-5 accent-primary cursor-pointer"
-          checked={checked}
-          onChange={onChange}
-        />
+        <Switch checked={checked} onChange={onChange} />
       </div>
     </label>
   );
@@ -157,12 +154,14 @@ export function ConfirmModal({
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  useDialogFocusTrap(open, panelRef, { onEscape: onCancel });
+
   if (!open) return null;
   return (
     <div
       className="fixed inset-0 z-[120] flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
+      role="presentation"
     >
       <button
         type="button"
@@ -170,8 +169,16 @@ export function ConfirmModal({
         onClick={onCancel}
         aria-label="Закрити"
       />
-      <div className="relative w-full max-w-sm bg-panel border border-line rounded-2xl shadow-soft p-5 z-10">
-        <h2 className="text-base font-bold text-text">{title}</h2>
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+        className="relative w-full max-w-sm bg-panel border border-line rounded-2xl shadow-soft p-5 z-10"
+      >
+        <h2 id="confirm-modal-title" className="text-base font-bold text-text">
+          {title}
+        </h2>
         {body && <p className="text-sm text-muted mt-2">{body}</p>}
         <div className="flex gap-2 mt-5">
           <button

--- a/apps/web/src/shared/components/ui/Switch.tsx
+++ b/apps/web/src/shared/components/ui/Switch.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@shared/lib/cn";
+import type { ChangeEvent } from "react";
+
+export interface SwitchProps {
+  checked: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * iOS-style pill toggle switch.
+ *
+ * - 44×26 px track satisfies the 44px minimum touch target.
+ * - Uses a hidden `<input type="checkbox">` for form semantics and a11y.
+ * - Thumb slides with a 200ms spring transition.
+ *
+ * Expects to be placed inside a `<label>` that already provides visible
+ * accessible text (e.g. `ToggleRow`).
+ */
+export function Switch({
+  checked,
+  onChange,
+  disabled = false,
+  className,
+}: SwitchProps) {
+  return (
+    <span
+      className={cn(
+        "relative inline-flex items-center cursor-pointer select-none",
+        disabled && "opacity-50 cursor-not-allowed",
+        className,
+      )}
+    >
+      <input
+        type="checkbox"
+        className="sr-only peer"
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+      />
+      <span
+        className={cn(
+          "block w-[44px] h-[26px] rounded-full transition-colors duration-200",
+          "bg-line peer-checked:bg-brand-500",
+          "peer-focus-visible:ring-2 peer-focus-visible:ring-brand-500/45 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-bg",
+        )}
+      />
+      <span
+        className={cn(
+          "absolute left-[3px] top-[3px] block w-5 h-5 rounded-full bg-panel shadow-card",
+          "transition-transform duration-200",
+          "peer-checked:translate-x-[18px]",
+        )}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -103,6 +103,9 @@ export type { SkipLinkProps } from "./SkipLink";
 export { Spinner } from "./Spinner";
 export type { SpinnerProps, SpinnerSize } from "./Spinner";
 
+export { Switch } from "./Switch";
+export type { SwitchProps } from "./Switch";
+
 export { Stat } from "./Stat";
 export type { StatProps, StatSize, StatTone } from "./Stat";
 

--- a/apps/web/src/shared/lib/parseFizrukWorkouts.ts
+++ b/apps/web/src/shared/lib/parseFizrukWorkouts.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse fizruk workouts from a raw localStorage string.
+ *
+ * Handles both the flat array format (`[{...}, ...]`) and the wrapped
+ * format (`{ workouts: [...] }`). Returns an empty array on any failure.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseFizrukWorkouts(raw: string | null): Record<string, any>[] {
+  if (!raw) return [];
+  try {
+    const p = JSON.parse(raw);
+    if (Array.isArray(p)) return p;
+    if (p && Array.isArray(p.workouts)) return p.workouts;
+  } catch {
+    /* malformed — return empty */
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

Implements the actionable items from the comprehensive UI/UX audit. Focuses on the items that required real code changes; several audit items were already addressed in the codebase or turned out to be valid design exceptions.

### Changes

**#1 — WelcomeScreen backdrop → bento grid**
- `PeekBackdrop` now renders a 2×2 card grid matching the real `HubDashboard` layout (was a flat list of `ModuleRow`-style rows)
- New users see an accurate blurred preview of the dashboard they're about to use

**#4 — Custom Switch component**
- New `Switch` primitive (`@shared/components/ui/Switch`) — iOS-style pill toggle (44×26 px)
- Replaces native `<input type="checkbox">` in `ToggleRow` which was only 20×20 px and inconsistent across platforms
- Exported from the barrel `@shared/components/ui`

**#5 — ConfirmModal accessibility**
- Added `aria-labelledby` pointing to the dialog title
- Added `useDialogFocusTrap` (Escape key + Tab cycling)
- Outer container now uses `role="presentation"` (dialog role moved to the panel)

**#7 — DRY localStorage helpers**
- `HubReports` now imports `safeReadLS` from `@shared/lib/storage` instead of defining its own
- Extracted `parseFizrukWorkouts` into `@shared/lib/parseFizrukWorkouts.ts`

**#9 + #11 — URL-based tab state + scroll-to-top**
- `useHubUIState` syncs `hubView` to `?tab=reports` / `?tab=settings` URL search params
- Back/forward browser buttons now navigate between hub tabs via `popstate` listener
- `setHubView` scrolls to top on tab change

### Items already addressed in codebase
- **#6** FAB overlap — `pb-28` already on `<main>`
- **#8** Reduced motion — global `@media (prefers-reduced-motion)` rule already in `index.css`
- **#14** AuthPage loading — already passes `loading={loading}` to `<Button>`

### Items that were valid exceptions
- **#2/#13** `bg-white` usages — all on colored hero/gradient/photo backgrounds (not semantic surfaces)
- **#3** Hex colors — all in chart/data-viz code (CategoryManager, BudgetTrendChart)
- **#10** Loading skeletons — data is synchronous from localStorage, no async gap
- **#12** Dark mode emoji — native emojis render fine on dark backgrounds

## Review & Testing Checklist for Human

- [ ] Open `/welcome` route — verify the blurred backdrop shows a 2×2 bento grid (not a flat list)
- [ ] Open Settings → toggle any setting — verify the new pill-style Switch renders and animates correctly
- [ ] Open Settings → trigger a danger action (e.g. reset data) — verify ConfirmModal traps focus (Tab cycles inside) and Escape closes it
- [ ] Navigate between tabs (Головна → Звіти → Налаштування) — verify URL updates with `?tab=` param and back button works
- [ ] Verify scroll resets to top when switching tabs

### Notes

Lint and typecheck both pass. The `Switch` uses `<span>` wrappers (not `<label>`) since it's always placed inside `ToggleRow`'s outer `<label>` element — avoids nested labels which are invalid HTML.


Link to Devin session: https://app.devin.ai/sessions/2c622ba3027a4685ac4101d34e45bab4
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
