### PR TITLE
fix(server): pass Kyiv date context to coach insight prompt

### DIFF
--- a/apps/server/src/modules/coach.test.ts
+++ b/apps/server/src/modules/coach.test.ts
@@ -267,4 +267,54 @@ describe("coachInsight", () => {
       "Даних за поточний тиждень ще немає.",
     );
   });
+
+  it("dateContext → prompt містить 'Сьогодні:' та день тижня з 7", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "ok" }] },
+    });
+    const res = makeRes();
+    await coachInsight(
+      makeReq({
+        snapshot: {
+          dateContext: {
+            todayKey: "2026-04-26",
+            weekDayUk: "неділя",
+            dayOfWeekIso: 7,
+            daysIntoWeek: 7,
+            weekRange: "20.04–26.04",
+          },
+        },
+      }),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    const [, payload] = anthropicMessages.mock.calls[0] as [
+      unknown,
+      { messages: { content: string }[] },
+    ];
+    const prompt = payload.messages[0].content;
+    expect(prompt).toContain("КОНТЕКСТ ДАТИ");
+    expect(prompt).toContain("Сьогодні: 2026-04-26, неділя.");
+    expect(prompt).toContain(
+      "Поточний тиждень (понеділок–неділя): 20.04–26.04.",
+    );
+    expect(prompt).toContain("День тижня: 7 з 7");
+    expect(prompt).toContain("завершується");
+  });
+
+  it("без dateContext → prompt інструктує НЕ використовувати темпоральні маркери", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "ok" }] },
+    });
+    const res = makeRes();
+    await coachInsight(makeReq({ snapshot: {} }), res);
+    expect(res.statusCode).toBe(200);
+    const [, payload] = anthropicMessages.mock.calls[0] as [
+      unknown,
+      { messages: { content: string }[] },
+    ];
+    expect(payload.messages[0].content).toContain("Поточну дату не передано");
+  });
 });

