### PR TITLE
feat(server): add TTL cache + tests for barcode lookup

### DIFF
--- a/apps/server/src/modules/barcode.test.ts
+++ b/apps/server/src/modules/barcode.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Request, Response } from "express";
+import handler, { __barcodeTestHooks } from "./barcode.js";
+
+interface TestRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): TestRes;
+  json(payload: unknown): TestRes;
+}
+
+function mockRes(): TestRes & Response {
+  const res: TestRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as TestRes & Response;
+}
+
+function asReq(query: Record<string, string>): Request {
+  return { query } as unknown as Request;
+}
+
+/**
+ * Фабрика mock-ів для `global.fetch`. Прихильна до контракту, який очікує
+ * `barcode.ts`: `r.ok`, `r.json()`. Не реалізує streaming/headers — handler
+ * їх не торкається.
+ */
+function mockFetchResponse({
+  ok = true,
+  status = 200,
+  body = {} as unknown,
+}: { ok?: boolean; status?: number; body?: unknown } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+// OFF returns { status: 1, product: {...} } для hit, інакше status !== 1.
+const OFF_HIT = mockFetchResponse({
+  body: {
+    status: 1,
+    product: {
+      product_name_uk: "Молоко",
+      brands: "Галичина",
+      nutriments: {
+        "energy-kcal_100g": 60,
+        proteins_100g: 3.2,
+        fat_100g: 2.5,
+        carbohydrates_100g: 4.8,
+      },
+    },
+  },
+});
+
+// OFF "miss" — status: 0 (барcode не знайдено в базі).
+const OFF_MISS = mockFetchResponse({ body: { status: 0 } });
+
+// USDA returns { foods: [{...}] } для hit, інакше { foods: [] }.
+const USDA_HIT = mockFetchResponse({
+  body: {
+    foods: [
+      {
+        description: "Greek Yogurt",
+        brandOwner: "Chobani",
+        gtinUpc: "0818290015938",
+        servingSize: 170,
+        servingSizeUnit: "g",
+        foodNutrients: [
+          { nutrientId: 1008, value: 59 }, // kcal
+          { nutrientId: 1003, value: 10 }, // protein
+          { nutrientId: 1004, value: 0 }, // fat
+          { nutrientId: 1005, value: 3.6 }, // carbs
+        ],
+      },
+    ],
+  },
+});
+
+const USDA_MISS = mockFetchResponse({ body: { foods: [] } });
+
+// UPCitemdb returns { items: [{...}] } для hit.
+const UPCITEMDB_HIT = mockFetchResponse({
+  body: {
+    items: [
+      {
+        title: "Energy Bar 50g",
+        brand: "GenericBrand",
+      },
+    ],
+  },
+});
+
+const UPCITEMDB_MISS = mockFetchResponse({ body: { items: [] } });
+
+describe("barcode handler", () => {
+  const origFetch = global.fetch;
+
+  beforeEach(() => {
+    __barcodeTestHooks().reset();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("validation", () => {
+    it("повертає 400 коли barcode параметр відсутній", async () => {
+      const req = asReq({});
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("повертає 400 коли barcode після нормалізації коротший за 8 цифр", async () => {
+      const req = asReq({ barcode: "1234567" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toMatchObject({
+        error: expect.stringMatching(/штрихкод/i),
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("повертає 400 коли barcode містить лише нецифрові символи", async () => {
+      const req = asReq({ barcode: "abcdefgh" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("нормалізує barcode (видаляє пробіли/дефіси) перед валідацією", async () => {
+      // 13-digit barcode із дефісами (стандартний EAN-13 формат)
+      global.fetch = vi.fn().mockResolvedValueOnce(OFF_HIT);
+      const req = asReq({ barcode: "5-901234-123457" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(global.fetch).toHaveBeenCalledOnce();
+      // OFF URL має містити нормалізований barcode
+      const url = (global.fetch as unknown as { mock: { calls: unknown[][] } })
+        .mock.calls[0][0] as string;
+      expect(url).toContain("5901234123457");
+    });
+  });
+
+  describe("cascade OFF → USDA → UPCitemdb", () => {
+    it("OFF hit зупиняє cascade — USDA та UPCitemdb не викликаються", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce(OFF_HIT);
+      const req = asReq({ barcode: "3017620422003" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        product: {
+          name: "Молоко",
+          brand: "Галичина",
+          source: "off",
+          kcal_100g: 60,
+        },
+      });
+      expect(global.fetch).toHaveBeenCalledOnce();
+    });
+
+    it("OFF miss → USDA hit зупиняє cascade на USDA", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_HIT);
+      const req = asReq({ barcode: "0818290015938" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        product: {
+          name: "Greek Yogurt",
+          brand: "Chobani",
+          source: "usda",
+          kcal_100g: 59,
+        },
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("OFF + USDA miss → UPCitemdb hit повертає partial:true", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_HIT);
+      const req = asReq({ barcode: "1234567890123" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        product: {
+          name: "Energy Bar 50g",
+          brand: "GenericBrand",
+          source: "upcitemdb",
+          partial: true,
+          kcal_100g: null,
+        },
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("всі три upstream miss → 404 без crash", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_MISS);
+      const req = asReq({ barcode: "9999999999999" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toMatchObject({
+        error: expect.stringMatching(/не знайдено/i),
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("OFF кидає → USDA hit рятує cascade", async () => {
+      global.fetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("ECONNRESET"))
+        .mockResolvedValueOnce(USDA_HIT);
+      const req = asReq({ barcode: "0818290015938" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        product: { source: "usda" },
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("всі три upstream кидають → 404 (handler не падає)", async () => {
+      global.fetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OFF down"))
+        .mockRejectedValueOnce(new Error("USDA down"))
+        .mockRejectedValueOnce(new Error("UPCitemdb down"));
+      const req = asReq({ barcode: "9999999999999" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(404);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("OFF повертає !ok (HTTP 500) → cascade продовжує на USDA", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ ok: false, status: 500 }))
+        .mockResolvedValueOnce(USDA_HIT);
+      const req = asReq({ barcode: "0818290015938" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({ product: { source: "usda" } });
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("OFF повертає продукт без жодного макроса — нормалізатор віддає null, cascade продовжує", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            body: {
+              status: 1,
+              product: {
+                product_name: "Empty shell",
+                nutriments: {},
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(USDA_HIT);
+      const req = asReq({ barcode: "0818290015938" });
+      const res = mockRes();
+      await handler(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({ product: { source: "usda" } });
+    });
+  });
+
+  describe("TTL cache", () => {
+    it("повторний lookup на той самий barcode не викликає upstream (hit cache)", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce(OFF_HIT);
+      const req1 = asReq({ barcode: "3017620422003" });
+      const res1 = mockRes();
+      await handler(req1, res1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const req2 = asReq({ barcode: "3017620422003" });
+      const res2 = mockRes();
+      await handler(req2, res2);
+      // Жодного нового fetch-у — все взято з cache-у.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(res2.statusCode).toBe(200);
+      expect(res2.body).toEqual(res1.body);
+    });
+
+    it("кешує miss-sentinel — другий запит на той самий невідомий barcode не йде в upstream", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_MISS);
+      const res1 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res1);
+      expect(res1.statusCode).toBe(404);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+
+      const res2 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res2);
+      expect(res2.statusCode).toBe(404);
+      // Cascade НЕ повторюється — miss кеш спрацював.
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("НЕ кешує transient failure (upstream throw) — повторний запит знову проганяє cascade", async () => {
+      global.fetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OFF down"))
+        .mockRejectedValueOnce(new Error("USDA down"))
+        .mockRejectedValueOnce(new Error("UPCitemdb down"));
+      const res1 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res1);
+      expect(res1.statusCode).toBe(404);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+
+      // Повторний lookup — оскільки miss НЕ закешований (upstream-и кинули),
+      // cascade проганяється знову. На цей раз upstream-и віддають MISS.
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_MISS);
+      const res2 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res2);
+      expect(res2.statusCode).toBe(404);
+      expect(global.fetch).toHaveBeenCalledTimes(6);
+    });
+
+    it("після того як hit-TTL вийшов, наступний запит знову викликає upstream", async () => {
+      // Скорочуємо hit TTL до 0 — будь-яка перевірка експірації одразу вважає
+      // запис прострочений.
+      __barcodeTestHooks().configure({ hitTtlMs: 0 });
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_HIT)
+        .mockResolvedValueOnce(OFF_HIT);
+
+      await handler(asReq({ barcode: "3017620422003" }), mockRes());
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      await handler(asReq({ barcode: "3017620422003" }), mockRes());
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("після того як miss-TTL вийшов, наступний запит знову проганяє cascade", async () => {
+      __barcodeTestHooks().configure({ missTtlMs: 0 });
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(OFF_MISS)
+        // Підставимо USDA + UPCitemdb miss кожен раз.
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_MISS)
+        .mockResolvedValueOnce(OFF_MISS)
+        .mockResolvedValueOnce(USDA_MISS)
+        .mockResolvedValueOnce(UPCITEMDB_MISS);
+
+      const res1 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res1);
+      expect(res1.statusCode).toBe(404);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+
+      const res2 = mockRes();
+      await handler(asReq({ barcode: "9999999999999" }), res2);
+      expect(res2.statusCode).toBe(404);
+      // Miss експірований → cascade повторився.
+      expect(global.fetch).toHaveBeenCalledTimes(6);
+    });
+
+    it("обмежує cache до maxSize (FIFO eviction)", async () => {
+      __barcodeTestHooks().configure({ maxSize: 2 });
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(OFF_HIT)
+        .mockResolvedValueOnce(OFF_HIT)
+        .mockResolvedValueOnce(OFF_HIT)
+        .mockResolvedValueOnce(OFF_HIT);
+
+      await handler(asReq({ barcode: "11111111" }), mockRes());
+      await handler(asReq({ barcode: "22222222" }), mockRes());
+      await handler(asReq({ barcode: "33333333" }), mockRes());
+
+      // Тільки 2 з 3 ключів зберігаються; найстаріший evict-нутий.
+      expect(__barcodeTestHooks().cacheSize()).toBe(2);
+    });
+
+    it("різні barcode-и кешуються незалежно", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(OFF_HIT)
+        .mockResolvedValueOnce(OFF_HIT);
+
+      await handler(asReq({ barcode: "11111111" }), mockRes());
+      await handler(asReq({ barcode: "22222222" }), mockRes());
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Обидва підтягуються з cache-у.
+      await handler(asReq({ barcode: "11111111" }), mockRes());
+      await handler(asReq({ barcode: "22222222" }), mockRes());
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("env config", () => {
+    it("читає TTL з env при reset()", async () => {
+      const prevHit = process.env.BARCODE_CACHE_HIT_TTL_MS;
+      const prevMiss = process.env.BARCODE_CACHE_MISS_TTL_MS;
+      const prevMax = process.env.BARCODE_CACHE_MAX_SIZE;
+      try {
+        process.env.BARCODE_CACHE_HIT_TTL_MS = "12345";
+        process.env.BARCODE_CACHE_MISS_TTL_MS = "67890";
+        process.env.BARCODE_CACHE_MAX_SIZE = "42";
+        __barcodeTestHooks().reset();
+        const cfg = __barcodeTestHooks().config();
+        expect(cfg.hitTtlMs).toBe(12345);
+        expect(cfg.missTtlMs).toBe(67890);
+        expect(cfg.maxSize).toBe(42);
+      } finally {
+        if (prevHit == null) delete process.env.BARCODE_CACHE_HIT_TTL_MS;
+        else process.env.BARCODE_CACHE_HIT_TTL_MS = prevHit;
+        if (prevMiss == null) delete process.env.BARCODE_CACHE_MISS_TTL_MS;
+        else process.env.BARCODE_CACHE_MISS_TTL_MS = prevMiss;
+        if (prevMax == null) delete process.env.BARCODE_CACHE_MAX_SIZE;
+        else process.env.BARCODE_CACHE_MAX_SIZE = prevMax;
+        __barcodeTestHooks().reset();
+      }
+    });
+
+    it("ігнорує невалідні env (нечисловий рядок) і падає назад на default", async () => {
+      const prev = process.env.BARCODE_CACHE_HIT_TTL_MS;
+      try {
+        process.env.BARCODE_CACHE_HIT_TTL_MS = "not-a-number";
+        __barcodeTestHooks().reset();
+        const cfg = __barcodeTestHooks().config();
+        // Default = 6h
+        expect(cfg.hitTtlMs).toBe(6 * 60 * 60 * 1000);
+      } finally {
+        if (prev == null) delete process.env.BARCODE_CACHE_HIT_TTL_MS;
+        else process.env.BARCODE_CACHE_HIT_TTL_MS = prev;
+        __barcodeTestHooks().reset();
+      }
+    });
+  });
+});

--- a/apps/server/src/modules/barcode.ts
+++ b/apps/server/src/modules/barcode.ts
@@ -17,6 +17,117 @@ interface NormalizedProduct {
   partial?: boolean;
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// In-memory TTL cache for cascade results.
+//
+// Key: normalized barcode (digits only, 8–14). Value: either a found product
+// or a "miss" sentinel (so 404-у не доводиться знов проганяти cascade на
+// 3 upstream-и для популярних, але не існуючих штрихкодів).
+//
+// TTL-и розділено: hit живе довше (продукт майже не змінюється — 6 годин
+// дефолт), miss — коротше (30 хв), бо upstream-и регулярно поповнюють бази.
+//
+// Bounded size: коли заповнено, evict-имо найстаріший вставлений ключ
+// (Map зберігає insertion order — це FIFO, не справжній LRU, але для barcode
+// lookup-у з 99% read-через-write патерном різниця не суттєва і простіше).
+//
+// Усі TTL/розмір env-overridable; `__barcodeTestHooks()` дозволяє юніт-тестам
+// скидати стан і темпорально override-ити TTL для cache-expiry-сценаріїв.
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface BarcodeCacheConfig {
+  hitTtlMs: number;
+  missTtlMs: number;
+  maxSize: number;
+}
+
+interface BarcodeCacheEntry {
+  product: NormalizedProduct | null; // null = "miss" sentinel
+  expiresAt: number; // monotonic ms (Date.now())
+}
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+const DEFAULT_HIT_TTL_MS = 6 * 60 * 60 * 1000; // 6 годин
+const DEFAULT_MISS_TTL_MS = 30 * 60 * 1000; // 30 хвилин
+const DEFAULT_MAX_SIZE = 1000;
+
+const cacheConfig: BarcodeCacheConfig = {
+  hitTtlMs: readPositiveIntEnv("BARCODE_CACHE_HIT_TTL_MS", DEFAULT_HIT_TTL_MS),
+  missTtlMs: readPositiveIntEnv(
+    "BARCODE_CACHE_MISS_TTL_MS",
+    DEFAULT_MISS_TTL_MS,
+  ),
+  maxSize: readPositiveIntEnv("BARCODE_CACHE_MAX_SIZE", DEFAULT_MAX_SIZE),
+};
+
+const cache = new Map<string, BarcodeCacheEntry>();
+
+function cacheGet(key: string): BarcodeCacheEntry | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry;
+}
+
+function cacheSet(key: string, product: NormalizedProduct | null): void {
+  const ttlMs = product ? cacheConfig.hitTtlMs : cacheConfig.missTtlMs;
+  // Refresh insertion order if updating an existing entry.
+  if (cache.has(key)) cache.delete(key);
+  cache.set(key, { product, expiresAt: Date.now() + ttlMs });
+  while (cache.size > cacheConfig.maxSize) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+export interface BarcodeTestHooks {
+  configure(overrides: Partial<BarcodeCacheConfig>): void;
+  reset(): void;
+  cacheSize(): number;
+  config(): Readonly<BarcodeCacheConfig>;
+}
+
+/**
+ * Test-only hooks. Не використовуй у прод-коді.
+ */
+export function __barcodeTestHooks(): BarcodeTestHooks {
+  return {
+    configure(overrides) {
+      if (overrides.hitTtlMs != null) cacheConfig.hitTtlMs = overrides.hitTtlMs;
+      if (overrides.missTtlMs != null)
+        cacheConfig.missTtlMs = overrides.missTtlMs;
+      if (overrides.maxSize != null) cacheConfig.maxSize = overrides.maxSize;
+    },
+    reset() {
+      cache.clear();
+      cacheConfig.hitTtlMs = readPositiveIntEnv(
+        "BARCODE_CACHE_HIT_TTL_MS",
+        DEFAULT_HIT_TTL_MS,
+      );
+      cacheConfig.missTtlMs = readPositiveIntEnv(
+        "BARCODE_CACHE_MISS_TTL_MS",
+        DEFAULT_MISS_TTL_MS,
+      );
+      cacheConfig.maxSize = readPositiveIntEnv(
+        "BARCODE_CACHE_MAX_SIZE",
+        DEFAULT_MAX_SIZE,
+      );
+    },
+    cacheSize: () => cache.size,
+    config: () => ({ ...cacheConfig }),
+  };
+}
+
 interface OFFProduct {
   product_name?: string;
   product_name_uk?: string;
@@ -335,35 +446,53 @@ export default async function handler(
     return;
   }
 
+  // Cache hit short-circuits the cascade entirely. Miss-sentinel returns the
+  // same 404 без чергового round-trip-у на upstream-и.
+  const cached = cacheGet(barcode);
+  if (cached) {
+    if (cached.product) {
+      res.status(200).json({ product: cached.product });
+    } else {
+      res.status(404).json({ error: "Продукт не знайдено" });
+    }
+    return;
+  }
+
   try {
     // Cascade: OFF → USDA → UPCitemdb
     let product: NormalizedProduct | null = null;
+    let upstreamThrew = false;
 
     try {
       product = await lookupOFF(barcode);
     } catch {
-      /* continue to next source */
+      upstreamThrew = true;
     }
     if (!product) {
       try {
         product = await lookupUSDA(barcode);
       } catch {
-        /* continue to next source */
+        upstreamThrew = true;
       }
     }
     if (!product) {
       try {
         product = await lookupUPCitemdb(barcode);
       } catch {
-        /* continue to next source */
+        upstreamThrew = true;
       }
     }
 
     if (!product) {
+      // Кешуємо miss тільки якщо жоден upstream НЕ кинув: інакше це не
+      // справжній miss, а transient failure — повторний запит має пройти
+      // cascade знову.
+      if (!upstreamThrew) cacheSet(barcode, null);
       res.status(404).json({ error: "Продукт не знайдено" });
       return;
     }
 
+    cacheSet(barcode, product);
     res.status(200).json({ product });
   } catch (e: unknown) {
     if (hasErrorName(e, "TimeoutError") || hasErrorName(e, "AbortError")) {


### PR DESCRIPTION
## What changed

Backend hardening для `apps/server/src/modules/barcode.ts`. Закриває два пункти з `docs/backend-tech-debt.md` (`modules/barcode.ts`):

1. **In-memory TTL cache** для cascade результатів (OFF → USDA → UPCitemdb):
   - Key: нормалізований штрихкод (тільки цифри, 8–14).
   - Value: `NormalizedProduct` (hit) АБО `null` (miss-sentinel — щоб популярні-але-невідомі коди не дзвонили на 3 upstream-и кожен раз).
   - **Розділені TTL** (env-overridable):
     - `BARCODE_CACHE_HIT_TTL_MS` (default 6h) — продукт майже не змінюється.
     - `BARCODE_CACHE_MISS_TTL_MS` (default 30m) — upstream-и регулярно поповнюють бази.
   - **Bounded size:** `BARCODE_CACHE_MAX_SIZE` (default 1000), FIFO-eviction по insertion order Map-у.
   - **Transient failures НЕ кешуються:** якщо хоч один з 3 upstream-ів кинув exception, miss НЕ записується (інакше flaky OFF/USDA отруює cache на 30 хв).
   - `__barcodeTestHooks()` (test-only): `reset()`, `configure(overrides)`, `cacheSize()`, `config()` — за патерном `__bankProxyTestHooks()`.

2. **Comprehensive `barcode.test.ts`** (21 тест-кейс, всі зелені):
   - **Validation (4):** немає param → 400; <8 цифр → 400; нецифри → 400; нормалізація EAN-13 з дефісами.
   - **Cascade (8):** OFF hit зупиняє cascade; OFF miss → USDA; OFF+USDA miss → UPCitemdb (partial:true); всі miss → 404; OFF throw → USDA рятує; всі throw → 404 без crash; OFF !ok → continue; OFF empty-shell normalizer → null → continue.
   - **TTL cache (7):** hit short-circuit; miss-sentinel short-circuit; transient failure НЕ кешується; hit/miss TTL expiry replay-ить upstream; maxSize FIFO eviction; distinct keys кешуються незалежно.
   - **Env config (2):** `reset()` читає env; невалідний env → default.

## Why

`barcode.ts` робить cascade на 3 upstream-и (OFF → USDA → UPCitemdb), кожен з 6–7s timeout-ом. Без cache-у популярний штрихкод проходить весь cascade на кожен запит — це зайва латенція + витрати rate-limit-у (UPCitemdb особливо: 100/день).

Тестове покриття для `barcode.ts` було відсутнє повністю — це згадано як середньопріоритетний debt у `docs/backend-tech-debt.md` (`modules/barcode.ts → немає barcode.test.ts`). Після цього PR-у — є.

## How to test

```bash
pnpm --filter @sergeant/server test -- barcode  # 21/21 passed
pnpm --filter @sergeant/server typecheck         # clean
pnpm --filter @sergeant/server lint              # clean
pnpm --filter @sergeant/server test              # 387/387 passed (повний suite)
```

Жодного зміни response shape (`{ product }` / `{ error }`) — `api-client` types не зачеплено (rule #3 не triggered).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm --filter @sergeant/server test` — 387 тестів, всі зелені; `typecheck` + `lint` без помилок.
- [x] Vitest passes: `barcode.test.ts` — 21/21.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/2f3272a8ad7f456698028008b2ba7660
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
