### PR TITLE
feat(web): move retro entry into start-workout block, rename template button

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -742,10 +742,13 @@ function WorkoutsHome({
             Немає активного тренування
           </div>
           <div className="text-xs text-subtle mt-1">
-            Почни нове або обери один із збережених шаблонів.
+            Почни нове, обери шаблон або внеси проведене заняття заднім числом.
           </div>
           <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <Button className="h-12 text-base" onClick={handleStart}>
+            <Button
+              className="h-12 text-base sm:col-span-2"
+              onClick={handleStart}
+            >
               ▶︎ Почати тренування
             </Button>
             <Button
@@ -753,19 +756,18 @@ function WorkoutsHome({
               className="h-12 text-base"
               onClick={onOpenTemplates}
             >
-              📋 Почати з шаблону →
+              📋 Тренування за шаблоном →
+            </Button>
+            <Button
+              variant="ghost"
+              className="h-12 text-base"
+              onClick={onOpenRetro}
+            >
+              ✏️ Внести проведене заняття
             </Button>
           </div>
         </div>
       )}
-
-      <Button
-        variant="ghost"
-        className="h-11 w-full text-sm"
-        onClick={onOpenRetro}
-      >
-        ✏️ Внести проведене заняття
-      </Button>
 
       <div>
         <div className="flex items-center justify-between px-1 mb-2">


### PR DESCRIPTION
## What changed

Сторінка Фізрук → Тренування, стан «Немає активного тренування»:

- **Перейменував** ghost-кнопку **«📋 Почати з шаблону →» → «📋 Тренування за шаблоном →»**. Слово «Почати» вже на основній зеленій кнопці, дублювання прибрано — друга кнопка тепер чітко описує сам спосіб («тренуватися за готовим набором вправ»), а не дію.
- **Переніс «✏️ Внести проведене заняття» всередину тієї ж картки** (раніше була окрема ghost-кнопка нижче, поза карткою). Тепер усі три способи стартанути сесію — нове / за шаблоном / заднім числом — лежать поряд як один логічний блок.
- Підтекст підправив відповідно: «Почни нове, обери шаблон **або внеси проведене заняття заднім числом.**»
- Layout: на mobile (default) — три кнопки одна під одною; на `sm:` і ширше — основна зелена «Почати тренування» розтягнута на обидва стовпці (`sm:col-span-2`), під нею — два ghost-варіанти у дві колонки.

## Why

Скріншот від користувача: «Внести проведене заняття» висіла самотньо посеред порожнього простору між карткою «Немає активного тренування» і блоком «Останні тренування», візуально не належала до жодного контексту. По змісту це теж старт сесії (тільки з минулого), тож логічно тримати поруч з іншими стартами. Одне місце для всіх трьох входів = менше когнітивного навантаження + зменшує висоту порожнього стану.

«Почати з шаблону» було повтором слова «Почати» зі сусідньої CTA, тож рідко читалось як окрема дія — частіше як «синонім».

**Поведінкова деталь:** retro-кнопка тепер показується **тільки** в порожньому стані. Якщо є активне тренування, на цьому екрані рендериться інша картка («Активне тренування → Відкрити»), і retro-кнопки немає. Це свідома спрощуюча зміна — внести заняття заднім числом ширше можна після завершення активного. Якщо це створить незручність — легко повернути окрему кнопку поза карткою.

## How to test

```bash
cd apps/web
pnpm exec vitest run src/modules/fizruk
# 44/44 passed
pnpm typecheck   # ✓
pnpm lint        # ✓
```

Вручну (після деплою / `pnpm dev` у `apps/web`):

1. Відкрий **Фізрук → Тренування** без активного тренування.
2. Очікуване:
   - Заголовок картки «Немає активного тренування» з підтекстом про три варіанти.
   - Зелена «▶︎ Почати тренування» на всю ширину.
   - Нижче дві ghost-кнопки в один ряд (sm+) або стек (mobile): «📋 Тренування за шаблоном →» і «✏️ Внести проведене заняття».
   - Під карткою — одразу секція «Останні тренування» (без зайвої кнопки між ними).
3. Перевір що кліки працюють:
   - «Тренування за шаблоном» → відкриває список шаблонів.
   - «Внести проведене заняття» → відкриває retro-форму.
4. Запусти будь-яке тренування → картка змінюється на «Активне тренування»; retro-кнопка зникає (свідома поведінка, див. секцію Why).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прогнав vitest по `apps/web/src/modules/fizruk` (44/44).
- [x] Vitest passes: `apps/web/src/modules/fizruk` — 44/44.
- [x] Typecheck/lint у `apps/web` — clean.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c50c5ee58be64e95a3d45801cb185ffb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
