### PR TITLE
feat(web,server): parallel tool execution + compare_weeks tool

### DIFF
--- a/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
+++ b/apps/server/src/modules/chat/toolDefs/__snapshots__/systemPrompt.test.ts.snap
@@ -9,9 +9,9 @@ exports[`SYSTEM_PREFIX — registry-driven > matches the canonical snapshot 1`] 
 - Якщо користувач просить змінити або записати дані — використай відповідний tool.
   - Фінанси: create_transaction, change_category, find_transaction, batch_categorize (dry_run спершу), hide_transaction, delete_transaction (лише ручні m_<id>), create_debt, create_receivable, mark_debt_paid, set_budget_limit, update_budget (ліміт або ціль), set_monthly_plan, add_asset, import_monobank_range, split_transaction, recurring_expense, export_report
   - Фізрук: start_workout, log_set, finish_workout, plan_workout, add_program_day, log_measurement, log_weight, log_wellbeing, suggest_workout, copy_workout, compare_progress
-  - Рутина: mark_habit_done, complete_habit_for_date, create_habit, create_reminder, edit_habit, archive_habit, reorder_habits, habit_stats, set_habit_schedule, pause_habit (ідемпотентно), add_calendar_event
+  - Рутина: mark_habit_done, complete_habit_for_date, create_habit, create_reminder, edit_habit, set_habit_schedule (примусово weekly), pause_habit (ідемпотентно), archive_habit, reorder_habits, habit_stats, add_calendar_event
   - Харчування: log_meal, log_water, set_daily_plan, suggest_meal, add_recipe, add_to_shopping_list, consume_from_pantry, copy_meal_from_date, plan_meals_for_day
-  - Кросмодульні: morning_briefing, weekly_summary, set_goal
+  - Кросмодульні: morning_briefing, weekly_summary, compare_weeks (YYYY-Www; default цей+минулий), set_goal
   - Аналітика: spending_trend, category_breakdown, weight_chart, habit_trend, detect_anomalies
   - Утиліти: calculate_1rm, convert_units, save_note, list_notes, export_module_data
   - Пам'ять: remember, forget, my_profile

--- a/apps/server/src/modules/chat/toolDefs/crossModule.ts
+++ b/apps/server/src/modules/chat/toolDefs/crossModule.ts
@@ -136,4 +136,31 @@ export const CROSS_MODULE_TOOLS: AnthropicTool[] = [
       },
     },
   },
+  {
+    name: "compare_weeks",
+    description:
+      "Порівняти два тижні по всіх модулях: витрати, вага, виконання звичок, калорії. Викликай коли користувач каже 'порівняй цей тиждень з минулим' або 'як я провів тиждень порівняно з попереднім'.",
+    input_schema: {
+      type: "object",
+      properties: {
+        week_a: {
+          type: "string",
+          description:
+            "Тиждень A як YYYY-Www (наприклад 2026-W17). Default — поточний.",
+        },
+        week_b: {
+          type: "string",
+          description: "Тиждень B як YYYY-Www. Default — попередній.",
+        },
+        modules: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["finyk", "fizruk", "routine", "nutrition"],
+          },
+          description: "Які модулі включити (default — всі 4).",
+        },
+      },
+    },
+  },
 ];

--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -26,7 +26,7 @@ import {
   getActiveModule,
 } from "../lib/hubChatUtils";
 import { buildContextMeasured } from "../lib/hubChatContext";
-import { executeAction } from "../lib/hubChatActions";
+import { executeActions } from "../lib/hubChatActions";
 import { VOICE_KEYWORDS, speak, stopSpeaking } from "../lib/hubChatSpeech";
 import { buildActionCard } from "../lib/hubChatActionCards";
 import type { ChatActionCard } from "../lib/hubChatActionCards";
