### PR TITLE
docs(docs): add 5 high-ROI playbooks + fix formatUah reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Things that bite hard if assumed wrong.
 ### Money (UAH)
 
 - **Database & API: minor units (kopiykas) as `number`** after bigint coercion. Mono webhook delivers minor units; we keep that representation through the stack.
-- **UI display:** divide by 100 at render time only. Use `formatUah(minor)` from `@sergeant/shared` — never inline `value / 100`.
+- **UI display:** divide by 100 at render time only. For Finyk transactions and balances use `fmtAmt(minor, currencyCode?)` from `@sergeant/finyk-domain/lib/formatting` — it handles `+`/`-` sign and currency symbol consistently. For other contexts (insights, dashboards) write a thin local helper that wraps `(minor / 100).toLocaleString("uk-UA", { minimumFractionDigits: 2 })` rather than re-inlining the math at every call site.
 - **Negative = expense, positive = income.** Match Mono's convention; transfers between own accounts come as a pair (-X on source, +X on destination) and are netted in budget calculations, not summed.
 
 ### Identity

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -24,6 +24,11 @@ Each playbook is a checklist that **AI agents and human developers** can follow 
 | [add-api-endpoint.md](add-api-endpoint.md)                                     | "Додати новий endpoint в apps/server" / нова API-функціональність                 |
 | [onboard-external-api.md](onboard-external-api.md)                             | "Інтегрувати нову зовнішню API" / новий third-party сервіс                        |
 | [investigate-alert.md](investigate-alert.md)                                   | Prometheus alert спрацював / Sentry alert / деградація `/health`                  |
+| [add-hubchat-tool.md](add-hubchat-tool.md)                                     | «Дай асистенту нову дію X» / новий tool-call для Anthropic-асистента              |
+| [add-react-query-hook.md](add-react-query-hook.md)                             | Новий `useQuery` / `useMutation` у `apps/web` / нова server-state дата            |
+| [add-onboarding-step.md](add-onboarding-step.md)                               | «Додай новий крок в онбординг» / новий FTUX-етап для нових юзерів                 |
+| [tune-system-prompt.md](tune-system-prompt.md)                                 | «AI відповідає не так як треба» / зміна тону / правил tool-calling                |
+| [stabilize-flaky-test.md](stabilize-flaky-test.md)                             | «Тест X падає 1 з 5 разів» / тест у AGENTS.md flaky-list                          |
 
 ## How to Use
 

