### PR TITLE
docs(roadmap): mark Tier 1 + Tier 2 items as done with PR links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,12 @@
 
 Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-design/ai-marker-syntax` (warn).
 
-| Marker | Purpose | Example |
-|--------|---------|---------|
-| `// AI-NOTE: <text>` | Contextual hint for future AI agents (not a human TODO) | `// AI-NOTE: coerce bigint→number; see rule #1` |
-| `// AI-DANGER: <text>` | High-risk zone — AI should confirm before changing | `// AI-DANGER: timing-safe comparison is critical here` |
-| `// AI-GENERATED: <generator>` | File is generated — edit the generator, not this file | `// AI-GENERATED: from codegen.ts` |
-| `// AI-LEGACY: expires YYYY-MM-DD` | Temporary code scheduled for removal | `// AI-LEGACY: expires 2026-06-01` |
+| Marker                             | Purpose                                                 | Example                                                 |
+| ---------------------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| `// AI-NOTE: <text>`               | Contextual hint for future AI agents (not a human TODO) | `// AI-NOTE: coerce bigint→number; see rule #1`         |
+| `// AI-DANGER: <text>`             | High-risk zone — AI should confirm before changing      | `// AI-DANGER: timing-safe comparison is critical here` |
+| `// AI-GENERATED: <generator>`     | File is generated — edit the generator, not this file   | `// AI-GENERATED: from codegen.ts`                      |
+| `// AI-LEGACY: expires YYYY-MM-DD` | Temporary code scheduled for removal                    | `// AI-LEGACY: expires 2026-06-01`                      |
 
 **Rules:**
 

--- a/docs/ai-coding-improvements.md
+++ b/docs/ai-coding-improvements.md
@@ -8,16 +8,16 @@
 
 ## Прогрес (2026-04-25)
 
