### PR TITLE
fix(web): filter zero-amount splits in detect_anomalies average

### DIFF
--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -373,7 +373,11 @@ export function handleCrossAction(action: ChatAction): string | undefined {
       });
       if (expenses.length < 3)
         return "Недостатньо транзакцій для аналізу аномалій.";
-      const amounts = expenses.map((t) => getTxStatAmount(t, anomalySplits));
+      const amounts = expenses
+        .map((t) => getTxStatAmount(t, anomalySplits))
+        .filter((a) => a > 0);
+      if (amounts.length < 3)
+        return "Недостатньо транзакцій для аналізу аномалій.";
       const avg = amounts.reduce((a, b) => a + b, 0) / amounts.length;
       const anomalies = expenses
         .filter((t) => getTxStatAmount(t, anomalySplits) > avg * threshold)


### PR DESCRIPTION
## What changed

У `detect_anomalies` (crossActions.ts) додано `.filter((a) => a > 0)` після `getTxStatAmount`, щоб нульові значення від повністю-internal-transfer сплітів не потрапляли у підрахунок середньої.

## Why

Follow-up до #776. `getTxStatAmount` повертає 0 для транзакцій де всі спліти — `internal_transfer`. Ці нулі потрапляли в масив `amounts` і занижували середню + поріг аномалій, що могло призводити до хибних спрацювань. Старий код (`Math.abs(t.amount / 100)`) завжди давав позитивне значення для `amount < 0`, тому проблеми не було.

Виявлено [Devin Review на PR #776](https://github.com/Skords-01/Sergeant/pull/776#discussion_r3143233720).

## How to test

1. `pnpm test` — всі 804 тести проходять
2. Перевірити `detect_anomalies` chat action з транзакціями що мають internal_transfer спліти

---

## How AI-tested this PR

- [x] Vitest passes: 804/804 (apps/web)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/4821aa1b4ec5473ba4377dfd140380e5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
