### PR TITLE
fix(web): exclude internal transfers from Finyk day-header total

### DIFF
--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -18,6 +18,7 @@ import {
   writeDayCollapse,
   isDayExpanded,
   formatStickyDayLabel,
+  computeDaySummary,
 } from "./transactionsLib";
 import { TransactionsHeader } from "./TransactionsHeader";
 import { TransactionsBatchToolbar } from "./TransactionsBatchToolbar";
@@ -325,18 +326,17 @@ export function Transactions({
     return groups;
   }, [filtered]);
 
-  // Per-day totals (signed amount in cents, item count). Cheap enough to
-  // compute during grouping, but kept separate so the collapsed-header
-  // summary doesn't force us to touch the hot grouping loop.
+  // Per-day totals (signed amount in cents, item count). Внутрішні
+  // перекази та явно виключені з статистики транзакції НЕ йдуть у
+  // `total` — інакше header-суми розходяться з «Підсумком місяця» і
+  // перекази тихо рахуються як дохід (див. issue про «++15 403,58₴»).
   const daySummaries = useMemo(() => {
-    const map = {};
+    const map: Record<string, ReturnType<typeof computeDaySummary>> = {};
     for (const g of groupedByDate) {
-      let total = 0;
-      for (const t of g.items) total += Number(t.amount || 0);
-      map[g.key] = { total, count: g.items.length };
+      map[g.key] = computeDaySummary(g.items, { excludedTxIds, txSplits });
     }
     return map;
-  }, [groupedByDate]);
+  }, [groupedByDate, excludedTxIds, txSplits]);
 
   // Day collapse/expand state. Persisted as a sparse override map:
   // absence → default rule (only "today" is expanded). Explicit boolean
