### PR TITLE
chore(design-tokens): додати TypeScript типи до пакету

### DIFF
--- a/packages/design-tokens/index.d.ts
+++ b/packages/design-tokens/index.d.ts
@@ -1,0 +1,54 @@
+/**
+ * Sergeant Design Tokens — shared TypeScript types.
+ *
+ * Single source of truth for module/semantic/brand identifiers used across
+ * web, mobile, and shared packages. Component-level redefinitions of these
+ * unions should be removed in favour of these exports.
+ */
+
+/** Module accent identifiers — one per product domain. */
+export type ModuleAccent = "finyk" | "fizruk" | "routine" | "nutrition";
+
+/** Soft (tinted-surface) variants of module accents. */
+export type ModuleSoftAccent =
+  | "finyk-soft"
+  | "fizruk-soft"
+  | "routine-soft"
+  | "nutrition-soft";
+
+/** Status / semantic colour identifiers used for feedback UI. */
+export type StatusColor = "success" | "warning" | "danger" | "info";
+
+/** Semantic tone for neutral/feedback components (no `info`). */
+export type SemanticTone = "default" | "success" | "warning" | "danger";
+
+/**
+ * Union of semantic tones and module accents.
+ * Useful for components that can be themed either by feedback tone
+ * (e.g. `success`) or by module identity (e.g. `finyk`).
+ */
+export type SemanticOrModuleTone = SemanticTone | ModuleAccent;
+
+/** Primary brand colour ramps exposed by `brandColors` in tokens.js. */
+export type BrandColor = "emerald" | "teal" | "cream" | "coral" | "lime";
+
+// ─── Runtime token shapes ────────────────────────────────────────────────
+
+type ColorRamp = Readonly<Record<string, string>>;
+
+/** Brand colour ramps. Mirrors `brandColors` in `tokens.js`. */
+export declare const brandColors: Readonly<Record<BrandColor, ColorRamp>>;
+
+/** Chart segment palette (1..N) — soft organic colours for pie charts. */
+export declare const chartPalette: Readonly<Record<string, string>>;
+
+/** Ordered list view of `chartPalette` values. */
+export declare const chartPaletteList: readonly string[];
+
+/** Module-specific accent colours keyed by module identifier. */
+export declare const moduleColors: Readonly<
+  Record<ModuleAccent, Readonly<Record<string, string>>>
+>;
+
+/** Status / semantic colours, keyed by `StatusColor`. */
+export declare const statusColors: Readonly<Record<StatusColor, string>>;

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -6,12 +6,20 @@
   "description": "Shared Sergeant design tokens & Tailwind preset (web + mobile)",
   "files": [
     "tailwind-preset.js",
-    "tokens.js"
+    "tokens.js",
+    "index.d.ts"
   ],
   "main": "./tokens.js",
+  "types": "./index.d.ts",
   "exports": {
-    ".": "./tokens.js",
-    "./tokens": "./tokens.js",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./tokens.js"
+    },
+    "./tokens": {
+      "types": "./index.d.ts",
+      "default": "./tokens.js"
+    },
     "./tailwind-preset": "./tailwind-preset.js"
   },
   "scripts": {


### PR DESCRIPTION
## What changed

- Створено `packages/design-tokens/index.d.ts` з єдиним джерелом правди для спільних union-типів:
  - `ModuleAccent` = `"finyk" | "fizruk" | "routine" | "nutrition"`
  - `ModuleSoftAccent` = `"finyk-soft" | "fizruk-soft" | "routine-soft" | "nutrition-soft"`
  - `StatusColor` = `"success" | "warning" | "danger" | "info"`
  - `SemanticTone` = `"default" | "success" | "warning" | "danger"`
  - `SemanticOrModuleTone` = `SemanticTone | ModuleAccent`
  - `BrandColor` = `"emerald" | "teal" | "cream" | "coral" | "lime"`
- Додано ambient-декларації для runtime-експортів `tokens.js` (`brandColors`, `chartPalette`, `chartPaletteList`, `moduleColors`, `statusColors`), типізовані через нові union-типи — інакше `index.d.ts` "затулив" би `tokens.js` і існуючі імпорти `from "@sergeant/design-tokens/tokens"` зламались би.
- `packages/design-tokens/package.json`:
  - додано `"types": "./index.d.ts"`,
  - додано `index.d.ts` у `files`,
  - оновлено `exports["."]` та `exports["./tokens"]` на conditional форму з `"types"` → `"./index.d.ts"` і `"default"` → `"./tokens.js"`, щоб TS бачив типи з обох вхідних точок.

## Why

Раніше пакет експортував лише runtime JS, тому компоненти у web/mobile/shared дублювали ті самі union-типи (`ModuleAccent`, `SemanticTone`, тощо) у себе. Це створювало drift і шум при правках. Тепер є один централізований `@sergeant/design-tokens` як джерело типів — компоненти можна поступово мігрувати на спільні імпорти окремими PR.

## How to test

```bash
pnpm install
pnpm typecheck   # 13 tasks, все має бути зелене
```

Локально перевірено:
- `pnpm --filter @sergeant/web typecheck` — OK
- `pnpm --filter @sergeant/mobile typecheck` — OK
- `pnpm typecheck` (turbo, всі пакети) — 13 successful, 13 total
- `pnpm prettier --check packages/design-tokens/index.d.ts packages/design-tokens/package.json` — OK
- Husky `pre-commit` (lint-staged) відпрацював на коміті без помилок

Sanity-check імпортів: існуючі `import { statusColors } from "@sergeant/design-tokens/tokens"` (apps/mobile) та `import { brandColors, chartPalette, chartPaletteList, moduleColors, statusColors } from "@sergeant/design-tokens/tokens"` (apps/web) тепер бачать типи з нового `.d.ts`.

---

## How AI-tested this PR

- [x] Vitest passes: не запускав — зміни лише типові, runtime коду не торкаються; натомість прогнав повний `pnpm typecheck` (13/13 tasks pass).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c12d9deebd924e5c9fe2ace6ab800489
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TypeScript type definitions for design tokens, enabling type-safe usage across projects and improving IDE support with autocompletion and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->