### PR TITLE
fix(server): bump chat max_tokens so briefings/summaries don't truncate mid-sentence

### DIFF
--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -170,9 +170,15 @@ export default async function handler(
       { role: "user", content: toolResultMessages },
     ];
 
+    // AI-CONTEXT: cap на tool-result відповідь — це фінальний текст для
+    // юзера після того як модель отримала дані з tool_result (брифінги,
+    // підсумки, аналіз бюджету). Markdown-таблиці + кілька секцій по-українськи
+    // легко займають 1.5–2k токенів; нижчі значення обрізали відповідь
+    // посеред речення. Тримаємо із запасом — модель сама зупиниться раніше,
+    // якщо контент закінчився.
     const payload = {
       model: "claude-sonnet-4-6",
-      max_tokens: 400,
+      max_tokens: 2500,
       system: buildSystem(context),
       tools: TOOLS_WITH_CACHE,
       messages: fullMessages,
@@ -227,9 +233,14 @@ export default async function handler(
   try {
     ({ response, data } = await anthropicMessages(
       apiKey,
+      // AI-CONTEXT: перший крок чату — модель може повернути text або tool_use.
+      // Direct-text відповіді на питання типу «що з фінансами?» потребують
+      // більше за 600 токенів, бо це часто структуровані пояснення з
+      // markdown-форматуванням. Тримаємо нижче за tool-result cap, бо тут
+      // зазвичай немає таблиць/брифінгів.
       {
         model: "claude-sonnet-4-6",
-        max_tokens: 600,
+        max_tokens: 1500,
         system: buildSystem(context),
         tools: TOOLS_WITH_CACHE,
         messages: cleaned,


### PR DESCRIPTION
## What changed

`apps/server/src/modules/chat.ts` — підняв `max_tokens` для `/api/chat`:

| Шлях                                  | Було | Стало |
| ------------------------------------- | ---- | ----- |
| Перший крок (text або tool_use)       | 600  | 1500  |
| Другий крок (відповідь на tool_result)| 400  | 2500  |

Додав короткі `AI-CONTEXT`-коментарі поряд з payload, щоб майбутні агенти розуміли, чому саме такі ліміти.

## Why

Юзер прислав скріншот, де відповідь HubChat-а на «Брифінг» обрізається посеред речення — на «1. Поставити ліміт на ШІ — рек» (сумарно близько 7 секцій з таблицею + bullet-ами).

Корінь — `max_tokens: 400` на tool-result шляху. Брифінги/підсумки/аналіз бюджету генеруються саме там (модель робить tool_use → клієнт виконує `handleCrossAction`/`handleFinykAction` тощо → сервер шле `tool_result` назад в Anthropic). Markdown-таблиці + 3-4 секції українською легко займають 1.5–2k токенів — старий cap різав їх посеред слова.

Перший крок з 600 теж піднято — direct-text відповіді на питання типу «що з фінансами?» теж бували обрізані, хоч і рідше.

## How to test

1. Відкрити HubChat (Hub → іконка чату).
2. Натиснути quick action **«Брифінг»** (або написати «ранковий брифінг»).
3. Переконатись, що відповідь приходить повна — закінчується знаком пунктуації, не обривається посеред слова. Розгорнутий брифінг із таблицею критичних ризиків + секціями «Серйозні проблеми» / «Що варто змінити» має поміститись у відповідь.
4. Аналогічно перевірити «Підсумок» та «Тижні».

Або через curl з валідним `ANTHROPIC_API_KEY` зловити `stop_reason` у відповіді — повинен бути `end_turn`, а не `max_tokens`.

---

## How AI-tested this PR

- [x] `pnpm lint` (apps/server) — проходить.
- [x] `pnpm typecheck` (apps/server) — проходить.
- [x] `pnpm test` (apps/server) — 366/366 passed.
- [ ] Manual smoke (HubChat «Брифінг») — не виконано локально, бо потрібен `ANTHROPIC_API_KEY` + наповнені дані по 4 модулях.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (це чисто корекція runtime-cap-а, нової конвенції не вводимо).


Link to Devin session: https://app.devin.ai/sessions/c50c5ee58be64e95a3d45801cb185ffb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased capacity for chat responses to deliver more detailed and comprehensive outputs, including support for complex formatted content like tables and multi-section summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->