### PR TITLE
feat(server): generate SYSTEM_PREFIX from assistant capability registry

### DIFF
--- a/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
+++ b/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SYSTEM_PREFIX — registry-driven > matches the canonical snapshot 1`] = `
+"Ти персональний асистент додатку "Мій простір". Ти маєш доступ до 4 модулів: Фінік (фінанси), Фізрук (тренування), Рутина (щоденні звички) та Харчування (нутрієнти й калорії). Відповідай ТІЛЬКИ українською, стисло (2-4 речення).
+
+ПРАВИЛА:
+- Усі числа бери з блоку ДАНІ нижче.
+- Якщо потрібно порахувати (середня/день, прогноз, залишок ліміту, відсоток виконання) — рахуй на основі наданих чисел.
+- Якщо користувач просить змінити або записати дані — використай відповідний tool.
+  - Фінанси: create_transaction, change_category, find_transaction, batch_categorize (dry_run спершу), hide_transaction, delete_transaction (лише ручні m_<id>), create_debt, create_receivable, mark_debt_paid, set_budget_limit, update_budget (ліміт або ціль), set_monthly_plan, add_asset, import_monobank_range, split_transaction, recurring_expense, export_report
+  - Фізрук: start_workout, log_set, finish_workout, plan_workout, add_program_day, log_measurement, log_weight, log_wellbeing, suggest_workout, copy_workout, compare_progress
+  - Рутина: mark_habit_done, complete_habit_for_date, create_habit, create_reminder, edit_habit, archive_habit, reorder_habits, habit_stats, set_habit_schedule, pause_habit (ідемпотентно), add_calendar_event
+  - Харчування: log_meal, log_water, set_daily_plan, suggest_meal, add_recipe, add_to_shopping_list, consume_from_pantry, copy_meal_from_date, plan_meals_for_day
+  - Кросмодульні: morning_briefing, weekly_summary, set_goal
+  - Аналітика: spending_trend, category_breakdown, weight_chart, habit_trend, detect_anomalies
+  - Утиліти: calculate_1rm, convert_units, save_note, list_notes, export_module_data
+  - Пам'ять: remember, forget, my_profile
+- Транзакції мають id і дату — використовуй для tool calls.
+- Якщо користувач каже щось важливе про себе (алергії, уподобання, цілі, обмеження) — АВТОМАТИЧНО використай remember щоб запам'ятати. Не питай дозволу.
+- Блок [Профіль користувача] містить раніше запам'ятовані факти — ЗАВЖДИ враховуй їх у порадах (тренування, їжа, цілі).
+- Категорії та їх id перелічені в [Категорії].
+- Відповідай на питання по всіх 4 модулях.
+
+ДАНІ:
+"
+`;

--- a/apps/server/src/modules/chat/toolDefs/systemPrompt.test.ts
+++ b/apps/server/src/modules/chat/toolDefs/systemPrompt.test.ts
@@ -1,0 +1,142 @@
+/**
+ * SYSTEM_PREFIX is generated from the assistant capability registry. These
+ * tests lock in the contract between the registry and the prompt:
+ *
+ *   1. Prompt shape is preserved (Anthropic prompt-cache key sensitivity —
+ *      any drift requires a deliberate `SYSTEM_PROMPT_VERSION` bump).
+ *   2. Every non-prompt-only capability appears in the prompt.
+ *   3. Every server tool actually wired into `TOOLS` has a matching registry
+ *      entry (no "ghost" tools the user can never discover).
+ *   4. Token budget guard (≤10% growth vs. baseline) — handoff requirement.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ASSISTANT_CAPABILITIES,
+  getCapabilityServerTool,
+} from "@sergeant/shared";
+import {
+  SYSTEM_PREFIX,
+  SYSTEM_PROMPT_VERSION,
+  buildModuleToolList,
+  buildSystemPrompt,
+} from "./systemPrompt.js";
+import { TOOLS } from "../tools.js";
+
+describe("SYSTEM_PREFIX — registry-driven", () => {
+  it("starts with the canonical assistant intro (cache key sensitivity)", () => {
+    expect(SYSTEM_PREFIX).toMatch(/^Ти персональний асистент/);
+  });
+
+  it("ends with the ДАНІ marker so the per-user context block can append cleanly", () => {
+    expect(SYSTEM_PREFIX.endsWith("ДАНІ:\n")).toBe(true);
+  });
+
+  it("buildSystemPrompt() is deterministic", () => {
+    expect(buildSystemPrompt()).toBe(SYSTEM_PREFIX);
+    expect(buildSystemPrompt()).toBe(buildSystemPrompt());
+  });
+
+  it("exposes a non-empty SYSTEM_PROMPT_VERSION marker", () => {
+    expect(SYSTEM_PROMPT_VERSION).toMatch(/^v\d+/);
+  });
+
+  it("every non-prompt-only capability appears in the prompt", () => {
+    for (const c of ASSISTANT_CAPABILITIES) {
+      const tool = getCapabilityServerTool(c);
+      if (!tool) continue;
+      expect(SYSTEM_PREFIX, `${c.id} (${tool})`).toContain(tool);
+    }
+  });
+
+  it("prompt-only capabilities are NOT listed as tools", () => {
+    const promptOnly = ASSISTANT_CAPABILITIES.filter(
+      (c) => c.serverTool === null,
+    );
+    expect(promptOnly.length).toBeGreaterThan(0); // sanity
+    const toolList = buildModuleToolList();
+    for (const c of promptOnly) {
+      // The id may legitimately appear elsewhere as plain text — but it must
+      // not appear in the comma-delimited tool list bullets.
+      const inList = toolList.split(/\n/).some((line) => line.includes(c.id));
+      expect(inList, `${c.id} (prompt-only) leaked into tool list`).toBe(false);
+    }
+  });
+
+  it("every server tool in TOOLS has a matching registry entry", () => {
+    const registryToolNames = new Set(
+      ASSISTANT_CAPABILITIES.map(getCapabilityServerTool).filter(
+        (t): t is string => t !== null,
+      ),
+    );
+    for (const t of TOOLS) {
+      expect(
+        registryToolNames.has(t.name),
+        `tool ${t.name} exists in TOOLS but has no AssistantCapability — add it to assistantCatalogue.ts`,
+      ).toBe(true);
+    }
+  });
+
+  it("registry server-tool names are unique (no duplicate mappings)", () => {
+    const seen = new Set<string>();
+    for (const c of ASSISTANT_CAPABILITIES) {
+      const t = getCapabilityServerTool(c);
+      if (!t) continue;
+      expect(seen.has(t), `duplicate serverTool: ${t}`).toBe(false);
+      seen.add(t);
+    }
+  });
+
+  it("aiHints are short (≤30 chars) so the prompt stays terse", () => {
+    for (const c of ASSISTANT_CAPABILITIES) {
+      if (c.aiHint == null) continue;
+      expect(c.aiHint.length, `${c.id} aiHint too long`).toBeLessThanOrEqual(
+        30,
+      );
+      expect(c.aiHint.trim()).toBe(c.aiHint);
+    }
+  });
+
+  // AI-CONTEXT: baseline computed 2026-04-26 from v5 (hand-written) prompt.
+  // Approximation: chars / 3.5 ≈ tokens for mixed Cyrillic/ASCII Anthropic
+  // tokenizer. Real measurement happens server-side in usage logs.
+  // Allow up to 1.10× growth per the PR2 handoff guard.
+  it("token budget: stays within 110% of baseline (~1012 tokens)", () => {
+    const BASELINE_TOKENS = 1012;
+    const BUDGET = Math.round(BASELINE_TOKENS * 1.1);
+    const approxTokens = Math.round(SYSTEM_PREFIX.length / 3.5);
+    expect(
+      approxTokens,
+      `prompt grew to ~${approxTokens} tokens (budget ${BUDGET})`,
+    ).toBeLessThanOrEqual(BUDGET);
+  });
+
+  it("module bullets follow the canonical Ukrainian module labels", () => {
+    const list = buildModuleToolList();
+    expect(list).toMatch(/- Фінанси: /);
+    expect(list).toMatch(/- Фізрук: /);
+    expect(list).toMatch(/- Рутина: /);
+    expect(list).toMatch(/- Харчування: /);
+    expect(list).toMatch(/- Кросмодульні: /);
+    expect(list).toMatch(/- Аналітика: /);
+    expect(list).toMatch(/- Утиліти: /);
+    expect(list).toMatch(/- Пам'ять: /);
+  });
+
+  it("aiHints are rendered in parentheses next to the tool name", () => {
+    // Spot-check: delete_transaction has aiHint "лише ручні m_<id>"
+    expect(SYSTEM_PREFIX).toContain("delete_transaction (лише ручні m_<id>)");
+    expect(SYSTEM_PREFIX).toContain("update_budget (ліміт або ціль)");
+    expect(SYSTEM_PREFIX).toContain("batch_categorize (dry_run спершу)");
+  });
+
+  it("does NOT contain the legacy /help instruction (PR #795 redirected it)", () => {
+    expect(SYSTEM_PREFIX).not.toContain("/help");
+    expect(SYSTEM_PREFIX).not.toContain("/допомога");
+  });
+
+  // Snapshot: locks the exact prompt text. Updating this requires bumping
+  // SYSTEM_PROMPT_VERSION and is a deliberate, reviewed change.
+  it("matches the canonical snapshot", () => {
+    expect(SYSTEM_PREFIX).toMatchSnapshot();
+  });
+});

--- a/apps/server/src/modules/chat/toolDefs/systemPrompt.ts
+++ b/apps/server/src/modules/chat/toolDefs/systemPrompt.ts
@@ -1,3 +1,11 @@
+import {
+  ASSISTANT_CAPABILITIES,
+  CAPABILITY_MODULE_ORDER,
+  getCapabilityServerTool,
+  type AssistantCapability,
+  type CapabilityModule,
+} from "@sergeant/shared";
+
 /**
  * Семантична версія `SYSTEM_PREFIX`. Бампай при кожній свідомій зміні промпта.
  *
@@ -8,29 +16,71 @@
  *
  * Бамп-політика: будь-яка зміна тексту SYSTEM_PREFIX → +1 до мажора. Без формального
  * семвер — впорядкованих версій вистачить, бо бамп ручний і свідомий.
+ *
+ * v6 (2026-04-26): tool-list bullets тепер генеруються з `ASSISTANT_CAPABILITIES`
+ *   у `@sergeant/shared` — реджистр є єдиним джерелом істини. Видалено блок
+ *   інструкції про /help (PR #795 редіректить /help у каталог UI).
  */
 export const SYSTEM_PROMPT_VERSION = "v6";
 
-export const SYSTEM_PREFIX = `Ти персональний асистент додатку "Мій простір". Ти маєш доступ до 4 модулів: Фінік (фінанси), Фізрук (тренування), Рутина (щоденні звички) та Харчування (нутрієнти й калорії). Відповідай ТІЛЬКИ українською, стисло (2-4 речення).
+// AI-CONTEXT: модульний label у промпті відрізняється від `CAPABILITY_MODULE_META.title`,
+// бо UI показує "Фінік", а промпту історично подавали "Фінанси" (тон-нейтральніше для
+// AI tool-selection). Не перекладаємо мітки на `Фінік` без A/B-тесту.
+const MODULE_PROMPT_LABEL: Record<CapabilityModule, string> = {
+  finyk: "Фінанси",
+  fizruk: "Фізрук",
+  routine: "Рутина",
+  nutrition: "Харчування",
+  cross: "Кросмодульні",
+  analytics: "Аналітика",
+  utility: "Утиліти",
+  memory: "Пам'ять",
+};
+
+function formatToolEntry(c: AssistantCapability): string | null {
+  const tool = getCapabilityServerTool(c);
+  if (!tool) return null;
+  return c.aiHint ? `${tool} (${c.aiHint})` : tool;
+}
+
+/**
+ * Per-module bullet list of available tools, generated from the
+ * assistant capability registry. Mirrors the ordering of
+ * `CAPABILITY_MODULE_ORDER`. Skips prompt-only capabilities
+ * (those with `serverTool: null`).
+ */
+export function buildModuleToolList(): string {
+  const lines: string[] = [];
+  for (const m of CAPABILITY_MODULE_ORDER) {
+    const tools = ASSISTANT_CAPABILITIES.filter((c) => c.module === m)
+      .map(formatToolEntry)
+      .filter((s): s is string => s !== null);
+    if (tools.length === 0) continue;
+    lines.push(`  - ${MODULE_PROMPT_LABEL[m]}: ${tools.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Build the canonical system prefix string. Pure / deterministic —
+ * the result is memoised once into `SYSTEM_PREFIX` at module load.
+ */
+export function buildSystemPrompt(): string {
+  return `Ти персональний асистент додатку "Мій простір". Ти маєш доступ до 4 модулів: Фінік (фінанси), Фізрук (тренування), Рутина (щоденні звички) та Харчування (нутрієнти й калорії). Відповідай ТІЛЬКИ українською, стисло (2-4 речення).
 
 ПРАВИЛА:
 - Усі числа бери з блоку ДАНІ нижче.
 - Якщо потрібно порахувати (середня/день, прогноз, залишок ліміту, відсоток виконання) — рахуй на основі наданих чисел.
 - Якщо користувач просить змінити або записати дані — використай відповідний tool.
-  - Фінанси: create_transaction, find_transaction, batch_categorize (dry_run спершу), delete_transaction (лише ручні m_<id>), change_category, hide_transaction, create_debt, mark_debt_paid, create_receivable, set_budget_limit, update_budget (ліміт або ціль), set_monthly_plan, add_asset, import_monobank_range, split_transaction, recurring_expense, export_report
-  - Фізрук: start_workout / finish_workout, log_set, plan_workout, add_program_day, log_measurement, log_wellbeing, suggest_workout, copy_workout, compare_progress
-  - Рутина: create_habit, mark_habit_done, complete_habit_for_date, create_reminder, archive_habit, add_calendar_event, edit_habit, reorder_habits, habit_stats, set_habit_schedule, pause_habit
-  - Харчування: log_meal, log_water, add_recipe, add_to_shopping_list, consume_from_pantry, set_daily_plan, log_weight, suggest_meal, copy_meal_from_date, plan_meals_for_day
-  - Кросмодульні: morning_briefing, weekly_summary, set_goal
-  - Аналітика: spending_trend, weight_chart, category_breakdown, detect_anomalies, habit_trend
-  - Утиліти: calculate_1rm, convert_units, save_note, list_notes, export_module_data
-  - Пам'ять: remember, forget, my_profile
+${buildModuleToolList()}
 - Транзакції мають id і дату — використовуй для tool calls.
 - Якщо користувач каже щось важливе про себе (алергії, уподобання, цілі, обмеження) — АВТОМАТИЧНО використай remember щоб запам'ятати. Не питай дозволу.
 - Блок [Профіль користувача] містить раніше запам'ятовані факти — ЗАВЖДИ враховуй їх у порадах (тренування, їжа, цілі).
 - Категорії та їх id перелічені в [Категорії].
 - Відповідай на питання по всіх 4 модулях.
-- Якщо користувач пише /help або /допомога або просить допомоги — поверни структурований список усіх доступних інструментів. Форматуй відповідь як markdown: використовуй #### заголовки для секцій (по модулях: Фінік, Фізрук, Рутина, Харчування, Кросмодульні, Аналітика, Утиліти, Пам'ять), дефіс-списки (- ) для команд, і \`приклад\` для прикладів. Кожна команда — окремий пункт списку.
 
 ДАНІ:
 `;
+}
+
+export const SYSTEM_PREFIX = buildSystemPrompt();

--- a/packages/shared/src/lib/assistantCatalogue.test.ts
+++ b/packages/shared/src/lib/assistantCatalogue.test.ts
@@ -3,6 +3,7 @@ import {
   ASSISTANT_CAPABILITIES,
   CAPABILITY_MODULE_ORDER,
   CAPABILITY_MODULE_META,
+  getCapabilityServerTool,
   getQuickActionCapabilities,
   groupCapabilitiesByModule,
   searchCapabilities,
@@ -106,6 +107,53 @@ describe("ASSISTANT_CAPABILITIES — invariants", () => {
     for (const c of ASSISTANT_CAPABILITIES) {
       expect(c.examples.length, `${c.id} has no examples`).toBeGreaterThan(0);
     }
+  });
+
+  it("aiHint is short (≤30 chars) and trimmed when present", () => {
+    for (const c of ASSISTANT_CAPABILITIES) {
+      if (c.aiHint == null) continue;
+      expect(c.aiHint.length, `${c.id} aiHint too long`).toBeLessThanOrEqual(
+        30,
+      );
+      expect(c.aiHint.trim(), `${c.id} aiHint must be trimmed`).toBe(c.aiHint);
+    }
+  });
+
+  it("serverTool overrides resolve to a non-empty snake_case string", () => {
+    for (const c of ASSISTANT_CAPABILITIES) {
+      const tool = getCapabilityServerTool(c);
+      if (tool === null) continue;
+      expect(tool, `${c.id} resolves to empty tool name`).toMatch(
+        /^[a-z][a-z0-9_]*$/,
+      );
+    }
+  });
+});
+
+describe("getCapabilityServerTool", () => {
+  it("returns id when serverTool is undefined", () => {
+    const c = ASSISTANT_CAPABILITIES.find((x) => x.id === "create_transaction");
+    expect(c).toBeDefined();
+    expect(getCapabilityServerTool(c!)).toBe("create_transaction");
+  });
+
+  it("returns null for prompt-only entries (serverTool: null)", () => {
+    const c = ASSISTANT_CAPABILITIES.find((x) => x.id === "budget_risks");
+    expect(c).toBeDefined();
+    expect(getCapabilityServerTool(c!)).toBeNull();
+  });
+
+  it("at least 3 prompt-only entries exist (budget_risks, daily_summary, missed_this_week)", () => {
+    const promptOnly = ASSISTANT_CAPABILITIES.filter(
+      (c) => c.serverTool === null,
+    ).map((c) => c.id);
+    expect(promptOnly).toEqual(
+      expect.arrayContaining([
+        "budget_risks",
+        "daily_summary",
+        "missed_this_week",
+      ]),
+    );
   });
 });
 

--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -63,6 +63,24 @@ export interface AssistantCapability {
   requiresOnline?: boolean;
   /** Extra search keywords (not displayed). */
   keywords?: readonly string[];
+
+  /**
+   * Server tool name for system-prompt generation.
+   * - `undefined` (default): `id` IS the server tool name (validated against
+   *   the actual TOOLS array on the server).
+   * - `string`: explicit override when capability `id` diverges from the
+   *   server tool name.
+   * - `null`: prompt-only capability — no backing server tool. The model
+   *   answers from the injected ДАНІ block (e.g. budget risk analysis,
+   *   daily summary derived from numbers already in context).
+   */
+  serverTool?: string | null;
+  /**
+   * Optional terse hint emitted next to the tool name in the generated
+   * system prompt (e.g. "dry_run спершу", "лише ручні m_<id>"). Helps the
+   * model pick the right tool without bloating the prompt.
+   */
+  aiHint?: string;
 }
 
 /** Display order of modules in the catalogue UI. */
@@ -95,7 +113,7 @@ export const CAPABILITY_MODULE_META: Record<
 // AI-NOTE: counts in section comments below match `ASSISTANT_CAPABILITIES`.
 // Update them when adding/removing entries; tests assert per-module totals.
 export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
-  // ───── Фінік (16) ─────────────────────────────────────────────────────
+  // ───── Фінік (18) ─────────────────────────────────────────────────────
   {
     id: "create_transaction",
     module: "finyk",
@@ -130,6 +148,40 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
   {
+    id: "find_transaction",
+    module: "finyk",
+    label: "Знайти транзакцію",
+    icon: "search",
+    description:
+      "Пошук транзакції за описом, мерчантом, сумою або датою. Не змінює дані.",
+    examples: [
+      "знайди покупку в АТБ",
+      "транзакція на 450 грн позавчора",
+      "що було в Сільпо за тиждень",
+    ],
+    prompt: "Знайди транзакцію: ",
+    requiresInput: true,
+    requiresOnline: true,
+    keywords: ["search", "пошук", "merchant"],
+  },
+  {
+    id: "batch_categorize",
+    module: "finyk",
+    label: "Категоризувати масово",
+    icon: "tags",
+    description:
+      "Перенести багато транзакцій в одну категорію за патерном. Спочатку показує preview (dry_run), застосовує лише після підтвердження.",
+    examples: [
+      "віднеси все Сільпо в продукти",
+      "категоризуй всі АЗС на транспорт",
+    ],
+    prompt: "Категоризуй масово: ",
+    requiresInput: true,
+    requiresOnline: true,
+    aiHint: "dry_run спершу",
+    keywords: ["batch", "масово", "категорія"],
+  },
+  {
     id: "hide_transaction",
     module: "finyk",
     label: "Приховати транзакцію",
@@ -153,6 +205,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresInput: true,
     risky: true,
     requiresOnline: true,
+    aiHint: "лише ручні m_<id>",
   },
   {
     id: "create_debt",
@@ -201,6 +254,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     quickActionPriority: 20,
     requiresOnline: true,
     keywords: ["budget", "ліміт", "risk"],
+    serverTool: null,
   },
   {
     id: "set_budget_limit",
@@ -226,6 +280,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Онови бюджет: ",
     requiresInput: true,
     requiresOnline: true,
+    aiHint: "ліміт або ціль",
   },
   {
     id: "set_monthly_plan",
@@ -428,7 +483,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
 
-  // ───── Рутина (10) ─────────────────────────────────────────────────────
+  // ───── Рутина (12) ─────────────────────────────────────────────────────
   {
     id: "mark_habit_done",
     module: "routine",
@@ -522,6 +577,37 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
   {
+    id: "set_habit_schedule",
+    module: "routine",
+    label: "Розклад звички",
+    icon: "calendar-check",
+    description:
+      "Виставити дні тижня для звички (recurrence='weekly'). Англ. ('mon'..'sun') або укр. ('пн'..'нд').",
+    examples: [
+      "тренування пн/ср/пт",
+      "медитація щодня крім вихідних",
+      "англійська вт чт",
+    ],
+    prompt: "Постав розклад звички: ",
+    requiresInput: true,
+    requiresOnline: true,
+    keywords: ["schedule", "розклад", "дні тижня", "weekly"],
+  },
+  {
+    id: "pause_habit",
+    module: "routine",
+    label: "Пауза звички",
+    icon: "pause",
+    description:
+      "Тимчасово поставити звичку на паузу або зняти з неї. Зберігає історію виконань.",
+    examples: ["постав на паузу 'Англійська'", "зніми паузу зі звички 'Біг'"],
+    prompt: "Пауза звички: ",
+    requiresInput: true,
+    requiresOnline: true,
+    aiHint: "ідемпотентно",
+    keywords: ["pause", "пауза", "відновити"],
+  },
+  {
     id: "missed_this_week",
     module: "routine",
     label: "Що пропущено за тиждень",
@@ -535,6 +621,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     quickActionPriority: 20,
     requiresOnline: true,
     keywords: ["missed", "тиждень", "streak"],
+    serverTool: null,
   },
   {
     id: "add_calendar_event",
@@ -688,6 +775,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     quickActionPriority: 20,
     requiresOnline: true,
     keywords: ["підсумок", "звіт", "вечір"],
+    serverTool: null,
   },
   {
     id: "weekly_summary",
@@ -873,6 +961,17 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
 ];
+
+/**
+ * Resolve the server tool name for a capability.
+ * - `null` ⇒ prompt-only capability (no backing tool).
+ * - `string` ⇒ explicit override.
+ * - default ⇒ capability `id` is used as the tool name.
+ */
+export function getCapabilityServerTool(c: AssistantCapability): string | null {
+  if (c.serverTool === null) return null;
+  return c.serverTool ?? c.id;
+}
 
 /**
  * Capabilities surfaced as quick-action chips below the chat input.


### PR DESCRIPTION
## What changed

`apps/server/src/modules/chat/toolDefs/systemPrompt.ts` no longer hand-codes the per-module tool list. The bullets are generated from `ASSISTANT_CAPABILITIES` (`@sergeant/shared`) via a new `buildSystemPrompt()` / `buildModuleToolList()` pair. The legacy `/help` instruction block is dropped (PR #795 already redirects `/help` to the catalogue UI).

`AssistantCapability` gains two optional fields used only by the prompt builder:

- `serverTool?: string | null` — `undefined` ⇒ `id` is the server tool name (default); `string` ⇒ explicit override; `null` ⇒ prompt-only capability with no backing tool. Three existing entries are flagged `null`: `budget_risks`, `daily_summary`, `missed_this_week` (they're answered from the injected `ДАНІ` block, not via tool calls).
- `aiHint?: string` — terse parenthetical hint emitted next to the tool name in the prompt (e.g. `dry_run спершу`, `лише ручні m_<id>`, `ліміт або ціль`, `ідемпотентно`). Preserves the model-tuning hints that lived in v5.

Server tools that were already in `TOOLS` but missing from the catalogue are added so the registry is exhaustive: `find_transaction`, `batch_categorize`, plus `set_habit_schedule` and `pause_habit` (added by #797 mid-rebase). Counts updated: Фінік 16 → 18, Рутина 10 → 12.

`SYSTEM_PROMPT_VERSION` bumps `v5` → `v6` (Anthropic prompt-cache invalidation marker).

## Why

PR #795 made the registry the source of truth for the catalogue UI, the chat quick-action chips, and `/help`. The system prompt was the last hand-written consumer — adding a new tool required editing two files and could silently drift. PR #797 (merged today) is a perfect example: it added `set_habit_schedule` / `pause_habit` to `TOOLS` and the hand-written prompt, but missed the registry. After this PR, dropping a new entry into `assistantCatalogue.ts` automatically:

- shows it in `/assistant`,
- exposes it as a chip if `isQuickAction`,
- lists it under the right module in `SYSTEM_PREFIX`.

The `every server tool in TOOLS has a matching registry entry` invariant in `systemPrompt.test.ts` will catch this drift in CI from now on.

Per the PR2 handoff (2026-04-25), the scope is intentionally narrow: tool **names** + parenthetical hints, no per-capability examples. Tool `input_schema` continues to live in the per-domain `toolDefs/*.ts` files; the registry doesn't generate Zod-style schemas.

## How to test

Reviewers:

```bash
pnpm --filter @sergeant/shared test           # 256/256
pnpm --filter @sergeant/server test           # incl. 14 systemPrompt + 10 chat
pnpm --filter web test                        # 832/832
pnpm --filter @sergeant/shared --filter @sergeant/server --filter web typecheck
pnpm --filter @sergeant/shared --filter @sergeant/server --filter web lint
```

Manual smoke (post-merge or against Vercel preview): a few representative chat prompts to catch tool-selection regressions —

1. "що в мене на сьогодні" → `morning_briefing`
2. "додай витрату 200 на каву" → `create_transaction`
3. "почни тренування ноги" → `start_workout`
4. "що пропущено за тиждень" → routine missed analysis (no tool, prompt-only `missed_this_week`)
5. "з'їв 100г сиру" → `log_meal`
6. "тренування пн/ср/пт" → `set_habit_schedule` (added in #797, now in registry)

`SYSTEM_PROMPT_VERSION` bump means the first request after deploy will report `cache_creation_input_tokens > 0` (expected; cache rewarms within ~5 min TTL).

---

## How AI-tested this PR

- [x] Manual smoke: not yet — chat is Anthropic-bound and needs the `ANTHROPIC_API_KEY`. Proposed for post-merge against Vercel preview using the 6 prompts above.
- [x] Vitest passes locally: shared 256/256, server (chat slice) 24/24 (incl. 14 new `systemPrompt.test.ts`), web 832/832.
- [x] CI red checks (`check`, `detox-android`, `detox-ios`) match the `AGENTS.md` _Pre-existing flaky tests (do not block merge)_ list — not regressions from this PR.
- [x] No new `AI-DANGER` markers added without justification. (One new `AI-CONTEXT` on the divergent `Фінанси` vs `Фінік` module-label choice in the prompt vs the UI title.)
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. The new `serverTool` / `aiHint` fields are documented at their declaration site in `assistantCatalogue.ts` and locked by `systemPrompt.test.ts` invariants.

---
Requested by: Ка А (ka3576381@gmail.com)
Devin session: https://app.devin.ai/sessions/46d552e958104208911b32a3b0526769