### PR TITLE
fix(mono): coerce bigint columns to numbers in /api/mono/{accounts,transactions}

### DIFF
--- a/apps/server/src/modules/mono/read.test.ts
+++ b/apps/server/src/modules/mono/read.test.ts
@@ -96,6 +96,80 @@ describe("accountsHandler", () => {
 
     expect(res.statusCode).toBe(401);
   });
+
+  it("coerces bigint string columns (balance, creditLimit) to numbers", async () => {
+    // node-postgres returns bigint columns as strings by default. The
+    // client computes `!a.creditLimit` — non-empty string "0" is truthy
+    // and would silently exclude all non-credit cards from "На картках".
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          userId: "user_1",
+          monoAccountId: "white",
+          type: "white",
+          currencyCode: 980,
+          cashbackType: null,
+          maskedPan: ["444111******0131"],
+          iban: null,
+          balance: "46789",
+          creditLimit: "0",
+          lastSeenAt: new Date("2025-01-01T00:00:00Z"),
+          sendId: null,
+        },
+        {
+          userId: "user_1",
+          monoAccountId: "black",
+          type: "black",
+          currencyCode: 980,
+          cashbackType: null,
+          maskedPan: ["444111******3551"],
+          iban: null,
+          balance: "-42739",
+          creditLimit: "4000000",
+          lastSeenAt: new Date("2025-01-01T00:00:00Z"),
+          sendId: null,
+        },
+      ],
+    });
+
+    const res = makeRes();
+    await accountsHandler(makeReq(), res);
+
+    const body = res.body as Array<Record<string, unknown>>;
+    expect(body[0].balance).toBe(46789);
+    expect(body[0].creditLimit).toBe(0);
+    expect(typeof body[0].balance).toBe("number");
+    expect(typeof body[0].creditLimit).toBe("number");
+    expect(body[1].balance).toBe(-42739);
+    expect(body[1].creditLimit).toBe(4000000);
+  });
+
+  it("preserves null balance/creditLimit", async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          userId: "user_1",
+          monoAccountId: "acc1",
+          type: null,
+          currencyCode: 980,
+          cashbackType: null,
+          maskedPan: null,
+          iban: null,
+          balance: null,
+          creditLimit: null,
+          lastSeenAt: new Date("2025-01-01T00:00:00Z"),
+          sendId: null,
+        },
+      ],
+    });
+
+    const res = makeRes();
+    await accountsHandler(makeReq(), res);
+
+    const body = res.body as Array<Record<string, unknown>>;
+    expect(body[0].balance).toBeNull();
+    expect(body[0].creditLimit).toBeNull();
+  });
 });
 
 describe("transactionsHandler", () => {
@@ -222,5 +296,49 @@ describe("transactionsHandler", () => {
     await transactionsHandler({ query: {} } as unknown as Request, res);
 
     expect(res.statusCode).toBe(401);
+  });
+
+  it("coerces bigint string columns (amount, balance, etc.) to numbers", async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          userId: "user_1",
+          monoAccountId: "acc1",
+          monoTxId: "tx_1",
+          time: new Date("2025-01-15T12:00:00Z"),
+          amount: "-12345",
+          operationAmount: "-12345",
+          currencyCode: 980,
+          mcc: 5411,
+          originalMcc: 5411,
+          hold: false,
+          description: "test",
+          comment: null,
+          cashbackAmount: "100",
+          commissionRate: "0",
+          balance: "987654",
+          receiptId: null,
+          invoiceId: null,
+          counterEdrpou: null,
+          counterIban: null,
+          counterName: null,
+          source: "webhook",
+          receivedAt: new Date("2025-01-15T00:00:00Z"),
+        },
+      ],
+    });
+
+    const res = makeRes();
+    await transactionsHandler(makeReq({}), res);
+
+    const body = res.body as { data: Array<Record<string, unknown>> };
+    const tx = body.data[0];
+    expect(tx.amount).toBe(-12345);
+    expect(tx.operationAmount).toBe(-12345);
+    expect(tx.cashbackAmount).toBe(100);
+    expect(tx.commissionRate).toBe(0);
+    expect(tx.balance).toBe(987654);
+    expect(typeof tx.amount).toBe("number");
+    expect(typeof tx.commissionRate).toBe("number");
   });
 });

