### PR TITLE
feat(hub): collapse weekly digest card back to compact row

### DIFF
--- a/apps/web/src/core/HubDashboard.tsx
+++ b/apps/web/src/core/HubDashboard.tsx
@@ -29,7 +29,12 @@ import { getModulePrimaryAction } from "@shared/lib/moduleQuickActions";
 import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard";
 import { HubInsightsPanel } from "./HubInsightsPanel";
 import { WeeklyDigestCard, hasLiveWeeklyDigest } from "./WeeklyDigestCard";
-import { useWeeklyDigest, loadDigest, getWeekKey } from "./useWeeklyDigest";
+import {
+  useWeeklyDigest,
+  loadDigest,
+  getWeekKey,
+  getWeekRange,
+} from "./useWeeklyDigest";
 import { useCoachInsight } from "./useCoachInsight";
 import { AssistantAdviceCard } from "./AssistantAdviceCard";
 import { SoftAuthPromptCard } from "./onboarding/SoftAuthPromptCard";
@@ -626,26 +631,62 @@ function WeeklyDigestFooter({
   onExpand: () => void;
   fresh: boolean;
 }) {
+  const weekRange = getWeekRange();
   return (
     <button
       type="button"
       onClick={onExpand}
+      aria-label="Розгорнути звіт тижня"
       className={cn(
-        "w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl",
-        "text-xs font-medium text-muted hover:text-text",
-        "hover:bg-panelHi transition-colors",
+        "w-full flex items-center gap-3 rounded-2xl border border-line bg-panel px-3 py-2.5",
+        "shadow-card hover:shadow-float transition-[box-shadow,filter,opacity,transform]",
+        "text-left",
       )}
     >
-      <span className="flex items-center gap-2">
-        Тижневий звіт
-        {fresh && (
-          <span
-            className="inline-block w-1.5 h-1.5 rounded-full bg-primary"
-            aria-label="Новий звіт"
-          />
+      <span
+        className={cn(
+          "w-8 h-8 rounded-xl flex items-center justify-center shrink-0",
+          "bg-gradient-to-br from-brand-100 to-teal-100",
+          "dark:from-brand-900/40 dark:to-teal-900/30",
         )}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="text-brand-600 dark:text-brand-400"
+          aria-hidden
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="16" y1="13" x2="8" y2="13" />
+          <line x1="16" y1="17" x2="8" y2="17" />
+          <polyline points="10 9 9 9 8 9" />
+        </svg>
       </span>
-      <Icon name="chevron-right" size={14} strokeWidth={2.5} />
+      <span className="flex-1 min-w-0 flex flex-col">
+        <span className="flex items-center gap-1.5">
+          <span className="text-sm font-semibold text-text">Звіт тижня</span>
+          {fresh && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full bg-primary"
+              aria-label="Новий звіт"
+            />
+          )}
+        </span>
+        <span className="text-2xs text-muted truncate">{weekRange}</span>
+      </span>
+      <Icon
+        name="chevron-right"
+        size={14}
+        strokeWidth={2.5}
+        className="text-muted shrink-0"
+      />
     </button>
   );
 }
@@ -885,7 +926,7 @@ export function HubDashboard({
           />
 
           {digestExpanded ? (
-            <WeeklyDigestCard />
+            <WeeklyDigestCard onCollapse={() => setDigestExpanded(false)} />
           ) : showDigestFooter ? (
             <WeeklyDigestFooter
               fresh={digestFresh}

--- a/apps/web/src/core/WeeklyDigestCard.collapse.test.tsx
+++ b/apps/web/src/core/WeeklyDigestCard.collapse.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// `WeeklyDigestCard` reads from a TanStack-Query hook + a digest-history
+// hook + (when expanded) renders the stories overlay. None of that is
+// relevant to the collapse contract being tested here, so we stub all
+// three at the module boundary.
+vi.mock("./useWeeklyDigest", () => ({
+  useWeeklyDigest: () => ({
+    digest: null,
+    loading: false,
+    error: null,
+    weekRange: "10 — 16 листоп.",
+    generate: vi.fn(),
+    isCurrentWeek: true,
+  }),
+  useDigestHistory: () => ({ data: [] }),
+  getWeekKey: () => "2025-W46",
+}));
+
+vi.mock("./WeeklyDigestStories", () => ({
+  WeeklyDigestStories: () => null,
+}));
+
+import { WeeklyDigestCard } from "./WeeklyDigestCard";
+
+describe("WeeklyDigestCard — collapse contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT render the collapse control when `onCollapse` is omitted", () => {
+    render(<WeeklyDigestCard />);
+    expect(
+      screen.queryByRole("button", { name: /згорнути звіт тижня/i }),
+    ).toBeNull();
+  });
+
+  it("renders the collapse control when `onCollapse` is provided and invokes it on click", () => {
+    const onCollapse = vi.fn();
+    render(<WeeklyDigestCard onCollapse={onCollapse} />);
+
+    const button = screen.getByRole("button", {
+      name: /згорнути звіт тижня/i,
+    });
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button);
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/core/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/WeeklyDigestCard.tsx
@@ -308,7 +308,17 @@ function DigestContent({
   );
 }
 
-export function WeeklyDigestCard() {
+interface WeeklyDigestCardProps {
+  /**
+   * Optional callback that collapses the card back to its single-line
+   * default state (the `WeeklyDigestFooter` rendered by HubDashboard).
+   * When provided, a chevron-up button is shown in the header so the
+   * user can dismiss the expanded card the same way they opened it.
+   */
+  onCollapse?: () => void;
+}
+
+export function WeeklyDigestCard({ onCollapse }: WeeklyDigestCardProps = {}) {
   const currentWeekKey = getWeekKey();
   const [selectedWeekKey, setSelectedWeekKey] = useState(currentWeekKey);
   const [showHistory, setShowHistory] = useState(false);
@@ -398,6 +408,17 @@ export function WeeklyDigestCard() {
                 <line x1="8" y1="2" x2="8" y2="6" />
                 <line x1="3" y1="10" x2="21" y2="10" />
               </svg>
+            </button>
+          )}
+          {onCollapse && (
+            <button
+              type="button"
+              onClick={onCollapse}
+              title="Згорнути"
+              aria-label="Згорнути звіт тижня"
+              className="w-7 h-7 flex items-center justify-center rounded-lg text-muted hover:text-text hover:bg-panelHi transition-colors"
+            >
+              <Icon name="chevron-up" size={15} strokeWidth={2.5} />
             </button>
           )}
         </div>

--- a/apps/web/src/core/useWeeklyDigest.ts
+++ b/apps/web/src/core/useWeeklyDigest.ts
@@ -54,7 +54,7 @@ function localDateKey(d = new Date()): string {
 // further down in this file.
 export const getWeekKey = sharedGetWeekKey;
 
-function getWeekRange(d = new Date()): string {
+export function getWeekRange(d = new Date()): string {
   const monday = new Date(d);
   monday.setDate(d.getDate() - ((d.getDay() + 6) % 7));
   const sunday = new Date(monday);


### PR DESCRIPTION
## Summary

Розгорнутий `WeeklyDigestCard` тепер можна згорнути назад у дефолтний компактний рядок — раніше для цього треба було релоадити dashboard.

**Зміни:**

- `WeeklyDigestCard` приймає опціональний `onCollapse?: () => void`. Коли його передано — у хедері з'являється кнопка з іконкою `chevron-up` (поряд з історією тижнів), aria-label «Згорнути звіт тижня».
- `HubDashboard` передає `onCollapse={() => setDigestExpanded(false)}` — повертає UI у footer-стан.
- `WeeklyDigestFooter` (default-state) перероблений із тонкого посилання на повноцінний компактний рядок: іконка документу + «Звіт тижня» + діапазон тижня + chevron-right + fresh-dot. Тепер згорнутий і розгорнутий стани мають однакову візуальну мову.
- `getWeekRange` експортовано з `useWeeklyDigest.ts`, щоб footer міг показати діапазон без зайвої query-підписки.

**Без змін:**

- Default стан — `digestExpanded = false` (на кожному завантаженні картка згорнута). Persist у localStorage не робив — користувач підтвердив.
- Видимість самого footer (`showDigestFooter` = `digestFresh || isMondayOrTuesday`) — стара логіка, не чіпав.

Тест `WeeklyDigestCard.collapse.test.tsx` фіксує контракт: без `onCollapse` кнопки немає; з `onCollapse` — є і клік викликає колбек.

## Review & Testing Checklist for Human

- [ ] Відкрити hub у понеділок (або зі свіжим digest) → переконатись, що footer показує іконку + «Звіт тижня» + діапазон тижня; натиснути → розгортається повна картка; натиснути chevron-up у хедері → повертається у footer.
- [ ] У середу-неділю без свіжого digest — секція не показується (як і раніше). Перевірити, що це не зламано.
- [ ] Перезавантажити сторінку у розгорнутому стані — має згорнутись назад у footer (default).

### Notes

`pnpm --filter @sergeant/web lint` ✓, `typecheck` ✓, vitest 81/81.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapse control to weekly digest card for better user control over content visibility.
  * Weekly digest footer now displays a formatted week range for improved clarity.
  * Enhanced accessibility with updated labels and improved UI layout.

* **Tests**
  * Added comprehensive test suite for collapse functionality verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->