### PR TITLE
feat(web): badge legend + «Новинка» label in assistant catalogue

### DIFF
--- a/apps/mobile/src/core/AssistantCataloguePage.test.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.test.tsx
@@ -178,6 +178,32 @@ describe("AssistantCataloguePage — group collapsing", () => {
     expect(queryByTestId("catalogue-toggle-all")).toBeNull();
   });
 
+  it("renders the legend explaining badges (Чіп / Ризик / Новинка)", () => {
+    const { getByTestId, getByText, getAllByText } = render(
+      <AssistantCataloguePage />,
+    );
+    expect(getByTestId("catalogue-legend")).toBeTruthy();
+    expect(getByText("Позначки:")).toBeTruthy();
+    // Badge labels also appear on real rows (e.g. compare_weeks is a chip
+    // and isNew), so allow ≥1 match for the chip text.
+    expect(getAllByText("⚡ ЧІП").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("⚠ РИЗИК").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("✨ НОВИНКА").length).toBeGreaterThanOrEqual(1);
+    // The captions are legend-only.
+    expect(getByText("швидкий сценарій")).toBeTruthy();
+    expect(getByText("критична дія")).toBeTruthy();
+    expect(getByText("нещодавно додано")).toBeTruthy();
+  });
+
+  it("renders the Новинка badge on rows flagged isNew (compare_weeks)", () => {
+    const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
+    expect(getByTestId("catalogue-capability-compare_weeks-new")).toBeTruthy();
+    // create_transaction is not flagged isNew → no badge rendered for it.
+    expect(
+      queryByTestId("catalogue-capability-create_transaction-new"),
+    ).toBeNull();
+  });
+
   it("auto-expands persisted-collapsed groups while searching, restores them after", () => {
     const { getByTestId, queryByTestId } = render(<AssistantCataloguePage />);
 

--- a/apps/mobile/src/core/AssistantCataloguePage.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.tsx
@@ -170,6 +170,8 @@ export function AssistantCataloguePage({
           Запуск сценаріїв — у HubChat (наразі веб-версія).
         </Text>
 
+        <CapabilityLegend />
+
         <View className="bg-white border border-cream-300 rounded-2xl px-3 py-2 mb-4 flex-row items-center gap-2">
           <Text className="text-stone-400 text-base">🔍</Text>
           <TextInput
@@ -286,6 +288,38 @@ function ModuleGroup({
   );
 }
 
+function CapabilityLegend() {
+  return (
+    <View
+      testID="catalogue-legend"
+      accessibilityLabel="Що означають позначки"
+      className="bg-white border border-cream-300 rounded-2xl px-3 py-2.5 mb-3 flex-row flex-wrap gap-x-3 gap-y-1.5 items-center"
+    >
+      <Text className="text-xs font-semibold text-stone-500">Позначки:</Text>
+      <View className="flex-row items-center gap-1.5">
+        <View className="border border-stone-300 rounded-full px-2 py-0.5">
+          <Text className="text-[10px] font-bold text-stone-700">⚡ ЧІП</Text>
+        </View>
+        <Text className="text-[11px] text-stone-500">швидкий сценарій</Text>
+      </View>
+      <View className="flex-row items-center gap-1.5">
+        <View className="border border-amber-400 bg-amber-50 rounded-full px-2 py-0.5">
+          <Text className="text-[10px] font-bold text-amber-700">⚠ РИЗИК</Text>
+        </View>
+        <Text className="text-[11px] text-stone-500">критична дія</Text>
+      </View>
+      <View className="flex-row items-center gap-1.5">
+        <View className="border border-emerald-400 bg-emerald-50 rounded-full px-2 py-0.5">
+          <Text className="text-[10px] font-bold text-emerald-700">
+            ✨ НОВИНКА
+          </Text>
+        </View>
+        <Text className="text-[11px] text-stone-500">нещодавно додано</Text>
+      </View>
+    </View>
+  );
+}
+
 interface CapabilityRowProps {
   capability: AssistantCapability;
   onActivate: (cap: AssistantCapability) => void;
@@ -305,6 +339,16 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
           <Text className="text-sm font-semibold text-stone-900 flex-shrink">
             {capability.label}
           </Text>
+          {capability.isNew ? (
+            <View
+              testID={`catalogue-capability-${capability.id}-new`}
+              className="border border-emerald-400 bg-emerald-50 rounded-full px-2 py-0.5"
+            >
+              <Text className="text-[10px] font-bold text-emerald-700">
+                ✨ НОВИНКА
+              </Text>
+            </View>
+          ) : null}
           {capability.isQuickAction ? (
             <View className="border border-stone-300 rounded-full px-2 py-0.5">
               <Text className="text-[10px] font-bold text-stone-700">

--- a/apps/web/src/core/AssistantCataloguePage.collapse.test.tsx
+++ b/apps/web/src/core/AssistantCataloguePage.collapse.test.tsx
@@ -123,6 +123,31 @@ describe("AssistantCataloguePage — group collapsing", () => {
     ]);
   });
 
+  it("renders the legend explaining Чіп / Ризик / Новинка badges", () => {
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    const legend = screen.getByTestId("catalogue-legend");
+    expect(legend.textContent).toMatch(/Позначки/);
+    expect(legend.textContent).toMatch(/ЧІП/);
+    expect(legend.textContent).toMatch(/швидкий сценарій/);
+    expect(legend.textContent).toMatch(/РИЗИК/);
+    expect(legend.textContent).toMatch(/критична дія/);
+    expect(legend.textContent).toMatch(/НОВИНКА/);
+    expect(legend.textContent).toMatch(/нещодавно додано/);
+  });
+
+  it("renders the Новинка badge on capabilities flagged with isNew", () => {
+    render(<AssistantCataloguePage onClose={() => {}} />);
+    // compare_weeks is flagged isNew in the registry; its row renders the
+    // badge alongside the label.
+    const row = screen.getByTestId("catalogue-capability-compare_weeks");
+    expect(row.textContent).toMatch(/Новинка/);
+    // Non-new capability has no Новинка text.
+    const plainRow = screen.getByTestId(
+      "catalogue-capability-create_transaction",
+    );
+    expect(plainRow.textContent).not.toMatch(/Новинка/);
+  });
+
   it("ignores corrupt persisted shapes (non-array, unknown module ids)", () => {
     localStorage.setItem(COLLAPSED_LS_KEY, JSON.stringify({ bad: true }));
     render(<AssistantCataloguePage onClose={() => {}} />);

--- a/apps/web/src/core/AssistantCataloguePage.tsx
+++ b/apps/web/src/core/AssistantCataloguePage.tsx
@@ -131,10 +131,12 @@ export function AssistantCataloguePage({
           <h1 className="text-xl font-bold text-text">Можливості асистента</h1>
         </div>
 
-        <p className="text-sm text-subtle mb-4">
+        <p className="text-sm text-subtle mb-3">
           Усе, що вміє робити асистент. Натисни картку щоб запустити сценарій
           або побачити приклади.
         </p>
+
+        <CapabilityLegend />
 
         <div className="relative mb-3">
           <span
@@ -301,25 +303,29 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
           <span className="text-sm font-semibold text-text">
             {capability.label}
           </span>
+          {capability.isNew && (
+            <BadgeChip
+              tone="success"
+              icon="sparkles"
+              label="Новинка"
+              title="Нещодавно додана можливість"
+            />
+          )}
           {capability.isQuickAction && (
-            <span
+            <BadgeChip
+              tone="brand"
+              icon="zap"
+              label="Чіп"
               title="Швидкий сценарій (показується chip-ом у чаті)"
-              // eslint-disable-next-line sergeant-design/no-eyebrow-drift
-              className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-bold text-brand-600 bg-brand-500/10 border border-brand-500/40 rounded-full px-1.5 py-0.5"
-            >
-              <Icon name="zap" size={10} aria-hidden />
-              Чіп
-            </span>
+            />
           )}
           {capability.risky && (
-            <span
+            <BadgeChip
+              tone="warning"
+              icon="alert-triangle"
+              label="Ризик"
               title="Критична дія — скасувати не можна"
-              // eslint-disable-next-line sergeant-design/no-eyebrow-drift
-              className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-bold text-warning bg-warning/10 border border-warning/40 rounded-full px-1.5 py-0.5"
-            >
-              <Icon name="alert-triangle" size={10} aria-hidden />
-              Ризик
-            </span>
+            />
           )}
         </span>
         <span className="block text-xs text-subtle mt-0.5">
@@ -333,6 +339,62 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
         />
       </span>
     </button>
+  );
+}
+
+function CapabilityLegend() {
+  return (
+    <div
+      data-testid="catalogue-legend"
+      className={cn(
+        "mb-4 bg-panel/60 border border-line rounded-2xl px-3 py-2.5",
+        "flex flex-wrap items-center gap-x-3 gap-y-2",
+      )}
+      aria-label="Що означають позначки"
+    >
+      <span className="text-xs font-semibold text-muted">Позначки:</span>
+      <span className="inline-flex items-center gap-1.5 text-xs text-subtle">
+        <BadgeChip tone="brand" icon="zap" label="ЧІП" />
+        швидкий сценарій
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-xs text-subtle">
+        <BadgeChip tone="warning" icon="alert-triangle" label="РИЗИК" />
+        критична дія
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-xs text-subtle">
+        <BadgeChip tone="success" icon="sparkles" label="НОВИНКА" />
+        нещодавно додано
+      </span>
+    </div>
+  );
+}
+
+interface BadgeChipProps {
+  tone: "brand" | "warning" | "success";
+  icon: string;
+  label: string;
+  title?: string;
+}
+
+function BadgeChip({ tone, icon, label, title }: BadgeChipProps) {
+  const cls =
+    tone === "brand"
+      ? "text-brand-600 bg-brand-500/10 border-brand-500/40"
+      : tone === "warning"
+        ? "text-warning bg-warning/10 border-warning/40"
+        : "text-success bg-success/10 border-success/40";
+  return (
+    <span
+      title={title}
+      className={cn(
+        "inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-bold",
+        "border rounded-full px-1.5 py-0.5",
+        cls,
+      )}
+    >
+      <Icon name={icon} size={10} aria-hidden />
+      {label}
+    </span>
   );
 }
 

--- a/apps/web/src/shared/components/ui/Icon.tsx
+++ b/apps/web/src/shared/components/ui/Icon.tsx
@@ -22,6 +22,21 @@ const PATHS: Record<string, ReactNode> = {
   "chevron-left": <polyline points="15 18 9 12 15 6" />,
   "chevron-down": <polyline points="6 9 12 15 18 9" />,
   "chevron-up": <polyline points="18 15 12 9 6 15" />,
+  zap: <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />,
+  "alert-triangle": (
+    <>
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </>
+  ),
+  sparkles: (
+    <>
+      <path d="M12 3l1.7 4.6L18 9l-4.3 1.4L12 15l-1.7-4.6L6 9l4.3-1.4L12 3z" />
+      <path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8L19 14z" />
+      <path d="M5 16l.6 1.6L7 18l-1.4.4L5 20l-.6-1.6L3 18l1.4-.4L5 16z" />
+    </>
+  ),
   close: (
     <>
       <line x1="18" y1="6" x2="6" y2="18" />

--- a/packages/shared/src/lib/assistantCatalogue.ts
+++ b/packages/shared/src/lib/assistantCatalogue.ts
@@ -55,6 +55,12 @@ export interface AssistantCapability {
 
   /** Destructive — shown with a warning badge. */
   risky?: boolean;
+  /**
+   * Recently added — shown with a "Новинка" badge in the catalogue.
+   * Set to `true` for capabilities introduced in the last few releases;
+   * flip back to `undefined` once the feature is no longer notable.
+   */
+  isNew?: boolean;
   /** Surfaced as a chip below the chat input. */
   isQuickAction?: boolean;
   /** Lower number sorts higher among quick-action chips. */
@@ -558,6 +564,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Постав розклад звички: ",
     requiresInput: true,
     requiresOnline: true,
+    isNew: true,
     aiHint: "примусово weekly",
     keywords: ["weekday", "schedule", "weekly", "розклад", "дні"],
   },
@@ -577,6 +584,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     prompt: "Постав звичку на паузу: ",
     requiresInput: true,
     requiresOnline: true,
+    isNew: true,
     aiHint: "ідемпотентно",
     keywords: ["pause", "resume", "unpause", "пауза", "відновити"],
   },
@@ -814,6 +822,7 @@ export const ASSISTANT_CAPABILITIES: readonly AssistantCapability[] = [
     requiresInput: false,
     isQuickAction: true,
     quickActionPriority: 40,
+    isNew: true,
     requiresOnline: true,
     keywords: ["тиждень", "порівняння", "аналіз"],
     aiHint: "YYYY-Www; default цей+минулий",


### PR DESCRIPTION
## What changed

- Додав легенду в шапку екрану «Можливості асистента» (web + mobile), яка пояснює всі позначки на картках:
  - **ЧІП** — швидкий сценарій (показується chip-ом у чаті)
  - **РИЗИК** — критична дія (скасувати не можна)
  - **НОВИНКА** — нещодавно додано
- У схемі `AssistantCapability` (`packages/shared`) з'явився опціональний прапорець `isNew?: boolean`. Картки з ним отримують зелений лейбл «Новинка». Зняти його так само просто, як додати — щойно функція перестає бути новою, прибираємо поле і чіп зникне сам по собі.
- Помітив три найсвіжіші можливості як `isNew: true`:
  - `compare_weeks` (cross) — щойно замержив #803
  - `set_habit_schedule` (routine) — #798
  - `pause_habit` (routine) — #798
- Заодно поклав `zap` / `alert-triangle` / `sparkles` у `apps/web/src/shared/components/ui/Icon.tsx` — раніше старі картки в каталозі так і ходили з `[Icon] unknown name: …` warning-ом у dev-консолі (легенда тепер демонструє ці іконки явно, тож хотілося нарешті закрити).

## Why

Каталог асистента вже досить великий, у нас є кілька кольорів/позначок на картках, і нові користувачі (а також я сам, через тиждень після перерви) дивляться на «ризикові» помаранчеві badge і не одразу розуміють, що то означає. Легенда на старті екрана відповідає на це питання за один погляд — і дає природне місце, де представити «Новинку» замість того, щоб писати окремий релізний пост.

«Новинка» — flag-driven, не date-driven. Так ми зберігаємо контроль над тим, що показувати як нове (іноді хочемо підсвітити «старе» але raised-up feature, наприклад, recently-stabilized).

## How to test

1. Відкрити Hub → шапка асистента → «Можливості асистента». Над пошуком має зʼявитись плашка з 3 чипами + поясненнями.
2. Прокрутити до Routine → побачити «Новинка» біля «Дні тижня для звички» і «Поставити звичку на паузу».
3. Прокрутити до Кросмодульних → побачити «Новинка» біля «Порівняти тижні».
4. Mobile (`pnpm --filter @sergeant/mobile test`) — рендериться той самий лейаут (Pressable + emoji-чипи замість SVG, як і скрізь у мобільному UI).
5. Згортання/розгортання груп з PR #805 продовжує працювати — я перезапустив всі тести.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web test -- --run AssistantCataloguePage` (8/8 ✓ — додалось 2 нові кейси: легенда + ізолована перевірка `isNew`-badge на `compare_weeks` vs `create_transaction`).
- [x] Vitest passes: `pnpm --filter @sergeant/shared test` (256/256 — інваріанти каталогу не зачеплені, `isNew` опціональний).
- [x] Jest passes: `pnpm --filter @sergeant/mobile test -- --testPathPattern AssistantCataloguePage` (12/12 ✓ — 2 нові кейси: легенда показує всі чипи, `compare_weeks` має NEW-чип, `create_transaction` — ні).
- [x] `pnpm --filter @sergeant/web typecheck` — clean.
- [x] `pnpm --filter @sergeant/mobile typecheck` — clean.
- [x] `pnpm --filter @sergeant/web lint` + `pnpm --filter @sergeant/mobile lint` — clean (прибрав один stale `eslint-disable sergeant-design/no-eyebrow-drift`).
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian where practical.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/2d415f7f3c004731974580e68d5ac9ea
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
