### PR TITLE
fix(mobile): підключити dark-mode семантичні токени у NativeWind конфіг

### DIFF
--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -24,13 +24,15 @@
  *   dropped — RN has no hover state and press feedback is applied via
  *   `Pressable`'s `pressed` callback. Callers that need press feedback
  *   should wrap the Card in their own `Pressable` (or swap to `Button`).
- * - Dark-mode `dark:` modifiers on branded variants are dropped for
- *   now — mobile's semantic dark-mode tokens are not wired up yet
- *   (same caveat as Button.tsx). Branded surfaces render the light
- *   variant only until mobile CSS variables land.
- * - `CardFooter` uses `borderTopWidth: 1` via a NativeWind class; the
- *   web uses `border-t border-line`. Same visual outcome, mobile-safe
- *   class set.
+ * - Dark-mode `dark:` modifiers on branded module variants are still
+ *   dropped — module-branded surfaces render the light variant only
+ *   (same caveat as Button.tsx). Core variants and sub-components
+ *   (`CardTitle`, `CardDescription`, `CardFooter`) now resolve via
+ *   the shared semantic `fg` / `fg-muted` / `line` CSS-variable
+ *   tokens from `@sergeant/design-tokens`, so they re-tint with the
+ *   `:root` ↔ `.dark` palette in `apps/mobile/global.css`.
+ * - `CardFooter` mirrors the web `border-t border-line` divider via
+ *   the same semantic token (no more hardcoded `cream-300`).
  */
 
 import { forwardRef, type ReactNode } from "react";
