### PR TITLE
fix(finyk): keep Monobank tx visible during partial-failure sync

### DIFF
--- a/apps/web/src/modules/finyk/hooks/useMonoStatements.test.tsx
+++ b/apps/web/src/modules/finyk/hooks/useMonoStatements.test.tsx
@@ -19,7 +19,12 @@ vi.mock("@shared/api", async () => {
 });
 
 import { monoApi } from "@shared/api";
-import { useMonoStatements, currentMonthRange } from "./useMonoStatements";
+import {
+  useMonoStatements,
+  currentMonthRange,
+  enqueueStatementCall,
+  __resetMonoStatementQueues,
+} from "./useMonoStatements";
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -47,6 +52,7 @@ const RANGE = { from: 1_700_000_000, to: 1_700_500_000 };
 describe("useMonoStatements", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetMonoStatementQueues();
   });
 
   it("нічого не фетчить, поки немає токена або рахунків", async () => {
@@ -167,5 +173,63 @@ describe("useMonoStatements", () => {
     const r = currentMonthRange(new Date(2025, 11, 20, 10, 0, 0));
     expect(r.from).toBe(Math.floor(new Date(2025, 11, 1).getTime() / 1000));
     expect(r.to).toBe(Math.floor(new Date(2026, 0, 1).getTime() / 1000));
+  });
+
+  it("серіалізує statement-запити по токену: другий старт лише після завершення першого", async () => {
+    // Регресія: Monobank `/personal/statement` rate-limit-ить 1 req/60s/token.
+    // Раніше `useQueries` з кількома UAH-рахунками стартував усі запити
+    // паралельно, що гарантовано спричиняло 429 на 2-3-му рахунку.
+    // Тепер `enqueueStatementCall` серіалізує per-token, тож наступний
+    // mock-виклик не має навіть стартувати, поки попередній не зарезолвився.
+    let resolveFirst: (() => void) | null = null;
+    let secondStarted = false;
+
+    mockedStatement.mockImplementation(async (_t: string, accId: string) => {
+      if (accId === "a1") {
+        await new Promise<void>((res) => {
+          resolveFirst = res;
+        });
+        return [{ id: "tx1", time: 100, amount: -1000 }];
+      }
+      // a2 не повинен стартувати, поки a1 у польоті
+      secondStarted = true;
+      return [{ id: "tx2", time: 200, amount: -500 }];
+    });
+
+    const accounts = [makeAcc("a1"), makeAcc("a2")];
+    const { result } = renderHook(
+      () => useMonoStatements("TOKEN", accounts, RANGE),
+      { wrapper: makeWrapper() },
+    );
+
+    // Дамо мікротаскам відпрацювати, але першу проміс не резолвимо.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(secondStarted).toBe(false);
+    expect(mockedStatement).toHaveBeenCalledTimes(1);
+
+    // Розблоковуємо першу — друга має піти у роботу.
+    resolveFirst?.();
+
+    await waitFor(() => expect(result.current.accountsOk).toBe(2));
+    expect(secondStarted).toBe(true);
+    expect(mockedStatement).toHaveBeenCalledTimes(2);
+  });
+
+  it("enqueueStatementCall: помилка одного запиту не блокує наступний у тій самій черзі", async () => {
+    // Якби ми не робили `.catch(() => undefined)` у chain-у — `prev.then(fn)`
+    // закидав би причину далі і всі майбутні enqueue по цьому токену
+    // ламались би. Перевіряємо: rejection не псує чергу.
+    const order: string[] = [];
+    const p1 = enqueueStatementCall("T", async () => {
+      order.push("a-start");
+      throw new Error("boom");
+    }).catch(() => "swallowed");
+    const p2 = enqueueStatementCall("T", async () => {
+      order.push("b-start");
+      return "ok";
+    });
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["a-start", "b-start"]);
+    await expect(p2).resolves.toBe("ok");
   });
 });

--- a/apps/web/src/modules/finyk/hooks/useMonoStatements.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonoStatements.ts
@@ -38,6 +38,52 @@ import type { Transaction } from "@sergeant/finyk-domain/domain/types";
 const STALE_TIME = 60_000;
 const GC_TIME = 5 * 60_000;
 
