### PR TITLE
fix(web): add explicit brotli flag and CI size-limit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Format, lint, test, build
         run: pnpm check
 
+      - name: Bundle size guard (size-limit)
+        run: pnpm --filter @sergeant/web exec size-limit
+
   coverage:
     name: Test coverage (vitest)
     runs-on: ubuntu-latest

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -434,6 +434,7 @@
 - [istanbul-lib-instrument@5.2.1](https://istanbul.js.org/) - BSD-3-Clause
 - [jackspeak@3.4.3](https://github.com/isaacs/jackspeak#readme) - BlueOak-1.0.0
 - [jimp-compact@0.16.1](https://github.com/nuxt-community/jimp-compact#readme) - MIT
+- [jiti@1.21.7](https://github.com/unjs/jiti#readme) - MIT
 - [jiti@2.6.1](https://github.com/unjs/jiti#readme) - MIT
 - [join-component@1.1.0](undefined) - MIT
 - [jose@6.2.2](https://github.com/panva/jose) - MIT

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,11 +21,13 @@
     {
       "name": "JS (усього)",
       "path": "../server/dist/assets/*.js",
+      "brotli": true,
       "limit": "615 kB"
     },
     {
       "name": "CSS",
       "path": "../server/dist/assets/*.css",
+      "brotli": true,
       "limit": "18 kB"
     }
   ],

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -161,8 +161,9 @@ read & write the shared cache.
 #### size-limit + bundle-analyzer — як користуватись
 
 `size-limit` перевіряє brotli-розмір зібраного бандла проти бюджету у
-`apps/web/package.json` → `"size-limit"`. CI крок «Bundle size guard»
-запускається автоматично після `pnpm check`.
+`apps/web/package.json` → `"size-limit"` (явно `"brotli": true`).
+CI крок «Bundle size guard» у `.github/workflows/ci.yml` запускається
+автоматично після `pnpm check`.
 
 ```bash
 # Перевірити розмір бандла (потребує попередній build):


### PR DESCRIPTION
## What changed

Follow-up до #740 — виправлення знайдених Devin Review issues:

1. **Explicit `"brotli": true`** у кожному entry `size-limit` конфігу (`apps/web/package.json`) — size-limit v12 дефолтить brotli для `@size-limit/file`, але явний прапор прибирає неоднозначність.
2. **CI step «Bundle size guard»** додано до `.github/workflows/ci.yml` (job `check`, після `pnpm check`) — раніше не вдалося запушити через відсутність `workflow` scope.
3. **Документація** оновлена: згадано `"brotli": true` і точне місце CI step-у (`.github/workflows/ci.yml`).
4. **`THIRD_PARTY_LICENSES.md`** перегенеровано для нових залежностей (`size-limit`, `@size-limit/file`).

## Why

Devin Review на #740 зафіксував два issues:
- Документація стверджувала brotli, але конфіг не мав явного прапора
- Документація згадувала CI step, якого не було у ci.yml

## How to test

```bash
pnpm --filter @sergeant/web build
pnpm --filter @sergeant/web exec size-limit  # exit 0, shows "brotlied"
pnpm licenses:check                          # exit 0
```

CI step перевірить себе сам на цьому PR.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `build` + `size-limit` — exit 0, виводить "brotlied".
- [x] Vitest passes: не змінювались тести.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/3f388bfa53024cb58964f3fdd8c4b207
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced bundle size validation in the CI pipeline with Brotli compression checks for JavaScript and CSS assets.
  * Updated third-party license records.

* **Documentation**
  * Updated developer documentation to clarify bundle size validation configuration and CI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->