### PR TITLE
docs(root): prefer Ukrainian docs prose

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] Manual smoke (which flow?): ...
 - [ ] Vitest passes: ...
 - [ ] No new `AI-DANGER` markers added without justification.
+- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
 
 ## AGENTS.md updated?
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-desi
 - Use path aliases (`@shared/*`, `@finyk/*`, etc.) instead of relative `../../../`.
 - Dependency bumps — separate PRs (don't mix with features).
 - When deleting a file — first `grep` its imports across the entire monorepo.
+- Documentation language: write new/updated prose docs in Ukrainian where practical. Keep code identifiers, commands, API names, commit scopes, stack terms, and external quotes in their original language when that is clearer.
 
 ## Verification before PR
 


### PR DESCRIPTION
## What changed

Added a repo guidance rule in `AGENTS.md` to prefer Ukrainian for new/updated prose documentation where practical, while keeping code identifiers, commands, API names, commit scopes, stack terms, and external quotes in their original language when clearer.

Added a matching PR template checkbox so AI-created PRs remember to verify docs language.

## Why

The project docs are primarily Ukrainian, and future docs changes should follow that convention consistently without losing technical precision for code/stack terminology.

## How to test

Review the new `AGENTS.md` soft rule and the PR template checklist item.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Reviewed the rendered markdown diff for `AGENTS.md` and `.github/PULL_REQUEST_TEMPLATE.md`.
- [ ] Vitest passes: N/A — docs/template-only change.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — `AGENTS.md` Soft rules section adds the docs language preference.
- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/a1927c8c26e24a4d80a39fb669caa1a3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
