### PR TITLE
feat(web): card-style chips for Finyk Limits/Goals section headers

### DIFF
--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -424,19 +424,31 @@ export function Budgets({
           type="button"
           onClick={toggleLimits}
           aria-expanded={limitsOpen}
-          className="w-full flex items-center justify-between gap-3 -mb-1 px-1 py-2 text-left rounded-md hover:bg-panelHi transition-colors"
+          className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left bg-panel border border-line rounded-2xl shadow-card hover:bg-panelHi transition-colors"
         >
-          <SectionHeading as="span" size="sm">
-            Ліміти · {monthStart.toLocaleDateString("uk-UA", { month: "long" })}
-            {limitBudgets.length > 0 && (
-              <span className="ml-1 text-subtle">({limitBudgets.length})</span>
-            )}
-          </SectionHeading>
+          <span className="flex items-center gap-2 min-w-0">
+            <span className="text-muted" aria-hidden>
+              <Icon name="calendar" size={16} />
+            </span>
+            <SectionHeading
+              as="span"
+              size="sm"
+              className="!mb-0 normal-case tracking-normal"
+            >
+              Ліміти ·{" "}
+              {monthStart.toLocaleDateString("uk-UA", { month: "long" })}
+              {limitBudgets.length > 0 && (
+                <span className="ml-1 text-subtle font-normal">
+                  ({limitBudgets.length})
+                </span>
+              )}
+            </SectionHeading>
+          </span>
           <Icon
             name="chevron-down"
             size={14}
             className={cn(
-              "transition-transform text-muted",
+              "transition-transform text-muted shrink-0",
               limitsOpen ? "rotate-180" : "",
             )}
           />
@@ -554,19 +566,30 @@ export function Budgets({
           type="button"
           onClick={toggleGoals}
           aria-expanded={goalsOpen}
-          className="w-full flex items-center justify-between gap-3 -mb-1 px-1 py-2 text-left rounded-md hover:bg-panelHi transition-colors"
+          className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left bg-panel border border-line rounded-2xl shadow-card hover:bg-panelHi transition-colors"
         >
-          <SectionHeading as="span" size="sm">
-            Цілі накопичення
-            {goalBudgets.length > 0 && (
-              <span className="ml-1 text-subtle">({goalBudgets.length})</span>
-            )}
-          </SectionHeading>
+          <span className="flex items-center gap-2 min-w-0">
+            <span className="text-muted" aria-hidden>
+              <Icon name="target" size={16} />
+            </span>
+            <SectionHeading
+              as="span"
+              size="sm"
+              className="!mb-0 normal-case tracking-normal"
+            >
+              Цілі накопичення
+              {goalBudgets.length > 0 && (
+                <span className="ml-1 text-subtle font-normal">
+                  ({goalBudgets.length})
+                </span>
+              )}
+            </SectionHeading>
+          </span>
           <Icon
             name="chevron-down"
             size={14}
             className={cn(
-              "transition-transform text-muted",
+              "transition-transform text-muted shrink-0",
               goalsOpen ? "rotate-180" : "",
             )}
           />


### PR DESCRIPTION
## Summary

The "Ліміти · &lt;місяць&gt;" and "Цілі накопичення" toggles on the Finyk Планування page were rendered as plain `SectionHeading` text inside a button — so when both sections were collapsed they looked like loose text floating between the framed `FinykStatsStrip` / `MonthlyPlanCard` above and the dashed "Додати ліміт або ціль" button below.

This PR wraps the two header buttons in panel chips that match the visual weight of the existing `MonthlyPlanCard`:

- `bg-panel border border-line rounded-2xl shadow-card` wrapper.
- Leading icon (`calendar` for Ліміти, `target` for Цілі).
- Title rendered via `SectionHeading size="sm"` with `normal-case tracking-normal` so the chip-look matches the regular semibold "Фінплан на місяць" header above (instead of the small-eyebrow uppercase look that drew attention to the lack of frame).
- Existing collapsibility (chevron rotation, `limitsOpen` / `goalsOpen` state, persisted via `useLocalStorageState`) is unchanged.
- The body (budget cards / `EmptyState`) still renders below the chip when expanded — same layout, no nested cards.

Files: `apps/web/src/modules/finyk/pages/Budgets.tsx`. No logic changes; pure markup/Tailwind tweaks.

## Review & Testing Checklist for Human

- [ ] Open Finyk → Планування with both sections collapsed; the two headers should look like bordered panel chips, not loose text on the bg.
- [ ] Toggle each section open/closed — chevron rotates, body cards expand and collapse correctly, persisted across reload.
- [ ] Verify month label renders correctly (e.g. "Ліміти · квітень") — `normal-case` preserves the locale-formatted lowercase month name.
- [ ] Quick check on dark theme that `bg-panel`/`border-line`/`shadow-card` look the same as `MonthlyPlanCard` (no contrast regressions).

### Notes

- Vitest, typecheck, lint all pass locally for `@sergeant/web` (82 finyk tests green).
- No new component files; the chip is inline JSX since it lives only on this page.
- Did not touch `LimitBudgetCard` / `GoalBudgetCard` — they remain individual cards and continue to be rendered below the chip when expanded.


Link to Devin session: https://app.devin.ai/sessions/48ea64634a384379a8a2021766623479
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
