### PR TITLE
docs(docs): document prompt caching tools breakpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,8 @@ When Anthropic returns `stop_reason: "max_tokens"`, the model may truncate **mid
 1. **Don't churn `SYSTEM_PREFIX`.** Each edit invalidates the cache for every active user, so a casual wording tweak can briefly multiply Anthropic spend. Batch prompt changes; bump a `SYSTEM_PROMPT_VERSION` constant when wiring caching so cache misses are observable.
 2. **`context` (the dynamic data block) must stay outside the cached segment.** When caching is wired, the cached prefix is `SYSTEM_PREFIX` only; the per-user `context` is appended as a separate, non-cached `text` block.
 
+Anthropic cache breakpoints have a model-specific minimum length and silently no-op below it: the request succeeds, but both `cache_creation_input_tokens` and `cache_read_input_tokens` stay `0`. In the PR #790 smoke, `SYSTEM_PREFIX` alone was ~987 tokens — below the Sonnet 1024-token floor observed there — so the viable Sergeant rollout also marks the last stable tool definition with `cache_control`. That tools breakpoint is the real cost win today; the `SYSTEM_PREFIX` marker stays forward-looking for when the prompt grows past the minimum.
+
 See the `enable-prompt-caching` playbook for the actual rollout steps.
 
 ## Performance budgets

--- a/docs/playbooks/enable-prompt-caching.md
+++ b/docs/playbooks/enable-prompt-caching.md
@@ -117,7 +117,7 @@ Payload-и мають використовувати `TOOLS_WITH_CACHE`:
 }
 ```
 
-Anthropic docs описують cache prefix ordering як `tools` → `system` → `messages`; `tools` і `system` обидва cacheable. Для Sergeant важливий практичний контракт: usage має показати non-zero `cache_creation_input_tokens` на першому запиті і non-zero `cache_read_input_tokens` на повторному.
+Серверний `chat.ts` тримає rollout invariant як `system` → `tools` → `messages`: `SYSTEM_PREFIX` і tool definitions мають бути стабільними, а `context` лишається окремим non-cached system block. Для Sergeant важливий практичний контракт: usage має показати non-zero `cache_creation_input_tokens` на першому запиті і non-zero `cache_read_input_tokens` на повторному.
 
 ### 3. (Опц.) Beta header — лише для старих моделей
 

--- a/docs/playbooks/enable-prompt-caching.md
+++ b/docs/playbooks/enable-prompt-caching.md
@@ -1,55 +1,125 @@
 # Playbook: Enable Anthropic Prompt Caching
 
-**Trigger:** «Зменшити cost Anthropic» / «Anthropic API занадто дорогий» / `aiTokensTotal{kind="prompt"}` росте лінійно з трафіком, бо `SYSTEM_PREFIX` повторюється на кожному запиті.
+**Trigger:** «Зменшити cost Anthropic» / «Anthropic API занадто дорогий» / `aiTokensTotal{kind="prompt"}` росте лінійно з трафіком, бо стабільні `SYSTEM_PREFIX` і `TOOLS` повторюються на кожному запиті.
 
 ---
 
 ## Контекст
 
-`SYSTEM_PREFIX` (`apps/server/src/modules/chat/toolDefs/systemPrompt.ts`) — стабільний на всіх запитах: змінюється тільки appended `context` блок з даними юзера. Anthropic prompt caching дозволяє позначити стабільну частину `cache_control: { type: "ephemeral" }`; перший запит «запишеться» у кеш (cost трохи вищий — `cache_creation_input_tokens`), наступні протягом ~5 хв читатимуть з кешу за ~10% від звичайної ціни (`cache_read_input_tokens`).
+`SYSTEM_PREFIX` (`apps/server/src/modules/chat/toolDefs/systemPrompt.ts`) і `TOOLS` (`apps/server/src/modules/chat/tools.ts`) — стабільні на всіх `/api/chat` запитах: змінюється тільки appended `context` блок з даними юзера. Anthropic prompt caching дозволяє позначити стабільну частину `cache_control: { type: "ephemeral" }`; перший запит «запишеться» у кеш (cost трохи вищий — `cache_creation_input_tokens`), наступні протягом ~5 хв читатимуть з кешу за ~10% від звичайної ціни (`cache_read_input_tokens`).
 
 Деталі — `AGENTS.md` → _SYSTEM_PREFIX is a prompt-cache candidate_. Цей playbook — конкретний rollout.
 
 **Передумови:**
 
 - Модель підтримує prompt caching. На момент написання — всі актуальні Claude (3.5 Sonnet, Sonnet 4 і `claude-sonnet-4-6`, який зараз у `chat.ts`) підтримують.
-- Будь-який `model` upgrade пізніше — перевір release notes Anthropic; якщо нова модель не підтримує — feature виродиться у звичайний non-cached запит без помилки.
+- Будь-який `model` upgrade пізніше — перевір Anthropic docs/release notes: підтримку prompt caching і мінімальний cacheable prompt length для цієї моделі.
 - `SYSTEM_PREFIX` уже стабільний (не міксує per-user дані). Якщо ти збираєшся рефакторити промпт у тому ж PR — спочатку зроби prompt caching, потім окремим PR — рефактор. Інакше cache miss-и за перші 5 хв після деплою накладуться.
+
+---
+
+## Важливий урок з PR #790
+
+Не покладайся тільки на `cache_control` на `SYSTEM_PREFIX`.
+
+Live smoke з реальним Anthropic key показав:
+
+```text
+SYSTEM_PREFIX-only:
+request 1: cache_creation=0 cache_read=0
+request 2: cache_creation=0 cache_read=0
+SMOKE NOT OK
+```
+
+Причина: у PR #790 `SYSTEM_PREFIX` був ~987 токенів, нижче Sonnet-порогу 1024 токени, який діяв для поточної моделі. Anthropic не повертає error для занадто короткого breakpoint-а — request проходить, але usage має `cache_creation_input_tokens = 0` і `cache_read_input_tokens = 0`.
+
+Viable rollout для Sergeant:
+
+1. Залишити `SYSTEM_PREFIX` як окремий cached `system` block — forward-looking marker.
+2. Додати другий breakpoint на останній stable tool definition — це реально проходить minimum length, бо `TOOLS` значно більші за `SYSTEM_PREFIX`.
+
+Observed smoke після tools breakpoint:
+
+```text
++ tools breakpoint:
+request 1: input=360 cache_creation=12284 cache_read=0
+request 2: input=3   cache_creation=357   cache_read=12284
+SMOKE OK
+```
 
 ---
 
 ## Steps
 
-### 1. Перетвори `system` з string на масив із `cache_control`
+### 1. Перетвори `system` з string на блоки
 
-`apps/server/src/modules/chat.ts` зараз шле `system: SYSTEM_PREFIX + context` (рядок ~115 для tool-result continuation; рядок ~171 для першого запиту). Перетвори на масив із двома `text` блоками — кешований префікс і динамічний контекст:
+`apps/server/src/modules/chat.ts` має передавати `system` як масив — кешований префікс і динамічний контекст:
 
 ```ts
