### PR TITLE
fix(finyk): handle paginated response from /api/mono/transactions

### DIFF
--- a/apps/web/src/modules/finyk/hooks/useMonoTransactions.test.tsx
+++ b/apps/web/src/modules/finyk/hooks/useMonoTransactions.test.tsx
@@ -70,7 +70,10 @@ describe("useMonoTransactions", () => {
         receivedAt: "2025-01-15T12:00:01Z",
       },
     ];
-    mockedTransactions.mockResolvedValueOnce(txData);
+    mockedTransactions.mockResolvedValueOnce({
+      data: txData,
+      nextCursor: null,
+    });
 
     const { result } = renderHook(
       () =>
@@ -86,7 +89,7 @@ describe("useMonoTransactions", () => {
   });
 
   it("returns empty array when no data", async () => {
-    mockedTransactions.mockResolvedValueOnce([]);
+    mockedTransactions.mockResolvedValueOnce({ data: [], nextCursor: null });
 
     const { result } = renderHook(
       () => useMonoTransactions("2025-01-01", "2025-01-31"),

--- a/apps/web/src/modules/finyk/hooks/useMonoTransactions.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonoTransactions.ts
@@ -49,7 +49,7 @@ export function useMonoTransactions(
   });
 
   return {
-    transactions: data ?? [],
+    transactions: data?.data ?? [],
     isFetching,
     isLoading,
     error: error ?? null,

--- a/apps/web/src/modules/finyk/hooks/useMonobankWebhook.test.tsx
+++ b/apps/web/src/modules/finyk/hooks/useMonobankWebhook.test.tsx
@@ -108,32 +108,35 @@ describe("useMonobankWebhook", () => {
         lastSeenAt: "2024-01-15T10:00:00Z",
       },
     ]);
-    mockedTransactions.mockResolvedValue([
-      {
-        userId: "u1",
-        monoAccountId: "acc1",
-        monoTxId: "tx1",
-        time: "2024-01-15T09:00:00Z",
-        amount: -5000,
-        operationAmount: -5000,
-        currencyCode: 980,
-        mcc: 5411,
-        originalMcc: null,
-        hold: false,
-        description: "Сільпо",
-        comment: null,
-        cashbackAmount: 50,
-        commissionRate: null,
-        balance: 95000,
-        receiptId: null,
-        invoiceId: null,
-        counterEdrpou: null,
-        counterIban: null,
-        counterName: null,
-        source: "webhook",
-        receivedAt: "2024-01-15T09:00:01Z",
-      },
-    ]);
+    mockedTransactions.mockResolvedValue({
+      data: [
+        {
+          userId: "u1",
+          monoAccountId: "acc1",
+          monoTxId: "tx1",
+          time: "2024-01-15T09:00:00Z",
+          amount: -5000,
+          operationAmount: -5000,
+          currencyCode: 980,
+          mcc: 5411,
+          originalMcc: null,
+          hold: false,
+          description: "Сільпо",
+          comment: null,
+          cashbackAmount: 50,
+          commissionRate: null,
+          balance: 95000,
+          receiptId: null,
+          invoiceId: null,
+          counterEdrpou: null,
+          counterIban: null,
+          counterName: null,
+          source: "webhook",
+          receivedAt: "2024-01-15T09:00:01Z",
+        },
+      ],
+      nextCursor: null,
+    });
 
     const { result } = renderHook(() => useMonobankWebhook(), {
       wrapper: makeWrapper(),
@@ -202,7 +205,7 @@ describe("useMonobankWebhook", () => {
         lastSeenAt: "2024-01-15T10:00:00Z",
       },
     ]);
-    mockedTransactions.mockResolvedValue([]);
+    mockedTransactions.mockResolvedValue({ data: [], nextCursor: null });
 
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -234,7 +237,7 @@ describe("useMonobankWebhook", () => {
       accountsCount: 1,
     });
     mockedAccounts.mockResolvedValue([]);
-    mockedTransactions.mockResolvedValue([]);
+    mockedTransactions.mockResolvedValue({ data: [], nextCursor: null });
     mockedDisconnect.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useMonobankWebhook(), {

--- a/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
@@ -6,6 +6,7 @@ import {
   type MonoSyncState,
   type MonoAccountDto,
   type MonoTransactionDto,
+  type MonoTransactionsPage,
 } from "@shared/api";
 import { finykKeys, hubKeys } from "@shared/lib/queryKeys";
 import { authAwareRetry } from "@shared/lib/queryClient";
@@ -120,7 +121,7 @@ export function useMonobankWebhook({
   ).toISOString();
   const txQueryKey = `${fromDate}|${toDate}`;
 
-  const txQuery = useQuery<MonoTransactionDto[]>({
+  const txQuery = useQuery<MonoTransactionsPage>({
     queryKey: finykKeys.monoWebhookTransactions(txQueryKey),
     queryFn: ({ signal }) =>
       monoWebhookApi.transactions({ from: fromDate, to: toDate }, { signal }),
@@ -131,8 +132,9 @@ export function useMonobankWebhook({
   });
 
   const transactions: Transaction[] = useMemo(() => {
-    if (!txQuery.data) return [];
-    return txQuery.data
+    const items = txQuery.data?.data;
+    if (!items) return [];
+    return items
       .map(webhookTxToNormalized)
       .sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
   }, [txQuery.data]);
@@ -200,7 +202,7 @@ export function useMonobankWebhook({
         const to = new Date(year, month + 1, 1).toISOString();
         const key = `${from}|${to}`;
 
-        const data = await queryClient.fetchQuery({
+        const page = await queryClient.fetchQuery({
           queryKey: finykKeys.monoWebhookTransactions(key),
           queryFn: ({ signal }) =>
             monoWebhookApi.transactions({ from, to }, { signal }),
@@ -208,7 +210,7 @@ export function useMonobankWebhook({
           retry: authAwareRetry(2),
         });
 
-        const normalized = (data || [])
+        const normalized = (page?.data ?? [])
           .map(webhookTxToNormalized)
           .sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
         setHistoryTx(normalized);

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -89,6 +89,7 @@ export type {
   MonoStatementEntry,
   MonoSyncState,
   MonoTransactionDto,
+  MonoTransactionsPage,
   MonoWebhookEndpoints,
   NutritionBackupDownloadResponse,
   NutritionBackupUploadResponse,

--- a/packages/api-client/src/endpoints/mono-webhook.test.ts
+++ b/packages/api-client/src/endpoints/mono-webhook.test.ts
@@ -102,7 +102,8 @@ describe("createMonoWebhookEndpoints", () => {
         receivedAt: "2025-01-15T12:00:01Z",
       },
     ];
-    fetchMock.mockResolvedValueOnce(jsonResponse(txs));
+    const page = { data: txs, nextCursor: null };
+    fetchMock.mockResolvedValueOnce(jsonResponse(page));
 
     const endpoints = createMonoWebhookEndpoints(createHttpClient());
     const result = await endpoints.transactions({
@@ -112,7 +113,7 @@ describe("createMonoWebhookEndpoints", () => {
       limit: 10,
     });
 
-    expect(result).toEqual(txs);
+    expect(result).toEqual(page);
     const url = new URL(
       fetchMock.mock.calls[0][0] as string,
       "http://localhost",

--- a/packages/api-client/src/endpoints/mono.ts
+++ b/packages/api-client/src/endpoints/mono.ts
@@ -66,6 +66,16 @@ export interface MonoSyncState {
   accountsCount: number;
 }
 
+/**
+ * Cursor-paginated response from `GET /api/mono/transactions`. Server returns
+ * up to `limit` items (default 50) ordered by `(time DESC, monoTxId DESC)`;
+ * `nextCursor` is non-null when more rows are available.
+ */
+export interface MonoTransactionsPage {
+  data: MonoTransactionDto[];
+  nextCursor: string | null;
+}
+
 export interface MonoAccount {
   id: string;
   sendId?: string;
@@ -286,7 +296,7 @@ export interface MonoWebhookEndpoints {
       cursor?: string;
     },
     opts?: { signal?: AbortSignal },
-  ) => Promise<MonoTransactionDto[]>;
+  ) => Promise<MonoTransactionsPage>;
   backfill: (opts?: { signal?: AbortSignal }) => Promise<void>;
 }
 
@@ -313,7 +323,7 @@ export function createMonoWebhookEndpoints(
         signal: opts?.signal,
       }),
     transactions: (params, opts) =>
-      http.get<MonoTransactionDto[]>("/api/mono/transactions", {
+      http.get<MonoTransactionsPage>("/api/mono/transactions", {
         query: params,
         signal: opts?.signal,
       }),

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -130,6 +130,7 @@ export {
   type MonoStatementEntry,
   type MonoSyncState,
   type MonoTransactionDto,
+  type MonoTransactionsPage,
   type MonoWebhookEndpoints,
 } from "./endpoints/mono";
 


### PR DESCRIPTION
## Summary

**HOTFIX для регресії після розкатки `mono_webhook=true`** (PR #705). Усі юзери з активним webhook-підключенням бачили на сторінці Фінік помилку:

```
T.data.map is not a function. (In 'T.data.map(vs)', 'T.data.map' is undefined)
```

### Root cause

Track B (PR #700) реалізував cursor pagination для `GET /api/mono/transactions` — сервер повертає `{ data: MonoTransactionDto[], nextCursor: string | null }`. Track C (PR #702) написав фронт-консьюмери (`useMonobankWebhook`, `useMonoTransactions`), припустивши що ендпоінт повертає bare array — типи в `@sergeant/api-client` оголошували `Promise<MonoTransactionDto[]>`. Невідповідність типу сервер↔клієнт була; вона ховалася бо:

1. Фіче-флаг був OFF за замовчуванням → код-шлях ніколи не виконувався у проді.
2. Тести мокали `monoWebhookApi.transactions` через `mockResolvedValue([...])` (масив) замість справжньої форми, тож контракт ніхто не валідував end-to-end.

PR #705 зробив default `true` → код-шлях активувався → впала спроба `txQuery.data.map(webhookTxToNormalized)` де `txQuery.data` фактично `{ data: [...], nextCursor }`, а `.map` на ньому undefined.

### Зміни

- **`packages/api-client/src/endpoints/mono.ts`**: новий тип `MonoTransactionsPage = { data: MonoTransactionDto[]; nextCursor: string | null }`; `transactions(...)` тепер `Promise<MonoTransactionsPage>`. Це тепер відповідає реальному контракту сервера у <ref_snippet file="/home/ubuntu/repos/Sergeant/apps/server/src/modules/mono/read.ts" lines="186-188" />.
- **`packages/api-client/src/index.ts` + `apps/web/src/shared/api/index.ts`**: re-export нового типу.
- **`apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts`**: `txQuery.data?.data` замість `txQuery.data` у двох місцях (поточний місяць + історичні місяці через `fetchMonth`).
- **`apps/web/src/modules/finyk/hooks/useMonoTransactions.ts`**: `data?.data ?? []` замість `data ?? []`.
- **Тести оновлено** під новий контракт відповіді (`useMonobankWebhook.test.tsx`, `useMonoTransactions.test.tsx`, `mono-webhook.test.ts`). Усі 6+4+5+6+6 = 27 тестів проходять.

### Обмеження

- `nextCursor` поки що не використовується — у поточних викликах беремо першу сторінку (default `limit=50`). Для бекфіл-навантажень за 31 день цього достатньо у переважній більшості кейсів. Реалізація pagination consume-лога — окремий PR (не блокер).

## Review & Testing Checklist for Human

- [ ] Відкрити Фінік на проді після merge → переконатися що `T.data.map` помилка зникла, транзакції відображаються.
- [ ] Перейти у вкладку «Огляд», переглянути попередні місяці (історичний `fetchMonth`) — переконатися що минулі місяці теж завантажуються без помилок.
- [ ] Зробити маленьку транзакцію — переконатися що з'явилася на сторінці у реальному часі (~2-5 с).
- [ ] Перевірити Sentry / Railway logs протягом години після merge — кількість 5xx на `/api/mono/transactions` має лишатися нульовою, frontend error rate має впасти.

### Notes

Cleanup-PR (видалення legacy polling) робити після кількох днів observability щоб мати fallback на legacy.

Link to Devin session: https://app.devin.ai/sessions/1b89fd935c5849029a2746bd5e89114c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination support for transaction retrieval.

* **Bug Fixes**
  * Updated transaction endpoints and hooks to correctly handle paginated response structures with cursor navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->