### PR TITLE
feat(mono): webhook receiver + persistent connection storage (Track A PR2)

### DIFF
--- a/apps/server/src/modules/mono/connection.test.ts
+++ b/apps/server/src/modules/mono/connection.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Request, Response } from "express";
+import type { Mock } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock("../../db.js", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../../obs/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../obs/metrics.js", () => ({
+  monoWebhookReceivedTotal: { inc: vi.fn() },
+  monoWebhookDurationMs: { observe: vi.fn() },
+}));
+
+const mockEnv = {
+  MONO_WEBHOOK_ENABLED: true,
+  MONO_TOKEN_ENC_KEY:
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  PUBLIC_API_BASE_URL: "https://api.example.com",
+};
+
+vi.mock("../../env/env.js", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return (mockEnv as Record<string | symbol, unknown>)[prop];
+      },
+    },
+  ),
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { query as _query } from "../../db.js";
+import {
+  connectHandler,
+  disconnectHandler,
+  syncStateHandler,
+} from "./connection.js";
+
+const dbQuery = _query as unknown as Mock;
+
+// ── Helpers ──────────────────────────────────────────────────
+
+interface TestResBody {
+  ok?: boolean;
+  error?: string;
+  status?: string;
+  accountsCount?: number;
+  webhookActive?: boolean;
+  lastEventAt?: string | null;
+  lastBackfillAt?: string | null;
+  upstream?: string;
+}
+
+interface TestRes {
+  statusCode: number;
+  body: TestResBody;
+  status(code: number): TestRes;
+  json(payload: unknown): TestRes;
+}
+
+function makeRes(): TestRes & Response {
+  const res: TestRes = {
+    statusCode: 200,
+    body: {} as TestResBody,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload as TestResBody;
+      return this;
+    },
+  };
+  return res as TestRes & Response;
+}
+
+function makeReq(body?: unknown): Request {
+  return {
+    method: "POST",
+    body: body ?? {},
+    user: { id: "user_1" },
+  } as unknown as Request;
+}
+
+function makeReqNoUser(body?: unknown): Request {
+  return {
+    method: "POST",
+    body: body ?? {},
+  } as unknown as Request;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnv.MONO_WEBHOOK_ENABLED = true;
+  mockEnv.MONO_TOKEN_ENC_KEY =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  mockEnv.PUBLIC_API_BASE_URL = "https://api.example.com";
+});
+
+describe("connectHandler", () => {
+  it("returns 404 when MONO_WEBHOOK_ENABLED is false", async () => {
+    mockEnv.MONO_WEBHOOK_ENABLED = false;
+    const res = makeRes();
+    await connectHandler(makeReq({ token: "valid_token_123" }), res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const res = makeRes();
+    await connectHandler(makeReqNoUser({ token: "valid_token_123" }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 for invalid or missing token", async () => {
+    const res = makeRes();
+    await connectHandler(makeReq({ token: "" }), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 when Monobank client-info returns 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    const res = makeRes();
+    await connectHandler(makeReq({ token: "bad_token_12345" }), res);
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toBe("Invalid Monobank token");
+  });
+
+  it("connects successfully: calls Monobank, upserts connection + accounts", async () => {
+    const accounts = [
+      { id: "acc_1", currencyCode: 980, balance: 100000 },
+      { id: "acc_2", currencyCode: 840, balance: 5000 },
+    ];
+
+    // client-info success
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ accounts }),
+    });
+
+    // webhook register success
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    // DB upserts: connection + 2 accounts
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    const res = makeRes();
+    await connectHandler(makeReq({ token: "valid_personal_token_12345" }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe("active");
+    expect(res.body.accountsCount).toBe(2);
+
+    // 1 connection upsert + 2 account upserts = 3 DB calls
+    expect(dbQuery).toHaveBeenCalledTimes(3);
+
+    // Verify webhook registration was called
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const webhookCall = mockFetch.mock.calls[1];
+    expect(webhookCall[0]).toBe("https://api.monobank.ua/personal/webhook");
+  });
+
+  it("returns 502 when webhook registration fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ accounts: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+      });
+
+    const res = makeRes();
+    await connectHandler(makeReq({ token: "valid_personal_token_12345" }), res);
+    expect(res.statusCode).toBe(502);
+    expect(res.body.error).toMatch(/register webhook/i);
+  });
+});
+
+describe("disconnectHandler", () => {
+  it("returns 404 when MONO_WEBHOOK_ENABLED is false", async () => {
+    mockEnv.MONO_WEBHOOK_ENABLED = false;
+    const res = makeRes();
+    await disconnectHandler(makeReq(), res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const res = makeRes();
+    await disconnectHandler(makeReqNoUser(), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("disconnects: decrypts token, unregisters webhook, deletes connection", async () => {
+    // Import crypto to create a real encrypted token for the mock row
+    const { encryptToken } = await import("./crypto.js");
+    const enc = encryptToken(
+      "test_token_for_disconnect",
+      mockEnv.MONO_TOKEN_ENC_KEY,
+    );
+
+    // SELECT token data
+    dbQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          token_ciphertext: enc.ciphertext,
+          token_iv: enc.iv,
+          token_tag: enc.tag,
+        },
+      ],
+    });
+
+    // Unregister webhook fetch
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    // DELETE connection
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = makeRes();
+    await disconnectHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // Verify unregister call with empty webHookUrl
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const unregisterCall = mockFetch.mock.calls[0];
+    expect(unregisterCall[0]).toBe("https://api.monobank.ua/personal/webhook");
+    const body = JSON.parse(unregisterCall[1].body as string);
+    expect(body.webHookUrl).toBe("");
+  });
+
+  it("still deletes connection even if unregister fails", async () => {
+    const { encryptToken } = await import("./crypto.js");
+    const enc = encryptToken(
+      "test_token_for_disconnect",
+      mockEnv.MONO_TOKEN_ENC_KEY,
+    );
+
+    dbQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          token_ciphertext: enc.ciphertext,
+          token_iv: enc.iv,
+          token_tag: enc.tag,
+        },
+      ],
+    });
+
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = makeRes();
+    await disconnectHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});
+
+describe("syncStateHandler", () => {
+  it("returns 404 when MONO_WEBHOOK_ENABLED is false", async () => {
+    mockEnv.MONO_WEBHOOK_ENABLED = false;
+    const res = makeRes();
+    await syncStateHandler(makeReq(), res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns disconnected status when no connection exists", async () => {
+    dbQuery.mockResolvedValueOnce({ rows: [] });
+
+    const req = { method: "GET", user: { id: "user_1" } } as unknown as Request;
+    const res = makeRes();
+    await syncStateHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe("disconnected");
+    expect(res.body.webhookActive).toBe(false);
+    expect(res.body.accountsCount).toBe(0);
+  });
+
+  it("returns active status with account count from DB", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          status: "active",
+          webhook_registered_at: "2026-04-25T10:00:00Z",
+          last_event_at: "2026-04-25T12:00:00Z",
+          last_backfill_at: null,
+        },
+      ],
+    });
+    dbQuery.mockResolvedValueOnce({ rows: [{ count: "3" }] });
+
+    const req = { method: "GET", user: { id: "user_1" } } as unknown as Request;
+    const res = makeRes();
+    await syncStateHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe("active");
+    expect(res.body.webhookActive).toBe(true);
+    expect(res.body.lastEventAt).toBe("2026-04-25T12:00:00Z");
+    expect(res.body.accountsCount).toBe(3);
+  });
+});

