### PR TITLE
docs(docs): fix two Devin Review nits from #806

### DIFF
--- a/docs/frontend-tech-debt.md
+++ b/docs/frontend-tech-debt.md
@@ -50,9 +50,10 @@ try/catch крашить на quota exceeded, corrupted storage або private b
   файла = видалення рядка зі списку. На 2026-04-26 TODO-список
   містить 55 файлів (базовий рівень при введенні був 49; оновиться вниз
   після чергових міграцій).
-  Фактичних raw `localStorage.*` call-сайтів у production файлах
-  (включно з wrappers) — ~78 (`rg "\blocalStorage\." apps/web/src` = 118
-  рядків разом з тестами).
+  Фактичних raw `localStorage.*` production-файлів
+  (включно з wrappers) — ~78 (`rg -l "\blocalStorage\." apps/web/src` = 119
+  файлів разом з тестами; ~532 рядки матчів усього, з них ~246 у
+  production-файлах).
 
 **Що це дає:** новий код / нові файли НЕ зможуть додати прямий
 `localStorage.*` без явного оновлення allowlist (видно в diff). Існуючі

--- a/docs/structure-refactor-plan.md
+++ b/docs/structure-refactor-plan.md
@@ -178,9 +178,10 @@ core/
 - `chartPalette` ✅ переведено на `.ts`
   (`apps/web/src/modules/finyk/constants/chartPalette.ts`).
 - `setup.js` — більше не існує у `apps/web/src/`.
-- Залишаються лише `apps/web/src/sw.js` (service worker;
-  використовує Workbox API без білд-кроку) і `apps/web/src/main.jsx`
-  (Vite entry). Strict TS — окремий пункт у `dev-stack-roadmap.md` §3.1.
+- `sw.js` ✅ переведено на `.ts` (`apps/web/src/sw.ts`,
+  service worker через Workbox).
+- Залишається лише `apps/web/src/main.jsx` (Vite entry).
+  Strict TS — окремий пункт у `dev-stack-roadmap.md` §3.1.
 
 ### 4.3 Перенести `eslint-plugins/` у `packages/` ✅ done
 


### PR DESCRIPTION
## What changed

Follow-up до [#806](https://github.com/Skords-01/Sergeant/pull/806) — закриває 2 знахідки [Devin Review](https://app.devin.ai/review/skords-01/sergeant/pull/806).

- **`docs/structure-refactor-plan.md` §4.2** — `sw.js` вже мігрований у `sw.ts`. Прибрано неправдиве твердження «залишається `sw.js`». Єдиний non-`.ts` файл у `apps/web/src/` тепер — `main.jsx` (Vite entry).
- **`docs/frontend-tech-debt.md` (TODO-список)** — попередній текст плутав file count і line count. Виправлено: `rg -l "\blocalStorage\." apps/web/src` = **119 файлів** (включно з тестами); усіх рядків матчів — ~532, з них ~246 у production-файлах. Цифра «~78» — це файли (production), не call-сайти.

## Why

Doc audit-PR #806 не повинен сам містити неточностей. Devin Review зловив обидва — fix у тому ж напрямі, що й сам #806 (sync docs з реальністю).

## How to test

- `pnpm exec prettier --check docs/structure-refactor-plan.md docs/frontend-tech-debt.md` — green.
- Перевірка claims:
  - `ls apps/web/src/sw.*` → `sw.ts` (а не `sw.js`).
  - `rg "\blocalStorage\." apps/web/src | wc -l` → 532 рядки.
  - `rg -l "\blocalStorage\." apps/web/src | wc -l` → 119 файлів.
  - Production-only: `rg -l "\blocalStorage\." apps/web/src --glob '!*.test.*' --glob '!**/__tests__/**' | wc -l` → 78 файлів.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `prettier --check` + `rg`/`ls` для перевірки чисел.
- [x] Vitest passes: docs-only — Vitest не зачеплений.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/2f3272a8ad7f456698028008b2ba7660
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
