### PR TITLE
docs: sync max_tokens references with chat.ts (1500/2500)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,13 +263,13 @@ The HubChat assistant uses Anthropic tool-calling. Tools are **defined on the se
 
 `apps/server/src/modules/chat.ts` uses two distinct `max_tokens` values, intentionally:
 
-| Request                      | `max_tokens` | Where (chat.ts)                 | Why                                                                                             |
-| ---------------------------- | ------------ | ------------------------------- | ----------------------------------------------------------------------------------------------- |
-| First user-message chat call | **600**      | line ~171, payload to Anthropic | Enough for a tool call + short reply, or a 2–4-sentence answer.                                 |
-| Tool-result continuation     | **400**      | line ~114, follow-up payload    | Just enough to summarise the tool result; the model already "used" its budget on the tool call. |
+| Request                      | `max_tokens` | Where (chat.ts)                 | Why                                                                                                                                              |
+| ---------------------------- | ------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| First user-message chat call | **1500**     | line ~243, payload to Anthropic | Enough for a tool call + short reply, OR a structured direct-text answer with markdown formatting (3–6 sentences українською).                   |
+| Tool-result continuation     | **2500**     | line ~181, follow-up payload    | Фінальна відповідь юзеру після tool_result — брифінги, підсумки, аналіз бюджету. Markdown-таблиці + кілька секцій легко займають 1.5–2k токенів. |
 
