### PR TITLE
fix(design-tokens): register 8% opacity step so dark module tints render

### DIFF
--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -166,6 +166,19 @@ const preset = {
       },
 
       // ═══════════════════════════════════════════════════════════════════
+      // OPACITY — module/status tint scale
+      // ═══════════════════════════════════════════════════════════════════
+      // AI-CONTEXT: Tailwind's default opacity scale steps in 5-pt
+      // increments (5, 10, 15…), so `<color>/8` is otherwise undefined.
+      // The Sergeant palette uses an 8 % wash as the canonical "barely
+      // there" tint over panel surfaces (e.g. dark-mode module bento
+      // tiles, primary/danger row highlights). Keep this entry — many
+      // call sites depend on it.
+      opacity: {
+        8: "0.08",
+      },
+
+      // ═══════════════════════════════════════════════════════════════════
       // BORDER RADIUS — Soft, organic, friendly shapes
       // ═══════════════════════════════════════════════════════════════════
       borderRadius: {


### PR DESCRIPTION
## Summary

Reported by @Skords-01: Hub bento tiles (Рутина / Фінік / Харчування / Фізрук) look washed-out and too bright in dark mode — they appear to be using their light-mode background instead of the intended dark tint.

Root cause: Tailwind's default opacity scale steps in 5-pt increments (`5, 10, 15, 20…`), so the modifier `<color>/8` is **not** a valid utility — Tailwind silently drops the class. About **24 call sites** rely on it, including:

- `apps/web/src/core/hub/dashboard/moduleConfigs.tsx` — `dark:bg-{finyk,fizruk,routine,nutrition}/8` (the user-visible bug)
- `apps/web/src/core/app/WelcomeScreen.tsx` — same four modules in the welcome wizard
- `apps/web/src/modules/finyk/components/{TxRow,TxListItem}.tsx` — `bg-primary/8`, `bg-success/8`, `bg-danger/8`, `bg-text/8`
- `apps/web/src/modules/finyk/pages/overview/BudgetAlertsList.tsx` — `bg-{danger,warning}/8`
- `apps/web/src/modules/finyk/pages/TransactionsHeader.tsx`
- `apps/web/src/modules/nutrition/components/{NutritionDashboard,PhotoAnalyzeCard,meal-sheet/FoodPickerSection}.tsx`
- `apps/web/src/modules/routine/components/HabitLeadersBlock.tsx`
- `apps/web/src/modules/routine/lib/routineConstants.ts`
- `apps/web/src/core/onboarding/OnboardingWizard.tsx`

The fix registers `opacity: { 8: "0.08" }` in the shared `@sergeant/design-tokens` Tailwind preset. This wires up every existing `<color>/8` utility to the intended 8% wash with **no per-call-site changes** — the original author's design intent was already encoded in the class names; the scale step just wasn't reachable.

Verified locally with `tailwindcss` CLI against the updated preset: `bg-finyk/8`, `bg-routine/8`, etc. now produce real CSS rules (where they previously produced none).

Files: `packages/design-tokens/tailwind-preset.js` (single 13-line addition).

## Review & Testing Checklist for Human

- [ ] **(most important)** On the device, open Hub in dark mode — the four module tiles (Рутина / Фінік / Харчування / Фізрук) should now show a barely-visible coloured tint over the dark panel, not the washed-out light-mode bg.
- [ ] Light mode still looks the same on Hub — light backgrounds use `bg-finyk-soft/40` etc., which are unaffected.
- [ ] Spot-check one Finyk page that uses the brighter tints: open the Транзакції list (TxRow / TxListItem) — selected rows now have a subtle primary highlight instead of nothing.
- [ ] Spot-check overview: the budget-alerts list shows the danger/warning tinted rows.

### Notes

- This is a pure design-tokens config change; no component code is touched.
- `opacity-8` (the standalone utility) was not used anywhere in the codebase before this change, so the new step has no unintended fallout beyond enabling the `<color>/8` modifier.
- I did not extend the scale further (e.g. add `12` or `18`) — only `8` is referenced in source.
- Vitest / typecheck / lint pass locally for `@sergeant/web`.


Link to Devin session: https://app.devin.ai/sessions/48ea64634a384379a8a2021766623479
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
