### PR TITLE
Guard malformed remember action input

### DIFF
--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -441,7 +441,11 @@ export function handleCrossAction(action: ChatAction): string | undefined {
     case "remember": {
       const { fact, category } = (action as RememberAction).input || {};
       try {
-        const result = upsertMemoryFact(readMemoryEntries(), fact, category);
+        const result = upsertMemoryFact(
+          readMemoryEntries(),
+          typeof fact === "string" ? fact : "",
+          typeof category === "string" ? category : undefined,
+        );
         writeMemoryEntries(result.entries);
         const meta = CATEGORY_META[result.entry.category];
         const label = meta?.label ?? result.entry.category;

--- a/apps/web/src/core/lib/hubChatActionsExtended.test.ts
+++ b/apps/web/src/core/lib/hubChatActionsExtended.test.ts
@@ -544,6 +544,16 @@ describe("add_calendar_event", () => {
 });
 
 describe("profile memory actions", () => {
+  it("remember повертає зрозумілу помилку без fact", () => {
+    const msg = executeAction({
+      name: "remember",
+      input: {},
+    });
+
+    expect(msg).toBe("Потрібен факт для запам'ятовування.");
+    expect(readLS("hub_user_profile_v1", [])).toHaveLength(0);
+  });
+
   it("remember зберігає факт у профіль і my_profile його показує", () => {
     const msg = executeAction({
       name: "remember",


### PR DESCRIPTION
## Summary
- Guard the profile `remember` chat action against malformed input where `fact` or `category` are missing/non-string.
- Preserve the intended Ukrainian validation message instead of surfacing a raw `TypeError`.
- Add regression coverage for `remember` without `fact` to ensure no profile memory is written.

## Review & Testing Checklist for Human
- [ ] Verify `remember` with a valid fact still saves profile memory.
- [ ] Verify malformed AI input for `remember` returns `Потрібен факт для запам'ятовування.` and does not create a profile entry.

### Notes
Validated locally:
- `pnpm --filter @sergeant/web test hubChatActionsExtended.test.ts`
- `pnpm --filter @sergeant/web typecheck`
- `pnpm --filter @sergeant/web lint`

CI note: the web tests for this PR pass in CI (`hubChatActionsExtended.test.ts` is green). The failing checks are from `@sergeant/mobile#test`, specifically pre-existing `apps/mobile/src/core/OnboardingWizard.test.tsx` expectations that the first screen contains module chips; the current mobile component renders a welcome screen first. This PR only changes `apps/web/src/core/lib/chatActions/crossActions.ts` and its web test.

Follow-up for Devin Review finding on merged PR #691.

Link to Devin session: https://app.devin.ai/sessions/d2db8b800ec24d1d9b56d79e856d2d4f
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
