### PR TITLE
feat(web): collapsible groups in assistant catalogue

### DIFF
--- a/apps/mobile/src/core/AssistantCataloguePage.test.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.test.tsx
@@ -23,6 +23,7 @@ import {
   CAPABILITY_MODULE_ORDER,
 } from "@sergeant/shared";
 
+import { _getMMKVInstance } from "@/lib/storage";
 import { AssistantCataloguePage } from "./AssistantCataloguePage";
 
 jest.mock("react-native-safe-area-context", () => {
@@ -34,6 +35,7 @@ jest.mock("react-native-safe-area-context", () => {
 });
 
 beforeEach(() => {
+  _getMMKVInstance().clearAll();
   jest
     .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
     .mockResolvedValue(false);
@@ -126,5 +128,72 @@ describe("AssistantCataloguePage", () => {
     expect(getAllByText(sample!.description).length).toBeGreaterThanOrEqual(2);
     // Example bullets are sheet-only — a single match is enough.
     expect(getByText(`«${sample!.examples[0]}»`)).toBeTruthy();
+  });
+});
+
+describe("AssistantCataloguePage — group collapsing", () => {
+  it("toggles a group on header tap and hides its rows when collapsed", () => {
+    const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
+    const finykHeader = getByTestId("catalogue-module-finyk-toggle");
+
+    expect(
+      queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+    fireEvent.press(finykHeader);
+    expect(queryByTestId("catalogue-capability-create_transaction")).toBeNull();
+    // Other groups stay expanded.
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeTruthy();
+
+    // Tapping the header again re-expands.
+    fireEvent.press(finykHeader);
+    expect(
+      queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+  });
+
+  it("`Згорнути все` collapses every group and the toggle flips its label", () => {
+    const { getByTestId, queryByTestId, getByText } = render(
+      <AssistantCataloguePage />,
+    );
+    const toggleAll = getByTestId("catalogue-toggle-all");
+    expect(getByText("Згорнути все")).toBeTruthy();
+
+    fireEvent.press(toggleAll);
+    expect(queryByTestId("catalogue-capability-create_transaction")).toBeNull();
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeNull();
+    expect(getByText("Розгорнути все")).toBeTruthy();
+
+    fireEvent.press(toggleAll);
+    expect(
+      queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+  });
+
+  it("hides the toggle-all control while a search query is active", () => {
+    const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
+    fireEvent.changeText(
+      getByTestId("assistant-catalogue-search"),
+      "тренування",
+    );
+    expect(queryByTestId("catalogue-toggle-all")).toBeNull();
+  });
+
+  it("auto-expands persisted-collapsed groups while searching, restores them after", () => {
+    const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
+
+    // Persist `fizruk` as collapsed.
+    fireEvent.press(getByTestId("catalogue-module-fizruk-toggle"));
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeNull();
+
+    // Searching forces the group open so matches are visible.
+    fireEvent.changeText(
+      getByTestId("assistant-catalogue-search"),
+      "тренування",
+    );
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeTruthy();
+
+    // Clearing the query restores the persisted collapsed state.
+    fireEvent.changeText(getByTestId("assistant-catalogue-search"), "");
+    expect(queryByTestId("catalogue-capability-start_workout")).toBeNull();
   });
 });

--- a/apps/mobile/src/core/AssistantCataloguePage.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.tsx
@@ -25,7 +25,7 @@
  *    `max-w-2xl` container.
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -33,6 +33,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import {
   ASSISTANT_CAPABILITIES,
   CAPABILITY_MODULE_META,
+  CAPABILITY_MODULE_ORDER,
   groupCapabilitiesByModule,
   searchCapabilities,
   type AssistantCapability,
@@ -42,6 +43,21 @@ import {
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Sheet } from "@/components/ui/Sheet";
+import { useLocalStorage } from "@/lib/storage";
+
+// AI-NOTE: keep in lockstep with web — see
+// apps/web/src/core/AssistantCataloguePage.tsx (`COLLAPSED_GROUPS_LS_KEY`).
+const COLLAPSED_GROUPS_KEY = "assistant_catalogue_collapsed_v1";
+
+const CAPABILITY_MODULE_SET = new Set<string>(CAPABILITY_MODULE_ORDER);
+
+function sanitizeCollapsed(value: unknown): CapabilityModule[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (v): v is CapabilityModule =>
+      typeof v === "string" && CAPABILITY_MODULE_SET.has(v),
+  );
+}
 
 // Emoji prefix per module — keeps a consistent visual rhythm with the
 // existing settings sections (`💳 Фінік`, `🏋 Фізрук`, `✅ Рутина`,
@@ -72,12 +88,51 @@ export function AssistantCataloguePage({
 }: AssistantCataloguePageProps) {
   const [query, setQuery] = useState("");
   const [detail, setDetail] = useState<AssistantCapability | null>(null);
+  // AI-CONTEXT: persisting *collapsed* (not expanded) ids keeps every
+  // module visible by default — newly registered modules surface
+  // immediately without a one-off migration.
+  const [collapsedRaw, setCollapsedRaw] = useLocalStorage<CapabilityModule[]>(
+    COLLAPSED_GROUPS_KEY,
+    [],
+  );
+  const collapsedModules = useMemo(
+    () => sanitizeCollapsed(collapsedRaw),
+    [collapsedRaw],
+  );
+  const collapsedSet = useMemo(
+    () => new Set(collapsedModules),
+    [collapsedModules],
+  );
 
   const filtered = useMemo(
     () => (query.trim() ? searchCapabilities(query) : ASSISTANT_CAPABILITIES),
     [query],
   );
   const groups = useMemo(() => groupCapabilitiesByModule(filtered), [filtered]);
+  const isSearching = query.trim().length > 0;
+  // While searching all groups expand so matches are immediately visible.
+  // The persisted collapsed set is left untouched.
+  const isModuleCollapsed = (module: CapabilityModule) =>
+    !isSearching && collapsedSet.has(module);
+
+  const toggleModule = useCallback(
+    (module: CapabilityModule) => {
+      setCollapsedRaw((prev) => {
+        const list = sanitizeCollapsed(prev);
+        return list.includes(module)
+          ? list.filter((m) => m !== module)
+          : [...list, module];
+      });
+    },
+    [setCollapsedRaw],
+  );
+
+  const allCollapsed =
+    groups.length > 0 && groups.every((g) => collapsedSet.has(g.module));
+
+  const toggleAll = useCallback(() => {
+    setCollapsedRaw(allCollapsed ? [] : CAPABILITY_MODULE_ORDER.slice());
+  }, [allCollapsed, setCollapsedRaw]);
 
   const handleClose = () => {
     if (onClose) {
@@ -131,6 +186,27 @@ export function AssistantCataloguePage({
           />
         </View>
 
+        {!isSearching && groups.length > 0 ? (
+          <View className="flex-row justify-end mb-3">
+            <Pressable
+              onPress={toggleAll}
+              accessibilityRole="button"
+              accessibilityLabel={
+                allCollapsed ? "Розгорнути все" : "Згорнути все"
+              }
+              testID="catalogue-toggle-all"
+              className="flex-row items-center gap-1 px-2.5 py-1 rounded-full active:opacity-70"
+            >
+              <Text className="text-stone-500 text-xs">
+                {allCollapsed ? "⌄" : "⌃"}
+              </Text>
+              <Text className="text-stone-600 text-xs font-semibold">
+                {allCollapsed ? "Розгорнути все" : "Згорнути все"}
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+
         {filtered.length === 0 ? (
           <Text className="text-center text-stone-500 py-8 text-sm">
             Нічого не знайдено за «{query}». Спробуй інший термін.
@@ -142,6 +218,8 @@ export function AssistantCataloguePage({
                 key={g.module}
                 module={g.module}
                 capabilities={g.capabilities}
+                collapsed={isModuleCollapsed(g.module)}
+                onToggle={() => toggleModule(g.module)}
                 onActivate={setDetail}
               />
             ))}
@@ -160,28 +238,50 @@ export function AssistantCataloguePage({
 interface ModuleGroupProps {
   module: CapabilityModule;
   capabilities: readonly AssistantCapability[];
+  collapsed: boolean;
+  onToggle: () => void;
   onActivate: (cap: AssistantCapability) => void;
 }
 
-function ModuleGroup({ module, capabilities, onActivate }: ModuleGroupProps) {
+function ModuleGroup({
+  module,
+  capabilities,
+  collapsed,
+  onToggle,
+  onActivate,
+}: ModuleGroupProps) {
   const meta = CAPABILITY_MODULE_META[module];
   return (
     <View accessibilityLabel={meta.title}>
-      <Text className="text-sm font-bold text-stone-900 mb-2">
-        {MODULE_EMOJI[module]} {meta.title}{" "}
-        <Text className="text-stone-400 font-normal">
-          ({capabilities.length})
+      <Pressable
+        onPress={onToggle}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: !collapsed }}
+        accessibilityLabel={`${meta.title}, ${capabilities.length}`}
+        testID={`catalogue-module-${module}-toggle`}
+        className="flex-row items-center gap-1 mb-2 active:opacity-70"
+      >
+        <Text className="text-sm font-bold text-stone-900 flex-1">
+          {MODULE_EMOJI[module]} {meta.title}{" "}
+          <Text className="text-stone-400 font-normal">
+            ({capabilities.length})
+          </Text>
         </Text>
-      </Text>
-      <View className="gap-2">
-        {capabilities.map((cap) => (
-          <CapabilityRow
-            key={cap.id}
-            capability={cap}
-            onActivate={onActivate}
-          />
-        ))}
-      </View>
+        <Text className="text-stone-400 text-base">
+          {collapsed ? "⌄" : "⌃"}
+        </Text>
+      </Pressable>
+      {!collapsed ? (
+        <View className="gap-2">
+          {capabilities.map((cap) => (
+            <CapabilityRow
+              key={cap.id}
+              capability={cap}
+              onActivate={onActivate}
+            />
+          ))}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/apps/web/src/core/AssistantCataloguePage.collapse.test.tsx
+++ b/apps/web/src/core/AssistantCataloguePage.collapse.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { AssistantCataloguePage } from "./AssistantCataloguePage";
+
+// Stub the detail modal — it pulls in chat plumbing we don't need to
+// exercise the per-group collapse contract.
+vi.mock("./components/CapabilityDetailModal", () => ({
+  CapabilityDetailModal: () => null,
+}));
+
+const COLLAPSED_LS_KEY = "assistant_catalogue_collapsed_v1";
+
+describe("AssistantCataloguePage — group collapsing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => cleanup());
+
+  it("groups are expanded by default and a representative row is visible", () => {
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    expect(
+      screen.getByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+    const finykToggle = screen.getByTestId("catalogue-module-finyk-toggle");
+    expect(finykToggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("clicking a module header collapses just that group and persists to localStorage", () => {
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    const finykToggle = screen.getByTestId("catalogue-module-finyk-toggle");
+    fireEvent.click(finykToggle);
+
+    expect(finykToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      screen.queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeNull();
+    // Other groups stay expanded.
+    expect(
+      screen
+        .getByTestId("catalogue-module-fizruk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+
+    const stored = JSON.parse(
+      localStorage.getItem(COLLAPSED_LS_KEY) ?? "[]",
+    ) as string[];
+    expect(stored).toEqual(["finyk"]);
+  });
+
+  it("rehydrates collapsed groups from localStorage on mount", () => {
+    localStorage.setItem(COLLAPSED_LS_KEY, JSON.stringify(["finyk", "fizruk"]));
+    render(<AssistantCataloguePage onClose={() => {}} />);
+
+    expect(
+      screen
+        .getByTestId("catalogue-module-finyk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByTestId("catalogue-module-fizruk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(
+      screen.queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeNull();
+    // routine/nutrition headers stay expanded → at least one of their rows
+    // is rendered.
+    expect(
+      screen
+        .getByTestId("catalogue-module-routine-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
+  it("`Згорнути все` collapses every group, second click re-expands", () => {
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    const toggleAll = screen.getByTestId("catalogue-toggle-all");
+
+    fireEvent.click(toggleAll);
+    expect(
+      screen.queryByTestId("catalogue-capability-create_transaction"),
+    ).toBeNull();
+    expect(
+      screen
+        .getByTestId("catalogue-module-finyk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(toggleAll.textContent).toMatch(/Розгорнути все/);
+
+    fireEvent.click(toggleAll);
+    expect(
+      screen.getByTestId("catalogue-capability-create_transaction"),
+    ).toBeTruthy();
+    expect(toggleAll.textContent).toMatch(/Згорнути все/);
+  });
+
+  it("collapsed groups expand automatically while searching, persisted state is preserved", () => {
+    localStorage.setItem(COLLAPSED_LS_KEY, JSON.stringify(["fizruk"]));
+    render(<AssistantCataloguePage onClose={() => {}} />);
+
+    const search = screen.getByLabelText("Пошук можливостей");
+    fireEvent.change(search, { target: { value: "тренування" } });
+
+    // Search hides the toggle-all row.
+    expect(screen.queryByTestId("catalogue-toggle-all")).toBeNull();
+    // start_workout (fizruk) row is now visible despite fizruk being
+    // persisted as collapsed.
+    expect(
+      screen.getByTestId("catalogue-capability-start_workout"),
+    ).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: "" } });
+    // Persisted state restored: fizruk back to collapsed.
+    expect(
+      screen
+        .getByTestId("catalogue-module-fizruk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_LS_KEY) ?? "[]")).toEqual([
+      "fizruk",
+    ]);
+  });
+
+  it("ignores corrupt persisted shapes (non-array, unknown module ids)", () => {
+    localStorage.setItem(COLLAPSED_LS_KEY, JSON.stringify({ bad: true }));
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    expect(
+      screen
+        .getByTestId("catalogue-module-finyk-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+});

--- a/apps/web/src/core/AssistantCataloguePage.tsx
+++ b/apps/web/src/core/AssistantCataloguePage.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
+import { useLocalStorageState } from "@shared/hooks";
 import { cn } from "@shared/lib/cn";
 import {
   ASSISTANT_CAPABILITIES,
@@ -17,6 +18,16 @@ import { CapabilityDetailModal } from "./components/CapabilityDetailModal";
 interface AssistantCataloguePageProps {
   onClose: () => void;
 }
+
+// AI-NOTE: bumping the suffix invalidates older shapes if we change semantics.
+const COLLAPSED_GROUPS_LS_KEY = "assistant_catalogue_collapsed_v1";
+
+const isCapabilityModule = (v: unknown): v is CapabilityModule =>
+  typeof v === "string" &&
+  (CAPABILITY_MODULE_ORDER as readonly string[]).includes(v);
+
+const isCollapsedShape = (v: unknown): v is CapabilityModule[] =>
+  Array.isArray(v) && v.every(isCapabilityModule);
 
 /**
  * Send a chat message via the global `hub:openChat` event. Avoids importing
@@ -37,12 +48,51 @@ export function AssistantCataloguePage({
 }: AssistantCataloguePageProps) {
   const [query, setQuery] = useState("");
   const [detail, setDetail] = useState<AssistantCapability | null>(null);
+  // AI-CONTEXT: persisting collapsed groups (not expanded) keeps "everything
+  // open" the default — adding a new module to the registry stays visible
+  // until the user explicitly collapses it.
+  const [collapsedModules, setCollapsedModules] = useLocalStorageState<
+    CapabilityModule[]
+  >(COLLAPSED_GROUPS_LS_KEY, [], { validate: isCollapsedShape });
 
   const filtered = useMemo(
     () => (query.trim() ? searchCapabilities(query) : ASSISTANT_CAPABILITIES),
     [query],
   );
   const groups = useMemo(() => groupCapabilitiesByModule(filtered), [filtered]);
+  const isSearching = query.trim().length > 0;
+
+  const collapsedSet = useMemo(
+    () => new Set(collapsedModules),
+    [collapsedModules],
+  );
+  // While searching we always show matches expanded so the user can read
+  // results without re-toggling each section. The persisted state is left
+  // untouched so the previous layout returns once the query is cleared.
+  const isModuleCollapsed = (module: CapabilityModule) =>
+    !isSearching && collapsedSet.has(module);
+
+  const toggleModule = useCallback(
+    (module: CapabilityModule) => {
+      setCollapsedModules((prev) =>
+        prev.includes(module)
+          ? prev.filter((m) => m !== module)
+          : [...prev, module],
+      );
+    },
+    [setCollapsedModules],
+  );
+
+  const allCollapsed =
+    groups.length > 0 && groups.every((g) => collapsedSet.has(g.module));
+
+  const toggleAll = useCallback(() => {
+    if (allCollapsed) {
+      setCollapsedModules([]);
+    } else {
+      setCollapsedModules(CAPABILITY_MODULE_ORDER.slice());
+    }
+  }, [allCollapsed, setCollapsedModules]);
 
   const handleActivate = (cap: AssistantCapability) => {
     if (cap.requiresInput) {
@@ -86,7 +136,7 @@ export function AssistantCataloguePage({
           або побачити приклади.
         </p>
 
-        <div className="relative mb-4">
+        <div className="relative mb-3">
           <span
             aria-hidden
             className="absolute left-3 top-1/2 -translate-y-1/2 text-subtle"
@@ -103,6 +153,28 @@ export function AssistantCataloguePage({
           />
         </div>
 
+        {!isSearching && groups.length > 0 && (
+          <div className="flex justify-end mb-3">
+            <button
+              type="button"
+              onClick={toggleAll}
+              data-testid="catalogue-toggle-all"
+              className={cn(
+                "inline-flex items-center gap-1.5 text-xs font-semibold text-muted",
+                "rounded-full px-2.5 py-1 hover:bg-panel hover:text-text transition-colors",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+              )}
+            >
+              <Icon
+                name={allCollapsed ? "chevron-down" : "chevron-up"}
+                size={12}
+                aria-hidden
+              />
+              {allCollapsed ? "Розгорнути все" : "Згорнути все"}
+            </button>
+          </div>
+        )}
+
         {filtered.length === 0 && (
           <div className="text-center text-subtle py-12 text-sm">
             Нічого не знайдено за «{query}». Спробуй інший термін.
@@ -115,6 +187,8 @@ export function AssistantCataloguePage({
               key={g.module}
               module={g.module}
               capabilities={g.capabilities}
+              collapsed={isModuleCollapsed(g.module)}
+              onToggle={() => toggleModule(g.module)}
               onActivate={handleActivate}
             />
           ))}
@@ -133,33 +207,67 @@ export function AssistantCataloguePage({
 interface ModuleGroupProps {
   module: CapabilityModule;
   capabilities: readonly AssistantCapability[];
+  collapsed: boolean;
+  onToggle: () => void;
   onActivate: (cap: AssistantCapability) => void;
 }
 
-function ModuleGroup({ module, capabilities, onActivate }: ModuleGroupProps) {
+function ModuleGroup({
+  module,
+  capabilities,
+  collapsed,
+  onToggle,
+  onActivate,
+}: ModuleGroupProps) {
   const meta = CAPABILITY_MODULE_META[module];
+  const headingId = `catalogue-module-${module}`;
+  const listId = `catalogue-module-${module}-list`;
   return (
-    <section aria-labelledby={`catalogue-module-${module}`}>
-      <SectionHeading
-        as="h2"
-        size="sm"
-        tone="text"
-        id={`catalogue-module-${module}`}
-        className="flex items-center gap-2 mb-2"
+    <section aria-labelledby={headingId}>
+      <button
+        type="button"
+        onClick={onToggle}
+        data-testid={`catalogue-module-${module}-toggle`}
+        aria-expanded={!collapsed}
+        aria-controls={listId}
+        className={cn(
+          "w-full flex items-center gap-2 text-left rounded-lg",
+          "-mx-1 px-1 py-0.5 mb-2 hover:bg-panel/60 transition-colors",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+        )}
       >
         <Icon name={meta.icon} size={14} aria-hidden />
-        {meta.title}
-        <span className="text-subtle font-normal normal-case tracking-normal">
-          ({capabilities.length})
-        </span>
-      </SectionHeading>
-      <ul className="space-y-2">
-        {capabilities.map((cap) => (
-          <li key={cap.id}>
-            <CapabilityRow capability={cap} onActivate={onActivate} />
-          </li>
-        ))}
-      </ul>
+        <SectionHeading
+          as="span"
+          size="sm"
+          tone="text"
+          id={headingId}
+          className="flex items-center gap-2 m-0"
+        >
+          {meta.title}
+          <span className="text-subtle font-normal normal-case tracking-normal">
+            ({capabilities.length})
+          </span>
+        </SectionHeading>
+        <Icon
+          name="chevron-down"
+          size={14}
+          aria-hidden
+          className={cn(
+            "ml-auto text-muted transition-transform",
+            collapsed ? "-rotate-90" : "rotate-0",
+          )}
+        />
+      </button>
+      {!collapsed && (
+        <ul id={listId} className="space-y-2">
+          {capabilities.map((cap) => (
+            <li key={cap.id}>
+              <CapabilityRow capability={cap} onActivate={onActivate} />
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## What changed

`AssistantCataloguePage` (web + mobile) now lets the user collapse / expand each module group on the **«Можливості асистента»** screen.

- Each module header is a button (`aria-expanded`, chevron rotates) — tap to toggle.
- "Згорнути все" / "Розгорнути все" toggle right above the list folds every group in one step.
- Collapsed module ids are persisted under `assistant_catalogue_collapsed_v1` (web → `useLocalStorageState`, mobile → `useLocalStorage` over MMKV). The persisted shape is fail-soft validated; corrupt values are ignored.
- While the search input is non-empty, every group auto-expands so matches are immediately visible. The persisted layout returns once the query clears.
- New modules added to the registry stay visible by default (we persist *collapsed*, not *expanded*).

## Why

Каталог росте з кожним релізом — 18+ карток у Фініку, окремо Фізрук, Рутина, Харчування, кросмодульні, аналітика, утиліти, пам'ять. Прокручувати це на телефоні стає важко. Згортання дозволяє швидко зорієнтуватись по модулях і фокусуватись на одному.

Мобайл — дзеркальна реалізація, бо тести `apps/mobile/src/core/AssistantCataloguePage.test.tsx` уже трактують його як парну поверхню до веба (див. AGENTS.md → Module ownership map).

## How to test

1. `pnpm --filter @sergeant/web test -- --run AssistantCataloguePage`
2. `pnpm --filter @sergeant/mobile test -- --testPathPattern AssistantCataloguePage`
3. Локально (web): відкрити Hub → шапка асистента → «Можливості асистента». Тапнути «Фінік» — група згортається; перезавантажити сторінку — група лишається згорнута. «Згорнути все» / «Розгорнути все» працює. Ввести «тренування» в пошук — `start_workout` видно, навіть якщо `fizruk` був у згорнутих.

---

## How AI-tested this PR

- [x] Vitest passes: `apps/web/src/core/AssistantCataloguePage.collapse.test.tsx` (6 нових тестів — дефолт, toggle одного, перезавантаження стану, «Згорнути все», auto-expand під час пошуку, fail-soft на побитих формах LS).
- [x] Jest passes: `apps/mobile/src/core/AssistantCataloguePage.test.tsx` (4 нові describe-блоки на згортання + збереження попередніх 6 тестів).
- [x] `pnpm --filter @sergeant/web typecheck` — clean.
- [x] `pnpm --filter @sergeant/mobile typecheck` — clean.
- [x] `pnpm --filter @sergeant/web lint` + `pnpm --filter @sergeant/mobile lint` — clean.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/2d415f7f3c004731974580e68d5ac9ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Module groups in the Assistant Catalogue are now collapsible; tap/click headers to toggle visibility.
  * Added "collapse/expand all" control for quick management of all groups.
  * Collapsed state is persisted and restored across sessions.
  * During search, groups automatically expand to show matches, then revert to saved state.

* **Tests**
  * Added comprehensive test coverage for catalogue collapse/expand interactions and state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->