### PR TITLE
refactor(web): винести дубльовані prop типи у спільний types файл

### DIFF
--- a/apps/web/src/shared/components/ui/Input.tsx
+++ b/apps/web/src/shared/components/ui/Input.tsx
@@ -6,6 +6,7 @@ import {
   type TextareaHTMLAttributes,
 } from "react";
 import { cn } from "../../lib/cn";
+import type { FormVariant, SmallMediumLarge } from "./types";
 
 /**
  * Opinionated per-`type` defaults for `spellCheck`, `inputMode`, and
@@ -46,8 +47,8 @@ const DEFAULT_INPUT_MODE: Partial<
  * States: error, success
  */
 
-export type InputSize = "sm" | "md" | "lg";
-export type InputVariant = "default" | "filled" | "ghost";
+export type InputSize = SmallMediumLarge;
+export type InputVariant = FormVariant;
 
 const sizes: Record<InputSize, string> = {
   sm: "h-9 px-3 text-sm rounded-xl",

--- a/apps/web/src/shared/components/ui/Select.tsx
+++ b/apps/web/src/shared/components/ui/Select.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, type ReactNode, type SelectHTMLAttributes } from "react";
 import { cn } from "../../lib/cn";
+import type { FormVariant, SmallMediumLarge } from "./types";
 
 /**
  * Sergeant Design System — Select
@@ -12,8 +13,8 @@ import { cn } from "../../lib/cn";
  * pickers; this component is a styled wrapper with a caret affordance.
  */
 
-export type SelectSize = "sm" | "md" | "lg";
-export type SelectVariant = "default" | "filled" | "ghost";
+export type SelectSize = SmallMediumLarge;
+export type SelectVariant = FormVariant;
 
 const sizes: Record<SelectSize, string> = {
   sm: "h-9 pl-3 pr-9 text-sm rounded-xl",

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -119,3 +119,5 @@ export type {
 } from "./Tabs";
 
 export { ToastContainer } from "./Toast";
+
+export type { FormVariant, SmallMediumLarge } from "./types";

--- a/apps/web/src/shared/components/ui/types.ts
+++ b/apps/web/src/shared/components/ui/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Sergeant Design System — Shared UI prop types.
+ *
+ * Several primitives in this folder share identical prop unions
+ * (e.g. `Input` and `Select` both accept `default | filled | ghost`
+ * and `sm | md | lg`). Defining those unions in one place keeps the
+ * surface honest — when we add a new form variant, every consumer
+ * picks it up at once instead of drifting per-component.
+ *
+ * Component-local aliases (e.g. `InputVariant`, `SelectSize`) are kept
+ * as type aliases of these shared types so existing call sites and
+ * deep imports continue to work.
+ */
+
+/**
+ * Visual variant shared by form controls (`Input`, `Textarea`, `Select`).
+ * `default` is the bordered surface, `filled` removes the border in
+ * favour of a tinted panel, `ghost` is transparent until hover/focus.
+ */
+export type FormVariant = "default" | "filled" | "ghost";
+
+/**
+ * Standard small / medium / large sizing scale used across multiple
+ * primitives (`Input`, `Select`, `Button`, etc.). Components that
+ * need a different scale (e.g. `Avatar`'s `xs..xl`) define their own.
+ */
+export type SmallMediumLarge = "sm" | "md" | "lg";


### PR DESCRIPTION
## What changed

- Додано новий файл `apps/web/src/shared/components/ui/types.ts` зі спільними prop-типами:
  - `FormVariant = "default" | "filled" | "ghost"` — використовується `Input`, `Textarea`, `Select`.
  - `SmallMediumLarge = "sm" | "md" | "lg"` — стандартна шкала розмірів для form-control примітивів.
- `apps/web/src/shared/components/ui/Input.tsx`: `InputSize`/`InputVariant` тепер це type-aliases на `SmallMediumLarge`/`FormVariant`. Публічний API (імена типів, прийняті значення) не змінився.
- `apps/web/src/shared/components/ui/Select.tsx`: те саме для `SelectSize`/`SelectVariant`.
- `apps/web/src/shared/components/ui/index.ts`: ре-експортує `FormVariant`, `SmallMediumLarge`.

## Why

`InputVariant` та `SelectVariant` мали ідентичну юніон-форму (`"default" | "filled" | "ghost"`), як і `InputSize`/`SelectSize` (`"sm" | "md" | "lg"`). Дубль означає, що при додаванні нового варіанту довелося б синхронно правити кілька місць — і дуже легко забути одне. Спільні типи тримають поверхню чесною.

Перейменування `InputVariant`/`SelectVariant` залишені як aliases, щоб не ламати існуючі deep-import'и (`@shared/components/ui/Input` тощо) і call-сайти.

> Примітка: оригінальний план також згадував ре-експорт `ModuleAccent` / `SemanticOrModuleTone` з `@sergeant/design-tokens`. Цей пакет — JS-only (`tokens.js` + `tailwind-preset.js`), TS-типів з такими іменами там не існує, тому крок пропущений. Якщо потрібно — це окрема задача (додати TS-декларації в design-tokens).

## How to test

```bash
pnpm install
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Input.test.tsx
```

Усі — зелені.

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): не виконувався — рефактор тільки на рівні типів, runtime-поведінка не змінюється.
- [x] Vitest passes: `vitest run src/shared/components/ui/Input.test.tsx` — 6/6 passed.
- [x] `pnpm --filter @sergeant/web typecheck` — clean (`tsc --noEmit` для tsconfig.json та tsconfig.sw.json).
- [x] `pnpm --filter @sergeant/web lint` — clean.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/96fc5d76b7644754af6791c6e93076ad
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated UI component type definitions to use shared types, improving consistency and maintainability across form-related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->