### PR TITLE
refactor(web): замінити dark:bg-&lt;m&gt;/[op] оверрайди на семантичні токени

### DIFF
--- a/apps/web/src/core/app/WelcomeScreen.tsx
+++ b/apps/web/src/core/app/WelcomeScreen.tsx
@@ -10,8 +10,8 @@ const PEEK_CARDS = [
   {
     id: "finyk",
     label: "💰 Фінік",
-    cardBg: "bg-finyk-soft/40 dark:bg-finyk/8",
-    iconClass: "bg-finyk-soft text-finyk dark:bg-finyk/15",
+    cardBg: "bg-finyk-soft/40 dark:bg-finyk-surface-dark/8",
+    iconClass: "bg-finyk-soft text-finyk dark:bg-finyk-surface-dark/15",
     icon: "credit-card",
     metric: "−320 ₴",
     sub: "тиждень",
@@ -19,8 +19,8 @@ const PEEK_CARDS = [
   {
     id: "fizruk",
     label: "💪 Фізрук",
-    cardBg: "bg-fizruk-soft/40 dark:bg-fizruk/8",
-    iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk/15",
+    cardBg: "bg-fizruk-soft/40 dark:bg-fizruk-surface-dark/8",
+    iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk-surface-dark/15",
     icon: "dumbbell",
     metric: "5 трен.",
     sub: "14 днів",
@@ -28,8 +28,9 @@ const PEEK_CARDS = [
   {
     id: "routine",
     label: "✅ Рутина",
-    cardBg: "bg-routine-surface/40 dark:bg-routine/8",
-    iconClass: "bg-routine-surface text-routine dark:bg-routine/15",
+    cardBg: "bg-routine-surface/40 dark:bg-routine-surface-dark/8",
+    iconClass:
+      "bg-routine-surface text-routine dark:bg-routine-surface-dark/15",
     icon: "check",
     metric: "7 днів",
     sub: "стрік",
@@ -37,8 +38,9 @@ const PEEK_CARDS = [
   {
     id: "nutrition",
     label: "🥗 Харчування",
-    cardBg: "bg-nutrition-soft/40 dark:bg-nutrition/8",
-    iconClass: "bg-nutrition-soft text-nutrition dark:bg-nutrition/15",
+    cardBg: "bg-nutrition-soft/40 dark:bg-nutrition-surface-dark/8",
+    iconClass:
+      "bg-nutrition-soft text-nutrition dark:bg-nutrition-surface-dark/15",
     icon: "utensils",
     metric: "420 ккал",
     sub: "сніданок",

--- a/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
+++ b/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
@@ -52,10 +52,10 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     label: "Фінік",
     emoji: "\uD83D\uDCB0",
     module: "finyk",
-    iconClass: "bg-finyk-soft text-finyk dark:bg-finyk/15",
+    iconClass: "bg-finyk-soft text-finyk dark:bg-finyk-surface-dark/15",
     accentClass: "bg-finyk",
     cardBg:
-      "bg-finyk-soft/40 dark:bg-finyk/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-finyk-soft/40 dark:bg-finyk-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
     description: "Транзакції та бюджети",
     hasGoal: false,
     emptyLabel: "Почни тут \u2192",
@@ -85,10 +85,10 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     label: "Фізрук",
     emoji: "\uD83D\uDCAA",
     module: "fizruk",
-    iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk/15",
+    iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk-surface-dark/15",
     accentClass: "bg-fizruk",
     cardBg:
-      "bg-fizruk-soft/40 dark:bg-fizruk/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-fizruk-soft/40 dark:bg-fizruk-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
     description: "Тренування та прогрес",
     hasGoal: false,
     emptyLabel: "Почни тут \u2192",
@@ -117,10 +117,11 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     label: "Рутина",
     emoji: "\u2705",
     module: "routine",
-    iconClass: "bg-routine-surface text-routine dark:bg-routine/15",
+    iconClass:
+      "bg-routine-surface text-routine dark:bg-routine-surface-dark/15",
     accentClass: "bg-routine",
     cardBg:
-      "bg-routine-surface/40 dark:bg-routine/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-routine-surface/40 dark:bg-routine-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
     description: "Звички та щоденні цілі",
     hasGoal: true,
     emptyLabel: "Почни тут \u2192",
@@ -150,10 +151,11 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     label: "Харчування",
     emoji: "\uD83E\uDD57",
     module: "nutrition",
-    iconClass: "bg-nutrition-soft text-nutrition dark:bg-nutrition/15",
+    iconClass:
+      "bg-nutrition-soft text-nutrition dark:bg-nutrition-surface-dark/15",
     accentClass: "bg-nutrition",
     cardBg:
-      "bg-nutrition-soft/40 dark:bg-nutrition/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-nutrition-soft/40 dark:bg-nutrition-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
     description: "КБЖВ та раціон",
     hasGoal: true,
     emptyLabel: "Почни тут \u2192",

--- a/apps/web/src/core/insights/TodayFocusCard.tsx
+++ b/apps/web/src/core/insights/TodayFocusCard.tsx
@@ -168,21 +168,23 @@ const MODULE_CHIP_ACCENT: Record<
   { bubble: string; hoverBorder: string }
 > = {
   finyk: {
-    bubble: "bg-finyk-soft text-finyk dark:bg-finyk/20 dark:text-finyk",
+    bubble:
+      "bg-finyk-soft text-finyk dark:bg-finyk-surface-dark/20 dark:text-finyk",
     hoverBorder: "hover:border-finyk/40 hover:bg-finyk-soft/40",
   },
   fizruk: {
-    bubble: "bg-fizruk-soft text-fizruk dark:bg-fizruk/20 dark:text-fizruk",
+    bubble:
+      "bg-fizruk-soft text-fizruk dark:bg-fizruk-surface-dark/20 dark:text-fizruk",
     hoverBorder: "hover:border-fizruk/40 hover:bg-fizruk-soft/40",
   },
   routine: {
     bubble:
-      "bg-routine-surface text-routine dark:bg-routine/20 dark:text-routine",
+      "bg-routine-surface text-routine dark:bg-routine-surface-dark/20 dark:text-routine",
     hoverBorder: "hover:border-routine/40 hover:bg-routine-surface/40",
   },
   nutrition: {
     bubble:
-      "bg-nutrition-soft text-nutrition dark:bg-nutrition/20 dark:text-nutrition",
+      "bg-nutrition-soft text-nutrition dark:bg-nutrition-surface-dark/20 dark:text-nutrition",
     hoverBorder: "hover:border-nutrition/40 hover:bg-nutrition-soft/40",
   },
 };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -144,6 +144,26 @@
     --c-warning-soft: 146 64 14; /* slightly brighter amber-900 */
     --c-danger-soft: 153 27 27; /* red-800 — brighter than red-900 */
     --c-info-soft: 7 89 133; /* sky-800 — brighter than sky-900 */
+
+    /* ───────────────────────────────────────────────────────────────────
+       MODULE DARK SURFACES & BORDERS
+       Premixed accents tuned for use over the dark `panel` background.
+       Decoupled from the live `--c-finyk` / `--c-routine` / … accents so
+       the visual proportions of `bg-<m>-surface-dark/N` and
+       `border-<m>-border-dark/N` opacity tints don't silently drift if a
+       module's primary colour is later retuned. Initial RGB values mirror
+       the corresponding `moduleColors.<m>.primary` from
+       `packages/design-tokens/tokens.js` — change them here independently
+       when dark-mode tints need their own treatment.
+       ─────────────────────────────────────────────────────────────────── */
+    --c-finyk-surface-dark: 16 185 129; /* emerald-500 */
+    --c-finyk-border-dark: 16 185 129; /* emerald-500 */
+    --c-fizruk-surface-dark: 20 184 166; /* teal-500 */
+    --c-fizruk-border-dark: 20 184 166; /* teal-500 */
+    --c-routine-surface-dark: 249 112 102; /* coral-500 */
+    --c-routine-border-dark: 249 112 102; /* coral-500 */
+    --c-nutrition-surface-dark: 146 204 23; /* lime-500 */
+    --c-nutrition-border-dark: 146 204 23; /* lime-500 */
   }
 
   /* ═══════════════════════════════════════════════════════════════════════

--- a/apps/web/src/modules/routine/components/DayReportSheet.tsx
+++ b/apps/web/src/modules/routine/components/DayReportSheet.tsx
@@ -52,7 +52,7 @@ export function DayReportSheet({
             {done.map((h) => (
               <li
                 key={h.id}
-                className="flex items-center gap-3 rounded-xl bg-routine-surface/40 dark:bg-routine/10 border border-routine-line/30 dark:border-routine/20 px-3 py-2.5"
+                className="flex items-center gap-3 rounded-xl bg-routine-surface/40 dark:bg-routine-surface-dark/10 border border-routine-line/30 dark:border-routine-border-dark/20 px-3 py-2.5"
               >
                 <button
                   type="button"

--- a/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
+++ b/apps/web/src/modules/routine/components/HabitDetailSheet.tsx
@@ -183,7 +183,7 @@ export function HabitDetailSheet({
         {tag.map((t) => (
           <span
             key={t}
-            className="text-2xs px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine/10 border border-routine-line/50 dark:border-routine/25 text-routine-strong dark:text-routine font-medium"
+            className="text-2xs px-2 py-0.5 rounded-full bg-routine-surface dark:bg-routine-surface-dark/10 border border-routine-line/50 dark:border-routine-border-dark/25 text-routine-strong dark:text-routine font-medium"
           >
             {t}
           </span>
@@ -321,11 +321,12 @@ export function HabitDetailSheet({
                 className={cn(
                   "aspect-square flex items-center justify-center rounded-lg text-xs font-medium transition-colors",
                   done
-                    ? "bg-routine-surface2 dark:bg-routine/15 text-routine-strong dark:text-routine border border-routine-ring/40 dark:border-routine/30 font-bold"
+                    ? "bg-routine-surface2 dark:bg-routine-surface-dark/15 text-routine-strong dark:text-routine border border-routine-ring/40 dark:border-routine-border-dark/30 font-bold"
                     : scheduled
                       ? "bg-panelHi/60 text-muted border border-line/30"
                       : "text-subtle/50",
-                  isToday && "ring-1 ring-routine-ring/60 dark:ring-routine/50",
+                  isToday &&
+                    "ring-1 ring-routine-ring/60 dark:ring-routine-border-dark/50",
                 )}
                 title={
                   done
@@ -342,7 +343,7 @@ export function HabitDetailSheet({
         </div>
         <div className="flex items-center gap-3 mt-2 text-3xs text-subtle">
           <span className="flex items-center gap-1">
-            <span className="inline-block w-3 h-3 rounded bg-routine-surface2 dark:bg-routine/15 border border-routine-ring/40 dark:border-routine/30" />
+            <span className="inline-block w-3 h-3 rounded bg-routine-surface2 dark:bg-routine-surface-dark/15 border border-routine-ring/40 dark:border-routine-border-dark/30" />
             Виконано
           </span>
           <span className="flex items-center gap-1">

--- a/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -43,7 +43,7 @@ export function HabitLeadersBlock({
         Лідери та аутсайдери (30 днів)
       </SectionHeading>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        <div className="rounded-xl border border-routine-line/40 dark:border-routine/20 bg-routine-surface/30 dark:bg-routine/8 p-3">
+        <div className="rounded-xl border border-routine-line/40 dark:border-routine-border-dark/20 bg-routine-surface/30 dark:bg-routine-surface-dark/8 p-3">
           <SectionHeading as="p" size="xs" tone="subtle" className="mb-1">
             Найстабільніша
           </SectionHeading>

--- a/apps/web/src/modules/routine/components/PushupsWidget.tsx
+++ b/apps/web/src/modules/routine/components/PushupsWidget.tsx
@@ -115,7 +115,7 @@ export function PushupsWidget() {
                 addReps(n);
                 setOpen(false);
               }}
-              className="min-h-[44px] rounded-2xl border border-routine-line/80 dark:border-routine/30 bg-routine-surface dark:bg-routine/10 px-1 py-2.5 text-center text-xs font-bold text-routine-strong dark:text-routine transition-colors active:opacity-90 sm:px-2 sm:text-sm"
+              className="min-h-[44px] rounded-2xl border border-routine-line/80 dark:border-routine-border-dark/30 bg-routine-surface dark:bg-routine-surface-dark/10 px-1 py-2.5 text-center text-xs font-bold text-routine-strong dark:text-routine transition-colors active:opacity-90 sm:px-2 sm:text-sm"
             >
               +{n}
             </button>

--- a/apps/web/src/modules/routine/components/WeekDayStrip.tsx
+++ b/apps/web/src/modules/routine/components/WeekDayStrip.tsx
@@ -52,7 +52,7 @@ export function WeekDayStrip({
               className={cn(
                 "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-xs",
                 isSel
-                  ? "border-routine-ring dark:border-routine/40 bg-routine-surface2 dark:bg-routine/15 text-text shadow-sm ring-1 ring-routine-line/50 dark:ring-routine/30"
+                  ? "border-routine-ring dark:border-routine-border-dark/40 bg-routine-surface2 dark:bg-routine-surface-dark/15 text-text shadow-sm ring-1 ring-routine-line/50 dark:ring-routine-border-dark/30"
                   : "border-transparent bg-panelHi/50 text-muted hover:bg-panelHi hover:text-text",
                 isToday && !isSel && "ring-1 ring-routine/40",
               )}

--- a/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
+++ b/apps/web/src/modules/routine/components/settings/CategoriesSection.tsx
@@ -115,7 +115,7 @@ export function CategoriesSection({
                   className={cn(
                     "flex items-center justify-between gap-2 px-3 py-2 rounded-xl bg-panelHi border border-line",
                     editingCatId === c.id &&
-                      "ring-2 ring-routine-ring/60 dark:ring-routine/40",
+                      "ring-2 ring-routine-ring/60 dark:ring-routine-border-dark/40",
                   )}
                 >
                   <div className="flex items-center gap-2 min-w-0">

--- a/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitListItem.tsx
@@ -51,7 +51,7 @@ export const HabitListItem = memo(function HabitListItem({
       className={cn(
         "flex flex-col gap-2 border-b border-line/40 pb-3 last:border-0 last:pb-0 cursor-grab active:cursor-grabbing",
         editing &&
-          "ring-2 ring-routine-ring/60 dark:ring-routine/40 rounded-xl p-2 -mx-1",
+          "ring-2 ring-routine-ring/60 dark:ring-routine-border-dark/40 rounded-xl p-2 -mx-1",
         dragging && "opacity-70",
       )}
       onDragStart={onDragStart}
@@ -94,7 +94,7 @@ export const HabitListItem = memo(function HabitListItem({
             type="button"
             variant="ghost"
             size="sm"
-            className="!h-9 !px-3 !text-xs border border-routine-line/60 dark:border-routine/25 bg-routine-surface/40 dark:bg-routine/10"
+            className="!h-9 !px-3 !text-xs border border-routine-line/60 dark:border-routine-border-dark/25 bg-routine-surface/40 dark:bg-routine-surface-dark/10"
             onClick={onOpenDetails}
           >
             Деталі

--- a/apps/web/src/modules/routine/lib/routineConstants.ts
+++ b/apps/web/src/modules/routine/lib/routineConstants.ts
@@ -14,11 +14,11 @@ export const ROUTINE_THEME = {
   statCard:
     "rounded-2xl bg-panel/80 border border-coral-100/60 dark:border-coral-800/30 p-3 text-center shadow-card backdrop-blur-sm",
   statCardHighlight:
-    "rounded-2xl bg-routine-surface/80 border border-routine-ring/50 dark:border-routine/30 p-3 text-center shadow-card",
+    "rounded-2xl bg-routine-surface/80 border border-routine-ring/50 dark:border-routine-border-dark/30 p-3 text-center shadow-card",
 
   // Empty state
   emptyStateWarm:
-    "rounded-2xl border border-coral-100/60 dark:border-routine/25 bg-coral-50/50 dark:bg-routine/8 p-6 text-center shadow-card",
+    "rounded-2xl border border-coral-100/60 dark:border-routine-border-dark/25 bg-coral-50/50 dark:bg-routine-surface-dark/8 p-6 text-center shadow-card",
 
   // Links & accents
   linkAccent:
@@ -26,11 +26,12 @@ export const ROUTINE_THEME = {
 
   // Habit list items
   habitRowAccent: "border-l-routine",
-  habitRowDone: "border-l-routine bg-coral-50/50 dark:bg-routine/10",
+  habitRowDone:
+    "border-l-routine bg-coral-50/50 dark:bg-routine-surface-dark/10",
 
   // Icon containers
   iconBox:
-    "bg-routine-surface dark:bg-routine/10 border-coral-100 dark:border-routine/30 text-routine-strong dark:text-routine",
+    "bg-routine-surface dark:bg-routine-surface-dark/10 border-coral-100 dark:border-routine-border-dark/30 text-routine-strong dark:text-routine",
 
   // Navigation
   navActive: "text-routine-strong dark:text-routine",
@@ -38,7 +39,7 @@ export const ROUTINE_THEME = {
 
   // Chips/pills
   chipOn:
-    "border-routine-ring dark:border-routine/40 bg-routine-surface dark:bg-routine/15 text-routine-strong dark:text-routine shadow-sm",
+    "border-routine-ring dark:border-routine-border-dark/40 bg-routine-surface dark:bg-routine-surface-dark/15 text-routine-strong dark:text-routine shadow-sm",
   chipOff:
     "border-line bg-panel text-muted hover:text-text hover:bg-panelHi transition-colors",
 
@@ -48,10 +49,10 @@ export const ROUTINE_THEME = {
 
   // Month selector
   monthSel:
-    "bg-routine-surface dark:bg-routine/15 border-routine-ring dark:border-routine/40 ring-1 ring-coral-100/50 dark:ring-routine/30",
+    "bg-routine-surface dark:bg-routine-surface-dark/15 border-routine-ring dark:border-routine-border-dark/40 ring-1 ring-coral-100/50 dark:ring-routine-border-dark/30",
 
   // Completion states
-  done: "border-routine/45 bg-routine-surface dark:bg-routine/10 text-routine-strong dark:text-routine",
+  done: "border-routine/45 bg-routine-surface dark:bg-routine-surface-dark/10 text-routine-strong dark:text-routine",
   doneCheck: "text-routine-strong dark:text-routine",
 
   // Primary button

--- a/apps/web/src/shared/components/ui/Badge.tsx
+++ b/apps/web/src/shared/components/ui/Badge.tsx
@@ -56,13 +56,13 @@ const softVariants: Record<BadgeVariant, string> = {
     "bg-danger-soft text-danger border-danger/30 dark:bg-danger/15 dark:border-danger/30",
   info: "bg-blue-50 text-blue-700 border-blue-200/70 dark:bg-info/15 dark:text-blue-300 dark:border-info/30",
   finyk:
-    "bg-finyk-soft text-finyk-strong border-finyk-ring/50 dark:bg-finyk/15 dark:text-finyk dark:border-finyk/30",
+    "bg-finyk-soft text-finyk-strong border-finyk-ring/50 dark:bg-finyk-surface-dark/15 dark:text-finyk dark:border-finyk-border-dark/30",
   fizruk:
-    "bg-fizruk-soft text-fizruk-strong border-fizruk-ring/50 dark:bg-fizruk/15 dark:text-fizruk dark:border-fizruk/30",
+    "bg-fizruk-soft text-fizruk-strong border-fizruk-ring/50 dark:bg-fizruk-surface-dark/15 dark:text-fizruk dark:border-fizruk-border-dark/30",
   routine:
-    "bg-routine-surface text-routine-strong border-routine-ring/50 dark:bg-routine/15 dark:text-routine dark:border-routine/30",
+    "bg-routine-surface text-routine-strong border-routine-ring/50 dark:bg-routine-surface-dark/15 dark:text-routine dark:border-routine-border-dark/30",
   nutrition:
-    "bg-nutrition-soft text-nutrition-strong border-nutrition-ring/50 dark:bg-nutrition/15 dark:text-nutrition dark:border-nutrition/30",
+    "bg-nutrition-soft text-nutrition-strong border-nutrition-ring/50 dark:bg-nutrition-surface-dark/15 dark:text-nutrition dark:border-nutrition-border-dark/30",
 };
 
 const outlineVariants: Record<BadgeVariant, string> = {

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -67,13 +67,13 @@ const variants: Record<ButtonVariant, string> = {
   // low opacity so the button blends with the warm dark panel instead of
   // reading as an acidic pastel — same convention used by Badge/Tabs.
   "finyk-soft":
-    "bg-finyk-soft text-finyk-strong dark:bg-finyk/15 dark:text-finyk border border-finyk-ring/50 dark:border-finyk/30 hover:bg-brand-100 dark:hover:bg-finyk/25 active:scale-[0.98]",
+    "bg-finyk-soft text-finyk-strong dark:bg-finyk-surface-dark/15 dark:text-finyk border border-finyk-ring/50 dark:border-finyk-border-dark/30 hover:bg-brand-100 dark:hover:bg-finyk-surface-dark/25 active:scale-[0.98]",
   "fizruk-soft":
-    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk/15 dark:text-fizruk border border-fizruk-ring/50 dark:border-fizruk/30 hover:bg-teal-100 dark:hover:bg-fizruk/25 active:scale-[0.98]",
+    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk-surface-dark/15 dark:text-fizruk border border-fizruk-ring/50 dark:border-fizruk-border-dark/30 hover:bg-teal-100 dark:hover:bg-fizruk-surface-dark/25 active:scale-[0.98]",
   "routine-soft":
-    "bg-routine-surface text-routine-strong dark:bg-routine/15 dark:text-routine border border-routine-ring/50 dark:border-routine/30 hover:bg-coral-100 dark:hover:bg-routine/25 active:scale-[0.98]",
+    "bg-routine-surface text-routine-strong dark:bg-routine-surface-dark/15 dark:text-routine border border-routine-ring/50 dark:border-routine-border-dark/30 hover:bg-coral-100 dark:hover:bg-routine-surface-dark/25 active:scale-[0.98]",
   "nutrition-soft":
-    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition border border-nutrition-ring/50 dark:border-nutrition/30 hover:bg-lime-100 dark:hover:bg-nutrition/25 active:scale-[0.98]",
+    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition-surface-dark/15 dark:text-nutrition border border-nutrition-ring/50 dark:border-nutrition-border-dark/30 hover:bg-lime-100 dark:hover:bg-nutrition-surface-dark/25 active:scale-[0.98]",
 };
 
 const sizes: Record<ButtonSize, string> = {

--- a/apps/web/src/shared/components/ui/Segmented.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.tsx
@@ -55,13 +55,13 @@ const ACCENT_SOFT: Record<SegmentedAccent, string> = {
   brand:
     "border-brand-200 bg-brand-50 text-brand-700 shadow-sm dark:border-brand/40 dark:bg-brand/15 dark:text-brand",
   fizruk:
-    "border-fizruk-ring bg-fizruk-surface text-fizruk-strong shadow-sm dark:border-fizruk/40 dark:bg-fizruk/15 dark:text-fizruk",
+    "border-fizruk-ring bg-fizruk-surface text-fizruk-strong shadow-sm dark:border-fizruk-border-dark/40 dark:bg-fizruk-surface-dark/15 dark:text-fizruk",
   routine:
-    "border-routine-ring bg-routine-surface text-routine-strong shadow-sm dark:border-routine/40 dark:bg-routine/15 dark:text-routine",
+    "border-routine-ring bg-routine-surface text-routine-strong shadow-sm dark:border-routine-border-dark/40 dark:bg-routine-surface-dark/15 dark:text-routine",
   nutrition:
-    "border-nutrition-ring bg-nutrition-surface text-nutrition-strong shadow-sm dark:border-nutrition/40 dark:bg-nutrition/15 dark:text-nutrition",
+    "border-nutrition-ring bg-nutrition-surface text-nutrition-strong shadow-sm dark:border-nutrition-border-dark/40 dark:bg-nutrition-surface-dark/15 dark:text-nutrition",
   finyk:
-    "border-finyk-ring bg-finyk-surface text-finyk-strong shadow-sm dark:border-finyk/40 dark:bg-finyk/15 dark:text-finyk",
+    "border-finyk-ring bg-finyk-surface text-finyk-strong shadow-sm dark:border-finyk-border-dark/40 dark:bg-finyk-surface-dark/15 dark:text-finyk",
 };
 
 const INACTIVE =

--- a/apps/web/src/shared/components/ui/Tabs.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.tsx
@@ -74,13 +74,14 @@ const ACCENT_UNDERLINE: Record<TabsAccent, string> = {
 
 const ACCENT_PILL: Record<TabsAccent, string> = {
   brand: "bg-brand-50 text-brand-700 dark:bg-brand/15 dark:text-brand",
-  finyk: "bg-finyk-soft text-finyk-strong dark:bg-finyk/15 dark:text-finyk",
+  finyk:
+    "bg-finyk-soft text-finyk-strong dark:bg-finyk-surface-dark/15 dark:text-finyk",
   fizruk:
-    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk/15 dark:text-fizruk",
+    "bg-fizruk-soft text-fizruk-strong dark:bg-fizruk-surface-dark/15 dark:text-fizruk",
   routine:
-    "bg-routine-surface text-routine-strong dark:bg-routine/15 dark:text-routine",
+    "bg-routine-surface text-routine-strong dark:bg-routine-surface-dark/15 dark:text-routine",
   nutrition:
-    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition",
+    "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition-surface-dark/15 dark:text-nutrition",
 };
 
 const ACCENT_RING: Record<TabsAccent, string> = {

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -163,6 +163,41 @@ const preset = {
           ring: brandColors.lime[200],
           soft: brandColors.lime[50],
         },
+
+        // ═══════════════════════════════════════════════════════════════════
+        // MODULE DARK-MODE TOKENS — semantic surfaces & borders for dark
+        // theme. Each is a standalone CSS variable (see `.dark` block in
+        // `apps/web/src/index.css`) decoupled from the live module accent
+        // (`finyk`, `routine`, …) so that opacity tints applied in dark
+        // mode don't silently drift if the primary accent is retuned.
+        //
+        // Use them with the `dark:` variant + an opacity step on the
+        // registered scale (8 / 10 / 15 / 20 / 25 / 30 / 40 / …):
+        //
+        //   dark:bg-routine-surface-dark/10
+        //   dark:hover:bg-routine-surface-dark/25
+        //   dark:border-routine-border-dark/30
+        //   dark:ring-routine-border-dark/40
+        //
+        // AI-CONTEXT: Replaces the older `dark:bg-routine/10` /
+        // `dark:border-finyk/30` pattern. The named token makes the
+        // design intent explicit and survives accent retuning.
+        // ═══════════════════════════════════════════════════════════════════
+        "finyk-surface-dark":
+          "rgb(var(--c-finyk-surface-dark) / <alpha-value>)",
+        "finyk-border-dark": "rgb(var(--c-finyk-border-dark) / <alpha-value>)",
+        "fizruk-surface-dark":
+          "rgb(var(--c-fizruk-surface-dark) / <alpha-value>)",
+        "fizruk-border-dark":
+          "rgb(var(--c-fizruk-border-dark) / <alpha-value>)",
+        "routine-surface-dark":
+          "rgb(var(--c-routine-surface-dark) / <alpha-value>)",
+        "routine-border-dark":
+          "rgb(var(--c-routine-border-dark) / <alpha-value>)",
+        "nutrition-surface-dark":
+          "rgb(var(--c-nutrition-surface-dark) / <alpha-value>)",
+        "nutrition-border-dark":
+          "rgb(var(--c-nutrition-border-dark) / <alpha-value>)",
       },
 
       // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What changed

Заміна 50+ занумерованих opacity-вершин на semantic dark-mode токени для модулів **finyk / fizruk / routine / nutrition**.

**Нові CSS-змінні** (`apps/web/src/index.css` → блок `.dark`):

```css
--c-finyk-surface-dark    --c-finyk-border-dark
--c-fizruk-surface-dark   --c-fizruk-border-dark
--c-routine-surface-dark  --c-routine-border-dark
--c-nutrition-surface-dark --c-nutrition-border-dark
```

Стартові RGB-значення дзеркалять `moduleColors.<m>.primary` з `packages/design-tokens/tokens.js` — візуально нічого не змінилось — але живуть незалежно від акцентного токена. Тепер dark-mode тінти можна пере-тьюнати в одному місці без впливу на світлу тему й без коупленга з `--c-routine` / `--c-finyk` / тощо.

**Tailwind preset** (`packages/design-tokens/tailwind-preset.js`) — додано іменовані utility-кольори:

```
finyk-surface-dark / finyk-border-dark
fizruk-surface-dark / fizruk-border-dark
routine-surface-dark / routine-border-dark
nutrition-surface-dark / nutrition-border-dark
```

Працюють зі стандартним opacity-modifier-ом на зареєстрованій шкалі (`/8`, `/10`, `/15`, `/20`, `/25`, `/30`, `/40`).

**Заміни по `apps/web/src` (15 файлів)**:

```
dark:bg-<m>/N        → dark:bg-<m>-surface-dark/N
dark:hover:bg-<m>/N  → dark:hover:bg-<m>-surface-dark/N
dark:border-<m>/N    → dark:border-<m>-border-dark/N
dark:ring-<m>/N      → dark:ring-<m>-border-dark/N
```

Файли: `Badge.tsx`, `Button.tsx`, `Tabs.tsx`, `Segmented.tsx`, `routineConstants.ts`, `PushupsWidget.tsx`, `DayReportSheet.tsx`, `HabitListItem.tsx`, `WeekDayStrip.tsx`, `HabitLeadersBlock.tsx`, `HabitDetailSheet.tsx`, `CategoriesSection.tsx`, `TodayFocusCard.tsx`, `moduleConfigs.tsx`, `WelcomeScreen.tsx`.

`dark:text-<m>/N` залишено як є — текст свідомо успадковує живий accent (це read-out, не surface).

## Why

40+ входжень типу `dark:bg-routine/10` та `dark:border-finyk/30` тривіально ламаються, якщо `--c-routine` чи `--c-finyk` колись ретьюнять — opacity-пропорції накладання зміщуються видимо, але без жодного сигналу від тестів чи лінтера (PR #814 — той самий клас бaгів). Семантичний token робить design intent явним і виживає при перенастройці акцентного кольору.

## How to test

1. `pnpm install` (без змін у lockfile).
2. `pnpm lint && pnpm typecheck` — мають бути зелені.
3. `pnpm --filter @sergeant/web test` — 864 pass.
4. `pnpm build:web` — успішно; `apps/server/dist/assets/index-*.css` містить:
   - `.dark .dark\:bg-routine-surface-dark\/15:is(.dark *)` (та аналоги для всіх 4 модулів)
   - CSS-змінні `--c-<m>-surface-dark` / `--c-<m>-border-dark`
5. Візуальна перевірка тем (light + dark) на сторінках:
   - Routine: список звичок, `WeekDayStrip`, `HabitDetailSheet`, `HabitLeadersBlock`, `PushupsWidget`.
   - Hub Dashboard tiles, `WelcomeScreen`, `TodayFocusCard`.
   - Загальні UI: `Badge`, `Button` soft-варіанти, `Tabs`, `Segmented` для всіх 4 акцентів.

Очікування — pixel-identical до main; refactor суто semantic.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): зібрано CSS, перевірено наявність нових утиліт і vars у production-bundle (`apps/server/dist/assets/index-*.css`).
- [x] Vitest passes: `pnpm --filter @sergeant/web test` → 94 файли / 864 тести pass.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

Також пройшли: `pnpm lint` (включно з `lint:plugins` 53/53 і `valid-tailwind-opacity` rule), `pnpm typecheck` (13 проєктів, всі ОК), `pnpm format:check`, `pnpm build:web`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Опис патерну живе у `AI-CONTEXT` коментарі в `tailwind-preset.js`.

Link to Devin session: https://app.devin.ai/sessions/0af48f8e9dc9435480719e33e2f2b759
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