-Do **not** lower these without testing the worst-case `/help` response and the largest tool-result blob.
-When Anthropic returns `stop_reason: "max_tokens"`, the model may truncate **mid-JSON-tool-call**— the client `executeAction` then throws a parse error and the user sees "Невідома дія". If you need a longer system prompt or more tools, raise `max_tokens` first; do not silently squeeze the budget.
+Do **not** lower these without testing the worst-case `/help` response and the largest tool-result blob (briefing + weekly summary go through the continuation path).
+When Anthropic returns `stop_reason: "max_tokens"`, the model may truncate **mid-JSON-tool-call** — the client `executeAction` then throws a parse error and the user sees "Невідома дія". On the continuation path it instead truncates the user-facing markdown mid-sentence (this is what motivated the bump from 400→2500 / 600→1500 in PR #804). If you need a longer system prompt or more tools, raise `max_tokens` first; do not silently squeeze the budget.
 
 ### `SYSTEM_PREFIX` is a prompt-cache candidate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ curl -X POST http://localhost:3000/api/chat \
   -d '{"messages":[{"role":"user","content":"залогуй 200мл води"}],"context":""}'
 ```
 
-Якщо відповідь містить блоки `tool_use` але `localStorage` не змінився — це **норма**: сервер лише визначив tool call, виконання відбувається в `executeAction` на клієнті після рендеру відповіді в HubChat. Для перевірки повного циклу без UI треба вручну прогнати `tool_result` через другий `/api/chat` запит (див. continuation handler у `chat.ts`, `max_tokens: 400`).
+Якщо відповідь містить блоки `tool_use` але `localStorage` не змінився — це **норма**: сервер лише визначив tool call, виконання відбувається в `executeAction` на клієнті після рендеру відповіді в HubChat. Для перевірки повного циклу без UI треба вручну прогнати `tool_result` через другий `/api/chat` запит (див. continuation handler у `chat.ts`, `max_tokens: 2500`).
 
 ### Пов'язані playbookи
 

--- a/docs/playbooks/debug-chat-tool.md
+++ b/docs/playbooks/debug-chat-tool.md
@@ -64,7 +64,7 @@ Response **другого** `/api/chat` запиту повертає `{ type: "
 
 - Текст відповіді згадує результат tool-а («Залоговано 200 мл води») — все ок, проблема була не в pipeline, а у UI: action card / quick action не оновився, або `cloudsync` не синхронізував.
 - Текст відповіді — generic «Готово» без конкретики → handler повернув занадто короткий результат. Розширь, додай числа з input-а у return string.
-- `stop_reason: "max_tokens"` → continuation request обірвано на 400 токенах (див. `AGENTS.md` → _max_tokens budget per request_). Або скороти `tool_result.content`, або тимчасово підніми `max_tokens` і прогни ще раз.
+- `stop_reason: "max_tokens"` → continuation request обірвано на 2500 токенах (див. `AGENTS.md` → _max_tokens budget per request_). Або скороти `tool_result.content`, або тимчасово підніми `max_tokens` і прогни ще раз.
 
 ### 6. Чи UI оновився?
 
@@ -83,7 +83,7 @@ Response **другого** `/api/chat` запиту повертає `{ type: "
 | `Невідома дія: foo`                                             | Case у `chatActions/<domain>Actions.ts` не додано              |
 | Handler write успішний, але після reload даних нема             | `localStorage.setItem` замість `lsSet` → quota throw silently  |
 | `tool_result.content` порожній → модель «зависла»               | Handler return undefined (TypeScript це не зловив через `any`) |
-| Друге `/api/chat` обірвало JSON → parse error в `executeAction` | `stop_reason: "max_tokens"` на continuation (400)              |
+| Друге `/api/chat` обірвало JSON → parse error в `executeAction` | `stop_reason: "max_tokens"` на continuation (2500)             |
 | Tool взагалі не викликається                                    | `SYSTEM_PREFIX` не згадує tool у списку рядки 7–14             |
 
 ---

--- a/docs/playbooks/enable-prompt-caching.md
+++ b/docs/playbooks/enable-prompt-caching.md
@@ -110,7 +110,7 @@ Payload-и мають використовувати `TOOLS_WITH_CACHE`:
 ```ts
 {
   model: "claude-sonnet-4-6",
-  max_tokens: 600,
+  max_tokens: 1500,
   system: buildSystem(context),
   tools: TOOLS_WITH_CACHE,
   messages: cleaned,


### PR DESCRIPTION
## What changed

Follow-up до #804. Синхронізував текстові згадки `max_tokens` у документації з фактичними значеннями в `apps/server/src/modules/chat.ts` (`1500` для першого кроку, `2500` для tool-result continuation).

| Файл                                       | Було         | Стало           |
| ------------------------------------------ | ------------ | --------------- |
| `AGENTS.md` (таблиця budget-ів, рядки ~268-269) | 600 / 400    | 1500 / 2500     |
| `AGENTS.md` (line-references)              | ~171 / ~114  | ~243 / ~181     |
| `CONTRIBUTING.md:133`                      | `max_tokens: 400` | `max_tokens: 2500` |
| `docs/playbooks/debug-chat-tool.md:67,86`  | 400          | 2500            |
| `docs/playbooks/enable-prompt-caching.md:113` | `max_tokens: 600` | `max_tokens: 1500` |

Також освіжив рядок під таблицею в `AGENTS.md`, щоб залишити мотив зміни (truncation на continuation шляху) і посилання на PR #804 для майбутніх агентів — щоб ніхто випадково не зніс ліміти назад до старих значень як «нібито надмірних».

## Why

Devin Review на #804 правильно зловив, що документація задубльовує числа з коду текстом — після підняття лімітів у самому `chat.ts` ці згадки залишились зі старими значеннями і вводили б майбутніх агентів в оману (наприклад, AGENTS.md — обовʼязкове читання перед змінами, тож стале значення там — потенційний регрес).

## How to test

- Прочитати оновлені файли — числа збігаються з кодом (`grep -n max_tokens apps/server/src/modules/chat.ts` → `181: max_tokens: 2500`, `243: max_tokens: 1500`).
- `pnpm exec prettier --check AGENTS.md CONTRIBUTING.md docs/playbooks/*.md` — pass.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `grep -rn 'max_tokens\|400\|600' AGENTS.md CONTRIBUTING.md docs/playbooks/` — більше немає старих посилань.
- [x] Vitest passes: docs-only, vitest не зачепило (запускати немає сенсу).
- [x] Prettier passes: `pnpm exec prettier --check` на змінених файлах — clean.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (англомовні рядки в `AGENTS.md` залишив у тому ж стилі, що й сусідні; українські — у `CONTRIBUTING.md` / playbooks).

## AGENTS.md updated?

- [x] Yes — `AGENTS.md` рядки 266-272 (таблиця `max_tokens` + пояснювальний параграф)
- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c50c5ee58be64e95a3d45801cb185ffb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
