### PR TITLE
refactor(server): move aiQuota.ts to apps/server/src/modules/

### DIFF
--- a/apps/server/src/http/requireAiQuota.ts
+++ b/apps/server/src/http/requireAiQuota.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from "express";
-import { assertAiQuota } from "../aiQuota.js";
+import { assertAiQuota } from "../modules/aiQuota.js";
 
 /**
  * Router-middleware обгортка над `assertAiQuota`. Якщо квоту вичерпано —

--- a/apps/server/src/modules/aiQuota.test.ts
+++ b/apps/server/src/modules/aiQuota.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Request, Response } from "express";
 
-vi.mock("./auth.js", () => ({
+vi.mock("../auth.js", () => ({
   getSessionUser: vi.fn(),
 }));
 
-vi.mock("./db.js", () => {
+vi.mock("../db.js", () => {
   const pool = { connect: vi.fn(), query: vi.fn() };
   return { default: pool, pool };
 });
 
-import { getSessionUser as _getSessionUser } from "./auth.js";
-import _pool from "./db.js";
+import { getSessionUser as _getSessionUser } from "../auth.js";
+import _pool from "../db.js";
 import {
   assertAiQuota,
   consumeToolQuota,

--- a/apps/server/src/modules/aiQuota.ts
+++ b/apps/server/src/modules/aiQuota.ts
@@ -1,9 +1,9 @@
 import type { Request, Response } from "express";
-import { getSessionUser } from "./auth.js";
-import pool from "./db.js";
-import { getIp } from "./http/rateLimit.js";
-import { logger } from "./obs/logger.js";
-import { aiQuotaBlocksTotal, aiQuotaFailOpenTotal } from "./obs/metrics.js";
+import { getSessionUser } from "../auth.js";
+import pool from "../db.js";
+import { getIp } from "../http/rateLimit.js";
+import { logger } from "../obs/logger.js";
+import { aiQuotaBlocksTotal, aiQuotaFailOpenTotal } from "../obs/metrics.js";
 
 type SessionUser = { id: string } | null;
 

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -6,7 +6,7 @@ import {
   anthropicMessagesStream,
   extractAnthropicText,
 } from "../lib/anthropic.js";
-import type { WithAiQuotaRefund } from "../aiQuota.js";
+import type { WithAiQuotaRefund } from "./aiQuota.js";
 import { TOOLS, SYSTEM_PREFIX } from "./chat/tools.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };


### PR DESCRIPTION
## What changed

Реалізація п. **3.1** з [`docs/structure-refactor-plan.md`](docs/structure-refactor-plan.md). `aiQuota.ts` — це доменна логіка (квоти AI-викликів), яка лежала в корені `apps/server/src/` поруч з інфраструктурними файлами (`app.ts`, `db.ts`, `config.ts`, `sentry.ts`).

- `git mv apps/server/src/aiQuota.ts → apps/server/src/modules/aiQuota.ts`
- `git mv apps/server/src/aiQuota.test.ts → apps/server/src/modules/aiQuota.test.ts`
- Оновив імпорти всередині `aiQuota.ts`: `./auth.js`, `./db.js`, `./http/rateLimit.js`, `./obs/logger.js` → `../...` (бо файл тепер на рівень глибше).
- Оновив `vi.mock("./auth.js"|"./db.js")` → `vi.mock("../auth.js"|"../db.js")` у `aiQuota.test.ts`.
- Оновив споживачів:
  - `apps/server/src/modules/chat.ts`: `from "../aiQuota.js"` → `from "./aiQuota.js"`.
  - `apps/server/src/http/requireAiQuota.ts`: `from "../aiQuota.js"` → `from "../modules/aiQuota.js"`.

## Why

> «`aiQuota.ts` — це доменна логіка (квоти AI-викликів), але лежить у корені `src/` поруч з інфраструктурними файлами» — `docs/structure-refactor-plan.md` (п. 3.1).

Тримає `apps/server/src/` корінь чистим і консистентним з рештою modular-структури сервера: усі бізнес-модулі живуть у `modules/`, infra (db, config, app, sentry, auth) — у корені.

## How to test

```sh
pnpm --filter @sergeant/server typecheck
pnpm --filter @sergeant/server lint
pnpm --filter @sergeant/server test -- aiQuota
```

---

## How AI-tested this PR

- [x] Manual smoke: `pnpm --filter @sergeant/server typecheck` ✅, `lint` ✅, `test -- aiQuota` ✅ (15/15 testів).
- [x] Vitest passes: aiQuota suite — 15/15.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — модуль ownership map посилається на `apps/server/src/modules/**`, нове розташування потрапляє в той самий напрям.


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