@@ -529,9 +529,15 @@ export function Transactions({
                 if (!group) return null;
                 const key = group.key;
                 const collapsed = collapsedKeys.has(key);
-                const summary = daySummaries[key] ?? { total: 0, count: 0 };
-                const showTotal = showBalance && summary.count > 0;
-                const sign = summary.total > 0 ? "+" : "";
+                const summary = daySummaries[key] ?? {
+                  total: 0,
+                  count: 0,
+                  statCount: 0,
+                };
+                // Коли у день є тільки «не в статистиці» транзакції, сховати
+                // суму — інакше побачимо «0,00₴» або (як раніше) злиплі
+                // перекази у вигляді доходу.
+                const showTotal = showBalance && summary.statCount > 0;
                 const label = formatStickyDayLabel(key);
                 return (
                   <button
@@ -573,7 +579,7 @@ export function Transactions({
                           summary.total > 0 ? "text-success" : "text-text",
                         )}
                       >
-                        {sign}
+                        {/* fmtAmt сам додає `+`/`-` — не дублюємо префікс. */}
                         {fmtAmt(summary.total, CURRENCY.UAH)}
                       </span>
                     )}

--- a/apps/web/src/modules/finyk/pages/transactionsLib.test.ts
+++ b/apps/web/src/modules/finyk/pages/transactionsLib.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { INTERNAL_TRANSFER_ID } from "@sergeant/finyk-domain/constants";
+import { computeDaySummary } from "./transactionsLib";
+
+describe("computeDaySummary", () => {
+  it("сумує amounts без спліту та без excludes", () => {
+    const s = computeDaySummary([
+      { id: "a", amount: -10000 },
+      { id: "b", amount: 50000 },
+    ]);
+    expect(s).toEqual({ total: 40000, count: 2, statCount: 2 });
+  });
+
+  it("виключає транзакції з excludedTxIds (внутрішні перекази, приховані тощо)", () => {
+    const s = computeDaySummary(
+      [
+        { id: "a", amount: 75000 }, // внутрішній переказ (income)
+        { id: "b", amount: 335000 }, // внутрішній переказ (income)
+        { id: "c", amount: 1130358 }, // реальний дохід
+      ],
+      { excludedTxIds: new Set(["a", "b"]) },
+    );
+    // Лише `c` враховано; збіг з поведінкою «не в статистиці» з TxRow.
+    expect(s).toEqual({ total: 1130358, count: 3, statCount: 1 });
+  });
+
+  it("повертає statCount=0 коли всі транзакції виключені — UI ховає суму", () => {
+    const s = computeDaySummary(
+      [
+        { id: "a", amount: 75000 },
+        { id: "b", amount: 335000 },
+      ],
+      { excludedTxIds: new Set(["a", "b"]) },
+    );
+    expect(s.statCount).toBe(0);
+    expect(s.total).toBe(0);
+    expect(s.count).toBe(2);
+  });
+
+  it("при сплітах сумує лише не-internal_transfer частини, зберігаючи знак", () => {
+    // Витрата -500.00₴ (amount = -50000 копійок), розділена:
+    // 300.00₴ — продукти, 200.00₴ — внутрішній переказ. У день-total
+    // має зайти лише 300.00₴ з правильним знаком (витрата → -30000).
+    const s = computeDaySummary([{ id: "x", amount: -50000 }], {
+      txSplits: {
+        x: [
+          { categoryId: "food", amount: 300 },
+          { categoryId: INTERNAL_TRANSFER_ID, amount: 200 },
+        ],
+      },
+    });
+    expect(s.total).toBe(-30000);
+    expect(s.statCount).toBe(1);
+  });
+
+  it("при сплітах на доходній транзакції віддає позитивну суму", () => {
+    const s = computeDaySummary([{ id: "y", amount: 50000 }], {
+      txSplits: {
+        y: [
+          { categoryId: "in_salary", amount: 400 },
+          { categoryId: INTERNAL_TRANSFER_ID, amount: 100 },
+        ],
+      },
+    });
+    expect(s.total).toBe(40000);
+  });
+
+  it("пустий вхід повертає нулі", () => {
+    expect(computeDaySummary([])).toEqual({
+      total: 0,
+      count: 0,
+      statCount: 0,
+    });
+  });
+});

--- a/apps/web/src/modules/finyk/pages/transactionsLib.ts
+++ b/apps/web/src/modules/finyk/pages/transactionsLib.ts
@@ -1,5 +1,7 @@
 import { STORAGE_KEYS } from "@sergeant/shared";
 import { safeReadLS, safeWriteLS } from "@shared/lib/storage";
+import { INTERNAL_TRANSFER_ID } from "@sergeant/finyk-domain/constants";
+import type { TxSplit, TxSplitsMap } from "@sergeant/finyk-domain/domain/types";
 
 export const DAY_COLLAPSE_KEY = STORAGE_KEYS.FINYK_TX_DAY_COLLAPSE;
 
@@ -47,6 +49,79 @@ export function isDayExpanded(
   _todayKey: string,
 ): boolean {
   return !!overrides[key];
+}
+
+/**
+ * Мінімальний контракт транзакції для підрахунку підсумку дня. Навмисно
+ * вужчий за `Transaction` з finyk-domain — гарантує, що `computeDaySummary`
+ * приймає будь-який список з `amount` / `id` без додаткового casting-у
+ * з боку викликача (MonoStatementItem, manualExpenseTx тощо).
+ */
+export interface DaySummaryTx {
+  id: string;
+  amount: number;
+}
+
+export interface DaySummary {
+  /**
+   * Знакова сума дня в мінорних одиницях (копійках). Позитивне = дохід,
+   * негативне = витрата. Узгоджено з `fmtAmt`, що очікує копійки.
+   */
+  total: number;
+  /** Загальна кількість транзакцій у групі (включно з «не в статистиці»). */
+  count: number;
+  /** Скільки транзакцій реально враховано у `total`. */
+  statCount: number;
+}
+
+function splitStatAmount(splits: readonly TxSplit[]): number {
+  // Сума спліт-частин, що НЕ є внутрішнім переказом. Повертаємо в
+  // мінорних одиницях, щоб не ламати UI-формат (fmtAmt ділить на 100).
+  let sum = 0;
+  for (const s of splits) {
+    if (s.categoryId === INTERNAL_TRANSFER_ID) continue;
+    const a = Number(s.amount) || 0;
+    sum += a;
+  }
+  return Math.round(sum * 100);
+}
+
+/**
+ * Підсумок однієї денної групи транзакцій для sticky-header-а.
+ *
+ * Враховує ті самі виключення, що й `statTx` у `Transactions.tsx`:
+ * - `excludedTxIds` (приховані + внутрішні перекази + дебіторка + явне «не в статистиці»)
+ * - `txSplits` — якщо транзакція має спліт, то у підсумок йде лише сума
+ *   частин, що НЕ позначені як внутрішній переказ.
+ *
+ * Відповідає правилу з AGENTS.md: «перекази між своїми рахунками …
+ * є neted у budget calculations, not summed».
+ */
+export function computeDaySummary(
+  items: readonly DaySummaryTx[],
+  opts: {
+    excludedTxIds?: ReadonlySet<string> | null;
+    txSplits?: TxSplitsMap | null;
+  } = {},
+): DaySummary {
+  const excluded = opts.excludedTxIds;
+  const splitsMap = opts.txSplits ?? {};
+  let total = 0;
+  let statCount = 0;
+  for (const t of items) {
+    const count = !excluded || !excluded.has(t.id);
+    if (!count) continue;
+    const splits = splitsMap[t.id];
+    const amt = Number(t.amount) || 0;
+    if (splits && splits.length > 0) {
+      const sign = amt >= 0 ? 1 : -1;
+      total += sign * splitStatAmount(splits);
+    } else {
+      total += amt;
+    }
+    statCount++;
+  }
+  return { total, count: items.length, statCount };
 }
 
 /**


### PR DESCRIPTION
## What changed

**1. Денний підсумок у «Фінік → Операції» — основна тема PR**
- `computeDaySummary` у `apps/web/src/modules/finyk/pages/transactionsLib.ts` — чиста функція, що рахує підсумок однієї денної групи з урахуванням `excludedTxIds` (приховані + внутрішні перекази + дебіторка + явне «не в статистиці») і `txSplits` (тільки не-`internal_transfer` частини йдуть у total, знак успадковується від транзакції).
- `Transactions.tsx` → `daySummaries` більше не робить наївний `reduce(amount)`; викликає `computeDaySummary`. Якщо усі транзакції дня виключені зі статистики (`statCount === 0`), підсумок ховаємо — інакше користувач побачив би «0,00₴» або, як зараз, злиплі перекази у вигляді доходу.
- Прибрано дубльований префікс «+»: `fmtAmt` сам додає знак для позитиву, а код додатково рендерив `{sign}{fmtAmt(...)}` → у скріншотах виходило «++15 403,58₴».
- Новий `transactionsLib.test.ts` з 6 кейсами, що фіксують поведінку (базовий підсумок, виключення, пустий statCount, спліти на витратах і доходах, порожній вхід).

**2. Супутній typecheck-фікс (CI розблокування)**
- `GetCategorySpendListOptions.txSplits` у `packages/finyk-domain/src/domain/categories.ts` звужений до `Record<string, readonly { categoryId; amount? }[]>`, хоча викликачі (`financeContext`, рекомендації) тримають `TxSplitsLike = Record<string, unknown>` — той самий shape, що вже приймає `calcCategorySpent` під капотом. Ця невідповідність ламала `pnpm --filter @sergeant/web typecheck` на `main` (введена в af80e6c9 / #783) і на кожному наступному PR. Розширив тип до `TxSplitsLike`, щоб контракт функції збігався з її ж реалізацією.

## Why

В операціях Фініка день із лише «внутрішніми переказами» між власними рахунками показував додатний дохід (див. звіт: неділя 12 квітня · 3 · ++15 403,58₴). Формально ці транзакції мають бейдж «не в статистиці» у рядку, але денний header їх усе одно сумував, бо рахував сирий `t.amount` без узгодження з `statTx`/`excludedTxIds`. Це суперечить правилу з AGENTS.md:

> Negative = expense, positive = income. … transfers between own accounts come as a pair (-X on source, +X on destination) and are netted in budget calculations, not summed.

Фікс узгоджує денний підсумок з «Підсумком місяця» та категорійними селекторами (`getMonthlySummary`, `computeCategorySpendIndex`, `getTxStatAmount`), де виключення переказів уже працює.

## How to test

1. Відкрити «Фінік → Операції» у місяці з внутрішнім переказом між власними рахунками (обидві половинки пари).
2. Згорнути/розгорнути день — у хедері має бути сума БЕЗ цих транзакцій; якщо на день лишились лише перекази, сума має не відображатись узагалі.
3. На будь-якому дні з позитивним підсумком перевірити, що префікс тепер єдиний `+` (не `++`).
4. `pnpm --filter @sergeant/web test transactionsLib` має зеленіти (6 тестів).

---

## How AI-tested this PR

- [x] Manual smoke: вкрито кейси юніт-тестами `transactionsLib.test.ts` (включно зі сценарієм скріншота: три income-tx, дві з яких у `excludedTxIds`).
- [x] Vitest passes: `pnpm --filter @sergeant/web test` → 810/810 passed; `pnpm --filter @sergeant/finyk-domain test` → 217/217 passed.
- [x] `pnpm --filter @sergeant/web lint` → clean.
- [x] `pnpm --filter @sergeant/web typecheck` → clean після typecheck-фіксу (до цього падав на main у `financeContext.ts:122`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules