### PR TITLE
chore(ci): wire Turborepo remote cache (roadmap #6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Turborepo remote cache — speeds up turbo tasks across CI runs.
+  # Secrets are configured in the repo's GitHub settings; when absent
+  # turbo silently falls back to local-only caching (no CI breakage).
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -17,7 +17,7 @@
 | 3   | **Strict TypeScript (incremental)**               | 1-2 тижні | $0               | 🔥🔥🔥 | ⏳ pending                                                     |
 | 4   | **Testcontainers** для server tests               | 4 год     | $0               | 🔥🔥🔥 | ⏳ pending                                                     |
 | 5   | **Vercel Pro plan** (рятує preview deploy)        | 5 хв      | $20/міс          | 🔥🔥   | 🟡 not started (потребує credit card мейнтейнера)              |
-| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ⏳ pending                                                     |
+| 6   | **Turbo remote cache**                            | 1 год     | $0 (Vercel free) | 🔥🔥   | ✅ done (CI wiring merged; needs secrets — see §1.1)           |
 | 7   | **Renovate** замість Dependabot                   | 1 год     | $0               | 🔥🔥   | ✅ done [#721](https://github.com/Skords-01/Sergeant/pull/721) |
 | 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714) |
 | 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ⏳ pending                                                     |
@@ -30,7 +30,7 @@
 
 **Сумарно:** ~3-5 робочих днів + ~$50/міс. Це 80% wins за 20% effort-у.
 
-**Прогрес (2026-04-25):** 5 / 15 закрито — #2 Knip+depcheck, #7 Renovate, #8 AGENTS.md, #10 Snapshot tests, #12 Playwright E2E. Наступні логічні кроки: #15 (CONTRIBUTING.md — дешевий win), #11 (Pino logging — розблокує Sentry/PostHog), #4 (Testcontainers — підсилить #10), #6 (Turbo remote cache — пришвидшить CI).
+**Прогрес (2026-04-25):** 6 / 15 закрито — #2 Knip+depcheck, #6 Turbo remote cache, #7 Renovate, #8 AGENTS.md, #10 Snapshot tests, #12 Playwright E2E. Наступні логічні кроки: #15 (CONTRIBUTING.md — дешевий win), #11 (Pino logging — розблокує Sentry/PostHog), #4 (Testcontainers — підсилить #10).
 
 ---
 
@@ -47,6 +47,37 @@
 | **direnv**                 | Auto `.envrc` activation per repo  | $0   | 30 хв  | nice |
 | **Lefthook**               | Faster pre-commit (Go)             | $0   | 1 год  | nice |
 | **Turbo remote cache**     | CI build cache (5 → 1 хв)          | $0   | 1 год  | must |
+
+#### Turbo remote cache — setup guide
+
+CI already passes `TURBO_TOKEN` / `TURBO_TEAM` env vars to every turbo
+invocation. When the secrets are absent turbo silently falls back to
+local-only caching, so nothing breaks.
+
+**To activate remote caching (maintainer steps):**
+
+1. Go to [vercel.com/account/tokens](https://vercel.com/account/tokens)
+   and create a new token (scope: the team that owns the Sergeant project).
+2. Copy the token value.
+3. In the GitHub repo → **Settings → Secrets and variables → Actions**,
+   add two repository secrets:
+   - `TURBO_TOKEN` — the Vercel token from step 2.
+   - `TURBO_TEAM` — your Vercel team slug (e.g. `my-team`). Find it at
+     the top-left of the Vercel dashboard or in the URL
+     (`vercel.com/<team-slug>`).
+4. Re-run any CI workflow — turbo will log
+   `Remote caching enabled` in the output.
+
+**Optional — local dev remote cache:**
+
+```bash
+# one-time setup
+npx turbo login          # opens Vercel OAuth in browser
+npx turbo link           # links the repo to the Vercel team
+```
+
+After linking, local `turbo run build` / `turbo run test` will also
+read & write the shared cache.
 
 **Sergeant-specific:**
 


### PR DESCRIPTION
## What changed

- Added workflow-level `TURBO_TOKEN` and `TURBO_TEAM` env vars to `.github/workflows/ci.yml` — every `turbo run` invocation in CI now automatically uses the Vercel remote cache when the secrets are present.
- Updated `docs/dev-stack-roadmap.md`: marked roadmap item **#6 (Turbo remote cache)** as done and added a step-by-step setup guide in §1.1 for maintainers.

## Why

Roadmap item #6 — Turbo remote cache can cut CI turbo task times from ~5 min to ~1 min by sharing build/test/lint artifacts across runs. This is an infra-only change; no app behavior is modified.

When the `TURBO_TOKEN` / `TURBO_TEAM` secrets are **not configured**, turbo silently falls back to local-only caching — zero breakage.

## How to test

1. Verify CI passes on this PR (no secrets needed — graceful fallback).
2. To activate remote caching, follow the setup guide in `docs/dev-stack-roadmap.md` §1.1:
   - Create a Vercel token at [vercel.com/account/tokens](https://vercel.com/account/tokens)
   - Add `TURBO_TOKEN` and `TURBO_TEAM` as GitHub repository secrets
   - Re-run CI and look for `Remote caching enabled` in turbo output

## Secrets required (maintainer action)

| Secret | Where | Value |
|--------|-------|-------|
| `TURBO_TOKEN` | GitHub repo → Settings → Secrets → Actions | Vercel API token ([create here](https://vercel.com/account/tokens)) |
| `TURBO_TEAM` | GitHub repo → Settings → Secrets → Actions | Vercel team slug (from dashboard URL) |

---

## How AI-tested this PR

- [x] Manual smoke: confirmed `pnpm lint` (turbo lint + check-imports) passes — `Remote caching disabled` log confirms graceful fallback.
- [x] `pnpm typecheck` passes (13/13 packages).
- [x] Prettier format check passes on both changed files.
- [x] YAML lint passes on `ci.yml`.
- [x] Pre-commit hooks (Husky + lint-staged) pass.
- [x] No new `AI-DANGER` markers added without justification.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (infra-only CI wiring + docs update)

Link to Devin session: https://app.devin.ai/sessions/cd7bead4a9d549ff9d6652a2c94c8fd4
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guide for Turborepo remote caching, including CI configuration, environment variable requirements, and fallback behavior documentation.

* **Chores**
  * Enabled Turborepo remote caching in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->