### PR TITLE
feat(web): HubChat quick actions v1

### DIFF
--- a/apps/web/src/core/HubChat.tsx
+++ b/apps/web/src/core/HubChat.tsx
@@ -23,57 +23,17 @@ import {
   requestIdle,
   cancelIdle,
   isHelpCommand,
+  getActiveModule,
   HELP_TEXT,
 } from "./lib/hubChatUtils";
 import { buildContextMeasured } from "./lib/hubChatContext";
 import { executeAction } from "./lib/hubChatActions";
 import { VOICE_KEYWORDS, speak, stopSpeaking } from "./lib/hubChatSpeech";
+import { buildActionCard } from "./lib/hubChatActionCards";
+import type { ChatActionCard } from "./lib/hubChatActionCards";
 import { ChatMessage, TypingIndicator } from "./components/ChatMessage";
 import { ChatInput } from "./components/ChatInput";
-
-const QUICK_WITH_MONO = [
-  "Як справи з бюджетом?",
-  "Які борги маю?",
-  "Скільки витратив?",
-  "Порадь щось",
-];
-
-const QUICK_NO_MONO = [
-  "Як почати тренування у Фізруку?",
-  "Що ти знаєш про мої тренування?",
-  "Порадь розминку перед залом",
-  "Порадь щось",
-];
-
-// Контекстні підказки, що залежать від модуля, з якого користувач
-// відкрив чат (якщо знаємо). Робимо підказки більш actionable, щоб
-// перший тап одразу вів до дії, а не до generic small-talk.
-const QUICK_BY_CONTEXT: Record<string, string[]> = {
-  finyk: [
-    "Додай витрату 120 грн на каву",
-    "Скільки витратив за тиждень?",
-    "Які мої активні підписки?",
-    "Склади короткий звіт по тижню",
-  ],
-  fizruk: [
-    "Почни тренування ноги",
-    "Порадь розминку перед залом",
-    "Скільки я тренувався цього тижня?",
-    "Додай сет присідання 5 повторів 40 кг",
-  ],
-  routine: [
-    "Познач звичку «вода» на сьогодні",
-    "Яка моя серія за цей тиждень?",
-    "Додай звичку читати 20 хв щодня",
-    "Що я пропустив цього тижня?",
-  ],
-  nutrition: [
-    "Залогай сніданок: вівсянка 100г + яблуко",
-    "Скільки ккал я з'їв сьогодні?",
-    "Порадь високобілкову вечерю",
-    "Склади короткий звіт по калоріях",
-  ],
-};
+import { ChatQuickActions } from "./components/ChatQuickActions";
 
 function HubChat({ onClose, initialMessage }) {
   const [messages, setMessages] = useState(() => {
@@ -199,25 +159,9 @@ function HubChat({ onClose, initialMessage }) {
   }, [finykPreviewUpdatedAt, scheduleContextBuild]);
 
   // Якщо чат відкрився з-під модуля (через URL hash або подію), беремо
-  // контекстні підказки; інакше — генеричні mono/no-mono.
-  const activeModule = (() => {
-    try {
-      const hash = (window.location.hash || "")
-        .replace(/^#\/?/, "")
-        .toLowerCase();
-      const first = hash.split(/[/?#]/)[0];
-      if (["finyk", "fizruk", "routine", "nutrition"].includes(first))
-        return first;
-    } catch {
-      /* noop */
-    }
-    return null;
-  })();
-  const quickPrompts = useMemo(() => {
-    if (activeModule && QUICK_BY_CONTEXT[activeModule])
-      return QUICK_BY_CONTEXT[activeModule];
-    return hasData ? QUICK_WITH_MONO : QUICK_NO_MONO;
-  }, [hasData, activeModule]);
+  // контекстні підказки. Helper винесено у hubChatUtils для перевикористання
+  // в ChatQuickActions.
+  const activeModule = useMemo(() => getActiveModule(), []);
 
   useEffect(() => {
     if (chatRef.current)
@@ -246,6 +190,9 @@ function HubChat({ onClose, initialMessage }) {
   }, [speaking]);
 
   const sendRef = useRef(null);
+  // Callback ref на `.focus()` ChatInput — використовується після
+  // prefill з ChatQuickActions, щоб фокус приходив на input одразу.
+  const focusInputRef = useRef<(() => void) | null>(null);
 
   const maybeSpeak = useCallback((text) => {
     speak(text);
@@ -346,10 +293,28 @@ function HubChat({ onClose, initialMessage }) {
           .map((r) => `✅ ${r.content}`)
           .join("\n");
         const prefix = `${actionsText}\n\n`;
+
+        // Паралельно будуємо action-картки для відомих tool-ів.
+        // Якщо tool невідомий — повертається null, лишається лише текст.
+        const cards: ChatActionCard[] = data.tool_calls
+          .map((tc, idx) =>
+            buildActionCard({
+              name: tc.name,
+              input: tc.input,
+              result: toolResults[idx]?.content || "",
+            }),
+          )
+          .filter((c): c is ChatActionCard => c !== null);
+
         const assistantId = newMsgId();
         setMessages((m) => [
           ...m,
-          { id: assistantId, role: "assistant", text: prefix },
+          {
+            id: assistantId,
+            role: "assistant",
+            text: prefix,
+            ...(cards.length > 0 ? { cards } : {}),
+          },
         ]);
 
         let followUpText = "";
@@ -613,24 +578,19 @@ function HubChat({ onClose, initialMessage }) {
           )}
         </div>
 
-        {/* Quick prompts */}
-        <div
-          className="flex gap-2 px-4 pt-2 pb-1 overflow-x-auto scrollbar-hide shrink-0"
-          role="group"
-          aria-label="Швидкі запити"
-        >
-          {quickPrompts.map((q) => (
-            <button
-              key={q}
-              type="button"
-              onClick={() => send(q)}
-              disabled={loading || !online}
-              className="text-xs px-3 py-1.5 bg-panel border border-line rounded-full text-subtle hover:text-text hover:border-muted whitespace-nowrap transition-colors shrink-0 disabled:opacity-40"
-            >
-              {q}
-            </button>
-          ))}
-        </div>
+        {/* Quick action chips (spec: assistant-quick-actions-v1) */}
+        <ChatQuickActions
+          activeModule={activeModule}
+          loading={loading}
+          online={online}
+          onSend={(prompt) => send(prompt)}
+          onPrefill={(prompt) => {
+            setInput(prompt);
+            // Невелика затримка, щоб React встиг змонтувати оновлений
+            // value у input перш ніж ми поставимо фокус.
+            setTimeout(() => focusInputRef.current?.(), 0);
+          }}
+        />
 
         {!online && (
           <div
@@ -653,6 +613,7 @@ function HubChat({ onClose, initialMessage }) {
           onSend={() => send()}
           onHelp={() => send("/help")}
           sendRef={sendRef}
+          focusInputRef={focusInputRef}
         />
       </div>
     </div>

--- a/apps/web/src/core/components/ChatInput.tsx
+++ b/apps/web/src/core/components/ChatInput.tsx
@@ -22,6 +22,12 @@ interface ChatInputProps {
   sendRef: MutableRefObject<
     ((text?: string, fromVoice?: boolean) => void) | null
   >;
+  /**
+   * Опційний callback ref для фокусу інпуту зовні (наприклад, після
+   * prefill з ChatQuickActions). HubChat прив'язує сюди функцію, яка
+   * потім викликає `.focus()`.
+   */
+  focusInputRef?: MutableRefObject<(() => void) | null>;
 }
 
 export function ChatInput({
@@ -34,8 +40,20 @@ export function ChatInput({
   onSend,
   onHelp,
   sendRef,
+  focusInputRef,
 }: ChatInputProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Експозимо зовні лише метод `focus` — без разкривання самого DOM
+  // вузла. Це дозволяє ChatQuickActions викликати focus() після
+  // prefill, але не відкриває ChatInput для випадкового вживання.
+  useEffect(() => {
+    if (!focusInputRef) return;
+    focusInputRef.current = () => inputRef.current?.focus();
+    return () => {
+      focusInputRef.current = null;
+    };
+  }, [focusInputRef]);
 
   // Автофокус лише на пристроях з «точним» вказівником — без спливаючої
   // клавіатури на телефонах (Web Interface Guidelines).

--- a/apps/web/src/core/components/ChatMessage.tsx
+++ b/apps/web/src/core/components/ChatMessage.tsx
@@ -1,15 +1,65 @@
 import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
 import { AssistantMessageBody } from "./AssistantMessageBody";
 import { speak } from "../lib/hubChatSpeech";
 import type { ChatMessage as ChatMessageData } from "../lib/hubChatUtils";
+import type { ChatActionCard } from "../lib/hubChatActionCards";
 
 interface ChatMessageProps {
   message: ChatMessageData;
   onSpeak?: () => void;
 }
 
+function ActionCard({ card }: { card: ChatActionCard }) {
+  const failed = card.status === "failed";
+  return (
+    <div
+      data-testid={`chat-action-card-${card.toolName}`}
+      role="status"
+      aria-label={`${card.title}: ${card.summary}`}
+      className={cn(
+        "mt-2 flex items-start gap-2 rounded-xl border px-3 py-2",
+        failed
+          ? "bg-warning/10 border-warning/30"
+          : card.risky
+            ? "bg-warning/5 border-warning/40"
+            : "bg-brand-500/5 border-brand-500/30",
+      )}
+    >
+      <span
+        className={cn(
+          "shrink-0 mt-0.5",
+          failed
+            ? "text-warning"
+            : card.risky
+              ? "text-warning"
+              : "text-brand-500",
+        )}
+        aria-hidden
+      >
+        <Icon name={card.icon || (failed ? "alert" : "check")} size={14} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 text-xs font-semibold text-text">
+          <span className="truncate">{card.title}</span>
+          {card.risky && (
+            <span className="text-2xs font-semibold text-warning shrink-0 rounded-full bg-warning/15 px-1.5 py-0.5">
+              Критична дія
+            </span>
+          )}
+        </div>
+        {card.summary && (
+          <div className="text-2xs text-subtle mt-0.5 break-words">
+            {card.summary}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function ChatMessage({ message, onSpeak }: ChatMessageProps) {
-  const { role, text } = message;
+  const { role, text, cards } = message;
   const isAssistant = role === "assistant";
 
   return (
@@ -31,6 +81,10 @@ export function ChatMessage({ message, onSpeak }: ChatMessageProps) {
         )}
       >
         {isAssistant ? <AssistantMessageBody text={text} /> : text}
+        {isAssistant &&
+          cards &&
+          cards.length > 0 &&
+          cards.map((c) => <ActionCard key={c.id} card={c} />)}
         {isAssistant && text && text.length > 3 && (
           <button
             type="button"

--- a/apps/web/src/core/components/ChatQuickActions.test.tsx
+++ b/apps/web/src/core/components/ChatQuickActions.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ChatQuickActions } from "./ChatQuickActions";
+import { QUICK_ACTIONS } from "../lib/hubChatQuickActions";
+
+afterEach(() => cleanup());
+
+function setup(
+  overrides: Partial<React.ComponentProps<typeof ChatQuickActions>> = {},
+) {
+  const onSend = vi.fn();
+  const onPrefill = vi.fn();
+  const utils = render(
+    <ChatQuickActions
+      activeModule={null}
+      loading={false}
+      online={true}
+      onSend={onSend}
+      onPrefill={onPrefill}
+      {...overrides}
+    />,
+  );
+  return { onSend, onPrefill, ...utils };
+}
+
+describe("ChatQuickActions", () => {
+  it("рендерить chip-и для top-сценаріїв", () => {
+    setup();
+    // Hub-сценарій має бути серед видимих
+    expect(
+      screen.getByTestId("chat-quick-action-morning-briefing"),
+    ).toBeTruthy();
+    expect(screen.getByTestId("chat-quick-action-daily-summary")).toBeTruthy();
+  });
+
+  it("повний prompt → onSend, не onPrefill", () => {
+    const { onSend, onPrefill } = setup();
+    fireEvent.click(screen.getByTestId("chat-quick-action-morning-briefing"));
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend.mock.calls[0]?.[0]).toMatch(/брифінг/i);
+    expect(onPrefill).not.toHaveBeenCalled();
+  });
+
+  it("неповний prompt (закінчується на ': ') → onPrefill, не onSend", () => {
+    const { onSend, onPrefill } = setup({ activeModule: "finyk" });
+    fireEvent.click(screen.getByTestId("chat-quick-action-add-expense"));
+    expect(onPrefill).toHaveBeenCalledTimes(1);
+    expect(onPrefill.mock.calls[0]?.[0]).toMatch(/^Додай витрату:\s$/);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("loading=true → всі chip-и disabled", () => {
+    setup({ loading: true });
+    const briefing = screen.getByTestId("chat-quick-action-morning-briefing");
+    expect((briefing as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("offline + requiresOnline → chip disabled з пояснювальним title", () => {
+    setup({ online: false });
+    const briefing = screen.getByTestId(
+      "chat-quick-action-morning-briefing",
+    ) as HTMLButtonElement;
+    expect(briefing.disabled).toBe(true);
+    expect(briefing.getAttribute("title")).toMatch(/з'єднання/i);
+  });
+
+  it("кнопка «Ще» розгортає прихований список", () => {
+    setup();
+    const more = screen.queryByTestId("chat-quick-actions-more");
+    if (!more) {
+      // Якщо всі сценарії помістилися — скіп
+      expect(QUICK_ACTIONS.length).toBeLessThanOrEqual(6);
+      return;
+    }
+    expect(more.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(more);
+    expect(more.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("activeModule=fizruk підіймає сценарії Фізрука першими", () => {
+    setup({ activeModule: "fizruk" });
+    // Перші два testid у DOM-порядку мають належати fizruk
+    const buttons = screen
+      .getAllByRole("button")
+      .filter((b) =>
+        b.getAttribute("data-testid")?.startsWith("chat-quick-action-"),
+      );
+    const firstId = buttons[0]?.getAttribute("data-testid");
+    expect(firstId).toMatch(/start-workout|log-set/);
+  });
+});

--- a/apps/web/src/core/components/ChatQuickActions.tsx
+++ b/apps/web/src/core/components/ChatQuickActions.tsx
@@ -1,0 +1,155 @@
+// Quick action chips для HubChat (spec §2).
+//
+// - top-level показує до 6 chip-ів + кнопку "Ще";
+// - "Ще" відкриває розширений inline-список (без modal — щоб не ламати
+//   focus trap і keyboard inset на mobile);
+// - повний prompt → одразу `onSend(prompt)`;
+// - неповний prompt (`isIncompletePrompt`) → `onPrefill(prompt)` + focus
+//   на input (фокус робить викликаючий компонент через ref);
+// - в `loading` або `offline` AI-залежні chip-и disabled.
+
+import { useState } from "react";
+import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+import {
+  QUICK_ACTIONS,
+  isIncompletePrompt,
+  pickTopQuickActions,
+  sortQuickActionsForModule,
+  type QuickAction,
+  type QuickActionModule,
+} from "../lib/hubChatQuickActions";
+
+interface ChatQuickActionsProps {
+  /** Активний модуль (з URL hash). `null` — генеричний топ. */
+  activeModule: QuickActionModule | null;
+  /** Чи в стрімі / завантаженні відповіді. Disable-ить усі chip-и. */
+  loading: boolean;
+  /** Стан мережі. Якщо false — disable-ить `requiresOnline`. */
+  online: boolean;
+  /** Викликається для повних prompt-ів — одразу шле повідомлення. */
+  onSend: (prompt: string) => void;
+  /**
+   * Викликається для неповних prompt-ів (закінчуються на `: `):
+   * вставляє текст в input і фокусує поле.
+   */
+  onPrefill: (prompt: string) => void;
+}
+
+const MAX_VISIBLE = 6;
+
+function chipClassName({
+  disabled,
+  module,
+  active,
+}: {
+  disabled: boolean;
+  module: QuickActionModule;
+  active: boolean;
+}): string {
+  return cn(
+    "inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full whitespace-nowrap shrink-0 transition-colors",
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+    active
+      ? "bg-brand-500/10 border border-brand-500/40 text-brand-600 hover:bg-brand-500/15"
+      : module === "hub"
+        ? "bg-panel border border-line text-text hover:border-muted"
+        : "bg-panel border border-line text-subtle hover:text-text hover:border-muted",
+    disabled && "opacity-40 cursor-not-allowed",
+  );
+}
+
+export function ChatQuickActions({
+  activeModule,
+  loading,
+  online,
+  onSend,
+  onPrefill,
+}: ChatQuickActionsProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const topActions = pickTopQuickActions(
+    QUICK_ACTIONS,
+    activeModule,
+    MAX_VISIBLE,
+  );
+  const allSorted = sortQuickActionsForModule(QUICK_ACTIONS, activeModule);
+  const moreActions = allSorted.slice(MAX_VISIBLE);
+
+  const handleClick = (a: QuickAction) => {
+    if (isIncompletePrompt(a.prompt)) {
+      onPrefill(a.prompt);
+    } else {
+      onSend(a.prompt);
+    }
+  };
+
+  const renderChip = (a: QuickAction) => {
+    const disabled = loading || (a.requiresOnline && !online);
+    const reason =
+      !online && a.requiresOnline ? "Потрібне з'єднання" : undefined;
+    return (
+      <button
+        key={a.id}
+        type="button"
+        data-testid={`chat-quick-action-${a.id}`}
+        onClick={() => handleClick(a)}
+        disabled={disabled}
+        title={reason || a.description || a.label}
+        aria-label={a.label}
+        className={chipClassName({
+          disabled,
+          module: a.module,
+          active: activeModule === a.module && a.module !== "hub",
+        })}
+      >
+        <Icon name={a.icon} size={13} aria-hidden />
+        <span className="hidden sm:inline">{a.label}</span>
+        <span className="sm:hidden">{a.shortLabel}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div
+      className="px-4 pt-2 pb-1 shrink-0"
+      role="group"
+      aria-label="Швидкі сценарії"
+    >
+      <div className="flex gap-2 overflow-x-auto scrollbar-hide">
+        {topActions.map(renderChip)}
+        {moreActions.length > 0 && (
+          <button
+            type="button"
+            data-testid="chat-quick-actions-more"
+            onClick={() => setExpanded((v) => !v)}
+            disabled={loading}
+            aria-expanded={expanded}
+            aria-controls="chat-quick-actions-more-list"
+            className={chipClassName({
+              disabled: loading,
+              module: "hub",
+              active: false,
+            })}
+          >
+            <Icon
+              name={expanded ? "chevron-up" : "chevron-down"}
+              size={13}
+              aria-hidden
+            />
+            {expanded ? "Згорнути" : "Ще"}
+          </button>
+        )}
+      </div>
+
+      {expanded && moreActions.length > 0 && (
+        <div
+          id="chat-quick-actions-more-list"
+          className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3"
+        >
+          {moreActions.map(renderChip)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/core/lib/hubChatActionCards.test.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { buildActionCard, isRiskyTool } from "./hubChatActionCards";
+
+describe("buildActionCard", () => {
+  it("повертає картку для основного tool-а (create_transaction)", () => {
+    const card = buildActionCard({
+      name: "create_transaction",
+      input: { amount: 120, description: "кава" },
+      result: "Витрату 120 ₴ записано",
+    });
+    expect(card).not.toBeNull();
+    expect(card?.toolName).toBe("create_transaction");
+    expect(card?.status).toBe("completed");
+    expect(card?.module).toBe("finyk");
+    expect(card?.title).toContain("Транзакцію");
+    expect(card?.summary).toContain("120");
+    expect(card?.summary).toContain("кава");
+  });
+
+  it("повертає null для невідомого tool-а", () => {
+    const card = buildActionCard({
+      name: "some_internal_lookup",
+      input: {},
+      result: "ok",
+    });
+    expect(card).toBeNull();
+  });
+
+  it("позначає failed коли result починається з «Помилка»", () => {
+    const card = buildActionCard({
+      name: "log_set",
+      input: { exercise: "жим", weight_kg: 80, reps: 8 },
+      result: "Помилка виконання: щось зламалося",
+    });
+    expect(card?.status).toBe("failed");
+    expect(card?.title).toMatch(/не вийшло/);
+  });
+
+  it("позначає failed коли result починається з «Невідома дія»", () => {
+    const card = buildActionCard({
+      name: "log_meal",
+      input: {},
+      result: "Невідома дія: log_meal",
+    });
+    expect(card?.status).toBe("failed");
+  });
+
+  it("приймає explicit failed=true навіть якщо текст ок", () => {
+    const card = buildActionCard({
+      name: "log_water",
+      input: { amount_ml: 250 },
+      result: "ok",
+      failed: true,
+    });
+    expect(card?.status).toBe("failed");
+  });
+
+  it("витягує summary для log_set з input полів", () => {
+    const card = buildActionCard({
+      name: "log_set",
+      input: { exercise: "жим лежачи", weight_kg: 80, reps: 8 },
+      result: "Підхід додано",
+    });
+    expect(card?.summary).toContain("жим лежачи");
+    expect(card?.summary).toContain("80");
+    expect(card?.summary).toContain("8");
+  });
+
+  it("витягує summary для log_meal", () => {
+    const card = buildActionCard({
+      name: "log_meal",
+      input: { meal_type: "сніданок", description: "вівсянка", calories: 350 },
+      result: "Залоговано",
+    });
+    expect(card?.summary).toContain("сніданок");
+    expect(card?.summary).toContain("вівсянка");
+    expect(card?.summary).toContain("350");
+  });
+
+  it("витягує summary для log_water", () => {
+    const card = buildActionCard({
+      name: "log_water",
+      input: { amount_ml: 500 },
+      result: "ok",
+    });
+    expect(card?.summary).toBe("500 мл");
+  });
+
+  it("ставить module=finyk для create_transaction", () => {
+    const card = buildActionCard({
+      name: "create_transaction",
+      input: {},
+      result: "ok",
+    });
+    expect(card?.module).toBe("finyk");
+  });
+
+  it("ставить module=fizruk для log_set", () => {
+    const card = buildActionCard({
+      name: "log_set",
+      input: {},
+      result: "ok",
+    });
+    expect(card?.module).toBe("fizruk");
+  });
+
+  it("ставить module=routine для mark_habit_done", () => {
+    const card = buildActionCard({
+      name: "mark_habit_done",
+      input: { habit_id: "вода" },
+      result: "ok",
+    });
+    expect(card?.module).toBe("routine");
+    expect(card?.summary).toBe("вода");
+  });
+
+  it("ставить module=nutrition для log_meal", () => {
+    const card = buildActionCard({
+      name: "log_meal",
+      input: {},
+      result: "ok",
+    });
+    expect(card?.module).toBe("nutrition");
+  });
+
+  it("ставить module=hub для morning_briefing", () => {
+    const card = buildActionCard({
+      name: "morning_briefing",
+      input: {},
+      result: "ok",
+    });
+    expect(card?.module).toBe("hub");
+    expect(card?.title).toContain("брифінг");
+  });
+
+  it("картка для morning_briefing і weekly_summary не risky", () => {
+    const briefing = buildActionCard({
+      name: "morning_briefing",
+      input: {},
+      result: "ok",
+    });
+    const summary = buildActionCard({
+      name: "weekly_summary",
+      input: {},
+      result: "ok",
+    });
+    expect(briefing?.risky).toBeUndefined();
+    expect(summary?.risky).toBeUndefined();
+  });
+
+  it("кожна картка має непустий id, title і summary", () => {
+    const card = buildActionCard({
+      name: "create_habit",
+      input: { name: "Пити воду" },
+      result: "ok",
+    });
+    expect(card?.id).toMatch(/^card_/);
+    expect(card?.title.length).toBeGreaterThan(0);
+    expect(card?.summary.length).toBeGreaterThan(0);
+  });
+});
+
+describe("isRiskyTool", () => {
+  it("розпізнає risky tools", () => {
+    expect(isRiskyTool("delete_transaction")).toBe(true);
+    expect(isRiskyTool("hide_transaction")).toBe(true);
+    expect(isRiskyTool("forget")).toBe(true);
+    expect(isRiskyTool("archive_habit")).toBe(true);
+    expect(isRiskyTool("import_monobank_range")).toBe(true);
+  });
+
+  it("звичайні tools — не risky", () => {
+    expect(isRiskyTool("create_transaction")).toBe(false);
+    expect(isRiskyTool("log_meal")).toBe(false);
+    expect(isRiskyTool("morning_briefing")).toBe(false);
+  });
+});

--- a/apps/web/src/core/lib/hubChatActionCards.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.ts
@@ -1,0 +1,263 @@
+// Lightweight mapper з tool-call result у структуровану action-картку.
+// За специфікацією `docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md` §3.
+//
+// Без змін у `executeAction`/Anthropic протоколі — карти будуються
+// поруч і додаються до assistant-message як metadata. Якщо tool
+// невідомий мапперу — повертаємо `null`, і UI лишає текстовий fallback.
+
+import type { ChatAction } from "./chatActions/types";
+
+export type ChatActionCardModule =
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition"
+  | "hub";
+
+export type ChatActionCardStatus = "completed" | "failed";
+
+export interface ChatActionCard {
+  id: string;
+  toolName: string;
+  status: ChatActionCardStatus;
+  title: string;
+  summary: string;
+  module: ChatActionCardModule;
+  /** Іконка з shared Icon registry. Опційно — UI має fallback. */
+  icon?: string;
+  /**
+   * Маркер ризикової дії (delete/forget/import). v1 лише підсвічує
+   * картку, повний confirmation flow — у v2.
+   */
+  risky?: boolean;
+}
+
+/** Tools, які класифіковані як ризикові за специфікацією §4. */
+const RISKY_TOOLS: ReadonlySet<string> = new Set([
+  "delete_transaction",
+  "hide_transaction",
+  "forget",
+  "archive_habit",
+  "import_monobank_range",
+]);
+
+/**
+ * Сабсет tool names, для яких v1 малює картку.
+ * Перший набір зі спеки §3.
+ */
+const KNOWN_TOOLS: ReadonlySet<string> = new Set([
+  "create_transaction",
+  "log_meal",
+  "log_water",
+  "start_workout",
+  "log_set",
+  "mark_habit_done",
+  "create_habit",
+  "morning_briefing",
+  "weekly_summary",
+]);
+
+interface CardInput {
+  /** Назва tool-а від Anthropic — `action.name`. */
+  name: string;
+  /** Сирий input до tool-а (для генерації summary). */
+  input: ChatAction["input"] | Record<string, unknown>;
+  /** Текстовий результат `executeAction` — fallback summary. */
+  result: string;
+  /**
+   * Ознака помилки: якщо result починається з «Помилка» / «Невідома дія»
+   * — статус failed.
+   */
+  failed?: boolean;
+}
+
+const FAILURE_RE = /^(Помилка|Невідома дія)/;
+
+function deriveStatus(
+  result: string,
+  explicitFailed?: boolean,
+): ChatActionCardStatus {
+  if (explicitFailed) return "failed";
+  return FAILURE_RE.test(result) ? "failed" : "completed";
+}
+
+function moduleFor(name: string): ChatActionCardModule {
+  if (
+    name === "create_transaction" ||
+    name === "delete_transaction" ||
+    name === "hide_transaction" ||
+    name === "import_monobank_range"
+  ) {
+    return "finyk";
+  }
+  if (name === "log_meal" || name === "log_water") return "nutrition";
+  if (name === "start_workout" || name === "log_set") return "fizruk";
+  if (
+    name === "mark_habit_done" ||
+    name === "create_habit" ||
+    name === "archive_habit"
+  ) {
+    return "routine";
+  }
+  return "hub";
+}
+
+function iconFor(name: string): string | undefined {
+  switch (name) {
+    case "create_transaction":
+      return "credit-card";
+    case "log_meal":
+      return "utensils";
+    case "log_water":
+      return "utensils";
+    case "start_workout":
+    case "log_set":
+      return "dumbbell";
+    case "mark_habit_done":
+    case "create_habit":
+      return "check";
+    case "morning_briefing":
+      return "sun";
+    case "weekly_summary":
+      return "bar-chart";
+    default:
+      return undefined;
+  }
+}
+
+function titleFor(name: string, status: ChatActionCardStatus): string {
+  const failedSuffix = status === "failed" ? " — не вийшло" : "";
+  switch (name) {
+    case "create_transaction":
+      return `Транзакцію записано${failedSuffix}`;
+    case "log_meal":
+      return `Прийом їжі залоговано${failedSuffix}`;
+    case "log_water":
+      return `Воду залоговано${failedSuffix}`;
+    case "start_workout":
+      return `Тренування стартувало${failedSuffix}`;
+    case "log_set":
+      return `Підхід записано${failedSuffix}`;
+    case "mark_habit_done":
+      return `Звичка виконана${failedSuffix}`;
+    case "create_habit":
+      return `Звичку створено${failedSuffix}`;
+    case "morning_briefing":
+      return `Ранковий брифінг`;
+    case "weekly_summary":
+      return `Тижневий підсумок`;
+    default:
+      return name;
+  }
+}
+
+/**
+ * Дуже коротке summary під картку: пробуємо витягти з input ключові поля,
+ * інакше fallback на скорочений `result`.
+ */
+function summaryFor(
+  name: string,
+  input: Record<string, unknown>,
+  result: string,
+): string {
+  const truncate = (s: string, max = 120): string =>
+    s.length > max ? `${s.slice(0, max - 1)}…` : s;
+
+  const stringField = (key: string): string | undefined => {
+    const v = input[key];
+    return typeof v === "string" && v.trim() ? v.trim() : undefined;
+  };
+  const numberField = (key: string): number | undefined => {
+    const v = input[key];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v.trim() && !Number.isNaN(Number(v))) {
+      return Number(v);
+    }
+    return undefined;
+  };
+
+  switch (name) {
+    case "create_transaction": {
+      const amount = numberField("amount");
+      const desc = stringField("description") || stringField("category_id");
+      const parts: string[] = [];
+      if (amount !== undefined) parts.push(`${amount} ₴`);
+      if (desc) parts.push(desc);
+      if (parts.length) return parts.join(" · ");
+      break;
+    }
+    case "log_meal": {
+      const meal = stringField("meal_type");
+      const desc = stringField("description") || stringField("name");
+      const kcal = numberField("calories");
+      const parts: string[] = [];
+      if (meal) parts.push(meal);
+      if (desc) parts.push(desc);
+      if (kcal !== undefined) parts.push(`${kcal} ккал`);
+      if (parts.length) return parts.join(" · ");
+      break;
+    }
+    case "log_water": {
+      const ml = numberField("amount_ml") ?? numberField("amount");
+      if (ml !== undefined) return `${ml} мл`;
+      break;
+    }
+    case "log_set": {
+      const exercise = stringField("exercise") || stringField("name");
+      const weight = numberField("weight_kg") ?? numberField("weight");
+      const reps = numberField("reps");
+      const parts: string[] = [];
+      if (exercise) parts.push(exercise);
+      if (weight !== undefined) parts.push(`${weight} кг`);
+      if (reps !== undefined) parts.push(`${reps} повт.`);
+      if (parts.length) return parts.join(" · ");
+      break;
+    }
+    case "mark_habit_done":
+    case "create_habit": {
+      const habit = stringField("habit_id") || stringField("name");
+      if (habit) return habit;
+      break;
+    }
+    case "start_workout": {
+      const program = stringField("program_id") || stringField("name");
+      if (program) return program;
+      break;
+    }
+    default:
+      break;
+  }
+
+  return truncate(result);
+}
+
+/**
+ * Будує картку для одного tool-call. Якщо tool не у KNOWN_TOOLS —
+ * повертає `null` (UI лишає лише текстовий fallback).
+ */
+export function buildActionCard(input: CardInput): ChatActionCard | null {
+  if (!KNOWN_TOOLS.has(input.name)) return null;
+
+  const status = deriveStatus(input.result, input.failed);
+  const inputObj = (input.input || {}) as Record<string, unknown>;
+  const title = titleFor(input.name, status);
+  const summary = summaryFor(input.name, inputObj, input.result);
+  const module = moduleFor(input.name);
+  const icon = iconFor(input.name);
+  const risky = RISKY_TOOLS.has(input.name);
+
+  return {
+    id: `card_${input.name}_${Math.random().toString(36).slice(2, 10)}`,
+    toolName: input.name,
+    status,
+    title,
+    summary,
+    module,
+    icon,
+    ...(risky ? { risky: true } : {}),
+  };
+}
+
+export function isRiskyTool(name: string): boolean {
+  return RISKY_TOOLS.has(name);
+}

--- a/apps/web/src/core/lib/hubChatQuickActions.test.ts
+++ b/apps/web/src/core/lib/hubChatQuickActions.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  QUICK_ACTIONS,
+  isIncompletePrompt,
+  sortQuickActionsForModule,
+  pickTopQuickActions,
+  type QuickAction,
+} from "./hubChatQuickActions";
+
+describe("isIncompletePrompt", () => {
+  it("повертає true для prompt-а, що закінчується на ': '", () => {
+    expect(isIncompletePrompt("Додай витрату: ")).toBe(true);
+    expect(isIncompletePrompt("Додай підхід: ")).toBe(true);
+  });
+
+  it("повертає false для повного prompt-а", () => {
+    expect(isIncompletePrompt("Що важливого на сьогодні?")).toBe(false);
+    expect(isIncompletePrompt("Підсумуй мій день")).toBe(false);
+  });
+
+  it("не плутає двокрапку всередині речення з закінченням", () => {
+    expect(isIncompletePrompt("Звіт: загальний по тижню")).toBe(false);
+  });
+});
+
+describe("sortQuickActionsForModule", () => {
+  it("ставить активний модуль першим, потім hub, потім решту", () => {
+    const sorted = sortQuickActionsForModule(QUICK_ACTIONS, "fizruk");
+    const modules = sorted.map((a) => a.module);
+    const fizrukIdx = modules.indexOf("fizruk");
+    const hubIdx = modules.indexOf("hub");
+    const finykIdx = modules.indexOf("finyk");
+    // fizruk (active) — на початку
+    expect(fizrukIdx).toBe(0);
+    // hub — після всіх fizruk-сценаріїв
+    const lastFizrukIdx = modules.lastIndexOf("fizruk");
+    expect(hubIdx).toBeGreaterThan(lastFizrukIdx);
+    // решта (finyk) — після hub-блоку
+    expect(finykIdx).toBeGreaterThan(hubIdx);
+  });
+
+  it("без активного модуля показує hub першим", () => {
+    const sorted = sortQuickActionsForModule(QUICK_ACTIONS, null);
+    expect(sorted[0]?.module).toBe("hub");
+  });
+
+  it("у межах одного модуля впорядковує за priority (зростаючим)", () => {
+    const sorted = sortQuickActionsForModule(QUICK_ACTIONS, "finyk");
+    const finykOnly = sorted.filter((a) => a.module === "finyk");
+    for (let i = 1; i < finykOnly.length; i++) {
+      const prev = finykOnly[i - 1];
+      const curr = finykOnly[i];
+      if (prev && curr) {
+        expect(curr.priority).toBeGreaterThanOrEqual(prev.priority);
+      }
+    }
+  });
+
+  it("є stable для рівних priority", () => {
+    const a: QuickAction = {
+      id: "x1",
+      module: "hub",
+      label: "X1",
+      shortLabel: "X1",
+      icon: "sun",
+      prompt: "x1",
+      priority: 1,
+      requiresOnline: true,
+    };
+    const b: QuickAction = { ...a, id: "x2", label: "X2", shortLabel: "X2" };
+    const sorted = sortQuickActionsForModule([a, b], null);
+    expect(sorted.map((q) => q.id)).toEqual(["x1", "x2"]);
+  });
+});
+
+describe("pickTopQuickActions", () => {
+  it("обмежує до limit штук", () => {
+    const top = pickTopQuickActions(QUICK_ACTIONS, "hub", 4);
+    expect(top).toHaveLength(4);
+  });
+
+  it("default limit = 6", () => {
+    const top = pickTopQuickActions(QUICK_ACTIONS, "hub");
+    expect(top).toHaveLength(6);
+  });
+});
+
+describe("QUICK_ACTIONS registry", () => {
+  it("має унікальні id", () => {
+    const ids = QUICK_ACTIONS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("кожен сценарій має непустий prompt і label", () => {
+    for (const a of QUICK_ACTIONS) {
+      expect(a.prompt.trim().length).toBeGreaterThan(0);
+      expect(a.label.trim().length).toBeGreaterThan(0);
+      expect(a.shortLabel.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("incomplete prompts не auto-send (по конвенції тільки для модульних дій)", () => {
+    const incomplete = QUICK_ACTIONS.filter((a) =>
+      isIncompletePrompt(a.prompt),
+    );
+    // Принаймні одна incomplete action на кожен з основних доменів
+    expect(incomplete.some((a) => a.module === "finyk")).toBe(true);
+    expect(incomplete.some((a) => a.module === "fizruk")).toBe(true);
+    expect(incomplete.some((a) => a.module === "routine")).toBe(true);
+    expect(incomplete.some((a) => a.module === "nutrition")).toBe(true);
+  });
+
+  it("має сценарії для всіх 5 модулів", () => {
+    const modules = new Set(QUICK_ACTIONS.map((a) => a.module));
+    expect(modules.has("hub")).toBe(true);
+    expect(modules.has("finyk")).toBe(true);
+    expect(modules.has("fizruk")).toBe(true);
+    expect(modules.has("routine")).toBe(true);
+    expect(modules.has("nutrition")).toBe(true);
+  });
+});

--- a/apps/web/src/core/lib/hubChatQuickActions.ts
+++ b/apps/web/src/core/lib/hubChatQuickActions.ts
@@ -1,0 +1,228 @@
+// Швидкі сценарії для HubChat — registry за специфікацією
+// `docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md`.
+//
+// Registry лише описує сценарії і генерує prompt; виконання іде через
+// існуючий `send` у HubChat → Anthropic tool-use → `executeAction`.
+// Жодних побічних ефектів тут бути не повинно — тримаємо файл pure,
+// щоб тести були тривіальні.
+
+export type QuickActionModule =
+  | "hub"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export interface QuickAction {
+  /** Унікальний id (kebab-case) — стабільний ключ для React і аналітики. */
+  id: string;
+  /** Модуль, до якого належить сценарій. `hub` — крос-модульні дії. */
+  module: QuickActionModule;
+  /** Повний текст кнопки (desktop, modal "Ще"). */
+  label: string;
+  /** Короткий текст для chip-ів на mobile, де місця обмаль. */
+  shortLabel: string;
+  /** Назва іконки з `@shared/components/ui/Icon`. */
+  icon: string;
+  /**
+   * Prompt, що передається в `send`. Якщо закінчується на `: ` —
+   * сценарій неповний: треба вставити в input і дати юзеру дописати,
+   * а не одразу відправляти.
+   */
+  prompt: string;
+  /** Описова підказка для tooltip / "Ще" sheet. */
+  description?: string;
+  /**
+   * Сортувальний пріоритет (нижче = вище у списку). Між модулями
+   * сортуємо спершу по `module`-приналежності, потім по `priority`.
+   */
+  priority: number;
+  /** Якщо true — кнопка disabled у offline-режимі. */
+  requiresOnline: boolean;
+  /** Ключові слова для майбутнього search/usage ranking. */
+  keywords?: readonly string[];
+}
+
+/**
+ * Базовий набір сценаріїв v1 (точно за таблицею у спеці §1).
+ * Усі require online — без AI ці сценарії безглузді.
+ */
+export const QUICK_ACTIONS: readonly QuickAction[] = [
+  // Hub — крос-модульні
+  {
+    id: "morning-briefing",
+    module: "hub",
+    label: "Ранковий брифінг",
+    shortLabel: "Брифінг",
+    icon: "sun",
+    prompt: "Що важливого на сьогодні? Дай короткий ранковий брифінг.",
+    description: "Підсумок з усіх 4 модулів за сьогодні.",
+    priority: 10,
+    requiresOnline: true,
+    keywords: ["день", "сьогодні", "огляд"],
+  },
+  {
+    id: "daily-summary",
+    module: "hub",
+    label: "Підсумок дня",
+    shortLabel: "Підсумок",
+    icon: "bar-chart",
+    prompt: "Підсумуй мій день по фінансах, тренуваннях, звичках і харчуванню.",
+    description: "Звіт по всіх 4 модулях за день.",
+    priority: 20,
+    requiresOnline: true,
+    keywords: ["підсумок", "звіт", "вечір"],
+  },
+
+  // Фінік
+  {
+    id: "add-expense",
+    module: "finyk",
+    label: "Додати витрату",
+    shortLabel: "Витрата",
+    icon: "credit-card",
+    prompt: "Додай витрату: ",
+    description: "Швидко записати витрату — допиши суму і опис.",
+    priority: 10,
+    requiresOnline: true,
+    keywords: ["expense", "транзакція"],
+  },
+  {
+    id: "budget-risks",
+    module: "finyk",
+    label: "Ліміт бюджету",
+    shortLabel: "Бюджет",
+    icon: "target",
+    prompt: "Покажи ризики по бюджетах і що варто змінити.",
+    description: "Аналіз поточних лімітів і відхилень.",
+    priority: 20,
+    requiresOnline: true,
+    keywords: ["budget", "ліміт"],
+  },
+
+  // Фізрук
+  {
+    id: "start-workout",
+    module: "fizruk",
+    label: "Почати тренування",
+    shortLabel: "Тренування",
+    icon: "dumbbell",
+    prompt: "Почни тренування на сьогодні.",
+    description: "Стартує сесію за програмою на сьогодні.",
+    priority: 10,
+    requiresOnline: true,
+    keywords: ["workout", "gym"],
+  },
+  {
+    id: "log-set",
+    module: "fizruk",
+    label: "Додати підхід",
+    shortLabel: "Підхід",
+    icon: "plus",
+    prompt: "Додай підхід: ",
+    description: "Допиши вправу, вагу і повторення.",
+    priority: 20,
+    requiresOnline: true,
+    keywords: ["set", "підхід", "вправа"],
+  },
+
+  // Рутина
+  {
+    id: "mark-habit-done",
+    module: "routine",
+    label: "Позначити звичку",
+    shortLabel: "Звичка",
+    icon: "check",
+    prompt: "Познач звичку виконаною: ",
+    description: "Допиши назву звички, яку зробив сьогодні.",
+    priority: 10,
+    requiresOnline: true,
+    keywords: ["habit", "звичка"],
+  },
+  {
+    id: "missed-this-week",
+    module: "routine",
+    label: "Що пропущено",
+    shortLabel: "Пропущено",
+    icon: "calendar",
+    prompt: "Що я пропустив у рутині цього тижня?",
+    description: "Аналіз пропущених звичок за тиждень.",
+    priority: 20,
+    requiresOnline: true,
+    keywords: ["streak", "тиждень"],
+  },
+
+  // Харчування
+  {
+    id: "log-meal",
+    module: "nutrition",
+    label: "Залогати їжу",
+    shortLabel: "Їжа",
+    icon: "utensils",
+    prompt: "Залогай їжу: ",
+    description: "Допиши страву і кількість.",
+    priority: 10,
+    requiresOnline: true,
+    keywords: ["meal", "їжа"],
+  },
+  {
+    id: "protein-target",
+    module: "nutrition",
+    label: "Добити білок",
+    shortLabel: "Білок",
+    icon: "target",
+    prompt: "Що з'їсти сьогодні, щоб добити білок без перебору калорій?",
+    description: "Підказка по їжі під поточний macro-баланс.",
+    priority: 20,
+    requiresOnline: true,
+    keywords: ["protein", "macro"],
+  },
+];
+
+/**
+ * Чи закінчується prompt на `: ` — ознака неповного сценарію (треба
+ * вставити в input, а не одразу відправляти). Спираємось на конвенцію
+ * зі спеки §1.
+ */
+export function isIncompletePrompt(prompt: string): boolean {
+  return /:\s$/.test(prompt);
+}
+
+/**
+ * Сортує сценарії так, щоб першими були дії активного модуля, далі —
+ * крос-модульні `hub`, далі — все інше. У межах однієї групи —
+ * за `priority` (зростаюче). Stable: для рівних `priority` зберігаємо
+ * порядок з `actions`.
+ */
+export function sortQuickActionsForModule(
+  actions: readonly QuickAction[],
+  activeModule: QuickActionModule | null,
+): QuickAction[] {
+  const groupRank = (m: QuickActionModule): number => {
+    if (activeModule && m === activeModule) return 0;
+    if (m === "hub") return 1;
+    return 2;
+  };
+  return actions
+    .map((a, idx) => ({ a, idx }))
+    .sort((x, y) => {
+      const dg = groupRank(x.a.module) - groupRank(y.a.module);
+      if (dg !== 0) return dg;
+      const dp = x.a.priority - y.a.priority;
+      if (dp !== 0) return dp;
+      return x.idx - y.idx;
+    })
+    .map(({ a }) => a);
+}
+
+/**
+ * Готує впорядкований топ для chips. Обмежуємо до `limit` (default 6),
+ * решта йде під кнопку «Ще» у викликаючому компоненті.
+ */
+export function pickTopQuickActions(
+  actions: readonly QuickAction[],
+  activeModule: QuickActionModule | null,
+  limit = 6,
+): QuickAction[] {
+  return sortQuickActionsForModule(actions, activeModule).slice(0, limit);
+}

--- a/apps/web/src/core/lib/hubChatUtils.ts
+++ b/apps/web/src/core/lib/hubChatUtils.ts
@@ -1,6 +1,8 @@
 // Utility functions shared across HubChat modules
 
 import { friendlyApiError as baseFriendlyApiError } from "@shared/lib/friendlyApiError";
+import type { ChatActionCard } from "./hubChatActionCards";
+import type { QuickActionModule } from "./hubChatQuickActions";
 
 export const CONTEXT_TTL_MS = 15_000;
 export const CHAT_HISTORY_WRITE_DEBOUNCE_MS = 600;
@@ -11,8 +13,36 @@ export interface ChatMessage {
   id: string;
   role: ChatRole;
   text: string;
+  /** Опційний набір action-карт (рендериться у `ChatMessage` UI). */
+  cards?: ChatActionCard[];
   /** Optional extra fields preserved from persisted history. */
   [key: string]: unknown;
+}
+
+/**
+ * Визначає активний модуль за URL hash. Раніше дублювалося inline у
+ * `HubChat.tsx`; винесено сюди для перевикористання у quick actions
+ * та подальших helper-ах. Якщо hash не вказує на жоден з відомих
+ * модулів — повертає `null`.
+ */
+export function getActiveModule(): QuickActionModule | null {
+  try {
+    const hash = (globalThis.window?.location?.hash || "")
+      .replace(/^#\/?/, "")
+      .toLowerCase();
+    const first = hash.split(/[/?#]/)[0];
+    if (
+      first === "finyk" ||
+      first === "fizruk" ||
+      first === "routine" ||
+      first === "nutrition"
+    ) {
+      return first;
+    }
+  } catch {
+    /* noop */
+  }
+  return null;
 }
 
 /**
@@ -149,6 +179,14 @@ export function isHelpCommand(text: string): boolean {
 }
 
 export const HELP_TEXT = `### Доступні інструменти
+
+#### ⚡ Швидкі сценарії
+Тапни chip під чатом, щоб одразу запустити дію:
+- **Ранковий брифінг** / **Підсумок дня** — крос-модульний огляд.
+- **Додати витрату** / **Залогати їжу** / **Додати підхід** / **Позначити звичку** — швидкий старт; допиши деталі в інпуті.
+- **Ліміт бюджету** / **Що пропущено** / **Добити білок** — аналітика і поради.
+
+Залежно від модуля, з якого відкрив чат, релевантні chip-и підсвічуються першими.
 
 #### 💰 Фінік (фінанси)
 - Записати витрату/дохід — \`додай витрату 200 грн на каву\`


### PR DESCRIPTION
## What changed

Реалізовано **Assistant Quick Actions v1** за специфікацією `docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md`.

**Додано:**
- `apps/web/src/core/lib/hubChatQuickActions.ts` — registry з 10 module-aware сценаріїв (Hub, Фінік, Фізрук, Рутина, Харчування), pure helper-и `isIncompletePrompt`, `sortQuickActionsForModule`, `pickTopQuickActions`.
- `apps/web/src/core/components/ChatQuickActions.tsx` — chip-секція під чатом: до 6 видимих + кнопка «Ще» з `aria-expanded`. Mobile — горизонтальний scroll, desktop — grid. Disabled у loading / offline (з пояснювальним `title`).
- `apps/web/src/core/lib/hubChatActionCards.ts` — мапер tool-call → структурована action-картка (`create_transaction`, `log_meal`, `log_water`, `start_workout`, `log_set`, `mark_habit_done`, `create_habit`, `morning_briefing`, `weekly_summary`). Невідомий tool → `null`. Risky tools (`delete_transaction`, `hide_transaction`, `forget`, `archive_habit`, `import_monobank_range`) позначаються `risky: true`.

**Змінено:**
- `apps/web/src/core/HubChat.tsx` — замінив старі `QUICK_*` константи на `<ChatQuickActions />`. Активний модуль тепер береться з винесеного `getActiveModule()`. Після tool-calls парсер `buildActionCard` додає `cards` у assistant-message.
- `apps/web/src/core/components/ChatMessage.tsx` — рендерить action-cards під markdown (icon + title + summary + статус: brand для completed, warning для failed/risky).
- `apps/web/src/core/components/ChatInput.tsx` — додано `focusInputRef` callback для prefill-сценаріїв (incomplete prompts вставляють текст і фокусують input замість auto-send).
- `apps/web/src/core/lib/hubChatUtils.ts` — `ChatMessage.cards?: ChatActionCard[]`, `getActiveModule()`, секція «⚡ Швидкі сценарії» в `HELP_TEXT`.

**Поза скоупом v1 (свідомо, як рекомендує спец §4):**
- Confirmation flow для risky tools — лишається execution path як зараз. v2.
- Local usage ranking / pinned actions — лише `priority` registry.
- Undo для виконаних дій.

## Why

HubChat вже вмів модульні tool-calls, але кожна часта дія потребувала від юзера набору цілого речення. Quick actions роблять перший тап у чаті дієвим: ранковий брифінг / додавання витрати / залогати їжу / позначити звичку — одне натискання. Action cards дають візуальний підтверджуючий feedback того, що саме AI зробив, без зміни Anthropic-протоколу і backend.

Spec: `docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md`.

## How to test

1. `pnpm install && pnpm --filter @sergeant/web dev`.
2. У застосунку відкрий «Асистент» (`#hub` або з-під будь-якого модуля).
3. Перевір кейси:
   - **Flow A (Hub)** — натисни «Ранковий брифінг» → запит йде одразу, бачиш стрім + action-card під текстом.
   - **Flow B (Фізрук)** — відкрий чат із `#fizruk`, fizruk-chips мають іти першими і бути підсвічені (brand-tint).
   - **Flow C (incomplete)** — натисни «Додай витрату» → текст `Додай витрату: ` з'являється в input, інпут отримує фокус, нічого не відправляється до твого Enter.
   - **Offline** — вимкни мережу → chip-и AI-залежні disabled з title «Потрібне з'єднання».
   - **Loading** — почни відповідь → всі chip-и disabled.
   - **«Ще»** — розгортає 4 решти сценаріїв у 2-колонкову сітку, `aria-expanded="true"`.
4. `/help` — у списку має бути нова секція «⚡ Швидкі сценарії».

---

## How AI-tested this PR

- [x] Vitest passes:
  - `apps/web/src/core/lib/hubChatQuickActions.test.ts` — 13 тестів (registry, sort, isIncompletePrompt, pickTop).
  - `apps/web/src/core/lib/hubChatActionCards.test.ts` — 17 тестів (mapper, status derivation, summary витяг, risky).
  - `apps/web/src/core/components/ChatQuickActions.test.tsx` — 7 React тестів (render, complete→onSend, incomplete→onPrefill, loading/offline disabled, «Ще» toggle, activeModule sort).
  - Сусідні тести `hubChatActions.test.ts` + `hubChatActionsExtended.test.ts` — без регресій (52 тести).
- [x] `pnpm --filter @sergeant/web typecheck` — green.
- [x] `pnpm --filter @sergeant/web lint` — green.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose використовує українську (коментарі коду + HELP_TEXT).

## AGENTS.md updated?

- [x] No — нових permanent rules немає, лише імплементація фічі за існуючим spec.

Link to Devin session: https://app.devin.ai/sessions/fe8672abf0624957910d400023283d3e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