-| Блок                                       | Статус              | PR                                                     | Notes                                                                                  |
-| ------------------------------------------ | ------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| 1. `AGENTS.md` + repo-rules                | ✅ done             | [#714](https://github.com/Skords-01/Sergeant/pull/714) | + `.github/PULL_REQUEST_TEMPLATE.md` із секцією «How AI-tested this PR».               |
-| 2. Playbooks (4 шаблони)                   | ⏳ pending          | —                                                      | Не зачіпали поки що.                                                                   |
-| 3. Code markers + ESLint rule              | ✅ done             | [#715](https://github.com/Skords-01/Sergeant/pull/715) | Правило `sergeant-design/ai-marker-syntax` (warn) + 20 unit-тестів + реальні маркери.  |
-| 4. Vercel paid + preview-on-PR             | 🟡 not started      | —                                                      | Потребує credentials/upgrade від мейнтейнера ($20/міс).                                |
-| 5. Playwright E2E enabled on PR            | ✅ done             | [#717](https://github.com/Skords-01/Sergeant/pull/717) | Видалено блокуючий `needs: check`, додано Postgres service + кешування браузерів.      |
-| 6. Visual regression (Argos / Chromatic)   | ⏳ pending          | —                                                      | Залежить від блоку 5 (зроблено) і стабільного Vercel preview.                          |
-| 7. Storybook                               | ⏳ pending          | —                                                      | Не зачіпали поки що.                                                                   |
-| 8. Snapshot tests для server serializers   | ✅ done             | [#718](https://github.com/Skords-01/Sergeant/pull/718) | Покрито `accountsHandler` + `transactionsHandler`; всі bigint-поля вже мали coercion.  |
+| Блок                                     | Статус         | PR                                                     | Notes                                                                                 |
+| ---------------------------------------- | -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| 1. `AGENTS.md` + repo-rules              | ✅ done        | [#714](https://github.com/Skords-01/Sergeant/pull/714) | + `.github/PULL_REQUEST_TEMPLATE.md` із секцією «How AI-tested this PR».              |
+| 2. Playbooks (4 шаблони)                 | ⏳ pending     | —                                                      | Не зачіпали поки що.                                                                  |
+| 3. Code markers + ESLint rule            | ✅ done        | [#715](https://github.com/Skords-01/Sergeant/pull/715) | Правило `sergeant-design/ai-marker-syntax` (warn) + 20 unit-тестів + реальні маркери. |
+| 4. Vercel paid + preview-on-PR           | 🟡 not started | —                                                      | Потребує credentials/upgrade від мейнтейнера ($20/міс).                               |
+| 5. Playwright E2E enabled on PR          | ✅ done        | [#717](https://github.com/Skords-01/Sergeant/pull/717) | Видалено блокуючий `needs: check`, додано Postgres service + кешування браузерів.     |
+| 6. Visual regression (Argos / Chromatic) | ⏳ pending     | —                                                      | Залежить від блоку 5 (зроблено) і стабільного Vercel preview.                         |
+| 7. Storybook                             | ⏳ pending     | —                                                      | Не зачіпали поки що.                                                                  |
+| 8. Snapshot tests для server serializers | ✅ done        | [#718](https://github.com/Skords-01/Sergeant/pull/718) | Покрито `accountsHandler` + `transactionsHandler`; всі bigint-поля вже мали coercion. |
 
 Додатково з `dev-stack-roadmap.md`: **Knip + depcheck** — ✅ done у [#716](https://github.com/Skords-01/Sergeant/pull/716) (видалено 6 файлів, 4 unused exports, 2 stale eslint entries).
 
@@ -25,16 +25,16 @@
 
 ## TL;DR
 
-| #     | Блок                                                  | Effort   | Impact     | Залежності | Статус               |
-| ----- | ----------------------------------------------------- | -------- | ---------- | ---------- | -------------------- |
-| **1** | `AGENTS.md` + repo-rules                              | пів дня  | висок      | —          | ✅ done (#714)        |
-| **2** | Playbooks (4 шаблони)                                 | 1 день   | висок      | блок 1     | ⏳ pending            |
-| **3** | Code markers (`AI-NOTE`, `AI-DANGER`, `AI-GENERATED`) | пів дня  | середн     | —          | ✅ done (#715)        |
-| **4** | Vercel paid + preview-on-PR                           | 1 година | дуже висок | $20/міс    | 🟡 not started        |
-| **5** | Playwright E2E enabled on PR                          | 1 день   | висок      | блок 4     | ✅ done (#717)        |
-| **6** | Visual regression (Argos / Chromatic)                 | пів дня  | середн     | блок 5     | ⏳ pending            |
-| **7** | Storybook                                             | 2 дні    | середн     | —          | ⏳ pending            |
-| **8** | Snapshot tests для server-side serializers            | пів дня  | висок      | —          | ✅ done (#718)        |
+| #     | Блок                                                  | Effort   | Impact     | Залежності | Статус         |
+| ----- | ----------------------------------------------------- | -------- | ---------- | ---------- | -------------- |
+| **1** | `AGENTS.md` + repo-rules                              | пів дня  | висок      | —          | ✅ done (#714) |
+| **2** | Playbooks (4 шаблони)                                 | 1 день   | висок      | блок 1     | ⏳ pending     |
+| **3** | Code markers (`AI-NOTE`, `AI-DANGER`, `AI-GENERATED`) | пів дня  | середн     | —          | ✅ done (#715) |
+| **4** | Vercel paid + preview-on-PR                           | 1 година | дуже висок | $20/міс    | 🟡 not started |
+| **5** | Playwright E2E enabled on PR                          | 1 день   | висок      | блок 4     | ✅ done (#717) |
+| **6** | Visual regression (Argos / Chromatic)                 | пів дня  | середн     | блок 5     | ⏳ pending     |
+| **7** | Storybook                                             | 2 дні    | середн     | —          | ⏳ pending     |
+| **8** | Snapshot tests для server-side serializers            | пів дня  | висок      | —          | ✅ done (#718) |
 
 **Рекомендована черговість:** 4 → 1 → 3 → 8 → 2 → 5 → 6 → 7.
 Логіка: 4 (Vercel) знімає найбільший денний pain. 1+3 — швидкі низько-ризикові wins. 8 — захист від класу регресій типу bigint→string (#708). 2 формалізує повторювані задачі. 5+6+7 — більш дорогі infra-інвестиції.

--- a/docs/ai-coding-improvements.md
+++ b/docs/ai-coding-improvements.md
@@ -1,32 +1,53 @@
 # AI-coding improvements roadmap
 
-**Статус:** plan / draft. Створено 2026-04-25 з ідей розмови про вайб-кодинг.
+**Статус:** in progress. Створено 2026-04-25 з ідей розмови про вайб-кодинг. Останнє оновлення: 2026-04-25 (Tier 1 + частина Tier 2 закриті, див. таблицю прогресу нижче).
 **Скоуп:** репо-конвенції, playbooks, code markers, testing/preview infra. Це **не** про конкретні фічі продукту — це про **інфраструктуру для AI-агентів** (Devin, Cursor, Claude Code), які пишуть код у Sergeant.
 **Принцип:** менший variance результатів + більше контексту в репо = швидше і якісніше виходять PR-и від AI.
 
 ---
 
+## Прогрес (2026-04-25)
+
+| Блок                                       | Статус              | PR                                                     | Notes                                                                                  |
+| ------------------------------------------ | ------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| 1. `AGENTS.md` + repo-rules                | ✅ done             | [#714](https://github.com/Skords-01/Sergeant/pull/714) | + `.github/PULL_REQUEST_TEMPLATE.md` із секцією «How AI-tested this PR».               |
+| 2. Playbooks (4 шаблони)                   | ⏳ pending          | —                                                      | Не зачіпали поки що.                                                                   |
+| 3. Code markers + ESLint rule              | ✅ done             | [#715](https://github.com/Skords-01/Sergeant/pull/715) | Правило `sergeant-design/ai-marker-syntax` (warn) + 20 unit-тестів + реальні маркери.  |
+| 4. Vercel paid + preview-on-PR             | 🟡 not started      | —                                                      | Потребує credentials/upgrade від мейнтейнера ($20/міс).                                |
+| 5. Playwright E2E enabled on PR            | ✅ done             | [#717](https://github.com/Skords-01/Sergeant/pull/717) | Видалено блокуючий `needs: check`, додано Postgres service + кешування браузерів.      |
+| 6. Visual regression (Argos / Chromatic)   | ⏳ pending          | —                                                      | Залежить від блоку 5 (зроблено) і стабільного Vercel preview.                          |
+| 7. Storybook                               | ⏳ pending          | —                                                      | Не зачіпали поки що.                                                                   |
+| 8. Snapshot tests для server serializers   | ✅ done             | [#718](https://github.com/Skords-01/Sergeant/pull/718) | Покрито `accountsHandler` + `transactionsHandler`; всі bigint-поля вже мали coercion.  |
+
+Додатково з `dev-stack-roadmap.md`: **Knip + depcheck** — ✅ done у [#716](https://github.com/Skords-01/Sergeant/pull/716) (видалено 6 файлів, 4 unused exports, 2 stale eslint entries).
+
+---
+
 ## TL;DR
 
-| #     | Блок                                                  | Effort   | Impact     | Залежності |
-| ----- | ----------------------------------------------------- | -------- | ---------- | ---------- |
-| **1** | `AGENTS.md` + repo-rules                              | пів дня  | висок      | —          |
-| **2** | Playbooks (4 шаблони)                                 | 1 день   | висок      | блок 1     |
-| **3** | Code markers (`AI-NOTE`, `AI-DANGER`, `AI-GENERATED`) | пів дня  | середн     | —          |
-| **4** | Vercel paid + preview-on-PR                           | 1 година | дуже висок | $20/міс    |
-| **5** | Playwright E2E enabled on PR                          | 1 день   | висок      | блок 4     |
-| **6** | Visual regression (Argos / Chromatic)                 | пів дня  | середн     | блок 5     |
-| **7** | Storybook                                             | 2 дні    | середн     | —          |
-| **8** | Snapshot tests для server-side serializers            | пів дня  | висок      | —          |
+| #     | Блок                                                  | Effort   | Impact     | Залежності | Статус               |
+| ----- | ----------------------------------------------------- | -------- | ---------- | ---------- | -------------------- |
+| **1** | `AGENTS.md` + repo-rules                              | пів дня  | висок      | —          | ✅ done (#714)        |
+| **2** | Playbooks (4 шаблони)                                 | 1 день   | висок      | блок 1     | ⏳ pending            |
+| **3** | Code markers (`AI-NOTE`, `AI-DANGER`, `AI-GENERATED`) | пів дня  | середн     | —          | ✅ done (#715)        |
+| **4** | Vercel paid + preview-on-PR                           | 1 година | дуже висок | $20/міс    | 🟡 not started        |
+| **5** | Playwright E2E enabled on PR                          | 1 день   | висок      | блок 4     | ✅ done (#717)        |
+| **6** | Visual regression (Argos / Chromatic)                 | пів дня  | середн     | блок 5     | ⏳ pending            |
+| **7** | Storybook                                             | 2 дні    | середн     | —          | ⏳ pending            |
+| **8** | Snapshot tests для server-side serializers            | пів дня  | висок      | —          | ✅ done (#718)        |
 
 **Рекомендована черговість:** 4 → 1 → 3 → 8 → 2 → 5 → 6 → 7.
 Логіка: 4 (Vercel) знімає найбільший денний pain. 1+3 — швидкі низько-ризикові wins. 8 — захист від класу регресій типу bigint→string (#708). 2 формалізує повторювані задачі. 5+6+7 — більш дорогі infra-інвестиції.
 
+**Реальний порядок виконання (2026-04-25):** 1 → 8 → 5 → 3 (паралельно з Knip/depcheck). 4 (Vercel paid) пропущено через відсутність credentials — це створило rate-limit на preview deploy у CI блоку 5, але smoke-тести запускаються проти локально стартанутого Vite preview всередині CI job-а, тому сам блок 5 розблокувати вдалося.
+
 ---
 
-# Блок 1. Repo-level rule-файли
+# Блок 1. Repo-level rule-файли ✅ implemented (#714)
 
 ## 1.1. `AGENTS.md` (новий файл у корені репо)
+
+**Статус:** ✅ створено у [PR #714](https://github.com/Skords-01/Sergeant/pull/714). Файл живе у `/AGENTS.md`. Факти верифіковані проти реального стану репо (pnpm 9, Turbo, 4 apps, 9 packages, RQ keys factories `finykKeys`/`hubKeys`/`nutritionKeys`/`coachKeys`/`digestKeys`/`pushKeys` у `apps/web/src/shared/lib/queryKeys.ts`, міграції 001–008). Має бути reviewed quarterly (last-reviewed-line у самому файлі).
 
 **Що це:** конвенція Anthropic / Cursor / Devin — markdown-файл у корені репо з правилами **тільки для AI-агентів**. Усі сучасні coding-AI його читають автоматично.
 
@@ -288,7 +309,9 @@ module.exports = {
 };
 ```
 
-## 3.3. Convention для PR template
+## 3.3. Convention для PR template ✅ implemented (#714)
+
+**Статус:** ✅ `.github/PULL_REQUEST_TEMPLATE.md` створено у [PR #714](https://github.com/Skords-01/Sergeant/pull/714) з секціями `How AI-tested this PR` і `AGENTS.md updated?`.
 
 Доповнити `.github/PULL_REQUEST_TEMPLATE.md`:
 
@@ -340,7 +363,13 @@ module.exports = {
 
 Рекомендую paid Vercel.
 
-## 4.2. Playwright E2E на PR
+## 4.2. Playwright E2E на PR ✅ implemented (#717)
+
+**Статус:** ✅ enabled у [PR #717](https://github.com/Skords-01/Sergeant/pull/717).
+
+**Root cause skipped-стану:** job `Smoke E2E (Playwright)` мав `needs: check`, який не виконувався на більшості PR. Виправлено: dependency знято, додано PostgreSQL service container, Playwright browser caching, явний старт Vite preview-сервера всередині job-а (щоб обійти Vercel free-tier rate-limit). Доданий smoke-тест: `apps/web/tests/smoke/dashboard-health.spec.ts`. Job тепер біжить на КОЖЕН PR і завантажує `playwright-report` як artifact.
+
+**Caveat:** оскільки Vercel preview rate-limit-иться (free tier), тести працюють проти локального preview, а НЕ проти Vercel deployment. Це достатньо для catastrophic-regression detection, але не покриває edge-cases SSR/Vercel-specific behavior. Для цього треба блок 4.1 (Vercel paid).
 
 **Поточний стан:** у вас уже є job `Smoke E2E (Playwright)` у CI workflow, але він `skipped` (бачу в pr_checks #708). Чому skipped — треба з'ясувати (можливо `if: ...` condition не виконується для всіх PR).
 
@@ -397,7 +426,9 @@ Argos рекомендую — найкращий fit для open-source workflo
 
 **Win:** AI prototypes UI-компонент за 5 хв замість 30. Visual regression (4.3) автоматично покриває всі stories.
 
-## 4.5. Snapshot tests для server-side serializers
+## 4.5. Snapshot tests для server-side serializers ✅ implemented (#718)
+
+**Статус:** ✅ покрито у [PR #718](https://github.com/Skords-01/Sergeant/pull/718) — `accountsHandler` і `transactionsHandler` у `apps/server/src/modules/mono/read.ts`. Snapshot-файл: `apps/server/src/modules/mono/__snapshots__/read.test.ts.snap`. Бонус: під час review перевірено всі bigint-колонки → coercion вже на місці (новий клас регресій #708 не знайдений). JSDoc на `toNumberOrNull` розширено.
 
 **Контекст:** баг #708 (bigint→string) виглядав так: API повернув правильні значення, але типи не відповідали контракту. Unit-тест на shape ловить це.
 
@@ -443,21 +474,21 @@ it("accountsHandler response shape matches snapshot", async () => {
 
 # Implementation order (concrete checklist)
 
-1. [ ] **Tier 1 (тиждень 1):**
-   - [ ] Vercel paid plan upgrade
-   - [ ] `AGENTS.md` створення з розділами вище
-   - [ ] PR template update з блоком «How AI-tested»
-   - [ ] Snapshot tests для `apps/server/src/modules/mono/read.ts` (3 endpoint-и)
-2. [ ] **Tier 2 (тиждень 2-3):**
-   - [ ] AI markers convention + ESLint rule
+1. [~] **Tier 1 (тиждень 1):** 3/4 done
+   - [ ] Vercel paid plan upgrade — потребує credentials від мейнтейнера
+   - [x] `AGENTS.md` створення з розділами вище — [#714](https://github.com/Skords-01/Sergeant/pull/714)
+   - [x] PR template update з блоком «How AI-tested» — [#714](https://github.com/Skords-01/Sergeant/pull/714)
+   - [x] Snapshot tests для `apps/server/src/modules/mono/read.ts` (accountsHandler + transactionsHandler) — [#718](https://github.com/Skords-01/Sergeant/pull/718)
+2. [~] **Tier 2 (тиждень 2-3):** 2/3 done
+   - [x] AI markers convention + ESLint rule — [#715](https://github.com/Skords-01/Sergeant/pull/715)
    - [ ] Playbooks `hotfix-prod`, `add-feature-flag`, `cleanup-dead-code`
-   - [ ] Activate Playwright E2E на PR
+   - [x] Activate Playwright E2E на PR — [#717](https://github.com/Skords-01/Sergeant/pull/717)
 3. [ ] **Tier 3 (місяць 2):**
    - [ ] Argos візуальна регресія
    - [ ] Storybook (або Histoire) для shared components
    - [ ] Knowledge notes для прод-environment, тест-юзерів, flaky tests
 4. [ ] **Maintenance:**
-   - [ ] Quarterly `AGENTS.md` review reminder
+   - [ ] Quarterly `AGENTS.md` review reminder (next due: 2026-07-25)
    - [ ] Monthly metrics check
 
 ---

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -1,6 +1,6 @@
 # Dev stack roadmap — інструменти і поради по всьому ЖЦ розробки
 
-**Статус:** plan / draft. Створено 2026-04-25.
+**Статус:** in progress. Створено 2026-04-25. Останнє оновлення: 2026-04-25 (4 з топ-15 закриті — див. колонку Статус у TL;DR).
 **Скоуп:** інструменти, інтеграції, практики для покращення розробки, тестування, CI/CD, проду, безпеки, performance і команди. Specifically для стеку Sergeant: pnpm + Turborepo + Vite/React + Express + Postgres + Railway + Vercel + Expo.
 **Принцип:** не «впровадити все одразу», а **поетапно** — від найдешевших і найважливіших до інвестиційних. Кожен пункт — самостійний tool / practice з ціною, effort-ом, ROI і dep-ами.
 
@@ -10,25 +10,27 @@
 
 Якщо є тиждень — зроби лише це:
 
-| #   | Інструмент / практика                             | Effort    | Cost             | ROI    |
-| --- | ------------------------------------------------- | --------- | ---------------- | ------ |
-| 1   | **Sentry** для error tracking                     | 2 год     | $26/міс          | 🔥🔥🔥 |
-| 2   | **Knip + depcheck** — clean dead code             | 1 год     | $0               | 🔥🔥   |
-| 3   | **Strict TypeScript (incremental)**               | 1-2 тижні | $0               | 🔥🔥🔥 |
-| 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 |
-| 5   | **Vercel Pro plan** (рятує preview deploy)        | 5 хв      | $20/міс          | 🔥🔥   |
-| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   |
-| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   |
-| 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 |
-| 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     |
-| 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 |
-| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   |
-| 12  | **Activate Playwright E2E на PR**                 | 2 год     | $0               | 🔥🔥   |
-| 13  | **PostHog** для product analytics                 | 4 год     | $0 (free tier)   | 🔥     |
-| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     |
-| 15  | **CONTRIBUTING.md + 5-min quickstart**            | 2 год     | $0               | 🔥🔥   |
+| #   | Інструмент / практика                             | Effort    | Cost             | ROI    | Статус                                                            |
+| --- | ------------------------------------------------- | --------- | ---------------- | ------ | ----------------------------------------------------------------- |
+| 1   | **Sentry** для error tracking                     | 2 год     | $26/міс          | 🔥🔥🔥 | ⏳ pending (потребує credentials)                                  |
+| 2   | **Knip + depcheck** — clean dead code             | 1 год     | $0               | 🔥🔥   | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
+| 3   | **Strict TypeScript (incremental)**               | 1-2 тижні | $0               | 🔥🔥🔥 | ⏳ pending                                                        |
+| 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 | ⏳ pending                                                        |
+| 5   | **Vercel Pro plan** (рятує preview deploy)        | 5 хв      | $20/міс          | 🔥🔥   | 🟡 not started (потребує credit card мейнтейнера)              |
+| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ⏳ pending                                                        |
+| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
+| 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714)    |
+| 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ⏳ pending                                                        |
+| 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718)    |
+| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
+| 12  | **Activate Playwright E2E на PR**                 | 2 год     | $0               | 🔥🔥   | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717)    |
+| 13  | **PostHog** для product analytics                 | 4 год     | $0 (free tier)   | 🔥     | ⏳ pending                                                        |
+| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     | ⏳ pending                                                        |
+| 15  | **CONTRIBUTING.md + 5-min quickstart**            | 2 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
 
 **Сумарно:** ~3-5 робочих днів + ~$50/міс. Це 80% wins за 20% effort-у.
+
+**Прогрес (2026-04-25):** 4 / 15 закрито — #2 Knip+depcheck, #8 AGENTS.md, #10 Snapshot tests, #12 Playwright E2E. Наступні логічні кроки: #15 (CONTRIBUTING.md — дешевий win), #11 (Pino logging — розблокує Sentry/PostHog), #4 (Testcontainers — підсилить #10), #7 (Renovate — безпека).
 
 ---
 
@@ -113,17 +115,19 @@
 
 ### 3.1. Must-have
 
-| Tool                       | What                                                        | Effort    |
-| -------------------------- | ----------------------------------------------------------- | --------- |
-| **TypeScript strict mode** | Incremental: `strictNullChecks` → `noImplicitAny` → full    | 1-2 тижні |
-| **ESLint 9**               | У вас є                                                     | —         |
-| **Prettier + lint-staged** | У вас є                                                     | —         |
-| **Knip**                   | Find unused exports/files/deps (~50+ findings on first run) | 1 год     |
-| **depcheck**               | Find unused deps в package.json                             | 30 хв     |
-| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     |
-| **CSpell**                 | Spell-checker для коду і коментарів                         | 30 хв     |
+| Tool                       | What                                                        | Effort    | Статус                                                            |
+| -------------------------- | ----------------------------------------------------------- | --------- | ----------------------------------------------------------------- |
+| **TypeScript strict mode** | Incremental: `strictNullChecks` → `noImplicitAny` → full    | 1-2 тижні | ⏳ pending                                                        |
+| **ESLint 9**               | У вас є                                                     | —         | ✅                                                                 |
+| **Prettier + lint-staged** | У вас є                                                     | —         | ✅                                                                 |
+| **Knip**                   | Find unused exports/files/deps (~50+ findings on first run) | 1 год     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
+| **depcheck**               | Find unused deps в package.json                             | 30 хв     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
+| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     | ⏳ pending                                                        |
+| **CSpell**                 | Spell-checker для коду і коментарів                         | 30 хв     | ⏳ pending                                                        |
 
 **Sergeant-priority:** strict TypeScript. Зараз `strict: false` — це баги waiting to happen.
+
+**Knip + depcheck — впроваджено у [#716](https://github.com/Skords-01/Sergeant/pull/716):** `knip.json` baseline + scripts у root `package.json`. Перший cleanup pass видалив: 6 невикористовуваних файлів (`CelebrationOverlay.tsx`, `ModuleChecklist.tsx`, `PermissionsPrompt.tsx`, `CategoryManager.tsx`, `PhotoProgress.tsx`, `useBodyPhotos.ts`), 4 unused exports, 2 stale eslint-plugin entries (`apps/server/src/obs/metrics.ts`, `logger.ts` cleanup).
 
 ### 3.2. Nice-to-have
 
@@ -154,13 +158,15 @@
 
 ### 4.1. Test infrastructure
 
-| Tool                          | What                                    | Effort | Tier |
-| ----------------------------- | --------------------------------------- | ------ | ---- |
-| **Testcontainers**            | Real Postgres у Docker для server tests | 4 год  | must |
-| **MSW (Mock Service Worker)** | Realistic API mocks для frontend tests  | 4 год  | must |
-| **fishery** / **factory-bot** | Test data factories                     | 2 год  | nice |
-| **faker**                     | Random test data                        | 30 хв  | nice |
-| **node:test**                 | If відмовляєтесь від Vitest для server  | 1 день | nice |
+| Tool                          | What                                    | Effort | Tier | Статус                                                            |
+| ----------------------------- | --------------------------------------- | ------ | ---- | ----------------------------------------------------------------- |
+| **Snapshot tests (server)**   | Mono serializers response shape         | 4 год  | must | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718)    |
+| **Playwright Smoke E2E (PR)** | Login → dashboard happy-path на кожен PR  | 2 год  | must | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717)    |
+| **Testcontainers**            | Real Postgres у Docker для server tests | 4 год  | must | ⏳ pending                                                        |
+| **MSW (Mock Service Worker)** | Realistic API mocks для frontend tests  | 4 год  | must | ⏳ pending                                                        |
+| **fishery** / **factory-bot** | Test data factories                     | 2 год  | nice | ⏳ pending                                                        |
+| **faker**                     | Random test data                        | 30 хв  | nice | ⏳ pending                                                        |
+| **node:test**                 | If відмовляєтесь від Vitest для server  | 1 день | nice | ⏳ pending                                                        |
 
 **Sergeant-priority:** Testcontainers. Зараз у server tests `queryMock.mockResolvedValueOnce(...)` — це не ловить SQL-помилки. Реальний PG ловить.
 
@@ -168,7 +174,7 @@
 
 | Tool           | What                                 | Cost                  |
 | -------------- | ------------------------------------ | --------------------- |
-| **Playwright** | У вас є, треба активувати на PR      | $0                    |
+| **Playwright** | ✅ активовано на PR ([#717](https://github.com/Skords-01/Sergeant/pull/717)) | $0                    |
 | **Detox**      | Mobile e2e (вже згаданий у Sergeant) | $0                    |
 | **Argos**      | Visual regression on PRs             | Free < 5K screenshots |
 | **Percy**      | BrowserStack-owned visual testing    | Free 5K screenshots   |

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -10,23 +10,23 @@
 
 Якщо є тиждень — зроби лише це:
 
-| #   | Інструмент / практика                             | Effort    | Cost             | ROI    | Статус                                                            |
-| --- | ------------------------------------------------- | --------- | ---------------- | ------ | ----------------------------------------------------------------- |
-| 1   | **Sentry** для error tracking                     | 2 год     | $26/міс          | 🔥🔥🔥 | ⏳ pending (потребує credentials)                                  |
-| 2   | **Knip + depcheck** — clean dead code             | 1 год     | $0               | 🔥🔥   | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
-| 3   | **Strict TypeScript (incremental)**               | 1-2 тижні | $0               | 🔥🔥🔥 | ⏳ pending                                                        |
-| 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 | ⏳ pending                                                        |
+| #   | Інструмент / практика                             | Effort    | Cost             | ROI    | Статус                                                         |
+| --- | ------------------------------------------------- | --------- | ---------------- | ------ | -------------------------------------------------------------- |
+| 1   | **Sentry** для error tracking                     | 2 год     | $26/міс          | 🔥🔥🔥 | ⏳ pending (потребує credentials)                              |
+| 2   | **Knip + depcheck** — clean dead code             | 1 год     | $0               | 🔥🔥   | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716) |
+| 3   | **Strict TypeScript (incremental)**               | 1-2 тижні | $0               | 🔥🔥🔥 | ⏳ pending                                                     |
+| 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 | ⏳ pending                                                     |
 | 5   | **Vercel Pro plan** (рятує preview deploy)        | 5 хв      | $20/міс          | 🔥🔥   | 🟡 not started (потребує credit card мейнтейнера)              |
-| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ⏳ pending                                                        |
-| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
-| 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714)    |
-| 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ⏳ pending                                                        |
-| 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718)    |
-| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
-| 12  | **Activate Playwright E2E на PR**                 | 2 год     | $0               | 🔥🔥   | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717)    |
-| 13  | **PostHog** для product analytics                 | 4 год     | $0 (free tier)   | 🔥     | ⏳ pending                                                        |
-| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     | ⏳ pending                                                        |
-| 15  | **CONTRIBUTING.md + 5-min quickstart**            | 2 год     | $0               | 🔥🔥   | ⏳ pending                                                        |
+| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ⏳ pending                                                     |
+| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ⏳ pending                                                     |
+| 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714) |
+| 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ⏳ pending                                                     |
+| 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718) |
+| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   | ⏳ pending                                                     |
+| 12  | **Activate Playwright E2E на PR**                 | 2 год     | $0               | 🔥🔥   | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717) |
+| 13  | **PostHog** для product analytics                 | 4 год     | $0 (free tier)   | 🔥     | ⏳ pending                                                     |
+| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     | ⏳ pending                                                     |
+| 15  | **CONTRIBUTING.md + 5-min quickstart**            | 2 год     | $0               | 🔥🔥   | ⏳ pending                                                     |
 
 **Сумарно:** ~3-5 робочих днів + ~$50/міс. Це 80% wins за 20% effort-у.
 
@@ -115,15 +115,15 @@
 
 ### 3.1. Must-have
 
-| Tool                       | What                                                        | Effort    | Статус                                                            |
-| -------------------------- | ----------------------------------------------------------- | --------- | ----------------------------------------------------------------- |
-| **TypeScript strict mode** | Incremental: `strictNullChecks` → `noImplicitAny` → full    | 1-2 тижні | ⏳ pending                                                        |
-| **ESLint 9**               | У вас є                                                     | —         | ✅                                                                 |
-| **Prettier + lint-staged** | У вас є                                                     | —         | ✅                                                                 |
-| **Knip**                   | Find unused exports/files/deps (~50+ findings on first run) | 1 год     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
-| **depcheck**               | Find unused deps в package.json                             | 30 хв     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716)    |
-| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     | ⏳ pending                                                        |
-| **CSpell**                 | Spell-checker для коду і коментарів                         | 30 хв     | ⏳ pending                                                        |
+| Tool                       | What                                                        | Effort    | Статус                                                         |
+| -------------------------- | ----------------------------------------------------------- | --------- | -------------------------------------------------------------- |
+| **TypeScript strict mode** | Incremental: `strictNullChecks` → `noImplicitAny` → full    | 1-2 тижні | ⏳ pending                                                     |
+| **ESLint 9**               | У вас є                                                     | —         | ✅                                                             |
+| **Prettier + lint-staged** | У вас є                                                     | —         | ✅                                                             |
+| **Knip**                   | Find unused exports/files/deps (~50+ findings on first run) | 1 год     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716) |
+| **depcheck**               | Find unused deps в package.json                             | 30 хв     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716) |
+| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     | ⏳ pending                                                     |
+| **CSpell**                 | Spell-checker для коду і коментарів                         | 30 хв     | ⏳ pending                                                     |
 
 **Sergeant-priority:** strict TypeScript. Зараз `strict: false` — це баги waiting to happen.
 
@@ -158,28 +158,28 @@
 
 ### 4.1. Test infrastructure
 
-| Tool                          | What                                    | Effort | Tier | Статус                                                            |
-| ----------------------------- | --------------------------------------- | ------ | ---- | ----------------------------------------------------------------- |
-| **Snapshot tests (server)**   | Mono serializers response shape         | 4 год  | must | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718)    |
-| **Playwright Smoke E2E (PR)** | Login → dashboard happy-path на кожен PR  | 2 год  | must | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717)    |
-| **Testcontainers**            | Real Postgres у Docker для server tests | 4 год  | must | ⏳ pending                                                        |
-| **MSW (Mock Service Worker)** | Realistic API mocks для frontend tests  | 4 год  | must | ⏳ pending                                                        |
-| **fishery** / **factory-bot** | Test data factories                     | 2 год  | nice | ⏳ pending                                                        |
-| **faker**                     | Random test data                        | 30 хв  | nice | ⏳ pending                                                        |
-| **node:test**                 | If відмовляєтесь від Vitest для server  | 1 день | nice | ⏳ pending                                                        |
+| Tool                          | What                                     | Effort | Tier | Статус                                                         |
+| ----------------------------- | ---------------------------------------- | ------ | ---- | -------------------------------------------------------------- |
+| **Snapshot tests (server)**   | Mono serializers response shape          | 4 год  | must | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718) |
+| **Playwright Smoke E2E (PR)** | Login → dashboard happy-path на кожен PR | 2 год  | must | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717) |
+| **Testcontainers**            | Real Postgres у Docker для server tests  | 4 год  | must | ⏳ pending                                                     |
+| **MSW (Mock Service Worker)** | Realistic API mocks для frontend tests   | 4 год  | must | ⏳ pending                                                     |
+| **fishery** / **factory-bot** | Test data factories                      | 2 год  | nice | ⏳ pending                                                     |
+| **faker**                     | Random test data                         | 30 хв  | nice | ⏳ pending                                                     |
+| **node:test**                 | If відмовляєтесь від Vitest для server   | 1 день | nice | ⏳ pending                                                     |
 
 **Sergeant-priority:** Testcontainers. Зараз у server tests `queryMock.mockResolvedValueOnce(...)` — це не ловить SQL-помилки. Реальний PG ловить.
 
 ### 4.2. E2E і visual
 
-| Tool           | What                                 | Cost                  |
-| -------------- | ------------------------------------ | --------------------- |
+| Tool           | What                                                                         | Cost                  |
+| -------------- | ---------------------------------------------------------------------------- | --------------------- |
 | **Playwright** | ✅ активовано на PR ([#717](https://github.com/Skords-01/Sergeant/pull/717)) | $0                    |
-| **Detox**      | Mobile e2e (вже згаданий у Sergeant) | $0                    |
-| **Argos**      | Visual regression on PRs             | Free < 5K screenshots |
-| **Percy**      | BrowserStack-owned visual testing    | Free 5K screenshots   |
-| **Chromatic**  | Storybook-integrated visual testing  | $149/міс              |
-| **Lost Pixel** | Self-hosted visual testing           | $0                    |
+| **Detox**      | Mobile e2e (вже згаданий у Sergeant)                                         | $0                    |
+| **Argos**      | Visual regression on PRs                                                     | Free < 5K screenshots |
+| **Percy**      | BrowserStack-owned visual testing                                            | Free 5K screenshots   |
+| **Chromatic**  | Storybook-integrated visual testing                                          | $149/міс              |
+| **Lost Pixel** | Self-hosted visual testing                                                   | $0                    |
 
 ### 4.3. Performance і load
 


### PR DESCRIPTION
## What changed

Оновив `docs/ai-coding-improvements.md` і `docs/dev-stack-roadmap.md` — додав секції прогресу, колонку **Статус** до TL;DR таблиць і позначив зроблені пункти посиланнями на PR.

**Закриті блоки з `ai-coding-improvements.md`:**

| Блок | PR | Notes |
|------|----|-------|
| 1. `AGENTS.md` + PR template | [#714](https://github.com/Skords-01/Sergeant/pull/714) | Факти верифіковано проти реального стану репо |
| 3. Code markers + ESLint rule | [#715](https://github.com/Skords-01/Sergeant/pull/715) | `sergeant-design/ai-marker-syntax` (warn) + 20 unit-тестів |
| 4.2. Playwright E2E на PR | [#717](https://github.com/Skords-01/Sergeant/pull/717) | Видалено блокуючий `needs: check`, додано Postgres service + кешування |
| 4.5. Snapshot tests серверних serializers | [#718](https://github.com/Skords-01/Sergeant/pull/718) | `accountsHandler` + `transactionsHandler`; bigint coercion вже на місці |

**Закриті пункти з `dev-stack-roadmap.md`:**

- #2 Knip + depcheck — [#716](https://github.com/Skords-01/Sergeant/pull/716): 6 файлів видалено, 4 unused exports, 2 stale eslint entries
- #8 AGENTS.md — #714
- #10 Snapshot tests на server serializers — #718
- #12 Activate Playwright E2E на PR — #717

**Залишається не зробленим (потребує credentials):**

- Vercel Pro ($20/міс) — блок 4 у ai-coding, #5 у dev-stack
- Sentry ($26/міс) — #1 у dev-stack

## Why

Документи були помічені як `plan / draft`, але після 5 паралельних сесій 4 з 8 блоків `ai-coding-improvements.md` і 4 з топ-15 `dev-stack-roadmap.md` фактично закриті. Без оновлення доків майбутні AI-сесії будуть пробувати «зробити те що вже зроблено».

## How to test

```sh
git checkout devin/1777144791-roadmap-status-update
diff main..HEAD -- docs/ai-coding-improvements.md docs/dev-stack-roadmap.md
```

Verify markdown renders correctly on GitHub (tables, посилання на PR).

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): N/A — docs-only change
- [ ] Vitest passes: N/A — no code changes
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/7f6f38641bff44e69c300705220edf91
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