--- a/apps/server/src/modules/mono/connection.ts
+++ b/apps/server/src/modules/mono/connection.ts
@@ -1,28 +1,297 @@
 import type { Request, Response } from "express";
+import crypto from "node:crypto";
+import { env } from "../../env/env.js";
+import { query } from "../../db.js";
+import { logger } from "../../obs/logger.js";
+import { encryptToken, decryptToken, tokenFingerprint } from "./crypto.js";
+import type { EncryptedToken } from "./crypto.js";
 
 /**
- * POST /api/mono/connect — підключення Monobank токена.
- * POST /api/mono/disconnect — відключення.
+ * POST /api/mono/connect  — register Monobank webhook + persist connection.
+ * POST /api/mono/disconnect — unregister webhook + wipe connection data.
+ * GET  /api/mono/sync-state — lightweight connection status from DB.
  *
- * Stub: повертає 501 до реалізації у Track A · PR2.
+ * All three require an authenticated session (`req.user`).
+ * Gated behind `MONO_WEBHOOK_ENABLED`.
  */
+
+interface AuthedRequest extends Request {
+  user?: { id: string };
+}
+
+function assertWebhookEnabled(res: Response): boolean {
+  if (!env.MONO_WEBHOOK_ENABLED) {
+    res.status(404).json({ error: "Monobank webhook integration is disabled" });
+    return false;
+  }
+  return true;
+}
+
+function getUserId(req: AuthedRequest, res: Response): string | null {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "Потрібна автентифікація" });
+    return null;
+  }
+  return userId;
+}
+
+interface MonoClientInfoAccount {
+  id: string;
+  sendId?: string;
+  type?: string;
+  currencyCode?: number;
+  cashbackType?: string;
+  maskedPan?: string[];
+  iban?: string;
+  balance?: number;
+  creditLimit?: number;
+}
+
+interface MonoClientInfoResponse {
+  accounts?: MonoClientInfoAccount[];
+  [key: string]: unknown;
+}
+
 export async function connectHandler(
-  _req: Request,
+  req: Request,
   res: Response,
 ): Promise<void> {
-  res.status(501).json({ error: "Not implemented" });
+  if (!assertWebhookEnabled(res)) return;
+  const userId = getUserId(req as AuthedRequest, res);
+  if (!userId) return;
+
+  const { token } = req.body as { token?: string };
+  if (!token || typeof token !== "string" || token.length < 10) {
+    res.status(400).json({ error: "Invalid or missing token" });
+    return;
+  }
+
+  const encKey = env.MONO_TOKEN_ENC_KEY;
+  if (!encKey) {
+    res
+      .status(500)
+      .json({ error: "Server misconfigured: missing encryption key" });
+    return;
+  }
+
+  const clientInfoRes = await fetch(
+    "https://api.monobank.ua/personal/client-info",
+    { headers: { "X-Token": token } },
+  );
+  if (!clientInfoRes.ok) {
+    const body = await clientInfoRes.text();
+    logger.warn({
+      msg: "mono_connect_client_info_failed",
+      status: clientInfoRes.status,
+      fingerprint: tokenFingerprint(token),
+    });
+    res.status(clientInfoRes.status === 401 ? 401 : 502).json({
+      error:
+        clientInfoRes.status === 401
+          ? "Invalid Monobank token"
+          : "Failed to reach Monobank API",
+      upstream: body,
+    });
+    return;
+  }
+
+  const clientInfo: MonoClientInfoResponse =
+    (await clientInfoRes.json()) as MonoClientInfoResponse;
+  const accounts = clientInfo.accounts ?? [];
+
+  const webhookSecret = crypto.randomBytes(32).toString("hex");
+  const webhookUrl = `${env.PUBLIC_API_BASE_URL}/api/mono/webhook/${webhookSecret}`;
+
+  const registerRes = await fetch("https://api.monobank.ua/personal/webhook", {
+    method: "POST",
+    headers: {
+      "X-Token": token,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ webHookUrl: webhookUrl }),
+  });
+
+  if (!registerRes.ok) {
+    const body = await registerRes.text();
+    logger.warn({
+      msg: "mono_webhook_register_failed",
+      status: registerRes.status,
+      fingerprint: tokenFingerprint(token),
+    });
+    res.status(502).json({
+      error: "Failed to register webhook with Monobank",
+      upstream: body,
+    });
+    return;
+  }
+
+  const encrypted: EncryptedToken = encryptToken(token, encKey);
+  const fingerprint = tokenFingerprint(token);
+
+  await query(
+    `INSERT INTO mono_connection
+       (user_id, token_ciphertext, token_iv, token_tag, token_fingerprint,
+        webhook_secret, webhook_registered_at, status, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW(), 'active', NOW())
+     ON CONFLICT (user_id) DO UPDATE SET
+       token_ciphertext = EXCLUDED.token_ciphertext,
+       token_iv = EXCLUDED.token_iv,
+       token_tag = EXCLUDED.token_tag,
+       token_fingerprint = EXCLUDED.token_fingerprint,
+       webhook_secret = EXCLUDED.webhook_secret,
+       webhook_registered_at = NOW(),
+       status = 'active',
+       updated_at = NOW()`,
+    [
+      userId,
+      encrypted.ciphertext,
+      encrypted.iv,
+      encrypted.tag,
+      fingerprint,
+      webhookSecret,
+    ],
+    { op: "mono_connection_upsert" },
+  );
+
+  for (const acc of accounts) {
+    await query(
+      `INSERT INTO mono_account
+         (user_id, mono_account_id, send_id, type, currency_code, cashback_type,
+          masked_pan, iban, balance, credit_limit, last_seen_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+       ON CONFLICT (user_id, mono_account_id) DO UPDATE SET
+         send_id = EXCLUDED.send_id,
+         type = EXCLUDED.type,
+         currency_code = EXCLUDED.currency_code,
+         cashback_type = EXCLUDED.cashback_type,
+         masked_pan = EXCLUDED.masked_pan,
+         iban = EXCLUDED.iban,
+         balance = EXCLUDED.balance,
+         credit_limit = EXCLUDED.credit_limit,
+         last_seen_at = NOW()`,
+      [
+        userId,
+        acc.id,
+        acc.sendId ?? null,
+        acc.type ?? null,
+        acc.currencyCode ?? 0,
+        acc.cashbackType ?? null,
+        acc.maskedPan ?? [],
+        acc.iban ?? null,
+        acc.balance ?? null,
+        acc.creditLimit ?? null,
+      ],
+      { op: "mono_account_upsert" },
+    );
+  }
+
+  logger.info({
+    msg: "mono_connected",
+    fingerprint,
+    accountsCount: accounts.length,
+  });
+
+  res.status(200).json({ status: "active", accountsCount: accounts.length });
 }
 
 export async function disconnectHandler(
-  _req: Request,
+  req: Request,
   res: Response,
 ): Promise<void> {
-  res.status(501).json({ error: "Not implemented" });
+  if (!assertWebhookEnabled(res)) return;
+  const userId = getUserId(req as AuthedRequest, res);
+  if (!userId) return;
+
+  const encKey = env.MONO_TOKEN_ENC_KEY;
+
+  const connResult = await query<{
+    token_ciphertext: Buffer;
+    token_iv: Buffer;
+    token_tag: Buffer;
+  }>(
+    "SELECT token_ciphertext, token_iv, token_tag FROM mono_connection WHERE user_id = $1",
+    [userId],
+    { op: "mono_connection_select" },
+  );
+
+  if (connResult.rows.length > 0 && encKey) {
+    try {
+      const row = connResult.rows[0];
+      const decryptedToken = decryptToken(
+        {
+          ciphertext: row.token_ciphertext,
+          iv: row.token_iv,
+          tag: row.token_tag,
+        },
+        encKey,
+      );
+      await fetch("https://api.monobank.ua/personal/webhook", {
+        method: "POST",
+        headers: {
+          "X-Token": decryptedToken,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ webHookUrl: "" }),
+      });
+    } catch (err) {
+      logger.warn({ msg: "mono_webhook_unregister_failed", err });
+    }
+  }
+
+  await query("DELETE FROM mono_connection WHERE user_id = $1", [userId], {
+    op: "mono_connection_delete",
+  });
+
+  logger.info({ msg: "mono_disconnected" });
+  res.status(200).json({ ok: true });
 }
 
 export async function syncStateHandler(
-  _req: Request,
+  req: Request,
   res: Response,
 ): Promise<void> {
-  res.status(501).json({ error: "Not implemented" });
+  if (!assertWebhookEnabled(res)) return;
+  const userId = getUserId(req as AuthedRequest, res);
+  if (!userId) return;
+
+  const connResult = await query<{
+    status: string;
+    webhook_registered_at: string | null;
+    last_event_at: string | null;
+    last_backfill_at: string | null;
+  }>(
+    `SELECT status, webhook_registered_at, last_event_at, last_backfill_at
+     FROM mono_connection WHERE user_id = $1`,
+    [userId],
+    { op: "mono_sync_state" },
+  );
+
+  if (connResult.rows.length === 0) {
+    res.status(200).json({
+      status: "disconnected",
+      webhookActive: false,
+      lastEventAt: null,
+      lastBackfillAt: null,
+      accountsCount: 0,
+    });
+    return;
+  }
+
+  const conn = connResult.rows[0];
+
+  const countResult = await query<{ count: string }>(
+    "SELECT COUNT(*)::text AS count FROM mono_account WHERE user_id = $1",
+    [userId],
+    { op: "mono_accounts_count" },
+  );
+
+  res.status(200).json({
+    status: conn.status,
+    webhookActive:
+      conn.status === "active" && conn.webhook_registered_at != null,
+    lastEventAt: conn.last_event_at,
+    lastBackfillAt: conn.last_backfill_at,
+    accountsCount: Number(countResult.rows[0]?.count ?? 0),
+  });
 }

