### PR TITLE
fix(finyk): trim Monobank token inside enqueueStatementCall to share queue

### DIFF
--- a/apps/web/src/modules/finyk/hooks/useMonoStatements.test.tsx
+++ b/apps/web/src/modules/finyk/hooks/useMonoStatements.test.tsx
@@ -215,6 +215,34 @@ describe("useMonoStatements", () => {
     expect(mockedStatement).toHaveBeenCalledTimes(2);
   });
 
+  it("enqueueStatementCall: однакова черга для trim/untrim варіантів того самого токена", async () => {
+    // Регресія: до фіксу `useMonoStatements` нормалізував токен через
+    // `tok.trim()`, а `fetchMonth` у `useMonobank` передавав `token` як є.
+    // Якщо у `localStorage` лежав токен зі space-ами/newline-ом
+    // (`readStoredToken` не trim-ить), історичні та поточні запити
+    // потрапляли б у різні черги і йшли паралельно — знов 1 req/60s
+    // race з Monobank. Перевіряємо: `"  TOKEN  "` і `"TOKEN"` ділять
+    // ту саму чергу.
+    let started = 0;
+    let resolveFirst: (() => void) | null = null;
+    const p1 = enqueueStatementCall("  TOKEN  ", async () => {
+      started++;
+      await new Promise<void>((r) => {
+        resolveFirst = r;
+      });
+      return "first";
+    });
+    const p2 = enqueueStatementCall("TOKEN", async () => {
+      started++;
+      return "second";
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(started).toBe(1); // другий ще не стартував — у тій самій черзі
+    resolveFirst?.();
+    await Promise.all([p1, p2]);
+    expect(started).toBe(2);
+  });
+
   it("enqueueStatementCall: помилка одного запиту не блокує наступний у тій самій черзі", async () => {
     // Якби ми не робили `.catch(() => undefined)` у chain-у — `prev.then(fn)`
     // закидав би причину далі і всі майбутні enqueue по цьому токену

--- a/apps/web/src/modules/finyk/hooks/useMonoStatements.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonoStatements.ts
@@ -62,7 +62,17 @@ export function enqueueStatementCall<T>(
   token: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const prev = tokenStatementQueues.get(token) ?? Promise.resolve();
+  // Нормалізуємо токен до trim-ового вигляду — той самий ключ, який
+  // `useMonoStatements` використовує у `tok = (token ?? "").trim()`. Без
+  // цього `fetchMonth(...)` (history-fetch у `useMonobank`) і
+  // `useMonoStatements` (поточний місяць) могли б опинитись у різних
+  // чергах, якби збережений токен мав leading/trailing whitespace
+  // (`readStoredToken` його не trim-ить — на відміну від `connect`).
+  // У такому випадку обидва call-site-и стартували б паралельно і знов
+  // ламали б 1 req/60s rate-limit Monobank — той самий баг, який
+  // `enqueueStatementCall` мав фіксити.
+  const key = (token ?? "").trim();
+  const prev = tokenStatementQueues.get(key) ?? Promise.resolve();
   // `prev.catch` гарантує, що навіть rejection попереднього запиту не
   // обвалить чергу — наступний `fn` стартує однаково.
   const work = prev.catch(() => undefined).then(fn);
@@ -70,10 +80,10 @@ export function enqueueStatementCall<T>(
   // флагував unhandled rejection для черги. Викликачу повертаємо
   // оригінальний `work`, щоб він міг ловити його помилку штатно.
   const tail = work.catch(() => undefined);
-  tokenStatementQueues.set(token, tail);
+  tokenStatementQueues.set(key, tail);
   tail.finally(() => {
-    if (tokenStatementQueues.get(token) === tail) {
-      tokenStatementQueues.delete(token);
+    if (tokenStatementQueues.get(key) === tail) {
+      tokenStatementQueues.delete(key);
     }
   });
   return work;


### PR DESCRIPTION
## Summary

Follow-up до PR #690 за фідбеком Devin Review.

**Проблема**: `fetchMonth` (history-fetch у `useMonobank`) передавав у `enqueueStatementCall` сирий `token` зі state-у, а `useMonoStatements` (поточний місяць) — попередньо trim-нутий `tok`. Якщо у localStorage збережений токен мав leading/trailing whitespace (`readStoredToken` його не trim-ить — на відміну від `connect()`), два call-site-и потрапляли б у різні пер-токен черги і робили б statement-запити паралельно, відновлюючи 1 req/60s race з Monobank, який черга й мала зупиняти.

**Фікс**: нормалізація біля джерела — `enqueueStatementCall` сама `(token ?? "").trim()`-ить ключ Map-у, тож усі майбутні call-site-и автоматично потрапляють у спільну чергу незалежно від whitespace.

Додав регресійний тест (`'  TOKEN  '` і `'TOKEN'` ділять чергу — другий не стартує, поки перший не зарезолвиться).

## Review & Testing Checklist for Human

- [ ] Перевірити, що активний flow з токеном без whitespace не змінив поведінку (UI підвантаження поточного місяця, refetch on focus).

### Notes

- Альтернатива — trim-нути на call-site (`enqueueStatementCall(token.trim(), ...)`) — теж робоча, але fragile: легко забути в наступному call-site-і. Нормалізація всередині черги робить інваріант "queue key завжди trim-нутий" властивістю функції, не дисципліною викликача.
- Не змінює observable behavior для коректних токенів — лише виправляє edge-case з legacy storage.
- Окремо у відповідь користувачеві планується великий рефактор: міграція з polling на Monobank webhooks + серверне зберігання транзакцій. Цей PR — точкова правка по review-фідбеку, не пов'язаний із міграцією.

Link to Devin session: https://app.devin.ai/sessions/b924f678f0ca413d8d32ca00b1a04a39
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token serialization to consistently handle whitespace variations, ensuring proper request queuing and preventing unintended concurrent operations.

* **Tests**
  * Added regression test to verify token normalization behavior in request queuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->