### PR TITLE
chore(deps): add Renovate config to replace Dependabot

### DIFF
--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -18,7 +18,7 @@
 | 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 | ⏳ pending                                                     |
 | 5   | **Vercel Pro plan** (рятує preview deploy)        | 5 хв      | $20/міс          | 🔥🔥   | 🟡 not started (потребує credit card мейнтейнера)              |
 | 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ⏳ pending                                                     |
-| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ⏳ pending                                                     |
+| 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ✅ done [#721](https://github.com/Skords-01/Sergeant/pull/721) |
 | 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714) |
 | 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ⏳ pending                                                     |
 | 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718) |
@@ -30,7 +30,7 @@
 
 **Сумарно:** ~3-5 робочих днів + ~$50/міс. Це 80% wins за 20% effort-у.
 
-**Прогрес (2026-04-25):** 4 / 15 закрито — #2 Knip+depcheck, #8 AGENTS.md, #10 Snapshot tests, #12 Playwright E2E. Наступні логічні кроки: #15 (CONTRIBUTING.md — дешевий win), #11 (Pino logging — розблокує Sentry/PostHog), #4 (Testcontainers — підсилить #10), #7 (Renovate — безпека).
+**Прогрес (2026-04-25):** 5 / 15 закрито — #2 Knip+depcheck, #7 Renovate, #8 AGENTS.md, #10 Snapshot tests, #12 Playwright E2E. Наступні логічні кроки: #15 (CONTRIBUTING.md — дешевий win), #11 (Pino logging — розблокує Sentry/PostHog), #4 (Testcontainers — підсилить #10), #6 (Turbo remote cache — пришвидшить CI).
 
 ---
 
@@ -519,7 +519,7 @@ CI gate: `vitest --coverage` + threshold (наприклад 70% lines) на cri
 - [ ] Sentry + source maps upload
 - [ ] Vercel Pro plan upgrade
 - [ ] Knip + depcheck + видалення dead code
