### PR TITLE
docs(roadmap): refresh after evening wave + fix failedSuffix in action cards

### DIFF
--- a/apps/web/src/core/lib/hubChatActionCards.test.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.test.ts
@@ -37,6 +37,24 @@ describe("buildActionCard", () => {
     expect(card?.title).toMatch(/не вийшло/);
   });
 
+  it("title для morning_briefing/weekly_summary містить failedSuffix при failed", () => {
+    const morning = buildActionCard({
+      name: "morning_briefing",
+      input: {},
+      result: "Помилка виконання: timeout",
+    });
+    expect(morning?.status).toBe("failed");
+    expect(morning?.title).toMatch(/не вийшло/);
+
+    const weekly = buildActionCard({
+      name: "weekly_summary",
+      input: {},
+      result: "Помилка виконання: timeout",
+    });
+    expect(weekly?.status).toBe("failed");
+    expect(weekly?.title).toMatch(/не вийшло/);
+  });
+
   it("позначає failed коли result починається з «Невідома дія»", () => {
     const card = buildActionCard({
       name: "log_meal",

--- a/apps/web/src/core/lib/hubChatActionCards.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.ts
@@ -143,9 +143,9 @@ function titleFor(name: string, status: ChatActionCardStatus): string {
     case "create_habit":
       return `Звичку створено${failedSuffix}`;
     case "morning_briefing":
-      return `Ранковий брифінг`;
+      return `Ранковий брифінг${failedSuffix}`;
     case "weekly_summary":
-      return `Тижневий підсумок`;
+      return `Тижневий підсумок${failedSuffix}`;
     default:
       return name;
   }

--- a/docs/ai-coding-improvements.md
+++ b/docs/ai-coding-improvements.md
@@ -543,6 +543,19 @@ it("accountsHandler response shape matches snapshot", async () => {
 
 Блок 2 повністю закрито: 4/4 playbook-и створено (`add-feature-flag`, `cleanup-dead-code`, `hotfix-prod-regression`, `add-monobank-event-handler`).
 
+## 2026-04-25 (вечір) — друга хвиля сесій
+
+Після оновлення статусів у [#733](https://github.com/Skords-01/Sergeant/pull/733) запущено три паралельні child-сесії + одна продуктова фіча у поточному чаті:
+
+| PR                                                     | Що                                                                                         | Скоуп                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------ | --------------------------------- |
+| [#737](https://github.com/Skords-01/Sergeant/pull/737) | Додано 2 playbook-и (`hotfix-prod-regression`, `add-monobank-event-handler`)               | блок 2 → ✅ full                  |
+| [#738](https://github.com/Skords-01/Sergeant/pull/738) | Pino + `pino-http` у `apps/server/src/obs/logger.ts`, structured JSON у проді              | dev-stack #11                     |
+| [#740](https://github.com/Skords-01/Sergeant/pull/740) | `size-limit` budget на `apps/web` + CI step                                                | dev-stack #14                     |
+| [#743](https://github.com/Skords-01/Sergeant/pull/743) | HubChat **Quick Actions v1** — chip-секція + action cards (продукт, але AI-сесія написала) | (продукт; demo швидкості з infra) |
+
+**Висновок:** інфра з блоків 1–8 дала результат — #743 це фіча на ~1200 рядків (UI + tests + 30 unit-кейсів), яку AI-сесія написала за один сеанс. Без `AGENTS.md` (#714), без MSW (#729) і без stable CI (`#717` + `#720`) це б не вийшло однією сесією.
+
 ### Метрики (з блоку 5 цього документа) — оновлення
 
 | Метрика                                 | Baseline (до сесії)   | Зараз                                                                        |

--- a/docs/dev-stack-roadmap.md
+++ b/docs/dev-stack-roadmap.md
@@ -1,6 +1,6 @@
 # Dev stack roadmap — інструменти і поради по всьому ЖЦ розробки
 
-**Статус:** in progress. Створено 2026-04-25. Останнє оновлення: 2026-04-25 (9 з топ-15 закриті — див. колонку Статус у TL;DR + повний session log нижче).
+**Статус:** in progress. Створено 2026-04-25. Останнє оновлення: 2026-04-25 (11 з топ-15 закриті — додано Pino logging (#738) і size-limit (#740). Див. колонку Статус у TL;DR + повний session log нижче).
 **Скоуп:** інструменти, інтеграції, практики для покращення розробки, тестування, CI/CD, проду, безпеки, performance і команди. Specifically для стеку Sergeant: pnpm + Turborepo + Vite/React + Express + Postgres + Railway + Vercel + Expo.
 **Принцип:** не «впровадити все одразу», а **поетапно** — від найдешевших і найважливіших до інвестиційних. Кожен пункт — самостійний tool / practice з ціною, effort-ом, ROI і dep-ами.
 
@@ -22,15 +22,15 @@
 | 8   | **AGENTS.md** (з #711)                            | 1 год     | $0               | 🔥🔥🔥 | ✅ done [#714](https://github.com/Skords-01/Sergeant/pull/714) |
 | 9   | **MSW** для frontend tests                        | 4 год     | $0               | 🔥     | ✅ done [#729](https://github.com/Skords-01/Sergeant/pull/729) |
 | 10  | **Snapshot tests на server serializers** (з #711) | 4 год     | $0               | 🔥🔥🔥 | ✅ done [#718](https://github.com/Skords-01/Sergeant/pull/718) |
-| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   | ⏳ pending                                                     |
+| 11  | **Pino structured logging**                       | 4 год     | $0               | 🔥🔥   | ✅ done [#738](https://github.com/Skords-01/Sergeant/pull/738) |
 | 12  | **Activate Playwright E2E на PR**                 | 2 год     | $0               | 🔥🔥   | ✅ done [#717](https://github.com/Skords-01/Sergeant/pull/717) |
 | 13  | **PostHog** для product analytics                 | 4 год     | $0 (free tier)   | 🔥     | ⏳ pending                                                     |
-| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     | ⏳ pending                                                     |
+| 14  | **size-limit** + bundle-analyzer                  | 2 год     | $0               | 🔥     | ✅ done [#740](https://github.com/Skords-01/Sergeant/pull/740) |
 | 15  | **CONTRIBUTING.md + 5-min quickstart**            | 2 год     | $0               | 🔥🔥   | ✅ done [#726](https://github.com/Skords-01/Sergeant/pull/726) |
 
 **Сумарно:** ~3-5 робочих днів + ~$50/міс. Це 80% wins за 20% effort-у.
 
-**Прогрес (2026-04-25):** 9 / 15 закрито — #2 Knip+depcheck, #4 Testcontainers (#728), #6 Turbo remote cache, #7 Renovate, #8 AGENTS.md, #9 MSW (#729), #10 Snapshot tests, #12 Playwright E2E, #15 CONTRIBUTING.md (#726). Наступні логічні кроки (без платних credentials): #11 (Pino logging — розблокує Sentry/PostHog), #14 (size-limit + bundle-analyzer), #3 (Strict TS incremental). #1 (Sentry) і #5 (Vercel Pro) чекають credentials мейнтейнера.
+**Прогрес (2026-04-25):** 11 / 15 закрито — #2 Knip+depcheck, #4 Testcontainers (#728), #6 Turbo remote cache, #7 Renovate, #8 AGENTS.md, #9 MSW (#729), #10 Snapshot tests, #11 Pino logging (#738), #12 Playwright E2E, #14 size-limit + bundle-analyzer (#740), #15 CONTRIBUTING.md (#726). Наступні кроки (без платних credentials): #3 (Strict TS incremental), #13 (PostHog free tier). #1 (Sentry) і #5 (Vercel Pro) чекають credentials мейнтейнера. Pino вже структурує логи у JSON — Sentry/PostHog stream підключаться без зміни коду.
 
 ---
 
@@ -153,7 +153,7 @@ read & write the shared cache.
 | **Prettier + lint-staged** | У вас є                                                     | —         | ✅                                                             |
 | **Knip**                   | Find unused exports/files/deps (~50+ findings on first run) | 1 год     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716) |
 | **depcheck**               | Find unused deps в package.json                             | 30 хв     | ✅ done [#716](https://github.com/Skords-01/Sergeant/pull/716) |
-| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     | ⏳ pending                                                     |
+| **size-limit**             | Bundle size budget; fails CI on regression                  | 2 год     | ✅ done [#740](https://github.com/Skords-01/Sergeant/pull/740) |
 | **CSpell**                 | Spell-checker для коду і коментарів                         | 30 хв     | ⏳ pending                                                     |
 
 **Sergeant-priority:** strict TypeScript. Зараз `strict: false` — це баги waiting to happen.
@@ -338,7 +338,7 @@ CI gate: `vitest --coverage` + threshold (наприклад 70% lines) на cri
 | **Vector**                 | OSS log router                       |
 | **Grafana Loki**           | OSS log storage                      |
 
-**Sergeant:** ваш `apps/server/src/obs/` модуль вже має logging. Перевірити що це pino + structured JSON. Якщо `console.log` — мігрувати.
+**Sergeant:** ✅ done у [#738](https://github.com/Skords-01/Sergeant/pull/738). `apps/server/src/obs/logger.ts` тепер на pino + `pino-http` middleware, JSON-формат у проді (Railway), pretty-print у dev. Sentry/PostHog stream підключаться без зміни коду.
 
 ### 6.4. Uptime і health
 
@@ -719,6 +719,29 @@ CI gate: `vitest --coverage` + threshold (наприклад 70% lines) на cri
 - `docs/ai-coding-improvements.md` — TL;DR таблиця з Status-колонкою, прогрес-блок, маркери ✅ на блоках 1, 3, 4.2, 4.5, implementation checklist з лінками на PR.
 - `docs/dev-stack-roadmap.md` — TL;DR з Status-колонкою (5/15 done), §3.1 Static analysis і §4.1 Test infrastructure з ✅, §8.1 Security оновлений з Renovate vulnerabilityAlerts.
 - `docs/renovate-usage.md` — новий файл, як працювати з Renovate-PR-ами щодня.
+
+### 2026-04-25 (вечір) — друга хвиля + продуктова фіча
+
+Запущено три паралельні child-сесії після оновлення статусів у [#733](https://github.com/Skords-01/Sergeant/pull/733), плюс одна продуктова фіча в чаті:
+
+| PR                                                     | Що                                                                                    | Roadmap                |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------------- |
+| [#737](https://github.com/Skords-01/Sergeant/pull/737) | `hotfix-prod-regression.md` + `add-monobank-event-handler.md` playbooks               | ai-coding §2 (✅ full) |
+| [#738](https://github.com/Skords-01/Sergeant/pull/738) | Pino + `pino-http` middleware у `apps/server/src/obs/logger.ts`, regenerated licenses | #11                    |
+| [#740](https://github.com/Skords-01/Sergeant/pull/740) | `size-limit` budget на `apps/web` + `Bundle size guard` CI step                       | #14                    |
+| [#743](https://github.com/Skords-01/Sergeant/pull/743) | HubChat **Quick Actions v1** (chip-секція + action cards у чаті)                      | (продуктова фіча)      |
+
+**Прогрес топ-15:** 9/15 → **11/15**.
+
+**Bonus:**
+
+- Vercel preview rate-limit лишається активний (free tier) — це неблокуюче, бо Smoke E2E запускається проти локально стартованого preview.
+- License policy CI крок один раз падав на #743 через регенерацію `THIRD_PARTY_LICENSES.md` у #738; merge-up закрив проблему.
+
+**Що залишилось без credentials:**
+
+- #3 Strict TypeScript (incremental, починаючи зі `strictNullChecks`).
+- #13 PostHog (free tier) — тепер легко завдяки структурованим логам з #11.
 
 ---
 


### PR DESCRIPTION
## What changed

**Документи (продовження роботи #733):**

- `docs/dev-stack-roadmap.md`:
  - TL;DR оновлено: **#11 Pino logging** (#738) і **#14 size-limit + bundle-analyzer** (#740) тепер ✅ done.
  - Прогрес топ-15: **11 / 15** (було 9 / 15).
  - §3.1 Static analysis і §6.3 Logs позначено done з посиланнями на PR.
  - Додано session-log запис «2026-04-25 (вечір)» з описом 4 PR-ів і висновком.
- `docs/ai-coding-improvements.md`:
  - Додано session-log «2026-04-25 (вечір)» з описом другої хвилі: #737, #738, #740 і #743 (фіча, що демонструє ROI вкладеної інфри).

**Bug fix (виявлений Devin Review на #743):**

- `apps/web/src/core/lib/hubChatActionCards.ts` — `morning_briefing` і `weekly_summary` повертали title без `${failedSuffix}` ("— не вийшло"). Усі 7 інших tool-cases додають suffix коректно. Це призводило до того, що при failed-результаті card мала warning-стиль і `alert`-icon, але текст показував успіх ("Ранковий брифінг" замість "Ранковий брифінг — не вийшло"), а screen-reader через `aria-label` чув те ж саме.
- `apps/web/src/core/lib/hubChatActionCards.test.ts` — додано regression test, що перевіряє `failedSuffix` для обох tool.

## Why

Доки відставали від реальності на одну хвилю PR-ів (Pino + size-limit + playbooks + quick-actions). Без цього важко зрозуміти, де ми реально стоїмо в roadmap.

Bug-fix — пряме слідування коменту Devin Review (concrete behavioral mismatch між visual станом і текстом, не стилістика).

## How to test

```bash
pnpm --filter @sergeant/web exec vitest run src/core/lib/hubChatActionCards.test.ts
# 18 passed (раніше було 17, новий test покриває fix)
```

Документація — markdown, рендеритьcя на GitHub.

---

## How AI-tested this PR

- [x] Vitest passes: `hubChatActionCards.test.ts` — 18 / 18.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose використовує українську.

## AGENTS.md updated?

- [x] No — лише оновлення roadmap-доків і bug-fix у мапері.

Link to Devin session: https://app.devin.ai/sessions/fe8672abf0624957910d400023283d3e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
