### PR TITLE
fix(finyk-domain): widen getCategorySpendList txSplits to TxSplitsLike

### DIFF
--- a/packages/finyk-domain/src/domain/categories.ts
+++ b/packages/finyk-domain/src/domain/categories.ts
@@ -12,7 +12,7 @@ import {
   getIncomeCategory,
   resolveExpenseCategoryMeta,
 } from "../utils";
-import type { SpendingTxLike } from "../lib/transactions.js";
+import type { SpendingTxLike, TxSplitsLike } from "../lib/transactions.js";
 
 export {
   calcCategorySpent,
@@ -99,10 +99,11 @@ interface CategorySpend extends Category {
 
 export interface GetCategorySpendListOptions {
   txCategories?: Record<string, string | undefined>;
-  txSplits?: Record<
-    string,
-    readonly { categoryId: string; amount?: number }[] | undefined
-  >;
+  // `TxSplitsLike` — навмисно широкий контракт, співпадає з тим, що
+  // приймає `calcCategorySpent`. Так викликачі (web + mobile) можуть
+  // передавати той самий `Record<string, unknown>`, що тримають у
+  // localStorage/MMKV, без додаткового `as` на місці.
+  txSplits?: TxSplitsLike;
   customCategories?: CustomCategory[];
 }
 


### PR DESCRIPTION
## What changed

`GetCategorySpendListOptions.txSplits` у `packages/finyk-domain/src/domain/categories.ts` звужений до `Record<string, readonly { categoryId: string; amount?: number }[] | undefined>`, хоча єдиний реальний callee всередині (`calcCategorySpent`) уже приймає ширший `TxSplitsLike = Record<string, unknown>`. Викликачі в `apps/web` (`core/lib/recommendations/financeContext.ts`, рекомендації) тримають саме `TxSplitsLike`, бо читають JSON з `localStorage` без строгого cast-у. Розширив тип опції до `TxSplitsLike`, щоб публічний контракт збігався з внутрішньою реалізацією.

## Why

Невідповідність типів ламає `pnpm --filter @sergeant/web typecheck` на `main` (введено в af80e6c9 при `fix(web): eliminate duplicated finyk-domain logic in Hub`, бачу у CI-логах PR #783 ту саму помилку). Кожен новий PR у репо зараз успадковує red `check` job, поки тип не зафіксовано. Сам ран `pnpm --filter @sergeant/web typecheck` до фіксу падає на `financeContext.ts:122`; після — зелений.

## How to test

```
pnpm install --frozen-lockfile
pnpm --filter @sergeant/web typecheck      # має пройти без помилок
pnpm --filter @sergeant/finyk-domain test  # 217/217 passed
```

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/finyk-domain test` → 217/217 passed (існуючі тести `categories.test.ts` включно).
- [x] `pnpm --filter @sergeant/web typecheck` → clean (раніше падав на `financeContext.ts:122`).
- [x] `pnpm --filter @sergeant/web test` → 810/810 passed.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