@@ -176,15 +178,12 @@ export interface CardTitleProps extends Omit<TextProps, "style"> {
 
 /**
  * CardTitle — Title text for cards. Mirrors the web `text-lg font-semibold`
- * treatment; colour falls back to `stone-900` until mobile `text-text`
- * token lands (see TODO above).
+ * treatment; colour resolves through the semantic `fg` token so it
+ * automatically follows the active light/dark palette.
  */
 export function CardTitle({ className, children, ...props }: CardTitleProps) {
   return (
-    <Text
-      className={cx("text-lg font-semibold text-stone-900", className)}
-      {...props}
-    >
+    <Text className={cx("text-lg font-semibold text-fg", className)} {...props}>
       {children}
     </Text>
   );
@@ -204,7 +203,7 @@ export function CardDescription({
   ...props
 }: CardDescriptionProps) {
   return (
-    <Text className={cx("text-sm text-stone-500 mt-1", className)} {...props}>
+    <Text className={cx("text-sm text-fg-muted mt-1", className)} {...props}>
       {children}
     </Text>
   );
@@ -236,15 +235,14 @@ export interface CardFooterProps extends Omit<ViewProps, "style"> {
 }
 
 /**
- * CardFooter — Footer row for actions. Web uses `border-t border-line`;
- * mobile uses a concrete `cream-300` divider until the semantic token
- * is wired up (see TODO in `variantContainer`).
+ * CardFooter — Footer row for actions. Mirrors the web
+ * `border-t border-line` divider through the shared semantic token.
  */
 export function CardFooter({ className, children, ...props }: CardFooterProps) {
   return (
     <View
       className={cx(
-        "flex-row items-center gap-3 mt-4 pt-4 border-t border-cream-300",
+        "flex-row items-center gap-3 mt-4 pt-4 border-t border-line",
         className,
       )}
       {...props}

--- a/apps/mobile/src/components/ui/ConfirmDialog.tsx
+++ b/apps/mobile/src/components/ui/ConfirmDialog.tsx
@@ -123,7 +123,7 @@ export function ConfirmDialog({
           accessibilityLabel={cancelLabel}
           onPress={onCancel}
           testID="confirm-dialog-scrim"
-          className="absolute inset-0 bg-stone-900/40"
+          className="absolute inset-0 bg-fg/40"
         />
 
         {/* Card */}
@@ -133,12 +133,12 @@ export function ConfirmDialog({
           accessibilityLabel={title}
           className="w-full max-w-sm bg-cream-50 border border-cream-300 rounded-3xl p-6 shadow-lg"
         >
-          <Text className="text-[17px] font-bold text-stone-900 mb-2 leading-snug">
+          <Text className="text-[17px] font-bold text-fg mb-2 leading-snug">
             {title}
           </Text>
           {typeof description === "string" ||
           typeof description === "number" ? (
-            <Text className="text-sm text-stone-500 leading-relaxed mb-5">
+            <Text className="text-sm text-fg-muted leading-relaxed mb-5">
               {description}
             </Text>
           ) : description ? (

--- a/apps/mobile/src/components/ui/Input.tsx
+++ b/apps/mobile/src/components/ui/Input.tsx
@@ -232,7 +232,7 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
           setFocused(false);
           onBlur?.(event);
         }}
-        className={cx("flex-1 text-base text-stone-900", className)}
+        className={cx("flex-1 text-base text-fg", className)}
         {...props}
       />
       {suffix ? <View className="ml-2">{suffix}</View> : null}
@@ -304,7 +304,7 @@ export const Textarea = forwardRef<TextInput, TextareaProps>(function Textarea(
           setFocused(false);
           onBlur?.(event);
         }}
-        className={cx("text-base text-stone-900", className)}
+        className={cx("text-base text-fg", className)}
         style={{ minHeight: rows * 20 }}
         {...props}
       />

--- a/apps/mobile/src/components/ui/Sheet.tsx
+++ b/apps/mobile/src/components/ui/Sheet.tsx
@@ -169,11 +169,11 @@ export function Sheet({
             </View>
             <View className="flex-row items-start justify-between gap-3 px-5 pt-1 pb-3">
               <View className="flex-1">
-                <Text className="text-lg font-extrabold text-stone-900 leading-tight">
+                <Text className="text-lg font-extrabold text-fg leading-tight">
                   {title}
                 </Text>
                 {description ? (
-                  <Text className="text-xs text-stone-500 mt-1">
+                  <Text className="text-xs text-fg-muted mt-1">
                     {description}
                   </Text>
                 ) : null}
@@ -186,7 +186,7 @@ export function Sheet({
                 accessibilityLabel={closeLabel}
                 className="bg-cream-100"
               >
-                <Text className="text-stone-500 text-lg font-bold">✕</Text>
+                <Text className="text-fg-muted text-lg font-bold">✕</Text>
               </Button>
             </View>
             <ScrollView

--- a/apps/mobile/src/core/AssistantCataloguePage.tsx
+++ b/apps/mobile/src/core/AssistantCataloguePage.tsx
@@ -153,9 +153,9 @@ export function AssistantCataloguePage({
           accessibilityLabel="Назад"
           testID="assistant-catalogue-back"
         >
-          <Text className="text-stone-700 text-lg">‹</Text>
+          <Text className="text-fg text-lg">‹</Text>
         </Button>
-        <Text className="text-[20px] font-bold text-stone-900">
+        <Text className="text-[20px] font-bold text-fg">
           Можливості асистента
         </Text>
       </View>
@@ -165,7 +165,7 @@ export function AssistantCataloguePage({
         contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 32 }}
         keyboardShouldPersistTaps="handled"
       >
-        <Text className="text-sm text-stone-500 mb-3 leading-snug">
+        <Text className="text-sm text-fg-muted mb-3 leading-snug">
           Усе, що вміє асистент. Тапни картку — побачиш приклади команд та опис.
           Запуск сценаріїв — у HubChat (наразі веб-версія).
         </Text>
@@ -173,13 +173,13 @@ export function AssistantCataloguePage({
         <CapabilityLegend />
 
         <View className="bg-white border border-cream-300 rounded-2xl px-3 py-2 mb-4 flex-row items-center gap-2">
-          <Text className="text-stone-400 text-base">🔍</Text>
+          <Text className="text-fg-subtle text-base">🔍</Text>
           <TextInput
             value={query}
             onChangeText={setQuery}
             placeholder="Пошук — «витрата», «звичка», «1RM»…"
             placeholderTextColor="#a8a29e"
-            className="flex-1 text-sm text-stone-900 py-1"
+            className="flex-1 text-sm text-fg py-1"
             accessibilityLabel="Пошук можливостей"
             testID="assistant-catalogue-search"
             returnKeyType="search"
@@ -199,10 +199,10 @@ export function AssistantCataloguePage({
               testID="catalogue-toggle-all"
               className="flex-row items-center gap-1 px-2.5 py-1 rounded-full active:opacity-70"
             >
-              <Text className="text-stone-500 text-xs">
+              <Text className="text-fg-muted text-xs">
                 {allCollapsed ? "⌄" : "⌃"}
               </Text>
-              <Text className="text-stone-600 text-xs font-semibold">
+              <Text className="text-fg-muted text-xs font-semibold">
                 {allCollapsed ? "Розгорнути все" : "Згорнути все"}
               </Text>
             </Pressable>
@@ -210,7 +210,7 @@ export function AssistantCataloguePage({
         ) : null}
 
         {filtered.length === 0 ? (
-          <Text className="text-center text-stone-500 py-8 text-sm">
+          <Text className="text-center text-fg-muted py-8 text-sm">
             Нічого не знайдено за «{query}». Спробуй інший термін.
           </Text>
         ) : (
@@ -263,13 +263,13 @@ function ModuleGroup({
         testID={`catalogue-module-${module}-toggle`}
         className="flex-row items-center gap-1 mb-2 active:opacity-70"
       >
-        <Text className="text-sm font-bold text-stone-900 flex-1">
+        <Text className="text-sm font-bold text-fg flex-1">
           {MODULE_EMOJI[module]} {meta.title}{" "}
-          <Text className="text-stone-400 font-normal">
+          <Text className="text-fg-subtle font-normal">
             ({capabilities.length})
           </Text>
         </Text>
-        <Text className="text-stone-400 text-base">
+        <Text className="text-fg-subtle text-base">
           {collapsed ? "⌄" : "⌃"}
         </Text>
       </Pressable>
@@ -295,18 +295,18 @@ function CapabilityLegend() {
       accessibilityLabel="Що означають позначки"
       className="bg-white border border-cream-300 rounded-2xl px-3 py-2.5 mb-3 flex-row flex-wrap gap-x-3 gap-y-1.5 items-center"
     >
-      <Text className="text-xs font-semibold text-stone-500">Позначки:</Text>
+      <Text className="text-xs font-semibold text-fg-muted">Позначки:</Text>
       <View className="flex-row items-center gap-1.5">
-        <View className="border border-stone-300 rounded-full px-2 py-0.5">
-          <Text className="text-[10px] font-bold text-stone-700">⚡ ЧІП</Text>
+        <View className="border border-line rounded-full px-2 py-0.5">
+          <Text className="text-[10px] font-bold text-fg">⚡ ЧІП</Text>
         </View>
-        <Text className="text-[11px] text-stone-500">швидкий сценарій</Text>
+        <Text className="text-[11px] text-fg-muted">швидкий сценарій</Text>
       </View>
       <View className="flex-row items-center gap-1.5">
         <View className="border border-amber-400 bg-amber-50 rounded-full px-2 py-0.5">
           <Text className="text-[10px] font-bold text-amber-700">⚠ РИЗИК</Text>
         </View>
-        <Text className="text-[11px] text-stone-500">критична дія</Text>
+        <Text className="text-[11px] text-fg-muted">критична дія</Text>
       </View>
       <View className="flex-row items-center gap-1.5">
         <View className="border border-emerald-400 bg-emerald-50 rounded-full px-2 py-0.5">
@@ -314,7 +314,7 @@ function CapabilityLegend() {
             ✨ НОВИНКА
           </Text>
         </View>
-        <Text className="text-[11px] text-stone-500">нещодавно додано</Text>
+        <Text className="text-[11px] text-fg-muted">нещодавно додано</Text>
       </View>
     </View>
   );
@@ -336,7 +336,7 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
     >
       <Card variant="default" radius="lg" padding="md">
         <View className="flex-row items-start gap-2 flex-wrap">
-          <Text className="text-sm font-semibold text-stone-900 flex-shrink">
+          <Text className="text-sm font-semibold text-fg flex-shrink">
             {capability.label}
           </Text>
           {capability.isNew ? (
@@ -350,10 +350,8 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
             </View>
           ) : null}
           {capability.isQuickAction ? (
-            <View className="border border-stone-300 rounded-full px-2 py-0.5">
-              <Text className="text-[10px] font-bold text-stone-700">
-                ⚡ ЧІП
-              </Text>
+            <View className="border border-line rounded-full px-2 py-0.5">
+              <Text className="text-[10px] font-bold text-fg">⚡ ЧІП</Text>
             </View>
           ) : null}
           {capability.risky ? (
@@ -364,7 +362,7 @@ function CapabilityRow({ capability, onActivate }: CapabilityRowProps) {
             </View>
           ) : null}
         </View>
-        <Text className="text-xs text-stone-500 mt-1 leading-snug">
+        <Text className="text-xs text-fg-muted mt-1 leading-snug">
           {capability.description}
         </Text>
       </Card>
@@ -391,7 +389,7 @@ function CapabilityDetailSheet({
     >
       {cap ? (
         <View className="px-5 py-4 gap-4">
-          <Text className="text-sm text-stone-900">{cap.description}</Text>
+          <Text className="text-sm text-fg">{cap.description}</Text>
 
           {cap.risky ? (
             <View className="border border-amber-400 bg-amber-50 rounded-2xl px-3 py-2">
@@ -403,22 +401,20 @@ function CapabilityDetailSheet({
           ) : null}
 
           <View>
-            <Text className="text-sm font-bold text-stone-900 mb-2">
-              Приклади
-            </Text>
+            <Text className="text-sm font-bold text-fg mb-2">Приклади</Text>
             <View className="gap-1.5">
               {cap.examples.map((ex, i) => (
                 <View
                   key={i}
                   className="border border-cream-300 bg-white rounded-xl px-3 py-2"
                 >
-                  <Text className="text-sm text-stone-900">«{ex}»</Text>
+                  <Text className="text-sm text-fg">«{ex}»</Text>
                 </View>
               ))}
             </View>
           </View>
 
-          <Text className="text-xs text-stone-500 leading-snug">
+          <Text className="text-xs text-fg-muted leading-snug">
             Запуск сценарію відбувається в HubChat. Поки що чат AI-асистента
             доступний у веб-версії — мобільна версія в дорозі.
           </Text>

--- a/apps/mobile/src/core/ErrorBoundary.tsx
+++ b/apps/mobile/src/core/ErrorBoundary.tsx
@@ -29,9 +29,10 @@
  *   via `expo-router` so the user lands on the hub after a crash
  *   (chosen over `DevSettings.reload()` which is dev-only; see PR body
  *   for the trade-off write-up).
- * - NativeWind classes lean on concrete `cream-*` / `stone-*` tokens
- *   until mobile's semantic design-token variables land — same caveat
- *   noted in `Button.tsx` / `Card.tsx`.
+ * - NativeWind classes resolve through the shared semantic
+ *   `fg` / `fg-muted` / `panel` / `line` CSS-variable tokens so the
+ *   fallback re-tints with the active light/dark palette — same
+ *   wiring noted in `Card.tsx`.
  */
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
@@ -60,7 +61,7 @@ function DefaultErrorFallback({ error, resetError }: FallbackProps) {
   return (
     <View className="flex-1 bg-cream-50 items-stretch justify-center p-6">
       <Card variant="default" padding="lg">
-        <Text className="text-lg font-semibold text-stone-900 mb-2">
+        <Text className="text-lg font-semibold text-fg mb-2">
           Щось пішло не так
         </Text>
         <ScrollView className="max-h-40 mb-4">

--- a/apps/mobile/src/core/ModuleErrorBoundary.tsx
+++ b/apps/mobile/src/core/ModuleErrorBoundary.tsx
@@ -31,8 +31,9 @@
  *   The fallback uses a slightly "less aggressive" surface
  *   (`Card padding="lg"`) than the top-level boundary so a module
  *   crash doesn't visually masquerade as a full-app crash.
- * - NativeWind classes lean on concrete `cream-*` / `stone-*` tokens
- *   pending mobile design-token rollout — same caveat as elsewhere.
+ * - NativeWind classes resolve through the shared semantic
+ *   `fg` / `fg-muted` / `panel` / `line` CSS-variable tokens so the
+ *   fallback re-tints with the active light/dark palette.
  */
 
 import { Component, type ReactNode } from "react";
@@ -103,7 +104,7 @@ export default class ModuleErrorBoundary extends Component<
       return (
         <View className="flex-1 bg-cream-50 items-stretch justify-center p-6">
           <Card variant="default" padding="lg">
-            <Text className="text-base font-semibold text-stone-900 mb-2">
+            <Text className="text-base font-semibold text-fg mb-2">
               {title}
             </Text>
             <ScrollView className="max-h-40 mb-4">

--- a/apps/mobile/src/core/OnboardingWizard.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.tsx
@@ -195,9 +195,7 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
           key={i}
           className={cx(
             "rounded-full",
-            i === current
-              ? "h-1.5 w-6 bg-brand-500"
-              : "h-1.5 w-1.5 bg-stone-300",
+            i === current ? "h-1.5 w-6 bg-brand-500" : "h-1.5 w-1.5 bg-line",
           )}
         />
       ))}
@@ -216,17 +214,17 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
         <Text className="text-4xl">✨</Text>
       </View>
       <View className="items-center gap-2">
-        <Text className="text-center text-2xl font-bold text-stone-900">
+        <Text className="text-center text-2xl font-bold text-fg">
           Привіт. Це Sergeant.
         </Text>
-        <Text className="text-center text-sm leading-relaxed text-stone-500">
+        <Text className="text-center text-sm leading-relaxed text-fg-muted">
           Гроші, тіло, звички, їжа — все в одному місці. Офлайн. Приватно.
         </Text>
       </View>
       <View className="flex-row items-center gap-3">
-        <Text className="text-xs text-stone-400">📶 Офлайн</Text>
-        <Text className="text-xs text-stone-400">🔒 Локально</Text>
-        <Text className="text-xs text-stone-400">⚡ ~30 сек</Text>
+        <Text className="text-xs text-fg-subtle">📶 Офлайн</Text>
+        <Text className="text-xs text-fg-subtle">🔒 Локально</Text>
+        <Text className="text-xs text-fg-subtle">⚡ ~30 сек</Text>
       </View>
       <Button
         variant="primary"
@@ -259,10 +257,10 @@ function ModulesStep({
   return (
     <View className="items-center gap-4">
       <View className="items-center gap-1">
-        <Text className="text-center text-xl font-bold text-stone-900">
+        <Text className="text-center text-xl font-bold text-fg">
           Що тобі важливо?
         </Text>
-        <Text className="text-center text-xs text-stone-500">
+        <Text className="text-center text-xs text-fg-muted">
           Обери модулі — решту легко додати потім.
         </Text>
       </View>
@@ -302,13 +300,13 @@ function ModulesStep({
                 <Text className="text-lg">{CHIP_GLYPH[id]}</Text>
               </View>
               <View className="min-w-0 flex-1 pr-4">
-                <Text className="text-sm font-bold leading-tight text-stone-900">
+                <Text className="text-sm font-bold leading-tight text-fg">
                   {DASHBOARD_MODULE_LABELS[id]}
                 </Text>
-                <Text className="mt-0.5 text-xs leading-snug text-stone-500">
+                <Text className="mt-0.5 text-xs leading-snug text-fg-muted">
                   {ONBOARDING_MODULE_DESCRIPTIONS[id]}
                 </Text>
-                <Text className="mt-1 text-[11px] leading-tight text-stone-400">
+                <Text className="mt-1 text-[11px] leading-tight text-fg-subtle">
                   {ONBOARDING_VIBE_TEASERS[id]}
                 </Text>
               </View>
@@ -322,7 +320,7 @@ function ModulesStep({
           className="items-center justify-center rounded-xl px-4 py-3 active:opacity-70"
           testID="onboarding-back-modules"
         >
-          <Text className="text-sm text-stone-500">←</Text>
+          <Text className="text-sm text-fg-muted">←</Text>
         </Pressable>
         <Button
           variant="primary"
@@ -335,7 +333,7 @@ function ModulesStep({
         </Button>
       </View>
       {picks.length === 0 && (
-        <Text className="text-center text-[11px] text-stone-500">
+        <Text className="text-center text-[11px] text-fg-muted">
           Без вибору — всі 4 модулі.
         </Text>
       )}
@@ -373,10 +371,10 @@ function GoalsStep({
   return (
     <View className="items-center gap-4">
       <View className="items-center gap-1">
-        <Text className="text-center text-xl font-bold text-stone-900">
+        <Text className="text-center text-xl font-bold text-fg">
           {hasQuestions ? "Твої цілі" : "Готово!"}
         </Text>
-        <Text className="text-center text-xs text-stone-500">
+        <Text className="text-center text-xs text-fg-muted">
           {hasQuestions
             ? "Необов'язково — можна пропустити."
             : "Налаштуй деталі потім у кожному модулі."}
@@ -391,7 +389,7 @@ function GoalsStep({
               const currentVal = (goals[goalKey] as string | null) ?? null;
               return (
                 <View key={q.id} className="gap-1.5">
-                  <Text className="text-sm font-semibold text-stone-900">
+                  <Text className="text-sm font-semibold text-fg">
                     {q.title}
                   </Text>
                   <View className="flex-row flex-wrap gap-2">
@@ -417,7 +415,7 @@ function GoalsStep({
                             : "border-cream-300 bg-cream-50",
                         )}
                       >
-                        <Text className="text-sm font-medium text-stone-900">
+                        <Text className="text-sm font-medium text-fg">
                           {opt.label}
                         </Text>
                       </Pressable>
@@ -437,7 +435,7 @@ function GoalsStep({
               ];
               return (
                 <View key={q.id} className="gap-1.5">
-                  <Text className="text-sm font-semibold text-stone-900">
+                  <Text className="text-sm font-semibold text-fg">
                     {q.title}
                   </Text>
                   <View className="flex-row flex-wrap gap-2">
@@ -456,7 +454,7 @@ function GoalsStep({
                             : "border-cream-300 bg-cream-50",
                         )}
                       >
-                        <Text className="text-sm font-medium text-stone-900">
+                        <Text className="text-sm font-medium text-fg">
                           {preset.toLocaleString("uk-UA")}
                           {s.unit ? ` ${s.unit}` : ""}
                         </Text>
@@ -477,7 +475,7 @@ function GoalsStep({
           className="items-center justify-center rounded-xl px-4 py-3 active:opacity-70"
           testID="onboarding-back-goals"
         >
-          <Text className="text-sm text-stone-500">←</Text>
+          <Text className="text-sm text-fg-muted">←</Text>
         </Pressable>
         <Button
           variant="primary"

--- a/apps/mobile/src/core/SyncStatusIndicator.tsx
+++ b/apps/mobile/src/core/SyncStatusIndicator.tsx
@@ -207,13 +207,9 @@ export function SyncStatusIndicator({
           style={{ opacity: dotOpacity }}
           className="h-2 w-2 rounded-full bg-amber-500"
         />
-        <Text className="text-xs font-medium text-stone-900">
-          Синхронізація…
-        </Text>
+        <Text className="text-xs font-medium text-fg">Синхронізація…</Text>
         {pending > 0 ? (
-          <Text className="text-xs text-stone-500">
-            {pendingLabel(pending)}
-          </Text>
+          <Text className="text-xs text-fg-muted">{pendingLabel(pending)}</Text>
         ) : null}
       </View>
     );

--- a/apps/mobile/src/core/dashboard/FirstActionHeroCard.tsx
+++ b/apps/mobile/src/core/dashboard/FirstActionHeroCard.tsx
@@ -199,13 +199,13 @@ export function FirstActionHeroCard({
       <View className="flex-row items-start justify-between gap-3">
         <View className="flex-1">
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- intentional FTUX eyebrow, mirrors web FirstActionHeroCard */}
-          <Text className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+          <Text className="text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
             Почнемо
           </Text>
-          <Text className="mt-1 text-base font-bold leading-snug text-stone-900">
+          <Text className="mt-1 text-base font-bold leading-snug text-fg">
             {primary.title}
           </Text>
-          <Text className="mt-1 text-xs leading-relaxed text-stone-500">
+          <Text className="mt-1 text-xs leading-relaxed text-fg-muted">
             {primary.desc}
           </Text>
         </View>
@@ -216,7 +216,7 @@ export function FirstActionHeroCard({
           className="rounded-lg px-2 py-1 active:opacity-60"
           testID="first-action-dismiss"
         >
-          <Text className="text-xs font-medium text-stone-400">Пізніше</Text>
+          <Text className="text-xs font-medium text-fg-subtle">Пізніше</Text>
         </Pressable>
       </View>
 
@@ -239,7 +239,7 @@ export function FirstActionHeroCard({
             className="rounded-lg px-2.5 py-1.5 active:opacity-60"
             testID="first-action-expand"
           >
-            <Text className="text-xs font-medium text-stone-500">
+            <Text className="text-xs font-medium text-fg-muted">
               {expanded ? "Приховати" : "Інший модуль"}
             </Text>
           </Pressable>

--- a/apps/mobile/src/core/dashboard/HubDashboard.tsx
+++ b/apps/mobile/src/core/dashboard/HubDashboard.tsx
@@ -221,12 +221,12 @@ export function HubDashboard() {
       >
         <View className="flex-row items-start justify-between gap-3">
           <View className="flex-1 gap-1">
-            <Text className="text-[26px] font-bold text-stone-900">
+            <Text className="text-[26px] font-bold text-fg">
               Привіт, {greetingName}
             </Text>
             <Text
               accessibilityRole="text"
-              className="text-sm text-stone-500 capitalize"
+              className="text-sm text-fg-muted capitalize"
             >
               {todayLabel}
             </Text>
@@ -269,14 +269,14 @@ export function HubDashboard() {
         </View>
 
         <View className="gap-2">
-          <Text className="text-sm font-semibold text-stone-600">Статус</Text>
+          <Text className="text-sm font-semibold text-fg-muted">Статус</Text>
           <DraggableDashboard
             modules={visibleOrder}
             onReorder={reorderVisible}
             onOpenModule={openModule}
             previews={previews}
           />
-          <Text className="mt-1 text-[11px] leading-snug text-stone-400">
+          <Text className="mt-1 text-[11px] leading-snug text-fg-subtle">
             Утримай і потягни, щоб змінити порядок модулів. Порядок
             синхронізується з вебом.
           </Text>

--- a/apps/mobile/src/core/dashboard/HubInsightsPanel.tsx
+++ b/apps/mobile/src/core/dashboard/HubInsightsPanel.tsx
@@ -114,14 +114,14 @@ const RecRow = memo(function RecRow({
         importantForAccessibility="no-hide-descendants"
       />
       <View className="flex-1 pl-1">
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           {rec.icon ? (
             <Text accessibilityElementsHidden>{`${rec.icon} `}</Text>
           ) : null}
           {rec.title}
         </Text>
         {rec.body ? (
-          <Text className="mt-0.5 text-xs leading-relaxed text-stone-500">
+          <Text className="mt-0.5 text-xs leading-relaxed text-fg-muted">
             {rec.body}
           </Text>
         ) : null}
@@ -133,10 +133,8 @@ const RecRow = memo(function RecRow({
             className="mt-1.5 flex-row items-center gap-1 self-start active:opacity-70"
             testID={testID ? `${testID}-action` : undefined}
           >
-            <Text className="text-xs font-semibold text-stone-900">
-              Відкрити
-            </Text>
-            <Text className="text-xs text-stone-900">›</Text>
+            <Text className="text-xs font-semibold text-fg">Відкрити</Text>
+            <Text className="text-xs text-fg">›</Text>
           </Pressable>
         ) : null}
       </View>
@@ -150,7 +148,7 @@ const RecRow = memo(function RecRow({
           className="shrink-0 -mr-1 -mt-1"
           testID={testID ? `${testID}-dismiss` : undefined}
         >
-          <Text className="text-sm text-stone-500">✕</Text>
+          <Text className="text-sm text-fg-muted">✕</Text>
         </Button>
       ) : null}
     </View>
@@ -225,15 +223,13 @@ export function HubInsightsPanel({
         testID={`${baseTestID}-toggle`}
       >
         <View className="flex-row items-center gap-2">
-          <Text className="text-xs font-semibold text-stone-900">Інсайти</Text>
+          <Text className="text-xs font-semibold text-fg">Інсайти</Text>
           <View className="min-w-[20px] items-center justify-center rounded-full bg-cream-200 px-1.5 py-0.5">
-            <Text className="text-[10px] font-bold text-stone-500">
-              {total}
-            </Text>
+            <Text className="text-[10px] font-bold text-fg-muted">{total}</Text>
           </View>
         </View>
         <Text
-          className="text-sm text-stone-500"
+          className="text-sm text-fg-muted"
           style={{
             transform: [{ rotate: open ? "90deg" : "0deg" }],
           }}

--- a/apps/mobile/src/core/dashboard/SoftAuthPromptCard.tsx
+++ b/apps/mobile/src/core/dashboard/SoftAuthPromptCard.tsx
@@ -105,10 +105,10 @@ export function SoftAuthPromptCard({
           <Text className="text-lg">☁️</Text>
         </View>
         <View className="min-w-0 flex-1">
-          <Text className="text-sm font-semibold text-stone-900">
+          <Text className="text-sm font-semibold text-fg">
             Зберегти на всіх пристроях?
           </Text>
-          <Text className="mt-1 text-xs leading-relaxed text-stone-500">
+          <Text className="mt-1 text-xs leading-relaxed text-fg-muted">
             Акаунт синхронізує твої дані між телефоном і браузером. 20 секунд.
           </Text>
           <View className="mt-3 flex-row items-center gap-2">
@@ -127,7 +127,7 @@ export function SoftAuthPromptCard({
               className="rounded-xl px-3 py-2 active:opacity-60"
               testID="soft-auth-dismiss"
             >
-              <Text className="text-xs text-stone-500">Пізніше</Text>
+              <Text className="text-xs text-fg-muted">Пізніше</Text>
             </Pressable>
           </View>
         </View>

--- a/apps/mobile/src/core/dashboard/StatusRow.tsx
+++ b/apps/mobile/src/core/dashboard/StatusRow.tsx
@@ -86,13 +86,10 @@ export const StatusRow = memo(function StatusRow({
           <Text className="text-xl">{config.glyph}</Text>
         </View>
         <View className="flex-1">
-          <Text
-            className="text-base font-semibold text-stone-900"
-            numberOfLines={1}
-          >
+          <Text className="text-base font-semibold text-fg" numberOfLines={1}>
             {config.label}
           </Text>
-          <Text className="text-xs text-stone-500" numberOfLines={1}>
+          <Text className="text-xs text-fg-muted" numberOfLines={1}>
             {config.description}
           </Text>
           {showProgress ? (
@@ -119,21 +116,18 @@ export const StatusRow = memo(function StatusRow({
             testID={`dashboard-row-${id}-preview`}
           >
             {preview?.main ? (
-              <Text
-                className="text-sm font-semibold text-stone-900"
-                numberOfLines={1}
-              >
+              <Text className="text-sm font-semibold text-fg" numberOfLines={1}>
                 {preview.main}
               </Text>
             ) : null}
             {preview?.sub ? (
-              <Text className="text-[11px] text-stone-500" numberOfLines={1}>
+              <Text className="text-[11px] text-fg-muted" numberOfLines={1}>
                 {preview.sub}
               </Text>
             ) : null}
           </View>
         ) : null}
-        <Text className="text-stone-400 text-lg">›</Text>
+        <Text className="text-fg-subtle text-lg">›</Text>
       </View>
     </Pressable>
   );

--- a/apps/mobile/src/core/dashboard/TodayFocusCard.tsx
+++ b/apps/mobile/src/core/dashboard/TodayFocusCard.tsx
@@ -86,14 +86,14 @@ function EmptyFocus({
     >
       <View className="mb-2 flex-row items-center justify-between">
         {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- intentional narrative eyebrow, mirrors web TodayFocusCard */}
-        <Text className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+        <Text className="text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
           Зараз
         </Text>
       </View>
-      <Text className="text-base font-bold leading-snug text-stone-900">
+      <Text className="text-base font-bold leading-snug text-fg">
         Що зафіксуємо?
       </Text>
-      <Text className="mt-1 text-xs leading-relaxed text-stone-500">
+      <Text className="mt-1 text-xs leading-relaxed text-fg-muted">
         Один тап — один запис. Обери модуль і продовжуй.
       </Text>
       <View className="mt-3 flex-row flex-wrap gap-2">
@@ -164,24 +164,24 @@ export function TodayFocusCard({
       <View className="pl-3">
         <View className="mb-1 flex-row items-center justify-between gap-3">
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- intentional narrative eyebrow, mirrors web TodayFocusCard */}
-          <Text className="text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+          <Text className="text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
             Зараз
           </Text>
         </View>
 
-        <Text className="text-base font-bold leading-snug text-stone-900">
+        <Text className="text-base font-bold leading-snug text-fg">
           {focus.icon ? `${focus.icon} ` : ""}
           {focus.title}
         </Text>
 
         {focus.body ? (
-          <Text className="mt-1 text-xs leading-relaxed text-stone-500">
+          <Text className="mt-1 text-xs leading-relaxed text-fg-muted">
             {focus.body}
           </Text>
         ) : null}
 
         {coachInsight ? (
-          <Text className="mt-2 border-l-2 border-brand-500/40 pl-2 text-xs italic leading-relaxed text-stone-800">
+          <Text className="mt-2 border-l-2 border-brand-500/40 pl-2 text-xs italic leading-relaxed text-fg">
             {coachInsight}
           </Text>
         ) : null}
@@ -210,9 +210,7 @@ export function TodayFocusCard({
               className="ml-auto rounded-lg px-2.5 py-1.5 active:opacity-60"
               testID="today-focus-dismiss"
             >
-              <Text className="text-xs font-medium text-stone-500">
-                Пізніше
-              </Text>
+              <Text className="text-xs font-medium text-fg-muted">Пізніше</Text>
             </Pressable>
           ) : null}
         </View>

--- a/apps/mobile/src/core/dashboard/WeeklyDigestCard.tsx
+++ b/apps/mobile/src/core/dashboard/WeeklyDigestCard.tsx
@@ -76,7 +76,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
       onRequestClose={onClose}
       testID={testID ?? "weekly-digest-card"}
     >
-      <View className="flex-1 bg-stone-900/40 px-4 justify-end">
+      <View className="flex-1 bg-fg/40 px-4 justify-end">
         <Pressable
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
@@ -86,14 +86,14 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
         <Card className="mb-6 max-h-[85%] rounded-3xl bg-cream-50 p-5">
           <ScrollView>
             <View className="gap-2">
-              <Text className="text-sm font-semibold uppercase text-stone-500">
+              <Text className="text-sm font-semibold uppercase text-fg-muted">
                 Тижневий дайджест
               </Text>
-              <Text className="text-xl font-bold text-stone-900">
+              <Text className="text-xl font-bold text-fg">
                 Тиждень {resolvedWeekKey}
               </Text>
               {generatedAt ? (
-                <Text className="text-xs text-stone-500">
+                <Text className="text-xs text-fg-muted">
                   Згенеровано{" "}
                   {generatedAt.toLocaleDateString("uk-UA", {
                     day: "numeric",
@@ -105,7 +105,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
               {showBody && loading ? (
                 <View className="flex-row items-center gap-2 py-4">
                   <ActivityIndicator size="small" color="#0d9488" />
-                  <Text className="text-xs text-stone-500">Генерую звіт…</Text>
+                  <Text className="text-xs text-fg-muted">Генерую звіт…</Text>
                 </View>
               ) : null}
 
@@ -116,7 +116,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
                   </Text>
                   {isCurrentWeek ? (
                     <Button variant="secondary" onPress={onGenerate}>
-                      <Text className="text-sm font-semibold text-stone-900">
+                      <Text className="text-sm font-semibold text-fg">
                         Спробувати знову
                       </Text>
                     </Button>
@@ -126,7 +126,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
 
               {showBody && !hasData && !loading && !error && isCurrentWeek ? (
                 <View className="gap-2 py-1">
-                  <Text className="text-xs leading-relaxed text-stone-500">
+                  <Text className="text-xs leading-relaxed text-fg-muted">
                     AI-звіт підсумовує прогрес по всіх модулях і дає
                     рекомендації на тиждень.
                   </Text>
@@ -147,18 +147,18 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
                     return (
                       <View
                         key={key}
-                        className="mt-1 rounded-xl border border-stone-200 bg-white/80 p-2.5"
+                        className="mt-1 rounded-xl border border-line bg-white/80 p-2.5"
                       >
-                        <Text className="text-xs font-semibold text-stone-800">
+                        <Text className="text-xs font-semibold text-fg">
                           {MODULE_LABEL[key]}
                         </Text>
                         {typeof summary === "string" && summary ? (
-                          <Text className="text-xs text-stone-600">
+                          <Text className="text-xs text-fg-muted">
                             {summary}
                           </Text>
                         ) : null}
                         {typeof comment === "string" && comment ? (
-                          <Text className="mt-0.5 text-xs leading-relaxed text-stone-500">
+                          <Text className="mt-0.5 text-xs leading-relaxed text-fg-muted">
                             {comment}
                           </Text>
                         ) : null}
@@ -169,7 +169,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
                               typeof rec === "string" ? (
                                 <Text
                                   key={i}
-                                  className="text-xs leading-snug text-stone-700"
+                                  className="text-xs leading-snug text-fg"
                                 >
                                   → {rec}
                                 </Text>
@@ -200,7 +200,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
                     (digest as Record<string, unknown>)
                       .overallRecommendations as string[]
                   ).map((rec, i) => (
-                    <Text key={i} className="text-xs text-stone-800">
+                    <Text key={i} className="text-xs text-fg">
                       ★ {rec}
                     </Text>
                   ))}
@@ -208,7 +208,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
               ) : null}
 
               {showBody && !hasData && !isCurrentWeek && !loading && !error ? (
-                <Text className="text-xs text-stone-500">
+                <Text className="text-xs text-fg-muted">
                   За цей тиждень звіт у кеші не знайдено.
                 </Text>
               ) : null}
@@ -219,9 +219,7 @@ export const WeeklyDigestCard = memo(function WeeklyDigestCard({
                 className="mt-4 self-end"
                 testID={testID ? `${testID}-close` : "weekly-digest-card-close"}
               >
-                <Text className="text-sm font-semibold text-stone-900">
-                  Закрити
-                </Text>
+                <Text className="text-sm font-semibold text-fg">Закрити</Text>
               </Button>
             </View>
           </ScrollView>

--- a/apps/mobile/src/core/dashboard/WeeklyDigestFooter.tsx
+++ b/apps/mobile/src/core/dashboard/WeeklyDigestFooter.tsx
@@ -74,10 +74,10 @@ export const WeeklyDigestFooter = memo(function WeeklyDigestFooter({
             testID="weekly-digest-footer-fresh-dot"
           />
         ) : null}
-        <Text className="text-xs font-medium text-stone-500">
+        <Text className="text-xs font-medium text-fg-muted">
           Тижневий дайджест
         </Text>
-        <Text className="text-xs text-stone-400">›</Text>
+        <Text className="text-xs text-fg-subtle">›</Text>
       </Pressable>
       <WeeklyDigestCard open={open} onClose={handleClose} />
     </View>

--- a/apps/mobile/src/core/onboarding/ModuleChecklist.tsx
+++ b/apps/mobile/src/core/onboarding/ModuleChecklist.tsx
@@ -97,9 +97,9 @@ export function ModuleChecklist({
   return (
     <View className="rounded-2xl border border-cream-200 bg-cream-50 p-4">
       <View className="mb-3 flex-row items-center justify-between">
-        <Text className="text-sm font-bold text-stone-900">
+        <Text className="text-sm font-bold text-fg">
           {def.title}{" "}
-          <Text className="text-xs font-normal text-stone-400">
+          <Text className="text-xs font-normal text-fg-subtle">
             ({completed}/{total})
           </Text>
         </Text>
@@ -108,7 +108,7 @@ export function ModuleChecklist({
           hitSlop={12}
           accessibilityLabel="Сховати чекліст"
         >
-          <Text className="text-xs text-stone-400">✕</Text>
+          <Text className="text-xs text-fg-subtle">✕</Text>
         </Pressable>
       </View>
 
@@ -145,13 +145,13 @@ export function ModuleChecklist({
               <Text
                 className={cx(
                   "flex-1 text-sm",
-                  done ? "text-stone-400 line-through" : "text-stone-900",
+                  done ? "text-fg-subtle line-through" : "text-fg",
                 )}
               >
                 {step.label}
               </Text>
               {!done && step.action && (
-                <Text className="text-xs text-stone-400">›</Text>
+                <Text className="text-xs text-fg-subtle">›</Text>
               )}
             </Pressable>
           );

--- a/apps/mobile/src/core/onboarding/SplashStep.tsx
+++ b/apps/mobile/src/core/onboarding/SplashStep.tsx
@@ -36,10 +36,10 @@ export function SplashStep({ picks, togglePick, onContinue }: SplashStepProps) {
         <Text className="text-4xl">✨</Text>
       </View>
       <View className="items-center">
-        <Text className="text-center text-2xl font-bold text-stone-900">
+        <Text className="text-center text-2xl font-bold text-fg">
           Твоє життя — один екран.
         </Text>
-        <Text className="mt-2 text-center text-sm leading-relaxed text-stone-500">
+        <Text className="mt-2 text-center text-sm leading-relaxed text-fg-muted">
           Гроші, тіло, звички, їжа. Офлайн. ~5 секунд на перший запис.
         </Text>
       </View>
@@ -55,12 +55,12 @@ export function SplashStep({ picks, togglePick, onContinue }: SplashStepProps) {
           Заповни мій хаб
         </Button>
         {!hasPicks ? (
-          <Text className="text-center text-[11px] text-stone-500">
+          <Text className="text-center text-[11px] text-fg-muted">
             Без вибору — всі 4 модулі. Налаштуєш потім.
           </Text>
         ) : null}
       </View>
-      <Text className="text-center text-[11px] leading-relaxed text-stone-400">
+      <Text className="text-center text-[11px] leading-relaxed text-fg-subtle">
         Усе локально. Синхрон — коли сам захочеш.
       </Text>
     </View>

--- a/apps/mobile/src/core/onboarding/VibeChipRow.tsx
+++ b/apps/mobile/src/core/onboarding/VibeChipRow.tsx
@@ -46,7 +46,7 @@ function cx(...classes: Array<string | false | null | undefined>): string {
 export function VibeChipRow({ picks, togglePick }: VibeChipRowProps) {
   return (
     <View className="w-full gap-2">
-      <Text className="text-center text-[11px] text-stone-500">
+      <Text className="text-center text-[11px] text-fg-muted">
         Зніми зайве — решту легко додати потім.
       </Text>
       <View className="flex-row flex-wrap gap-2">
@@ -82,13 +82,13 @@ export function VibeChipRow({ picks, togglePick }: VibeChipRowProps) {
               <View className="min-w-0 flex-1">
                 <Text
                   numberOfLines={1}
-                  className="text-sm font-semibold leading-tight text-stone-900"
+                  className="text-sm font-semibold leading-tight text-fg"
                 >
                   {DASHBOARD_MODULE_LABELS[id]}
                 </Text>
                 <Text
                   numberOfLines={1}
-                  className="text-[11px] leading-tight text-stone-500"
+                  className="text-[11px] leading-tight text-fg-muted"
                 >
                   {ONBOARDING_VIBE_TEASERS[id]}
                 </Text>

--- a/apps/mobile/src/core/settings/AIDigestSection.tsx
+++ b/apps/mobile/src/core/settings/AIDigestSection.tsx
@@ -64,17 +64,15 @@ export function AIDigestSection() {
 
   return (
     <SettingsGroup title="AI Звіт тижня" emoji="📋">
-      <Text className="text-xs text-stone-500 leading-snug">
+      <Text className="text-xs text-fg-muted leading-snug">
         Тижневий AI-аналіз прогресу по всіх модулях: фінанси, тренування,
         харчування та звички. Звіт доступний на дашборді щопонеділка або за
         запитом.
       </Text>
       <Card variant="flat" radius="md" padding="md">
-        <Text className="text-xs font-semibold text-stone-900">
-          Поточний тиждень
-        </Text>
+        <Text className="text-xs font-semibold text-fg">Поточний тиждень</Text>
         <Text
-          className="text-xs text-stone-500 mt-0.5"
+          className="text-xs text-fg-muted mt-0.5"
           testID="aidigest-week-range"
         >
           {weekRange}
@@ -91,7 +89,7 @@ export function AIDigestSection() {
           onPress={onGenerate}
           testID="aidigest-generate-now"
         >
-          <Text className="text-sm font-semibold text-stone-900">
+          <Text className="text-sm font-semibold text-fg">
             Згенерувати дайджест зараз
           </Text>
         </Button>

--- a/apps/mobile/src/core/settings/AccountSection.tsx
+++ b/apps/mobile/src/core/settings/AccountSection.tsx
@@ -47,12 +47,12 @@ function DevPushTestButton() {
         className="items-center rounded-xl border border-cream-300 bg-cream-50 px-4 py-3 active:opacity-80"
         testID="account-dev-push-test"
       >
-        <Text className="text-sm font-semibold text-stone-700">
+        <Text className="text-sm font-semibold text-fg">
           {pushTest.isPending ? "Надсилаю…" : "DEV: надіслати тестовий пуш"}
         </Text>
       </Pressable>
       <View>
-        <Text className="text-[11px] leading-snug text-stone-400">
+        <Text className="text-[11px] leading-snug text-fg-subtle">
           Видно лише у dev-збірках. Використовується для швидкої перевірки
           push-пайплайна без виходу з дашборду.
         </Text>

--- a/apps/mobile/src/core/settings/AssistantCatalogueSection.tsx
+++ b/apps/mobile/src/core/settings/AssistantCatalogueSection.tsx
@@ -24,7 +24,7 @@ import { SettingsGroup } from "./SettingsPrimitives";
 export function AssistantCatalogueSection() {
   return (
     <SettingsGroup title="Можливості асистента" emoji="✨">
-      <Text className="text-xs text-stone-500 leading-snug">
+      <Text className="text-xs text-fg-muted leading-snug">
         ~60+ інструментів, які може запустити AI-асистент: фінанси, тренування,
         звички, харчування, аналітика, утиліти, пам&apos;ять. Тапни — побачиш
         приклади команд.

--- a/apps/mobile/src/core/settings/FinykSection.tsx
+++ b/apps/mobile/src/core/settings/FinykSection.tsx
@@ -61,7 +61,7 @@ function makeCategoryId(): string {
 function DeferredNotice({ children }: { children: string }) {
   return (
     <Card variant="flat" radius="md" padding="md" className="border-dashed">
-      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+      <Text className="text-xs text-fg-muted leading-snug">{children}</Text>
     </Card>
   );
 }
@@ -117,7 +117,7 @@ export function FinykSection() {
       />
 
       <SettingsSubGroup title="Власні категорії витрат">
-        <Text className="text-xs text-stone-500 leading-snug">
+        <Text className="text-xs text-fg-muted leading-snug">
           Додаються до списку категорій у транзакціях, сплітах і лімітах (можна
           вказати емодзі на початку назви).
         </Text>
@@ -156,7 +156,7 @@ export function FinykSection() {
                 testID={`finyk-custom-cat-row-${item.id}`}
               >
                 <Text
-                  className="text-sm font-medium text-stone-900 flex-1 min-w-0"
+                  className="text-sm font-medium text-fg flex-1 min-w-0"
                   numberOfLines={1}
                 >
                   {item.label}
@@ -176,7 +176,7 @@ export function FinykSection() {
             )}
           />
         ) : (
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             Поки немає власних категорій.
           </Text>
         )}

--- a/apps/mobile/src/core/settings/FizrukSection.tsx
+++ b/apps/mobile/src/core/settings/FizrukSection.tsx
@@ -51,7 +51,7 @@ function cx(...classes: Array<string | false | null | undefined>): string {
 function DeferredNotice({ children }: { children: string }) {
   return (
     <Card variant="flat" radius="md" padding="md" className="border-dashed">
-      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+      <Text className="text-xs text-fg-muted leading-snug">{children}</Text>
     </Card>
   );
 }
@@ -74,7 +74,7 @@ export function FizrukSection() {
   return (
     <SettingsGroup title="Фізрук" emoji="🏋️">
       <SettingsSubGroup title="Таймер відпочинку">
-        <Text className="text-xs text-stone-500 leading-snug">
+        <Text className="text-xs text-fg-muted leading-snug">
           Рекомендований час відпочинку підбирається автоматично за типом
           вправи. Ці значення з&apos;являться як кнопка за замовчуванням у
           кожній вправі.
@@ -86,9 +86,7 @@ export function FizrukSection() {
               className="flex-row items-center gap-3"
               testID={`fizruk-rest-row-${cat}`}
             >
-              <Text className="text-xs text-stone-900 flex-1 min-w-0">
-                {label}
-              </Text>
+              <Text className="text-xs text-fg flex-1 min-w-0">{label}</Text>
               <View className="flex-row items-center gap-1 flex-wrap justify-end">
                 {REST_PRESETS.map((sec) => {
                   const selected = resolved[cat] === sec;
@@ -112,7 +110,7 @@ export function FizrukSection() {
                       <Text
                         className={cx(
                           "text-xs font-semibold",
-                          selected ? "text-brand-700" : "text-stone-500",
+                          selected ? "text-brand-700" : "text-fg-muted",
                         )}
                       >
                         {sec}с

--- a/apps/mobile/src/core/settings/GeneralSection.tsx
+++ b/apps/mobile/src/core/settings/GeneralSection.tsx
@@ -105,7 +105,7 @@ const mmkvStore: KVStore = {
 function DeferredNotice({ children }: { children: string }) {
   return (
     <Card variant="flat" radius="md" padding="md" className="border-dashed">
-      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+      <Text className="text-xs text-fg-muted leading-snug">{children}</Text>
     </Card>
   );
 }
@@ -134,10 +134,10 @@ function ModuleReorderList() {
               isFirst ? "" : "border-t border-cream-300"
             }`}
           >
-            <Text className="w-4 text-xs font-semibold text-stone-500 tabular-nums">
+            <Text className="w-4 text-xs font-semibold text-fg-muted tabular-nums">
               {index + 1}
             </Text>
-            <Text className="flex-1 text-sm text-stone-900" numberOfLines={1}>
+            <Text className="flex-1 text-sm text-fg" numberOfLines={1}>
               {label}
             </Text>
             <Pressable
@@ -151,7 +151,7 @@ function ModuleReorderList() {
               }`}
               testID={`dashboard-reorder-up-${id}`}
             >
-              <Text className="text-sm text-stone-600">▲</Text>
+              <Text className="text-sm text-fg-muted">▲</Text>
             </Pressable>
             <Pressable
               accessibilityRole="button"
@@ -164,7 +164,7 @@ function ModuleReorderList() {
               }`}
               testID={`dashboard-reorder-down-${id}`}
             >
-              <Text className="text-sm text-stone-600">▼</Text>
+              <Text className="text-sm text-fg-muted">▼</Text>
             </Pressable>
           </View>
         );
@@ -212,7 +212,7 @@ export function GeneralSection() {
         />
       </SettingsSubGroup>
       <SettingsSubGroup title="Онбординг">
-        <Text className="text-xs text-stone-500 leading-snug">
+        <Text className="text-xs text-fg-muted leading-snug">
           Перезапуск не видаляє твої дані — лише повертає вітальний екран та
           підказки першого запуску.
         </Text>
@@ -246,7 +246,7 @@ export function GeneralSection() {
         </DeferredNotice>
       </SettingsSubGroup>
       <View className="gap-1">
-        <Text className="text-[11px] text-stone-400 leading-snug">
+        <Text className="text-[11px] text-fg-subtle leading-snug">
           Решта опцій цього блоку (push/pull хмари, backup) портується разом із
           відповідними інфраструктурними кроками — див. примітки у кожній
           під-групі вище.

--- a/apps/mobile/src/core/settings/HubSettingsPage.tsx
+++ b/apps/mobile/src/core/settings/HubSettingsPage.tsx
@@ -48,9 +48,7 @@ export function HubSettingsPage() {
         contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 12 }}
         keyboardShouldPersistTaps="handled"
       >
-        <Text className="text-[22px] font-bold text-stone-900 mb-1">
-          Налаштування
-        </Text>
+        <Text className="text-[22px] font-bold text-fg mb-1">Налаштування</Text>
 
         <GeneralSection />
         <NotificationsSection />

--- a/apps/mobile/src/core/settings/NotificationsSection.tsx
+++ b/apps/mobile/src/core/settings/NotificationsSection.tsx
@@ -85,7 +85,7 @@ interface RoutinePrefs {
 function DeferredNotice({ children }: { children: string }) {
   return (
     <Card variant="flat" radius="md" padding="md" className="border-dashed">
-      <Text className="text-xs text-stone-500 leading-snug">{children}</Text>
+      <Text className="text-xs text-fg-muted leading-snug">{children}</Text>
     </Card>
   );
 }
@@ -150,7 +150,7 @@ export function NotificationsSection() {
       <Card variant="flat" radius="md" padding="md">
         <View className="flex-row items-center justify-between gap-3">
           <View className="flex-1 min-w-0">
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Push-сповіщення
             </Text>
             <Text
@@ -181,7 +181,7 @@ export function NotificationsSection() {
           ) : null}
         </View>
         {permStatus === "denied" ? (
-          <Text className="text-xs text-stone-500 mt-2 leading-snug">
+          <Text className="text-xs text-fg-muted mt-2 leading-snug">
             Сповіщення заблоковано у системних налаштуваннях. Увімкни їх там,
             щоб отримувати нагадування.
           </Text>

--- a/apps/mobile/src/core/settings/SettingsPrimitives.tsx
+++ b/apps/mobile/src/core/settings/SettingsPrimitives.tsx
@@ -62,14 +62,11 @@ export function SettingsGroup({
       >
         <View className="flex-row items-center gap-2 flex-1 min-w-0">
           {emoji ? <Text className="text-base">{emoji}</Text> : null}
-          <Text
-            className="text-sm font-semibold text-stone-900"
-            numberOfLines={1}
-          >
+          <Text className="text-sm font-semibold text-fg" numberOfLines={1}>
             {title}
           </Text>
         </View>
-        <Text className="text-stone-500 text-base">{open ? "▾" : "▸"}</Text>
+        <Text className="text-fg-muted text-base">{open ? "▾" : "▸"}</Text>
       </Pressable>
       {open ? (
         <View className="border-t border-cream-300 p-4 gap-5">{children}</View>
@@ -98,13 +95,13 @@ export function ToggleRow({
     <View className="flex-row items-start justify-between gap-3">
       <View className="flex-1 min-w-0">
         {typeof label === "string" ? (
-          <Text className="text-sm text-stone-900">{label}</Text>
+          <Text className="text-sm text-fg">{label}</Text>
         ) : (
           label
         )}
         {description ? (
           typeof description === "string" ? (
-            <Text className={cx("text-xs text-stone-500 mt-0.5 leading-snug")}>
+            <Text className={cx("text-xs text-fg-muted mt-0.5 leading-snug")}>
               {description}
             </Text>
           ) : (
@@ -136,7 +133,7 @@ export function SettingsSubGroup({ title, children }: SettingsSubGroupProps) {
   return (
     <View className="gap-3">
       {title ? (
-        <Text className="text-xs font-semibold text-stone-500">{title}</Text>
+        <Text className="text-xs font-semibold text-fg-muted">{title}</Text>
       ) : null}
       <View className="gap-3">{children}</View>
     </View>

--- a/apps/mobile/src/modules/finyk/components/CategoryPickerSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/CategoryPickerSheet.tsx
@@ -75,7 +75,7 @@ export function CategoryPickerSheet({
           testID={`${testID}-clear`}
           className="flex-row items-center px-3 py-3 rounded-xl bg-cream-100 active:opacity-70"
         >
-          <Text className="text-stone-500 text-sm flex-1">↺ Скинути</Text>
+          <Text className="text-fg-muted text-sm flex-1">↺ Скинути</Text>
           {selectedId == null && (
             <Text className="text-brand-500 text-base">✓</Text>
           )}
@@ -99,7 +99,7 @@ export function CategoryPickerSheet({
                 className={
                   selected
                     ? "text-brand-700 text-sm font-semibold flex-1"
-                    : "text-stone-900 text-sm flex-1"
+                    : "text-fg text-sm flex-1"
                 }
               >
                 {opt.label}

--- a/apps/mobile/src/modules/finyk/components/FinykNavGrid.tsx
+++ b/apps/mobile/src/modules/finyk/components/FinykNavGrid.tsx
@@ -30,10 +30,8 @@ function NavCard({ entry }: { entry: NavEntry }) {
       className="flex-1 min-w-[46%] rounded-2xl border border-cream-300 bg-cream-50 p-4 active:opacity-80"
     >
       <Text className="text-2xl mb-2">{entry.emoji}</Text>
-      <Text className="text-sm font-semibold text-stone-900">
-        {entry.label}
-      </Text>
-      <Text className="text-xs text-stone-500 mt-1" numberOfLines={2}>
+      <Text className="text-sm font-semibold text-fg">{entry.label}</Text>
+      <Text className="text-xs text-fg-muted mt-1" numberOfLines={2}>
         {entry.description}
       </Text>
     </Pressable>

--- a/apps/mobile/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -240,9 +240,7 @@ export function ManualExpenseSheet({
     >
       <View className="px-4 pb-4" testID={testID}>
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Сума ₴
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Сума ₴</Text>
           <Input
             value={amount}
             onChangeText={(v) => {
@@ -261,9 +259,7 @@ export function ManualExpenseSheet({
         </View>
 
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Категорія
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Категорія</Text>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -293,7 +289,7 @@ export function ManualExpenseSheet({
                     className={
                       selected
                         ? "text-white text-sm font-medium"
-                        : "text-stone-700 text-sm font-medium"
+                        : "text-fg text-sm font-medium"
                     }
                   >
                     {c}
@@ -305,7 +301,7 @@ export function ManualExpenseSheet({
         </View>
 
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">Опис</Text>
+          <Text className="text-sm font-medium text-fg mb-1">Опис</Text>
           <Input
             value={description}
             onChangeText={setDescription}
@@ -316,7 +312,7 @@ export function ManualExpenseSheet({
         </View>
 
         <View className="mb-2">
-          <Text className="text-sm font-medium text-stone-700 mb-1">Дата</Text>
+          <Text className="text-sm font-medium text-fg mb-1">Дата</Text>
           <Input
             value={date}
             onChangeText={setDate}

--- a/apps/mobile/src/modules/finyk/components/TxListItem.tsx
+++ b/apps/mobile/src/modules/finyk/components/TxListItem.tsx
@@ -87,13 +87,13 @@ function TxListItemImpl({
     ? "bg-danger"
     : canSwipeUnhide
       ? "bg-brand-500"
-      : "bg-stone-500";
+      : "bg-fg-muted";
 
   const hasSwipe = canSwipeDelete || canSwipeHide || canSwipeUnhide;
   const hasPress = isManual && !!onPressManual;
 
   return (
-    <View className={rowIndex % 2 === 1 ? "bg-stone-100/40" : ""}>
+    <View className={rowIndex % 2 === 1 ? "bg-panel-hi/40" : ""}>
       <SwipeToAction
         onSwipeLeft={hasSwipe ? onSwipeLeft : undefined}
         leftLabel={swipeLabel}

--- a/apps/mobile/src/modules/finyk/components/TxRow.tsx
+++ b/apps/mobile/src/modules/finyk/components/TxRow.tsx
@@ -157,26 +157,24 @@ function TxRowImpl({
           <Text
             numberOfLines={1}
             className={cx(
-              "text-sm font-medium text-stone-900",
+              "text-sm font-medium text-fg",
               hidden && "line-through",
             )}
           >
             {tx.description || "Транзакція"}
           </Text>
           <View className="flex-row flex-wrap items-center mt-0.5">
-            <Text className="text-xs text-stone-500 mr-1.5">{catName}</Text>
+            <Text className="text-xs text-fg-muted mr-1.5">{catName}</Text>
             {cat.id === INTERNAL_TRANSFER_ID && (
-              <View className="bg-stone-200 rounded-full px-1.5 py-0.5 mr-1.5">
-                <Text className="text-[10px] font-semibold text-stone-700">
+              <View className="bg-panel-hi rounded-full px-1.5 py-0.5 mr-1.5">
+                <Text className="text-[10px] font-semibold text-fg">
                   не в статистиці
                 </Text>
               </View>
             )}
             {overrideCatId && cat.id !== INTERNAL_TRANSFER_ID && (
-              <View className="bg-stone-200 rounded-full px-1.5 py-0.5 mr-1.5">
-                <Text className="text-[10px] font-semibold text-stone-700">
-                  змін.
-                </Text>
+              <View className="bg-panel-hi rounded-full px-1.5 py-0.5 mr-1.5">
+                <Text className="text-[10px] font-semibold text-fg">змін.</Text>
               </View>
             )}
             {hasSplit && (
@@ -194,7 +192,7 @@ function TxRowImpl({
               </View>
             )}
             {!isCreditCard && accountName && (
-              <Text className="text-[10px] text-stone-400 mr-1.5">
+              <Text className="text-[10px] text-fg-subtle mr-1.5">
                 {accountName}
               </Text>
             )}
@@ -205,7 +203,7 @@ function TxRowImpl({
                 </Text>
               </View>
             )}
-            <Text className="text-xs text-stone-500">· {fmtDate(tx.time)}</Text>
+            <Text className="text-xs text-fg-muted">· {fmtDate(tx.time)}</Text>
           </View>
         </View>
       </View>
@@ -214,7 +212,7 @@ function TxRowImpl({
         <Text
           className={cx(
             "text-sm font-semibold",
-            tx.amount > 0 ? "text-brand-700" : "text-stone-900",
+            tx.amount > 0 ? "text-brand-700" : "text-fg",
           )}
           style={{ fontVariant: ["tabular-nums"] }}
         >
@@ -222,7 +220,7 @@ function TxRowImpl({
         </Text>
         {tx.currencyCode !== CURRENCY.UAH && tx.operationAmount && (
           <Text
-            className="text-[10px] text-stone-400"
+            className="text-[10px] text-fg-subtle"
             style={{ fontVariant: ["tabular-nums"] }}
           >
             {hideAmount ? "••••" : fmtAmt(tx.operationAmount, tx.currencyCode)}

--- a/apps/mobile/src/modules/finyk/components/assets/DebtSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/DebtSheet.tsx
@@ -141,7 +141,7 @@ export function DebtSheet({
     >
       <View className="gap-3">
         <View>
-          <Text className="text-xs font-medium text-stone-700 mb-1">Назва</Text>
+          <Text className="text-xs font-medium text-fg mb-1">Назва</Text>
           <Input
             placeholder="Кому / за що"
             value={draft.name}
@@ -152,9 +152,7 @@ export function DebtSheet({
         </View>
         <View className="flex-row gap-3">
           <View className="w-24">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Емодзі
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Емодзі</Text>
             <Input
               value={draft.emoji}
               onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
@@ -163,9 +161,7 @@ export function DebtSheet({
             />
           </View>
           <View className="flex-1">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Сума, ₴
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Сума, ₴</Text>
             <Input
               placeholder="0"
               type="number"
@@ -177,9 +173,7 @@ export function DebtSheet({
           </View>
         </View>
         <View>
-          <Text className="text-xs font-medium text-stone-700 mb-1">
-            Нотатка
-          </Text>
+          <Text className="text-xs font-medium text-fg mb-1">Нотатка</Text>
           <Input
             placeholder="Необов'язково"
             value={draft.note}

--- a/apps/mobile/src/modules/finyk/components/assets/ManualAssetSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/ManualAssetSheet.tsx
@@ -141,7 +141,7 @@ export function ManualAssetSheet({
       <View className="gap-3">
         <View>
           <Text
-            className="text-xs font-medium text-stone-700 mb-1"
+            className="text-xs font-medium text-fg mb-1"
             nativeID={testID ? `${testID}-name-label` : undefined}
           >
             Назва
@@ -157,9 +157,7 @@ export function ManualAssetSheet({
         </View>
         <View className="flex-row gap-3">
           <View className="w-24">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Емодзі
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Емодзі</Text>
             <Input
               value={draft.emoji}
               onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
@@ -168,9 +166,7 @@ export function ManualAssetSheet({
             />
           </View>
           <View className="flex-1">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Сума
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Сума</Text>
             <Input
               placeholder="0"
               type="number"
@@ -182,9 +178,7 @@ export function ManualAssetSheet({
           </View>
         </View>
         <View>
-          <Text className="text-xs font-medium text-stone-700 mb-1">
-            Валюта
-          </Text>
+          <Text className="text-xs font-medium text-fg mb-1">Валюта</Text>
           <View className="flex-row gap-2">
             {(["UAH", "USD", "EUR"] as const).map((c) => {
               const active = draft.currency === c;
@@ -205,7 +199,7 @@ export function ManualAssetSheet({
                     className={
                       active
                         ? "text-sm font-medium text-white"
-                        : "text-sm font-medium text-stone-700"
+                        : "text-sm font-medium text-fg"
                     }
                   >
                     {c}

--- a/apps/mobile/src/modules/finyk/components/assets/ReceivableSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/ReceivableSheet.tsx
@@ -139,9 +139,7 @@ export function ReceivableSheet({
     >
       <View className="gap-3">
         <View>
-          <Text className="text-xs font-medium text-stone-700 mb-1">
-            Хто винен
-          </Text>
+          <Text className="text-xs font-medium text-fg mb-1">Хто винен</Text>
           <Input
             placeholder="Ім'я або назва"
             value={draft.name}
@@ -152,9 +150,7 @@ export function ReceivableSheet({
         </View>
         <View className="flex-row gap-3">
           <View className="w-24">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Емодзі
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Емодзі</Text>
             <Input
               value={draft.emoji}
               onChangeText={(t) => setDraft((d) => ({ ...d, emoji: t }))}
@@ -163,9 +159,7 @@ export function ReceivableSheet({
             />
           </View>
           <View className="flex-1">
-            <Text className="text-xs font-medium text-stone-700 mb-1">
-              Сума, ₴
-            </Text>
+            <Text className="text-xs font-medium text-fg mb-1">Сума, ₴</Text>
             <Input
               placeholder="0"
               type="number"
@@ -177,9 +171,7 @@ export function ReceivableSheet({
           </View>
         </View>
         <View>
-          <Text className="text-xs font-medium text-stone-700 mb-1">
-            Нотатка
-          </Text>
+          <Text className="text-xs font-medium text-fg mb-1">Нотатка</Text>
           <Input
             placeholder="Необов'язково"
             value={draft.note}

--- a/apps/mobile/src/modules/finyk/components/assets/rows.tsx
+++ b/apps/mobile/src/modules/finyk/components/assets/rows.tsx
@@ -73,13 +73,10 @@ export const AccountRow = memo(function AccountRow({
       <View className="flex-row items-center gap-3 min-w-0 flex-1">
         <Text className="text-xl">💳</Text>
         <View className="min-w-0 flex-1">
-          <Text
-            className="text-sm font-medium text-stone-900"
-            numberOfLines={1}
-          >
+          <Text className="text-sm font-medium text-fg" numberOfLines={1}>
             {getAccountLabel(account)}
           </Text>
-          <Text className="text-xs text-stone-500 mt-0.5">
+          <Text className="text-xs text-fg-muted mt-0.5">
             {fmtKop(account.balance ?? 0)} {symbol}
           </Text>
         </View>
@@ -109,14 +106,11 @@ export const ManualAssetRow = memo(function ManualAssetRow({
     >
       <View className="flex-row items-center gap-3 min-w-0 flex-1">
         <Text className="text-xl">{asset.emoji || "💰"}</Text>
-        <Text
-          className="text-sm font-medium text-stone-900 flex-1"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-medium text-fg flex-1" numberOfLines={1}>
           {asset.name}
         </Text>
       </View>
-      <Text className="text-sm font-semibold text-stone-900">
+      <Text className="text-sm font-semibold text-fg">
         {fmtMajor(asset.amount)} {symbol}
       </Text>
     </Pressable>
@@ -146,10 +140,7 @@ export const DebtRow = memo(function DebtRow({
     >
       <View className="flex-row items-center gap-3 min-w-0 flex-1">
         <Text className="text-xl">{debt.emoji || "💸"}</Text>
-        <Text
-          className="text-sm font-medium text-stone-900 flex-1"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-medium text-fg flex-1" numberOfLines={1}>
           {debt.name || "Борг"}
         </Text>
       </View>
@@ -186,10 +177,7 @@ export const ReceivableRow = memo(function ReceivableRow({
     >
       <View className="flex-row items-center gap-3 min-w-0 flex-1">
         <Text className="text-xl">{receivable.emoji || "👤"}</Text>
-        <Text
-          className="text-sm font-medium text-stone-900 flex-1"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-medium text-fg flex-1" numberOfLines={1}>
           {receivable.name || "Дебіторка"}
         </Text>
       </View>

--- a/apps/mobile/src/modules/finyk/components/budgets/AddBudgetSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/AddBudgetSheet.tsx
@@ -160,7 +160,7 @@ export function AddBudgetSheet({
               className={
                 form.type === "limit"
                   ? "text-sm font-semibold text-white"
-                  : "text-sm font-semibold text-stone-700"
+                  : "text-sm font-semibold text-fg"
               }
             >
               🔴 Ліміт
@@ -181,7 +181,7 @@ export function AddBudgetSheet({
               className={
                 form.type === "goal"
                   ? "text-sm font-semibold text-white"
-                  : "text-sm font-semibold text-stone-700"
+                  : "text-sm font-semibold text-fg"
               }
             >
               🟢 Ціль
@@ -191,9 +191,7 @@ export function AddBudgetSheet({
 
         {form.type === "limit" ? (
           <>
-            <Text className="text-sm font-medium text-stone-700 mb-1">
-              Категорія
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-1">Категорія</Text>
             <ScrollView
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -223,7 +221,7 @@ export function AddBudgetSheet({
                         className={
                           selected
                             ? "text-white text-sm font-medium"
-                            : "text-stone-700 text-sm font-medium"
+                            : "text-fg text-sm font-medium"
                         }
                       >
                         {c.label}
@@ -232,9 +230,7 @@ export function AddBudgetSheet({
                   );
                 })}
             </ScrollView>
-            <Text className="text-sm font-medium text-stone-700 mb-1">
-              Ліміт ₴
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-1">Ліміт ₴</Text>
             <Input
               value={form.limit}
               onChangeText={(v) => setForm((f) => ({ ...f, limit: v }))}
@@ -245,9 +241,7 @@ export function AddBudgetSheet({
           </>
         ) : (
           <>
-            <Text className="text-sm font-medium text-stone-700 mb-1">
-              Іконка
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-1">Іконка</Text>
             <View className="flex-row flex-wrap gap-2 mb-3">
               {GOAL_EMOJIS.map((e) => {
                 const selected = form.emoji === e;
@@ -268,9 +262,7 @@ export function AddBudgetSheet({
                 );
               })}
             </View>
-            <Text className="text-sm font-medium text-stone-700 mb-1">
-              Назва цілі
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-1">Назва цілі</Text>
             <Input
               value={form.name}
               onChangeText={(v) => setForm((f) => ({ ...f, name: v }))}
@@ -278,7 +270,7 @@ export function AddBudgetSheet({
               testID={testID ? `${testID}-name` : undefined}
             />
             <View className="h-2" />
-            <Text className="text-sm font-medium text-stone-700 mb-1">
+            <Text className="text-sm font-medium text-fg mb-1">
               Сума цілі ₴
             </Text>
             <Input
@@ -289,7 +281,7 @@ export function AddBudgetSheet({
               testID={testID ? `${testID}-target` : undefined}
             />
             <View className="h-2" />
-            <Text className="text-sm font-medium text-stone-700 mb-1">
+            <Text className="text-sm font-medium text-fg mb-1">
               Вже відкладено ₴
             </Text>
             <Input
@@ -299,7 +291,7 @@ export function AddBudgetSheet({
               placeholder="0"
             />
             <View className="h-2" />
-            <Text className="text-sm font-medium text-stone-700 mb-1">
+            <Text className="text-sm font-medium text-fg mb-1">
               Дата (YYYY-MM-DD)
             </Text>
             <Input

--- a/apps/mobile/src/modules/finyk/components/budgets/BudgetForecastCard.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/BudgetForecastCard.tsx
@@ -40,18 +40,16 @@ function BudgetForecastCardImpl({
       <View className="flex-row items-center justify-between mb-2">
         <View className="flex-1 min-w-0">
           <Text
-            className="text-sm font-semibold text-stone-900"
+            className="text-sm font-semibold text-fg"
             numberOfLines={1}
             testID={testID ? `${testID}-label` : undefined}
           >
             {categoryLabel}
           </Text>
-          <Text className="text-[11px] text-stone-500">
+          <Text className="text-[11px] text-fg-muted">
             Факт {fmt(spent)} ₴ · Прогноз{" "}
             <Text
-              className={
-                overLimit ? "text-danger font-semibold" : "text-stone-700"
-              }
+              className={overLimit ? "text-danger font-semibold" : "text-fg"}
               testID={testID ? `${testID}-forecast` : undefined}
             >
               {fmt(forecast)} ₴

--- a/apps/mobile/src/modules/finyk/components/budgets/BudgetTrendChart.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/BudgetTrendChart.tsx
@@ -35,7 +35,7 @@ function BudgetTrendChartImpl({
     return (
       <View className="rounded-xl border border-dashed border-cream-300 px-4 py-6">
         <Text
-          className="text-xs text-stone-500 text-center"
+          className="text-xs text-fg-muted text-center"
           testID={testID ? `${testID}-empty` : undefined}
         >
           Замало даних для прогнозу — повертайся за кілька днів.

--- a/apps/mobile/src/modules/finyk/components/budgets/GoalBudgetRow.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/GoalBudgetRow.tsx
@@ -55,14 +55,14 @@ function GoalBudgetRowImpl({
     >
       <View className="flex-row items-center justify-between mb-2">
         <Text
-          className="text-sm font-semibold text-stone-900 flex-1"
+          className="text-sm font-semibold text-fg flex-1"
           numberOfLines={1}
         >
           {budget.emoji ? `${budget.emoji} ` : ""}
           {budget.name || "—"}
         </Text>
         <Text
-          className="text-xs text-stone-500"
+          className="text-xs text-fg-muted"
           testID={testID ? `${testID}-amount` : undefined}
         >
           {fmt(saved)} / {fmt(target)} ₴
@@ -78,9 +78,9 @@ function GoalBudgetRowImpl({
         <View style={{ width: barWidth }} className="h-full bg-emerald-500" />
       </View>
       {monthlyLabel ? (
-        <Text className="text-xs text-stone-500 mt-1.5">{monthlyLabel}</Text>
+        <Text className="text-xs text-fg-muted mt-1.5">{monthlyLabel}</Text>
       ) : null}
-      <Text className="text-xs text-stone-500 mt-0.5">
+      <Text className="text-xs text-fg-muted mt-0.5">
         {pct}% ·{" "}
         {daysLeft !== null
           ? daysLeft > 0

--- a/apps/mobile/src/modules/finyk/components/budgets/GoalEditSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/GoalEditSheet.tsx
@@ -116,9 +116,7 @@ export function GoalEditSheet({
     >
       <View testID={testID}>
         <View className="mb-3">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Назва цілі
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Назва цілі</Text>
           <Input
             value={name}
             onChangeText={setName}
@@ -126,9 +124,7 @@ export function GoalEditSheet({
           />
         </View>
         <View className="mb-3">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Сума цілі ₴
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Сума цілі ₴</Text>
           <Input
             value={target}
             onChangeText={setTarget}
@@ -138,7 +134,7 @@ export function GoalEditSheet({
           />
         </View>
         <View className="mb-3">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             Вже відкладено ₴
           </Text>
           <Input
@@ -150,7 +146,7 @@ export function GoalEditSheet({
           />
         </View>
         <View className="mb-2">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             Дата (YYYY-MM-DD)
           </Text>
           <Input value={date} onChangeText={setDate} placeholder="2026-12-31" />

--- a/apps/mobile/src/modules/finyk/components/budgets/LimitBudgetRow.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/LimitBudgetRow.tsx
@@ -48,7 +48,7 @@ function LimitBudgetRowImpl({
     >
       <View className="flex-row items-center justify-between mb-2">
         <Text
-          className="text-sm font-semibold text-stone-900 flex-1"
+          className="text-sm font-semibold text-fg flex-1"
           numberOfLines={1}
         >
           {categoryLabel || "—"}
@@ -59,7 +59,7 @@ function LimitBudgetRowImpl({
               ? "text-xs font-semibold text-danger"
               : warnLimit
                 ? "text-xs text-amber-600"
-                : "text-xs text-stone-500"
+                : "text-xs text-fg-muted"
           }
           testID={testID ? `${testID}-amount` : undefined}
         >
@@ -96,7 +96,7 @@ function LimitBudgetRowImpl({
             ? "text-xs text-danger mt-2"
             : warnLimit
               ? "text-xs text-amber-700 mt-2"
-              : "text-xs text-stone-500 mt-2"
+              : "text-xs text-fg-muted mt-2"
         }
         testID={testID ? `${testID}-status` : undefined}
       >

--- a/apps/mobile/src/modules/finyk/components/budgets/LimitEditSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/LimitEditSheet.tsx
@@ -89,7 +89,7 @@ export function LimitEditSheet({
       }
     >
       <View testID={testID}>
-        <Text className="text-sm font-medium text-stone-700 mb-1">Ліміт ₴</Text>
+        <Text className="text-sm font-medium text-fg mb-1">Ліміт ₴</Text>
         <Input
           value={limit}
           onChangeText={(v) => {

--- a/apps/mobile/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/MonthlyPlanCard.tsx
@@ -61,10 +61,8 @@ function MonthlyPlanCardImpl({
       }
     >
       <View className="flex-row items-center justify-between mb-3">
-        <Text className="text-sm font-semibold text-stone-900">
-          Фінплан на місяць
-        </Text>
-        <Text className="text-xs text-stone-500">✏️</Text>
+        <Text className="text-sm font-semibold text-fg">Фінплан на місяць</Text>
+        <Text className="text-xs text-fg-muted">✏️</Text>
       </View>
 
       {hasPlan ? (
@@ -72,22 +70,22 @@ function MonthlyPlanCardImpl({
           {/* Header row: (empty) | План | Факт | Δ */}
           <View className="flex-row items-center mb-1.5 px-1">
             <View className="w-16" />
-            <Text className="flex-1 text-[10px] text-stone-500 text-right">
+            <Text className="flex-1 text-[10px] text-fg-muted text-right">
               План
             </Text>
-            <Text className="flex-1 text-[10px] text-stone-500 text-right">
+            <Text className="flex-1 text-[10px] text-fg-muted text-right">
               Факт
             </Text>
-            <Text className="flex-1 text-[10px] text-stone-500 text-right">
+            <Text className="flex-1 text-[10px] text-fg-muted text-right">
               Δ
             </Text>
           </View>
 
           {/* Дохід */}
           <View className="flex-row items-center mb-1 px-1">
-            <Text className="w-16 text-xs text-stone-500">Дохід</Text>
+            <Text className="w-16 text-xs text-fg-muted">Дохід</Text>
             <Text
-              className="flex-1 text-right text-sm text-stone-700"
+              className="flex-1 text-right text-sm text-fg"
               testID={testID ? `${testID}-income` : undefined}
             >
               {planIncome > 0 ? `${fmt(planIncome)} ₴` : "—"}
@@ -98,7 +96,7 @@ function MonthlyPlanCardImpl({
             <Text
               className={
                 planIncome === 0
-                  ? "flex-1 text-right text-[11px] text-stone-400"
+                  ? "flex-1 text-right text-[11px] text-fg-subtle"
                   : incomeDelta >= 0
                     ? "flex-1 text-right text-[11px] text-emerald-600"
                     : "flex-1 text-right text-[11px] text-amber-600"
@@ -110,8 +108,8 @@ function MonthlyPlanCardImpl({
 
           {/* Витрати */}
           <View className="flex-row items-center mb-1 px-1">
-            <Text className="w-16 text-xs text-stone-500">Витрати</Text>
-            <Text className="flex-1 text-right text-sm text-stone-700">
+            <Text className="w-16 text-xs text-fg-muted">Витрати</Text>
+            <Text className="flex-1 text-right text-sm text-fg">
               {planExpense > 0 ? `${fmt(planExpense)} ₴` : "—"}
             </Text>
             <Text
@@ -127,7 +125,7 @@ function MonthlyPlanCardImpl({
             <Text
               className={
                 planExpense === 0
-                  ? "flex-1 text-right text-[11px] text-stone-400"
+                  ? "flex-1 text-right text-[11px] text-fg-subtle"
                   : expenseDelta > 0
                     ? "flex-1 text-right text-[11px] text-danger"
                     : "flex-1 text-right text-[11px] text-emerald-600"
@@ -139,8 +137,8 @@ function MonthlyPlanCardImpl({
 
           {/* Накопичення */}
           <View className="flex-row items-center mb-2 px-1">
-            <Text className="w-16 text-xs text-stone-500">Накопич.</Text>
-            <Text className="flex-1 text-right text-sm text-stone-700">
+            <Text className="w-16 text-xs text-fg-muted">Накопич.</Text>
+            <Text className="flex-1 text-right text-sm text-fg">
               {planSavings > 0 ? `${fmt(planSavings)} ₴` : "—"}
             </Text>
             <Text
@@ -155,7 +153,7 @@ function MonthlyPlanCardImpl({
             <Text
               className={
                 planSavings === 0 && factSavings === 0
-                  ? "flex-1 text-right text-[11px] text-stone-400"
+                  ? "flex-1 text-right text-[11px] text-fg-subtle"
                   : savingsDelta >= 0
                     ? "flex-1 text-right text-[11px] text-emerald-600"
                     : "flex-1 text-right text-[11px] text-danger"
@@ -170,14 +168,14 @@ function MonthlyPlanCardImpl({
           {planExpense > 0 ? (
             <>
               <View className="flex-row justify-between mb-1">
-                <Text className="text-[11px] text-stone-500">
+                <Text className="text-[11px] text-fg-muted">
                   {pctExpense}% витрачено
                 </Text>
                 <Text
                   className={
                     isOver
                       ? "text-[11px] text-danger font-semibold"
-                      : "text-[11px] text-stone-500"
+                      : "text-[11px] text-fg-muted"
                   }
                   testID={testID ? `${testID}-remaining` : undefined}
                 >
@@ -228,7 +226,7 @@ function MonthlyPlanCardImpl({
           ) : null}
         </>
       ) : (
-        <Text className="text-sm text-stone-500">
+        <Text className="text-sm text-fg-muted">
           Постав план — і побачиш скільки безпечно витрачати на день.
         </Text>
       )}

--- a/apps/mobile/src/modules/finyk/components/budgets/PlanEditSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/PlanEditSheet.tsx
@@ -72,7 +72,7 @@ export function PlanEditSheet({
     >
       <View testID={testID}>
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             План доходу ₴
           </Text>
           <Input
@@ -84,7 +84,7 @@ export function PlanEditSheet({
           />
         </View>
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             План витрат ₴
           </Text>
           <Input
@@ -96,7 +96,7 @@ export function PlanEditSheet({
           />
         </View>
         <View className="mb-2">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             План накопичень ₴
           </Text>
           <Input

--- a/apps/mobile/src/modules/finyk/components/budgets/Sparkline.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/Sparkline.tsx
@@ -18,7 +18,7 @@ export interface SparklineProps {
 }
 
 const TONE_CLASSES: Record<NonNullable<SparklineProps["tone"]>, string> = {
-  neutral: "bg-stone-400",
+  neutral: "bg-line",
   positive: "bg-emerald-500",
   warn: "bg-amber-500",
   danger: "bg-danger",

--- a/apps/mobile/src/modules/finyk/components/budgets/SubscriptionEditSheet.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/SubscriptionEditSheet.tsx
@@ -112,7 +112,7 @@ export function SubscriptionEditSheet({
       }
     >
       <View testID={testID}>
-        <Text className="text-sm font-medium text-stone-700 mb-1">Іконка</Text>
+        <Text className="text-sm font-medium text-fg mb-1">Іконка</Text>
         <View className="flex-row flex-wrap gap-2 mb-3">
           {EMOJIS.map((e) => {
             const selected = form.emoji === e;
@@ -134,7 +134,7 @@ export function SubscriptionEditSheet({
           })}
         </View>
 
-        <Text className="text-sm font-medium text-stone-700 mb-1">Назва</Text>
+        <Text className="text-sm font-medium text-fg mb-1">Назва</Text>
         <Input
           value={form.name}
           onChangeText={(v) => setForm((f) => ({ ...f, name: v }))}
@@ -143,7 +143,7 @@ export function SubscriptionEditSheet({
         />
         <View className="h-2" />
 
-        <Text className="text-sm font-medium text-stone-700 mb-1">
+        <Text className="text-sm font-medium text-fg mb-1">
           Ключове слово (для авто-пошуку)
         </Text>
         <Input
@@ -153,9 +153,7 @@ export function SubscriptionEditSheet({
         />
         <View className="h-2" />
 
-        <Text className="text-sm font-medium text-stone-700 mb-1">
-          День оплати
-        </Text>
+        <Text className="text-sm font-medium text-fg mb-1">День оплати</Text>
         <Input
           value={String(form.billingDay)}
           onChangeText={(v) =>
@@ -167,7 +165,7 @@ export function SubscriptionEditSheet({
         />
         <View className="h-2" />
 
-        <Text className="text-sm font-medium text-stone-700 mb-1">Валюта</Text>
+        <Text className="text-sm font-medium text-fg mb-1">Валюта</Text>
         <View className="flex-row gap-2 mb-3">
           {CURRENCIES.map((c) => {
             const selected = form.currency === c;
@@ -183,13 +181,13 @@ export function SubscriptionEditSheet({
                     : "px-3 py-1.5 rounded-full border border-cream-300"
                 }
               >
-                <Text className="text-sm font-medium text-stone-700">{c}</Text>
+                <Text className="text-sm font-medium text-fg">{c}</Text>
               </Pressable>
             );
           })}
         </View>
 
-        <Text className="text-sm font-medium text-stone-700 mb-1">
+        <Text className="text-sm font-medium text-fg mb-1">
           Очікувана сума (опц.)
         </Text>
         <Input

--- a/apps/mobile/src/modules/finyk/components/budgets/SubscriptionRow.tsx
+++ b/apps/mobile/src/modules/finyk/components/budgets/SubscriptionRow.tsx
@@ -36,19 +36,16 @@ function SubscriptionRowImpl({
     >
       <Text className="text-xl mr-3">{subscription.emoji || "📦"}</Text>
       <View className="flex-1 min-w-0">
-        <Text
-          className="text-sm font-semibold text-stone-900"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-semibold text-fg" numberOfLines={1}>
           {subscription.name}
         </Text>
-        <Text className="text-xs text-stone-500" numberOfLines={1}>
+        <Text className="text-xs text-fg-muted" numberOfLines={1}>
           {amountLabel ?? `${subscription.currency || "UAH"}`} · день{" "}
           {subscription.billingDay}
         </Text>
         {nextChargeLabel ? (
           <Text
-            className="text-[11px] text-stone-400"
+            className="text-[11px] text-fg-subtle"
             numberOfLines={1}
             testID={testID ? `${testID}-next-date` : undefined}
           >
@@ -68,7 +65,7 @@ function SubscriptionRowImpl({
             className={
               daysToNext <= 3
                 ? "text-[11px] font-medium text-amber-800"
-                : "text-[11px] font-medium text-stone-600"
+                : "text-[11px] font-medium text-fg-muted"
             }
           >
             {daysToNext === 0 ? "сьогодні" : `за ${daysToNext} дн.`}

--- a/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/Analytics.tsx
@@ -93,7 +93,7 @@ interface SectionProps {
 function Section({ title, children }: SectionProps) {
   return (
     <Card variant="default" radius="lg" padding="lg">
-      <Text className="text-xs font-medium text-stone-500 mb-3">{title}</Text>
+      <Text className="text-xs font-medium text-fg-muted mb-3">{title}</Text>
       {children}
     </Card>
   );
@@ -102,7 +102,7 @@ function Section({ title, children }: SectionProps) {
 function EmptyRow({ message }: { message: string }) {
   return (
     <View className="rounded-xl border border-dashed border-cream-300 bg-cream-50 px-4 py-6 items-center">
-      <Text className="text-sm text-stone-500 text-center">{message}</Text>
+      <Text className="text-sm text-fg-muted text-center">{message}</Text>
     </View>
   );
 }

--- a/apps/mobile/src/modules/finyk/pages/Analytics/CategoryDonut.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/CategoryDonut.tsx
@@ -209,15 +209,15 @@ function CategoryDonutComponent({ data, size = 160 }: CategoryDonutProps) {
                 style={{ backgroundColor: arc.color }}
               />
               <Text
-                className="text-xs text-stone-900 flex-1 min-w-0"
+                className="text-xs text-fg flex-1 min-w-0"
                 numberOfLines={1}
               >
                 {arc.label}
               </Text>
-              <Text className="text-xs text-stone-500 tabular-nums">
+              <Text className="text-xs text-fg-muted tabular-nums">
                 {arc.pct < 1 && arc.pct > 0 ? "<1" : arc.pct}%
               </Text>
-              <Text className="text-xs font-medium text-stone-900 tabular-nums">
+              <Text className="text-xs font-medium text-fg tabular-nums">
                 {arc.spent.toLocaleString("uk-UA")} ₴
               </Text>
             </View>
@@ -234,7 +234,7 @@ function CategoryDonutComponent({ data, size = 160 }: CategoryDonutProps) {
           testID="finyk-analytics-donut-toggle"
           className="self-center px-3 py-1.5 rounded-full border border-cream-300 bg-cream-50 active:opacity-70"
         >
-          <Text className="text-xs font-medium text-stone-700">
+          <Text className="text-xs font-medium text-fg">
             {expanded ? "Згорнути ↑" : `Показати всі (${data.length}) ↓`}
           </Text>
         </Pressable>

--- a/apps/mobile/src/modules/finyk/pages/Analytics/ComparisonCard.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/ComparisonCard.tsx
@@ -38,7 +38,7 @@ function ComparisonRow({
   const good = diff === 0 ? null : up === upIsGood;
   const tint =
     good === null
-      ? "text-stone-500"
+      ? "text-fg-muted"
       : good
         ? "text-emerald-600"
         : "text-rose-600";
@@ -48,9 +48,9 @@ function ComparisonRow({
       className="flex-row items-center justify-between"
       testID={`finyk-analytics-compare-${kind}`}
     >
-      <Text className="text-sm text-stone-500">{label}</Text>
+      <Text className="text-sm text-fg-muted">{label}</Text>
       <View className="flex-row items-center gap-2">
-        <Text className="text-sm font-medium text-stone-900 tabular-nums">
+        <Text className="text-sm font-medium text-fg tabular-nums">
           {fmt(current)} ₴
         </Text>
         {prev > 0 && pct !== null ? (

--- a/apps/mobile/src/modules/finyk/pages/Analytics/MerchantList.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/MerchantList.tsx
@@ -26,18 +26,18 @@ function MerchantListComponent({ merchants }: MerchantListProps) {
         const barPct = Math.max(2, Math.round((m.total / maxTotal) * 100));
         return (
           <View key={m.name} className="flex-row items-center gap-3">
-            <Text className="text-xs text-stone-500 w-4 text-right tabular-nums">
+            <Text className="text-xs text-fg-muted w-4 text-right tabular-nums">
               {i + 1}
             </Text>
             <View className="flex-1 min-w-0">
               <View className="flex-row items-center justify-between mb-0.5">
                 <Text
-                  className="text-sm text-stone-900 flex-1 min-w-0 pr-2"
+                  className="text-sm text-fg flex-1 min-w-0 pr-2"
                   numberOfLines={1}
                 >
                   {m.name}
                 </Text>
-                <Text className="text-sm font-semibold tabular-nums text-stone-900">
+                <Text className="text-sm font-semibold tabular-nums text-fg">
                   {m.total.toLocaleString("uk-UA")} ₴
                 </Text>
               </View>
@@ -48,7 +48,7 @@ function MerchantListComponent({ merchants }: MerchantListProps) {
                     style={{ width: `${barPct}%` }}
                   />
                 </View>
-                <Text className="text-[10px] text-stone-500">
+                <Text className="text-[10px] text-fg-muted">
                   {m.count} разів
                 </Text>
               </View>

--- a/apps/mobile/src/modules/finyk/pages/Analytics/MonthNav.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/MonthNav.tsx
@@ -51,10 +51,10 @@ function MonthNavComponent({ year, month, onChange, now }: MonthNavProps) {
         testID="finyk-analytics-month-prev"
         className="w-10 h-10 rounded-xl border border-cream-300 items-center justify-center active:opacity-60"
       >
-        <Text className="text-base text-stone-600">‹</Text>
+        <Text className="text-base text-fg-muted">‹</Text>
       </Pressable>
       <Text
-        className="text-sm font-semibold text-stone-900 capitalize"
+        className="text-sm font-semibold text-fg capitalize"
         testID="finyk-analytics-month-label"
       >
         {label}
@@ -71,7 +71,7 @@ function MonthNavComponent({ year, month, onChange, now }: MonthNavProps) {
           (isCurrentMonth ? "opacity-30" : "active:opacity-60")
         }
       >
-        <Text className="text-base text-stone-600">›</Text>
+        <Text className="text-base text-fg-muted">›</Text>
       </Pressable>
     </View>
   );

--- a/apps/mobile/src/modules/finyk/pages/Analytics/SummaryCard.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Analytics/SummaryCard.tsx
@@ -41,19 +41,19 @@ function SummaryCardComponent({ summary, loading }: SummaryCardProps) {
   return (
     <View className="flex-row gap-3" testID="finyk-analytics-summary">
       <View className="flex-1 items-center">
-        <Text className="text-[10px] text-stone-500 mb-1">Витрати</Text>
+        <Text className="text-[10px] text-fg-muted mb-1">Витрати</Text>
         <Text className="text-sm font-bold tabular-nums text-rose-600">
           {fmt(summary.spent)} ₴
         </Text>
       </View>
       <View className="flex-1 items-center">
-        <Text className="text-[10px] text-stone-500 mb-1">Дохід</Text>
+        <Text className="text-[10px] text-fg-muted mb-1">Дохід</Text>
         <Text className="text-sm font-bold tabular-nums text-emerald-600">
           {fmt(summary.income)} ₴
         </Text>
       </View>
       <View className="flex-1 items-center">
-        <Text className="text-[10px] text-stone-500 mb-1">Баланс</Text>
+        <Text className="text-[10px] text-fg-muted mb-1">Баланс</Text>
         <Text
           className={
             "text-sm font-bold tabular-nums " +

--- a/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Assets/AssetsPage.tsx
@@ -94,16 +94,13 @@ function SectionHeader({
       className="flex-row items-center justify-between px-4 py-3 bg-cream-50 border border-cream-300 rounded-2xl"
     >
       <View className="flex-row items-center gap-2 min-w-0 flex-1">
-        <Text
-          className="text-sm font-semibold text-stone-900"
-          numberOfLines={1}
-        >
+        <Text className="text-sm font-semibold text-fg" numberOfLines={1}>
           {title}
         </Text>
       </View>
       <View className="flex-row items-center gap-3">
-        <Text className="text-sm font-medium text-stone-700">{summary}</Text>
-        <Text className="text-xs text-stone-500">{open ? "▲" : "▼"}</Text>
+        <Text className="text-sm font-medium text-fg">{summary}</Text>
+        <Text className="text-xs text-fg-muted">{open ? "▲" : "▼"}</Text>
       </View>
     </Pressable>
   );
@@ -216,11 +213,9 @@ export function AssetsPage({ seed, testID }: AssetsPageProps) {
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">🏦</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Активи
-        </Text>
+        <Text className="text-[22px] font-bold text-fg flex-1">Активи</Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-2">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-2">
         Рахунки, борги і дебіторка в одному місці.
       </Text>
 
@@ -262,7 +257,7 @@ export function AssetsPage({ seed, testID }: AssetsPageProps) {
               {visibleAccounts.length === 0 &&
               store.manualAssets.length === 0 ? (
                 <Text
-                  className="text-sm text-stone-500 py-4 text-center"
+                  className="text-sm text-fg-muted py-4 text-center"
                   testID={testID ? `${testID}-accounts-empty` : undefined}
                 >
                   Ще немає рахунків
@@ -316,7 +311,7 @@ export function AssetsPage({ seed, testID }: AssetsPageProps) {
             <View className="rounded-2xl border border-cream-300 bg-white px-3 py-1">
               {store.manualDebts.length === 0 ? (
                 <Text
-                  className="text-sm text-stone-500 py-4 text-center"
+                  className="text-sm text-fg-muted py-4 text-center"
                   testID={testID ? `${testID}-debts-empty` : undefined}
                 >
                   Ще немає боргів
@@ -362,7 +357,7 @@ export function AssetsPage({ seed, testID }: AssetsPageProps) {
             <View className="rounded-2xl border border-cream-300 bg-white px-3 py-1">
               {store.receivables.length === 0 ? (
                 <Text
-                  className="text-sm text-stone-500 py-4 text-center"
+                  className="text-sm text-fg-muted py-4 text-center"
                   testID={testID ? `${testID}-receivables-empty` : undefined}
                 >
                   Ще немає дебіторки

--- a/apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Budgets/BudgetsPage.tsx
@@ -291,11 +291,9 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">📅</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Планування
-        </Text>
+        <Text className="text-[22px] font-bold text-fg flex-1">Планування</Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-2">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-2">
         Місячний план, ліміти, цілі та підписки.
       </Text>
 
@@ -320,7 +318,7 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
         {/* Limits section */}
         <View className="gap-2">
           <View className="flex-row items-center justify-between px-1">
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               🔴 Ліміти за категоріями
             </Text>
             <Pressable
@@ -336,7 +334,7 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
           {limitBudgets.length === 0 ? (
             <View className="rounded-2xl border border-dashed border-cream-300 px-4 py-6">
               <Text
-                className="text-sm text-stone-500 text-center"
+                className="text-sm text-fg-muted text-center"
                 testID="finyk-budgets-limits-empty"
               >
                 Ще немає лімітів. Додай перший — і Finyk покаже, скільки
@@ -374,7 +372,7 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
         {/* Forecast */}
         {forecasts.length > 0 ? (
           <View className="gap-2">
-            <Text className="text-sm font-semibold text-stone-900 px-1">
+            <Text className="text-sm font-semibold text-fg px-1">
               📈 Прогноз на кінець місяця
             </Text>
             {forecasts.map((fc) => (
@@ -397,13 +395,13 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
 
         {/* Goals */}
         <View className="gap-2">
-          <Text className="text-sm font-semibold text-stone-900 px-1">
+          <Text className="text-sm font-semibold text-fg px-1">
             🟢 Цілі накопичень
           </Text>
           {goalBudgets.length === 0 ? (
             <View className="rounded-2xl border border-dashed border-cream-300 px-4 py-6">
               <Text
-                className="text-sm text-stone-500 text-center"
+                className="text-sm text-fg-muted text-center"
                 testID="finyk-budgets-goals-empty"
               >
                 Ще немає цілей. Додай ціль — і відстежуй прогрес місяць за
@@ -436,9 +434,7 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
         {/* Subscriptions */}
         <View className="gap-2">
           <View className="flex-row items-center justify-between px-1">
-            <Text className="text-sm font-semibold text-stone-900">
-              🔁 Підписки
-            </Text>
+            <Text className="text-sm font-semibold text-fg">🔁 Підписки</Text>
             <Pressable
               onPress={() =>
                 setSheet({ kind: "subscription", subscription: null })
@@ -454,7 +450,7 @@ export function BudgetsPage({ seed, now, testID }: BudgetsPageProps) {
           <View className="rounded-2xl border border-cream-300 bg-white">
             {budgetsStore.subscriptions.length === 0 ? (
               <Text
-                className="text-sm text-stone-500 py-4 text-center"
+                className="text-sm text-fg-muted py-4 text-center"
                 testID="finyk-budgets-subs-empty"
               >
                 Ще немає підписок

--- a/apps/mobile/src/modules/finyk/pages/Overview/BudgetAlertsList.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/BudgetAlertsList.tsx
@@ -63,7 +63,7 @@ const BudgetAlertsListImpl = function BudgetAlertsList({
                 : "bg-amber-50 border-amber-200",
             )}
           >
-            <Text className="text-sm font-medium text-stone-900 flex-1 mr-2">
+            <Text className="text-sm font-medium text-fg flex-1 mr-2">
               {cat?.label || catId}
             </Text>
             <Text

--- a/apps/mobile/src/modules/finyk/pages/Overview/CategoryChartSection.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/CategoryChartSection.tsx
@@ -46,10 +46,8 @@ const CategoryChartSectionImpl = function CategoryChartSection({
   if (catSpends.length === 0) {
     return (
       <View className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-6 items-center">
-        <Text className="text-sm font-semibold text-stone-900">
-          Поки немає витрат
-        </Text>
-        <Text className="text-xs text-stone-500 mt-1 text-center">
+        <Text className="text-sm font-semibold text-fg">Поки немає витрат</Text>
+        <Text className="text-xs text-fg-muted mt-1 text-center">
           Цього місяця витрат за категоріями ще немає.
         </Text>
         <Pressable
@@ -71,7 +69,7 @@ const CategoryChartSectionImpl = function CategoryChartSection({
 
   return (
     <Card radius="lg" padding="lg">
-      <Text className="text-xs font-medium text-stone-500 mb-4">
+      <Text className="text-xs font-medium text-fg-muted mb-4">
         Витрати за категоріями
       </Text>
       <View className="gap-3">
@@ -82,12 +80,12 @@ const CategoryChartSectionImpl = function CategoryChartSection({
             <>
               <View className="flex-row justify-between mb-1.5">
                 <Text
-                  className="text-xs text-stone-500 flex-1 mr-2"
+                  className="text-xs text-fg-muted flex-1 mr-2"
                   numberOfLines={1}
                 >
                   {cat.label}
                 </Text>
-                <Text className="text-xs font-bold text-stone-900">
+                <Text className="text-xs font-bold text-fg">
                   −{fmt(cat.spent)} ₴
                 </Text>
               </View>

--- a/apps/mobile/src/modules/finyk/pages/Overview/FirstInsightBanner.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/FirstInsightBanner.tsx
@@ -26,10 +26,10 @@ const FirstInsightBannerImpl = function FirstInsightBanner({
         <Text className="text-xl">💡</Text>
       </View>
       <View className="flex-1">
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           Ось куди йдуть твої гроші
         </Text>
-        <Text className="text-xs text-stone-500 mt-0.5">
+        <Text className="text-xs text-fg-muted mt-0.5">
           Хочеш поставити бюджет — і бачити, коли починаєш виходити за рамки?
         </Text>
         <View className="flex-row gap-2 mt-3">
@@ -49,7 +49,7 @@ const FirstInsightBannerImpl = function FirstInsightBanner({
             onPress={onDismiss}
             className="px-3 py-1.5 rounded-xl active:opacity-60"
           >
-            <Text className="text-xs text-stone-500">Пізніше</Text>
+            <Text className="text-xs text-fg-muted">Пізніше</Text>
           </Pressable>
         </View>
       </View>
@@ -59,7 +59,7 @@ const FirstInsightBannerImpl = function FirstInsightBanner({
         onPress={onDismiss}
         className="w-8 h-8 items-center justify-center active:opacity-60"
       >
-        <Text className="text-stone-400 text-lg">×</Text>
+        <Text className="text-fg-subtle text-lg">×</Text>
       </Pressable>
     </View>
   );

--- a/apps/mobile/src/modules/finyk/pages/Overview/FlowRow.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/FlowRow.tsx
@@ -37,13 +37,10 @@ export const FlowRow = memo(function FlowRow({
       )}
     >
       <View className="flex-1 mr-3">
-        <Text
-          className="text-base font-medium text-stone-900"
-          numberOfLines={1}
-        >
+        <Text className="text-base font-medium text-fg" numberOfLines={1}>
           {flow.title}
         </Text>
-        <Text className="text-xs text-stone-500 mt-0.5">{flow.hint}</Text>
+        <Text className="text-xs text-fg-muted mt-0.5">{flow.hint}</Text>
       </View>
       <Text
         className={cn(

--- a/apps/mobile/src/modules/finyk/pages/Overview/MonthPulseCard.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/MonthPulseCard.tsx
@@ -77,28 +77,28 @@ const MonthPulseCardImpl = function MonthPulseCard({
     >
       <View className="flex-row items-start justify-between mb-4">
         <View>
-          <Text className="text-xs font-medium text-stone-500">Місяць</Text>
-          <Text className="text-xs text-stone-400 mt-0.5 capitalize">
+          <Text className="text-xs font-medium text-fg-muted">Місяць</Text>
+          <Text className="text-xs text-fg-subtle mt-0.5 capitalize">
             {dateLabel}
           </Text>
         </View>
-        <Text className="text-xs text-stone-400">
+        <Text className="text-xs text-fg-subtle">
           {Math.max(0, daysInMonth - daysPassed)} дн. залишилось
         </Text>
       </View>
 
       <View className="flex-row justify-between items-start gap-4">
         <View>
-          <Text className="text-xs text-stone-500 font-medium">Витрати</Text>
-          <Text className="text-3xl font-bold mt-1 text-stone-900">
+          <Text className="text-xs text-fg-muted font-medium">Витрати</Text>
+          <Text className="text-3xl font-bold mt-1 text-fg">
             {showBalance ? fmt(spent) : "••••"}
             {showBalance && (
-              <Text className="text-base font-medium text-stone-400"> ₴</Text>
+              <Text className="text-base font-medium text-fg-subtle"> ₴</Text>
             )}
           </Text>
         </View>
         <View className="items-end">
-          <Text className="text-xs text-stone-500 font-medium">Дохід</Text>
+          <Text className="text-xs text-fg-muted font-medium">Дохід</Text>
           <Text className="text-3xl font-bold mt-1 text-emerald-600">
             {showBalance ? `+${fmt(income)}` : "••••"}
             {showBalance && (
@@ -113,8 +113,8 @@ const MonthPulseCardImpl = function MonthPulseCard({
 
       <View className="mt-4">
         <View className="flex-row justify-between">
-          <Text className="text-xs text-stone-500">Витрати від доходу</Text>
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">Витрати від доходу</Text>
+          <Text className="text-xs text-fg-muted">
             {showBalance ? `${Math.round(spendPct)}%` : "—"}
           </Text>
         </View>
@@ -129,12 +129,12 @@ const MonthPulseCardImpl = function MonthPulseCard({
           />
         </View>
         <View className="flex-row justify-between mt-1.5">
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             {showBalance
               ? `Залишок: ${monthBalance >= 0 ? "+" : "−"}${fmt(Math.abs(monthBalance))} ₴`
               : "—"}
           </Text>
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             {showBalance && !showMonthForecast && projectedSpend > 0
               ? `Прогноз витрат ${fmt(projectedSpend)} ₴`
               : "—"}
@@ -144,15 +144,15 @@ const MonthPulseCardImpl = function MonthPulseCard({
 
       {showMonthForecast && (
         <View className="mt-4 pt-4 border-t border-cream-300">
-          <Text className="text-xs font-medium text-stone-500">
+          <Text className="text-xs font-medium text-fg-muted">
             Факт і прогноз витрат
           </Text>
-          <Text className="text-xs text-stone-500 mt-2">
+          <Text className="text-xs text-fg-muted mt-2">
             За {daysPassed}{" "}
             {daysPassed === 1 ? "день" : daysPassed < 5 ? "дні" : "дн."} · факт{" "}
-            <Text className="font-semibold text-stone-900">{fmt(spent)} ₴</Text>
+            <Text className="font-semibold text-fg">{fmt(spent)} ₴</Text>
             {" · "}до кінця місяця ~{" "}
-            <Text className="font-semibold text-stone-900">
+            <Text className="font-semibold text-fg">
               {fmt(Math.round(projectedSpend))} ₴
             </Text>
           </Text>
@@ -164,7 +164,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
               }}
             />
           </View>
-          <Text className="text-xs text-stone-500 mt-1">
+          <Text className="text-xs text-fg-muted mt-1">
             {forecastTrendPct}% від прогнозу за темпом
           </Text>
         </View>
@@ -172,8 +172,8 @@ const MonthPulseCardImpl = function MonthPulseCard({
 
       <View className="mt-4 pt-4 border-t border-cream-300">
         <View className="flex-row items-center justify-between">
-          <Text className="text-xs font-medium text-stone-500">Фінпульс</Text>
-          <Text className="text-xs text-stone-400">
+          <Text className="text-xs font-medium text-fg-muted">Фінпульс</Text>
+          <Text className="text-xs text-fg-subtle">
             цільова витрата на день
           </Text>
         </View>
@@ -187,7 +187,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
           {showBalance ? (
             <>
               {fmt(Math.abs(dayBudget))}
-              <Text className="text-base font-medium text-stone-500">
+              <Text className="text-base font-medium text-fg-muted">
                 {" "}
                 ₴/день
               </Text>
@@ -199,7 +199,7 @@ const MonthPulseCardImpl = function MonthPulseCard({
         <Text className={cn("text-sm mt-0.5", color)}>{statusText}</Text>
         {(recurringOutThisMonth > 0 || recurringInThisMonth > 0) &&
           showBalance && (
-            <Text className="text-xs text-stone-500 mt-2">
+            <Text className="text-xs text-fg-muted mt-2">
               Враховано планових: −{fmt(recurringOutThisMonth)} / +
               {fmt(recurringInThisMonth)} ₴
               {unknownOutCount > 0 && ` + ${unknownOutCount} без суми`}

--- a/apps/mobile/src/modules/finyk/pages/Overview/NetworthSection.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/NetworthSection.tsx
@@ -40,7 +40,7 @@ const NetworthSectionImpl = function NetworthSection({
         className="border-dashed"
       >
         <Text
-          className="text-sm text-stone-500 text-center"
+          className="text-sm text-fg-muted text-center"
           testID="finyk-overview-networth-empty"
         >
           Ще мало знімків для графіка нетворсу — з’явиться після кількох змін
@@ -64,10 +64,10 @@ const NetworthSectionImpl = function NetworthSection({
       className="px-5 pt-4 pb-3"
     >
       <View className="flex-row items-center justify-between mb-3">
-        <Text className="text-xs font-medium text-stone-500">
+        <Text className="text-xs font-medium text-fg-muted">
           Динаміка нетворсу
         </Text>
-        <Text className="text-xs text-stone-400">
+        <Text className="text-xs text-fg-subtle">
           {networthHistory.length} міс.
         </Text>
       </View>

--- a/apps/mobile/src/modules/finyk/pages/Overview/Overview.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/Overview.tsx
@@ -312,7 +312,7 @@ export function Overview({
         showBalance={showBalance}
       />
 
-      <Text className="text-xs text-stone-500 px-1 -mt-1">
+      <Text className="text-xs text-fg-muted px-1 -mt-1">
         Огляд, категорії та бюджети на цій сторінці — у гривні (UAH). Інші
         валюти рахунків у загальному балансі не конвертуються автоматично.
       </Text>
@@ -380,13 +380,13 @@ export function Overview({
           onPress={() => handleOverviewNavigate("transactions")}
           className="w-full py-4 rounded-2xl border border-dashed border-cream-300 active:opacity-70"
         >
-          <Text className="text-sm font-medium text-stone-500 text-center">
+          <Text className="text-sm font-medium text-fg-muted text-center">
             Усі операції ({realTx.length}) →
           </Text>
         </Pressable>
       )}
       {loadingTx && (
-        <Text className="text-center text-xs text-stone-500 py-4">
+        <Text className="text-center text-xs text-fg-muted py-4">
           Оновлення…
         </Text>
       )}

--- a/apps/mobile/src/modules/finyk/pages/Overview/PlanFactCard.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/PlanFactCard.tsx
@@ -52,7 +52,7 @@ const PlanFactCardImpl = function PlanFactCard({
     <Card radius="lg" padding="lg">
       <View className="flex-row items-center justify-between">
         <View className="flex-1">
-          <Text className="text-xs font-medium text-stone-500">
+          <Text className="text-xs font-medium text-fg-muted">
             📅 Фінплан на місяць
           </Text>
           <Text
@@ -61,14 +61,14 @@ const PlanFactCardImpl = function PlanFactCard({
                 ? "text-sm font-semibold text-danger mt-1"
                 : pctExpense >= 85
                   ? "text-sm font-semibold text-amber-700 mt-1"
-                  : "text-sm font-semibold text-stone-800 mt-1"
+                  : "text-sm font-semibold text-fg mt-1"
             }
           >
             {summary}
           </Text>
         </View>
         {onNavigate ? (
-          <Text className="text-xs text-stone-400 ml-3">›</Text>
+          <Text className="text-xs text-fg-subtle ml-3">›</Text>
         ) : null}
       </View>
       {planExpense > 0 ? (

--- a/apps/mobile/src/modules/finyk/pages/Overview/PlannedFlowsCard.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Overview/PlannedFlowsCard.tsx
@@ -29,7 +29,7 @@ const PlannedFlowsCardImpl = function PlannedFlowsCard({
   return (
     <Card radius="lg" padding="lg">
       <View className="flex-row items-center justify-between mb-2">
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           Заплановані платежі
         </Text>
         <Pressable

--- a/apps/mobile/src/modules/finyk/pages/PageStub.tsx
+++ b/apps/mobile/src/modules/finyk/pages/PageStub.tsx
@@ -37,21 +37,19 @@ export function FinykPageStub({
         contentContainerClassName="px-5 pt-4 pb-16"
         showsVerticalScrollIndicator={false}
       >
-        <Text className="text-2xl font-bold text-stone-900">{title}</Text>
-        <Text className="text-sm text-stone-500 mt-1 mb-5">{description}</Text>
+        <Text className="text-2xl font-bold text-fg">{title}</Text>
+        <Text className="text-sm text-fg-muted mt-1 mb-5">{description}</Text>
 
         {children}
 
         <Card variant="default" padding="lg">
-          <Text className="text-sm font-semibold text-stone-900 mb-3">
+          <Text className="text-sm font-semibold text-fg mb-3">
             Заплановано до порту
           </Text>
           {plannedFeatures.map((item) => (
             <View key={item} className="flex-row items-start mb-2">
               <Text className="text-brand-600 mr-2">•</Text>
-              <Text className="text-sm text-stone-700 flex-1 leading-5">
-                {item}
-              </Text>
+              <Text className="text-sm text-fg flex-1 leading-5">{item}</Text>
             </View>
           ))}
         </Card>

--- a/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
@@ -564,7 +564,7 @@ export function TransactionsPage({
           >
             <View className="flex-row items-center flex-1 min-w-0">
               <Text
-                className="text-stone-500 mr-2 text-xs"
+                className="text-fg-muted mr-2 text-xs"
                 style={{ width: 10 }}
                 accessibilityElementsHidden
                 importantForAccessibility="no"
@@ -572,11 +572,11 @@ export function TransactionsPage({
                 {item.collapsed ? "▸" : "▾"}
               </Text>
               {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
-              <Text className="text-xs font-semibold uppercase tracking-wide text-stone-500 flex-shrink">
+              <Text className="text-xs font-semibold uppercase tracking-wide text-fg-muted flex-shrink">
                 {item.label}
               </Text>
               {item.count > 0 ? (
-                <Text className="text-[10px] font-normal text-stone-400 ml-2">
+                <Text className="text-[10px] font-normal text-fg-subtle ml-2">
                   · {item.count}
                 </Text>
               ) : null}
@@ -586,7 +586,7 @@ export function TransactionsPage({
                 className={
                   item.total >= 0
                     ? "text-xs font-semibold text-brand-600"
-                    : "text-xs font-semibold text-stone-700"
+                    : "text-xs font-semibold text-fg"
                 }
                 style={{ fontVariant: ["tabular-nums"] }}
               >
@@ -705,9 +705,9 @@ export function TransactionsPage({
               testID={`${testID}-prev-month`}
               className="w-9 h-9 items-center justify-center rounded-xl active:opacity-60"
             >
-              <Text className="text-xl text-stone-500">‹</Text>
+              <Text className="text-xl text-fg-muted">‹</Text>
             </Pressable>
-            <Text className="text-sm font-semibold text-stone-900 capitalize px-2">
+            <Text className="text-sm font-semibold text-fg capitalize px-2">
               {monthLabel}
             </Text>
             <Pressable
@@ -722,8 +722,8 @@ export function TransactionsPage({
               <Text
                 className={
                   isCurrentMonth
-                    ? "text-xl text-stone-300"
-                    : "text-xl text-stone-500"
+                    ? "text-xl text-fg-subtle"
+                    : "text-xl text-fg-muted"
                 }
               >
                 ›
@@ -743,7 +743,7 @@ export function TransactionsPage({
                 testID={`${testID}-clear-filters`}
                 className="bg-cream-100 border border-cream-300 rounded-full h-9 px-3 items-center justify-center active:opacity-70"
               >
-                <Text className="text-stone-600 text-xs font-medium">
+                <Text className="text-fg-muted text-xs font-medium">
                   ✕ Скинути
                 </Text>
               </Pressable>
@@ -762,13 +762,13 @@ export function TransactionsPage({
 
         {/* Search */}
         <View className="bg-cream-100 border border-cream-300 rounded-2xl px-3 flex-row items-center">
-          <Text className="text-stone-400 mr-2">🔍</Text>
+          <Text className="text-fg-subtle mr-2">🔍</Text>
           <TextInput
             value={search}
             onChangeText={setSearch}
             placeholder="Пошук по транзакціях…"
             placeholderTextColor="#a8a29e"
-            className="flex-1 py-2.5 text-sm text-stone-900"
+            className="flex-1 py-2.5 text-sm text-fg"
             accessibilityLabel="Пошук транзакцій"
             testID={`${testID}-search`}
           />
@@ -779,7 +779,7 @@ export function TransactionsPage({
               accessibilityLabel="Очистити пошук"
               hitSlop={8}
             >
-              <Text className="text-stone-400 px-1">✕</Text>
+              <Text className="text-fg-subtle px-1">✕</Text>
             </Pressable>
           )}
         </View>
@@ -807,7 +807,7 @@ export function TransactionsPage({
                   className={
                     selected
                       ? "text-white text-xs font-semibold"
-                      : "text-stone-700 text-xs font-medium"
+                      : "text-fg text-xs font-medium"
                   }
                   numberOfLines={1}
                 >
@@ -831,7 +831,7 @@ export function TransactionsPage({
               className={
                 activeCategoryLabel
                   ? "text-white text-xs font-semibold"
-                  : "text-stone-700 text-xs font-medium"
+                  : "text-fg text-xs font-medium"
               }
               numberOfLines={1}
             >
@@ -853,7 +853,7 @@ export function TransactionsPage({
               className={
                 filters.range.startMs != null || filters.range.endMs != null
                   ? "text-white text-xs font-semibold"
-                  : "text-stone-700 text-xs font-medium"
+                  : "text-fg text-xs font-medium"
               }
             >
               📅 {rangeLabel ?? "Період"}
@@ -875,7 +875,7 @@ export function TransactionsPage({
                 className={
                   filters.accountIds.length > 0
                     ? "text-white text-xs font-semibold"
-                    : "text-stone-700 text-xs font-medium"
+                    : "text-fg text-xs font-medium"
                 }
               >
                 🏦 Рахунки
@@ -895,12 +895,12 @@ export function TransactionsPage({
           testID={`${testID}-empty`}
         >
           <Text className="text-5xl mb-3">🧾</Text>
-          <Text className="text-base font-semibold text-stone-900 mb-1 text-center">
+          <Text className="text-base font-semibold text-fg mb-1 text-center">
             {hasActiveFilter
               ? "Нічого не знайдено"
               : "Немає транзакцій за цей місяць"}
           </Text>
-          <Text className="text-sm text-stone-500 text-center mb-4">
+          <Text className="text-sm text-fg-muted text-center mb-4">
             {hasActiveFilter
               ? "Спробуйте інший фільтр або очистіть пошук."
               : "Додайте першу витрату — і вона з'явиться тут."}
@@ -965,7 +965,7 @@ export function TransactionsPage({
       >
         <View testID={`${testID}-accounts-sheet`}>
           {accounts.length === 0 ? (
-            <Text className="text-sm text-stone-500 px-3 py-2">
+            <Text className="text-sm text-fg-muted px-3 py-2">
               Немає підключених рахунків.
             </Text>
           ) : (
@@ -986,11 +986,11 @@ export function TransactionsPage({
                   testID={`${testID}-account-opt-${aid}`}
                   className="flex-row items-center px-3 py-3 rounded-xl active:opacity-70"
                 >
-                  <Text className="text-sm text-stone-900 flex-1">
+                  <Text className="text-sm text-fg flex-1">
                     {a.type ?? aid ?? "Рахунок"}
                   </Text>
                   <Text
-                    className={checked ? "text-brand-500" : "text-stone-300"}
+                    className={checked ? "text-brand-500" : "text-fg-subtle"}
                   >
                     {checked ? "☑" : "☐"}
                   </Text>
@@ -1005,7 +1005,7 @@ export function TransactionsPage({
               testID={`${testID}-account-clear`}
               className="mt-2 px-3 py-3 rounded-xl bg-cream-100 active:opacity-70"
             >
-              <Text className="text-sm text-stone-600 text-center">
+              <Text className="text-sm text-fg-muted text-center">
                 Скинути вибір рахунків
               </Text>
             </Pressable>
@@ -1029,9 +1029,7 @@ export function TransactionsPage({
               testID={`${testID}-range-clear`}
               className="flex-1 h-11 rounded-xl bg-cream-100 items-center justify-center active:opacity-70"
             >
-              <Text className="text-sm text-stone-700 font-medium">
-                Скинути
-              </Text>
+              <Text className="text-sm text-fg font-medium">Скинути</Text>
             </Pressable>
             <Pressable
               onPress={applyDateRange}
@@ -1048,7 +1046,7 @@ export function TransactionsPage({
       >
         <View className="px-4 pb-4 gap-3" testID={`${testID}-range-sheet`}>
           <View>
-            <Text className="text-xs text-stone-500 mb-1">Від</Text>
+            <Text className="text-xs text-fg-muted mb-1">Від</Text>
             <TextInput
               value={draftRange.start}
               onChangeText={(v) => setDraftRange((r) => ({ ...r, start: v }))}
@@ -1056,12 +1054,12 @@ export function TransactionsPage({
               placeholderTextColor="#a8a29e"
               autoCapitalize="none"
               autoCorrect={false}
-              className="bg-cream-100 border border-cream-300 rounded-xl px-3 py-2.5 text-sm text-stone-900"
+              className="bg-cream-100 border border-cream-300 rounded-xl px-3 py-2.5 text-sm text-fg"
               testID={`${testID}-range-start`}
             />
           </View>
           <View>
-            <Text className="text-xs text-stone-500 mb-1">До</Text>
+            <Text className="text-xs text-fg-muted mb-1">До</Text>
             <TextInput
               value={draftRange.end}
               onChangeText={(v) => setDraftRange((r) => ({ ...r, end: v }))}
@@ -1069,7 +1067,7 @@ export function TransactionsPage({
               placeholderTextColor="#a8a29e"
               autoCapitalize="none"
               autoCorrect={false}
-              className="bg-cream-100 border border-cream-300 rounded-xl px-3 py-2.5 text-sm text-stone-900"
+              className="bg-cream-100 border border-cream-300 rounded-xl px-3 py-2.5 text-sm text-fg"
               testID={`${testID}-range-end`}
             />
           </View>
@@ -1096,7 +1094,7 @@ export function TransactionsPage({
             testID={`${testID}-bank-edit-categorize`}
             className="px-3 py-3 rounded-xl active:opacity-70"
           >
-            <Text className="text-sm text-stone-900">🏷 Змінити категорію</Text>
+            <Text className="text-sm text-fg">🏷 Змінити категорію</Text>
           </Pressable>
           <Pressable
             onPress={() => {
@@ -1107,7 +1105,7 @@ export function TransactionsPage({
             testID={`${testID}-bank-edit-hide`}
             className="px-3 py-3 rounded-xl active:opacity-70"
           >
-            <Text className="text-sm text-stone-900">🙈 Приховати</Text>
+            <Text className="text-sm text-fg">🙈 Приховати</Text>
           </Pressable>
         </View>
       </Sheet>
@@ -1123,7 +1121,7 @@ export function TransactionsPage({
           testID={`${testID}-filter-cat-sheet`}
         >
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
-          <Text className="text-[11px] uppercase tracking-wide text-stone-400 px-3 pt-2 pb-1">
+          <Text className="text-[11px] uppercase tracking-wide text-fg-subtle px-3 pt-2 pb-1">
             Витрати
           </Text>
           {allExpenseCategories.map((c) => {
@@ -1140,15 +1138,15 @@ export function TransactionsPage({
                 testID={`${testID}-filter-cat-opt-${c.id}`}
                 className="flex-row items-center px-3 py-3 rounded-xl active:opacity-70"
               >
-                <Text className="text-sm text-stone-900 flex-1">{c.label}</Text>
-                <Text className={checked ? "text-brand-500" : "text-stone-300"}>
+                <Text className="text-sm text-fg flex-1">{c.label}</Text>
+                <Text className={checked ? "text-brand-500" : "text-fg-subtle"}>
                   {checked ? "☑" : "☐"}
                 </Text>
               </Pressable>
             );
           })}
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift */}
-          <Text className="text-[11px] uppercase tracking-wide text-stone-400 px-3 pt-3 pb-1">
+          <Text className="text-[11px] uppercase tracking-wide text-fg-subtle px-3 pt-3 pb-1">
             Доходи
           </Text>
           {allIncomeCategories.map((c) => {
@@ -1165,8 +1163,8 @@ export function TransactionsPage({
                 testID={`${testID}-filter-cat-opt-${c.id}`}
                 className="flex-row items-center px-3 py-3 rounded-xl active:opacity-70"
               >
-                <Text className="text-sm text-stone-900 flex-1">{c.label}</Text>
-                <Text className={checked ? "text-brand-500" : "text-stone-300"}>
+                <Text className="text-sm text-fg flex-1">{c.label}</Text>
+                <Text className={checked ? "text-brand-500" : "text-fg-subtle"}>
                   {checked ? "☑" : "☐"}
                 </Text>
               </Pressable>
@@ -1182,7 +1180,7 @@ export function TransactionsPage({
               testID={`${testID}-filter-cat-clear`}
               className="mt-2 px-3 py-3 rounded-xl bg-cream-100 active:opacity-70"
             >
-              <Text className="text-sm text-stone-600 text-center">
+              <Text className="text-sm text-fg-muted text-center">
                 Скинути категорію
               </Text>
             </Pressable>

--- a/apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx
+++ b/apps/mobile/src/modules/fizruk/components/BodyAtlas.tsx
@@ -84,8 +84,8 @@ export interface BodyAtlasProps {
 // Shapes are painted through inline SVG attributes (not NativeWind),
 // which is why we resolve hex strings eagerly here.
 const ACCENT_HEX = "#14b8a6"; // teal-500 (Fizruk primary).
-const SILHOUETTE_FILL = "#e7e5e4"; // stone-200 — neutral body colour.
-const SILHOUETTE_STROKE = "#a8a29e"; // stone-400 — subtle outline.
+const SILHOUETTE_FILL = "#e7e5e4"; // warm neutral body colour.
+const SILHOUETTE_STROKE = "#a8a29e"; // subtle warm-grey outline.
 
 /** Clamp `n` into [min, max]. */
 function clamp(n: number, min: number, max: number): number {
@@ -225,14 +225,14 @@ export function BodyAtlas({
             className={
               side === "front"
                 ? "px-3 py-1.5 rounded-full bg-teal-600"
-                : "px-3 py-1.5 rounded-full border border-stone-300 bg-white"
+                : "px-3 py-1.5 rounded-full border border-line bg-white"
             }
           >
             <Text
               className={
                 side === "front"
                   ? "text-xs font-semibold text-white"
-                  : "text-xs font-semibold text-stone-700"
+                  : "text-xs font-semibold text-fg"
               }
             >
               Спереду
@@ -250,14 +250,14 @@ export function BodyAtlas({
             className={
               side === "back"
                 ? "px-3 py-1.5 rounded-full bg-teal-600"
-                : "px-3 py-1.5 rounded-full border border-stone-300 bg-white"
+                : "px-3 py-1.5 rounded-full border border-line bg-white"
             }
           >
             <Text
               className={
                 side === "back"
                   ? "text-xs font-semibold text-white"
-                  : "text-xs font-semibold text-stone-700"
+                  : "text-xs font-semibold text-fg"
               }
             >
               Ззаду

--- a/apps/mobile/src/modules/fizruk/components/body/BodySummaryCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/body/BodySummaryCard.tsx
@@ -62,10 +62,10 @@ function deltaClass(
   direction: BodyTrendDirection,
   positiveDirection: "up" | "down" | "flat",
 ): string {
-  if (direction === "none") return "text-stone-400";
-  if (direction === "flat") return "text-stone-500";
+  if (direction === "none") return "text-fg-subtle";
+  if (direction === "flat") return "text-fg-muted";
   if (direction === positiveDirection) return "text-emerald-700";
-  if (positiveDirection === "flat") return "text-stone-500";
+  if (positiveDirection === "flat") return "text-fg-muted";
   return "text-amber-700";
 }
 
@@ -136,12 +136,12 @@ const BodySummaryCardImpl = function BodySummaryCard({
           </Text>
         ) : null}
         {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- compact summary-tile label, mirrors web Body.tsx kicker */}
-        <Text className="text-[11px] uppercase tracking-wide text-stone-500">
+        <Text className="text-[11px] uppercase tracking-wide text-fg-muted">
           {label}
         </Text>
       </View>
       <Text
-        className="mt-1 text-xl font-extrabold text-stone-900 tabular-nums"
+        className="mt-1 text-xl font-extrabold text-fg tabular-nums"
         testID={testID ? `${testID}-value` : undefined}
       >
         {valueStr}
@@ -157,7 +157,7 @@ const BodySummaryCardImpl = function BodySummaryCard({
           {arrow ? `${arrow} ` : ""}
           {deltaStr}
         </Text>
-        <Text className="text-[10px] text-stone-400">
+        <Text className="text-[10px] text-fg-subtle">
           {`· ${windowDays} дн.`}
         </Text>
       </View>

--- a/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/body/BodyTrendCard.tsx
@@ -128,11 +128,11 @@ const BodyTrendCardImpl = function BodyTrendCard({
         testID={`${rootTestID}-toggle`}
       >
         <View className="flex-1 min-w-0">
-          <Text className="text-sm font-semibold text-stone-900">{title}</Text>
+          <Text className="text-sm font-semibold text-fg">{title}</Text>
         </View>
         {latest != null ? (
           <View className="flex-row items-baseline gap-2 shrink-0">
-            <Text className="text-sm font-semibold text-stone-900 tabular-nums">
+            <Text className="text-sm font-semibold text-fg tabular-nums">
               {`${latest.toFixed(0)}${unit}`}
             </Text>
             {delta != null && delta !== 0 ? (
@@ -149,7 +149,7 @@ const BodyTrendCardImpl = function BodyTrendCard({
           </View>
         ) : null}
         <Text
-          className={`text-stone-500 ${open ? "rotate-180" : ""}`}
+          className={`text-fg-muted ${open ? "rotate-180" : ""}`}
           accessibilityElementsHidden
         >
           ▾
@@ -158,7 +158,7 @@ const BodyTrendCardImpl = function BodyTrendCard({
       {open ? (
         <View className="px-4 pb-4">
           <View className="flex-row items-baseline justify-end mb-2">
-            <Text className="text-[11px] text-stone-500">
+            <Text className="text-[11px] text-fg-muted">
               {`останні ${limit ?? 8}`}
             </Text>
           </View>

--- a/apps/mobile/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -120,7 +120,7 @@ export function HeroCard({
               className={
                 isToday
                   ? "text-xl font-bold text-white"
-                  : "text-xl font-bold text-stone-900"
+                  : "text-xl font-bold text-fg"
               }
               testID={`${testID}-title`}
             >
@@ -161,7 +161,7 @@ export function HeroCard({
           <Text className="text-xs font-semibold text-teal-800">
             Швидкий старт
           </Text>
-          <Text className="text-base font-semibold text-stone-900">
+          <Text className="text-base font-semibold text-fg">
             План поки порожній
           </Text>
           <Text className="text-sm text-teal-800/80 leading-snug">

--- a/apps/mobile/src/modules/fizruk/components/dashboard/KpiRow.tsx
+++ b/apps/mobile/src/modules/fizruk/components/dashboard/KpiRow.tsx
@@ -30,7 +30,7 @@ function Tile({ label, value, hint, testID, tone = "default" }: TileProps) {
       ? "text-teal-700"
       : tone === "negative"
         ? "text-rose-600"
-        : "text-stone-900";
+        : "text-fg";
   return (
     <Card
       variant="default"
@@ -39,10 +39,10 @@ function Tile({ label, value, hint, testID, tone = "default" }: TileProps) {
       className="flex-1"
       testID={testID}
     >
-      <Text className="text-[10px] font-semibold text-stone-500">{label}</Text>
+      <Text className="text-[10px] font-semibold text-fg-muted">{label}</Text>
       <Text className={`text-lg font-bold ${toneClass} mt-0.5`}>{value}</Text>
       {hint ? (
-        <Text className="text-[10px] text-stone-500 mt-0.5">{hint}</Text>
+        <Text className="text-[10px] text-fg-muted mt-0.5">{hint}</Text>
       ) : null}
     </Card>
   );

--- a/apps/mobile/src/modules/fizruk/components/dashboard/QuickLinksRow.tsx
+++ b/apps/mobile/src/modules/fizruk/components/dashboard/QuickLinksRow.tsx
@@ -101,7 +101,7 @@ export function QuickLinksRow({
 }: QuickLinksRowProps) {
   return (
     <View className="gap-2" testID={testID}>
-      <Text className="text-sm font-semibold text-stone-700">Розділи</Text>
+      <Text className="text-sm font-semibold text-fg">Розділи</Text>
       <View className="flex-row flex-wrap -mx-1">
         {QUICK_LINK_TILES.map((tile) => (
           <View key={tile.id} className="w-1/2 px-1 mb-2">
@@ -119,10 +119,10 @@ export function QuickLinksRow({
                   className={pressed ? "opacity-80" : ""}
                 >
                   <Text className="text-2xl">{tile.glyph}</Text>
-                  <Text className="text-sm font-semibold text-stone-900 mt-1.5">
+                  <Text className="text-sm font-semibold text-fg mt-1.5">
                     {tile.title}
                   </Text>
-                  <Text className="text-[11px] text-stone-500 leading-snug">
+                  <Text className="text-[11px] text-fg-muted leading-snug">
                     {tile.subtitle}
                   </Text>
                 </Card>

--- a/apps/mobile/src/modules/fizruk/components/dashboard/RecentPRsSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/dashboard/RecentPRsSection.tsx
@@ -36,7 +36,7 @@ export function RecentPRsSection({
   if (prs.length === 0) {
     return (
       <View className="gap-2" testID={testID}>
-        <Text className="text-sm font-semibold text-stone-700">Рекорди</Text>
+        <Text className="text-sm font-semibold text-fg">Рекорди</Text>
         <Card
           variant="default"
           radius="lg"
@@ -44,10 +44,10 @@ export function RecentPRsSection({
           className="items-center"
           testID={`${testID}-empty`}
         >
-          <Text className="text-sm font-semibold text-stone-900">
+          <Text className="text-sm font-semibold text-fg">
             Поки без рекордів
           </Text>
-          <Text className="text-xs text-stone-500 text-center mt-1">
+          <Text className="text-xs text-fg-muted text-center mt-1">
             Запиши вагу й повторення у сетах — Dashboard підсвітить найкращі.
           </Text>
         </Card>
@@ -57,7 +57,7 @@ export function RecentPRsSection({
 
   return (
     <View className="gap-2" testID={testID}>
-      <Text className="text-sm font-semibold text-stone-700">Рекорди</Text>
+      <Text className="text-sm font-semibold text-fg">Рекорди</Text>
       <View className="gap-2">
         {prs.map((pr) => (
           <Card
@@ -70,12 +70,12 @@ export function RecentPRsSection({
             <View className="flex-row items-center justify-between gap-3">
               <View className="flex-1">
                 <Text
-                  className="text-sm font-semibold text-stone-900"
+                  className="text-sm font-semibold text-fg"
                   numberOfLines={1}
                 >
                   {pr.nameUk ?? pr.exerciseId}
                 </Text>
-                <Text className="text-[11px] text-stone-500 mt-0.5">
+                <Text className="text-[11px] text-fg-muted mt-0.5">
                   {pr.weightKg} × {pr.reps}
                   {pr.atIso ? ` · ${formatDateShort(pr.atIso)}` : ""}
                 </Text>
@@ -84,7 +84,7 @@ export function RecentPRsSection({
                 <Text className="text-sm font-bold text-teal-700">
                   {pr.oneRmKg} кг
                 </Text>
-                <Text className="text-[10px] text-stone-500">1ПМ</Text>
+                <Text className="text-[10px] text-fg-muted">1ПМ</Text>
               </View>
             </View>
           </Card>

--- a/apps/mobile/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/dashboard/RecentWorkoutsSection.tsx
@@ -59,7 +59,7 @@ export function RecentWorkoutsSection({
   return (
     <View className="gap-2" testID={testID}>
       <View className="flex-row items-baseline justify-between">
-        <Text className="text-sm font-semibold text-stone-700">
+        <Text className="text-sm font-semibold text-fg">
           Останні тренування
         </Text>
         <Pressable
@@ -86,10 +86,10 @@ export function RecentWorkoutsSection({
           className="items-center"
           testID={`${testID}-empty`}
         >
-          <Text className="text-sm font-semibold text-stone-900">
+          <Text className="text-sm font-semibold text-fg">
             Ще жодного завершеного тренування
           </Text>
-          <Text className="text-xs text-stone-500 text-center mt-1">
+          <Text className="text-xs text-fg-muted text-center mt-1">
             Почни сесію — результати з&apos;являться тут автоматично.
           </Text>
         </Card>
@@ -106,12 +106,12 @@ export function RecentWorkoutsSection({
               <View className="flex-row items-center justify-between gap-3">
                 <View className="flex-1">
                   <Text
-                    className="text-sm font-semibold text-stone-900"
+                    className="text-sm font-semibold text-fg"
                     numberOfLines={1}
                   >
                     {row.label}
                   </Text>
-                  <Text className="text-[11px] text-stone-500 mt-0.5">
+                  <Text className="text-[11px] text-fg-muted mt-0.5">
                     {formatDateShort(row.endedAt)} ·{" "}
                     {formatDuration(row.durationSec)}
                   </Text>
@@ -120,7 +120,7 @@ export function RecentWorkoutsSection({
                   <Text className="text-sm font-bold text-teal-700">
                     {formatTonnage(row.tonnageKg)}
                   </Text>
-                  <Text className="text-[10px] text-stone-500">тоннаж</Text>
+                  <Text className="text-[10px] text-fg-muted">тоннаж</Text>
                 </View>
               </View>
             </Card>

--- a/apps/mobile/src/modules/fizruk/components/exercise/ExerciseHeader.tsx
+++ b/apps/mobile/src/modules/fizruk/components/exercise/ExerciseHeader.tsx
@@ -24,7 +24,7 @@ const ExerciseHeaderImpl = function ExerciseHeader({
   return (
     <View testID={testID} className="gap-2">
       <Text
-        className="text-xl font-bold text-stone-900 leading-tight"
+        className="text-xl font-bold text-fg leading-tight"
         accessibilityRole="header"
       >
         {title}
@@ -45,10 +45,10 @@ const ExerciseHeaderImpl = function ExerciseHeader({
           ))}
         </View>
       ) : (
-        <Text className="text-xs text-stone-500">{"Профіль вправи"}</Text>
+        <Text className="text-xs text-fg-muted">{"Профіль вправи"}</Text>
       )}
       {description ? (
-        <Text className="text-xs text-stone-600 leading-snug">
+        <Text className="text-xs text-fg-muted leading-snug">
           {description}
         </Text>
       ) : null}

--- a/apps/mobile/src/modules/fizruk/components/exercise/ExerciseHistoryList.tsx
+++ b/apps/mobile/src/modules/fizruk/components/exercise/ExerciseHistoryList.tsx
@@ -80,10 +80,10 @@ const ExerciseHistoryListImpl = function ExerciseHistoryList({
         testID={`${testID}-empty`}
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           Поки немає записів
         </Text>
-        <Text className="text-xs text-stone-500 mt-1">
+        <Text className="text-xs text-fg-muted mt-1">
           Заверши хоча б один підхід — історія з&apos;явиться тут.
         </Text>
       </View>
@@ -102,18 +102,16 @@ const ExerciseHistoryListImpl = function ExerciseHistoryList({
             testID={`${testID}-row-${key}`}
           >
             <View className="flex-row items-center justify-between gap-2">
-              <Text className="text-xs text-stone-500">
+              <Text className="text-xs text-fg-muted">
                 {formatHistoryDate(workout?.startedAt)}
               </Text>
               <View className="px-2 py-0.5 rounded-full border border-cream-300">
-                <Text className="text-[10px] text-stone-500">
+                <Text className="text-[10px] text-fg-muted">
                   {entryTypeLabel(entry)}
                 </Text>
               </View>
             </View>
-            <Text className="text-sm text-stone-900 mt-2">
-              {describeEntry(entry)}
-            </Text>
+            <Text className="text-sm text-fg mt-2">{describeEntry(entry)}</Text>
           </View>
         );
       })}

--- a/apps/mobile/src/modules/fizruk/components/exercise/ExerciseLoadCalculator.tsx
+++ b/apps/mobile/src/modules/fizruk/components/exercise/ExerciseLoadCalculator.tsx
@@ -35,7 +35,7 @@ const ExerciseLoadCalculatorImpl = function ExerciseLoadCalculator({
   if (zones.length === 0) return null;
   return (
     <Card variant="default" radius="lg" padding="md" testID={testID}>
-      <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+      <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
         Калькулятор навантаження
       </Text>
       <View className="gap-2">

--- a/apps/mobile/src/modules/fizruk/components/exercise/ExerciseSummaryCards.tsx
+++ b/apps/mobile/src/modules/fizruk/components/exercise/ExerciseSummaryCards.tsx
@@ -64,17 +64,17 @@ const ExerciseSummaryCardsImpl = function ExerciseSummaryCards({
           padding="md"
           testID={`${testID}-pr`}
         >
-          <Text className="text-[10px] uppercase font-bold text-stone-500">
+          <Text className="text-[10px] uppercase font-bold text-fg-muted">
             Особистий рекорд
           </Text>
-          <Text className="text-2xl font-extrabold text-stone-900 mt-1 tabular-nums">
+          <Text className="text-2xl font-extrabold text-fg mt-1 tabular-nums">
             {best.best1rm > 0 ? formatKg(best.best1rm, 0) : "—"}
           </Text>
-          <Text className="text-xs text-stone-500 mt-1">
+          <Text className="text-xs text-fg-muted mt-1">
             {describeBestSet(best.bestSet)}
           </Text>
           {prDate ? (
-            <Text className="text-[10px] text-stone-400 mt-1">{prDate}</Text>
+            <Text className="text-[10px] text-fg-subtle mt-1">{prDate}</Text>
           ) : null}
         </Card>
       </View>
@@ -86,13 +86,13 @@ const ExerciseSummaryCardsImpl = function ExerciseSummaryCards({
           padding="md"
           testID={`${testID}-next`}
         >
-          <Text className="text-[10px] uppercase font-bold text-stone-500">
+          <Text className="text-[10px] uppercase font-bold text-fg-muted">
             Наступного разу
           </Text>
-          <Text className="text-2xl font-extrabold text-stone-900 mt-1 tabular-nums">
+          <Text className="text-2xl font-extrabold text-fg mt-1 tabular-nums">
             {suggestedNext ? formatKg(suggestedNext.weightKg, 1) : "—"}
           </Text>
-          <Text className="text-xs text-stone-500 mt-1">
+          <Text className="text-xs text-fg-muted mt-1">
             {suggestedNext
               ? `× ${suggestedNext.reps} повт.`
               : "Заповни сети, щоб з'явилась рекомендація"}
@@ -104,7 +104,7 @@ const ExerciseSummaryCardsImpl = function ExerciseSummaryCards({
             </Text>
           ) : null}
           {suggestedNext && best.lastTop ? (
-            <Text className="text-[10px] text-stone-400 mt-1">
+            <Text className="text-[10px] text-fg-subtle mt-1">
               {`зараз: ${best.lastTop.weightKg ?? 0} × ${best.lastTop.reps ?? 0}`}
             </Text>
           ) : null}

--- a/apps/mobile/src/modules/fizruk/components/exercise/ExerciseTrendChart.tsx
+++ b/apps/mobile/src/modules/fizruk/components/exercise/ExerciseTrendChart.tsx
@@ -53,10 +53,10 @@ const ExerciseTrendChartImpl = function ExerciseTrendChart({
         testID={`${testIDPrefix}-empty`}
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           Немає даних для графіка
         </Text>
-        <Text className="text-xs text-stone-500 mt-1">
+        <Text className="text-xs text-fg-muted mt-1">
           Заверши хоча б один силовий підхід, щоб побачити тренд.
         </Text>
       </View>
@@ -69,10 +69,10 @@ const ExerciseTrendChartImpl = function ExerciseTrendChart({
         testID={`${testIDPrefix}-empty`}
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           Замало точок для лінії
         </Text>
-        <Text className="text-xs text-stone-500 mt-1">
+        <Text className="text-xs text-fg-muted mt-1">
           {`Потрібні щонайменше два тижні з даними, щоб побудувати ${label.toLowerCase()}.`}
         </Text>
       </View>
@@ -92,7 +92,7 @@ const ExerciseTrendChartImpl = function ExerciseTrendChart({
   return (
     <View testID={`${testIDPrefix}-chart`}>
       <View className="flex-row items-baseline justify-between mb-2">
-        <Text className="text-base font-bold text-stone-900 tabular-nums">
+        <Text className="text-base font-bold text-fg tabular-nums">
           {`${latest.value}${unit}`}
         </Text>
         <Text
@@ -102,7 +102,7 @@ const ExerciseTrendChartImpl = function ExerciseTrendChart({
               ? "text-xs font-semibold text-emerald-700 tabular-nums"
               : delta < 0
                 ? "text-xs font-semibold text-amber-700 tabular-nums"
-                : "text-xs font-semibold text-stone-500 tabular-nums"
+                : "text-xs font-semibold text-fg-muted tabular-nums"
           }
         >
           {`${delta > 0 ? "+" : ""}${delta}${unit}`}
@@ -129,8 +129,8 @@ const ExerciseTrendChartImpl = function ExerciseTrendChart({
         </VictoryGroup>
       </View>
       <View className="flex-row justify-between mt-1">
-        <Text className="text-[10px] text-stone-400">{first.dateLabel}</Text>
-        <Text className="text-[10px] text-stone-400">{latest.dateLabel}</Text>
+        <Text className="text-[10px] text-fg-subtle">{first.dateLabel}</Text>
+        <Text className="text-[10px] text-fg-subtle">{latest.dateLabel}</Text>
       </View>
     </View>
   );

--- a/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryForm.tsx
+++ b/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryForm.tsx
@@ -133,10 +133,10 @@ export function MeasurementEntryForm({
                 className="w-1/2 px-1 mb-3"
                 testID={`${testID}-field-${field.id}`}
               >
-                <Text className="text-xs font-semibold text-stone-700 mb-1">
+                <Text className="text-xs font-semibold text-fg mb-1">
                   {field.label}
                   {field.unit ? (
-                    <Text className="text-stone-500">{` (${field.unit})`}</Text>
+                    <Text className="text-fg-muted">{` (${field.unit})`}</Text>
                   ) : null}
                 </Text>
                 <Input

--- a/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryList.tsx
+++ b/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryList.tsx
@@ -34,10 +34,8 @@ export function MeasurementEntryList({
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4 items-center"
         testID={`${testID}-empty`}
       >
-        <Text className="text-sm font-semibold text-stone-900">
-          Поки порожньо
-        </Text>
-        <Text className="text-xs text-stone-500 mt-1 text-center">
+        <Text className="text-sm font-semibold text-fg">Поки порожньо</Text>
+        <Text className="text-xs text-fg-muted mt-1 text-center">
           Натисни «+ Додати» і запиши свій перший замір.
         </Text>
       </View>

--- a/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryRow.tsx
+++ b/apps/mobile/src/modules/fizruk/components/measurements/MeasurementEntryRow.tsx
@@ -56,11 +56,11 @@ export function MeasurementEntryRow({
         accessibilityLabel={`Редагувати запис ${formatMeasurementDate(entry.at)}`}
         testID={`${rowTestID}-edit`}
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           {formatMeasurementDate(entry.at)}
         </Text>
         <Text
-          className="text-xs text-stone-600 mt-0.5"
+          className="text-xs text-fg-muted mt-0.5"
           numberOfLines={2}
           testID={`${rowTestID}-summary`}
         >

--- a/apps/mobile/src/modules/fizruk/components/measurements/MeasurementsTrendCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/measurements/MeasurementsTrendCard.tsx
@@ -52,8 +52,8 @@ const TrendCardImpl = function MeasurementsTrendCard({
       testID={testID}
     >
       <View className="flex-row items-baseline justify-between mb-2">
-        <Text className="text-sm font-semibold text-stone-900">Тренд ваги</Text>
-        <Text className="text-[11px] text-stone-500">останні 8</Text>
+        <Text className="text-sm font-semibold text-fg">Тренд ваги</Text>
+        <Text className="text-[11px] text-fg-muted">останні 8</Text>
       </View>
       <TrendChart
         series={weightSeries}

--- a/apps/mobile/src/modules/fizruk/components/programs/ProgramCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/programs/ProgramCard.tsx
@@ -60,7 +60,7 @@ export function ProgramCard({
       <View className="gap-3">
         <View className="gap-1.5">
           <View className="flex-row items-center gap-2 flex-wrap">
-            <Text className="text-base font-bold text-stone-900 flex-1">
+            <Text className="text-base font-bold text-fg flex-1">
               {program.name}
             </Text>
             {active ? (
@@ -74,10 +74,10 @@ export function ProgramCard({
               </View>
             ) : null}
           </View>
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             {formatProgramCadence(program)}
           </Text>
-          <Text className="text-sm text-stone-700 leading-snug">
+          <Text className="text-sm text-fg leading-snug">
             {program.description}
           </Text>
         </View>
@@ -95,7 +95,7 @@ export function ProgramCard({
               ? isToday && active
                 ? "text-white"
                 : "text-teal-800"
-              : "text-stone-400";
+              : "text-fg-subtle";
             return (
               <View
                 key={`${program.id}-d${i}`}

--- a/apps/mobile/src/modules/fizruk/components/programs/TodaySessionCard.tsx
+++ b/apps/mobile/src/modules/fizruk/components/programs/TodaySessionCard.tsx
@@ -38,16 +38,16 @@ export function TodaySessionCard({
     return (
       <Card variant="default" radius="lg" padding="lg" testID={testID}>
         <View className="gap-1.5">
-          <Text className="text-xs font-semibold text-stone-500">
+          <Text className="text-xs font-semibold text-fg-muted">
             Сьогоднішня сесія
           </Text>
           <Text
-            className="text-base font-semibold text-stone-900"
+            className="text-base font-semibold text-fg"
             testID={`${testID}-empty`}
           >
             Активуй програму, щоб побачити план на сьогодні
           </Text>
-          <Text className="text-sm text-stone-500 leading-snug">
+          <Text className="text-sm text-fg-muted leading-snug">
             Обери програму нижче — її сесії автоматично з&apos;являтимуться тут
             за днем тижня.
           </Text>
@@ -64,12 +64,12 @@ export function TodaySessionCard({
             {activeProgram.name}
           </Text>
           <Text
-            className="text-base font-semibold text-stone-900"
+            className="text-base font-semibold text-fg"
             testID={`${testID}-rest`}
           >
             Сьогодні — вихідний
           </Text>
-          <Text className="text-sm text-stone-600 leading-snug">
+          <Text className="text-sm text-fg-muted leading-snug">
             Наступна сесія — згідно графіка програми. Відпочинок — частина
             прогресу.
           </Text>

--- a/apps/mobile/src/modules/fizruk/components/progress/MeasurementsChartSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/MeasurementsChartSection.tsx
@@ -25,7 +25,7 @@ const MeasurementsChartSectionImpl = function MeasurementsChartSection({
 }: MeasurementsChartSectionProps) {
   return (
     <Card radius="lg" padding="lg" testID="fizruk-progress-bodyfat">
-      <Text className="text-xs font-semibold text-stone-500 mb-3">
+      <Text className="text-xs font-semibold text-fg-muted mb-3">
         {"Тренд % жиру"}
       </Text>
       <TrendChart

--- a/apps/mobile/src/modules/fizruk/components/progress/ProgressKPIs.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/ProgressKPIs.tsx
@@ -32,21 +32,21 @@ const ProgressKPIsImpl = function ProgressKPIs({ kpis }: ProgressKPIsProps) {
     <Card radius="lg" padding="lg" testID="fizruk-progress-kpis">
       <View className="flex-row items-start justify-between gap-3">
         <View className="flex-1 min-w-0">
-          <Text className="text-xl font-bold text-stone-900">{"Прогрес"}</Text>
-          <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+          <Text className="text-xl font-bold text-fg">{"Прогрес"}</Text>
+          <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
             {subtitle}
           </Text>
         </View>
         <View className="flex-row items-center gap-4">
           <View className="items-center" testID="fizruk-progress-prs-stat">
-            <Text className="text-xs text-stone-500">{"PR"}</Text>
-            <Text className="text-base font-extrabold text-stone-900 tabular-nums">
+            <Text className="text-xs text-fg-muted">{"PR"}</Text>
+            <Text className="text-base font-extrabold text-fg tabular-nums">
               {kpis.prsCount}
             </Text>
           </View>
           <View className="items-center" testID="fizruk-progress-entries-stat">
-            <Text className="text-xs text-stone-500">{"Заміри"}</Text>
-            <Text className="text-base font-extrabold text-stone-900 tabular-nums">
+            <Text className="text-xs text-fg-muted">{"Заміри"}</Text>
+            <Text className="text-base font-extrabold text-fg tabular-nums">
               {kpis.entriesCount}
             </Text>
           </View>

--- a/apps/mobile/src/modules/fizruk/components/progress/TrendChart.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/TrendChart.tsx
@@ -72,10 +72,10 @@ const TrendChartImpl = function TrendChart({
         testID={`${testIDPrefix}-empty`}
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           {"Немає числових даних"}
         </Text>
-        <Text className="text-xs text-stone-500 mt-1">
+        <Text className="text-xs text-fg-muted mt-1">
           {`Додай записи в розділі «Заміри», щоб відстежувати ${metricLabel}.`}
         </Text>
       </View>
@@ -88,10 +88,10 @@ const TrendChartImpl = function TrendChart({
         testID={`${testIDPrefix}-empty`}
         className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4"
       >
-        <Text className="text-sm font-semibold text-stone-900">
+        <Text className="text-sm font-semibold text-fg">
           {"Замало точок для лінії"}
         </Text>
-        <Text className="text-xs text-stone-500 mt-1">
+        <Text className="text-xs text-fg-muted mt-1">
           {`Потрібні щонайменше два заміри з ${metricLabel}, щоб побудувати тренд.`}
         </Text>
       </View>
@@ -116,7 +116,7 @@ const TrendChartImpl = function TrendChart({
   return (
     <View testID={`${testIDPrefix}-chart`}>
       <View className="flex-row items-baseline justify-between mb-2">
-        <Text className="text-base font-bold text-stone-900 tabular-nums">
+        <Text className="text-base font-bold text-fg tabular-nums">
           {`${latest.y}${unit}`}
         </Text>
         <Text
@@ -126,7 +126,7 @@ const TrendChartImpl = function TrendChart({
               ? "text-xs font-semibold text-amber-700 tabular-nums"
               : delta < 0
                 ? "text-xs font-semibold text-emerald-700 tabular-nums"
-                : "text-xs font-semibold text-stone-500 tabular-nums"
+                : "text-xs font-semibold text-fg-muted tabular-nums"
           }
         >
           {`${delta > 0 ? "+" : ""}${delta.toFixed(1)}${unit}`}
@@ -151,8 +151,8 @@ const TrendChartImpl = function TrendChart({
         </VictoryGroup>
       </View>
       <View className="flex-row items-center justify-between mt-1">
-        <Text className="text-[10px] text-stone-400">{first.raw.label}</Text>
-        <Text className="text-[10px] text-stone-400">{latest.raw.label}</Text>
+        <Text className="text-[10px] text-fg-subtle">{first.raw.label}</Text>
+        <Text className="text-[10px] text-fg-subtle">{latest.raw.label}</Text>
       </View>
     </View>
   );

--- a/apps/mobile/src/modules/fizruk/components/progress/WeightChartSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/progress/WeightChartSection.tsx
@@ -24,7 +24,7 @@ const WeightChartSectionImpl = function WeightChartSection({
 }: WeightChartSectionProps) {
   return (
     <Card radius="lg" padding="lg" testID="fizruk-progress-weight">
-      <Text className="text-xs font-semibold text-stone-500 mb-3">
+      <Text className="text-xs font-semibold text-fg-muted mb-3">
         {"Тренд ваги"}
       </Text>
       <TrendChart

--- a/apps/mobile/src/modules/fizruk/components/workouts/ActiveSetEditor.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/ActiveSetEditor.tsx
@@ -186,7 +186,7 @@ export function ActiveSetEditor({
       <View className="gap-4 py-2" testID={testID}>
         {/* Weight */}
         <View className="gap-2">
-          <Text className="text-xs font-semibold uppercase text-stone-500">
+          <Text className="text-xs font-semibold uppercase text-fg-muted">
             Вага (кг)
           </Text>
           <View className="flex-row items-center gap-2">
@@ -198,7 +198,7 @@ export function ActiveSetEditor({
               accessibilityLabel="Зменшити вагу"
               testID={`${testID}-weight-dec`}
             >
-              <Text className="text-stone-900 text-lg font-bold">−</Text>
+              <Text className="text-fg text-lg font-bold">−</Text>
             </Button>
             <Input
               value={numInputValue(draft.weightKg)}
@@ -217,7 +217,7 @@ export function ActiveSetEditor({
               accessibilityLabel="Збільшити вагу"
               testID={`${testID}-weight-inc`}
             >
-              <Text className="text-stone-900 text-lg font-bold">+</Text>
+              <Text className="text-fg text-lg font-bold">+</Text>
             </Button>
           </View>
           {errors.weightKg ? (
@@ -232,7 +232,7 @@ export function ActiveSetEditor({
 
         {/* Reps */}
         <View className="gap-2">
-          <Text className="text-xs font-semibold uppercase text-stone-500">
+          <Text className="text-xs font-semibold uppercase text-fg-muted">
             Повторення
           </Text>
           <View className="flex-row items-center gap-2">
@@ -244,7 +244,7 @@ export function ActiveSetEditor({
               accessibilityLabel="Зменшити повторення"
               testID={`${testID}-reps-dec`}
             >
-              <Text className="text-stone-900 text-lg font-bold">−</Text>
+              <Text className="text-fg text-lg font-bold">−</Text>
             </Button>
             <Input
               value={numInputValue(draft.reps)}
@@ -263,7 +263,7 @@ export function ActiveSetEditor({
               accessibilityLabel="Збільшити повторення"
               testID={`${testID}-reps-inc`}
             >
-              <Text className="text-stone-900 text-lg font-bold">+</Text>
+              <Text className="text-fg text-lg font-bold">+</Text>
             </Button>
           </View>
           {errors.reps ? (
@@ -278,7 +278,7 @@ export function ActiveSetEditor({
 
         {/* RPE */}
         <View className="gap-2">
-          <Text className="text-xs font-semibold uppercase text-stone-500">
+          <Text className="text-xs font-semibold uppercase text-fg-muted">
             RPE (Borg 1..10) — необов&apos;язково
           </Text>
           <View className="flex-row flex-wrap gap-1.5">

--- a/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/ExerciseCatalogSection.tsx
@@ -108,7 +108,7 @@ function EquipmentChips({
 
   return (
     <View className="gap-1">
-      <Text className="text-xs font-semibold text-stone-500 px-1">
+      <Text className="text-xs font-semibold text-fg-muted px-1">
         Обладнання
       </Text>
       <ScrollView
@@ -168,7 +168,7 @@ function Chip({
         className={
           active
             ? "text-xs font-semibold text-white"
-            : "text-xs font-semibold text-stone-700"
+            : "text-xs font-semibold text-fg"
         }
       >
         {label}
@@ -204,14 +204,11 @@ function ExerciseRow({
       className="px-3 py-3 rounded-xl border border-cream-300 bg-cream-50 flex-row items-center justify-between"
     >
       <View className="flex-1 pr-2">
-        <Text
-          className="text-sm font-semibold text-stone-900"
-          numberOfLines={2}
-        >
+        <Text className="text-sm font-semibold text-fg" numberOfLines={2}>
           {title}
         </Text>
         {groupLabel ? (
-          <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+          <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
             {groupLabel}
           </Text>
         ) : null}
@@ -317,10 +314,10 @@ export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
           padding="lg"
           testID={`${testID}-empty`}
         >
-          <Text className="text-sm font-semibold text-stone-900">
+          <Text className="text-sm font-semibold text-fg">
             Нічого не знайдено
           </Text>
-          <Text className="text-xs text-stone-500 mt-1">
+          <Text className="text-xs text-fg-muted mt-1">
             Спробуй інший пошук або очисти фільтр по групі.
           </Text>
         </Card>
@@ -333,10 +330,10 @@ export const ExerciseCatalogSection = memo(function ExerciseCatalogSection({
               testID={`${testID}-group-${group.id}`}
             >
               <View className="flex-row items-center justify-between px-1">
-                <Text className="text-xs font-semibold uppercase text-stone-500">
+                <Text className="text-xs font-semibold uppercase text-fg-muted">
                   {group.label}
                 </Text>
-                <Text className="text-xs text-stone-500">
+                <Text className="text-xs text-fg-muted">
                   {group.items.length}/{group.total}
                 </Text>
               </View>

--- a/apps/mobile/src/modules/fizruk/components/workouts/WorkoutActivePanel.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/WorkoutActivePanel.tsx
@@ -55,7 +55,7 @@ export const WorkoutActivePanel = memo(function WorkoutActivePanel({
             <Text className="text-xs font-semibold text-teal-800">
               Немає активного тренування
             </Text>
-            <Text className="text-base text-stone-700 mt-1">
+            <Text className="text-base text-fg mt-1">
               Почни сесію, щоб додавати вправи та запускати таймер відпочинку.
             </Text>
           </View>
@@ -84,7 +84,7 @@ export const WorkoutActivePanel = memo(function WorkoutActivePanel({
             Активне тренування
           </Text>
           <Text
-            className="text-3xl font-extrabold text-stone-900"
+            className="text-3xl font-extrabold text-fg"
             accessibilityLabel={`Пройшло ${elapsedLabel}`}
             testID={`${testID}-elapsed`}
           >
@@ -93,7 +93,7 @@ export const WorkoutActivePanel = memo(function WorkoutActivePanel({
         </View>
 
         <View className="gap-2">
-          <Text className="text-xs font-semibold text-stone-700">
+          <Text className="text-xs font-semibold text-fg">
             Швидкий відпочинок
           </Text>
           <View className="flex-row flex-wrap gap-2">

--- a/apps/mobile/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/mobile/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -41,10 +41,10 @@ export interface WorkoutJournalSectionProps<W extends WorkoutLike> {
 function JournalEmpty({ testID }: { testID: string }) {
   return (
     <Card variant="flat" radius="lg" padding="lg" testID={testID}>
-      <Text className="text-sm font-semibold text-stone-900">
+      <Text className="text-sm font-semibold text-fg">
         Журнал поки порожній
       </Text>
-      <Text className="text-xs text-stone-500 mt-1">
+      <Text className="text-xs text-fg-muted mt-1">
         Щойно ти додаси перше тренування і додаси в нього вправи, воно
         з&apos;явиться тут згруповане по днях.
       </Text>
@@ -101,9 +101,7 @@ function WorkoutRow<W extends WorkoutLike>({
     >
       <View className="flex-1 pr-2">
         <View className="flex-row items-center gap-2">
-          <Text className="text-sm font-semibold text-stone-900">
-            {startedAt}
-          </Text>
+          <Text className="text-sm font-semibold text-fg">{startedAt}</Text>
           {isActive ? (
             <Text className="text-[10px] uppercase font-bold text-teal-700 bg-teal-100 px-2 py-0.5 rounded-full">
               Активне
@@ -114,11 +112,11 @@ function WorkoutRow<W extends WorkoutLike>({
             </Text>
           ) : null}
         </View>
-        <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+        <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
           {subtitle}
         </Text>
       </View>
-      <Text className="text-stone-400 text-lg">›</Text>
+      <Text className="text-fg-subtle text-lg">›</Text>
     </Pressable>
   );
 }
@@ -148,7 +146,7 @@ export const WorkoutJournalSection = memo(function WorkoutJournalSection<
       {sections.map((section) => (
         <View key={section.dateKey || "unknown"} className="gap-2">
           <Text
-            className="text-xs font-semibold uppercase text-stone-500 px-1"
+            className="text-xs font-semibold uppercase text-fg-muted px-1"
             testID={`${testID}-heading-${section.dateKey || "unknown"}`}
           >
             {formatWorkoutDateLabel(section.dateKey)}

--- a/apps/mobile/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Atlas.tsx
@@ -41,10 +41,10 @@ export function Atlas() {
         contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 12 }}
       >
         <View>
-          <Text className="text-[22px] font-bold text-stone-900">
+          <Text className="text-[22px] font-bold text-fg">
             {"Атлас м'язів"}
           </Text>
-          <Text className="text-sm text-stone-600 leading-snug">
+          <Text className="text-sm text-fg-muted leading-snug">
             {
               "Інтерактивна карта груп м'язів. Тапни зону — отримаєш назву, інтенсивність навантаження та можливість перейти до вправ у наступних PR."
             }
@@ -58,7 +58,7 @@ export function Atlas() {
             height={420}
           />
           <View className="mt-2 items-center">
-            <Text className="text-xs text-stone-500">
+            <Text className="text-xs text-fg-muted">
               {selected
                 ? `Обрано: ${BODY_ATLAS_MUSCLE_LABELS_UK[selected]}`
                 : "Натисни на м'яз, щоб побачити деталі."}

--- a/apps/mobile/src/modules/fizruk/pages/Body.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Body.tsx
@@ -181,8 +181,8 @@ export function Body({
           🫀
         </Text>
         <View className="flex-1">
-          <Text className="text-[22px] font-bold text-stone-900">Тіло</Text>
-          <Text className="text-xs text-stone-500 mt-0.5">
+          <Text className="text-[22px] font-bold text-fg">Тіло</Text>
+          <Text className="text-xs text-fg-muted mt-0.5">
             Вага · сон · самопочуття
           </Text>
         </View>
@@ -210,10 +210,8 @@ export function Body({
             className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-4 items-center"
             testID={`${testID}-empty`}
           >
-            <Text className="text-sm font-semibold text-stone-900">
-              Поки порожньо
-            </Text>
-            <Text className="text-xs text-stone-500 mt-1 text-center">
+            <Text className="text-sm font-semibold text-fg">Поки порожньо</Text>
+            <Text className="text-xs text-fg-muted mt-1 text-center">
               Додай перший запис у розділі «Вимірювання», щоб побачити тут
               зведення й графіки.
             </Text>

--- a/apps/mobile/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Dashboard.tsx
@@ -210,10 +210,10 @@ export function Dashboard({
         testID={`${testID}-scroll`}
       >
         <View>
-          <Text className="text-[22px] font-bold text-stone-900">Сьогодні</Text>
+          <Text className="text-[22px] font-bold text-fg">Сьогодні</Text>
           <Text
             accessibilityRole="text"
-            className="text-sm text-stone-500 capitalize"
+            className="text-sm text-fg-muted capitalize"
           >
             {todayLabel}
           </Text>

--- a/apps/mobile/src/modules/fizruk/pages/Exercise.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Exercise.tsx
@@ -234,7 +234,7 @@ export function Exercise({
       >
         <View className="px-4 pt-4">
           <Card variant="flat" radius="lg" padding="lg">
-            <Text className="text-sm text-stone-500">Невірний ID вправи</Text>
+            <Text className="text-sm text-fg-muted">Невірний ID вправи</Text>
           </Card>
         </View>
       </SafeAreaView>
@@ -274,7 +274,7 @@ export function Exercise({
 
         {hasStrength ? (
           <Card variant="default" radius="lg" padding="md">
-            <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+            <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
               Прогресія 1RM (за тижнями)
             </Text>
             <ExerciseTrendChart
@@ -289,7 +289,7 @@ export function Exercise({
 
         {hasStrength ? (
           <Card variant="default" radius="lg" padding="md">
-            <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+            <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
               Обʼєм тренування (кг × повтори)
             </Text>
             <ExerciseTrendChart
@@ -304,7 +304,7 @@ export function Exercise({
 
         {hasCardio ? (
           <Card variant="default" radius="lg" padding="md">
-            <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+            <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
               Темп (хв/км)
             </Text>
             <ExerciseTrendChart
@@ -318,7 +318,7 @@ export function Exercise({
               label="Темп"
               testIDPrefix={`${testID}-trend-pace`}
             />
-            <Text className="text-[10px] text-stone-400 mt-1">
+            <Text className="text-[10px] text-fg-subtle mt-1">
               Менше — краще (швидший темп)
             </Text>
           </Card>
@@ -326,7 +326,7 @@ export function Exercise({
 
         {hasCardio ? (
           <Card variant="default" radius="lg" padding="md">
-            <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+            <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
               Дистанція (км)
             </Text>
             <ExerciseTrendChart
@@ -348,7 +348,7 @@ export function Exercise({
         ) : null}
 
         <Card variant="default" radius="lg" padding="md">
-          <Text className="text-[10px] uppercase font-bold text-stone-500 mb-2">
+          <Text className="text-[10px] uppercase font-bold text-fg-muted mb-2">
             Історія сетів
           </Text>
           <ExerciseHistoryList history={history} testID={`${testID}-history`} />

--- a/apps/mobile/src/modules/fizruk/pages/Measurements.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Measurements.tsx
@@ -103,11 +103,11 @@ export function Measurements({
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">📏</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
+        <Text className="text-[22px] font-bold text-fg flex-1">
           Вимірювання
         </Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-3">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-3">
         Вага, обхвати та самопочуття — все в одному місці. Записи зберігаються
         локально й синхронізуються через CloudSync.
       </Text>
@@ -119,8 +119,8 @@ export function Measurements({
         <MeasurementsTrendCard entries={entries} testID={`${testID}-trend`} />
 
         <View className="flex-row items-baseline justify-between">
-          <Text className="text-sm font-semibold text-stone-900">Історія</Text>
-          <Text className="text-xs text-stone-500" testID={`${testID}-count`}>
+          <Text className="text-sm font-semibold text-fg">Історія</Text>
+          <Text className="text-xs text-fg-muted" testID={`${testID}-count`}>
             {entries.length > 0 ? `${entries.length} записів` : ""}
           </Text>
         </View>

--- a/apps/mobile/src/modules/fizruk/pages/PagePlaceholder.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/PagePlaceholder.tsx
@@ -42,28 +42,28 @@ export function PagePlaceholder({
         contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 12 }}
         keyboardShouldPersistTaps="handled"
       >
-        <Text className="text-[22px] font-bold text-stone-900">{title}</Text>
-        <Text className="text-sm text-stone-600 leading-snug">
+        <Text className="text-[22px] font-bold text-fg">{title}</Text>
+        <Text className="text-sm text-fg-muted leading-snug">
           {description}
         </Text>
 
         <Card radius="lg" padding="md">
           <View className="gap-2">
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Заплановано до порту
             </Text>
             <View className="gap-1.5">
               {plannedFeatures.map((item) => (
                 <View key={item} className="flex-row gap-2">
                   <Text className="text-teal-600">•</Text>
-                  <Text className="text-sm text-stone-700 flex-1 leading-snug">
+                  <Text className="text-sm text-fg flex-1 leading-snug">
                     {item}
                   </Text>
                 </View>
               ))}
             </View>
             {phaseHint ? (
-              <Text className="text-xs text-stone-500 mt-1">{phaseHint}</Text>
+              <Text className="text-xs text-fg-muted mt-1">{phaseHint}</Text>
             ) : null}
           </View>
         </Card>

--- a/apps/mobile/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -191,7 +191,7 @@ function recoveryDotClass(
     case "ready":
       return "bg-emerald-500";
     case "fresh":
-      return "bg-stone-300";
+      return "bg-line";
     default:
       return "";
   }
@@ -357,10 +357,8 @@ export function PlanCalendar({
         contentContainerStyle={{ padding: 16, paddingBottom: 32, gap: 14 }}
       >
         <View>
-          <Text className="text-[22px] font-bold text-stone-900">
-            План на місяць
-          </Text>
-          <Text className="text-sm text-stone-500">
+          <Text className="text-[22px] font-bold text-fg">План на місяць</Text>
+          <Text className="text-sm text-fg-muted">
             Шаблон тренування на кожен день + заплановані сесії.
           </Text>
         </View>
@@ -371,25 +369,25 @@ export function PlanCalendar({
               accessibilityRole="button"
               accessibilityLabel="Попередній місяць"
               onPress={() => go(-1)}
-              className="w-10 h-10 rounded-xl border border-stone-200 items-center justify-center"
+              className="w-10 h-10 rounded-xl border border-line items-center justify-center"
             >
-              <Text className="text-lg text-stone-700">‹</Text>
+              <Text className="text-lg text-fg">‹</Text>
             </Pressable>
-            <Text className="text-base font-bold text-stone-900 capitalize">
+            <Text className="text-base font-bold text-fg capitalize">
               {monthTitle}
             </Text>
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Наступний місяць"
               onPress={() => go(1)}
-              className="w-10 h-10 rounded-xl border border-stone-200 items-center justify-center"
+              className="w-10 h-10 rounded-xl border border-line items-center justify-center"
             >
-              <Text className="text-lg text-stone-700">›</Text>
+              <Text className="text-lg text-fg">›</Text>
             </Pressable>
           </View>
 
           <View className="flex-row items-center justify-between mb-2">
-            <Text className="text-[11px] text-stone-500">
+            <Text className="text-[11px] text-fg-muted">
               {days && Object.keys(days).length > 0
                 ? `${Object.keys(days).length} днів із шаблоном`
                 : "Ще немає призначених шаблонів"}
@@ -409,7 +407,7 @@ export function PlanCalendar({
           <View className="flex-row mb-1">
             {WEEKDAYS.map((w) => (
               <View key={w} className="w-[14.2857%] items-center">
-                <Text className="text-[10px] font-semibold text-stone-400">
+                <Text className="text-[10px] font-semibold text-fg-subtle">
                   {w}
                 </Text>
               </View>
@@ -421,7 +419,7 @@ export function PlanCalendar({
               if (day == null) {
                 return (
                   <View key={`e-${i}`} className="w-[14.2857%] p-0.5">
-                    <View className="min-h-[52px] rounded-xl bg-stone-100/40" />
+                    <View className="min-h-[52px] rounded-xl bg-panel-hi/40" />
                   </View>
                 );
               }
@@ -438,7 +436,7 @@ export function PlanCalendar({
                 ? "border-emerald-500 bg-emerald-50"
                 : hasPlan
                   ? "border-emerald-400/60 bg-emerald-50/60"
-                  : "border-stone-200 bg-stone-100/40";
+                  : "border-line bg-panel-hi/40";
 
               const forecast = recoveryForecast[key] ?? null;
               const dotClass = recoveryDotClass(forecast?.status);
@@ -457,9 +455,7 @@ export function PlanCalendar({
                     className={`min-h-[52px] rounded-xl border ${borderClass} p-1 items-center active:opacity-70`}
                   >
                     <View className="flex-row items-center gap-1">
-                      <Text className="text-xs font-bold text-stone-900">
-                        {day}
-                      </Text>
+                      <Text className="text-xs font-bold text-fg">{day}</Text>
                       {forecast ? (
                         <View
                           testID={`plan-day-${key}-recovery-${forecast.status}`}
@@ -470,7 +466,7 @@ export function PlanCalendar({
                     {tpl ? (
                       <Text
                         numberOfLines={1}
-                        className="text-[9px] text-stone-500 leading-tight mt-0.5"
+                        className="text-[9px] text-fg-muted leading-tight mt-0.5"
                       >
                         {tpl.name}
                       </Text>
@@ -486,17 +482,17 @@ export function PlanCalendar({
             })}
           </View>
 
-          <Text className="text-[11px] text-stone-500 mt-3">
+          <Text className="text-[11px] text-fg-muted mt-3">
             Натисни день, щоб призначити або зняти шаблон.
           </Text>
         </Card>
 
         {isEmpty ? (
           <Card radius="lg" padding="lg">
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Порожній місяць
             </Text>
-            <Text className="text-xs text-stone-500 leading-snug mt-1">
+            <Text className="text-xs text-fg-muted leading-snug mt-1">
               Ще немає ні шаблонів на день, ні запланованих тренувань. Створи
               перше тренування або шаблон — і вони з&apos;являться тут.
             </Text>
@@ -540,7 +536,7 @@ export function PlanCalendar({
                     ? "border-red-200 bg-red-50"
                     : sheetForecast.status === "ready"
                       ? "border-emerald-200 bg-emerald-50"
-                      : "border-stone-200 bg-stone-50"
+                      : "border-line bg-bg"
                 }`}
               >
                 <View className="flex-row items-center gap-2 mb-1">
@@ -549,7 +545,7 @@ export function PlanCalendar({
                       sheetForecast.status,
                     )}`}
                   />
-                  <Text className="text-xs font-bold text-stone-900">
+                  <Text className="text-xs font-bold text-fg">
                     {sheetForecast.status === "overworked"
                       ? "Відновлення: перевантаження"
                       : sheetForecast.status === "ready"
@@ -558,7 +554,7 @@ export function PlanCalendar({
                   </Text>
                 </View>
                 {sheetForecast.overworkedMuscles.length > 0 ? (
-                  <Text className="text-xs text-stone-600 leading-snug">
+                  <Text className="text-xs text-fg-muted leading-snug">
                     Перевантажені:{" "}
                     {sheetForecast.overworkedMuscles
                       .map((m) => m.label)
@@ -566,7 +562,7 @@ export function PlanCalendar({
                   </Text>
                 ) : null}
                 {sheetForecast.recoveredMuscles.length > 0 ? (
-                  <Text className="text-xs text-stone-600 leading-snug">
+                  <Text className="text-xs text-fg-muted leading-snug">
                     Відновлені:{" "}
                     {sheetForecast.recoveredMuscles
                       .map((m) => m.label)
@@ -605,7 +601,7 @@ export function PlanCalendar({
                         key={w.id}
                         className="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2"
                       >
-                        <Text className="text-sm font-semibold text-stone-900">
+                        <Text className="text-sm font-semibold text-fg">
                           {time ? (
                             <Text className="text-emerald-700">{time} </Text>
                           ) : null}
@@ -614,7 +610,7 @@ export function PlanCalendar({
                             : "Тренування"}
                         </Text>
                         {itemNames.length > 0 ? (
-                          <Text className="text-xs text-stone-500 mt-0.5">
+                          <Text className="text-xs text-fg-muted mt-0.5">
                             {itemNames.join(" · ")}
                           </Text>
                         ) : null}
@@ -626,7 +622,7 @@ export function PlanCalendar({
             ) : null}
 
             <View>
-              <Text className="text-xs text-stone-500 mb-2">
+              <Text className="text-xs text-fg-muted mb-2">
                 Шаблон тренування
               </Text>
               <View className="gap-2">
@@ -637,12 +633,10 @@ export function PlanCalendar({
                   className={`px-3 py-3 rounded-xl border ${
                     !sheet.templateId
                       ? "border-emerald-500 bg-emerald-50"
-                      : "border-stone-200"
+                      : "border-line"
                   }`}
                 >
-                  <Text className="text-sm text-stone-900">
-                    Без плану (вихідний)
-                  </Text>
+                  <Text className="text-sm text-fg">Без плану (вихідний)</Text>
                 </Pressable>
                 {templates.map((t) => (
                   <Pressable
@@ -653,15 +647,15 @@ export function PlanCalendar({
                     className={`px-3 py-3 rounded-xl border ${
                       sheet.templateId === t.id
                         ? "border-emerald-500 bg-emerald-50"
-                        : "border-stone-200"
+                        : "border-line"
                     }`}
                   >
-                    <Text className="text-sm text-stone-900">{t.name}</Text>
+                    <Text className="text-sm text-fg">{t.name}</Text>
                   </Pressable>
                 ))}
               </View>
               {templates.length === 0 ? (
-                <Text className="text-xs text-stone-500 mt-2">
+                <Text className="text-xs text-fg-muted mt-2">
                   Спочатку створи шаблон у «Тренування → Шаблони».
                 </Text>
               ) : null}

--- a/apps/mobile/src/modules/fizruk/pages/Programs.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Programs.tsx
@@ -71,11 +71,9 @@ export function Programs({ testID = "fizruk-programs" }: ProgramsProps) {
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">🗓️</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Програми
-        </Text>
+        <Text className="text-[22px] font-bold text-fg flex-1">Програми</Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-3">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-3">
         Готові програми тренувань. Активуй одну — сьогоднішня сесія
         з&apos;явиться вгорі з кнопкою «Почати».
       </Text>
@@ -96,13 +94,13 @@ export function Programs({ testID = "fizruk-programs" }: ProgramsProps) {
             className="items-center justify-center py-10"
             testID={`${testID}-empty`}
           >
-            <Text className="text-sm text-stone-500">
+            <Text className="text-sm text-fg-muted">
               Каталог порожній — спробуй пізніше.
             </Text>
           </View>
         ) : (
           <View className="gap-3" testID={`${testID}-list`}>
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Каталог програм
             </Text>
             {programs.map((program) => (

--- a/apps/mobile/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Progress.tsx
@@ -67,10 +67,10 @@ export function Progress({ data }: ProgressProps = {}) {
             testID="fizruk-progress-empty"
           >
             <Text className="text-3xl mb-2">{"📈"}</Text>
-            <Text className="text-sm font-semibold text-stone-900 mb-1">
+            <Text className="text-sm font-semibold text-fg mb-1">
               {"Даних ще немає"}
             </Text>
-            <Text className="text-xs text-stone-500 text-center">
+            <Text className="text-xs text-fg-muted text-center">
               {"Додай тренування або заміри — і тут зʼявиться аналітика"}
             </Text>
           </Card>
@@ -81,7 +81,7 @@ export function Progress({ data }: ProgressProps = {}) {
             <WeightChartSection weightTrend={weightTrend} />
             <MeasurementsChartSection bodyFatTrend={bodyFatTrend} />
             <View testID="fizruk-progress-phase-hint" className="pt-1">
-              <Text className="text-[10px] text-stone-400 text-center">
+              <Text className="text-[10px] text-fg-subtle text-center">
                 {
                   "Фаза 6 · PR-D — графіки (victory-native). Фотопрогрес і бекап — у PR-E."
                 }

--- a/apps/mobile/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Workouts.tsx
@@ -284,13 +284,13 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
             className="w-10 h-10 items-center justify-center -ml-2"
             hitSlop={8}
           >
-            <Text className="text-2xl text-stone-800">‹</Text>
+            <Text className="text-2xl text-fg">‹</Text>
           </Pressable>
         ) : (
           <Text className="text-[22px]">🏋️</Text>
         )}
         <View className="flex-1">
-          <Text className="text-[22px] font-bold text-stone-900">
+          <Text className="text-[22px] font-bold text-fg">
             {view === "catalog"
               ? "Каталог вправ"
               : view === "journal"
@@ -298,7 +298,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
                 : "Тренування"}
           </Text>
           {view === "home" ? (
-            <Text className="text-xs text-stone-500 mt-0.5">{subtitle}</Text>
+            <Text className="text-xs text-fg-muted mt-0.5">{subtitle}</Text>
           ) : null}
         </View>
       </View>
@@ -324,7 +324,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
           <>
             {activeWorkout && activeItems.length > 0 ? (
               <View className="gap-3" testID={`${testID}-items`}>
-                <Text className="text-sm font-semibold text-stone-900 px-1">
+                <Text className="text-sm font-semibold text-fg px-1">
                   Вправи тренування
                 </Text>
                 <View className="gap-3">
@@ -344,7 +344,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
             ) : null}
 
             <View className="gap-3" testID={`${testID}-quicklinks`}>
-              <Text className="text-sm font-semibold text-stone-700 px-1">
+              <Text className="text-sm font-semibold text-fg px-1">
                 Довідники
               </Text>
               <Pressable
@@ -366,14 +366,14 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
                     <View className="flex-row items-center gap-3">
                       <Text className="text-2xl">📚</Text>
                       <View className="flex-1">
-                        <Text className="text-sm font-semibold text-stone-900">
+                        <Text className="text-sm font-semibold text-fg">
                           Каталог вправ
                         </Text>
-                        <Text className="text-[11px] text-stone-500 mt-0.5">
+                        <Text className="text-[11px] text-fg-muted mt-0.5">
                           Пошук · групи м&apos;язів · своя вправа
                         </Text>
                       </View>
-                      <Text className="text-stone-400 text-lg">›</Text>
+                      <Text className="text-fg-subtle text-lg">›</Text>
                     </View>
                   </Card>
                 )}
@@ -382,7 +382,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
 
             <View className="gap-3" testID={`${testID}-recent`}>
               <View className="flex-row items-center justify-between px-1">
-                <Text className="text-sm font-semibold text-stone-700">
+                <Text className="text-sm font-semibold text-fg">
                   Останні тренування
                 </Text>
                 {workouts.length > 0 ? (
@@ -415,7 +415,7 @@ export function Workouts({ testID = "fizruk-workouts" }: WorkoutsProps) {
                 </View>
               ) : (
                 <Card variant="flat" radius="lg" padding="lg">
-                  <Text className="text-sm text-stone-600">
+                  <Text className="text-sm text-fg-muted">
                     Після першого завершеного тренування тут з&apos;являться
                     останні сесії.
                   </Text>
@@ -481,7 +481,7 @@ function ActiveItemCard({
   const sets = item.sets ?? [];
   return (
     <Card variant="default" radius="lg" padding="md" testID={testID}>
-      <Text className="text-sm font-semibold text-stone-900">
+      <Text className="text-sm font-semibold text-fg">
         {item.nameUk || "Вправа"}
       </Text>
       {sets.length > 0 ? (
@@ -495,8 +495,8 @@ function ActiveItemCard({
               testID={`${testID}-set-${idx}`}
               className="flex-row items-center justify-between py-1.5 px-2 rounded-lg bg-cream-100"
             >
-              <Text className="text-xs text-stone-500">Сет {idx + 1}</Text>
-              <Text className="text-sm font-semibold text-stone-900">
+              <Text className="text-xs text-fg-muted">Сет {idx + 1}</Text>
+              <Text className="text-sm font-semibold text-fg">
                 {set.weightKg} кг × {set.reps}
               </Text>
             </Pressable>
@@ -552,9 +552,7 @@ function RecentWorkoutRow({
     >
       <View className="flex-1 pr-2">
         <View className="flex-row items-center gap-2">
-          <Text className="text-sm font-semibold text-stone-900">
-            {dateLabel}
-          </Text>
+          <Text className="text-sm font-semibold text-fg">{dateLabel}</Text>
           {isActive ? (
             <Text className="text-[10px] uppercase font-bold text-teal-700 bg-teal-100 px-2 py-0.5 rounded-full">
               Активне
@@ -565,7 +563,7 @@ function RecentWorkoutRow({
             </Text>
           ) : null}
         </View>
-        <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={1}>
+        <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={1}>
           {subtitle}
         </Text>
       </View>

--- a/apps/mobile/src/modules/nutrition/components/AddMealSheet.tsx
+++ b/apps/mobile/src/modules/nutrition/components/AddMealSheet.tsx
@@ -331,7 +331,7 @@ export function AddMealSheet({
     >
       {step === "source" ? (
         <View>
-          <Text className="text-xs text-stone-400 mb-4">
+          <Text className="text-xs text-fg-subtle mb-4">
             Оберіть джерело нижче. Макроси, назву й час відредагуєте на
             наступному кроці.
           </Text>
@@ -357,9 +357,7 @@ export function AddMealSheet({
               testID="add-meal-photo-analyzing"
             >
               <ActivityIndicator />
-              <Text className="text-xs text-stone-500 mt-2">
-                Аналізую фото…
-              </Text>
+              <Text className="text-xs text-fg-muted mt-2">Аналізую фото…</Text>
             </View>
           ) : (
             <View className="mt-2 gap-2">
@@ -386,7 +384,7 @@ export function AddMealSheet({
             <View className="flex-row items-center gap-3">
               <View className="flex-1 h-px bg-cream-300" />
               {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- divider text */}
-              <Text className="text-[10px] text-stone-400 uppercase tracking-wider">
+              <Text className="text-[10px] text-fg-subtle uppercase tracking-wider">
                 або
               </Text>
               <View className="flex-1 h-px bg-cream-300" />
@@ -426,7 +424,7 @@ export function AddMealSheet({
               accessibilityLabel="Назад до вибору джерела"
               className="mb-3"
             >
-              <Text className="text-xs text-stone-400 underline">
+              <Text className="text-xs text-fg-subtle underline">
                 ← Назад до вибору джерела
               </Text>
             </Pressable>
@@ -440,16 +438,16 @@ export function AddMealSheet({
               className="mt-3 p-3 rounded-xl border border-cream-200 bg-cream-50/80"
               testID="add-meal-photo-refine-block"
             >
-              <Text className="text-sm font-medium text-stone-800 mb-1">
+              <Text className="text-sm font-medium text-fg mb-1">
                 Уточнення AI
               </Text>
-              <Text className="text-xs text-stone-500 mb-2">
+              <Text className="text-xs text-fg-muted mb-2">
                 Можна вказати вагу порції та відповіді на питання — перерахунок
                 КБЖВ через сервер.
               </Text>
-              <Text className="text-xs text-stone-500 mb-0.5">Порція, г</Text>
+              <Text className="text-xs text-fg-muted mb-0.5">Порція, г</Text>
               <TextInput
-                className="border border-cream-200 rounded-lg px-2 py-1.5 text-stone-900 bg-white text-sm"
+                className="border border-cream-200 rounded-lg px-2 py-1.5 text-fg bg-white text-sm"
                 value={refinePortion}
                 onChangeText={setRefinePortion}
                 keyboardType="decimal-pad"
@@ -460,13 +458,13 @@ export function AddMealSheet({
               {photoSession.prior.questions.slice(0, 6).map((q) => (
                 <View key={q} className="mt-2">
                   <Text
-                    className="text-xs text-stone-500 mb-0.5"
+                    className="text-xs text-fg-muted mb-0.5"
                     numberOfLines={3}
                   >
                     {q}
                   </Text>
                   <TextInput
-                    className="border border-cream-200 rounded-lg px-2 py-1.5 text-stone-900 bg-white text-sm"
+                    className="border border-cream-200 rounded-lg px-2 py-1.5 text-fg bg-white text-sm"
                     value={refineAnswers[q] ?? ""}
                     onChangeText={(v) =>
                       setRefineAnswers((a) => ({ ...a, [q]: v }))
@@ -483,7 +481,7 @@ export function AddMealSheet({
                   testID="add-meal-refine-busy"
                 >
                   <ActivityIndicator />
-                  <Text className="text-xs text-stone-500 mt-1">Уточнюю…</Text>
+                  <Text className="text-xs text-fg-muted mt-1">Уточнюю…</Text>
                 </View>
               ) : (
                 <View className="mt-2">

--- a/apps/mobile/src/modules/nutrition/components/MacroRing.tsx
+++ b/apps/mobile/src/modules/nutrition/components/MacroRing.tsx
@@ -70,16 +70,16 @@ export function MacroRing({
           ) : null}
         </Svg>
         <View className="absolute inset-0 items-center justify-center">
-          <Text className="text-xs font-bold text-stone-900 leading-none">
+          <Text className="text-xs font-bold text-fg leading-none">
             {Math.round(value)}
           </Text>
         </View>
       </View>
-      <Text className="text-[10px] font-semibold text-stone-500 leading-none">
+      <Text className="text-[10px] font-semibold text-fg-muted leading-none">
         {label}
       </Text>
       {target > 0 ? (
-        <Text className="text-[9px] text-stone-400 leading-none">
+        <Text className="text-[9px] text-fg-subtle leading-none">
           / {target}
           {unit || ""}
         </Text>

--- a/apps/mobile/src/modules/nutrition/components/NutritionBarcodeScanScreen.tsx
+++ b/apps/mobile/src/modules/nutrition/components/NutritionBarcodeScanScreen.tsx
@@ -118,7 +118,7 @@ export function NutritionBarcodeScanScreen() {
   if (!permission) {
     return (
       <View className="flex-1 p-4 justify-center">
-        <Text className="text-stone-600">Перевіряємо дозвіл на камеру…</Text>
+        <Text className="text-fg-muted">Перевіряємо дозвіл на камеру…</Text>
       </View>
     );
   }
@@ -126,7 +126,7 @@ export function NutritionBarcodeScanScreen() {
   if (!permission.granted) {
     return (
       <View className="flex-1 p-4 justify-center gap-4">
-        <Text className="text-stone-700 text-center">
+        <Text className="text-fg text-center">
           Щоб сканувати штрихкоди, потрібен доступ до камери.
         </Text>
         <Button variant="nutrition" onPress={() => void requestPermission()}>
@@ -146,7 +146,7 @@ export function NutritionBarcodeScanScreen() {
     );
     return (
       <View className="flex-1 p-4 bg-cream-50 justify-center gap-3">
-        <Text className="text-lg font-semibold text-stone-800 text-center">
+        <Text className="text-lg font-semibold text-fg text-center">
           {f.name || "Продукт"}
         </Text>
         {productPreview.p.partial ? (
@@ -154,7 +154,7 @@ export function NutritionBarcodeScanScreen() {
             Дані часткові — уточни КБЖВ вручну після додавання.
           </Text>
         ) : null}
-        <Text className="text-sm text-stone-600 text-center">
+        <Text className="text-sm text-fg-muted text-center">
           {f.kcal} ккал · Б {f.protein_g} г · Ж {f.fat_g} г · В {f.carbs_g} г
         </Text>
         <Button
@@ -203,14 +203,14 @@ export function NutritionBarcodeScanScreen() {
           <Text className="text-sm text-red-600 text-center">{error}</Text>
         ) : null}
         {idleHint && !error ? (
-          <Text className="text-xs text-stone-500 text-center">{idleHint}</Text>
+          <Text className="text-xs text-fg-muted text-center">{idleHint}</Text>
         ) : null}
         {isAddMeal ? (
-          <Text className="text-xs text-stone-500 text-center">
+          <Text className="text-xs text-fg-muted text-center">
             Після зчитання ти повернешся до форми додавання прийому їжі.
           </Text>
         ) : (
-          <Text className="text-xs text-stone-500 text-center">
+          <Text className="text-xs text-fg-muted text-center">
             Наведи камеру на штрихкод продукту.
           </Text>
         )}
@@ -222,7 +222,7 @@ export function NutritionBarcodeScanScreen() {
           }}
           className="py-2"
         >
-          <Text className="text-center text-stone-500 text-xs">
+          <Text className="text-center text-fg-muted text-xs">
             Скинути блокування й сканерувати знову
           </Text>
         </Pressable>

--- a/apps/mobile/src/modules/nutrition/components/NutritionBottomNav.tsx
+++ b/apps/mobile/src/modules/nutrition/components/NutritionBottomNav.tsx
@@ -68,7 +68,7 @@ export function NutritionBottomNav({
             </Text>
             <Text
               className={`text-[11px] mt-0.5 ${
-                selected ? "text-coral-700 font-semibold" : "text-stone-500"
+                selected ? "text-coral-700 font-semibold" : "text-fg-muted"
               }`}
             >
               {item.label}

--- a/apps/mobile/src/modules/nutrition/components/WaterTrackerCard.tsx
+++ b/apps/mobile/src/modules/nutrition/components/WaterTrackerCard.tsx
@@ -71,10 +71,10 @@ export function WaterTrackerCard({
         <View className="flex-row items-center gap-2">
           <Text className="text-lg leading-none">💧</Text>
           <View>
-            <Text className="text-sm font-semibold text-stone-900 leading-none">
+            <Text className="text-sm font-semibold text-fg leading-none">
               Вода
             </Text>
-            <Text className="text-xs text-stone-500 mt-0.5">
+            <Text className="text-xs text-fg-muted mt-0.5">
               {fmt(todayMl)}
               {goalMl > 0 ? ` / ${fmt(goalMl)}` : ""}
               {done ? " ✓" : ""}
@@ -93,7 +93,7 @@ export function WaterTrackerCard({
             testID={testID ? `${testID}-reset` : undefined}
             className="px-2 py-1 rounded-lg"
           >
-            <Text className="text-xs text-stone-500">
+            <Text className="text-xs text-fg-muted">
               {resetPending ? "Скинути?" : "↺"}
             </Text>
           </Pressable>
@@ -101,7 +101,7 @@ export function WaterTrackerCard({
       </View>
 
       {goalMl > 0 ? (
-        <View className="h-2 bg-stone-200 rounded-full overflow-hidden mb-3">
+        <View className="h-2 bg-panel-hi rounded-full overflow-hidden mb-3">
           <View
             style={{ width: `${pct}%` }}
             className={`h-full rounded-full ${

--- a/apps/mobile/src/modules/nutrition/components/WeekKcalChart.tsx
+++ b/apps/mobile/src/modules/nutrition/components/WeekKcalChart.tsx
@@ -51,8 +51,8 @@ export function WeekKcalChart({
             <Text
               className={
                 isToday
-                  ? "text-[9px] leading-none text-stone-900 font-bold"
-                  : "text-[9px] leading-none text-stone-400"
+                  ? "text-[9px] leading-none text-fg font-bold"
+                  : "text-[9px] leading-none text-fg-subtle"
               }
             >
               {label}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
@@ -27,13 +27,13 @@ export function MacrosEditor({ form, field }: MacrosEditorProps) {
   return (
     <View className="mb-1">
       {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- section heading in form */}
-      <Text className="text-xs font-bold uppercase text-stone-500 mb-2 tracking-wider">
+      <Text className="text-xs font-bold uppercase text-fg-muted mb-2 tracking-wider">
         КБЖВ
       </Text>
       <View className="flex-row flex-wrap gap-2">
         {FIELDS.map(({ key, label, placeholder }) => (
           <View key={key} className="flex-1 min-w-[45%]">
-            <Text className="text-[10px] font-bold uppercase text-stone-400 mb-1">
+            <Text className="text-[10px] font-bold uppercase text-fg-subtle mb-1">
               {label}
             </Text>
             <Input

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/MealTypePicker.tsx
@@ -19,7 +19,7 @@ export function MealTypePicker({ mealType, setForm }: MealTypePickerProps) {
   return (
     <View className="mb-4">
       {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- section heading in form */}
-      <Text className="text-xs font-bold uppercase text-stone-500 mb-2 tracking-wider">
+      <Text className="text-xs font-bold uppercase text-fg-muted mb-2 tracking-wider">
         Прийом їжі
       </Text>
       <View className="flex-row flex-wrap gap-2">
@@ -43,7 +43,7 @@ export function MealTypePicker({ mealType, setForm }: MealTypePickerProps) {
             >
               <Text
                 className={`text-sm font-semibold ${
-                  active ? "text-white" : "text-stone-600"
+                  active ? "text-white" : "text-fg-muted"
                 }`}
               >
                 {mt.emoji} {mt.label}

--- a/apps/mobile/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
+++ b/apps/mobile/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
@@ -26,7 +26,7 @@ export function NameTimeRow({ form, field }: NameTimeRowProps) {
       <View className={timeVisible ? "flex-row gap-3" : ""}>
         <View className={timeVisible ? "flex-1" : ""}>
           {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- form label */}
-          <Text className="text-xs font-bold uppercase text-stone-500 mb-1 tracking-wider">
+          <Text className="text-xs font-bold uppercase text-fg-muted mb-1 tracking-wider">
             Назва страви
           </Text>
           <Input
@@ -40,7 +40,7 @@ export function NameTimeRow({ form, field }: NameTimeRowProps) {
         {timeVisible ? (
           <View className="w-24">
             {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- form label */}
-            <Text className="text-xs font-bold uppercase text-stone-500 mb-1 tracking-wider">
+            <Text className="text-xs font-bold uppercase text-fg-muted mb-1 tracking-wider">
               Час
             </Text>
             <Input
@@ -60,7 +60,7 @@ export function NameTimeRow({ form, field }: NameTimeRowProps) {
           accessibilityLabel={`Змінити час (${form.time})`}
           className="mt-2"
         >
-          <Text className="text-xs text-stone-400 underline">
+          <Text className="text-xs text-fg-subtle underline">
             Не зараз? Змінити час ({form.time})
           </Text>
         </Pressable>

--- a/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Dashboard.tsx
@@ -129,10 +129,10 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
       <Card testID="nutrition-today-card">
         <View className="flex-row items-center justify-between mb-3">
           <View>
-            <Text className="text-sm font-semibold text-stone-900 leading-none">
+            <Text className="text-sm font-semibold text-fg leading-none">
               Сьогодні
             </Text>
-            <Text className="text-xs text-stone-500 mt-1">
+            <Text className="text-xs text-fg-muted mt-1">
               {summary.mealCount} {mealCountLabel(summary.mealCount)} їжі
             </Text>
           </View>
@@ -170,7 +170,7 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
                 <Text className="text-[10px] font-bold uppercase text-lime-700 leading-none mb-1">
                   {m.label}
                 </Text>
-                <Text className="text-sm font-extrabold text-stone-900 leading-none">
+                <Text className="text-sm font-extrabold text-fg leading-none">
                   {Math.round(macros[m.key] || 0)}
                   {m.unit ? ` ${m.unit}` : ""}
                 </Text>
@@ -181,7 +181,7 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
       </Card>
 
       <Card testID="nutrition-week-card">
-        <Text className="text-sm font-semibold text-stone-900 mb-2 leading-none">
+        <Text className="text-sm font-semibold text-fg mb-2 leading-none">
           Тиждень · ккал
         </Text>
         <WeekKcalChart
@@ -202,12 +202,12 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
           className="flex-row items-center justify-between"
         >
           <View>
-            <Text className="text-sm font-semibold text-stone-900">Комора</Text>
-            <Text className="text-xs text-stone-500 mt-0.5">
+            <Text className="text-sm font-semibold text-fg">Комора</Text>
+            <Text className="text-xs text-fg-muted mt-0.5">
               Склад продуктів (кілька комор)
             </Text>
           </View>
-          <Text className="text-stone-400 text-lg" aria-hidden>
+          <Text className="text-fg-subtle text-lg" aria-hidden>
             ›
           </Text>
         </Pressable>
@@ -224,14 +224,14 @@ export function Dashboard({ testID, onMealAdded }: DashboardProps) {
           className="flex-row items-center justify-between"
         >
           <View>
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Збережені рецепти
             </Text>
-            <Text className="text-xs text-stone-500 mt-0.5">
+            <Text className="text-xs text-fg-muted mt-0.5">
               Локальна книга, імпорт з web (JSON)
             </Text>
           </View>
-          <Text className="text-stone-400 text-lg" aria-hidden>
+          <Text className="text-fg-subtle text-lg" aria-hidden>
             ›
           </Text>
         </Pressable>

--- a/apps/mobile/src/modules/nutrition/pages/Log.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Log.tsx
@@ -169,7 +169,7 @@ export function Log({ testID, onMealAdded }: LogProps) {
           testID="nutrition-log-prev-day"
           className="w-10 h-10 items-center justify-center rounded-full"
         >
-          <Text className="text-xl text-stone-600">‹</Text>
+          <Text className="text-xl text-fg-muted">‹</Text>
         </Pressable>
         <Pressable
           onPress={goToday}
@@ -178,11 +178,11 @@ export function Log({ testID, onMealAdded }: LogProps) {
           testID="nutrition-log-today"
           className="flex-1 items-center"
         >
-          <Text className="text-sm font-bold text-stone-900">
+          <Text className="text-sm font-bold text-fg">
             {formatIsoDate(selectedDate)}
           </Text>
           {!isToday ? (
-            <Text className="text-[10px] text-stone-400 mt-0.5">
+            <Text className="text-[10px] text-fg-subtle mt-0.5">
               {selectedDate}
             </Text>
           ) : null}
@@ -194,7 +194,7 @@ export function Log({ testID, onMealAdded }: LogProps) {
           testID="nutrition-log-next-day"
           className="w-10 h-10 items-center justify-center rounded-full"
         >
-          <Text className="text-xl text-stone-600">›</Text>
+          <Text className="text-xl text-fg-muted">›</Text>
         </Pressable>
       </View>
 
@@ -203,34 +203,34 @@ export function Log({ testID, onMealAdded }: LogProps) {
         <Card>
           <View className="flex-row justify-around py-1">
             <View className="items-center">
-              <Text className="text-[10px] font-bold uppercase text-stone-500">
+              <Text className="text-[10px] font-bold uppercase text-fg-muted">
                 Ккал
               </Text>
-              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+              <Text className="text-sm font-extrabold text-fg mt-1">
                 {Math.round(macros.kcal)}
               </Text>
             </View>
             <View className="items-center">
-              <Text className="text-[10px] font-bold uppercase text-stone-500">
+              <Text className="text-[10px] font-bold uppercase text-fg-muted">
                 Б
               </Text>
-              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+              <Text className="text-sm font-extrabold text-fg mt-1">
                 {Math.round(macros.protein_g)} г
               </Text>
             </View>
             <View className="items-center">
-              <Text className="text-[10px] font-bold uppercase text-stone-500">
+              <Text className="text-[10px] font-bold uppercase text-fg-muted">
                 Ж
               </Text>
-              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+              <Text className="text-sm font-extrabold text-fg mt-1">
                 {Math.round(macros.fat_g)} г
               </Text>
             </View>
             <View className="items-center">
-              <Text className="text-[10px] font-bold uppercase text-stone-500">
+              <Text className="text-[10px] font-bold uppercase text-fg-muted">
                 В
               </Text>
-              <Text className="text-sm font-extrabold text-stone-900 mt-1">
+              <Text className="text-sm font-extrabold text-fg mt-1">
                 {Math.round(macros.carbs_g)} г
               </Text>
             </View>
@@ -255,10 +255,10 @@ export function Log({ testID, onMealAdded }: LogProps) {
       {rows.length === 0 ? (
         <View className="flex-1 items-center justify-center px-6 pb-20">
           <Text className="text-5xl mb-3">🍽️</Text>
-          <Text className="text-sm font-semibold text-stone-900 text-center">
+          <Text className="text-sm font-semibold text-fg text-center">
             Немає записів за цей день
           </Text>
-          <Text className="text-xs text-stone-500 text-center mt-1">
+          <Text className="text-xs text-fg-muted text-center mt-1">
             Натисніть «+ Додати прийом», щоб записати їжу.
           </Text>
         </View>
@@ -282,17 +282,17 @@ export function Log({ testID, onMealAdded }: LogProps) {
                 <View className="flex-row items-start gap-3">
                   <Text className="text-2xl leading-none">{item.emoji}</Text>
                   <View className="flex-1">
-                    <Text className="text-[10px] font-bold uppercase text-stone-500 leading-none">
+                    <Text className="text-[10px] font-bold uppercase text-fg-muted leading-none">
                       {item.typeLabel}
                     </Text>
-                    <Text className="text-sm font-semibold text-stone-900 mt-1">
+                    <Text className="text-sm font-semibold text-fg mt-1">
                       {item.meal.name || "Без назви"}
                     </Text>
                     <View className="flex-row items-center gap-3 mt-2">
-                      <Text className="text-xs text-stone-500">
+                      <Text className="text-xs text-fg-muted">
                         {Math.round(item.meal.macros?.kcal || 0)} ккал
                       </Text>
-                      <Text className="text-xs text-stone-400">
+                      <Text className="text-xs text-fg-subtle">
                         Б{Math.round(item.meal.macros?.protein_g || 0)} · Ж
                         {Math.round(item.meal.macros?.fat_g || 0)} · В
                         {Math.round(item.meal.macros?.carbs_g || 0)}

--- a/apps/mobile/src/modules/nutrition/pages/Pantry.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Pantry.tsx
@@ -97,9 +97,7 @@ export function PantryPage({ testID }: { testID?: string }) {
         >
           <Text className="text-coral-700 text-base">‹ Назад</Text>
         </Pressable>
-        <Text className="text-lg font-semibold text-stone-800 flex-1">
-          Комора
-        </Text>
+        <Text className="text-lg font-semibold text-fg flex-1">Комора</Text>
       </View>
 
       <ScrollView
@@ -125,9 +123,7 @@ export function PantryPage({ testID }: { testID?: string }) {
                   }
                 >
                   <Text
-                    className={
-                      sel ? "text-white text-xs" : "text-stone-700 text-xs"
-                    }
+                    className={sel ? "text-white text-xs" : "text-fg text-xs"}
                     numberOfLines={1}
                   >
                     {p.name}
@@ -138,16 +134,16 @@ export function PantryPage({ testID }: { testID?: string }) {
           </View>
         ) : null}
 
-        <Text className="text-xs text-stone-500">
+        <Text className="text-xs text-fg-muted">
           Додавай рядок як на веб: «2 л молока», «яйця 10 шт» — парсер
           `parseLoosePantryText` зведе в структуровані позиції.
         </Text>
 
         <Card>
-          <Text className="text-sm font-medium text-stone-800 mb-1">
+          <Text className="text-sm font-medium text-fg mb-1">
             AI-розбір списку
           </Text>
-          <Text className="text-xs text-stone-500 mb-2">
+          <Text className="text-xs text-fg-muted mb-2">
             Великий список мовою природи — на сервері Claude розкладе в позиції
             й додасть у цей склад (злиття, як на web). Потрібен Anthropic key на
             бекенді; за `NUTRITION_API_TOKEN` — те саме в
@@ -157,7 +153,7 @@ export function PantryPage({ testID }: { testID?: string }) {
             value={bulkText}
             onChangeText={setBulkText}
             placeholder="молоко, яйця, борошно… (кілька рядків)"
-            className="border border-cream-300 rounded-xl px-3 py-2 text-stone-800 bg-white min-h-[88px] text-sm"
+            className="border border-cream-300 rounded-xl px-3 py-2 text-fg bg-white min-h-[88px] text-sm"
             multiline
             textAlignVertical="top"
             placeholderTextColor="#a8a29e"
@@ -190,7 +186,7 @@ export function PantryPage({ testID }: { testID?: string }) {
             value={draft}
             onChangeText={setDraft}
             placeholder="Продукт або список…"
-            className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-stone-800 bg-white"
+            className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-fg bg-white"
             placeholderTextColor="#a8a29e"
             onSubmitEditing={onAdd}
           />
@@ -201,14 +197,14 @@ export function PantryPage({ testID }: { testID?: string }) {
 
         {grouped.length === 0 ? (
           <Card className="p-4">
-            <Text className="text-stone-600 text-sm text-center">
+            <Text className="text-fg-muted text-sm text-center">
               Склад порожній. Додай продукти рядком вище.
             </Text>
           </Card>
         ) : (
           grouped.map((bucket) => (
             <View key={bucket.cat.id} className="gap-1">
-              <Text className="text-xs font-semibold text-stone-500">
+              <Text className="text-xs font-semibold text-fg-muted">
                 {bucket.cat.emoji} {bucket.cat.label}
               </Text>
               {bucket.items.map(({ item, idx }) => {
@@ -219,9 +215,9 @@ export function PantryPage({ testID }: { testID?: string }) {
                     className="flex-row items-center py-1.5 border-b border-cream-200/80"
                   >
                     <View className="flex-1">
-                      <Text className="text-stone-800 text-sm">{it.name}</Text>
+                      <Text className="text-fg text-sm">{it.name}</Text>
                       {it.qty != null || it.unit ? (
-                        <Text className="text-xs text-stone-500">
+                        <Text className="text-xs text-fg-muted">
                           {it.qty != null && it.unit
                             ? `${it.qty} ${it.unit}`
                             : it.qty != null
@@ -238,7 +234,7 @@ export function PantryPage({ testID }: { testID?: string }) {
                       accessibilityLabel={`Видалити ${it.name}`}
                       className="px-2 py-1"
                     >
-                      <Text className="text-stone-400 text-lg leading-none">
+                      <Text className="text-fg-subtle text-lg leading-none">
                         ×
                       </Text>
                     </Pressable>
@@ -250,7 +246,7 @@ export function PantryPage({ testID }: { testID?: string }) {
         )}
 
         <View className="mt-4 border-t border-cream-200 pt-4 gap-2">
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             Новий склад (кілька комор)
           </Text>
           <View className="flex-row gap-2">
@@ -258,7 +254,7 @@ export function PantryPage({ testID }: { testID?: string }) {
               value={newPantryName}
               onChangeText={setNewPantryName}
               placeholder="Назва (напр. Офіс)"
-              className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-stone-800 bg-white"
+              className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-fg bg-white"
               placeholderTextColor="#a8a29e"
             />
             <Button

--- a/apps/mobile/src/modules/nutrition/pages/RecipeDetail.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/RecipeDetail.tsx
@@ -75,7 +75,7 @@ export function RecipeDetailPage({
       <View className="flex-1 bg-cream-50">
         <Header onBack={onBack} title="Рецепт" />
         <View className="p-4">
-          <Text className="text-stone-600">Некоректний ID рецепта.</Text>
+          <Text className="text-fg-muted">Некоректний ID рецепта.</Text>
         </View>
       </View>
     );
@@ -86,8 +86,8 @@ export function RecipeDetailPage({
       <View className="flex-1 bg-cream-50">
         <Header onBack={onBack} title="Рецепт" />
         <View className="p-4 gap-3" testID={`recipe-${recipeId}-missing`}>
-          <Text className="text-stone-800 font-medium">Рецепт не знайдено</Text>
-          <Text className="text-stone-600 text-sm">
+          <Text className="text-fg font-medium">Рецепт не знайдено</Text>
+          <Text className="text-fg-muted text-sm">
             ID: {recipeId}. На пристрої немає цієї копії. Web (IndexedDB) треба
             імпортувати вручну (список рецептів → Імпорт JSON) або створити
             рецепт з тим самим id.
@@ -154,12 +154,12 @@ export function RecipeDetailPage({
       >
         <View className="flex-row flex-wrap gap-2">
           {recipe.timeMinutes != null ? (
-            <Text className="text-xs text-stone-600 bg-cream-200 px-2 py-1 rounded">
+            <Text className="text-xs text-fg-muted bg-cream-200 px-2 py-1 rounded">
               ⏱ {recipe.timeMinutes} хв
             </Text>
           ) : null}
           {recipe.servings != null && recipe.servings > 0 ? (
-            <Text className="text-xs text-stone-600 bg-cream-200 px-2 py-1 rounded">
+            <Text className="text-xs text-fg-muted bg-cream-200 px-2 py-1 rounded">
               Порції: {recipe.servings}
             </Text>
           ) : null}
@@ -167,11 +167,11 @@ export function RecipeDetailPage({
 
         {hasMacros ? (
           <Card>
-            <Text className="text-sm font-medium text-stone-800 mb-1">
+            <Text className="text-sm font-medium text-fg mb-1">
               Макроси (на порцію)
             </Text>
             <Text
-              className="text-stone-700 text-sm"
+              className="text-fg text-sm"
               testID={`recipe-${recipe.id}-macros`}
             >
               {macrosText}
@@ -179,7 +179,7 @@ export function RecipeDetailPage({
           </Card>
         ) : (
           <Text
-            className="text-xs text-stone-500"
+            className="text-xs text-fg-muted"
             testID={`recipe-${recipe.id}-empty-macros`}
           >
             Макроси не зазначено
@@ -188,11 +188,11 @@ export function RecipeDetailPage({
 
         {recipe.ingredients.length > 0 ? (
           <Card>
-            <Text className="text-sm font-medium text-stone-800 mb-2">
+            <Text className="text-sm font-medium text-fg mb-2">
               Інгредієнти
             </Text>
             {recipe.ingredients.map((line, i) => (
-              <Text key={i} className="text-stone-700 text-sm mb-1">
+              <Text key={i} className="text-fg text-sm mb-1">
                 • {line}
               </Text>
             ))}
@@ -201,11 +201,9 @@ export function RecipeDetailPage({
 
         {recipe.steps.length > 0 ? (
           <Card>
-            <Text className="text-sm font-medium text-stone-800 mb-2">
-              Покроково
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-2">Покроково</Text>
             {recipe.steps.map((line, i) => (
-              <Text key={i} className="text-stone-700 text-sm mb-2">
+              <Text key={i} className="text-fg text-sm mb-2">
                 {i + 1}. {line}
               </Text>
             ))}
@@ -214,11 +212,9 @@ export function RecipeDetailPage({
 
         {recipe.tips.length > 0 ? (
           <Card>
-            <Text className="text-sm font-medium text-stone-800 mb-2">
-              Поради
-            </Text>
+            <Text className="text-sm font-medium text-fg mb-2">Поради</Text>
             {recipe.tips.map((line, i) => (
-              <Text key={i} className="text-stone-700 text-sm mb-1">
+              <Text key={i} className="text-fg text-sm mb-1">
                 {line}
               </Text>
             ))}
@@ -239,10 +235,7 @@ function Header({ title, onBack }: { title: string; onBack: () => void }) {
       >
         <Text className="text-coral-700 text-base">‹ Назад</Text>
       </Pressable>
-      <Text
-        className="text-lg font-semibold text-stone-800 flex-1"
-        numberOfLines={2}
-      >
+      <Text className="text-lg font-semibold text-fg flex-1" numberOfLines={2}>
         {title}
       </Text>
     </View>

--- a/apps/mobile/src/modules/nutrition/pages/RecipeForm.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/RecipeForm.tsx
@@ -184,7 +184,7 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
           <Text className="text-coral-700 text-base">‹ Назад</Text>
         </Pressable>
         <Text
-          className="text-lg font-semibold text-stone-800 flex-1"
+          className="text-lg font-semibold text-fg flex-1"
           numberOfLines={1}
         >
           {titleBar}
@@ -197,9 +197,9 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         keyboardShouldPersistTaps="handled"
       >
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">Назва *</Text>
+          <Text className="text-xs text-fg-muted mb-1">Назва *</Text>
           <TextInput
-            className="border border-cream-200 rounded-lg p-2 text-stone-900"
+            className="border border-cream-200 rounded-lg p-2 text-fg"
             value={title}
             onChangeText={setTitle}
             placeholder="Борщ"
@@ -210,11 +210,11 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
 
         {!isEdit ? (
           <Card>
-            <Text className="text-xs text-stone-500 mb-1">
+            <Text className="text-xs text-fg-muted mb-1">
               ID (необов’язково, для deep link)
             </Text>
             <TextInput
-              className="border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="border border-cream-200 rounded-lg p-2 text-fg"
               value={idDraft}
               onChangeText={setIdDraft}
               placeholder="Залиш порожнім — згенеруємо"
@@ -226,10 +226,10 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         ) : null}
 
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">Час, хв · Порції</Text>
+          <Text className="text-xs text-fg-muted mb-1">Час, хв · Порції</Text>
           <View className="flex-row gap-2">
             <TextInput
-              className="flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={timeStr}
               onChangeText={setTimeStr}
               keyboardType="number-pad"
@@ -237,7 +237,7 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
               placeholderTextColor="#a8a29e"
             />
             <TextInput
-              className="flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={servingsStr}
               onChangeText={setServingsStr}
               keyboardType="decimal-pad"
@@ -248,12 +248,12 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         </Card>
 
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">
+          <Text className="text-xs text-fg-muted mb-1">
             Ккал · Б / Ж / В (г, на порцію)
           </Text>
           <View className="flex-row flex-wrap gap-2">
             <TextInput
-              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={k}
               onChangeText={setK}
               keyboardType="decimal-pad"
@@ -261,7 +261,7 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
               placeholderTextColor="#a8a29e"
             />
             <TextInput
-              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={p}
               onChangeText={setP}
               keyboardType="decimal-pad"
@@ -269,7 +269,7 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
               placeholderTextColor="#a8a29e"
             />
             <TextInput
-              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={f}
               onChangeText={setF}
               keyboardType="decimal-pad"
@@ -277,7 +277,7 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
               placeholderTextColor="#a8a29e"
             />
             <TextInput
-              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-stone-900"
+              className="min-w-[20%] flex-1 border border-cream-200 rounded-lg p-2 text-fg"
               value={c}
               onChangeText={setC}
               keyboardType="decimal-pad"
@@ -288,11 +288,11 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         </Card>
 
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">
+          <Text className="text-xs text-fg-muted mb-1">
             Інгредієнти (кожен з нового рядка)
           </Text>
           <TextInput
-            className="border border-cream-200 rounded-lg p-2 text-stone-900 min-h-[100px] text-sm"
+            className="border border-cream-200 rounded-lg p-2 text-fg min-h-[100px] text-sm"
             value={ingText}
             onChangeText={setIngText}
             multiline
@@ -301,9 +301,9 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         </Card>
 
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">Покроково (рядки)</Text>
+          <Text className="text-xs text-fg-muted mb-1">Покроково (рядки)</Text>
           <TextInput
-            className="border border-cream-200 rounded-lg p-2 text-stone-900 min-h-[120px] text-sm"
+            className="border border-cream-200 rounded-lg p-2 text-fg min-h-[120px] text-sm"
             value={stepsText}
             onChangeText={setStepsText}
             multiline
@@ -312,9 +312,9 @@ export function RecipeFormPage({ testID }: { testID?: string }) {
         </Card>
 
         <Card>
-          <Text className="text-xs text-stone-500 mb-1">Поради (рядки)</Text>
+          <Text className="text-xs text-fg-muted mb-1">Поради (рядки)</Text>
           <TextInput
-            className="border border-cream-200 rounded-lg p-2 text-stone-900 min-h-[64px] text-sm"
+            className="border border-cream-200 rounded-lg p-2 text-fg min-h-[64px] text-sm"
             value={tipsText}
             onChangeText={setTipsText}
             multiline

--- a/apps/mobile/src/modules/nutrition/pages/SavedRecipesList.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/SavedRecipesList.tsx
@@ -60,11 +60,11 @@ export function SavedRecipesListPage({ testID }: { testID?: string }) {
         testID={`saved-recipe-row-${item.id}`}
       >
         <Card>
-          <Text className="text-stone-900 font-medium" numberOfLines={2}>
+          <Text className="text-fg font-medium" numberOfLines={2}>
             {item.title}
           </Text>
           {item.timeMinutes != null ? (
-            <Text className="text-xs text-stone-500 mt-1">
+            <Text className="text-xs text-fg-muted mt-1">
               {item.timeMinutes} хв
             </Text>
           ) : null}
@@ -84,7 +84,7 @@ export function SavedRecipesListPage({ testID }: { testID?: string }) {
         >
           <Text className="text-coral-700 text-base">‹ Назад</Text>
         </Pressable>
-        <Text className="text-lg font-semibold text-stone-800 flex-1">
+        <Text className="text-lg font-semibold text-fg flex-1">
           Збережені рецепти
         </Text>
       </View>
@@ -120,7 +120,7 @@ export function SavedRecipesListPage({ testID }: { testID?: string }) {
 
       {recipes.length === 0 ? (
         <View className="px-4 py-6">
-          <Text className="text-stone-600 text-sm">
+          <Text className="text-fg-muted text-sm">
             Порожньо. Додай рецепт вручну, імпортуй копію з web (експорт JSON)
             або збережи згодом з AI, коли з’явиться на мобайлі.
           </Text>
@@ -141,7 +141,7 @@ export function SavedRecipesListPage({ testID }: { testID?: string }) {
         transparent
       >
         <Pressable
-          className="flex-1 justify-end bg-stone-900/40"
+          className="flex-1 justify-end bg-fg/40"
           onPress={() => setImportOpen(false)}
         >
           <Pressable
@@ -149,11 +149,11 @@ export function SavedRecipesListPage({ testID }: { testID?: string }) {
             className="bg-cream-50 p-4 rounded-t-2xl max-h-[80%]"
             accessibilityViewIsModal
           >
-            <Text className="text-stone-800 font-medium mb-2">
+            <Text className="text-fg font-medium mb-2">
               Встав JSON (масив, об’єкт з recipes або один рецепт)
             </Text>
             <TextInput
-              className="border border-cream-200 rounded-lg p-2 text-stone-900 min-h-[160px] text-sm"
+              className="border border-cream-200 rounded-lg p-2 text-fg min-h-[160px] text-sm"
               value={importText}
               onChangeText={setImportText}
               multiline

--- a/apps/mobile/src/modules/nutrition/pages/Shopping.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Shopping.tsx
@@ -28,24 +28,22 @@ export function Shopping({ testID }: { testID?: string }) {
       testID={testID}
       contentContainerClassName="p-4 gap-3 pb-8"
     >
-      <Text className="text-lg font-semibold text-stone-800">
-        Список покупок
-      </Text>
-      <Text className="text-xs text-stone-500">
+      <Text className="text-lg font-semibold text-fg">Список покупок</Text>
+      <Text className="text-xs text-fg-muted">
         Паритет із web-даними в одному ключі сховища. Повна генерація з рецептів
         / плану — поки в основному веб-клієнті; тут — перегляд, галочки та ручні
         позиції в «Інше».
       </Text>
 
       <View className="flex-row items-center justify-between">
-        <Text className="text-sm text-stone-600" testID="shopping-count">
+        <Text className="text-sm text-fg-muted" testID="shopping-count">
           {totalCount.total} поз. · відмічено {totalCount.checked}
         </Text>
       </View>
 
       {shoppingList.categories.length === 0 ? (
         <Card className="p-4">
-          <Text className="text-stone-600 text-sm text-center">
+          <Text className="text-fg-muted text-sm text-center">
             Список порожній. Додай позицію нижче або згенеруй список у
             веб-версії (Рецепти / план) — після sync він з’явиться тут, коли
             додамо той самий сценарій в додатку.
@@ -55,7 +53,7 @@ export function Shopping({ testID }: { testID?: string }) {
 
       {shoppingList.categories.map((cat) => (
         <View key={cat.name} className="gap-1">
-          <Text className="text-xs font-semibold text-stone-500 mt-1">
+          <Text className="text-xs font-semibold text-fg-muted mt-1">
             {cat.name}
           </Text>
           {cat.items.map((item) => (
@@ -69,8 +67,8 @@ export function Shopping({ testID }: { testID?: string }) {
               <Text
                 className={
                   item.checked
-                    ? "text-stone-400 line-through flex-1"
-                    : "text-stone-800 flex-1"
+                    ? "text-fg-subtle line-through flex-1"
+                    : "text-fg flex-1"
                 }
               >
                 {item.name}
@@ -86,7 +84,7 @@ export function Shopping({ testID }: { testID?: string }) {
           value={draft}
           onChangeText={setDraft}
           placeholder="Назва продукту"
-          className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-stone-800 bg-white"
+          className="flex-1 border border-cream-300 rounded-xl px-3 py-2 text-fg bg-white"
           placeholderTextColor="#a8a29e"
         />
         <Button variant="nutrition" onPress={onAdd} disabled={!draft.trim()}>

--- a/apps/mobile/src/modules/nutrition/pages/Water.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Water.tsx
@@ -25,15 +25,13 @@ export function Water({ testID }: WaterProps) {
       contentContainerStyle={{ padding: 16, gap: 12 }}
     >
       <View>
-        <Text className="text-xs text-stone-500 mb-1 leading-none">
+        <Text className="text-xs text-fg-muted mb-1 leading-none">
           Щоденний трекер
         </Text>
-        <Text className="text-lg font-bold text-stone-900 leading-none">
-          Вода
-        </Text>
+        <Text className="text-lg font-bold text-fg leading-none">Вода</Text>
       </View>
       <WaterTrackerCard goalMl={goalMl} testID="nutrition-water-card" />
-      <Text className="text-[11px] text-stone-400 leading-snug">
+      <Text className="text-[11px] text-fg-subtle leading-snug">
         Підрахунок скидається опівночі локального часу. Зміна денної цілі
         доступна у налаштуваннях харчування — з&apos;явиться в PR-7.
       </Text>

--- a/apps/mobile/src/modules/routine/components/HabitHeatmap.tsx
+++ b/apps/mobile/src/modules/routine/components/HabitHeatmap.tsx
@@ -211,7 +211,7 @@ export function HabitHeatmap({
       testID={testID}
       className="rounded-2xl border border-cream-300 bg-cream-50 p-4"
     >
-      <Text className="text-sm font-semibold text-stone-700 mb-3">
+      <Text className="text-sm font-semibold text-fg mb-3">
         Активність за рік
       </Text>
 
@@ -231,7 +231,7 @@ export function HabitHeatmap({
                 justifyContent: "center",
               }}
             >
-              <Text className="text-[8px] leading-[12px] text-stone-500 text-right pr-1">
+              <Text className="text-[8px] leading-[12px] text-fg-muted text-right pr-1">
                 {lbl}
               </Text>
             </View>
@@ -279,7 +279,7 @@ export function HabitHeatmap({
         {grid.monthMarkers.map((marker) => (
           <Text
             key={`${marker.year}-${marker.monthIdx}`}
-            className="text-[10px] text-stone-500"
+            className="text-[10px] text-fg-muted"
             testID={`${testID}-month-${marker.year}-${marker.monthIdx}`}
           >
             {MONTH_LABELS_UK[marker.monthIdx]}
@@ -292,10 +292,10 @@ export function HabitHeatmap({
           testID={`${testID}-details`}
           className="mt-3 flex-row items-center justify-between gap-2 rounded-xl border border-cream-300 bg-cream-100 px-3 py-2"
         >
-          <Text className="text-xs text-stone-600 flex-1" numberOfLines={1}>
+          <Text className="text-xs text-fg-muted flex-1" numberOfLines={1}>
             {formatSelectedDate(selectedCell)}
           </Text>
-          <Text className="text-xs font-semibold text-stone-900">
+          <Text className="text-xs font-semibold text-fg">
             {formatSelectedStatus(selectedCell)}
           </Text>
           <Pressable
@@ -305,7 +305,7 @@ export function HabitHeatmap({
             testID={`${testID}-details-close`}
             className="ml-1 px-2 py-1"
           >
-            <Text className="text-xs font-bold text-stone-500">✕</Text>
+            <Text className="text-xs font-bold text-fg-muted">✕</Text>
           </Pressable>
         </View>
       ) : (
@@ -313,7 +313,7 @@ export function HabitHeatmap({
           testID={`${testID}-legend`}
           className="mt-3 flex-row items-center gap-2"
         >
-          <Text className="text-[10px] text-stone-500">менше</Text>
+          <Text className="text-[10px] text-fg-muted">менше</Text>
           {LEGEND_ORDER.map((lvl) => (
             <View
               key={lvl}
@@ -326,7 +326,7 @@ export function HabitHeatmap({
               }}
             />
           ))}
-          <Text className="text-[10px] text-stone-500">більше</Text>
+          <Text className="text-[10px] text-fg-muted">більше</Text>
         </View>
       )}
     </View>

--- a/apps/mobile/src/modules/routine/components/RoutineBottomNav.tsx
+++ b/apps/mobile/src/modules/routine/components/RoutineBottomNav.tsx
@@ -82,7 +82,7 @@ export function RoutineBottomNav({
             </Text>
             <Text
               className={`text-[11px] mt-0.5 ${
-                selected ? "text-coral-700 font-semibold" : "text-stone-500"
+                selected ? "text-coral-700 font-semibold" : "text-fg-muted"
               }`}
             >
               {item.label}

--- a/apps/mobile/src/modules/routine/components/RoutineTabPlaceholder.tsx
+++ b/apps/mobile/src/modules/routine/components/RoutineTabPlaceholder.tsx
@@ -36,27 +36,25 @@ export function RoutineTabPlaceholder({
       >
         <View className="flex-row items-center gap-2 mb-1">
           <Text className="text-[22px]">{emoji}</Text>
-          <Text className="text-[22px] font-bold text-stone-900 flex-1">
-            {title}
-          </Text>
+          <Text className="text-[22px] font-bold text-fg flex-1">{title}</Text>
         </View>
-        <Text className="text-sm text-stone-600 mb-2 leading-snug">
+        <Text className="text-sm text-fg-muted mb-2 leading-snug">
           {description}
         </Text>
 
         <Card radius="lg" padding="md">
-          <Text className="text-sm font-semibold text-stone-900 mb-2">
+          <Text className="text-sm font-semibold text-fg mb-2">
             Заплановано до порту
           </Text>
           {plannedFeatures.map((item) => (
             <View key={item} className="flex-row mb-1.5">
               <Text className="text-coral-600 mr-2">•</Text>
-              <Text className="text-sm text-stone-700 flex-1 leading-snug">
+              <Text className="text-sm text-fg flex-1 leading-snug">
                 {item}
               </Text>
             </View>
           ))}
-          <Text className="text-xs text-stone-500 mt-2 leading-snug">
+          <Text className="text-xs text-fg-muted mt-2 leading-snug">
             Скоро — буде портовано у наступному PR Фази 5.
           </Text>
         </Card>

--- a/apps/mobile/src/modules/routine/pages/Habits/HabitForm.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/HabitForm.tsx
@@ -226,7 +226,7 @@ export function HabitForm({
       <View className="px-4 pb-4" testID={testID}>
         {/* Emoji + Name */}
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">Назва</Text>
+          <Text className="text-sm font-medium text-fg mb-1">Назва</Text>
           <View className="flex-row gap-2 items-start">
             <Pressable
               onPress={() => setShowEmoji((v) => !v)}
@@ -288,9 +288,7 @@ export function HabitForm({
 
         {/* Recurrence */}
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Регулярність
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Регулярність</Text>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -319,7 +317,7 @@ export function HabitForm({
                     className={
                       active
                         ? "text-xs font-medium text-white"
-                        : "text-xs font-medium text-stone-700"
+                        : "text-xs font-medium text-fg"
                     }
                   >
                     {o.shortLabel ?? o.label}
@@ -357,9 +355,7 @@ export function HabitForm({
 
         {/* Reminder presets */}
         <View className="mb-4">
-          <Text className="text-sm font-medium text-stone-700 mb-1">
-            Нагадування
-          </Text>
+          <Text className="text-sm font-medium text-fg mb-1">Нагадування</Text>
           <View className="flex-row flex-wrap gap-2">
             {REMINDER_PRESETS.map((p) => {
               const active = activePresetId === p.id;
@@ -380,7 +376,7 @@ export function HabitForm({
                     className={
                       active
                         ? "text-xs font-medium text-white"
-                        : "text-xs font-medium text-stone-700"
+                        : "text-xs font-medium text-fg"
                     }
                   >
                     {p.label}
@@ -396,7 +392,7 @@ export function HabitForm({
                 testID={testID ? `${testID}-reminder-clear` : undefined}
                 className="h-9 px-3 rounded-full border border-cream-300 bg-transparent items-center justify-center"
               >
-                <Text className="text-xs font-medium text-stone-500">
+                <Text className="text-xs font-medium text-fg-muted">
                   Без нагадувань
                 </Text>
               </Pressable>
@@ -412,10 +408,10 @@ export function HabitForm({
           testID={testID ? `${testID}-advanced-toggle` : undefined}
           className="flex-row items-center gap-1 py-2"
         >
-          <Text className="text-xs text-stone-500">
+          <Text className="text-xs text-fg-muted">
             {showAdvanced ? "Менше опцій" : "Більше опцій"}
           </Text>
-          <Text className="text-xs text-stone-400">
+          <Text className="text-xs text-fg-subtle">
             {showAdvanced ? "▲" : "▼"}
           </Text>
         </Pressable>
@@ -423,7 +419,7 @@ export function HabitForm({
         {showAdvanced ? (
           <View className="mb-2">
             <View className="mb-3">
-              <Text className="text-sm font-medium text-stone-700 mb-1">
+              <Text className="text-sm font-medium text-fg mb-1">
                 Початок (дата)
               </Text>
               <Input
@@ -436,7 +432,7 @@ export function HabitForm({
               />
             </View>
             <View className="mb-3">
-              <Text className="text-sm font-medium text-stone-700 mb-1">
+              <Text className="text-sm font-medium text-fg mb-1">
                 Кінець (необовʼязково)
               </Text>
               <Input
@@ -451,9 +447,7 @@ export function HabitForm({
 
             {routine.tags.length > 0 ? (
               <View className="mb-3">
-                <Text className="text-sm font-medium text-stone-700 mb-1">
-                  Тег
-                </Text>
+                <Text className="text-sm font-medium text-fg mb-1">Тег</Text>
                 <View className="flex-row flex-wrap gap-2">
                   <Pressable
                     onPress={() => setDraft((d) => ({ ...d, tagIds: [] }))}
@@ -472,7 +466,7 @@ export function HabitForm({
                       className={
                         draft.tagIds.length === 0
                           ? "text-xs font-medium text-white"
-                          : "text-xs font-medium text-stone-700"
+                          : "text-xs font-medium text-fg"
                       }
                     >
                       — без тегу —
@@ -499,7 +493,7 @@ export function HabitForm({
                           className={
                             selected
                               ? "text-xs font-medium text-white"
-                              : "text-xs font-medium text-stone-700"
+                              : "text-xs font-medium text-fg"
                           }
                         >
                           {t.name}
@@ -513,7 +507,7 @@ export function HabitForm({
 
             {routine.categories.length > 0 ? (
               <View className="mb-1">
-                <Text className="text-sm font-medium text-stone-700 mb-1">
+                <Text className="text-sm font-medium text-fg mb-1">
                   Категорія
                 </Text>
                 <View className="flex-row flex-wrap gap-2">
@@ -536,7 +530,7 @@ export function HabitForm({
                       className={
                         !draft.categoryId
                           ? "text-xs font-medium text-white"
-                          : "text-xs font-medium text-stone-700"
+                          : "text-xs font-medium text-fg"
                       }
                     >
                       — без категорії —
@@ -565,7 +559,7 @@ export function HabitForm({
                           className={
                             selected
                               ? "text-xs font-medium text-white"
-                              : "text-xs font-medium text-stone-700"
+                              : "text-xs font-medium text-fg"
                           }
                         >
                           {c.emoji ? `${c.emoji} ` : ""}

--- a/apps/mobile/src/modules/routine/pages/Habits/HabitListItem.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/HabitListItem.tsx
@@ -78,14 +78,11 @@ export const HabitListItem = memo(function HabitListItem({
     <View className={rowClass} testID={testID}>
       <View className="flex-row items-start justify-between gap-2">
         <View className="min-w-0 flex-1">
-          <Text
-            className="text-sm font-medium text-stone-900"
-            numberOfLines={1}
-          >
+          <Text className="text-sm font-medium text-fg" numberOfLines={1}>
             {(h.emoji || "✓") + " " + (h.name || "")}
           </Text>
           {meta ? (
-            <Text className="text-xs text-stone-500 mt-0.5" numberOfLines={2}>
+            <Text className="text-xs text-fg-muted mt-0.5" numberOfLines={2}>
               {meta}
             </Text>
           ) : null}
@@ -102,7 +99,7 @@ export const HabitListItem = memo(function HabitListItem({
               testID={testID ? `${testID}-up` : undefined}
               className="min-w-[36px] min-h-[36px] rounded-lg border border-cream-300 bg-cream-50 items-center justify-center"
             >
-              <Text className="text-xs text-stone-600">↑</Text>
+              <Text className="text-xs text-fg-muted">↑</Text>
             </Pressable>
             <Pressable
               onPress={onMoveDown}
@@ -111,7 +108,7 @@ export const HabitListItem = memo(function HabitListItem({
               testID={testID ? `${testID}-down` : undefined}
               className="min-w-[36px] min-h-[36px] rounded-lg border border-cream-300 bg-cream-50 items-center justify-center"
             >
-              <Text className="text-xs text-stone-600">↓</Text>
+              <Text className="text-xs text-fg-muted">↓</Text>
             </Pressable>
             <Pressable
               onPress={onStartEdit}
@@ -120,9 +117,7 @@ export const HabitListItem = memo(function HabitListItem({
               testID={testID ? `${testID}-edit` : undefined}
               className="h-9 px-3 rounded-lg border border-cream-300 bg-cream-50 items-center justify-center"
             >
-              <Text className="text-xs font-medium text-stone-700">
-                Змінити
-              </Text>
+              <Text className="text-xs font-medium text-fg">Змінити</Text>
             </Pressable>
             <Pressable
               onPress={onArchive}
@@ -131,9 +126,7 @@ export const HabitListItem = memo(function HabitListItem({
               testID={testID ? `${testID}-archive` : undefined}
               className="h-9 px-3 rounded-lg border border-cream-300 bg-cream-50 items-center justify-center"
             >
-              <Text className="text-xs font-medium text-stone-700">
-                В архів
-              </Text>
+              <Text className="text-xs font-medium text-fg">В архів</Text>
             </Pressable>
           </>
         ) : onUnarchive ? (
@@ -144,9 +137,7 @@ export const HabitListItem = memo(function HabitListItem({
             testID={testID ? `${testID}-unarchive` : undefined}
             className="h-9 px-3 rounded-lg border border-cream-300 bg-cream-50 items-center justify-center"
           >
-            <Text className="text-xs font-medium text-stone-700">
-              Відновити
-            </Text>
+            <Text className="text-xs font-medium text-fg">Відновити</Text>
           </Pressable>
         ) : null}
         <Pressable

--- a/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.tsx
@@ -150,11 +150,9 @@ export function HabitsPage({ testID }: HabitsPageProps) {
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">⚙️</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Звички
-        </Text>
+        <Text className="text-[22px] font-bold text-fg flex-1">Звички</Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-2">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-2">
         Додавай, редагуй і архівуй звички. Порядок у списку = порядок у
         календарі — використай ↑ / ↓ для зміни.
       </Text>
@@ -164,7 +162,7 @@ export function HabitsPage({ testID }: HabitsPageProps) {
         contentContainerStyle={{ padding: 16, paddingBottom: 96, gap: 12 }}
       >
         <View className="rounded-2xl border border-cream-300 bg-white px-3 py-2">
-          <Text className="text-sm font-semibold text-stone-900 mb-1">
+          <Text className="text-sm font-semibold text-fg mb-1">
             Активні звички
           </Text>
           {activeHabits.length === 0 ? (
@@ -172,8 +170,8 @@ export function HabitsPage({ testID }: HabitsPageProps) {
               className="py-6 items-center"
               testID={testID ? `${testID}-empty` : undefined}
             >
-              <Text className="text-sm text-stone-500">Поки порожньо</Text>
-              <Text className="text-xs text-stone-400 mt-1 text-center">
+              <Text className="text-sm text-fg-muted">Поки порожньо</Text>
+              <Text className="text-xs text-fg-subtle mt-1 text-center">
                 Натисни «+ Додати» нижче, щоб створити першу звичку.
               </Text>
             </View>
@@ -201,19 +199,19 @@ export function HabitsPage({ testID }: HabitsPageProps) {
             testID={testID ? `${testID}-archive-toggle` : undefined}
             className="flex-row items-center justify-between py-1"
           >
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Архів{" "}
-              <Text className="text-xs font-normal text-stone-500">
+              <Text className="text-xs font-normal text-fg-muted">
                 ({archivedHabits.length})
               </Text>
             </Text>
-            <Text className="text-xs text-stone-500">
+            <Text className="text-xs text-fg-muted">
               {archiveOpen ? "▲" : "▼"}
             </Text>
           </Pressable>
           {archiveOpen ? (
             archivedHabits.length === 0 ? (
-              <Text className="text-xs text-stone-500 py-3">
+              <Text className="text-xs text-fg-muted py-3">
                 Архів порожній.
               </Text>
             ) : (

--- a/apps/mobile/src/modules/routine/pages/Habits/WeekdayPicker.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/WeekdayPicker.tsx
@@ -62,7 +62,7 @@ export const WeekdayPicker = memo(function WeekdayPicker({
 
   return (
     <View testID={testID}>
-      <Text className="text-xs text-stone-500 mb-2">Дні тижня</Text>
+      <Text className="text-xs text-fg-muted mb-2">Дні тижня</Text>
       <View className="flex-row flex-wrap gap-2">
         {WEEKDAY_LABELS.map((label, wd) => {
           const on = active.includes(wd);
@@ -84,7 +84,7 @@ export const WeekdayPicker = memo(function WeekdayPicker({
                 className={
                   on
                     ? "text-xs font-semibold text-white"
-                    : "text-xs font-semibold text-stone-700"
+                    : "text-xs font-semibold text-fg"
                 }
               >
                 {label}

--- a/apps/mobile/src/modules/routine/pages/Heatmap/HeatmapPage.tsx
+++ b/apps/mobile/src/modules/routine/pages/Heatmap/HeatmapPage.tsx
@@ -57,11 +57,9 @@ export function HeatmapPage({
     >
       <View className="flex-row items-center gap-2 px-4 pt-4 pb-1">
         <Text className="text-[22px]">📊</Text>
-        <Text className="text-[22px] font-bold text-stone-900 flex-1">
-          Хітмеп
-        </Text>
+        <Text className="text-[22px] font-bold text-fg flex-1">Хітмеп</Text>
       </View>
-      <Text className="px-4 text-sm text-stone-600 leading-snug mb-2">
+      <Text className="px-4 text-sm text-fg-muted leading-snug mb-2">
         Активність виконання звичок за останній рік. Тап по клітинці — деталі
         дня.
       </Text>
@@ -75,10 +73,10 @@ export function HeatmapPage({
             testID={`${testID}-empty`}
             className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-6 items-center"
           >
-            <Text className="text-sm font-semibold text-stone-900">
+            <Text className="text-sm font-semibold text-fg">
               Поки немає звичок
             </Text>
-            <Text className="text-xs text-stone-500 mt-1 text-center">
+            <Text className="text-xs text-fg-muted mt-1 text-center">
               Додай звичку на вкладці «Налаштування», щоб побачити свою
               активність тут.
             </Text>
@@ -89,10 +87,10 @@ export function HeatmapPage({
               testID={`${testID}-empty-completions`}
               className="rounded-2xl border border-dashed border-cream-300 bg-cream-50 p-6 items-center"
             >
-              <Text className="text-sm font-semibold text-stone-900">
+              <Text className="text-sm font-semibold text-fg">
                 Ще немає виконаних днів
               </Text>
-              <Text className="text-xs text-stone-500 mt-1 text-center">
+              <Text className="text-xs text-fg-muted mt-1 text-center">
                 Відмічай виконання звичок на вкладці «Календар» — тут зʼявиться
                 карта активності.
               </Text>

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -2,9 +2,31 @@
 // config Node wraps it as `{ __esModule, default }`, so we unwrap here.
 const designTokensPreset = require("@sergeant/design-tokens/tailwind-preset");
 
-/** @type {import('tailwindcss').Config} */
+/**
+ * Mobile NativeWind config — extends the shared Sergeant design-tokens preset.
+ *
+ * Dark-mode wiring:
+ *  - The shared preset (`packages/design-tokens/tailwind-preset.js`)
+ *    registers CSS-variable-backed semantic colour utilities — `bg`,
+ *    `panel`, `panel-hi`, `line`, `fg`, `fg-muted`, `fg-subtle`,
+ *    `border`, `border-strong`, plus status-soft tokens.
+ *  - Their values come from `apps/mobile/global.css`, which defines the
+ *    `:root` (light) and `.dark` (dark) palettes mirroring `apps/web`.
+ *  - NativeWind's CSS-interop resolves these variables at compile time,
+ *    so utilities like `bg-panel`, `text-fg`, `text-fg-muted` and
+ *    `border-line` re-tint with the active scheme without bespoke
+ *    `dark:` modifiers per call site.
+ *  - `darkMode: "class"` mirrors the web config so both apps toggle the
+ *    palette through the same `.dark` selector — see
+ *    `apps/web/tailwind.config.ts`. The actual `colorScheme` toggle
+ *    wiring through the app root is tracked separately (see
+ *    `apps/mobile/src/core/settings/GeneralSection.tsx` header).
+ *
+ * @type {import('tailwindcss').Config}
+ */
 module.exports = {
   content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  darkMode: "class",
   // NativeWind's preset MUST come first so Sergeant design tokens layer on top
   // of its RN-specific defaults.
   presets: [


### PR DESCRIPTION
## What changed

Mobile-компоненти використовували **746 хардкодних `stone-*`** утиліт, які не реагують на світлу/темну тему. Card.tsx явно визнавав цей борг у заголовку файлу. Цей PR підключає CSS-variable-backed семантичні утиліти зі shared `@sergeant/design-tokens` preset і переводить весь `apps/mobile/src/` на них.

**`apps/mobile/tailwind.config.js`** — задокументовано dark-mode wiring і додано `darkMode: "class"` у відповідність до `apps/web/tailwind.config.ts`. Семантичні утиліти (`bg`, `panel`, `panel-hi`, `line`, `fg`, `fg-muted`, `fg-subtle`, `border`, `border-strong`, status-soft) приходять зі shared preset; їх значення резолвляться через `:root` ↔ `.dark` змінні в `apps/mobile/global.css`.

**`apps/mobile/src/components/ui/Card.tsx`** — відповідно до тексту таски:
- рядок 185: `text-stone-900` → `text-fg` (CardTitle);
- рядок 207: `text-stone-500` → `text-fg-muted` (CardDescription);
- рядок 247: `border-cream-300` → `border-line` (CardFooter, тепер дзеркалить web-варіант `border-t border-line`);
- header-коментар оновлено: модульно-брендовані варіанти все ще без `dark:` оверрайдів (їх не торкав), але core-варіанти й text-сабкомпоненти тепер семантичні.

**130 інших файлів у `apps/mobile/src/`** — масова заміна `stone-*` через regex (`/tmp/replace_stone.py`, з word-boundary щоб опціональні `/40`-modifier-и зберігались). Mapping (light-mode parity, дарк автоматом через global.css):

| Початково | Семантичний токен |
| --- | --- |
| `text-stone-{700..900}` | `text-fg` |
| `text-stone-{500,600}` | `text-fg-muted` |
| `text-stone-{100..400}` | `text-fg-subtle` |
| `text-stone-50` | `text-bg` |
| `bg-stone-{700..900}` (включно з `/40` backdrop-ами) | `bg-fg` |
| `bg-stone-{500,600}` | `bg-fg-muted` |
| `bg-stone-{300,400}` | `bg-line` |
| `bg-stone-{100,200}` (включно з `/40`) | `bg-panel-hi` |
| `bg-stone-50` | `bg-bg` |
| `border-stone-{100..600}` | `border-line` |

**Підчищено коментарі** про токен-debt у `ErrorBoundary.tsx`, `ModuleErrorBoundary.tsx`, `BodyAtlas.tsx` (там були посилання на «`stone-*` поки семантичних токенів немає» — вже неактуально).

`packages/design-tokens` сам по собі вже мав потрібні токени, тому йому правки не потрібні.

## Why

Card.tsx (рядки 27-30 до цього PR) і `GeneralSection.tsx` явно фіксували:
> "Mobile has no semantic dark-mode tokens yet ... actually re-tinting surfaces lands once mobile CSS variables land."

CSS-variables в `apps/mobile/global.css` уже були (і `:root`, і `.dark`), і shared preset уже експонував `fg`/`fg-muted`/`panel`/`line`. Але компоненти все одно сипали `text-stone-900`, тож фактичний dark mode не міг ввімкнутись навіть коли користувач перемикав «Темна тема» в `GeneralSection` (preference вже зберігався в MMKV/cloud-sync, просто нічого не перетинявалось). Цей PR закриває візуальну частину боргу — `colorScheme` toggle через app root залишається окремим follow-up (зафіксовано в header-коментарі `GeneralSection.tsx`).

## How to test

```bash
# 0. Sanity — жодного stone-* не лишилось:
grep -r "stone-" apps/mobile/src/    # → 0 рядків

# 1. Mobile pipeline:
pnpm --filter @sergeant/mobile typecheck    # OK
pnpm --filter @sergeant/mobile lint         # OK (eslint --max-warnings=0)
pnpm --filter @sergeant/mobile test         # 588 passed (87 suites)

# 2. Smoke у Expo (опційно):
pnpm --filter @sergeant/mobile start
# Відкрити Hub Dashboard / Routine Heatmap / Habit form / Onboarding wizard
# у симуляторі. Текст / фони / бордери мають виглядати ідентично до main
# у світлій темі (semantic tokens мапляться на ті самі warm-stone значення
# через CSS variable preset).
```

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/mobile test` → 87 suites / 588 tests passed.
- [x] Lint passes: `pnpm --filter @sergeant/mobile lint` (eslint --max-warnings=0).
- [x] Typecheck passes: `pnpm --filter @sergeant/mobile typecheck`.
- [x] Verification per task: `grep -r "stone-" apps/mobile/src/` returns **0**.
- [x] Spot-checked diff на `HabitHeatmap.tsx`, `Card.tsx`, `Sheet.tsx`, `ConfirmDialog.tsx`, `Input.tsx`, `HeatmapPage.tsx` — заміни консистентні, opacity-modifier-и (`/40`) збережені.
- [ ] Manual smoke у симуляторі — не проводилось у цій сесії (UI-зміна 1:1 у світлій темі через однакові CSS-variable значення; візуальна перевірка в темній — окремий follow-up разом з `colorScheme` toggle).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical (header-коментарі Card.tsx / tailwind.config.js).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules; PR опирається на наявне правило #8 (Tailwind opacity scale) — всі використані `/40` modifier-и вже на зареєстрованій scale.

Link to Devin session: https://app.devin.ai/sessions/be81b2a45398452d84394e43697b4fb6
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