--- a/docs/playbooks/add-hubchat-tool.md
+++ b/docs/playbooks/add-hubchat-tool.md
@@ -1,0 +1,205 @@
+# Playbook: Add HubChat Tool
+
+**Trigger:** «Дай асистенту нову дію X» / «Додай tool в HubChat» / новий tool-call для Anthropic-асистента (наприклад `log_water`, `log_set`, `mark_habit_done`).
+
+---
+
+## Контекст
+
+HubChat tools визначаються **на сервері** (`apps/server/src/modules/chat/toolDefs/<domain>.ts`), але виконуються **на клієнті** (`apps/web/src/core/lib/chatActions/<domain>Actions.ts`). Сервер — тонкий пас-зрізу до Anthropic API. Тому новий tool — це 3-4 синхронні правки в різних файлах. Дивись «Architecture: AI tool execution path» в `AGENTS.md`.
+
+---
+
+## Steps
+
+### 1. Tool definition (server)
+
+Додати запис у `apps/server/src/modules/chat/toolDefs/<domain>.ts`. Доступні домени: `finyk`, `fizruk`, `nutrition`, `routine`, `crossModule`, `utility`, `memory`. Якщо tool належить до конкретного модуля — клади у цей файл; крос-модульні (`morning_briefing`, `weekly_summary`) — у `crossModule.ts`.
+
+```ts
+// apps/server/src/modules/chat/toolDefs/nutrition.ts
+{
+  name: "log_water",
+  description:
+    "Залогувати випиту воду. Викликай коли користувач каже скільки води випив.",
+  input_schema: {
+    type: "object",
+    properties: {
+      amount_ml: {
+        type: "number",
+        description: "Кількість мілілітрів",
+      },
+      time: {
+        type: "string",
+        description: "Час прийому ISO 8601 (опціонально, default — зараз)",
+      },
+    },
+    required: ["amount_ml"],
+  },
+}
+```
+
+Description пишемо **українською** і **імперативно** (Anthropic вибирає tool за descriptions). Не «Tool that logs water», а «Залогувати випиту воду. Викликай коли...».
+
+### 2. Action type (client)
+
+Додати typed action у `apps/web/src/core/lib/chatActions/types.ts`:
+
+```ts
+export interface LogWaterAction {
+  name: "log_water";
+  input: { amount_ml: number; time?: string };
+}
+
+export type ChatAction =
+  | ...
+  | LogWaterAction;
+```
+
+`name` має точно збігатися з `name` з tool definition.
+
+### 3. Action handler (client)
+
+Додати case у відповідний `chatActions/<domain>Actions.ts`:
+
+```ts
+// apps/web/src/core/lib/chatActions/nutritionActions.ts
+case "log_water": {
+  const { amount_ml, time } = (action as LogWaterAction).input;
+  const log = ls<WaterEntry[]>("nutrition_water_log_v1", []);
+  log.push({
+    id: crypto.randomUUID(),
+    amount_ml,
+    ts: time ? Date.parse(time) : Date.now(),
+  });
+  lsSet("nutrition_water_log_v1", log);
+  return `Залоговано ${amount_ml} мл води`;
+}
+```
+
+Правила handler-а:
+
+- **Повертає рядок** — це `tool_result`, який модель побачить наступним кроком. Має бути коротким і інформативним.
+- При помилці — викидай `Error`; `executeAction` обгортає в `Помилка виконання: ...`.
+- Запис у `localStorage` через `ls`/`lsSet` helper-и (НЕ `localStorage.setItem` напряму).
+- Якщо tool пише в API — використовуй `@sergeant/api-client`, не `fetch`.
+
+### 4. Action card (опціонально, але майже завжди)
+
+Якщо tool — user-visible action (тобто не `morning_briefing`-style summary), додай мапер у `apps/web/src/core/lib/hubChatActionCards.ts`:
+
+```ts
+case "log_water": {
+  const amount = typeof input.amount_ml === "number" ? input.amount_ml : 0;
+  return {
+    icon: "droplet",
+    title: titleFor(name, status), // → "Воду залоговано"
+    summary: `${amount} мл`,
+  };
+}
+```
+
+І додай case у `titleFor`:
+
+```ts
+case "log_water":
+  return `Воду залоговано${failedSuffix}`;
+```
+
+**Обов'язково** додавай `${failedSuffix}` — це гарантує, що при `failed`-статусі заголовок матиме `— не вийшло` замість success-tone тексту (див. fix у [#754](https://github.com/Skords-01/Sergeant/pull/754)).
+
+### 5. Risky tool (якщо застосовно)
+
+Якщо tool **деструктивний** (видалення, забути факт, масовий імпорт) — додай у `RISKY_TOOLS` в `hubChatActionCards.ts`:
+
+```ts
+const RISKY_TOOLS: ReadonlySet<string> = new Set([
+  "delete_transaction",
+  "hide_transaction",
+  "forget",
+  "archive_habit",
+  "import_monobank_range",
+  // "your_destructive_tool",
+]);
+```
+
+Це автоматично додає лейбл «Критична дія» в action card і warning-стиль.
+
+### 6. Quick action chip (опціонально)
+
+Якщо tool корисно мати під одне натискання — додай у registry `apps/web/src/core/lib/hubChatQuickActions.ts`:
+
+```ts
+{
+  id: "log-water",
+  module: "nutrition",
+  label: "Залогувати воду",
+  shortLabel: "Вода",
+  icon: "droplet",
+  prompt: "Залогуй: ", // закінчується на ": " → prefill flow
+  description: "Швидкий запис склянки води.",
+  priority: 30,
+  requiresOnline: true,
+  keywords: ["вода", "пиття"],
+}
+```
+
+Якщо `prompt` закінчується на `: ` — натискання вставляє текст у input замість одразу відправляти (для випадків, де треба число).
+
+### 7. Тести
+
+Як мінімум:
+
+- **Tool def**: можна не тестувати окремо — Anthropic перевіряє при call.
+- **Handler**: unit-test у `chatActions/<domain>Actions.test.ts` — щоб успіх зберігав у localStorage і повертав очікуваний рядок.
+- **Action card** (якщо додав): додай у `hubChatActionCards.test.ts` — перевір title + status + summary, зокрема `failed` → `— не вийшло`.
+- **Quick action** (якщо додав): додай у `hubChatQuickActions.test.ts` — перевір що input у `pickTopQuickActions` для відповідного modul-у повертає його.
+
+```bash
+pnpm --filter @sergeant/web exec vitest run src/core/lib/chatActions
+pnpm --filter @sergeant/web exec vitest run src/core/lib/hubChatActionCards
+pnpm --filter @sergeant/web exec vitest run src/core/lib/hubChatQuickActions
+```
+
+### 8. PR
+
+Branch: `devin/<unix-ts>-feat-chat-<tool-name>`. Conventional commit:
+
+```
+feat(web): add HubChat tool log_water
+
+- toolDef in chat/toolDefs/nutrition.ts
+- handler in chatActions/nutritionActions.ts
+- action card mapper + titleFor case
+- quick action chip (prefill flow)
+- 4 unit tests
+```
+
+---
+
+## Verification
+
+- [ ] Tool def додано у відповідний `toolDefs/<domain>.ts`.
+- [ ] Action type у `chatActions/types.ts`.
+- [ ] Handler у `chatActions/<domain>Actions.ts`, повертає informative string.
+- [ ] Якщо user-visible — action card у `hubChatActionCards.ts` з `${failedSuffix}` в title.
+- [ ] Якщо destructive — додано у `RISKY_TOOLS`.
+- [ ] Якщо часта — quick action chip у `hubChatQuickActions.ts`.
+- [ ] Unit tests для handler + (опційно) action card + quick action.
+- [ ] `pnpm lint` + `pnpm typecheck` — green.
+- [ ] Smoke-перевірка: відкрити HubChat у dev → попросити модель зробити дію → побачити action card.
+
+## Notes
+
+- **DB writes ніколи у `chat.ts`**. Tool handler пише або у localStorage, або через `@sergeant/api-client` → серверні endpoint-и (звичайні Express routes), які пишуть у БД.
+- Якщо tool потребує **серверної логіки** (наприклад агрегація з БД) — спочатку зроби API endpoint через `add-api-endpoint.md`, потім handler tool-а викликає його через `api-client`.
+- System prompt (контекст модулі, instruction tone) — НЕ міняй у цьому playbook. Для цього є окремий `tune-system-prompt.md`.
+- Tool name — **snake_case** (Anthropic convention), action type — `PascalCaseAction`.
+
+## See also
+
+- [tune-system-prompt.md](tune-system-prompt.md) — як міняти системний промпт без поломки tool-calling
+- [add-api-endpoint.md](add-api-endpoint.md) — якщо tool пише у БД
+- [AGENTS.md](../../AGENTS.md) — секція «Architecture: AI tool execution path»
+- `apps/web/src/core/lib/hubChatQuickActions.ts` — registry з прикладами
+- `docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md` — дизайн quick actions v1