--- a/apps/server/src/modules/coach.ts
+++ b/apps/server/src/modules/coach.ts
@@ -235,6 +235,13 @@ export async function coachInsight(req: Request, res: Response): Promise<void> {
   if (!parsed.ok) return;
   const { snapshot, memory } = parsed.data as {
     snapshot: {
+      dateContext?: {
+        todayKey?: string;
+        weekDayUk?: string;
+        dayOfWeekIso?: number;
+        daysIntoWeek?: number;
+        weekRange?: string;
+      };
       finyk?: {
         totalSpent?: number;
         totalIncome?: number;
@@ -258,6 +265,34 @@ export async function coachInsight(req: Request, res: Response): Promise<void> {
   };
 
   const memorySummary = buildMemorySummary(memory);
+
+  const dateContext = snapshot?.dateContext;
+  // AI-NOTE: Темпоральний контекст шлемо явно — без нього модель імпровізує
+  // "середина тижня" в неділю (issue з порадою на 26.04.2026). `daysIntoWeek`
+  // = `dayOfWeekIso` (понеділок-старт), повторюємо як окреме поле, щоб модель
+  // не плуталась між «номером дня» і «скільки пройшло».
+  const dateLines: string[] = [];
+  if (dateContext?.todayKey || dateContext?.weekDayUk) {
+    const parts: string[] = [];
+    if (dateContext.todayKey) parts.push(dateContext.todayKey);
+    if (dateContext.weekDayUk) parts.push(dateContext.weekDayUk);
+    dateLines.push(`Сьогодні: ${parts.join(", ")}.`);
+  }
+  if (dateContext?.weekRange) {
+    dateLines.push(
+      `Поточний тиждень (понеділок–неділя): ${dateContext.weekRange}.`,
+    );
+  }
+  if (typeof dateContext?.daysIntoWeek === "number") {
+    dateLines.push(
+      `День тижня: ${dateContext.daysIntoWeek} з 7 (тиждень ${
+        dateContext.daysIntoWeek >= 7 ? "завершується" : "у процесі"
+      }).`,
+    );
+  }
+  const dateContextText = dateLines.length
+    ? dateLines.join("\n")
+    : 'Поточну дату не передано — НЕ використовуй темпоральні маркери ("сьогодні", "середина тижня", "кінець тижня").';
 
   const snapshotLines: string[] = [];
   if (snapshot?.finyk) {
@@ -295,6 +330,9 @@ export async function coachInsight(req: Request, res: Response): Promise<void> {
 
   const systemPrompt = `Ти персональний AI-коуч у додатку "Мій простір". Ти знаєш цю людину по місяцях даних і говориш з нею як довірений коуч — тепло, але конкретно.
 
+КОНТЕКСТ ДАТИ (Київ):
+${dateContextText}
+
 ПАМ'ЯТЬ (попередні тижні):
 ${memorySummary}
 
@@ -305,6 +343,7 @@ ${snapshotText}
 - Відзначити конкретний патерн або прогрес (з даних)
 - Запропонувати одну конкретну дію на сьогодні
 - Бути особистим і мотивуючим, але без загальних фраз
+- Якщо згадуєш "сьогодні" чи прогрес тижня — спирайся ТІЛЬКИ на КОНТЕКСТ ДАТИ; не вигадуй "середина тижня" / "кінець тижня" самостійно. Тиждень = понеділок→неділя.
 
 Відповідай ТІЛЬКИ текстом повідомлення, без вітань, без підписів, без лапок.`;
 

--- a/apps/web/src/core/insights/useCoachInsight.ts
+++ b/apps/web/src/core/insights/useCoachInsight.ts
@@ -51,11 +51,55 @@ interface RoutineSnapshot {
   overallRate: number;
 }
 
+interface DateContext {
+  todayKey: string;
+  weekDayUk: string;
+  dayOfWeekIso: number;
+  daysIntoWeek: number;
+  weekRange: string;
+}
+
 interface CoachSnapshot {
+  dateContext: DateContext;
   finyk: FinykSnapshot;
   fizruk: FizrukSnapshot | null;
   nutrition: NutritionSnapshot | null;
   routine: RoutineSnapshot | null;
+}
+
+const WEEKDAY_UK_FROM_ISO: Record<number, string> = {
+  1: "понеділок",
+  2: "вівторок",
+  3: "середа",
+  4: "четвер",
+  5: "п'ятниця",
+  6: "субота",
+  7: "неділя",
+};
+
+// AI-NOTE: Кийвський "сьогодні" + ISO weekday — з тих самих частин Date,
+// що й існуючий `localDateKey` (без `toISOString().slice(0,10)`, бо UTC-зсув
+// ламає Routine-стрики ввечері — див. domain invariants у `AGENTS.md`).
+function buildDateContext(
+  now: Date,
+  weekStart: Date,
+  mondayOffset: number,
+): DateContext {
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 6);
+
+  // mondayOffset: 0 у понеділок, 6 у неділю → ISO 1..7.
+  const dayOfWeekIso = mondayOffset + 1;
+  const formatDayMonth = (d: Date): string =>
+    `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}`;
+
+  return {
+    todayKey: localDateKey(now),
+    weekDayUk: WEEKDAY_UK_FROM_ISO[dayOfWeekIso] ?? "",
+    dayOfWeekIso,
+    daysIntoWeek: dayOfWeekIso,
+    weekRange: `${formatDayMonth(weekStart)}–${formatDayMonth(weekEnd)}`,
+  };
 }
 
 function aggregateCurrentSnapshot(): CoachSnapshot {
@@ -215,7 +259,9 @@ function aggregateCurrentSnapshot(): CoachSnapshot {
     /* non-fatal */
   }
 
-  return { finyk, fizruk, nutrition, routine };
+  const dateContext = buildDateContext(now, weekStart, mondayOffset);
+
+  return { dateContext, finyk, fizruk, nutrition, routine };
 }
 
 async function fetchCoachInsight(): Promise<string | null> {

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -307,8 +307,28 @@ export const WeeklyDigestSchema = z.object({
   routine: RoutineDigestSchema.nullish(),
 });
 
+// AI-NOTE: `dateContext` обов'язковий для адекватного темпорального
+// обрамлення інсайту (без нього модель імпровізує "середина тижня" в неділю).
+// Поля: `todayKey` — Kyiv-time `YYYY-MM-DD`; `weekDayUk` — день тижня
+// українською ("понеділок"…"неділя"); `dayOfWeekIso` — 1 (пн)…7 (нд);
+// `daysIntoWeek` — скільки днів тижня вже пройшло (= `dayOfWeekIso`);
+// `weekRange` — людиночитабельний діапазон тижня для контексту.
+const CoachDateContextSchema = z
+  .object({
+    todayKey: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
+    weekDayUk: z.string().max(20).optional(),
+    dayOfWeekIso: z.number().int().min(1).max(7).optional(),
+    daysIntoWeek: z.number().int().min(1).max(7).optional(),
+    weekRange: z.string().max(80).optional(),
+  })
+  .partial();
+
 const CoachSnapshotSchema = z
   .object({
+    dateContext: CoachDateContextSchema.nullish(),
     finyk: FinykDigestSchema.nullish(),
     fizruk: FizrukDigestSchema.nullish(),
     nutrition: NutritionDigestSchema.nullish(),


### PR DESCRIPTION
## What changed

- `apps/web/src/core/insights/useCoachInsight.ts`: `aggregateCurrentSnapshot()` тепер кладе у payload коуч-інсайту явний `dateContext`:
  - `todayKey` — Kyiv-time `YYYY-MM-DD` (з тих самих частин `Date`, що й `localDateKey`, без `toISOString().slice(0,10)`).
  - `weekDayUk` — день тижня українською (`понеділок`…`неділя`).
  - `dayOfWeekIso` — 1 (пн)…7 (нд).
  - `daysIntoWeek` — = `dayOfWeekIso` (повторено окремо, щоб модель не плутала «номер дня» і «скільки пройшло»).
  - `weekRange` — `dd.MM–dd.MM` для контексту.
- `packages/shared/src/schemas/api.ts`: розширено `CoachSnapshotSchema` новим `dateContext: CoachDateContextSchema.nullish()`. Поля опціональні — back-compat зі старими клієнтами зберігається.
- `apps/server/src/modules/coach.ts`: системний промпт `coachInsight` тепер містить блок `КОНТЕКСТ ДАТИ (Київ):` з рядками «Сьогодні: YYYY-MM-DD, день тижня», «Поточний тиждень …», «День тижня: N з 7 (тиждень у процесі/завершується)». Додана інструкція спиратись виключно на цей блок для темпорального обрамлення; якщо контексту нема — явна заборона вигадувати «середина тижня» / «кінець тижня».
- `apps/server/src/modules/coach.test.ts`: два нові тести фіксують контракт промпту (з `dateContext` і без).

## Why

На головній у неділю 26.04 порада асистента казала «це лише середина тижня». Це питання користувача в чаті. Розбір показав:

1. Дані з модулів **збираються коректно** в `aggregateCurrentSnapshot` (`calcFinykPeriodAggregate` для Finyk, `fizruk_workouts_v1`/`nutrition_log_v1`/`hub_routine_v1` для решти, тиждень з понеділка).
2. Текст пише Anthropic Claude на сервері; він не захардкоджений.
3. Промпт **не передає** ні поточну дату, ні день тижня, ні прогрес тижня → модель імпровізує темпоральне обрамлення. Звідси «середина тижня» в неділю.

Цей PR не змінює агрегацію даних, лише додає темпоральний якір у контекст моделі і явну інструкцію не вигадувати фрази-маркери.

## How to test

1. Відкрити головну → блок «Порада асистента». Згенерувати нову пораду (кнопка refresh).
2. Перевірити `Network` → `POST /api/coach/insight` має містити `snapshot.dateContext` з `todayKey`, `weekDayUk`, `dayOfWeekIso`, `daysIntoWeek`, `weekRange`.
3. Текст поради в неділю не повинен говорити «середина тижня» (модель тепер бачить «День тижня: 7 з 7 (тиждень завершується)»).
4. Регрес: `pnpm --filter @sergeant/server test -- coach` — 12 passed, в т.ч. два нові кейси на `КОНТЕКСТ ДАТИ`.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/server test -- coach` (12 tests, +2 нові на формат `КОНТЕКСТ ДАТИ`); `pnpm --filter @sergeant/server test -- validate` (26); `pnpm --filter @sergeant/shared test` (256).
- [x] Typecheck: `pnpm --filter @sergeant/server typecheck`, `pnpm --filter @sergeant/web typecheck` — обидва зелені.
- [x] Lint: `pnpm --filter @sergeant/web lint`, `pnpm --filter @sergeant/server lint`, `pnpm --filter @sergeant/shared lint` — без зауважень.
- [x] `pnpm format:check` — clean.
- [ ] Manual smoke: не виконував — потрібен реальний Anthropic ключ і живі модулі. Контракт промпту покрито юніт-тестами.
- [x] No new `AI-DANGER` markers added without justification (додано лише `AI-NOTE`).
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules. Зміна локальна (контракт payload-у coach insight) і вже задокументована Zod-схемою + тестами.

Link to Devin session: https://app.devin.ai/sessions/bc3e6031356e4b11a2259816b57bcc6c
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