+/**
+ * Monobank `/personal/statement/{acc}/{from}/{to}` rate-лімітований 1 req/60 s
+ * на токен. У користувачів з кількома UAH-рахунками паралельний запуск
+ * `useQueries` гарантовано спричиняє 429 на 2-му/3-му рахунку. Внутрішній
+ * pagination-loop у `mono.ts` потім чекає `Retry-After` (~60 с) і дотягує —
+ * але доки чекає, у `combine` лежать дані лише першого рахунку, snapshot
+ * перетирається меншою порцією (фікс у `useMonobank.ts`), а на боці
+ * Monobank ми робимо зайвий запит "наосліп" замість дочекатись.
+ *
+ * Пер-токен черга нижче серіалізує всі statement-запити для одного токена
+ * (поки не виконається попередній — наступний чекає в .then). Це політно
+ * до Monobank і дає predictable timeline в UI: запити йдуть один за одним,
+ * без вибуху 429-ок.
+ *
+ * `tokenStatementQueues` — module-level Map, ключ — самий токен. Очищаємо
+ * запис щойно остання Promise у ланцюжку завершилась, щоб не тримати
+ * посилання на старі (вже зарезолвлені) проміси.
+ */
+const tokenStatementQueues = new Map<string, Promise<unknown>>();
+
+export function enqueueStatementCall<T>(
+  token: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = tokenStatementQueues.get(token) ?? Promise.resolve();
+  // `prev.catch` гарантує, що навіть rejection попереднього запиту не
+  // обвалить чергу — наступний `fn` стартує однаково.
+  const work = prev.catch(() => undefined).then(fn);
+  // У Map тримаємо НЕ-rejecting tail (`work.catch(...)`), щоб V8 не
+  // флагував unhandled rejection для черги. Викликачу повертаємо
+  // оригінальний `work`, щоб він міг ловити його помилку штатно.
+  const tail = work.catch(() => undefined);
+  tokenStatementQueues.set(token, tail);
+  tail.finally(() => {
+    if (tokenStatementQueues.get(token) === tail) {
+      tokenStatementQueues.delete(token);
+    }
+  });
+  return work;
+}
+
+/** Test-only: очистити чергу між тестами. */
+export function __resetMonoStatementQueues(): void {
+  tokenStatementQueues.clear();
+}
+
 export interface MonoStatementsRange {
   /** Unix seconds, inclusive. */
   from: number;
@@ -109,7 +155,9 @@ export function useMonoStatements(
     queries: uahAccounts.map((acc) => ({
       queryKey: finykKeys.monoStatement(acc.id, from, to),
       queryFn: ({ signal }: { signal: AbortSignal }) =>
-        monoApi.statement(tok, acc.id, from, to, { signal }),
+        enqueueStatementCall(tok, () =>
+          monoApi.statement(tok, acc.id, from, to, { signal }),
+        ),
       enabled: Boolean(tok) && Boolean(acc?.id),
       staleTime: STALE_TIME,
       gcTime: GC_TIME,

--- a/apps/web/src/modules/finyk/hooks/useMonobank.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobank.ts
@@ -17,8 +17,9 @@ import {
 } from "../lib/finykStorage";
 import { normalizeTransaction } from "@sergeant/finyk-domain/domain/transactions";
 import type { Transaction } from "@sergeant/finyk-domain/domain/types";
+import { mergeTxByIdDesc } from "../lib/mergeTx";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
-import { useMonoStatements } from "./useMonoStatements";
+import { useMonoStatements, enqueueStatementCall } from "./useMonoStatements";
 
 /**
  * @typedef {{
@@ -241,12 +242,43 @@ export function useMonobank() {
     () => loadCacheSnapshot() ?? loadLastGoodBackup(),
   );
 
+  // Snapshot читаємо у write-ефекті через ref, щоб не додавати `snapshot`
+  // у залежності — інакше `setSnapshot(payload)` усередині запустить ефект
+  // знову нескінченним циклом.
+  const snapshotRef = useRef(snapshot);
+  useEffect(() => {
+    snapshotRef.current = snapshot;
+  }, [snapshot]);
+
+  // `incomplete` — у комбінованому результаті присутні дані не від усіх
+  // цільових рахунків. Це покриває і явний `hasPartialFailure` (один з
+  // акаунтів повернув error), і "ще не догрузилось" (RQ повернув data
+  // лише для частини per-account запитів). У обох випадках поточний
+  // snapshot — завідомо менший за повний місяць, тож писати його у
+  // localStorage без злиття з попереднім означає втратити дані тих
+  // рахунків, які тимчасово не відповіли.
+  const incomplete =
+    statements.accountsTotal > 0 &&
+    statements.accountsOk < statements.accountsTotal;
+
   useEffect(() => {
     if (statements.transactions.length === 0) return;
-    const payload: Snapshot = {
-      txs: statements.transactions,
-      timestamp: Date.now(),
-    };
+    const prev = snapshotRef.current;
+    const merged =
+      incomplete && prev
+        ? mergeTxByIdDesc(statements.transactions, prev.txs)
+        : statements.transactions;
+    // Якщо merge не дав приросту і snapshot уже свіжий — зайві writeJSON
+    // дають синхронні JSON.stringify по сотнях транзакцій + invalidate
+    // hub preview. Skip, якщо нічого не змінилось.
+    if (
+      prev &&
+      prev.txs.length === merged.length &&
+      prev.txs.every((t, i) => t.id === merged[i]?.id)
+    ) {
+      return;
+    }
+    const payload: Snapshot = { txs: merged, timestamp: Date.now() };
     if (writeJSON(CACHE_KEY, payload)) {
       notifyHubFinykPreview(queryClient);
     }
@@ -254,17 +286,32 @@ export function useMonobank() {
     // "Last good" — тільки коли усі рахунки успішні або транзакцій ≥ 15
     // (той самий поріг, що й раніше; захист від порожніх відповідей, які
     // іноді віддає Monobank при rate-limit відновленні).
-    if (!statements.hasPartialFailure || statements.transactions.length >= 15) {
-      if (statements.transactions.length >= 3) {
+    if (!statements.hasPartialFailure || merged.length >= 15) {
+      if (merged.length >= 3) {
         writeJSON(LAST_GOOD_KEY, payload);
       }
     }
-  }, [statements.transactions, statements.hasPartialFailure, queryClient]);
+  }, [
+    statements.transactions,
+    statements.hasPartialFailure,
+    incomplete,
+    queryClient,
+  ]);
 
-  const transactions: Transaction[] =
-    statements.transactions.length > 0
-      ? statements.transactions
-      : (snapshot?.txs ?? []);
+  // Видимі UI транзакції: коли частина акаунтів ще не повернулась/упала —
+  // зливаємо те, що маємо, з snapshot-ом, щоб не "зникали" транзакції
+  // інших рахунків. Коли все успішно — поточний `statements.transactions`
+  // авторитетний (це покриває refund-и/відкат-и на стороні Monobank, які
+  // не мають "закріплюватись" злиттям зі старим snapshot-ом).
+  const transactions: Transaction[] = useMemo(() => {
+    if (statements.transactions.length === 0) {
+      return snapshot?.txs ?? [];
+    }
+    if (incomplete && snapshot) {
+      return mergeTxByIdDesc(statements.transactions, snapshot.txs);
+    }
+    return statements.transactions;
+  }, [statements.transactions, incomplete, snapshot]);
 
   // `lastUpdated` — час останньої успішної відповіді RQ серед усіх
   // per-account запитів. Поки ще нема успіху або нульовий фетч — беремо
@@ -473,14 +520,19 @@ export function useMonobank() {
         new Date(year, month + 1, 0, 23, 59, 59).getTime() / 1000,
       );
       const results: Transaction[][] = [];
-      // Послідовно з паузами, щоб не натрапити на rate-limit Monobank.
+      // Послідовно через `enqueueStatementCall` (та сама пер-токен черга,
+      // що серіалізує і поточний місяць у `useMonoStatements`). Так
+      // history-fetch не "переплутується" з живими per-account запитами,
+      // які можуть бути в leті паралельно — все йде в один потік на токен.
       for (let i = 0; i < targetAccounts.length; i++) {
         const acc = targetAccounts[i];
         try {
           const txs = await queryClient.fetchQuery({
             queryKey: finykKeys.monoStatement(acc.id, from, to),
             queryFn: ({ signal }) =>
-              monoApi.statement(token, acc.id, from, to, { signal }),
+              enqueueStatementCall(token, () =>
+                monoApi.statement(token, acc.id, from, to, { signal }),
+              ),
             staleTime: STATEMENT_STALE_TIME,
             retry: authAwareRetry(2),
             retryDelay: (attempt) => 1000 * (attempt + 1),

--- a/apps/web/src/modules/finyk/lib/mergeTx.test.ts
+++ b/apps/web/src/modules/finyk/lib/mergeTx.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { mergeTxByIdDesc } from "./mergeTx";
+import type { Transaction } from "@sergeant/finyk-domain/domain/types";
+
+function tx(id: string, time: number, amount = -100): Transaction {
+  return {
+    id,
+    time,
+    amount,
+    description: id,
+    date: new Date(time * 1000).toISOString(),
+    type: "expense",
+    source: "mono",
+  } as Transaction;
+}
+
+describe("mergeTxByIdDesc", () => {
+  it("повертає порожній масив для двох порожніх входів", () => {
+    expect(mergeTxByIdDesc([], [])).toEqual([]);
+  });
+
+  it("сортує за спаданням time", () => {
+    const out = mergeTxByIdDesc([tx("a", 100), tx("b", 300), tx("c", 200)], []);
+    expect(out.map((t) => t.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("дедупить по id, current перекриває previous", () => {
+    const prev = [tx("a", 100, -100)];
+    const cur = [tx("a", 100, -150)]; // оновлена сума
+    const out = mergeTxByIdDesc(cur, prev);
+    expect(out).toHaveLength(1);
+    expect(out[0].amount).toBe(-150);
+  });
+
+  it("зберігає id зі snapshot-у, яких немає у поточному (partial-failure кейс)", () => {
+    // Регресія: при rate-limit-і Monobank поточний combine повертав tx
+    // лише одного акаунта; без злиття зі snapshot-ом UI втрачав дані інших.
+    const prev = [tx("a", 100), tx("b", 200), tx("c", 300)];
+    const cur = [tx("b", 200)]; // тільки 1 акаунт встиг відповісти
+    const out = mergeTxByIdDesc(cur, prev);
+    expect(out.map((t) => t.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("у current всі унікальні + previous всі унікальні — об'єднує всі без втрат", () => {
+    const prev = [tx("a", 100), tx("b", 200)];
+    const cur = [tx("c", 300), tx("d", 400)];
+    const out = mergeTxByIdDesc(cur, prev);
+    expect(out.map((t) => t.id)).toEqual(["d", "c", "b", "a"]);
+  });
+
+  it("обробляє відсутній time як 0 (поведінка дефолту)", () => {
+    const a = { ...tx("a", 100), time: undefined } as unknown as Transaction;
+    const b = tx("b", 200);
+    const out = mergeTxByIdDesc([a, b], []);
+    expect(out.map((t) => t.id)).toEqual(["b", "a"]);
+  });
+});

--- a/apps/web/src/modules/finyk/lib/mergeTx.ts
+++ b/apps/web/src/modules/finyk/lib/mergeTx.ts
@@ -1,0 +1,26 @@
+import type { Transaction } from "@sergeant/finyk-domain/domain/types";
+
+/**
+ * Об'єднує дві колекції транзакцій по `id`. Дані з `current` мають пріоритет
+ * (свіжіша версія від API перекриває стару зі snapshot-у), але всі id, які
+ * були у `previous` і відсутні у `current` — зберігаються. Сортуємо за
+ * спаданням `time`, щоб UI отримував уже готовий до показу список.
+ *
+ * Використовується у `useMonobank.ts` для злиття часткових даних від
+ * `useMonoStatements` із кешованим snapshot-ом, коли частина рахунків не
+ * повернула відповідь (rate-limit Monobank, тимчасова мережна помилка).
+ * Без цього злиття UI показував би лише транзакції успішних рахунків, а
+ * snapshot перетирався меншим набором — звідси симптом «залишилось
+ * декілька транзакцій за весь місяць».
+ */
+export function mergeTxByIdDesc(
+  current: readonly Transaction[],
+  previous: readonly Transaction[],
+): Transaction[] {
+  const byId = new Map<string, Transaction>();
+  for (const t of previous) byId.set(t.id, t);
+  for (const t of current) byId.set(t.id, t);
+  return Array.from(byId.values()).sort(
+    (a, b) => (b.time ?? 0) - (a.time ?? 0),
+  );
+}


### PR DESCRIPTION
## Summary

Закриває симптом «у Monobank залишилось декілька транзакцій за весь місяць, після синхронізації і трохи часу — повертається».

**Причина:** Monobank `/personal/statement` rate-limit-ить `1 req / 60 s / token`. У користувачів з кількома UAH-рахунками `useMonoStatements` запускав запити паралельно через `useQueries` — перший рахунок проходив, наступні отримували 429 і чекали `Retry-After`. У цей вікно:

- `combine` повертав tx лише успішного рахунку → UI показував лише його.
- ефект-write у `useMonobank` беззастережно перетирав `finyk_tx_cache` цим маленьким набором → кеш-fallback теж ставав маленьким.
- `last_good` зберігався лише при `≥ 15` tx або повному успіху, але читався ПІСЛЯ `loadCacheSnapshot()`, який уже зіпсований.

Через ~60 с retry-loop у `mono.ts` дотягував решту акаунтів — тоді у `combine` з'являвся повний місяць → snapshot оновлювався → "відновилось".

**Виправлення (3 узгоджені пункти):**

1. **Snapshot write з union-ом.** Якщо `accountsOk < accountsTotal` (частковий стан — explicit failure або ще не догрузилось), новий payload зливається з попереднім snapshot-ом по `id`. `finyk_tx_cache` більше не «всихає» під часткові відповіді.
2. **UI-видимі transactions з union-ом.** Та сама умова застосовується до показу: під часткою користувач бачить максимум того, що ми колись знали за цей місяць, замість падіння до одного рахунку.
3. **Per-token серіалізація.** Module-level черга `enqueueStatementCall(token, fn)` у `useMonoStatements.ts` пропускає всі statement-запити одного токена через єдиний ланцюжок Promise. `useMonoStatements` (поточний місяць) і `fetchMonth` (історія) ділять одну чергу — більше ніяких самонавмисних 429-storm-ів. Існуючий 429-retry у `mono.ts` залишається запобіжником.

Винесена `mergeTxByIdDesc` у `apps/web/src/modules/finyk/lib/mergeTx.ts` з unit-тестами; додані тести серіалізації та resilience черги у `useMonoStatements.test.tsx`.

## Review & Testing Checklist for Human

- [ ] Перевірити на власному акаунті з `≥ 2` UAH-картками: відкрити Фінік, дочекатись повного завантаження місяця, потім вручну натиснути «Оновити». Транзакції не мають коротко зникати/блимати «3 з 200» між запусками.
- [ ] Симулювати rate-limit: відкрити вкладку, потім швидко відкрити ще раз (refetch on focus) — у DevTools Network має бути послідовність запитів `/api/mono?path=/personal/statement/...`, не вибух-паралель. Видимий список не повинен на жоден кадр падати до даних 1 акаунту.
- [ ] Перевірити LocalStorage `finyk_tx_cache` після часткового збою (можна тимчасово зламати один acc id у `mono.ts` сервері або відрубати мережу під час другого запиту): кеш не має зменшитись у розмірі.
- [ ] Регрес: відключення (disconnect) і підключення з нуля — кеш чиститься, повний місяць перезавантажується послідовно.
- [ ] Історія минулих місяців (`fetchMonth`) — переключення між місяцями не має шараханути в активний поточний-місяць flow (обидва ділять `enqueueStatementCall`).

### Notes

- Не змінено сервісну логіку (`apps/server/src/modules/mono.ts`) і pagination-loop у `packages/api-client/src/endpoints/mono.ts` — там вже є коректний 429+`Retry-After` retry. Серіалізація в клієнті — комплементарна політика, що зменшує рейс на rate-limit ще до того як він перетвориться на 429.
- Існуючий тест `повертає часткові дані при збої одного рахунку` у `useMonoStatements.test.tsx` лишився чинним — серіалізація не змінює observable behavior `combine` для error-кейсу.
- Mobile-тести у `apps/mobile` падають і на `main` (не пов'язано з цим PR — `OnboardingWizard`, `WeeklyDigestFooter`, `HubSettingsPage`).

Link to Devin session: https://app.devin.ai/sessions/b924f678f0ca413d8d32ca00b1a04a39
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate-limit errors from parallel statement requests by serializing API calls per token
  * Improved transaction data integrity by preserving data from accounts with temporary errors or incomplete responses
  * Enhanced transaction deduplication and sorting for more reliable statement handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->