### PR TITLE
docs(web): fix stale ./cloudSync/ comment in useCloudSync barrel

### DIFF
--- a/apps/web/src/core/cloudSync/useCloudSync.ts
+++ b/apps/web/src/core/cloudSync/useCloudSync.ts
@@ -1,5 +1,5 @@
-// Backward-compatible barrel. The real implementation lives in
-// `./cloudSync/` (see that directory's index.ts for module-by-module
-// layout). This file exists so existing consumers and tests — which import
-// from `./useCloudSync.js` — keep working unchanged.
+// Backward-compatible barrel. The real implementation lives next to this
+// file (see `./index.ts` for the module-by-module layout). This file
+// exists so existing consumers and tests — which import from
+// `./useCloudSync.js` — keep working unchanged.
 export * from "./index";


### PR DESCRIPTION
## What changed

Виправляю follow-up до [PR #763](https://github.com/Skords-01/Sergeant/pull/763) (реорг `core/`). Файл-барель `apps/web/src/core/cloudSync/useCloudSync.ts` після переміщення в підпапку `cloudSync/` мав застарілий коментар, який казав, що «справжня реалізація живе в `./cloudSync/`» — а з нової локації цей шлях розкривається у неіснуючий `apps/web/src/core/cloudSync/cloudSync/`. `export * from "./index"` уже коректний; виправляю тільки опис.

## Why

Зловив [Devin Review](https://app.devin.ai/review/skords-01/sergeant/pull/763) як 🟡 stale-comment finding. Сам export працює, але коментар вводить в оману майбутніх читачів файлу. Робить ту ж саму помилку, що могла б зробити людина, читаючи цей barrel і шукаючи реалізацію.

## How to test

Тест-purelyDocs change. Quick sanity:

```sh
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web lint
```

---

## How AI-tested this PR

- [x] Manual smoke: змінив тільки prose-коментар; `export *` лишився той самий.
- [x] Vitest passes: не зачіпає тести.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — це чистий fix-up до існуючого коментаря.


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
