### PR TITLE
fix(shared): drop duplicate set_habit_schedule + pause_habit catalogue rows

### DIFF
--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -558,6 +558,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Постав розклад звички: ",
     requiresInput: true,
     requiresOnline: true,
+    aiHint: "примусово weekly",
     keywords: ["weekday", "schedule", "weekly", "розклад", "дні"],
   },
   {
@@ -576,6 +577,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Постав звичку на паузу: ",
     requiresInput: true,
     requiresOnline: true,
+    aiHint: "ідемпотентно",
     keywords: ["pause", "resume", "unpause", "пауза", "відновити"],
   },
   {
@@ -611,37 +613,6 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Статистика звички: ",
     requiresInput: true,
     requiresOnline: true,
-  },
-  {
-    id: "set_habit_schedule",
-    module: "routine",
-    label: "Розклад звички",
-    icon: "calendar-check",
-    description:
-      "Виставити дні тижня для звички (recurrence='weekly'). Англ. ('mon'..'sun') або укр. ('пн'..'нд').",
-    examples: [
-      "тренування пн/ср/пт",
-      "медитація щодня крім вихідних",
-      "англійська вт чт",
-    ],
-    prompt: "Постав розклад звички: ",
-    requiresInput: true,
-    requiresOnline: true,
-    keywords: ["schedule", "розклад", "дні тижня", "weekly"],
-  },
-  {
-    id: "pause_habit",
-    module: "routine",
-    label: "Пауза звички",
-    icon: "pause",
-    description:
-      "Тимчасово поставити звичку на паузу або зняти з неї. Зберігає історію виконань.",
-    examples: ["постав на паузу 'Англійська'", "зніми паузу зі звички 'Біг'"],
-    prompt: "Пауза звички: ",
-    requiresInput: true,
-    requiresOnline: true,
-    aiHint: "ідемпотентно",
-    keywords: ["pause", "пауза", "відновити"],
   },
   {
     id: "missed_this_week",


### PR DESCRIPTION
## What changed

Drops 2 duplicate entries from `ASSISTANT_CAPABILITIES`:

- `set_habit_schedule` (lines 616–631 on main, icon `calendar-check`)
- `pause_habit` (lines 633–645 on main, icon `pause`)

Keeps the entries added by #798 (icons `calendar` / `pause-circle`, with `shortLabel`s) because they match the action-card icons shipped in #797 (`hubChatActionCards.ts`). Ports the useful `aiHint` field from the deleted entries (`"ідемпотентно"` for pause; added `"примусово weekly"` for schedule).

## Why

PR #796 ("generate `SYSTEM_PREFIX` from assistant capability registry") and PR #798 ("catalogue rows for `set_habit_schedule` + `pause_habit`") were authored in parallel. Both added catalogue entries for the same two ids:

- #796 (merged 14:18 UTC) → added `set_habit_schedule` + `pause_habit` rows.
- #798 (merged 14:36 UTC, with red CI) → added the same two ids again.

Result on main (`6e429e83`):

```
$ grep -nE 'id: "(set_habit_schedule|pause_habit)"' packages/shared/src/lib/assistantCatalogue.ts
546:    id: "set_habit_schedule",
564:    id: "pause_habit",
616:    id: "set_habit_schedule",
633:    id: "pause_habit",
```

…and `assistantCatalogue.test.ts > "has unique ids"` failing on every commit since #798. CI is red on main as a result. This restores the invariant.

## How to test

```bash
pnpm --filter @sergeant/shared exec vitest run src/lib/assistantCatalogue.test.ts
# 23/23 pass; "has unique ids" passes again.

pnpm format:check && pnpm typecheck && pnpm lint
```

---

## How AI-tested this PR

- [x] Manual smoke: not yet — covered by invariants test.
- [x] Vitest passes: `assistantCatalogue.test.ts` (23/23). Full repo: `pnpm typecheck` (13/13) + `pnpm lint` (12/12) clean.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


---

**Update (commit 35318e7f):** also refresh `systemPrompt.test.ts.snap` and bump `SYSTEM_PROMPT_VERSION` v6 → v7. Cleaning up the duplicates moves `set_habit_schedule`+`pause_habit` from after `habit_stats` to after `edit_habit` in the registry-driven Routine tool-list bullet (since #796), and adds an `aiHint` parenthesis. The actual prompt-cache key is byte-pinned to the prefix text, so the version constant is just an observability marker — but bumping it makes 'cache_creation_input_tokens > 0' on the next deploy a clearly attributed signal in Grafana.
