### PR TITLE
test(mobile): refresh stale hub core tests

### DIFF
--- a/apps/mobile/src/core/OnboardingWizard.test.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.test.tsx
@@ -22,7 +22,7 @@ describe("OnboardingWizard", () => {
     // act warnings. Matches the pattern used by Sheet/Skeleton tests.
     jest
       .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
-      .mockResolvedValue(false);
+      .mockImplementation(() => new Promise<boolean>(() => {}));
     jest
       .spyOn(AccessibilityInfo, "addEventListener")
       .mockReturnValue({ remove: () => {} } as ReturnType<
@@ -34,37 +34,51 @@ describe("OnboardingWizard", () => {
     jest.restoreAllMocks();
   });
 
-  it("renders the splash headline and all four vibe chips", () => {
+  function renderOnModulesStep(onDone = jest.fn()) {
+    const screen = render(<OnboardingWizard onDone={onDone} />);
+    fireEvent.press(screen.getByTestId("onboarding-next-welcome"));
+    return screen;
+  }
+
+  function renderOnGoalsStep(onDone = jest.fn()) {
+    const screen = renderOnModulesStep(onDone);
+    fireEvent.press(screen.getByTestId("onboarding-next-modules"));
+    return screen;
+  }
+
+  it("renders the welcome headline and all four module cards", () => {
     const { getByText, getByTestId } = render(
       <OnboardingWizard onDone={jest.fn()} />,
     );
-    expect(getByText("Твоє життя — один екран.")).toBeTruthy();
-    expect(getByTestId("onboarding-chip-finyk")).toBeTruthy();
-    expect(getByTestId("onboarding-chip-fizruk")).toBeTruthy();
-    expect(getByTestId("onboarding-chip-routine")).toBeTruthy();
-    expect(getByTestId("onboarding-chip-nutrition")).toBeTruthy();
+    expect(getByText("Привіт. Це Sergeant.")).toBeTruthy();
+    expect(getByText(/Гроші, тіло, звички, їжа/)).toBeTruthy();
+
+    fireEvent.press(getByTestId("onboarding-next-welcome"));
+
+    expect(getByTestId("onboarding-module-finyk")).toBeTruthy();
+    expect(getByTestId("onboarding-module-fizruk")).toBeTruthy();
+    expect(getByTestId("onboarding-module-routine")).toBeTruthy();
+    expect(getByTestId("onboarding-module-nutrition")).toBeTruthy();
   });
 
-  it("defaults every chip to the selected state (lazy-path)", () => {
-    const { getByTestId } = render(<OnboardingWizard onDone={jest.fn()} />);
+  it("defaults every module card to the selected state (lazy-path)", () => {
+    const { getByTestId } = renderOnModulesStep();
     for (const id of ["finyk", "fizruk", "routine", "nutrition"] as const) {
-      const chip = getByTestId(`onboarding-chip-${id}`);
+      const chip = getByTestId(`onboarding-module-${id}`);
       expect(chip.props.accessibilityState?.selected).toBe(true);
     }
   });
 
-  it("toggles a chip off and surfaces the empty-picks hint when every chip is cleared", () => {
-    const { getByTestId, getByText, queryByText } = render(
-      <OnboardingWizard onDone={jest.fn()} />,
-    );
-    fireEvent.press(getByTestId("onboarding-chip-finyk"));
+  it("toggles a module off and surfaces the empty-picks hint when every module is cleared", () => {
+    const { getByTestId, getByText, queryByText } = renderOnModulesStep();
+    fireEvent.press(getByTestId("onboarding-module-finyk"));
     expect(
-      getByTestId("onboarding-chip-finyk").props.accessibilityState?.selected,
+      getByTestId("onboarding-module-finyk").props.accessibilityState?.selected,
     ).toBe(false);
     expect(queryByText(/Без вибору — всі 4 модулі/)).toBeNull();
 
     for (const id of ["fizruk", "routine", "nutrition"] as const) {
-      fireEvent.press(getByTestId(`onboarding-chip-${id}`));
+      fireEvent.press(getByTestId(`onboarding-module-${id}`));
     }
     expect(getByText(/Без вибору — всі 4 модулі/)).toBeTruthy();
   });
@@ -72,7 +86,7 @@ describe("OnboardingWizard", () => {
   it("persists picks + done flag + first-action markers on finish", () => {
     const onDone = jest.fn();
     const mmkv = _getMMKVInstance();
-    const { getByTestId } = render(<OnboardingWizard onDone={onDone} />);
+    const { getByTestId } = renderOnGoalsStep(onDone);
 
     fireEvent.press(getByTestId("onboarding-finish"));
 
@@ -95,12 +109,13 @@ describe("OnboardingWizard", () => {
     });
   });
 
-  it("falls back to every module when the user cleared every chip before tapping finish", () => {
+  it("falls back to every module when the user cleared every module before tapping finish", () => {
     const onDone = jest.fn();
-    const { getByTestId } = render(<OnboardingWizard onDone={onDone} />);
+    const { getByTestId } = renderOnModulesStep(onDone);
     for (const id of ["finyk", "fizruk", "routine", "nutrition"] as const) {
-      fireEvent.press(getByTestId(`onboarding-chip-${id}`));
+      fireEvent.press(getByTestId(`onboarding-module-${id}`));
     }
+    fireEvent.press(getByTestId("onboarding-next-modules"));
 
     fireEvent.press(getByTestId("onboarding-finish"));
 
@@ -115,9 +130,10 @@ describe("OnboardingWizard", () => {
 
   it("persists the caller's chosen subset when they deselected some modules", () => {
     const onDone = jest.fn();
-    const { getByTestId } = render(<OnboardingWizard onDone={onDone} />);
-    fireEvent.press(getByTestId("onboarding-chip-fizruk"));
-    fireEvent.press(getByTestId("onboarding-chip-nutrition"));
+    const { getByTestId } = renderOnModulesStep(onDone);
+    fireEvent.press(getByTestId("onboarding-module-fizruk"));
+    fireEvent.press(getByTestId("onboarding-module-nutrition"));
+    fireEvent.press(getByTestId("onboarding-next-modules"));
 
     fireEvent.press(getByTestId("onboarding-finish"));
 

--- a/apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx
+++ b/apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx
@@ -10,8 +10,11 @@
  */
 
 import { act, fireEvent, render } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider } from "@sergeant/api-client/react";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
+import { apiClient } from "@/api/apiClient";
 import { _getMMKVInstance } from "@/lib/storage";
 
 import { WeeklyDigestFooter } from "./WeeklyDigestFooter";
@@ -31,6 +34,17 @@ function weekKeyFor(d: Date): string {
   )}-${String(monday.getDate()).padStart(2, "0")}`;
 }
 
+function renderFooter(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <ApiClientProvider client={apiClient}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </ApiClientProvider>,
+  );
+}
+
 describe("WeeklyDigestFooter", () => {
   beforeEach(() => {
     _getMMKVInstance().clearAll();
@@ -42,21 +56,19 @@ describe("WeeklyDigestFooter", () => {
   it("renders on Monday even without a digest (ready-to-generate CTA)", () => {
     // 2026-04-20 is a Monday.
     const monday = new Date("2026-04-20T10:00:00");
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = renderFooter(
       <WeeklyDigestFooter now={monday} />,
     );
 
     expect(getByTestId("weekly-digest-footer")).toBeTruthy();
-    // Monday *always* renders, but without a digest the fresh-dot
-    // stays hidden — the shared helper treats Monday as "live" only
-    // when actively checking freshness, not for presence reasons.
+    // Monday is live by definition so the CTA surfaces as fresh.
     expect(queryByTestId("weekly-digest-footer-fresh-dot")).toBeTruthy();
   });
 
   it("hides the footer on a quiet mid-week day with no digest", () => {
     // 2026-04-24 is a Friday.
     const friday = new Date("2026-04-24T10:00:00");
-    const { queryByTestId } = render(<WeeklyDigestFooter now={friday} />);
+    const { queryByTestId } = renderFooter(<WeeklyDigestFooter now={friday} />);
 
     expect(queryByTestId("weekly-digest-footer")).toBeNull();
   });
@@ -65,7 +77,7 @@ describe("WeeklyDigestFooter", () => {
     const wed = new Date("2026-04-22T10:00:00");
     writeDigest(weekKeyFor(wed), { generatedAt: wed.toISOString() });
 
-    const { getByTestId } = render(<WeeklyDigestFooter now={wed} />);
+    const { getByTestId } = renderFooter(<WeeklyDigestFooter now={wed} />);
 
     expect(getByTestId("weekly-digest-footer")).toBeTruthy();
     expect(getByTestId("weekly-digest-footer-fresh-dot")).toBeTruthy();
@@ -73,7 +85,7 @@ describe("WeeklyDigestFooter", () => {
 
   it("opens the placeholder digest card when the link is pressed", () => {
     const mon = new Date("2026-04-20T10:00:00");
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = renderFooter(
       <WeeklyDigestFooter now={mon} />,
     );
 

--- a/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.test.tsx
@@ -2,14 +2,17 @@
  * Render smoke test for the Hub-core Settings shell.
  *
  * Keeps the scope tight: the shell renders the screen title and all
- * seven Hub-core section headers (General / Notifications / Routine /
- * Finyk / Fizruk / AIDigest / Experimental). Section-level behaviour
+ * nine Hub-core section headers (General / Notifications / Routine /
+ * Finyk / Fizruk / AIDigest / Assistant / Experimental / Account).
+ * Section-level behaviour
  * is covered by the per-section suites.
  */
 
 import { render } from "@testing-library/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientProvider } from "@sergeant/api-client/react";
 
+import { apiClient } from "@/api/apiClient";
 import { _getMMKVInstance } from "@/lib/storage";
 
 import { HubSettingsPage } from "./HubSettingsPage";
@@ -45,9 +48,11 @@ function renderPage() {
     defaultOptions: { queries: { retry: false } },
   });
   return render(
-    <QueryClientProvider client={client}>
-      <HubSettingsPage />
-    </QueryClientProvider>,
+    <ApiClientProvider client={apiClient}>
+      <QueryClientProvider client={client}>
+        <HubSettingsPage />
+      </QueryClientProvider>
+    </ApiClientProvider>,
   );
 }
 


### PR DESCRIPTION
## What changed

- Updated `OnboardingWizard` tests for the current multi-step welcome → modules → goals flow and current `onboarding-module-*` test IDs.
- Wrapped weekly digest footer/settings smoke tests with the API client provider required by `useWeeklyDigest`.
- Aligned weekly digest expectations with the shared Monday-live rule and refreshed settings section-count prose.

## Why

The handoff identified three stale mobile tests that were failing on `main` and masking real CI regressions:

- `apps/mobile/src/core/OnboardingWizard.test.tsx`
- `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
- `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`

## How to test

```bash
pnpm --filter @sergeant/mobile test -- \
  src/core/OnboardingWizard.test.tsx \
  src/core/dashboard/WeeklyDigestFooter.test.tsx \
  src/core/settings/HubSettingsPage.test.tsx \
  --runInBand
```

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): not applicable — test-only PR.
- [x] Vitest passes: mobile Jest target above passes (`11 passed`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/fb48eb5cc79b4c4380c3d89b7c7cb4f9
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced onboarding flow test structure to model multi-step user journey with improved assertions.
  * Updated weekly digest footer tests to properly render components within required providers for accurate API and state management testing.
  * Improved settings page test setup to ensure proper context availability during component rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->