-// chat.ts (обидва місця, де передається system)
-const payload = {
-  model: "claude-sonnet-4-6",
-  max_tokens: 600,
-  system: [
-    {
-      type: "text" as const,
-      text: SYSTEM_PREFIX,
-      cache_control: { type: "ephemeral" as const },
-    },
-    {
-      type: "text" as const,
-      text: context, // per-user dynamic data — НЕ кешується
-    },
-  ],
-  tools: TOOLS,
-  messages: cleaned,
-};
+interface AnthropicSystemBlock {
+  type: "text";
+  text: string;
+  cache_control?: { type: "ephemeral" };
+}
+
+function buildSystem(context: string): AnthropicSystemBlock[] {
+  const cached: AnthropicSystemBlock = {
+    type: "text",
+    text: SYSTEM_PREFIX,
+    cache_control: { type: "ephemeral" },
+  };
+  if (!context) return [cached];
+  return [cached, { type: "text", text: context }];
+}
 ```
 
 **Чому два блоки, а не один:** `cache_control` помічає границю кешу. Все ДО і ВКЛЮЧНО з блоком `cache_control` йде в кеш; що після — динамічна частина. Якщо лишити одну строку `SYSTEM_PREFIX + context`, то `context` теж потрапить у кеш-ключ і кожен різний user отруїть свій slot.
 
-Те саме застосуй для tool-result continuation payload (рядок ~115).
+**Правила:**
 
-### 2. (Опц.) Beta header — лише для старих моделей
+- `SYSTEM_PREFIX` — окремий `text` block із `cache_control`.
+- `context` — окремий `text` block **без** `cache_control`.
+- Якщо `context === ""`, не додавай empty text block: Anthropic відхиляє empty text blocks.
+- Застосуй `buildSystem(context)` і для першого request-а, і для tool-result continuation.
+
+### 2. Додай tools breakpoint
+
+`SYSTEM_PREFIX` може бути нижче мінімальної довжини cached prefix, тому додай `cache_control` до останнього tool. Не мутуй імпортований `TOOLS`, бо він реекспортується і може використовуватись у тестах/інших модулях.
+
+```ts
+function applyToolsCacheBreakpoint(
+  tools: typeof TOOLS,
+): Array<(typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }> {
+  if (tools.length === 0) return tools;
+  const cloned = tools.slice();
+  const last = cloned[cloned.length - 1];
+  cloned[cloned.length - 1] = {
+    ...last,
+    cache_control: { type: "ephemeral" },
+  } as typeof last & { cache_control: { type: "ephemeral" } };
+  return cloned as Array<
+    (typeof TOOLS)[number] & { cache_control?: { type: "ephemeral" } }
+  >;
+}
+
+const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(TOOLS);
+```
+
+Payload-и мають використовувати `TOOLS_WITH_CACHE`:
+
+```ts
+{
+  model: "claude-sonnet-4-6",
+  max_tokens: 600,
+  system: buildSystem(context),
+  tools: TOOLS_WITH_CACHE,
+  messages: cleaned,
+}
+```
+
+Anthropic docs описують cache prefix ordering як `tools` → `system` → `messages`; `tools` і `system` обидва cacheable. Для Sergeant важливий практичний контракт: usage має показати non-zero `cache_creation_input_tokens` на першому запиті і non-zero `cache_read_input_tokens` на повторному.
+
+### 3. (Опц.) Beta header — лише для старих моделей
 
 На моделях, що офіційно підтримують prompt caching у GA (Sonnet 4-сімейство, 3.5 Sonnet після Sep 2024), beta header **не обов'язковий**. Якщо переходиш на legacy модель або хочеш бути захищеним від drift Anthropic — додай у `apps/server/src/lib/anthropic.ts` рядок ~166 і ~245:
 
@@ -66,7 +136,7 @@ headers: {
 
 Якщо пропускаєш цей крок — нічого не зламається на актуальних моделях. Прочитай Anthropic release notes перед увімкненням, якщо нова модель додалась.
 
-### 3. Версіонуй `SYSTEM_PREFIX`
+### 4. Версіонуй `SYSTEM_PREFIX`
 
 Додай константу версії, щоб **навмисні** зміни промпту легко логувати у Prometheus:
 
@@ -78,7 +148,7 @@ export const SYSTEM_PREFIX = `Ти персональний асистент …
 
 Бампай при кожній свідомій зміні `SYSTEM_PREFIX`. Після bump — перші запити кожного юзера будуть cache miss (нова cache key), що очікувано і коротко.
 