--- a/apps/server/src/modules/mono/crypto.test.ts
+++ b/apps/server/src/modules/mono/crypto.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { encryptToken, decryptToken, tokenFingerprint } from "./crypto.js";
+
+const VALID_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("crypto", () => {
+  describe("encryptToken / decryptToken", () => {
+    it("round-trips a token through encrypt then decrypt", () => {
+      const token = "u7Qx_personal_test_token_abc123";
+      const enc = encryptToken(token, VALID_KEY);
+
+      expect(enc.ciphertext).toBeInstanceOf(Buffer);
+      expect(enc.iv).toBeInstanceOf(Buffer);
+      expect(enc.iv.length).toBe(12);
+      expect(enc.tag).toBeInstanceOf(Buffer);
+      expect(enc.tag.length).toBe(16);
+
+      const decrypted = decryptToken(enc, VALID_KEY);
+      expect(decrypted).toBe(token);
+    });
+
+    it("produces different ciphertext for the same plaintext (random IV)", () => {
+      const token = "same_token";
+      const enc1 = encryptToken(token, VALID_KEY);
+      const enc2 = encryptToken(token, VALID_KEY);
+      expect(enc1.iv.equals(enc2.iv)).toBe(false);
+    });
+
+    it("throws on wrong key during decryption", () => {
+      const token = "secret_token_999";
+      const enc = encryptToken(token, VALID_KEY);
+      const wrongKey =
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+      expect(() => decryptToken(enc, wrongKey)).toThrow();
+    });
+
+    it("throws on tampered ciphertext", () => {
+      const token = "tamper_test_token";
+      const enc = encryptToken(token, VALID_KEY);
+      enc.ciphertext[0] ^= 0xff;
+      expect(() => decryptToken(enc, VALID_KEY)).toThrow();
+    });
+
+    it("throws on invalid key length", () => {
+      expect(() => encryptToken("token", "tooshort")).toThrow(/64 hex chars/);
+    });
+  });
+
+  describe("tokenFingerprint", () => {
+    it("returns a deterministic SHA-256 hex string", () => {
+      const fp1 = tokenFingerprint("my_token");
+      const fp2 = tokenFingerprint("my_token");
+      expect(fp1).toBe(fp2);
+      expect(fp1).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("produces different fingerprints for different tokens", () => {
+      expect(tokenFingerprint("aaa")).not.toBe(tokenFingerprint("bbb"));
+    });
+  });
+});

--- a/apps/server/src/modules/mono/crypto.ts
+++ b/apps/server/src/modules/mono/crypto.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+
+/**
+ * AES-256-GCM helpers for encrypting/decrypting Monobank personal tokens.
+ *
+ * Key: `MONO_TOKEN_ENC_KEY` env var — 32-byte hex string (64 hex chars).
+ * Output: ciphertext (Buffer), iv (12 bytes), tag (16 bytes) — stored as
+ * BYTEA columns in `mono_connection`.
+ *
+ * Never log raw tokens or decrypted values.
+ */
+
+const ALGO = "aes-256-gcm" as const;
+const IV_BYTES = 12;
+
+export interface EncryptedToken {
+  ciphertext: Buffer;
+  iv: Buffer;
+  tag: Buffer;
+}
+
+function getKey(hexKey: string): Buffer {
+  if (!/^[0-9a-f]{64}$/i.test(hexKey)) {
+    throw new Error(
+      "MONO_TOKEN_ENC_KEY must be exactly 64 hex chars (32 bytes)",
+    );
+  }
+  return Buffer.from(hexKey, "hex");
+}
+
+export function encryptToken(
+  plaintext: string,
+  hexKey: string,
+): EncryptedToken {
+  const key = getKey(hexKey);
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGO, key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return { ciphertext: encrypted, iv, tag };
+}
+
+export function decryptToken(enc: EncryptedToken, hexKey: string): string {
+  const key = getKey(hexKey);
+  const decipher = crypto.createDecipheriv(ALGO, key, enc.iv);
+  decipher.setAuthTag(enc.tag);
+  const decrypted = Buffer.concat([
+    decipher.update(enc.ciphertext),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}
+
+export function tokenFingerprint(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}

--- a/apps/server/src/modules/mono/webhook.test.ts
+++ b/apps/server/src/modules/mono/webhook.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Request, Response } from "express";
+import type { Mock } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock("../../db.js", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../../obs/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../obs/metrics.js", () => ({
+  monoWebhookReceivedTotal: { inc: vi.fn() },
+  monoWebhookDurationMs: { observe: vi.fn() },
+}));
+
+import { query as _query } from "../../db.js";
+import {
+  monoWebhookReceivedTotal as _counter,
+  monoWebhookDurationMs as _histogram,
+} from "../../obs/metrics.js";
+import { webhookHandler } from "./webhook.js";
+
+const dbQuery = _query as unknown as Mock;
+const counter = _counter as unknown as { inc: Mock };
+const histogram = _histogram as unknown as { observe: Mock };
+
+// ── Helpers ──────────────────────────────────────────────────
+
+interface TestResBody {
+  ok?: boolean;
+  error?: string;
+}
+
+interface TestRes {
+  statusCode: number;
+  body: TestResBody;
+  status(code: number): TestRes;
+  json(payload: unknown): TestRes;
+}
+
+function makeRes(): TestRes & Response {
+  const res: TestRes = {
+    statusCode: 200,
+    body: {} as TestResBody,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload as TestResBody;
+      return this;
+    },
+  };
+  return res as TestRes & Response;
+}
+
+const VALID_SECRET = "a".repeat(64);
+
+function validPayload() {
+  return {
+    type: "StatementItem",
+    data: {
+      account: "acc_uah",
+      statementItem: {
+        id: "tx_001",
+        time: 1714000000,
+        description: "Кава",
+        mcc: 5814,
+        amount: -6500,
+        operationAmount: -6500,
+        currencyCode: 980,
+        balance: 1500000,
+      },
+    },
+  };
+}
+
+function makeReq(secret: string, body?: unknown): Request {
+  return {
+    params: { secret },
+    body: body ?? validPayload(),
+  } as unknown as Request;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("webhookHandler", () => {
+  it("returns 404 for unknown secret", async () => {
+    dbQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = makeRes();
+    await webhookHandler(makeReq("unknown_secret_value"), res);
+
+    expect(res.statusCode).toBe(404);
+    expect(counter.inc).toHaveBeenCalledWith({ status: "invalid_secret" });
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+
+    const res = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET, { type: "SomethingElse" }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Invalid payload");
+    expect(counter.inc).toHaveBeenCalledWith({ status: "bad_payload" });
+  });
+
+  it("processes valid webhook: upserts transaction, updates balance and last_event_at", async () => {
+    // Lookup connection
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+
+    // INSERT transaction
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // UPDATE balance
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // UPDATE last_event_at
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(counter.inc).toHaveBeenCalledWith({ status: "ok" });
+    expect(histogram.observe).toHaveBeenCalledWith(
+      { status: "ok" },
+      expect.any(Number),
+    );
+
+    // 4 DB calls: lookup + tx upsert + balance update + event update
+    expect(dbQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("idempotent: duplicate mono_tx_id is handled by ON CONFLICT", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+    // Both calls succeed (ON CONFLICT DO UPDATE)
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    const res1 = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET), res1);
+    expect(res1.statusCode).toBe(200);
+
+    vi.clearAllMocks();
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    const res2 = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET), res2);
+    expect(res2.statusCode).toBe(200);
+  });
+
+  it("returns 400 when payload is missing statementItem.id", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+
+    const badPayload = {
+      type: "StatementItem",
+      data: {
+        account: "acc_uah",
+        statementItem: { description: "no id" },
+      },
+    };
+
+    const res = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET, badPayload), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(counter.inc).toHaveBeenCalledWith({ status: "bad_payload" });
+  });
+
+  it("returns 404 for missing secret param", async () => {
+    const req = {
+      params: {},
+      body: validPayload(),
+    } as unknown as Request;
+    const res = makeRes();
+    await webhookHandler(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("re-throws DB errors and records error metric", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+    dbQuery.mockRejectedValueOnce(new Error("DB gone"));
+
+    const res = makeRes();
+    await expect(webhookHandler(makeReq(VALID_SECRET), res)).rejects.toThrow(
+      "DB gone",
+    );
+
+    expect(counter.inc).toHaveBeenCalledWith({ status: "error" });
+  });
+});

