### PR TITLE
fix(finyk): consume nextCursor when reading mono transactions

### DIFF
--- a/apps/web/src/modules/finyk/hooks/monoTransactionsLoader.test.ts
+++ b/apps/web/src/modules/finyk/hooks/monoTransactionsLoader.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@shared/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@shared/api")>("@shared/api");
+  return {
+    ...actual,
+    monoWebhookApi: {
+      ...actual.monoWebhookApi,
+      transactions: vi.fn(),
+    },
+  };
+});
+
+import { monoWebhookApi, type MonoTransactionDto } from "@shared/api";
+import { fetchAllMonoTransactions } from "./monoTransactionsLoader";
+
+const mockedTransactions = monoWebhookApi.transactions as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+function tx(
+  id: string,
+  overrides: Partial<MonoTransactionDto> = {},
+): MonoTransactionDto {
+  return {
+    userId: "u1",
+    monoAccountId: "acc1",
+    monoTxId: id,
+    time: "2025-01-15T12:00:00Z",
+    amount: -100,
+    operationAmount: -100,
+    currencyCode: 980,
+    mcc: null,
+    originalMcc: null,
+    hold: false,
+    description: "test",
+    comment: null,
+    cashbackAmount: null,
+    commissionRate: null,
+    balance: 100000,
+    receiptId: null,
+    invoiceId: null,
+    counterEdrpou: null,
+    counterIban: null,
+    counterName: null,
+    source: "webhook",
+    receivedAt: "2025-01-15T12:00:01Z",
+    ...overrides,
+  };
+}
+
+describe("fetchAllMonoTransactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns single page when nextCursor is null", async () => {
+    mockedTransactions.mockResolvedValueOnce({
+      data: [tx("t1"), tx("t2")],
+      nextCursor: null,
+    });
+
+    const result = await fetchAllMonoTransactions({
+      from: "2025-01-01",
+      to: "2025-01-31",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.monoTxId)).toEqual(["t1", "t2"]);
+    expect(mockedTransactions).toHaveBeenCalledTimes(1);
+    expect(mockedTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 200, cursor: undefined }),
+      expect.anything(),
+    );
+  });
+
+  it("follows cursor through multiple pages and concatenates results", async () => {
+    mockedTransactions
+      .mockResolvedValueOnce({
+        data: [tx("t1"), tx("t2")],
+        nextCursor: "2025-01-15T11:00:00Z:t2",
+      })
+      .mockResolvedValueOnce({
+        data: [tx("t3"), tx("t4")],
+        nextCursor: "2025-01-15T10:00:00Z:t4",
+      })
+      .mockResolvedValueOnce({
+        data: [tx("t5")],
+        nextCursor: null,
+      });
+
+    const result = await fetchAllMonoTransactions({});
+
+    expect(result).toHaveLength(5);
+    expect(result.map((t) => t.monoTxId)).toEqual([
+      "t1",
+      "t2",
+      "t3",
+      "t4",
+      "t5",
+    ]);
+    expect(mockedTransactions).toHaveBeenCalledTimes(3);
+    expect(mockedTransactions).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: "2025-01-15T11:00:00Z:t2" }),
+      expect.anything(),
+    );
+  });
+
+  it("returns [] when first page has no items", async () => {
+    mockedTransactions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+    const result = await fetchAllMonoTransactions({});
+    expect(result).toEqual([]);
+  });
+
+  it("propagates errors from monoWebhookApi.transactions", async () => {
+    mockedTransactions.mockRejectedValueOnce(new Error("boom"));
+    await expect(fetchAllMonoTransactions({})).rejects.toThrow("boom");
+  });
+
+  it("stops at MAX_PAGES (50) safety cap if server keeps returning a cursor", async () => {
+    mockedTransactions.mockResolvedValue({
+      data: [tx("loop")],
+      nextCursor: "infinite",
+    });
+
+    const result = await fetchAllMonoTransactions({});
+    expect(result.length).toBe(50);
+    expect(mockedTransactions).toHaveBeenCalledTimes(50);
+  });
+});

