### PR TITLE
feat(hub): лого Sergeant — головний заголовок хедера, привітання — другорядне

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -1,41 +1,9 @@
 import { useMemo } from "react";
 import { Icon } from "@shared/components/ui/Icon";
+import { BrandLogo } from "./BrandLogo";
 import { DarkModeToggle } from "./DarkModeToggle";
 import { UserMenuButton } from "./UserMenuButton";
 import type { User } from "@sergeant/shared";
-
-const CHEVRON_ICON = (
-  <svg
-    viewBox="0 0 18 18"
-    width={18}
-    height={18}
-    fill="none"
-    aria-hidden="true"
-    className="shrink-0"
-  >
-    <path
-      d="M3 6.5 L9 3 L15 6.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M3 10.5 L9 7 L15 10.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M3 14.5 L9 11 L15 14.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
 
 const ICON_BUTTON_CLS =
   "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
@@ -116,12 +84,10 @@ export function HubHeader({
       style={{ paddingTop: "max(2.5rem, env(safe-area-inset-top))" }}
     >
       <div className="min-w-0">
-        <div className="flex items-center gap-1.5 text-brand-500 mb-0.5">
-          {CHEVRON_ICON}
-        </div>
-        <h1 className="text-2xl font-bold text-text leading-tight truncate">
+        <BrandLogo as="h1" size="lg" className="mb-1" />
+        <p className="text-sm text-muted leading-tight truncate">
           {greeting.text} <span aria-hidden>{greeting.emoji}</span>
-        </h1>
+        </p>
         {dateStr && <p className="text-xs text-muted mt-0.5">{dateStr}</p>}
       </div>
       <div className="pt-1 flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Summary
У хедері хабу тепер **BrandLogo** (шеврон + «Sergeant») є головним заголовком (`<h1>`), а привітання «Доброго ранку, юзер» стало меншим другорядним текстом (`<p class="text-sm text-muted">`).

**Що змінилось:**
- Видалено дубльований `CHEVRON_ICON` з `HubHeader` — тепер використовується спільний компонент `BrandLogo`
- `BrandLogo` рендериться як `<h1>` з розміром `lg` (шеврон + градієнтний текст «Sergeant»)
- Привітання (Доброго ранку/дня/вечора, ім'я) тепер `text-sm text-muted` — менше і не head-заголовок
- Дата залишилась без змін

## Review & Testing Checklist for Human
- [ ] Відкрити хаб і переконатись що лого «Sergeant» з шевроном відображається як головний великий заголовок
- [ ] Привітання («Доброго ранку/дня/вечора, ім'я») відображається дрібнішим текстом під лого
- [ ] Перевірити в темній і світлій темах — градієнт тексту лого адаптується

### Notes
Компонент `BrandLogo` вже використовувався в AuthPage, OnboardingWizard — тепер він також у HubHeader, що забезпечує єдиний стиль бренду.

Link to Devin session: https://app.devin.ai/sessions/d755890a9c3e48e7a2a3a3deba22162b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated header layout with a new logo component and refined typography styling.

* **Refactor**
  * Restructured header greeting section for improved visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->