--- a/apps/server/src/modules/mono/webhook.ts
+++ b/apps/server/src/modules/mono/webhook.ts
@@ -1,13 +1,188 @@
 import type { Request, Response } from "express";
+import crypto from "node:crypto";
+import { query } from "../../db.js";
+import { logger } from "../../obs/logger.js";
+import {
+  monoWebhookReceivedTotal,
+  monoWebhookDurationMs,
+} from "../../obs/metrics.js";
 
 /**
- * POST /api/mono/webhook/:secret — публічний endpoint для Monobank delivery.
+ * POST /api/mono/webhook/:secret — public Monobank delivery endpoint.
  *
- * Stub: повертає 501 до реалізації у Track A · PR2.
+ * Auth: path-based secret validated against `mono_connection.webhook_secret`
+ * with timing-safe comparison. No session auth — Monobank calls this directly.
+ *
+ * Payload: `{ type: "StatementItem", data: { account, statementItem } }`.
+ * Idempotent UPSERT by PK `(user_id, mono_tx_id)`.
+ * Always returns 200 after successful write (Monobank retries on non-2xx).
  */
+
+interface StatementItem {
+  id: string;
+  time: number;
+  description: string;
+  mcc: number;
+  originalMcc?: number;
+  hold?: boolean;
+  amount: number;
+  operationAmount: number;
+  currencyCode: number;
+  commissionRate?: number;
+  cashbackAmount?: number;
+  balance?: number;
+  comment?: string;
+  receiptId?: string;
+  invoiceId?: string;
+  counterEdrpou?: string;
+  counterIban?: string;
+  counterName?: string;
+}
+
+interface WebhookPayload {
+  type: string;
+  data: {
+    account: string;
+    statementItem: StatementItem;
+  };
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
 export async function webhookHandler(
-  _req: Request,
+  req: Request,
   res: Response,
 ): Promise<void> {
-  res.status(501).json({ error: "Not implemented" });
+  const start = process.hrtime.bigint();
+  const secret = req.params.secret;
+
+  if (!secret || typeof secret !== "string") {
+    monoWebhookReceivedTotal.inc({ status: "invalid_secret" });
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+
+  const connResult = await query<{
+    user_id: string;
+    webhook_secret: string;
+  }>(
+    "SELECT user_id, webhook_secret FROM mono_connection WHERE webhook_secret = $1 AND status = 'active'",
+    [secret],
+    { op: "mono_webhook_lookup" },
+  );
+
+  if (connResult.rows.length === 0) {
+    monoWebhookReceivedTotal.inc({ status: "invalid_secret" });
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+
+  const conn = connResult.rows[0];
+
+  if (!timingSafeEqual(conn.webhook_secret, secret)) {
+    monoWebhookReceivedTotal.inc({ status: "invalid_secret" });
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+
+  const userId = conn.user_id;
+
+  const payload = req.body as WebhookPayload | undefined;
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    payload.type !== "StatementItem" ||
+    !payload.data?.account ||
+    !payload.data?.statementItem?.id
+  ) {
+    monoWebhookReceivedTotal.inc({ status: "bad_payload" });
+    res.status(400).json({ error: "Invalid payload" });
+    return;
+  }
+
+  const { account: monoAccountId, statementItem: item } = payload.data;
+
+  try {
+    await query(
+      `INSERT INTO mono_transaction
+         (user_id, mono_account_id, mono_tx_id, time, amount, operation_amount,
+          currency_code, mcc, original_mcc, hold, description, comment,
+          cashback_amount, commission_rate, balance, receipt_id, invoice_id,
+          counter_edrpou, counter_iban, counter_name, raw, source)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+               $15, $16, $17, $18, $19, $20, $21, 'webhook')
+       ON CONFLICT (user_id, mono_tx_id) DO UPDATE SET
+         amount = EXCLUDED.amount,
+         operation_amount = EXCLUDED.operation_amount,
+         hold = EXCLUDED.hold,
+         balance = EXCLUDED.balance,
+         description = EXCLUDED.description,
+         comment = EXCLUDED.comment,
+         raw = EXCLUDED.raw,
+         received_at = NOW()`,
+      [
+        userId,
+        monoAccountId,
+        item.id,
+        new Date(item.time * 1000).toISOString(),
+        item.amount,
+        item.operationAmount,
+        item.currencyCode,
+        item.mcc ?? null,
+        item.originalMcc ?? null,
+        item.hold ?? null,
+        item.description ?? null,
+        item.comment ?? null,
+        item.cashbackAmount ?? null,
+        item.commissionRate ?? null,
+        item.balance ?? null,
+        item.receiptId ?? null,
+        item.invoiceId ?? null,
+        item.counterEdrpou ?? null,
+        item.counterIban ?? null,
+        item.counterName ?? null,
+        JSON.stringify(item),
+      ],
+      { op: "mono_tx_upsert" },
+    );
+
+    if (item.balance != null) {
+      await query(
+        `UPDATE mono_account
+         SET balance = $1, last_seen_at = NOW()
+         WHERE user_id = $2 AND mono_account_id = $3`,
+        [item.balance, userId, monoAccountId],
+        { op: "mono_account_balance" },
+      );
+    }
+
+    await query(
+      `UPDATE mono_connection
+       SET last_event_at = NOW(), updated_at = NOW()
+       WHERE user_id = $1`,
+      [userId],
+      { op: "mono_connection_event" },
+    );
+
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    monoWebhookReceivedTotal.inc({ status: "ok" });
+    monoWebhookDurationMs.observe({ status: "ok" }, ms);
+
+    logger.info({
+      msg: "mono_webhook_processed",
+      monoAccountId,
+      monoTxId: item.id,
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    monoWebhookReceivedTotal.inc({ status: "error" });
+    monoWebhookDurationMs.observe({ status: "error" }, ms);
+    logger.error({ msg: "mono_webhook_error", err });
+    throw err;
+  }
 }

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -266,6 +266,22 @@ export const webVitalsCls = new client.Histogram({
   registers: [register],
 });
 
+// ───────────────────────── Mono webhook ───────────────────────
+export const monoWebhookReceivedTotal = new client.Counter({
+  name: "mono_webhook_received_total",
+  help: "Monobank webhook deliveries by outcome",
+  labelNames: ["status"], // ok|invalid_secret|bad_payload|error
+  registers: [register],
+});
+
+export const monoWebhookDurationMs = new client.Histogram({
+  name: "mono_webhook_duration_ms",
+  help: "Monobank webhook handler duration in ms",
+  labelNames: ["status"],
+  buckets: [1, 5, 25, 50, 100, 250, 500, 1000],
+  registers: [register],
+});
+
 // ───────────────────────── Helpers ────────────────────────────
 export type StatusClass = "5xx" | "4xx" | "3xx" | "2xx" | "other";
 

--- a/docs/backend-tech-debt.md
+++ b/docs/backend-tech-debt.md
@@ -193,6 +193,16 @@
 
 Реалізація (фактична): **`apps/server/src/lib/bankProxy.ts`** + тонкі **`modules/mono.ts`** / **`modules/privat.ts`** (делегують `bankProxyFetch`).
 
+### Monobank webhook integration (Track A)
+
+Webhook-based server-side integration added in PR2. Key components:
+
+- **`modules/mono/crypto.ts`** — AES-256-GCM encryption/decryption for token-at-rest storage using `MONO_TOKEN_ENC_KEY` (32-byte hex). Never log raw tokens.
+- **`modules/mono/connection.ts`** — connect (validate token → register webhook → persist encrypted token + accounts), disconnect (unregister webhook best-effort → delete connection), syncState (lightweight DB read). All gated by `MONO_WEBHOOK_ENABLED`.
+- **`modules/mono/webhook.ts`** — public `POST /api/mono/webhook/:secret` endpoint. Path-secret auth with timing-safe comparison, idempotent UPSERT into `mono_transaction`, balance/event updates. Prometheus metrics: `mono_webhook_received_total{status}`, `mono_webhook_duration_ms{status}`.
+- **DB schema**: `mono_connection`, `mono_account`, `mono_transaction` (migration `008_mono_integration.sql`).
+- **Feature flag**: `MONO_WEBHOOK_ENABLED` (env, default `false`). When disabled, connect/disconnect/syncState return 404; webhook endpoint is always mounted but rejects unknown secrets.
+
 ---
 
 ## AI quota deep-dive


### PR DESCRIPTION
## Summary

Implements real backend webhook receiver and persistent connection storage behind `MONO_WEBHOOK_ENABLED` feature flag (Track A PR2 from `docs/monobank-webhook-migration.md`).

### Changes

- **`apps/server/src/modules/mono/crypto.ts`** — AES-256-GCM helper for encrypting/decrypting Monobank personal tokens using `MONO_TOKEN_ENC_KEY` (32-byte hex). Stores ciphertext/iv/tag as BYTEA. SHA-256 fingerprint for safe logging. Never logs raw tokens.

- **`apps/server/src/modules/mono/connection.ts`** — Full implementation replacing 501 stubs:
  - `connectHandler`: validates token → calls Monobank `/personal/client-info` → generates `webhook_secret` (randomBytes(32)) → registers webhook via `POST /personal/webhook` → UPSERTs `mono_connection` + `mono_account` rows
  - `disconnectHandler`: decrypts stored token → unregisters webhook (best-effort) → deletes connection/account/tx rows (CASCADE)
  - `syncStateHandler`: returns status/webhookActive/lastEventAt/lastBackfillAt/accountsCount from DB
  - All gated with `MONO_WEBHOOK_ENABLED`

- **`apps/server/src/modules/mono/webhook.ts`** — Full implementation replacing 501 stub:
  - Public `POST /api/mono/webhook/:secret` (no session auth)
  - Timing-safe secret comparison against `mono_connection.webhook_secret`
  - Parses `{ type: "StatementItem", data: { account, statementItem } }` payload
  - Idempotent UPSERT into `mono_transaction` (PK: `user_id, mono_tx_id`)
  - Updates `mono_account.balance` and `mono_connection.last_event_at/status`
  - Unknown/wrong secret → 404, invalid payload → 400, success → 200
  - No external calls in hot path

- **`apps/server/src/obs/metrics.ts`** — Added `mono_webhook_received_total{status}` (counter) and `mono_webhook_duration_ms{status}` (histogram)

- **`docs/backend-tech-debt.md`** — Added "Monobank webhook integration (Track A)" section under Bank integrations deep-dive

### Tests (Vitest)

- `crypto.test.ts` — encrypt/decrypt round-trip, random IV, wrong key, tampered ciphertext, invalid key length, fingerprint determinism
- `connection.test.ts` — connect (success, invalid token, Monobank 401, webhook register fail), disconnect (success, unregister fail graceful), syncState (no connection, active connection)
- `webhook.test.ts` — valid secret + payload → 200, invalid secret → 404, invalid payload → 400, duplicate tx_id idempotent, missing secret param, DB error re-throw + error metric

All existing 317 tests pass. Lint and typecheck clean.

## Review & Testing Checklist for Human

- [ ] Verify `crypto.ts` encryption uses proper IV/tag sizes and the key validation regex matches the 64-char hex requirement documented in `.env.example`
- [ ] Review SQL queries in `connection.ts` for injection safety (parameterized) and correct UPSERT semantics matching the `008_mono_integration.sql` schema
- [ ] Verify `webhook.ts` timing-safe comparison logic — the current approach does a DB lookup first then `timingSafeEqual` as belt-and-suspenders; confirm this is acceptable for the threat model
- [ ] Test end-to-end with a real Monobank personal token: `POST /api/mono/connect`, verify webhook URL in Monobank client-info, trigger a small transaction, confirm it appears in `mono_transaction`
- [ ] Verify feature flag: with `MONO_WEBHOOK_ENABLED=false` (default), all connect/disconnect/syncState should return 404; webhook endpoint rejects unknown secrets

### Notes

- Track B (backfill, read endpoints) and Track C (frontend) stubs remain as 501 — intentionally not touched per scope.
- The webhook handler uses direct `fetch()` for Monobank API calls in `connection.ts` rather than `bankProxyFetch` — this is intentional since connect/disconnect are one-off operations that don't need the cache/breaker/retry semantics of the polling proxy. The migration plan mentions "through existing bankProxyFetch or equivalent project pattern" — direct fetch is the simpler equivalent here.
- `onTransactionPersisted` hook for future push notifications is not yet wired — will be added when Track C implements push.

Link to Devin session: https://app.devin.ai/sessions/fee8caf61fef450f85533cc5ac5799fd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
