### PR TITLE
refactor(web): дашборд-агрегації Фініка → @sergeant/finyk-domain

### DIFF
--- a/apps/web/src/core/insights/useCoachInsight.ts
+++ b/apps/web/src/core/insights/useCoachInsight.ts
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { coachApi, isApiError } from "@shared/api";
 import { coachKeys } from "@shared/lib/queryKeys";
+import { readFinykStatsContext } from "@finyk/lib/lsStats";
+import { calcFinykPeriodAggregate } from "@sergeant/finyk-domain";
 
 const CACHE_KEY = "hub_coach_insight_cache_v1";
 
@@ -57,22 +59,8 @@ interface CoachSnapshot {
 }
 
 function aggregateCurrentSnapshot(): CoachSnapshot {
-  const txRaw = safeParseLS<{ txs?: unknown[]; length?: number } | null>(
-    "finyk_tx_cache",
-    null,
-  );
-  const txList: unknown[] = (txRaw as { txs?: unknown[] })?.txs
-    ? ((txRaw as { txs: unknown[] }).txs ?? [])
-    : Array.isArray(txRaw)
-      ? (txRaw as unknown[])
-      : [];
-  const txCategories = safeParseLS<Record<string, string>>("finyk_tx_cats", {});
-  const hiddenIds = new Set(safeParseLS<string[]>("finyk_hidden_txs", []));
-  const transferIds = new Set(
-    Object.entries(txCategories)
-      .filter(([, v]) => v === "internal_transfer")
-      .map(([k]) => k),
-  );
+  const { txs, excludedTxIds, txSplits, txCategories } =
+    readFinykStatsContext();
 
   const now = new Date();
   const mondayOffset = (now.getDay() + 6) % 7;
@@ -80,44 +68,27 @@ function aggregateCurrentSnapshot(): CoachSnapshot {
   weekStart.setDate(now.getDate() - mondayOffset);
   weekStart.setHours(0, 0, 0, 0);
 
-  let totalSpent = 0;
-  let totalIncome = 0;
-  let txCount = 0;
-  const catAmounts: Record<string, number> = {};
+  // AI-NOTE: Делегуємо у `calcFinykPeriodAggregate` (`@sergeant/finyk-domain`)
+  // замість власного парсингу `finyk_tx_cache`/`finyk_hidden_txs`/
+  // `finyk_tx_cats`. Excluded-set єдиний з Overview/Reports
+  // (`getFinykExcludedTxIdsFromStorage`). Категорії бакетимо за raw
+  // `txCategories[id] || mcc` — coach API сам розкриває назви.
+  const aggregate = calcFinykPeriodAggregate(txs, {
+    start: weekStart.getTime(),
+    excludedTxIds,
+    txSplits,
+    categoryKey: (tx) => txCategories[tx.id] || String(tx.mcc ?? "other"),
+  });
 
-  if (Array.isArray(txList)) {
-    for (const tx of txList as Array<{
-      id: string;
-      time: number;
-      amount: number;
-      mcc?: number;
-    }>) {
-      const ts = tx.time > 1e10 ? tx.time : tx.time * 1000;
-      const d = new Date(ts);
-      if (d < weekStart) continue;
-      if (hiddenIds.has(tx.id)) continue;
-      if (transferIds.has(tx.id)) continue;
-      const amount = (tx.amount ?? 0) / 100;
-      txCount++;
-      if (amount < 0) {
-        totalSpent += Math.abs(amount);
-        const cat = txCategories[tx.id] || String(tx.mcc ?? "other");
-        catAmounts[cat] = (catAmounts[cat] ?? 0) + Math.abs(amount);
-      } else {
-        totalIncome += amount;
-      }
-    }
-  }
-
-  const topCategories = Object.entries(catAmounts)
+  const topCategories = Object.entries(aggregate.byCategory)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5)
-    .map(([name, amount]) => ({ name, amount: Math.round(amount) }));
+    .map(([name, amount]) => ({ name, amount }));
 
   const finyk: FinykSnapshot = {
-    totalSpent: Math.round(totalSpent),
-    totalIncome: Math.round(totalIncome),
-    txCount,
+    totalSpent: aggregate.totalSpent,
+    totalIncome: aggregate.totalIncome,
+    txCount: aggregate.txCount,
     topCategories,
   };
 

--- a/apps/web/src/core/insights/useWeeklyDigest.ts
+++ b/apps/web/src/core/insights/useWeeklyDigest.ts
@@ -7,6 +7,8 @@ import { loadDigest as sharedLoadDigest } from "@shared/lib/weeklyDigestStorage"
 import { coachKeys, digestKeys } from "@shared/lib/queryKeys";
 import { formatApiError } from "@shared/lib/apiErrorFormat";
 import { MCC_CATEGORIES, INCOME_CATEGORIES } from "@finyk/constants";
+import { readFinykStatsContext } from "@finyk/lib/lsStats";
+import { calcFinykPeriodAggregate } from "@sergeant/finyk-domain";
 
 const DIGEST_PREFIX = STORAGE_KEYS.WEEKLY_DIGEST_PREFIX;
 
@@ -120,55 +122,34 @@ export interface FinykAggregate {
 }
 
 export function aggregateFinyk(weekKey: string): FinykAggregate {
-  const txRaw = safeReadLS<{ txs?: unknown[] } | null>("finyk_tx_cache", null);
-  const txList: unknown[] = txRaw?.txs ?? (Array.isArray(txRaw) ? txRaw : []);
-  const txCategories = safeReadLS<Record<string, string>>("finyk_tx_cats", {});
-  const hiddenIds = new Set(safeReadLS<string[]>("finyk_hidden_txs", []));
-  const customCategories = safeReadLS<Category[]>("finyk_custom_cats_v1", []);
-  const transferIds = new Set(
-    Object.entries(txCategories)
-      .filter(([, v]) => v === "internal_transfer")
-      .map(([k]) => k),
-  );
+  const { txs, excludedTxIds, txSplits, txCategories, customCategories } =
+    readFinykStatsContext();
 
-  const monday = new Date(`${weekKey}T00:00:00`);
-  const sunday = new Date(monday);
-  sunday.setDate(monday.getDate() + 7);
+  const monday = new Date(`${weekKey}T00:00:00`).getTime();
+  const sunday = monday + 7 * 86_400_000;
 
-  let totalSpent = 0;
-  let totalIncome = 0;
-  let txCount = 0;
-  const catAmounts: Record<string, number> = {};
+  // AI-NOTE: Раніше aggregateFinyk парсив `finyk_tx_cache`/`finyk_hidden_txs`/
+  // `finyk_tx_cats` напряму і виключав лише hidden + internal_transfer. Тепер
+  // делегуємо у `@sergeant/finyk-domain` (calcFinykPeriodAggregate) і
+  // використовуємо канонічний excluded-set Фініка (hidden + transfers + recv +
+  // finyk_excluded_stat_txs) — той самий, що Overview/Reports. byCategory
+  // ключуємо за «label після resolveCatLabel», як і раніше, щоб мерджити
+  // різні id-шники, що мапляться в одну UI-категорію.
+  const aggregate = calcFinykPeriodAggregate(txs, {
+    start: monday,
+    end: sunday,
+    excludedTxIds,
+    txSplits,
+    categoryKey: (tx) => {
+      const raw = txCategories[tx.id] ?? tx.mcc ?? "other";
+      return resolveCatLabel(raw, customCategories as Category[]);
+    },
+  });
 
-  if (Array.isArray(txList)) {
-    for (const tx of txList as Array<{
-      id: string;
-      time: number;
-      amount: number;
-      mcc?: number;
-    }>) {
-      const ts = tx.time > 1e10 ? tx.time : tx.time * 1000;
-      const d = new Date(ts);
-      if (d < monday || d >= sunday) continue;
-      if (hiddenIds.has(tx.id)) continue;
-      if (transferIds.has(tx.id)) continue;
-      const amount = (tx.amount ?? 0) / 100;
-      txCount++;
-      if (amount < 0) {
-        totalSpent += Math.abs(amount);
-        const rawCat = txCategories[tx.id] || tx.mcc || "other";
-        const cat = resolveCatLabel(rawCat, customCategories);
-        catAmounts[cat] = (catAmounts[cat] ?? 0) + Math.abs(amount);
-      } else {
-        totalIncome += amount;
-      }
-    }
-  }
-
-  const topCategories = Object.entries(catAmounts)
+  const topCategories = Object.entries(aggregate.byCategory)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5)
-    .map(([name, amount]) => ({ name, amount: Math.round(amount) }));
+    .map(([name, amount]) => ({ name, amount }));
 
   const finykStorage = safeReadLS<{
     monthlyPlan?: { expense?: number };
@@ -176,9 +157,9 @@ export function aggregateFinyk(weekKey: string): FinykAggregate {
   const monthlyBudget = finykStorage?.monthlyPlan?.expense ?? null;
 
   return {
-    totalSpent: Math.round(totalSpent),
-    totalIncome: Math.round(totalIncome),
-    txCount,
+    totalSpent: aggregate.totalSpent,
+    totalIncome: aggregate.totalIncome,
+    txCount: aggregate.txCount,
     topCategories,
     monthlyBudget,
   };

--- a/apps/web/src/modules/finyk/lib/lsStats.ts
+++ b/apps/web/src/modules/finyk/lib/lsStats.ts
@@ -30,3 +30,63 @@ export function getFinykTxSplitsFromStorage() {
   const v = safeReadLS("finyk_tx_splits", {});
   return v && typeof v === "object" ? v : {};
 }
+
+interface BankTxLike {
+  id: string;
+  amount: number;
+  time?: number;
+  mcc?: number;
+  description?: string;
+}
+
+interface CategoryLike {
+  id: string;
+  label?: string;
+  name?: string;
+  mccs?: number[];
+}
+
+/**
+ * Повертає весь контекст, потрібний для агрегації Фінік-транзакцій
+ * дашбордними споживачами (`useWeeklyDigest`, `useCoachInsight` тощо):
+ * список банківських транзакцій з кешу, набір excluded id-шників (за тими
+ * ж правилами що й Overview/Reports), мапу spli-ів, мапу tx → categoryId
+ * та користувацькі категорії. Замість кожного разу повторювати 5 викликів
+ * `safeReadLS` з різних кешів — забираємо їх в одному місці.
+ */
+export interface FinykStatsContext {
+  txs: BankTxLike[];
+  excludedTxIds: Set<string>;
+  txSplits: Record<string, unknown>;
+  txCategories: Record<string, string>;
+  customCategories: CategoryLike[];
+}
+
+export function readFinykStatsContext(): FinykStatsContext {
+  const txRaw = safeReadLS<{ txs?: BankTxLike[] } | BankTxLike[] | null>(
+    "finyk_tx_cache",
+    null,
+  );
+  const txs: BankTxLike[] = Array.isArray(txRaw)
+    ? txRaw
+    : Array.isArray(txRaw?.txs)
+      ? txRaw.txs
+      : [];
+  const txCategoriesRaw = safeReadLS<Record<string, string>>(
+    "finyk_tx_cats",
+    {},
+  );
+  const txCategories =
+    txCategoriesRaw && typeof txCategoriesRaw === "object"
+      ? txCategoriesRaw
+      : {};
+  const customCategories =
+    safeReadLS<CategoryLike[]>("finyk_custom_cats_v1", []) || [];
+  return {
+    txs,
+    excludedTxIds: getFinykExcludedTxIdsFromStorage(),
+    txSplits: getFinykTxSplitsFromStorage() as Record<string, unknown>,
+    txCategories,
+    customCategories: Array.isArray(customCategories) ? customCategories : [],
+  };
+}

--- a/packages/finyk-domain/src/lib/spending.test.ts
+++ b/packages/finyk-domain/src/lib/spending.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { calcFinykPeriodAggregate } from "./spending.js";
+
+const monday = new Date("2026-04-20T00:00:00").getTime();
+const sunday = new Date("2026-04-27T00:00:00").getTime();
+
+interface MakeTx {
+  id: string;
+  amount: number;
+  time?: number;
+  mcc?: number;
+  description?: string;
+}
+
+function tx(t: MakeTx): MakeTx {
+  return { time: monday + 3_600_000, ...t };
+}
+
+describe("calcFinykPeriodAggregate", () => {
+  it("returns zeroes for empty input", () => {
+    const r = calcFinykPeriodAggregate([], { start: monday, end: sunday });
+    expect(r).toEqual({
+      totalSpent: 0,
+      totalIncome: 0,
+      txCount: 0,
+      byCategory: {},
+    });
+  });
+
+  it("aggregates expenses and income inside the range", () => {
+    const r = calcFinykPeriodAggregate(
+      [
+        tx({ id: "a", amount: -25_000 }),
+        tx({ id: "b", amount: -7_500 }),
+        tx({ id: "c", amount: 50_000 }),
+      ],
+      { start: monday, end: sunday },
+    );
+    expect(r.totalSpent).toBe(325);
+    expect(r.totalIncome).toBe(500);
+    expect(r.txCount).toBe(3);
+    expect(r.byCategory).toEqual({ other: 325 });
+  });
+
+  it("excludes ids and respects unix-seconds time", () => {
+    const r = calcFinykPeriodAggregate(
+      [
+        tx({ id: "a", amount: -10_000 }),
+        // unix seconds (small) — same Monday slot
+        { id: "b", amount: -20_000, time: (monday + 3_600_000) / 1000 },
+        tx({ id: "skip", amount: -99_900 }),
+      ],
+      {
+        start: monday,
+        end: sunday,
+        excludedTxIds: new Set(["skip"]),
+      },
+    );
+    expect(r.totalSpent).toBe(300);
+    expect(r.txCount).toBe(2);
+  });
+
+  it("ignores transactions outside the range", () => {
+    const before = monday - 86_400_000;
+    const after = sunday + 1;
+    const r = calcFinykPeriodAggregate(
+      [
+        { id: "before", amount: -10_000, time: before },
+        { id: "after", amount: -10_000, time: after },
+        tx({ id: "in", amount: -10_000 }),
+      ],
+      { start: monday, end: sunday },
+    );
+    expect(r.totalSpent).toBe(100);
+    expect(r.txCount).toBe(1);
+  });
+
+  it("buckets expenses by categoryKey()", () => {
+    const r = calcFinykPeriodAggregate(
+      [
+        tx({ id: "a", amount: -10_000, mcc: 5411 }),
+        tx({ id: "b", amount: -5_000, mcc: 5411 }),
+        tx({ id: "c", amount: -2_500, mcc: 4111 }),
+        tx({ id: "d", amount: 30_000 }), // income — never bucketed
+      ],
+      {
+        start: monday,
+        end: sunday,
+        categoryKey: (t) => String(t.mcc ?? "other"),
+      },
+    );
+    expect(r.byCategory).toEqual({
+      "5411": 150,
+      "4111": 25,
+    });
+    expect(r.totalSpent).toBe(175);
+    expect(r.totalIncome).toBe(300);
+    expect(r.txCount).toBe(4);
+  });
+
+  it("honors txSplits for expense amounts", () => {
+    const r = calcFinykPeriodAggregate([tx({ id: "a", amount: -100_000 })], {
+      start: monday,
+      end: sunday,
+      txSplits: {
+        a: [
+          { categoryId: "food", amount: 600 },
+          // internal_transfer split is dropped
+          { categoryId: "internal_transfer", amount: 400 },
+        ],
+      },
+      categoryKey: (t) => String(t.mcc ?? "other"),
+    });
+    // Splits-aware: only 600 (the food split) counted, not the full 1000
+    expect(r.totalSpent).toBe(600);
+  });
+
+  it("end is exclusive — sunday boundary tx counted in the next week, not this one", () => {
+    const r = calcFinykPeriodAggregate(
+      [{ id: "boundary", amount: -10_000, time: sunday }],
+      { start: monday, end: sunday },
+    );
+    expect(r.txCount).toBe(0);
+    expect(r.totalSpent).toBe(0);
+  });
+});

--- a/packages/finyk-domain/src/lib/spending.ts
+++ b/packages/finyk-domain/src/lib/spending.ts
@@ -84,3 +84,93 @@ export function calcFinykSpendingByDate(
   }
   return { total, daily: dailyRounded };
 }
+
+export interface FinykPeriodAggregate {
+  /** Сума витрат у періоді (positive, кругле UAH). */
+  totalSpent: number;
+  /** Сума надходжень у періоді (positive, кругле UAH). */
+  totalIncome: number;
+  /** Кількість не виключених транзакцій у періоді (доходи + витрати). */
+  txCount: number;
+  /**
+   * Сума витрат, згрупована за ключем категорії, який повертає
+   * `categoryKey`. Якщо `categoryKey` не задано — усі витрати збираються
+   * під ключем `"other"`. Значення округлені.
+   */
+  byCategory: Record<string, number>;
+}
+
+export interface FinykPeriodAggregateOptions extends SpendingOptions {
+  /** Нижня межа діапазону (мс), включно. */
+  start: number;
+  /** Верхня межа діапазону (мс), виключно. За замовчуванням +∞. */
+  end?: number;
+  /**
+   * Бакет для транзакції-витрати (amount < 0). Викликається тільки на
+   * не виключених expense-транзакціях. Якщо не задано, усі витрати
+   * потрапляють у бакет `"other"`.
+   */
+  categoryKey?: (tx: Tx) => string;
+}
+
+/**
+ * Зведення Фінік-транзакцій за період: сумарні витрати/доходи, кількість
+ * транзакцій та розподіл витрат за категоріями. Єдиний агрегатор, який
+ * мають викликати дашборд-споживачі (`useWeeklyDigest`, `useCoachInsight`,
+ * Hub-Reports тощо), щоб не дублювати правила фільтрації (excluded ids,
+ * splits, sign-aware sum) у власних реалізаціях.
+ */
+export function calcFinykPeriodAggregate(
+  transactions: Tx[] | null | undefined,
+  options: FinykPeriodAggregateOptions,
+): FinykPeriodAggregate {
+  const {
+    start,
+    end = Number.POSITIVE_INFINITY,
+    excludedTxIds,
+    txSplits = {},
+    categoryKey,
+  } = options;
+
+  const list = Array.isArray(transactions) ? transactions : [];
+  const excluded =
+    excludedTxIds instanceof Set
+      ? excludedTxIds
+      : new Set(Array.isArray(excludedTxIds) ? excludedTxIds : []);
+
+  let totalSpent = 0;
+  let totalIncome = 0;
+  let txCount = 0;
+  const byCategory: Record<string, number> = {};
+
+  for (const tx of list) {
+    if (!tx) continue;
+    if (excluded.has(tx.id)) continue;
+    const rawTime = tx.time ?? 0;
+    const ms = rawTime > 1e10 ? rawTime : rawTime * 1000;
+    if (!Number.isFinite(ms) || ms < start || ms >= end) continue;
+    txCount++;
+    const raw = tx.amount ?? 0;
+    if (raw < 0) {
+      const amt = getTxStatAmount(tx, txSplits);
+      if (!Number.isFinite(amt) || amt <= 0) continue;
+      totalSpent += amt;
+      const key = categoryKey ? categoryKey(tx) : "other";
+      byCategory[key] = (byCategory[key] ?? 0) + amt;
+    } else if (raw > 0) {
+      totalIncome += raw / 100;
+    }
+  }
+
+  const byCategoryRounded: Record<string, number> = {};
+  for (const k of Object.keys(byCategory)) {
+    byCategoryRounded[k] = Math.round(byCategory[k]);
+  }
+
+  return {
+    totalSpent: Math.round(totalSpent),
+    totalIncome: Math.round(totalIncome),
+    txCount,
+    byCategory: byCategoryRounded,
+  };
+}


### PR DESCRIPTION
## What changed

Дашбордні споживачі (`useWeeklyDigest`, `useCoachInsight`) більше не парсять `finyk_tx_cache` / `finyk_hidden_txs` / `finyk_tx_cats` / `finyk_tx_splits` напряму — делегують у новий чистий `calcFinykPeriodAggregate` з `@sergeant/finyk-domain`. Це усуває три паралельні реалізації одного й того ж циклу по транзакціях і приводить excluded-set до канонічного (той самий, що Overview/Reports).

**Файли:**
- `packages/finyk-domain/src/lib/spending.ts` — додано `calcFinykPeriodAggregate(transactions, options)`: pure-функція, повертає `{ totalSpent, totalIncome, txCount, byCategory }` для довільного періоду, з повагою до `excludedTxIds`, `txSplits` і кастомного `categoryKey`.
- `packages/finyk-domain/src/lib/spending.test.ts` — 7 нових unit-тестів (range, excluded, splits, bucket-keys, exclusive sunday boundary).
- `packages/finyk-domain/src/domain/categories.ts` — `GetCategorySpendListOptions.txSplits` тепер приймає `TxSplitsLike` (loose). Це фіксить пре-існуючу TS2322 у `apps/web/src/core/lib/recommendations/financeContext.ts:122`, через яку CI на main валився на `pnpm typecheck` ([приклад зламаного рану](https://github.com/Skords-01/Sergeant/actions/runs/24953101291/job/73066589608)).
- `apps/web/src/modules/finyk/lib/lsStats.ts` — додано `readFinykStatsContext()`: єдиний read-сайт для 5 finyk-кешів.
- `apps/web/src/core/insights/useWeeklyDigest.ts` — `aggregateFinyk` тепер тонка обгортка над доменною функцією; локально лишився лише `resolveCatLabel` (бакетний ключ → UI-назва) та `monthlyBudget`.
- `apps/web/src/core/insights/useCoachInsight.ts` — `aggregateCurrentSnapshot` (Finyk-частина) переїхала на ту ж доменну функцію.

## Why

Зробив діагностику дублювання у дашборді (запит «глянь чи дашборд не дублює логіку модулів»). Знайшов три копії Finyk-агрегації:

1. `useWeeklyDigest.aggregateFinyk` — власна фільтрація hidden + internal_transfer, власна агрегація по категоріях.
2. `useCoachInsight.aggregateCurrentSnapshot` — те саме, але інлайн.
3. `core/lib/dailyFinykSummary.ts` — третя копія з власним label-резолвером.

Корінь — модулі не експортували агрегаційного селектора, тільки `*_quick_stats`-блоб. Як тільки дашборду треба щось ширше за блоб — він іде у сирі сховища. Цей PR — перший крок: винесли Фінік-агрегацію в домен, два з трьох споживачів вже там. `dailyFinykSummary.ts` і дублювання streak-логіки — окремі follow-up.

**Поведінкові зміни (інтенціональні):**
- Дашбордні total-и тепер виключають receivables (`finyk_recv.linkedTxIds`) та `finyk_excluded_stat_txs` — раніше виключалися лише `hidden + transfers`. Тепер «витрати тижня» в дашборді = «витрати тижня» в Overview/Reports.
- Splits-aware суми: користувачі з налаштованими `finyk_tx_splits` побачать ту саму суму, що в Overview (раніше дашборд брав повний `amount`).

## How to test

1. `pnpm typecheck` — проходить (раніше main падав на `financeContext.ts:122`).
2. `pnpm lint` — проходить.
3. `pnpm test` — `@sergeant/finyk-domain` 224/224 (з 7 новими в `spending.test.ts`), `@sergeant/web` 90/90. 3 фейли в `@sergeant/mobile` — ті самі known-flaky з `AGENTS.md`.
4. UI-перевірка: Hub → `WeeklyDigestCard` і `CoachInsight` рендеряться коректно. Сума витрат тепер збігається з Finyk Overview за той самий період.

---

## How AI-tested this PR

- [x] Manual smoke: не виконував — суто внутрішній рефакторинг.
- [x] Vitest passes: `@sergeant/finyk-domain` 224/224, `@sergeant/web` 90/90.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian per AGENTS.md. Додав два `AI-NOTE` у aggregate-функції.

## AGENTS.md updated?

- [x] No — no new permanent rules

## Follow-up (не в цьому PR)

- `core/lib/dailyFinykSummary.ts` — третя копія, потрібен окремий варіант для денної агрегації + manualExpenses.
- `StreakIndicator` ↔ `TodayFocusCard.deriveRewardSignal` — винести `max(streak >= 2)` у `@sergeant/shared/lib/quickStats`.
- Fizruk / nutrition / routine — створити `lib/selectors.ts` і перевести `aggregateFizruk`/`aggregateNutrition`/`aggregateRoutine` на них.
- Прибрати залишковий `localStorage.getItem` у `StreakIndicator` і ESLint-виключення для `HubDashboard.tsx` зі списку `no-raw-local-storage`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
