### PR TITLE
refactor(web): замінити inline rgba() рядки тіней/градієнтів на CSS змінні

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -58,6 +58,39 @@
 
     --shadow-soft: 0 8px 32px rgba(28, 25, 23, 0.12);
 
+    /* Module glow drop-shadows for bottom nav icons (active state). */
+    --shadow-finyk-nav: 0 0 8px rgba(16, 185, 129, 0.3);
+    --shadow-fizruk-nav: 0 0 8px rgba(20, 184, 166, 0.3);
+    --shadow-routine-nav: 0 0 8px rgba(249, 112, 102, 0.3);
+    --shadow-nutrition-nav: 0 0 8px rgba(132, 204, 22, 0.3);
+
+    /* Destructive hover ring (Button variant="destructive"). */
+    --shadow-danger-ring: 0 0 0 3px rgba(239, 68, 68, 0.15);
+
+    /* Dark-mode overlay gradients for module hero Card variants. These are
+       layered on top of `bg-panel` when the theme is dark so the card keeps
+       a faint module tint instead of reading as a neutral warm panel. */
+    --gradient-card-finyk-dark: linear-gradient(
+      135deg,
+      rgba(16, 185, 129, 0.1) 0%,
+      transparent 100%
+    );
+    --gradient-card-fizruk-dark: linear-gradient(
+      135deg,
+      rgba(20, 184, 166, 0.1) 0%,
+      transparent 100%
+    );
+    --gradient-card-routine-dark: linear-gradient(
+      135deg,
+      rgba(249, 112, 102, 0.1) 0%,
+      transparent 100%
+    );
+    --gradient-card-nutrition-dark: linear-gradient(
+      135deg,
+      rgba(146, 204, 23, 0.1) 0%,
+      transparent 100%
+    );
+
     /* Brand accent for focus states */
     --c-accent: 16 185 129; /* emerald-500 */
 

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -48,7 +48,7 @@ const variants: Record<ButtonVariant, string> = {
   danger:
     "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
-    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
+    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-danger-ring active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
 

--- a/apps/web/src/shared/components/ui/Card.tsx
+++ b/apps/web/src/shared/components/ui/Card.tsx
@@ -70,13 +70,13 @@ const variants: Record<CardVariant, string> = {
 
   // Module hero cards — branded surface in light, subtle tinted panel in dark.
   finyk:
-    "rounded-3xl border border-brand-200/50 bg-hero-emerald shadow-card dark:border-brand-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(16,185,129,0.1)_0%,transparent_100%)]",
+    "rounded-3xl border border-brand-200/50 bg-hero-emerald shadow-card dark:border-brand-800/30 dark:bg-panel dark:bg-card-finyk-dark",
   fizruk:
-    "rounded-3xl border border-teal-200/50 bg-hero-teal shadow-card dark:border-teal-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.1)_0%,transparent_100%)]",
+    "rounded-3xl border border-teal-200/50 bg-hero-teal shadow-card dark:border-teal-800/30 dark:bg-panel dark:bg-card-fizruk-dark",
   routine:
-    "rounded-3xl border border-coral-200/50 bg-hero-coral shadow-card dark:border-[rgba(162,51,51,0.3)] dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(249,112,102,0.1)_0%,transparent_100%)]",
+    "rounded-3xl border border-coral-200/50 bg-hero-coral shadow-card dark:border-[rgba(162,51,51,0.3)] dark:bg-panel dark:bg-card-routine-dark",
   nutrition:
-    "rounded-3xl border border-lime-200/50 bg-hero-lime shadow-card dark:border-[rgba(70,98,18,0.3)] dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(146,204,23,0.1)_0%,transparent_100%)]",
+    "rounded-3xl border border-lime-200/50 bg-hero-lime shadow-card dark:border-[rgba(70,98,18,0.3)] dark:bg-panel dark:bg-card-nutrition-dark",
 
   // Soft module cards (less prominent)
   "finyk-soft":

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -59,25 +59,25 @@ const COLORS: Record<ModuleNavColor, ColorTokens> = {
   finyk: {
     text: "text-finyk",
     pill: "bg-gradient-to-r from-brand-400 to-brand-500",
-    glow: "drop-shadow-[0_0_8px_rgba(16,185,129,0.3)]",
+    glow: "drop-shadow-module-nav-finyk",
     badge: "bg-finyk",
   },
   fizruk: {
     text: "text-fizruk",
     pill: "bg-gradient-to-r from-teal-400 to-teal-500",
-    glow: "drop-shadow-[0_0_8px_rgba(20,184,166,0.3)]",
+    glow: "drop-shadow-module-nav-fizruk",
     badge: "bg-fizruk",
   },
   routine: {
     text: "text-routine",
     pill: "bg-gradient-to-r from-coral-400 to-coral-500",
-    glow: "drop-shadow-[0_0_8px_rgba(249,112,102,0.3)]",
+    glow: "drop-shadow-module-nav-routine",
     badge: "bg-routine",
   },
   nutrition: {
     text: "text-nutrition",
     pill: "bg-gradient-to-r from-lime-400 to-lime-500",
-    glow: "drop-shadow-[0_0_8px_rgba(132,204,22,0.3)]",
+    glow: "drop-shadow-module-nav-nutrition",
     badge: "bg-nutrition",
   },
 };

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -200,11 +200,24 @@ const preset = {
         "glow-teal": "0 0 0 3px rgba(20, 184, 166, 0.15)",
         "glow-coral": "0 0 0 3px rgba(249, 112, 102, 0.15)",
         "glow-lime": "0 0 0 3px rgba(146, 204, 23, 0.15)",
+        // Destructive hover ring (Button variant="destructive").
+        "danger-ring": "var(--shadow-danger-ring)",
         // Elevated cards (hover state)
         cardHover:
           "0 2px 4px rgba(13, 23, 38, 0.06), 0 12px 32px rgba(13, 23, 38, 0.12)",
         // Inner shadows for depth
         inner: "inset 0 2px 4px rgba(0, 0, 0, 0.05)",
+      },
+
+      // ═══════════════════════════════════════════════════════════════════
+      // DROP SHADOWS — SVG/icon glows for module bottom-nav active state.
+      // Backed by CSS variables so a token change cascades everywhere.
+      // ═══════════════════════════════════════════════════════════════════
+      dropShadow: {
+        "module-nav-finyk": "var(--shadow-finyk-nav)",
+        "module-nav-fizruk": "var(--shadow-fizruk-nav)",
+        "module-nav-routine": "var(--shadow-routine-nav)",
+        "module-nav-nutrition": "var(--shadow-nutrition-nav)",
       },
 
       // ═══════════════════════════════════════════════════════════════════
@@ -234,6 +247,14 @@ const preset = {
         "card-teal": "linear-gradient(135deg, #f0fdfa 0%, #ffffff 100%)",
         "card-coral": "linear-gradient(135deg, #fff5f3 0%, #ffffff 100%)",
         "card-lime": "linear-gradient(135deg, #f8fee7 0%, #ffffff 100%)",
+
+        // Dark-mode overlays for module hero Card variants. Layered on top
+        // of `bg-panel` so branded cards keep a faint module tint in dark
+        // mode instead of reading as a neutral warm surface.
+        "card-finyk-dark": "var(--gradient-card-finyk-dark)",
+        "card-fizruk-dark": "var(--gradient-card-fizruk-dark)",
+        "card-routine-dark": "var(--gradient-card-routine-dark)",
+        "card-nutrition-dark": "var(--gradient-card-nutrition-dark)",
 
         hero: "linear-gradient(150deg, #fdf9f3 0%, #fefdfb 100%)",
         "hero-g": "linear-gradient(150deg, #f0fdfa 0%, #ffffff 100%)",


### PR DESCRIPTION
## What changed

Виніс «прибиті» inline `rgba()` рядки зі спільних UI-компонентів у CSS змінні (`apps/web/src/index.css`) та іменовані Tailwind утиліти (`packages/design-tokens/tailwind-preset.js`). Тепер ці значення резолвляться через дизайн-токени — зміна кольору чи opacity в одному місці каскадно оновлює всі місця, де ця тінь/градієнт використовується.

**`apps/web/src/index.css`** — нові CSS змінні в `:root`:
- `--shadow-danger-ring` — `0 0 0 3px rgba(239,68,68,0.15)` (hover `Button` destructive)
- `--shadow-finyk-nav` / `--shadow-fizruk-nav` / `--shadow-routine-nav` / `--shadow-nutrition-nav` — `0 0 8px rgba(...,0.3)` module glows для `ModuleBottomNav` active icon
- `--gradient-card-{finyk,fizruk,routine,nutrition}-dark` — dark-mode overlay градієнти для hero-варіантів `Card`

**`packages/design-tokens/tailwind-preset.js`** — розширено:
- `theme.extend.boxShadow["danger-ring"]` → `var(--shadow-danger-ring)`
- `theme.extend.dropShadow["module-nav-*"]` → `var(--shadow-*-nav)` (нова секція — `drop-shadow-*` використовує `filter`, тож не живе в `boxShadow`)
- `theme.extend.backgroundImage["card-*-dark"]` → `var(--gradient-card-*-dark)`

**Компоненти:**
- `apps/web/src/shared/components/ui/Button.tsx` — `hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)]` → `hover:shadow-danger-ring`
- `apps/web/src/shared/components/ui/Card.tsx` — `dark:[background-image:linear-gradient(135deg,rgba(...,0.1)_0%,transparent_100%)]` → `dark:bg-card-{module}-dark` (для всіх 4 module hero варіантів)
- `apps/web/src/shared/components/ui/ModuleBottomNav.tsx` — `drop-shadow-[0_0_8px_rgba(...)]` → `drop-shadow-module-nav-{module}`

Значення (колір, opacity, zoffset) збережені 1:1 — це чистий рефактор без візуальних змін. Два `dark:border-[rgba(...)]` в `Card.tsx` (routine/nutrition) лишив як є — користувач явно позначив скоуп як «рядки 73-79 (dark градієнти)», і це інша категорія токена (border-color, не shadow/gradient).

## Why

Inline `rgba()` рядки в Tailwind arbitrary values — це непрозорі дубліковані магічні числа: токен кольору `brand-500` можна змінити в `tokens.js`, але `rgba(16,185,129,0.1)` у `Card.tsx` цього не помітить. Підхід через CSS-змінні + іменовані Tailwind утиліти узгоджений із рештою дизайн-системи (див. існуючі `--shadow-card`, `--shadow-float` → `boxShadow.card/float`).

Побічний ефект: `dropShadow` тепер має іменовану секцію в preset — наступні модульні glow'и мають куди дописуватись.

## How to test

Візуальна регресія — шукати ідентичний вигляд:

1. `pnpm dev:web` → перемкнути світлу/темну тему.
2. **Dark mode**: відкрити хаб-сторінку, де рендеряться `<Card variant="finyk" />`, `variant="fizruk"`, `routine`, `nutrition` → у темній темі кожна картка має мати ледь-помітний кольоровий overlay-градієнт (той самий 10 % wash, що й раніше).
3. **Button**: будь-де `<Button variant="destructive" />` → hover має давати червоне кільце `0 0 0 3px rgba(239,68,68,0.15)`.
4. **ModuleBottomNav**: відкрити `/фінік`, `/фізрук`, `/рутина`, `/харчування` → активна іконка має світитись module-color glow (той самий `drop-shadow(0 0 8px)`).

---

## How AI-tested this PR

- [x] Manual smoke: N/A — чистий рефактор токенів. Візуально не змінював нічого; значення `rgba()` скопійовані 1:1.
- [x] Vitest passes: `pnpm --filter @sergeant/web test` → **94/94 test files, 530/534 tests passed** (4 `skipped`/`todo` — не пов'язані зі змінами).
- [x] Lint passes: `pnpm --filter @sergeant/web lint` → exit 0.
- [x] Typecheck passes: `pnpm --filter @sergeant/web typecheck` → exit 0.
- [x] Build passes: `pnpm build:web` → exit 0 (попередження про `@import` у `index.css` — попередньо існуюче, не від цього PR).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/09a8ccce02b44ace9ae42a98b9550570
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
