### PR TITLE
fix(web): eliminate duplicated finyk-domain logic in Hub

### DIFF
--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -6,7 +6,14 @@ import {
   upsertMemoryFact,
   writeMemoryEntries,
 } from "../../profile/memoryBank";
-import { resolveExpenseCategoryMeta } from "../../../modules/finyk/utils";
+import {
+  calcCategorySpent,
+  getTxStatAmount,
+} from "../../../modules/finyk/utils";
+import {
+  mergeExpenseCategoryDefinitions,
+  INTERNAL_TRANSFER_ID,
+} from "../../../modules/finyk/constants";
 import type {
   SetGoalAction,
   SpendingTrendAction,
@@ -161,14 +168,21 @@ export function handleCrossAction(action: ChatAction): string | undefined {
         parts.push(`Калорії: ~${avg} ккал/день (${weekKcal.length} днів)`);
       }
       const txCache = ls<{
-        txs?: Array<{ amount: number; time?: number }>;
+        txs?: Array<{
+          id: string;
+          amount: number;
+          time?: number;
+          description?: string;
+          mcc?: number;
+        }>;
       } | null>("finyk_tx_cache", null);
+      const txSplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
       if (txCache?.txs) {
         const weekTs = weekAgo.getTime() / 1000;
         const weekTxs = txCache.txs.filter((t) => (t.time || 0) > weekTs);
         const spent = weekTxs
           .filter((t) => t.amount < 0)
-          .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
+          .reduce((s, t) => s + getTxStatAmount(t, txSplits), 0);
         parts.push(`Витрати: ${Math.round(spent)} грн`);
       }
       return parts.join("\n");
@@ -240,13 +254,18 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       const currentStart = now - days * 86400000;
       const prevStart = currentStart - days * 86400000;
       const txCache = ls<{
-        txs?: Array<{ amount: number; time?: number; description?: string }>;
+        txs?: Array<{
+          id: string;
+          amount: number;
+          time?: number;
+          description?: string;
+          mcc?: number;
+        }>;
       } | null>("finyk_tx_cache", null);
       const allTxs = txCache?.txs || [];
       const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
-      const txs = allTxs.filter(
-        (t) => !hiddenTxIds.includes((t as { id?: string }).id || ""),
-      );
+      const trendSplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
+      const txs = allTxs.filter((t) => !hiddenTxIds.includes(t.id || ""));
       const currentPeriod = txs.filter((t) => {
         const ts = (t.time || 0) * 1000;
         return ts >= currentStart && ts <= now;
@@ -258,7 +277,7 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       const sumExpenses = (arr: typeof txs) =>
         arr
           .filter((t) => t.amount < 0)
-          .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
+          .reduce((s, t) => s + getTxStatAmount(t, trendSplits), 0);
       const sumIncome = (arr: typeof txs) =>
         arr.filter((t) => t.amount > 0).reduce((s, t) => s + t.amount / 100, 0);
       const curExp = sumExpenses(currentPeriod);
@@ -283,42 +302,50 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       const cutoff = Date.now() - days * 86400000;
       const txCache = ls<{
         txs?: Array<{
-          id?: string;
+          id: string;
           amount: number;
           time?: number;
-          categoryId?: string;
+          description?: string;
+          mcc?: number;
         }>;
       } | null>("finyk_tx_cache", null);
       const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
       const customC = ls<unknown[]>("finyk_custom_cats_v1", []);
       const catMap = ls<Record<string, string>>("finyk_tx_cats", {});
+      const breakdownSplits = ls<Record<string, unknown>>(
+        "finyk_tx_splits",
+        {},
+      );
       const expenses = (txCache?.txs || []).filter((t) => {
         if (hiddenTxIds.includes(t.id || "")) return false;
         const ts = (t.time || 0) * 1000;
         return t.amount < 0 && ts >= cutoff;
       });
-      const byCategory: Record<string, number> = {};
-      for (const tx of expenses) {
-        const catId = catMap[tx.id || ""] || tx.categoryId || "other";
-        byCategory[catId] =
-          (byCategory[catId] || 0) + Math.abs(tx.amount / 100);
+      interface CatDef {
+        id: string;
+        label: string;
       }
-      const total = Object.values(byCategory).reduce((a, b) => a + b, 0);
-      const sorted = Object.entries(byCategory)
-        .map(([id, amount]) => {
-          const meta = resolveExpenseCategoryMeta(id, customC);
-          return {
-            label: meta?.label || id,
-            amount,
-            pct: total > 0 ? Math.round((amount / total) * 100) : 0,
-          };
-        })
+      const sorted = (mergeExpenseCategoryDefinitions(customC) as CatDef[])
+        .filter((c) => c.id !== "income" && c.id !== INTERNAL_TRANSFER_ID)
+        .map((c) => ({
+          label: c.label,
+          amount: calcCategorySpent(
+            expenses,
+            c.id,
+            catMap,
+            breakdownSplits,
+            customC,
+          ),
+        }))
+        .filter((c) => c.amount > 0)
         .sort((a, b) => b.amount - a.amount);
+      const total = sorted.reduce((s, c) => s + c.amount, 0);
       const parts: string[] = [
         `Витрати по категоріях за ${days} днів (${Math.round(total)} грн):`,
       ];
       for (const c of sorted.slice(0, 15)) {
-        parts.push(`  ${c.label}: ${Math.round(c.amount)} грн (${c.pct}%)`);
+        const pct = total > 0 ? Math.round((c.amount / total) * 100) : 0;
+        parts.push(`  ${c.label}: ${Math.round(c.amount)} грн (${pct}%)`);
       }
       return parts.join("\n");
     }
@@ -330,13 +357,15 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       const cutoff = Date.now() - days * 86400000;
       const txCache = ls<{
         txs?: Array<{
-          id?: string;
+          id: string;
           amount: number;
           time?: number;
           description?: string;
+          mcc?: number;
         }>;
       } | null>("finyk_tx_cache", null);
       const hiddenTxIds = ls<string[]>("finyk_hidden_txs", []);
+      const anomalySplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
       const expenses = (txCache?.txs || []).filter((t) => {
         if (hiddenTxIds.includes(t.id || "")) return false;
         const ts = (t.time || 0) * 1000;
@@ -344,11 +373,15 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       });
       if (expenses.length < 3)
         return "Недостатньо транзакцій для аналізу аномалій.";
-      const amounts = expenses.map((t) => Math.abs(t.amount / 100));
+      const amounts = expenses.map((t) => getTxStatAmount(t, anomalySplits));
       const avg = amounts.reduce((a, b) => a + b, 0) / amounts.length;
       const anomalies = expenses
-        .filter((t) => Math.abs(t.amount / 100) > avg * threshold)
-        .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
+        .filter((t) => getTxStatAmount(t, anomalySplits) > avg * threshold)
+        .sort(
+          (a, b) =>
+            getTxStatAmount(b, anomalySplits) -
+            getTxStatAmount(a, anomalySplits),
+        )
         .slice(0, 5);
       if (anomalies.length === 0) {
         return `За ${days} днів аномалій не виявлено (середня витрата: ${Math.round(avg)} грн, поріг: ${Math.round(avg * threshold)} грн).`;
@@ -361,7 +394,7 @@ export function handleCrossAction(action: ChatAction): string | undefined {
           ? new Date(tx.time * 1000).toLocaleDateString("uk-UA")
           : "?";
         parts.push(
-          `  ${d}: ${Math.round(Math.abs(tx.amount / 100))} грн — ${tx.description || "(без опису)"}`,
+          `  ${d}: ${Math.round(getTxStatAmount(tx, anomalySplits))} грн — ${tx.description || "(без опису)"}`,
         );
       }
       return parts.join("\n");

--- a/apps/web/src/core/lib/chatActions/finykActions.ts
+++ b/apps/web/src/core/lib/chatActions/finykActions.ts
@@ -1,5 +1,8 @@
 import { ls, lsSet } from "../hubChatUtils";
-import { resolveExpenseCategoryMeta } from "../../../modules/finyk/utils";
+import {
+  resolveExpenseCategoryMeta,
+  getTxStatAmount,
+} from "../../../modules/finyk/utils";
 import type {
   ChangeCategoryAction,
   CreateDebtAction,
@@ -424,9 +427,11 @@ export function handleFinykAction(action: ChatAction): string | undefined {
           id: string;
           amount: number;
           description?: string;
+          mcc?: number;
           time?: number;
         }>;
       } | null>("finyk_tx_cache", null);
+      const reportSplits = ls<Record<string, unknown>>("finyk_tx_splits", {});
       const txs = (txCache?.txs || []).filter((t) => {
         const ts = (t.time || 0) * 1000;
         return ts >= fromTs && ts <= toTs;
@@ -436,7 +441,7 @@ export function handleFinykAction(action: ChatAction): string | undefined {
       const expenses = filtered.filter((t) => t.amount < 0);
       const income = filtered.filter((t) => t.amount > 0);
       const totalExpense = expenses.reduce(
-        (s, t) => s + Math.abs(t.amount / 100),
+        (s, t) => s + getTxStatAmount(t, reportSplits),
         0,
       );
       const totalIncome = income.reduce((s, t) => s + t.amount / 100, 0);

--- a/apps/web/src/core/lib/insightsEngine.ts
+++ b/apps/web/src/core/lib/insightsEngine.ts
@@ -9,6 +9,7 @@
  */
 
 import { STORAGE_KEYS } from "@sergeant/shared";
+import { getTxStatAmount } from "../../modules/finyk/utils";
 
 export interface Insight {
   id: string;
@@ -27,6 +28,8 @@ interface Transaction {
   id: string;
   amount: number;
   time: number;
+  description?: string;
+  mcc?: number;
 }
 
 interface Habit {
@@ -146,6 +149,10 @@ function activeWeeksSpendingInsight(): Insight | null {
       .filter(([, v]) => v === "internal_transfer")
       .map(([k]) => k),
   );
+  const txSplits = safeLS<Record<string, unknown>>(
+    STORAGE_KEYS.FINYK_TX_SPLITS,
+    {},
+  );
 
   if (workouts.length < 6) return null;
 
@@ -173,7 +180,7 @@ function activeWeeksSpendingInsight(): Insight | null {
         const d = new Date(ts);
         return d >= mon && d <= sun && (tx.amount ?? 0) < 0;
       })
-      .reduce((s, tx) => s + Math.abs(tx.amount / 100), 0);
+      .reduce((s, tx) => s + getTxStatAmount(tx, txSplits), 0);
 
     if (spending > 0) weekStats.push({ wCount, spending });
   }

--- a/apps/web/src/core/lib/recommendations/financeContext.ts
+++ b/apps/web/src/core/lib/recommendations/financeContext.ts
@@ -8,6 +8,8 @@
 // єдина точка, де контекст «запікається» з Web-LS.
 
 import { getCategory } from "../../../modules/finyk/utils";
+import { getCategorySpendList } from "@sergeant/finyk-domain/domain/categories";
+import type { TxSplitsLike } from "@sergeant/finyk-domain/lib/transactions";
 import { manualCategoryToCanonicalId } from "@sergeant/finyk-domain/domain/personalization";
 import { Recommendations } from "@sergeant/insights";
 
@@ -45,10 +47,7 @@ interface TxSplit {
   amount?: number;
 }
 
-function readSplits(
-  txSplits: Record<string, unknown>,
-  id: string,
-): readonly TxSplit[] {
+function readSplits(txSplits: TxSplitsLike, id: string): readonly TxSplit[] {
   const v = txSplits[id];
   return Array.isArray(v) ? (v as readonly TxSplit[]) : [];
 }
@@ -79,8 +78,8 @@ export function buildFinanceContext(): FinanceContext {
     "finyk_manual_expenses_v1",
     [],
   );
-  const txSplitsRaw = safeLS<Record<string, unknown>>("finyk_tx_splits", {});
-  const txSplits: Record<string, unknown> =
+  const txSplitsRaw = safeLS<TxSplitsLike>("finyk_tx_splits", {});
+  const txSplits: TxSplitsLike =
     txSplitsRaw && typeof txSplitsRaw === "object" ? txSplitsRaw : {};
 
   const thisMonthTx = transactions.filter((tx) => {
@@ -89,9 +88,9 @@ export function buildFinanceContext(): FinanceContext {
     return txTimestamp(tx) >= monthStartMs;
   });
 
-  // Legacy categorySpend (raw keys) — залишаємо для сумісності з існуючими
-  // правилами budget_over/budget_warn, які працюють з raw `txCategories` /
-  // manual labels. Це ЯВНА тимчасова двоякість — див. canonicalMonthSpend.
+  // Legacy categorySpend (raw override keys) — збережено для сумісності з
+  // правилами, де categoryId бюджету може не збігатися з canonical id.
+  // budgetLimitsRule використовує як fallback після canonicalMonthSpend.
   const categorySpend: Record<string, number> = {};
   for (const tx of thisMonthTx) {
     if ((tx.amount ?? 0) >= 0) continue;
@@ -116,8 +115,31 @@ export function buildFinanceContext(): FinanceContext {
     categorySpend[catId] = (categorySpend[catId] || 0) + Math.abs(me.amount);
   }
 
-  // Canonical-id сумарні — для правил, що оперують МСС-резолвом.
+  // Canonical-id витрати — делегуємо до getCategorySpendList (єдине
+  // джерело правди для Finyk Overview, Budgets і Hub).
+  const spendList = getCategorySpendList(thisMonthTx, {
+    txCategories,
+    txSplits,
+    customCategories,
+  });
   const canonicalMonthSpend = new Map<string, number>();
+  for (const { id, spent } of spendList) {
+    canonicalMonthSpend.set(id, spent);
+  }
+  // Ручні витрати — додаємо поверх результатів getCategorySpendList.
+  for (const me of manualExpenses) {
+    if (new Date(me.date).getTime() < monthStartMs) continue;
+    const canonKey = manualCategoryToCanonicalId(me.category) || "other";
+    if (canonKey === "internal_transfer") continue;
+    canonicalMonthSpend.set(
+      canonKey,
+      (canonicalMonthSpend.get(canonKey) || 0) +
+        Math.abs(Number(me.amount) || 0),
+    );
+  }
+
+  // canonicalTotalCount — лічильник транзакцій за ВСЕ завантажене (не лише
+  // поточний місяць); використовується правилом `frequentNoBudget`.
   const canonicalTotalCount = new Map<string, number>();
   for (const tx of transactions) {
     if (hiddenTxIds.has(tx.id) || transferIds.has(tx.id)) continue;
@@ -130,14 +152,6 @@ export function buildFinanceContext(): FinanceContext {
           s.categoryId,
           (canonicalTotalCount.get(s.categoryId) || 0) + 1,
         );
-        if (txTimestamp(tx) >= monthStartMs) {
-          const amt = Math.abs(Number(s.amount) || 0);
-          if (amt <= 0) continue;
-          canonicalMonthSpend.set(
-            s.categoryId,
-            (canonicalMonthSpend.get(s.categoryId) || 0) + amt,
-          );
-        }
       }
     } else {
       const override = txCategories[tx.id] || null;
@@ -150,24 +164,12 @@ export function buildFinanceContext(): FinanceContext {
       const catId = cat?.id;
       if (!catId || catId === "internal_transfer") continue;
       canonicalTotalCount.set(catId, (canonicalTotalCount.get(catId) || 0) + 1);
-      if (txTimestamp(tx) >= monthStartMs) {
-        canonicalMonthSpend.set(
-          catId,
-          (canonicalMonthSpend.get(catId) || 0) + Math.abs(tx.amount / 100),
-        );
-      }
     }
   }
   for (const me of manualExpenses) {
     const key = manualCategoryToCanonicalId(me.category) || "other";
     if (key === "internal_transfer") continue;
     canonicalTotalCount.set(key, (canonicalTotalCount.get(key) || 0) + 1);
-    if (new Date(me.date).getTime() >= monthStartMs) {
-      canonicalMonthSpend.set(
-        key,
-        (canonicalMonthSpend.get(key) || 0) + Math.abs(Number(me.amount) || 0),
-      );
-    }
   }
 
   const limits = budgets.filter((b) => b.type === "limit");


### PR DESCRIPTION
## What changed

Усунено дублювання бізнес-логіки `@sergeant/finyk-domain` у 5 файлах Hub:

| Файл | Що змінено |
|---|---|
| `financeContext.ts` | `canonicalMonthSpend` тепер делегує до `getCategorySpendList` замість ручного `getCategory()` циклу |
| `crossActions.ts` → `category_breakdown` | Ручний `byCategory` акумулятор замінено на `calcCategorySpent` per-category (підтримка сплітів + MCC) |
| `crossActions.ts` → `spending_trend`, `weekly_summary`, `detect_anomalies` | `Math.abs(amount/100)` замінено на `getTxStatAmount` для підтримки сплітів |
| `finykActions.ts` → `export_report` | Та ж заміна `getTxStatAmount` |
| `insightsEngine.ts` → `activeWeeksSpending` | Та ж заміна `getTxStatAmount` |

## Why

Продовження #772. Хаб дублював обчислення витрат по категоріях, ділення суми, резолв категорій через MCC замість того щоб делегувати до `@sergeant/finyk-domain`. Це призводило до розбіжностей (наприклад, 91% vs 118% для одного бюджету) і порушувало принцип єдиного джерела правди.

Тепер Hub використовує domain-функції (`calcCategorySpent`, `getTxStatAmount`, `getCategorySpendList`) замість реімплементації тієї ж логіки inline.

## How to test

1. Перевірити що бюджетні відсотки на хабі збігаються з Фініком
2. Перевірити що `category_breakdown`, `spending_trend`, `detect_anomalies` chat actions повертають коректні суми з урахуванням сплітів
3. Перевірити що `export_report` правильно враховує сплітовані транзакції

---

## How AI-tested this PR

- [x] Vitest passes: 804/804 (apps/web)
- [x] ESLint passes: 0 errors
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/4821aa1b4ec5473ba4377dfd140380e5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
