### PR TITLE
refactor(web): split RoutineCalendarPanel.tsx — extract hero stats and month grid

### DIFF
--- a/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { DayProgressRing } from "./DayProgressRing";
+import { ROUTINE_THEME as C } from "../lib/routineConstants";
+
+export interface RoutineCalendarHeroProps {
+  rangeLabel: string;
+  headlineDate: string;
+  dayProgress: { completed: number; scheduled: number };
+  filteredCount: number;
+  activeHabitsCount: number;
+  completionRate: { rate: number; completed: number; scheduled: number };
+  currentStreak: number;
+  onOpenDayReport: () => void;
+}
+
+/**
+ * Top "hero" card for the Routine calendar tab. Combines the period
+ * label, headline date, the daily progress ring (clickable to open
+ * the day report sheet), and four KPI tiles: events in range, active
+ * habits, completion %, current streak.
+ *
+ * Layout is intentionally responsive: ring + tiles stack on mobile,
+ * lay out side-by-side from `sm:` upwards. The 4 tiles wrap from
+ * 2-col → 4-col at `lg:` so the period KPI doesn't compete with the
+ * page-tabbar at narrow widths.
+ */
+export function RoutineCalendarHero({
+  rangeLabel,
+  headlineDate,
+  dayProgress,
+  filteredCount,
+  activeHabitsCount,
+  completionRate,
+  currentStreak,
+  onOpenDayReport,
+}: RoutineCalendarHeroProps) {
+  return (
+    <Card
+      as="section"
+      variant="routine"
+      padding="lg"
+      aria-label="Огляд періоду"
+    >
+      <p
+        className={cn(
+          // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Calendar hero kicker composed with dynamic C.heroKicker routine tint; see RoutineApp header for the sibling pattern.
+          "text-xs font-bold tracking-widest uppercase",
+          C.heroKicker,
+        )}
+      >
+        {rangeLabel}
+      </p>
+      <p className="text-xs text-subtle mt-1">{headlineDate}</p>
+      <div className="mt-4 flex flex-col sm:flex-row items-center gap-4">
+        <DayProgressRing
+          completed={dayProgress.completed}
+          scheduled={dayProgress.scheduled}
+          onClick={onOpenDayReport}
+        />
+        <div className="flex-1 grid grid-cols-2 gap-2 w-full sm:grid-cols-2 lg:grid-cols-4">
+          <div className={C.statCard}>
+            <SectionHeading as="p" size="xs" tone="subtle">
+              Подій у зрізі
+            </SectionHeading>
+            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
+              {filteredCount}
+            </p>
+          </div>
+          <div className={C.statCard}>
+            <SectionHeading as="p" size="xs" tone="subtle">
+              Звичок активних
+            </SectionHeading>
+            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
+              {activeHabitsCount}
+            </p>
+          </div>
+          <div className={C.statCard}>
+            <SectionHeading as="p" size="xs" tone="subtle">
+              Виконання
+            </SectionHeading>
+            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
+              {Math.round(completionRate.rate * 100)}%
+            </p>
+            <p className="text-3xs text-subtle tabular-nums">
+              {completionRate.completed}/{completionRate.scheduled}
+            </p>
+          </div>
+          <div className={C.statCard}>
+            <SectionHeading as="p" size="xs" tone="subtle">
+              Поточна серія
+            </SectionHeading>
+            <p className="text-2xl font-black text-text tabular-nums mt-0.5">
+              {currentStreak}
+            </p>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/modules/routine/components/RoutineCalendarMonthGrid.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarMonthGrid.tsx
@@ -1,0 +1,240 @@
+import { cn } from "@shared/lib/cn";
+import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { ROUTINE_THEME as C } from "../lib/routineConstants";
+import { parseDateKey } from "../lib/hubCalendarAggregate";
+import type { HubCalendarEvent } from "../lib/types";
+
+type GroupedListItem =
+  | { kind: "header"; label: string }
+  | { kind: "event"; e: HubCalendarEvent };
+
+export interface RoutineCalendarMonthGridProps {
+  monthCursor: { y: number; m: number };
+  monthTitle: string;
+  cells: ReadonlyArray<number | null>;
+  dayCounts: Map<string, number>;
+  selectedDay: string;
+  goMonth: (delta: number) => void;
+  goToToday: () => void;
+  onSelectDay: (key: string) => void;
+  showFizrukShortcut: boolean;
+  onPlanFizruk: (dateKey: string) => void;
+  flatGroupedItems: GroupedListItem[];
+  onToggleHabit: (habitId: string, dateKey: string) => void;
+}
+
+/**
+ * Month-mode block: top nav (‹ / month / ›), "Today" CTA, the 7×N grid
+ * of day cells, the selected-day caption, and an inline list of the
+ * day's grouped events. Only mounted when `timeMode === "month"`, so
+ * the parent controls visibility.
+ *
+ * Day cells highlight `selectedDay` via `C.monthSel`; non-empty days
+ * get a colour dot (and a count badge once `n > 1`). The 7-day weekday
+ * header (Пн…Нд) is fixed Ukrainian, ISO-Monday-first to match the
+ * routine streak invariants documented in AGENTS.md.
+ */
+export function RoutineCalendarMonthGrid({
+  monthCursor,
+  monthTitle,
+  cells,
+  dayCounts,
+  selectedDay,
+  goMonth,
+  goToToday,
+  onSelectDay,
+  showFizrukShortcut,
+  onPlanFizruk,
+  flatGroupedItems,
+  onToggleHabit,
+}: RoutineCalendarMonthGridProps) {
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
+            onClick={() => goMonth(-1)}
+            aria-label="Попередній місяць"
+          >
+            ‹
+          </button>
+          <span className="text-sm font-semibold capitalize flex-1 text-center">
+            {monthTitle}
+          </span>
+          <button
+            type="button"
+            className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
+            onClick={() => goMonth(1)}
+            aria-label="Наступний місяць"
+          >
+            ›
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={goToToday}
+          className={cn(
+            "w-full min-h-[40px] rounded-xl text-xs font-semibold border transition-colors",
+            C.chipOn,
+          )}
+        >
+          Сьогодні
+        </button>
+      </div>
+
+      <Card as="section" radius="lg" padding="md">
+        <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
+          {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"].map((d) => (
+            <div key={d}>{d}</div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {cells.map((day, i) => {
+            if (day == null)
+              return (
+                <div key={`e-${i}`} className="aspect-square min-h-[40px]" />
+              );
+            const key = `${monthCursor.y}-${String(monthCursor.m + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+            const n = dayCounts.get(key) || 0;
+            const sel = selectedDay === key;
+            const label = parseDateKey(key).toLocaleDateString("uk-UA", {
+              weekday: "long",
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            });
+            const aria =
+              n > 0
+                ? `${label}, подій: ${n}${sel ? ", обрано" : ""}`
+                : `${label}${sel ? ", обрано" : ""}`;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => onSelectDay(key)}
+                aria-label={aria}
+                aria-pressed={sel}
+                className={cn(
+                  "aspect-square min-h-[40px] rounded-xl text-sm font-semibold flex flex-col items-center justify-center gap-0.5 transition-colors",
+                  sel
+                    ? C.monthSel
+                    : "hover:bg-panelHi border border-transparent",
+                )}
+              >
+                <span aria-hidden>{day}</span>
+                {n > 0 && (
+                  <span className="flex items-center gap-0.5" aria-hidden>
+                    <span className={cn("w-1.5 h-1.5 rounded-full", C.dot)} />
+                    {n > 1 && (
+                      <span className="text-3xs text-subtle tabular-nums">
+                        {n}
+                      </span>
+                    )}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-subtle mt-3 pt-3 border-t border-line">
+          Обрано:{" "}
+          {parseDateKey(selectedDay).toLocaleDateString("uk-UA", {
+            weekday: "long",
+            day: "numeric",
+            month: "long",
+          })}
+        </p>
+        {showFizrukShortcut && (
+          <button
+            type="button"
+            onClick={() => onPlanFizruk(selectedDay)}
+            className="mt-2 w-full rounded-xl border border-sky-400/30 bg-sky-500/5 hover:bg-sky-500/10 px-3 py-2 text-xs font-medium text-sky-600 dark:text-sky-400 transition-colors text-center"
+          >
+            Планувати тренування
+          </button>
+        )}
+        {flatGroupedItems.length > 0 && (
+          <div className="mt-3 space-y-1">
+            {flatGroupedItems.map((item, idx) => {
+              if (item.kind === "header") {
+                return (
+                  <SectionHeading
+                    key={`dh-${item.label}`}
+                    as="p"
+                    size="xs"
+                    tone="subtle"
+                    className={cn(idx > 0 && "mt-2")}
+                  >
+                    {item.label}
+                  </SectionHeading>
+                );
+              }
+              const e = item.e;
+              return (
+                <div
+                  key={`dd-${e.id}`}
+                  role={e.fizruk ? "button" : undefined}
+                  tabIndex={e.fizruk ? 0 : undefined}
+                  onClick={() => e.fizruk && onPlanFizruk(e.date)}
+                  onKeyDown={(ev) => {
+                    if (e.fizruk && (ev.key === "Enter" || ev.key === " ")) {
+                      ev.preventDefault();
+                      onPlanFizruk(e.date);
+                    }
+                  }}
+                  className={cn(
+                    "flex items-center gap-2 rounded-xl px-3 py-2 border border-line bg-panel/60",
+                    e.completed && "opacity-70",
+                    e.fizruk && "cursor-pointer hover:bg-sky-500/5",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "w-1.5 h-1.5 rounded-full shrink-0",
+                      e.fizruk
+                        ? "bg-sky-500"
+                        : e.finykSub
+                          ? "bg-emerald-500"
+                          : C.dot,
+                    )}
+                  />
+                  <span className="flex-1 min-w-0 text-sm font-medium text-text truncate">
+                    {e.title}
+                  </span>
+                  <span className="text-2xs text-subtle shrink-0">
+                    {e.subtitle}
+                  </span>
+                  {e.habitId && (
+                    <button
+                      type="button"
+                      onClick={() => onToggleHabit(e.habitId, e.date)}
+                      className={cn(
+                        "w-7 h-7 rounded-lg border flex items-center justify-center text-xs font-bold transition-colors shrink-0",
+                        e.completed
+                          ? C.done
+                          : "border-line hover:bg-panelHi text-muted",
+                      )}
+                      aria-label={
+                        e.completed ? "Скасувати виконання" : "Виконано"
+                      }
+                    >
+                      {e.completed ? "✓" : "○"}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {flatGroupedItems.length === 0 && (
+          <p className="mt-2 text-2xs text-subtle text-center">
+            Подій на цей день немає
+          </p>
+        )}
+      </Card>
+    </>
+  );
+}

--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -19,8 +19,9 @@ import { HabitDetailSheet } from "./HabitDetailSheet";
 import { FizrukDayPlanSheet } from "./FizrukDayPlanSheet";
 import { SwipeToAction } from "@shared/components/ui/SwipeToAction";
 import { completionNoteKey } from "../lib/completionNoteKey";
-import { DayProgressRing } from "./DayProgressRing";
 import { DayReportSheet } from "./DayReportSheet";
+import { RoutineCalendarHero } from "./RoutineCalendarHero";
+import { RoutineCalendarMonthGrid } from "./RoutineCalendarMonthGrid";
 import {
   FIZRUK_GROUP_LABEL,
   parseDateKey,
@@ -212,67 +213,16 @@ export function RoutineCalendarPanel({
       hidden={panelHidden}
       className="space-y-4"
     >
-      <Card
-        as="section"
-        variant="routine"
-        padding="lg"
-        aria-label="Огляд періоду"
-      >
-        <p
-          className={cn(
-            // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Calendar hero kicker composed with dynamic C.heroKicker routine tint; see RoutineApp header for the sibling pattern.
-            "text-xs font-bold tracking-widest uppercase",
-            C.heroKicker,
-          )}
-        >
-          {rangeLabel}
-        </p>
-        <p className="text-xs text-subtle mt-1">{headlineDate}</p>
-        <div className="mt-4 flex flex-col sm:flex-row items-center gap-4">
-          <DayProgressRing
-            completed={dayProgress.completed}
-            scheduled={dayProgress.scheduled}
-            onClick={() => setDayReportOpen(true)}
-          />
-          <div className="flex-1 grid grid-cols-2 gap-2 w-full sm:grid-cols-2 lg:grid-cols-4">
-            <div className={C.statCard}>
-              <SectionHeading as="p" size="xs" tone="subtle">
-                Подій у зрізі
-              </SectionHeading>
-              <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-                {filtered.length}
-              </p>
-            </div>
-            <div className={C.statCard}>
-              <SectionHeading as="p" size="xs" tone="subtle">
-                Звичок активних
-              </SectionHeading>
-              <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-                {routine.habits.filter((h) => !h.archived).length}
-              </p>
-            </div>
-            <div className={C.statCard}>
-              <SectionHeading as="p" size="xs" tone="subtle">
-                Виконання
-              </SectionHeading>
-              <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-                {Math.round(completionRate.rate * 100)}%
-              </p>
-              <p className="text-3xs text-subtle tabular-nums">
-                {completionRate.completed}/{completionRate.scheduled}
-              </p>
-            </div>
-            <div className={C.statCard}>
-              <SectionHeading as="p" size="xs" tone="subtle">
-                Поточна серія
-              </SectionHeading>
-              <p className="text-2xl font-black text-text tabular-nums mt-0.5">
-                {currentStreak}
-              </p>
-            </div>
-          </div>
-        </div>
-      </Card>
+      <RoutineCalendarHero
+        rangeLabel={rangeLabel}
+        headlineDate={headlineDate}
+        dayProgress={dayProgress}
+        filteredCount={filtered.length}
+        activeHabitsCount={routine.habits.filter((h) => !h.archived).length}
+        completionRate={completionRate}
+        currentStreak={currentStreak}
+        onOpenDayReport={() => setDayReportOpen(true)}
+      />
 
       <DayReportSheet
         open={dayReportOpen}
@@ -399,192 +349,20 @@ export function RoutineCalendarPanel({
       </div>
 
       {timeMode === "month" && (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between gap-2">
-            <button
-              type="button"
-              className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
-              onClick={() => goMonth(-1)}
-              aria-label="Попередній місяць"
-            >
-              ‹
-            </button>
-            <span className="text-sm font-semibold capitalize flex-1 text-center">
-              {monthTitle}
-            </span>
-            <button
-              type="button"
-              className="w-10 h-10 rounded-xl border border-line bg-panel/90 text-muted hover:text-text shadow-sm"
-              onClick={() => goMonth(1)}
-              aria-label="Наступний місяць"
-            >
-              ›
-            </button>
-          </div>
-          <button
-            type="button"
-            onClick={goToToday}
-            className={cn(
-              "w-full min-h-[40px] rounded-xl text-xs font-semibold border transition-colors",
-              C.chipOn,
-            )}
-          >
-            Сьогодні
-          </button>
-        </div>
-      )}
-
-      {timeMode === "month" && (
-        <Card as="section" radius="lg" padding="md">
-          <div className="grid grid-cols-7 gap-1 text-center text-2xs font-semibold text-subtle mb-2">
-            {["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Нд"].map((d) => (
-              <div key={d}>{d}</div>
-            ))}
-          </div>
-          <div className="grid grid-cols-7 gap-1">
-            {cells.map((day, i) => {
-              if (day == null)
-                return (
-                  <div key={`e-${i}`} className="aspect-square min-h-[40px]" />
-                );
-              const key = `${monthCursor.y}-${String(monthCursor.m + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-              const n = dayCounts.get(key) || 0;
-              const sel = selectedDay === key;
-              const label = parseDateKey(key).toLocaleDateString("uk-UA", {
-                weekday: "long",
-                day: "numeric",
-                month: "long",
-                year: "numeric",
-              });
-              const aria =
-                n > 0
-                  ? `${label}, подій: ${n}${sel ? ", обрано" : ""}`
-                  : `${label}${sel ? ", обрано" : ""}`;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => setSelectedDay(key)}
-                  aria-label={aria}
-                  aria-pressed={sel}
-                  className={cn(
-                    "aspect-square min-h-[40px] rounded-xl text-sm font-semibold flex flex-col items-center justify-center gap-0.5 transition-colors",
-                    sel
-                      ? C.monthSel
-                      : "hover:bg-panelHi border border-transparent",
-                  )}
-                >
-                  <span aria-hidden>{day}</span>
-                  {n > 0 && (
-                    <span className="flex items-center gap-0.5" aria-hidden>
-                      <span className={cn("w-1.5 h-1.5 rounded-full", C.dot)} />
-                      {n > 1 && (
-                        <span className="text-3xs text-subtle tabular-nums">
-                          {n}
-                        </span>
-                      )}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-subtle mt-3 pt-3 border-t border-line">
-            Обрано:{" "}
-            {parseDateKey(selectedDay).toLocaleDateString("uk-UA", {
-              weekday: "long",
-              day: "numeric",
-              month: "long",
-            })}
-          </p>
-          {routine.prefs.showFizrukInCalendar !== false && (
-            <button
-              type="button"
-              onClick={() => setFizrukPlanDateKey(selectedDay)}
-              className="mt-2 w-full rounded-xl border border-sky-400/30 bg-sky-500/5 hover:bg-sky-500/10 px-3 py-2 text-xs font-medium text-sky-600 dark:text-sky-400 transition-colors text-center"
-            >
-              Планувати тренування
-            </button>
-          )}
-          {flatGroupedItems.length > 0 && (
-            <div className="mt-3 space-y-1">
-              {flatGroupedItems.map((item, idx) => {
-                if (item.kind === "header") {
-                  return (
-                    <SectionHeading
-                      key={`dh-${item.label}`}
-                      as="p"
-                      size="xs"
-                      tone="subtle"
-                      className={cn(idx > 0 && "mt-2")}
-                    >
-                      {item.label}
-                    </SectionHeading>
-                  );
-                }
-                const e = item.e;
-                return (
-                  <div
-                    key={`dd-${e.id}`}
-                    role={e.fizruk ? "button" : undefined}
-                    tabIndex={e.fizruk ? 0 : undefined}
-                    onClick={() => e.fizruk && setFizrukPlanDateKey(e.date)}
-                    onKeyDown={(ev) => {
-                      if (e.fizruk && (ev.key === "Enter" || ev.key === " ")) {
-                        ev.preventDefault();
-                        setFizrukPlanDateKey(e.date);
-                      }
-                    }}
-                    className={cn(
-                      "flex items-center gap-2 rounded-xl px-3 py-2 border border-line bg-panel/60",
-                      e.completed && "opacity-70",
-                      e.fizruk && "cursor-pointer hover:bg-sky-500/5",
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "w-1.5 h-1.5 rounded-full shrink-0",
-                        e.fizruk
-                          ? "bg-sky-500"
-                          : e.finykSub
-                            ? "bg-emerald-500"
-                            : C.dot,
-                      )}
-                    />
-                    <span className="flex-1 min-w-0 text-sm font-medium text-text truncate">
-                      {e.title}
-                    </span>
-                    <span className="text-2xs text-subtle shrink-0">
-                      {e.subtitle}
-                    </span>
-                    {e.habitId && (
-                      <button
-                        type="button"
-                        onClick={() => onToggleHabit(e.habitId, e.date)}
-                        className={cn(
-                          "w-7 h-7 rounded-lg border flex items-center justify-center text-xs font-bold transition-colors shrink-0",
-                          e.completed
-                            ? C.done
-                            : "border-line hover:bg-panelHi text-muted",
-                        )}
-                        aria-label={
-                          e.completed ? "Скасувати виконання" : "Виконано"
-                        }
-                      >
-                        {e.completed ? "✓" : "○"}
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {flatGroupedItems.length === 0 && (
-            <p className="mt-2 text-2xs text-subtle text-center">
-              Подій на цей день немає
-            </p>
-          )}
-        </Card>
+        <RoutineCalendarMonthGrid
+          monthCursor={monthCursor}
+          monthTitle={monthTitle}
+          cells={cells}
+          dayCounts={dayCounts}
+          selectedDay={selectedDay}
+          goMonth={goMonth}
+          goToToday={goToToday}
+          onSelectDay={setSelectedDay}
+          showFizrukShortcut={routine.prefs.showFizrukInCalendar !== false}
+          onPlanFizruk={setFizrukPlanDateKey}
+          flatGroupedItems={flatGroupedItems}
+          onToggleHabit={onToggleHabit}
+        />
       )}
 
       <section className="space-y-4 pb-2">


### PR DESCRIPTION
## What changed

Розбив `apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx` (824 рядки) на три файли:

- `components/RoutineCalendarPanel.tsx` (824 → **602 рядки**) — лишилися: data/actions hooks, completion-note draft logic (`noteDrafts` + debounce flush), `flatGroupedItems` мемо, week-strip card, search input, tag-filter chips, list-view (Virtuoso) і модальні sheets.
- `components/RoutineCalendarHero.tsx` (102 рядки) — top hero card з `rangeLabel` / `headlineDate` / `DayProgressRing` / 4 KPI tiles (events count, active habits, completion %, streak). Чисто presentational, отримує всі дані як props.
- `components/RoutineCalendarMonthGrid.tsx` (240 рядків) — увесь month-mode блок: month nav (‹ / місяць / ›), CTA "Сьогодні", 7×N сітка днів з підсвіткою `selectedDay` і дотами на днях з подіями, "Планувати тренування" CTA та inline-список згрупованих подій для обраного дня. Залежить виключно від props (`monthCursor`, `cells`, `dayCounts`, `flatGroupedItems`, …) — жодних внутрішніх стейтів.

Поведінка не змінилася: усі handlers (`setSelectedDay`, `setFizrukPlanDateKey`, `goMonth`, `goToToday`, `onToggleHabit`) лишилися у parent-компоненті і передаються як props.

## Why

Останній з 6 PR-ів плану `docs/structure-refactor-plan.md` § 5.2 (розбити 6 файлів ≥800 рядків):

- ✅ FinykApp.tsx (#773)
- ✅ HubDashboard.tsx (#775)
- ✅ ActiveWorkoutPanel.tsx (#777)
- ✅ Assets.tsx (#779)
- ✅ Transactions.tsx (#780)
- ➡️ **RoutineCalendarPanel.tsx (цей PR)**

Hero — це самостійний presentational-блок (період + KPI). Month grid — це окрема "сторінка" календаря з власною ієрархією, яка ніколи не комбінується з іншими режимами (week/day/list рендеряться окремо). Обидва добре відокремлюються без зміни поведінки.

## How to test

```sh
pnpm --filter @sergeant/web typecheck   # 0 нових помилок (1 pre-existing у financeContext.ts на main)
pnpm --filter @sergeant/web lint        # 0 помилок
pnpm --filter @sergeant/web test -- --run   # 90 файлів / 804 тести passed
```

Smoke-флоу для рев'юера у Hub → Рутина → Календар:
1. Hero card: 4 KPI tiles мають правильні значення; тап на `DayProgressRing` відкриває DayReportSheet.
2. Перемикнути час-режим у `Місяць`: бачиш month nav (‹ / місяць / ›), кнопку "Сьогодні", 7×N сітку, у клітинках з подіями — точку (і число якщо ≥ 2).
3. Тап на день — підсвітка міняється; нижче з'являється список згрупованих подій того дня. Тап на чек-кнопку події → `onToggleHabit` працює, підсвітка чек-стану оновлюється.
4. Тап "Планувати тренування" → відкривається `FizrukDayPlanSheet`.

---

## How AI-tested this PR

- [x] Vitest passes: 90 files / 804 tests passed
- [x] Manual smoke: typecheck + lint clean (1 pre-existing TS error у `financeContext.ts:122` — не моя зміна, відтворюється на чистому main)
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian.

## AGENTS.md updated?

- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a109f350df194bd59d292d64031c6b17
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
