### PR TITLE
fix(finyk): show asset and liability forms above lists

### DIFF
--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DebtCard } from "../components/DebtCard";
 import { SubCard } from "../components/SubCard";
 import { RecurringSuggestions } from "../components/RecurringSuggestions";
@@ -208,6 +208,10 @@ export function Assets({
     assets: false,
     liabilities: initialOpenDebt,
   });
+  const assetFormRef = useRef<HTMLElement | null>(null);
+  const assetNameInputRef = useRef<HTMLInputElement | null>(null);
+  const debtFormRef = useRef<HTMLElement | null>(null);
+  const debtNameInputRef = useRef<HTMLInputElement | null>(null);
 
   const { balance: monoTotal, debt: monoTotalDebt } = getMonoTotals(
     accounts,
@@ -271,6 +275,38 @@ export function Assets({
     setOpen((v) => ({ ...v, liabilities: true }));
     setShowDebtForm(true);
   };
+
+  useEffect(() => {
+    if (!showAssetForm || !open.assets) return;
+    const frame = requestAnimationFrame(() => {
+      assetFormRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+      try {
+        assetNameInputRef.current?.focus({ preventScroll: true });
+      } catch {
+        assetNameInputRef.current?.focus();
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [showAssetForm, open.assets]);
+
+  useEffect(() => {
+    if (!showDebtForm || !open.liabilities) return;
+    const frame = requestAnimationFrame(() => {
+      debtFormRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+      try {
+        debtNameInputRef.current?.focus({ preventScroll: true });
+      } catch {
+        debtNameInputRef.current?.focus();
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [showDebtForm, open.liabilities]);
 
   if (txPicker) {
     // --- Mono credit card repayment linking ---
@@ -899,41 +935,21 @@ export function Assets({
                 Інші активи
               </span>
             </SectionHeading>
-            {manualAssets.map((a, i) => (
-              <div
-                key={i}
-                className="flex items-center justify-between py-2.5 border-b border-text"
+            {showAssetForm ? (
+              <Card
+                ref={assetFormRef}
+                variant="finyk-soft"
+                radius="md"
+                className="space-y-3"
               >
-                <div className="flex items-center gap-3">
-                  <span className="text-xl leading-none">{a.emoji}</span>
-                  <div>
-                    <div className="text-sm font-medium">{a.name}</div>
-                    <div className="text-xs text-subtle">{a.currency}</div>
+                <div>
+                  <div className="text-sm font-bold text-text">Новий актив</div>
+                  <div className="text-xs text-muted mt-0.5">
+                    Готівка, брокерський рахунок, крипта тощо.
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-bold text-success">
-                    {Number(a.amount).toLocaleString("uk-UA")}{" "}
-                    {a.currency === "UAH"
-                      ? "₴"
-                      : a.currency === "USD"
-                        ? "$"
-                        : a.currency}
-                  </span>
-                  <button
-                    onClick={() =>
-                      setManualAssets((as) => as.filter((_, j) => j !== i))
-                    }
-                    className="text-subtle hover:text-danger text-sm transition-colors"
-                  >
-                    🗑
-                  </button>
-                </div>
-              </div>
-            ))}
-            {showAssetForm ? (
-              <Card variant="flat" radius="md" className="space-y-3">
                 <Input
+                  ref={assetNameInputRef}
                   placeholder="Назва"
                   value={newAsset.name}
                   onChange={(e) =>
@@ -997,6 +1013,38 @@ export function Assets({
                 + Додати актив
               </button>
             )}
+            {manualAssets.map((a, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between py-2.5 border-b border-text"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-xl leading-none">{a.emoji}</span>
+                  <div>
+                    <div className="text-sm font-medium">{a.name}</div>
+                    <div className="text-xs text-subtle">{a.currency}</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-success">
+                    {Number(a.amount).toLocaleString("uk-UA")}{" "}
+                    {a.currency === "UAH"
+                      ? "₴"
+                      : a.currency === "USD"
+                        ? "$"
+                        : a.currency}
+                  </span>
+                  <button
+                    onClick={() =>
+                      setManualAssets((as) => as.filter((_, j) => j !== i))
+                    }
+                    className="text-subtle hover:text-danger text-sm transition-colors"
+                  >
+                    🗑
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
         )}
 
@@ -1015,46 +1063,22 @@ export function Assets({
         />
         {open.liabilities && (
           <div className="mb-3 space-y-0">
-            {monoDebtAccounts.map((a, i) => {
-              const linkedIds = monoDebtLinkedTxIds[a.id] || [];
-              const paidFromLinked = transactions
-                .filter((t) => linkedIds.includes(t.id))
-                .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
-              const remaining = getMonoDebt(a);
-              const volatileTotal = paidFromLinked + remaining;
-              return (
-                <DebtCard
-                  key={i}
-                  name={getAccountLabel(a)}
-                  emoji="🖤"
-                  remaining={remaining}
-                  paid={paidFromLinked}
-                  total={volatileTotal}
-                  onLink={() => setTxPicker({ id: a.id, type: "monoDebt" })}
-                  linkedCount={linkedIds.length}
-                />
-              );
-            })}
-            {manualDebts.map((d) => (
-              <DebtCard
-                key={d.id}
-                name={d.name}
-                emoji={d.emoji}
-                remaining={calcDebtRemaining(d, transactions)}
-                paid={getDebtPaid(d, transactions)}
-                total={getDebtEffectiveTotal(d, transactions)}
-                dueDate={d.dueDate}
-                onDelete={() =>
-                  setManualDebts((ds) => ds.filter((x) => x.id !== d.id))
-                }
-                onLink={() => setTxPicker({ id: d.id, type: "debt" })}
-                linkedCount={d.linkedTxIds?.length || 0}
-              />
-            ))}
             {showDebtForm ? (
-              <Card variant="flat" radius="md" className="space-y-3">
+              <Card
+                ref={debtFormRef}
+                variant="finyk-soft"
+                radius="md"
+                className="space-y-3 mb-2"
+              >
+                <div>
+                  <div className="text-sm font-bold text-text">Новий пасив</div>
+                  <div className="text-xs text-muted mt-0.5">
+                    Кредит, борг або інше зобовʼязання.
+                  </div>
+                </div>
                 <div className="flex gap-2">
                   <Input
+                    ref={debtNameInputRef}
                     className="flex-1"
                     placeholder="Назва пасиву (кредит, борг…)"
                     value={newDebt.name}
@@ -1134,11 +1158,47 @@ export function Assets({
             ) : (
               <button
                 onClick={() => setShowDebtForm(true)}
-                className="w-full py-2.5 text-sm text-muted border border-dashed border-line rounded-xl hover:border-primary hover:text-primary transition-colors"
+                className="w-full py-2.5 text-sm text-muted border border-dashed border-line rounded-xl hover:border-primary hover:text-primary transition-colors mb-2"
               >
                 + Додати пасив
               </button>
             )}
+            {monoDebtAccounts.map((a, i) => {
+              const linkedIds = monoDebtLinkedTxIds[a.id] || [];
+              const paidFromLinked = transactions
+                .filter((t) => linkedIds.includes(t.id))
+                .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
+              const remaining = getMonoDebt(a);
+              const volatileTotal = paidFromLinked + remaining;
+              return (
+                <DebtCard
+                  key={i}
+                  name={getAccountLabel(a)}
+                  emoji="🖤"
+                  remaining={remaining}
+                  paid={paidFromLinked}
+                  total={volatileTotal}
+                  onLink={() => setTxPicker({ id: a.id, type: "monoDebt" })}
+                  linkedCount={linkedIds.length}
+                />
+              );
+            })}
+            {manualDebts.map((d) => (
+              <DebtCard
+                key={d.id}
+                name={d.name}
+                emoji={d.emoji}
+                remaining={calcDebtRemaining(d, transactions)}
+                paid={getDebtPaid(d, transactions)}
+                total={getDebtEffectiveTotal(d, transactions)}
+                dueDate={d.dueDate}
+                onDelete={() =>
+                  setManualDebts((ds) => ds.filter((x) => x.id !== d.id))
+                }
+                onLink={() => setTxPicker({ id: d.id, type: "debt" })}
+                linkedCount={d.linkedTxIds?.length || 0}
+              />
+            ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Move the manual asset creation form above the existing asset list so it is visible immediately after tapping `+ Актив`.
- Move the liability creation form above existing liabilities/credit cards so `+ Пасив` opens directly into an obvious form.
- Smooth-scroll and focus the first input when either quick action opens its section.

## Review & Testing Checklist for Human
- [ ] On the Finyk assets page, tap `+ Актив` with several existing assets and confirm the new form appears at the top of “Інші активи”, not after the list.
- [ ] Tap `+ Пасив` with existing credit/manual debts and confirm the new form appears above the liability cards.
- [ ] Add/cancel an asset and a passive liability to confirm existing save/cancel behavior still works.

### Notes
Local checks run:
- `pnpm --filter @sergeant/web typecheck`
- `pnpm --filter @sergeant/web lint`
- `pnpm --filter @sergeant/web build`
- `pnpm typecheck`
- `source /home/ubuntu/.nvm/nvm.sh && nvm use 20 && pnpm lint`

`pnpm --filter @sergeant/web build` still emits existing PostCSS warnings about `@import` order in CSS, but exits successfully.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forms for adding assets and liabilities now automatically scroll into view and set focus when opened, streamlining the data entry process

* **Style**
  * Reorganized layout structure for Assets and Liabilities sections
  * Improved spacing and visual presentation of form management buttons and section headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->