### PR TITLE
fix(nutrition): address audit findings (H1-H5, M1-M9)

### DIFF
--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -306,20 +306,16 @@ export default function NutritionApp({
     shopping.clearChecked();
   }, [shopping, pantry]);
 
-  const {
-    uploadCloudBackup,
-    downloadCloudBackup,
-    handleBackupPasswordConfirm,
-    applyRestorePayload,
-  } = useNutritionCloudBackup({
-    toast,
-    setErr,
-    cloudBackupBusy,
-    setCloudBackupBusy,
-    backupPasswordDialog,
-    setBackupPasswordDialog,
-    setRestoreConfirm,
-  });
+  const { handleBackupPasswordConfirm, applyRestorePayload } =
+    useNutritionCloudBackup({
+      toast,
+      setErr,
+      cloudBackupBusy,
+      setCloudBackupBusy,
+      backupPasswordDialog,
+      setBackupPasswordDialog,
+      setRestoreConfirm,
+    });
 
   const recipeCacheEntry = useMemo(
     () => readRecipeCache(recipeCacheKey),
@@ -383,6 +379,10 @@ export default function NutritionApp({
                   log={log.nutritionLog}
                   prefs={prefs}
                   onGoToLog={() => setActivePageAndHash("log")}
+                  onGoToDailyPlan={() => {
+                    setMenuSubTab("plan");
+                    setActivePageAndHash("menu");
+                  }}
                   onFetchDayHint={fetchDayHint}
                   dayHintText={dayHintText}
                   dayHintBusy={dayHintBusy}
@@ -517,18 +517,8 @@ export default function NutritionApp({
                   log.setAddMealPhotoResult(null);
                   log.setAddMealSheetOpen(true);
                 }}
-                prefs={prefs}
-                setPrefs={setPrefs}
                 onDuplicateYesterday={log.duplicateYesterday}
-                onImportMerge={log.mergeLogFromJsonText}
-                onImportReplace={log.replaceLogFromJsonText}
                 onTrimLog={log.trimLogToLastDays}
-                onFetchDayHint={fetchDayHint}
-                dayHintText={dayHintText}
-                dayHintBusy={dayHintBusy}
-                onCloudBackupUpload={uploadCloudBackup}
-                onCloudBackupDownload={downloadCloudBackup}
-                cloudBackupBusy={cloudBackupBusy}
               />
             )}
 
@@ -572,6 +562,7 @@ export default function NutritionApp({
                     fmtMacro={fmtMacro}
                     recipeCacheEntry={recipeCacheEntry}
                     addMealToLog={wrappedSaveMeal}
+                    selectedDate={log.selectedDate}
                   />
                 )}
               </>

--- a/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
+++ b/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
@@ -358,23 +358,34 @@ export function DailyPlanCard({
                             : null;
                       setPrefs((p) => {
                         const next = { ...p, [key]: v };
+                        // Авто-перерахунок Ккал лише коли користувач явно не
+                        // задав ціль (kcal === null) або коли вона дорівнює
+                        // попередньому авто-значенню. Інакше тиха перезапис
+                        // з'їдала кастомні значення (M7 з аудиту).
                         if (key !== "dailyTargetKcal") {
-                          const prot =
-                            key === "dailyTargetProtein_g"
-                              ? v
-                              : (p.dailyTargetProtein_g ?? 0);
-                          const fat =
-                            key === "dailyTargetFat_g"
-                              ? v
-                              : (p.dailyTargetFat_g ?? 0);
-                          const carb =
-                            key === "dailyTargetCarbs_g"
-                              ? v
-                              : (p.dailyTargetCarbs_g ?? 0);
-                          const calc = Math.round(
-                            (prot || 0) * 4 + (fat || 0) * 9 + (carb || 0) * 4,
+                          const prevProt = p.dailyTargetProtein_g ?? 0;
+                          const prevFat = p.dailyTargetFat_g ?? 0;
+                          const prevCarb = p.dailyTargetCarbs_g ?? 0;
+                          const prevCalc = Math.round(
+                            prevProt * 4 + prevFat * 9 + prevCarb * 4,
                           );
-                          if (calc > 0) next.dailyTargetKcal = calc;
+                          const isAutoKcal =
+                            p.dailyTargetKcal == null ||
+                            p.dailyTargetKcal === prevCalc;
+                          if (isAutoKcal) {
+                            const prot =
+                              key === "dailyTargetProtein_g" ? v : prevProt;
+                            const fat =
+                              key === "dailyTargetFat_g" ? v : prevFat;
+                            const carb =
+                              key === "dailyTargetCarbs_g" ? v : prevCarb;
+                            const calc = Math.round(
+                              (prot || 0) * 4 +
+                                (fat || 0) * 9 +
+                                (carb || 0) * 4,
+                            );
+                            next.dailyTargetKcal = calc > 0 ? calc : null;
+                          }
                         }
                         return next;
                       });

--- a/apps/web/src/modules/nutrition/components/LogCard.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCard.tsx
@@ -15,6 +15,7 @@ import {
   estimateLogBytes,
   toLocalISODate,
 } from "../lib/nutritionStorage.js";
+import { addDaysISODate } from "@sergeant/nutrition-domain";
 import {
   MEAL_ORDER,
   MEAL_META,
@@ -36,9 +37,11 @@ function toISODate(d) {
 
 function formatDate(isoDate) {
   const today = toISODate(new Date());
-  const yesterday = toISODate(new Date(Date.now() - 86400000));
+  const yesterday = addDaysISODate(today, -1);
+  const tomorrow = addDaysISODate(today, 1);
   if (isoDate === today) return "Сьогодні";
   if (isoDate === yesterday) return "Вчора";
+  if (isoDate === tomorrow) return "Завтра";
   const [y, m, d] = isoDate.split("-");
   return `${d}.${m}.${y}`;
 }
@@ -92,22 +95,13 @@ export function LogCard({
   onAddMealFromSearch,
   onRemoveMeal,
   onEditMeal,
-  prefs: _prefs,
-  setPrefs: _setPrefs,
   onDuplicateYesterday,
-  onImportMerge: _onImportMerge,
-  onImportReplace: _onImportReplace,
   onTrimLog,
-  onFetchDayHint: _onFetchDayHint,
-  dayHintText: _dayHintText,
-  dayHintBusy: _dayHintBusy,
-  onCloudBackupUpload: _onCloudBackupUpload,
-  onCloudBackupDownload: _onCloudBackupDownload,
-  cloudBackupBusy: _cloudBackupBusy,
 }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [duplicateConfirm, setDuplicateConfirm] = useState(false);
+  const [trimConfirm, setTrimConfirm] = useState(false);
   const [statsRange, setStatsRange] = useState(30);
   const [weekOpen, setWeekOpen] = useState(false);
 
@@ -152,12 +146,11 @@ export function LogCard({
   function shiftDate(delta) {
     const [y, m, d] = selectedDate.split("-").map(Number);
     const next = new Date(y, m - 1, d + delta);
-    const nextIso = toISODate(next);
-    const todayIso = toISODate(new Date());
-    if (nextIso <= todayIso) setSelectedDate(nextIso);
+    setSelectedDate(toISODate(next));
   }
 
-  const isToday = selectedDate === toISODate(new Date());
+  const previousDayIso = addDaysISODate(selectedDate, -1);
+  const hasPreviousDayMeals = (log[previousDayIso]?.meals?.length || 0) > 0;
 
   return (
     <>
@@ -180,18 +173,22 @@ export function LogCard({
           <button
             type="button"
             onClick={() => shiftDate(1)}
-            disabled={isToday}
-            className={cn(
-              "w-10 h-10 flex items-center justify-center rounded-full transition-colors",
-              isToday
-                ? "text-line cursor-not-allowed"
-                : "bg-panelHi text-muted hover:text-text",
-            )}
+            className="w-10 h-10 flex items-center justify-center rounded-full bg-panelHi text-muted hover:text-text transition-colors"
             aria-label="Наступний день"
           >
             ›
           </button>
         </div>
+
+        {typeof onDuplicateYesterday === "function" && hasPreviousDayMeals && (
+          <button
+            type="button"
+            onClick={() => setDuplicateConfirm(true)}
+            className="w-full h-10 rounded-2xl border border-line bg-panel/40 px-3 text-xs font-semibold text-subtle hover:text-text hover:border-nutrition/50 transition-colors flex items-center justify-center gap-1.5"
+          >
+            Скопіювати з попереднього дня ({previousDayIso})
+          </button>
+        )}
 
         <Card
           variant="flat"
@@ -514,9 +511,22 @@ export function LogCard({
         danger={false}
         onConfirm={() => {
           setDuplicateConfirm(false);
-          onDuplicateYesterday();
+          onDuplicateYesterday?.();
         }}
         onCancel={() => setDuplicateConfirm(false)}
+      />
+
+      <ConfirmDialog
+        open={trimConfirm}
+        title="Видалити стару історію?"
+        description="Журнал буде обрізано до останніх 365 днів. Старіші прийоми та фото страв безповоротно видаляються."
+        confirmLabel="Видалити"
+        danger
+        onConfirm={() => {
+          setTrimConfirm(false);
+          onTrimLog?.(365);
+        }}
+        onCancel={() => setTrimConfirm(false)}
       />
     </>
   );

--- a/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
+import { pluralUa } from "@sergeant/shared";
 import {
   getDayMacros,
   getDaySummary,
@@ -126,6 +127,7 @@ export function NutritionDashboard({
   log,
   prefs,
   onGoToLog,
+  onGoToDailyPlan,
   onAddMeal,
   onFetchDayHint,
   dayHintText,
@@ -154,11 +156,11 @@ export function NutritionDashboard({
             <div className="text-sm font-semibold text-text">Сьогодні</div>
             <div className="text-xs text-subtle">
               {summary.mealCount}{" "}
-              {summary.mealCount === 1
-                ? "прийом"
-                : summary.mealCount >= 2 && summary.mealCount <= 4
-                  ? "прийоми"
-                  : "прийомів"}{" "}
+              {pluralUa(summary.mealCount, {
+                one: "прийом",
+                few: "прийоми",
+                many: "прийомів",
+              })}{" "}
               їжі
             </div>
           </div>
@@ -233,7 +235,7 @@ export function NutritionDashboard({
         {!hasTargets && (
           <button
             type="button"
-            onClick={onGoToLog}
+            onClick={onGoToDailyPlan ?? onGoToLog}
             className="mt-3 w-full text-xs text-nutrition-strong dark:text-nutrition font-medium hover:underline text-center"
           >
             Налаштувати денні цілі КБЖВ →

--- a/apps/web/src/modules/nutrition/components/RecipesCard.tsx
+++ b/apps/web/src/modules/nutrition/components/RecipesCard.tsx
@@ -5,6 +5,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { toLocalISODate } from "@sergeant/shared";
 import {
   deleteSavedRecipe,
   listSavedRecipes,
@@ -48,6 +49,7 @@ export function RecipesCard({
   fmtMacro,
   recipeCacheEntry,
   addMealToLog,
+  selectedDate,
 }) {
   const [saved, setSaved] = useState([]);
   const [savedBusy, setSavedBusy] = useState(false);
@@ -110,9 +112,16 @@ export function RecipesCard({
     const mealType = guessMealTypeIdNow();
     const label =
       MEAL_TYPES.find((x) => x.id === mealType)?.label || "Прийом їжі";
+    // Не пишемо поточний час, якщо журнал відкритий не на сьогодні —
+    // інакше "вчора 09:30" виглядає як артефакт. Див. H5 з аудиту.
+    const now = new Date();
+    const isToday = !selectedDate || selectedDate === toLocalISODate(now);
+    const time = isToday
+      ? `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`
+      : "";
     await addMealToLog({
       id: `meal_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
-      time: `${String(new Date().getHours()).padStart(2, "0")}:${String(new Date().getMinutes()).padStart(2, "0")}`,
+      time,
       mealType,
       label,
       name: r?.title || "Рецепт",
@@ -333,9 +342,13 @@ export function RecipesCard({
                 <div className="text-xs text-subtle mb-1">Порції</div>
                 <Input
                   value={String(prefs.servings)}
-                  onChange={(e) =>
-                    setPrefs((p) => ({ ...p, servings: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    const n = Number(e.target.value);
+                    setPrefs((p) => ({
+                      ...p,
+                      servings: Number.isFinite(n) && n > 0 ? n : 1,
+                    }));
+                  }}
                   inputMode="numeric"
                   disabled={busy}
                 />
@@ -344,9 +357,13 @@ export function RecipesCard({
                 <div className="text-xs text-subtle mb-1">Хвилин</div>
                 <Input
                   value={String(prefs.timeMinutes)}
-                  onChange={(e) =>
-                    setPrefs((p) => ({ ...p, timeMinutes: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    const n = Number(e.target.value);
+                    setPrefs((p) => ({
+                      ...p,
+                      timeMinutes: Number.isFinite(n) && n >= 0 ? n : 0,
+                    }));
+                  }}
                   inputMode="numeric"
                   disabled={busy}
                 />

--- a/apps/web/src/modules/nutrition/components/ShoppingListCard.tsx
+++ b/apps/web/src/modules/nutrition/components/ShoppingListCard.tsx
@@ -97,8 +97,8 @@ export function ShoppingListCard({
           {!canGenerate && (
             <div className="mt-2 text-xs text-subtle text-center">
               {source === "recipes"
-                ? 'Згенеруй рецепти на сторінці "Рецепти" спочатку'
-                : 'Згенеруй тижневий план на сторінці "Рецепти" спочатку'}
+                ? "Спершу згенеруй рецепти у Меню → Рецепти"
+                : "Спершу згенеруй тижневий план у Меню → План на день"}
             </div>
           )}
         </div>

--- a/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
+++ b/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { useWaterTracker } from "../hooks/useWaterTracker.js";
 import { Card } from "@shared/components/ui/Card";
+import { Input } from "@shared/components/ui/Input";
 
 const QUICK_ML = [200, 300, 500, 750];
 
@@ -10,9 +11,32 @@ function fmt(ml) {
 }
 
 export function WaterTrackerCard({ goalMl = 2000 }) {
-  const { todayMl, add, reset } = useWaterTracker();
+  const { todayMl, add, subtract, reset } = useWaterTracker();
   const [resetPending, setResetPending] = useState(false);
   const resetTimerRef = useRef(null);
+  const [customMl, setCustomMl] = useState("");
+  const [lastAddedMl, setLastAddedMl] = useState(0);
+
+  const handleAdd = (ml) => {
+    const n = Number(ml);
+    if (!Number.isFinite(n) || n <= 0) return;
+    const clamped = Math.min(Math.floor(n), 5000);
+    add(clamped);
+    setLastAddedMl(clamped);
+  };
+
+  const handleUndo = () => {
+    if (lastAddedMl <= 0) return;
+    subtract(lastAddedMl);
+    setLastAddedMl(0);
+  };
+
+  const handleCustomAdd = () => {
+    const n = Number(customMl);
+    if (!Number.isFinite(n) || n <= 0) return;
+    handleAdd(n);
+    setCustomMl("");
+  };
 
   const pct = goalMl > 0 ? Math.min(100, (todayMl / goalMl) * 100) : 0;
   const done = todayMl >= goalMl && goalMl > 0;
@@ -101,7 +125,7 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
           <button
             key={ml}
             type="button"
-            onClick={() => add(ml)}
+            onClick={() => handleAdd(ml)}
             className={cn(
               "h-9 rounded-xl text-xs font-semibold transition-colors",
               "bg-sky-500/10 text-sky-700 dark:text-sky-400 border border-sky-500/20",
@@ -111,6 +135,46 @@ export function WaterTrackerCard({ goalMl = 2000 }) {
             +{ml < 1000 ? ml : `${ml / 1000}л`}
           </button>
         ))}
+      </div>
+
+      {/* Custom amount + undo */}
+      <div className="mt-2 flex items-center gap-1.5">
+        <Input
+          value={customMl}
+          onChange={(e) => setCustomMl(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleCustomAdd();
+            }
+          }}
+          placeholder="мл"
+          inputMode="numeric"
+          className="h-9 flex-1"
+          aria-label="Свій об'єм у мл"
+        />
+        <button
+          type="button"
+          onClick={handleCustomAdd}
+          disabled={!customMl || Number(customMl) <= 0}
+          className={cn(
+            "h-9 px-3 rounded-xl text-xs font-semibold transition-colors",
+            "bg-sky-500/10 text-sky-700 dark:text-sky-400 border border-sky-500/20",
+            "hover:bg-sky-500/20 disabled:opacity-50 active:scale-95",
+          )}
+        >
+          + Додати
+        </button>
+        {lastAddedMl > 0 && (
+          <button
+            type="button"
+            onClick={handleUndo}
+            className="h-9 px-3 rounded-xl text-xs font-semibold text-subtle hover:text-text border border-line transition-colors"
+            aria-label={`Відмінити останнє додавання (${lastAddedMl} мл)`}
+          >
+            ↶ {lastAddedMl}
+          </button>
+        )}
       </div>
     </Card>
   );

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
@@ -254,9 +254,13 @@ export function useNutritionPantries({
         const unit = String(item.unit || "г")
           .toLowerCase()
           .trim();
-        let remaining = qty;
-        if (unit === "кг") remaining = qty - gramsConsumed / 1000;
-        else remaining = qty - gramsConsumed;
+        // Only deduct from mass-based units (грами/кілограми). Inventory in
+        // штуках, мл/л, чи будь-яких інших одиницях не має одно-однозначної
+        // конверсії з "грамів спожитого", тому лишаємо позицію як є —
+        // інакше "200г молока" з'їдало б всю пляшку "2 л" (див. H2 з аудиту).
+        if (unit !== "г" && unit !== "кг") return p;
+        const remaining =
+          unit === "кг" ? qty - gramsConsumed / 1000 : qty - gramsConsumed;
         if (remaining <= 0) {
           items.splice(idx, 1);
         } else {

--- a/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, type Dispatch, type SetStateAction } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { nutritionApi } from "@shared/api";
+import { toLocalISODate } from "@sergeant/shared";
 import type {
   NutritionDayMeal,
   NutritionDayPlan as ApiNutritionDayPlan,
@@ -464,9 +465,17 @@ export function useNutritionRemoteActions({
         dinner: "Вечеря",
         snack: "Перекус",
       };
+      // Тільки коли користувач переглядає сьогодні, ставимо поточний час —
+      // інакше для минулих/майбутніх днів сьогоднішній час виглядав би як баг
+      // (запис "вчора 09:30 ранку" створений увечері). Див. H5 з аудиту.
+      const now = new Date();
+      const isToday = log.selectedDate === toLocalISODate(now);
+      const time = isToday
+        ? `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`
+        : "";
       log.handleAddMeal({
         id,
-        time: `${String(new Date().getHours()).padStart(2, "0")}:${String(new Date().getMinutes()).padStart(2, "0")}`,
+        time,
         mealType: (meal.type || "snack") as Meal["mealType"],
         label: (meal.type ? typeLabels[meal.type] : undefined) || "Прийом їжі",
         name: meal.name || "Страва",

--- a/apps/web/src/modules/nutrition/hooks/useWaterTracker.ts
+++ b/apps/web/src/modules/nutrition/hooks/useWaterTracker.ts
@@ -4,6 +4,7 @@ import {
   saveWaterLog,
   getTodayWaterMl,
   addWaterMl,
+  subtractWaterMl,
   resetTodayWater,
   type WaterLog,
 } from "../lib/waterStorage.js";
@@ -11,6 +12,7 @@ import {
 export interface UseWaterTrackerResult {
   todayMl: number;
   add: (ml: number) => void;
+  subtract: (ml: number) => void;
   reset: () => void;
 }
 
@@ -27,9 +29,13 @@ export function useWaterTracker(): UseWaterTrackerResult {
     setLog((prev) => addWaterMl(prev, ml));
   }, []);
 
+  const subtract = useCallback((ml: number) => {
+    setLog((prev) => subtractWaterMl(prev, ml));
+  }, []);
+
   const reset = useCallback(() => {
     setLog((prev) => resetTodayWater(prev));
   }, []);
 
-  return { todayMl, add, reset };
+  return { todayMl, add, subtract, reset };
 }

--- a/apps/web/src/modules/nutrition/lib/waterStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/waterStorage.ts
@@ -17,6 +17,7 @@ import { nutritionStorage } from "./nutritionStorageInstance.js";
 export {
   WATER_LOG_KEY,
   addWaterMl,
+  subtractWaterMl,
   getTodayWaterMl,
   normalizeWaterLog,
   resetTodayWater,

--- a/packages/nutrition-domain/src/mergeItems.test.ts
+++ b/packages/nutrition-domain/src/mergeItems.test.ts
@@ -10,13 +10,22 @@ describe("mergeItems", () => {
     expect(out.map((x) => x.name)).toEqual(["яйця", "рис"]);
   });
 
-  it("sums compatible qty+unit to base unit", () => {
+  it("sums compatible qty+unit while keeping the existing human-friendly unit", () => {
     const out = mergeItems(
       [{ name: "молоко", qty: 1, unit: "л" }],
       [{ name: "молоко", qty: 500, unit: "мл" }],
     );
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({ name: "молоко", unit: "мл", qty: 1500 });
+    expect(out[0]).toMatchObject({ name: "молоко", unit: "л", qty: 1.5 });
+  });
+
+  it("sums when existing entry uses a sub-unit and stays in that sub-unit", () => {
+    const out = mergeItems(
+      [{ name: "борошно", qty: 200, unit: "г" }],
+      [{ name: "борошно", qty: 1, unit: "кг" }],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: "борошно", unit: "г", qty: 1200 });
   });
 
   it("avoids exact duplicates by fingerprint", () => {

--- a/packages/nutrition-domain/src/mergeItems.ts
+++ b/packages/nutrition-domain/src/mergeItems.ts
@@ -22,6 +22,25 @@ function toBaseUnit(qty: unknown, unit: unknown): BaseUnit | null {
   return null;
 }
 
+// Convert a base-unit value back to a human-friendly unit, preferring the
+// existing pantry entry's unit so що "1 кг борошна" + "200 г" лишається у
+// кг, а не перетворюється на 1200 г (M9 з аудиту).
+function fromBaseUnit(
+  base: BaseUnit,
+  preferredUnit: string | null,
+): { qty: number; unit: string } {
+  const pref = String(preferredUnit || "").toLowerCase();
+  if (base.base === "г") {
+    if (pref === "кг") return { qty: base.value / 1000, unit: "кг" };
+    return { qty: base.value, unit: "г" };
+  }
+  if (base.base === "мл") {
+    if (pref === "л") return { qty: base.value / 1000, unit: "л" };
+    return { qty: base.value, unit: "мл" };
+  }
+  return { qty: base.value, unit: "шт" };
+}
+
 function roundNice(n: number): number {
   const x = Number(n);
   if (!Number.isFinite(x)) return n;
@@ -82,10 +101,15 @@ export function mergeItems(
           const ux = normalizeUnit(cur.unit);
           const baseX = toBaseUnit(qx, ux);
           if (baseX) {
+            const totalBase: BaseUnit = {
+              base: baseX.base,
+              value: baseX.value + baseIncoming.value,
+            };
+            const out = fromBaseUnit(totalBase, ux);
             merged[idx] = {
               ...cur,
-              qty: roundNice(baseX.value + baseIncoming.value),
-              unit: baseIncoming.base,
+              qty: roundNice(out.qty),
+              unit: out.unit,
             };
             continue;
           }

--- a/packages/nutrition-domain/src/waterLog.ts
+++ b/packages/nutrition-domain/src/waterLog.ts
@@ -46,6 +46,20 @@ export function addWaterMl(log: unknown, ml: unknown): WaterLog {
   return { ...base, [today]: (base[today] || 0) + delta };
 }
 
+export function subtractWaterMl(log: unknown, ml: unknown): WaterLog {
+  const delta = sanitizeMl(ml);
+  const base = normalizeWaterLog(log);
+  if (delta <= 0) return base;
+  const today = toLocalISODate();
+  const next = (base[today] || 0) - delta;
+  if (next <= 0) {
+    const { [today]: _removed, ...rest } = base;
+    void _removed;
+    return rest;
+  }
+  return { ...base, [today]: next };
+}
+
 export function resetTodayWater(log: unknown): WaterLog {
   const base = normalizeWaterLog(log);
   const today = toLocalISODate();


### PR DESCRIPTION
## Summary

Усуває критичні (H1–H5) та середні (M1–M9) знахідки з `nutrition-audit.md`. Все в межах модуля Харчування. M8 (масовий typing) свідомо залишено поза цим PR — це ширший рефактор.

### Critical (high)

- **H1** — у `LogCard` додав видиму кнопку «Скопіювати з попереднього дня (YYYY-MM-DD)» в шапці дня; `setDuplicateConfirm(true)` тепер реально викликається. Кнопка показується лише коли в попередньому дні є прийоми.
- **H2** — `consumePantryItem` тепер списує тільки з масоодиниць (`г`/`кг`). Для `шт`/`мл`/`л`/`уп`/інших позиція лишається без змін, бо немає однозначної конверсії з «грамів спожитого».
- **H3** — синхронізував поведінку: web більше не блокує перехід у майбутнє; mobile уже й так не блокувала.
- **H4** — `RecipesCard` парсить `prefs.servings` / `prefs.timeMinutes` через `Number(...)` із дефолтами (1 / 0).
- **H5** — `addMealFromPlan` і `addRecipeAsMeal` пишуть час `""` коли журнал відкритий не на сьогодні.

### Medium

- **M1** — `LogCard` більше не приймає мертві пропси (10 шт). У `NutritionApp` прибрав unused destructure для cloud-backup тригерів.
- **M2** — кнопка «Залишити лише останні 365 днів» проходить через `ConfirmDialog` із `danger`.
- **M3** — підказки в `ShoppingListCard` указують на «Меню → Рецепти» / «Меню → План на день».
- **M4** — CTA «Налаштувати денні цілі КБЖВ →» з дашборду веде в Меню → План на день.
- **M5** — українська плюралізація йде через спільний `pluralUa` (CLDR-правила).
- **M6** — `WaterTrackerCard`: custom-мл інпут + undo останнього додавання. Додав `subtractWaterMl`.
- **M7** — `DailyPlanCard` авто-перераховує Ккал лише коли `dailyTargetKcal === null` або дорівнює попередньому авто-значенню.
- **M9** — `mergeItems` зберігає human-friendly одиницю існуючого запису. «1 кг» + «200 г» → 1.2 кг.

## Review & Testing Checklist for Human

Risk: yellow:

- [ ] Кнопка «Скопіювати з попереднього дня» з'являється тільки коли у попередньому дні є прийоми; підтвердження дублює всі прийоми.
- [ ] Прокачати ціль Ккал руками в Меню → План на день, потім змінити білки/жири/вуглеводи — Ккал лишається. На свіжих prefs (kcal=null) — авто-рахується.
- [ ] У трекері води: ввести custom мл (Enter), потім «↶ N» — скорочує саме на ту кількість; «Скинути» все ще працює.

### Test plan

1. Web: `#nutrition` → Журнал, стрілка «вперед» проходить у майбутнє. «Скопіювати з попереднього дня» — лише якщо є дані.
2. Меню → План на день: Ккал = 2200, Білки = 150 → Ккал лишається 2200. Потім видалити Ккал — авто-рахується.
3. Меню → Рецепти: поміняти Порції / Хвилин — зберігаються як числа.
4. Дашборд (Старт): без цілей натиснути «Налаштувати денні цілі КБЖВ →» → Меню → План на день.
5. Склад: позиція з unit=`шт` → залогувати фото-страву. Кількість в шт не змінилась.
6. Список покупок: без рецептів/плану → нові підказки про Меню → Рецепти / План.

### Notes

- `pnpm typecheck` — зелено по 13 пакетах.
- `pnpm lint` робочого коду — зелено. `lint:plugins` падає локально на Node 22; CI Node 20 — ок.
- `pnpm test`: web 469/469, домени — зелено. У `apps/mobile` 10 раніше зламаних тестів (Onboarding/WeeklyDigest/HubSettings) — pre-existing, не зачіпає nutrition.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Water tracker now supports custom ml entry and undo of recent additions
* Added "Duplicate from Previous Day" meal action and optional history trimming (365-day retention)
* Direct navigation to daily plan from nutrition dashboard

**Improvements**
* Recipes now correctly handle meal times based on selected journal date
* Enhanced date navigation without blocking future date selection
* Updated shopping list guidance for menu-based recipe generation
* Improved pantry consumption to only deduct from mass-based units

<!-- end of auto-generated comment: release notes by coderabbit.ai -->