### PR TITLE
refactor(web): split Assets.tsx — extract section bars and tx-picker view

### DIFF
--- a/apps/web/src/modules/finyk/pages/Assets.tsx
+++ b/apps/web/src/modules/finyk/pages/Assets.tsx
@@ -2,12 +2,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { DebtCard } from "../components/DebtCard";
 import { SubCard } from "../components/SubCard";
 import { RecurringSuggestions } from "../components/RecurringSuggestions";
-import { TxRow } from "../components/TxRow";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
-import { Icon, type IconName } from "@shared/components/ui/Icon";
+import { Icon } from "@shared/components/ui/Icon";
 import {
   getAccountLabel,
   getMonoDebt,
@@ -20,10 +19,6 @@ import {
   getDebtEffectiveTotal,
   getReceivableEffectiveTotal,
 } from "../utils";
-import {
-  getDebtTxRole,
-  getReceivableTxRole,
-} from "@sergeant/finyk-domain/domain/debtEngine";
 import { filterVisibleAccounts } from "@sergeant/finyk-domain/domain/assets/aggregates";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
@@ -32,111 +27,12 @@ import { VoiceMicButton } from "@shared/components/ui/VoiceMicButton";
 import { parseExpenseSpeech as parseExpenseVoice } from "@sergeant/shared";
 import { computeFinykSchedule, startOfToday } from "../lib/upcomingSchedule";
 import { FinykStatsStrip } from "../components/FinykStatsStrip";
-
-type SectionBarProps = {
-  title: string;
-  iconName: IconName;
-  iconTone?: "success" | "danger" | "muted";
-  summary?: string | null;
-  open: boolean;
-  onToggle: () => void;
-};
-
-function AssetsLiabilitiesBar({
-  assets,
-  liabilities,
-}: {
-  assets: number;
-  liabilities: number;
-}) {
-  const total = assets + liabilities;
-  if (total <= 0) return null;
-  const assetsPct = Math.round((assets / total) * 100);
-  const liabilitiesPct = 100 - assetsPct;
-  return (
-    <div className="mt-3">
-      <div
-        className="flex h-1.5 w-full overflow-hidden rounded-full bg-white/10"
-        role="img"
-        aria-label={`Активи ${assetsPct}% · Пасиви ${liabilitiesPct}%`}
-      >
-        <div className="bg-emerald-300/90" style={{ width: `${assetsPct}%` }} />
-        <div
-          className="bg-rose-400/80"
-          style={{ width: `${liabilitiesPct}%` }}
-        />
-      </div>
-      <div className="flex justify-between text-[11px] text-emerald-100/80 mt-1.5">
-        <span>Активи {assetsPct}%</span>
-        <span>Пасиви {liabilitiesPct}%</span>
-      </div>
-    </div>
-  );
-}
-
-function QuickActionButton({
-  iconName,
-  label,
-  onClick,
-}: {
-  iconName: IconName;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex flex-col items-center justify-center gap-1 py-2.5 text-xs text-muted border border-dashed border-line rounded-2xl hover:border-primary hover:text-primary transition-colors"
-    >
-      <Icon name={iconName} size={18} />
-      <span className="font-medium">+ {label}</span>
-    </button>
-  );
-}
-
-function SectionBar({
-  title,
-  iconName,
-  iconTone = "muted",
-  summary,
-  open,
-  onToggle,
-}: SectionBarProps) {
-  const toneClass =
-    iconTone === "success"
-      ? "text-success"
-      : iconTone === "danger"
-        ? "text-danger"
-        : "text-muted";
-  return (
-    <button
-      onClick={onToggle}
-      className="w-full flex items-center justify-between px-4 py-3 bg-panelHi border border-line rounded-2xl mb-2 text-left transition-colors hover:border-muted/50"
-    >
-      <div className="flex items-center gap-3 min-w-0">
-        <span
-          className={cn(
-            "inline-flex items-center justify-center shrink-0",
-            toneClass,
-          )}
-          aria-hidden
-        >
-          <Icon name={iconName} size={18} />
-        </span>
-        <div className="min-w-0">
-          <div className="text-sm font-bold text-text truncate">{title}</div>
-          {summary && (
-            <div className="text-xs text-muted mt-0.5 truncate">{summary}</div>
-          )}
-        </div>
-      </div>
-      <span className="text-xs text-muted shrink-0 ml-2">
-        {open ? "Згорнути ↑" : "Розкласти ↓"}
-      </span>
-    </button>
-  );
-}
+import {
+  AssetsLiabilitiesBar,
+  QuickActionButton,
+  SectionBar,
+} from "./AssetsBars";
+import { AssetsTxPickerView } from "./AssetsTxPickerView";
 
 export function Assets({
   mono,
@@ -309,253 +205,22 @@ export function Assets({
   }, [showDebtForm, open.liabilities]);
 
   if (txPicker) {
-    // --- Mono credit card repayment linking ---
-    if (txPicker.type === "monoDebt") {
-      const account = accounts.find((a) => a.id === txPicker.id);
-      const linkedIds = monoDebtLinkedTxIds[txPicker.id] || [];
-      const paid = transactions
-        .filter((t) => linkedIds.includes(t.id))
-        .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
-      const remaining = getMonoDebt(account);
-      const total = paid + remaining;
-      const label = getAccountLabel(account);
-
-      const isSuggested = (t) => t._accountId === txPicker.id && t.amount > 0;
-
-      return (
-        <div className="flex flex-col flex-1 overflow-hidden">
-          <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
-            <button
-              onClick={() => setTxPicker(null)}
-              className="text-sm text-muted hover:text-text transition-colors"
-            >
-              ← Назад
-            </button>
-            <span className="text-sm font-bold">Погашення: {label}</span>
-          </div>
-          <div className="flex-1 overflow-y-auto">
-            <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-              <Card variant="flat" radius="md" className="mb-3">
-                <div className="text-xs text-subtle mb-1">{label}</div>
-                <div className="text-2xl font-extrabold text-danger">
-                  −
-                  {remaining.toLocaleString("uk-UA", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  ₴ залишок боргу
-                </div>
-                <div className="text-xs text-subtle mt-1">
-                  Погашено цього місяця:{" "}
-                  {paid.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
-                  · Базовий борг:{" "}
-                  {total.toLocaleString("uk-UA", { maximumFractionDigits: 0 })}{" "}
-                  ₴
-                </div>
-                <div className="h-1.5 bg-line rounded-full overflow-hidden mt-3">
-                  <div
-                    className="h-full bg-danger rounded-full transition-[width,background-color] duration-500"
-                    style={{
-                      width: `${total > 0 ? Math.min(100, Math.round((paid / total) * 100)) : 0}%`,
-                    }}
-                  />
-                </div>
-              </Card>
-              <p className="text-xs text-subtle mb-3 px-1">
-                Тапни транзакцію щоб прив&apos;язати як погашення. Виділені
-                зеленим — автоматично виявлені поповнення картки.
-              </p>
-              {transactions.map((t, i) => {
-                const isLinked = linkedIds.includes(t.id);
-                const suggested = isSuggested(t);
-                return (
-                  <div key={i}>
-                    {suggested && !isLinked && (
-                      <div className="text-2xs font-semibold text-success px-1 pt-1">
-                        ↑ Поповнення картки
-                      </div>
-                    )}
-                    <TxRow
-                      tx={t}
-                      highlighted={isLinked}
-                      onClick={() => toggleMonoDebtTx(txPicker.id, t.id)}
-                      accounts={accounts}
-                      hideAmount={!showBalance}
-                      customCategories={customCategories}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    if (txPicker.type === "sub") {
-      const sub = subscriptions.find((s) => s.id === txPicker.subId);
-      if (!sub) {
-        return (
-          <div className="flex flex-col flex-1 overflow-hidden">
-            <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
-              <button
-                type="button"
-                onClick={() => setTxPicker(null)}
-                className="text-sm text-muted hover:text-text transition-colors"
-              >
-                ← Назад
-              </button>
-            </div>
-          </div>
-        );
-      }
-      const linkedId = sub.linkedTxId;
-      const expenses = transactions
-        .filter((t) => t.amount < 0)
-        .sort((a, b) => (b.time || 0) - (a.time || 0));
-      return (
-        <div className="flex flex-col flex-1 overflow-hidden">
-          <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
-            <button
-              type="button"
-              onClick={() => setTxPicker(null)}
-              className="text-sm text-muted hover:text-text transition-colors"
-            >
-              ← Назад
-            </button>
-            <span className="text-sm font-bold">
-              Транзакція для «{sub.name}»
-            </span>
-          </div>
-          <div className="flex-1 overflow-y-auto">
-            <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-              <Card variant="flat" radius="md" className="mb-4">
-                <p className="text-xs text-subtle leading-relaxed">
-                  Обери списання (наприклад через Apple/Google). День місяця з
-                  транзакції підставиться в «день списання»; сума піде в огляд і
-                  в Рутину.
-                  {linkedId && (
-                    <button
-                      type="button"
-                      className="block mt-2 text-sm font-semibold text-danger hover:underline"
-                      onClick={() => {
-                        updateSubscription(sub.id, { linkedTxId: null });
-                        setTxPicker(null);
-                      }}
-                    >
-                      Зняти привʼязку
-                    </button>
-                  )}
-                </p>
-              </Card>
-              {expenses.map((t, i) => {
-                const isLinked = linkedId === t.id;
-                return (
-                  <TxRow
-                    key={t.id || i}
-                    tx={t}
-                    highlighted={isLinked}
-                    customCategories={customCategories}
-                    onClick={() => {
-                      if (isLinked) {
-                        updateSubscription(sub.id, { linkedTxId: null });
-                      } else {
-                        const bd = new Date((t.time || 0) * 1000).getDate();
-                        updateSubscription(sub.id, {
-                          linkedTxId: t.id,
-                          billingDay: bd,
-                        });
-                      }
-                      setTxPicker(null);
-                    }}
-                    accounts={accounts}
-                    hideAmount={!showBalance}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // --- Manual debt / receivable linking ---
-    const isDebt = txPicker.type === "debt";
-    const items = isDebt ? manualDebts : receivables;
-    const item = items.find((d) => d.id === txPicker.id);
-    const linked = item?.linkedTxIds || [];
-    const paid = isDebt
-      ? getDebtPaid(item, transactions)
-      : getRecvPaid(item, transactions);
-    const total = isDebt
-      ? getDebtEffectiveTotal(item, transactions)
-      : getReceivableEffectiveTotal(item, transactions);
-    const remaining = isDebt
-      ? calcDebtRemaining(item, transactions)
-      : calcReceivableRemaining(item, transactions);
-    const getTxRole = (tx) =>
-      isDebt ? getDebtTxRole(tx) : getReceivableTxRole(tx);
-
     return (
-      <div className="flex flex-col flex-1 overflow-hidden">
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
-          <button
-            onClick={() => setTxPicker(null)}
-            className="text-sm text-muted hover:text-text transition-colors"
-          >
-            ← Назад
-          </button>
-          <span className="text-sm font-bold">
-            {isDebt ? "Транзакції по пасиву" : "Транзакції по активу"}
-          </span>
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-            <Card variant="flat" radius="md" className="mb-4">
-              <div className="text-xs text-subtle">
-                {item?.emoji} {item?.name}
-              </div>
-              <div
-                className={cn(
-                  "text-2xl font-extrabold mt-1",
-                  isDebt ? "text-danger" : "text-success",
-                )}
-              >
-                {isDebt ? "−" : "+"}
-                {remaining.toLocaleString("uk-UA")} ₴ залишок
-              </div>
-              <div className="text-xs text-subtle mt-1">
-                Сплачено: {paid.toLocaleString("uk-UA")} з{" "}
-                {total?.toLocaleString("uk-UA")} ₴
-              </div>
-            </Card>
-            {transactions.map((t, i) => {
-              const isLinked = linked.includes(t.id);
-              const role = isLinked ? getTxRole(t) : null;
-              return (
-                <div key={i}>
-                  {isLinked && (
-                    <div
-                      className="text-xs font-bold px-1 py-1"
-                      style={{ color: role.color }}
-                    >
-                      {role.label}
-                    </div>
-                  )}
-                  <TxRow
-                    tx={t}
-                    highlighted={isLinked}
-                    onClick={() =>
-                      toggleLinkedTx(txPicker.id, t.id, txPicker.type)
-                    }
-                    hideAmount={!showBalance}
-                    customCategories={customCategories}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
+      <AssetsTxPickerView
+        txPicker={txPicker}
+        setTxPicker={setTxPicker}
+        accounts={accounts}
+        transactions={transactions}
+        monoDebtLinkedTxIds={monoDebtLinkedTxIds}
+        toggleMonoDebtTx={toggleMonoDebtTx}
+        subscriptions={subscriptions}
+        updateSubscription={updateSubscription}
+        manualDebts={manualDebts}
+        receivables={receivables}
+        toggleLinkedTx={toggleLinkedTx}
+        showBalance={showBalance}
+        customCategories={customCategories}
+      />
     );
   }
 

--- a/apps/web/src/modules/finyk/pages/AssetsBars.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsBars.tsx
@@ -1,0 +1,123 @@
+import { Icon, type IconName } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Single-row stacked bar that visualises the assets vs. liabilities split
+ * inside the Networth header. Only rendered when the user has at least
+ * one of each bucket — a lone bar would be misleading.
+ */
+export function AssetsLiabilitiesBar({
+  assets,
+  liabilities,
+}: {
+  assets: number;
+  liabilities: number;
+}) {
+  const total = assets + liabilities;
+  if (total <= 0) return null;
+  const assetsPct = Math.round((assets / total) * 100);
+  const liabilitiesPct = 100 - assetsPct;
+  return (
+    <div className="mt-3">
+      <div
+        className="flex h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+        role="img"
+        aria-label={`Активи ${assetsPct}% · Пасиви ${liabilitiesPct}%`}
+      >
+        <div className="bg-emerald-300/90" style={{ width: `${assetsPct}%` }} />
+        <div
+          className="bg-rose-400/80"
+          style={{ width: `${liabilitiesPct}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-[11px] text-emerald-100/80 mt-1.5">
+        <span>Активи {assetsPct}%</span>
+        <span>Пасиви {liabilitiesPct}%</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dashed-border CTA used in the 3-button quick-action row above the
+ * sections. Each button collapses the "expand → scroll → tap +" flow
+ * into a single tap that opens the relevant section *and* reveals its
+ * inline form.
+ */
+export function QuickActionButton({
+  iconName,
+  label,
+  onClick,
+}: {
+  iconName: IconName;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-center justify-center gap-1 py-2.5 text-xs text-muted border border-dashed border-line rounded-2xl hover:border-primary hover:text-primary transition-colors"
+    >
+      <Icon name={iconName} size={18} />
+      <span className="font-medium">+ {label}</span>
+    </button>
+  );
+}
+
+export type SectionBarProps = {
+  title: string;
+  iconName: IconName;
+  iconTone?: "success" | "danger" | "muted";
+  summary?: string | null;
+  open: boolean;
+  onToggle: () => void;
+};
+
+/**
+ * Collapsible section header used for Subscriptions / Assets / Liabilities
+ * blocks. The trailing label switches between "Розкласти ↓" / "Згорнути ↑"
+ * to make the affordance unambiguous on mobile.
+ */
+export function SectionBar({
+  title,
+  iconName,
+  iconTone = "muted",
+  summary,
+  open,
+  onToggle,
+}: SectionBarProps) {
+  const toneClass =
+    iconTone === "success"
+      ? "text-success"
+      : iconTone === "danger"
+        ? "text-danger"
+        : "text-muted";
+  return (
+    <button
+      onClick={onToggle}
+      className="w-full flex items-center justify-between px-4 py-3 bg-panelHi border border-line rounded-2xl mb-2 text-left transition-colors hover:border-muted/50"
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center shrink-0",
+            toneClass,
+          )}
+          aria-hidden
+        >
+          <Icon name={iconName} size={18} />
+        </span>
+        <div className="min-w-0">
+          <div className="text-sm font-bold text-text truncate">{title}</div>
+          {summary && (
+            <div className="text-xs text-muted mt-0.5 truncate">{summary}</div>
+          )}
+        </div>
+      </div>
+      <span className="text-xs text-muted shrink-0 ml-2">
+        {open ? "Згорнути ↑" : "Розкласти ↓"}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/modules/finyk/pages/AssetsTxPickerView.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTxPickerView.tsx
@@ -1,0 +1,296 @@
+import { TxRow } from "../components/TxRow";
+import { Card } from "@shared/components/ui/Card";
+import {
+  getAccountLabel,
+  getMonoDebt,
+  getDebtPaid,
+  getRecvPaid,
+  calcDebtRemaining,
+  calcReceivableRemaining,
+  getDebtEffectiveTotal,
+  getReceivableEffectiveTotal,
+} from "../utils";
+import {
+  getDebtTxRole,
+  getReceivableTxRole,
+} from "@sergeant/finyk-domain/domain/debtEngine";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Sub-screen rendered by the Assets page when the user enters a
+ * transaction-linking flow. Three modes share the same back-button +
+ * scrolling list shell:
+ *
+ *  - `monoDebt` — repayment linking for a Mono credit card. Suggested
+ *    rows (positive amount on the same account) get a green eyebrow.
+ *  - `sub` — subscription → recurring expense linking. Tapping a row
+ *    sets `linkedTxId` + `billingDay` from that transaction's day.
+ *  - `debt` / `receivable` — manual debt or receivable. Each linked
+ *    transaction shows its role (charge / payment / partial) above the
+ *    row tinted by `getDebtTxRole` / `getReceivableTxRole`.
+ *
+ * The host page mounts this view as a full-screen overlay (header is
+ * sticky, content scrolls) instead of the regular Assets layout — the
+ * caller switches by checking `txPicker !== null` and rendering one or
+ * the other.
+ */
+export function AssetsTxPickerView({
+  txPicker,
+  setTxPicker,
+  accounts,
+  transactions,
+  monoDebtLinkedTxIds,
+  toggleMonoDebtTx,
+  subscriptions,
+  updateSubscription,
+  manualDebts,
+  receivables,
+  toggleLinkedTx,
+  showBalance,
+  customCategories,
+}) {
+  if (txPicker.type === "monoDebt") {
+    const account = accounts.find((a) => a.id === txPicker.id);
+    const linkedIds = monoDebtLinkedTxIds[txPicker.id] || [];
+    const paid = transactions
+      .filter((t) => linkedIds.includes(t.id))
+      .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
+    const remaining = getMonoDebt(account);
+    const total = paid + remaining;
+    const label = getAccountLabel(account);
+
+    const isSuggested = (t) => t._accountId === txPicker.id && t.amount > 0;
+
+    return (
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
+          <button
+            onClick={() => setTxPicker(null)}
+            className="text-sm text-muted hover:text-text transition-colors"
+          >
+            ← Назад
+          </button>
+          <span className="text-sm font-bold">Погашення: {label}</span>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
+            <Card variant="flat" radius="md" className="mb-3">
+              <div className="text-xs text-subtle mb-1">{label}</div>
+              <div className="text-2xl font-extrabold text-danger">
+                −
+                {remaining.toLocaleString("uk-UA", {
+                  maximumFractionDigits: 0,
+                })}{" "}
+                ₴ залишок боргу
+              </div>
+              <div className="text-xs text-subtle mt-1">
+                Погашено цього місяця:{" "}
+                {paid.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴ ·
+                Базовий борг:{" "}
+                {total.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
+              </div>
+              <div className="h-1.5 bg-line rounded-full overflow-hidden mt-3">
+                <div
+                  className="h-full bg-danger rounded-full transition-[width,background-color] duration-500"
+                  style={{
+                    width: `${total > 0 ? Math.min(100, Math.round((paid / total) * 100)) : 0}%`,
+                  }}
+                />
+              </div>
+            </Card>
+            <p className="text-xs text-subtle mb-3 px-1">
+              Тапни транзакцію щоб прив&apos;язати як погашення. Виділені
+              зеленим — автоматично виявлені поповнення картки.
+            </p>
+            {transactions.map((t, i) => {
+              const isLinked = linkedIds.includes(t.id);
+              const suggested = isSuggested(t);
+              return (
+                <div key={i}>
+                  {suggested && !isLinked && (
+                    <div className="text-2xs font-semibold text-success px-1 pt-1">
+                      ↑ Поповнення картки
+                    </div>
+                  )}
+                  <TxRow
+                    tx={t}
+                    highlighted={isLinked}
+                    onClick={() => toggleMonoDebtTx(txPicker.id, t.id)}
+                    accounts={accounts}
+                    hideAmount={!showBalance}
+                    customCategories={customCategories}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (txPicker.type === "sub") {
+    const sub = subscriptions.find((s) => s.id === txPicker.subId);
+    if (!sub) {
+      return (
+        <div className="flex flex-col flex-1 overflow-hidden">
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
+            <button
+              type="button"
+              onClick={() => setTxPicker(null)}
+              className="text-sm text-muted hover:text-text transition-colors"
+            >
+              ← Назад
+            </button>
+          </div>
+        </div>
+      );
+    }
+    const linkedId = sub.linkedTxId;
+    const expenses = transactions
+      .filter((t) => t.amount < 0)
+      .sort((a, b) => (b.time || 0) - (a.time || 0));
+    return (
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
+          <button
+            type="button"
+            onClick={() => setTxPicker(null)}
+            className="text-sm text-muted hover:text-text transition-colors"
+          >
+            ← Назад
+          </button>
+          <span className="text-sm font-bold">Транзакція для «{sub.name}»</span>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
+            <Card variant="flat" radius="md" className="mb-4">
+              <p className="text-xs text-subtle leading-relaxed">
+                Обери списання (наприклад через Apple/Google). День місяця з
+                транзакції підставиться в «день списання»; сума піде в огляд і в
+                Рутину.
+                {linkedId && (
+                  <button
+                    type="button"
+                    className="block mt-2 text-sm font-semibold text-danger hover:underline"
+                    onClick={() => {
+                      updateSubscription(sub.id, { linkedTxId: null });
+                      setTxPicker(null);
+                    }}
+                  >
+                    Зняти привʼязку
+                  </button>
+                )}
+              </p>
+            </Card>
+            {expenses.map((t, i) => {
+              const isLinked = linkedId === t.id;
+              return (
+                <TxRow
+                  key={t.id || i}
+                  tx={t}
+                  highlighted={isLinked}
+                  customCategories={customCategories}
+                  onClick={() => {
+                    if (isLinked) {
+                      updateSubscription(sub.id, { linkedTxId: null });
+                    } else {
+                      const bd = new Date((t.time || 0) * 1000).getDate();
+                      updateSubscription(sub.id, {
+                        linkedTxId: t.id,
+                        billingDay: bd,
+                      });
+                    }
+                    setTxPicker(null);
+                  }}
+                  accounts={accounts}
+                  hideAmount={!showBalance}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Manual debt / receivable linking ---
+  const isDebt = txPicker.type === "debt";
+  const items = isDebt ? manualDebts : receivables;
+  const item = items.find((d) => d.id === txPicker.id);
+  const linked = item?.linkedTxIds || [];
+  const paid = isDebt
+    ? getDebtPaid(item, transactions)
+    : getRecvPaid(item, transactions);
+  const total = isDebt
+    ? getDebtEffectiveTotal(item, transactions)
+    : getReceivableEffectiveTotal(item, transactions);
+  const remaining = isDebt
+    ? calcDebtRemaining(item, transactions)
+    : calcReceivableRemaining(item, transactions);
+  const getTxRole = (tx) =>
+    isDebt ? getDebtTxRole(tx) : getReceivableTxRole(tx);
+
+  return (
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-line bg-bg sticky top-0 z-10">
+        <button
+          onClick={() => setTxPicker(null)}
+          className="text-sm text-muted hover:text-text transition-colors"
+        >
+          ← Назад
+        </button>
+        <span className="text-sm font-bold">
+          {isDebt ? "Транзакції по пасиву" : "Транзакції по активу"}
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
+          <Card variant="flat" radius="md" className="mb-4">
+            <div className="text-xs text-subtle">
+              {item?.emoji} {item?.name}
+            </div>
+            <div
+              className={cn(
+                "text-2xl font-extrabold mt-1",
+                isDebt ? "text-danger" : "text-success",
+              )}
+            >
+              {isDebt ? "−" : "+"}
+              {remaining.toLocaleString("uk-UA")} ₴ залишок
+            </div>
+            <div className="text-xs text-subtle mt-1">
+              Сплачено: {paid.toLocaleString("uk-UA")} з{" "}
+              {total?.toLocaleString("uk-UA")} ₴
+            </div>
+          </Card>
+          {transactions.map((t, i) => {
+            const isLinked = linked.includes(t.id);
+            const role = isLinked ? getTxRole(t) : null;
+            return (
+              <div key={i}>
+                {isLinked && (
+                  <div
+                    className="text-xs font-bold px-1 py-1"
+                    style={{ color: role.color }}
+                  >
+                    {role.label}
+                  </div>
+                )}
+                <TxRow
+                  tx={t}
+                  highlighted={isLinked}
+                  onClick={() =>
+                    toggleLinkedTx(txPicker.id, t.id, txPicker.type)
+                  }
+                  hideAmount={!showBalance}
+                  customCategories={customCategories}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

Розбив `apps/web/src/modules/finyk/pages/Assets.tsx` (1207 рядків) на три файли в межах одного каталогу:

- `pages/Assets.tsx` (1207 → **873 рядки**) — лишилися: state, бізнес-обчислення (totals/networth, schedule), три розділи (Subscriptions / Assets / Liabilities) і їхні inline-форми. Поведінка не змінилася.
- `pages/AssetsBars.tsx` (123 рядки) — три невеликих presentational-помічники, винесені без змін:
  - `AssetsLiabilitiesBar` — стек-бар Активи vs Пасиви у Networth-хедері.
  - `QuickActionButton` — пунктирна CTA-кнопка для quick-action ряду.
  - `SectionBar` — клікабельний хедер кожного collapsible-блоку (з типом `SectionBarProps`).
- `pages/AssetsTxPickerView.tsx` (299 рядків) — повноекранний overlay для прив'язки транзакцій. Усі три гілки (`monoDebt` погашення кредитки, `sub` підписка → списання, `debt`/`receivable` ручні борги/борги мені) тепер живуть тут із власним sticky-back-button-шеллом. Хост-сторінка лише відрисовує `<AssetsTxPickerView … />` коли `txPicker !== null` — зовнішній API/UX однаковий.

Жодних логічних змін: усі обчислення (`getMonoDebt`, `getDebtPaid`, `getRecvPaid`, `calcDebtRemaining`, `calcReceivableRemaining`, `getDebtEffectiveTotal`, `getReceivableEffectiveTotal`, `getDebtTxRole`, `getReceivableTxRole`) лишилися ідентичні, переважно — переїхали разом із JSX, що їх використовує.

## Why

Продовження плану `docs/structure-refactor-plan.md` § 5.2 — розбити 6 великих компонентів (≥800 рядків). Це 4-й з 6 (Assets):

- ✅ FinykApp.tsx (#773)
- ✅ HubDashboard.tsx (#775)
- ✅ ActiveWorkoutPanel.tsx (#777)
- ➡️ **Assets.tsx (цей PR)**
- ⏭️ Transactions.tsx
- ⏭️ RoutineCalendarPanel.tsx

Файл був найбільший із шести (1207 рядків). TxPicker-view був окремою «сторінкою» всередині того ж компонента — природний екстракт. Section-bar-helpers це чисті presentational-функції без залежності на стейт сторінки — теж добре відокремлюються.

## How to test

```sh
pnpm --filter @sergeant/web typecheck   # 0 нових помилок (1 pre-existing у financeContext.ts на main)
pnpm --filter @sergeant/web lint        # 0 помилок
pnpm --filter @sergeant/web test -- --run   # 90 файлів / 804 тести passed
```

Smoke-флоу для рев'юера:
1. Відкрити Finyk → Активи. Networth-хедер, Активи/Пасиви бар, FinykStatsStrip, 3 quick-action CTA — без візуальних змін.
2. Розкрити «Підписки» → тапнути по підписці без linkedTx → відкривається TxPicker, обрати витрату → `linkedTxId` + `billingDay` оновлюється, повертає на список.
3. Розкрити «Пасиви» → тапнути «Прив'язати транзакції» на ручному борзі → TxPicker показує всі транзакції, ролі (charge/payment/partial) видно над зв'язаними рядками.
4. У «Пасивах» тапнути на Mono-кредитку → погашення-пікер з прогрес-баром «paid / total».

---

## How AI-tested this PR

- [x] Vitest passes: 90 files / 804 tests passed (Vitest)
- [x] Manual smoke: typecheck + lint clean (1 pre-existing TS error у `financeContext.ts:122` — не моя зміна, відтворюється на чистому main)
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian.

## AGENTS.md updated?

- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
