### PR TITLE
feat(mono): DB schema + DTO stubs for webhook migration (Track A · PR1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,7 +162,22 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # історичним ім'ям.
 # USDA_API_KEY=
 
-# ── Monobank / PrivatBank ─────────────────────────────────────
+# ── Monobank webhook integration ──────────────────────────────
+# Feature flag: увімкнути webhook-based інтеграцію (default: false).
+# Коли true — MONO_TOKEN_ENC_KEY і PUBLIC_API_BASE_URL обов'язкові.
+# MONO_WEBHOOK_ENABLED=false
+
+# 32-byte hex ключ для AES-256-GCM шифрування Monobank токенів.
+# Згенерувати: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# MONO_TOKEN_ENC_KEY=
+
+# Публічна базова URL API (Railway) для реєстрації webhook у Monobank.
+# Webhook URL = ${PUBLIC_API_BASE_URL}/api/mono/webhook/${secret}
+# Production: https://sergeant-production.up.railway.app
+# Dev: https://xxx.trycloudflare.com (cloudflared tunnel --url http://localhost:3000)
+# PUBLIC_API_BASE_URL=
+
+# ── Monobank / PrivatBank (legacy polling proxy) ─────────────
 # УВАГА: токени банків НЕ читаються з env — вони надходять від клієнта через
 # заголовок `X-Token` і форвардяться до upstream. Сервер їх зберігає лише у
 # memory кешу TTL=60с (хешовано). Якщо потрібно підкрутити resilience,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -134,6 +134,7 @@ export function createApp({
   app.use("/api/sync", express.json({ limit: "6mb" }));
   app.use("/api/coach/memory", express.json({ limit: "6mb" }));
   app.use("/api/chat", express.json({ limit: "1mb" }));
+  app.use("/api/mono/webhook", express.json({ limit: "32kb" }));
   app.use(express.json({ limit: "128kb" }));
 
   // Global CORS for the whole /api surface. Individual handlers may re-set

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -122,6 +122,17 @@ const envSchema = z.object({
   /** Bearer token для захисту nutrition API endpoints. */
   NUTRITION_API_TOKEN: z.string().optional(),
 
+  // ── Monobank webhook ─────────────────────────────────────────────────
+  /** Feature flag: увімкнути webhook-based Monobank інтеграцію. */
+  MONO_WEBHOOK_ENABLED: z
+    .enum(["true", "false", "1", "0", ""])
+    .optional()
+    .transform((v) => v === "true" || v === "1"),
+  /** 32-byte hex ключ для AES-256-GCM шифрування Monobank токенів. */
+  MONO_TOKEN_ENC_KEY: z.string().optional(),
+  /** Публічна базова URL API (Railway) для реєстрації webhook у Monobank. */
+  PUBLIC_API_BASE_URL: z.string().optional(),
+
   // ── External APIs ──────────────────────────────────────────────────
   /** USDA FoodData Central API key. Fallback: `DEMO_KEY`. */
   USDA_API_KEY: z.string().optional(),
@@ -193,6 +204,19 @@ export function assertStartupEnv(): void {
     warnings.push(
       "METRICS_TOKEN is not set — /metrics endpoint is unprotected.",
     );
+  }
+
+  if (env.MONO_WEBHOOK_ENABLED) {
+    if (!env.MONO_TOKEN_ENC_KEY) {
+      throw new Error(
+        "MONO_TOKEN_ENC_KEY is required when MONO_WEBHOOK_ENABLED=true. Must be 32-byte hex (64 chars).",
+      );
+    }
+    if (!env.PUBLIC_API_BASE_URL) {
+      throw new Error(
+        "PUBLIC_API_BASE_URL is required when MONO_WEBHOOK_ENABLED=true.",
+      );
+    }
   }
 
   if (warnings.length > 0) {

--- a/apps/server/src/migrations/008_mono_integration.down.sql
+++ b/apps/server/src/migrations/008_mono_integration.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS mono_tx_user_account_time_idx;
+DROP INDEX IF EXISTS mono_tx_user_time_idx;
+DROP TABLE IF EXISTS mono_transaction;
+DROP TABLE IF EXISTS mono_account;
+DROP TABLE IF EXISTS mono_connection;

--- a/apps/server/src/migrations/008_mono_integration.sql
+++ b/apps/server/src/migrations/008_mono_integration.sql
@@ -1,0 +1,64 @@
+-- Monobank webhook integration: DB schema for server-side token storage,
+-- webhook delivery, and transaction persistence.
+-- Plan: docs/monobank-webhook-migration.md (Track A)
+
+CREATE TABLE mono_connection (
+  user_id              TEXT PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  token_ciphertext     BYTEA NOT NULL,
+  token_iv             BYTEA NOT NULL,
+  token_tag            BYTEA NOT NULL,
+  token_fingerprint    TEXT NOT NULL,
+  webhook_secret       TEXT NOT NULL UNIQUE,
+  webhook_registered_at TIMESTAMPTZ,
+  last_event_at        TIMESTAMPTZ,
+  last_backfill_at     TIMESTAMPTZ,
+  status               TEXT NOT NULL DEFAULT 'pending',
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE mono_account (
+  user_id          TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  mono_account_id  TEXT NOT NULL,
+  send_id          TEXT,
+  type             TEXT,
+  currency_code    INT NOT NULL,
+  cashback_type    TEXT,
+  masked_pan       TEXT[],
+  iban             TEXT,
+  balance          BIGINT,
+  credit_limit     BIGINT,
+  last_seen_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, mono_account_id)
+);
+
+CREATE TABLE mono_transaction (
+  user_id          TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  mono_account_id  TEXT NOT NULL,
+  mono_tx_id       TEXT NOT NULL,
+  time             TIMESTAMPTZ NOT NULL,
+  amount           BIGINT NOT NULL,
+  operation_amount BIGINT NOT NULL,
+  currency_code    INT NOT NULL,
+  mcc              INT,
+  original_mcc     INT,
+  hold             BOOLEAN,
+  description      TEXT,
+  comment          TEXT,
+  cashback_amount  BIGINT,
+  commission_rate  BIGINT,
+  balance          BIGINT,
+  receipt_id       TEXT,
+  invoice_id       TEXT,
+  counter_edrpou   TEXT,
+  counter_iban     TEXT,
+  counter_name     TEXT,
+  raw              JSONB NOT NULL,
+  source           TEXT NOT NULL,
+  received_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, mono_tx_id),
+  FOREIGN KEY (user_id, mono_account_id) REFERENCES mono_account(user_id, mono_account_id) ON DELETE CASCADE
+);
+
+CREATE INDEX mono_tx_user_time_idx ON mono_transaction(user_id, time DESC);
+CREATE INDEX mono_tx_user_account_time_idx ON mono_transaction(user_id, mono_account_id, time DESC);

--- a/apps/server/src/modules/mono/backfill.ts
+++ b/apps/server/src/modules/mono/backfill.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from "express";
+
+/**
+ * POST /api/mono/backfill — тригер re-backfill останніх 31 дня.
+ *
+ * Stub: повертає 501 до реалізації у Track B.
+ */
+export async function backfillHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}

--- a/apps/server/src/modules/mono/connection.ts
+++ b/apps/server/src/modules/mono/connection.ts
@@ -1,0 +1,28 @@
+import type { Request, Response } from "express";
+
+/**
+ * POST /api/mono/connect — підключення Monobank токена.
+ * POST /api/mono/disconnect — відключення.
+ *
+ * Stub: повертає 501 до реалізації у Track A · PR2.
+ */
+export async function connectHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}
+
+export async function disconnectHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}
+
+export async function syncStateHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}

