### PR TITLE
docs(root): add 10 new playbooks — infra, frontend, mobile, backend, observability

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -8,18 +8,22 @@ Each playbook is a checklist that **AI agents and human developers** can follow 
 
 ## Available Playbooks
 
-| Playbook                                                       | Trigger                                                                           |
-| -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [add-feature-flag.md](add-feature-flag.md)                     | "Put feature X behind a flag" / new experimental feature                          |
-| [cleanup-dead-code.md](cleanup-dead-code.md)                   | "Remove X and all its usages" / dead code cleanup                                 |
-| [hotfix-prod-regression.md](hotfix-prod-regression.md)         | "Прод впав" / HTTP 500 на `/health` / Sentry alert / production incident response |
-| [add-monobank-event-handler.md](add-monobank-event-handler.md) | "Треба обробити нову подію X від Monobank" / новий тип webhook event              |
-
-## Future Candidates
-
-These are described in `docs/ai-coding-improvements.md § 2.2` and can be added as the need arises:
-
-- `bump-dep-safely.md` — dependency upgrade protocol
+| Playbook                                                                       | Trigger                                                                           |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| [add-feature-flag.md](add-feature-flag.md)                                     | "Put feature X behind a flag" / new experimental feature                          |
+| [cleanup-dead-code.md](cleanup-dead-code.md)                                   | "Remove X and all its usages" / dead code cleanup                                 |
+| [hotfix-prod-regression.md](hotfix-prod-regression.md)                         | "Прод впав" / HTTP 500 на `/health` / Sentry alert / production incident response |
+| [add-monobank-event-handler.md](add-monobank-event-handler.md)                 | "Треба обробити нову подію X від Monobank" / новий тип webhook event              |
+| [bump-dep-safely.md](bump-dep-safely.md)                                       | "Оновити X до версії Y" / Renovate major-bump / security advisory                 |
+| [add-sql-migration.md](add-sql-migration.md)                                   | "Додати нове поле / таблицю в БД" / зміна схеми PostgreSQL                        |
+| [rotate-secrets.md](rotate-secrets.md)                                         | "Secret leaked" / планова ротація / security audit                                |
+| [add-new-page-route.md](add-new-page-route.md)                                 | "Додати нову сторінку в apps/web" / новий route для SPA                           |
+| [migrate-localstorage-to-typedstore.md](migrate-localstorage-to-typedstore.md) | Мігрувати файл з прямого localStorage на typedStore (tech debt #2)                |
+| [fix-exhaustive-deps.md](fix-exhaustive-deps.md)                               | Виправити exhaustive-deps warnings / React hooks cleanup                          |
+| [port-web-screen-to-mobile.md](port-web-screen-to-mobile.md)                   | "Перенести екран X з apps/web в apps/mobile" / React Native міграція              |
+| [add-api-endpoint.md](add-api-endpoint.md)                                     | "Додати новий endpoint в apps/server" / нова API-функціональність                 |
+| [onboard-external-api.md](onboard-external-api.md)                             | "Інтегрувати нову зовнішню API" / новий third-party сервіс                        |
+| [investigate-alert.md](investigate-alert.md)                                   | Prometheus alert спрацював / Sentry alert / деградація `/health`                  |
 
 ## How to Use
 

--- a/docs/playbooks/add-api-endpoint.md
+++ b/docs/playbooks/add-api-endpoint.md
@@ -1,0 +1,110 @@
+# Playbook: Add API Endpoint
+
+**Trigger:** "Додати новий endpoint в apps/server" / нова API-функціональність / розширення REST API.
+
+---
+
+## Steps
+
+### 1. Створити handler
+
+Створити або оновити handler у `apps/server/src/modules/<module>/`:
+
+```ts
+// apps/server/src/modules/<module>/http/<endpoint>.ts
+import { z } from "zod";
+import type { Request, Response } from "express";
+
+const QuerySchema = z.object({
+  // валідація query params
+});
+
+export async function myEndpointHandler(req: Request, res: Response) {
+  const query = QuerySchema.parse(req.query);
+  // бізнес-логіка
+  res.json({ data: result });
+}
+```
+
+Правила:
+
+- Використовувати **zod** для валідації (не ручний `req.body.X`).
+- Error handling через `asyncHandler` + typed errors (`ExternalServiceError`, `ValidationError`).
+- Bigint→number coercion у response serializer (AGENTS.md rule #1).
+
+### 2. Додати zod-schema
+
+Якщо endpoint приймає body або query params — створити або оновити schema в `http/schemas.ts`:
+
+```ts
+export const MyEndpointBodySchema = z.object({
+  field: z.string(),
+  count: z.number().int().positive(),
+});
+```
+
+### 3. Зареєструвати route
+
+Додати route у відповідний router файл:
+
+```ts
+router.get("/api/<module>/<endpoint>", asyncHandler(myEndpointHandler));
+```
+
+### 4. Оновити типи в `packages/api-client`
+
+Додати endpoint у `packages/api-client/src/endpoints/<module>.ts` (AGENTS.md rule #3):
+
+```ts
+export async function myEndpoint(params: MyParams): Promise<MyResponse> {
+  return httpClient.get("/api/<module>/<endpoint>", { params });
+}
+```
+
+Типи request і response мають збігатися з серверним handler-ом.
+
+### 5. Тести
+
+```bash
+# Unit-тест для handler-а
+pnpm --filter @sergeant/server exec vitest run apps/server/src/modules/<module>/
+
+# Перевірити що zod відхиляє невалідний input
+# Перевірити bigint coercion у snapshot-тесті (якщо є DB)
+```
+
+### 6. Prometheus label (якщо потрібно)
+
+Якщо endpoint потребує окремого моніторингу — перевірити що `path` label коректно групується в `http_requests_total` метриці.
+
+### 7. Створити PR
+
+- Branch: `devin/<unix-ts>-feat-<module>-<endpoint>`
+- Commit: `feat(server): add <method> /api/<module>/<endpoint>`
+- PR description: що робить endpoint, request/response shape, які клієнти його використовують.
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] Server тести — green
+- [ ] Zod-schema відхиляє невалідний payload
+- [ ] Bigint→number coercion у serializer (rule #1)
+- [ ] Типи в `packages/api-client` оновлені (rule #3)
+- [ ] Endpoint доступний через `curl` або Playwright E2E
+
+## Notes
+
+- Express 4 з `asyncHandler` wrapper для async route handlers.
+- Structured logging через Pino — кожен request має `requestId` в ALS context.
+- Якщо endpoint потребує нової DB-таблиці — спочатку [add-sql-migration.md](add-sql-migration.md).
+- Auth через Better Auth — перевірити middleware якщо endpoint потребує авторизації.
+
+## See also
+
+- [add-sql-migration.md](add-sql-migration.md) — якщо потрібна міграція БД
+- [backend-tech-debt.md](../backend-tech-debt.md) — конвенції серверного коду
+- [AGENTS.md](../../AGENTS.md) — rule #1 (bigint), rule #3 (API contract)
+- [api-v1.md](../api-v1.md) — документація API

--- a/docs/playbooks/add-new-page-route.md
+++ b/docs/playbooks/add-new-page-route.md
@@ -1,0 +1,104 @@
+# Playbook: Add New Page Route
+
+**Trigger:** "Додати нову сторінку в apps/web" / новий розділ UI / новий route для SPA.
+
+---
+
+## Steps
+
+### 1. Створити компонент сторінки
+
+Створити файл в `apps/web/src/modules/<module>/pages/` або `apps/web/src/core/pages/`:
+
+```tsx
+export function NewPage() {
+  return (
+    <div>
+      <h1>New Page</h1>
+    </div>
+  );
+}
+```
+
+Дотримуватись існуючих конвенцій:
+
+- Path aliases (`@shared/*`, `@finyk/*`) замість relative imports (AGENTS.md soft rule).
+- Компонент — named export (не default).
+
+### 2. Додати route
+
+Додати route у відповідний router файл (`apps/web/src/core/router.tsx` або module-level router):
+
+```tsx
+import { NewPage } from "@module/pages/NewPage";
+
+// у route config:
+{ path: "/new-page", element: <NewPage /> }
+```
+
+### 3. Додати React Query key factory (якщо потрібен data fetching)
+
+Якщо сторінка завантажує дані — додати ключі **тільки** через centralized factories в `apps/web/src/shared/lib/queryKeys.ts` (AGENTS.md rule #2):
+
+```ts
+export const myModuleKeys = {
+  all: ["myModule"] as const,
+  list: () => [...myModuleKeys.all, "list"] as const,
+  detail: (id: string) => [...myModuleKeys.all, "detail", id] as const,
+};
+```
+
+**Ніколи** не писати hardcoded `["myModule", ...]` в компонентах.
+
+### 4. Feature flag (якщо experimental)
+
+Якщо сторінка — експериментальна фіча:
+
+- Додати flag в `apps/web/src/core/lib/featureFlags.ts`
+- Обгорнути route або компонент в `useFlag("flag_name")`
+- Див. [add-feature-flag.md](add-feature-flag.md) playbook
+
+### 5. Навігація
+
+Додати посилання на нову сторінку в sidebar / navbar / menu (де доречно).
+
+### 6. Тести
+
+```bash
+# Unit-тест для компонента
+pnpm --filter @sergeant/web exec vitest run src/modules/<module>/pages/NewPage.test.tsx
+
+# Playwright E2E smoke (якщо критичний route)
+pnpm --filter @sergeant/web exec playwright test
+```
+
+### 7. Створити PR
+
+- Branch: `devin/<unix-ts>-feat-<page-name>`
+- Commit: `feat(web): add <page-name> page`
+- PR description: screenshot нової сторінки, link на route.
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] Тести — green
+- [ ] React Query keys — через factories з `queryKeys.ts` (rule #2)
+- [ ] Path aliases замість relative imports
+- [ ] Screenshot додано до PR description
+- [ ] Навігація на нову сторінку працює
+
+## Notes
+
+- `apps/web` — Vite + React 18 SPA з React Router.
+- Feature flags — client-only (localStorage via `typedStore`).
+- Якщо сторінка потребує даних з нового endpoint — спочатку [add-api-endpoint.md](add-api-endpoint.md).
+
+## See also
+
+- [add-feature-flag.md](add-feature-flag.md) — якщо сторінка за feature flag
+- [add-api-endpoint.md](add-api-endpoint.md) — якщо потрібен новий backend endpoint
+- [frontend-tech-debt.md](../frontend-tech-debt.md) — загальні фронтенд-конвенції
+- [AGENTS.md](../../AGENTS.md) — rule #2 (RQ keys)

--- a/docs/playbooks/add-sql-migration.md
+++ b/docs/playbooks/add-sql-migration.md
@@ -1,0 +1,94 @@
+# Playbook: Add SQL Migration
+
+**Trigger:** "Додати нове поле / таблицю в БД" / зміна схеми PostgreSQL / нова колонка для існуючої таблиці.
+
+---
+
+## Steps
+
+### 1. Визначити поточний номер міграції
+
+```bash
+ls apps/server/src/migrations/
+# Наприклад: 001_init.sql, 002_..., ..., 008_mono_integration.sql
+# Наступний файл — 009_*.sql
+```
+
+Номер має бути **sequential, без gaps** (AGENTS.md rule #4).
+
+### 2. Створити файл міграції
+
+```bash
+touch apps/server/src/migrations/NNN_<short_desc>.sql
+```
+
+Правила для SQL:
+
+- Використовувати `IF NOT EXISTS` / `IF EXISTS` де можливо (ідемпотентність).
+- `TIMESTAMPTZ` замість `TIMESTAMP` (з timezone).
+- Foreign keys з `ON DELETE CASCADE` якщо логічно.
+- Індекси для полів які будуть в `WHERE` / `JOIN`.
+
+### 3. Оновити серверний код
+
+- Оновити типи в `apps/server/src/modules/<module>/types.ts`.
+- Оновити serializer — **обов'язково** коерсити bigint→number (AGENTS.md rule #1, [#708](https://github.com/Skords-01/Sergeant/issues/708)).
+- Оновити handler якщо новий endpoint або змінений response shape.
+
+### 4. Оновити `packages/api-client`
+
+Якщо змінюється response shape — оновити типи в `packages/api-client/src/endpoints/*` (AGENTS.md rule #3).
+
+### 5. Тести
+
+```bash
+# Запустити тести сервера
+pnpm --filter @sergeant/server exec vitest run
+
+# Snapshot-тест на serializer (якщо є)
+pnpm --filter @sergeant/server exec vitest run apps/server/src/modules/<module>/
+```
+
+Перевірити:
+
+- Bigint поля повертаються як `number`, не як `string`.
+- Нові поля присутні у response.
+- Міграція виконується без помилок.
+
+### 6. Перевірити локально
+
+```bash
+# Запустити міграцію локально
+pnpm db:migrate
+```
+
+### 7. Створити PR
+
+- Branch: `devin/<unix-ts>-feat-<desc>`
+- Commit: `feat(server): add migration NNN — <what changed>`
+- PR description: що змінилось в схемі, які endpoint-и зачеплено.
+
+---
+
+## Verification
+
+- [ ] Номер міграції sequential, без gaps
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] Тести сервера — green
+- [ ] Bigint→number coercion у serializer (rule #1)
+- [ ] Типи в `packages/api-client` оновлені (rule #3)
+- [ ] `pnpm db:migrate` працює локально
+
+## Notes
+
+- Pre-deploy job на Railway автоматично запускає `pnpm db:migrate`.
+- Міграції копіюються через `apps/server/build.mjs` (виправлено в [#704](https://github.com/Skords-01/Sergeant/issues/704)).
+- `MIGRATE_DATABASE_URL` env потрібен для міграцій (= public DB URL).
+- **Ніколи** не видаляй колонки в тій самій міграції що додає нові — це окремий крок після деплою нового коду.
+
+## See also
+
+- [AGENTS.md](../../AGENTS.md) — rule #1 (bigint), rule #3 (API contract), rule #4 (migrations)
+- [monobank-webhook-migration.md](../monobank-webhook-migration.md) — приклад великої міграції (008)
+- [backend-tech-debt.md](../backend-tech-debt.md) — §Database & migrations review

--- a/docs/playbooks/bump-dep-safely.md
+++ b/docs/playbooks/bump-dep-safely.md
@@ -1,0 +1,89 @@
+# Playbook: Bump Dependency Safely
+
+**Trigger:** "Оновити X до версії Y" / Renovate PR з major-bump / security advisory на залежність.
+
+---
+
+## Steps
+
+### 1. Перевірити поточну версію та scope
+
+```bash
+# Де саме використовується пакет?
+pnpm why <pkg> --recursive
+
+# Яка поточна версія?
+grep "<pkg>" pnpm-lock.yaml | head -5
+```
+
+### 2. Прочитати CHANGELOG між версіями
+
+Перед оновленням — прочитати CHANGELOG або release notes між поточною та цільовою версією:
+
+- Breaking changes?
+- Deprecated API?
+- Нові peer dependencies?
+
+### 3. Оновити залежність
+
+```bash
+# Оновити в конкретних workspace-ах
+pnpm --filter <workspace> up <pkg>@<version>
+
+# Або по всьому монорепо
+pnpm up <pkg>@<version> --recursive
+
+# Перевстановити lockfile
+pnpm install
+```
+
+### 4. Build та тести
+
+```bash
+pnpm build       # має пройти
+pnpm typecheck   # має пройти
+pnpm test        # має пройти
+pnpm lint        # має пройти
+```
+
+Якщо є breaking changes — виправити код відповідно до migration guide.
+
+### 5. Візуальна перевірка (для UI-залежностей)
+
+Якщо оновлений пакет впливає на UI (React, Tailwind, UI-бібліотека тощо):
+
+- Запустити `pnpm --filter @sergeant/web dev`
+- Перевірити ключові сторінки
+- Зробити screenshot для PR description
+
+### 6. Створити PR
+
+- Branch: `devin/<unix-ts>-chore-bump-<pkg>`
+- Commit: `chore(deps): bump <pkg> from <old> to <new>`
+- PR description:
+  - Яка залежність оновлена і в яких workspace-ах
+  - Breaking changes (якщо є) та як адаптовано
+  - Лінк на CHANGELOG / release notes
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] `pnpm test` — green
+- [ ] `pnpm build` — green
+- [ ] Lockfile diff виглядає очікувано (немає неочікуваних transitive змін)
+- [ ] Screenshot ключових сторінок (якщо UI-dep)
+
+## Notes
+
+- **Окремий PR** — не змішувати dependency bumps з feature work (AGENTS.md soft rule).
+- Renovate автоматично створює PR-и для minor/patch — для major потрібен manual review.
+- Перевірити `THIRD_PARTY_LICENSES.md` — може потребувати регенерації (`pnpm licenses:gen`).
+- Якщо оновлюється `@types/*` — це зазвичай safe, але все одно `pnpm typecheck`.
+
+## See also
+
+- [AGENTS.md](../../AGENTS.md) — soft rule про dependency bumps
+- [renovate-usage.md](../renovate-usage.md) — як працює Renovate в цьому репо

--- a/docs/playbooks/fix-exhaustive-deps.md
+++ b/docs/playbooks/fix-exhaustive-deps.md
@@ -1,0 +1,104 @@
+# Playbook: Fix Exhaustive Deps Warnings
+
+**Trigger:** "Виправити exhaustive-deps warnings" / ESLint `react-hooks/exhaustive-deps` violations / стале закриття з `apps-web-exhaustive-deps.md`.
+
+---
+
+## Steps
+
+### 1. Знайти поточні warnings
+
+```bash
+# Запустити ESLint з фільтром на правило
+pnpm --filter @sergeant/web exec eslint . --rule 'react-hooks/exhaustive-deps: warn' 2>&1 | grep "exhaustive-deps"
+
+# Або перевірити документ-трекер
+cat docs/apps-web-exhaustive-deps.md
+```
+
+### 2. Класифікувати кожен warning
+
+Для кожного випадку визначити правильну стратегію:
+
+| Ситуація                         | Рішення                                                   |
+| -------------------------------- | --------------------------------------------------------- |
+| Залежність дійсно потрібна       | Додати в dep array                                        |
+| Callback рекреюється щоразу      | Обгорнути у `useCallback`                                 |
+| Обчислення пересчитується щоразу | Обгорнути у `useMemo`                                     |
+| Object/array literal в dep       | Винести за межі компонента або `useMemo`                  |
+| Ref використовується в effect    | Ref не потрібно в deps (він стабільний)                   |
+| Навмисний "mount-only" effect    | Додати `// eslint-disable-next-line` з коментарем причини |
+
+### 3. Виправити
+
+**Варіант A — додати dep:**
+
+```tsx
+// До:
+useEffect(() => {
+  fetchData(userId);
+}, []); // warning: missing 'userId'
+
+// Після:
+useEffect(() => {
+  fetchData(userId);
+}, [userId]);
+```
+
+**Варіант B — useCallback:**
+
+```tsx
+// До:
+const handleClick = () => doSomething(value);
+useEffect(() => {
+  element.addEventListener("click", handleClick);
+}, [handleClick]); // handleClick рекреюється кожен рендер
+
+// Після:
+const handleClick = useCallback(() => doSomething(value), [value]);
+useEffect(() => {
+  element.addEventListener("click", handleClick);
+}, [handleClick]);
+```
+
+### 4. Перевірити рендер-цикл
+
+Після кожного виправлення — перевірити що не створено infinite re-render loop:
+
+- Відкрити сторінку в dev-mode
+- Перевірити React DevTools → Profiler
+- Впевнитись що effect не тригериться безкінечно
+
+### 5. Оновити трекер
+
+Оновити `docs/apps-web-exhaustive-deps.md` — видалити або позначити виправлені файли.
+
+### 6. Створити PR
+
+- Branch: `devin/<unix-ts>-fix-exhaustive-deps-<module>`
+- Commit: `fix(web): resolve exhaustive-deps warnings in <module>`
+- PR description: які файли виправлено, яку стратегію обрано для кожного.
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green (warnings зникли)
+- [ ] `pnpm typecheck` — green
+- [ ] Тести — green
+- [ ] Немає infinite re-render loops (перевірити в dev-mode)
+- [ ] `docs/apps-web-exhaustive-deps.md` оновлено
+- [ ] `eslint-disable` використано тільки для обґрунтованих mount-only effects
+
+## Notes
+
+- Не вимикай правило глобально — `exhaustive-deps` попереджає про реальні баги (stale closures).
+- `eslint-disable-next-line` — тільки з коментарем **чому** deps навмисно пропущені.
+- Групуй виправлення по модулю (finyk, nutrition, fizruk тощо) — легше ревювити.
+- React Query hooks (`useQuery`, `useMutation`) мають свої правила щодо deps — не плутати з `useEffect`.
+
+## See also
+
+- [apps-web-exhaustive-deps.md](../apps-web-exhaustive-deps.md) — повний список warnings
+- [frontend-tech-debt.md](../frontend-tech-debt.md) — загальний фронтенд tech debt
+- [AGENTS.md](../../AGENTS.md) — загальні конвенції

--- a/docs/playbooks/investigate-alert.md
+++ b/docs/playbooks/investigate-alert.md
@@ -1,0 +1,100 @@
+# Playbook: Investigate Alert
+
+**Trigger:** Prometheus alert спрацював / Sentry повідомлення / підозрілі 5xx у логах / деградація `/health`.
+
+---
+
+## Steps
+
+### 1. Визначити тип алерту
+
+Відкрити `docs/observability/runbook.md` і знайти відповідний розділ:
+
+| Алерт                     | Що горить                                     |
+| ------------------------- | --------------------------------------------- |
+| `HttpErrorBudgetBurn`     | Сплеск 5xx responses                          |
+| `DbPoolSaturation`        | DB connection pool заповнений                 |
+| `AiQuotaBudgetBurn`       | AI-запити перевищують квоту                   |
+| `PushDeliveryDegradation` | Push-нотифікації не доставляються             |
+| `ExternalApiCircuitOpen`  | Circuit breaker відкрився для зовнішнього API |
+| `HighMemoryUsage`         | Memory leak або spike                         |
+
+### 2. Перевірити /metrics
+
+```bash
+# Prometheus метрики
+curl -H "Authorization: Bearer $METRICS_TOKEN" https://<prod>/metrics
+
+# Ключові метрики для 5xx:
+# http_requests_total{status=~"5.."}
+# app_errors_total{kind,status,code,module}
+# external_http_requests_total{upstream,outcome}
+```
+
+### 3. Перевірити Pino логи
+
+```bash
+# Railway logs (JSON, Pino format)
+railway logs --tail 200 | jq 'select(.level >= 50)'
+
+# Фільтрувати по module
+railway logs --tail 200 | jq 'select(.module == "<module>")'
+
+# Шукати конкретну помилку
+railway logs --tail 500 | jq 'select(.err != null) | {time, module, msg, err: .err.message}'
+```
+
+Кожен лог-запис має ALS-контекст: `requestId`, `userId`, `module`.
+
+### 4. Класифікувати root cause
+
+| Категорія             | Ознаки                                        | Дії                                                      |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------- |
+| DB saturated          | `db_pool_waiting` високий, повільні queries   | Перевірити slow queries, можливо потрібен індекс         |
+| External API down     | `circuit_open` outcome, timeouts              | Нічого не робити — circuit breaker захищає; чекати       |
+| Code bug (regression) | Конкретний path + stack trace                 | → [hotfix-prod-regression.md](hotfix-prod-regression.md) |
+| AI quota exceeded     | `ai_requests_total{outcome="quota_exceeded"}` | Збільшити ліміт або оптимізувати prompts                 |
+| Memory leak           | Зростаючий RSS, OOMKilled у Railway           | Профілювати з `--inspect`, знайти leak                   |
+| Rate limit (Monobank) | 429 у логах для mono upstream                 | Очікувано — rate limit 1 req/60s/token                   |
+
+### 5. Виправити або ескалувати
+
+- **Якщо code bug** → слідуй [hotfix-prod-regression.md](hotfix-prod-regression.md).
+- **Якщо external API** → зачекай, circuit breaker автоматично відновиться через `resetTimeout` (30s).
+- **Якщо DB** → додай індекс або оптимізуй query → [add-sql-migration.md](add-sql-migration.md).
+- **Якщо незрозуміло** → ескалуй до мейнтейнера з зібраними даними.
+
+### 6. Документувати
+
+Якщо інцидент значний (downtime > 5 хв, data loss, user impact):
+
+- Створити `docs/postmortems/YYYY-MM-DD-<short-desc>.md`
+- Timeline: алерт → виявлено → пофіксено → verified
+- Root cause
+- Prevention: який тест / моніторинг запобіг би
+
+---
+
+## Verification
+
+- [ ] Root cause визначено
+- [ ] `/health` повертає 200
+- [ ] Алерт resolved (метрики повернулись до норми)
+- [ ] Фікс задеплоєно (якщо code bug)
+- [ ] Post-mortem створено (якщо значний інцидент)
+
+## Notes
+
+- **Не панікуй** — circuit breaker і retry захищають від більшості transient failures.
+- Pino логи — JSON у stdout. Використовуй `jq` для фільтрації.
+- `METRICS_TOKEN` потрібен для доступу до `/metrics` endpoint.
+- Sentry ловить `fatal`/`error` рівні включно з `err.cause` chain.
+- Flaky external APIs (Monobank, Anthropic) — очікувана поведінка, circuit breaker повинен справлятись.
+
+## See also
+
+- [observability/runbook.md](../observability/runbook.md) — повний runbook для кожного типу алерту
+- [observability/SLO.md](../observability/SLO.md) — SLO визначення та бюджети
+- [observability/dashboards.md](../observability/dashboards.md) — Grafana dashboards
+- [hotfix-prod-regression.md](hotfix-prod-regression.md) — якщо root cause = code bug
+- [AGENTS.md](../../AGENTS.md) — deployment та health endpoint

--- a/docs/playbooks/migrate-localstorage-to-typedstore.md
+++ b/docs/playbooks/migrate-localstorage-to-typedstore.md
@@ -1,0 +1,99 @@
+# Playbook: Migrate localStorage to typedStore
+
+**Trigger:** "Мігрувати файл X з прямого localStorage на typedStore" / зменшити TODO-список у ESLint allowlist / `frontend-tech-debt.md` #2.
+
+---
+
+## Steps
+
+### 1. Знайти всі прямі виклики у файлі
+
+```bash
+grep -n "localStorage\.\(getItem\|setItem\|removeItem\)" apps/web/src/<path-to-file>
+```
+
+Зафіксувати кожен виклик: яка функція, який ключ, який формат даних.
+
+### 2. Визначити правильну обгортку
+
+Sergeant має кілька storage-абстракцій:
+
+- **`typedStore`** (`apps/web/src/core/lib/typedStore.ts`) — основна, типобезпечна, sync across tabs.
+- **`safeReadLS`** — safe JSON parse з fallback.
+- **`createModuleStorage`** — для module-scoped ключів.
+- **`useLocalStorageState`** — React hook з автоматичною підпискою.
+
+Обрати найвідповідніший варіант залежно від use-case.
+
+### 3. Замінити прямі виклики
+
+**До:**
+
+```ts
+const data = JSON.parse(localStorage.getItem("myKey") || "null");
+localStorage.setItem("myKey", JSON.stringify(data));
+```
+
+**Після:**
+
+```ts
+import { typedStore } from "@shared/../core/lib/typedStore";
+
+const data = typedStore.get("myKey");
+typedStore.set("myKey", data);
+```
+
+Перевірити:
+
+- Error handling (try/catch не потрібен з typedStore — вже вбудований).
+- Quota exceeded — typedStore обробляє gracefully.
+- Private browsing — typedStore має fallback.
+
+### 4. Видалити файл з ESLint allowlist
+
+У `eslint.config.js` знайти файл у списку дозволених для `sergeant-design/no-raw-local-storage`:
+
+```bash
+grep -n "<filename>" eslint.config.js
+```
+
+Видалити рядок зі списку. Це гарантує що нові прямі `localStorage.*` у цьому файлі будуть блокуватись лінтером.
+
+### 5. Тести
+
+```bash
+# Запустити тести файла (якщо є)
+pnpm --filter @sergeant/web exec vitest run src/<path>/<file>.test.tsx
+
+# Перевірити що лінтер тепер не дозволяє прямий localStorage в цьому файлі
+pnpm lint
+```
+
+### 6. Створити PR
+
+- Branch: `devin/<unix-ts>-chore-migrate-ls-<module>`
+- Commit: `chore(web): migrate <file> from raw localStorage to typedStore`
+- PR description: які виклики замінено, яку обгортку обрано і чому.
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green (файл видалено з allowlist і лінтер не скаржиться)
+- [ ] `pnpm typecheck` — green
+- [ ] Тести — green
+- [ ] Файл видалено з ESLint allowlist у `eslint.config.js`
+- [ ] Немає прямих `localStorage.*` в мігрованому файлі
+
+## Notes
+
+- Наразі ~49 файлів у TODO-списку (ESLint allowlist). Кожна міграція — окремий PR або група по модулю.
+- `typedStore` sync across tabs автоматично через `storage` event.
+- При міграції — не змінювати ключі localStorage (щоб не втратити дані існуючих юзерів).
+- Якщо ключ потрібно перейменувати — додати migration logic (як `useMonoTokenMigration`).
+
+## See also
+
+- [frontend-tech-debt.md](../frontend-tech-debt.md) — §2 Прямі localStorage виклики
+- [cleanup-dead-code.md](cleanup-dead-code.md) — якщо під час міграції знайдено мертвий код
+- [AGENTS.md](../../AGENTS.md) — загальні конвенції

--- a/docs/playbooks/onboard-external-api.md
+++ b/docs/playbooks/onboard-external-api.md
@@ -1,0 +1,161 @@
+# Playbook: Onboard External API
+
+**Trigger:** "Інтегрувати нову зовнішню API" / додати новий third-party сервіс / нова банківська інтеграція / новий AI-провайдер.
+
+---
+
+## Steps
+
+### 1. Створити HTTP-клієнт з resilience
+
+Використовувати патерн з `apps/server/src/lib/bankProxy.ts`:
+
+```ts
+// apps/server/src/lib/<service>Client.ts
+const client = {
+  timeout: 15_000, // AbortController + Promise.race
+  retry: {
+    attempts: 3,
+    backoff: "jitter", // exponential з jitter
+    retryOn: [502, 503, 504, "ECONNRESET", "ETIMEDOUT"],
+    respectRetryAfter: true,
+  },
+  circuitBreaker: {
+    failureThreshold: 5,
+    resetTimeout: 30_000, // 30 секунд
+  },
+};
+```
+
+**Обов'язково:**
+
+- **Timeout** — ніяких HTTP-запитів без timeout.
+- **Retry з jitter** — для 5xx та network errors.
+- **Circuit breaker** — per-origin, щоб один зламаний сервіс не каскадував.
+
+### 2. Додати env vars
+
+Додати необхідні credentials / config:
+
+```bash
+# .env.example — документація формату (без реальних значень!)
+SERVICE_API_KEY=your-api-key-here
+SERVICE_BASE_URL=https://api.example.com
+```
+
+Оновити:
+
+- `.env.example` — з placeholder-ами
+- Railway Variables — реальні значення
+- CI secrets — якщо потрібні для тестів
+
+### 3. Створити module в server
+
+```
+apps/server/src/modules/<service>/
+├── types.ts          # TypeScript типи для API response
+├── http/
+│   ├── schemas.ts    # Zod-schemas для валідації
+│   └── handlers.ts   # Express route handlers
+├── connection.ts     # HTTP-клієнт зі step 1
+└── <service>.test.ts # Тести
+```
+
+### 4. Prometheus metrics
+
+Додати метрики для моніторингу зовнішнього сервісу:
+
+```ts
+// Використати існуючий паттерн
+external_http_requests_total{upstream="<service>", status, outcome}
+external_http_duration_ms{upstream="<service>"}
+```
+
+Outcome: `ok`, `timeout`, `rate_limited`, `circuit_open`, `error`.
+
+### 5. Оновити `packages/api-client`
+
+Додати client-side типи та endpoint functions (AGENTS.md rule #3):
+
+```ts
+// packages/api-client/src/endpoints/<service>.ts
+export async function serviceEndpoint(params: Params): Promise<Response> {
+  return httpClient.get("/api/<service>/...", { params });
+}
+```
+
+### 6. Тести з MSW
+
+Мокати зовнішню API через MSW (Mock Service Worker):
+
+```ts
+import { http, HttpResponse } from "msw";
+import { server } from "../test/mswServer";
+
+server.use(
+  http.get("https://api.example.com/endpoint", () => {
+    return HttpResponse.json({ data: "mocked" });
+  }),
+);
+```
+
+Тест-кейси:
+
+- Happy path — API відповідає нормально.
+- Timeout — API не відповідає протягом timeout.
+- Rate limit (429) — retry з backoff.
+- Server error (5xx) — retry, потім circuit breaker.
+
+### 7. Health check
+
+Додати перевірку зовнішнього сервісу у `/health` або окремий health-endpoint:
+
+```ts
+// Опціонально: GET /api/<service>/health
+async function healthCheck() {
+  try {
+    await client.ping(); // lightweight request
+    return { status: "ok" };
+  } catch {
+    return { status: "degraded", error: "..." };
+  }
+}
+```
+
+### 8. Створити PR
+
+- Branch: `devin/<unix-ts>-feat-<service>-integration`
+- Commit: `feat(server): integrate <service> API`
+- PR description:
+  - Що робить інтеграція
+  - Які env vars потрібні (без реальних значень!)
+  - Resilience: timeout, retry, circuit breaker параметри
+  - Які метрики додано
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] Тести з MSW — green (happy path, timeout, rate-limit, 5xx)
+- [ ] Timeout на всіх HTTP-запитах
+- [ ] Circuit breaker конфігурований
+- [ ] Prometheus metrics додано
+- [ ] `.env.example` оновлено (без реальних secrets!)
+- [ ] Типи в `packages/api-client` додані (rule #3)
+- [ ] Railway Variables задокументовані
+
+## Notes
+
+- **Ніколи** не логувати API keys / tokens (навіть частково).
+- Використовувати `ExternalServiceError` для помилок зовнішніх сервісів — вони потрапляють у Sentry з правильним тегом.
+- Per-origin circuit breaker — різні upstream-и ізольовані (FCM, Apple Push, Monobank тощо).
+- Для банківських API — додатково `Retry-After` header respect.
+
+## See also
+
+- [monobank-webhook-migration.md](../monobank-webhook-migration.md) — приклад повної інтеграції
+- [backend-tech-debt.md](../backend-tech-debt.md) — §Bank integrations deep-dive
+- [railway-vercel.md](../railway-vercel.md) — як додати env vars у Railway
+- [AGENTS.md](../../AGENTS.md) — rule #3 (API contract)

--- a/docs/playbooks/port-web-screen-to-mobile.md
+++ b/docs/playbooks/port-web-screen-to-mobile.md
@@ -1,0 +1,123 @@
+# Playbook: Port Web Screen to Mobile
+
+**Trigger:** "Перенести екран X з apps/web в apps/mobile" / чергова фаза React Native міграції / `react-native-migration.md`.
+
+---
+
+## Steps
+
+### 1. Визначити scope web-екрану
+
+```bash
+# Знайти компонент в apps/web
+find apps/web/src -name "<ScreenName>*" -type f
+
+# Перевірити залежності компонента
+grep -n "import" apps/web/src/modules/<module>/pages/<Screen>.tsx
+```
+
+Розділити залежності на:
+
+- **Reusable** (domain packages: `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/finyk-domain` тощо) — переносяться as-is.
+- **Web-specific** (React Router, Tailwind, web-only hooks) — потрібні RN-аналоги.
+
+### 2. Створити screen в apps/mobile
+
+```bash
+# Expo Router використовує file-based routing
+touch apps/mobile/app/(tabs)/<screen-name>.tsx
+```
+
+Базова структура:
+
+```tsx
+import { View, Text } from "react-native";
+// Реюзати domain-пакети напряму
+import { someUtil } from "@sergeant/shared";
+
+export default function ScreenName() {
+  return (
+    <View>
+      <Text>Screen Name</Text>
+    </View>
+  );
+}
+```
+
+### 3. Замінити web-специфічні компоненти
+
+| Web (apps/web)                   | Mobile (apps/mobile)                   |
+| -------------------------------- | -------------------------------------- |
+| `<div>`, `<span>`                | `<View>`, `<Text>`                     |
+| Tailwind classes                 | StyleSheet / NativeWind                |
+| `<Link to="...">` (React Router) | `<Link href="...">` (Expo Router)      |
+| `useNavigate()`                  | `useRouter()` (Expo Router)            |
+| `localStorage`                   | `AsyncStorage` / `SecureStore`         |
+| `fetch` / React Query            | React Query (той самий `api-client`)   |
+| `<img src="...">`                | `<Image source={{uri: "..."}}>`        |
+| CSS animations                   | `react-native-reanimated`              |
+| `window.addEventListener`        | RN `AppState` / `Dimensions` listeners |
+
+### 4. Data fetching
+
+Реюзати `@sergeant/api-client` напряму — ті самі endpoint-и, ті самі типи:
+
+```tsx
+import { api } from "@sergeant/api-client";
+import { useQuery } from "@tanstack/react-query";
+import { finykKeys } from "@shared/lib/queryKeys";
+
+const { data } = useQuery({
+  queryKey: finykKeys.accounts(),
+  queryFn: () => api.mono.accounts(),
+});
+```
+
+React Query key factories — ті самі з `queryKeys.ts` (AGENTS.md rule #2).
+
+### 5. Навігація
+
+Додати screen до tab-бару або stack navigator в `apps/mobile/app/_layout.tsx` (Expo Router).
+
+### 6. Тести
+
+```bash
+# Тест на mobile
+pnpm --filter @sergeant/mobile exec vitest run src/<path>/<Screen>.test.tsx
+```
+
+Перевірити на Expo Go (або Expo Dev Client) на реальному пристрої / емуляторі.
+
+### 7. Створити PR
+
+- Branch: `devin/<unix-ts>-feat-mobile-<screen>`
+- Commit: `feat(mobile): port <screen-name> from web`
+- PR description:
+  - Який екран перенесено
+  - Що реюзано з domain-пакетів
+  - Які web-компоненти замінено на RN-аналоги
+  - Screenshot з мобільного (обов'язково)
+
+---
+
+## Verification
+
+- [ ] `pnpm lint` — green
+- [ ] `pnpm typecheck` — green
+- [ ] Mobile тести — green (окрім known flaky: `OnboardingWizard`, `WeeklyDigestFooter`, `HubSettingsPage`)
+- [ ] React Query keys — через factories (rule #2)
+- [ ] Domain packages реюзано без дублювання
+- [ ] Screenshot з мобільного додано до PR
+
+## Notes
+
+- `apps/mobile` — Expo 52 + React Native 0.76 + Expo Router (file-based routing).
+- Domain packages (`@sergeant/finyk-domain`, `@sergeant/api-client` тощо) — спільні між web і mobile.
+- Flaky mobile-тести не блокують merge (AGENTS.md).
+- Якщо screen потребує native module — перевірити чи він доступний в Expo Go або потрібен dev-client build.
+
+## See also
+
+- [react-native-migration.md](../react-native-migration.md) — повний план міграції
+- [mobile.md](../mobile.md) — загальна документація mobile app
+- [AGENTS.md](../../AGENTS.md) — rule #2 (RQ keys), flaky tests

--- a/docs/playbooks/rotate-secrets.md
+++ b/docs/playbooks/rotate-secrets.md
@@ -1,0 +1,90 @@
+# Playbook: Rotate Secrets
+
+**Trigger:** "Secret leaked" / планова ротація / security audit / підозріла активність.
+
+---
+
+## Steps
+
+### 1. Оцінити scope витоку
+
+- Який secret скомпрометовано?
+- Де він використовується? (Railway env, CI secrets, `.env` файли)
+- Чи є ознаки зловживання? (логи, Sentry, незвичайні запити)
+
+### 2. Згенерувати новий secret
+
+```bash
+# Для загальних secrets (BETTER_AUTH_SECRET, etc.)
+openssl rand -hex 32
+
+# Для VAPID keys
+pnpm exec web-push generate-vapid-keys
+
+# Для Monobank webhook secret (per-user, зберігається в DB)
+# Це server-side — потребує код-зміну якщо ротація всіх юзерів
+```
+
+### 3. Оновити secret у середовищах
+
+**Railway (Production):**
+
+1. Відкрити Railway dashboard → Service → Variables
+2. Оновити значення змінної
+3. Railway автоматично перезапустить сервіс
+
+**GitHub Actions (CI):**
+
+1. Settings → Secrets and variables → Actions
+2. Оновити відповідний secret
+
+**Локальна розробка:**
+
+1. Оновити `.env` файл (НЕ комітити!)
+2. Оновити `.env.example` якщо формат secret-а змінився
+
+### 4. Перевірити `/health` endpoint
+
+```bash
+# Після того як Railway передеплоїть
+curl -sS https://<prod-domain>/health | jq .
+```
+
+Переконатись що сервіс стартанув з новим secret-ом без помилок.
+
+### 5. Інвалідувати старий secret
+
+- Якщо це API key зовнішнього сервісу — revoke через dashboard провайдера (Anthropic, Resend, Sentry тощо).
+- Якщо це `BETTER_AUTH_SECRET` — всі існуючі сесії стануть невалідними (юзерам треба буде re-login).
+- Якщо це Monobank `MONO_TOKEN_ENC_KEY` — потрібна re-encryption всіх збережених токенів.
+
+### 6. Post-mortem (якщо leak)
+
+Якщо secret витік (а не планова ротація):
+
+- Створити `docs/postmortems/YYYY-MM-DD-secret-rotation.md`
+- Описати: що витекло, як, timeline, impact, prevention.
+
+---
+
+## Verification
+
+- [ ] Новий secret встановлено у всіх середовищах (Railway, CI, local)
+- [ ] `/health` — 200
+- [ ] Старий secret інвалідовано
+- [ ] `.env.example` оновлено (якщо формат змінився)
+- [ ] Логи не містять нових помилок автентифікації
+- [ ] Post-mortem створено (якщо leak)
+
+## Notes
+
+- **НІКОЛИ** не комітити secrets у git (навіть тимчасово).
+- `BETTER_AUTH_SECRET` ротація = всі сесії інвалідуються. Робити в low-traffic час.
+- `MONO_TOKEN_ENC_KEY` ротація — найскладніша, потребує re-encrypt всіх `mono_connection.token_ciphertext`. Окремий migration script.
+- Railway Variables з типом «Reference» (`${{ Postgres.DATABASE_URL }}`) — змінюються автоматично при зміні DB credentials.
+
+## See also
+
+- [railway-vercel.md](../railway-vercel.md) — список env vars для Railway
+- [AGENTS.md](../../AGENTS.md) — ніколи не комітити credentials
+- [hotfix-prod-regression.md](hotfix-prod-regression.md) — якщо ротація зламала прод


### PR DESCRIPTION
## What changed

Додано 10 нових playbook-ів у `docs/playbooks/`, оновлено README з повною таблицею. Тепер у репо **14 playbook-ів** (4 попередніх + 10 нових).

### Нові playbooks

**🔧 Інфраструктура / DevOps:**
- `bump-dep-safely.md` — протокол оновлення залежностей (раніше був у Future Candidates)
- `add-sql-migration.md` — додавання SQL-міграції з дотриманням sequential numbering (rule #4), bigint coercion (rule #1), API contract (rule #3)
- `rotate-secrets.md` — ротація secrets (planned / leak response), Railway + CI + local

**🖥 Frontend:**
- `add-new-page-route.md` — додавання нової сторінки з RQ key factories (rule #2), feature flags, Playwright test
- `migrate-localstorage-to-typedstore.md` — міграція з прямого localStorage на typedStore (frontend tech debt #2, 49 файлів у TODO)
- `fix-exhaustive-deps.md` — виправлення React exhaustive-deps warnings з класифікацією стратегій

**📱 Mobile:**
- `port-web-screen-to-mobile.md` — перенесення web-екранів на React Native/Expo з реюзом domain-пакетів

**🏗 Backend:**
- `add-api-endpoint.md` — додавання нового Express endpoint з zod, api-client types, Prometheus
- `onboard-external-api.md` — інтеграція зовнішнього API з timeout/retry/circuit-breaker (per bankProxy.ts pattern)

**📊 Observability:**
- `investigate-alert.md` — розслідування Prometheus/Sentry алертів з класифікацією root cause

### Оновлені файли

- `docs/playbooks/README.md` — таблиця Available Playbooks розширена до 14 записів, Future Candidates секція видалена (всі кандидати реалізовані)

## Why

Розширення playbook-бібліотеки для покриття найчастіших задач у Sergeant монорепо. Playbook-и зменшують variance результатів AI-агентів та працюють як чек-листи для людей. Кожен playbook посилається на відповідні AGENTS.md rules та існуючу документацію.

## How to test

1. `pnpm exec prettier --check docs/playbooks/*.md` — passes
2. Перевірити що лінки в кожному playbook валідні (See also секції)
3. Перевірити що README.md таблиця коректно рендериться

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): prettier formatting verified on all 15 playbook files
- [x] Vitest passes: docs-only PR, тести не зачеплені
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/0dec8a5d73d44eeb8005d914944bff7e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
