### PR TITLE
fix: combine greeting + date into single line with dot separator

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -141,17 +141,18 @@ export function HubHeader({
         </span>
       </div>
 
-      {/* ── Row 3: Greeting + date ────────────────────────────── */}
-      <div className="mt-2 ml-[3px]">
-        <p className="text-[13px] leading-snug text-muted truncate">
-          {greetingText}
-        </p>
+      {/* ── Row 3: Greeting · date (single line) ──────────────── */}
+      <p className="mt-1.5 ml-[3px] text-[13px] leading-snug text-muted truncate">
+        {greetingText}
         {dateStr && (
-          <p className="text-[13px] leading-snug text-subtle truncate">
-            {dateStr}
-          </p>
+          <>
+            <span className="mx-1.5 text-subtle" aria-hidden="true">
+              ·
+            </span>
+            <span className="text-subtle">{dateStr}</span>
+          </>
         )}
-      </div>
+      </p>
     </header>
   );
 }


### PR DESCRIPTION
## Summary

Merges the two-line greeting/date block into a compact single line with a middle-dot separator:

**Before:** two stacked lines
```
Доброго дня
Субота, 25 квітня
```

**After:** single clean line
```
Доброго дня · Субота, 25 квітня
```

Tighter visual hierarchy, more balanced with the subtitle row above it.

## Review & Testing Checklist for Human
- [ ] Verify the greeting + date render on one line on a narrow mobile viewport (375px) — check that `truncate` kicks in gracefully if the combined text overflows

### Notes
- Only `HubHeader.tsx` changed — 1 line replaces 2, wrapped in `<p>` with inline `<span>` for the dot separator and date
- ESLint and TypeScript clean

Link to Devin session: https://app.devin.ai/sessions/defd10fbe48b414bbd58511b35dde31c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
