### PR TITLE
fix(ci): enable Smoke E2E (Playwright) job on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,33 @@ jobs:
   smoke-e2e:
     name: Smoke E2E (Playwright)
     runs-on: ubuntu-latest
-    needs: check
-    timeout-minutes: 25
+    # No `needs:` — runs in parallel with other jobs so a lint/test failure in
+    # `check` never causes this job to be skipped.  Previously `needs: check`
+    # was the root cause of the job being skipped on most PRs.
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: hub
+          POSTGRES_PASSWORD: hub
+          POSTGRES_DB: hub
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U hub -d hub"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://hub:hub@127.0.0.1:5432/hub
+      BETTER_AUTH_SECRET: smoke_test_better_auth_secret_32_chars_min
+      AI_QUOTA_DISABLED: "1"
+      VITE_API_BASE_URL: http://127.0.0.1:3000
+      ALLOWED_ORIGINS: http://127.0.0.1:4173
+
     steps:
       # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -167,17 +192,52 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter @sergeant/web exec playwright --version | head -1)" >> "$GITHUB_OUTPUT"
+
+      # actions/cache v4.2.3 (SHA-pinned for supply-chain hardening)
+      - name: Cache Playwright browsers
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
       - name: Install Playwright Chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @sergeant/web exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browsers)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @sergeant/web exec playwright install-deps chromium
+
+      - name: Run database migrations
+        run: pnpm --filter @sergeant/server db:migrate:dev
+
+      - name: Build web app
+        run: pnpm --filter @sergeant/web build
+
+      - name: Start API server
+        run: pnpm --filter @sergeant/server dev &
+
+      - name: Start Vite preview server
+        run: pnpm --filter @sergeant/web preview -- --port 4173 --host 127.0.0.1 &
+
+      - name: Wait for servers
+        run: |
+          echo "Waiting for API server on :3000…"
+          timeout 60 bash -c 'until curl -sf http://127.0.0.1:3000/health >/dev/null 2>&1; do sleep 2; done'
+          echo "Waiting for preview server on :4173…"
+          timeout 60 bash -c 'until curl -sf http://127.0.0.1:4173 >/dev/null 2>&1; do sleep 2; done'
+          echo "Both servers ready."
 
       - name: Run smoke E2E suite
         run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts
         env:
           CI: "true"
-          DATABASE_URL: postgresql://hub:hub@127.0.0.1:5432/hub
-          BETTER_AUTH_SECRET: smoke_test_better_auth_secret_32_chars_min
-          AI_QUOTA_DISABLED: "1"
-          VITE_API_BASE_URL: http://127.0.0.1:3000
+          PW_SKIP_WEBSERVER: "1"
+          PW_BASE_URL: http://127.0.0.1:4173
 
       - name: Upload Playwright report
         if: always()

--- a/apps/web/tests/smoke/dashboard-health.spec.ts
+++ b/apps/web/tests/smoke/dashboard-health.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const SEEDED_LS: Record<string, string> = {
+  hub_onboarding_done_v1: "1",
+  hub_first_action_done_v1: "1",
+  hub_vibe_picks_v1: JSON.stringify({
+    picks: ["finyk", "fizruk", "nutrition", "routine"],
+    firstActionPending: null,
+    firstActionStartedAt: null,
+    firstRealEntryAt: Date.now(),
+    updatedAt: Date.now(),
+  }),
+};
+
+async function seedLocalStorage(page: Page) {
+  await page.addInitScript((entries: Record<string, string>) => {
+    try {
+      for (const [k, v] of Object.entries(entries)) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, SEEDED_LS);
+}
+
+test("dashboard: renders without console errors", async ({ page }) => {
+  await seedLocalStorage(page);
+
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("#root")).toBeVisible();
+  await expect(page.locator("main")).toBeVisible({ timeout: 10_000 });
+
+  const fatal = errors.filter(
+    (e) =>
+      !e.includes("Failed to load resource") &&
+      !e.includes("net::ERR_") &&
+      !e.includes("service-worker"),
+  );
+  expect(fatal, "Unexpected console errors on dashboard").toEqual([]);
+});
+
+test("dashboard: API health endpoint responds", async ({ request }) => {
+  const res = await request.get(
+    (process.env.VITE_API_BASE_URL || "http://127.0.0.1:3000") + "/health",
+  );
+  expect(res.ok()).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

**Root cause:** `needs: check` made the `smoke-e2e` job depend on the `check` job. When `check` failed (lint / format / typecheck / test / build), GitHub Actions automatically skipped all dependent jobs — including `Smoke E2E (Playwright)`. This is why the job showed `skipped` on most PRs (ref: `docs/ai-coding-improvements.md` §4.2, `docs/dev-stack-roadmap.md` #12).

**Secondary issue:** even when `check` passed, the old job lacked a PostgreSQL service and relied on Docker Compose via Playwright's `webServer` command, which was never properly wired for CI runners.

### Changes in `.github/workflows/ci.yml`

| Before | After |
|---|---|
| `needs: check` — skipped when check fails | No `needs:` — runs in parallel, independently |
| No database service | PostgreSQL 16-alpine as GHA service (matches `docker-compose.yml`) |
| Playwright started DB via `docker compose up` | Explicit CI steps: migrate → build → start API → start preview → wait for readiness |
| No browser caching | `actions/cache` keyed by Playwright version |
| `timeout-minutes: 25` | `timeout-minutes: 20` |
| Env vars only on test step | Job-level `env` block (`DATABASE_URL`, `BETTER_AUTH_SECRET`, `ALLOWED_ORIGINS`, etc.) |

### New smoke test: `apps/web/tests/smoke/dashboard-health.spec.ts`

- **Dashboard renders without console errors** — loads `/`, asserts `#root` + `<main>` visible, catches fatal `console.error` / `pageerror`
- **API health endpoint responds** — `GET /health` returns 200

### Full smoke test coverage (3 files, 6 tests)

| File | Tests |
|---|---|
| `auth.spec.ts` | sign-up → authenticated hub surface |
| `dashboard-health.spec.ts` | dashboard renders without console errors; API `/health` responds |
| `navigation-offline-sw.spec.ts` | module routes render; offline banner shows; SW debug roundtrip |

### Vercel free-tier note

This approach boots a local Vite preview server + Express API inside the CI runner, so **no Vercel preview URL is needed**. When/if Vercel Pro is enabled, the `PW_BASE_URL` env can be pointed at the preview deployment instead.

## Review & Testing Checklist for Human

- [ ] Verify that `Smoke E2E (Playwright)` job shows **passed** (not skipped) on this PR's CI run
- [ ] Check `playwright-smoke-report` artifact is uploaded
- [ ] Confirm job execution time < 20 min
- [ ] Review the new `dashboard-health.spec.ts` test for false-positive risk (console error filter)

### Notes

- The `a11y` job still has `needs: check` — not changed per task scope ("не зачіпай unit/lint job-и")
- `actions/cache` SHA `5a3ec84eff668545956fd18022155c47e93e2684` = v4.2.3 (pinned for supply-chain hardening)
- No branch protection changes made (as requested)


Link to Devin session: https://app.devin.ai/sessions/e54e7dcc59c0489c8ca687454afd6306
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
