### PR TITLE
docs: rename MOBILE.md to docs/mobile-shell.md

### DIFF
--- a/apps/mobile-shell/README.md
+++ b/apps/mobile-shell/README.md
@@ -13,17 +13,17 @@ React Native). Співіснують навмисно: `applicationId` у shell
 
 ## Що готово
 
-| Функція                                       | Плагін / PR                                                                                                                                                                                                                                                                           |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                                                                                                                                                                                                     |
-| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                                                                                                                                                                                          |
-| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506)                                                                                                                                                                         |
-| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                                                                                                                                                                                           |
-| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                                                                                                                                                                                                      |
-| Push у shell — лише нативний (FCM/APNs)       | `@capacitor/push-notifications` через `@shared/lib/pushNative`. Web Push (VAPID + `PushManager.subscribe`) повністю виключений з shell-бандла через `VITE_TARGET=capacitor` + dynamic `import()` → [#524](https://github.com/Skords-01/Sergeant/pull/524)                             |
-| Android debug-APK у CI                        | [`.github/workflows/mobile-shell-android.yml`](../../.github/workflows/mobile-shell-android.yml) → артефакт `sergeant-shell-debug-apk`                                                                                                                                                |
-| Android release-signing + ProGuard/R8         | `signingConfigs.release` у `android/app/build.gradle` читає `SERGEANT_RELEASE_*` з env/`gradle.properties`; `minifyEnabled true` + `shrinkResources true` + Capacitor keep-rules у `android/app/proguard-rules.pro`                                                                   |
-| Android release pipeline (AAB + APK у CI)     | [`.github/workflows/mobile-shell-android-release.yml`](../../.github/workflows/mobile-shell-android-release.yml) → `sergeant-shell-release-aab` (Play) + `sergeant-shell-release-apk` (sideload); setup-інструкція — [`MOBILE.md#release--android`](../../MOBILE.md#release--android) |
+| Функція                                       | Плагін / PR                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bearer-auth (Keychain / EncryptedSharedPrefs) | `@capacitor/preferences` — [#505](https://github.com/Skords-01/Sergeant/pull/505)                                                                                                                                                                                                                           |
+| Native barcode scanner                        | `@capacitor-mlkit/barcode-scanning` — [#504](https://github.com/Skords-01/Sergeant/pull/504)                                                                                                                                                                                                                |
+| Status bar + splash + keyboard + deep links   | `@capacitor/{status-bar,splash-screen,keyboard,app}` — [#506](https://github.com/Skords-01/Sergeant/pull/506)                                                                                                                                                                                               |
+| Android hardware Back → web-history traversal | `@capacitor/app#backButton` — `canGoBack` → `window.history.back()`, інакше `App.exitApp()`                                                                                                                                                                                                                 |
+| Android native проєкт (закомічено)            | `android/` (з `cap add android`)                                                                                                                                                                                                                                                                            |
+| Push у shell — лише нативний (FCM/APNs)       | `@capacitor/push-notifications` через `@shared/lib/pushNative`. Web Push (VAPID + `PushManager.subscribe`) повністю виключений з shell-бандла через `VITE_TARGET=capacitor` + dynamic `import()` → [#524](https://github.com/Skords-01/Sergeant/pull/524)                                                   |
+| Android debug-APK у CI                        | [`.github/workflows/mobile-shell-android.yml`](../../.github/workflows/mobile-shell-android.yml) → артефакт `sergeant-shell-debug-apk`                                                                                                                                                                      |
+| Android release-signing + ProGuard/R8         | `signingConfigs.release` у `android/app/build.gradle` читає `SERGEANT_RELEASE_*` з env/`gradle.properties`; `minifyEnabled true` + `shrinkResources true` + Capacitor keep-rules у `android/app/proguard-rules.pro`                                                                                         |
+| Android release pipeline (AAB + APK у CI)     | [`.github/workflows/mobile-shell-android-release.yml`](../../.github/workflows/mobile-shell-android-release.yml) → `sergeant-shell-release-aab` (Play) + `sergeant-shell-release-apk` (sideload); setup-інструкція — [`docs/mobile-shell.md#release--android`](../../docs/mobile-shell.md#release--android) |
 
 Точка входу native-side — `src/index.ts → initNativeShell()`. Вона
 ідемпотентна (повторні виклики безпечні під HMR / LiveReload) і
@@ -53,7 +53,7 @@ PR, що чіпає `apps/mobile-shell/**`, `apps/web/**`, `apps/server/**`
 `sergeant-shell-debug-apk` (14 днів retention). iOS-сторона живе в
 сибілінгу `mobile-shell-ios.yml` (macOS runner, build-only без
 підпису). Огляд кроків і локальних команд — у
-[`MOBILE.md`](../../MOBILE.md).
+[`docs/mobile-shell.md`](../../docs/mobile-shell.md).
 
 ### Варіант Б — локальна збірка
 
@@ -95,7 +95,7 @@ pnpm --filter @sergeant/mobile-shell open:android
 `.github/workflows/mobile-shell-ios-release.yml` (триггери `push tag
 'v*'` + `workflow_dispatch`): сам робить `cap add ios` на `macos-latest`,
 архівує, експортує `.ipa` і заливає у TestFlight. Контракт секретів і
-інструкції для першого запуску — у [`MOBILE.md` → Release — iOS](../../MOBILE.md#release--ios).
+інструкції для першого запуску — у [`docs/mobile-shell.md` → Release — iOS](../../docs/mobile-shell.md#release--ios).
 
 ## Що НЕ зроблено
 
@@ -117,7 +117,7 @@ pnpm --filter @sergeant/mobile-shell open:android
 - ~~**Release pipeline на iOS не налаштований**~~ — зроблено
   сканфолдом у `.github/workflows/mobile-shell-ios-release.yml`. Для
   першого запуску потрібні всі Apple-секрети з контракту у
-  [`MOBILE.md` → Release — iOS](../../MOBILE.md#release--ios);
+  [`docs/mobile-shell.md` → Release — iOS](../../docs/mobile-shell.md#release--ios);
   без них job логить `::warning::iOS release secrets not configured`
   і падає у unsigned-Simulator-фолбек.
 - ~~**Native push notifications.** `usePushNotifications` у web тримає

--- a/docs/mobile-shell.md
+++ b/docs/mobile-shell.md
@@ -3,15 +3,15 @@
 > Short operator-oriented reference for the Capacitor shell
 > (`@sergeant/mobile-shell`). For the design rationale, plugin list, and
 > history of the shell, read
-> [`apps/mobile-shell/README.md`](apps/mobile-shell/README.md). For the
+> [`apps/mobile-shell/README.md`](../apps/mobile-shell/README.md). For the
 > Expo / React Native app (`@sergeant/mobile`) see
-> [`apps/mobile/README.md`](apps/mobile/README.md) and
-> [`docs/mobile.md`](docs/mobile.md).
+> [`apps/mobile/README.md`](../apps/mobile/README.md) and
+> [`mobile.md`](./mobile.md).
 
 The Capacitor shell wraps the existing `@sergeant/web` Vite bundle as a
 native Android/iOS app. The web bundle lands in `apps/server/dist` — the
 shell reads it from there via `webDir: "../server/dist"` in
-[`apps/mobile-shell/capacitor.config.ts`](apps/mobile-shell/capacitor.config.ts).
+[`apps/mobile-shell/capacitor.config.ts`](../apps/mobile-shell/capacitor.config.ts).
 
 > Shell білдить web-бандл через
 > `pnpm --filter @sergeant/mobile-shell build:web`, який делегує до
@@ -104,10 +104,10 @@ after cloning a fresh machine).
 Two dedicated workflows build the shell on every PR that touches
 `apps/mobile-shell/**`, `apps/web/**`, `apps/server/**`, or `packages/**`:
 
-| Workflow                                                                 | Runner          | Output                                                    |
-| ------------------------------------------------------------------------ | --------------- | --------------------------------------------------------- |
-| [`mobile-shell-android.yml`](.github/workflows/mobile-shell-android.yml) | `ubuntu-latest` | Debug APK uploaded as `sergeant-shell-debug-apk` artifact |
-| [`mobile-shell-ios.yml`](.github/workflows/mobile-shell-ios.yml)         | `macos-latest`  | Simulator `.app` (build-only, no artifact)                |
+| Workflow                                                                    | Runner          | Output                                                    |
+| --------------------------------------------------------------------------- | --------------- | --------------------------------------------------------- |
+| [`mobile-shell-android.yml`](../.github/workflows/mobile-shell-android.yml) | `ubuntu-latest` | Debug APK uploaded as `sergeant-shell-debug-apk` artifact |
+| [`mobile-shell-ios.yml`](../.github/workflows/mobile-shell-ios.yml)         | `macos-latest`  | Simulator `.app` (build-only, no artifact)                |
 
 Both debug jobs run `pnpm build:web` → `cap sync <platform>` → native
 build with no signing. The signed / release lanes live in dedicated
@@ -121,7 +121,7 @@ the Capacitor shell.
 ## Release — iOS
 
 The release lane lives in
-[`mobile-shell-ios-release.yml`](.github/workflows/mobile-shell-ios-release.yml)
+[`mobile-shell-ios-release.yml`](../.github/workflows/mobile-shell-ios-release.yml)
 on `macos-latest`. It triggers on tag pushes matching `v*` and on
 manual `workflow_dispatch`; the PR-time `mobile-shell-ios.yml`
 workflow is unchanged.
@@ -129,7 +129,7 @@ workflow is unchanged.
 The job runs an unsigned Simulator fallback (identical to the PR-time
 workflow) until all signing secrets below are present. Once they are,
 it archives `App.xcarchive`, exports a signed `.ipa` using
-[`apps/mobile-shell/ci/ExportOptions.plist`](apps/mobile-shell/ci/ExportOptions.plist)
+[`apps/mobile-shell/ci/ExportOptions.plist`](../apps/mobile-shell/ci/ExportOptions.plist)
 (rendered with `envsubst`), uploads the IPA as a GitHub artifact
 (`sergeant-shell-ipa`, 14 days retention), and ships it to TestFlight
 via `apple-actions/upload-testflight-build@v1`.
@@ -202,7 +202,7 @@ The release lane produces **two** artefacts from one workflow run:
 > key — so you never need to re-run the workflow just to get the other
 > format.
 
-Workflow: [`mobile-shell-android-release.yml`](.github/workflows/mobile-shell-android-release.yml).
+Workflow: [`mobile-shell-android-release.yml`](../.github/workflows/mobile-shell-android-release.yml).
 Triggers:
 
 - `workflow_dispatch` — manual run from the Actions UI (select the

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -153,7 +153,7 @@ Android-частина (`android/`) закомічена, `applicationId`
   як smoke-test ProGuard/R8 + Capacitor sync на PR-ах. ProGuard/R8
   keep-rules для всіх `@capacitor/*` плагінів — у
   `android/app/proguard-rules.pro`. Setup-інструкція (keytool → base64
-  → GitHub Secrets) — у [`MOBILE.md#release--android`](../MOBILE.md#release--android).
+  → GitHub Secrets) — у [`mobile-shell.md#release--android`](./mobile-shell.md#release--android).
 - **Play Store upload workflow (internal track).** Release-signing pipeline
   уже стоїть; автоматичний upload через `google-github-actions/upload-google-play`
   - service-account JSON (новий secret `ANDROID_PLAY_SERVICE_ACCOUNT_JSON`)
@@ -167,7 +167,7 @@ Android-частина (`android/`) закомічена, `applicationId`
   `workflow_dispatch`): архів → `.ipa` → TestFlight через
   `apple-actions/upload-testflight-build@v1`. Для першого реального
   запуску потрібні Apple-секрети (контракт у
-  [`MOBILE.md` → Release — iOS](../MOBILE.md#release--ios)). Без них
+  [`mobile-shell.md` → Release — iOS](./mobile-shell.md#release--ios)). Без них
   job падає в unsigned-Simulator-фолбек і не ламається.
 - ~~**Native push.** `usePushNotifications` у web користується Service
   Worker-ом + VAPID — у WebView це працює кульгаво (iOS тільки 16.4+,


### PR DESCRIPTION
## What changed

- `git mv MOBILE.md docs/mobile-shell.md`
- Оновлено посилання на новий шлях у `apps/mobile-shell/README.md` (4 місця) і `docs/platforms.md` (2 місця).
- Оновлено внутрішні відносні посилання у `docs/mobile-shell.md` (тепер з `docs/`, тому `apps/...` → `../apps/...`, `.github/...` → `../.github/...`).

## Why

Реалізація п. 1.4 з `docs/structure-refactor-plan.md`. Великий 17K-документ про мобілку лежав у корені — переніс у `docs/`, де вже є `docs/mobile.md`.

Файли **не об'єднано в один**, бо вони описують різні речі:

- `docs/mobile.md` — API-контракт для **Expo / React Native** клієнта (`apps/mobile`): bearer-auth, deep links, push.
- `docs/mobile-shell.md` (раніше `MOBILE.md`) — operator-reference для **Capacitor**-shell (`apps/mobile-shell`): build/sync команди, CI, iOS/Android release-pipeline і signing-секрети.

Об'єднання заплутало б, бо це два різні мобільні стеки. Вирішив назвати новий файл `mobile-shell.md` — він самодокументний.

Перевірив, що жодних `MOBILE.md` посилань більше не залишилось:

```
$ rg "MOBILE\.md"
(нічого, окрім посилання у `docs/structure-refactor-plan.md`, що описує саме цей крок)
```

## How to test

```sh
pnpm install
pnpm lint
pnpm typecheck
pnpm build
```

Опціонально перейти на `docs/mobile-shell.md` у GitHub і перевірити що всі лінки клікабельні (релативні шляхи переписано).

---

## How AI-tested this PR

- [x] Manual smoke: ручне переглядання посилань у `docs/mobile-shell.md` у GitHub UI.
- [x] Vitest passes: змін у TS-коді немає.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