--- a/docs/playbooks/add-onboarding-step.md
+++ b/docs/playbooks/add-onboarding-step.md
@@ -1,0 +1,200 @@
+# Playbook: Add Onboarding Step
+
+**Trigger:** «Додай новий крок в онбординг» / зміна послідовності перших кроків нового юзера / новий FTUX-етап.
+
+---
+
+## Контекст
+
+Onboarding wizard є двох видів:
+
+- **Web** — `apps/web/src/core/OnboardingWizard.tsx` (production, стабільний).
+- **Mobile** — `apps/mobile/src/core/OnboardingWizard.tsx` (v2, **з 3 known flaky тестами** — див. AGENTS.md).
+
+Послідовність кроків — single source of truth у `packages/shared/src/lib/onboarding.ts`:
+
+```ts
+export type OnboardingStepId = "welcome" | "modules" | "goals";
+export const ONBOARDING_STEPS: readonly OnboardingStepId[] = [...];
+```
+
+Обидва wizard-и читають цей масив; додавання кроку = змінити масив + додати UI-блок у обох wizard-ах.
+
+**Обережно:** уже-онбоджені юзери мають `markOnboardingDone()` у localStorage/MMKV. Новий крок для них **не з'явиться** — це by design (не хочемо повторно мучити). Якщо крок настільки важливий, що треба показати всім — окрема логіка через `shouldShowOnboarding()` override, обговорити окремо.
+
+---
+
+## Steps
+
+### 1. Оновити enum + ORDER
+
+Додай `id` у `packages/shared/src/lib/onboarding.ts`:
+
+```ts
+export type OnboardingStepId =
+  | "welcome"
+  | "modules"
+  | "goals"
+  | "your_new_step"; // ➕
+
+export const ONBOARDING_STEPS: readonly OnboardingStepId[] = [
+  "welcome",
+  "modules",
+  "goals",
+  "your_new_step", // ➕ додай у потрібну позицію
+] as const;
+```
+
+Тест `onboarding.test.ts` зразу впаде — це нормально, оновлюй очікувану довжину/порядок:
+
+```ts
+expect(ONBOARDING_STEPS).toHaveLength(4);
+expect(ONBOARDING_STEPS).toEqual([
+  "welcome",
+  "modules",
+  "goals",
+  "your_new_step",
+]);
+```
+
+### 2. Локалізація / описи
+
+Якщо крок має заголовок, підзаголовок чи іконку — додай поля у відповідні мапи в `packages/shared/src/lib/onboarding.ts`:
+
+```ts
+// якщо потрібен опис
+export const ONBOARDING_STEP_DESCRIPTIONS: Record<OnboardingStepId, string> = {
+  welcome: "...",
+  modules: "...",
+  goals: "...",
+  your_new_step: "Дозволь сповіщення, щоб не пропустити брифінги.",
+};
+```
+
+### 3. Web wizard
+
+`apps/web/src/core/OnboardingWizard.tsx` — додай case у render-функцію step body:
+
+```tsx
+{
+  state.step === "your_new_step" && (
+    <YourNewStepView
+      onContinue={() => dispatch({ type: "NEXT" })}
+      onBack={() => dispatch({ type: "BACK" })}
+    />
+  );
+}
+```
+
+State уже керується через `wizardReducer` — `NEXT`/`BACK` працюють із новою позицією автоматично, не треба їх чіпати.
+
+### 4. Mobile wizard
+
+`apps/mobile/src/core/OnboardingWizard.tsx` — той самий патерн, але з NativeWind замість Tailwind і `Pressable` замість `<button>`:
+
+```tsx
+{
+  state.step === "your_new_step" && (
+    <View className="flex-1 px-6 py-8">
+      <Text className="text-2xl font-bold mb-4">Заголовок</Text>
+      {/* ... */}
+      <Pressable onPress={() => dispatch({ type: "NEXT" })}>
+        <Text>Далі</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+**Не** копіюй DOM-API (`localStorage`, `window`) у mobile — використовуй MMKV adapter через `@sergeant/shared/lib/kvStore`.
+
+### 5. Persistence (якщо крок збирає дані)
+
+Якщо новий крок збирає юзерські відповіді (наприклад, дозволи, преференції) — пиши через `saveVibePicks` / `saveOnboardingGoals` patterns:
+
+```ts
+// packages/shared/src/lib/onboardingNotifications.ts (новий файл)
+import { saveKv, readKv } from "./kvStore";
+
+const KEY = "onboarding_notifications_v1";
+
+export interface NotifPrefs {
+  morning: boolean;
+  weekly: boolean;
+}
+
+export function saveNotifPrefs(prefs: NotifPrefs): void {
+  saveKv(KEY, prefs);
+}
+
+export function readNotifPrefs(): NotifPrefs | null {
+  return readKv<NotifPrefs>(KEY);
+}
+```
+
+`kvStore` дає однаковий API на web (localStorage) і mobile (MMKV) — один файл працює всюди.
+
+### 6. Тести
+
+Web:
+
+```bash
+pnpm --filter @sergeant/web exec vitest run src/core/OnboardingWizard.test.tsx
+```
+
+Shared:
+
+```bash
+pnpm --filter @sergeant/shared exec vitest run src/lib/onboarding.test.ts
+```
+
+Mobile:
+
+```bash
+pnpm --filter @sergeant/mobile exec vitest run src/core/OnboardingWizard.test.tsx
+```
+
+**Mobile-тест уже flaky** (AGENTS.md). Якщо він **став падати по-новому** після твоїх змін — це регресія, треба фіксити, **не списуй на flaky**. Якщо падає тим самим способом, як до твоїх змін, — ОК.
+
+### 7. Аналітика
+
+`OnboardingWizard.tsx` емітить `ANALYTICS_EVENTS.onboarding_step_*`. Перевір, що твій новий step_id з'являється в подіях. Якщо потрібен новий event для дії всередині кроку (наприклад, `notif_permission_granted`) — додай у `apps/web/src/core/analytics.ts` constants.
+
+### 8. PR
+
+Branch: `devin/<unix-ts>-feat-onboarding-<step-id>`. Commit:
+
+```
+feat(shared): add `<step_id>` onboarding step
+
+- ONBOARDING_STEPS extended (test updated)
+- web + mobile wizard render the new step
+- new kvStore-backed prefs helper (if applicable)
+- analytics events for step view + completion
+```
+
+---
+
+## Verification
+
+- [ ] `OnboardingStepId` + `ONBOARDING_STEPS` оновлено в `packages/shared/src/lib/onboarding.ts`.
+- [ ] `onboarding.test.ts` оновлено та проходить.
+- [ ] Web `OnboardingWizard.tsx` має render для нового step.
+- [ ] Mobile `OnboardingWizard.tsx` має render для нового step (NativeWind, без DOM).
+- [ ] Persistence (якщо є) — через `kvStore`, не пряме `localStorage`/MMKV.
+- [ ] Аналітика подій (`onboarding_step_*`) працює для нового step_id.
+- [ ] `pnpm lint` + `pnpm typecheck` — green.
+- [ ] Mobile flaky тест: не зламано **по-новому** (ті ж failures, що до змін, — ОК).
+
+## Notes
+
+- **Юзери, які вже завершили onboarding, новий крок не побачать.** Це навмисно. Якщо потрібен «catch-up flow» — це окрема фіча, не сюди.
+- **Не зміщуй порядок існуючих кроків** без сильної причини: для in-progress юзерів їх збережений `state.step` буде раптово вказувати на інший крок.
+- **A/B тестування кроків** — через `featureFlags.ts`, не паралельні енумерації. Прапорець вмикає/вимикає присутність step-у у `ONBOARDING_STEPS`.
+
+## See also
+
+- [add-feature-flag.md](add-feature-flag.md) — якщо новий крок під A/B
+- [migrate-localstorage-to-typedstore.md](migrate-localstorage-to-typedstore.md) — для KV persistence патернів
+- `packages/shared/src/lib/onboarding.ts` — single source of truth
+- [AGENTS.md](../../AGENTS.md) — flaky-tests список (mobile OnboardingWizard)

--- a/docs/playbooks/add-react-query-hook.md
+++ b/docs/playbooks/add-react-query-hook.md
@@ -1,0 +1,192 @@
+# Playbook: Add React Query Hook
+
+**Trigger:** «Дай хук який тягне X з API» / новий useQuery або useMutation у `apps/web` / нова server-state дата.
+
+---
+
+## Контекст
+
+Усі RQ-ключі в Sergeant централізовані в `apps/web/src/shared/lib/queryKeys.ts` (AGENTS.md hard rule #2). Це гарантує, що `invalidateQueries({ queryKey: xxxKeys.all })` дійсно знижує всі дочірні запити, і що ключі type-safe. **Hardcoded keys заборонені** — ESLint ще не ловить, але код-рев'ю ловить.
+
+---
+
+## Steps
+
+### 1. Зареєструвати ключ у factory
+
+Знайти або створити factory у `apps/web/src/shared/lib/queryKeys.ts`. Конвенція: `[domain, resource, ...params] as const`, домен = назва модуля.
+
+```ts
+// apps/web/src/shared/lib/queryKeys.ts
+export const finykKeys = {
+  all: ["finyk"] as const,
+
+  // ... існуючі ключі ...
+
+  // ➕ новий ключ
+  monoBudgetForecast: (monthKey: string) =>
+    ["finyk", "mono", "budget-forecast", monthKey] as const,
+};
+```
+
+Правила:
+
+- Перший елемент tuple — домен (= перша частина `all`).
+- Параметри — від найширшого до найвужчого (місяць → категорія → юзер). Це підтримує bulk-invalidate.
+- **Секрети** (Mono token, API ключі) — ніколи в ключ. Хешуй через `hashToken()` у тому ж файлі.
+- Експорт `as const`, щоб TypeScript виводив літеральні tuples.
+
+### 2. Endpoint у `@sergeant/api-client`
+
+Якщо це новий endpoint — додай функцію у `packages/api-client/src/endpoints/<module>.ts`:
+
+```ts
+// packages/api-client/src/endpoints/finyk.ts
+export interface MonoBudgetForecast {
+  monthKey: string;
+  projected: number; // minor units (kopiykas)
+  confidence: number; // 0..1
+}
+
+export async function getMonoBudgetForecast(
+  monthKey: string,
+): Promise<MonoBudgetForecast> {
+  return httpClient.get(`/api/finyk/mono/budget-forecast?month=${monthKey}`);
+}
+```
+
+Pешта endpoint-у (handler, route, zod-schema) — див. [add-api-endpoint.md](add-api-endpoint.md).
+
+### 3. Хук
+
+Створити в `apps/web/src/modules/<module>/hooks/use<Name>.ts` (для модульних) або `apps/web/src/core/hooks/use<Name>.ts` (для крос-модульних).
+
+```ts
+// apps/web/src/modules/finyk/hooks/useMonoBudgetForecast.ts
+import { useQuery } from "@tanstack/react-query";
+import { getMonoBudgetForecast } from "@sergeant/api-client";
+import { finykKeys } from "@shared/lib/queryKeys";
+
+export function useMonoBudgetForecast(monthKey: string) {
+  return useQuery({
+    queryKey: finykKeys.monoBudgetForecast(monthKey),
+    queryFn: () => getMonoBudgetForecast(monthKey),
+    staleTime: 60_000, // 1 хв — прогноз не змінюється часто
+    enabled: Boolean(monthKey),
+  });
+}
+```
+
+Конвенції:
+
+- Один хук — один factory call. Не `queryKey: ["finyk", ...]` навіть «тимчасово».
+- `staleTime` обери осмислено. Webhook-pushed дані — низький; статичні (категорії, налаштування) — високий.
+- `enabled` — для умовних ключів (`monthKey ? ... : skip`).
+- Mutation — `useMutation` з `onSuccess` що викликає `queryClient.invalidateQueries({ queryKey: finykKeys.all })` або вузький підрозділ.
+
+### 4. MSW handler для тестів
+
+Додай handler у `apps/web/src/test/msw/handlers/<module>.ts`:
+
+```ts
+// apps/web/src/test/msw/handlers/finyk.ts
+import { http, HttpResponse } from "msw";
+
+export const finykHandlers = [
+  // ...
+  http.get("*/api/finyk/mono/budget-forecast", ({ request }) => {
+    const url = new URL(request.url);
+    const month = url.searchParams.get("month");
+    return HttpResponse.json({
+      monthKey: month,
+      projected: 1234500, // 12 345 ₴ у копійках
+      confidence: 0.82,
+    });
+  }),
+];
+```
+
+Якщо в репо ще нема `apps/web/src/test/msw/handlers/<module>.ts` — глянь сусідній модуль; всі handlers агрегуються у `setupServer()` у `apps/web/src/test/setup.ts` (MSW landed у [#729](https://github.com/Skords-01/Sergeant/pull/729)).
+
+### 5. Тест хука
+
+```ts
+// apps/web/src/modules/finyk/hooks/useMonoBudgetForecast.test.ts
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useMonoBudgetForecast } from "./useMonoBudgetForecast";
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+it("повертає прогноз для місяця", async () => {
+  const { result } = renderHook(() => useMonoBudgetForecast("2026-04"), {
+    wrapper: makeWrapper(),
+  });
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  expect(result.current.data?.projected).toBe(1234500);
+});
+```
+
+### 6. Optional: prefetch у Server-Side або at-route-level
+
+Якщо хук критичний для first paint — додай prefetch у `apps/web/src/App.tsx` або у відповідному route-level loader-і:
+
+```ts
+queryClient.prefetchQuery({
+  queryKey: finykKeys.monoBudgetForecast(currentMonth),
+  queryFn: () => getMonoBudgetForecast(currentMonth),
+});
+```
+
+### 7. PR
+
+Branch: `devin/<unix-ts>-feat-<module>-<hook-name>`. Commit example:
+
+```
+feat(web): add useMonoBudgetForecast hook
+
+- finykKeys.monoBudgetForecast factory
+- api-client endpoint getMonoBudgetForecast
+- MSW handler + unit test
+```
+
+---
+
+## Verification
+
+- [ ] Ключ у `queryKeys.ts` factory (НЕ hardcoded).
+- [ ] Параметри в правильному порядку (від широкого до вузького).
+- [ ] Endpoint у `@sergeant/api-client` з типами, що збігаються із серверним response shape (AGENTS.md rule #3).
+- [ ] MSW handler в `apps/web/src/test/msw/handlers/<module>.ts`.
+- [ ] Unit test для хука (минaute success path як мінімум).
+- [ ] `pnpm lint` + `pnpm typecheck` — green.
+- [ ] Якщо змінив API shape — оновлено snapshot-тест на сервері.
+
+## Notes
+
+- Don't put fetch logic in the component. Завжди через хук.
+- Mutation `onSuccess` має invalidate-ити **і** широкий ключ (для списків), **і** конкретний (для деталей):
+  ```ts
+  onSuccess: () => {
+    queryClient.invalidateQueries({
+      queryKey: finykKeys.monoTransactionsDb(undefined, undefined, undefined),
+    });
+    queryClient.invalidateQueries({ queryKey: finykKeys.monoSyncState });
+  };
+  ```
+- Не плутай **`queryKey`** і **`mutationKey`** — для `useMutation` ключ зазвичай не потрібен (RQ використовує функцію).
+- Якщо хук тягне ту ж саму дату двома різними способами (DB-backed + webhook-backed) — зроби 2 ключі (`monoTransactionsDb` vs `monoWebhookTransactions`), не один з прапорцем.
+
+## See also
+
+- [add-api-endpoint.md](add-api-endpoint.md) — як зробити endpoint, який потім тягне цей хук
+- [AGENTS.md](../../AGENTS.md) — hard rule #2 (RQ keys), rule #3 (API contract)
+- `apps/web/src/shared/lib/queryKeys.ts` — приклади existing factories
+- [#729](https://github.com/Skords-01/Sergeant/pull/729) — MSW setup

--- a/docs/playbooks/stabilize-flaky-test.md
+++ b/docs/playbooks/stabilize-flaky-test.md
@@ -1,0 +1,209 @@
+# Playbook: Stabilize Flaky Test
+
+**Trigger:** «Тест X падає 1 з 5 разів» / у CI red, локально green / тест у списку **«Pre-existing flaky tests»** в AGENTS.md.
+
+---
+
+## Контекст
+
+Sergeant має 3 відомі flaky тести у `apps/mobile` (зафіксовано в AGENTS.md):
+
+- `apps/mobile/src/core/OnboardingWizard.test.tsx`
+- `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
+- `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
+
+Вони падають у CI на `main`, але не блокують merge — це by design, поки їх не стабілізували. Якщо береш flaky — мета **видалити з AGENTS.md flaky-list**, а не тимчасово приховати.
+
+---
+
+## Steps
+
+### 1. Підтверди flakiness емпірично
+
+Запусти тест **20 разів** локально й порахуй failures:
+
+```bash
+for i in {1..20}; do
+  pnpm --filter @sergeant/mobile exec vitest run src/core/OnboardingWizard.test.tsx --reporter=basic 2>&1 | tail -1 || echo "RUN $i: FAIL"
+done | grep FAIL | wc -l
+```
+
+Якщо < 1 з 20 — скоріш за все environment-залежне (Node version, кеш). Якщо 5+ з 20 — справжня flakiness.
+
+Якщо тест **завжди** падає у CI і **завжди** проходить локально — це **environment differences**, не flaky. Перевір Node version (CI = 20.x), часовий пояс runner-а, locale. Це окремий жанр, фікс простіший: задізолюй те, що відрізняється.
+
+### 2. Класифікуй причину flakiness
+
+Топ-5 причин (порядок ймовірності):
+
+1. **Час / таймери.** `Date.now()`, `setTimeout` без `vi.useFakeTimers()`, race на `await waitFor`.
+2. **Async без await.** `fireEvent.click(button)` повертає void, але внутрі є promise — наступний assertion видно стейт «до».
+3. **Shared state між тестами.** `localStorage` / MMKV не очищується. Mock не сброшується (`vi.clearAllMocks` не викликано).
+4. **Залежність від порядку тестів.** Test A залишає state, Test B очікує fresh state. Vitest `--shuffle` робить це видимим.
+5. **DOM cleanup.** Кілька `render()` в одному тесті без `cleanup` між ними. Result: дублі `data-testid`.
+
+Для кожної причини — конкретні fix-патерни нижче.
+
+### 3. Fix patterns
+
+#### 3a. Час / таймери
+
+```ts
+// ❌ Залежить від реального часу — flaky
+const today = new Date();
+expect(screen.getByText(today.toLocaleDateString())).toBeVisible();
+
+// ✅ Заморозь час
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-04-25T12:00:00+03:00")); // Kyiv time!
+});
+afterEach(() => vi.useRealTimers());
+```
+
+Для Kyiv-day boundary (AGENTS.md domain invariants) — мокай **Kyiv-час** конкретно, бо UTC-час о 22:00 — це вже наступний день у Kyiv.
+
+#### 3b. Async race
+
+```ts
+// ❌ Race
+fireEvent.click(submitButton);
+expect(screen.getByText("Збережено")).toBeVisible();
+
+// ✅ Wait
+fireEvent.click(submitButton);
+await waitFor(() => {
+  expect(screen.getByText("Збережено")).toBeVisible();
+});
+
+// ✅ Або use userEvent (асинхронний)
+const user = userEvent.setup();
+await user.click(submitButton);
+expect(await screen.findByText("Збережено")).toBeVisible();
+```
+
+`findByX` (асинхронний get) майже завжди безпечніший за `getByX` для post-action assertions.
+
+#### 3c. Shared state
+
+```ts
+// vitest.config: setupFiles вже може містити global cleanup, перевір.
+// Локально для конкретного тесту:
+
+import { afterEach, beforeEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+beforeEach(() => {
+  localStorage.clear();
+  // mobile:
+  // require("@react-native-async-storage/async-storage").default.clear();
+});
+
+afterEach(() => {
+  cleanup(); // unmount + remove from document
+  vi.clearAllMocks();
+});
+```
+
+#### 3d. Test ordering
+
+Vitest за замовчуванням пускає файли паралельно, тести всередині — sequentially. Але якщо тести діляться module-scope state, ордер всередині файлу матиме значення.
+
+Запусти зі shuffle, щоб виявити приховану залежність:
+
+```bash
+pnpm --filter @sergeant/mobile exec vitest run src/core/OnboardingWizard.test.tsx --sequence.shuffle
+```
+
+Якщо падає по-новому — є залежність. Винеси setup у `beforeEach`, не в module top-level.
+
+#### 3e. DOM cleanup
+
+```ts
+// ❌ Multiple render без cleanup → "Found multiple elements by [data-testid='x']"
+it("test 1", () => { render(<App />); ... });
+it("test 2", () => { render(<App />); /* test 1 still in DOM */ });
+
+// ✅ Cleanup hook
+import { cleanup } from "@testing-library/react";
+afterEach(() => cleanup());
+```
+
+(Це fix-причина у `ChatQuickActions.test.tsx` під час quick-actions PR — див. контекст у [#743](https://github.com/Skords-01/Sergeant/pull/743).)
+
+### 4. Verify fix
+
+Запусти 50 разів:
+
+```bash
+for i in {1..50}; do
+  pnpm --filter @sergeant/mobile exec vitest run src/core/OnboardingWizard.test.tsx --reporter=basic 2>&1 \
+    | grep -qE "Tests.*\d+ passed" && echo "RUN $i: pass" || echo "RUN $i: FAIL"
+done | grep FAIL | wc -l
+```
+
+**Acceptance:** 0 failures з 50. Якщо 1 з 50 — продовжуй копати, не мерж.
+
+### 5. Видали з flaky-list
+
+Після того, як 50/50 — оновлення в `AGENTS.md`:
+
+```diff
+ ## Pre-existing flaky tests (do not block merge)
+
+-- `apps/mobile/src/core/OnboardingWizard.test.tsx`
+ - `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
+ - `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
+```
+
+Це **обов'язкова частина PR-у** — інакше наступний агент не знатиме, що тест уже стабілізований, і знов спишеть падіння на «known flaky».
+
+### 6. CI smoke
+
+Push, побач 3 послідовних зелених CI run-и для `Test coverage (vitest)` job. Якщо хоч один зелений-зелений-червоний — фікс не доведений, треба ще копати.
+
+### 7. PR
+
+Branch: `devin/<unix-ts>-fix-flaky-<test-name>`. Commit:
+
+```
+fix(mobile): stabilize OnboardingWizard flaky test
+
+Root cause: Date.now() used for stepStartedAt assertion; non-deterministic
+in CI when test runs slow.
+
+Fix:
+- mock vi.useFakeTimers in beforeEach
+- assert relative time delta, not absolute timestamp
+- add cleanup hook for DOM (was missing)
+
+Verified: 50/50 runs locally pass; AGENTS.md flaky-list trimmed.
+```
+
+---
+
+## Verification
+
+- [ ] Підтверджено flakiness емпірично (≥ 5 з 20 ранів падає до фіксу).
+- [ ] Знайдено root cause (одна з 5 категорій з кроку 2).
+- [ ] Застосовано відповідний fix-pattern (`fakeTimers`, `findByX`, `cleanup`, etc.).
+- [ ] **50 з 50** локальних ранів зелені після фіксу.
+- [ ] AGENTS.md flaky-list оновлений (тест видалено).
+- [ ] CI: 3 послідовних зелених `Test coverage (vitest)` runs.
+- [ ] `pnpm lint` + `pnpm typecheck` — green.
+
+## Notes
+
+- **Не маскуй flakiness через `it.skip`** і не додавай `retry: 3` локально для тесту. Це лише ховає, не фіксить.
+- **Mobile-specific:** `vi.useFakeTimers` працює, але Hermes runtime іноді поводиться інакше за Node — перевір що тест використовує `vitest` env, не `node:test`.
+- Якщо корінь проблеми — **компонент**, а не тест (race у `useEffect`, що депендиться від render order) — фікс у компоненті, не в тесті. Тест-фікс перетворює тест на placeholder.
+- Якщо падіння **environment-only** (CI Linux vs локальний macOS) — задізолюй timezone і locale у тесті:
+  ```ts
+  process.env.TZ = "Europe/Kyiv";
+  ```
+
+## See also
+
+- [AGENTS.md](../../AGENTS.md) — секція «Pre-existing flaky tests»
+- [#743](https://github.com/Skords-01/Sergeant/pull/743) — приклад DOM-cleanup fix у `ChatQuickActions.test.tsx`
+- [hotfix-prod-regression.md](hotfix-prod-regression.md) — якщо це не flaky, а справжня регресія

--- a/docs/playbooks/tune-system-prompt.md
+++ b/docs/playbooks/tune-system-prompt.md
@@ -1,0 +1,155 @@
+# Playbook: Tune System Prompt
+
+**Trigger:** «AI відповідає не так як треба» / «Зміни тон асистента» / «Додай нову інструкцію в системний промпт» / зміна як модель розуміє контекст модулі.
+
+---
+
+## Контекст
+
+System prompt для HubChat живе у `apps/server/src/modules/chat/toolDefs/systemPrompt.ts` як константа `SYSTEM_PREFIX`. Передається в Anthropic Messages API на кожен `/api/chat`, разом з `TOOLS` (визначення tool-ів).
+
+**Чому це дороге:** system prompt прямо керує тим, **які tool-и викликає модель** і **як**. Маленька зміна тексту може:
+
+- зламати tool-calling (модель перестає викликати `log_meal`, бо нова інструкція двозначна)
+- збільшити cost (довший prompt = більше input tokens × всі юзери × всі messages)
+- змінити tone у небажаний бік («стало занадто сухо», «надто перепрошує»)
+
+Тому **завжди тестуй** перед мерджем, не редагуй наосліп.
+
+---
+
+## Steps
+
+### 1. Прочитай поточний промпт повністю
+
+```bash
+cat apps/server/src/modules/chat/toolDefs/systemPrompt.ts
+```
+
+Зверни увагу на структуру: ввід/роль → інструкції по модулях → правила tool-calling → формат відповіді. Зміна найкраще лягає в **існуючу секцію**, а не як новий блок наприкінці.
+
+### 2. Сформулюй зміну як **delta**
+
+❌ Не «перепиши все, як ти вважаєш правильним».
+✅ «У секції про Фінік замінити рядок X на Y» / «Додати після інструкції про tool-calling новий пункт N».
+
+Чим точніше delta — тим менше шансів випадково задушити інший aspect.
+
+### 3. Mini-eval перед запуском
+
+Зроби список **3-5 канонічних запитів**, які мають викликати конкретний tool:
+
+```
+запит → очікуваний tool → очікувана модель відповіді
+─────────────────────────────────────────────────────
+"витратив 200 на каву" → create_transaction → коротке підтвердження
+"добав витрату" (incomplete) → НЕ викликає tool, питає скільки і на що
+"скільки в мене на чорній?" → НЕ викликає tool, читає з контексту
+"Видали останню транзакцію" → delete_transaction (risky)
+"Як справи?" → НЕ викликає tool, маленький smalltalk
+```
+
+Цей eval-set став **regression baseline**. Прогни його **до** і **після** зміни промпту, порівняй.
+
+### 4. Запусти модель локально
+
+```bash
+# 1) Стартни сервер з реальним ANTHROPIC_API_KEY:
+ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @sergeant/server dev
+
+# 2) Стартни web:
+pnpm --filter @sergeant/web dev
+
+# 3) Відкрий localhost:5173, увійди тестовим юзером (AGENTS.md), піди в HubChat,
+#    прогни eval-set вручну.
+```
+
+Альтернатива (без UI): прямий `curl` на `/api/chat`:
+
+```bash
+curl -X POST http://localhost:3000/api/chat \
+  -H "Cookie: better-auth.session_token=..." \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"витратив 200 на каву"}]}'
+```
+
+### 5. Зроби зміну
+
+Едитай `systemPrompt.ts`. Дотримуйся стилю:
+
+- **Українською** (модель розуміє і відповідає українською краще, ніж англійським промптом).
+- **Імперативно** («Викликай `create_transaction` коли...», не «Tool create_transaction can be used to...»).
+- **Конкретні приклади** замість абстрактних правил, де можливо.
+- **Один пункт — одна думка.** Розбивай довгі речення.
+
+### 6. Repeat eval після зміни
+
+Прогни ту ж саму mini-eval (крок 3). Перевір:
+
+- ✅ Усі очікувані tool-calls — на місці.
+- ✅ Tone не дрейфонув.
+- ✅ Формат відповіді (markdown headings, emoji) лишається.
+- ✅ Не з'явились галюцинації нових tool-ів («execute_transfer» якого не існує — модель таке вигадує, якщо новий промпт натякає на нього).
+
+Якщо щось зламалось — повертайся до кроку 5. **Не коміт зміну, що зламала eval.**
+
+### 7. Token cost check
+
+```bash
+# Кількість символів промпту (грубо ≈ tokens × 3 для української):
+node -e "console.log(require('./apps/server/src/modules/chat/toolDefs/systemPrompt.js').SYSTEM_PREFIX.length)"
+```
+
+Якщо промпт виріс на >10% — це бачити на бюджеті Anthropic. Подумай, чи можна **видалити** щось зайве, перш ніж додавати.
+
+### 8. Тести (юніт-рівень)
+
+Тести чату в `apps/server/src/modules/chat/chat.test.ts` мокають Anthropic — вони перевіряють route plumbing, не якість промпту. Eval-якість лишається мануальним кроком 6.
+
+```bash
+pnpm --filter @sergeant/server exec vitest run src/modules/chat
+```
+
+### 9. PR з прикладами
+
+Branch: `devin/<unix-ts>-tune-system-prompt-<topic>`. PR description **обов'язково** містить:
+
+- Diff промпту (GitHub покаже автоматично).
+- Eval-set до / після — як таблицю «request → tool called (before)`/`tool called (after)`».
+- Token-count change.
+- Якщо це продуктовий tone-change — короткий приклад «до/після» розмови.
+
+Conventional commit:
+
+```
+feat(server): tighten Finyk tool-calling rules in system prompt
+
+- bias toward asking back when amount missing (was eagerly creating zero-amount tx)
+- explicit example: "витратив на каву" without amount → ask
+- token count: 4823 → 4901 (+78 chars; insignificant cost change)
+```
+
+---
+
+## Verification
+
+- [ ] Зміна промпту — як точна delta, не повний переписав.
+- [ ] Mini-eval (3-5 запитів) пройдено до зміни → зафіксовано baseline.
+- [ ] Mini-eval пройдено після зміни → жоден tool-call не зламався, tone OK.
+- [ ] Token-count change задокументовано в PR.
+- [ ] Server unit-тести `chat/*` — green.
+- [ ] PR description містить eval-таблицю до/після.
+
+## Notes
+
+- **Не маскуй tool-bug як prompt-issue.** Якщо модель не викликає tool, бо tool definition двозначний (опис tool-а), фіксь у `toolDefs/<domain>.ts`, не в системному промпті.
+- **Системний промпт — НЕ місце для контексту юзера.** Юзер-специфічні дані (баланси, останні транзакції) ін'ектяться в `messages[0].content` як «[Останні операції] ...» блоки в `chat.ts`, не у `SYSTEM_PREFIX`.
+- **Про cost:** Anthropic Messages кешує prompt-prefix (prompt caching) — стабільний `SYSTEM_PREFIX` = дешеві наступні запити. Якщо змінюєш його часто, втрачається cache benefit.
+- **Якщо потрібен A/B тест двох промптів** — використовуй `featureFlags.ts` з `apps/server/src` (потрібен серверний контекст). Не роби це через два хардкоднутих рядки.
+
+## See also
+
+- [add-hubchat-tool.md](add-hubchat-tool.md) — для додавання tool, не зміна тону
+- [add-feature-flag.md](add-feature-flag.md) — якщо A/B тест двох промптів
+- `apps/server/src/modules/chat/toolDefs/systemPrompt.ts` — поточний промпт
+- [AGENTS.md](../../AGENTS.md) — секція «Architecture: AI tool execution path»


