### PR TITLE
docs: add AGENTS.md, PR template, and Cursor rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What changed
+
+<!-- Brief description of the changes. -->
+
+## Why
+
+<!-- Motivation, linked issue, or context. -->
+
+## How to test
+
+<!-- Steps for a reviewer to verify correctness. -->
+
+---
+
+## How AI-tested this PR
+
+<!-- If this PR was created by an AI agent, describe what was verified. -->
+
+- [ ] Manual smoke (which flow?): ...
+- [ ] Vitest passes: ...
+- [ ] No new `AI-DANGER` markers added without justification.
+
+## AGENTS.md updated?
+
+- [ ] Yes — link to changed line(s)
+- [ ] No — no new permanent rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Agents in Sergeant
+
+> Last reviewed: 2026-04-25. Reviewer: @Skords-01
+
+## Repo overview
+
+- **pnpm 9** + **Turborepo** monorepo, **Node 20**, **TypeScript 6**.
+- **Apps** (4):
+  - `apps/web` — Vite + React 18 SPA (frontend).
+  - `apps/server` — Express + PostgreSQL (`pg`) + Better Auth (API).
+  - `apps/mobile` — Expo 52 + React Native 0.76.
+  - `apps/mobile-shell` — Capacitor wrapper for the web app.
+- **Packages** (9): `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/config`, `@sergeant/design-tokens`, `@sergeant/insights`, and 4 domain packages (`@sergeant/finyk-domain`, `@sergeant/fizruk-domain`, `@sergeant/nutrition-domain`, `@sergeant/routine-domain`).
+- Pre-commit: **Husky** runs `lint-staged` (ESLint --fix + Prettier).
+
+## Hard rules (do not break)
+
+1. **DB types**: the `pg` driver returns `bigint` as **string**. Always coerce to `number` in the serializer (see [#708](https://github.com/Skords-01/Sergeant/issues/708)).
+2. **RQ keys**: only via centralized factories in `apps/web/src/shared/lib/queryKeys.ts` — `finykKeys`, `nutritionKeys`, `hubKeys`, `coachKeys`, `digestKeys`, `pushKeys`. Never write hardcoded `["finyk", ...]`.
+3. **API contract**: when changing a response shape in `apps/server/src/modules/*`, also update types in `packages/api-client/src/endpoints/*` AND add a test.
+4. **SQL migrations**: sequential `NNN_*.sql` files in `apps/server/src/migrations/` (currently 001–008). No gaps. Pre-deploy job copies them via `apps/server/build.mjs` (fixed in [#704](https://github.com/Skords-01/Sergeant/issues/704)).
+5. **Conventional Commits**: `feat(scope):`, `fix(scope):`, `docs(scope):`, `chore(scope):`. Scope = package name without `@sergeant/` prefix.
+6. **No force push to main/master.** `--force-with-lease` on feature branches is OK.
+7. **Pre-commit hooks** via Husky — do not skip (`--no-verify` is forbidden).
+
+## Soft rules (preferred)
+
+- Branch naming: `devin/<unix-ts>-<short-area>-<desc>`. Example: `devin/1777137234-mono-bigint-coercion`.
+- Tests next to code: `foo.ts` + `foo.test.ts` in the same folder (Vitest).
+- Use path aliases (`@shared/*`, `@finyk/*`, etc.) instead of relative `../../../`.
+- Dependency bumps — separate PRs (don't mix with features).
+- When deleting a file — first `grep` its imports across the entire monorepo.
+
+## Verification before PR
+
+- `pnpm lint` — must be green.
+- `pnpm typecheck` — must be green.
+- `pnpm --filter <package> exec vitest run <path>` — for affected tests.
+- When changing DB / API: `apps/server` tests must be green.
+- When changing UI: take a screenshot and attach it to the PR description.
+
+## Deployment
+
+- **Frontend**: Vercel (preview deploy on each PR; free tier may rate-limit).
+- **Backend**: Railway via `Dockerfile.api`. Pre-deploy: `pnpm db:migrate`. Health endpoint: `/health`.
+- Migrations require `MIGRATE_DATABASE_URL` env (= public DB URL).
+
+## Pre-existing flaky tests (do not block merge)
+
+- `apps/mobile/src/core/OnboardingWizard.test.tsx`
+- `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
+- `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
+
+These three fail on `main`. Ignore them if your PR does not touch `apps/mobile`.
+
+## Test users
+
+- `I3BUW5atld8oOHM7lpFEJBIInpW1hzv7` — primary test user, 6 Monobank accounts, ~2 246 ₴ on UAH cards.
+
+## See also
+
+- `docs/monobank-roadmap.md`
+- `docs/monobank-webhook-migration.md`
+- `docs/frontend-tech-debt.md`
+- `docs/backend-tech-debt.md`
+- `docs/ai-coding-improvements.md`
+- `docs/dev-stack-roadmap.md`


### PR DESCRIPTION
## What changed

Added three documentation/convention files per [Block 1 of `docs/ai-coding-improvements.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/ai-coding-improvements.md) and [#8 in `docs/dev-stack-roadmap.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/dev-stack-roadmap.md):

1. **`AGENTS.md`** (repo root) — Anthropic/Cursor/Devin convention file with:
   - Repo overview (pnpm 9, Turbo, Node 20, TS 6, 4 apps, 9 packages)
   - Hard rules (bigint→string coercion per #708, RQ key factories, API contract, migration conventions, conventional commits, Husky hooks)
   - Soft rules (branch naming, test colocation, path aliases, dep bumps)
   - Verification checklist (`pnpm lint`, `pnpm typecheck`, vitest)
   - Deployment info (Vercel frontend, Railway backend)
   - Pre-existing flaky tests (3 mobile tests)
   - Test users and See also links

2. **`.github/PULL_REQUEST_TEMPLATE.md`** — with "How AI-tested this PR" section and "AGENTS.md updated?" checkbox (per §3.3).

**Note:** `.cursor/rules/*.mdc` files (§1.2) were prepared but `.cursor/` is in `.gitignore` — un-ignore `.cursor/rules/` if you want scoped Cursor rules committed to the repo.

## Why

Implements Block 1 of the AI-coding improvements roadmap. Gives AI agents (Devin, Cursor, Claude Code) verified project context on every session, reducing variance and preventing recurring bugs like #708.

## How to test

1. Verify `AGENTS.md` facts against repo structure (`ls apps/ packages/`, check `queryKeys.ts`, check `apps/server/src/migrations/`).
2. Open a new PR — the template should auto-populate with the new sections.
3. `pnpm lint` and `pnpm typecheck` should remain green (docs-only changes).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Verified all facts in AGENTS.md against actual repo — package names, migration files (001–008), RQ key factories (6 found in `queryKeys.ts`), flaky test file existence, build script path, dependency versions.
- [x] Vitest passes: docs-only changes, no code touched.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [x] Yes — this PR **creates** AGENTS.md
- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/105b97865713436481bcf595828883b0
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pull request template to standardize change descriptions with structured prompts for rationale, testing procedures, and verification status.
  * Established repository engineering guidelines documenting workflow expectations, coding conventions, database serialization requirements, commit formats, and pre-submission verification commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->