--- a/apps/web/src/modules/finyk/hooks/monoTransactionsLoader.ts
+++ b/apps/web/src/modules/finyk/hooks/monoTransactionsLoader.ts
@@ -1,0 +1,41 @@
+import { monoWebhookApi, type MonoTransactionDto } from "@shared/api";
+
+const PAGE_LIMIT = 200;
+// 50 pages × 200 items = 10 000 — same upper bound as legacy
+// Monobank statement API window. Захист від нескінченного циклу
+// якщо сервер раптом поверне сам себе як `nextCursor`.
+const MAX_PAGES = 50;
+
+export interface MonoTransactionsRange {
+  from?: string;
+  to?: string;
+  accountId?: string;
+}
+
+/**
+ * Fetches all transactions for the given range by following the
+ * `nextCursor` pagination of `GET /api/mono/transactions`. Server caps
+ * `limit` at 200 (default 50) — without cursor consumption a user with
+ * >50 tx/місяць silently втрачав видимість старіших операцій.
+ *
+ * Returns a flat array sorted server-side by `(time DESC, monoTxId DESC)`.
+ */
+export async function fetchAllMonoTransactions(
+  params: MonoTransactionsRange,
+  opts?: { signal?: AbortSignal },
+): Promise<MonoTransactionDto[]> {
+  const all: MonoTransactionDto[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const result = await monoWebhookApi.transactions(
+      { ...params, limit: PAGE_LIMIT, cursor },
+      { signal: opts?.signal },
+    );
+    if (result.data.length > 0) all.push(...result.data);
+    if (!result.nextCursor) return all;
+    cursor = result.nextCursor;
+  }
+
+  return all;
+}

--- a/apps/web/src/modules/finyk/hooks/useMonoTransactions.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonoTransactions.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { monoWebhookApi, type MonoTransactionDto } from "@shared/api";
+import { type MonoTransactionDto } from "@shared/api";
 import { finykKeys } from "@shared/lib/queryKeys";
 import { authAwareRetry } from "@shared/lib/queryClient";
+import { fetchAllMonoTransactions } from "./monoTransactionsLoader";
 
 const STALE_TIME = 30_000;
 const GC_TIME = 5 * 60_000;