@@ -297,9 +297,10 @@ function HubChat({
       }
 
       if (data.tool_calls && data.tool_calls.length > 0) {
-        const toolResults = data.tool_calls.map((tc) => ({
+        const handlerResults = await executeActions(data.tool_calls);
+        const toolResults = data.tool_calls.map((tc, idx) => ({
           tool_use_id: tc.id,
-          content: executeAction(tc),
+          content: handlerResults[idx]?.result ?? "",
         }));
 
         const actionsText = toolResults
@@ -307,7 +308,7 @@ function HubChat({
           .join("\n");
         const prefix = `${actionsText}\n\n`;
 
-        // Паралельно будуємо action-картки для відомих tool-ів.
+        // Будуємо action-картки для відомих tool-ів.
         // Якщо tool невідомий — повертається null, лишається лише текст.
         const cards: ChatActionCard[] = data.tool_calls
           .map((tc, idx) =>

--- a/apps/web/src/core/lib/chatActions/crossActions.test.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for `compare_weeks` handler in crossActions.ts.
+ *
+ * The handler delegates to `aggregateFinyk/Fizruk/Routine/Nutrition` from
+ * `useWeeklyDigest.ts`, which read localStorage. Each test seeds the
+ * relevant keys for two weeks and asserts the returned diff string.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { handleCrossAction } from "./crossActions";
+import type { CompareWeeksAction } from "./types";
+
+// 2026-W17 = Mon 2026-04-20 .. Sun 2026-04-26
+// 2026-W16 = Mon 2026-04-13 .. Sun 2026-04-19
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  // Wednesday inside W17, so getWeekKey() picks W17 by default.
+  vi.setSystemTime(new Date("2026-04-22T12:00:00"));
+});
+afterEach(() => {
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+function call(input: CompareWeeksAction["input"]): string {
+  const out = handleCrossAction({ name: "compare_weeks", input });
+  if (typeof out !== "string") {
+    throw new Error("handler did not return a string");
+  }
+  return out;
+}
+
+describe("compare_weeks — параметри", () => {
+  it("без параметрів використовує поточний vs попередній", () => {
+    const out = call({});
+    expect(out).toContain("Порівняння тижнів");
+    // Both ranges should appear in the header (formatted as 'd MMM').
+    // We only assert structural shape — exact locale strings depend on Node
+    // ICU build, which differs across CI runners.
+    expect(out).toMatch(/Порівняння тижнів: .* vs .*/);
+  });
+
+  it("приймає YYYY-Www і конвертує у Monday-key", () => {
+    const out = call({ week_a: "2026-W17", week_b: "2026-W16" });
+    expect(out).toContain("Порівняння тижнів");
+  });
+
+  it("приймає YYYY-MM-DD (snapping до Monday)", () => {
+    // 2026-04-22 (Wed) має снапнутись до 2026-W17 Monday.
+    const out = call({ week_a: "2026-04-22", week_b: "2026-04-15" });
+    expect(out).toContain("Порівняння тижнів");
+  });
+
+  it("повертає помилку на некоректний week_a", () => {
+    const out = call({ week_a: "not-a-week" });
+    expect(out).toContain("Некоректний week_a");
+    expect(out).toContain("YYYY-Www");
+  });
+
+  it("повертає помилку на некоректний week_b", () => {
+    const out = call({ week_a: "2026-W17", week_b: "garbage" });
+    expect(out).toContain("Некоректний week_b");
+  });
+
+  it("modules=[] — fallback на всі 4", () => {
+    const out = call({ week_a: "2026-W17", week_b: "2026-W16", modules: [] });
+    expect(out).toContain("Фінік:");
+    expect(out).toContain("Фізрук:");
+    expect(out).toContain("Рутина:");
+    expect(out).toContain("Харчування:");
+  });
+
+  it("modules=['finyk'] — інші модулі не показуються", () => {
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["finyk"],
+    });
+    expect(out).toContain("Фінік:");
+    expect(out).not.toContain("Фізрук:");
+    expect(out).not.toContain("Рутина:");
+    expect(out).not.toContain("Харчування:");
+  });
+
+  it("невалідні значення в modules ігноруються", () => {
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: [
+        "finyk",
+        // @ts-expect-error intentionally unknown module name
+        "unknown",
+      ],
+    });
+    expect(out).toContain("Фінік:");
+    expect(out).not.toContain("Фізрук:");
+  });
+});
+
+describe("compare_weeks — Фінік diff", () => {
+  it("обчислює різницю витрат за два тижні", () => {
+    // Seed Mono cache with manual transactions across both weeks.
+    // Amount у minor units (kopiykas), negative = spend.
+    const mkTx = (
+      id: string,
+      isoDate: string,
+      grnAmount: number,
+      desc: string,
+    ) => ({
+      id,
+      time: Math.floor(new Date(`${isoDate}T12:00:00Z`).getTime() / 1000),
+      amount: grnAmount * 100,
+      description: desc,
+      mcc: 5411,
+    });
+    localStorage.setItem(
+      "finyk_tx_cache",
+      JSON.stringify({
+        txs: [
+          mkTx("a1", "2026-04-22", -200, "АТБ"),
+          mkTx("a2", "2026-04-23", -300, "Сільпо"),
+          mkTx("b1", "2026-04-15", -150, "АТБ"),
+        ],
+      }),
+    );
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["finyk"],
+    });
+    expect(out).toContain("Фінік:");
+    // Витрати W17 = 500, W16 = 150 → діфф +350
+    expect(out).toMatch(/Витрати:.*500.*150.*\+350/);
+    // Транзакцій W17 = 2, W16 = 1 → діфф +1
+    expect(out).toMatch(/Транзакцій:.*2.*1.*\+1/);
+  });
+
+  it("працює коли в одному тижні нема даних", () => {
+    localStorage.setItem(
+      "finyk_tx_cache",
+      JSON.stringify({
+        txs: [
+          {
+            id: "a1",
+            time: Math.floor(new Date("2026-04-22T12:00:00Z").getTime() / 1000),
+            amount: -10000,
+            description: "АТБ",
+            mcc: 5411,
+          },
+        ],
+      }),
+    );
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["finyk"],
+    });
+    expect(out).toContain("Фінік:");
+    expect(out).toMatch(/Витрати:.*100.*0/);
+  });
+});
+
+describe("compare_weeks — Рутина diff", () => {
+  it("показує % виконання звичок за обидва тижні", () => {
+    localStorage.setItem(
+      "hub_routine_v1",
+      JSON.stringify({
+        habits: [{ id: "h1", name: "Біг" }],
+        completions: {
+          h1: [
+            // W17 — 4 з 7 днів
+            "2026-04-20",
+            "2026-04-21",
+            "2026-04-23",
+            "2026-04-25",
+            // W16 — 2 з 7
+            "2026-04-13",
+            "2026-04-14",
+          ],
+        },
+      }),
+    );
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["routine"],
+    });
+    expect(out).toContain("Рутина:");
+    // 4/7 ≈ 57%, 2/7 ≈ 29% → дельта +28%
+    expect(out).toMatch(/Виконання:.*57%.*29%/);
+    expect(out).toContain("Звичок: 1 vs 1");
+  });
+
+  it("повертає 'Немає активних звичок' коли немає state", () => {
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["routine"],
+    });
+    expect(out).toContain("Рутина:");
+    expect(out).toContain("Немає активних звичок");
+  });
+});
+
+describe("compare_weeks — Харчування diff", () => {
+  it("обчислює середні калорії за два тижні", () => {
+    localStorage.setItem(
+      "nutrition_log_v1",
+      JSON.stringify({
+        "2026-04-21": { meals: [{ macros: { kcal: 2000 } }] },
+        "2026-04-22": { meals: [{ macros: { kcal: 2200 } }] },
+        "2026-04-14": { meals: [{ macros: { kcal: 1800 } }] },
+      }),
+    );
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["nutrition"],
+    });
+    expect(out).toContain("Харчування:");
+    // W17 avg = (2000 + 2200) / 2 = 2100; W16 avg = 1800 → +300
+    expect(out).toMatch(/Калорії\/день:.*2100.*1800.*\+300/);
+    expect(out).toContain("Днів залоговано: 2 vs 1");
+  });
+
+  it("повертає 'Немає логів' коли обидва тижні порожні", () => {
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["nutrition"],
+    });
+    expect(out).toContain("Харчування:");
+    expect(out).toContain("Немає логів їжі");
+  });
+});
+
+describe("compare_weeks — Фізрук diff", () => {
+  it("показує count і об'єм за два тижні", () => {
+    localStorage.setItem(
+      "fizruk_workouts_v1",
+      JSON.stringify([
+        {
+          startedAt: "2026-04-21T10:00:00Z",
+          endedAt: "2026-04-21T11:00:00Z",
+          exercises: [
+            {
+              name: "Жим",
+              sets: [
+                { weight: 100, reps: 5 },
+                { weight: 100, reps: 5 },
+              ],
+            },
+          ],
+        },
+        {
+          startedAt: "2026-04-23T10:00:00Z",
+          endedAt: "2026-04-23T11:00:00Z",
+          exercises: [{ name: "Присід", sets: [{ weight: 80, reps: 8 }] }],
+        },
+        {
+          startedAt: "2026-04-14T10:00:00Z",
+          endedAt: "2026-04-14T11:00:00Z",
+          exercises: [{ name: "Жим", sets: [{ weight: 100, reps: 5 }] }],
+        },
+      ]),
+    );
+    const out = call({
+      week_a: "2026-W17",
+      week_b: "2026-W16",
+      modules: ["fizruk"],
+    });
+    expect(out).toContain("Фізрук:");
+    // W17: 2 workouts; volume = 100*5 + 100*5 + 80*8 = 1640
+    // W16: 1 workout; volume = 500
+    expect(out).toMatch(/Тренувань:.*2.*1/);
+    expect(out).toMatch(/Об'єм:.*1640.*500/);
+  });
+});

--- a/apps/web/src/core/lib/chatActions/crossActions.ts
+++ b/apps/web/src/core/lib/chatActions/crossActions.ts
@@ -14,6 +14,13 @@ import {
   mergeExpenseCategoryDefinitions,
   INTERNAL_TRANSFER_ID,
 } from "../../../modules/finyk/constants";
+import {
+  aggregateFinyk,
+  aggregateFizruk,
+  aggregateNutrition,
+  aggregateRoutine,
+  getWeekKey,
+} from "../../insights/useWeeklyDigest";
 import type {
   SetGoalAction,
   SpendingTrendAction,
@@ -26,11 +33,75 @@ import type {
   RememberAction,
   ForgetAction,
   MyProfileAction,
+  CompareWeeksAction,
+  CompareWeeksModule,
   HabitState,
   Workout,
   NutritionDay,
   ChatAction,
 } from "./types";
+
+/**
+ * Convert an ISO-8601 week label `YYYY-Www` (e.g. `2026-W17`) to the
+ * `YYYY-MM-DD` of that week's Monday — the format `aggregate*` functions
+ * expect. Also accepts a bare `YYYY-MM-DD` for resilience: when the model
+ * "guesses" today's day key instead of the week key, we still do the right
+ * thing by snapping to that week's Monday.
+ *
+ * Returns `null` if the input cannot be parsed.
+ */
+function weekLabelToMondayKey(input: string): string | null {
+  const wwwMatch = /^(\d{4})-W(\d{1,2})$/.exec(input.trim());
+  if (wwwMatch) {
+    const year = Number(wwwMatch[1]);
+    const week = Number(wwwMatch[2]);
+    if (!Number.isFinite(year) || !Number.isFinite(week)) return null;
+    if (week < 1 || week > 53) return null;
+    const jan4 = new Date(year, 0, 4);
+    const jan4Day = jan4.getDay() || 7;
+    const week1Monday = new Date(jan4);
+    week1Monday.setDate(jan4.getDate() - (jan4Day - 1));
+    const target = new Date(week1Monday);
+    target.setDate(week1Monday.getDate() + (week - 1) * 7);
+    return [
+      target.getFullYear(),
+      String(target.getMonth() + 1).padStart(2, "0"),
+      String(target.getDate()).padStart(2, "0"),
+    ].join("-");
+  }
+  const dayMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input.trim());
+  if (dayMatch) {
+    const d = new Date(`${input.trim()}T00:00:00`);
+    if (Number.isNaN(d.getTime())) return null;
+    return getWeekKey(d);
+  }
+  return null;
+}
+
+function previousWeekKey(weekKey: string): string {
+  const monday = new Date(`${weekKey}T00:00:00`);
+  monday.setDate(monday.getDate() - 7);
+  return [
+    monday.getFullYear(),
+    String(monday.getMonth() + 1).padStart(2, "0"),
+    String(monday.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function formatWeekRangeLabel(weekKey: string): string {
+  const monday = new Date(`${weekKey}T00:00:00`);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("uk-UA", { day: "numeric", month: "short" });
+  return `${fmt(monday)} – ${fmt(sunday)}`;
+}
+
+function diffLine(label: string, a: number, b: number, unit: string): string {
+  const delta = a - b;
+  const sign = delta > 0 ? "+" : "";
+  return `${label}: ${a}${unit} vs ${b}${unit} (${sign}${delta}${unit})`;
+}
 
 export function handleCrossAction(action: ChatAction): string | undefined {
   switch (action.name) {
@@ -564,6 +635,112 @@ export function handleCrossAction(action: ChatAction): string | undefined {
         default:
           return `Невідомий модуль: ${mod}. Доступні: finyk, fizruk, routine, nutrition.`;
       }
+    }
+    case "compare_weeks": {
+      const { week_a, week_b, modules } = (action as CompareWeeksAction).input;
+      const allModules: CompareWeeksModule[] = [
+        "finyk",
+        "fizruk",
+        "routine",
+        "nutrition",
+      ];
+      const selected: CompareWeeksModule[] =
+        Array.isArray(modules) && modules.length > 0
+          ? (modules.filter((m) =>
+              allModules.includes(m as CompareWeeksModule),
+            ) as CompareWeeksModule[])
+          : allModules;
+      if (selected.length === 0) {
+        return "Не вказано жодного валідного модуля. Доступні: finyk, fizruk, routine, nutrition.";
+      }
+
+      const aKey = week_a
+        ? weekLabelToMondayKey(week_a)
+        : getWeekKey(new Date());
+      if (!aKey) {
+        return `Некоректний week_a: "${week_a}". Очікую YYYY-Www (наприклад 2026-W17).`;
+      }
+      const bKey = week_b
+        ? weekLabelToMondayKey(week_b)
+        : previousWeekKey(aKey);
+      if (!bKey) {
+        return `Некоректний week_b: "${week_b}". Очікую YYYY-Www (наприклад 2026-W16).`;
+      }
+
+      const aLabel = formatWeekRangeLabel(aKey);
+      const bLabel = formatWeekRangeLabel(bKey);
+      const lines: string[] = [`Порівняння тижнів: ${aLabel} vs ${bLabel}`];
+
+      if (selected.includes("finyk")) {
+        const fa = aggregateFinyk(aKey);
+        const fb = aggregateFinyk(bKey);
+        const aSpent = Math.round(fa.totalSpent);
+        const bSpent = Math.round(fb.totalSpent);
+        lines.push("");
+        lines.push("Фінік:");
+        lines.push(`  ${diffLine("Витрати", aSpent, bSpent, " грн")}`);
+        lines.push(`  ${diffLine("Транзакцій", fa.txCount, fb.txCount, "")}`);
+        const topA = fa.topCategories[0];
+        const topB = fb.topCategories[0];
+        if (topA || topB) {
+          lines.push(
+            `  Топ категорія: ${topA ? `${topA.name} (${Math.round(topA.amount)} грн)` : "—"} vs ${topB ? `${topB.name} (${Math.round(topB.amount)} грн)` : "—"}`,
+          );
+        }
+      }
+
+      if (selected.includes("fizruk")) {
+        const za = aggregateFizruk(aKey);
+        const zb = aggregateFizruk(bKey);
+        lines.push("");
+        lines.push("Фізрук:");
+        if (!za && !zb) {
+          lines.push("  Немає тренувань у обидва тижні.");
+        } else {
+          const aCount = za?.workoutsCount ?? 0;
+          const bCount = zb?.workoutsCount ?? 0;
+          const aVol = za?.totalVolume ?? 0;
+          const bVol = zb?.totalVolume ?? 0;
+          lines.push(`  ${diffLine("Тренувань", aCount, bCount, "")}`);
+          lines.push(`  ${diffLine("Об'єм", aVol, bVol, " кг·повт")}`);
+        }
+      }
+
+      if (selected.includes("routine")) {
+        const ra = aggregateRoutine(aKey);
+        const rb = aggregateRoutine(bKey);
+        lines.push("");
+        lines.push("Рутина:");
+        if (!ra && !rb) {
+          lines.push("  Немає активних звичок.");
+        } else {
+          const aRate = ra?.overallRate ?? 0;
+          const bRate = rb?.overallRate ?? 0;
+          lines.push(`  ${diffLine("Виконання", aRate, bRate, "%")}`);
+          if (ra && rb) {
+            lines.push(`  Звичок: ${ra.habitCount} vs ${rb.habitCount}`);
+          }
+        }
+      }
+
+      if (selected.includes("nutrition")) {
+        const na = aggregateNutrition(aKey);
+        const nb = aggregateNutrition(bKey);
+        lines.push("");
+        lines.push("Харчування:");
+        if (!na && !nb) {
+          lines.push("  Немає логів їжі у обидва тижні.");
+        } else {
+          const aKcal = na?.avgKcal ?? 0;
+          const bKcal = nb?.avgKcal ?? 0;
+          const aDays = na?.daysLogged ?? 0;
+          const bDays = nb?.daysLogged ?? 0;
+          lines.push(`  ${diffLine("Калорії/день", aKcal, bKcal, " ккал")}`);
+          lines.push(`  Днів залоговано: ${aDays} vs ${bDays}`);
+        }
+      }
+
+      return lines.join("\n");
     }
     default:
       return undefined;

--- a/apps/web/src/core/lib/chatActions/types.ts
+++ b/apps/web/src/core/lib/chatActions/types.ts
@@ -421,6 +421,17 @@ export interface HabitTrendAction {
   input: { habit_id?: string; period_days?: number | string };
 }
 
+export type CompareWeeksModule = "finyk" | "fizruk" | "routine" | "nutrition";
+
+export interface CompareWeeksAction {
+  name: "compare_weeks";
+  input: {
+    week_a?: string;
+    week_b?: string;
+    modules?: CompareWeeksModule[];
+  };
+}
+
 export interface Calculate1rmAction {
   name: "calculate_1rm";
   input: {
@@ -522,6 +533,7 @@ export type ChatAction =
   | CategoryBreakdownAction
   | DetectAnomaliesAction
   | HabitTrendAction
+  | CompareWeeksAction
   | Calculate1rmAction
   | ConvertUnitsAction
   | SaveNoteAction

--- a/apps/web/src/core/lib/hubChatActionCards.test.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.test.ts
@@ -259,6 +259,47 @@ describe("buildActionCard", () => {
     expect(card?.title.length).toBeGreaterThan(0);
     expect(card?.summary.length).toBeGreaterThan(0);
   });
+
+  describe("compare_weeks", () => {
+    it("картка з обома тижнями у summary", () => {
+      const card = buildActionCard({
+        name: "compare_weeks",
+        input: { week_a: "2026-W17", week_b: "2026-W16" },
+        result: "Порівняння тижнів: 20 квіт – 26 квіт vs 13 квіт – 19 квіт",
+      });
+      expect(card).not.toBeNull();
+      expect(card?.module).toBe("hub");
+      expect(card?.title).toBe("Порівняння тижнів");
+      expect(card?.summary).toBe("2026-W17 vs 2026-W16");
+      expect(card?.icon).toBe("bar-chart");
+      expect(card?.risky).toBeUndefined();
+    });
+
+    it("без аргументів — fallback summary 'поточний vs попередній'", () => {
+      const card = buildActionCard({
+        name: "compare_weeks",
+        input: {},
+        result: "Порівняння тижнів: … vs …",
+      });
+      expect(card?.summary).toBe("поточний vs попередній");
+    });
+
+    it("failed — title із суфіксом «не вийшло»", () => {
+      const card = buildActionCard({
+        name: "compare_weeks",
+        input: { week_a: "2026-W17" },
+        result: 'Некоректний week_a: "bad". Очікую YYYY-Www.',
+      });
+      expect(card?.status).toBe("completed");
+      const failed = buildActionCard({
+        name: "compare_weeks",
+        input: {},
+        result: "Помилка виконання: timeout",
+      });
+      expect(failed?.status).toBe("failed");
+      expect(failed?.title).toBe("Порівняння тижнів — не вийшло");
+    });
+  });
 });
 
 describe("isRiskyTool", () => {

--- a/apps/web/src/core/lib/hubChatActionCards.ts
+++ b/apps/web/src/core/lib/hubChatActionCards.ts
@@ -60,6 +60,7 @@ const KNOWN_TOOLS: ReadonlySet<string> = new Set([
   "pause_habit",
   "morning_briefing",
   "weekly_summary",
+  "compare_weeks",
 ]);
 
 interface CardInput {
@@ -135,6 +136,8 @@ function iconFor(name: string): string | undefined {
       return "sun";
     case "weekly_summary":
       return "bar-chart";
+    case "compare_weeks":
+      return "bar-chart";
     default:
       return undefined;
   }
@@ -169,6 +172,8 @@ function titleFor(name: string, status: ChatActionCardStatus): string {
       return `Ранковий брифінг${failedSuffix}`;
     case "weekly_summary":
       return `Тижневий підсумок${failedSuffix}`;
+    case "compare_weeks":
+      return `Порівняння тижнів${failedSuffix}`;
     default:
       return name;
   }
@@ -281,6 +286,14 @@ function summaryFor(
       const program = stringField("program_id") || stringField("name");
       if (program) return program;
       break;
+    }
+    case "compare_weeks": {
+      const weekA = stringField("week_a");
+      const weekB = stringField("week_b");
+      if (weekA && weekB) return `${weekA} vs ${weekB}`;
+      if (weekA) return `${weekA} vs попередній`;
+      if (weekB) return `поточний vs ${weekB}`;
+      return "поточний vs попередній";
     }
     default:
       break;

--- a/apps/web/src/core/lib/hubChatActions.test.ts
+++ b/apps/web/src/core/lib/hubChatActions.test.ts
@@ -4,7 +4,7 @@
  * create_habit, create_transaction, log_set, log_water.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { executeAction } from "./hubChatActions";
+import { executeAction, executeActions } from "./hubChatActions";
 
 beforeEach(() => {
   localStorage.clear();
@@ -215,5 +215,49 @@ describe("log_water", () => {
         input: { amount_ml: 0 },
       }),
     ).toContain("Некоректна");
+  });
+});
+
+describe("executeActions — паралельне виконання", () => {
+  it("повертає результати у тому ж порядку, що й input", async () => {
+    const results = await executeActions([
+      { name: "create_habit", input: { name: "Пити воду" } },
+      {
+        name: "create_transaction",
+        input: { amount: 50, description: "кава" },
+      },
+      { name: "log_water", input: { amount_ml: 250 } },
+    ]);
+    expect(results).toHaveLength(3);
+    expect(results[0].name).toBe("create_habit");
+    expect(results[1].name).toBe("create_transaction");
+    expect(results[2].name).toBe("log_water");
+    expect(results[0].result).toContain("Пити воду");
+    expect(results[1].result).toContain("50");
+    expect(results[2].result).toContain("250");
+  });
+
+  it("ізолює помилки — один failure не валить інші", async () => {
+    const results = await executeActions([
+      { name: "create_habit", input: { name: "" } },
+      { name: "create_habit", input: { name: "Біг" } },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results[0].result).toContain("назви");
+    expect(results[1].result).toContain("Біг");
+  });
+
+  it("порожній масив → порожній результат", async () => {
+    const results = await executeActions([]);
+    expect(results).toEqual([]);
+  });
+
+  it("обгортає кожен виклик у Promise — підтримує майбутні async-handler-и", async () => {
+    const promise = executeActions([
+      { name: "log_water", input: { amount_ml: 100 } },
+    ]);
+    expect(promise).toBeInstanceOf(Promise);
+    const out = await promise;
+    expect(out[0].result).toContain("100");
   });
 });

--- a/apps/web/src/core/lib/hubChatActions.ts
+++ b/apps/web/src/core/lib/hubChatActions.ts
@@ -6,9 +6,9 @@ import { handleCrossAction } from "./chatActions/crossActions";
 
 export type { ChatAction } from "./chatActions/types";
 
-export function executeAction(
-  action: import("./chatActions/types").ChatAction,
-): string {
+type ChatAction = import("./chatActions/types").ChatAction;
+
+export function executeAction(action: ChatAction): string {
   try {
     return (
       handleFinykAction(action) ??
@@ -21,4 +21,31 @@ export function executeAction(
   } catch (e) {
     return `Помилка виконання: ${e instanceof Error ? e.message : String(e)}`;
   }
+}
+
+/**
+ * Execute multiple tool calls and return their results in the same order.
+ *
+ * Today every handler is synchronous (writes go to localStorage) so this is
+ * effectively the same as `actions.map(executeAction)` — the value is in
+ * pinning the API shape now. As soon as a handler needs to hit the network
+ * (e.g. `compare_weeks` aggregating from `/api/...` snapshots), we can flip
+ * its `handle*Action` signature to `Promise<string>` and `Promise.all` here
+ * starts giving real parallelism without touching `HubChat.tsx`.
+ *
+ * AI-CONTEXT: parallel write-tools that target the same localStorage key can
+ * race — Anthropic rarely emits two writes to the same key in one turn but
+ * if it ever does, the last `JSON.parse` → mutate → `JSON.stringify` pair
+ * wins. Сompose handlers so each domain owns one key per turn, or sequence
+ * conflicting writes via a queue if it becomes a real problem.
+ */
+export async function executeActions(
+  actions: ReadonlyArray<ChatAction>,
+): Promise<Array<{ name: string; result: string }>> {
+  return Promise.all(
+    actions.map(async (action) => ({
+      name: action.name,
+      result: await Promise.resolve(executeAction(action)),
+    })),
+  );
 }

--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -752,7 +752,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresOnline: true,
   },
 
-  // ───── Кросмодульні (3) ───────────────────────────────────────────────
+  // ───── Кросмодульні (5) ───────────────────────────────────────────────
   {
     id: "morning_briefing",
     module: "cross",
@@ -796,6 +796,27 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresInput: false,
     requiresOnline: true,
     keywords: ["тиждень", "звіт"],
+  },
+  {
+    id: "compare_weeks",
+    module: "cross",
+    label: "Порівняти тижні",
+    shortLabel: "Тижні",
+    icon: "bar-chart",
+    description:
+      "Порівняти два тижні по 4 модулях: витрати, тренування, звички, калорії.",
+    examples: [
+      "порівняй цей тиждень з минулим",
+      "як я провів тиждень порівняно з попереднім",
+      "compare_weeks 2026-W17 vs 2026-W16",
+    ],
+    prompt: "Порівняй цей тиждень з минулим по всіх модулях.",
+    requiresInput: false,
+    isQuickAction: true,
+    quickActionPriority: 40,
+    requiresOnline: true,
+    keywords: ["тиждень", "порівняння", "аналіз"],
+    aiHint: "YYYY-Www; default цей+минулий",
   },
   {
     id: "set_goal",


### PR DESCRIPTION
## What changed

Combined PR 7 + PR 8 з плану `claude/review-ai-chat-improvements-TkHfe`.

### PR 7 — паралельне виконання незалежних tool calls

- `apps/web/src/core/lib/hubChatActions.ts`: новий `executeActions(actions)` повертає `Promise<Array<{ name, result }>>` через `Promise.all`, чекаючи кожен `executeAction()` як `Promise.resolve(...)`.
- `apps/web/src/core/hub/HubChat.tsx`: послідовний `.map(...executeAction)` замінено на `await executeActions(data.tool_calls)`.
- AI-CONTEXT біля `executeActions`: race на localStorage можливий, якщо модель повертає два write-tools одного ключа в одному turn → last write wins. Сьогодні всі handler-и синхронні, тож це pin під майбутні async-handler-и.

### PR 8 — HubChat tool `compare_weeks`

- **Server**: tool def у `apps/server/src/modules/chat/toolDefs/crossModule.ts` (`week_a`, `week_b` як `YYYY-Www`, `modules` enum-array з default = всі 4).
- **Client handler** у `apps/web/src/core/lib/chatActions/crossActions.ts`:
  - `weekLabelToMondayKey(input)` парсить `YYYY-Www` → `YYYY-MM-DD` (Monday). Як bonus — приймає й `YYYY-MM-DD` зі snap до тижня.
  - Default `week_a` = поточний тиждень (Kyiv-day boundary через `getWeekKey`), `week_b` = попередній.
  - Делегує `aggregateFinyk` / `aggregateFizruk` / `aggregateNutrition` / `aggregateRoutine` з `useWeeklyDigest.ts`.
  - Складає diff-рядок: витрати, транзакції, топ-категорія / тренування + об'єм / % виконання звичок / середні калорії та дні залоговано.
- **Type** `CompareWeeksAction` + `CompareWeeksModule` додано у `chatActions/types.ts` і у `ChatAction` union.
- **Action card** у `hubChatActionCards.ts` (`module: hub`, `icon: bar-chart`, `risky: false`). Summary показує `2026-W17 vs 2026-W16` коли передано обидва, або `поточний vs попередній` як fallback.
- **Registry entry** у `packages/shared/src/lib/assistantCatalogue.ts` (`module: cross`, `isQuickAction: true`, `quickActionPriority: 40`, `aiHint: "YYYY-Www; default цей+минулий"`). Чіп з'являється у HubChat автоматично — `hubChatQuickActions.ts` уже back-compat shim над реджистром.
- **Snapshot** `SYSTEM_PREFIX` оновлено: bullet рутини виправлено (стейл після PR #797 → e6dafd0c) + додано `compare_weeks (YYYY-Www; default цей+минулий)` у Кросмодульних.

## Why

- PR 7 пинить async-сигнатуру для tool execution, навіть коли всі handler-и сьогодні синхронні. Як тільки буде перший async-handler — `Promise.all` дасть реальний паралелізм без зміни `HubChat.tsx`.
- PR 8 додає природний UX-патерн ("порівняй цей тиждень з минулим") який раніше вимагав двох викликів `weekly_summary` і ручної дельти моделлю.

## How to test

```bash
pnpm --filter @sergeant/web exec vitest run src/core/lib/chatActions src/core/lib/hubChatActions src/core/lib/hubChatActionCards
pnpm --filter @sergeant/server exec vitest run src/modules/chat
pnpm --filter @sergeant/shared exec vitest run
pnpm lint
pnpm typecheck
```

Локально все зелене:
- shared: 256/256
- server: 366/366 (snapshot оновлено)
- web: 854/854 (60 у трьох змінених файлах)
- lint clean (eslint + check-imports + custom plugins)

Manual smoke після мерджу:
1. `Порівняй цей тиждень з минулим` → асистент кличе `compare_weeks` без аргументів, action card показує "Порівняння тижнів · поточний vs попередній", у тілі — diff по 4 модулях.
2. `Порівняй 2026-W17 з 2026-W16 тільки фінансами` → modules фільтрується на `["finyk"]`.
3. `Порівняй з тижнем тому` → defaults працюють.
4. Подивитися чіп "Тижні" внизу HubChat (priority 40, після Брифінгу/Підсумку).

## How AI-tested this PR

- [x] Manual smoke (which flow?): не виконував — буде після мерджу на Vercel preview, бо chat-flow вимагає Anthropic API key
- [x] Vitest passes: shared 256/256, server 366/366, web 854/854 (включно з 22 новими тестами для executeActions/compare_weeks/action card)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules. AI-CONTEXT біля `executeActions` слідує існуючому правилу з `AGENTS.md` (#5 anti-pattern про lsSet) і race-warning — це задокументоване обмеження, не правило.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to compare weekly data across expenses, workouts, habits, and nutrition for any two weeks.
  * Shows comparative metrics including spending changes, transaction counts, workout volume, habit completion rates, and calorie differences.
  * Available as a quick assistant action with flexible week and module selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->