--- a/apps/server/src/modules/mono/read.ts
+++ b/apps/server/src/modules/mono/read.ts
@@ -8,6 +8,21 @@ interface AuthedRequest extends Request {
 }
 
 /**
+ * `node-postgres` returns Postgres `bigint` (int8) columns as **strings**
+ * by default — losing precision is impossible, but JavaScript boolean
+ * coercion of a non-empty string `"0"` is `true`, breaking client-side
+ * predicates like `!a.creditLimit`. We coerce to plain numbers because
+ * Monobank balances are denominated in cents and stay well within the
+ * safe-integer range (≤ 9 × 10¹⁵).
+ */
+function toNumberOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === "number") return v;
+  if (typeof v === "string" || typeof v === "bigint") return Number(v);
+  return null;
+}
+
+/**
  * GET /api/mono/accounts — returns user's Monobank accounts from DB.
  */
 export async function accountsHandler(
@@ -43,6 +58,8 @@ export async function accountsHandler(
   res.json(
     rows.map((r) => ({
       ...r,
+      balance: toNumberOrNull(r.balance),
+      creditLimit: toNumberOrNull(r.creditLimit),
       maskedPan: r.maskedPan ?? [],
       lastSeenAt:
         r.lastSeenAt instanceof Date
@@ -175,6 +192,11 @@ export async function transactionsHandler(
 
   const result = items.map((r) => ({
     ...r,
+    amount: toNumberOrNull(r.amount) ?? 0,
+    operationAmount: toNumberOrNull(r.operationAmount) ?? 0,
+    cashbackAmount: toNumberOrNull(r.cashbackAmount),
+    commissionRate: toNumberOrNull(r.commissionRate),
+    balance: toNumberOrNull(r.balance),
     time: r.time instanceof Date ? r.time.toISOString() : r.time,
     receivedAt:
       r.receivedAt instanceof Date ? r.receivedAt.toISOString() : r.receivedAt,


### PR DESCRIPTION
## Summary

Hotfix продовження #706 / #707. Юзер скаржиться: «На картках +0 ₴», хоча в БД є дві UAH-картки з ненульовим балансом (`white = 467.89 ₴`, `madeInUkraine = 1778.40 ₴`). Дані в `mono_account` — є; фронт показує нуль.

### Root cause: `node-postgres` повертає `bigint` як рядки

Postgres `bigint` у `pg`-драйвера за замовчуванням мапиться у JS `string` — щоб не втратити точність на значеннях > 2⁵³. Усі грошові поля у схемі — `bigint` (`balance`, `credit_limit`, `amount`, `operation_amount`, `cashback_amount`, `commission_rate`).

Клієнт у `getMonoTotals` (`packages/finyk-domain/src/lib/accounts.ts`) фільтрує:

```ts
a.balance > 0 && !a.creditLimit && a.currencyCode === 980
```

Боолн-коерсія `!"0"` у JS → **`false`** (непорожній рядок завжди truthy). Тому **всі картки з нульовим кредит-лімітом** (white, madeInUkraine, eAid, diia) вилітали з суми. Залишилась тільки чорна-кредитка з `creditLimit > 0` — там `>0` спрацьовує, тому її **борг** рахується правильно (40 427 ₴ узгоджується з UI), але **«На картках»** ламається повністю.

### Зміни

- **`apps/server/src/modules/mono/read.ts`**: helper `toNumberOrNull(v)` — коерсить `string | bigint | number → number | null`.
  - `accountsHandler`: `balance`, `creditLimit` у відповіді тепер — `number | null`.
  - `transactionsHandler`: `amount`, `operationAmount` (default 0), `cashbackAmount`, `commissionRate`, `balance` — `number | null`.
- **`apps/server/src/modules/mono/read.test.ts`**: +3 тести (accounts: ненульовий і нульовий лімит + null edge; transactions: усі грошові поля).

### Чому НЕ глобальний `pg.types.setTypeParser`

Глобальний type parser перетворить **усі** bigint-и в кодовій базі на numbers — afecue будь-які майбутні bigint-стовпчики (з ID-полями ризик колізії з 2⁵³ реальніший). Точкова коерсія у serializer-і безпечніша і робить контракт явним.

## Review & Testing Checklist for Human

- [ ] На проді відкрити Фінік → Огляд: **«На картках»** має показати суму UAH-карток (для тестового юзера ≈ 2246 ₴).
- [ ] Networth-формула збігається: `monoTotal + manualAssets + receivables − totalDebt`.
- [ ] Транзакції на сторінці Операції — суми відображаються правильно (без NaN / `[object Object]`).
- [ ] За 30 хв подивитись Railway logs `/api/mono/{accounts,transactions}` — error-rate не зріс після деплою.

### Notes

Після цього PR-у Monobank webhook-міграція повністю чиста для прод-юзерів. Cleanup legacy polling — окремим PR-ом після 24-год спостереження.

Link to Devin session: https://app.devin.ai/sessions/1b89fd935c5849029a2746bd5e89114c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monetary values in accounts and transactions API responses to be returned as numbers instead of strings for improved type consistency and financial data handling.

* **Tests**
  * Extended test coverage to validate numeric coercion of monetary fields in account and transaction handlers, including edge cases with zero values and null preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->