### PR TITLE
ci(coverage): add vitest --coverage with per-package floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,60 @@ jobs:
       - name: Format, lint, test, build
         run: pnpm check
 
+  coverage:
+    name: Test coverage (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # pnpm/action-setup v4.1.0 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+
+      # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Run vitest with coverage
+        # apps/server and apps/web enforce per-package floor thresholds in
+        # their vitest.config files (~2pp below baseline). A drop below the
+        # floor fails this job. Domain packages are already near 100%, so
+        # they don't carry explicit floors yet.
+        run: pnpm test:coverage
+
+      - name: Upload coverage HTML reports
+        if: always()
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: vitest-coverage-html
+          path: |
+            apps/server/coverage
+            apps/web/coverage
+            apps/mobile-shell/coverage
+            packages/*/coverage
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload coverage JSON summaries
+        if: always()
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        with:
+          name: vitest-coverage-summary
+          path: |
+            apps/server/coverage/coverage-summary.json
+            apps/web/coverage/coverage-summary.json
+            apps/mobile-shell/coverage/coverage-summary.json
+            packages/*/coverage/coverage-summary.json
+          if-no-files-found: ignore
+          retention-days: 30
+
   a11y:
     name: Accessibility (axe-core)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ apps/server/dist-server/
 # Turbo
 .turbo/
 
+# Vitest coverage
+coverage/
+
 # Playwright (a11y tests)
 playwright-report/
 test-results/

--- a/apps/mobile-shell/package.json
+++ b/apps/mobile-shell/package.json
@@ -25,7 +25,8 @@
     "build:ios": "pnpm build:web && pnpm sync ios",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@capacitor-mlkit/barcode-scanning": "^7.5.0",
@@ -41,6 +42,8 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^7.6.2",
+    "@sergeant/config": "workspace:*",
+    "@vitest/coverage-v8": "^3.0.0",
     "jsdom": "^29.0.2",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"

--- a/apps/mobile-shell/vitest.config.ts
+++ b/apps/mobile-shell/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "db:migrate": "node dist-server/migrate.js",
     "db:migrate:dev": "node --import tsx ./migrate.mjs"
   },
@@ -37,6 +38,7 @@
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
     "@types/web-push": "^3.6.4",