-- [ ] Renovate setup
+- [x] Renovate setup ([#721](https://github.com/Skords-01/Sergeant/pull/721))
 - [ ] Turbo remote cache
 - [ ] AGENTS.md (з #711)
 - [ ] CONTRIBUTING.md з 5-хв quickstart

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScope(deps)",
+    ":dependencyDashboard",
+    ":maintainLockFilesWeekly",
+    ":separateMultipleMajorReleases",
+    ":prHourlyLimit2",
+    ":prConcurrentLimit10",
+    "group:monorepos",
+    "group:recommended"
+  ],
+  "timezone": "Europe/Kyiv",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "rebaseWhen": "conflicted",
+  "prCreation": "not-pending",
+  "automergeStrategy": "squash",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/dist-server/**",
+    "apps/mobile-shell/android/**",
+    "apps/mobile-shell/ios/**",
+    "apps/mobile/android/**",
+    "apps/mobile/ios/**"
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "minimumReleaseAge": "0 days"
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"],
+    "commitMessageAction": "refresh",
+    "extends": ["schedule:weekly"]
+  },
+  "packageRules": [
+    {
+      "description": "All @types/* together (type-only updates rarely break anything)",
+      "matchPackageNames": ["/^@types//"],
+      "groupName": "type definitions",
+      "automerge": false
+    },
+    {
+      "description": "ESLint and plugins",
+      "matchPackageNames": [
+        "eslint",
+        "/^eslint-/",
+        "/^@typescript-eslint//",
+        "/^@eslint//"
+      ],
+      "groupName": "eslint"
+    },
+    {
+      "description": "Vitest ecosystem",
+      "matchPackageNames": ["vitest", "/^@vitest//"],
+      "groupName": "vitest"
+    },
+    {
+      "description": "Playwright (browsers + runner together)",
+      "matchPackageNames": ["/^@playwright//", "/^playwright/"],
+      "groupName": "playwright"
+    },
+    {
+      "description": "TanStack ecosystem (Query, Router, etc.)",
+      "matchPackageNames": ["/^@tanstack//"],
+      "groupName": "tanstack"
+    },
+    {
+      "description": "Radix UI primitives",
+      "matchPackageNames": ["/^@radix-ui//"],
+      "groupName": "radix-ui"
+    },
+    {
+      "description": "Vite ecosystem",
+      "matchPackageNames": ["vite", "/^@vitejs//", "/^vite-/"],
+      "groupName": "vite"
+    },
+    {
+      "description": "Turbo + tooling",
+      "matchPackageNames": ["turbo"],
+      "groupName": "turborepo"
+    },
+    {
+      "description": "Expo SDK pieces stay grouped — version is tied to Expo SDK release",
+      "matchPackageNames": ["expo", "/^expo-/", "/^@expo//"],
+      "groupName": "expo sdk",
+      "rangeStrategy": "pin",
+      "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "Capacitor stays grouped",
+      "matchPackageNames": ["/^@capacitor//"],
+      "groupName": "capacitor"
+    },
+    {
+      "description": "React Native + react-native-* peers",
+      "matchPackageNames": ["react-native", "/^react-native-/"],
+      "groupName": "react-native",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Pin Node engine — must match CI matrix",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
+      "description": "Auto-merge dev-only patch updates after CI passes",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch",
+      "platformAutomerge": true
+    },
+    {
+      "description": "GitHub Actions: pin to commit SHA + add a comment with the version tag",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "groupName": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- New `renovate.json` at repo root with sensible defaults for this monorepo.
- `docs/dev-stack-roadmap.md` #7 marked ✅ done.
- No `.github/dependabot.yml` to remove (none existed before).

## Why

Sergeant is **pnpm 9 + Turborepo**. Dependabot's pnpm support is shallow — it can't refresh `pnpm-lock.yaml` correctly, can't group across workspaces, and creates a flood of PRs (one per package per workspace). Renovate handles this natively.

This unblocks `dev-stack-roadmap` #7 and starts the slow work of keeping the dep tree fresh, which makes #4 (Testcontainers), #11 (Pino), and #1 (Sentry) safer to ship later.

### Config highlights

| What | Behaviour |
|---|---|
| Schedule | Monday before 6am Europe/Kyiv, ≤ 2 PRs/hr, ≤ 10 concurrent |
| Lockfile | `lockFileMaintenance` weekly to refresh `pnpm-lock.yaml` |
| Commits | `chore(deps): …` — passes commitlint, AGENTS.md hard rule #5 |
| Security | `vulnerabilityAlerts` run **any time**, no min-release-age |
| Auto-merge | Only dev-only `patch`/`pin`/`digest`. Everything else → human review |
| Grouping | `eslint`, `vitest`, `vite`, `playwright`, `tanstack`, `radix-ui`, `expo sdk`, `capacitor`, `react-native`, `turborepo`, `@types/*`, `github-actions` |
| Pinning | GitHub Actions get pinned to commit SHAs (supply-chain hygiene) |
| Ignored | iOS/Android native folders, `node_modules`, `dist*` |
| Locked | Node `engines` is `enabled: false` (must match CI matrix manually) |

`expo` and `react-native` use `rangeStrategy: "pin"` because both ecosystems break aggressively across minor bumps; pinning + grouping keeps Expo SDK upgrades coherent.

## How to test

1. **Validate the config locally** (no install needed):
   ```sh
   npx --package=renovate -- renovate-config-validator renovate.json
   ```
   Expected:
   ```
   INFO: Validating renovate.json
   INFO: Config validated successfully
   ```
   (Already verified — no deprecated patterns; uses modern `matchPackageNames` regex syntax.)

2. **Format check**:
   ```sh
   pnpm exec prettier --check renovate.json docs/dev-stack-roadmap.md
   ```
   Expected: `All matched files use Prettier code style!`

3. **Activate after merge** (maintainer):
   1. Install the **Mend Renovate** GitHub App on `Skords-01/Sergeant`: <https://github.com/apps/renovate>.
   2. Renovate will open an "onboarding" PR within ~10 min — review the proposed schedule + grouping and merge it.
   3. Watch the first weekly batch on Monday morning.

   Optional dry-run before installing the app:
   ```sh
   LOG_LEVEL=debug npx --package=renovate renovate \
     --platform=local --dry-run=full
   ```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `npx --package=renovate -- renovate-config-validator renovate.json` → config valid; `pnpm exec prettier --check renovate.json docs/dev-stack-roadmap.md` → clean.
- [x] Vitest passes: N/A — config-only PR, no source code changed, no tests affected.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (config-only).

Link to Devin session: https://app.devin.ai/sessions/7f6f38641bff44e69c300705220edf91
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
