### PR TITLE
docs(roadmap): session log for 2026-04-25 + renovate-usage guide

### DIFF
--- a/docs/ai-coding-improvements.md
+++ b/docs/ai-coding-improvements.md
@@ -502,6 +502,51 @@ it("accountsHandler response shape matches snapshot", async () => {
 
 ---
 
+# Session log
+
+## 2026-04-25 — інфра-спринт (8 PR, 4 з 8 блоків закрито)
+
+| PR                                                     | Що                                                                       | Блок          |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ | ------------- |
+| [#714](https://github.com/Skords-01/Sergeant/pull/714) | `AGENTS.md` + PR template "How AI-tested"                                | 1             |
+| [#715](https://github.com/Skords-01/Sergeant/pull/715) | AI markers + ESLint rule `sergeant-design/ai-marker-syntax`              | 3             |
+| [#716](https://github.com/Skords-01/Sergeant/pull/716) | Knip + depcheck + cleanup (бонус з `dev-stack-roadmap` #2)               | (bonus)       |
+| [#717](https://github.com/Skords-01/Sergeant/pull/717) | Activate Playwright E2E на PR                                            | 4.2 / dev #12 |
+| [#718](https://github.com/Skords-01/Sergeant/pull/718) | Snapshot tests `accountsHandler` + `transactionsHandler`                 | 4.5 / dev #10 |
+| [#719](https://github.com/Skords-01/Sergeant/pull/719) | Оновлення roadmap-ів зі статусом                                         | (meta)        |
+| [#720](https://github.com/Skords-01/Sergeant/pull/720) | Fix `vitest.base.ts` ESM bug (розблокувало `pnpm test` для всіх пакетів) | (infra)       |
+| [#721](https://github.com/Skords-01/Sergeant/pull/721) | Renovate config (заміна Dependabot, dev-stack #7)                        | (bonus)       |
+
+### Що з блоків 1-8 цього документа залишилось
+
+| Блок | Статус             | Наступний крок                                                                                       |
+| ---- | ------------------ | ---------------------------------------------------------------------------------------------------- |
+| 1    | ✅ done            | Quarterly review reminder (next due: 2026-07-25)                                                     |
+| 2    | ⏳ pending         | Створити 4 playbook-и (`hotfix-prod`, `add-feature-flag`, `cleanup-dead-code`, `add-domain-package`) |
+| 3    | ✅ done            | Додавати маркери поступово при роботі з legacy-кодом                                                 |
+| 4    | 🟡 not started     | Потребує credentials мейнтейнера ($20/міс Vercel Pro)                                                |
+| 5    | ✅ done            | Workflow: Smoke E2E (#717). Visual regression (Argos) — далі                                         |
+| 6    | ⏳ pending         | Argos / Chromatic — після стабільного preview deploy (блок 4)                                        |
+| 7    | ⏳ pending         | Storybook або Histoire — окрема велика задача                                                        |
+| 8    | ✅ done (частково) | Покриті 2 endpoint-и Mono. Решта endpoint-ів — поступово                                             |
+
+### Bonus відкриття під час спринту
+
+- **`vitest.base.ts` ESM bug ([#720](https://github.com/Skords-01/Sergeant/pull/720))** — `pnpm test` був повністю зламаний на main з commit `dab67bdc`. Native Node ESM loader не вміє резолвити `.ts` через package exports. Конвертовано у `.js` з JSDoc-типами. Це регресія яку б ловив CI з блоку 4.5, якби він був повністю налаштований до того.
+- **AGENTS.md без prettier ([#719](https://github.com/Skords-01/Sergeant/pull/719))** — фідбек для майбутніх AI-сесій що створюють docs: завжди прогнати `prettier --write` перед commit-ом.
+
+### Метрики (з блоку 5 цього документа) — оновлення
+
+| Метрика                                 | Baseline (до сесії)   | Зараз                                                                        |
+| --------------------------------------- | --------------------- | ---------------------------------------------------------------------------- |
+| Time-to-PR (chat → open)                | ~30 хв                | без замірів (потребує телеметрії)                                            |
+| CI-fail-rate першої спроби              | n/a (CI був зламаний) | потребує спостереження кілька PR-ів                                          |
+| % PR-ів від AI які revert-нули          | n/a                   | 0 / 8 за цей спринт                                                          |
+| Recurring bugs                          | n/a                   | track via [#708](https://github.com/Skords-01/Sergeant/issues/708) reference |
+| AGENTS.md staleness (дні з last review) | n/a                   | 0 (last review: 2026-04-25)                                                  |
+
+---
+
 # Поза скоупом цього документа
 
 - Knowledge notes (це окремо — вже згадано у попередньому повідомленні чату).

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -1,6 +1,6 @@
 # Dev stack roadmap — інструменти і поради по всьому ЖЦ розробки
 
-**Статус:** in progress. Створено 2026-04-25. Останнє оновлення: 2026-04-25 (4 з топ-15 закриті — див. колонку Статус у TL;DR).
+**Статус:** in progress. Створено 2026-04-25. Останнє оновлення: 2026-04-25 (5 з топ-15 закриті — див. колонку Статус у TL;DR + повний session log нижче).
 **Скоуп:** інструменти, інтеграції, практики для покращення розробки, тестування, CI/CD, проду, безпеки, performance і команди. Specifically для стеку Sergeant: pnpm + Turborepo + Vite/React + Express + Postgres + Railway + Vercel + Expo.
 **Принцип:** не «впровадити все одразу», а **поетапно** — від найдешевших і найважливіших до інвестиційних. Кожен пункт — самостійний tool / practice з ціною, effort-ом, ROI і dep-ами.
 
@@ -364,16 +364,16 @@ CI gate: `vitest --coverage` + threshold (наприклад 70% lines) на cri
 
 ### 8.1. Must-have
 
-| Practice                             | Tool                                | Effort       |
-| ------------------------------------ | ----------------------------------- | ------------ |
-| Dependency CVE scanning              | Snyk / Dependabot security alerts   | 30 хв        |
-| Secrets pre-commit hook              | git-secrets / gitleaks / trufflehog | 30 хв        |
-| HTTP security headers                | helmet.js (Express)                 | 1 год        |
-| CORS strict whitelist                | manual config                       | 30 хв        |
-| Rate limiting                        | express-rate-limit                  | 1 год        |
-| HttpOnly + Secure + SameSite cookies | manual config                       | 30 хв        |
-| Strong password hashing              | Better Auth (handle-ить argon2)     | already done |
-| HTTPS everywhere                     | Railway / Vercel automatic          | done         |
+| Practice                             | Tool                                                                                                        | Effort       |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------- | ------------ |
+| Dependency CVE scanning              | Renovate `vulnerabilityAlerts` (✅ enabled у [#721](https://github.com/Skords-01/Sergeant/pull/721)) / Snyk | 30 хв        |
+| Secrets pre-commit hook              | git-secrets / gitleaks / trufflehog                                                                         | 30 хв        |
+| HTTP security headers                | helmet.js (Express)                                                                                         | 1 год        |
+| CORS strict whitelist                | manual config                                                                                               | 30 хв        |
+| Rate limiting                        | express-rate-limit                                                                                          | 1 год        |
+| HttpOnly + Secure + SameSite cookies | manual config                                                                                               | 30 хв        |
+| Strong password hashing              | Better Auth (handle-ить argon2)                                                                             | already done |
+| HTTPS everywhere                     | Railway / Vercel automatic                                                                                  | done         |
 
 ### 8.2. Nice-to-have
 
@@ -594,6 +594,77 @@ CI gate: `vitest --coverage` + threshold (наприклад 70% lines) на cri
 | **Total new cost**  | **~$46-50/міс** | —       |
 
 Збільшення cost-у мінімальне. ROI — годин на тиждень.
+
+---
+
+## Session log
+
+### 2026-04-25 — інфра-спринт
+
+8 PR замерджено, 5 пунктів топ-15 закрито. Хронологія:
+
+| PR                                                     | Що                                                               | Roadmap         | Тривалість |
+| ------------------------------------------------------ | ---------------------------------------------------------------- | --------------- | ---------- |
+| [#714](https://github.com/Skords-01/Sergeant/pull/714) | `AGENTS.md` + PR template "How AI-tested"                        | #8              | паралельно |
+| [#715](https://github.com/Skords-01/Sergeant/pull/715) | AI markers + ESLint rule `sergeant-design/ai-marker-syntax`      | (ai-coding §3)  | паралельно |
+| [#716](https://github.com/Skords-01/Sergeant/pull/716) | Knip + depcheck + first-pass dead-code cleanup                   | #2              | паралельно |
+| [#717](https://github.com/Skords-01/Sergeant/pull/717) | Activate Playwright E2E на PR (Postgres service + browser cache) | #12             | паралельно |
+| [#718](https://github.com/Skords-01/Sergeant/pull/718) | Snapshot tests для `accountsHandler` + `transactionsHandler`     | #10             | паралельно |
+| [#719](https://github.com/Skords-01/Sergeant/pull/719) | Оновлення roadmap-ів зі статусом + Status-колонкою               | (meta)          | sequential |
+| [#720](https://github.com/Skords-01/Sergeant/pull/720) | Fix `vitest.base.ts` ESM (всі 13 пакетів падали на startup)      | (infra unblock) | sequential |
+| [#721](https://github.com/Skords-01/Sergeant/pull/721) | Renovate config (заміна Dependabot)                              | #7              | sequential |
+
+**Bonus discoveries (поза планом):**
+
+- `pnpm test` на main був повністю зламаний з commit `dab67bdc` через `ERR_UNKNOWN_FILE_EXTENSION` для `packages/config/vitest.base.ts`. Native Node ESM loader не вміє резолвити `.ts` через package exports. Fixed у [#720](https://github.com/Skords-01/Sergeant/pull/720): конвертація у `.js` з JSDoc-типами. Без цього #721 (і всі наступні PR) теж не пройшли б CI.
+- AGENTS.md з [#714](https://github.com/Skords-01/Sergeant/pull/714) був закомічений без `prettier --write`; виправлено у [#719](https://github.com/Skords-01/Sergeant/pull/719) разом з doc-апдейтами.
+
+**Що НЕ робили і чому:**
+
+- #1 Sentry, #5 Vercel Pro, #13 PostHog — потребують credentials/credit card мейнтейнера.
+- #3 Strict TypeScript, #4 Testcontainers, #11 Pino — кожне 4-8 годин роботи; залишено на наступні спринти.
+- #15 CONTRIBUTING.md — найдешевший залишковий win, але вирішено зробити Renovate першим (безпека).
+
+**Метрики до/після:**
+
+| Метрика                     | До 2026-04-25               | Після                                  |
+| --------------------------- | --------------------------- | -------------------------------------- |
+| Топ-15 закрито              | 0/15                        | 5/15                                   |
+| `pnpm test` працює          | ❌ (всі 13 пакетів падають) | ✅ (12/13; mobile flaky per AGENTS.md) |
+| Smoke E2E у PR              | ⏭️ skipped                  | ✅ runs                                |
+| `AGENTS.md` контекст для AI | ❌                          | ✅                                     |
+| AI markers convention       | ❌                          | ✅ + lint warn                         |
+| Snapshot захист API форм    | 0 endpoint-ів               | 2 endpoint-и Mono                      |
+| Auto-PR для оновлень        | ❌                          | ✅ Renovate (Mon 6am EU/Kyiv)          |
+| Dead-code detection         | manual                      | Knip + depcheck                        |
+
+**Поточні pre-merge checks на PR:**
+
+1. `Smoke E2E (Playwright)` ([#717](https://github.com/Skords-01/Sergeant/pull/717))
+2. `Test coverage (vitest)` ([dab67bdc](https://github.com/Skords-01/Sergeant/commit/dab67bdc), unblocked by [#720](https://github.com/Skords-01/Sergeant/pull/720))
+3. `check` (`format:check && lint && typecheck && test && build`)
+4. `Vercel — sergeant` (rate-limited на free, потребує #5 Vercel Pro)
+5. CodeRabbit + Devin Review (AI коментарі, не блокують)
+
+**Наступні логічні кроки** (у порядку вартості/користі):
+
+1. **#15 CONTRIBUTING.md + 5-min quickstart** — найдешевший win, ~1 год.
+2. **#11 Pino structured logging** — 4 год, але **розблокує** Sentry і PostHog (треба структуровані логи з request-id перш ніж їх десь агрегувати).
+3. **#4 Testcontainers** — 4 год, посилює #10 (snapshot тести з реальним Postgres у CI ловлять ще більше регресій).
+4. **#6 Turbo remote cache** — 1 год, прискорить CI з ~5 хв до ~1 хв на повторних білдах.
+5. **#9 MSW + #14 size-limit** — frontend тести і bundle budget, по 2-4 год кожне.
+
+**Dependent на платних сервісах** (черга на коли мейнтейнер додасть credit card):
+
+- [ ] #5 Vercel Pro ($20/міс) — розблокує preview deploy на PR
+- [ ] #1 Sentry ($26/міс) — потребує #11 Pino перш ніж приносити користь
+- [ ] #13 PostHog ($0 free tier) — теж краще з #11
+
+### Документи що оновились разом
+
+- `docs/ai-coding-improvements.md` — TL;DR таблиця з Status-колонкою, прогрес-блок, маркери ✅ на блоках 1, 3, 4.2, 4.5, implementation checklist з лінками на PR.
+- `docs/dev-stack-roadmap.md` — TL;DR з Status-колонкою (5/15 done), §3.1 Static analysis і §4.1 Test infrastructure з ✅, §8.1 Security оновлений з Renovate vulnerabilityAlerts.
+- `docs/renovate-usage.md` — новий файл, як працювати з Renovate-PR-ами щодня.
 
 ---
 

--- a/docs/renovate-usage.md
+++ b/docs/renovate-usage.md
@@ -1,0 +1,177 @@
+# Renovate — як працювати з PR-ами
+
+> Створено 2026-04-25 разом з [#721](https://github.com/Skords-01/Sergeant/pull/721). Конфіг: `renovate.json` у корені.
+
+## TL;DR
+
+1. **Понеділок ранок** → подивись список нових PR від `renovate[bot]`.
+2. **CI зелений + diff виглядає sane** → merge.
+3. **Dev-only patch** → нічого не роби, замерджиться сам.
+4. **Major (6.x → 7.x)** → читаєш changelog у тілі PR, тестуєш локально, merge або close.
+
+Більше нічого не треба.
+
+## Настройка одноразова
+
+1. Постав GitHub-додаток **Mend Renovate** на акаунт `Skords-01`: <https://github.com/apps/renovate>.
+2. У dashboard <https://developer.mend.io/> переключи **Default Engine Settings → Dependency Updates** з `Silent` на **`Auto`** (інакше PR-ів не буде).
+3. Перевір що Sergeant є в **Installed Repositories**. Якщо ні — додай через Settings.
+4. Чекай ~10-30 хв → Renovate створить **онбординг-PR** з тайтлом `Configure Renovate`. Замерджай. Це підтверджує `renovate.json`.
+
+Після цього все автоматично.
+
+## Що приходитиме
+
+### Окремі PR-и
+
+Тайтл: `chore(deps): update <package> to v<version>`
+
+Розклад: **щопонеділка до 6:00 за Києвом**, max 10 одночасних, max 2 на годину.
+
+Згруповані за екосистемами (один PR на групу, не один на кожен пакет):
+
+- `eslint` — eslint, eslint-\*, @typescript-eslint/\*, @eslint/\*
+- `vitest` — vitest, @vitest/\*
+- `vite` — vite, @vitejs/\*, vite-\*
+- `playwright` — @playwright/\*, playwright
+- `tanstack` — @tanstack/\*
+- `radix-ui` — @radix-ui/\*
+- `expo sdk` — expo, expo-\*, @expo/\* (pinned, бо ламається)
+- `capacitor` — @capacitor/\*
+- `react-native` — react-native, react-native-\* (pinned)
+- `turborepo` — turbo
+- `type definitions` — @types/\*
+- `github-actions` — всі actions, пінятся до commit SHA
+
+### Dependency Dashboard
+
+Один **GitHub Issue** з тайтлом `Dependency Dashboard`. Створиться при першому запуску і буде оновлюватись.
+
+Що там:
+
+- Всі pending updates з чекбоксами — можна руками тригернути PR не чекаючи понеділка.
+- Список того що Renovate ігнорує і чому.
+- Errors якщо щось зламалось.
+
+Прибагмаркай це Issue.
+
+### Security PR-и
+
+Тайтл містить лейбл `security`. Створюються **миттєво**, поза розкладом, без min-release-age.
+
+Пріоритет: **завжди перший**. Дивись changelog → merge.
+
+### Lockfile maintenance PR
+
+Тайтл: `chore(deps): refresh pnpm-lock.yaml`. Раз на тиждень. Автоматично перегенерує lockfile щоб підтягнути secondary updates у транзитивних деплях.
+
+Безпечно мерджити після зеленого CI.
+
+## Що merge-аю автоматично (не треба робити нічого)
+
+- **Dev-only patch / pin / digest** оновлення → автомердж після зеленого CI.
+- Платформа автомерджу — `branch` (Renovate сам викличе merge через GitHub API коли всі required checks зеленіли).
+
+Це означає що `@types/node 20.10.5 → 20.10.6` або `eslint 9.15.0 → 9.15.1` не вимагатимуть твоєї уваги.
+
+## Що **не** автомерджу — потрібне ручне ревʼю
+
+- Будь-який major (`vitest 3.x → 4.x`).
+- Будь-який minor (`react 19.0.0 → 19.1.0`).
+- Будь-яка production-залежність (не `devDependencies`) — навіть patch.
+- Будь-який security PR (свідоме рішення).
+
+## Як ревʼюїти
+
+### Швидкий cheatsheet
+
+1. **Відкриваєш PR**.
+2. **Дивишся "Files changed"**: має бути тільки `package.json` + `pnpm-lock.yaml`. Якщо є щось інше — це не Renovate-PR, обережно.
+3. **Читаєш "Release Notes" розділ** (Renovate сам клеїть changelog у body PR-а):
+   - Є **Breaking changes**? Якщо так — або відкладай, або тестуй вручну.
+   - Є тільки bug fixes / docs? → merge.
+4. **Чекаєш зеленого CI** (Smoke E2E + Test coverage + check).
+5. **Merge** (squash, як завжди).
+
+### Коли червоний CI
+
+Це часто означає:
+
+- API залежності змінилось (breaking) — почитай error в логах CI.
+- Або тип посилився і знайшов реальну проблему в нашому коді.
+
+Опції:
+
+- Закрити PR (Renovate знову створить його через тиждень або при наступному релізі — змусить розібратись).
+- Попросити AI-сесію (нову Devin) пофіксити код у тій же гілці.
+- Додати правило в `renovate.json`: `"matchPackageNames": ["X"], "enabled": false` — і Renovate більше не пробуватиме.
+
+### Як заборонити апдейт пакета
+
+`renovate.json` → `packageRules` → новий запис:
+
+```jsonc
+{
+  "description": "Залишаємось на старій версії бо ...",
+  "matchPackageNames": ["package-name"],
+  "enabled": false,
+}
+```
+
+Або пін на конкретну major-версію:
+
+```jsonc
+{
+  "matchPackageNames": ["package-name"],
+  "allowedVersions": "<5.0.0",
+}
+```
+
+## Розклад і timing
+
+| Подія                | Коли                          |
+| -------------------- | ----------------------------- |
+| Звичайні PR          | Mon 00:00–06:00 Europe/Kyiv   |
+| Security PR          | негайно, поза розкладом       |
+| Lockfile maintenance | Mon ранок                     |
+| Dependency Dashboard | оновлюється при кожному скані |
+| Скан репо            | приблизно раз на годину       |
+| Concurrent PRs       | max 10                        |
+| PRs per hour         | max 2                         |
+
+Якщо хочеш на тиждень "тихо" — закрий усі PR без merge, наступного понеділка прийдуть нові.
+
+## Faq
+
+**Q: Renovate не створює PR-и.**
+
+- Перевір що в Mend dashboard режим **`Auto`**, не `Silent`.
+- Перевір що Sergeant є в Installed Repositories.
+- Подивись Dependency Dashboard Issue — там може бути зазначено помилку конфігу.
+
+**Q: Я закрив PR — він прийде знову?**
+
+- Так, при наступному скані того ж пакета (зазвичай при наступному релізі або через тиждень). Якщо хочеш заборонити навсегда — додай `enabled: false` правило.
+
+**Q: Renovate створив 50 PR-ів одразу.**
+
+- При першому запуску — нормально, він проходить весь беклог. Подальше — обмежено `prHourlyLimit2` + `prConcurrentLimit10`. Якщо все одно багато — запини що тобі найважливіше, решта почекає.
+
+**Q: Чи бачить Renovate приватні дані?**
+
+- Renovate бачить `package.json` + lockfiles + дозвіл писати в репо. Не бачить твій код за межами цих файлів. Mend (хост) не бачить нічого окрім метаданих.
+
+**Q: Як зробити dry-run перед merge-ом онбордингу?**
+
+```sh
+LOG_LEVEL=debug npx --package=renovate renovate \
+  --platform=local --dry-run=full
+```
+
+Покаже що Renovate планує зробити без будь-яких реальних PR.
+
+## Зв'язки
+
+- `renovate.json` — сам конфіг
+- `docs/dev-stack-roadmap.md` #7 — навіщо ми це робили
+- AGENTS.md hard rule #5 — конвенціональні commit-меседжі (Renovate їх дотримується через `:semanticCommitTypeAll(chore)` + `:semanticCommitScope(deps)`)


### PR DESCRIPTION
## What changed

- `docs/ai-coding-improvements.md` — додано `# Session log → ## 2026-04-25 — інфра-спринт` з таблицею 8 PR, оновлений status кожного блоку 1-8, метрики baseline → after, bonus discoveries.
- `docs/dev-stack-roadmap.md` — додано `## Session log → ### 2026-04-25 — інфра-спринт` з тією ж таблицею + наступні логічні кроки + платні залежності у черзі. Bumped header "5 з топ-15 закриті". Виправлено §8.1 щоб посилатись на Renovate `vulnerabilityAlerts` замість Dependabot.
- `docs/renovate-usage.md` — **новий файл**. Practical guide для мейнтейнера: коли приходять PR, що автомерджиться, як ревʼюїти, як заборонити апдейт, FAQ.

## Why

За одну сесію закрили 5/15 топ-задач dev-stack roadmap і 4/8 блоків ai-coding-improvements (#714–#721). Без цієї документації:

- Не зрозуміло хто/коли/чому закрив які блоки.
- Renovate щойно встановили — наступного понеділка користувач отримає 10+ PR-ів і не знатиме що з ними робити (особливо що patch-апдейти dev-deps автомерджаться, а security PR-и приходять негайно).
- Прогрес-метрики з ai-coding §5 не оновлено — їх не з чим буде порівнювати наступного разу.

`renovate-usage.md` — хочу щоб користувач міг відкрити один файл і за 30 секунд зрозуміти який сьогодні workflow, замість гуглити Renovate docs.

## How to test

1. **Lint / format**:
   ```sh
   pnpm exec prettier --check docs/dev-stack-roadmap.md docs/ai-coding-improvements.md docs/renovate-usage.md
   ```
   Should output `All matched files use Prettier code style!`.

2. **Read-through review**: відкрий три файли, перевір що:
   - Всі лінки на PR (#714–#721) працюють.
   - Таблиці рендеряться (без зламаних `|`).
   - Renovate-секція "Що merge-аю автоматично" відповідає реальним правилам у `renovate.json` (групи, `automerge: true` для dev-only patch).

3. **No source code changed**: `git diff --stat origin/main` має показати тільки 3 файли в `docs/`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm exec prettier --check` на трьох файлах — clean.
- [x] Vitest passes: N/A — docs-only PR, no source code changed.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (docs only).

Link to Devin session: https://app.devin.ai/sessions/7f6f38641bff44e69c300705220edf91
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a session log capturing sprint outcomes with metrics and remaining work items.
  * Updated roadmap progress header and revised dependency scanning recommendation to Renovate.
  * Added comprehensive guide for configuring and operating Renovate PRs, including setup, merge policies, review process, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->