### PR TITLE
fix(server): chat continuation must keep user/assistant alternation

### DIFF
--- a/apps/server/src/modules/chat.test.ts
+++ b/apps/server/src/modules/chat.test.ts
@@ -60,6 +60,10 @@ function asRec(v: unknown): Record<string, unknown> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // mockResolvedValueOnce-черга НЕ скидається через clearAllMocks — потрібен mockReset.
+  // Інакше leftover-моки з попереднього тесту (наприклад cap-тест queue-ить 5, а
+  // консьюмить лише 4) залежать у наступному.
+  anthropicMessages.mockReset();
 });
 
 describe("chat handler — tool_use parsing", () => {
@@ -537,5 +541,77 @@ describe("chat handler — auto-continuation на stop_reason=max_tokens", () =>
 
     expect(anthropicMessages.mock.calls.length).toBeLessThanOrEqual(4);
     expect(res.body).toEqual({ text: "chunk1 chunk2 chunk3 chunk4 " });
+  });
+
+  it("у 2-му continuation messages мають user/assistant alternation (а не два assistant-msg поспіль)", async () => {
+    // Anthropic Messages API rejects consecutive same-role messages → перевіряємо,
+    // що при 2+ continuation в payload завжди один merged assistant-msg, а не
+    // окремий msg на кожен chunk.
+    const part = (i: number) => ({
+      response: { ok: true, status: 200 },
+      data: {
+        stop_reason: "max_tokens",
+        content: [{ type: "text", text: `c${i} ` }],
+      },
+    });
+    anthropicMessages
+      .mockResolvedValueOnce(part(1))
+      .mockResolvedValueOnce(part(2))
+      .mockResolvedValueOnce({
+        response: { ok: true, status: 200 },
+        data: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "c3" }],
+        },
+      });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "запит" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(anthropicMessages).toHaveBeenCalledTimes(3);
+    const thirdCallMessages = anthropicMessages.mock.calls[2][1].messages;
+    // [user, assistant("c1 c2 ")] — рівно один assistant, накопичений текст
+    expect(thirdCallMessages).toHaveLength(2);
+    expect(thirdCallMessages[0]).toEqual({ role: "user", content: "запит" });
+    expect(thirdCallMessages[1]).toEqual({
+      role: "assistant",
+      content: "c1 c2 ",
+    });
+    // Sanity: не два assistant-msg-и поспіль
+    const roles = thirdCallMessages.map((m: { role: string }) => m.role);
+    for (let k = 1; k < roles.length; k++) {
+      expect(roles[k]).not.toBe(roles[k - 1]);
+    }
+    expect(res.body).toEqual({ text: "c1 c2 c3" });
+  });
+
+  it("graceful degradation: повертає накопичений partial-text коли continuation впав з помилкою", async () => {
+    // Перший виклик ок з max_tokens, другий — 500 з upstream. Очікуємо partial успіх,
+    // НЕ помилку: юзер бачить що було склеєно, refund не викликається.
+    anthropicMessages
+      .mockResolvedValueOnce({
+        response: { ok: true, status: 200 },
+        data: {
+          stop_reason: "max_tokens",
+          content: [{ type: "text", text: "Перша частина… " }],
+        },
+      })
+      .mockResolvedValueOnce({
+        response: { ok: false, status: 500 },
+        data: { error: { message: "Anthropic 500" } },
+      });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "запит" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(anthropicMessages).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(asRec(res.body).text).toBe("Перша частина… ");
   });
 });

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -178,7 +178,24 @@ async function callAnthropicWithContinuation(
     lastData = data as AnthropicMessagesResponseData;
 
     if (!response?.ok) {
-      // Upstream error — caller обробить (refund + propagate).
+      // Якщо вже є partial-текст з попередніх успішних викликів — повертаємо його
+      // як успішний результат (graceful degradation): юзер бачить часткову
+      // відповідь замість 5xx, квоту не рефандимо (перші виклики легітимно
+      // обслужені). Без partial-у — помилку віддаємо caller-у на refund.
+      // Синтезуємо ok-response, щоб caller-и (які роблять `if (!response.ok)`)
+      // потрапили у success-гілку.
+      if (continued && mergedTextChunks.length > 0) {
+        return {
+          response: { ok: true, status: 200 } as unknown as FetchResponse,
+          data: {
+            content: buildMergedContent(
+              mergedTextChunks.join(""),
+              lastNonTextBlocks,
+            ),
+          },
+          continued,
+        };
+      }
       return { response, data: lastData, continued };
     }
 
@@ -210,10 +227,13 @@ async function callAnthropicWithContinuation(
       };
     }
 
