### PR TITLE
fix(server): copy SQL migrations to dist-server during build

### DIFF
--- a/apps/server/build.mjs
+++ b/apps/server/build.mjs
@@ -1,6 +1,9 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
-const isCi = process.env.CI === "true";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import("esbuild").BuildOptions} */
 const base = {
@@ -46,7 +49,14 @@ await build({
   legalComments: "none",
 });
 
-if (!isCi) {
-  // Best-effort sanity check: ensure the output files exist by letting
-  // esbuild throw if anything failed above.
-}
+// `runPendingSqlMigrations` resolves `migrationsDir` as
+// `path.join(__dirname, "migrations")`, де `__dirname` після bundling — це
+// `dist-server/`. esbuild не копіює нон-JS ассети сам, тому без цього кроку
+// `fs.readdir` на проді падав у ENOENT і runner мовчки no-op-ив (повертав
+// `migrate_ok` для порожнього списку файлів). Копіюємо `src/migrations` у
+// `dist-server/migrations`, щоб і runtime-старт, і Pre-Deploy job бачили
+// усі pending SQL-файли.
+const srcMigrations = path.join(__dirname, "src", "migrations");
+const distMigrations = path.join(__dirname, "dist-server", "migrations");
+await fs.rm(distMigrations, { recursive: true, force: true });
+await fs.cp(srcMigrations, distMigrations, { recursive: true });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,8 @@ export default [
     ignores: [
       "dist/**",
       "**/dist/**",
+      "dist-server/**",
+      "**/dist-server/**",
       "**/node_modules/**",
       "node_modules/**",
       ".agents/**",


### PR DESCRIPTION
## Summary

Latent bug у білді сервера: `apps/server/build.mjs` бандлить тільки JS-ентрі (`src/index.ts`, `migrate.mjs`) і **не копіює** `src/migrations/*.sql` у `dist-server/`. Runtime-код у `apps/server/src/db.ts:154` резолвить `migrationsDir = path.join(__dirname, "migrations")`, що після bundling = `/app/apps/server/dist-server/migrations` — такого каталогу не існує.

`runPendingSqlMigrations` ловить `ENOENT` від `fs.readdir` і **silently no-ops** (повертає без помилки → `migrate.mjs` логує `migrate_ok` для нуля файлів). Реальний ефект на Railway prod: жодна нова міграція не застосовувалася через Pre-Deploy job (`npm run db:migrate` → `node dist-server/migrate.js`), хоча у логах було `migrate_ok`.

Це вилізло сьогодні під час cutover-у Monobank webhook міграції: `008_mono_integration.sql` не застосувалася → webhook handler падав з `42P01 (relation does not exist)` на `mono_connection`. Міграцію застосував руками через `psql` напряму на проді (запис у `schema_migrations` додав), але без цього фіксу наступна міграція впаде так само.

### Зміни

- **`apps/server/build.mjs`**: після `esbuild` додаємо `fs.cp(src/migrations, dist-server/migrations, { recursive: true })`. `fs.rm` перед цим — щоб stale-файли (наприклад видалена міграція) не залишалися у dist.
- **`eslint.config.js`**: додано `dist-server/**` у `ignores`. Без цього локальний `pnpm lint` після `pnpm build` падав з 800+ no-unused-vars помилок на згенерованому 14k-рядковому бандлі. CI це не зачіпає (там build і lint у різних job-ах), але локальна DX тепер чистіша.

### Чому це впливало раніше

001-007 міграції у `schema_migrations` потрапили туди раніше (можливо через `db:migrate:dev` + tsx, або руками). Тому додаток працював і ніхто не помічав, що Pre-Deploy job насправді no-op-ить. Тепер фіксується по-справжньому.

## Review & Testing Checklist for Human

- [ ] Перевір, що `pnpm --filter @sergeant/server build` створює `apps/server/dist-server/migrations/` з усіма 8 SQL-файлами (включно з `*.down.sql`).
- [ ] У наступному релізі на Railway переконайся що **новий** Pre-Deploy лог показує `migrate_applied` для будь-якої pending міграції (зараз `008_mono_integration.sql` уже у `schema_migrations`, тому він буде no-op — але якщо створиш `009_*.sql`, перевір що він застосувався автоматично).
- [ ] Локально виконати `pnpm --filter @sergeant/server lint` після `pnpm build` — лінт має пройти (раніше падав через bundle).

### Notes

- `*.down.sql` теж копіюються; runner їх явно фільтрує (`db.ts:168`), так що це безпечно.
- Розглянь окремо: додати у `migrate.mjs` warning-лог якщо `migrationsDir` ENOENT — щоб у майбутньому така проблема не була мовчазною. Не включаю у цей PR щоб не змішувати скоупи.

Link to Devin session: https://app.devin.ai/sessions/1b89fd935c5849029a2746bd5e89114c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build script to ensure database migration assets are correctly included in server distributions.
  * Updated linting configuration to exclude server distribution directories from code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->