### PR TITLE
refactor(web): мігрувати локальні типи модулів на @sergeant/design-tokens

### DIFF
--- a/apps/mobile/src/components/ui/Banner.tsx
+++ b/apps/mobile/src/components/ui/Banner.tsx
@@ -30,9 +30,10 @@
  */
 
 import type { ReactNode } from "react";
+import type { StatusColor } from "@sergeant/design-tokens";
 import { View, type ViewProps } from "react-native";
 
-export type BannerVariant = "info" | "success" | "warning" | "danger";
+export type BannerVariant = StatusColor;
 
 const variants: Record<BannerVariant, string> = {
   info: "border-cream-300 bg-cream-100",

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -20,7 +20,7 @@
       "@sergeant/fizruk-domain/*": ["../../packages/fizruk-domain/src/*"],
       "@sergeant/finyk-domain": ["../../packages/finyk-domain/src/index.ts"],
       "@sergeant/finyk-domain/*": ["../../packages/finyk-domain/src/*"],
-      "@sergeant/design-tokens": ["../../packages/design-tokens/tokens.js"],
+      "@sergeant/design-tokens": ["../../packages/design-tokens/index.d.ts"],
       "@sergeant/design-tokens/*": ["../../packages/design-tokens/*"]
     }
   },

--- a/apps/web/src/core/hooks/useHubNavigation.ts
+++ b/apps/web/src/core/hooks/useHubNavigation.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 const VALID_MODULES = new Set(["finyk", "fizruk", "routine", "nutrition"]);
 