### PR DESCRIPTION
## What changed

Top-5 нових playbook-ів за ROI (часті задачі, де AI-агенти зараз імпровізують):

### 1. `add-hubchat-tool.md`
Координує **3-4 синхронних правки** для нового HubChat tool:
- server tool definition (`apps/server/src/modules/chat/toolDefs/<domain>.ts`)
- client action type (`apps/web/src/core/lib/chatActions/types.ts`)
- client action handler (`chatActions/<domain>Actions.ts`)
- (опційно) action card mapper, risky-tools list, quick action chip

Запобігає тому, щоб новий tool жив тільки на сервері або тільки на клієнті.

### 2. `add-react-query-hook.md`
Закладає AGENTS.md hard rule #2 (centralized RQ keys) у конкретний flow:
- factory у `queryKeys.ts` (НЕ hardcoded)
- endpoint + types у `@sergeant/api-client`
- MSW handler у `apps/web/src/test/msw/handlers/<module>.ts`
- unit test з `QueryClientProvider` wrapper

Прямо рекомендує форму mutation `onSuccess` для bulk + targeted invalidate.

### 3. `add-onboarding-step.md`
Wizard є на web і mobile; single source of truth — `ONBOARDING_STEPS` у `@sergeant/shared/lib/onboarding`. Покриває:
- enum + ORDER + тест-update
- web рендер
- mobile рендер (NativeWind, без DOM-API)
- persistence через `kvStore` (web localStorage / mobile MMKV)
- застереження «вже-онбоджені юзери не побачать нового кроку» — це by design

