### PR TITLE
feat(finyk): roll out Monobank webhook to all users (default flag → true)

### DIFF
--- a/apps/web/src/core/lib/featureFlags.ts
+++ b/apps/web/src/core/lib/featureFlags.ts
@@ -55,9 +55,8 @@ export const FLAG_REGISTRY: readonly FlagDefinition[] = [
     id: "mono_webhook",
     label: "Monobank Webhook (server-side sync)",
     description:
-      "Використовувати серверні webhook-транзакції замість клієнтського polling. Потрібна підтримка бекенду (Track A/B).",
-    defaultValue: false,
-    experimental: true,
+      "Серверні webhook-транзакції замість клієнтського polling. Реалтайм-доставка, токен зберігається на сервері (зашифровано).",
+    defaultValue: true,
   },
 ] as const;
 

--- a/docs/monobank-webhook-migration.md
+++ b/docs/monobank-webhook-migration.md
@@ -1,6 +1,6 @@
 # Monobank: міграція з polling на webhook
 
-> Status: **Draft** (2026-04-25). Складено перед розпаралелюванням робіт у 3 child-сесії. Після review та merge перших PR — оновлювати **Status log** внизу.
+> Status: **Rolled out** (2026-04-25). Усі 3 треки змерджено в `main`, env Railway виставлено, smoke-тест на проді пройдено (webhook-доставка ~2 с після транзакції). Default фіче-флагу `mono_webhook` → `true` цим PR-ом. Cleanup legacy polling — окремим PR після кількох днів observability.
 
 ## TL;DR
 
@@ -286,6 +286,14 @@ pnpm --filter @sergeant/server dev
 
 ## Status log
 
-| Дата       | PR      | Track | Результат                     |
-| ---------- | ------- | ----- | ----------------------------- |
-| 2026-04-25 | (draft) | —     | План створено, очікує review. |
+| Дата       | PR    | Track   | Результат                                                                                                                                                                                             |
+| ---------- | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-25 | #695  | —       | План змерджено.                                                                                                                                                                                       |
+| 2026-04-25 | #697  | A.PR1   | DB-міграція `008_mono_integration.sql` + DTO стаби.                                                                                                                                                   |
+| 2026-04-25 | #699  | A.PR2   | Webhook receiver, AES-GCM шифрування токена, connect/disconnect.                                                                                                                                      |
+| 2026-04-25 | #700  | B       | DB-backed `/api/mono/{accounts,transactions,sync-state,backfill}`, backfill 31д, `useMonoTransactions`.                                                                                               |
+| 2026-04-25 | #702  | C       | Frontend connect flow, settings UX, auto token migration.                                                                                                                                             |
+| 2026-04-25 | (ops) | cutover | Виставлено `MONO_WEBHOOK_ENABLED=true`, `MONO_TOKEN_ENC_KEY`, `PUBLIC_API_BASE_URL` на Railway. Міграцію 008 застосовано вручну на проді (див. PR #704 — фікс білда). Smoke-тест webhook delivery ОК. |
+| 2026-04-25 | #704  | ops     | Fix: `build.mjs` тепер копіює `src/migrations/*.sql` у `dist-server/migrations` (раніше Pre-Deploy job мовчки no-op-ив).                                                                              |
+| 2026-04-25 | (TBD) | rollout | `mono_webhook` default → `true`, прибрано `experimental`.                                                                                                                                             |
+| TBD        | TBD   | cleanup | Видалено `useMonobankLegacy`, `enqueueStatementCall`, `useMonoStatements`, snapshot fallback, ключі `finyk_token*`.                                                                                   |


### PR DESCRIPTION
## Summary

Розкатуємо Monobank webhook-міграцію на всіх юзерів. Усі залежності вже на місці:

- ✓ DB-міграція `008_mono_integration.sql` застосована на проді
- ✓ Env-змінні `MONO_WEBHOOK_ENABLED=true`, `MONO_TOKEN_ENC_KEY`, `PUBLIC_API_BASE_URL` виставлені у Railway
- ✓ Webhook-receiver, connect/disconnect, backfill, read-endpoints, frontend connect-flow, auto token migration — усе змерджено (PR #697, #699, #700, #702)
- ✓ Smoke-тест на проді: транзакція 1 грн → 2 webhook events у БД через ~2 с (`source='webhook'`, `last_event_at` оновлено)
- ✓ Latent build bug пофіксено у #704 (raніше pre-deploy мовчки no-op-ив)

### Зміни

- **`apps/web/src/core/lib/featureFlags.ts`**:
  - `mono_webhook.defaultValue: false → true` — нові юзери на свіжому web автоматично у webhook-режимі.
  - `experimental: true` прибрано — флаг більше не у розділі «🧪 Експериментальне» (`ExperimentalSection` фільтрує по цьому полю).
  - `description` переписано під актуальний стан (без згадок про backend dependencies).

- **`docs/monobank-webhook-migration.md`**: status 'Draft' → 'Rolled out', status log заповнено по всіх треках + ops-крокам.

### Поведінка для існуючих юзерів

| Стан LS | Раніше | Тепер |
| --- | --- | --- |
| `mono_webhook` не торкався (немає у `hub_flags_v1`) | legacy polling | webhook (auto-token-migration з `finyk_token` у LS → `POST /api/mono/connect`, потім `removeItem`) |
| `mono_webhook=true` явно увімкнено | webhook | webhook (без змін) |
| `mono_webhook=false` явно вимкнено | legacy | legacy (поважаємо вибір; cleanup-PR пізніше зніме цю можливість) |

`useMonoTokenMigration.ts` гард: повторно не мігрує (ref + `mono_token_migrated` флаг у LS).

## Review & Testing Checklist for Human

- [ ] Перевір на свіжому браузері (incognito) що Settings → ФІНІК одразу показує webhook UI без потреби вмикати флаг.
- [ ] Перевір на пристрої де `finyk_token` живе у LS, що auto-migration працює (один раз POST на `/api/mono/connect`, потім ключ видаляється з storage).
- [ ] Якщо є тестовий юзер з явно вимкненим флагом — переконайся що legacy polling все ще працює (бо ми бережемо їх вибір).
- [ ] Дай 24-48 год observability (`mono_webhook_received_total{status}`, `mono_webhook_duration_seconds`, error rate) перед cleanup-PR-ом, який видалить legacy код.

### Notes

- Cleanup-PR (наступний у цій лінійці) видалить: `useMonobankLegacy`, `enqueueStatementCall`, `useMonoStatements` (старий), snapshot fallback, ключі `finyk_token*` з `storageKeys.ts`, legacy proxy `/api/mono?path=/personal/statement/...`. Не змішую з цим, щоб у разі регресу можна було revert-нути тільки розкатку.
- 6 featureFlags тестів проходять локально, FinykSection (5) і useMonobankWebhook+useMonoTokenMigration (12) теж зелені.

Link to Devin session: https://app.devin.ai/sessions/1b89fd935c5849029a2746bd5e89114c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Monobank webhook feature is now enabled by default, providing real-time transaction delivery with secure server-stored encrypted tokens.

* **Documentation**
  * Updated migration documentation to reflect completed rollout of webhook functionality across all tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->