-export type HubModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
+export type HubModuleId = ModuleAccent;
 
 export interface OpenModuleOptions {
   hash?: string | null;

--- a/apps/web/src/core/hub/HubSearch.tsx
+++ b/apps/web/src/core/hub/HubSearch.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { EmptyState } from "@shared/components/ui/EmptyState";
@@ -106,7 +107,7 @@ function localDateKey(d = new Date()) {
 
 type Hit = {
   id: string;
-  module: "finyk" | "fizruk" | "routine" | "nutrition";
+  module: ModuleAccent;
   moduleLabel: string;
   title: string;
   subtitle: string;

--- a/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
+++ b/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { safeReadStringLS } from "@shared/lib/storage";
 import {
   STORAGE_KEYS,
@@ -20,7 +21,7 @@ export interface ModuleConfig {
   getPreview: () => ModulePreview;
 }
 
-export type ModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
+export type ModuleId = ModuleAccent;
 
 /**
  * Per-module bento-card configuration: icon glyph, label/description,

--- a/apps/web/src/core/insights/TodayFocusCard.tsx
+++ b/apps/web/src/core/insights/TodayFocusCard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { StatusColor } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
@@ -270,7 +271,7 @@ function EmptyFocus() {
 interface FocusRec {
   id: string;
   module: keyof typeof MODULE_ACCENT;
-  severity?: "info" | "success" | "warning" | "danger";
+  severity?: StatusColor;
   title: string;
   body?: string;
   icon?: string;

--- a/apps/web/src/core/lib/chatActions/types.ts
+++ b/apps/web/src/core/lib/chatActions/types.ts
@@ -1,3 +1,5 @@
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
 export interface ChangeCategoryAction {
   name: "change_category";
   input: { tx_id: string; category_id: string };
@@ -421,7 +423,7 @@ export interface HabitTrendAction {
   input: { habit_id?: string; period_days?: number | string };
 }
 
-export type CompareWeeksModule = "finyk" | "fizruk" | "routine" | "nutrition";
+export type CompareWeeksModule = ModuleAccent;
 
 export interface CompareWeeksAction {
   name: "compare_weeks";

--- a/apps/web/src/shared/components/ui/Banner.tsx
+++ b/apps/web/src/shared/components/ui/Banner.tsx
@@ -1,7 +1,8 @@
 import type { HTMLAttributes, ReactNode } from "react";
+import type { StatusColor } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 
-export type BannerVariant = "info" | "success" | "warning" | "danger";
+export type BannerVariant = StatusColor;
 
 const variants: Record<BannerVariant, string> = {
   info: "border-line bg-panelHi/60 text-text",

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "../../lib/cn";
 
 /**
@@ -24,7 +25,7 @@ import { cn } from "../../lib/cn";
  *   tabs semantics.
  */
 
-export type ModuleNavColor = "finyk" | "fizruk" | "routine" | "nutrition";
+export type ModuleNavColor = ModuleAccent;
 
 export interface ModuleBottomNavItem {
   id: string;

--- a/apps/web/src/shared/components/ui/Tabs.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.tsx
@@ -5,6 +5,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -27,7 +28,7 @@ import { cn } from "@shared/lib/cn";
 
 export type TabsTone = "underline" | "pill";
 
-export type TabsAccent = "brand" | "finyk" | "fizruk" | "routine" | "nutrition";
+export type TabsAccent = "brand" | ModuleAccent;
 
 export type TabsSize = "sm" | "md";
 

--- a/apps/web/src/shared/lib/hubNav.ts
+++ b/apps/web/src/shared/lib/hubNav.ts
@@ -10,9 +10,11 @@
  * вони лишаються як є. Це доповнювальний, опційний канал.
  */
 
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
 export const HUB_OPEN_MODULE_EVENT = "hub:open-module";
 
-export type HubModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
+export type HubModuleId = ModuleAccent;
 export type HubModuleAction =
   | "add_expense"
   | "start_workout"

--- a/apps/web/src/shared/lib/moduleLabels.ts
+++ b/apps/web/src/shared/lib/moduleLabels.ts
@@ -9,7 +9,9 @@
 // Тримаємо константу у `shared/lib`, щоб імпорт не тягнув за собою
 // увесь onboarding-модуль.
 
-export type HubModuleId = "finyk" | "fizruk" | "routine" | "nutrition";
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
+export type HubModuleId = ModuleAccent;
 
 export const MODULE_LABELS: Record<HubModuleId, string> = {
   finyk: "Фінік",

--- a/apps/web/src/shared/lib/queryKeys.ts
+++ b/apps/web/src/shared/lib/queryKeys.ts
@@ -1,3 +1,5 @@
+import type { ModuleAccent } from "@sergeant/design-tokens";
+
 /**
  * Централізовані ключі для @tanstack/react-query.
  *
@@ -92,8 +94,7 @@ export const pushKeys = {
 // ─── Hub (dashboard previews, shared state) ───────────────────────────────
 export const hubKeys = {
   all: ["hub"] as const,
-  preview: (module: "finyk" | "fizruk" | "routine" | "nutrition") =>
-    ["hub", "preview", module] as const,
+  preview: (module: ModuleAccent) => ["hub", "preview", module] as const,
 };
 
 // ─── Token hashing helper ─────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Замінено локальні дублікати union-типів модулів і статусних кольорів на імпорти з `@sergeant/design-tokens` (PR #820 додав ці типи як єдине джерело правди). Локальні `export type X = ...` зберігаються — кожен файл далі експортує свою семантичну назву (`HubModuleId`, `ModuleId`, `TabsAccent`, `BannerVariant` тощо), але тепер як alias на централізовані `ModuleAccent` / `StatusColor`, щоб усі поточні імпорти продовжували працювати без правок call sites.

**Web — `ModuleAccent` ("finyk" | "fizruk" | "routine" | "nutrition"):**
- `apps/web/src/shared/components/ui/ModuleBottomNav.tsx` — `ModuleNavColor`
- `apps/web/src/shared/components/ui/Tabs.tsx` — `TabsAccent = "brand" | ModuleAccent`
- `apps/web/src/shared/lib/hubNav.ts` — `HubModuleId`
- `apps/web/src/shared/lib/moduleLabels.ts` — `HubModuleId`
- `apps/web/src/shared/lib/queryKeys.ts` — анонімний union у сигнатурі `hubKeys.preview`
- `apps/web/src/core/hub/HubSearch.tsx` — інлайн поле `Hit.module`
- `apps/web/src/core/hub/dashboard/moduleConfigs.tsx` — `ModuleId`
- `apps/web/src/core/hooks/useHubNavigation.ts` — `HubModuleId`
- `apps/web/src/core/lib/chatActions/types.ts` — `CompareWeeksModule`

**Web — `StatusColor` ("info" | "success" | "warning" | "danger"):**
- `apps/web/src/shared/components/ui/Banner.tsx` — `BannerVariant`
- `apps/web/src/core/insights/TodayFocusCard.tsx` — інлайн поле `FocusRec.severity`

**Mobile:**
- `apps/mobile/src/components/ui/Banner.tsx` — `BannerVariant = StatusColor`
- `apps/mobile/tsconfig.json` — `paths["@sergeant/design-tokens"]` тепер вказує на `index.d.ts` (раніше — на `tokens.js`, через що TS у мобілці не бачив експортовані з PR #820 type-only символи).

## Why

Раніше кожен компонент сам визначав ті самі union-типи, що призводило до drift і типового шуму при правках (PR #820 у тілі вже згадував цю проблему). Після #820 в `@sergeant/design-tokens` з'явились централізовані `ModuleAccent`, `StatusColor` тощо — тепер компоненти перевикористовують їх як єдине джерело правди.

`packages/shared` та `packages/insights` свідомо не чіпав: вони наразі не залежать від `@sergeant/design-tokens` у `package.json`, а додавання нової workspace-залежності — окреме рішення. Їхні локальні `RecModule` / `Module` (`ModuleAccent | "hub"`) і `RecSeverity` (`= StatusColor`) можна мігрувати окремим PR, коли/якщо зробимо `design-tokens` залежністю цих пакетів.

## How to test

```bash
pnpm install
pnpm typecheck   # 13/13 tasks pass
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/mobile lint
node scripts/check-imports.mjs
```

Локально все зелене. Runtime поведінка не змінюється — це лише type-only refactor.

---

## How AI-tested this PR

- [x] Vitest passes: не запускав (type-only, без логіки); прогнав повний `pnpm typecheck` (13/13), `pnpm --filter @sergeant/web lint`, `pnpm --filter @sergeant/mobile lint`, `node scripts/check-imports.mjs` — все зелене.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c12d9deebd924e5c9fe2ace6ab800489
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
