### PR TITLE
fix(config): convert vitest.base to .js for Node ESM compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,12 @@
 
 Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-design/ai-marker-syntax` (warn).
 
-| Marker | Purpose | Example |
-|--------|---------|---------|
-| `// AI-NOTE: <text>` | Contextual hint for future AI agents (not a human TODO) | `// AI-NOTE: coerce bigint→number; see rule #1` |
-| `// AI-DANGER: <text>` | High-risk zone — AI should confirm before changing | `// AI-DANGER: timing-safe comparison is critical here` |
-| `// AI-GENERATED: <generator>` | File is generated — edit the generator, not this file | `// AI-GENERATED: from codegen.ts` |
-| `// AI-LEGACY: expires YYYY-MM-DD` | Temporary code scheduled for removal | `// AI-LEGACY: expires 2026-06-01` |
+| Marker                             | Purpose                                                 | Example                                                 |
+| ---------------------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| `// AI-NOTE: <text>`               | Contextual hint for future AI agents (not a human TODO) | `// AI-NOTE: coerce bigint→number; see rule #1`         |
+| `// AI-DANGER: <text>`             | High-risk zone — AI should confirm before changing      | `// AI-DANGER: timing-safe comparison is critical here` |
+| `// AI-GENERATED: <generator>`     | File is generated — edit the generator, not this file   | `// AI-GENERATED: from codegen.ts`                      |
+| `// AI-LEGACY: expires YYYY-MM-DD` | Temporary code scheduled for removal                    | `// AI-LEGACY: expires 2026-06-01`                      |
 
 **Rules:**
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,13 +7,13 @@
     "tsconfig.base.json",
     "tsconfig.node.json",
     "tsconfig.react.json",
-    "vitest.base.ts"
+    "vitest.base.js"
   ],
   "exports": {
     "./tsconfig.base.json": "./tsconfig.base.json",
     "./tsconfig.node.json": "./tsconfig.node.json",
     "./tsconfig.react.json": "./tsconfig.react.json",
-    "./vitest.base": "./vitest.base.ts"
+    "./vitest.base": "./vitest.base.js"
   },
   "scripts": {
     "typecheck": "echo 'config has no ts sources'",

--- a/packages/config/vitest.base.js
+++ b/packages/config/vitest.base.js
@@ -1,11 +1,17 @@
-import type { UserConfig } from "vitest/config";
-
 /**
  * Shared Vitest defaults used by every package in the monorepo. Individual
  * packages override `include`, `environment`, `setupFiles` and path aliases
  * as needed.
+ *
+ * AI-NOTE: this file is plain `.js` (not `.ts`) so Node's ESM loader can
+ * resolve it through the `@sergeant/config/vitest.base` package export
+ * without a transpiler. Vitest config files are loaded by vite-node which
+ * handles their own `.ts`, but transitive imports across package boundaries
+ * fall back to native Node ESM and choke on `.ts`. See PR #719 / #720.
+ *
+ * @type {import("vitest/config").UserConfig}
  */
-export const baseVitestConfig: UserConfig = {
+export const baseVitestConfig = {
   test: {
     environment: "node",
     passWithNoTests: true,
@@ -20,8 +26,8 @@ export const baseVitestConfig: UserConfig = {
  * future PRs cannot decrease coverage.
  */
 export const baseCoverageConfig = {
-  provider: "v8" as const,
-  reporter: ["text", "html", "json-summary", "lcov"] as const,
+  provider: /** @type {const} */ ("v8"),
+  reporter: /** @type {const} */ (["text", "html", "json-summary", "lcov"]),
   reportsDirectory: "./coverage",
   exclude: [
     "**/node_modules/**",


### PR DESCRIPTION
## What changed

- `packages/config/vitest.base.ts` → `packages/config/vitest.base.js` (JSDoc types instead of TS syntax).
- `packages/config/package.json` exports/files updated to point to `.js`.
- Re-ran `prettier --write AGENTS.md` (drifted out of format on main since #714/#719).

## Why

Every PR's `check` job has been failing since `dab67bdc ci(coverage): add vitest --coverage with per-package floors` with:

```
@sergeant/finyk-domain:test:coverage
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
  for packages/config/vitest.base.ts
    at Object.getFileProtocolModuleFormat
    at defaultGetFormat
    at defaultLoad
    at async ModuleLoader.loadAndTranslate
```

Vitest loads each `vitest.config.ts` via vite-node (which handles `.ts`), but the transitive `import { baseCoverageConfig } from "@sergeant/config/vitest.base"` is resolved via Node's native ESM loader (because `@sergeant/config` has `type: "module"` and the export points at a `.ts` file). Native Node ESM has no idea how to load a TypeScript file → startup error → 0/13 tasks succeed.

Reproduced locally on `origin/main` HEAD (`6833138d`):

```sh
pnpm --filter @sergeant/finyk-domain test
# → ERR_UNKNOWN_FILE_EXTENSION
```

After this fix:

```sh
pnpm --filter @sergeant/finyk-domain test
# Test Files  13 passed (13)
#      Tests  217 passed (217)
```

`pnpm test` runs 11/13 packages cleanly (only `@sergeant/mobile` still fails, which is the documented React-Native flaky test set in `AGENTS.md`).

## How to test

```sh
git checkout devin/1777145517-vitest-config-esm-fix
pnpm install --frozen-lockfile
pnpm --filter @sergeant/finyk-domain test
pnpm --filter @sergeant/server test
pnpm --filter @sergeant/web test
pnpm typecheck
pnpm format:check
```

All should pass. Then in CI: the `check` and `Test coverage (vitest)` jobs should turn green for the first time since `dab67bdc`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm --filter @sergeant/finyk-domain test` (217 pass), `pnpm typecheck` (13/13), `pnpm format:check` (clean), `pnpm test` (11/13 — mobile is the documented flaky exception).
- [x] Vitest passes: yes for every non-mobile package — see above.
- [x] No new `AI-DANGER` markers added without justification. Added one `AI-NOTE` to `vitest.base.js` explaining why it's `.js` not `.ts`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (only re-formatted)

Link to Devin session: https://app.devin.ai/sessions/7f6f38641bff44e69c300705220edf91
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting in contributor guidelines for improved clarity.

* **Chores**
  * Updated configuration module exports to point to compiled JavaScript distribution.
  * Improved internal type handling for better module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->