### PR TITLE
feat(hub): chevron-badge brand mark + balanced header typography

### DIFF
--- a/apps/web/src/core/OnboardingWizard.tsx
+++ b/apps/web/src/core/OnboardingWizard.tsx
@@ -135,7 +135,12 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
       <div className="space-y-2">
         <h2 className="text-2xl font-bold text-text">
           Привіт. Це{" "}
-          <BrandLogo size="md" className="inline-flex align-baseline" />.
+          <BrandLogo
+            size="md"
+            variant="inline"
+            className="inline-flex align-baseline"
+          />
+          .
         </h2>
         <p className="text-sm text-muted leading-relaxed max-w-xs mx-auto">
           Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно. Через

--- a/apps/web/src/core/app/BrandLogo.tsx
+++ b/apps/web/src/core/app/BrandLogo.tsx
@@ -1,53 +1,58 @@
 /**
- * Brand logo mark — styled "Sergeant" title with military chevron accent.
+ * Brand logo mark — Sergeant chevron badge + wordmark.
  *
- * Renders a small three-chevron SVG (sergeant rank insignia) in brand
- * emerald alongside the app name in DM Sans ExtraBold with a subtle
- * text gradient that adapts to light/dark themes via CSS variables.
+ * Renders a rounded emerald badge with three white sergeant chevrons
+ * paired with the "Sergeant" wordmark in DM Sans ExtraBold.
  *
- * Used in HubHeader, AuthPage, ResetPasswordPage and OnboardingWizard.
+ * Variants:
+ *   - "badge" (default): 32px rounded badge + wordmark side by side.
+ *     Used in HubHeader, AuthPage, ResetPasswordPage.
+ *   - "inline":           chevron icon inline with text (no badge).
+ *     Used in OnboardingWizard inside a sentence.
+ *
+ * Sizes:
+ *   - "lg": hub header — bigger badge + 22px wordmark.
+ *   - "md": auth/onboarding — smaller badge + 18px wordmark.
  */
 