--- a/apps/server/src/modules/mono/read.ts
+++ b/apps/server/src/modules/mono/read.ts
@@ -1,0 +1,21 @@
+import type { Request, Response } from "express";
+
+/**
+ * GET /api/mono/accounts — список акаунтів з DB.
+ * GET /api/mono/transactions — транзакції з DB (cursor pagination).
+ *
+ * Stub: повертає 501 до реалізації у Track B.
+ */
+export async function accountsHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}
+
+export async function transactionsHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}

--- a/apps/server/src/modules/mono/webhook.ts
+++ b/apps/server/src/modules/mono/webhook.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from "express";
+
+/**
+ * POST /api/mono/webhook/:secret — публічний endpoint для Monobank delivery.
+ *
+ * Stub: повертає 501 до реалізації у Track A · PR2.
+ */
+export async function webhookHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  res.status(501).json({ error: "Not implemented" });
+}

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import type { Pool } from "pg";
 import { createAuthRouter } from "./auth.js";
 import { createBanksRouter } from "./banks.js";
+import { createMonoWebhookRouter } from "./mono-webhook.js";
 import { createBarcodeRouter } from "./barcode.js";
 import { createChatRouter } from "./chat.js";
 import { createCoachRouter } from "./coach.js";
@@ -30,6 +31,7 @@ export function registerRoutes(app: Express, { pool }: { pool: Pool }): void {
   app.use(createMeRouter());
   app.use(createSyncRouter());
   app.use(createChatRouter());
+  app.use(createMonoWebhookRouter());
   app.use(createBanksRouter());
   app.use(createBarcodeRouter());
   app.use(createNutritionRouter());

--- a/apps/server/src/routes/mono-webhook.ts
+++ b/apps/server/src/routes/mono-webhook.ts
@@ -1,0 +1,55 @@
+import { Router } from "express";
+import { asyncHandler, requireSession, setModule } from "../http/index.js";
+import {
+  connectHandler,
+  disconnectHandler,
+  syncStateHandler,
+} from "../modules/mono/connection.js";
+import { accountsHandler, transactionsHandler } from "../modules/mono/read.js";
+import { backfillHandler } from "../modules/mono/backfill.js";
+import { webhookHandler } from "../modules/mono/webhook.js";
+
+/**
+ * Роутер для webhook-based Monobank інтеграції (Track A).
+ *
+ * Webhook endpoint (`POST /api/mono/webhook/:secret`) монтується БЕЗ session
+ * auth — це публічний endpoint, куди Monobank надсилає delivery. Авторизація
+ * через path-secret (constant-time compare у handler-і).
+ *
+ * Решта endpoints — під `requireSession()`.
+ */
+export function createMonoWebhookRouter(): Router {
+  const r = Router();
+
+  r.use("/api/mono/connect", setModule("finyk"));
+  r.use("/api/mono/disconnect", setModule("finyk"));
+  r.use("/api/mono/sync-state", setModule("finyk"));
+  r.use("/api/mono/accounts", setModule("finyk"));
+  r.use("/api/mono/transactions", setModule("finyk"));
+  r.use("/api/mono/backfill", setModule("finyk"));
+
+  // Webhook — публічний, без auth
+  r.post("/api/mono/webhook/:secret", asyncHandler(webhookHandler));
+
+  // Session-protected endpoints
+  r.post("/api/mono/connect", requireSession(), asyncHandler(connectHandler));
+  r.post(
+    "/api/mono/disconnect",
+    requireSession(),
+    asyncHandler(disconnectHandler),
+  );
+  r.get(
+    "/api/mono/sync-state",
+    requireSession(),
+    asyncHandler(syncStateHandler),
+  );
+  r.get("/api/mono/accounts", requireSession(), asyncHandler(accountsHandler));
+  r.get(
+    "/api/mono/transactions",
+    requireSession(),
+    asyncHandler(transactionsHandler),
+  );
+  r.post("/api/mono/backfill", requireSession(), asyncHandler(backfillHandler));
+
+  return r;
+}

--- a/packages/api-client/src/endpoints/mono.ts
+++ b/packages/api-client/src/endpoints/mono.ts
@@ -11,6 +11,61 @@ import type { HttpClient } from "../httpClient";
 
 export type MonoCashbackType = "" | "None" | "UAH" | "Miles" | string;
 
+// ── Webhook migration DTOs (Track A) ─────────────────────────────────────
+
+export type MonoConnectionStatus =
+  | "pending"
+  | "active"
+  | "invalid"
+  | "disconnected";
+
+export interface MonoAccountDto {
+  userId: string;
+  monoAccountId: string;
+  sendId: string | null;
+  type: string | null;
+  currencyCode: number;
+  cashbackType: string | null;
+  maskedPan: string[];
+  iban: string | null;
+  balance: number | null;
+  creditLimit: number | null;
+  lastSeenAt: string;
+}
+
+export interface MonoTransactionDto {
+  userId: string;
+  monoAccountId: string;
+  monoTxId: string;
+  time: string;
+  amount: number;
+  operationAmount: number;
+  currencyCode: number;
+  mcc: number | null;
+  originalMcc: number | null;
+  hold: boolean | null;
+  description: string | null;
+  comment: string | null;
+  cashbackAmount: number | null;
+  commissionRate: number | null;
+  balance: number | null;
+  receiptId: string | null;
+  invoiceId: string | null;
+  counterEdrpou: string | null;
+  counterIban: string | null;
+  counterName: string | null;
+  source: "webhook" | "backfill";
+  receivedAt: string;
+}
+
+export interface MonoSyncState {
+  status: MonoConnectionStatus;
+  webhookActive: boolean;
+  lastEventAt: string | null;
+  lastBackfillAt: string | null;
+  accountsCount: number;
+}
+
 export interface MonoAccount {
   id: string;
   sendId?: string;
@@ -209,5 +264,62 @@ export function createMonoEndpoints(http: HttpClient): MonoEndpoints {
       }
       return all;
     },
+  };
+}
+
+// ── Webhook-based API facade (Track A) ───────────────────────────────────
+
+export interface MonoWebhookEndpoints {
+  connect: (
+    token: string,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<{ status: MonoConnectionStatus; accountsCount: number }>;
+  disconnect: (opts?: { signal?: AbortSignal }) => Promise<void>;
+  syncState: (opts?: { signal?: AbortSignal }) => Promise<MonoSyncState>;
+  accounts: (opts?: { signal?: AbortSignal }) => Promise<MonoAccountDto[]>;
+  transactions: (
+    params: {
+      from?: string;
+      to?: string;
+      accountId?: string;
+      limit?: number;
+      cursor?: string;
+    },
+    opts?: { signal?: AbortSignal },
+  ) => Promise<MonoTransactionDto[]>;
+  backfill: (opts?: { signal?: AbortSignal }) => Promise<void>;
+}
+
+export function createMonoWebhookEndpoints(
+  http: HttpClient,
+): MonoWebhookEndpoints {
+  return {
+    connect: (token, opts) =>
+      http.post<{ status: MonoConnectionStatus; accountsCount: number }>(
+        "/api/mono/connect",
+        { token },
+        { signal: opts?.signal },
+      ),
+    disconnect: (opts) =>
+      http.post<void>("/api/mono/disconnect", undefined, {
+        signal: opts?.signal,
+      }),
+    syncState: (opts) =>
+      http.get<MonoSyncState>("/api/mono/sync-state", {
+        signal: opts?.signal,
+      }),
+    accounts: (opts) =>
+      http.get<MonoAccountDto[]>("/api/mono/accounts", {
+        signal: opts?.signal,
+      }),
+    transactions: (params, opts) =>
+      http.get<MonoTransactionDto[]>("/api/mono/transactions", {
+        query: params,
+        signal: opts?.signal,
+      }),
+    backfill: (opts) =>
+      http.post<void>("/api/mono/backfill", undefined, {
+        signal: opts?.signal,
+      }),
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -119,12 +119,18 @@ export {
 
 export {
   createMonoEndpoints,
+  createMonoWebhookEndpoints,
   type MonoAccount,
+  type MonoAccountDto,
   type MonoCashbackType,
   type MonoClientInfo,
+  type MonoConnectionStatus,
   type MonoEndpoints,
   type MonoJar,
   type MonoStatementEntry,
+  type MonoSyncState,
+  type MonoTransactionDto,
+  type MonoWebhookEndpoints,
 } from "./endpoints/mono";
 
 export {


### PR DESCRIPTION
## Summary

Schema-only PR що розблоковує треки B і C міграції Monobank з polling на webhook (план: `docs/monobank-webhook-migration.md`).

**Що входить:**

- **Міграція** `008_mono_integration.sql` / `.down.sql` — 3 таблиці (`mono_connection`, `mono_account`, `mono_transaction`) з усіма колонками та індексами згідно плану.
- **DTO типи** у `packages/api-client/src/endpoints/mono.ts`: `MonoConnectionStatus`, `MonoAccountDto`, `MonoTransactionDto`, `MonoSyncState`.
- **Клієнтський фасад** `createMonoWebhookEndpoints`: `connect`, `disconnect`, `syncState`, `accounts`, `transactions`, `backfill`.
- **Handler stubs** (501 Not Implemented) у `apps/server/src/modules/mono/{connection,read,backfill,webhook}.ts`.
- **Роутер** `routes/mono-webhook.ts` — webhook endpoint без auth (публічний, Monobank delivery), решта під `requireSession()`. Body cap 32 KB для webhook.
- **Feature flag** `MONO_WEBHOOK_ENABLED` (default `false`) як boolean у env. Validation: `MONO_TOKEN_ENC_KEY` і `PUBLIC_API_BASE_URL` обов'язкові коли `MONO_WEBHOOK_ENABLED=true`.
- **`.env.example`** оновлено з новими змінними та інструкціями.

**Що НЕ входить (PR2):** реальні handler-и, crypto, виклики Monobank API, тести webhook/connection.

## Review & Testing Checklist for Human

- [ ] Перевірити SQL міграцію: типи колонок, FK, індекси відповідають плану (`docs/monobank-webhook-migration.md` секція «DB схема»)
- [ ] Перевірити DTO типи: усі поля з плану присутні, naming convention (camelCase) консистентний
- [ ] Перевірити що webhook роут монтується ДО legacy `/api/mono` proxy (routes/index.ts)
- [ ] Запустити `pnpm lint && pnpm typecheck && pnpm --filter @sergeant/server test` — має бути зелено

### Notes

- Webhook endpoint `POST /api/mono/webhook/:secret` зареєстрований без session-middleware — це by design (Monobank delivery, авторизація через path-secret).
- `MONO_WEBHOOK_ENABLED` за замовчуванням `false` — жодних поведінкових змін до явного увімкнення.
- Legacy polling proxy (`/api/mono`) залишається без змін.
- Трек A · PR2 (реальні handlers) буде створений у цій же сесії після merge PR1.


Link to Devin session: https://app.devin.ai/sessions/0cb601db96b34a53b069a3e244f1bfcd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Monobank webhook integration infrastructure with new API endpoints for account connection, disconnection, synchronization, and transaction/account data retrieval.
  * Introduced webhook endpoint for receiving Monobank updates.

* **Configuration**
  * Added environment variables for Monobank webhook setup, including encryption key and API base URL configuration.

* **Database**
  * Created database schema migrations to store Monobank connections, accounts, and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->