### PR TITLE
feat(shared): add catalogue rows for set_habit_schedule + pause_habit

### DIFF
--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -428,7 +428,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
 
-  // ───── Рутина (10) ─────────────────────────────────────────────────────
+  // ───── Рутина (12) ─────────────────────────────────────────────────────
   {
     id: "mark_habit_done",
     module: "routine",
@@ -486,6 +486,42 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Онови звичку: ",
     requiresInput: true,
     requiresOnline: true,
+  },
+  {
+    id: "set_habit_schedule",
+    module: "routine",
+    label: "Дні тижня для звички",
+    shortLabel: "Розклад",
+    icon: "calendar",
+    description:
+      "Виставити точні дні тижня для звички (recurrence='weekly'). Приймає англ. (mon..sun) або укр. (пн..нд).",
+    examples: [
+      "тренування пн ср пт",
+      "медитація щодня крім неділі",
+      "біг tue thu sat",
+    ],
+    prompt: "Постав розклад звички: ",
+    requiresInput: true,
+    requiresOnline: true,
+    keywords: ["weekday", "schedule", "weekly", "розклад", "дні"],
+  },
+  {
+    id: "pause_habit",
+    module: "routine",
+    label: "Поставити звичку на паузу",
+    shortLabel: "Пауза",
+    icon: "pause-circle",
+    description:
+      "Тимчасово відключити звичку без архівування — не потрапляє в календар і не шле нагадування. Оборотно.",
+    examples: [
+      "постав 'Біг' на паузу",
+      "запаузь медитацію",
+      "знов активуй воду",
+    ],
+    prompt: "Постав звичку на паузу: ",
+    requiresInput: true,
+    requiresOnline: true,
+    keywords: ["pause", "resume", "unpause", "пауза", "відновити"],
   },
   {
     id: "archive_habit",


### PR DESCRIPTION
## What changed

Two new entries in `ASSISTANT_CAPABILITIES` (`packages/shared/src/lib/assistantCatalogue.ts`) for the tools shipped in #797:

- **`set_habit_schedule`** — icon `calendar`, shortLabel `"Розклад"`. Examples cover both English (`tue thu sat`) and Ukrainian (`пн ср пт`) day-name forms.
- **`pause_habit`** — icon `pause-circle`, shortLabel `"Пауза"`. Examples cover both pausing and unpausing phrasings.

Section header count bumped: `Рутина (10) → (12)`.

Neither is `risky` (mirrors `RISKY_TOOLS` in `apps/web/src/core/lib/hubChatActionCards.ts`) and neither is a quick-action — they're discoverable in the catalogue UI but don't crowd the chip strip below the chat input.

## Why

Per the design spec invariant in `assistantCatalogue.ts`:

> when adding a new server tool definition under `apps/server/src/modules/chat/toolDefs/`, add a matching entry here too. Without an entry the capability is invisible to the user and absent from `/help`, even though the model can still call it.

#797 added both tools to the server `toolDefs` and to the web action-card layer (icon + title + summary + KNOWN_TOOLS), but the catalogue itself was deliberately left out (called "non-goal" in the spec) so the catalogue PR could ship as a focused follow-up. This is that follow-up.

## How to test

```bash
pnpm --filter @sergeant/shared exec vitest run src/lib/assistantCatalogue.test.ts
pnpm format:check && pnpm typecheck && pnpm lint
```

Manually:

1. Open the in-chat catalogue → "Рутина" section now lists both new entries with the expected icons and Ukrainian labels.
2. `/help` lists them.
3. Search `розклад` / `pause` / `пауза` matches the right entries via `searchCapabilities`.

---

## How AI-tested this PR

- [x] Manual smoke: not yet — covered by invariants test.
- [x] Vitest passes: `assistantCatalogue.test.ts` (18/18). Full repo: `pnpm typecheck` + `pnpm lint` clean.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create custom weekly schedules for habits by selecting specific weekdays for recurring routines
  * Temporarily pause habits to exclude them from reminders and calendar while preserving all tracking data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->