-### 4. Метрики `cache_creation` / `cache_read`
+### 5. Метрики `cache_creation` / `cache_read`
 
 `apps/server/src/lib/anthropic.ts` `recordUsage()` сьогодні логує тільки `input_tokens` / `output_tokens`. Після увімкнення кеш-у Anthropic повертає у `usage`:
 
@@ -110,28 +180,14 @@ if (Number.isFinite(usage.cache_read_input_tokens)) {
 
 Те саме застосуй у `recordUsage` для streaming варіанта (`anthropicMessagesStream`).
 
-### 5. Тести
+### 6. Тести
 
-Існуючі тести `apps/server/src/modules/chat.test.ts` мокають Anthropic — структура `system` змінилась з string на масив, тому міг зламатись `expect.objectContaining({ system: expect.stringMatching(…) })`. Онови assertion на:
+Мінімальний набір для `apps/server/src/modules/chat.test.ts`:
 
-```ts
-expect(fetchMock).toHaveBeenCalledWith(
-  expect.anything(),
-  expect.objectContaining({
-    body: expect.stringContaining('"cache_control":{"type":"ephemeral"}'),
-  }),
-);
-```
-
-Або, безпечніше, парс body з JSON і перевіряй структуру:
-
-```ts
-const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-expect(body.system).toEqual([
-  { type: "text", text: SYSTEM_PREFIX, cache_control: { type: "ephemeral" } },
-  { type: "text", text: expect.stringContaining("[Категорії]") },
-]);
-```
+- `system` — масив: cached `SYSTEM_PREFIX` + non-cached `context`.
+- Empty `context` не створює empty text block.
+- Останній tool має `cache_control: { type: "ephemeral" }`, попередні tools — без breakpoint-ів.
+- Tool-result continuation також використовує cached `SYSTEM_PREFIX`.
 
 Запуск:
 
@@ -140,54 +196,59 @@ pnpm --filter @sergeant/server exec vitest run src/modules/chat
 pnpm --filter @sergeant/server exec vitest run src/lib/anthropic
 ```
 
-### 6. Manual verification у dev
+### 7. Manual verification у dev
 
 ```bash
-# 1. Старт сервера з реальним ANTHROPIC_API_KEY (не disabled).
+# 1. Старт сервера з реальним ANTHROPIC_API_KEY (не AI_QUOTA_DISABLED smoke).
 ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @sergeant/server dev
 
 # 2. Перший запит до /api/chat від тестового юзера.
-#    У логах logger пише response.usage → шукай cache_creation_input_tokens > 0.
+#    У логах response.usage → шукай cache_creation_input_tokens > 0.
 
 # 3. Другий ідентичний запит протягом ~5 хв.
-#    cache_creation_input_tokens → 0 (бо вже у кеші)
-#    cache_read_input_tokens > 0 (читає з кешу)
-#    input_tokens ~= ~залишок (динамічний context)
+#    cache_read_input_tokens > 0.
 ```
 
-Якщо у другому запиті `cache_read_input_tokens === 0` — значить `cache_control` не спрацював. Найчастіше: блок з `cache_control` не «співпав» побайтово — наприклад, ти випадково склеїв `SYSTEM_PREFIX` з context-ом всередині кешованого блоку.
+Якщо у другому запиті `cache_read_input_tokens === 0`:
 
-### 7. Production rollout
+- Перевір, що cached prefix достатньо довгий для моделі.
+- Перевір, що між двома запитами не змінився cached block (`TOOLS`, `SYSTEM_PREFIX`, whitespace, model, tool_choice).
+- Перевір, що другий запит пішов після того, як перший response почався/завершився; паралельні запити можуть не бачити щойно створений cache entry.
+
+### 8. Production rollout
 
 - Деплой → перші ~5 хв cache miss-и для всіх юзерів (що нормально).
 - Через 5–15 хв подивись Grafana `aiTokensTotal{kind="cache_read"}` — має лінійно рости.
-- Cost: typical 5–10× зниження input-token billing на стабільних запитах.
+- Cost: target — багаторазове зниження billed input tokens на repeated chat-flow.
 
-Якщо `cache_read` лишається на 0 на проді при non-zero `cache_write` — ймовірний `SYSTEM_PROMPT_VERSION` churn (хтось мерджить ще одну зміну промпту, інвалідуючи кеш). Заморозь промпт.
+Якщо `cache_read` лишається на 0 при non-zero traffic — зроби smoke з real key і подивись raw `usage`; length-based caching failures silent.
 
 ---
 
 ## Verification
 
-- [ ] `system` у обох викликах `chat.ts` — масив із двома `text` блоками: cached `SYSTEM_PREFIX` + dynamic `context`.
+- [ ] `system` у обох викликах `chat.ts` — block array: cached `SYSTEM_PREFIX` + optional dynamic `context`.
+- [ ] `context` не кешується і empty context не додає empty text block.
+- [ ] Останній stable tool у payload має `cache_control: { type: "ephemeral" }`.
 - [ ] (Якщо застосовно) `anthropic-beta: prompt-caching-2024-07-31` додано і в звичайний, і в стрімовий клієнт.
 - [ ] `SYSTEM_PROMPT_VERSION` додано і логічно підвищується з кожною свідомою зміною промпту.
 - [ ] `recordUsage` пише `kind: "cache_write"` і `kind: "cache_read"` у `aiTokensTotal`.
 - [ ] Dev smoke: два послідовні `/api/chat` дають `cache_creation > 0` (1-й) і `cache_read > 0` (2-й).
 - [ ] Тести `chat.test.ts` оновлені під нову структуру `system` і green.
-- [ ] PR description містить: token-cost diff (estimate), reference на Anthropic prompt caching docs, Grafana посилання на нові метрики.
+- [ ] PR description містить: token-cost diff або smoke output, reference на Anthropic prompt caching docs, Grafana/metrics notes.
 
 ## Notes
 
 - **Не міняй `SYSTEM_PREFIX` часто.** Кожна зміна — повний cache invalidation, для всіх активних юзерів. Якщо потрібно подіагностувати tone — кешуй stable prefix і додай експериментальний rider у `context` блок (не у кеш).
-- **Tool definitions у `tools` параметрі НЕ кешуються тим самим `cache_control`.** Якщо `TOOLS` теж великий і стабільний — постав окремий `cache_control` всередині `tools` як ще одну точку розриву (Anthropic дозволяє до 4 cache breakpoints на запит). На момент писання `tools.ts` у нас невеликий, тому економія мала; повертайся до цього кроку, якщо `TOOLS` виросте.
+- **Не додавай breakpoint-и всюди.** Anthropic має ліміт cache breakpoints на request; тримай один forward-looking system breakpoint і один practical tools breakpoint, доки немає виміряної потреби.
 - **TTL ephemeral кешу — ~5 хв** з останнього read. Для sparse трафіку (юзер заходить раз на годину) prompt caching не дасть значної економії; має сенс для активних сесій / інтенсивного chat-flow.
 - **Cache key чутливий побайтно.** Невидимий whitespace-diff, BOM, нерозривні пробіли — все робить cache miss. Не редагуй `SYSTEM_PREFIX` у редакторі без unicode-aware diff.
+- **Minimum length failures silent.** Якщо prompt нижче порогу моделі, request успішний, але `cache_creation_input_tokens` і `cache_read_input_tokens` лишаються 0.
 
 ## See also
 
 - [tune-system-prompt.md](tune-system-prompt.md) — як міняти `SYSTEM_PREFIX` без поломки tool-calling (виконуй до або в окремому PR від caching rollout)
 - [AGENTS.md](../../AGENTS.md) — секції _Architecture: AI tool execution path_ і _SYSTEM_PREFIX is a prompt-cache candidate_
 - `apps/server/src/lib/anthropic.ts` — `anthropicMessages` / `anthropicMessagesStream` / `recordUsage`
-- `apps/server/src/modules/chat.ts` — обидва payload-и (рядки ~115, ~171)
+- `apps/server/src/modules/chat.ts` — `buildSystem`, `applyToolsCacheBreakpoint`, request payload-и.
 - Anthropic docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching


### PR DESCRIPTION
## What changed

- Updated `AGENTS.md` with the PR #790 prompt-caching finding: Sonnet cache breakpoints have a minimum token floor and below-threshold breakpoints silently no-op.
- Reworked `docs/playbooks/enable-prompt-caching.md` around the viable Sergeant rollout: cached `SYSTEM_PREFIX`, last-tool `cache_control` breakpoint, silent length-failure troubleshooting, and concrete verification steps.
- Aligned the playbook wording with the server implementation ordering invariant: `system` → `tools` → `messages`.

## Why

PR #790 live smoke showed `SYSTEM_PREFIX`-only prompt caching did not engage because the prefix was below the observed Sonnet 1024-token minimum. The docs now capture the working tools-breakpoint strategy so future agents do not repeat the failed rollout path.

## How to test

```bash
pnpm format:check
pnpm typecheck
pnpm lint
pnpm --filter @sergeant/server exec vitest run src/modules/chat.test.ts
```

CI note: GitHub `Test coverage (vitest)` and `Smoke E2E (Playwright)` pass on this PR. The `check` job is currently failing in `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx` with `useApiClient must be used inside <ApiClientProvider>`. I reproduced that same failure from a fresh `main` checkout, so it is pre-existing and unrelated to this docs-only PR.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): docs-only review against current `chat.ts` / `chat.test.ts` prompt-caching implementation.
- [x] Vitest passes: `pnpm --filter @sergeant/server exec vitest run src/modules/chat.test.ts` (10 tests).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — `AGENTS.md:281` documents the prompt-cache minimum/token-floor finding.
- [ ] No — no new permanent rules