-const CHEVRON_ICON = (
-  <svg
-    viewBox="0 0 18 18"
-    width={18}
-    height={18}
-    fill="none"
-    aria-hidden="true"
-    className="shrink-0"
-  >
-    <path
-      d="M3 6.5 L9 3 L15 6.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M3 10.5 L9 7 L15 10.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M3 14.5 L9 11 L15 14.5"
-      stroke="currentColor"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
+interface ChevronMarkProps {
+  size: number;
+}
 
-const GRADIENT_STYLE: React.CSSProperties = {
-  background:
-    "linear-gradient(135deg, rgb(var(--c-text)) 50%, rgb(var(--c-accent)))",
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  backgroundClip: "text",
-};
+function ChevronMark({ size }: ChevronMarkProps) {
+  return (
+    <svg
+      viewBox="0 0 18 18"
+      width={size}
+      height={size}
+      fill="none"
+      aria-hidden="true"
+      className="shrink-0"
+    >
+      <path
+        d="M3 6.5 L9 3 L15 6.5"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3 10.5 L9 7 L15 10.5"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3 14.5 L9 11 L15 14.5"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
 type TagName = "span" | "h1" | "h2" | "h3" | "div";
 
@@ -58,26 +63,58 @@ interface BrandLogoProps {
   size?: "lg" | "md";
   /** HTML element for the outer wrapper (default "span"). Use "h1" on pages that need a heading landmark. */
   as?: TagName;
+  /**
+   * "badge" (default) renders the chevron inside an emerald rounded square
+   * next to the wordmark. "inline" renders a flat chevron icon next to the
+   * wordmark — used when the logo appears mid-sentence.
+   */
+  variant?: "badge" | "inline";
 }
 
 export function BrandLogo({
   className,
   size = "lg",
   as: Tag = "span",
+  variant = "badge",
 }: BrandLogoProps) {
-  const textCls =
+  const wordmarkCls =
     size === "lg"
-      ? "text-[26px] leading-none font-extrabold tracking-tight"
-      : "text-2xl leading-none font-extrabold tracking-tight";
+      ? "text-[22px] leading-none font-extrabold tracking-tight"
+      : "text-[18px] leading-none font-extrabold tracking-tight";
+
+  if (variant === "inline") {
+    const iconSize = size === "lg" ? 20 : 18;
+    return (
+      <Tag
+        className={`inline-flex items-center gap-1.5 select-none text-brand-500 ${className ?? ""}`}
+      >
+        <ChevronMark size={iconSize} />
+        <span className={`${wordmarkCls} text-text`}>Sergeant</span>
+      </Tag>
+    );
+  }
+
+  const badgePx = size === "lg" ? 32 : 28;
+  const chevronPx = size === "lg" ? 20 : 18;
+  const radiusPx = size === "lg" ? 10 : 9;
+  const gapCls = size === "lg" ? "gap-2.5" : "gap-2";
 
   return (
     <Tag
-      className={`inline-flex items-center gap-1.5 select-none text-brand-500 ${className ?? ""}`}
+      className={`inline-flex items-center select-none ${gapCls} ${className ?? ""}`}
     >
-      {CHEVRON_ICON}
-      <span className={textCls} style={GRADIENT_STYLE}>
-        Sergeant
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center justify-center bg-brand-500 text-white shadow-[0_1px_2px_rgba(16,185,129,0.25),0_4px_12px_-2px_rgba(16,185,129,0.35)]"
+        style={{
+          width: badgePx,
+          height: badgePx,
+          borderRadius: radiusPx,
+        }}
+      >
+        <ChevronMark size={chevronPx} />
       </span>
+      <span className={`${wordmarkCls} text-text`}>Sergeant</span>
     </Tag>
   );
 }

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -8,11 +8,11 @@ import type { User } from "@sergeant/shared";
 const ICON_BUTTON_CLS =
   "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
-const GREETINGS: Record<string, { text: string; emoji: string }> = {
-  morning: { text: "Доброго ранку", emoji: "\u2600\uFE0F" },
-  afternoon: { text: "Доброго дня", emoji: "\uD83C\uDF24\uFE0F" },
-  evening: { text: "Доброго вечора", emoji: "\uD83C\uDF19" },
-  night: { text: "Доброї ночі", emoji: "\uD83C\uDF1F" },
+const GREETINGS: Record<string, string> = {
+  morning: "Доброго ранку",
+  afternoon: "Доброго дня",
+  evening: "Доброго вечора",
+  night: "Доброї ночі",
 };
 
 function getTimeOfDay(): keyof typeof GREETINGS {
@@ -66,14 +66,11 @@ export function HubHeader({
   onToggleDark,
   hideAuthButton = false,
 }: HubHeaderProps) {
-  const greeting = useMemo(() => {
+  const greetingText = useMemo(() => {
     const tod = getTimeOfDay();
-    const g = GREETINGS[tod];
+    const base = GREETINGS[tod];
     const name = user?.name?.split(" ")[0];
-    return {
-      text: name ? `${g.text}, ${name}` : g.text,
-      emoji: g.emoji,
-    };
+    return name ? `${base}, ${name}` : base;
   }, [user?.name]);
 
   const dateStr = useMemo(formatUkrainianDate, []);
@@ -84,11 +81,15 @@ export function HubHeader({
       style={{ paddingTop: "max(2.5rem, env(safe-area-inset-top))" }}
     >
       <div className="min-w-0">
-        <BrandLogo as="h1" size="lg" className="mb-1" />
-        <p className="text-sm text-muted leading-tight truncate">
-          {greeting.text} <span aria-hidden>{greeting.emoji}</span>
+        <BrandLogo as="h1" size="lg" className="mb-1.5" />
+        <p className="text-[13px] leading-snug text-muted truncate">
+          {greetingText}
         </p>
-        {dateStr && <p className="text-xs text-muted mt-0.5">{dateStr}</p>}
+        {dateStr && (
+          <p className="text-[13px] leading-snug text-subtle truncate">
+            {dateStr}
+          </p>
+        )}
       </div>
       <div className="pt-1 flex items-center gap-1 shrink-0">
         <button


### PR DESCRIPTION
## Summary

Redesign of the hub header brand mark and meta lines (response to feedback that the inscriptions felt "disproportionate and inconsistent").

**What changed**

- `BrandLogo` gains a `variant` prop:
  - `"badge"` (default) — 32×32 rounded emerald square with three white sergeant chevrons + a solid-colour `Sergeant` wordmark. Visually balanced mass next to the wordmark; works as a recognisable mark beyond the header (PWA icon, splash, share images).
  - `"inline"` — flat chevron icon next to the wordmark, used only in `OnboardingWizard` where the logo sits inside a sentence (`Привіт. Це Sergeant.`) and a badge would break flow.
- The `Sergeant` wordmark drops the dark→emerald text gradient and uses solid `c-text` so the badge is the single, focused brand accent.
- `HubHeader` meta block: greeting + date are now two **consistent 13px lines** (`muted` + `subtle`), instead of the previous 14px greeting (with weather emoji) + 12px date. No more 🌤 / 🌙 emoji clutter — the typography itself carries the warmth.
- Badge has a soft emerald glow shadow; everything routes through the existing `brand-500` / `text-text` tokens so dark mode adapts automatically.

### Before / After

| Before | After (light) | After (dark) |
| --- | --- | --- |
| chevron 18px next to gradient `Sergeant` 26px, two mismatched meta lines + emoji | ![header light](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctM2NiZTM1ZDczYzUzNGExMDkyNjViOTUzODIwMjZiNWMiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctM2NiZTM1ZDczYzUzNGExMDkyNjViOTUzODIwMjZiNWMvZTE5OTgwYjQtNTFiZC00ZThkLWI1N2YtZGVhOGEwYmQyYmVkIiwiaWF0IjoxNzc3MTI1ODI1LCJleHAiOjE3Nzc3MzA2MjUsImZpbGVuYW1lIjoiaGVhZGVyLWxpZ2h0LnBuZyJ9.p4V8NvlFJd73rydDmDDJc57vKAv7FqM7Tnl5XIq_3_o) | ![header dark](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctM2NiZTM1ZDczYzUzNGExMDkyNjViOTUzODIwMjZiNWMiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctM2NiZTM1ZDczYzUzNGExMDkyNjViOTUzODIwMjZiNWMvN2E2NzNjNjItYzdiYS00YzIwLTk5OTAtOTNlYWE1NWU1MmUxIiwiaWF0IjoxNzc3MTI1ODI1LCJleHAiOjE3Nzc3MzA2MjUsImZpbGVuYW1lIjoiaGVhZGVyLWRhcmsucG5nIn0.hKIPKKRfMZVa3Wss-Lfj9TY48RO4Du63jwKnmUAzs1A) |

`AuthPage` and `ResetPasswordPage` automatically pick up the new badge variant at `size="md"` (28×28 badge) — same brand presence above their h1 sub-titles.

## Review & Testing Checklist for Human

- [ ] Hub header: badge + wordmark + two meta lines render correctly on iOS Safari (the original issue surfaced there). Sanity-check at iPhone SE width (~375px) and a Plus-sized device — meta lines should still fit without weird truncation.
- [ ] Toggle dark mode — badge stays emerald with white chevrons, wordmark switches to cream, both meta lines stay readable.
- [ ] `/sign-in` and `/reset-password` headings still look right with the smaller (md) badge above the sub-title.
- [ ] Onboarding `/welcome` first step still reads `Привіт. Це [chevron] Sergeant.` cleanly inline (no badge there by design).

### Notes

- The `BrandLogo` API is backwards compatible — every existing call-site still works without changes; only `OnboardingWizard` was opted into `variant="inline"` since that's the one place the inline form is required.
- No copy changes (greetings, date format) other than removing the time-of-day emoji.

Link to Devin session: https://app.devin.ai/sessions/bb4dbf753e5d4c6e863fa6020898b72c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
