### PR TITLE
fix(web): account for txSplits in recommendation budget % calc

### DIFF
--- a/apps/web/src/core/lib/recommendationEngine.test.ts
+++ b/apps/web/src/core/lib/recommendationEngine.test.ts
@@ -75,6 +75,30 @@ describe("generateRecommendations", () => {
     expect(warnRec).toBeDefined();
   });
 
+  it("враховує txSplits при обчисленні бюджетних витрат", () => {
+    const now = new Date();
+    const ts = Math.floor(now.getTime() / 1000);
+    // Одна транзакція -20000 коп (-200 грн), розбита: 120 грн smoking + 80 грн food
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "tx_s", amount: -20000, time: ts, description: "Магазин" }],
+    });
+    setLS("finyk_tx_cats", { tx_s: "food" });
+    setLS("finyk_tx_splits", {
+      tx_s: [
+        { categoryId: "smoking", amount: 120 },
+        { categoryId: "food", amount: 80 },
+      ],
+    });
+    setLS("finyk_budgets", [
+      { id: "b_s", type: "limit", categoryId: "smoking", limit: 100 },
+    ]);
+
+    const recs = generateRecommendations();
+    const overRec = recs.find((r) => r.id === "budget_over_smoking");
+    expect(overRec).toBeDefined();
+    expect(overRec!.title).toContain("перевищено");
+  });
+
   it("генерує рекомендацію про тренування якщо тиждень без тренувань", () => {
     // Останнє тренування > 7 днів тому
     const oldDate = new Date();

--- a/apps/web/src/core/lib/recommendations/financeContext.ts
+++ b/apps/web/src/core/lib/recommendations/financeContext.ts
@@ -40,6 +40,19 @@ function startOfCurrentMonth(): Date {
   return d;
 }
 
+interface TxSplit {
+  categoryId?: string;
+  amount?: number;
+}
+
+function readSplits(
+  txSplits: Record<string, unknown>,
+  id: string,
+): readonly TxSplit[] {
+  const v = txSplits[id];
+  return Array.isArray(v) ? (v as readonly TxSplit[]) : [];
+}
+
 export function buildFinanceContext(): FinanceContext {
   const now = new Date();
   const monthStart = startOfCurrentMonth();
@@ -66,6 +79,9 @@ export function buildFinanceContext(): FinanceContext {
     "finyk_manual_expenses_v1",
     [],
   );
+  const txSplitsRaw = safeLS<Record<string, unknown>>("finyk_tx_splits", {});
+  const txSplits: Record<string, unknown> =
+    txSplitsRaw && typeof txSplitsRaw === "object" ? txSplitsRaw : {};
 
   const thisMonthTx = transactions.filter((tx) => {
     if (hiddenTxIds.has(tx.id)) return false;
@@ -79,9 +95,19 @@ export function buildFinanceContext(): FinanceContext {
   const categorySpend: Record<string, number> = {};
   for (const tx of thisMonthTx) {
     if ((tx.amount ?? 0) >= 0) continue;
-    const catId = txCategories[tx.id] || "other";
-    categorySpend[catId] =
-      (categorySpend[catId] || 0) + Math.abs(tx.amount / 100);
+    const splits = readSplits(txSplits, tx.id);
+    if (splits.length > 0) {
+      for (const s of splits) {
+        if (!s.categoryId || s.categoryId === "internal_transfer") continue;
+        const amt = Math.abs(Number(s.amount) || 0);
+        if (amt <= 0) continue;
+        categorySpend[s.categoryId] = (categorySpend[s.categoryId] || 0) + amt;
+      }
+    } else {
+      const catId = txCategories[tx.id] || "other";
+      categorySpend[catId] =
+        (categorySpend[catId] || 0) + Math.abs(tx.amount / 100);
+    }
   }
   for (const me of manualExpenses) {
     const ts = new Date(me.date).getTime();
@@ -96,21 +122,40 @@ export function buildFinanceContext(): FinanceContext {
   for (const tx of transactions) {
     if (hiddenTxIds.has(tx.id) || transferIds.has(tx.id)) continue;
     if ((tx.amount ?? 0) >= 0) continue;
-    const override = txCategories[tx.id] || null;
-    const cat = getCategory(
-      tx.description || "",
-      tx.mcc || 0,
-      override,
-      customCategories,
-    );
-    const catId = cat?.id;
-    if (!catId || catId === "internal_transfer") continue;
-    canonicalTotalCount.set(catId, (canonicalTotalCount.get(catId) || 0) + 1);
-    if (txTimestamp(tx) >= monthStartMs) {
-      canonicalMonthSpend.set(
-        catId,
-        (canonicalMonthSpend.get(catId) || 0) + Math.abs(tx.amount / 100),
+    const splits = readSplits(txSplits, tx.id);
+    if (splits.length > 0) {
+      for (const s of splits) {
+        if (!s.categoryId || s.categoryId === "internal_transfer") continue;
+        canonicalTotalCount.set(
+          s.categoryId,
+          (canonicalTotalCount.get(s.categoryId) || 0) + 1,
+        );
+        if (txTimestamp(tx) >= monthStartMs) {
+          const amt = Math.abs(Number(s.amount) || 0);
+          if (amt <= 0) continue;
+          canonicalMonthSpend.set(
+            s.categoryId,
+            (canonicalMonthSpend.get(s.categoryId) || 0) + amt,
+          );
+        }
+      }
+    } else {
+      const override = txCategories[tx.id] || null;
+      const cat = getCategory(
+        tx.description || "",
+        tx.mcc || 0,
+        override,
+        customCategories,
       );
+      const catId = cat?.id;
+      if (!catId || catId === "internal_transfer") continue;
+      canonicalTotalCount.set(catId, (canonicalTotalCount.get(catId) || 0) + 1);
+      if (txTimestamp(tx) >= monthStartMs) {
+        canonicalMonthSpend.set(
+          catId,
+          (canonicalMonthSpend.get(catId) || 0) + Math.abs(tx.amount / 100),
+        );
+      }
     }
   }
   for (const me of manualExpenses) {


### PR DESCRIPTION
## What changed

`buildFinanceContext()` now reads `finyk_tx_splits` from localStorage and distributes split-transaction amounts per-category when computing both `categorySpend` (legacy) and `canonicalMonthSpend` (canonical). Previously the full transaction amount was attributed to a single category, ignoring splits entirely.

Added a regression test that verifies split transactions are correctly counted toward the split category's budget.

## Why

The Hub dashboard showed **91%** budget usage for "smoking" while the Finyk module showed **118%**. Root cause: the recommendation engine's `buildFinanceContext()` ignored `txSplits`. For a transaction split across categories (e.g. 120 ₴ smoking + 80 ₴ food), the engine assigned the full 200 ₴ to whichever category `getCategory()` or `txCategories` resolved — never distributing the split portions. The Finyk page uses `calcCategorySpent` which correctly handles splits, so numbers diverged.

## How to test

1. In Finyk, create a budget limit for a category (e.g. "smoking", limit 100 ₴).
2. Add a bank transaction and split it so that the split portion for "smoking" exceeds the limit.
3. Open the Hub — the budget alert percentage should now match the Finyk overview percentage.

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): N/A — no running instance available
- [x] Vitest passes: `pnpm test -- src/core/lib/recommendationEngine.test.ts` — 7/7 pass (including new split test)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/4821aa1b4ec5473ba4377dfd140380e5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of budget recommendations to properly account for transactions split across multiple categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->