+    "@vitest/coverage-v8": "^3.0.0",
     "esbuild": "^0.25.6",
     "pino-pretty": "^13.1.3",
     "supertest": "^7.2.2",

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,9 +1,27 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    // Coverage instrumentation + dynamic `await import("./module.js")` inside
+    // tests (e.g. push.test.ts re-imports push.ts per case to pick up env
+    // changes) can blow past the 5s default under turbo concurrency. Lift to
+    // 15s to absorb that without masking real hangs.
+    testTimeout: 15_000,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+      thresholds: {
+        // Baseline (2026-04-25): lines 67.13 / branches 76.68 / fns 71.28.
+        // Floors set ~2pp below baseline to absorb flake; raise per sprint.
+        lines: 65,
+        branches: 74,
+        functions: 69,
+        statements: 65,
+      },
+    },
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:a11y": "playwright test"
   },
   "dependencies": {
@@ -61,6 +62,7 @@
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.7.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "autoprefixer": "^10.4.21",
     "cross-env": "^10.1.0",
     "jsdom": "^29.0.2",

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   plugins: [react()],
@@ -9,6 +10,25 @@ export default defineConfig({
     include: ["src/**/*.test.{js,jsx,ts,tsx}", "server/**/*.test.{js,ts}"],
     passWithNoTests: false,
     setupFiles: ["src/test/setup.js"],
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.{js,jsx,ts,tsx}"],
+      exclude: [
+        ...baseCoverageConfig.exclude,
+        "src/test/**",
+        "src/sw.js",
+        "src/main.jsx",
+      ],
+      thresholds: {
+        // Baseline (2026-04-25): lines 17.42 / branches 65.51 / fns 52.42.
+        // Floors set ~2pp below baseline to absorb flake; raise per sprint
+        // as more component/hook tests land.
+        lines: 15,
+        branches: 63,
+        functions: 50,
+        statements: 15,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:plugins": "node --test eslint-plugins/sergeant-design/__tests__/",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
     "test:a11y": "pnpm --filter @sergeant/web test:a11y",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*",
@@ -36,6 +37,7 @@
     "@tanstack/react-query": "^5.99.0",
     "@types/node": "^25.6.0",
     "@types/react": "^18.3.28",
+    "@vitest/coverage-v8": "^3.0.0",
     "react": "^18.2.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/config/vitest.base.ts
+++ b/packages/config/vitest.base.ts
@@ -11,3 +11,32 @@ export const baseVitestConfig: UserConfig = {
     passWithNoTests: true,
   },
 };
+
+/**
+ * Shared coverage configuration. Each package merges this into its own
+ * `test.coverage` block. v8 provider is fast and ships with Node — no extra
+ * native deps. We deliberately do NOT set thresholds here yet: this PR
+ * establishes the baseline. A follow-up will lock per-package floors so
+ * future PRs cannot decrease coverage.
+ */
+export const baseCoverageConfig = {
+  provider: "v8" as const,
+  reporter: ["text", "html", "json-summary", "lcov"] as const,
+  reportsDirectory: "./coverage",
+  exclude: [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/dist-server/**",
+    "**/coverage/**",
+    "**/*.test.{js,jsx,ts,tsx,mjs}",
+    "**/*.spec.{js,jsx,ts,tsx,mjs}",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/*.d.ts",
+    "**/*.config.{js,cjs,mjs,ts}",
+    "**/build.mjs",
+    "**/migrate.mjs",
+  ],
+};

--- a/packages/finyk-domain/package.json
+++ b/packages/finyk-domain/package.json
@@ -21,7 +21,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*"
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/finyk-domain/vitest.config.ts
+++ b/packages/finyk-domain/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/fizruk-domain/package.json
+++ b/packages/fizruk-domain/package.json
@@ -19,7 +19,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*"
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/fizruk-domain/vitest.config.ts
+++ b/packages/fizruk-domain/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*"
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/insights/vitest.config.ts
+++ b/packages/insights/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/nutrition-domain/package.json
+++ b/packages/nutrition-domain/package.json
@@ -24,7 +24,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*"
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/nutrition-domain/vitest.config.ts
+++ b/packages/nutrition-domain/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/routine-domain/package.json
+++ b/packages/routine-domain/package.json
@@ -19,7 +19,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@sergeant/shared": "workspace:*"
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/routine-domain/vitest.config.ts
+++ b/packages/routine-domain/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "zod": "^4.3.6"
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@sergeant/config": "workspace:*",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { baseCoverageConfig } from "@sergeant/config/vitest.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    coverage: {
+      ...baseCoverageConfig,
+      include: ["src/**/*.ts"],
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,12 @@ importers:
       "@capacitor/cli":
         specifier: ^7.6.2
         version: 7.6.2
+      "@sergeant/config":
+        specifier: workspace:*
+        version: link:../../packages/config
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@2.2.0)
@@ -355,6 +361,9 @@ importers:
       "@types/web-push":
         specifier: ^3.6.4
         version: 3.6.4
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       esbuild:
         specifier: ^0.25.6
         version: 0.25.12
@@ -506,6 +515,9 @@ importers:
       "@vitejs/plugin-react":
         specifier: ^4.7.0
         version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.0(postcss@8.5.10)
@@ -558,6 +570,9 @@ importers:
       "@types/react":
         specifier: ^18.3.28
         version: 18.3.28
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -584,6 +599,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -603,6 +621,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -622,6 +643,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -641,6 +665,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -660,6 +687,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -679,6 +709,9 @@ importers:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
+      "@vitest/coverage-v8":
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -710,6 +743,13 @@ packages:
         integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
       }
     engines: { node: ">=10" }
+
+  "@ampproject/remapping@2.3.0":
+    resolution:
+      {
+        integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==,
+      }
+    engines: { node: ">=6.0.0" }
 
   "@apideck/better-ajv-errors@0.3.7":
     resolution:
@@ -1871,6 +1911,13 @@ packages:
       {
         integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==,
       }
+
+  "@bcoe/v8-coverage@1.0.2":
+    resolution:
+      {
+        integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
+      }
+    engines: { node: ">=18" }
 
   "@better-auth/core@1.6.5":
     resolution:
@@ -5140,6 +5187,18 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  "@vitest/coverage-v8@3.2.4":
+    resolution:
+      {
+        integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==,
+      }
+    peerDependencies:
+      "@vitest/browser": 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      "@vitest/browser":
+        optional: true
+
   "@vitest/expect@3.2.4":
     resolution:
       {
@@ -5705,6 +5764,12 @@ packages:
         integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==,
       }
     engines: { node: ">=4" }
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution:
+      {
+        integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==,
+      }
 
   astral-regex@2.0.0:
     resolution:
@@ -9780,6 +9845,13 @@ packages:
       }
     engines: { node: ">=10" }
 
+  istanbul-lib-source-maps@5.0.6:
+    resolution:
+      {
+        integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==,
+      }
+    engines: { node: ">=10" }
+
   istanbul-reports@3.2.0:
     resolution:
       {
@@ -10142,6 +10214,12 @@ packages:
         integrity: sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==,
       }
     engines: { node: ">=1.0.0" }
+
+  js-tokens@10.0.0:
+    resolution:
+      {
+        integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
+      }
 
   js-tokens@4.0.0:
     resolution:
@@ -10716,6 +10794,12 @@ packages:
     resolution:
       {
         integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
+  magicast@0.3.5:
+    resolution:
+      {
+        integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==,
       }
 
   make-dir@2.1.0:
@@ -14102,6 +14186,13 @@ packages:
       }
     engines: { node: ">=8" }
 
+  test-exclude@7.0.2:
+    resolution:
+      {
+        integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==,
+      }
+    engines: { node: ">=18" }
+
   text-hex@1.0.0:
     resolution:
       {
@@ -15706,6 +15797,11 @@ snapshots:
 
   "@alloc/quick-lru@5.2.0": {}
 
+  "@ampproject/remapping@2.3.0":
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+
   "@apideck/better-ajv-errors@0.3.7(ajv@8.18.0)":
     dependencies:
       ajv: 8.18.0
@@ -16647,6 +16743,8 @@ snapshots:
       "@babel/helper-validator-identifier": 7.28.5
 
   "@bcoe/v8-coverage@0.2.3": {}
+
+  "@bcoe/v8-coverage@1.0.2": {}
 
   "@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)":
     dependencies:
@@ -19069,6 +19167,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
+    dependencies:
+      "@ampproject/remapping": 2.3.0
+      "@bcoe/v8-coverage": 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   "@vitest/expect@3.2.4":
     dependencies:
       "@types/chai": 5.2.3
@@ -19452,6 +19569,12 @@ snapshots:
   ast-types@0.15.2:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -22135,6 +22258,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -22582,6 +22713,8 @@ snapshots:
     dependencies:
       easy-stack: 1.0.1
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -22946,6 +23079,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      "@babel/parser": 7.29.2
+      "@babel/types": 7.29.0
+      source-map-js: 1.2.1
 
   make-dir@2.1.0:
     dependencies:
@@ -25278,6 +25417,12 @@ snapshots:
       "@istanbuljs/schema": 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  test-exclude@7.0.2:
+    dependencies:
+      "@istanbuljs/schema": 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   text-hex@1.0.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "test:coverage": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Adds @vitest/coverage-v8 across the workspace and a CI job that runs
`pnpm test:coverage` with HTML/lcov/json-summary uploaded as artifacts.

apps/server and apps/web enforce floor thresholds (~2pp below the
baseline measured 2026-04-25):
- server: lines 65 / branches 74 / fns 69 (baseline 67 / 77 / 71)
- web:    lines 15 / branches 63 / fns 50 (baseline 17 / 65 / 52)

Domain packages already sit near 100%, so they don't carry explicit
floors yet — the coverage report is informational for them.

Floors should be raised 1–2pp per sprint as new tests land. Bumping
apps/server testTimeout to 15s absorbs the dynamic-import overhead
that v8 instrumentation adds under turbo concurrency (push.test.ts).

https://claude.ai/code/session_01PRHhcNhzLg9yC22nWcGU7R
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test coverage reporting capability via new `test:coverage` command across the monorepo.

* **Chores**
  * Updated CI pipeline to generate and publish coverage artifacts.
  * Configured coverage reporting tools and settings across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->