### PR TITLE
docs(root): fix typedStore path and import in migrate-localstorage playbook

### DIFF
--- a/docs/playbooks/migrate-localstorage-to-typedstore.md
+++ b/docs/playbooks/migrate-localstorage-to-typedstore.md
@@ -38,10 +38,16 @@ localStorage.setItem("myKey", JSON.stringify(data));
 
 ```ts
 import { createTypedStore } from "@shared/lib/typedStore";
+import { z } from "zod";
 
-const store = createTypedStore("myModule");
-const data = store.get("myKey");
-store.set("myKey", data);
+const store = createTypedStore({
+  key: "myKey",
+  version: 1,
+  schema: z.string().nullable(),
+  defaultValue: null,
+});
+const data = store.get();
+store.set(data);
 ```
 
 Перевірити:

--- a/docs/playbooks/migrate-localstorage-to-typedstore.md
+++ b/docs/playbooks/migrate-localstorage-to-typedstore.md
@@ -18,7 +18,7 @@ grep -n "localStorage\.\(getItem\|setItem\|removeItem\)" apps/web/src/<path-to-f
 
 Sergeant має кілька storage-абстракцій:
 
-- **`typedStore`** (`apps/web/src/core/lib/typedStore.ts`) — основна, типобезпечна, sync across tabs.
+- **`createTypedStore`** (`apps/web/src/shared/lib/typedStore.ts`) — основна, типобезпечна, sync across tabs.
 - **`safeReadLS`** — safe JSON parse з fallback.
 - **`createModuleStorage`** — для module-scoped ключів.
 - **`useLocalStorageState`** — React hook з автоматичною підпискою.
@@ -37,10 +37,11 @@ localStorage.setItem("myKey", JSON.stringify(data));
 **Після:**
 
 ```ts
-import { typedStore } from "@shared/../core/lib/typedStore";
+import { createTypedStore } from "@shared/lib/typedStore";
 
-const data = typedStore.get("myKey");
-typedStore.set("myKey", data);
+const store = createTypedStore("myModule");
+const data = store.get("myKey");
+store.set("myKey", data);
 ```
 
 Перевірити:


### PR DESCRIPTION
## What changed

Виправлено неправильний шлях, імпорт та API usage `typedStore` в `docs/playbooks/migrate-localstorage-to-typedstore.md`:

- Шлях: `apps/web/src/core/lib/typedStore.ts` → `apps/web/src/shared/lib/typedStore.ts`
- Ім'я експорту: `typedStore` → `createTypedStore` (це factory function)
- Імпорт: `from "@shared/../core/lib/typedStore"` → `from "@shared/lib/typedStore"`
- API usage: `createTypedStore("myModule")` → `createTypedStore({ key, version, schema, defaultValue })` з правильними `store.get()` / `store.set(value)` сигнатурами

## Why

Devin Review на #751 виявив що playbook посилався на неіснуючий файл, неіснуючий export та використовував неправильну API. AI-агенти слідують playbook-ам дослівно, тому ці помилки привели б до broken imports та typecheck failures.

## How to test

1. Порівняти приклад коду з `apps/web/src/shared/lib/typedStore.ts:14-23` (usage comment) — має збігатись
2. `pnpm exec prettier --check docs/playbooks/migrate-localstorage-to-typedstore.md` — passes

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): verified actual TypedStoreOptions interface, createTypedStore signature, and store.get()/store.set() API against source code
- [x] Vitest passes: docs-only change
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/0dec8a5d73d44eeb8005d914944bff7e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