### 4. `tune-system-prompt.md`
Найбільш ризиковий: зміна промпту може зламати tool-calling непомітно. Playbook вимагає:
- mini-eval baseline до зміни (3-5 канонічних запитів → очікуваний tool)
- локально прогнати модель з твоєю зміною
- порівняти token-count і cost (+ prompt-caching impact)
- PR description з таблицею eval-результатів до/після

### 5. `stabilize-flaky-test.md`
5 root-cause категорій (timers, async race, shared state, ordering, DOM cleanup) з patterns для кожної. Acceptance bar — **50/50 локально** + 3 послідовні зелені CI run-и. Зобов'язує оновити AGENTS.md flaky-list як частину PR.

### Bonus: fix у AGENTS.md
Devin Review на [#756](https://github.com/Skords-01/Sergeant/pull/756) вірно зазначив, що я написав «`formatUah` з `@sergeant/shared`», але такої функції нема. Виправлено: правильний public-формат — `fmtAmt(minor, currencyCode?)` з `@sergeant/finyk-domain/lib/formatting`. Для не-finyk контекстів — рекомендація обгортати `(minor/100).toLocaleString("uk-UA", ...)` у локальний хелпер.

## Why

Сьогодні в одній сесії пройшло 6 PR-ів від AI-агентів, і двічі повторно «винаходилось колесо»:
- На #743 (quick actions) — недодав `${failedSuffix}` у 2 з 9 tool case (виправлено в #754). Якби був `add-hubchat-tool.md` з прямим reminder-ом, цього не сталось би.
- На #756 (AGENTS.md) — посилався на `formatUah` від балди. Якби існував `tune-...` playbook з вимогою «перевір, що функція справді є» — теж би не сталося.

Playbook-и — це не «що ми робимо», це «як ми це робимо однаково кожного разу».

Після мерджу `docs/playbooks/` має **19 файлів** (було 14).

## How to test

Markdown — рендериться на GitHub. Швидкий smoke:
- Відкрити `docs/playbooks/README.md` на GitHub → перевірити, що 5 нових рядків додано в таблицю.
- Перевірити лінки на 5 нових файлів — не 404.

Жодних code-змін у репо нема (крім AGENTS.md prose).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): grep-перевірка, що кожне посилання у playbook-ах вказує на існуючий файл/функцію. Виявив `formatUah` як неіснуюче — виправлено в цьому ж PR.
- [x] Vitest passes: code-змін нема, лише markdown.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — секція «Domain invariants → Money (UAH)», `AGENTS.md:206`. `formatUah` (не існує) → `fmtAmt` з `@sergeant/finyk-domain/lib/formatting` (існує).

Link to Devin session: https://app.devin.ai/sessions/fe8672abf0624957910d400023283d3e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined currency formatting guidelines for consistent UAH display handling across the application.
  * Added five new developer playbooks providing standardized procedures for HubChat tool implementation, onboarding feature integration, React Query hook creation, test stabilization workflows, and AI system prompt optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->