### PR TITLE
refactor(web): стабілізувати naming пропів variant/style/tone у UI

### DIFF
--- a/apps/web/src/core/AssistantCataloguePage.tsx
+++ b/apps/web/src/core/AssistantCataloguePage.tsx
@@ -242,7 +242,7 @@ function ModuleGroup({
         <SectionHeading
           as="span"
           size="sm"
-          tone="text"
+          variant="text"
           id={headingId}
           className="flex items-center gap-2 m-0"
         >

--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -64,7 +64,7 @@ function Group({
 }) {
   return (
     <div>
-      <SectionHeading size="xs" tone="subtle" className="mb-3">
+      <SectionHeading size="xs" variant="subtle" className="mb-3">
         {label}
       </SectionHeading>
       <div className={row ? "flex flex-wrap items-center gap-3" : ""}>
@@ -323,28 +323,28 @@ export function DesignShowcase() {
           </Group>
 
           <Group label="SectionHeading — тони" row>
-            <SectionHeading size="xs" tone="subtle">
+            <SectionHeading size="xs" variant="subtle">
               subtle
             </SectionHeading>
-            <SectionHeading size="xs" tone="muted">
+            <SectionHeading size="xs" variant="muted">
               muted
             </SectionHeading>
-            <SectionHeading size="xs" tone="text">
+            <SectionHeading size="xs" variant="text">
               text
             </SectionHeading>
-            <SectionHeading size="xs" tone="accent">
+            <SectionHeading size="xs" variant="accent">
               accent
             </SectionHeading>
-            <SectionHeading size="xs" tone="finyk">
+            <SectionHeading size="xs" variant="finyk">
               finyk
             </SectionHeading>
-            <SectionHeading size="xs" tone="fizruk">
+            <SectionHeading size="xs" variant="fizruk">
               fizruk
             </SectionHeading>
-            <SectionHeading size="xs" tone="routine">
+            <SectionHeading size="xs" variant="routine">
               routine
             </SectionHeading>
-            <SectionHeading size="xs" tone="nutrition">
+            <SectionHeading size="xs" variant="nutrition">
               nutrition
             </SectionHeading>
           </Group>
@@ -446,8 +446,8 @@ export function DesignShowcase() {
 
         {/* ── 4. BADGES ──────────────────────────────────────────── */}
         <Sec id="badges" title="Бейджі">
-          {(["soft", "solid", "outline"] as const).map((tone) => (
-            <Group key={tone} label={`tone="${tone}"`} row>
+          {(["soft", "solid", "outline"] as const).map((badgeTone) => (
+            <Group key={badgeTone} label={`tone="${badgeTone}"`} row>
               {(
                 [
                   "neutral",
@@ -462,7 +462,7 @@ export function DesignShowcase() {
                   "nutrition",
                 ] as const
               ).map((variant) => (
-                <Badge key={variant} variant={variant} tone={tone}>
+                <Badge key={variant} variant={variant} tone={badgeTone}>
                   {variant}
                 </Badge>
               ))}
@@ -659,7 +659,7 @@ export function DesignShowcase() {
 
         {/* ── 7. DATA DISPLAY ────────────────────────────────────── */}
         <Sec id="data" title="Відображення даних">
-          <Group label="Stat — тони">
+          <Group label="Stat — варіанти">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
               {(
                 [
@@ -672,9 +672,14 @@ export function DesignShowcase() {
                   "routine",
                   "nutrition",
                 ] as const
-              ).map((tone) => (
-                <Card key={tone} variant="default" padding="md" radius="lg">
-                  <Stat label={tone} value="1 234" sublabel="+5%" tone={tone} />
+              ).map((variant) => (
+                <Card key={variant} variant="default" padding="md" radius="lg">
+                  <Stat
+                    label={variant}
+                    value="1 234"
+                    sublabel="+5%"
+                    variant={variant}
+                  />
                 </Card>
               ))}
             </div>
@@ -774,7 +779,7 @@ export function DesignShowcase() {
               ]}
               value={tabVal}
               onChange={setTabVal}
-              tone="underline"
+              style="underline"
             />
           </Group>
 
@@ -782,10 +787,10 @@ export function DesignShowcase() {
             <div className="space-y-3">
               {(
                 ["brand", "finyk", "fizruk", "routine", "nutrition"] as const
-              ).map((accent) => (
-                <div key={accent} className="flex items-center gap-3">
+              ).map((variant) => (
+                <div key={variant} className="flex items-center gap-3">
                   <span className="text-2xs text-subtle font-mono w-20 shrink-0">
-                    {accent}
+                    {variant}
                   </span>
                   <Tabs
                     items={[
@@ -801,8 +806,8 @@ export function DesignShowcase() {
                         : tabVal
                     }
                     onChange={setTabVal}
-                    tone="pill"
-                    accent={accent}
+                    style="pill"
+                    variant={variant}
                   />
                 </div>
               ))}
@@ -811,10 +816,10 @@ export function DesignShowcase() {
 
           <Group label="Segmented — solid та soft">
             <div className="space-y-5">
-              {(["solid", "soft"] as const).map((tone) => (
-                <div key={tone}>
+              {(["solid", "soft"] as const).map((segStyle) => (
+                <div key={segStyle}>
                   <div className="text-2xs text-subtle font-mono mb-2">
-                    tone=&quot;{tone}&quot;
+                    style=&quot;{segStyle}&quot;
                   </div>
                   <div className="flex flex-wrap gap-3">
                     {(
@@ -825,9 +830,9 @@ export function DesignShowcase() {
                         "routine",
                         "nutrition",
                       ] as const
-                    ).map((accent) => (
+                    ).map((variant) => (
                       <Segmented
-                        key={accent}
+                        key={variant}
                         items={[
                           { value: "day", label: "День" },
                           { value: "week", label: "Тиждень" },
@@ -837,8 +842,8 @@ export function DesignShowcase() {
                         onChange={(v) =>
                           setSegVal(v as "day" | "week" | "month")
                         }
-                        tone={tone}
-                        accent={accent}
+                        style={segStyle}
+                        variant={variant}
                       />
                     ))}
                   </div>

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -483,7 +483,7 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
         {showRecents && (
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <SectionHeading as="p" size="sm" tone="muted">
+              <SectionHeading as="p" size="sm" variant="muted">
                 Недавні запити
               </SectionHeading>
               <button
@@ -545,7 +545,7 @@ export function HubSearch({ onClose, onOpenModule }: HubSearchProps) {
 
         {Object.entries(grouped).map(([moduleId, group]) => (
           <div key={moduleId}>
-            <SectionHeading as="p" size="sm" tone="muted" className="mb-1.5">
+            <SectionHeading as="p" size="sm" variant="muted" className="mb-1.5">
               {group.label}
             </SectionHeading>
             <div className="space-y-1">

--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -156,8 +156,8 @@ export function HubSettingsPage({ syncing, onSync, onPull, user }) {
 
         {!q && (
           <Tabs
-            tone="pill"
-            accent="brand"
+            style="pill"
+            variant="brand"
             fill
             ariaLabel="Групи налаштувань"
             items={GROUPS.map((g) => ({ value: g.id, label: g.label }))}

--- a/apps/web/src/core/insights/AssistantAdviceCard.tsx
+++ b/apps/web/src/core/insights/AssistantAdviceCard.tsx
@@ -71,7 +71,7 @@ export function AssistantAdviceCard({
             >
               S
             </span>
-            <SectionHeading as="span" size="xs" tone="muted">
+            <SectionHeading as="span" size="xs" variant="muted">
               Порада асистента
             </SectionHeading>
           </div>

--- a/apps/web/src/core/insights/TodayFocusCard.tsx
+++ b/apps/web/src/core/insights/TodayFocusCard.tsx
@@ -207,7 +207,7 @@ function EmptyFocus() {
       )}
     >
       <div className="flex items-center justify-between gap-2 mb-2">
-        <SectionHeading as="span" size="xs" tone="muted">
+        <SectionHeading as="span" size="xs" variant="muted">
           Зараз
         </SectionHeading>
         {reward && (
@@ -356,7 +356,7 @@ export function TodayFocusCard({
           <SectionHeading
             as="span"
             size="xs"
-            tone="muted"
+            variant="muted"
             className={severityTone?.eyebrow}
           >
             Зараз

--- a/apps/web/src/core/onboarding/FirstActionSheet.tsx
+++ b/apps/web/src/core/onboarding/FirstActionSheet.tsx
@@ -200,7 +200,7 @@ export function FirstActionHeroCard({ onDismiss }) {
       >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <SectionHeading as="div" size="sm" tone="subtle">
+            <SectionHeading as="div" size="sm" variant="subtle">
               Старт
             </SectionHeading>
             <h2 className="text-base font-bold text-text mt-0.5">

--- a/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
+++ b/apps/web/src/modules/fizruk/components/dashboard/HeroCard.tsx
@@ -179,7 +179,7 @@ function HeroKicker({
   readonly today: string;
 }) {
   return (
-    <SectionHeading as="p" size="sm" tone="fizruk">
+    <SectionHeading as="p" size="sm" variant="fizruk">
       {greeting} · {today}
     </SectionHeading>
   );

--- a/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
+++ b/apps/web/src/modules/nutrition/components/DailyPlanCard.tsx
@@ -149,7 +149,7 @@ function MealRow({ meal, onAddToLog, onRegen, busy }) {
             <span className="text-base leading-none" aria-hidden>
               {MEAL_TYPE_ICONS[meal.type] || "🍴"}
             </span>
-            <SectionHeading as="span" size="sm" tone="nutrition">
+            <SectionHeading as="span" size="sm" variant="nutrition">
               {MEAL_TYPE_LABELS[meal.type] || meal.label}
             </SectionHeading>
           </div>

--- a/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionDashboard.tsx
@@ -217,7 +217,7 @@ export function NutritionDashboard({
                   <SectionHeading
                     as="div"
                     size="xs"
-                    tone="nutrition"
+                    variant="nutrition"
                     className="leading-none mb-1"
                   >
                     {m.label}

--- a/apps/web/src/modules/nutrition/components/NutritionPantrySelector.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionPantrySelector.tsx
@@ -5,7 +5,12 @@ export function NutritionPantrySelector({ pantry, busy }) {
   return (
     <div className="rounded-2xl bg-nutrition/10 border border-nutrition/20 px-4 py-3 mb-4 flex items-center gap-3">
       <div className="min-w-0 flex-1">
-        <SectionHeading as="div" size="xs" tone="nutrition" className="mb-0.5">
+        <SectionHeading
+          as="div"
+          size="xs"
+          variant="nutrition"
+          className="mb-0.5"
+        >
           Активний склад
         </SectionHeading>
         <div className="text-base font-extrabold text-text leading-tight">

--- a/apps/web/src/modules/nutrition/components/PhotoAnalyzeCard.tsx
+++ b/apps/web/src/modules/nutrition/components/PhotoAnalyzeCard.tsx
@@ -132,7 +132,7 @@ export function PhotoAnalyzeCard({
                 <SectionHeading
                   as="div"
                   size="xs"
-                  tone="nutrition"
+                  variant="nutrition"
                   className="leading-none mb-1"
                 >
                   {m.label}

--- a/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
+++ b/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
@@ -76,7 +76,7 @@ export function FizrukDayPlanSheet({
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-2">
                 <div className="min-w-0 flex-1">
-                  <SectionHeading as="p" size="xs" tone="subtle">
+                  <SectionHeading as="p" size="xs" variant="subtle">
                     Призначений шаблон
                   </SectionHeading>
                   <p className="text-base font-bold text-text mt-0.5">
@@ -99,7 +99,7 @@ export function FizrukDayPlanSheet({
                   <SectionHeading
                     as="p"
                     size="xs"
-                    tone="subtle"
+                    variant="subtle"
                     className="mb-1.5"
                   >
                     Вправи ({exerciseList.length})
@@ -134,7 +134,7 @@ export function FizrukDayPlanSheet({
           )}
 
           <div>
-            <SectionHeading as="p" size="xs" tone="subtle" className="mb-2">
+            <SectionHeading as="p" size="xs" variant="subtle" className="mb-2">
               {currentTemplate ? "Змінити шаблон" : "Обрати шаблон"}
             </SectionHeading>
             {templates.length === 0 ? (

--- a/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
+++ b/apps/web/src/modules/routine/components/HabitLeadersBlock.tsx
@@ -44,7 +44,7 @@ export function HabitLeadersBlock({
       </SectionHeading>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div className="rounded-xl border border-routine-line/40 dark:border-routine/20 bg-routine-surface/30 dark:bg-routine/8 p-3">
-          <SectionHeading as="p" size="xs" tone="subtle" className="mb-1">
+          <SectionHeading as="p" size="xs" variant="subtle" className="mb-1">
             Найстабільніша
           </SectionHeading>
           <p className="text-sm font-semibold text-text truncate">
@@ -56,7 +56,7 @@ export function HabitLeadersBlock({
         </div>
         {worst && (
           <div className="rounded-xl border border-line bg-panel p-3">
-            <SectionHeading as="p" size="xs" tone="subtle" className="mb-1">
+            <SectionHeading as="p" size="xs" variant="subtle" className="mb-1">
               Найслабша
             </SectionHeading>
             <p className="text-sm font-semibold text-text truncate">

--- a/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarHero.tsx
@@ -61,7 +61,7 @@ export function RoutineCalendarHero({
         />
         <div className="flex-1 grid grid-cols-2 gap-2 w-full sm:grid-cols-2 lg:grid-cols-4">
           <div className={C.statCard}>
-            <SectionHeading as="p" size="xs" tone="subtle">
+            <SectionHeading as="p" size="xs" variant="subtle">
               Подій у зрізі
             </SectionHeading>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -69,7 +69,7 @@ export function RoutineCalendarHero({
             </p>
           </div>
           <div className={C.statCard}>
-            <SectionHeading as="p" size="xs" tone="subtle">
+            <SectionHeading as="p" size="xs" variant="subtle">
               Звичок активних
             </SectionHeading>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -77,7 +77,7 @@ export function RoutineCalendarHero({
             </p>
           </div>
           <div className={C.statCard}>
-            <SectionHeading as="p" size="xs" tone="subtle">
+            <SectionHeading as="p" size="xs" variant="subtle">
               Виконання
             </SectionHeading>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">
@@ -88,7 +88,7 @@ export function RoutineCalendarHero({
             </p>
           </div>
           <div className={C.statCard}>
-            <SectionHeading as="p" size="xs" tone="subtle">
+            <SectionHeading as="p" size="xs" variant="subtle">
               Поточна серія
             </SectionHeading>
             <p className="text-2xl font-black text-text tabular-nums mt-0.5">

--- a/apps/web/src/modules/routine/components/RoutineCalendarMonthGrid.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarMonthGrid.tsx
@@ -165,7 +165,7 @@ export function RoutineCalendarMonthGrid({
                     key={`dh-${item.label}`}
                     as="p"
                     size="xs"
-                    tone="subtle"
+                    variant="subtle"
                     className={cn(idx > 0 && "mt-2")}
                   >
                     {item.label}

--- a/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
+++ b/apps/web/src/modules/routine/components/RoutineCalendarPanel.tsx
@@ -246,9 +246,9 @@ export function RoutineCalendarPanel({
       )}
 
       <Segmented
-        tone="soft"
+        style="soft"
         size="sm"
-        accent="routine"
+        variant="routine"
         ariaLabel="Часовий діапазон"
         items={timeModeItems}
         value={timeMode}

--- a/apps/web/src/shared/components/ui/SectionHeading.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.tsx
@@ -12,14 +12,15 @@ import { cn } from "../../lib/cn";
  *   - text-2xs text-nutrition/70 font-bold uppercase tracking-wide (nutrition macros)
  *
  * Sizes drive **font scale + weight + casing + tracking** only. Colour
- * is picked via `tone` so the same size can render in `subtle` (default
- * eyebrow on cards), `muted`, or a module-branded tint (finyk /
- * fizruk / routine / nutrition). Semantics default to <h3>.
+ * is picked via `variant` (see `docs/COMPONENT_API.md`) so the same size
+ * can render in `subtle` (default eyebrow on cards), `muted`, or a
+ * module-branded tint (finyk / fizruk / routine / nutrition). Semantics
+ * default to <h3>.
  */
 
 export type SectionHeadingSize = "xs" | "sm" | "md" | "lg" | "xl";
 
-export type SectionHeadingTone =
+export type SectionHeadingVariant =
   | "subtle"
   | "muted"
   | "text"
@@ -37,7 +38,7 @@ const sizes: Record<SectionHeadingSize, string> = {
   xl: "text-xl font-extrabold leading-tight",
 };
 
-const tones: Record<SectionHeadingTone, string> = {
+const variants: Record<SectionHeadingVariant, string> = {
   subtle: "text-subtle",
   muted: "text-muted",
   text: "text-text",
@@ -52,20 +53,21 @@ const tones: Record<SectionHeadingTone, string> = {
   nutrition: "text-nutrition-strong dark:text-nutrition/70",
 };
 
-// Default tone per size — eyebrow sizes (xs/sm) are muted/subtle;
+// Default variant per size — eyebrow sizes (xs/sm) are muted/subtle;
 // body-size headings default to the foreground text colour.
-const defaultToneForSize: Record<SectionHeadingSize, SectionHeadingTone> = {
-  xs: "subtle",
-  sm: "subtle",
-  md: "text",
-  lg: "text",
-  xl: "text",
-};
+const defaultVariantForSize: Record<SectionHeadingSize, SectionHeadingVariant> =
+  {
+    xs: "subtle",
+    sm: "subtle",
+    md: "text",
+    lg: "text",
+    xl: "text",
+  };
 
 export interface SectionHeadingProps extends HTMLAttributes<HTMLElement> {
   size?: SectionHeadingSize;
   /** Colour variant. Defaults to `subtle` for xs/sm and `text` for md+. */
-  tone?: SectionHeadingTone;
+  variant?: SectionHeadingVariant;
   as?: ElementType;
   /** Optional right-aligned slot for actions/links. */
   action?: ReactNode;
@@ -79,14 +81,14 @@ export interface SectionHeadingProps extends HTMLAttributes<HTMLElement> {
 export function SectionHeading({
   className,
   size = "xs",
-  tone,
+  variant,
   as: Component = "h3",
   action,
   children,
   ...props
 }: SectionHeadingProps) {
-  const resolvedTone = tone ?? defaultToneForSize[size];
-  const base = cn(sizes[size], tones[resolvedTone]);
+  const resolvedVariant = variant ?? defaultVariantForSize[size];
+  const base = cn(sizes[size], variants[resolvedVariant]);
 
   if (action) {
     return (
@@ -114,4 +116,4 @@ export function SectionHeading({
 export const SectionHeader = SectionHeading;
 export type SectionHeaderProps = SectionHeadingProps;
 export type SectionHeaderSize = SectionHeadingSize;
-export type SectionHeaderTone = SectionHeadingTone;
+export type SectionHeaderVariant = SectionHeadingVariant;

--- a/apps/web/src/shared/components/ui/Segmented.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.tsx
@@ -10,15 +10,23 @@ import { cn } from "@shared/lib/cn";
  *
  * Not intended to replace `<SubTabs>` (full-width bar-style) — that
  * pattern is a separate variant kept in its own component for now.
+ *
+ * Two-axis API (see `docs/COMPONENT_API.md`):
+ *   - `variant` — accent colour (`brand` for the default chrome; the four
+ *                 module tokens scope the active state to a module).
+ *   - `style`   — visual treatment of the active chip.
+ *                 `solid` — filled accent background (Fizruk Workouts).
+ *                 `soft`  (default) — tinted surface + accent border
+ *                                       + accent text (Routine chips).
  */
 
-export type SegmentedAccent =
+export type SegmentedVariant =
   | "brand"
   | "fizruk"
   | "routine"
   | "nutrition"
   | "finyk";
-export type SegmentedTone = "solid" | "soft";
+export type SegmentedStyle = "solid" | "soft";
 export type SegmentedSize = "sm" | "md";
 
 export interface SegmentedItem<V extends string = string> {
@@ -32,18 +40,20 @@ export interface SegmentedProps<V extends string = string> {
   items: ReadonlyArray<SegmentedItem<V>>;
   value: V;
   onChange: (value: V) => void;
-  /** "solid" = filled accent background (used in Fizruk Workouts tabs).
-   *  "soft"  = tinted surface + accent border + accent text (Routine chips). */
-  tone?: SegmentedTone;
+  /** Visual treatment of the active chip. Defaults to `soft`.
+   *  `solid` = filled accent background (used in Fizruk Workouts tabs).
+   *  `soft`  = tinted surface + accent border + accent text (Routine chips). */
+  style?: SegmentedStyle;
   /** "sm" ≈ 36px min-height; "md" = 44px min-height (touch target). */
   size?: SegmentedSize;
-  accent?: SegmentedAccent;
+  /** Accent colour token. Defaults to `brand`. */
+  variant?: SegmentedVariant;
   /** Accessible label for the underlying role="tablist". */
   ariaLabel?: string;
   className?: string;
 }
 
-const ACCENT_SOLID: Record<SegmentedAccent, string> = {
+const VARIANT_SOLID: Record<SegmentedVariant, string> = {
   brand: "bg-brand text-white border-brand",
   fizruk: "bg-fizruk text-white border-fizruk",
   routine: "bg-routine text-white border-routine",
@@ -51,7 +61,7 @@ const ACCENT_SOLID: Record<SegmentedAccent, string> = {
   finyk: "bg-finyk text-white border-finyk",
 };
 
-const ACCENT_SOFT: Record<SegmentedAccent, string> = {
+const VARIANT_SOFT: Record<SegmentedVariant, string> = {
   brand:
     "border-brand-200 bg-brand-50 text-brand-700 shadow-sm dark:border-brand/40 dark:bg-brand/15 dark:text-brand",
   fizruk:
@@ -76,14 +86,14 @@ export function Segmented<V extends string = string>({
   items,
   value,
   onChange,
-  tone = "soft",
+  style = "soft",
   size = "md",
-  accent = "brand",
+  variant = "brand",
   ariaLabel,
   className,
 }: SegmentedProps<V>) {
   const activeClass =
-    tone === "solid" ? ACCENT_SOLID[accent] : ACCENT_SOFT[accent];
+    style === "solid" ? VARIANT_SOLID[variant] : VARIANT_SOFT[variant];
 
   return (
     <div

--- a/apps/web/src/shared/components/ui/Stat.tsx
+++ b/apps/web/src/shared/components/ui/Stat.tsx
@@ -12,12 +12,12 @@ import { cn } from "../../lib/cn";
  *   <div className="text-2xl font-extrabold text-text mt-1 tabular-nums">82 кг</div>
  *   <div className="text-xs text-subtle mt-1">+0.4 кг</div>
  *
- * Tones tint the value: default (text-text), success, warning, danger,
- * and each module's brand token (finyk/fizruk/routine/nutrition) for the
- * rare branded metric readouts.
+ * `variant` tints the value (see `docs/COMPONENT_API.md`): default
+ * (text-text), success, warning, danger, and each module's brand token
+ * (finyk/fizruk/routine/nutrition) for the rare branded metric readouts.
  */
 
-export type StatTone =
+export type StatVariant =
   | "default"
   | "success"
   | "warning"
@@ -29,7 +29,7 @@ export type StatTone =
 
 export type StatSize = "sm" | "md" | "lg";
 
-const toneClass: Record<StatTone, string> = {
+const variantClass: Record<StatVariant, string> = {
   default: "text-text",
   success: "text-success",
   warning: "text-warning",
@@ -50,7 +50,8 @@ export interface StatProps {
   label: ReactNode;
   value: ReactNode;
   sublabel?: ReactNode;
-  tone?: StatTone;
+  /** Colour variant for the value. Defaults to `default` (text-text). */
+  variant?: StatVariant;
   size?: StatSize;
   /** Optional leading icon / emoji rendered left of the value. */
   icon?: ReactNode;
@@ -63,7 +64,7 @@ export function Stat({
   label,
   value,
   sublabel,
-  tone = "default",
+  variant = "default",
   size = "md",
   icon,
   align = "left",
@@ -87,7 +88,7 @@ export function Stat({
           align === "center" && "justify-center",
           align === "right" && "justify-end",
           valueSize[size],
-          toneClass[tone],
+          variantClass[variant],
         )}
       >
         {icon && (

--- a/apps/web/src/shared/components/ui/Tabs.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.tsx
@@ -20,14 +20,24 @@ import { cn } from "@shared/lib/cn";
  *                  navigation, supports controlled panels.
  *   - `Segmented`— compact mode/view switcher (chips). No panels, shorter.
  *
- * Tones:
- *   - `underline` — minimal underline under active tab (default)
- *   - `pill`      — soft tinted pill background on active tab
+ * Two-axis API (see `docs/COMPONENT_API.md`):
+ *   - `variant` — accent colour (`brand` is the navigation default; the
+ *                 four module tokens scope the active state to a module).
+ *   - `style`   — visual treatment of the active tab.
+ *                 `underline` (default) — thin border under the active
+ *                                          label; works in dense layouts.
+ *                 `pill`                 — soft tinted pill on the active
+ *                                          label; better when isolated.
  */
 
-export type TabsTone = "underline" | "pill";
+export type TabsStyle = "underline" | "pill";
 
-export type TabsAccent = "brand" | "finyk" | "fizruk" | "routine" | "nutrition";
+export type TabsVariant =
+  | "brand"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
 
 export type TabsSize = "sm" | "md";
 
@@ -45,8 +55,10 @@ export interface TabsProps<V extends string = string> {
   items: ReadonlyArray<TabItem<V>>;
   value: V;
   onChange: (value: V) => void;
-  tone?: TabsTone;
-  accent?: TabsAccent;
+  /** Visual treatment of the active tab. Defaults to `underline`. */
+  style?: TabsStyle;
+  /** Accent colour token. Defaults to `brand`. */
+  variant?: TabsVariant;
   size?: TabsSize;
   /** Stretch tabs to fill the container width. */
   fill?: boolean;
@@ -56,7 +68,7 @@ export interface TabsProps<V extends string = string> {
   tabsClassName?: string;
 }
 
-const ACCENT_TEXT: Record<TabsAccent, string> = {
+const VARIANT_TEXT: Record<TabsVariant, string> = {
   brand: "text-brand",
   finyk: "text-finyk",
   fizruk: "text-fizruk",
@@ -64,7 +76,7 @@ const ACCENT_TEXT: Record<TabsAccent, string> = {
   nutrition: "text-nutrition",
 };
 
-const ACCENT_UNDERLINE: Record<TabsAccent, string> = {
+const VARIANT_UNDERLINE: Record<TabsVariant, string> = {
   brand: "border-brand",
   finyk: "border-finyk",
   fizruk: "border-fizruk",
@@ -72,7 +84,7 @@ const ACCENT_UNDERLINE: Record<TabsAccent, string> = {
   nutrition: "border-nutrition",
 };
 
-const ACCENT_PILL: Record<TabsAccent, string> = {
+const VARIANT_PILL: Record<TabsVariant, string> = {
   brand: "bg-brand-50 text-brand-700 dark:bg-brand/15 dark:text-brand",
   finyk: "bg-finyk-soft text-finyk-strong dark:bg-finyk/15 dark:text-finyk",
   fizruk:
@@ -83,7 +95,7 @@ const ACCENT_PILL: Record<TabsAccent, string> = {
     "bg-nutrition-soft text-nutrition-strong dark:bg-nutrition/15 dark:text-nutrition",
 };
 
-const ACCENT_RING: Record<TabsAccent, string> = {
+const VARIANT_RING: Record<TabsVariant, string> = {
   brand: "focus-visible:ring-brand-500/45",
   finyk: "focus-visible:ring-finyk/45",
   fizruk: "focus-visible:ring-fizruk/45",
@@ -100,8 +112,8 @@ export function Tabs<V extends string = string>({
   items,
   value,
   onChange,
-  tone = "underline",
-  accent = "brand",
+  style = "underline",
+  variant = "brand",
   size = "md",
   fill = false,
   ariaLabel,
@@ -168,7 +180,7 @@ export function Tabs<V extends string = string>({
       aria-label={ariaLabel}
       className={cn(
         "flex items-stretch",
-        tone === "underline"
+        style === "underline"
           ? "gap-1 border-b border-line"
           : "gap-1 p-1 rounded-2xl bg-surface-muted",
         fill && "w-full",
@@ -181,24 +193,24 @@ export function Tabs<V extends string = string>({
           "inline-flex items-center justify-center gap-2 font-semibold",
           "transition-colors outline-none",
           "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
-          ACCENT_RING[accent],
+          VARIANT_RING[variant],
           SIZE[size],
           fill && "flex-1 min-w-0",
           item.disabled && "opacity-50 cursor-not-allowed",
         );
 
-        const toneClasses =
-          tone === "underline"
+        const styleClasses =
+          style === "underline"
             ? cn(
                 "rounded-none border-b-2 -mb-px",
                 isActive
-                  ? cn(ACCENT_UNDERLINE[accent], ACCENT_TEXT[accent])
+                  ? cn(VARIANT_UNDERLINE[variant], VARIANT_TEXT[variant])
                   : "border-transparent text-fg-muted hover:text-fg",
               )
             : cn(
                 "rounded-xl",
                 isActive
-                  ? ACCENT_PILL[accent]
+                  ? VARIANT_PILL[variant]
                   : "text-fg-muted hover:text-fg hover:bg-surface",
               );
 
@@ -215,7 +227,7 @@ export function Tabs<V extends string = string>({
             disabled={item.disabled}
             onClick={() => !item.disabled && onChange(item.value)}
             onKeyDown={(e) => handleKeyDown(e, index)}
-            className={cn(commonClasses, toneClasses, tabsClassName)}
+            className={cn(commonClasses, styleClasses, tabsClassName)}
           >
             {item.icon}
             <span className="truncate">{item.label}</span>

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -68,17 +68,19 @@ export { SectionHeader, SectionHeading } from "./SectionHeading";
 export type {
   SectionHeaderProps,
   SectionHeaderSize,
+  SectionHeaderVariant,
   SectionHeadingProps,
   SectionHeadingSize,
+  SectionHeadingVariant,
 } from "./SectionHeading";
 
 export { Segmented } from "./Segmented";
 export type {
-  SegmentedAccent,
   SegmentedItem,
   SegmentedProps,
   SegmentedSize,
-  SegmentedTone,
+  SegmentedStyle,
+  SegmentedVariant,
 } from "./Segmented";
 
 export { Select } from "./Select";
@@ -107,15 +109,15 @@ export { Switch } from "./Switch";
 export type { SwitchProps } from "./Switch";
 
 export { Stat } from "./Stat";
-export type { StatProps, StatSize, StatTone } from "./Stat";
+export type { StatProps, StatSize, StatVariant } from "./Stat";
 
 export { Tabs } from "./Tabs";
 export type {
   TabItem,
-  TabsAccent,
   TabsProps,
   TabsSize,
-  TabsTone,
+  TabsStyle,
+  TabsVariant,
 } from "./Tabs";
 
 export { ToastContainer } from "./Toast";

--- a/docs/COMPONENT_API.md
+++ b/docs/COMPONENT_API.md
@@ -1,0 +1,183 @@
+# Sergeant Component API — naming conventions
+
+> Last reviewed: 2026-04-26. Reviewer: @Skords-01
+
+This document is the single source of truth for **prop names** and
+**brand-colour values** across the design-system primitives in
+`apps/web/src/shared/components/ui`. It covers the trio of overlapping
+names (`variant` / `style` / `tone`) that historically drifted across
+components and the deliberate value differences between Button, form
+fields, and navigation primitives.
+
+---
+
+## 1. Two-dimensional API
+
+Most primitives have two visual axes:
+
+1. **Colour** — which palette the component renders in (brand,
+   semantic, or per-module).
+2. **Style** — how that colour is applied (filled, outlined, soft
+   tint, underline, …).
+
+The codebase uses two prop names for these axes:
+
+| Axis       | Prop name | Used by                                                                           |
+| ---------- | --------- | --------------------------------------------------------------------------------- |
+| **Colour** | `variant` | Button, Input, Select, Card, Banner, Badge, Tabs, Segmented, Stat, SectionHeading |
+| **Style**  | `style`   | Tabs, Segmented                                                                   |
+| **Style**  | `tone`    | Badge (soft / solid / outline)                                                    |
+
+> **Rule of thumb.** `variant` always means **colour / palette**.
+> The second axis (style of fill) is called `style` on the navigation
+> primitives (Tabs, Segmented). Badge keeps the historical `tone` prop
+> for its soft / solid / outline switch — it's stable, well-known, and
+> doesn't collide with anything else (Badge has no `style` prop).
+
+The deprecated names that used to exist — `TabsTone`, `TabsAccent`,
+`SegmentedTone`, `SegmentedAccent`, `StatTone`, `SectionHeadingTone` —
+have been removed. Re-exports from the barrel
+(`apps/web/src/shared/components/ui/index.ts`) point at the new names:
+`TabsStyle`, `TabsVariant`, `SegmentedStyle`, `SegmentedVariant`,
+`StatVariant`, `SectionHeadingVariant`.
+
+---
+
+## 2. Brand-colour value: three contexts, three defaults
+
+The most-used colour value across the system points to "the primary
+brand colour", but its **value** differs by component. This is
+intentional — the value reflects the semantic context the component
+lives in:
+
+| Context             | Components          | `variant` value | Why                                                                                                                                     |
+| ------------------- | ------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Action**          | Button              | `"primary"`     | Buttons drive actions. The default action is the **primary** call-to-action (Save / Submit). The word matches users' design vocabulary. |
+| **Form chrome**     | Input, Select, Card | `"default"`     | Form fields and surfaces start in a **default** neutral state and only opt into branded chrome (`"finyk"`, `"fizruk"`, …) when scoped.  |
+| **Nav / selection** | Tabs, Segmented     | `"brand"`       | Navigation exposes the active section in the global brand palette and lets module pages override to `"finyk"` / `"fizruk"` / etc.       |
+
+This is **deliberate, not drift**. Renaming all three to one shared
+token (e.g. `"primary"` everywhere) would force unrelated decisions to
+move together — a change to button styling would touch input chrome,
+which would touch tab strips. Keeping them distinct lets each axis
+evolve independently.
+
+When you add a new component, pick the value that matches its role:
+
+- Drives an action → `"primary"`.
+- Renders form / surface chrome → `"default"`.
+- Indicates active selection in a nav-like control → `"brand"`.
+
+---
+
+## 3. Per-component cheat sheet
+
+### `Badge`
+
+```tsx
+<Badge variant="success" tone="soft" size="sm">
+  3
+</Badge>
+```
+
+- `variant`: `"neutral" | "accent" | "success" | "warning" | "danger" |
+"info" | "finyk" | "fizruk" | "routine" | "nutrition"` — colour.
+- `tone`: `"soft" | "solid" | "outline"` — fill style. Default `"soft"`.
+- `size`: `"xs" | "sm" | "md"`.
+
+### `Banner`
+
+```tsx
+<Banner variant="warning">…</Banner>
+```
+
+- `variant`: `"info" | "success" | "warning" | "danger"`.
+
+### `Button`
+
+```tsx
+<Button variant="primary" size="md">
+  Зберегти
+</Button>
+```
+
+- `variant`: `"primary" | "secondary" | "ghost" | "danger" | "link" | …`.
+  **Default `"primary"`** — see §2.
+
+### `Card`
+
+```tsx
+<Card variant="default" padding="md" radius="lg">
+  …
+</Card>
+```
+
+- `variant`: `"default" | "interactive" | "flat" | "elevated" | "ghost"
+| "finyk" | "fizruk" | …` (full set in `Card.tsx`). **Default
+  `"default"`** — see §2.
+
+### `Input` / `Select`
+
+```tsx
+<Input variant="default" />
+<Select variant="default" />
+```
+
+- `variant`: `"default" | "filled" | "ghost"`. **Default `"default"`** —
+  see §2.
+
+### `Stat`
+
+```tsx
+<Stat label="Вага" value="82 кг" sublabel="+0.4 кг" variant="success" />
+```
+
+- `variant`: `"default" | "success" | "warning" | "danger" | "finyk" |
+"fizruk" | "routine" | "nutrition"`. Default `"default"`.
+
+### `SectionHeading` / `SectionHeader`
+
+```tsx
+<SectionHeading size="xs" variant="subtle">
+  Огляд
+</SectionHeading>
+```
+
+- `variant`: `"subtle" | "muted" | "text" | "accent" | "finyk" |
+"fizruk" | "routine" | "nutrition"`. Default depends on `size`
+  (eyebrow sizes default to `"subtle"`, body sizes to `"text"`).
+
+### `Tabs`
+
+```tsx
+<Tabs items={…} value={…} onChange={…} variant="brand" style="underline" />
+```
+
+- `variant`: `"brand" | "finyk" | "fizruk" | "routine" | "nutrition"`.
+  **Default `"brand"`** — see §2.
+- `style`: `"underline" | "pill"`. Default `"underline"`.
+
+### `Segmented`
+
+```tsx
+<Segmented items={…} value={…} onChange={…} variant="brand" style="soft" />
+```
+
+- `variant`: `"brand" | "fizruk" | "routine" | "nutrition" | "finyk"`.
+  **Default `"brand"`** — see §2.
+- `style`: `"solid" | "soft"`. Default `"soft"`.
+
+---
+
+## 4. When designing a new component
+
+1. Default the colour prop to `variant`. Don't introduce a new name
+   like `accent`, `palette`, `kind` — `variant` is the convention.
+2. If the component has a second visual axis, call it `style` (the
+   navigation convention) unless it specifically matches Badge's
+   soft/solid/outline switch — in which case `tone` is acceptable for
+   continuity.
+3. Pick the brand-colour value (`"primary"` / `"default"` / `"brand"`)
+   from §2 based on role. Don't invent a fourth.
+4. Add the new component to §3 in the same PR. The cheat sheet is the
+   contract; out-of-date docs here block review.


### PR DESCRIPTION
## What changed

Уніфікує колірний вимір під єдиною назвою `variant` у всіх UI-примітивах і вводить `style` як другу вісь у Tabs/Segmented.

**API renames у `apps/web/src/shared/components/ui/`:**

| Component        | Before                                | After                                |
| ---------------- | ------------------------------------- | ------------------------------------ |
| `Tabs`           | `accent`, `tone`                      | `variant`, `style`                   |
| `Segmented`      | `accent`, `tone`                      | `variant`, `style`                   |
| `Stat`           | `tone`                                | `variant`                            |
| `SectionHeading` | `tone`                                | `variant` (alias `SectionHeader` теж) |
| `Badge`          | `variant`, `tone`                     | без змін — стабільна історична пара  |

Re-експорти з барелю (`@shared/components/ui`):

- `TabsTone` / `TabsAccent` → `TabsStyle` / `TabsVariant`
- `SegmentedTone` / `SegmentedAccent` → `SegmentedStyle` / `SegmentedVariant`
- `StatTone` → `StatVariant`
- `SectionHeadingTone` / `SectionHeaderTone` → `SectionHeadingVariant` / `SectionHeaderVariant`

Усі модульні call-site (`apps/web/src/{modules,core}`) оновлено під нові імена; `DesignShowcase` демонструє новий API.

**Документація:** новий `docs/COMPONENT_API.md` пояснює двовимірне API (`variant` + `style` / `tone`) і **свідому** різницю значень брендового кольору по контекстах:

- `"primary"` — екшн-елементи (Button)
- `"default"` — форм-елементи (Input, Select, Card)
- `"brand"` — навігація / вибір (Tabs, Segmented)

## Why

Раніше для одного семантичного поняття (колір/варіант) використовувались три різних назви пропу — `variant`, `tone`, `accent` — що перевантажувало IDE-autocomplete і ускладнювало міграції. Особливо болюче в Tabs/Segmented, де `tone` та `accent` співіснували у тому ж компоненті.

`Badge.tone` свідомо лишається без змін: пара `variant + tone` стабільна, відома по всьому коду, і не конфліктує з нічим (Badge не має `style`).

Різницю значень брендового кольору (`primary` vs `default` vs `brand`) теж лишаємо — це не drift, а різний семантичний контекст. Уніфікація змусила б рухати непов'язані рішення разом. Замість цього зафіксували конвенцію в `docs/COMPONENT_API.md`.

## How to test

1. `pnpm --filter @sergeant/web typecheck` — TS бачить нові типи.
2. `pnpm --filter @sergeant/web lint` — ESLint clean.
3. `pnpm --filter @sergeant/web test` — 864 vitest pass.
4. `pnpm format:check` — Prettier clean.
5. Відкрити `/dev/showcase` (DesignShowcase) і пройтись по секціях Badges → Tabs → Segmented → Stat — візуально нічого не ламається, оскільки всі class-mappings збережені, тільки прив'язані до нових ключів пропа.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web test` → 94 файли / 864 теста, all green
- [x] Typecheck passes: `pnpm typecheck` (turbo, 13 пакетів) → all green
- [x] Lint passes: `pnpm --filter @sergeant/web lint` + root `pnpm lint` (eslint-plugin-sergeant-design unit tests 53/53 pass)
- [x] Prettier passes: `pnpm format:check` → all matched files clean
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules; only doc для дизайн-системи (`docs/COMPONENT_API.md`)

Link to Devin session: https://app.devin.ai/sessions/e5167567fea74a03bb2082a2241dd60f
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized component styling API architecture across design-system primitives for improved consistency and maintainability, with no changes to visual appearance or functionality.

* **Documentation**
  * Added comprehensive API documentation for design-system components outlining naming conventions and color options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->