### PR TITLE
fix(design-tokens): додати типи для statusHex та chartHex

### DIFF
--- a/packages/design-tokens/index.d.ts
+++ b/packages/design-tokens/index.d.ts
@@ -52,3 +52,22 @@ export declare const moduleColors: Readonly<
 
 /** Status / semantic colours, keyed by `StatusColor`. */
 export declare const statusColors: Readonly<Record<StatusColor, string>>;
+
+/**
+ * Status colours as a flat hex map — alias of `statusColors` for inline
+ * SVG / canvas / native call sites that consume raw `"#rrggbb"` strings.
+ */
+export declare const statusHex: Readonly<Record<StatusColor, string>>;
+
+/** Semantic chart colour identifiers (kcal/protein/fat/carbs + structural). */
+export type ChartHexKey =
+  | "primary"
+  | "limit"
+  | "neutral"
+  | "kcal"
+  | "protein"
+  | "fat"
+  | "carbs";
+
+/** Chart hex tokens — semantic names for inline-styled chart primitives. */
+export declare const chartHex: Readonly<Record<ChartHexKey, string>>;


### PR DESCRIPTION
## What changed

Додано в `packages/design-tokens/index.d.ts` ambient-декларації для двох runtime-експортів `tokens.js`, які з'явились у недавніх PR #821 / #823:

- `statusHex: Readonly<Record<StatusColor, string>>`
- `chartHex: Readonly<Record<ChartHexKey, string>>` + `export type ChartHexKey = "primary" | "limit" | "neutral" | "kcal" | "protein" | "fat" | "carbs"`

## Why

Після мерджу #820 (типи для design-tokens) `index.d.ts` став основним джерелом типів для `@sergeant/design-tokens/tokens`. Наступні PR #821 (`routine-surface2-token`) та #823 (`chart-tokens`) додали в `tokens.js` нові runtime-експорти `statusHex` і `chartHex`, але `index.d.ts` не оновили — тому TS їх не бачить, і `apps/web` перестав проходити typecheck на main:

```
src/shared/lib/themeHex.ts:10 - error TS2305: Module '"@sergeant/design-tokens/tokens"' has no exported member 'statusHex'.
src/modules/finyk/components/BudgetTrendChart.tsx:2 - error TS2305: ... 'chartHex'.
src/modules/finyk/components/analytics/CategoryPieChart.tsx:2 - error TS2305: ... 'chartHex'.
src/modules/nutrition/components/NutritionDashboard.tsx:2 - error TS2305: ... 'chartHex'.
```

Це блокує всі наступні PR. Цей PR — мінімальний фікс, без жодних змін у поведінці runtime.

## How to test

```bash
pnpm install
pnpm --filter @sergeant/web typecheck
```

Локально:
- `pnpm --filter @sergeant/web typecheck` — OK (раніше падав на 4 файлах)
- `pnpm prettier --check packages/design-tokens/index.d.ts` — OK

---

## How AI-tested this PR

- [x] Vitest passes: не запускав — type-only фікс; повторно прогнав `pnpm --filter @sergeant/web typecheck`, який падав на main, тепер зелений.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

> Коли в `tokens.js` додаються нові runtime-експорти, їх потрібно одночасно декларувати в `index.d.ts`, інакше TS їх не побачить. Можна занести в `AGENTS.md` окремим PR, якщо вважаєш потрібним.


Link to Devin session: https://app.devin.ai/sessions/c12d9deebd924e5c9fe2ace6ab800489
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
