### PR TITLE
fix(web): add Vercel config under web root

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack enable && corepack prepare pnpm@9.15.1 --activate && pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @sergeant/web build",
+  "outputDirectory": "../server/dist",
+  "headers": [
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/((?!api/|\\.well-known/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-04-26-vercel-root-directory-hotfix-design.md
+++ b/docs/superpowers/specs/2026-04-26-vercel-root-directory-hotfix-design.md
@@ -1,0 +1,28 @@
+# Hotfix Vercel Root Directory
+
+## Проблема
+
+Production `sergeant.vercel.app` повертає Vercel `404: NOT_FOUND`. Vercel project має Root Directory `apps/web`, а поточний Vercel config лежить у корені репозиторію. Project config читається з project root directory, тому root-level `vercel.json` може не застосовуватись до `apps/web` project.
+
+## Рішення
+
+Додати `apps/web/vercel.json` з тими самими production web settings:
+
+- install через pinned pnpm 9.15.1 з monorepo root;
+- build `@sergeant/web`;
+- лишити `outputDirectory` як `../server/dist`, що відповідає `apps/web/vite.config.js`;
+- зберегти static headers і SPA rewrites, включно з `.well-known` exclusions для app links.
+
+Не змінювати Vite `outDir` у цьому hotfix. Це зачепило б size-limit paths, docs і наявні server/static assumptions.
+
+## Перевірка
+
+- `pnpm --filter @sergeant/web build`
+- `pnpm --filter @sergeant/web exec size-limit`
+- PR CI і Vercel preview/prod deployment checks
+
+## Self-review
+
+- Немає placeholders.
+- Scope обмежений Vercel project configuration.
+- Збережено наявний build output contract: `apps/server/dist`.


### PR DESCRIPTION
## What changed

- Added `apps/web/vercel.json` so the Vercel project with Root Directory `apps/web` can read the web deployment config directly.
- Preserved the existing web build command, `../server/dist` output directory, cache headers, `.well-known` headers, and SPA rewrite behavior.
- Added the approved hotfix design spec under `docs/superpowers/specs/`.

## Why

Production `sergeant.vercel.app` was returning Vercel `404: NOT_FOUND`. Since the Vercel project root is `apps/web`, keeping deployment config only at repository root can leave the web project without the intended output directory and rewrites.

## How to test

- Verify Vercel preview/prod deployment uses `apps/web/vercel.json`.
- Open the deployment root and a client-side route; both should serve `index.html` instead of Vercel `404: NOT_FOUND`.
- Verify `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` still bypass the SPA rewrite.

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): not run yet; awaiting deployed preview/prod URL.
- [ ] Vitest passes: not run; config-only hotfix.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

Local checks run:

- `pnpm --filter @sergeant/web build`
- `pnpm --filter @sergeant/web exec size-limit`
- `pnpm exec prettier --check apps/web/vercel.json docs/superpowers/specs/2026-04-26-vercel-root-directory-hotfix-design.md`
- `pnpm lint`
- `pnpm typecheck`

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/2998cc9da348419a8ac2e93e85883abb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment configuration to resolve 404 errors on the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->