### PR TITLE
refactor(web): split Transactions.tsx — extract header, batch toolbar, day helpers

### DIFF
--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -7,68 +7,22 @@ import { mergeExpenseCategoryDefinitions, CURRENCY } from "../constants";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { Icon } from "@shared/components/ui/Icon";
-import { Sheet } from "@shared/components/ui/Sheet";
 import { cn } from "@shared/lib/cn";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
-import { STORAGE_KEYS } from "@sergeant/shared";
+import {
+  DAY_COLLAPSE_KEY,
+  dayKeyFromTx,
+  readDayCollapse,
+  writeDayCollapse,
+  isDayExpanded,
+  formatStickyDayLabel,
+} from "./transactionsLib";
+import { TransactionsHeader } from "./TransactionsHeader";
+import { TransactionsBatchToolbar } from "./TransactionsBatchToolbar";
 
 const now = new Date();
-const DAY_COLLAPSE_KEY = STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE;
-
-function dayKeyFromTx(ts) {
-  const d = new Date(ts * 1000);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-function readDayCollapse() {
-  try {
-    const raw = localStorage.getItem(DAY_COLLAPSE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-}
-
-function writeDayCollapse(v) {
-  try {
-    localStorage.setItem(DAY_COLLAPSE_KEY, JSON.stringify(v));
-  } catch {
-    /* quota / private-mode — drop silently */
-  }
-}
-
-// Усі дні згорнуті за замовчуванням; ручне розгортання зберігається
-// в `overrides` і переживає перезавантаження (та міжтабову синхронізацію).
-// `todayKey` лишається в сигнатурі на випадок, якщо колись захочемо
-// повернути логіку "сьогодні завжди відкрите" через feature-toggle,
-// але зараз користувач свідомо попросив згорнуто-за-замовчуванням.
-function isDayExpanded(overrides, key, _todayKey) {
-  return !!overrides[key];
-}
-
-function formatStickyDayLabel(key) {
-  const [y, m, da] = key.split("-").map(Number);
-  const d = new Date(y, m - 1, da);
-  const t0 = new Date();
-  t0.setHours(0, 0, 0, 0);
-  const d0 = new Date(d);
-  d0.setHours(0, 0, 0, 0);
-  const diffDays = Math.round((t0.getTime() - d0.getTime()) / 86400000);
-  if (diffDays === 0) return "Сьогодні";
-  if (diffDays === 1) return "Вчора";
-  return d.toLocaleDateString("uk-UA", {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-  });
-}
 
 export function Transactions({
   mono,
@@ -454,113 +408,19 @@ export function Transactions({
   return (
     <div ref={setScrollParent} className="flex-1 overflow-y-auto">
       <div className="max-w-4xl mx-auto px-4 pt-4 page-tabbar-pad">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-1">
-            <button
-              onClick={() => goMonth(-1)}
-              className="w-8 h-8 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors text-lg"
-            >
-              ‹
-            </button>
-            <span className="text-sm font-semibold text-text capitalize px-1">
-              {monthLabel}
-            </span>
-            <button
-              onClick={() => goMonth(1)}
-              disabled={isCurrentMonth}
-              className="w-8 h-8 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors text-lg disabled:opacity-30"
-            >
-              ›
-            </button>
-          </div>
-          <div className="flex items-center gap-1.5">
-            {selectMode ? (
-              <button
-                onClick={exitSelectMode}
-                className="text-xs px-3 py-2 rounded-full border border-primary/40 bg-primary/8 text-primary min-h-[36px] font-semibold"
-              >
-                Скасувати
-              </button>
-            ) : (
-              <>
-                {hiddenTxIds.length > 0 && (
-                  <button
-                    onClick={() => setShowHidden((v) => !v)}
-                    className={cn(
-                      "text-xs px-3 py-2 rounded-full border border-line transition-colors min-h-[36px]",
-                      showHidden
-                        ? "text-primary border-primary"
-                        : "text-subtle",
-                    )}
-                  >
-                    {showHidden ? (
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden
-                      >
-                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                        <circle cx="12" cy="12" r="3" />
-                      </svg>
-                    ) : (
-                      <span>{hiddenTxIds.length} прих.</span>
-                    )}
-                  </button>
-                )}
-                <button
-                  onClick={() => setSelectMode(true)}
-                  className="text-xs px-3 py-2 rounded-full border border-line text-subtle hover:text-text hover:border-muted transition-colors min-h-[36px]"
-                  title="Вибрати кілька"
-                  aria-label="Режим вибору"
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <polyline points="9 11 12 14 22 4" />
-                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-                  </svg>
-                </button>
-                <button
-                  onClick={refresh}
-                  disabled={activeLoading}
-                  className="text-xs px-3 py-2 rounded-full border border-line text-subtle hover:text-text hover:border-muted transition-colors disabled:opacity-40 min-h-[36px]"
-                  aria-label="Оновити"
-                >
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={activeLoading ? "motion-safe:animate-spin" : ""}
-                    aria-hidden
-                  >
-                    <polyline points="23 4 23 10 17 10" />
-                    <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-                  </svg>
-                </button>
-              </>
-            )}
-          </div>
-        </div>
+        <TransactionsHeader
+          monthLabel={monthLabel}
+          isCurrentMonth={isCurrentMonth}
+          goMonth={goMonth}
+          selectMode={selectMode}
+          exitSelectMode={exitSelectMode}
+          setSelectMode={setSelectMode}
+          showHidden={showHidden}
+          setShowHidden={setShowHidden}
+          hiddenCount={hiddenTxIds.length}
+          refresh={refresh}
+          loading={activeLoading}
+        />
 
         {/* Sync status */}
         {syncState?.status !== "idle" && (
@@ -754,74 +614,17 @@ export function Transactions({
         )}
       </div>
 
-      {/* Batch action toolbar */}
-      {selectMode && (
-        <div className="fixed bottom-0 left-0 right-0 z-[60] safe-area-pb">
-          <div className="max-w-4xl mx-auto px-4 pb-[calc(60px+env(safe-area-inset-bottom,0px)+0.5rem)] pt-3">
-            <div className="bg-panel border border-line rounded-2xl shadow-float px-4 py-3 flex items-center justify-between gap-3">
-              <span className="text-sm font-semibold text-text">
-                {selectedIds.size > 0
-                  ? `${selectedIds.size} обрано`
-                  : "Оберіть транзакції"}
-              </span>
-              <div className="flex items-center gap-2 flex-wrap">
-                {selectedIds.size > 0 && (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => setBatchCatPicker(true)}
-                      className="text-sm font-semibold px-4 py-2 rounded-xl bg-primary text-bg min-h-[40px] transition-colors"
-                    >
-                      Категорія
-                    </button>
-                    <button
-                      type="button"
-                      onClick={applyBatchHide}
-                      className="text-sm font-semibold px-4 py-2 rounded-xl border border-line bg-panelHi text-text min-h-[40px] transition-colors hover:border-muted"
-                    >
-                      Приховати
-                    </button>
-                    <button
-                      type="button"
-                      onClick={applyBatchExclude}
-                      className="text-sm font-semibold px-4 py-2 rounded-xl border border-line bg-panelHi text-text min-h-[40px] transition-colors hover:border-muted"
-                    >
-                      Зі статистики
-                    </button>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Batch category picker */}
-      <Sheet
-        open={batchCatPicker}
-        onClose={() => setBatchCatPicker(false)}
-        title="Вибрати категорію"
-        description={`Застосується до ${selectedIds.size} транзакц${selectedIds.size === 1 ? "ії" : "ій"}`}
-        panelClassName="finyk-sheet"
-        zIndex={70}
-        bodyClassName="px-4 pb-6 flex flex-col gap-1"
-      >
-        {mergeExpenseCategoryDefinitions(customCategories)
-          .filter((c) => c.id !== "income")
-          .map((cat) => (
-            <button
-              key={cat.id}
-              type="button"
-              onClick={() => applyBatchCategory(cat.id)}
-              className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-2xl hover:bg-panelHi transition-colors min-h-[48px]"
-            >
-              <span className="text-lg">
-                {(cat as { emoji?: string }).emoji}
-              </span>
-              <span className="text-sm font-medium text-text">{cat.label}</span>
-            </button>
-          ))}
-      </Sheet>
+      <TransactionsBatchToolbar
+        selectMode={selectMode}
+        selectedSize={selectedIds.size}
+        onOpenCatPicker={() => setBatchCatPicker(true)}
+        onApplyHide={applyBatchHide}
+        onApplyExclude={applyBatchExclude}
+        batchCatPicker={batchCatPicker}
+        onCloseCatPicker={() => setBatchCatPicker(false)}
+        onApplyCategory={applyBatchCategory}
+        customCategories={customCategories}
+      />
     </div>
   );
 }

--- a/apps/web/src/modules/finyk/pages/TransactionsBatchToolbar.tsx
+++ b/apps/web/src/modules/finyk/pages/TransactionsBatchToolbar.tsx
@@ -1,0 +1,110 @@
+import { Sheet } from "@shared/components/ui/Sheet";
+import { mergeExpenseCategoryDefinitions } from "../constants";
+
+export interface TransactionsBatchToolbarProps {
+  selectMode: boolean;
+  selectedSize: number;
+  onOpenCatPicker: () => void;
+  onApplyHide: () => void;
+  onApplyExclude: () => void;
+  batchCatPicker: boolean;
+  onCloseCatPicker: () => void;
+  onApplyCategory: (catId: string) => void;
+  customCategories: Parameters<typeof mergeExpenseCategoryDefinitions>[0];
+}
+
+/**
+ * Floating bottom toolbar that appears while the user is in batch
+ * select-mode, plus the bottom-sheet category picker that opens from
+ * its "Категорія" action. Both pieces share the same enter / exit
+ * lifecycle, so they live together.
+ *
+ * Visibility:
+ *   - the toolbar renders only when `selectMode === true`;
+ *   - action buttons render only when at least one row is selected
+ *     (so an empty selection shows just the prompt);
+ *   - the sheet is independently mounted because its open-state
+ *     overlaps with select-mode but is not the same.
+ */
+export function TransactionsBatchToolbar({
+  selectMode,
+  selectedSize,
+  onOpenCatPicker,
+  onApplyHide,
+  onApplyExclude,
+  batchCatPicker,
+  onCloseCatPicker,
+  onApplyCategory,
+  customCategories,
+}: TransactionsBatchToolbarProps) {
+  return (
+    <>
+      {selectMode && (
+        <div className="fixed bottom-0 left-0 right-0 z-[60] safe-area-pb">
+          <div className="max-w-4xl mx-auto px-4 pb-[calc(60px+env(safe-area-inset-bottom,0px)+0.5rem)] pt-3">
+            <div className="bg-panel border border-line rounded-2xl shadow-float px-4 py-3 flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-text">
+                {selectedSize > 0
+                  ? `${selectedSize} обрано`
+                  : "Оберіть транзакції"}
+              </span>
+              <div className="flex items-center gap-2 flex-wrap">
+                {selectedSize > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={onOpenCatPicker}
+                      className="text-sm font-semibold px-4 py-2 rounded-xl bg-primary text-bg min-h-[40px] transition-colors"
+                    >
+                      Категорія
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onApplyHide}
+                      className="text-sm font-semibold px-4 py-2 rounded-xl border border-line bg-panelHi text-text min-h-[40px] transition-colors hover:border-muted"
+                    >
+                      Приховати
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onApplyExclude}
+                      className="text-sm font-semibold px-4 py-2 rounded-xl border border-line bg-panelHi text-text min-h-[40px] transition-colors hover:border-muted"
+                    >
+                      Зі статистики
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Sheet
+        open={batchCatPicker}
+        onClose={onCloseCatPicker}
+        title="Вибрати категорію"
+        description={`Застосується до ${selectedSize} транзакц${selectedSize === 1 ? "ії" : "ій"}`}
+        panelClassName="finyk-sheet"
+        zIndex={70}
+        bodyClassName="px-4 pb-6 flex flex-col gap-1"
+      >
+        {mergeExpenseCategoryDefinitions(customCategories)
+          .filter((c) => c.id !== "income")
+          .map((cat) => (
+            <button
+              key={cat.id}
+              type="button"
+              onClick={() => onApplyCategory(cat.id)}
+              className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-2xl hover:bg-panelHi transition-colors min-h-[48px]"
+            >
+              <span className="text-lg">
+                {(cat as { emoji?: string }).emoji}
+              </span>
+              <span className="text-sm font-medium text-text">{cat.label}</span>
+            </button>
+          ))}
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/src/modules/finyk/pages/TransactionsHeader.tsx
+++ b/apps/web/src/modules/finyk/pages/TransactionsHeader.tsx
@@ -1,0 +1,144 @@
+import { cn } from "@shared/lib/cn";
+
+export interface TransactionsHeaderProps {
+  monthLabel: string;
+  isCurrentMonth: boolean;
+  goMonth: (delta: number) => void;
+  selectMode: boolean;
+  exitSelectMode: () => void;
+  setSelectMode: (v: boolean) => void;
+  showHidden: boolean;
+  setShowHidden: (updater: (v: boolean) => boolean) => void;
+  hiddenCount: number;
+  refresh: () => void;
+  loading: boolean;
+}
+
+/**
+ * Top header for the Transactions page: month switcher on the left,
+ * action buttons (toggle-hidden / select-mode / refresh) on the right.
+ *
+ * The "select-mode" toggle replaces the action cluster with a single
+ * "Скасувати" button while batch selection is active — the actions
+ * only make sense outside of select-mode anyway.
+ */
+export function TransactionsHeader({
+  monthLabel,
+  isCurrentMonth,
+  goMonth,
+  selectMode,
+  exitSelectMode,
+  setSelectMode,
+  showHidden,
+  setShowHidden,
+  hiddenCount,
+  refresh,
+  loading,
+}: TransactionsHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => goMonth(-1)}
+          className="w-8 h-8 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors text-lg"
+        >
+          ‹
+        </button>
+        <span className="text-sm font-semibold text-text capitalize px-1">
+          {monthLabel}
+        </span>
+        <button
+          onClick={() => goMonth(1)}
+          disabled={isCurrentMonth}
+          className="w-8 h-8 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors text-lg disabled:opacity-30"
+        >
+          ›
+        </button>
+      </div>
+      <div className="flex items-center gap-1.5">
+        {selectMode ? (
+          <button
+            onClick={exitSelectMode}
+            className="text-xs px-3 py-2 rounded-full border border-primary/40 bg-primary/8 text-primary min-h-[36px] font-semibold"
+          >
+            Скасувати
+          </button>
+        ) : (
+          <>
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setShowHidden((v) => !v)}
+                className={cn(
+                  "text-xs px-3 py-2 rounded-full border border-line transition-colors min-h-[36px]",
+                  showHidden ? "text-primary border-primary" : "text-subtle",
+                )}
+              >
+                {showHidden ? (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                ) : (
+                  <span>{hiddenCount} прих.</span>
+                )}
+              </button>
+            )}
+            <button
+              onClick={() => setSelectMode(true)}
+              className="text-xs px-3 py-2 rounded-full border border-line text-subtle hover:text-text hover:border-muted transition-colors min-h-[36px]"
+              title="Вибрати кілька"
+              aria-label="Режим вибору"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <polyline points="9 11 12 14 22 4" />
+                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+              </svg>
+            </button>
+            <button
+              onClick={refresh}
+              disabled={loading}
+              className="text-xs px-3 py-2 rounded-full border border-line text-subtle hover:text-text hover:border-muted transition-colors disabled:opacity-40 min-h-[36px]"
+              aria-label="Оновити"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className={loading ? "motion-safe:animate-spin" : ""}
+                aria-hidden
+              >
+                <polyline points="23 4 23 10 17 10" />
+                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+              </svg>
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/finyk/pages/transactionsLib.ts
+++ b/apps/web/src/modules/finyk/pages/transactionsLib.ts
@@ -1,0 +1,72 @@
+import { STORAGE_KEYS } from "@sergeant/shared";
+import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
+
+export const DAY_COLLAPSE_KEY = STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE;
+
+export type DayCollapseOverrides = Record<string, boolean>;
+
+/**
+ * Build a `YYYY-MM-DD` key from a Mono UNIX-seconds timestamp.
+ * Used to bucket transactions into days for the GroupedVirtuoso list.
+ */
+export function dayKeyFromTx(ts: number): string {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Read persisted day-expand overrides. Returns an empty object on
+ * missing / corrupt JSON / private-mode storage so the UI defaults
+ * to "all collapsed".
+ */
+export function readDayCollapse(): DayCollapseOverrides {
+  const parsed = safeReadLS<unknown>(DAY_COLLAPSE_KEY, null);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as DayCollapseOverrides;
+  }
+  return {};
+}
+
+/**
+ * Persist day-expand overrides. Drop silently on quota / private-mode
+ * failures — losing the preference is preferable to throwing.
+ */
+export function writeDayCollapse(v: DayCollapseOverrides): void {
+  safeWriteLS(DAY_COLLAPSE_KEY, v);
+}
+
+/**
+ * Days are collapsed by default; the user explicitly toggles them
+ * open via the sticky day-header. The third arg `_todayKey` is kept
+ * in the signature on purpose: a feature-toggle could re-introduce
+ * "today is always expanded" behaviour without changing call-sites.
+ */
+export function isDayExpanded(
+  overrides: DayCollapseOverrides,
+  key: string,
+  _todayKey: string,
+): boolean {
+  return !!overrides[key];
+}
+
+/**
+ * Localised day label rendered inside the sticky header.
+ * Today / Yesterday get word labels; everything else falls back to
+ * the long Ukrainian weekday + day-of-month.
+ */
+export function formatStickyDayLabel(key: string): string {
+  const [y, m, da] = key.split("-").map(Number);
+  const d = new Date(y, m - 1, da);
+  const t0 = new Date();
+  t0.setHours(0, 0, 0, 0);
+  const d0 = new Date(d);
+  d0.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((t0.getTime() - d0.getTime()) / 86400000);
+  if (diffDays === 0) return "Сьогодні";
+  if (diffDays === 1) return "Вчора";
+  return d.toLocaleDateString("uk-UA", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -245,7 +245,6 @@ export default [
       "apps/web/src/core/insights/useCoachInsight.ts",
       "apps/web/src/core/insights/useWeeklyDigest.ts",
       "apps/web/src/modules/finyk/pages/Overview.tsx",
-      "apps/web/src/modules/finyk/pages/Transactions.tsx",
       "apps/web/src/modules/fizruk/components/TodayPlanCard.tsx",
       "apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts",
       "apps/web/src/modules/fizruk/hooks/useFizrukProgramStart.ts",


### PR DESCRIPTION
## What changed

Розбив `apps/web/src/modules/finyk/pages/Transactions.tsx` (827 рядків) на чотири файли:

- `pages/Transactions.tsx` (827 → **630 рядків**) — лишилися: state, computations (filters / grouping / day overrides), GroupedVirtuoso з його `groupContent` + `itemContent`, sync-status / lastUpdated / filter-chips / skeleton / empty-state.
- `pages/transactionsLib.ts` (72 рядки) — чисті pure-helpers: `dayKeyFromTx`, `readDayCollapse`, `writeDayCollapse`, `isDayExpanded`, `formatStickyDayLabel`, `DAY_COLLAPSE_KEY`. Заразом мігрував з прямого `localStorage.getItem`/`setItem` на `safeReadLS`/`safeWriteLS` із `@shared/lib/storage` — це міграція, описана у коментарі правила `sergeant-design/no-raw-local-storage` (Web localStorage guardrail), завдяки чому з ignore-листа в `eslint.config.js` прибрано рядок `apps/web/src/modules/finyk/pages/Transactions.tsx` (інших raw-LS-доступів у файлі більше не лишилось).
- `pages/TransactionsHeader.tsx` (144 рядки) — верхній хедер: month-switcher (‹ / ›), кнопка перемикання прихованих, перемикач select-mode і refresh. Усі SVG-іконки і tailwind-класи перенесені 1:1.
- `pages/TransactionsBatchToolbar.tsx` (110 рядків) — фіксований нижній toolbar для batch-actions (Категорія / Приховати / Зі статистики) разом із `<Sheet>` бібліотекою категорій, що відкривається з нього. Власна видимість: `selectMode && (…)` для toolbar-а, `batchCatPicker` — для шита.

Жодних логічних змін: `applyBatchCategory`, `applyBatchHide`, `applyBatchExclude`, `setShowHidden`, `setSelectMode`, `setBatchCatPicker` лишилися у host-компоненті, передаються як props.

## Why

Продовження плану `docs/structure-refactor-plan.md` § 5.2 — розбити 6 великих компонентів. Це 5-й з 6:

- ✅ FinykApp.tsx (#773)
- ✅ HubDashboard.tsx (#775)
- ✅ ActiveWorkoutPanel.tsx (#777)
- ✅ Assets.tsx (#779)
- ➡️ **Transactions.tsx (цей PR)**
- ⏭️ RoutineCalendarPanel.tsx

Header і BatchToolbar — це самостійні presentational-блоки без власного бізнес-стейту, природно екстрагуються. Helpers (`dayKeyFromTx`, …) це чисті функції, що ніколи не залежали від компонента.

Бонусно — мікро-міграція з `localStorage.*` на `safe*LS`: відповідно до `eslint.config.js` коментаря "Migrate a file → drop it from the list", `Transactions.tsx` тепер у `safe`-світі і не потребує винятку.

## How to test

```sh
pnpm --filter @sergeant/web typecheck   # 0 нових помилок (1 pre-existing у financeContext.ts на main)
pnpm --filter @sergeant/web lint        # 0 помилок (включно з no-raw-local-storage на Transactions.tsx)
pnpm --filter @sergeant/web test -- --run   # 90 файлів / 804 тести passed
```

Smoke-флоу для рев'юера у Finyk → Транзакції:
1. Скрол через місяці кнопками ‹ / ›: майбутні місяці заблоковано (поточний — disabled на →).
2. Натиснути на чек-кнопку (selectMode) — header перемикається на «Скасувати», знизу з'являється toolbar.
3. Виділити кілька транзакцій → з'являються кнопки «Категорія / Приховати / Зі статистики». Тап «Категорія» відкриває Sheet з усіма expense-категоріями; вибір застосовується до всіх обраних і виходить з selectMode.
4. Тап на sticky-day-header → день згортається/розгортається; перезавантажити сторінку — стан зберігся (через `safeWriteLS`).

---

## How AI-tested this PR

- [x] Vitest passes: 90 files / 804 tests passed
- [x] Manual smoke: typecheck + lint clean (1 pre-existing TS error у `financeContext.ts:122` — не моя зміна, відтворюється на чистому main)
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian.

## AGENTS.md updated?

- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization of the transaction page interface with dedicated controls for month navigation, batch selection with category management, hidden transaction visibility toggle, and refresh functionality for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->