### PR TITLE
fix(design-tokens): замінити хардкодні hex кольори в чартах на design tokens

### DIFF
--- a/apps/web/src/modules/finyk/components/BudgetTrendChart.tsx
+++ b/apps/web/src/modules/finyk/components/BudgetTrendChart.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { chartHex } from "@sergeant/design-tokens/tokens";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -12,7 +13,7 @@ import { cn } from "@shared/lib/cn";
 function BudgetTrendChartComponent({
   dailyData,
   limit,
-  color = "#6366f1",
+  color = chartHex.primary,
   className,
 }) {
   if (!dailyData || dailyData.length === 0) return null;
@@ -94,7 +95,7 @@ function BudgetTrendChartComponent({
             x2={w - padR}
             y1={limitY}
             y2={limitY}
-            stroke="#ef4444"
+            stroke={chartHex.limit}
             strokeWidth="1.2"
             strokeDasharray="4 3"
             opacity="0.7"

--- a/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
+++ b/apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx
@@ -1,4 +1,5 @@
 import { memo, useState } from "react";
+import { chartHex } from "@sergeant/design-tokens/tokens";
 import { cn } from "@shared/lib/cn";
 
 // Convert a polar angle (0° = 12 o'clock, clockwise) to cartesian coordinates.
@@ -89,7 +90,7 @@ function CategoryPieChartComponent({ data = [], size = 160, className }) {
               categoryId: "_other",
               label: "Інше",
               spent: otherSpent,
-              color: "#94a3b8",
+              color: chartHex.neutral,
             },
           ]
         : top;

--- a/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { chartHex } from "@sergeant/design-tokens/tokens";
 import { Card } from "@shared/components/ui/Card";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { cn } from "@shared/lib/cn";
@@ -54,28 +55,28 @@ const MACRO_DEFS = [
   {
     key: "kcal",
     label: "Ккал",
-    color: "#f97316",
+    color: chartHex.kcal,
     prefKey: "dailyTargetKcal",
     unit: "",
   },
   {
     key: "protein_g",
     label: "Білки",
-    color: "#3b82f6",
+    color: chartHex.protein,
     prefKey: "dailyTargetProtein_g",
     unit: "г",
   },
   {
     key: "fat_g",
     label: "Жири",
-    color: "#eab308",
+    color: chartHex.fat,
     prefKey: "dailyTargetFat_g",
     unit: "г",
   },
   {
     key: "carbs_g",
     label: "Вуглев.",
-    color: "#22c55e",
+    color: chartHex.carbs,
     prefKey: "dailyTargetCarbs_g",
     unit: "г",
   },

--- a/apps/web/src/shared/lib/themeHex.ts
+++ b/apps/web/src/shared/lib/themeHex.ts
@@ -1,9 +1,16 @@
 /**
- * Hex для inline-стилів (SVG, body-highlighter), збігаються з tailwind.config.js
- * theme.extend.colors.* (success, danger, warning).
+ * Hex для inline-стилів (SVG, body-highlighter), збігаються з
+ * tailwind.config.js theme.extend.colors.* (success, danger, warning).
+ *
+ * Джерело істини — `@sergeant/design-tokens/tokens` (`statusHex`
+ * дзеркало `statusColors`, які також заведено в Tailwind preset).
+ * Тут лише ре-експорт + звужений web-only зріз (success / danger /
+ * warning) для сумісності з існуючими імпортерами.
  */
+import { statusHex } from "@sergeant/design-tokens/tokens";
+
 export const THEME_HEX = {
-  success: "#16a34a",
-  danger: "#dc2626",
-  warning: "#b45309",
+  success: statusHex.success,
+  danger: statusHex.danger,
+  warning: statusHex.warning,
 } as const;

--- a/packages/design-tokens/tokens.js
+++ b/packages/design-tokens/tokens.js
@@ -131,3 +131,42 @@ export const statusColors = {
   danger: "#ef4444", // red-500
   info: "#0ea5e9", // sky-500
 };
+
+/**
+ * Status colors as a flat hex map — alias of `statusColors` for inline
+ * SVG / canvas / native status-bar call sites that can't consume the
+ * Tailwind `text-success` / `bg-danger` utilities (body-highlighter,
+ * raw `<path stroke>` attrs, etc.). Same values as `statusColors`;
+ * exposed under `statusHex` so web-only code uses one consistent name
+ * across `@shared/lib/themeHex`, chart series and mobile status bar.
+ */
+export const statusHex = {
+  success: statusColors.success,
+  warning: statusColors.warning,
+  danger: statusColors.danger,
+  info: statusColors.info,
+};
+
+/**
+ * Chart hex tokens — semantic names for inline-styled chart primitives
+ * that accept a raw `"#rrggbb"` string (SVG `fill` / `stroke`, canvas
+ * contexts, `style={{ color }}`). Each key maps to exactly one design
+ * intent so callers never reach for raw Tailwind hex values.
+ *
+ *   primary / forecast — default budget trend stroke
+ *   limit              — "over budget" marker line (red-500)
+ *   neutral            — the "Інше" bucket in category donuts (slate-400)
+ *
+ * Macro ring colors (kcal / protein / fat / carbs) live here too so the
+ * Nutrition dashboard matches the mobile ring colors via a single
+ * source of truth.
+ */
+export const chartHex = {
+  primary: "#6366f1", // indigo-500 — budget trend default
+  limit: statusColors.danger, // #ef4444 — over-budget / limit line
+  neutral: "#94a3b8", // slate-400 — "Other" slice / unused category
+  kcal: "#f97316", // orange-500
+  protein: "#3b82f6", // blue-500
+  fat: "#eab308", // yellow-500
+  carbs: "#22c55e", // green-500
+};


### PR DESCRIPTION
## What changed

Централізовано inline hex кольори, які використовували чарти та дашборди, у `@sergeant/design-tokens`:

- `packages/design-tokens/tokens.js`
  - Нові експорти `statusHex` (дзеркало `statusColors`) та `chartHex` (семантичні токени для чарт-примитивів: `primary`, `limit`, `neutral`, `kcal`, `protein`, `fat`, `carbs`).
- `apps/web/src/shared/lib/themeHex.ts`
  - `THEME_HEX.{success,danger,warning}` тепер ре-експорт зі `statusHex`. Значення синхронізовано з Tailwind preset (`success: #10b981` замість старого `#16a34a`, `danger: #ef4444` замість `#dc2626`, `warning: #f59e0b` замість `#b45309`).
- `apps/web/src/modules/finyk/components/analytics/CategoryPieChart.tsx`
  - `"#94a3b8"` для “Інше” слайсу → `chartHex.neutral`.
- `apps/web/src/modules/finyk/components/BudgetTrendChart.tsx`
  - Default line colour `"#6366f1"` → `chartHex.primary`; limit-line `stroke="#ef4444"` → `chartHex.limit`.
- `apps/web/src/modules/nutrition/components/NutritionDashboard.tsx`
  - `MACRO_DEFS` кольори (ккал/білки/жири/вуглеводи) → `chartHex.kcal/protein/fat/carbs`.

`apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx` не змінено: файл був у початковому списку, але `#0d9488` / `#14b8a6` там залишилися лише у коментарі, який пояснює WCAG-контраст `bg-fizruk-strong` vs variant default. У runtime JSX жодного inline `"#hex"` рядка немає, тож нема що замінювати.

## Why

`themeHex.ts` перевизначав статусні кольори, які вже існували в `tokens.js`, але з іншими значеннями (`success: #16a34a` проти `emerald-500 #10b981`). Паралельно чарти передавали inline hex-рядки, не прив'язані до жодного токена, що відривало їх від Tailwind `theme.extend.colors` і ускладнювало узгодження з мобільною версією. Один джерело правди в `@sergeant/design-tokens` прибирає дрейф та полегшує тематизацію.

## How to test

1. `pnpm install && pnpm --filter @sergeant/web typecheck` — має пройти.
2. `pnpm --filter @sergeant/web lint` — має пройти без попереджень.
3. `pnpm --filter @sergeant/web test` — 864/864 tests pass (виконано локально).
4. Візуальна перевірка:
   - Фінік → Analytics: donut з категоріями; коли категорій > 5, слайс “Інше” має `slate-400` колір.
   - Фінік → Overview: Budget trend chart рендерить indigo-500 лінію + червону пунктирну limit-line при перевищенні ліміту.
   - Нутриція → Dashboard: 4 кільця з кольорами (ккал — orange-500, білки — blue-500, жири — yellow-500, вуглеводи — green-500).
   - Fizruk → BodyAtlas: м'язи success/warning/danger мають трохи соковитіші відтінки (emerald/amber/red замість старих green-600/red-600/amber-700 з `themeHex`) — очікувана поведінка, синхронізація з Tailwind.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web test` → 94 test files, 864 tests passed.
- [x] `pnpm --filter @sergeant/web typecheck` → clean.
- [x] `pnpm --filter @sergeant/web lint` → clean.
- [ ] Manual smoke: не виконувалось (лише рендер-константи; візуально підтвердити рекомендується рев'юером).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

Примітка до scope: AGENTS.md забороняє `tokens` scope — використано `design-tokens` (джерело-істини зміни), хоч PR і зачіпає `apps/web/**`. Якщо хочете `fix(web): …` — скажіть, перепишу.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/56ba49933a254b118e9f8af5c13b6386
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
