### PR TITLE
feat(mobile): assistant capability catalogue page

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -42,6 +42,7 @@ function RootShell() {
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="(auth)" options={{ presentation: "modal" }} />
         <Stack.Screen name="settings" options={{ presentation: "modal" }} />
+        <Stack.Screen name="assistant" options={{ presentation: "modal" }} />
         <Stack.Screen name="auth/callback" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/apps/mobile/app/assistant.tsx
+++ b/apps/mobile/app/assistant.tsx
@@ -1,0 +1,18 @@
+/**
+ * Assistant capability catalogue route.
+ *
+ * Modal stack screen registered in `app/_layout.tsx`. Mirrors the web
+ * `/assistant` route — surfaces the full `ASSISTANT_CAPABILITIES`
+ * registry from `@sergeant/shared` so the user can browse what the
+ * AI assistant can do.
+ *
+ * See `apps/mobile/src/core/AssistantCataloguePage.tsx` for the page
+ * implementation and `apps/mobile/src/core/settings/AssistantCatalogueSection.tsx`
+ * for the settings-shell launcher.
+ */
+
+import { AssistantCataloguePage } from "@/core/AssistantCataloguePage";
+
+export default function AssistantRoute() {
+  return <AssistantCataloguePage />;
+}

--- a/apps/mobile/src/core/AssistantCataloguePage.test.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Render + interaction tests for `<AssistantCataloguePage>`.
+ *
+ * Covers:
+ *  - shell renders the screen title and the search input;
+ *  - all eight registry modules render their localised header
+ *    (`Фінік`, `Фізрук`, `Рутина`, `Харчування`, `Кросмодульні`,
+ *    `Аналітика`, `Утиліти`, `Пам'ять`);
+ *  - module headers carry the visible per-module count derived from
+ *    `ASSISTANT_CAPABILITIES`;
+ *  - a representative capability row (`create_transaction`) renders
+ *    its label;
+ *  - typing a query filters down the list and tapping a row opens the
+ *    detail sheet with the capability's example commands;
+ *  - clearing the query restores all entries.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+import { AccessibilityInfo } from "react-native";
+import {
+  ASSISTANT_CAPABILITIES,
+  CAPABILITY_MODULE_META,
+  CAPABILITY_MODULE_ORDER,
+} from "@sergeant/shared";
+
+import { AssistantCataloguePage } from "./AssistantCataloguePage";
+
+jest.mock("react-native-safe-area-context", () => {
+  const actual = jest.requireActual("react-native-safe-area-context");
+  return {
+    ...actual,
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+beforeEach(() => {
+  jest
+    .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+    .mockResolvedValue(false);
+  jest
+    .spyOn(AccessibilityInfo, "addEventListener")
+    .mockImplementation(() => ({ remove: () => {} }) as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("AssistantCataloguePage", () => {
+  it("renders the screen title and the search input", () => {
+    const { getByText, getByTestId } = render(<AssistantCataloguePage />);
+    expect(getByText("Можливості асистента")).toBeTruthy();
+    expect(getByTestId("assistant-catalogue-search")).toBeTruthy();
+  });
+
+  it("renders every module header from the registry with its count", () => {
+    const { getAllByText } = render(<AssistantCataloguePage />);
+
+    for (const module of CAPABILITY_MODULE_ORDER) {
+      const total = ASSISTANT_CAPABILITIES.filter(
+        (c) => c.module === module,
+      ).length;
+      if (total === 0) continue;
+
+      // Module title + count render inside a single nested <Text>;
+      // assert the title substring is present at least once.
+      const matches = getAllByText(
+        new RegExp(CAPABILITY_MODULE_META[module].title),
+      );
+      if (matches.length === 0) {
+        throw new Error(`Module header missing for ${module}`);
+      }
+    }
+  });
+
+  it("renders a representative capability row from the registry", () => {
+    const { getByTestId, getByText } = render(<AssistantCataloguePage />);
+    const sample = ASSISTANT_CAPABILITIES.find(
+      (c) => c.id === "create_transaction",
+    );
+    expect(sample).toBeDefined();
+    expect(getByTestId(`catalogue-capability-${sample!.id}`)).toBeTruthy();
+    expect(getByText(sample!.label)).toBeTruthy();
+  });
+
+  it("filters the list as the user types and clears back when query empties", () => {
+    const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
+    const search = getByTestId("assistant-catalogue-search");
+
+    fireEvent.changeText(search, "тренування");
+    // create_transaction belongs to фінанси and shouldn't match the query.
+    expect(queryByTestId("catalogue-capability-create_transaction")).toBeNull();
+    // start_workout belongs to фізрук and should still be visible.
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeTruthy();
+
+    fireEvent.changeText(search, "");
+    expect(
+      queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeTruthy();
+  });
+
+  it("shows an empty state when nothing matches the query", () => {
+    const { getByTestId, getByText } = render(<AssistantCataloguePage />);
+    fireEvent.changeText(
+      getByTestId("assistant-catalogue-search"),
+      "zxqwerty12345",
+    );
+    expect(getByText(/Нічого не знайдено/)).toBeTruthy();
+  });
+
+  it("opens the detail sheet with the capability's examples on row tap", () => {
+    const { getByTestId, getByText, getAllByText } = render(
+      <AssistantCataloguePage />,
+    );
+    const sample = ASSISTANT_CAPABILITIES.find(
+      (c) => c.id === "create_transaction",
+    );
+    expect(sample).toBeDefined();
+
+    fireEvent.press(getByTestId(`catalogue-capability-${sample!.id}`));
+
+    // The capability description renders both in the row card and in
+    // the sheet (sheet covers the row but the row stays mounted), so
+    // at least two matches indicate the sheet opened.
+    expect(getAllByText(sample!.description).length).toBeGreaterThanOrEqual(2);
+    // Example bullets are sheet-only — a single match is enough.
+    expect(getByText(`«${sample!.examples[0]}»`)).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/core/AssistantCataloguePage.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.tsx
@@ -1,0 +1,287 @@
+/**
+ * Sergeant Hub-core — AssistantCataloguePage (React Native)
+ *
+ * Mobile mirror of `apps/web/src/core/AssistantCataloguePage.tsx`.
+ *
+ * Surfaces the full `ASSISTANT_CAPABILITIES` registry from
+ * `@sergeant/shared` so the user can browse what the AI assistant can
+ * do without typing `/help`, scrolling chat chips, or guessing tool
+ * names. Same source-of-truth as web — adding a capability there
+ * automatically lands here too (locked by the registry tests in
+ * `packages/shared/src/lib/assistantCatalogue.test.ts`).
+ *
+ * Differences from the web shell (intentional, see PR body):
+ *  - No "Try in chat" wiring. Mobile does not yet ship HubChat — the
+ *    backend `/api/chat` endpoint is wired only on web (see
+ *    `apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.tsx`
+ *    for the same caveat). The detail Sheet shows the capability
+ *    description + examples; the explicit "веб-версія" notice keeps
+ *    expectations honest until mobile chat lands.
+ *  - Module title prefix uses an emoji glyph rather than a Lucide
+ *    icon. Mobile has no icon component yet; settings sections
+ *    already use the same emoji-prefix pattern (`SettingsGroup`).
+ *  - Layout uses `ScrollView` + `SafeAreaView` (matching the rest of
+ *    the Hub-core mobile shells) instead of the web responsive
+ *    `max-w-2xl` container.
+ */
+
+import { useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { router } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  ASSISTANT_CAPABILITIES,
+  CAPABILITY_MODULE_META,
+  groupCapabilitiesByModule,
+  searchCapabilities,
+  type AssistantCapability,
+  type CapabilityModule,
+} from "@sergeant/shared";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Sheet } from "@/components/ui/Sheet";
+
+// Emoji prefix per module — keeps a consistent visual rhythm with the
+// existing settings sections (`💳 Фінік`, `🏋 Фізрук`, `✅ Рутина`,
+// …). A future mobile icon primitive can lift this into a shared
+// adapter that maps `CAPABILITY_MODULE_META[m].icon` → component.
+const MODULE_EMOJI: Record<CapabilityModule, string> = {
+  finyk: "💳",
+  fizruk: "🏋️",
+  routine: "✅",
+  nutrition: "🍎",
+  cross: "🔀",
+  analytics: "📊",
+  utility: "🧰",
+  memory: "🧠",
+};
+
+export interface AssistantCataloguePageProps {
+  /**
+   * Optional close handler — used when the page is rendered inside a
+   * controlled host (e.g. settings drilldown). When omitted, the
+   * default Expo-Router back action is used.
+   */
+  onClose?: () => void;
+}
+
+export function AssistantCataloguePage({
+  onClose,
+}: AssistantCataloguePageProps) {
+  const [query, setQuery] = useState("");
+  const [detail, setDetail] = useState<AssistantCapability | null>(null);
+
+  const filtered = useMemo(
+    () => (query.trim() ? searchCapabilities(query) : ASSISTANT_CAPABILITIES),
+    [query],
+  );
+  const groups = useMemo(() => groupCapabilitiesByModule(filtered), [filtered]);
+
+  const handleClose = () => {
+    if (onClose) {
+      onClose();
+      return;
+    }
+    if (router.canGoBack()) router.back();
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-cream-50" edges={["top"]}>
+      <View className="flex-row items-center gap-3 px-5 pt-3 pb-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          onPress={handleClose}
+          accessibilityLabel="Назад"
+          testID="assistant-catalogue-back"
+        >
+          <Text className="text-stone-700 text-lg">‹</Text>
+        </Button>
+        <Text className="text-[20px] font-bold text-stone-900">
+          Можливості асистента
+        </Text>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 32 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text className="text-sm text-stone-500 mb-3 leading-snug">
+          Усе, що вміє асистент. Тапни картку — побачиш приклади команд та опис.
+          Запуск сценаріїв — у HubChat (наразі веб-версія).
+        </Text>
+
+        <View className="bg-white border border-cream-300 rounded-2xl px-3 py-2 mb-4 flex-row items-center gap-2">
+          <Text className="text-stone-400 text-base">🔍</Text>
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Пошук — «витрата», «звичка», «1RM»…"
+            placeholderTextColor="#a8a29e"
+            className="flex-1 text-sm text-stone-900 py-1"
+            accessibilityLabel="Пошук можливостей"
+            testID="assistant-catalogue-search"
+            returnKeyType="search"
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
+        </View>
+
+        {filtered.length === 0 ? (
+          <Text className="text-center text-stone-500 py-8 text-sm">
+            Нічого не знайдено за «{query}». Спробуй інший термін.
+          </Text>
+        ) : (
+          <View className="gap-5">
+            {groups.map((g) => (
+              <ModuleGroup
+                key={g.module}
+                module={g.module}
+                capabilities={g.capabilities}
+                onActivate={setDetail}
+              />
+            ))}
+          </View>
+        )}
+      </ScrollView>
+
+      <CapabilityDetailSheet
+        capability={detail}
+        onClose={() => setDetail(null)}
+      />
+    </SafeAreaView>
+  );
+}
+
+interface ModuleGroupProps {
+  module: CapabilityModule;
+  capabilities: readonly AssistantCapability[];
+  onActivate: (cap: AssistantCapability) => void;
+}
+
+function ModuleGroup({ module, capabilities, onActivate }: ModuleGroupProps) {
+  const meta = CAPABILITY_MODULE_META[module];
+  return (
+    <View accessibilityLabel={meta.title}>
+      <Text className="text-sm font-bold text-stone-900 mb-2">
+        {MODULE_EMOJI[module]} {meta.title}{" "}
+        <Text className="text-stone-400 font-normal">
+          ({capabilities.length})
+        </Text>
+      </Text>
+      <View className="gap-2">
+        {capabilities.map((cap) => (
+          <CapabilityRow
+            key={cap.id}
+            capability={cap}
+            onActivate={onActivate}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+interface CapabilityRowProps {
+  capability: AssistantCapability;
+  onActivate: (cap: AssistantCapability) => void;
+}
+
+function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
+  return (
+    <Pressable
+      onPress={() => onActivate(capability)}
+      accessibilityRole="button"
+      accessibilityLabel={capability.label}
+      testID={`catalogue-capability-${capability.id}`}
+      className="active:opacity-70"
+    >
+      <Card variant="default" radius="lg" padding="md">
+        <View className="flex-row items-start gap-2 flex-wrap">
+          <Text className="text-sm font-semibold text-stone-900 flex-shrink">
+            {capability.label}
+          </Text>
+          {capability.isQuickAction ? (
+            <View className="border border-stone-300 rounded-full px-2 py-0.5">
+              <Text className="text-[10px] font-bold text-stone-700">
+                ⚡ ЧІП
+              </Text>
+            </View>
+          ) : null}
+          {capability.risky ? (
+            <View className="border border-amber-400 bg-amber-50 rounded-full px-2 py-0.5">
+              <Text className="text-[10px] font-bold text-amber-700">
+                ⚠ РИЗИК
+              </Text>
+            </View>
+          ) : null}
+        </View>
+        <Text className="text-xs text-stone-500 mt-1 leading-snug">
+          {capability.description}
+        </Text>
+      </Card>
+    </Pressable>
+  );
+}
+
+interface CapabilityDetailSheetProps {
+  capability: AssistantCapability | null;
+  onClose: () => void;
+}
+
+function CapabilityDetailSheet({
+  capability,
+  onClose,
+}: CapabilityDetailSheetProps) {
+  const cap = capability;
+  return (
+    <Sheet
+      open={cap !== null}
+      onClose={onClose}
+      title={cap?.label ?? ""}
+      description={cap ? CAPABILITY_MODULE_META[cap.module].title : undefined}
+    >
+      {cap ? (
+        <View className="px-5 py-4 gap-4">
+          <Text className="text-sm text-stone-900">{cap.description}</Text>
+
+          {cap.risky ? (
+            <View className="border border-amber-400 bg-amber-50 rounded-2xl px-3 py-2">
+              <Text className="text-xs text-amber-800">
+                Критична дія. Перевір дані перед відправкою — деякі зміни
+                скасувати не можна.
+              </Text>
+            </View>
+          ) : null}
+
+          <View>
+            <Text className="text-sm font-bold text-stone-900 mb-2">
+              Приклади
+            </Text>
+            <View className="gap-1.5">
+              {cap.examples.map((ex, i) => (
+                <View
+                  key={i}
+                  className="border border-cream-300 bg-white rounded-xl px-3 py-2"
+                >
+                  <Text className="text-sm text-stone-900">«{ex}»</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <Text className="text-xs text-stone-500 leading-snug">
+            Запуск сценарію відбувається в HubChat. Поки що чат AI-асистента
+            доступний у веб-версії — мобільна версія в дорозі.
+          </Text>
+        </View>
+      ) : null}
+    </Sheet>
+  );
+}
+
+export default AssistantCataloguePage;

--- a/apps/mobile/src/core/settings/AssistantCatalogueSection.test.tsx
+++ b/apps/mobile/src/core/settings/AssistantCatalogueSection.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Render + interaction tests for `<AssistantCatalogueSection>`.
+ *
+ * Covers:
+ *  - the collapsed group header renders ("Можливості асистента");
+ *  - expanding the group reveals the description + launcher button;
+ *  - tapping the launcher pushes `/assistant` via Expo Router.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AssistantCatalogueSection } from "./AssistantCatalogueSection";
+
+const mockRouterPush = jest.fn();
+jest.mock("expo-router", () => ({
+  router: {
+    push: (...args: unknown[]) => mockRouterPush(...args),
+  },
+}));
+
+beforeEach(() => {
+  mockRouterPush.mockClear();
+});
+
+describe("AssistantCatalogueSection", () => {
+  it("renders the collapsed group header", () => {
+    const { getByText, queryByText } = render(<AssistantCatalogueSection />);
+    expect(getByText("Можливості асистента")).toBeTruthy();
+    // Description copy starts with "~60+" and is hidden until expanded.
+    expect(queryByText(/~60\+/)).toBeNull();
+  });
+
+  it("reveals the launcher when expanded and routes to /assistant on tap", () => {
+    const { getByText, getByTestId } = render(<AssistantCatalogueSection />);
+    fireEvent.press(getByText("Можливості асистента"));
+
+    expect(getByText(/~60\+/)).toBeTruthy();
+
+    const launcher = getByTestId("open-assistant-catalogue");
+    fireEvent.press(launcher);
+
+    expect(mockRouterPush).toHaveBeenCalledTimes(1);
+    expect(mockRouterPush).toHaveBeenCalledWith("/assistant");
+  });
+});

--- a/apps/mobile/src/core/settings/AssistantCatalogueSection.tsx
+++ b/apps/mobile/src/core/settings/AssistantCatalogueSection.tsx
@@ -1,0 +1,44 @@
+/**
+ * Sergeant Hub-core — AssistantCatalogueSection (React Native)
+ *
+ * Mobile mirror of `apps/web/src/core/settings/AssistantCatalogueSection.tsx`.
+ *
+ * A thin launcher card that pushes `/assistant` (the full-screen
+ * capability catalogue). The catalogue itself is a route-addressable
+ * page so the settings shell stays a list of collapsible cards rather
+ * than embedding the long catalogue grid inline.
+ *
+ * Source-of-truth for the rendered capabilities is
+ * `ASSISTANT_CAPABILITIES` in `@sergeant/shared` — same registry the
+ * web settings entry, the web HubChat quick-action chips, and the
+ * server `SYSTEM_PREFIX` all read from.
+ */
+
+import { Text } from "react-native";
+import { router, type Href } from "expo-router";
+
+import { Button } from "@/components/ui/Button";
+
+import { SettingsGroup } from "./SettingsPrimitives";
+
+export function AssistantCatalogueSection() {
+  return (
+    <SettingsGroup title="Можливості асистента" emoji="✨">
+      <Text className="text-xs text-stone-500 leading-snug">
+        ~60+ інструментів, які може запустити AI-асистент: фінанси, тренування,
+        звички, харчування, аналітика, утиліти, пам&apos;ять. Тапни — побачиш
+        приклади команд.
+      </Text>
+      <Button
+        variant="secondary"
+        size="md"
+        onPress={() => router.push("/assistant" as Href)}
+        testID="open-assistant-catalogue"
+      >
+        Відкрити каталог
+      </Button>
+    </SettingsGroup>
+  );
+}
+
+export default AssistantCatalogueSection;

--- a/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
@@ -62,6 +62,7 @@ describe("HubSettingsPage", () => {
     expect(getByText("Фінік")).toBeTruthy();
     expect(getByText("Фізрук")).toBeTruthy();
     expect(getByText("AI Звіт тижня")).toBeTruthy();
+    expect(getByText("Можливості асистента")).toBeTruthy();
     expect(getByText("Експериментальне")).toBeTruthy();
     expect(getByText("Акаунт")).toBeTruthy();
   });

--- a/apps/mobile/src/core/settings/HubSettingsPage.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.tsx
@@ -6,9 +6,11 @@
  * Scope of this cut (Phase 2 / Hub-core — remaining sections PR):
  *  - Shell with a screen title ("Налаштування") and a vertical stack of
  *    collapsible `SettingsGroup` cards, one per section.
- *  - All seven Hub-core sections now porting in: `GeneralSection`,
+ *  - All eight Hub-core sections now porting in: `GeneralSection`,
  *    `NotificationsSection`, `RoutineSection`, `FinykSection`,
- *    `FizrukSection`, `AIDigestSection`, `ExperimentalSection`.
+ *    `FizrukSection`, `AIDigestSection`, `AssistantCatalogueSection`,
+ *    `ExperimentalSection`. The catalogue section is a thin launcher
+ *    for the `/assistant` modal route — see `app/assistant.tsx`.
  *
  * Intentional differences from the web shell:
  *  - No `Tabs` group switcher and no fuzzy search input yet — both
@@ -30,6 +32,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AccountSection } from "./AccountSection";
 import { AIDigestSection } from "./AIDigestSection";
+import { AssistantCatalogueSection } from "./AssistantCatalogueSection";
 import { ExperimentalSection } from "./ExperimentalSection";
 import { FinykSection } from "./FinykSection";
 import { FizrukSection } from "./FizrukSection";
@@ -55,6 +58,7 @@ export function HubSettingsPage() {
         <FinykSection />
         <FizrukSection />
         <AIDigestSection />
+        <AssistantCatalogueSection />
         <ExperimentalSection />
         <AccountSection />
       </ScrollView>


### PR DESCRIPTION
## What changed

Mobile port of `apps/web/src/core/AssistantCataloguePage.tsx` (PR #795). Surfaces the full `ASSISTANT_CAPABILITIES` registry from `@sergeant/shared` so users can discover what the AI assistant can do without typing `/help`, scrolling chat chips, or guessing tool names.

- New full-screen page `apps/mobile/src/core/AssistantCataloguePage.tsx` with search input, per-module groups, and capability rows that open a bottom-sheet with examples on tap.
- New modal route `apps/mobile/app/assistant.tsx` (registered in `app/_layout.tsx` as `presentation: "modal"`).
- New `AssistantCatalogueSection` settings entry (`router.push("/assistant")`) inserted between AIDigest and Experimental in `HubSettingsPage` — mirrors the web settings entry order.
- 8 new tests across `AssistantCataloguePage.test.tsx` and `AssistantCatalogueSection.test.tsx`: shell render, every module group from the registry rendering, representative capability row, search/filter both ways, empty state, detail sheet open, and settings launcher routing.

No HubChat on mobile yet, so the detail sheet shows description + examples + a notice that scenario execution lives in the web HubChat for now. Mirrors the existing `apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.tsx` caveat ("AI proactive advice + AI explain — chat API is web-only today"). When mobile chat lands, swap the notice for a `dispatchOpenChat`-equivalent without changing the page surface.

Intentional differences from the web shell:
- **No icon library on mobile yet.** Per-module title prefixes use emoji glyphs (💳 Фінік / 🏋️ Фізрук / ✅ Рутина / 🍎 Харчування / 🔀 Кросмодульні / 📊 Аналітика / 🧰 Утиліти / 🧠 Пам'ять) — same emoji-prefix pattern the existing `SettingsGroup` cards already use.
- Layout uses `ScrollView` + `SafeAreaView`, matching the rest of the Hub-core mobile shells, instead of the web `max-w-2xl` responsive container.
- Detail card is rendered via the existing mobile `Sheet` primitive (bottom sheet with scrim) instead of the web `Modal` portal.

## Why

This is PR 3 from the [2026-04-25 assistant catalogue handoff](#793). PRs 1 (#795) and 2 (#796) shipped:
- #795 made the registry the source of truth for the **web** catalogue UI, the chat quick-action chips, and `/help`.
- #796 made it the source of truth for the server `SYSTEM_PREFIX` (system prompt now generated from `ASSISTANT_CAPABILITIES`).

This PR closes the loop on **mobile**. Adding a new capability to `packages/shared/src/lib/assistantCatalogue.ts` now automatically:
1. shows up under `/assistant` on web (PR #795),
2. shows up as a chip in HubChat if `isQuickAction` (PR #795),
3. is listed under the right module in the system prompt (PR #796),
4. shows up under `/assistant` on mobile (this PR).

## How to test

Reviewers (CLI):

```bash
pnpm --filter @sergeant/mobile test -- --testPathPattern "(AssistantCataloguePage|AssistantCatalogueSection)"
pnpm --filter @sergeant/mobile typecheck
pnpm --filter @sergeant/mobile lint
```

Manual smoke (Expo dev client):
1. Open the mobile app → bottom-tab Hub → header settings icon → expand «Можливості асистента» → tap «Відкрити каталог».
2. The catalogue should open as a modal with all 8 module groups visible, totals matching the registry (e.g. Фінік 18, Рутина 12, …).
3. Type «звичка» in search — only routine capabilities remain. Clear → all groups return.
4. Type a junk string → empty-state copy shows.
5. Tap any capability row → bottom sheet shows description + examples + the «веб-версія» notice.
6. Close the sheet (scrim or close button) → row stays in the list.
7. Hardware Android back button on the sheet → closes the sheet, not the route.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): not run on a device — Expo build is out of scope for an autonomous session. CLI tests below cover the deterministic surface; a human smoke pass is the recommended pre-merge step (steps in «How to test»).
- [x] Vitest passes: all 8 new mobile tests green; full mobile suite reports 84/87 suites and 572/582 tests passing locally. The 3 failing suites (`OnboardingWizard.test.tsx`, `WeeklyDigestFooter.test.tsx`, `HubSettingsPage.test.tsx`) match the `AGENTS.md` _Pre-existing flaky tests (do not block merge)_ list and were already failing on `main` before this PR — `HubSettingsPage` happens to fail before reaching the new `«Можливості асистента»` assertion, but the dedicated `AssistantCatalogueSection.test.tsx` covers that surface independently and is green.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. The mobile catalogue surface follows existing settings-section conventions documented inline (`SettingsPrimitives.tsx`, `HubSettingsPage.tsx` shell comment) and the registry tests in `packages/shared/src/lib/assistantCatalogue.test.ts` already lock the data contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
