### PR TITLE
feat(eslint-plugins): add valid-tailwind-opacity rule + AGENTS.md guardrail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,29 @@ If a PR genuinely spans multiple scopes (rare), use the most "user-visible" one 
 
 `--no-verify` is forbidden. If a hook is broken, fix the hook in the same PR; do not bypass it.
 
+### 8. Tailwind colour-opacity steps must be on the registered scale
+
+Tailwind only generates the utility `<color>/<N>` when `N` exists in `theme.opacity`. The Sergeant preset (`packages/design-tokens/tailwind-preset.js`) registers:
+
+```
+0, 5, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100
+```
+
+(Default Tailwind v3 scale steps in 5-pt increments; the explicit `8` is Sergeant's "barely there" 8 % wash on panel surfaces — used for dark-mode module bento tiles, primary/danger row highlights, and Routine surface tints.)
+
+Any other step (`/7`, `/9`, `/12`, `/18`, …) is **silently dropped** — Tailwind emits no class, the surrounding `dark:` / `hover:` / `focus:` variant falls through to the previous declaration, and you typically only notice because dark mode looks wrong (this is exactly bug [#814](https://github.com/Skords-01/Sergeant/pull/814)).
+
+```tsx
+// ❌ BAD — `/12` is not on the scale; the `dark:` override silently
+// falls through to the light-mode background.
+<div className="bg-routine-surface/40 dark:bg-routine/12" />
+
+// ✅ GOOD — `/10` and `/15` are on the scale.
+<div className="bg-routine-surface/40 dark:bg-routine/10" />
+```
+
+Enforced by `sergeant-design/valid-tailwind-opacity` (`error`). To add a new step, extend the `opacity` map in the preset **and** the `ALLOWED_TAILWIND_OPACITY_STEPS` constant in `packages/eslint-plugin-sergeant-design/index.js` — they must stay in sync.
+
 ## AI markers
 
 Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-design/ai-marker-syntax` (warn).

--- a/apps/web/src/core/settings/FinykSection.tsx
+++ b/apps/web/src/core/settings/FinykSection.tsx
@@ -607,7 +607,7 @@ export function FinykSection() {
           {privatConnected ? (
             <div className="space-y-3">
               <div className="flex items-center gap-3 p-3 bg-bg border border-green-500/30 rounded-xl">
-                <div className="w-9 h-9 rounded-xl bg-green-500/12 border border-green-500/20 flex items-center justify-center text-base shrink-0">
+                <div className="w-9 h-9 rounded-xl bg-green-500/10 border border-green-500/20 flex items-center justify-center text-base shrink-0">
                   🏦
                 </div>
                 <div>

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -243,7 +243,7 @@ export default function App({
             <ModuleHeaderBackButton onClick={onBackToHub} />
           ) : (
             <div
-              className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/12 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
+              className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/10 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
               aria-hidden
             >
               <svg

--- a/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
@@ -183,7 +183,7 @@ export function HabitDetailSheet({
         {tag.map((t) => (
           <span
             key={t}
-            className="text-2xs px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine/12 border border-routine-line/50 dark:border-routine/25 text-routine-strong dark:text-routine font-medium"
+            className="text-2xs px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine/10 border border-routine-line/50 dark:border-routine/25 text-routine-strong dark:text-routine font-medium"
           >
             {t}
           </span>

--- a/apps/web/src/modules/routine/components/PushupsWidget.tsx
+++ b/apps/web/src/modules/routine/components/PushupsWidget.tsx
@@ -115,7 +115,7 @@ export function PushupsWidget() {
                 addReps(n);
                 setOpen(false);
               }}
-              className="min-h-[44px] rounded-2xl border border-routine-line/80 dark:border-routine/30 bg-routine-surface dark:bg-routine/12 px-1 py-2.5 text-center text-xs font-bold text-routine-strong dark:text-routine transition-colors active:opacity-90 sm:px-2 sm:text-sm"
+              className="min-h-[44px] rounded-2xl border border-routine-line/80 dark:border-routine/30 bg-routine-surface dark:bg-routine/10 px-1 py-2.5 text-center text-xs font-bold text-routine-strong dark:text-routine transition-colors active:opacity-90 sm:px-2 sm:text-sm"
             >
               +{n}
             </button>

--- a/apps/web/src/modules/routine/lib/routineConstants.ts
+++ b/apps/web/src/modules/routine/lib/routineConstants.ts
@@ -30,7 +30,7 @@ export const ROUTINE_THEME = {
 
   // Icon containers
   iconBox:
-    "bg-routine-surface dark:bg-routine/12 border-coral-100 dark:border-routine/30 text-routine-strong dark:text-routine",
+    "bg-routine-surface dark:bg-routine/10 border-coral-100 dark:border-routine/30 text-routine-strong dark:text-routine",
 
   // Navigation
   navActive: "text-routine-strong dark:text-routine",
@@ -51,7 +51,7 @@ export const ROUTINE_THEME = {
     "bg-routine-surface dark:bg-routine/15 border-routine-ring dark:border-routine/40 ring-1 ring-coral-100/50 dark:ring-routine/30",
 
   // Completion states
-  done: "border-routine/45 bg-routine-surface dark:bg-routine/12 text-routine-strong dark:text-routine",
+  done: "border-routine/45 bg-routine-surface dark:bg-routine/10 text-routine-strong dark:text-routine",
   doneCheck: "text-routine-strong dark:text-routine",
 
   // Primary button

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,13 @@ export default [
       // "warn" initially so it doesn't block CI; promote to "error" once
       // the codebase is clean.
       "sergeant-design/ai-marker-syntax": "warn",
+      // Tailwind opacity guardrail — `<color>/<N>` only renders when N
+      // is in `theme.opacity`. Sergeant's preset registers 0/5/8/10/…/100
+      // (see `packages/design-tokens/tailwind-preset.js`); any other
+      // step (e.g. `/7`, `/12`, `/18`) is silently dropped and the
+      // surrounding `dark:` / `hover:` override falls through to the
+      // light-mode background — this is what bug #814 was.
+      "sergeant-design/valid-tailwind-opacity": "error",
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-unused-vars": [
         "error",
@@ -128,6 +135,15 @@ export default [
     files: ["packages/eslint-plugin-sergeant-design/**/*.js"],
     rules: {
       "sergeant-design/no-ellipsis-dots": "off",
+    },
+  },
+  // The plugin's own __tests__ feed offending Tailwind opacity strings
+  // (`bg-finyk/7`, `text-danger/18`, …) into the linter as fixtures — the
+  // rule would otherwise self-flag every fixture.
+  {
+    files: ["packages/eslint-plugin-sergeant-design/**/*.{js,mjs}"],
+    rules: {
+      "sergeant-design/valid-tailwind-opacity": "off",
     },
   },
   // Jest setup / test files need jest globals.

--- a/packages/eslint-plugin-sergeant-design/__tests__/valid-tailwind-opacity.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/valid-tailwind-opacity.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the `sergeant-design/valid-tailwind-opacity` rule.
+ *
+ * Tailwind's default opacity scale steps in 5-pt increments; Sergeant's
+ * preset extends it with `8` for the canonical "barely there" 8 % wash
+ * (see `packages/design-tokens/tailwind-preset.js`). Any other step
+ * (`/7`, `/12`, `/18`, …) silently renders **no** class and the
+ * surrounding `dark:` / `hover:` override falls through, which caused
+ * the dark-mode regression #814.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/valid-tailwind-opacity";
+
+function lint(code) {
+  return linter.verify(code, {
+    plugins: { "sergeant-design": plugin },
+    rules: { [RULE_ID]: "error" },
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  });
+}
+
+describe("valid-tailwind-opacity", () => {
+  it("flags `bg-finyk/7` (not in scale)", () => {
+    const messages = lint(`const c = "bg-finyk/7";`);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.match(messages[0].message, /\/7/);
+  });
+
+  it("flags `dark:bg-routine/12` inside a className soup", () => {
+    const messages = lint(
+      `const c = "rounded-xl bg-routine-surface/40 dark:bg-routine/12 p-3";`,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /\/12/);
+  });
+
+  it("flags `text-danger/18` and `border-line/22` together", () => {
+    const messages = lint(
+      `const c = "text-danger/18 border-line/22 bg-panel/40";`,
+    );
+    assert.equal(messages.length, 2);
+  });
+
+  it("flags occurrences inside template literals", () => {
+    const messages = lint(
+      "const c = `flex items-center bg-primary/8 hover:bg-primary/9`;",
+    );
+    // `/8` is registered in the Sergeant preset; only `/9` should fire.
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /\/9/);
+  });
+
+  it("does NOT flag any of the registered steps", () => {
+    const code = `
+      const a = "bg-finyk/8 bg-finyk/10 bg-finyk/15";
+      const b = "text-routine/40 border-line/60 ring-primary/95";
+      const c = "from-finyk/0 to-finyk/100";
+    `;
+    const messages = lint(code);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag arbitrary values like `bg-[#fff]/[.5]`", () => {
+    const messages = lint(`const c = "bg-[#fff]/[.5] text-[rgb(0,0,0)]/30";`);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag plain `opacity-*` utilities (different syntax)", () => {
+    // `opacity-N` consults the same scale, but its missing-step failure
+    // mode is loud (CSS specificity mismatch), not silent — and we don't
+    // want to false-flag e.g. `opacity-50`.
+    const messages = lint(`const c = "opacity-50 opacity-12";`);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag dates / version strings / paths containing slashes", () => {
+    const code = `
+      const url = "https://example.com/api/v1/foo";
+      const date = "2026-04-26 19:30/40";
+      const ratio = "16/9 aspect-ratio";
+    `;
+    const messages = lint(code);
+    assert.equal(messages.length, 0);
+  });
+
+  it("flags occurrences across `cn(…)` argument soup", () => {
+    const messages = lint(
+      `cn("bg-finyk/40", isActive && "bg-finyk/9", "dark:bg-finyk/8");`,
+    );
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /\/9/);
+  });
+
+  it("reports the offending utility prefix in the message", () => {
+    const messages = lint(`const c = "ring-primary/13";`);
+    assert.equal(messages.length, 1);
+    assert.match(messages[0].message, /ring-primary\/13/);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -443,6 +443,120 @@ const noRawLocalStorage = {
   },
 };
 
+// ─────────────────────────────────────────────────────────────────────────
+// `valid-tailwind-opacity` — flag color/opacity modifiers that won't render
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Tailwind v3 only generates a `<color>/<N>` utility when `N` exists in
+// `theme.opacity`. The default scale steps in 5-pt increments
+// (0, 5, 10, 15, 20… 100); the Sergeant preset extends that with `8`
+// (canonical "barely there" 8 % wash on panel surfaces — see
+// `packages/design-tokens/tailwind-preset.js`). Every other value
+// (`bg-finyk/7`, `text-danger/12`, `border-line/18`) silently produces
+// **no class** and the surrounding `dark:` / `hover:` override falls
+// through to the light-mode background — exactly the dark-mode "светлые
+// плитки" regression #814 fixed.
+//
+// This rule scans className strings (and template literals / JSX
+// attributes) for the pattern `<utility>-<color>/<N>` and reports any
+// `N` that is not in the allowed set. Arbitrary values (`bg-[#fff]/[.5]`)
+// are left alone — Tailwind handles them via the JIT path.
+//
+// Keep `ALLOWED_TAILWIND_OPACITY_STEPS` in sync with the `opacity`
+// extension in `packages/design-tokens/tailwind-preset.js`.
+
+const ALLOWED_TAILWIND_OPACITY_STEPS = new Set([
+  0, 5, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90,
+  95, 100,
+]);
+
+const TAILWIND_OPACITY_UTILITIES = [
+  "bg",
+  "text",
+  "border",
+  "ring",
+  "fill",
+  "stroke",
+  "from",
+  "to",
+  "via",
+  "shadow",
+  "outline",
+  "divide",
+  "placeholder",
+  "caret",
+  "decoration",
+  "accent",
+];
+
+// Match `<utility>-<color-token>/<digits>` where:
+//   • `<utility>` is one of the color-aware utilities above,
+//   • `<color-token>` is a non-arbitrary identifier (letters, digits,
+//     hyphens) — the JIT path `bg-[#fff]/[.5]` is intentionally skipped,
+//   • `<digits>` is 1–3 decimal digits.
+// The leading `\b` lets variant prefixes (`dark:`, `hover:`, `lg:`) sit
+// in front of the utility.
+const RX_TAILWIND_OPACITY = new RegExp(
+  String.raw`\b(` +
+    TAILWIND_OPACITY_UTILITIES.join("|") +
+    String.raw`)-([a-zA-Z][a-zA-Z0-9-]*)\/(\d{1,3})\b`,
+  "g",
+);
+
+const TAILWIND_OPACITY_MESSAGE =
+  "Tailwind opacity step `/{{step}}` is not registered — `{{utility}}` will silently render no class. Use one of: 0, 5, 8, 10, 15, 20, 25 … 100, or extend `theme.opacity` in `packages/design-tokens/tailwind-preset.js`.";
+
+function findInvalidOpacitySteps(value) {
+  if (typeof value !== "string" || value.length === 0) return [];
+  // Skip strings that obviously aren't className soup — cheap escape so
+  // we don't tokenize unrelated literals (URLs, regexes, etc.).
+  if (!value.includes("/")) return [];
+  const hits = [];
+  let match;
+  RX_TAILWIND_OPACITY.lastIndex = 0;
+  while ((match = RX_TAILWIND_OPACITY.exec(value)) !== null) {
+    const [full, utilityPrefix, , stepRaw] = match;
+    const step = Number(stepRaw);
+    if (!Number.isFinite(step)) continue;
+    if (ALLOWED_TAILWIND_OPACITY_STEPS.has(step)) continue;
+    hits.push({ utility: full, prefix: utilityPrefix, step });
+  }
+  return hits;
+}
+
+const validTailwindOpacity = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid Tailwind `<color>/<N>` opacity modifiers whose step is not registered in `theme.opacity` — the class is silently dropped, breaking dark-mode and hover overrides.",
+    },
+    schema: [],
+    messages: { unregistered: TAILWIND_OPACITY_MESSAGE },
+  },
+  create(context) {
+    function report(node, value) {
+      const hits = findInvalidOpacitySteps(value);
+      for (const hit of hits) {
+        context.report({
+          node,
+          messageId: "unregistered",
+          data: { utility: hit.utility, step: String(hit.step) },
+        });
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") report(node, node.value);
+      },
+      TemplateElement(node) {
+        const cooked = node.value && node.value.cooked;
+        if (typeof cooked === "string") report(node, cooked);
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -450,6 +564,7 @@ const plugin = {
     "no-raw-tracked-storage": noRawTrackedStorage,
     "no-raw-local-storage": noRawLocalStorage,
     "ai-marker-syntax": aiMarkerSyntax,
+    "valid-tailwind-opacity": validTailwindOpacity,
   },
 };
 
@@ -458,6 +573,8 @@ export {
   TRACKED_STORAGE_KEY_VALUES,
   RAW_TRACKED_STORAGE_MESSAGE,
   RAW_LOCAL_STORAGE_MESSAGE,
+  ALLOWED_TAILWIND_OPACITY_STEPS,
+  TAILWIND_OPACITY_UTILITIES,
 };
 
 export default plugin;


### PR DESCRIPTION
## Summary

Follow-up to [#814](https://github.com/Skords-01/Sergeant/pull/814) — preventive guardrails so the silent-Tailwind-opacity-step regression can't happen again.

**1. New ESLint rule `sergeant-design/valid-tailwind-opacity`** (`packages/eslint-plugin-sergeant-design/index.js`)

Flags any Tailwind `<utility>-<color>/<N>` modifier whose `N` is not in the registered opacity scale. Tailwind v3 only emits the utility when `N` exists in `theme.opacity`; any other step (`/7`, `/9`, `/12`, `/18`…) **silently renders no class** and the surrounding `dark:` / `hover:` / `focus:` variant falls through to the previous declaration. That is exactly what #814 was — the rule catches it at lint time.

- Allowed steps: `0, 5, 8, 10, 15, 20, 25 … 100` (default 5-pt scale + the explicit `8` from #814).
- Skips arbitrary values (`bg-[#fff]/[.5]`) and plain `opacity-*` utilities.
- Skips strings without a `/` so URL/regex/path literals aren't tokenised needlessly.
- 10 unit tests cover positive cases (`/7`, `/12`, `/18`, `/22`, `/9`, `/13`), variant prefixes (`dark:bg-routine/12` inside className soup), template literals, `cn(...)` argument soup, and negative cases (registered steps, arbitrary values, `opacity-50`, dates / paths / aspect ratios).
- Wired as `"error"` in the root `eslint.config.js` with a self-override for the plugin's own `__tests__/` (which feed offending strings as fixtures).

**2. Codebase clean-up** (surfaced by the rule)

The new rule found 6 additional silently-broken `/12` call sites that #814 hadn't fixed (only `/8` was caught there). Replaced each with the closest registered step (`/10`):

- `apps/web/src/modules/routine/lib/routineConstants.ts` ×2 (`iconBox`, `done`)
- `apps/web/src/modules/routine/components/HabitDetailSheet.tsx` (tag chips)
- `apps/web/src/modules/routine/components/PushupsWidget.tsx` (set-counter buttons)
- `apps/web/src/core/settings/FinykSection.tsx` (Mono integration card)
- `apps/web/src/modules/finyk/FinykApp.tsx` (header icon box)

Visual delta is imperceptible (10 % vs 12 % wash); functional delta is "now actually renders in dark mode".

**3. AGENTS.md — Hard rule #8**

Documents the canonical opacity scale, links to #814, gives a BAD/GOOD example, and explains the contract: extending the scale requires updating **both** `packages/design-tokens/tailwind-preset.js` (the actual Tailwind config) **and** `ALLOWED_TAILWIND_OPACITY_STEPS` in the plugin (the lint allow-list). They must stay in sync.

## Review & Testing Checklist for Human

- [ ] **(most important)** Skim the rule implementation in `packages/eslint-plugin-sergeant-design/index.js` (the new ~80-line block at the bottom) — confirm the regex covers the utilities you care about (`bg`, `text`, `border`, `ring`, `from`, `to`, `via`, `shadow`, etc.) and that the allow-list of steps matches what you want enforced.
- [ ] Run `pnpm lint` locally — should be clean (no warnings, no errors).
- [ ] Run `pnpm lint:plugins` locally — 53 tests pass (10 new + 43 existing).
- [ ] Spot-check the 6 `/12 → /10` replacements visually in dark mode (Routine cards, Pushups widget, Finyk settings Mono card, Finyk app header) — the wash should now actually appear.
- [x] Confirm AGENTS.md placement — added as Hard Rule #8 right after #7 (Husky hooks). Move if a different home fits better.

### Notes

- The rule does **not** modify code — it's report-only. The 6 fixed call sites are explicit edits in this PR.
- I deliberately did NOT register `12` in the opacity scale to avoid scale sprawl — `/8` has a documented design rationale ("barely there 8 % wash"), and the codebase didn't have multiple intentional `/12` use cases. If you'd rather keep `/12`, swap the call-site fixes for `opacity: { 8: "0.08", 12: "0.12" }` in the preset and add `12` to `ALLOWED_TAILWIND_OPACITY_STEPS`.
- `valid-tailwind-opacity` is not auto-fixable — the right replacement (`/5` vs `/10` vs `/15`) is a design choice, not a mechanical one.


Link to Devin session: https://app.devin.ai/sessions/48ea64634a384379a8a2021766623479
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