-    // Продовжуємо: доклеюємо partial текст як assistant-повідомлення і б'ємо знову.
+    // Продовжуємо: rebuild з baseMessages + ОДИН assistant-msg з усім склеєним
+    // текстом. Anthropic Messages API вимагає user/assistant alternation —
+    // якщо просто .push-ити новий assistant-msg на кожній ітерації, на 2-му
+    // continuation-і отримаємо два assistant-and-row → 400 від upstream.
     currentMessages = [
-      ...currentMessages,
-      { role: "assistant", content: textParts },
+      ...baseMessages,
+      { role: "assistant", content: mergedTextChunks.join("") },
     ];
     continued = true;
   }
@@ -558,7 +578,8 @@ async function streamAnthropicToSse(
   }, SSE_HEARTBEAT_MS);
   if (typeof heartbeat.unref === "function") heartbeat.unref();
 
-  let currentMessages = (payload.messages as Array<unknown>) ?? [];
+  const baseMessages = (payload.messages as Array<unknown>) ?? [];
+  let accumulatedAllText = "";
   let currentResponse: FetchResponse = firstResponse;
   let currentRecordEnd = firstRecordEnd;
   let continuationsLeft = MAX_TEXT_CONTINUATIONS;
@@ -567,6 +588,7 @@ async function streamAnthropicToSse(
     while (true) {
       const iter = await streamOneIterationToSse(res, currentResponse);
       currentRecordEnd(iter.outcome);
+      if (iter.accumulatedText) accumulatedAllText += iter.accumulatedText;
 
       if (
         iter.outcome === "error" ||
@@ -579,16 +601,18 @@ async function streamAnthropicToSse(
         break;
       }
 
-      // Continuation: відкриваємо новий upstream з partial-text як assistant-msg.
-      currentMessages = [
-        ...currentMessages,
-        { role: "assistant", content: iter.accumulatedText },
+      // Continuation: rebuild з baseMessages + ОДИН assistant-msg з усім склеєним
+      // текстом (Anthropic API вимагає user/assistant alternation — два
+      // assistant-msg-и поспіль → 400).
+      const nextMessages = [
+        ...baseMessages,
+        { role: "assistant", content: accumulatedAllText },
       ];
       try {
         const { response: nextResponse, recordStreamEnd: nextRecordEnd } =
           await anthropicMessagesStream(
             apiKey,
-            { ...payload, messages: currentMessages },
+            { ...payload, messages: nextMessages },
             {
               endpoint: `${endpoint}-cont`,
               timeoutMs: 60000,


### PR DESCRIPTION
## What changed

Follow-up до #813. Devin Review знайшов 3 баги в auto-continuation, що 2 з яких ламають механізм при `MAX_TEXT_CONTINUATIONS > 1`. Цей PR їх усуває.

### 1. Consecutive `assistant`-messages при 2-му+ continuation (BUG_0001 + BUG_0002)

**Що було:** обидва шляхи (`callAnthropicWithContinuation` для non-stream і петля в `streamAnthropicToSse` для SSE) на кожній continuation-ітерації робили:

```ts
currentMessages = [...currentMessages, { role: "assistant", content: chunkN }];
```

Перша continuation (i=1) — ок: `[user, assistant:c1]` → call → `[user, assistant:c1, user-msg-немає, assistant:c2]` — тут одразу два `assistant`-повідомлення поспіль. Anthropic Messages API вимагає user/assistant alternation (в нашому ж коді це enforce-ить `sanitizeMessages`), тож друга continuation повертала **400 від upstream**, мовчки ламаючи фічу.

**Виправлення:** на кожній ітерації перебудовуємо messages з оригінального `baseMessages` + **один** merged `assistant`-msg з усім накопиченим текстом:

```ts
currentMessages = [
  ...baseMessages,
  { role: "assistant", content: mergedTextChunks.join("") },
];
```

Для streaming: тримаємо `accumulatedAllText` поза циклом і ребіл-димо `nextMessages` так само з `payload.messages` (зафіксованих перед циклом).

Чому unit-тест cap-а це не ловив: `anthropicMessages` повністю мокнутий, не валідує формат повідомлень. Додав окремий тест, що перевіряє `[user, assistant]` shape **і** alternation на 3-му виклику (2-га continuation).

### 2. Втрата накопиченого partial-text-у при failed-continuation (BUG_0003)

**Що було:** якщо перший виклик успішно повернув partial-text + `max_tokens`, а continuation-виклик упав (Anthropic 429/500), `callAnthropicWithContinuation` повертав error-response — caller робив `refundQuotaOnUpstreamFailure` і віддавав 5xx юзеру, **викидаючи** успішно згенерований текст.

**Виправлення:** якщо `continued === true` і `mergedTextChunks.length > 0`, повертаємо синтезовану ok-response з накопиченим текстом як `text`-блок. Caller бачить ok → не рефандить квоту (перші виклики легітимно обслужені) і віддає юзеру partial-success замість помилки.

Стрім-шлях вже мав схожу логіку (стрімнутий текст лишається у клієнта при continuation-помилці), просто додатково записуємо `err`-event у SSE — це поведінка вже була в #813.

### 3. Тест-ізоляція

`vi.clearAllMocks()` НЕ скидає чергу `mockResolvedValueOnce`. Cap-тест queue-ив 5 моків, але консьюмив 4 — leftover тікав у наступний тест і ламав його. Додав `anthropicMessages.mockReset()` у `beforeEach`, щоб стан був стабільним.

## Why

Без цих фіксів `MAX_TEXT_CONTINUATIONS=3` дає максимум **1** реальну continuation у проді — далі Anthropic відкидає payload з 400. Тобто PR #813 у проді частково дегенерує до старої поведінки (одна continuation = два upstream-виклики), і це silent.

Graceful degradation — м'якше UX-покращення, але теж важливе: поки в #813 при network-flakiness в середині мульти-continuation відповіді користувач отримує 5xx замість часткової відповіді, що особливо боляче на довгих брифінгах.

## How to test

```bash
cd apps/server
pnpm exec vitest run src/modules/chat.test.ts
# 17 passed (15 existing + 2 new: alternation, graceful degradation)
pnpm test
# 396 passed
```

Локально з root:

```bash
pnpm typecheck   # ✓
pnpm lint        # ✓
```

Нові тести:

1. **`у 2-му continuation messages мають user/assistant alternation`** — після 3 викликів з max_tokens/max_tokens/end_turn перевіряє: 3-й виклик отримав рівно `[user, assistant("c1 c2 ")]`, без 2 assistant-msg-ів поспіль.
2. **`graceful degradation: повертає накопичений partial-text коли continuation впав з помилкою`** — перший виклик ok+max_tokens з текстом, другий — 500. Очікуємо `statusCode 200` + `text: "Перша частина… "`, **не** 500.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm test` у `apps/server` — 396/396, `pnpm exec vitest run src/modules/chat.test.ts` — 17/17.
- [x] Vitest passes: server full suite + chat-spec.
- [x] Typecheck/lint у root — clean.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c50c5ee58be64e95a3d45801cb185ffb
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-turn conversation continuation flows with better error resilience when upstream failures occur.
  * Enhanced message sequencing to ensure proper user/assistant alternation is maintained across multiple continuation requests.

* **Tests**
  * Added test coverage for multi-continuation flows with proper message merging.
  * Added failure-path testing for upstream continuation errors with partial response recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->