### PR TITLE
fix(web): skip already-paid cycle in Finyk Планування next-payment tile

### DIFF
--- a/apps/web/src/modules/finyk/lib/upcomingSchedule.test.ts
+++ b/apps/web/src/modules/finyk/lib/upcomingSchedule.test.ts
@@ -4,7 +4,9 @@ import {
   getNextBillingDate,
   formatRelativeDue,
   startOfToday,
+  computeFinykSchedule,
 } from "./upcomingSchedule";
+import { CURRENCY } from "@sergeant/finyk-domain/constants";
 
 describe("parseLocalDate", () => {
   it("парсить ISO-дату без часового поясу", () => {
@@ -62,6 +64,58 @@ describe("formatRelativeDue", () => {
   it("коротка дата якщо більше тижня", () => {
     const result = formatRelativeDue(new Date(2025, 5, 30), today);
     expect(result).toContain("30");
+  });
+});
+
+describe("computeFinykSchedule — paid current cycle", () => {
+  // Фіксуємо `todayStart` на 26 квітня (день списання).
+  const todayStart = new Date(2026, 3, 26);
+
+  function makeSub(linkedTxId = "tx-today") {
+    return {
+      id: "sub-gpt",
+      name: "ChatGPT Plus",
+      billingDay: 26,
+      linkedTxId,
+      currency: "UAH",
+    };
+  }
+
+  it("переносить `nextCharge` на наступний місяць, якщо привʼязана транзакція припадає на сьогодні", () => {
+    const tx = {
+      id: "tx-today",
+      amount: -101694,
+      time: new Date(2026, 3, 26, 12, 37).getTime(),
+      currencyCode: CURRENCY.UAH,
+    };
+    const { nextCharge } = computeFinykSchedule({
+      subscriptions: [makeSub()],
+      manualDebts: [],
+      receivables: [],
+      transactions: [tx],
+      todayStart,
+    });
+    expect(nextCharge).not.toBeNull();
+    expect(nextCharge?.dueDate.getMonth()).toBe(4); // травень
+    expect(nextCharge?.dueDate.getDate()).toBe(26);
+  });
+
+  it("не переносить, якщо остання транзакція з минулого циклу", () => {
+    const tx = {
+      id: "tx-prev",
+      amount: -101694,
+      time: new Date(2026, 2, 26, 12, 0).getTime(), // 26 березня
+      currencyCode: CURRENCY.UAH,
+    };
+    const { nextCharge } = computeFinykSchedule({
+      subscriptions: [makeSub("tx-prev")],
+      manualDebts: [],
+      receivables: [],
+      transactions: [tx],
+      todayStart,
+    });
+    expect(nextCharge?.dueDate.getMonth()).toBe(3); // квітень (сьогодні)
+    expect(nextCharge?.dueDate.getDate()).toBe(26);
   });
 });
 

--- a/apps/web/src/modules/finyk/lib/upcomingSchedule.ts
+++ b/apps/web/src/modules/finyk/lib/upcomingSchedule.ts
@@ -119,17 +119,28 @@ export function computeFinykSchedule({
 
   type GetSubAmountMeta = typeof getSubscriptionAmountMeta;
   for (const sub of subs) {
-    const { amount, currency } = getSubscriptionAmountMeta(
+    const { amount, currency, lastTx } = getSubscriptionAmountMeta(
       sub as Parameters<GetSubAmountMeta>[0],
       transactions as Parameters<GetSubAmountMeta>[1],
     );
     if (!amount || currency !== "₴") continue;
     subsMonthly += amount;
+    // AI-NOTE: коли остання списана транзакція припадає на `dueDate`
+    // (тобто billingDay сьогодні і користувач уже привʼязав сьогоднішнє
+    // списання), цикл уже сплачено — переносимо `dueDate` на наступний
+    // billingDay, щоб тайл "Наступний платіж" не показував сплачений.
+    let dueDate = getNextBillingDate(Number(sub.billingDay), todayStart);
+    if (lastTx?.time && lastTx.time >= dueDate.getTime()) {
+      dueDate = getNextBillingDate(
+        Number(sub.billingDay),
+        new Date(dueDate.getTime() + 86400000),
+      );
+    }
     upcoming.push({
       label: sub.name ?? "Підписка",
       amount,
       sign: "-",
-      dueDate: getNextBillingDate(Number(sub.billingDay), todayStart),
+      dueDate,
     });
   }
 


### PR DESCRIPTION
## What changed

`computeFinykSchedule` (used by the Finyk **Планування** stats strip) now advances the candidate `dueDate` to the next month whenever the subscription's most recent linked / keyword-matched transaction falls on or after that day. The earlier logic re-used `getNextBillingDate(billingDay, todayStart)`, which returns **today** when `billingDay === today.getDate()` — even if the user had already linked today's auto-charge — so the "Наступний платіж" tile claimed a payment was still upcoming after it had already happened.

Concretely:

- `getSubscriptionAmountMeta` now also surfaces `lastTx` to the schedule loop.
- If `lastTx.time >= dueDate.getTime()`, we recompute `dueDate` starting one day past the original — i.e. roll forward one billing cycle.
- Behaviour for subscriptions that have not yet been charged this cycle is unchanged.

Files: `apps/web/src/modules/finyk/lib/upcomingSchedule.ts` + matching tests.

## Why

User reported that on the day of an autocharge (e.g. 26th for ChatGPT Plus, after binding today's transaction) the `Планування` tile still showed `Наступний платіж · сьогодні · −1 017 ₴`, while the subscription card on Активи already correctly showed "Через 30 днів · 26-го". The two surfaces were inconsistent because Активи uses `daysUntil` (which always rolls past today when `day === today`), while Планування used the stricter `getNextBillingDate` that does not consider whether the cycle has been paid.

## How to test

1. In Finyk, ensure you have at least one UAH subscription whose `billingDay` matches today (`new Date().getDate()`), with a linked transaction whose `time` is today.
2. Open the **Планування** tab — the "Наступний платіж" tile should now point to the same day next month (e.g. "26 трав." instead of "сьогодні") with the next billing's relative-due hint.
3. Remove the linked tx (or pick a sub whose last tx is from a prior month) and confirm the tile still falls back to today / the upcoming billingDay.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web exec vitest run src/modules/finyk/lib/upcomingSchedule.test.ts` — 12 tests pass, including two new cases under `computeFinykSchedule — paid current cycle`.
- [x] Typecheck: `pnpm --filter @sergeant/web typecheck` clean.
- [x] Lint: `pnpm --filter @sergeant/web lint` clean.
- [ ] Manual smoke: not done — change is a pure date-math tweak with deterministic unit tests covering the reported scenario.
- [x] No new `AI-DANGER` markers added; one short `AI-NOTE` documents why we roll the cycle forward.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/48ea64634a384379a8a2021766623479
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
