### PR TITLE
fix(web): restore FinykLoginScreen back-to-hub label and privacy text margin

### DIFF
--- a/apps/web/src/modules/finyk/components/FinykLoginScreen.tsx
+++ b/apps/web/src/modules/finyk/components/FinykLoginScreen.tsx
@@ -259,10 +259,10 @@ export function FinykLoginScreen({
               className="mt-1 w-full min-h-[44px]"
               onClick={onBackToHub}
             >
-              Назад до Hub
+              ← Назад до хабу
             </Button>
           )}
-          <p className="text-xs text-subtle text-center mt-3 flex items-center justify-center gap-1.5">
+          <p className="mt-4 text-center text-xs text-subtle flex items-center justify-center gap-1.5">
             <svg
               width="12"
               height="12"


### PR DESCRIPTION
## What changed

Fix-up до [#773](https://github.com/Skords-01/Sergeant/pull/773) за двома знахідками Devin Review (обидві — реальні regressions, що проникли під час extract-рефакторингу `FinykApp.tsx → FinykLoginScreen.tsx`):

1. **Back-to-hub button label** — `Назад до Hub` → `← Назад до хабу` (відновлено лівий arrow `←` + повний UA-варіант "хабу" замість "Hub"). До рефакторингу: `apps/web/src/modules/finyk/FinykApp.tsx@d1c5f7cd^:592` — `← Назад до хабу`.
2. **Privacy notice margin** — `text-xs text-subtle text-center mt-3` → `mt-4 text-center text-xs text-subtle` (4px margin-top більше, плюс відновлено оригінальний порядок класів). До рефакторингу: те саме місце, `mt-4 text-center text-xs text-subtle`.

## Why

PR #773 був заявлений як behavior-preserving extraction, тому будь-яка user-visible різниця — баг. Devin Review зробив diff проти видаленого блоку у `FinykApp.tsx` і знайшов обидва drift-и; верифікував через `git show d1c5f7cd^:apps/web/src/modules/finyk/FinykApp.tsx | grep "Назад\|mt-4 text-center"` — обидва випадки підтверджено в історії.

## How to test

```bash
pnpm --filter @sergeant/web typecheck   # 0 errors
pnpm --filter @sergeant/web lint        # 0 errors
```

Smoke вручну:
1. Відкрити Finyk login screen без token, з `onBackToHub` defined.
2. Кнопка "Назад до Hub" → має читатись `← Назад до хабу` із arrow.
3. Внизу login card — privacy notice "Токен зберігається лише у твоєму браузері" має margin-top 16px (було 12px).

---

## How AI-tested this PR

- [x] Typecheck passes: `tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit` → 0 errors
- [x] Lint passes: `eslint .` → 0 errors
- [x] Verified against original via `git show d1c5f7cd^:apps/web/src/modules/finyk/FinykApp.tsx` — both restored strings/classes match the pre-refactor source.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose уже UA — фікс просто повертає UA-текст.

## AGENTS.md updated?

- [x] No — суто bugfix, нових rules немає.


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
