### PR TITLE
docs(docs): add debug-chat-tool, add-push-notification, enable-prompt-caching playbooks

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -8,27 +8,30 @@ Each playbook is a checklist that **AI agents and human developers** can follow 
 
 ## Available Playbooks
 
-| Playbook                                                                       | Trigger                                                                           |
-| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| [add-feature-flag.md](add-feature-flag.md)                                     | "Put feature X behind a flag" / new experimental feature                          |
-| [cleanup-dead-code.md](cleanup-dead-code.md)                                   | "Remove X and all its usages" / dead code cleanup                                 |
-| [hotfix-prod-regression.md](hotfix-prod-regression.md)                         | "Прод впав" / HTTP 500 на `/health` / Sentry alert / production incident response |
-| [add-monobank-event-handler.md](add-monobank-event-handler.md)                 | "Треба обробити нову подію X від Monobank" / новий тип webhook event              |
-| [bump-dep-safely.md](bump-dep-safely.md)                                       | "Оновити X до версії Y" / Renovate major-bump / security advisory                 |
-| [add-sql-migration.md](add-sql-migration.md)                                   | "Додати нове поле / таблицю в БД" / зміна схеми PostgreSQL                        |
-| [rotate-secrets.md](rotate-secrets.md)                                         | "Secret leaked" / планова ротація / security audit                                |
-| [add-new-page-route.md](add-new-page-route.md)                                 | "Додати нову сторінку в apps/web" / новий route для SPA                           |
-| [migrate-localstorage-to-typedstore.md](migrate-localstorage-to-typedstore.md) | Мігрувати файл з прямого localStorage на typedStore (tech debt #2)                |
-| [fix-exhaustive-deps.md](fix-exhaustive-deps.md)                               | Виправити exhaustive-deps warnings / React hooks cleanup                          |
-| [port-web-screen-to-mobile.md](port-web-screen-to-mobile.md)                   | "Перенести екран X з apps/web в apps/mobile" / React Native міграція              |
-| [add-api-endpoint.md](add-api-endpoint.md)                                     | "Додати новий endpoint в apps/server" / нова API-функціональність                 |
-| [onboard-external-api.md](onboard-external-api.md)                             | "Інтегрувати нову зовнішню API" / новий third-party сервіс                        |
-| [investigate-alert.md](investigate-alert.md)                                   | Prometheus alert спрацював / Sentry alert / деградація `/health`                  |
-| [add-hubchat-tool.md](add-hubchat-tool.md)                                     | «Дай асистенту нову дію X» / новий tool-call для Anthropic-асистента              |
-| [add-react-query-hook.md](add-react-query-hook.md)                             | Новий `useQuery` / `useMutation` у `apps/web` / нова server-state дата            |
-| [add-onboarding-step.md](add-onboarding-step.md)                               | «Додай новий крок в онбординг» / новий FTUX-етап для нових юзерів                 |
-| [tune-system-prompt.md](tune-system-prompt.md)                                 | «AI відповідає не так як треба» / зміна тону / правил tool-calling                |
-| [stabilize-flaky-test.md](stabilize-flaky-test.md)                             | «Тест X падає 1 з 5 разів» / тест у AGENTS.md flaky-list                          |
+| Playbook                                                                       | Trigger                                                                                                         |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [add-feature-flag.md](add-feature-flag.md)                                     | "Put feature X behind a flag" / new experimental feature                                                        |
+| [cleanup-dead-code.md](cleanup-dead-code.md)                                   | "Remove X and all its usages" / dead code cleanup                                                               |
+| [hotfix-prod-regression.md](hotfix-prod-regression.md)                         | "Прод впав" / HTTP 500 на `/health` / Sentry alert / production incident response                               |
+| [add-monobank-event-handler.md](add-monobank-event-handler.md)                 | "Треба обробити нову подію X від Monobank" / новий тип webhook event                                            |
+| [bump-dep-safely.md](bump-dep-safely.md)                                       | "Оновити X до версії Y" / Renovate major-bump / security advisory                                               |
+| [add-sql-migration.md](add-sql-migration.md)                                   | "Додати нове поле / таблицю в БД" / зміна схеми PostgreSQL                                                      |
+| [rotate-secrets.md](rotate-secrets.md)                                         | "Secret leaked" / планова ротація / security audit                                                              |
+| [add-new-page-route.md](add-new-page-route.md)                                 | "Додати нову сторінку в apps/web" / новий route для SPA                                                         |
+| [migrate-localstorage-to-typedstore.md](migrate-localstorage-to-typedstore.md) | Мігрувати файл з прямого localStorage на typedStore (tech debt #2)                                              |
+| [fix-exhaustive-deps.md](fix-exhaustive-deps.md)                               | Виправити exhaustive-deps warnings / React hooks cleanup                                                        |
+| [port-web-screen-to-mobile.md](port-web-screen-to-mobile.md)                   | "Перенести екран X з apps/web в apps/mobile" / React Native міграція                                            |
+| [add-api-endpoint.md](add-api-endpoint.md)                                     | "Додати новий endpoint в apps/server" / нова API-функціональність                                               |
+| [onboard-external-api.md](onboard-external-api.md)                             | "Інтегрувати нову зовнішню API" / новий third-party сервіс                                                      |
+| [investigate-alert.md](investigate-alert.md)                                   | Prometheus alert спрацював / Sentry alert / деградація `/health`                                                |
+| [add-hubchat-tool.md](add-hubchat-tool.md)                                     | «Дай асистенту нову дію X» / новий tool-call для Anthropic-асистента                                            |
+| [add-react-query-hook.md](add-react-query-hook.md)                             | Новий `useQuery` / `useMutation` у `apps/web` / нова server-state дата                                          |
+| [add-onboarding-step.md](add-onboarding-step.md)                               | «Додай новий крок в онбординг» / новий FTUX-етап для нових юзерів                                               |
+| [tune-system-prompt.md](tune-system-prompt.md)                                 | «AI відповідає не так як треба» / зміна тону / правил tool-calling                                              |
+| [debug-chat-tool.md](debug-chat-tool.md)                                       | «Асистент каже що зробив, але нічого не сталось» / `Невідома дія: …` / tool call повернувся текстом замість дії |
+| [add-push-notification.md](add-push-notification.md)                           | «Надсилай push коли X» / нагадування / реакція на подію (Mono webhook, AI insight, scheduler)                   |
+| [enable-prompt-caching.md](enable-prompt-caching.md)                           | «Зменшити cost Anthropic» / `SYSTEM_PREFIX` повторюється на кожному запиті — ввімкнути prompt caching           |
+| [stabilize-flaky-test.md](stabilize-flaky-test.md)                             | «Тест X падає 1 з 5 разів» / тест у AGENTS.md flaky-list                                                        |
 
 ## How to Use
 

--- a/docs/playbooks/add-push-notification.md
+++ b/docs/playbooks/add-push-notification.md
@@ -1,0 +1,172 @@
+# Playbook: Add Push Notification
+
+**Trigger:** «Надсилай push коли X» / «Додати новий тип сповіщення» / нагадування / реакція на зовнішню подію (Mono webhook, AI insight, scheduler).
+
+---
+
+## Контекст
+
+Push-інфраструктура вже зібрана (див. `apps/server/src/push/` і `apps/server/src/lib/webpushSend.ts`):
+
+- **Контракт payload** — `PushPayload` у `packages/shared/src/types/index.ts` (cross-package: web SW, mobile handler, server `sendToUser`).
+- **Server fan-out** — `sendToUser(userId, payload)` з `apps/server/src/push/send.ts`. Читає з `push_devices` + `push_subscriptions`, паралельно б'є APNs/FCM/web-push, повертає аґреговану статистику. Не throw-ає; помилки конкретного каналу повертає у `errors[]`.
+- **Quiet variant** — `sendToUserQuietly(userId, payload)` для fire-and-forget (наприклад, всередині handler-а, що не має валитись через push).
+- **Client SW** (web) — `apps/web/src/sw.ts` рядок ~627, `self.addEventListener("push", …)`. Розпаковує JSON payload, показує `Notification` з `payload.title`, `payload.body`, `data.module` (для click-routing у `notificationclick`).
+- **VAPID** — `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_EMAIL` у `.env` (опціонально, без них web-push мовчки skip-ається).
+
+Додавання нового **типу** push-у — це не новий transport, а нова **точка тригера** + (опціонально) новий routing у SW.
+
+---
+
+## Steps
+
+### 1. Визнач тригер
+
+Запитай: коли саме push має полетіти?
+
+| Тип тригера                       | Куди вставити                                                                                                                                  |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Реакція на user-action (POST/PUT) | Всередині відповідного handler-а в `apps/server/src/modules/<domain>/`, після успішного write.                                                 |
+| Mono webhook event                | `apps/server/src/modules/monoWebhook/`. Див. `add-monobank-event-handler.md` для скелета.                                                      |
+| Періодичний (раз на день/тиждень) | Додай як HTTP endpoint, що тригериться зовнішнім cron-ом (Railway scheduler / GitHub Action). У репо немає вбудованого in-process scheduler-а. |
+| Side effect AI insight            | Дивись `coach.ts` як приклад: викликає `sendToUserQuietly` після генерації insight-а.                                                          |
+
+**Не клади** push логіку в `chat.ts` (порушує тонко-passthrough архітектуру; див. `AGENTS.md`).
+
+### 2. Сформуй payload
+
+Використовуй `PushPayload` з `@sergeant/shared`:
+
+```ts
+import type { PushPayload } from "@sergeant/shared";
+
+const payload: PushPayload = {
+  title: "Новий ліміт у Фінік",
+  body: "Ти витратив 80% місячного бюджету «Кафе».",
+  data: { module: "finyk", route: "/finyk/budgets" },
+  url: "/finyk/budgets",
+  threadId: "finyk-budget-warning",
+  badge: 1,
+};
+```
+
+Правила:
+
+- **`title` обов'язковий.** APNs / FCM / web-push всі вимагають.
+- **`body` коротко й конкретно.** Без «Привіт, ти ж знаєш, що…»; iOS обрізає на ~110 символів.
+- **`data.module`** використовується SW для click-routing (`apps/web/src/sw.ts` `notificationclick`). Якщо новий тип належить існуючому модулю — постав його значення (`finyk`/`fizruk`/`nutrition`/`routine`); якщо ні — вирішуй чи додавати новий case у SW (крок 4).
+- **`threadId`** групує нотифікації на iOS у єдиний thread (наприклад, всі бюджет-warning у одну групу). Без нього кожен push — окремий thread.
+- **`silent: true`** тільки якщо це реально data-only push без UI (background sync). За замовчуванням — visible.
+
+### 3. Викликай `sendToUser` (або quiet-варіант)
+
+```ts
+import { sendToUser, sendToUserQuietly } from "../push/send.js";
+
+// Шлях, де push — частина бізнес-логіки і failure має бачитись:
+const result = await sendToUser(user.id, payload);
+if (result.errors.length > 0) {
+  logger.warn({ userId: user.id, errors: result.errors }, "push partial fail");
+}
+
+// Шлях, де push — side effect і не має валити основний потік:
+void sendToUserQuietly(user.id, payload);
+```
+
+`sendToUser` сам соft-видаляє stale subscription-и (наприклад, користувач відписався у браузері) і реєструє Prometheus метрики. Не дублюй цю логіку у викликаючому коді.
+
+### 4. (Опц.) Розширити SW handler
+
+Якщо новий тип push-у потребує:
+
+- спеціального `notificationclick` routing (наприклад, deep-link на конкретну сторінку всередині модуля),
+- іншої іконки / badge,
+- кастомного `tag` (для replace-замість-стек семантики),
+
+— онови `apps/web/src/sw.ts` `push` event-listener. Проте більшість випадків покривається `data.module` + `data.route` без змін у SW.
+
+Для mobile (Expo) — окремий код в `apps/mobile/`; деталі за межами цього playbook-а.
+
+### 5. (Опц.) VAPID env
+
+Перевір що:
+
+- `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_EMAIL` присутні у Railway production.
+- Локально (у `.env`) — заповнено, якщо хочеш отримати web-push на dev-машині. Без них `sendWebPush` мовчки skip-ає web-канал, але APNs/FCM продовжують працювати.
+
+Згенерувати pair можна через `npx web-push generate-vapid-keys` (один раз на проєкт).
+
+### 6. Тести
+
+Mock `web-push` (як у `apps/server/src/lib/webpushSend.test.ts`) і пиши unit-тест на свій тригер:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../push/send.js", () => ({
+  sendToUser: vi.fn().mockResolvedValue({
+    delivered: { ios: 0, android: 0, web: 1 },
+    cleaned: 0,
+    errors: [],
+  }),
+  sendToUserQuietly: vi.fn().mockResolvedValue(undefined),
+}));
+
+it("notifies user when budget threshold reached", async () => {
+  await handleBudgetUpdate(user, { spent: 8500, limit: 10000 });
+  const { sendToUser } = await import("../push/send.js");
+  expect(sendToUser).toHaveBeenCalledWith(
+    user.id,
+    expect.objectContaining({
+      title: expect.stringContaining("ліміт"),
+      data: expect.objectContaining({ module: "finyk" }),
+    }),
+  );
+});
+```
+
+Запуск:
+
+```bash
+pnpm --filter @sergeant/server exec vitest run src/modules/<your-domain>
+```
+
+### 7. Smoke у dev
+
+```bash
+# 1. Web SW зареєстрований (DevTools → Application → Service Workers).
+# 2. Зайди на /settings, ввімкни push для test-юзера → у БД з'явиться запис у push_subscriptions.
+# 3. Тригерни тест POST'ом / cron-ом / AI flow і перевір браузерну нотифікацію.
+```
+
+Альтернатива — використай існуючий `/api/push/test` endpoint (`apps/server/src/routes/push.ts`) як reference, якщо потрібен ручний trigger.
+
+---
+
+## Verification
+
+- [ ] Тригер локалізований у відповідному `apps/server/src/modules/<domain>/` (НЕ у `chat.ts`).
+- [ ] `payload` побудовано через `PushPayload` тип з `@sergeant/shared`, не свавільний об'єкт.
+- [ ] `sendToUser` / `sendToUserQuietly` обрано свідомо (failure-visible vs fire-and-forget).
+- [ ] `data.module` встановлено для коректного click-routing у SW.
+- [ ] Unit test mock-ує `sendToUser` і перевіряє shape payload-у.
+- [ ] Якщо змінено SW — версію bumpнуто (workbox cache key) + smoke у DevTools, що SW дійсно оновився.
+- [ ] VAPID env заповнено в Railway (production); локально — опціонально.
+- [ ] `pnpm --filter @sergeant/server exec vitest run src/modules/<domain>` — green.
+
+## Notes
+
+- **Не шли push без user opt-in.** Web-push підписка вимагає явного `Notification.requestPermission`; без неї `push_subscriptions` буде порожнім і `sendToUser` мовчки skip-ає web-канал. Це норма.
+- **Не дублюй push.** Якщо вже існує тригер на ту ж подію — додай поле в `data` замість другого виклику `sendToUser`. Юзеру неприємно отримувати два банери на одну подію.
+- **Не клади приватні дані в `body`.** `body` рендериться lock-screen-ом; суми, баланси, медичні факти — в `data` (рендериться лише після відкриття).
+- **Soft-delete підписок** робить `sendToUser` сам, не викликай DELETE на `push_subscriptions` руками.
+- **Production rollout:** після релізу слідкуй у Prometheus `push_sends_total` за `result="error"` — drift сигналізує про зламаний APNs cert / VAPID drift.
+
+## See also
+
+- [add-monobank-event-handler.md](add-monobank-event-handler.md) — push як реакція на webhook event
+- [add-api-endpoint.md](add-api-endpoint.md) — якщо тригер push-у — це новий endpoint
+- `apps/server/src/push/send.ts` — реалізація `sendToUser` / `sendToUserQuietly`
+- `apps/server/src/lib/webpushSend.ts` — web-push transport
+- `apps/web/src/sw.ts` рядок ~627 — `push` event listener
+- `packages/shared/src/types/index.ts` — `PushPayload` контракт

--- a/docs/playbooks/debug-chat-tool.md
+++ b/docs/playbooks/debug-chat-tool.md
@@ -1,0 +1,111 @@
+# Playbook: Debug HubChat Tool
+
+**Trigger:** «Асистент каже що зробив, але нічого не сталось» / «Натиснув кнопку quick action — нема ефекту» / tool call повернувся текстом замість дії / `Невідома дія: …` у відповіді.
+
+---
+
+## Контекст
+
+HubChat tool execution path має 5 ланок (див. `AGENTS.md` → _Architecture: AI tool execution path_): user message → `/api/chat` (server pass-through) → Anthropic → `tool_use` блок → клієнтський `executeAction` → handler домену → `tool_result` → друге звернення до моделі. Зламатися може будь-яка з них; цей playbook — порядок локалізації.
+
+Перед діагностикою:
+
+- Відкрий DevTools → Console + Network → `/api/chat`.
+- Включи логування у браузері: `localStorage.setItem("hubchat:debug", "1")` і перезавантаж сторінку (якщо фіча є; інакше додай локально `console.log` у потрібну точку).
+- Перевір що `ANTHROPIC_API_KEY` справді є у `.env`. Без нього сервер віддає 500 і UI показує generic error.
+
+---
+
+## Steps
+
+### 1. Чи tool call взагалі дійшов до клієнта?
+
+Подивись у Network на response **першого** `/api/chat` запиту (одразу після відправки user message).
+
+Очікуваний JSON містить `content` масив з блоком `{ type: "tool_use", name: "<tool>", input: { … } }`. Якщо натомість тільки `{ type: "text", text: "…" }` — модель вирішила не викликати tool. Причини:
+
+- `description` tool-а в `toolDefs/<domain>.ts` неоднозначний (модель вибрала text-відповідь).
+- Tool взагалі не в списку `TOOLS` (`apps/server/src/modules/chat/tools.ts`) → перевір `toolDefs/index.ts`.
+- `SYSTEM_PREFIX` (`systemPrompt.ts`) не згадує tool у списку рядки 7–14 → модель не знає, що він є.
+
+→ Дій: підправ `description` (імперативно, з прикладом), переконайся що tool експортовано і доданий у `SYSTEM_PREFIX`. Деталі — `tune-system-prompt.md` і `add-hubchat-tool.md`.
+
+### 2. Чи виконався handler на клієнті?
+
+Постав `console.log("executeAction", action)` як перший рядок у `apps/web/src/core/lib/hubChatActions.ts`'s `executeAction`.
+
+- Лог не з'явився → клієнт не отримав `tool_use`. Це NetworkError, або сервер віддав 5xx, або UI ще пробує парсити streamed response. Перевір Network response code.
+- Лог є, але `Невідома дія: <name>` у `tool_result` → жоден `handle*Action` не повернув значення. Найчастіше: забули case у `apps/web/src/core/lib/chatActions/<domain>Actions.ts`, або `name` у tool def відрізняється від `name` у case (наприклад `findTransaction` vs `find_transaction`).
+
+→ Дій: знайди файл `chatActions/<domain>Actions.ts` для свого домена, додай case з тим самим snake_case `name`, що й у tool def.
+
+### 3. Чи правильний side effect (localStorage)?
+
+DevTools → Application → Local Storage → знайди ключ свого домену (наприклад `nutrition_water_log_v1`, `finyk_transactions_v1`).
+
+- Ключ не змінився після виклику → handler не записав. Перевір що ти використовуєш `lsSet(key, value)`, а не `localStorage.setItem` (anti-pattern #6 у `AGENTS.md` — race з cloud sync queue).
+- Ключ записався, але старе значення зникло → ти зробив `lsSet(key, newItem)` замість `lsSet(key, [...prev, newItem])`. Завжди читай попереднє значення через `ls(key, default)` і додавай у масив.
+
+→ Дій: handler пише через `ls`/`lsSet` з `@shared/lib/storage`. Якщо tool пише в API замість localStorage — перевір що використовується `@sergeant/api-client`, не fetch.
+
+### 4. Чи модель отримала `tool_result`?
+
+Дивись на **другий** `/api/chat` запит (continuation). У request body має бути масив повідомлень з `assistant` (raw tool_use блок) і `user` з `tool_results[].content`.
+
+- `tool_results[].content` — порожній → handler повернув `undefined` замість рядка. Поверни `string` (правило з `add-hubchat-tool.md`).
+- `tool_results[].content` — стрінговий error: `"Помилка виконання: …"` → handler кинув виняток. `executeAction` обгортає у такий рядок. Подивись `console.error` у тому ж handler-і, щоб побачити stack trace.
+- `is_error: true` у `tool_result` → клієнт явно позначив помилку. Зазвичай це означає, що handler кинув typed error.
+
+→ Дій: переконайся handler return-ить informative string, а не `void`. На помилку — кидай `Error("…")`, а не повертай порожній рядок (це втратить сигнал «щось не так» для моделі).
+
+### 5. Чи модель прийняла результат у фінальному тексті?
+
+Response **другого** `/api/chat` запиту повертає `{ type: "text", text: "…" }`. Перевір:
+
+- Текст відповіді згадує результат tool-а («Залоговано 200 мл води») — все ок, проблема була не в pipeline, а у UI: action card / quick action не оновився, або `cloudsync` не синхронізував.
+- Текст відповіді — generic «Готово» без конкретики → handler повернув занадто короткий результат. Розширь, додай числа з input-а у return string.
+- `stop_reason: "max_tokens"` → continuation request обірвано на 400 токенах (див. `AGENTS.md` → _max_tokens budget per request_). Або скороти `tool_result.content`, або тимчасово підніми `max_tokens` і прогни ще раз.
+
+### 6. Чи UI оновився?
+
+Якщо handler виконався і модель повернула підтвердження, але користувач не бачить ефекту:
+
+- `hubChatActionCards.ts` мапер не покриває новий tool → action card не відрендериться (теж не помилка, просто немає visual feedback).
+- React Query cache не invalidate-нув → відкрий React Query DevTools, перевір ключ домену (наприклад `finykKeys.transactions`). Handler має після write викликати `queryClient.invalidateQueries`.
+- localStorage-only домен (Routine, Fizruk) — UI читає з ls на render. Перевір що компонент дійсно re-render-ить (можливо, не передплачено зміни ls).
+
+---
+
+## Типові помилки
+
+| Симптом                                                         | Корінь                                                         |
+| --------------------------------------------------------------- | -------------------------------------------------------------- |
+| `Невідома дія: foo`                                             | Case у `chatActions/<domain>Actions.ts` не додано              |
+| Handler write успішний, але після reload даних нема             | `localStorage.setItem` замість `lsSet` → quota throw silently  |
+| `tool_result.content` порожній → модель «зависла»               | Handler return undefined (TypeScript це не зловив через `any`) |
+| Друге `/api/chat` обірвало JSON → parse error в `executeAction` | `stop_reason: "max_tokens"` на continuation (400)              |
+| Tool взагалі не викликається                                    | `SYSTEM_PREFIX` не згадує tool у списку рядки 7–14             |
+
+---
+
+## Verification
+
+- [ ] Локалізовано конкретну ланку pipeline (1–6 вище), не «щось не так».
+- [ ] Виправлення супроводжене юніт-тестом у `chatActions/<domain>Actions.test.ts` (happy path + error path) — щоб регресія не повернулась.
+- [ ] Якщо причина у tool def — також оновлено `SYSTEM_PREFIX` (рядки 7–14).
+- [ ] `pnpm --filter @sergeant/web exec vitest run src/core/lib/chatActions` — green.
+- [ ] Smoke у HubChat після фіксу: повна відповідь моделі і відповідний action card.
+
+## Notes
+
+- Не шукай помилку в `chat.ts` без потреби. Сервер — тонкий pass-through; tool side effects там не виконуються (`AGENTS.md` Architecture). Реальні баги — у `chatActions/<domain>Actions.ts` або `toolDefs/<domain>.ts`.
+- Якщо `executeAction` парсить tool input, обгорни доступ до полів у guard-и: модель може надіслати неповний об'єкт. Type assertion `(action as Foo).input` не безпечний.
+- Для regression-перевірок використовуй mini-eval з `tune-system-prompt.md` крок 3.
+
+## See also
+
+- [add-hubchat-tool.md](add-hubchat-tool.md) — як додати tool правильно з нуля
+- [tune-system-prompt.md](tune-system-prompt.md) — зміна системного промпту без поломки tool-calling
+- [AGENTS.md](../../AGENTS.md) — секції _Architecture: AI tool execution path_, _max_tokens budget per request_, anti-pattern #6 про `localStorage.setItem`
+- `apps/web/src/core/lib/hubChatActions.ts` — `executeAction` entry point
+- `apps/server/src/modules/chat.ts` — `/api/chat` handler і continuation logic

--- a/docs/playbooks/enable-prompt-caching.md
+++ b/docs/playbooks/enable-prompt-caching.md
@@ -1,0 +1,193 @@
+# Playbook: Enable Anthropic Prompt Caching
+
+**Trigger:** «Зменшити cost Anthropic» / «Anthropic API занадто дорогий» / `aiTokensTotal{kind="prompt"}` росте лінійно з трафіком, бо `SYSTEM_PREFIX` повторюється на кожному запиті.
+
+---
+
+## Контекст
+
+`SYSTEM_PREFIX` (`apps/server/src/modules/chat/toolDefs/systemPrompt.ts`) — стабільний на всіх запитах: змінюється тільки appended `context` блок з даними юзера. Anthropic prompt caching дозволяє позначити стабільну частину `cache_control: { type: "ephemeral" }`; перший запит «запишеться» у кеш (cost трохи вищий — `cache_creation_input_tokens`), наступні протягом ~5 хв читатимуть з кешу за ~10% від звичайної ціни (`cache_read_input_tokens`).
+
+Деталі — `AGENTS.md` → _SYSTEM_PREFIX is a prompt-cache candidate_. Цей playbook — конкретний rollout.
+
+**Передумови:**
+
+- Модель підтримує prompt caching. На момент написання — всі актуальні Claude (3.5 Sonnet, Sonnet 4 і `claude-sonnet-4-6`, який зараз у `chat.ts`) підтримують.
+- Будь-який `model` upgrade пізніше — перевір release notes Anthropic; якщо нова модель не підтримує — feature виродиться у звичайний non-cached запит без помилки.
+- `SYSTEM_PREFIX` уже стабільний (не міксує per-user дані). Якщо ти збираєшся рефакторити промпт у тому ж PR — спочатку зроби prompt caching, потім окремим PR — рефактор. Інакше cache miss-и за перші 5 хв після деплою накладуться.
+
+---
+
+## Steps
+
+### 1. Перетвори `system` з string на масив із `cache_control`
+
+`apps/server/src/modules/chat.ts` зараз шле `system: SYSTEM_PREFIX + context` (рядок ~115 для tool-result continuation; рядок ~171 для першого запиту). Перетвори на масив із двома `text` блоками — кешований префікс і динамічний контекст:
+
+```ts
+// chat.ts (обидва місця, де передається system)
+const payload = {
+  model: "claude-sonnet-4-6",
+  max_tokens: 600,
+  system: [
+    {
+      type: "text" as const,
+      text: SYSTEM_PREFIX,
+      cache_control: { type: "ephemeral" as const },
+    },
+    {
+      type: "text" as const,
+      text: context, // per-user dynamic data — НЕ кешується
+    },
+  ],
+  tools: TOOLS,
+  messages: cleaned,
+};
+```
+
+**Чому два блоки, а не один:** `cache_control` помічає границю кешу. Все ДО і ВКЛЮЧНО з блоком `cache_control` йде в кеш; що після — динамічна частина. Якщо лишити одну строку `SYSTEM_PREFIX + context`, то `context` теж потрапить у кеш-ключ і кожен різний user отруїть свій slot.
+
+Те саме застосуй для tool-result continuation payload (рядок ~115).
+
+### 2. (Опц.) Beta header — лише для старих моделей
+
+На моделях, що офіційно підтримують prompt caching у GA (Sonnet 4-сімейство, 3.5 Sonnet після Sep 2024), beta header **не обов'язковий**. Якщо переходиш на legacy модель або хочеш бути захищеним від drift Anthropic — додай у `apps/server/src/lib/anthropic.ts` рядок ~166 і ~245:
+
+```ts
+headers: {
+  "Content-Type": "application/json",
+  "x-api-key": apiKey,
+  "anthropic-version": "2023-06-01",
+  // NOTE: Prompt caching у GA для актуальних моделей; header додаємо
+  // як страхування для legacy моделей у майбутніх експериментах.
+  "anthropic-beta": "prompt-caching-2024-07-31",
+},
+```
+
+Якщо пропускаєш цей крок — нічого не зламається на актуальних моделях. Прочитай Anthropic release notes перед увімкненням, якщо нова модель додалась.
+
+### 3. Версіонуй `SYSTEM_PREFIX`
+
+Додай константу версії, щоб **навмисні** зміни промпту легко логувати у Prometheus:
+
+```ts
+// apps/server/src/modules/chat/toolDefs/systemPrompt.ts
+export const SYSTEM_PROMPT_VERSION = "v4";
+export const SYSTEM_PREFIX = `Ти персональний асистент …`;
+```
+
+Бампай при кожній свідомій зміні `SYSTEM_PREFIX`. Після bump — перші запити кожного юзера будуть cache miss (нова cache key), що очікувано і коротко.
+
+### 4. Метрики `cache_creation` / `cache_read`
+
+`apps/server/src/lib/anthropic.ts` `recordUsage()` сьогодні логує тільки `input_tokens` / `output_tokens`. Після увімкнення кеш-у Anthropic повертає у `usage`:
+
+```ts
+interface AnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+```
+
+Розшир `recordUsage`:
+
+```ts
+if (Number.isFinite(usage.cache_creation_input_tokens)) {
+  aiTokensTotal.inc(
+    { provider: "anthropic", model, kind: "cache_write" },
+    usage.cache_creation_input_tokens,
+  );
+}
+if (Number.isFinite(usage.cache_read_input_tokens)) {
+  aiTokensTotal.inc(
+    { provider: "anthropic", model, kind: "cache_read" },
+    usage.cache_read_input_tokens,
+  );
+}
+```
+
+Те саме застосуй у `recordUsage` для streaming варіанта (`anthropicMessagesStream`).
+
+### 5. Тести
+
+Існуючі тести `apps/server/src/modules/chat.test.ts` мокають Anthropic — структура `system` змінилась з string на масив, тому міг зламатись `expect.objectContaining({ system: expect.stringMatching(…) })`. Онови assertion на:
+
+```ts
+expect(fetchMock).toHaveBeenCalledWith(
+  expect.anything(),
+  expect.objectContaining({
+    body: expect.stringContaining('"cache_control":{"type":"ephemeral"}'),
+  }),
+);
+```
+
+Або, безпечніше, парс body з JSON і перевіряй структуру:
+
+```ts
+const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+expect(body.system).toEqual([
+  { type: "text", text: SYSTEM_PREFIX, cache_control: { type: "ephemeral" } },
+  { type: "text", text: expect.stringContaining("[Категорії]") },
+]);
+```
+
+Запуск:
+
+```bash
+pnpm --filter @sergeant/server exec vitest run src/modules/chat
+pnpm --filter @sergeant/server exec vitest run src/lib/anthropic
+```
+
+### 6. Manual verification у dev
+
+```bash
+# 1. Старт сервера з реальним ANTHROPIC_API_KEY (не disabled).
+ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @sergeant/server dev
+
+# 2. Перший запит до /api/chat від тестового юзера.
+#    У логах logger пише response.usage → шукай cache_creation_input_tokens > 0.
+
+# 3. Другий ідентичний запит протягом ~5 хв.
+#    cache_creation_input_tokens → 0 (бо вже у кеші)
+#    cache_read_input_tokens > 0 (читає з кешу)
+#    input_tokens ~= ~залишок (динамічний context)
+```
+
+Якщо у другому запиті `cache_read_input_tokens === 0` — значить `cache_control` не спрацював. Найчастіше: блок з `cache_control` не «співпав» побайтово — наприклад, ти випадково склеїв `SYSTEM_PREFIX` з context-ом всередині кешованого блоку.
+
+### 7. Production rollout
+
+- Деплой → перші ~5 хв cache miss-и для всіх юзерів (що нормально).
+- Через 5–15 хв подивись Grafana `aiTokensTotal{kind="cache_read"}` — має лінійно рости.
+- Cost: typical 5–10× зниження input-token billing на стабільних запитах.
+
+Якщо `cache_read` лишається на 0 на проді при non-zero `cache_write` — ймовірний `SYSTEM_PROMPT_VERSION` churn (хтось мерджить ще одну зміну промпту, інвалідуючи кеш). Заморозь промпт.
+
+---
+
+## Verification
+
+- [ ] `system` у обох викликах `chat.ts` — масив із двома `text` блоками: cached `SYSTEM_PREFIX` + dynamic `context`.
+- [ ] (Якщо застосовно) `anthropic-beta: prompt-caching-2024-07-31` додано і в звичайний, і в стрімовий клієнт.
+- [ ] `SYSTEM_PROMPT_VERSION` додано і логічно підвищується з кожною свідомою зміною промпту.
+- [ ] `recordUsage` пише `kind: "cache_write"` і `kind: "cache_read"` у `aiTokensTotal`.
+- [ ] Dev smoke: два послідовні `/api/chat` дають `cache_creation > 0` (1-й) і `cache_read > 0` (2-й).
+- [ ] Тести `chat.test.ts` оновлені під нову структуру `system` і green.
+- [ ] PR description містить: token-cost diff (estimate), reference на Anthropic prompt caching docs, Grafana посилання на нові метрики.
+
+## Notes
+
+- **Не міняй `SYSTEM_PREFIX` часто.** Кожна зміна — повний cache invalidation, для всіх активних юзерів. Якщо потрібно подіагностувати tone — кешуй stable prefix і додай експериментальний rider у `context` блок (не у кеш).
+- **Tool definitions у `tools` параметрі НЕ кешуються тим самим `cache_control`.** Якщо `TOOLS` теж великий і стабільний — постав окремий `cache_control` всередині `tools` як ще одну точку розриву (Anthropic дозволяє до 4 cache breakpoints на запит). На момент писання `tools.ts` у нас невеликий, тому економія мала; повертайся до цього кроку, якщо `TOOLS` виросте.
+- **TTL ephemeral кешу — ~5 хв** з останнього read. Для sparse трафіку (юзер заходить раз на годину) prompt caching не дасть значної економії; має сенс для активних сесій / інтенсивного chat-flow.
+- **Cache key чутливий побайтно.** Невидимий whitespace-diff, BOM, нерозривні пробіли — все робить cache miss. Не редагуй `SYSTEM_PREFIX` у редакторі без unicode-aware diff.
+
+## See also
+
+- [tune-system-prompt.md](tune-system-prompt.md) — як міняти `SYSTEM_PREFIX` без поломки tool-calling (виконуй до або в окремому PR від caching rollout)
+- [AGENTS.md](../../AGENTS.md) — секції _Architecture: AI tool execution path_ і _SYSTEM_PREFIX is a prompt-cache candidate_
+- `apps/server/src/lib/anthropic.ts` — `anthropicMessages` / `anthropicMessagesStream` / `recordUsage`
+- `apps/server/src/modules/chat.ts` — обидва payload-и (рядки ~115, ~171)
+- Anthropic docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching


### PR DESCRIPTION
## What changed

Додано три нові playbook-и у `docs/playbooks/` і оновлено `docs/playbooks/README.md`. Тільки документація — нічого в коді не торкнулося.

### `docs/playbooks/debug-chat-tool.md`

**Тригер:** «Асистент каже що зробив, але нічого не сталось» / `Невідома дія: …` / tool call повернувся текстом замість дії.

6-крокова локалізація проблеми по pipeline HubChat tool execution:

1. Чи `tool_use` блок повернувся з першого `/api/chat`?
2. Чи виконався `executeAction` на клієнті (через `console.log` у `hubChatActions.ts`)?
3. Чи правильний side effect у localStorage (DevTools → Application)?
4. Чи модель отримала `tool_result` з правильним `content`?
5. Чи модель прийняла результат у фінальному текстовому response (з нагадуванням про `stop_reason: "max_tokens"`)?
6. Чи UI оновився (action card мапер, RQ invalidate, ls subscription).

Плюс таблиця типових помилок (handler return undefined, `localStorage.setItem` замість `lsSet`, неспівпадаючий case у `chatActions/<domain>Actions.ts`).

### `docs/playbooks/add-push-notification.md`

**Тригер:** «Надсилай push коли X» / нагадування / реакція на подію (Mono webhook, AI insight, scheduler).

7-крокова процедура:

1. Визнач тригер (user-action handler, Mono webhook, періодичний endpoint, AI insight side effect — НЕ `chat.ts`).
2. Сформуй payload через `PushPayload` тип з `@sergeant/shared` (правила про `title`/`body`/`data.module`/`threadId`/`silent`).
3. Виклич `sendToUser` (failure-visible) або `sendToUserQuietly` (fire-and-forget) з `apps/server/src/push/send.ts`.
4. (Опц.) Розширити `apps/web/src/sw.ts` push handler, якщо потрібен спеціальний routing.
5. Перевір `VAPID_*` env (не мандаторні в dev — без них web-push мовчки skip).
6. Тести: mock `web-push` як у `apps/server/src/lib/webpushSend.test.ts`, `expect(sendToUser).toHaveBeenCalledWith(...)`.
7. Smoke у dev (DevTools → Application → Service Workers, push subscribe, тригер).

**Уточнено vs початковий план:** план посилався на `packages/shared/src/push.ts` як місце для constants — такого файлу немає. Дійсний контракт `PushPayload` живе в `packages/shared/src/types/index.ts`. У repo немає in-process scheduler-а; для cron-style тригерів потрібен зовнішній (Railway scheduler / GitHub Action), що відображено у таблиці типів тригерів.

### `docs/playbooks/enable-prompt-caching.md`

**Тригер:** «Зменшити cost Anthropic» / `SYSTEM_PREFIX` повторюється на кожному запиті.

7-крокова процедура rollout-у Anthropic prompt caching:

1. Перетворити `system` з string на масив із двома `text` блоками — кешований `SYSTEM_PREFIX` (з `cache_control: { type: "ephemeral" }`) і динамічний `context` без cache_control.
2. (Опц.) `anthropic-beta: prompt-caching-2024-07-31` header у `apps/server/src/lib/anthropic.ts` — лише як страховка для legacy моделей; на актуальних Sonnet 4 не обов'язковий (prompt caching тепер GA).
3. Додати `SYSTEM_PROMPT_VERSION` константу у `systemPrompt.ts` для observability cache invalidation events.
4. Розширити `recordUsage` метриками `cache_creation_input_tokens` / `cache_read_input_tokens` (`kind: "cache_write"` / `"cache_read"`).
5. Тести: `JSON.parse(body).system` має бути масивом з очікуваною структурою.
6. Manual dev verification: два послідовні `/api/chat` → `cache_creation > 0` (1-й), `cache_read > 0` (2-й).
7. Production rollout: моніторинг Grafana, перші 5 хв cache miss-ів очікувані.

**Уточнено vs початковий план:** план жорстко вимагав beta header — насправді у GA для актуальних моделей він не обов'язковий. Описав крок 2 як опціональний з поясненням коли потрібен. Також додано notes про cache breakpoint у `tools` (можна окремо), TTL ~5 хв, byte-sensitivity cache key.

### `docs/playbooks/README.md`

Три нові рядки додано у таблицю тригерів. Згруповано тематично: `debug-chat-tool` поруч з `tune-system-prompt`, `enable-prompt-caching` далі, `add-push-notification` поруч з іншими delivery channel playbook-ами.

## Why

Третій PR серії 1–3 (докси). Закриває три gaps:

- **`debug-chat-tool`** — найчастіша support-проблема за коментарями користувачів («натиснув — не спрацювало»). Без playbook agent / dev почне з повного перегляду `chat.ts`, замість таргетованої перевірки 6 точок pipeline.
- **`add-push-notification`** — push-інфра в репо є (`sendToUser`, VAPID, SW handler), але порядок «де тригер → який payload → як тестувати» розкиданий по 4 файлах. Один playbook тримає це разом.
- **`enable-prompt-caching`** — `SYSTEM_PREFIX` стабільний, але кеш досі не ввімкнено. Цей playbook — готовий рецепт; виконання — окремим кодовим PR (не в цій серії 1–3 docs-only).

## How to test

```bash
pnpm format:check    # green
```

Докс-онлі. Можна перевіряти fact-checking:

- `apps/server/src/push/send.ts` — `sendToUser` / `sendToUserQuietly` API, soft-delete семантика, метрики.
- `apps/server/src/lib/anthropic.ts` рядки ~165 і ~245 — місце для `anthropic-beta` header.
- `apps/server/src/modules/chat.ts` рядки ~115 і ~171 — обидва payload-и з `system`.
- `apps/web/src/sw.ts` рядок ~627 — `push` event listener.
- `packages/shared/src/types/index.ts` — `PushPayload`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm format:check` — green.
- [x] Vitest passes: docs-only, тестів не змінено й не додано.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (нові playbook-и; `AGENTS.md` оновлено окремим PR серії: #786).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated playbooks directory with new implementation guides.
  * Added guide for integrating push notification functionality.
  * Added guide for troubleshooting chat tool execution.
  * Added guide for enabling prompt caching to reduce token costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->