### PR TITLE
fix(design-tokens): додати відсутній кольоровий токен routine-surface2

### DIFF
--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -141,6 +141,9 @@ const preset = {
           DEFAULT: moduleColors.routine.primary,
           secondary: moduleColors.routine.secondary,
           surface: moduleColors.routine.surface,
+          // Tint крок між surface (coral-50 #fff5f3) та surfaceAlt (coral-100 #ffe8e3) —
+          // використовується для виділення активного дня / виконаного слота в календарі.
+          surface2: "#ffeeeb",
           surfaceAlt: moduleColors.routine.surfaceAlt,
           hover: brandColors.coral[600],
           strong: brandColors.coral[700],


### PR DESCRIPTION
## What changed

Додано токен `routine.surface2` (`#ffeeeb`) у `packages/design-tokens/tailwind-preset.js` як проміжний tint між `routine.surface` (coral-50, `#fff5f3`) та `routine.surfaceAlt` (coral-100, `#ffe8e3`).

```diff
  routine: {
    DEFAULT: moduleColors.routine.primary,
    secondary: moduleColors.routine.secondary,
    surface: moduleColors.routine.surface,
+   surface2: "#ffeeeb",
    surfaceAlt: moduleColors.routine.surfaceAlt,
    ...
  }
```

## Why

Клас `bg-routine-surface2` уже використовувався у трьох місцях, але токен не був визначений у presetі — Tailwind мовчки не генерував CSS-клас, тож відповідні фони (виділення активного дня, виконаного слота, легенди календаря) не відмальовувались:

- `apps/web/src/modules/routine/components/WeekDayStrip.tsx:55` — фон активного дня в стрічці тижня.
- `apps/web/src/modules/routine/components/HabitDetailSheet.tsx:324` — фон виконаного дня в календарі звички.
- `apps/web/src/modules/routine/components/HabitDetailSheet.tsx:345` — індикатор у легенді ("Виконано").

Значення `#ffeeeb` обрано як арифметичний midpoint між `surface`/`surfaceAlt` (R 255, G 238, B 235); за потреби можна підкоригувати під Figma — тоді достатньо змінити одну константу в presetі.

> Залишено інлайн hex (а не нову позицію в `coral.*` / `moduleColors.routine`), бо це проміжний крок саме для preset-рівня tint-сходинки; решту полів `routine` лишено без змін щоб не розширювати скоуп.

## How to test

1. Відкрити Routine → перейти на сьогоднішній/інший день у `WeekDayStrip` — активний день має виділятися персиковим фоном (раніше залишався прозорим).
2. Відкрити деталі будь-якої звички (`HabitDetailSheet`) → виконані дні в місячному календарі мають той самий персиковий фон; легенда "Виконано" — той самий swatch.
3. `pnpm --filter @sergeant/web lint` та `pnpm --filter @sergeant/web typecheck` — чисто.

## How AI-tested this PR

- [x] Vitest passes: не зачіпається (зміна суто токенна, без логіки).
- [x] `pnpm --filter @sergeant/web lint` — pass.
- [x] `pnpm --filter @sergeant/web typecheck` — pass.
- [x] `pnpm format:check` на зміненому файлі — pass.
- [ ] Manual smoke: не виконувався (для цього треба запустити web dev-сервер; зміна візуально перевіряється тільки в Routine UI).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/7c38ad5765a64f1992cf79888d22de31
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