@@ -29,17 +30,11 @@ export function useMonoTransactions(
 ): UseMonoTransactionsResult {
   const { data, isFetching, isLoading, error } = useQuery({
     queryKey: finykKeys.monoTransactionsDb(rangeFrom, rangeTo, accountId),
-    queryFn: async ({ signal }) => {
-      const result = await monoWebhookApi.transactions(
-        {
-          from: rangeFrom,
-          to: rangeTo,
-          accountId,
-        },
+    queryFn: ({ signal }) =>
+      fetchAllMonoTransactions(
+        { from: rangeFrom, to: rangeTo, accountId },
         { signal },
-      );
-      return result;
-    },
+      ),
     enabled,
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
@@ -49,7 +44,7 @@ export function useMonoTransactions(
   });
 
   return {
-    transactions: data?.data ?? [],
+    transactions: data ?? [],
     isFetching,
     isLoading,
     error: error ?? null,

--- a/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
@@ -6,7 +6,6 @@ import {
   type MonoSyncState,
   type MonoAccountDto,
   type MonoTransactionDto,
-  type MonoTransactionsPage,
 } from "@shared/api";
 import { finykKeys, hubKeys } from "@shared/lib/queryKeys";
 import { authAwareRetry } from "@shared/lib/queryClient";
@@ -14,6 +13,7 @@ import { normalizeTransaction } from "@sergeant/finyk-domain/domain/transactions
 import type { Transaction } from "@sergeant/finyk-domain/domain/types";
 import { CURRENCY } from "../constants";
 import { trackEvent, ANALYTICS_EVENTS } from "../../../core/analytics";
+import { fetchAllMonoTransactions } from "./monoTransactionsLoader";
 
 const SYNC_STATE_STALE = 30_000;
 const ACCOUNTS_STALE = 5 * 60_000;
@@ -121,10 +121,10 @@ export function useMonobankWebhook({
   ).toISOString();
   const txQueryKey = `${fromDate}|${toDate}`;
 
-  const txQuery = useQuery<MonoTransactionsPage>({
+  const txQuery = useQuery<MonoTransactionDto[]>({
     queryKey: finykKeys.monoWebhookTransactions(txQueryKey),
     queryFn: ({ signal }) =>
-      monoWebhookApi.transactions({ from: fromDate, to: toDate }, { signal }),
+      fetchAllMonoTransactions({ from: fromDate, to: toDate }, { signal }),
     enabled: enabled && isConnected,
     staleTime: TX_STALE,
     refetchOnWindowFocus: true,
@@ -132,9 +132,8 @@ export function useMonobankWebhook({
   });
 
   const transactions: Transaction[] = useMemo(() => {
-    const items = txQuery.data?.data;
-    if (!items) return [];
-    return items
+    if (!txQuery.data) return [];
+    return txQuery.data
       .map(webhookTxToNormalized)
       .sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
   }, [txQuery.data]);
@@ -202,15 +201,15 @@ export function useMonobankWebhook({
         const to = new Date(year, month + 1, 1).toISOString();
         const key = `${from}|${to}`;
 
-        const page = await queryClient.fetchQuery({
+        const data = await queryClient.fetchQuery({
           queryKey: finykKeys.monoWebhookTransactions(key),
           queryFn: ({ signal }) =>
-            monoWebhookApi.transactions({ from, to }, { signal }),
+            fetchAllMonoTransactions({ from, to }, { signal }),
           staleTime: TX_STALE,
           retry: authAwareRetry(2),
         });
 
-        const normalized = (page?.data ?? [])
+        const normalized = (data ?? [])
           .map(webhookTxToNormalized)
           .sort((a, b) => (b.time ?? 0) - (a.time ?? 0));
         setHistoryTx(normalized);


### PR DESCRIPTION
## Summary

Hotfix продовження PR #706. Той PR полагодив runtime crash (`T.data.map is not a function`), але проявив поведінкову регресію проти legacy polling: `/api/mono/transactions` віддає сторінками по 50 (default `MonoTransactionsQuerySchema.limit.default(50)`, max 200), і **жоден з трьох консьюмерів не йшов далі першої сторінки** — `nextCursor` ігнорувався.

**Користувач зі скріншотами підтвердив**: транзакції до 15 квітня зникли (на прод-юзера ~5 операцій/день × 10 днів ≈ 50 шт.). Legacy polling раніше тягнув до 10 000 операцій (Monobank statement API).

## Зміни

- **`apps/web/src/modules/finyk/hooks/monoTransactionsLoader.ts`**: новий helper `fetchAllMonoTransactions(params)` — `limit=200`, тягне всі сторінки через `nextCursor`, hard cap 50 сторінок (10 000 записів = ту ж стелю що legacy).
- **`useMonobankWebhook.ts`**: `txQuery` (поточний місяць) і `fetchMonth` (історичні місяці) тепер використовують helper. Тип повертається до `MonoTransactionDto[]` — споживачі бачать плаский масив, як і очікують.
- **`useMonoTransactions.ts`**: те ж саме.
- **`monoTransactionsLoader.test.ts`**: 5 unit-тестів — single page, multi-page (3 сторінки), порожня відповідь, помилка, safety cap (50 ітерацій).

## Чому MAX_PAGES=50

50 × 200 = 10 000 — повністю покриває обмеження legacy Monobank statement API. Якщо у юзера >10k транзакцій за період — питання архітектури (потрібен pagination у UI), не цього хотфіксу.

## Review & Testing Checklist for Human

- [ ] Перевір на проді що транзакції за весь місяць (>50) тепер видно — Operations → April 2026, прокрути до перших чисел місяця.
- [ ] Перевір історичні місяці (стрілка ←) — теж мають завантажуватися повністю.
- [ ] Запит-логи Railway: `/api/mono/transactions` тепер може робитися кілька разів поспіль із `cursor=...` — переконайся що це не вибиває rate-ліміти (db query op `mono_transactions_read`).

### Notes

`nextCursor` пагінація консьюмиться в queryFn-і всередині react-query — для кешу це одна логічна операція, тому `staleTime`/`refetchOnWindowFocus` поведінка не змінюється. На відміну від `useInfiniteQuery`, тут не потрібен UI-механізм "Load more" — для розмірів 31-денного вікна це надмірно.

Link to Devin session: https://app.devin.ai/sessions/1b89fd935c5849029a2746bd5e89114c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
