### PR TITLE
chore(web): tech-debt cleanup — strip .js/.jsx imports, add no-raw-local-storage rule

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -16,36 +16,36 @@ import { ToastContainer } from "@shared/components/ui/Toast";
 import { HUB_OPEN_MODULE_EVENT } from "@shared/lib/hubNav";
 import { ApiClientProvider } from "@sergeant/api-client/react";
 import { apiClient } from "@shared/api";
-import { AuthProvider, useAuth } from "./AuthContext.jsx";
-import { useCloudSync } from "./useCloudSync.js";
-import { PageLoader } from "./app/PageLoader.jsx";
-import { OfflineBanner } from "./app/OfflineBanner.jsx";
-import { MigrationPrompt } from "./app/MigrationPrompt.jsx";
-import { usePwaInstall } from "./app/usePwaInstall.js";
-import { useIosInstallBanner } from "./app/useIosInstallBanner.js";
-import { useSWUpdate } from "./app/useSWUpdate.js";
-import { PWA_ACTION_KEY } from "./app/pwaAction.js";
-import { HubHeader } from "./app/HubHeader.jsx";
-import { HubTabs } from "./app/HubTabs.jsx";
-import { HubMainContent } from "./app/HubMainContent.jsx";
-import { HubFloatingActions } from "./app/HubFloatingActions.jsx";
-import { HubModals } from "./app/HubModals.jsx";
-import { ActiveWorkoutBanner } from "./app/ActiveWorkoutBanner.jsx";
-import { WelcomeScreen } from "./app/WelcomeScreen.jsx";
-import { shouldShowOnboarding } from "./OnboardingWizard.jsx";
-import { isFirstRealEntryDone } from "./onboarding/vibePicks.js";
-import { hasAnyRealEntry } from "./onboarding/firstRealEntry.js";
-import { useHubNavigation } from "./hooks/useHubNavigation.js";
-import { useHubUIState } from "./hooks/useHubUIState.js";
-import { usePwaActions, type PwaAction } from "./hooks/usePwaActions.js";
+import { AuthProvider, useAuth } from "./AuthContext";
+import { useCloudSync } from "./useCloudSync";
+import { PageLoader } from "./app/PageLoader";
+import { OfflineBanner } from "./app/OfflineBanner";
+import { MigrationPrompt } from "./app/MigrationPrompt";
+import { usePwaInstall } from "./app/usePwaInstall";
+import { useIosInstallBanner } from "./app/useIosInstallBanner";
+import { useSWUpdate } from "./app/useSWUpdate";
+import { PWA_ACTION_KEY } from "./app/pwaAction";
+import { HubHeader } from "./app/HubHeader";
+import { HubTabs } from "./app/HubTabs";
+import { HubMainContent } from "./app/HubMainContent";
+import { HubFloatingActions } from "./app/HubFloatingActions";
+import { HubModals } from "./app/HubModals";
+import { ActiveWorkoutBanner } from "./app/ActiveWorkoutBanner";
+import { WelcomeScreen } from "./app/WelcomeScreen";
+import { shouldShowOnboarding } from "./OnboardingWizard";
+import { isFirstRealEntryDone } from "./onboarding/vibePicks";
+import { hasAnyRealEntry } from "./onboarding/firstRealEntry";
+import { useHubNavigation } from "./hooks/useHubNavigation";
+import { useHubUIState } from "./hooks/useHubUIState";
+import { usePwaActions, type PwaAction } from "./hooks/usePwaActions";
 import { ShellDeepLinkBridge } from "./app/ShellDeepLinkBridge";
 import { HintsOrchestrator } from "./hints/HintsOrchestrator";
 
 const AuthPage = lazy(() =>
-  import("./AuthPage.jsx").then((m) => ({ default: m.AuthPage })),
+  import("./AuthPage").then((m) => ({ default: m.AuthPage })),
 );
 const ResetPasswordPage = lazy(() =>
-  import("./ResetPasswordPage.jsx").then((m) => ({
+  import("./ResetPasswordPage").then((m) => ({
     default: m.ResetPasswordPage,
   })),
 );
@@ -53,7 +53,7 @@ const DesignShowcase = lazy(() =>
   import("./DesignShowcase").then((m) => ({ default: m.DesignShowcase })),
 );
 const ProfilePage = lazy(() =>
-  import("./ProfilePage.jsx").then((m) => ({ default: m.ProfilePage })),
+  import("./ProfilePage").then((m) => ({ default: m.ProfilePage })),
 );
 interface ModuleAppProps {
   onBackToHub: () => void;

--- a/apps/web/src/core/AuthContext.test.tsx
+++ b/apps/web/src/core/AuthContext.test.tsx
@@ -61,7 +61,7 @@ vi.mock("@sergeant/api-client/react", async () => {
   };
 });
 
-import { AuthProvider, useAuth } from "./AuthContext.js";
+import { AuthProvider, useAuth } from "./AuthContext";
 import { apiQueryKeys } from "@sergeant/api-client/react";
 
 interface UseUserState {

--- a/apps/web/src/core/AuthContext.tsx
+++ b/apps/web/src/core/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useUser, apiQueryKeys } from "@sergeant/api-client/react";
 import type { User } from "@sergeant/shared";
-import { signIn, signUp, signOut, forgetPassword } from "./authClient.js";
+import { signIn, signUp, signOut, forgetPassword } from "./authClient";
 
 /**
  * AuthContext — єдине джерело правди «хто я» для веб-додатку.

--- a/apps/web/src/core/AuthPage.tsx
+++ b/apps/web/src/core/AuthPage.tsx
@@ -3,7 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { useToast } from "@shared/hooks/useToast";
 import { BrandLogo } from "./app/BrandLogo";
-import { useAuth } from "./AuthContext.jsx";
+import { useAuth } from "./AuthContext";
 
 export function AuthPage({ onContinueWithoutAccount }) {
   const { login, register, requestPasswordReset, authError, setAuthError } =

--- a/apps/web/src/core/ErrorBoundary.tsx
+++ b/apps/web/src/core/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { captureException } from "./sentry.js";
+import { captureException } from "./sentry";
 
 interface FallbackProps {
   error: Error;

--- a/apps/web/src/core/HubBackupPanel.tsx
+++ b/apps/web/src/core/HubBackupPanel.tsx
@@ -3,7 +3,7 @@ import { downloadJson } from "@sergeant/shared";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
 import { cn } from "@shared/lib/cn";
-import { applyHubBackupPayload, buildHubBackupPayload } from "./hubBackup.js";
+import { applyHubBackupPayload, buildHubBackupPayload } from "./hubBackup";
 
 export function HubBackupPanel({ className }) {
   const fileRef = useRef(null);

--- a/apps/web/src/core/HubChat.tsx
+++ b/apps/web/src/core/HubChat.tsx
@@ -24,12 +24,12 @@ import {
   cancelIdle,
   isHelpCommand,
   HELP_TEXT,
-} from "./lib/hubChatUtils.js";
-import { buildContextMeasured } from "./lib/hubChatContext.js";
-import { executeAction } from "./lib/hubChatActions.js";
-import { VOICE_KEYWORDS, speak, stopSpeaking } from "./lib/hubChatSpeech.js";
-import { ChatMessage, TypingIndicator } from "./components/ChatMessage.jsx";
-import { ChatInput } from "./components/ChatInput.jsx";
+} from "./lib/hubChatUtils";
+import { buildContextMeasured } from "./lib/hubChatContext";
+import { executeAction } from "./lib/hubChatActions";
+import { VOICE_KEYWORDS, speak, stopSpeaking } from "./lib/hubChatSpeech";
+import { ChatMessage, TypingIndicator } from "./components/ChatMessage";
+import { ChatInput } from "./components/ChatInput";
 
 const QUICK_WITH_MONO = [
   "Як справи з бюджетом?",

--- a/apps/web/src/core/HubDashboard.tsx
+++ b/apps/web/src/core/HubDashboard.tsx
@@ -15,7 +15,7 @@ import {
   safeReadStringLS,
   safeWriteLS,
   safeRemoveLS,
-} from "@shared/lib/storage.js";
+} from "@shared/lib/storage";
 import {
   DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
   STORAGE_KEYS,
@@ -26,25 +26,25 @@ import {
 } from "@sergeant/shared";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { getModulePrimaryAction } from "@shared/lib/moduleQuickActions";
-import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard.jsx";
-import { HubInsightsPanel } from "./HubInsightsPanel.jsx";
-import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
-import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest.js";
-import { useCoachInsight } from "./useCoachInsight.js";
-import { AssistantAdviceCard } from "./AssistantAdviceCard.jsx";
-import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard.jsx";
-import { FirstActionHeroCard } from "./onboarding/FirstActionSheet.jsx";
-import { detectFirstRealEntry } from "./onboarding/firstRealEntry.js";
+import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard";
+import { HubInsightsPanel } from "./HubInsightsPanel";
+import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard";
+import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest";
+import { useCoachInsight } from "./useCoachInsight";
+import { AssistantAdviceCard } from "./AssistantAdviceCard";
+import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard";
+import { FirstActionHeroCard } from "./onboarding/FirstActionSheet";
+import { detectFirstRealEntry } from "./onboarding/firstRealEntry";
 import {
   isSoftAuthDismissed,
   isFirstActionPending,
   recordSessionDay,
   getSessionDays,
   getVibePicks,
-} from "./onboarding/vibePicks.js";
-import { useFirstEntryCelebration } from "./onboarding/useFirstEntryCelebration.js";
-import { DailyNudge } from "./onboarding/DailyNudge.jsx";
-import { ReEngagementCard } from "./onboarding/ReEngagementCard.jsx";
+} from "./onboarding/vibePicks";
+import { useFirstEntryCelebration } from "./onboarding/useFirstEntryCelebration";
+import { DailyNudge } from "./onboarding/DailyNudge";
+import { ReEngagementCard } from "./onboarding/ReEngagementCard";
 import {
   getActiveNudge,
   shouldShowReengagement,

--- a/apps/web/src/core/HubReports.tsx
+++ b/apps/web/src/core/HubReports.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import { safeReadLS } from "@shared/lib/storage";
 import { parseFizrukWorkouts } from "@shared/lib/parseFizrukWorkouts";
 import { generateInsights } from "./lib/insightsEngine";

--- a/apps/web/src/core/HubSettingsPage.tsx
+++ b/apps/web/src/core/HubSettingsPage.tsx
@@ -2,14 +2,14 @@ import { useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { Tabs } from "@shared/components/ui/Tabs";
-import { AIDigestSection } from "./settings/AIDigestSection.jsx";
-import { ExperimentalSection } from "./settings/ExperimentalSection.jsx";
-import { FinykSection } from "./settings/FinykSection.jsx";
-import { FizrukSection } from "./settings/FizrukSection.jsx";
-import { GeneralSection } from "./settings/GeneralSection.jsx";
-import { NotificationsSection } from "./settings/NotificationsSection.jsx";
-import { NutritionSection } from "./settings/NutritionSection.jsx";
-import { RoutineSection } from "./settings/RoutineSection.jsx";
+import { AIDigestSection } from "./settings/AIDigestSection";
+import { ExperimentalSection } from "./settings/ExperimentalSection";
+import { FinykSection } from "./settings/FinykSection";
+import { FizrukSection } from "./settings/FizrukSection";
+import { GeneralSection } from "./settings/GeneralSection";
+import { NotificationsSection } from "./settings/NotificationsSection";
+import { NutritionSection } from "./settings/NutritionSection";
+import { RoutineSection } from "./settings/RoutineSection";
 
 // Group definitions: each tab collects related sections. Search terms are
 // used for fuzzy search-by-keyword; matches fall back to showing every

--- a/apps/web/src/core/OnboardingWizard.tsx
+++ b/apps/web/src/core/OnboardingWizard.tsx
@@ -16,11 +16,11 @@ import {
   markFirstActionPending,
   markFirstActionStartedAt,
   saveVibePicks,
-} from "./onboarding/vibePicks.js";
+} from "./onboarding/vibePicks";
 import {
   markOnboardingDone,
   shouldShowOnboarding as sharedShouldShowOnboarding,
-} from "./onboarding/onboardingGate.js";
+} from "./onboarding/onboardingGate";
 import { MODULE_LABELS } from "@shared/lib/moduleLabels";
 import {
   ONBOARDING_MODULE_DESCRIPTIONS,

--- a/apps/web/src/core/ProfilePage.tsx
+++ b/apps/web/src/core/ProfilePage.tsx
@@ -7,7 +7,7 @@ import { Icon } from "@shared/components/ui/Icon";
 import { Input } from "@shared/components/ui/Input";
 import { useToast } from "@shared/hooks/useToast";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
-import { useAuth } from "./AuthContext.jsx";
+import { useAuth } from "./AuthContext";
 import { STORAGE_KEYS } from "@sergeant/shared";
 import {
   updateUser,
@@ -19,7 +19,7 @@ import {
   sendVerificationEmail,
   changeEmail,
   type SessionItem,
-} from "./authClient.js";
+} from "./authClient";
 
 // ────────────────────── Avatar helpers ──────────────────────
 

--- a/apps/web/src/core/ResetPasswordPage.tsx
+++ b/apps/web/src/core/ResetPasswordPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
 import { BrandLogo } from "./app/BrandLogo";
-import { resetPassword } from "./authClient.js";
+import { resetPassword } from "./authClient";
 
 /**
  * Landing page for the Better Auth password-reset magic link. The email

--- a/apps/web/src/core/TodayFocusCard.tsx
+++ b/apps/web/src/core/TodayFocusCard.tsx
@@ -11,8 +11,8 @@ import {
   MODULE_PRIMARY_ACTION,
   getModulePrimaryAction,
 } from "@shared/lib/moduleQuickActions";
-import { generateRecommendations } from "./lib/recommendationEngine.js";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { generateRecommendations } from "./lib/recommendationEngine";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 
 // Reuse the same dismissed-map key HubRecommendations used so user
 // dismissals remain stable across the redesign.

--- a/apps/web/src/core/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/WeeklyDigestCard.tsx
@@ -5,8 +5,8 @@ import {
   useWeeklyDigest,
   useDigestHistory,
   getWeekKey,
-} from "./useWeeklyDigest.js";
-import { WeeklyDigestStories } from "./WeeklyDigestStories.jsx";
+} from "./useWeeklyDigest";
+import { WeeklyDigestStories } from "./WeeklyDigestStories";
 
 // `hasLiveWeeklyDigest` now lives in `@sergeant/shared` (DOM-free, reused by
 // mobile). The web-side adapter in `@shared/lib/weeklyDigestStorage` binds

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Icon } from "@shared/components/ui/Icon";
-import { DarkModeToggle } from "./DarkModeToggle.jsx";
-import { UserMenuButton } from "./UserMenuButton.jsx";
+import { DarkModeToggle } from "./DarkModeToggle";
+import { UserMenuButton } from "./UserMenuButton";
 import type { User } from "@sergeant/shared";
 
 const CHEVRON_ICON = (

--- a/apps/web/src/core/app/HubMainContent.tsx
+++ b/apps/web/src/core/app/HubMainContent.tsx
@@ -2,10 +2,10 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { ErrorBoundary } from "../ErrorBoundary";
-import { HubDashboard } from "../HubDashboard.jsx";
-import { HubReports } from "../HubReports.jsx";
-import { HubSettingsPage } from "../HubSettingsPage.jsx";
-import { IOSInstallBanner } from "./IOSInstallBanner.jsx";
+import { HubDashboard } from "../HubDashboard";
+import { HubReports } from "../HubReports";
+import { HubSettingsPage } from "../HubSettingsPage";
+import { IOSInstallBanner } from "./IOSInstallBanner";
 
 // Дешевий inline-fallback для секцій хаба: повідомляємо про збій і
 // даємо кнопку `reset`, щоб спробувати перемонтувати секцію без

--- a/apps/web/src/core/app/HubModals.tsx
+++ b/apps/web/src/core/app/HubModals.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useEffect } from "react";
 import { ErrorBoundary } from "../ErrorBoundary";
 
 const HubSearch = lazy(() =>
-  import("../HubSearch.jsx").then((m) => ({ default: m.HubSearch })),
+  import("../HubSearch").then((m) => ({ default: m.HubSearch })),
 );
 const HubChat = lazy(() => import("../HubChat"));
 

--- a/apps/web/src/core/app/OfflineBanner.tsx
+++ b/apps/web/src/core/app/OfflineBanner.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@shared/components/ui/Icon";
-import { useSyncStatus } from "../useCloudSync.js";
+import { useSyncStatus } from "../useCloudSync";
 import { pluralUa } from "@sergeant/shared";
 
 /**

--- a/apps/web/src/core/app/UserMenuButton.tsx
+++ b/apps/web/src/core/app/UserMenuButton.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { cn } from "@shared/lib/cn";
 import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
-import { useSyncStatus } from "../useCloudSync.js";
+import { useSyncStatus } from "../useCloudSync";
 
 function SyncBadge({ user, syncing }) {
   const { dirtyCount, queuedCount, isOnline } = useSyncStatus();

--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
-import { OnboardingWizard } from "../OnboardingWizard.jsx";
+import { OnboardingWizard } from "../OnboardingWizard";
 
 // Static preview of the populated hub that sits behind the splash card on
 // `/welcome`. Renders a 2×2 bento grid matching `HubDashboard`'s module

--- a/apps/web/src/core/authClient.ts
+++ b/apps/web/src/core/authClient.ts
@@ -1,10 +1,10 @@
 import { createAuthClient } from "better-auth/react";
-import { apiUrl } from "@shared/lib/apiUrl.js";
+import { apiUrl } from "@shared/lib/apiUrl";
 import {
   clearBearerToken,
   getBearerToken,
   setBearerToken,
-} from "@shared/lib/bearerToken.js";
+} from "@shared/lib/bearerToken";
 import { isCapacitor } from "@sergeant/shared";
 
 function getAuthBaseURL(): string {

--- a/apps/web/src/core/components/ChatInput.tsx
+++ b/apps/web/src/core/components/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@shared/lib/cn";
-import { stopSpeaking, unlockTTS } from "../lib/hubChatSpeech.js";
-import { useSpeech } from "../hooks/useSpeech.js";
+import { stopSpeaking, unlockTTS } from "../lib/hubChatSpeech";
+import { useSpeech } from "../hooks/useSpeech";
 import {
   useRef,
   useCallback,

--- a/apps/web/src/core/components/ChatMessage.tsx
+++ b/apps/web/src/core/components/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@shared/lib/cn";
-import { AssistantMessageBody } from "./AssistantMessageBody.jsx";
-import { speak } from "../lib/hubChatSpeech.js";
-import type { ChatMessage as ChatMessageData } from "../lib/hubChatUtils.js";
+import { AssistantMessageBody } from "./AssistantMessageBody";
+import { speak } from "../lib/hubChatSpeech";
+import type { ChatMessage as ChatMessageData } from "../lib/hubChatUtils";
 
 interface ChatMessageProps {
   message: ChatMessageData;

--- a/apps/web/src/core/components/PushNotificationToggle.tsx
+++ b/apps/web/src/core/components/PushNotificationToggle.tsx
@@ -1,4 +1,4 @@
-import { usePushNotifications } from "@shared/hooks/usePushNotifications.js";
+import { usePushNotifications } from "@shared/hooks/usePushNotifications";
 import { cn } from "@shared/lib/cn";
 
 interface PushNotificationToggleProps {

--- a/apps/web/src/core/hasLiveWeeklyDigest.test.ts
+++ b/apps/web/src/core/hasLiveWeeklyDigest.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { STORAGE_KEYS } from "@sergeant/shared";
-import { hasLiveWeeklyDigest } from "./WeeklyDigestCard.jsx";
-import { getWeekKey } from "./useWeeklyDigest.js";
+import { hasLiveWeeklyDigest } from "./WeeklyDigestCard";
+import { getWeekKey } from "./useWeeklyDigest";
 
 const PREFIX = STORAGE_KEYS.WEEKLY_DIGEST_PREFIX;
 

--- a/apps/web/src/core/hooks/usePwaActions.ts
+++ b/apps/web/src/core/hooks/usePwaActions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { PWA_ACTION_KEY, consumePwaAction } from "../app/pwaAction.js";
+import { PWA_ACTION_KEY, consumePwaAction } from "../app/pwaAction";
 
 export type PwaAction =
   | "add_expense"

--- a/apps/web/src/core/hubBackup.test.ts
+++ b/apps/web/src/core/hubBackup.test.ts
@@ -3,7 +3,7 @@ import {
   HUB_BACKUP_KIND,
   HUB_BACKUP_SCHEMA_VERSION,
   isHubBackupPayload,
-} from "./hubBackup.js";
+} from "./hubBackup";
 
 describe("hubBackup", () => {
   it("isHubBackupPayload приймає валідний корінь", () => {

--- a/apps/web/src/core/hubBackup.ts
+++ b/apps/web/src/core/hubBackup.ts
@@ -2,7 +2,7 @@ import {
   normalizeFinykBackup,
   readFinykBackupFromStorage,
   persistFinykNormalizedToStorage,
-} from "../modules/finyk/lib/finykBackup.js";
+} from "../modules/finyk/lib/finykBackup";
 import {
   buildFizrukFullBackupPayload,
   applyFizrukFullBackupPayload,
@@ -10,11 +10,11 @@ import {
 import {
   buildRoutineBackupPayload,
   applyRoutineBackupPayload,
-} from "../modules/routine/lib/routineStorage.js";
+} from "../modules/routine/lib/routineStorage";
 import {
   applyNutritionBackupPayload,
   buildNutritionBackupPayload,
-} from "../modules/nutrition/domain/nutritionBackup.js";
+} from "../modules/nutrition/domain/nutritionBackup";
 
 const HUB_MODULE_KEY = "hub_last_module";
 const HUB_CHAT_KEY = "hub_chat_history";

--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -1,4 +1,4 @@
-import { ls, lsSet } from "../hubChatUtils.js";
+import { ls, lsSet } from "../hubChatUtils";
 import { resolveExpenseCategoryMeta } from "../../../modules/finyk/utils";
 import type {
   SetGoalAction,
@@ -13,7 +13,7 @@ import type {
   Workout,
   NutritionDay,
   ChatAction,
-} from "./types.js";
+} from "./types";
 
 export function handleCrossAction(action: ChatAction): string | undefined {
   switch (action.name) {

--- a/apps/web/src/core/lib/chatActions/finykActions.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.ts
@@ -1,4 +1,4 @@
-import { ls, lsSet } from "../hubChatUtils.js";
+import { ls, lsSet } from "../hubChatUtils";
 import { resolveExpenseCategoryMeta } from "../../../modules/finyk/utils";
 import type {
   ChangeCategoryAction,
@@ -23,7 +23,7 @@ import type {
   BudgetGoal,
   MonthlyPlan,
   ChatAction,
-} from "./types.js";
+} from "./types";
 
 export function handleFinykAction(action: ChatAction): string | undefined {
   switch (action.name) {

--- a/apps/web/src/core/lib/chatActions/fizrukActions.ts
+++ b/apps/web/src/core/lib/chatActions/fizrukActions.ts
@@ -1,4 +1,4 @@
-import { ls, lsSet } from "../hubChatUtils.js";
+import { ls, lsSet } from "../hubChatUtils";
 import type {
   PlanWorkoutAction,
   LogSetAction,
@@ -16,7 +16,7 @@ import type {
   WorkoutItem,
   Workout,
   ChatAction,
-} from "./types.js";
+} from "./types";
 
 export function handleFizrukAction(action: ChatAction): string | undefined {
   switch (action.name) {

--- a/apps/web/src/core/lib/chatActions/nutritionActions.ts
+++ b/apps/web/src/core/lib/chatActions/nutritionActions.ts
@@ -1,4 +1,4 @@
-import { ls, lsSet } from "../hubChatUtils.js";
+import { ls, lsSet } from "../hubChatUtils";
 import { saveRecipeToBook } from "../../../modules/nutrition/lib/recipeBook";
 import type {
   LogMealAction,
@@ -14,7 +14,7 @@ import type {
   NutritionMeal,
   NutritionDay,
   ChatAction,
-} from "./types.js";
+} from "./types";
 
 export function handleNutritionAction(action: ChatAction): string | undefined {
   switch (action.name) {

--- a/apps/web/src/core/lib/chatActions/routineActions.ts
+++ b/apps/web/src/core/lib/chatActions/routineActions.ts
@@ -1,4 +1,4 @@
-import { ls, lsSet } from "../hubChatUtils.js";
+import { ls, lsSet } from "../hubChatUtils";
 import {
   createHabit as routineCreateHabit,
   loadRoutineState,
@@ -16,7 +16,7 @@ import type {
   HabitTrendAction,
   HabitState,
   ChatAction,
-} from "./types.js";
+} from "./types";
 
 export function handleRoutineAction(action: ChatAction): string | undefined {
   switch (action.name) {

--- a/apps/web/src/core/lib/dailyFinykSummary.test.ts
+++ b/apps/web/src/core/lib/dailyFinykSummary.test.ts
@@ -4,7 +4,7 @@ import {
   computeDailyFinykSummary,
   isDailySummaryDismissedToday,
   DAILY_SUMMARY_DISMISS_KEY,
-} from "./dailyFinykSummary.js";
+} from "./dailyFinykSummary";
 
 function setLS(key, value) {
   localStorage.setItem(key, JSON.stringify(value));

--- a/apps/web/src/core/lib/dailyFinykSummary.ts
+++ b/apps/web/src/core/lib/dailyFinykSummary.ts
@@ -16,7 +16,7 @@
  * - усі нагадування dismissible на один день
  */
 
-import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants.js";
+import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants";
 
 interface Category {
   id: string;

--- a/apps/web/src/core/lib/featureFlags.test.ts
+++ b/apps/web/src/core/lib/featureFlags.test.ts
@@ -18,7 +18,7 @@ async function loadFresh() {
   // Чистимо кеш модулів + LS, щоб кожен кейс отримав свіжий store.
   vi.resetModules();
   globalThis.localStorage = makeLS();
-  return await import("./featureFlags.js");
+  return await import("./featureFlags");
 }
 
 describe("featureFlags", () => {

--- a/apps/web/src/core/lib/hubChatActions.ts
+++ b/apps/web/src/core/lib/hubChatActions.ts
@@ -1,13 +1,13 @@
-import { handleFinykAction } from "./chatActions/finykActions.js";
-import { handleFizrukAction } from "./chatActions/fizrukActions.js";
-import { handleRoutineAction } from "./chatActions/routineActions.js";
-import { handleNutritionAction } from "./chatActions/nutritionActions.js";
-import { handleCrossAction } from "./chatActions/crossActions.js";
+import { handleFinykAction } from "./chatActions/finykActions";
+import { handleFizrukAction } from "./chatActions/fizrukActions";
+import { handleRoutineAction } from "./chatActions/routineActions";
+import { handleNutritionAction } from "./chatActions/nutritionActions";
+import { handleCrossAction } from "./chatActions/crossActions";
 
-export type { ChatAction } from "./chatActions/types.js";
+export type { ChatAction } from "./chatActions/types";
 
 export function executeAction(
-  action: import("./chatActions/types.js").ChatAction,
+  action: import("./chatActions/types").ChatAction,
 ): string {
   try {
     return (

--- a/apps/web/src/core/lib/hubChatContext.ts
+++ b/apps/web/src/core/lib/hubChatContext.ts
@@ -25,9 +25,9 @@ import {
   weeklyVolumeSeriesNow,
 } from "@sergeant/fizruk-domain";
 import { perfMark, perfEnd } from "@shared/lib/perf";
-import { ls, fmt } from "./hubChatUtils.js";
-import { generateRecommendations } from "./recommendationEngine.js";
-import { generateInsights } from "./insightsEngine.js";
+import { ls, fmt } from "./hubChatUtils";
+import { generateRecommendations } from "./recommendationEngine";
+import { generateInsights } from "./insightsEngine";
 
 interface Transaction {
   id: string;

--- a/apps/web/src/core/lib/insightsEngine.test.ts
+++ b/apps/web/src/core/lib/insightsEngine.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { generateInsights } from "./insightsEngine.js";
+import { generateInsights } from "./insightsEngine";
 
 function createLocalStorageMock() {
   /** @type {Map<string, string>} */

--- a/apps/web/src/core/lib/recommendationEngine.test.ts
+++ b/apps/web/src/core/lib/recommendationEngine.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { generateRecommendations } from "./recommendationEngine.js";
+import { generateRecommendations } from "./recommendationEngine";
 
 function setLS(key, value) {
   localStorage.setItem(key, JSON.stringify(value));

--- a/apps/web/src/core/onboarding/CelebrationOverlay.tsx
+++ b/apps/web/src/core/onboarding/CelebrationOverlay.tsx
@@ -3,7 +3,7 @@ import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
-import { getTimeToValueMs } from "./vibePicks.js";
+import { getTimeToValueMs } from "./vibePicks";
 
 /**
  * Confetti particle rendered by the celebration overlay.

--- a/apps/web/src/core/onboarding/FirstActionSheet.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.tsx
@@ -4,8 +4,8 @@ import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
-import { clearFirstActionPending, getVibePicks } from "./vibePicks.js";
-import { PresetSheet, getPresetModule } from "./PresetSheet.jsx";
+import { clearFirstActionPending, getVibePicks } from "./vibePicks";
+import { PresetSheet, getPresetModule } from "./PresetSheet";
 import { getOnboardingGoals } from "@sergeant/shared";
 
 const localStorageStore = {

--- a/apps/web/src/core/onboarding/PresetSheet.tsx
+++ b/apps/web/src/core/onboarding/PresetSheet.tsx
@@ -4,8 +4,8 @@ import { Icon } from "@shared/components/ui/Icon";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { openHubModuleWithAction } from "@shared/lib/hubNav";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
-import { applyPreset } from "./presetApply.js";
-import { writePresetPrefill } from "./presetPrefill.js";
+import { applyPreset } from "./presetApply";
+import { writePresetPrefill } from "./presetPrefill";
 
 /**
  * Per-module "tap-to-log" presets. Each entry is deliberately narrow —

--- a/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
+++ b/apps/web/src/core/onboarding/SoftAuthPromptCard.tsx
@@ -3,7 +3,7 @@ import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
 import { trackEvent, ANALYTICS_EVENTS } from "../analytics";
-import { dismissSoftAuth } from "./vibePicks.js";
+import { dismissSoftAuth } from "./vibePicks";
 
 /**
  * Inline dashboard card offering cloud sync *after* the user has logged

--- a/apps/web/src/core/onboarding/useFirstEntryCelebration.ts
+++ b/apps/web/src/core/onboarding/useFirstEntryCelebration.ts
@@ -13,7 +13,7 @@
 
 import { useEffect, useRef } from "react";
 import { useToast } from "@shared/hooks/useToast";
-import { getTimeToValueMs } from "./vibePicks.js";
+import { getTimeToValueMs } from "./vibePicks";
 
 /**
  * Compose the success-moment toast. If we measured a time-to-value

--- a/apps/web/src/core/settings/AIDigestSection.tsx
+++ b/apps/web/src/core/settings/AIDigestSection.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Button } from "@shared/components/ui/Button";
-import { useToast } from "@shared/hooks/useToast.jsx";
-import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { useToast } from "@shared/hooks/useToast";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
-import { useWeeklyDigest } from "../useWeeklyDigest.js";
-import { SettingsGroup, ToggleRow } from "./SettingsPrimitives.jsx";
+import { useWeeklyDigest } from "../useWeeklyDigest";
+import { SettingsGroup, ToggleRow } from "./SettingsPrimitives";
 
 export function AIDigestSection() {
   const { digest, loading, error, weekRange, generate } = useWeeklyDigest();

--- a/apps/web/src/core/settings/ExperimentalSection.tsx
+++ b/apps/web/src/core/settings/ExperimentalSection.tsx
@@ -1,5 +1,5 @@
 import { FLAG_REGISTRY, setFlag, useAllFlags } from "../lib/featureFlags";
-import { SettingsGroup, ToggleRow } from "./SettingsPrimitives.jsx";
+import { SettingsGroup, ToggleRow } from "./SettingsPrimitives";
 
 /**
  * Секція «Експериментальне» у Settings. Рендерить FLAG_REGISTRY як toggle-

--- a/apps/web/src/core/settings/FinykSection.tsx
+++ b/apps/web/src/core/settings/FinykSection.tsx
@@ -5,8 +5,8 @@ import { Button } from "@shared/components/ui/Button";
 import { privatApi, isApiError } from "@shared/api";
 import { safeReadLS } from "@shared/lib/storage";
 import { hubKeys } from "@shared/lib/queryKeys";
-import { useStorage as useFinykStorage } from "../../modules/finyk/hooks/useStorage.js";
-import { getAccountLabel } from "../../modules/finyk/utils.js";
+import { useStorage as useFinykStorage } from "../../modules/finyk/hooks/useStorage";
+import { getAccountLabel } from "../../modules/finyk/utils";
 import {
   ConfirmModal,
   SettingsGroup,

--- a/apps/web/src/core/settings/FizrukSection.tsx
+++ b/apps/web/src/core/settings/FizrukSection.tsx
@@ -4,7 +4,7 @@ import {
   REST_CATEGORY_LABELS,
 } from "../../modules/fizruk/hooks/useRestSettings";
 import { WorkoutBackupBar } from "../../modules/fizruk/components/workouts/WorkoutBackupBar";
-import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives.jsx";
+import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
 
 type RestCategory = keyof typeof REST_CATEGORY_LABELS;
 

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
 import { resetOnboardingState, type KVStore } from "@sergeant/shared";
-import { HubBackupPanel } from "../HubBackupPanel.jsx";
+import { HubBackupPanel } from "../HubBackupPanel";
 import {
   swClearCaches,
   swGetDebugSnapshot,
@@ -15,13 +15,13 @@ import {
   loadDashboardOrder,
   resetDashboardOrder,
   saveDashboardOrder,
-} from "../HubDashboard.jsx";
+} from "../HubDashboard";
 import {
   SettingsGroup,
   SettingsSubGroup,
   ToggleRow,
-} from "./SettingsPrimitives.jsx";
-import { useHubPref } from "./hubPrefs.js";
+} from "./SettingsPrimitives";
+import { useHubPref } from "./hubPrefs";
 
 type ModuleId = keyof typeof DASHBOARD_MODULE_LABELS;
 

--- a/apps/web/src/core/settings/NotificationsSection.tsx
+++ b/apps/web/src/core/settings/NotificationsSection.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
-import { useToast } from "@shared/hooks/useToast.jsx";
-import { requestRoutineNotificationPermission } from "../../modules/routine/hooks/useRoutineReminders.js";
-import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
+import { useToast } from "@shared/hooks/useToast";
+import { requestRoutineNotificationPermission } from "../../modules/routine/hooks/useRoutineReminders";
+import { useRoutineState } from "../../modules/routine/hooks/useRoutineState";
 import { useMonthlyPlan } from "../../modules/fizruk/hooks/useMonthlyPlan";
 import {
   loadNutritionPrefs,
   persistNutritionPrefs,
   NUTRITION_PREFS_KEY,
   type NutritionPrefs,
-} from "../../modules/nutrition/lib/nutritionStorage.js";
-import { PushNotificationToggle } from "../components/PushNotificationToggle.jsx";
+} from "../../modules/nutrition/lib/nutritionStorage";
+import { PushNotificationToggle } from "../components/PushNotificationToggle";
 import {
   SettingsGroup,
   SettingsSubGroup,
   ToggleRow,
-} from "./SettingsPrimitives.jsx";
+} from "./SettingsPrimitives";
 
 type PermStatus = NotificationPermission | "unsupported";
 

--- a/apps/web/src/core/settings/NutritionSection.tsx
+++ b/apps/web/src/core/settings/NutritionSection.tsx
@@ -10,12 +10,12 @@ import {
   persistPantries,
   type NutritionPrefs,
   type Pantry,
-} from "../../modules/nutrition/lib/nutritionStorage.js";
+} from "../../modules/nutrition/lib/nutritionStorage";
 import {
   SettingsGroup,
   SettingsSubGroup,
   ToggleRow,
-} from "./SettingsPrimitives.jsx";
+} from "./SettingsPrimitives";
 
 function numberOrNullToInput(v: number | null): string {
   return v == null ? "" : String(Math.round(v));

--- a/apps/web/src/core/settings/RoutineSection.tsx
+++ b/apps/web/src/core/settings/RoutineSection.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
-import { useRoutineState } from "../../modules/routine/hooks/useRoutineState.js";
+import { useRoutineState } from "../../modules/routine/hooks/useRoutineState";
 import {
   deleteHabit,
   restoreHabit,
   snapshotHabit,
-} from "../../modules/routine/lib/routineStorage.js";
-import { ROUTINE_THEME as C } from "../../modules/routine/lib/routineConstants.js";
+} from "../../modules/routine/lib/routineStorage";
+import { ROUTINE_THEME as C } from "../../modules/routine/lib/routineConstants";
 import { HabitDetailSheet } from "../../modules/routine/components/HabitDetailSheet";
 import { HabitQuickCreateDialog } from "../../modules/routine/components/HabitQuickCreateDialog";
 import { RoutineBackupSection } from "../../modules/routine/components/RoutineBackupSection";
@@ -24,7 +24,7 @@ import {
   SettingsGroup,
   SettingsSubGroup,
   ToggleRow,
-} from "./SettingsPrimitives.jsx";
+} from "./SettingsPrimitives";
 
 export function RoutineSection() {
   const toast = useToast();

--- a/apps/web/src/core/useCloudSync.behavior.test.ts
+++ b/apps/web/src/core/useCloudSync.behavior.test.ts
@@ -20,7 +20,7 @@ import {
   notifySyncDirty,
   SYNC_EVENT,
   SYNC_STATUS_EVENT,
-} from "./useCloudSync.js";
+} from "./useCloudSync";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 beforeEach(() => {

--- a/apps/web/src/core/useCloudSync.hardening.test.ts
+++ b/apps/web/src/core/useCloudSync.hardening.test.ts
@@ -18,7 +18,7 @@ import {
   __internal_collectQueuedModules as collectQueued,
   __internal_addToOfflineQueue as enqueue,
   __internal_parseDateSafe as parseDate,
-} from "./useCloudSync.js";
+} from "./useCloudSync";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 beforeEach(() => localStorage.clear());

--- a/apps/web/src/core/useCloudSync.ts
+++ b/apps/web/src/core/useCloudSync.ts
@@ -2,4 +2,4 @@
 // `./cloudSync/` (see that directory's index.ts for module-by-module
 // layout). This file exists so existing consumers and tests — which import
 // from `./useCloudSync.js` — keep working unchanged.
-export * from "./cloudSync/index.js";
+export * from "./cloudSync/index";

--- a/apps/web/src/core/useCoachInsight.ts
+++ b/apps/web/src/core/useCoachInsight.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { coachApi, isApiError } from "@shared/api";
-import { coachKeys } from "@shared/lib/queryKeys.js";
+import { coachKeys } from "@shared/lib/queryKeys";
 
 const CACHE_KEY = "hub_coach_insight_cache_v1";
 

--- a/apps/web/src/core/useWeeklyDigest.ts
+++ b/apps/web/src/core/useWeeklyDigest.ts
@@ -2,11 +2,11 @@ import { useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { coachApi, weeklyDigestApi } from "@shared/api";
 import { STORAGE_KEYS, getWeekKey as sharedGetWeekKey } from "@sergeant/shared";
-import { safeReadLS } from "@shared/lib/storage.js";
+import { safeReadLS } from "@shared/lib/storage";
 import { loadDigest as sharedLoadDigest } from "@shared/lib/weeklyDigestStorage";
-import { coachKeys, digestKeys } from "@shared/lib/queryKeys.js";
+import { coachKeys, digestKeys } from "@shared/lib/queryKeys";
 import { formatApiError } from "@shared/lib/apiErrorFormat";
-import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants.js";
+import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants";
 
 const DIGEST_PREFIX = STORAGE_KEYS.WEEKLY_DIGEST_PREFIX;
 

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -2,11 +2,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useMonobank } from "./hooks/useMonobank";
 import { usePrivatbank } from "./hooks/usePrivatbank";
 import { useStorage } from "./hooks/useStorage";
-import { readRaw, writeRaw } from "./lib/finykStorage.js";
-import {
-  FINYK_MANUAL_ONLY_KEY,
-  enableFinykManualOnly,
-} from "./lib/demoData.js";
+import { readRaw, writeRaw } from "./lib/finykStorage";
+import { FINYK_MANUAL_ONLY_KEY, enableFinykManualOnly } from "./lib/demoData";
 import { PAGES } from "./constants";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
@@ -15,18 +12,18 @@ import {
   ModuleHeader,
   ModuleHeaderBackButton,
 } from "@shared/components/layout";
-import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
+import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
 import { cn } from "@shared/lib/cn";
 import { useToast } from "@shared/hooks/useToast";
-import { Overview } from "./pages/Overview.jsx";
-import { Transactions } from "./pages/Transactions.jsx";
-import { Budgets } from "./pages/Budgets.jsx";
-import { Assets } from "./pages/Assets.jsx";
-import { Analytics } from "./pages/Analytics.jsx";
-import { ManualExpenseSheet } from "./components/ManualExpenseSheet.jsx";
+import { Overview } from "./pages/Overview";
+import { Transactions } from "./pages/Transactions";
+import { Budgets } from "./pages/Budgets";
+import { Assets } from "./pages/Assets";
+import { Analytics } from "./pages/Analytics";
+import { ManualExpenseSheet } from "./components/ManualExpenseSheet";
 import { useUnifiedFinanceData } from "./hooks/useUnifiedFinanceData";
 import { useFinykPersonalization } from "./hooks/useFinykPersonalization";
-import { consumePresetPrefill } from "../../core/onboarding/presetPrefill.js";
+import { consumePresetPrefill } from "../../core/onboarding/presetPrefill";
 
 const NAV_ICONS = {
   overview: (

--- a/apps/web/src/modules/finyk/components/CategoryChart.tsx
+++ b/apps/web/src/modules/finyk/components/CategoryChart.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { chartPaletteList as COLORS } from "../constants/chartPalette.js";
+import { chartPaletteList as COLORS } from "../constants/chartPalette";
 
 // Чиста презентаційна діаграма: рендер залежить лише від `data` та `onBarClick`.
 // `memo` уникає перерендеру, коли батько оновлюється, а ці пропси не змінилися

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -3,7 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Label } from "@shared/components/ui/FormField";
 import { Sheet } from "@shared/components/ui/Sheet";
-import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
+import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import {
   parseExpenseSpeech,
   toLocalISODate,

--- a/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
@@ -3,7 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
-import { CategorySelector } from "../CategorySelector.jsx";
+import { CategorySelector } from "../CategorySelector";
 
 const GOAL_EMOJIS = [
   "🎯",

--- a/apps/web/src/modules/finyk/components/charts/lazy.ts
+++ b/apps/web/src/modules/finyk/components/charts/lazy.ts
@@ -7,25 +7,25 @@ import { lazy } from "react";
 // and rendering logic stay untouched.
 
 export const BudgetTrendChart = lazy(() =>
-  import("../BudgetTrendChart.jsx").then((m) => ({
+  import("../BudgetTrendChart").then((m) => ({
     default: m.BudgetTrendChart,
   })),
 );
 
 export const CategoryChart = lazy(() =>
-  import("../CategoryChart.jsx").then((m) => ({
+  import("../CategoryChart").then((m) => ({
     default: m.CategoryChart,
   })),
 );
 
 export const NetworthChart = lazy(() =>
-  import("../NetworthChart.jsx").then((m) => ({
+  import("../NetworthChart").then((m) => ({
     default: m.NetworthChart,
   })),
 );
 
 export const CategoryPieChart = lazy(() =>
-  import("../analytics/CategoryPieChart.jsx").then((m) => ({
+  import("../analytics/CategoryPieChart").then((m) => ({
     default: m.CategoryPieChart,
   })),
 );

--- a/apps/web/src/modules/finyk/hooks/useMonobank.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobank.ts
@@ -14,7 +14,7 @@ import {
   readRaw,
   writeRaw,
   removeItem,
-} from "../lib/finykStorage.js";
+} from "../lib/finykStorage";
 import { normalizeTransaction } from "@sergeant/finyk-domain/domain/transactions";
 import type { Transaction } from "@sergeant/finyk-domain/domain/types";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";

--- a/apps/web/src/modules/finyk/hooks/usePrivatbank.ts
+++ b/apps/web/src/modules/finyk/hooks/usePrivatbank.ts
@@ -7,7 +7,7 @@ import {
   removeItem,
   readJSON,
   writeJSON,
-} from "../lib/finykStorage.js";
+} from "../lib/finykStorage";
 
 const PRIVAT_ID_KEY = "finyk_privat_id";
 const PRIVAT_TOKEN_KEY = "finyk_privat_token";

--- a/apps/web/src/modules/finyk/hooks/useStorage.ts
+++ b/apps/web/src/modules/finyk/hooks/useStorage.ts
@@ -1,19 +1,19 @@
 import { useState, useEffect, useRef } from "react";
 import { DEFAULT_SUBSCRIPTIONS, INTERNAL_TRANSFER_ID } from "../constants";
-import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
+import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 import {
   normalizeFinykBackup,
   normalizeFinykSyncPayload,
   FINYK_BACKUP_VERSION,
-} from "../lib/finykBackup.js";
+} from "../lib/finykBackup";
 import { downloadJson, toLocalISODate } from "@sergeant/shared";
 import {
   readJSON,
   writeJSON,
   writeJSONDebounced,
   finykStorageManager,
-} from "../lib/finykStorage.js";
+} from "../lib/finykStorage";
 
 function reportSilentError(scope, error) {
   console.warn(`[finyk] ${scope}`, error);

--- a/apps/web/src/modules/finyk/lib/demoData.ts
+++ b/apps/web/src/modules/finyk/lib/demoData.ts
@@ -14,7 +14,7 @@
 // here don't need to be touched.
 
 import { FINYK_MANUAL_ONLY_KEY } from "@sergeant/finyk-domain/storage-keys";
-import { writeRaw } from "./finykStorage.js";
+import { writeRaw } from "./finykStorage";
 
 // Re-export under its existing name so `apps/web` call sites that
 // import `FINYK_MANUAL_ONLY_KEY` from `./lib/demoData` keep working.

--- a/apps/web/src/modules/finyk/lib/finykBackup.test.ts
+++ b/apps/web/src/modules/finyk/lib/finykBackup.test.ts
@@ -3,7 +3,7 @@ import {
   normalizeFinykBackup,
   normalizeFinykSyncPayload,
   FINYK_BACKUP_VERSION,
-} from "./finykBackup.js";
+} from "./finykBackup";
 
 describe("normalizeFinykBackup", () => {
   it("приймає мінімальний v1 без додаткових полів", () => {

--- a/apps/web/src/modules/finyk/lib/finykBackup.ts
+++ b/apps/web/src/modules/finyk/lib/finykBackup.ts
@@ -13,9 +13,9 @@
  * `@sergeant/finyk-domain/backup`.
  */
 
-import { DEFAULT_SUBSCRIPTIONS } from "../constants.js";
-import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
-import { readJSON, writeJSON } from "./finykStorage.js";
+import { DEFAULT_SUBSCRIPTIONS } from "../constants";
+import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync";
+import { readJSON, writeJSON } from "./finykStorage";
 import {
   DEFAULT_FINYK_MONTHLY_PLAN,
   FINYK_BACKUP_VERSION,

--- a/apps/web/src/modules/finyk/lib/finykStorage.test.ts
+++ b/apps/web/src/modules/finyk/lib/finykStorage.test.ts
@@ -15,7 +15,7 @@ import {
   saveCategories,
   getBudget,
   saveBudget,
-} from "./finykStorage.js";
+} from "./finykStorage";
 
 beforeEach(() => {
   localStorage.clear();

--- a/apps/web/src/modules/finyk/lib/finykStorage.ts
+++ b/apps/web/src/modules/finyk/lib/finykStorage.ts
@@ -11,8 +11,8 @@
  * "finto_*" → "finyk_*" виконуються через shared `storageManager`.
  */
 
-import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
-import { finykStorageManager } from "./storageManager.js";
+import { createModuleStorage } from "@shared/lib/createModuleStorage";
+import { finykStorageManager } from "./storageManager";
 import type {
   Budget,
   Category,

--- a/apps/web/src/modules/finyk/lib/lsStats.ts
+++ b/apps/web/src/modules/finyk/lib/lsStats.ts
@@ -1,4 +1,4 @@
-import { safeReadLS } from "@shared/lib/storage.js";
+import { safeReadLS } from "@shared/lib/storage";
 import { INTERNAL_TRANSFER_ID } from "../constants";
 
 // Збирає Set ID транзакцій, що виключаються зі статистики ФІНІК (та сама логіка, що

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -18,7 +18,7 @@ import { ChartFallback } from "../components/charts/ChartFallback";
 import { MerchantList } from "../components/analytics/MerchantList";
 import { getTrendComparison } from "@sergeant/finyk-domain/domain/selectors";
 import type { TxSplitsMap } from "@sergeant/finyk-domain/domain/types";
-import { readJSON } from "../lib/finykStorage.js";
+import { readJSON } from "../lib/finykStorage";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 interface SectionProps {

--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -27,8 +27,8 @@ import {
 import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets/aggregates";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
-import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync.js";
-import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
+import { notifyFinykRoutineCalendarSync } from "../hubRoutineSync";
+import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import { parseExpenseSpeech as parseExpenseVoice } from "@sergeant/shared";
 import { computeFinykSchedule, startOfToday } from "../lib/upcomingSchedule";
 import { FinykStatsStrip } from "../components/FinykStatsStrip";

--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -27,13 +27,13 @@ import {
 import { filterStatTransactions } from "@sergeant/finyk-domain/domain/transactions";
 import { getMonthlySummary } from "@sergeant/finyk-domain/domain/selectors";
 import { chatApi } from "@shared/api";
-import { finykKeys } from "@shared/lib/queryKeys.js";
-import { LimitBudgetCard } from "../components/budgets/LimitBudgetCard.jsx";
-import { GoalBudgetCard } from "../components/budgets/GoalBudgetCard.jsx";
-import { MonthlyPlanCard } from "../components/budgets/MonthlyPlanCard.jsx";
-import { AddBudgetForm } from "../components/budgets/AddBudgetForm.jsx";
-import { readJSON, writeJSON } from "../lib/finykStorage.js";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { finykKeys } from "@shared/lib/queryKeys";
+import { LimitBudgetCard } from "../components/budgets/LimitBudgetCard";
+import { GoalBudgetCard } from "../components/budgets/GoalBudgetCard";
+import { MonthlyPlanCard } from "../components/budgets/MonthlyPlanCard";
+import { AddBudgetForm } from "../components/budgets/AddBudgetForm";
+import { readJSON, writeJSON } from "../lib/finykStorage";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
 
 // ─── React Query integration for AI chat lookups ──────────────────────────

--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -17,15 +17,15 @@ import {
 } from "@sergeant/finyk-domain/domain/budget";
 import { filterStatTransactions } from "@sergeant/finyk-domain/domain/transactions";
 import { Skeleton } from "@shared/components/ui/Skeleton";
-import { THEME_HEX } from "@shared/lib/themeHex.js";
+import { THEME_HEX } from "@shared/lib/themeHex";
 import { SyncStatusBadge } from "../components/SyncStatusBadge";
 
-import { FirstInsightBanner } from "./overview/FirstInsightBanner.jsx";
-import { HeroCard } from "./overview/HeroCard.jsx";
-import { MonthPulseCard } from "./overview/MonthPulseCard.jsx";
-import { NetworthSection } from "./overview/NetworthSection.jsx";
-import { BudgetAlertsList } from "./overview/BudgetAlertsList.jsx";
-import { PlannedFlowsCard } from "./overview/PlannedFlowsCard.jsx";
+import { FirstInsightBanner } from "./overview/FirstInsightBanner";
+import { HeroCard } from "./overview/HeroCard";
+import { MonthPulseCard } from "./overview/MonthPulseCard";
+import { NetworthSection } from "./overview/NetworthSection";
+import { BudgetAlertsList } from "./overview/BudgetAlertsList";
+import { PlannedFlowsCard } from "./overview/PlannedFlowsCard";
 
 const parseLocalDate = (isoDate) => {
   const [y, m, d] = (isoDate || "").split("-").map(Number);

--- a/apps/web/src/modules/finyk/pages/overview/FlowRow.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/FlowRow.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { cn } from "@shared/lib/cn";
-import { THEME_HEX } from "@shared/lib/themeHex.js";
+import { THEME_HEX } from "@shared/lib/themeHex";
 
 export interface FlowItem {
   title: string;

--- a/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/MonthPulseCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
-import { computePulseStyle } from "./pulseStyle.js";
+import { computePulseStyle } from "./pulseStyle";
 
 /**
  * Картка «Місяць» — дохід/витрати/прогрес, блок факт+прогнозу, фінпульс.

--- a/apps/web/src/modules/finyk/utils.test.ts
+++ b/apps/web/src/modules/finyk/utils.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getFinykExcludedTxIdsFromStorage,
   getFinykTxSplitsFromStorage,
-} from "./utils.js";
+} from "./utils";
 import { INTERNAL_TRANSFER_ID } from "@sergeant/finyk-domain/constants";
 
 beforeEach(() => localStorage.clear());

--- a/apps/web/src/modules/finyk/utils.ts
+++ b/apps/web/src/modules/finyk/utils.ts
@@ -2,4 +2,4 @@
 // `@sergeant/finyk-domain`; web-специфічний `lsStats` (читає localStorage)
 // залишається у `./lib/lsStats.ts` і додається лише тут.
 export * from "@sergeant/finyk-domain/utils";
-export * from "./lib/lsStats.js";
+export * from "./lib/lsStats";

--- a/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/web/src/modules/fizruk/components/BodyAtlas.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import createBodyHighlighter from "body-highlighter";
 import { cn } from "@shared/lib/cn";
-import { THEME_HEX } from "@shared/lib/themeHex.js";
+import { THEME_HEX } from "@shared/lib/themeHex";
 
 const STATUS_TO_FREQ: Record<string, number> = { yellow: 1, red: 2 };
 

--- a/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
+++ b/apps/web/src/modules/fizruk/components/TodayPlanCard.tsx
@@ -3,7 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import {
   ACTIVE_WORKOUT_KEY,
   recoveryConflictsForExercise,

--- a/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -7,7 +7,7 @@ import {
   getRestCategory,
   REST_CATEGORY_LABELS,
 } from "../../hooks/useRestSettings";
-import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
+import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import { parseWorkoutSetSpeech } from "@sergeant/shared";
 import {
   makeDefaultWarmup,

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -6,7 +6,7 @@ import { compactToolbarButtonClass } from "@shared/components/ui/buttonPresets";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { ActiveWorkoutPanel } from "../workouts/ActiveWorkoutPanel";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
-import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary.jsx";
+import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary";
 import { Card } from "@shared/components/ui/Card";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticSuccess } from "@shared/lib/haptic";

--- a/apps/web/src/modules/fizruk/hooks/useDailyLog.ts
+++ b/apps/web/src/modules/fizruk/hooks/useDailyLog.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 const KEY = STORAGE_KEYS.FIZRUK_DAILY_LOG;

--- a/apps/web/src/modules/fizruk/hooks/useMeasurements.ts
+++ b/apps/web/src/modules/fizruk/hooks/useMeasurements.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 const KEY = STORAGE_KEYS.FIZRUK_MEASUREMENTS;

--- a/apps/web/src/modules/fizruk/hooks/usePushupActivity.ts
+++ b/apps/web/src/modules/fizruk/hooks/usePushupActivity.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { ROUTINE_EVENT } from "../../routine/lib/routineStorage.js";
-import { buildPushupHistoryFromRoutine } from "../../routine/lib/routinePushupsRead.js";
+import { ROUTINE_EVENT } from "../../routine/lib/routineStorage";
+import { buildPushupHistoryFromRoutine } from "../../routine/lib/routinePushupsRead";
 
 /**
  * Fizruk-side adapter for pushup activity sourced from the Routine module.

--- a/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
+++ b/apps/web/src/modules/fizruk/hooks/useRestSettings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
 import {
   REST_CATEGORY_LABELS,

--- a/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.ts
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { safeReadLS, safeWriteLS } from "@shared/lib/storage.js";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 const KEY = STORAGE_KEYS.FIZRUK_TEMPLATES;

--- a/apps/web/src/modules/fizruk/lib/fizrukStorage.ts
+++ b/apps/web/src/modules/fizruk/lib/fizrukStorage.ts
@@ -5,7 +5,7 @@
  * `createModuleStorage` для apps/web.
  */
 
-import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
+import { createModuleStorage } from "@shared/lib/createModuleStorage";
 import {
   CUSTOM_EXERCISES_KEY,
   FIZRUK_FULL_BACKUP_KEYS,

--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -1,41 +1,38 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { NutritionHeader } from "./components/NutritionHeader.jsx";
-import { NutritionBottomNav } from "./components/NutritionBottomNav.jsx";
-import { SubTabs } from "./components/SubTabs.jsx";
-import { PhotoAnalyzeCard } from "./components/PhotoAnalyzeCard.jsx";
-import { NutritionDashboard } from "./components/NutritionDashboard.jsx";
-import { PantryCard } from "./components/PantryCard.jsx";
-import { RecipesCard } from "./components/RecipesCard.jsx";
-import { DailyPlanCard } from "./components/DailyPlanCard.jsx";
-import { ShoppingListCard } from "./components/ShoppingListCard.jsx";
-import { LogCard } from "./components/LogCard.jsx";
-import { NutritionPantrySelector } from "./components/NutritionPantrySelector.jsx";
-import { NutritionOverlays } from "./components/NutritionOverlays.jsx";
-import { Banner } from "@shared/components/ui/Banner.jsx";
+import { NutritionHeader } from "./components/NutritionHeader";
+import { NutritionBottomNav } from "./components/NutritionBottomNav";
+import { SubTabs } from "./components/SubTabs";
+import { PhotoAnalyzeCard } from "./components/PhotoAnalyzeCard";
+import { NutritionDashboard } from "./components/NutritionDashboard";
+import { PantryCard } from "./components/PantryCard";
+import { RecipesCard } from "./components/RecipesCard";
+import { DailyPlanCard } from "./components/DailyPlanCard";
+import { ShoppingListCard } from "./components/ShoppingListCard";
+import { LogCard } from "./components/LogCard";
+import { NutritionPantrySelector } from "./components/NutritionPantrySelector";
+import { NutritionOverlays } from "./components/NutritionOverlays";
+import { Banner } from "@shared/components/ui/Banner";
 import { Icon } from "@shared/components/ui/Icon";
 import {
   loadNutritionPrefs,
   persistNutritionPrefs,
-} from "./lib/nutritionStorage.js";
-import { useNutritionPantries } from "./hooks/useNutritionPantries.js";
-import { useNutritionLog } from "./hooks/useNutritionLog.js";
-import { usePhotoAnalysis } from "./hooks/usePhotoAnalysis.js";
-import { useShoppingList } from "./hooks/useShoppingList.js";
-import { useNutritionUiState } from "./hooks/useNutritionUiState.js";
-import { useNutritionHashRoute } from "./hooks/useNutritionHashRoute.js";
-import { useNutritionReminders } from "./hooks/useNutritionReminders.js";
-import { usePantryBarcodeScan } from "./hooks/usePantryBarcodeScan.js";
-import { useNutritionCloudBackup } from "./hooks/useNutritionCloudBackup.js";
-import { useNutritionRemoteActions } from "./hooks/useNutritionRemoteActions.js";
-import { buildRecipeCacheKey, readRecipeCache } from "./lib/recipeCache.js";
-import { stableRecipeId } from "./lib/recipeIds.js";
-import {
-  fileToThumbnailBlob,
-  saveMealThumbnail,
-} from "./lib/mealPhotoStorage.js";
+} from "./lib/nutritionStorage";
+import { useNutritionPantries } from "./hooks/useNutritionPantries";
+import { useNutritionLog } from "./hooks/useNutritionLog";
+import { usePhotoAnalysis } from "./hooks/usePhotoAnalysis";
+import { useShoppingList } from "./hooks/useShoppingList";
+import { useNutritionUiState } from "./hooks/useNutritionUiState";
+import { useNutritionHashRoute } from "./hooks/useNutritionHashRoute";
+import { useNutritionReminders } from "./hooks/useNutritionReminders";
+import { usePantryBarcodeScan } from "./hooks/usePantryBarcodeScan";
+import { useNutritionCloudBackup } from "./hooks/useNutritionCloudBackup";
+import { useNutritionRemoteActions } from "./hooks/useNutritionRemoteActions";
+import { buildRecipeCacheKey, readRecipeCache } from "./lib/recipeCache";
+import { stableRecipeId } from "./lib/recipeIds";
+import { fileToThumbnailBlob, saveMealThumbnail } from "./lib/mealPhotoStorage";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
-import { fmtMacro, todayISODate } from "./lib/nutritionFormat.js";
+import { fmtMacro, todayISODate } from "./lib/nutritionFormat";
 
 interface NutritionAppProps {
   onBackToHub?: () => void;

--- a/apps/web/src/modules/nutrition/components/AddMealSheet.tsx
+++ b/apps/web/src/modules/nutrition/components/AddMealSheet.tsx
@@ -3,21 +3,21 @@ import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { useVisualKeyboardInset } from "@sergeant/shared";
 import { hapticSuccess } from "@shared/lib/haptic";
-import { MEAL_TYPES } from "../lib/mealTypes.js";
-import { ensureSeedFoods } from "../lib/foodDb/foodDb.js";
-import { BarcodeScanner } from "./BarcodeScanner.jsx";
-import { currentTime, emptyForm } from "./meal-sheet/mealFormUtils.js";
-import { MealTemplatesRow } from "./meal-sheet/MealTemplatesRow.jsx";
-import { MealTypePicker } from "./meal-sheet/MealTypePicker.jsx";
-import { NameTimeRow } from "./meal-sheet/NameTimeRow.jsx";
-import { FromPantryRow } from "./meal-sheet/FromPantryRow.jsx";
-import { FoodPickerSection } from "./meal-sheet/FoodPickerSection.jsx";
-import { BarcodeSection } from "./meal-sheet/BarcodeSection.jsx";
-import { MacrosEditor } from "./meal-sheet/MacrosEditor.jsx";
-import { SaveAsFood } from "./meal-sheet/SaveAsFood.jsx";
-import { SaveAsTemplate } from "./meal-sheet/SaveAsTemplate.jsx";
-import { useFoodSearch } from "./meal-sheet/useFoodSearch.js";
-import { useBarcodeLookup } from "./meal-sheet/useBarcodeLookup.js";
+import { MEAL_TYPES } from "../lib/mealTypes";
+import { ensureSeedFoods } from "../lib/foodDb/foodDb";
+import { BarcodeScanner } from "./BarcodeScanner";
+import { currentTime, emptyForm } from "./meal-sheet/mealFormUtils";
+import { MealTemplatesRow } from "./meal-sheet/MealTemplatesRow";
+import { MealTypePicker } from "./meal-sheet/MealTypePicker";
+import { NameTimeRow } from "./meal-sheet/NameTimeRow";
+import { FromPantryRow } from "./meal-sheet/FromPantryRow";
+import { FoodPickerSection } from "./meal-sheet/FoodPickerSection";
+import { BarcodeSection } from "./meal-sheet/BarcodeSection";
+import { MacrosEditor } from "./meal-sheet/MacrosEditor";
+import { SaveAsFood } from "./meal-sheet/SaveAsFood";
+import { SaveAsTemplate } from "./meal-sheet/SaveAsTemplate";
+import { useFoodSearch } from "./meal-sheet/useFoodSearch";
+import { useBarcodeLookup } from "./meal-sheet/useBarcodeLookup";
 
 export function AddMealSheet({
   open,

--- a/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
+++ b/apps/web/src/modules/nutrition/components/BarcodeScanner.tsx
@@ -5,7 +5,7 @@ import {
   useBarcodeScanner,
   useWebScanner,
   type BarcodeResult,
-} from "../hooks/useBarcodeScanner.js";
+} from "../hooks/useBarcodeScanner";
 
 interface BarcodeScannerProps {
   /**

--- a/apps/web/src/modules/nutrition/components/ItemEditSheet.tsx
+++ b/apps/web/src/modules/nutrition/components/ItemEditSheet.tsx
@@ -2,7 +2,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Sheet } from "@shared/components/ui/Sheet";
-import { normalizeUnit } from "../lib/pantryTextParser.js";
+import { normalizeUnit } from "../lib/pantryTextParser";
 
 export function ItemEditSheet({ itemEdit, setItemEdit, onClose, onSave }) {
   return (

--- a/apps/web/src/modules/nutrition/components/LogCard.tsx
+++ b/apps/web/src/modules/nutrition/components/LogCard.tsx
@@ -14,22 +14,22 @@ import {
   getMacrosForDateRange,
   estimateLogBytes,
   toLocalISODate,
-} from "../lib/nutritionStorage.js";
+} from "../lib/nutritionStorage";
 import { addDaysISODate } from "@sergeant/nutrition-domain";
 import {
   MEAL_ORDER,
   MEAL_META,
   isMealTypeId,
   mealTypeFromLabel,
-} from "../lib/mealTypes.js";
+} from "../lib/mealTypes";
 import {
   avgFromSummary,
   getRowsForRange,
   mealTypeBreakdown,
   summarizeRows,
   topMeals,
-} from "../lib/nutritionStats.js";
-import { getMealThumbnailBlob } from "../lib/mealPhotoStorage.js";
+} from "../lib/nutritionStats";
+import { getMealThumbnailBlob } from "../lib/mealPhotoStorage";
 
 function toISODate(d) {
   return toLocalISODate(d);

--- a/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
@@ -8,8 +8,8 @@ import {
   getDaySummary,
   getMacrosForDateRange,
   toLocalISODate,
-} from "../lib/nutritionStorage.js";
-import { WaterTrackerCard } from "./WaterTrackerCard.jsx";
+} from "../lib/nutritionStorage";
+import { WaterTrackerCard } from "./WaterTrackerCard";
 
 function todayISO() {
   return toLocalISODate(new Date());

--- a/apps/web/src/modules/nutrition/components/NutritionOverlays.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionOverlays.tsx
@@ -1,7 +1,7 @@
-import { PantryManagerSheet } from "./PantryManagerSheet.jsx";
-import { ItemEditSheet } from "./ItemEditSheet.jsx";
-import { BarcodeScanner } from "./BarcodeScanner.jsx";
-import { AddMealSheet } from "./AddMealSheet.jsx";
+import { PantryManagerSheet } from "./PantryManagerSheet";
+import { ItemEditSheet } from "./ItemEditSheet";
+import { BarcodeScanner } from "./BarcodeScanner";
+import { AddMealSheet } from "./AddMealSheet";
 import { InputDialog } from "@shared/components/ui/InputDialog";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 

--- a/apps/web/src/modules/nutrition/components/PantryCard.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryCard.tsx
@@ -3,9 +3,9 @@ import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
-import { groupItemsByCategory } from "../lib/foodCategories.js";
-import type { FoodCategory } from "../lib/foodCategories.js";
-import type { PantryItem } from "../lib/pantryTextParser.js";
+import { groupItemsByCategory } from "../lib/foodCategories";
+import type { FoodCategory } from "../lib/foodCategories";
+import type { PantryItem } from "../lib/pantryTextParser";
 
 /**
  * Мінімальний "view-shape" елемента комори для `ItemRow`. Runtime-потік

--- a/apps/web/src/modules/nutrition/components/RecipesCard.tsx
+++ b/apps/web/src/modules/nutrition/components/RecipesCard.tsx
@@ -11,8 +11,8 @@ import {
   listSavedRecipes,
   saveRecipeToBook,
   scaleMacros,
-} from "../lib/recipeBook.js";
-import { MEAL_TYPES } from "../lib/mealTypes.js";
+} from "../lib/recipeBook";
+import { MEAL_TYPES } from "../lib/mealTypes";
 
 function guessMealTypeIdNow() {
   const h = new Date().getHours();

--- a/apps/web/src/modules/nutrition/components/ShoppingListCard.tsx
+++ b/apps/web/src/modules/nutrition/components/ShoppingListCard.tsx
@@ -3,7 +3,7 @@ import { Card } from "@shared/components/ui/Card";
 import { Button } from "@shared/components/ui/Button";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
-import { getTotalCount } from "../lib/shoppingListStorage.js";
+import { getTotalCount } from "../lib/shoppingListStorage";
 
 const CATEGORY_ICONS = {
   "М'ясо та риба": "🥩",

--- a/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
+++ b/apps/web/src/modules/nutrition/components/WaterTrackerCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
-import { useWaterTracker } from "../hooks/useWaterTracker.js";
+import { useWaterTracker } from "../hooks/useWaterTracker";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 

--- a/apps/web/src/modules/nutrition/components/meal-sheet/FoodPickerSection.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/FoodPickerSection.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { cn } from "@shared/lib/cn";
-import { FoodHitRow } from "./FoodHitRow.jsx";
-import { MacroChip } from "./MacroChip.jsx";
-import { macrosForGrams } from "../../lib/foodDb/foodDb.js";
+import { FoodHitRow } from "./FoodHitRow";
+import { MacroChip } from "./MacroChip";
+import { macrosForGrams } from "../../lib/foodDb/foodDb";
 
 export function FoodPickerSection({
   form,

--- a/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
-import { emptyForm } from "./mealFormUtils.js";
+import { emptyForm } from "./mealFormUtils";
 
 export function MacrosEditor({
   form,

--- a/apps/web/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@shared/lib/cn";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
-import { MEAL_TYPES } from "../../lib/mealTypes.js";
+import { MEAL_TYPES } from "../../lib/mealTypes";
 
 export function MealTypePicker({ mealType, setForm }) {
   return (

--- a/apps/web/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Input } from "@shared/components/ui/Input";
-import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
+import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import { parseMealSpeech } from "@sergeant/shared";
-import { currentTime } from "./mealFormUtils.js";
+import { currentTime } from "./mealFormUtils";
 
 export function NameTimeRow({ form, field, setForm }) {
   // 95%+ of the time the user logs a meal «right now». Showing the time

--- a/apps/web/src/modules/nutrition/components/meal-sheet/SaveAsFood.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/SaveAsFood.tsx
@@ -1,8 +1,8 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@shared/components/ui/Button";
-import { nutritionKeys } from "@shared/lib/queryKeys.js";
-import { upsertFood, type FoodProduct } from "../../lib/foodDb/foodDb.js";
-import type { MealFormState } from "./mealFormUtils.js";
+import { nutritionKeys } from "@shared/lib/queryKeys";
+import { upsertFood, type FoodProduct } from "../../lib/foodDb/foodDb";
+import type { MealFormState } from "./mealFormUtils";
 
 interface SaveAsFoodProps {
   form: MealFormState;

--- a/apps/web/src/modules/nutrition/components/meal-sheet/mealFormUtils.ts
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/mealFormUtils.ts
@@ -1,4 +1,4 @@
-import { mealTypeByNow, type MealTypeId } from "../../lib/mealTypes.js";
+import { mealTypeByNow, type MealTypeId } from "../../lib/mealTypes";
 import type { NullableMacros } from "@sergeant/shared";
 
 export function currentTime(): string {

--- a/apps/web/src/modules/nutrition/components/meal-sheet/useBarcodeLookup.ts
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/useBarcodeLookup.ts
@@ -9,9 +9,9 @@ import {
   bindBarcodeToFood,
   lookupFoodByBarcode,
   type FoodProduct,
-} from "../../lib/foodDb/foodDb.js";
-import { useBarcodeProductLookup } from "../../hooks/useBarcodeProduct.js";
-import type { MealFormState } from "./mealFormUtils.js";
+} from "../../lib/foodDb/foodDb";
+import { useBarcodeProductLookup } from "../../hooks/useBarcodeProduct";
+import type { MealFormState } from "./mealFormUtils";
 
 export interface UseBarcodeLookupParams {
   pickedFood: FoodProduct | null;

--- a/apps/web/src/modules/nutrition/components/meal-sheet/useFoodSearch.ts
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/useFoodSearch.ts
@@ -2,9 +2,9 @@ import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { foodSearchApi } from "@shared/api";
 import type { FoodSearchProduct } from "@shared/api";
-import { nutritionKeys } from "@shared/lib/queryKeys.js";
-import { searchFoods } from "../../lib/foodDb/foodDb.js";
-import type { FoodProduct } from "../../lib/foodDb/foodDb.js";
+import { nutritionKeys } from "@shared/lib/queryKeys";
+import { searchFoods } from "../../lib/foodDb/foodDb";
+import type { FoodProduct } from "../../lib/foodDb/foodDb";
 
 const LOCAL_DEBOUNCE_MS = 180;
 const OFF_DEBOUNCE_MS = 600;

--- a/apps/web/src/modules/nutrition/domain/nutritionBackup.test.ts
+++ b/apps/web/src/modules/nutrition/domain/nutritionBackup.test.ts
@@ -3,12 +3,12 @@ import {
   applyNutritionBackupPayload,
   buildNutritionBackupPayload,
   NUTRITION_BACKUP_KIND,
-} from "./nutritionBackup.js";
+} from "./nutritionBackup";
 import {
   NUTRITION_ACTIVE_PANTRY_KEY,
   NUTRITION_PANTRIES_KEY,
   NUTRITION_PREFS_KEY,
-} from "../lib/nutritionStorage.js";
+} from "../lib/nutritionStorage";
 
 function createLocalStorageMock() {
   const store = new Map();

--- a/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
+++ b/apps/web/src/modules/nutrition/domain/nutritionBackup.ts
@@ -9,7 +9,7 @@ import {
   normalizeNutritionLog,
   type NutritionLog,
   type NutritionPrefs,
-} from "../lib/nutritionStorage.js";
+} from "../lib/nutritionStorage";
 
 export const NUTRITION_BACKUP_KIND = "hub-nutrition-backup";
 export const NUTRITION_BACKUP_SCHEMA_VERSION = 1;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.test.tsx
@@ -27,7 +27,7 @@ vi.mock("../lib/nutritionCloudBackup.js", () => ({
   decryptBlobToJson: vi.fn(() => Promise.resolve({ version: 1, log: {} })),
 }));
 
-import { useNutritionCloudBackup } from "./useNutritionCloudBackup.js";
+import { useNutritionCloudBackup } from "./useNutritionCloudBackup";
 import { nutritionApi } from "@shared/api";
 const apiBackupUpload = nutritionApi.backupUpload as unknown as ReturnType<
   typeof vi.fn
@@ -38,7 +38,7 @@ const apiBackupDownload = nutritionApi.backupDownload as unknown as ReturnType<
 import {
   encryptJsonToBlob,
   decryptBlobToJson,
-} from "../lib/nutritionCloudBackup.js";
+} from "../lib/nutritionCloudBackup";
 
 function makeWrapper() {
   const client = new QueryClient({

--- a/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
@@ -4,16 +4,16 @@ import { nutritionApi } from "@shared/api";
 import {
   applyNutritionBackupPayload,
   buildNutritionBackupPayload,
-} from "../domain/nutritionBackup.js";
+} from "../domain/nutritionBackup";
 import {
   decryptBlobToJson,
   encryptJsonToBlob,
-} from "../lib/nutritionCloudBackup.js";
-import { formatNutritionError } from "../lib/nutritionErrors.js";
+} from "../lib/nutritionCloudBackup";
+import { formatNutritionError } from "../lib/nutritionErrors";
 import type {
   BackupPasswordDialogState,
   RestoreConfirmState,
-} from "./useNutritionUiState.js";
+} from "./useNutritionUiState";
 
 export interface NutritionToast {
   success: (message: string) => void;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionHashRoute.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionHashRoute.ts
@@ -3,7 +3,7 @@ import {
   parseNutritionHash,
   setNutritionHash,
   type NutritionPage,
-} from "../lib/nutritionRouter.js";
+} from "../lib/nutritionRouter";
 
 export interface UseNutritionHashRouteResult {
   activePage: NutritionPage;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.test.tsx
@@ -4,8 +4,8 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { MockInstance } from "vitest";
-import { useNutritionLog } from "./useNutritionLog.js";
-import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage.js";
+import { useNutritionLog } from "./useNutritionLog";
+import { NUTRITION_LOG_KEY } from "../lib/nutritionStorage";
 
 function makeWrapper() {
   const client = new QueryClient({

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { coachKeys, digestKeys } from "@shared/lib/queryKeys.js";
+import { coachKeys, digestKeys } from "@shared/lib/queryKeys";
 import {
   NUTRITION_LOG_KEY,
   loadNutritionLog,
@@ -16,11 +16,8 @@ import {
   type Meal,
   type NutritionDay,
   type NutritionLog,
-} from "../lib/nutritionStorage.js";
-import {
-  deleteMealThumbnail,
-  gcMealThumbnails,
-} from "../lib/mealPhotoStorage.js";
+} from "../lib/nutritionStorage";
+import { deleteMealThumbnail, gcMealThumbnails } from "../lib/mealPhotoStorage";
 
 /**
  * Collect all meal IDs present in a log.

--- a/apps/web/src/modules/nutrition/hooks/useNutritionLog.undo.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionLog.undo.test.tsx
@@ -3,8 +3,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useNutritionLog } from "./useNutritionLog.js";
-import type { Meal } from "../lib/nutritionStorage.js";
+import { useNutritionLog } from "./useNutritionLog";
+import type { Meal } from "../lib/nutritionStorage";
 
 function makeWrapper() {
   const client = new QueryClient({

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@shared/api", async () => {
   };
 });
 
-import { useNutritionPantries } from "./useNutritionPantries.js";
+import { useNutritionPantries } from "./useNutritionPantries";
 import { nutritionApi } from "@shared/api";
 const apiParsePantry = nutritionApi.parsePantry as unknown as ReturnType<
   typeof vi.fn
@@ -24,7 +24,7 @@ import {
   NUTRITION_PANTRIES_KEY,
   NUTRITION_ACTIVE_PANTRY_KEY,
   type Pantry,
-} from "../lib/nutritionStorage.js";
+} from "../lib/nutritionStorage";
 
 function makeWrapper() {
   const client = new QueryClient({

--- a/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionPantries.ts
@@ -8,8 +8,8 @@ import {
 } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { nutritionApi } from "@shared/api";
-import { formatNutritionError } from "../lib/nutritionErrors.js";
-import { mergeItems } from "../lib/mergeItems.js";
+import { formatNutritionError } from "../lib/nutritionErrors";
+import { mergeItems } from "../lib/mergeItems";
 import {
   loadActivePantryId,
   loadPantries,
@@ -18,12 +18,12 @@ import {
   updatePantry,
   NUTRITION_PANTRIES_KEY,
   NUTRITION_ACTIVE_PANTRY_KEY,
-} from "../lib/nutritionStorage.js";
+} from "../lib/nutritionStorage";
 import {
   normalizeFoodName,
   parseLoosePantryText,
   type PantryItem,
-} from "../lib/pantryTextParser.js";
+} from "../lib/pantryTextParser";
 
 export interface UseNutritionPantriesParams {
   setBusy: Dispatch<SetStateAction<boolean>>;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { todayISODate } from "../lib/nutritionFormat.js";
+import { todayISODate } from "../lib/nutritionFormat";
 
 export interface NutritionReminderPrefs {
   reminderEnabled: boolean;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import type { UseNutritionRemoteActionsParams } from "./useNutritionRemoteActions.js";
+import type { UseNutritionRemoteActionsParams } from "./useNutritionRemoteActions";
 
 vi.mock("@shared/api", async () => {
   const actual =
@@ -23,7 +23,7 @@ vi.mock("../lib/recipeCache.js", () => ({
   writeRecipeCache: vi.fn(),
 }));
 
-import { useNutritionRemoteActions } from "./useNutritionRemoteActions.js";
+import { useNutritionRemoteActions } from "./useNutritionRemoteActions";
 import { nutritionApi } from "@shared/api";
 type MockFn = ReturnType<typeof vi.fn>;
 const apiRecommendRecipes = nutritionApi.recommendRecipes as unknown as MockFn;

--- a/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts
@@ -10,18 +10,18 @@ import type {
   NutritionShoppingCategory,
   NutritionWeekPlan as ApiNutritionWeekPlan,
 } from "@shared/api";
-import { formatNutritionError } from "../lib/nutritionErrors.js";
-import { writeRecipeCache } from "../lib/recipeCache.js";
-import { stableRecipeId } from "../lib/recipeIds.js";
-import { getDayMacros, getDaySummary } from "../lib/nutritionStorage.js";
-import type { Meal, NutritionLogLike } from "../lib/nutritionStorage.js";
-import type { PantryItem } from "../lib/pantryTextParser.js";
+import { formatNutritionError } from "../lib/nutritionErrors";
+import { writeRecipeCache } from "../lib/recipeCache";
+import { stableRecipeId } from "../lib/recipeIds";
+import { getDayMacros, getDaySummary } from "../lib/nutritionStorage";
+import type { Meal, NutritionLogLike } from "../lib/nutritionStorage";
+import type { PantryItem } from "../lib/pantryTextParser";
 import type {
   NutritionDayPlan as UiNutritionDayPlan,
   NutritionRecipe as UiNutritionRecipe,
   NutritionWeekPlan as UiNutritionWeekPlan,
-} from "./useNutritionUiState.js";
-import type { ShoppingCategory } from "../lib/shoppingListStorage.js";
+} from "./useNutritionUiState";
+import type { ShoppingCategory } from "../lib/shoppingListStorage";
 
 type AnySetter<T = unknown> =
   | Dispatch<SetStateAction<T>>

--- a/apps/web/src/modules/nutrition/hooks/usePantryBarcodeScan.ts
+++ b/apps/web/src/modules/nutrition/hooks/usePantryBarcodeScan.ts
@@ -1,6 +1,6 @@
 import { useCallback, type Dispatch, type SetStateAction } from "react";
 import { isApiError } from "@shared/api";
-import { useBarcodeProductLookup } from "./useBarcodeProduct.js";
+import { useBarcodeProductLookup } from "./useBarcodeProduct";
 
 export interface PantryBarcodeScanApi {
   upsertItem: (label: string) => void;

--- a/apps/web/src/modules/nutrition/hooks/usePhotoAnalysis.test.tsx
+++ b/apps/web/src/modules/nutrition/hooks/usePhotoAnalysis.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../lib/fileToBase64.js", () => ({
   fileToBase64: vi.fn(() => Promise.resolve("BASE64")),
 }));
 
-import { usePhotoAnalysis } from "./usePhotoAnalysis.js";
+import { usePhotoAnalysis } from "./usePhotoAnalysis";
 import { nutritionApi } from "@shared/api";
 const apiAnalyzePhoto = nutritionApi.analyzePhoto as unknown as ReturnType<
   typeof vi.fn

--- a/apps/web/src/modules/nutrition/hooks/usePhotoAnalysis.ts
+++ b/apps/web/src/modules/nutrition/hooks/usePhotoAnalysis.ts
@@ -8,8 +8,8 @@ import {
 } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { nutritionApi, type NutritionPhotoResult } from "@shared/api";
-import { fileToBase64 } from "../lib/fileToBase64.js";
-import { formatNutritionError } from "../lib/nutritionErrors.js";
+import { fileToBase64 } from "../lib/fileToBase64";
+import { formatNutritionError } from "../lib/nutritionErrors";
 
 export interface PhotoAnalysisPayload {
   image_base64: string;

--- a/apps/web/src/modules/nutrition/hooks/useShoppingList.ts
+++ b/apps/web/src/modules/nutrition/hooks/useShoppingList.ts
@@ -8,7 +8,7 @@ import {
   type ShoppingCategory,
   type ShoppingItem,
   type ShoppingList,
-} from "../lib/shoppingListStorage.js";
+} from "../lib/shoppingListStorage";
 
 export interface UseShoppingListResult {
   shoppingList: ShoppingList;

--- a/apps/web/src/modules/nutrition/hooks/useWaterTracker.ts
+++ b/apps/web/src/modules/nutrition/hooks/useWaterTracker.ts
@@ -7,7 +7,7 @@ import {
   subtractWaterMl,
   resetTodayWater,
   type WaterLog,
-} from "../lib/waterStorage.js";
+} from "../lib/waterStorage";
 
 export interface UseWaterTrackerResult {
   todayMl: number;

--- a/apps/web/src/modules/nutrition/lib/foodDb/foodDb.ts
+++ b/apps/web/src/modules/nutrition/lib/foodDb/foodDb.ts
@@ -1,5 +1,5 @@
-import type { Macros } from "../macros.js";
-import type { SeedFood } from "./seedFoodsUk.js";
+import type { Macros } from "../macros";
+import type { SeedFood } from "./seedFoodsUk";
 
 /**
  * Lazy-loader для 1600+ seed-продуктів. Статичний import затягував весь
@@ -8,7 +8,7 @@ import type { SeedFood } from "./seedFoodsUk.js";
  * ізолює ці дані у власний chunk, який vite/rollup вантажить на вимогу.
  */
 async function loadSeedFoods(): Promise<readonly SeedFood[]> {
-  const mod = await import("./seedFoodsUk.js");
+  const mod = await import("./seedFoodsUk");
   return mod.SEED_FOODS_UK;
 }
 

--- a/apps/web/src/modules/nutrition/lib/foodDb/seedFoodsUk.ts
+++ b/apps/web/src/modules/nutrition/lib/foodDb/seedFoodsUk.ts
@@ -1,4 +1,4 @@
-import type { Macros } from "../macros.js";
+import type { Macros } from "../macros";
 
 export interface SeedFood {
   name: string;

--- a/apps/web/src/modules/nutrition/lib/nutritionCloudBackup.test.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionCloudBackup.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { webcrypto } from "node:crypto";
-import {
-  decryptBlobToJson,
-  encryptJsonToBlob,
-} from "./nutritionCloudBackup.js";
+import { decryptBlobToJson, encryptJsonToBlob } from "./nutritionCloudBackup";
 
 describe("nutritionCloudBackup", () => {
   it("encrypts and decrypts JSON payload", async () => {

--- a/apps/web/src/modules/nutrition/lib/nutritionDaySummary.test.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionDaySummary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDaySummary } from "./nutritionStorage.js";
+import { getDaySummary } from "./nutritionStorage";
 
 describe("getDaySummary", () => {
   it("detects empty day", () => {

--- a/apps/web/src/modules/nutrition/lib/nutritionStats.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStats.ts
@@ -3,8 +3,8 @@ import {
   getDaySummary,
   type DaySummary,
   type NutritionLog,
-} from "./nutritionStorage.js";
-import { mealTypeFromLabel } from "./mealTypes.js";
+} from "./nutritionStorage";
+import { mealTypeFromLabel } from "./mealTypes";
 
 function clamp0(n: unknown): number {
   const v = Number(n);

--- a/apps/web/src/modules/nutrition/lib/nutritionStorage.test.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStorage.test.ts
@@ -12,8 +12,8 @@ import {
   normalizeNutritionLog,
   normalizePantries,
   persistPantries,
-} from "./nutritionStorage.js";
-import { storageManager } from "@shared/lib/storageManager.js";
+} from "./nutritionStorage";
+import { storageManager } from "@shared/lib/storageManager";
 
 function createLocalStorageMock() {
   /** @type {Map<string, string>} */

--- a/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/nutritionStorage.ts
@@ -22,7 +22,7 @@ import {
   type Pantry,
 } from "@sergeant/nutrition-domain";
 
-import { nutritionStorage } from "./nutritionStorageInstance.js";
+import { nutritionStorage } from "./nutritionStorageInstance";
 
 export {
   NUTRITION_ACTIVE_PANTRY_KEY,

--- a/apps/web/src/modules/nutrition/lib/recipeBook.ts
+++ b/apps/web/src/modules/nutrition/lib/recipeBook.ts
@@ -1,4 +1,4 @@
-import type { NullableMacros } from "./macros.js";
+import type { NullableMacros } from "./macros";
 
 const DB_NAME = "hub_nutrition_recipe_book";
 const DB_VERSION = 1;

--- a/apps/web/src/modules/nutrition/lib/recipeCache.ts
+++ b/apps/web/src/modules/nutrition/lib/recipeCache.ts
@@ -1,4 +1,4 @@
-import { normalizeFoodName } from "./pantryTextParser.js";
+import { normalizeFoodName } from "./pantryTextParser";
 
 const STORAGE_KEY = "nutrition_recipes_cache_v1";
 

--- a/apps/web/src/modules/nutrition/lib/shoppingListStorage.test.ts
+++ b/apps/web/src/modules/nutrition/lib/shoppingListStorage.test.ts
@@ -8,7 +8,7 @@ import {
   persistShoppingList,
   removeCheckedItems,
   toggleShoppingItem,
-} from "./shoppingListStorage.js";
+} from "./shoppingListStorage";
 
 function createLocalStorageMock() {
   const store = new Map();

--- a/apps/web/src/modules/nutrition/lib/shoppingListStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/shoppingListStorage.ts
@@ -12,7 +12,7 @@ import {
   type ShoppingList,
 } from "@sergeant/nutrition-domain";
 
-import { nutritionStorage } from "./nutritionStorageInstance.js";
+import { nutritionStorage } from "./nutritionStorageInstance";
 
 export {
   SHOPPING_LIST_KEY,

--- a/apps/web/src/modules/nutrition/lib/waterStorage.test.ts
+++ b/apps/web/src/modules/nutrition/lib/waterStorage.test.ts
@@ -7,7 +7,7 @@ import {
   normalizeWaterLog,
   resetTodayWater,
   saveWaterLog,
-} from "./waterStorage.js";
+} from "./waterStorage";
 
 function createLocalStorageMock() {
   const store = new Map();

--- a/apps/web/src/modules/nutrition/lib/waterStorage.ts
+++ b/apps/web/src/modules/nutrition/lib/waterStorage.ts
@@ -12,7 +12,7 @@ import {
   type WaterLog,
 } from "@sergeant/nutrition-domain";
 
-import { nutritionStorage } from "./nutritionStorageInstance.js";
+import { nutritionStorage } from "./nutritionStorageInstance";
 
 export {
   WATER_LOG_KEY,

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -12,11 +12,11 @@ import {
   markAllScheduledHabitsComplete,
   ROUTINE_EVENT,
   ROUTINE_STORAGE_ERROR,
-} from "./lib/routineStorage.js";
-import { addDays, startOfIsoWeek } from "./lib/weekUtils.js";
-import { maxActiveStreak, completionRateForRange } from "./lib/streaks.js";
+} from "./lib/routineStorage";
+import { addDays, startOfIsoWeek } from "./lib/weekUtils";
+import { maxActiveStreak, completionRateForRange } from "./lib/streaks";
 import { useRoutineReminders } from "./hooks/useRoutineReminders";
-import { useLocalStorageState } from "@shared/hooks/useLocalStorageState.js";
+import { useLocalStorageState } from "@shared/hooks/useLocalStorageState";
 import {
   buildHubCalendarEvents,
   countEventsByDate,
@@ -24,11 +24,11 @@ import {
   FIZRUK_GROUP_LABEL,
   parseDateKey,
   habitScheduledOnDate,
-} from "./lib/hubCalendarAggregate.js";
-import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar.js";
-import { HUB_FINYK_ROUTINE_SYNC_EVENT } from "../finyk/hubRoutineSync.js";
+} from "./lib/hubCalendarAggregate";
+import { FINYK_SUB_GROUP_LABEL } from "./lib/finykSubscriptionCalendar";
+import { HUB_FINYK_ROUTINE_SYNC_EVENT } from "../finyk/hubRoutineSync";
 import { useFinykHubPreview } from "../../core/hub/useFinykHubPreview";
-import { ROUTINE_THEME as C } from "./lib/routineConstants.js";
+import { ROUTINE_THEME as C } from "./lib/routineConstants";
 import { RoutineBottomNav } from "./components/RoutineBottomNav";
 import { RoutineCalendarPanel } from "./components/RoutineCalendarPanel";
 import { RoutineStatsPanel } from "./components/RoutineStatsPanel";

--- a/apps/web/src/modules/routine/components/DayReportSheet.tsx
+++ b/apps/web/src/modules/routine/components/DayReportSheet.tsx
@@ -1,7 +1,7 @@
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
-import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
+import { ROUTINE_THEME as C } from "../lib/routineConstants";
 import type { Habit } from "../lib/types";
 
 export interface ScheduledHabitForReport extends Habit {

--- a/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
+++ b/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
@@ -7,7 +7,7 @@ import { cn } from "@shared/lib/cn";
 import { useMonthlyPlan } from "../../fizruk/hooks/useMonthlyPlan";
 import { useWorkoutTemplates } from "../../fizruk/hooks/useWorkoutTemplates";
 import { useExerciseCatalog } from "../../fizruk/hooks/useExerciseCatalog";
-import { parseDateKey } from "../lib/hubCalendarAggregate.js";
+import { parseDateKey } from "../lib/hubCalendarAggregate";
 
 export interface FizrukDayPlanSheetProps {
   dateKey: string | null;

--- a/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
@@ -6,14 +6,14 @@ import {
   dateKeyFromDate,
   parseDateKey,
   habitScheduledOnDate,
-} from "../lib/hubCalendarAggregate.js";
-import { completionNoteKey } from "../lib/completionNoteKey.js";
-import { streakForHabit, maxStreakAllTime } from "../lib/streaks.js";
+} from "../lib/hubCalendarAggregate";
+import { completionNoteKey } from "../lib/completionNoteKey";
+import { streakForHabit, maxStreakAllTime } from "../lib/streaks";
 import {
   ROUTINE_THEME as C,
   RECURRENCE_OPTIONS,
   WEEKDAY_LABELS,
-} from "../lib/routineConstants.js";
+} from "../lib/routineConstants";
 import type { Habit, RoutineState } from "../lib/types";
 
 function todayKey(): string {

--- a/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { habitCompletionRate } from "../lib/streaks.js";
+import { habitCompletionRate } from "../lib/streaks";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Card } from "@shared/components/ui/Card";
 import type { Habit, RoutineState } from "../lib/types";

--- a/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -3,14 +3,14 @@ import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticSuccess } from "@shared/lib/haptic";
 import { cn } from "@shared/lib/cn";
-import { createHabit, updateHabit } from "../lib/routineStorage.js";
+import { createHabit, updateHabit } from "../lib/routineStorage";
 import {
   emptyHabitDraft,
   habitDraftToPatch,
   normalizeReminderTimes,
   routineTodayDate,
-} from "../lib/routineDraftUtils.js";
-import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
+} from "../lib/routineDraftUtils";
+import { dateKeyFromDate } from "../lib/hubCalendarAggregate";
 import { HabitForm, type HabitFormErrors } from "./settings/HabitForm";
 import type { Habit, HabitDraft, RoutineState } from "../lib/types";
 import type { Dispatch, SetStateAction } from "react";

--- a/apps/web/src/modules/routine/components/PushupsWidget.tsx
+++ b/apps/web/src/modules/routine/components/PushupsWidget.tsx
@@ -4,8 +4,8 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Sheet } from "@shared/components/ui/Sheet";
 import { Card } from "@shared/components/ui/Card";
 import { useVisualKeyboardInset } from "@sergeant/shared";
-import { useRoutinePushups } from "../hooks/useRoutinePushups.js";
-import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
+import { useRoutinePushups } from "../hooks/useRoutinePushups";
+import { dateKeyFromDate } from "../lib/hubCalendarAggregate";
 
 const C = {
   primary: "!bg-routine hover:!bg-routine-hover !text-white border-0",

--- a/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
+++ b/apps/web/src/modules/routine/components/RoutineBackupSection.tsx
@@ -3,7 +3,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/cn";
-import { buildRoutineBackupPayload } from "../lib/routineStorage.js";
+import { buildRoutineBackupPayload } from "../lib/routineStorage";
 
 export interface RoutineBackupTheme {
   primary?: string;

--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -18,20 +18,20 @@ import { WeekDayStrip } from "./WeekDayStrip";
 import { HabitDetailSheet } from "./HabitDetailSheet";
 import { FizrukDayPlanSheet } from "./FizrukDayPlanSheet";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
-import { completionNoteKey } from "../lib/completionNoteKey.js";
+import { completionNoteKey } from "../lib/completionNoteKey";
 import { DayProgressRing } from "./DayProgressRing";
 import { DayReportSheet } from "./DayReportSheet";
 import {
   FIZRUK_GROUP_LABEL,
   parseDateKey,
   habitScheduledOnDate,
-} from "../lib/hubCalendarAggregate.js";
+} from "../lib/hubCalendarAggregate";
 import {
   ROUTINE_THEME as C,
   ROUTINE_TIME_MODES as TIME_MODES,
   type RoutineTimeModeId,
-} from "../lib/routineConstants.js";
-import { setCompletionNote } from "../lib/routineStorage.js";
+} from "../lib/routineConstants";
+import { setCompletionNote } from "../lib/routineStorage";
 import {
   useRoutineCalendarActions,
   useRoutineCalendarData,

--- a/apps/web/src/modules/routine/components/RoutineStatsPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineStatsPanel.tsx
@@ -6,9 +6,9 @@ import { Stat } from "@shared/components/ui/Stat";
 import { PushupsWidget } from "./PushupsWidget";
 import { HabitHeatmap } from "./HabitHeatmap";
 import { HabitLeadersBlock } from "./HabitLeadersBlock";
-import { completionRateForRange, maxStreakAllTime } from "../lib/streaks.js";
-import { dateKeyFromDate, parseDateKey } from "../lib/hubCalendarAggregate.js";
-import { ROUTINE_THEME as C } from "../lib/routineConstants.js";
+import { completionRateForRange, maxStreakAllTime } from "../lib/streaks";
+import { dateKeyFromDate, parseDateKey } from "../lib/hubCalendarAggregate";
+import { ROUTINE_THEME as C } from "../lib/routineConstants";
 import type { RoutineState } from "../lib/types";
 
 function dateKeyMinusDays(baseKey: string, daysBack: number): string {

--- a/apps/web/src/modules/routine/components/WeekDayStrip.tsx
+++ b/apps/web/src/modules/routine/components/WeekDayStrip.tsx
@@ -4,7 +4,7 @@ import {
   dateKeyFromDate,
   parseDateKey,
   startOfIsoWeek,
-} from "../lib/weekUtils.js";
+} from "../lib/weekUtils";
 
 function weekKeysFromAnchor(anchorKey: string): string[] {
   const s = startOfIsoWeek(parseDateKey(anchorKey));

--- a/apps/web/src/modules/routine/components/settings/ActiveHabitsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/ActiveHabitsSection.tsx
@@ -4,13 +4,13 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { EmptyState } from "@shared/components/ui/EmptyState";
-import { sortHabitsByOrder } from "../../lib/habitOrder.js";
+import { sortHabitsByOrder } from "../../lib/habitOrder";
 import {
   moveHabitInOrder,
   setHabitArchived,
   setHabitOrder,
-} from "../../lib/routineStorage.js";
-import { HabitListItem } from "./HabitListItem.jsx";
+} from "../../lib/routineStorage";
+import { HabitListItem } from "./HabitListItem";
 import type {
   Habit,
   PendingHabitDeletion,

--- a/apps/web/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/ArchivedHabitsSection.tsx
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
-import { setHabitArchived } from "../../lib/routineStorage.js";
+import { setHabitArchived } from "../../lib/routineStorage";
 import type { PendingHabitDeletion, RoutineState } from "../../lib/types";
 
 export interface ArchivedHabitsSectionProps {

--- a/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -9,7 +9,7 @@ import {
   createCategory,
   updateCategory,
   deleteCategory,
-} from "../../lib/routineStorage.js";
+} from "../../lib/routineStorage";
 import type {
   CategoryDraft,
   PendingCategoryDeletion,

--- a/apps/web/src/modules/routine/components/settings/HabitForm.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitForm.tsx
@@ -12,13 +12,13 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import type { ReactNode } from "react";
-import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton.jsx";
+import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import {
   ROUTINE_THEME as C,
   RECURRENCE_OPTIONS,
-} from "../../lib/routineConstants.js";
-import { ReminderPresets } from "./ReminderPresets.jsx";
-import { WeekdayPicker } from "./WeekdayPicker.jsx";
+} from "../../lib/routineConstants";
+import { ReminderPresets } from "./ReminderPresets";
+import { WeekdayPicker } from "./WeekdayPicker";
 import type { HabitDraft, RoutineState } from "../../lib/types";
 
 export interface HabitFormErrors {

--- a/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
@@ -1,7 +1,7 @@
 import { memo, type DragEventHandler } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
-import { RECURRENCE_OPTIONS } from "../../lib/routineConstants.js";
+import { RECURRENCE_OPTIONS } from "../../lib/routineConstants";
 import type { Habit } from "../../lib/types";
 
 export interface HabitListItemProps {

--- a/apps/web/src/modules/routine/components/settings/ReminderPresets.tsx
+++ b/apps/web/src/modules/routine/components/settings/ReminderPresets.tsx
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from "react";
 import { cn } from "@shared/lib/cn";
 import { Input } from "@shared/components/ui/Input";
-import { ROUTINE_THEME as C } from "../../lib/routineConstants.js";
-import { REMINDER_PRESETS } from "../../lib/routineDraftUtils.js";
+import { ROUTINE_THEME as C } from "../../lib/routineConstants";
+import { REMINDER_PRESETS } from "../../lib/routineDraftUtils";
 import type { HabitDraft } from "../../lib/types";
 
 export interface ReminderPresetsProps {

--- a/apps/web/src/modules/routine/components/settings/TagsSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/TagsSection.tsx
@@ -3,7 +3,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
-import { createTag, deleteTag, updateTag } from "../../lib/routineStorage.js";
+import { createTag, deleteTag, updateTag } from "../../lib/routineStorage";
 import type { RoutineState } from "../../lib/types";
 
 export interface TagsSectionProps {

--- a/apps/web/src/modules/routine/components/settings/WeekdayPicker.tsx
+++ b/apps/web/src/modules/routine/components/settings/WeekdayPicker.tsx
@@ -1,9 +1,6 @@
 import { memo } from "react";
 import { cn } from "@shared/lib/cn";
-import {
-  ROUTINE_THEME as C,
-  WEEKDAY_LABELS,
-} from "../../lib/routineConstants.js";
+import { ROUTINE_THEME as C, WEEKDAY_LABELS } from "../../lib/routineConstants";
 
 export interface WeekdayPickerProps {
   weekdays: number[] | null | undefined;

--- a/apps/web/src/modules/routine/hooks/useRoutinePushups.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutinePushups.ts
@@ -3,8 +3,8 @@ import {
   addPushupReps,
   loadRoutineState,
   ROUTINE_EVENT,
-} from "../lib/routineStorage.js";
-import { dateKeyFromDate } from "../lib/hubCalendarAggregate.js";
+} from "../lib/routineStorage";
+import { dateKeyFromDate } from "../lib/hubCalendarAggregate";
 import type { RoutineState } from "../lib/types";
 
 const HISTORY_DAYS = 30;

--- a/apps/web/src/modules/routine/hooks/useRoutineReminders.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutineReminders.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef } from "react";
 import {
   dateKeyFromDate,
   habitScheduledOnDate,
-} from "../lib/hubCalendarAggregate.js";
-import { normalizeReminderTimes } from "../lib/routineDraftUtils.js";
+} from "../lib/hubCalendarAggregate";
+import { normalizeReminderTimes } from "../lib/routineDraftUtils";
 import type { RoutineState } from "../lib/types";
 
 export const ROUTINE_NOTIFY_PREFIX = "routine_notify_";

--- a/apps/web/src/modules/routine/hooks/useRoutineState.ts
+++ b/apps/web/src/modules/routine/hooks/useRoutineState.ts
@@ -4,7 +4,7 @@ import {
   ROUTINE_STORAGE_KEY,
   loadRoutineState,
   setPref,
-} from "../lib/routineStorage.js";
+} from "../lib/routineStorage";
 import type { RoutineState } from "../lib/types";
 
 /**

--- a/apps/web/src/modules/routine/lib/finykSubscriptionCalendar.ts
+++ b/apps/web/src/modules/routine/lib/finykSubscriptionCalendar.ts
@@ -1,6 +1,6 @@
-import { safeReadLS } from "@shared/lib/storage.js";
+import { safeReadLS } from "@shared/lib/storage";
 import { STORAGE_KEYS } from "@sergeant/shared";
-import { DEFAULT_SUBSCRIPTIONS } from "../../finyk/constants.js";
+import { DEFAULT_SUBSCRIPTIONS } from "../../finyk/constants";
 import { getSubscriptionAmountMeta } from "@sergeant/finyk-domain/domain/subscriptionUtils";
 import {
   buildFinykSubscriptionEvents as buildFinykSubscriptionEventsPure,

--- a/apps/web/src/modules/routine/lib/hubCalendarAggregate.test.ts
+++ b/apps/web/src/modules/routine/lib/hubCalendarAggregate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildHubCalendarEvents } from "./hubCalendarAggregate.js";
-import type { RoutineState } from "./types.js";
+import { buildHubCalendarEvents } from "./hubCalendarAggregate";
+import type { RoutineState } from "./types";
 
 describe("buildHubCalendarEvents", () => {
   it("додає подію звички на кожен день діапазону", () => {

--- a/apps/web/src/modules/routine/lib/hubCalendarAggregate.ts
+++ b/apps/web/src/modules/routine/lib/hubCalendarAggregate.ts
@@ -1,4 +1,4 @@
-import { safeReadLS } from "@shared/lib/storage.js";
+import { safeReadLS } from "@shared/lib/storage";
 import {
   MONTHLY_PLAN_STORAGE_KEY,
   TEMPLATES_STORAGE_KEY,
@@ -16,10 +16,10 @@ import {
   type HubCalendarEvent,
   type RoutineState,
 } from "@sergeant/routine-domain";
-import { buildFinykSubscriptionEvents } from "./finykSubscriptionCalendar.js";
+import { buildFinykSubscriptionEvents } from "./finykSubscriptionCalendar";
 
 // Re-export pure helpers under their historical names so the web
-// call-sites that `import { dateKeyFromDate } from "./hubCalendarAggregate.js"`
+// call-sites that `import { dateKeyFromDate } from "./hubCalendarAggregate"`
 // keep compiling unchanged after the Phase 5 / PR 2 extraction.
 export {
   dateKeyFromDate,

--- a/apps/web/src/modules/routine/lib/routinePushupsRead.ts
+++ b/apps/web/src/modules/routine/lib/routinePushupsRead.ts
@@ -1,4 +1,4 @@
-import { loadRoutineState } from "./routineStorage.js";
+import { loadRoutineState } from "./routineStorage";
 
 /** Для сторінки Прогрес Фізрука — історія відтискань з даних Рутини */
 export function buildPushupHistoryFromRoutine(days = 30) {

--- a/apps/web/src/modules/routine/lib/routineStorage.extended.test.ts
+++ b/apps/web/src/modules/routine/lib/routineStorage.extended.test.ts
@@ -27,8 +27,8 @@ import {
   buildRoutineBackupPayload,
   applyRoutineBackupPayload,
   ROUTINE_STORAGE_KEY,
-} from "./routineStorage.js";
-import { completionNoteKey } from "./completionNoteKey.js";
+} from "./routineStorage";
+import { completionNoteKey } from "./completionNoteKey";
 
 beforeEach(() => {
   localStorage.clear();

--- a/apps/web/src/modules/routine/lib/routineStorage.test.ts
+++ b/apps/web/src/modules/routine/lib/routineStorage.test.ts
@@ -3,7 +3,7 @@ import {
   loadRoutineState,
   saveRoutineState,
   ROUTINE_STORAGE_KEY,
-} from "./routineStorage.js";
+} from "./routineStorage";
 
 if (!globalThis.localStorage) {
   let store: Record<string, string> = {};

--- a/apps/web/src/modules/routine/lib/routineStorage.ts
+++ b/apps/web/src/modules/routine/lib/routineStorage.ts
@@ -1,6 +1,6 @@
 /** Hub «Рутина»: звички, теги, категорії (не-спорт), localStorage */
 
-import { createModuleStorage } from "@shared/lib/createModuleStorage.js";
+import { createModuleStorage } from "@shared/lib/createModuleStorage";
 import {
   ROUTINE_STORAGE_KEY,
   ROUTINE_EVENT,

--- a/apps/web/src/shared/charts/chartTheme.ts
+++ b/apps/web/src/shared/charts/chartTheme.ts
@@ -26,7 +26,7 @@ import {
   chartPaletteList,
   moduleColors,
   statusColors,
-} from "../../modules/finyk/constants/chartPalette.js";
+} from "../../modules/finyk/constants/chartPalette";
 
 export {
   brandColors,

--- a/apps/web/src/shared/hooks/useDebounce.test.ts
+++ b/apps/web/src/shared/hooks/useDebounce.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useDebounce } from "./useDebounce.js";
+import { useDebounce } from "./useDebounce";
 
 describe("useDebounce", () => {
   beforeEach(() => {

--- a/apps/web/src/shared/hooks/useDialogFocusTrap.test.ts
+++ b/apps/web/src/shared/hooks/useDialogFocusTrap.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { createRef } from "react";
-import { useDialogFocusTrap } from "./useDialogFocusTrap.js";
+import { useDialogFocusTrap } from "./useDialogFocusTrap";
 
 /**
  * Spec: restoring focus to the dialog trigger on close is a WCAG 2.4.3

--- a/apps/web/src/shared/hooks/useLocalStorageState.test.ts
+++ b/apps/web/src/shared/hooks/useLocalStorageState.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useLocalStorageState } from "./useLocalStorageState.js";
+import { useLocalStorageState } from "./useLocalStorageState";
 
 describe("useLocalStorageState", () => {
   beforeEach(() => {

--- a/apps/web/src/shared/hooks/useLocalStorageState.ts
+++ b/apps/web/src/shared/hooks/useLocalStorageState.ts
@@ -30,7 +30,7 @@ import {
   type SetStateAction,
 } from "react";
 
-import { safeReadLS } from "@shared/lib/storage.js";
+import { safeReadLS } from "@shared/lib/storage";
 
 export interface UseLocalStorageStateOptions<T> {
   /**

--- a/apps/web/src/shared/hooks/usePushNotifications.test.tsx
+++ b/apps/web/src/shared/hooks/usePushNotifications.test.tsx
@@ -55,7 +55,7 @@ vi.mock("@shared/lib/pushNative", () => ({
   getStoredNativePushToken: vi.fn(),
 }));
 
-import { usePushNotifications } from "./usePushNotifications.js";
+import { usePushNotifications } from "./usePushNotifications";
 import { pushApi } from "@shared/api";
 import { getPlatform, isCapacitor } from "@sergeant/shared";
 import {

--- a/apps/web/src/shared/lib/bearerToken.test.ts
+++ b/apps/web/src/shared/lib/bearerToken.test.ts
@@ -56,7 +56,7 @@ describe("поза Capacitor — все no-op", () => {
       importSpy as unknown as () => never,
     );
 
-    const { getBearerToken } = await import("./bearerToken.js");
+    const { getBearerToken } = await import("./bearerToken");
     await expect(getBearerToken()).resolves.toBeNull();
     expect(importSpy).not.toHaveBeenCalled();
   }, 20_000);
@@ -69,7 +69,7 @@ describe("поза Capacitor — все no-op", () => {
       clearBearerToken: vi.fn(),
     }));
 
-    const { setBearerToken } = await import("./bearerToken.js");
+    const { setBearerToken } = await import("./bearerToken");
     await expect(setBearerToken("x")).resolves.toBeUndefined();
     expect(setSpy).not.toHaveBeenCalled();
   });
@@ -82,7 +82,7 @@ describe("поза Capacitor — все no-op", () => {
       clearBearerToken: clearSpy,
     }));
 
-    const { clearBearerToken } = await import("./bearerToken.js");
+    const { clearBearerToken } = await import("./bearerToken");
     await expect(clearBearerToken()).resolves.toBeUndefined();
     expect(clearSpy).not.toHaveBeenCalled();
   });
@@ -101,7 +101,7 @@ describe("у Capacitor — делегує до auth-storage", () => {
       clearBearerToken: vi.fn(),
     }));
 
-    const { getBearerToken } = await import("./bearerToken.js");
+    const { getBearerToken } = await import("./bearerToken");
     await expect(getBearerToken()).resolves.toBe("tok-42");
     expect(storageGet).toHaveBeenCalledTimes(1);
   });
@@ -114,7 +114,7 @@ describe("у Capacitor — делегує до auth-storage", () => {
       clearBearerToken: vi.fn(),
     }));
 
-    const { setBearerToken } = await import("./bearerToken.js");
+    const { setBearerToken } = await import("./bearerToken");
     await setBearerToken("jwt-xyz");
     expect(storageSet).toHaveBeenCalledTimes(1);
     expect(storageSet).toHaveBeenCalledWith("jwt-xyz");
@@ -128,7 +128,7 @@ describe("у Capacitor — делегує до auth-storage", () => {
       clearBearerToken: storageClear,
     }));
 
-    const { clearBearerToken } = await import("./bearerToken.js");
+    const { clearBearerToken } = await import("./bearerToken");
     await clearBearerToken();
     expect(storageClear).toHaveBeenCalledTimes(1);
   });
@@ -143,17 +143,17 @@ describe("резилієнс: dynamic import падає", () => {
   });
 
   it("getBearerToken повертає null, не кидає", async () => {
-    const { getBearerToken } = await import("./bearerToken.js");
+    const { getBearerToken } = await import("./bearerToken");
     await expect(getBearerToken()).resolves.toBeNull();
   });
 
   it("setBearerToken — тихий no-op, не кидає", async () => {
-    const { setBearerToken } = await import("./bearerToken.js");
+    const { setBearerToken } = await import("./bearerToken");
     await expect(setBearerToken("x")).resolves.toBeUndefined();
   });
 
   it("clearBearerToken — тихий no-op, не кидає", async () => {
-    const { clearBearerToken } = await import("./bearerToken.js");
+    const { clearBearerToken } = await import("./bearerToken");
     await expect(clearBearerToken()).resolves.toBeUndefined();
   });
 });
@@ -172,7 +172,7 @@ describe("резилієнс: модуль резолвиться, але окр
       clearBearerToken: vi.fn(),
     }));
 
-    const { getBearerToken } = await import("./bearerToken.js");
+    const { getBearerToken } = await import("./bearerToken");
     await expect(getBearerToken()).resolves.toBeNull();
   });
 
@@ -185,7 +185,7 @@ describe("резилієнс: модуль резолвиться, але окр
       clearBearerToken: vi.fn(),
     }));
 
-    const { setBearerToken } = await import("./bearerToken.js");
+    const { setBearerToken } = await import("./bearerToken");
     await expect(setBearerToken("x")).resolves.toBeUndefined();
   });
 
@@ -198,7 +198,7 @@ describe("резилієнс: модуль резолвиться, але окр
       }),
     }));
 
-    const { clearBearerToken } = await import("./bearerToken.js");
+    const { clearBearerToken } = await import("./bearerToken");
     await expect(clearBearerToken()).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/shared/lib/createModuleStorage.test.ts
+++ b/apps/web/src/shared/lib/createModuleStorage.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createModuleStorage } from "./createModuleStorage.js";
+import { createModuleStorage } from "./createModuleStorage";
 
 let storage;
 

--- a/apps/web/src/shared/lib/storage.test.ts
+++ b/apps/web/src/shared/lib/storage.test.ts
@@ -4,7 +4,7 @@ import {
   safeReadStringLS,
   safeWriteLS,
   safeRemoveLS,
-} from "./storage.js";
+} from "./storage";
 
 // vitest is configured with environment: "node" so we need a minimal
 // localStorage polyfill for these tests.

--- a/apps/web/src/shared/lib/typedStore.ts
+++ b/apps/web/src/shared/lib/typedStore.ts
@@ -25,7 +25,7 @@
 
 import { useSyncExternalStore } from "react";
 import type { ZodType } from "zod";
-import { safeJsonSet } from "./storageQuota.js";
+import { safeJsonSet } from "./storageQuota";
 
 type Listener<T> = (value: T) => void;
 

--- a/docs/frontend-tech-debt.md
+++ b/docs/frontend-tech-debt.md
@@ -1,0 +1,217 @@
+# Frontend Tech Debt — Sergeant Web
+
+Аналіз кодової бази `apps/web/src` (434 source файли, 87k рядків).
+
+> **Як читати:** позначки в стовпчику «Статус» оновлюються в момент злиття PR.
+> Це жива сторінка — не «звіт», а контроль міграцій. Кожен запис стандартизує:
+> в чому проблема, як ловити нові випадки в CI, і де вже стоїть guardrail.
+
+---
+
+## 🔴 Критичне
+
+### 1. ~~Зламані тести~~ — Виконано
+
+Раніше виглядало як «141 failed test file / 29 unresolved imports». Зараз
+`apps/web/vitest.config.js` має повний alias-блок (`@shared`, `@finyk`,
+`@fizruk`, `@routine`, `@nutrition`), що збігається з `tsconfig.json paths`.
+`pnpm --filter @sergeant/web test` дає 80 test files / 722 теста, всі
+зелені.
+
+---
+
+### 2. Прямі `localStorage` виклики — guardrail додано, міграція в процесі
+
+**Раніше:** 71 файл напряму звертався до `localStorage.getItem/setItem` без
+error handling — будь-який `JSON.parse(localStorage.getItem(...))` без
+try/catch крашить на quota exceeded, corrupted storage або private browsing.
+
+**Зараз:** додано власне ESLint-правило
+[`sergeant-design/no-raw-local-storage`](../eslint-plugins/sergeant-design/index.js)
+зі scope `apps/web/src/**`. Воно блокує і `localStorage.foo`, і
+`window.localStorage.foo` / `globalThis.localStorage.foo`. У
+[`eslint.config.js`](../eslint.config.js) явний allowlist:
+
+- **Тести** (`**/*.test.{ts,tsx,js,jsx}`, `**/__tests__/**`) — повний opt-out,
+  бо виконують роль фікстур і ізольовані від production-ризиків.
+- **Storage primitives** — самі обгортки (`safeReadLS`, `storageManager`,
+  `storageQuota`, `typedStore`, `createModuleStorage`, `weeklyDigestStorage`,
+  `useLocalStorageState`, `useDarkMode`, `usePushNotifications`,
+  `useActiveFizrukWorkout`, `perf`).
+- **Cloud-sync internals** — черга, патчер, state writer.
+- **Module storage wrappers** — `modules/finyk/lib/storageManager`,
+  `modules/finyk/hooks/useStorage`, `modules/nutrition/domain/nutritionBackup`.
+- **TODO-список немігрованих файлів** — кожен файл, що ще
+  читає/пише напряму, перерахований у `eslint.config.js` явно. Міграція
+  файла = видалення рядка зі списку. На момент введення правила TODO-список
+  містить 49 файлів.
+
+**Що це дає:** новий код / нові файли НЕ зможуть додати прямий
+`localStorage.*` без явного оновлення allowlist (видно в diff). Існуючі
+call-сайти продовжують працювати, але зафіксовані як борг — список
+greppable в одному місці.
+
+**Fix recipes для міграції:**
+
+- Прочитати JSON з безпечним fallback: `safeReadLS<T>(key, fallback)` з
+  `@shared/lib/storage`.
+- Записати JSON з обробкою quota: `safeWriteLS(key, value)`.
+- Реактивне джерело істини в компоненті: хук
+  `useLocalStorageState<T>(key, initial)` з `@shared/hooks/useLocalStorageState`.
+- Цілий модуль зі своїм префіксом ключів: `createModuleStorage(prefix)`.
+
+---
+
+## 🟡 Бажане
+
+### 3. ~~Import extensions (.js/.jsx) в TypeScript файлах~~ — Виконано
+
+**Раніше:** 413 рядків з імпортами виду `from "./foo.js"` /
+`from "./bar.jsx"` у `.ts`/`.tsx` файлах — працювало через Vite resolve, але
+плутало IDE auto-imports і нових контриб'юторів.
+
+**Зараз:** виконано codemod
+[`scripts/strip-js-extensions.mjs`](../scripts/strip-js-extensions.mjs) —
+видалив `.js`/`.jsx` з 436 first-party-імпортів у 180 файлах. Зачіпає тільки
+шляхи, що починаються з `.`, `@shared/`, `@finyk/`, `@fizruk/`, `@routine/`,
+`@nutrition/` або `@sergeant/`. Зовнішні пакети (`@zxing/...`) спеціально
+не торкається — їхні subpath-імпорти можуть вимагати реальної `.js`.
+
+Codemod ідемпотентний: повторний запуск дасть `would rewrite 0 import(s)`.
+
+> **Не робилось:** ESLint-правило `import/extensions: never`. Воно б
+> вимагало `eslint-plugin-import` (зараз не встановлено) і одразу б
+> пофейлило зовнішній zxing-імпорт. Поки покладаємось на codemod +
+> код-рев'ю; додамо правило окремим PR разом з імпорт-плагіном.
+
+---
+
+### 4. Великі файли (>600 рядків) — 25 файлів
+
+| Рядків | Файл                                                |
+| ------ | --------------------------------------------------- |
+| 1614   | `nutrition/lib/foodDb/seedFoodsUk.ts`               |
+| 1147   | `finyk/pages/Assets.tsx`                            |
+| 1064   | `core/DesignShowcase.tsx`                           |
+| 1060   | `core/ProfilePage.tsx`                              |
+| 949    | `fizruk/components/workouts/ActiveWorkoutPanel.tsx` |
+| 907    | `core/onboarding/seedDemoData.ts`                   |
+| 902    | `core/HubDashboard.tsx`                             |
+| 894    | `fizruk/pages/Workouts.tsx`                         |
+| 827    | `finyk/pages/Transactions.tsx`                      |
+| 824    | `routine/components/RoutineCalendarPanel.tsx`       |
+| 824    | `finyk/FinykApp.tsx`                                |
+| 694    | `core/OnboardingWizard.tsx`                         |
+| 692    | `fizruk/pages/Progress.tsx`                         |
+| 688    | `core/lib/chatActions/fizrukActions.ts`             |
+| 686    | `core/lib/hubChatContext.ts`                        |
+| 671    | `routine/RoutineApp.tsx`                            |
+| 669    | `nutrition/components/LogCard.tsx`                  |
+| 662    | `core/HubChat.tsx`                                  |
+| 642    | `sw.js`                                             |
+| 638    | `core/HubReports.tsx`                               |
+| 637    | `fizruk/pages/Exercise.tsx`                         |
+| 631    | `fizruk/pages/Body.tsx`                             |
+| 610    | `nutrition/NutritionApp.tsx`                        |
+| 610    | `core/HubSearch.tsx`                                |
+
+**Імпакт:** повільніший code review, важче тестувати окремі частини, можливі
+circular deps.
+
+**Fix:** поступовий split — витягувати sub-components, hooks, utils. Окремі
+PR на кожен файл; великі data-файли (`seedFoodsUk.ts`) — кандидати на
+розбиття за категоріями.
+
+---
+
+### 5. ~~`eslint-disable react-hooks/exhaustive-deps`~~ — Виконано (документація)
+
+21 disable-сайт залишається, але тепер кожен має явне обґрунтування поряд
+(intentional ref-based callback, mount-only effect, навмисне виключення
+залежності щоб не зациклитись тощо). Див. зведений каталог
+[`docs/apps-web-exhaustive-deps.md`](apps-web-exhaustive-deps.md). Якщо
+з'являється новий disable без коментаря — рев'ю має його блокувати.
+
+---
+
+### 6. Тестове покриття — 80 test файлів на 434 source
+
+~18% файлів мають тести. Критичні модулі без тестів (актуально):
+
+- `HubReports.tsx` (638 рядків, складна агрегація)
+- `TodayFocusCard.tsx` (recommendation engine інтеграція)
+- `HubDashboard.tsx` (902 рядки)
+- `ProfilePage.tsx` (1060 рядків)
+
+**Fix:** пріоритетно додати тести на recommendation engine, reports
+aggregation, cloud sync flows.
+
+---
+
+## 🟢 Nice-to-have
+
+### 7. `console.log/debug` у production коді — 9 рядків
+
+```
+core/settings/GeneralSection.tsx:193  console.log("[sw] snapshot", snap)
+core/settings/GeneralSection.tsx:215  console.log("[sw] caches cleared", res)
+core/analytics.ts:58                  console.log("[analytics]", event)
+core/cloudSync/logger.ts:39-41        console.debug("[cloud-sync]")
+core/cloudSync/hook/useCloudSyncDebug.ts:15  (docstring reference)
+shared/lib/perf.ts:28                 console.debug("[perf]")
+sw.js:491                             console.log("[sw] debug enabled", …)
+```
+
+Усі 9 — навмисні. `cloud-sync` / `perf` / `analytics` — debug-mode logger,
+що пишеться через `console.debug` і не відображається в default-консолі.
+`GeneralSection` — кнопки «Діагностика SW», що цілеспрямовано виводять
+снапшот у консоль (toast: «SW-діагностика виведена в консоль»). `sw.js` —
+service worker власний debug toggle. Виправлень не потрібно.
+
+---
+
+### 8. `eslint-disable no-eyebrow-drift` — 25 рядків
+
+Custom DS-rule пригнічується 25 разів. Усі з обґрунтуваннями в коментарях
+(кастомні hero kickers, calendar headers). Не критично; колись варто
+розширити `SectionHeading` API, щоб ці випадки відпали.
+
+---
+
+### 9. `any` типи — 7 рядків (тільки в тестах)
+
+| Файл                                               | Рядки                             |
+| -------------------------------------------------- | --------------------------------- |
+| `nutrition/hooks/usePhotoAnalysis.test.tsx`        | 1                                 |
+| `nutrition/hooks/useNutritionCloudBackup.test.tsx` | 1                                 |
+| `nutrition/hooks/useNutritionPantries.test.tsx`    | 4                                 |
+| `nutrition/components/PantryCard.tsx`              | 1 (коментар про історичний `any`) |
+
+Production код чистий. Тестові `any` — фабрики фіктур / промісів.
+
+---
+
+### 10. `@ts-expect-error` — 2 рядки (тільки в тестах)
+
+`hubNav.test.ts:28,59` — тестування runtime guard з навмисно невалідним
+вводом. Обґрунтоване.
+
+---
+
+## Recently completed
+
+- ✅ Vitest path aliases — 80/80 файлів зелені
+- ✅ Codemod `.js`/`.jsx` extensions — 436 імпортів очищено
+- ✅ ESLint guardrail для прямих `localStorage.*` (нові виклики блокуються)
+- ✅ `react-hooks/exhaustive-deps` disable-сайти — задокументовано
+
+## Recommended next steps
+
+1. **Міграція TODO-списку `no-raw-local-storage`** — пріоритетно файли з
+   найбільшою кількістю викликів (`core/settings/FinykSection.tsx` — 20,
+   `core/lib/chatActions/fizrukActions.ts` — 7, `core/HubDashboard.tsx` — 5).
+2. **File splitting** — Assets, ProfilePage, ActiveWorkoutPanel.
+3. **Test coverage** — recommendation engine, reports aggregation, cloud
+   sync flows.
+4. Опційно — `eslint-plugin-import` + `import/extensions: never`, щоб
+   codemod #3 був самозабезпечений правилом.

--- a/eslint-plugins/sergeant-design/__tests__/no-raw-local-storage.test.mjs
+++ b/eslint-plugins/sergeant-design/__tests__/no-raw-local-storage.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the `sergeant-design/no-raw-local-storage` rule.
+ *
+ * The rule blocks direct `localStorage.*` / `window.localStorage.*`
+ * member access in `apps/web` so contributors are pushed toward the
+ * try/catch-wrapped helpers (`safeReadLS`, `useLocalStorageState`,
+ * `createModuleStorage`). Files that legitimately implement those
+ * wrappers — or that haven't been migrated yet — are listed in
+ * `eslint.config.js`'s override block, NOT via inline disables.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/no-raw-local-storage";
+
+function lint(code) {
+  return linter.verify(code, {
+    plugins: { "sergeant-design": plugin },
+    rules: { [RULE_ID]: "error" },
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  });
+}
+
+describe("no-raw-local-storage", () => {
+  it("flags `localStorage.getItem(…)`", () => {
+    const messages = lint(`localStorage.getItem("foo");`);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags `localStorage.setItem(…)`", () => {
+    const messages = lint(`localStorage.setItem("foo", "bar");`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags `localStorage.removeItem(…)`", () => {
+    const messages = lint(`localStorage.removeItem("foo");`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags `localStorage.clear()`", () => {
+    const messages = lint(`localStorage.clear();`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags `window.localStorage.getItem(…)`", () => {
+    const messages = lint(`window.localStorage.getItem("foo");`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags `globalThis.localStorage.setItem(…)`", () => {
+    const messages = lint(`globalThis.localStorage.setItem("a", "b");`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags computed-property access `localStorage[key]`", () => {
+    const messages = lint(`const v = localStorage["foo"];`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("does NOT flag passing `localStorage` as a value (no member access)", () => {
+    // Edge case: passing the global itself as an argument is fine —
+    // wrappers receive it and apply their own try/catch.
+    const messages = lint(`useStore(localStorage);`);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag a property named `localStorage` on an unrelated object", () => {
+    const messages = lint(
+      `const x = { localStorage: 1 }; const v = x.localStorage;`,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag `safeReadLS` / `useLocalStorageState` calls", () => {
+    const messages = lint(
+      `import { safeReadLS } from "@shared/lib/storage";
+       const v = safeReadLS("foo", null);`,
+    );
+    assert.equal(messages.length, 0);
+  });
+});

--- a/eslint-plugins/sergeant-design/index.js
+++ b/eslint-plugins/sergeant-design/index.js
@@ -309,11 +309,81 @@ const noRawTrackedStorage = {
   },
 };
 
+// ─── no-raw-local-storage ───────────────────────────────────────────────
+//
+// On the web app, every direct `localStorage.*` access is a hazard:
+// JSON.parse of corrupted contents throws, `setItem` throws on
+// QuotaExceededError, and the whole API throws in private-browsing
+// Safari. The shared helpers (`safeReadLS` / `safeWriteLS` from
+// `@shared/lib/storage`, `useLocalStorageState` from
+// `@shared/hooks/useLocalStorageState`, and `createModuleStorage` from
+// `@shared/lib/createModuleStorage`) wrap these calls with try/catch and
+// quota fallbacks, and they're the integration boundary tests already
+// mock.
+//
+// This rule blocks raw `localStorage.foo` and `window.localStorage.foo`
+// member access. Files that legitimately implement the wrappers above —
+// or that haven't been migrated yet — opt out via the eslint.config
+// override list, NOT via inline disables, so the migration list stays
+// greppable in one place.
+
+const RAW_LOCAL_STORAGE_MESSAGE =
+  "Direct `localStorage` access throws on quota / private-browsing / corrupt JSON. Use `safeReadLS` / `safeWriteLS` from `@shared/lib/storage`, the `useLocalStorageState` hook, or `createModuleStorage` so failures are handled and tests can mock the boundary.";
+
+function isLocalStorageMember(node) {
+  if (!node || node.type !== "MemberExpression") return false;
+  // Direct: `localStorage.foo` / `localStorage["foo"]`
+  if (
+    node.object.type === "Identifier" &&
+    node.object.name === "localStorage"
+  ) {
+    return true;
+  }
+  // `window.localStorage.foo` / `globalThis.localStorage.foo` (the chain
+  // shows up as a MemberExpression whose `object` is itself a
+  // MemberExpression resolving to `localStorage`).
+  if (
+    node.object.type === "MemberExpression" &&
+    !node.object.computed &&
+    node.object.property.type === "Identifier" &&
+    node.object.property.name === "localStorage" &&
+    node.object.object.type === "Identifier" &&
+    (node.object.object.name === "window" ||
+      node.object.object.name === "globalThis" ||
+      node.object.object.name === "self")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+const noRawLocalStorage = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid direct `localStorage.*` (and `window.localStorage.*`) access in apps/web. Use safeReadLS / useLocalStorageState / createModuleStorage instead.",
+    },
+    schema: [],
+    messages: { raw: RAW_LOCAL_STORAGE_MESSAGE },
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (isLocalStorageMember(node)) {
+          context.report({ node, messageId: "raw" });
+        }
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
     "no-ellipsis-dots": noEllipsisDots,
     "no-raw-tracked-storage": noRawTrackedStorage,
+    "no-raw-local-storage": noRawLocalStorage,
   },
 };
 
@@ -321,6 +391,7 @@ export {
   TRACKED_STORAGE_KEY_NAMES,
   TRACKED_STORAGE_KEY_VALUES,
   RAW_TRACKED_STORAGE_MESSAGE,
+  RAW_LOCAL_STORAGE_MESSAGE,
 };
 
 export default plugin;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -151,6 +151,115 @@ export default [
       "sergeant-design/no-raw-tracked-storage": "error",
     },
   },
+  // Web localStorage guardrail — direct `localStorage.*` access is a
+  // hazard (throws on quota / private-browsing / corrupt JSON). The
+  // shared `safeReadLS` / `safeWriteLS` helpers in
+  // `apps/web/src/shared/lib/storage.ts`, the `useLocalStorageState`
+  // hook, and `createModuleStorage` wrap the API with try/catch and
+  // quota fallbacks. New web code MUST go through one of those.
+  //
+  // The `ignores` list below names every existing call-site as of the
+  // rule's introduction (see `docs/frontend-tech-debt.md` §2). Migrate
+  // a file → drop it from the list. Test files are exempt entirely:
+  // they routinely seed/inspect raw `localStorage` as fixtures and are
+  // already isolated from production hazards.
+  {
+    files: ["apps/web/src/**/*.{js,jsx,ts,tsx}"],
+    ignores: [
+      // Tests can use `localStorage` freely as fixtures.
+      "apps/web/src/**/*.test.{js,jsx,ts,tsx}",
+      "apps/web/src/**/__tests__/**",
+      // Storage primitives — these are the wrappers everyone else
+      // should call into.
+      "apps/web/src/shared/lib/storage.ts",
+      "apps/web/src/shared/lib/storageManager.ts",
+      "apps/web/src/shared/lib/storageQuota.ts",
+      "apps/web/src/shared/lib/typedStore.ts",
+      "apps/web/src/shared/lib/createModuleStorage.ts",
+      "apps/web/src/shared/lib/weeklyDigestStorage.ts",
+      "apps/web/src/shared/lib/perf.ts",
+      "apps/web/src/shared/hooks/useLocalStorageState.ts",
+      "apps/web/src/shared/hooks/useDarkMode.ts",
+      "apps/web/src/shared/hooks/usePushNotifications.ts",
+      "apps/web/src/shared/hooks/useActiveFizrukWorkout.ts",
+      // Cloud-sync internals — the queue / patcher / state writer all
+      // need direct access; users should call the cloud-sync API.
+      "apps/web/src/core/cloudSync/logger.ts",
+      "apps/web/src/core/cloudSync/queue/offlineQueue.ts",
+      "apps/web/src/core/cloudSync/state/moduleData.ts",
+      "apps/web/src/core/cloudSync/storagePatch.ts",
+      // Module storage wrappers (legitimate primitives in their own
+      // namespace).
+      "apps/web/src/modules/finyk/hooks/useStorage.ts",
+      "apps/web/src/modules/finyk/lib/storageManager.ts",
+      "apps/web/src/modules/nutrition/domain/nutritionBackup.ts",
+      // Files that haven't been migrated yet — TODO: convert each to
+      // `safeReadLS` / `useLocalStorageState` / `createModuleStorage`
+      // and remove the entry below.
+      "apps/web/src/core/App.tsx",
+      "apps/web/src/core/AssistantAdviceCard.tsx",
+      "apps/web/src/core/HubChat.tsx",
+      "apps/web/src/core/HubDashboard.tsx",
+      "apps/web/src/core/HubReports.tsx",
+      "apps/web/src/core/HubSearch.tsx",
+      "apps/web/src/core/OnboardingWizard.tsx",
+      "apps/web/src/core/ProfilePage.tsx",
+      "apps/web/src/core/TodayFocusCard.tsx",
+      "apps/web/src/core/analytics.ts",
+      "apps/web/src/core/app/pwaAction.ts",
+      "apps/web/src/core/app/useIosInstallBanner.ts",
+      "apps/web/src/core/app/usePwaInstall.ts",
+      "apps/web/src/core/hints/HintsOrchestrator.tsx",
+      "apps/web/src/core/hooks/usePwaActions.ts",
+      "apps/web/src/core/hub/useFinykHubPreview.ts",
+      "apps/web/src/core/hubBackup.ts",
+      "apps/web/src/core/hubSearchEngine.ts",
+      "apps/web/src/core/lib/chatActions/crossActions.ts",
+      "apps/web/src/core/lib/chatActions/finykActions.ts",
+      "apps/web/src/core/lib/chatActions/fizrukActions.ts",
+      "apps/web/src/core/lib/dailyFinykSummary.ts",
+      "apps/web/src/core/lib/hubChatContext.ts",
+      "apps/web/src/core/lib/hubChatUtils.ts",
+      "apps/web/src/core/lib/insightsEngine.ts",
+      "apps/web/src/core/lib/recommendationEngine.ts",
+      "apps/web/src/core/lib/recommendations/financeContext.ts",
+      "apps/web/src/core/onboarding/DailyNudge.tsx",
+      "apps/web/src/core/onboarding/FirstActionSheet.tsx",
+      "apps/web/src/core/onboarding/ModuleChecklist.tsx",
+      "apps/web/src/core/onboarding/PermissionsPrompt.tsx",
+      "apps/web/src/core/onboarding/ReEngagementCard.tsx",
+      "apps/web/src/core/onboarding/cleanupDemoData.ts",
+      "apps/web/src/core/onboarding/firstRealEntry.ts",
+      "apps/web/src/core/onboarding/onboardingGate.ts",
+      "apps/web/src/core/onboarding/presetApply.ts",
+      "apps/web/src/core/onboarding/seedDemoData.ts",
+      "apps/web/src/core/onboarding/vibePicks.ts",
+      "apps/web/src/core/settings/FinykSection.tsx",
+      "apps/web/src/core/settings/GeneralSection.tsx",
+      "apps/web/src/core/settings/hubPrefs.ts",
+      "apps/web/src/core/useCoachInsight.ts",
+      "apps/web/src/core/useWeeklyDigest.ts",
+      "apps/web/src/modules/finyk/pages/Overview.tsx",
+      "apps/web/src/modules/finyk/pages/Transactions.tsx",
+      "apps/web/src/modules/fizruk/components/TodayPlanCard.tsx",
+      "apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts",
+      "apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts",
+      "apps/web/src/modules/fizruk/hooks/useFizrukWorkoutReminder.ts",
+      "apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts",
+      "apps/web/src/modules/fizruk/hooks/useTrainingProgram.ts",
+      "apps/web/src/modules/fizruk/hooks/useWorkouts.ts",
+      "apps/web/src/modules/fizruk/pages/Body.tsx",
+      "apps/web/src/modules/fizruk/pages/Dashboard.tsx",
+      "apps/web/src/modules/fizruk/pages/Progress.tsx",
+      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
+      "apps/web/src/modules/nutrition/hooks/useNutritionReminders.ts",
+      "apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx",
+      "apps/web/src/modules/routine/hooks/useRoutineReminders.ts",
+    ],
+    rules: {
+      "sergeant-design/no-raw-local-storage": "error",
+    },
+  },
   // AuthContext migration (Session 4B, PR after #390): "who am I" is
   // single-sourced via `useUser()` from `@sergeant/api-client/react` → GET
   // `/api/v1/me`. Better Auth stays only as the actions layer. Block

--- a/scripts/strip-js-extensions.mjs
+++ b/scripts/strip-js-extensions.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Codemod: remove `.js` / `.jsx` extensions from relative and path-aliased
+// imports inside `.ts` / `.tsx` files under `apps/web/src`. External
+// package imports (e.g. `@zxing/browser/esm/.../foo.js`) are intentionally
+// preserved — only first-party paths are rewritten.
+//
+// Usage:
+//   node scripts/strip-js-extensions.mjs            # dry run summary
+//   node scripts/strip-js-extensions.mjs --write    # apply in-place
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { argv } from "node:process";
+import { execSync } from "node:child_process";
+
+const WRITE = argv.includes("--write");
+const ROOT = new URL("../apps/web/src/", import.meta.url).pathname;
+
+// Path prefixes considered "first-party" — safe to strip extensions from.
+// Anything else (bare specifiers, `@zxing/...`, `@tanstack/...`, etc.) is
+// left untouched so external package subpath imports keep working.
+const FIRST_PARTY = [
+  ".",
+  "@shared/",
+  "@finyk/",
+  "@fizruk/",
+  "@routine/",
+  "@nutrition/",
+  "@sergeant/",
+];
+
+const isFirstParty = (spec) => FIRST_PARTY.some((p) => spec.startsWith(p));
+
+// One pattern per syntactic position to keep the rewriter readable.
+const PATTERNS = [
+  // `from "X.js"` / `from 'X.js'` (covers `import ... from`, `export ... from`)
+  /\bfrom\s+(["'])([^"']+?)\.(jsx?)(\1)/g,
+  // Side-effect import: `import "X.js"`
+  /\bimport\s+(["'])([^"']+?)\.(jsx?)(\1)/g,
+  // Dynamic import: `import("X.js")` (allow whitespace inside parens)
+  /\bimport\s*\(\s*(["'])([^"']+?)\.(jsx?)(\1)\s*\)/g,
+];
+
+function rewrite(source) {
+  let count = 0;
+  let next = source;
+  for (const pattern of PATTERNS) {
+    next = next.replace(pattern, (match, q1, spec, _ext, q2) => {
+      if (!isFirstParty(spec)) return match;
+      count += 1;
+      // Reconstruct with the original surrounding tokens.
+      if (match.startsWith("import") && match.includes("(")) {
+        return `import(${q1}${spec}${q2})`;
+      }
+      const keyword = match.startsWith("from") ? "from" : "import";
+      return `${keyword} ${q1}${spec}${q2}`;
+    });
+  }
+  return { source: next, count };
+}
+
+function listFiles() {
+  const out = execSync(
+    `find "${ROOT}" -type f \\( -name '*.ts' -o -name '*.tsx' \\)`,
+    { encoding: "utf8" },
+  );
+  return out.split("\n").filter(Boolean);
+}
+
+const files = listFiles();
+let totalFiles = 0;
+let totalReplacements = 0;
+
+for (const file of files) {
+  const before = readFileSync(file, "utf8");
+  const { source: after, count } = rewrite(before);
+  if (count === 0) continue;
+  totalFiles += 1;
+  totalReplacements += count;
+  if (WRITE) {
+    writeFileSync(file, after);
+  }
+}
+
+console.log(
+  `${WRITE ? "rewrote" : "would rewrite"} ${totalReplacements} import(s) across ${totalFiles} file(s)`,
+);


### PR DESCRIPTION
## Summary

Закриває механічні пункти з `frontend-tech-debt.md`, інші — фіксує статус.

**Зроблено:**

1. **Codemod `scripts/strip-js-extensions.mjs`** — видаляє `.js`/`.jsx` extensions з first-party імпортів у `apps/web/src/**/*.{ts,tsx}`. Зачіпає тільки шляхи з `.`, `@shared/`, `@finyk/`, `@fizruk/`, `@routine/`, `@nutrition/`, `@sergeant/`. Зовнішні пакети (`@zxing/.../foo.js`) лишаються незачепленими. **Переписано 436 імпортів у 180 файлах.** Скрипт ідемпотентний — повторний запуск дає `0 import(s)`.

2. **Нове ESLint-правило `sergeant-design/no-raw-local-storage`** — блокує прямий `localStorage.*` і `window.localStorage.*` / `globalThis.localStorage.*` у `apps/web/src/**`. Реалізовано як plugin-rule (не `no-restricted-properties`), щоб per-file override працював через стандартний `rules: { ..: 'off' }`. 10 unit-тестів у `eslint-plugins/sergeant-design/__tests__/no-raw-local-storage.test.mjs`. Allowlist у `eslint.config.js`:
   - тести (`**/*.test.{ts,tsx,js,jsx}`, `**/__tests__/**`),
   - storage primitives (`safeReadLS`, `storageManager`, `storageQuota`, `typedStore`, `createModuleStorage`, `weeklyDigestStorage`, `useLocalStorageState`, `useDarkMode`, `usePushNotifications`, `useActiveFizrukWorkout`, `perf`),
   - cloud-sync internals (черга, патчер, state writer),
   - module storage wrappers (`finyk/lib/storageManager`, `finyk/hooks/useStorage`, `nutrition/domain/nutritionBackup`),
   - **TODO-список з 49 ще-не-мігрованих файлів** — видалив рядок → файл мігровано.

3. **`docs/frontend-tech-debt.md`** — жива сторінка зі статусом по кожному пункту, recipes для міграції на безпечні обгортки.

**Не зачіпається в цьому PR (різні скоупи):**

- File splitting великих файлів (Assets, ProfilePage, ActiveWorkoutPanel, тощо).
- Міграція 49 не-мігрованих `localStorage`-сайтів — поступово.
- `eslint-plugin-import` + `import/extensions: never` — потребує додаткової залежності + конфліктує з zxing-імпортом.
- Тести на `HubReports` / `TodayFocusCard` / `HubDashboard` / `ProfilePage`.
- `console.log` у `core/settings/GeneralSection.tsx` — навмисні (кнопки «Діагностика SW», toast «SW-діагностика виведена в консоль»). Лишаю.

## Review & Testing Checklist for Human

- [ ] Перевірити, що PWA web app стартує і працює як раніше (codemod торкнувся багатьох файлів — це import resolution, але варто пройти основні флоу: онбординг, Фінік-транзакція, тренування, нутри-лог).
- [ ] Спробувати в новій гілці додати файл з прямим `localStorage.getItem(...)` десь у `apps/web/src/core/` — переконатись, що `pnpm lint` фейлиться зі зрозумілим повідомленням.
- [ ] Перегляд TODO-списку в `eslint.config.js` — підтвердити класифікацію.
- [ ] Опційно: `node scripts/strip-js-extensions.mjs` має дати `0 import(s)`.

### Notes

Локально: `pnpm lint` (12/12 ок), `pnpm typecheck` (13/13 ок), `pnpm --filter @sergeant/web test` (80 файлів / 722 теста, всі зелені), `pnpm build:web` (ок). Husky/lint-staged спрацював на коміті без зауважень.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
