### PR TITLE
fix(design-tokens): align mobile accent with web brand (emerald)

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -45,6 +45,7 @@
     --c-muted: 180 174 169;
     --c-subtle: 135 128 121;
     --c-primary: 250 247 241;
+    --c-accent: 16 185 129;
     --c-border-strong: 112 102 90;
     --c-success-soft: 6 95 70;
     --c-warning-soft: 146 64 14;

--- a/packages/design-tokens/mobile.d.ts
+++ b/packages/design-tokens/mobile.d.ts
@@ -12,7 +12,10 @@ export type MobileColor =
   | "text"
   | "textMuted"
   | "accent"
-  | "danger";
+  | "success"
+  | "warning"
+  | "danger"
+  | "info";
 
 /** Mobile spacing scale identifiers (pixel values defined in `mobile.js`). */
 export type MobileSpacing = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";

--- a/packages/design-tokens/mobile.js
+++ b/packages/design-tokens/mobile.js
@@ -9,15 +9,36 @@
  * AI-NOTE: must stay `.js` + `.d.ts` (see AGENTS.md anti-pattern #2 / #720).
  */
 
-/** @type {Readonly<{ bg: string; surface: string; border: string; text: string; textMuted: string; accent: string; danger: string; }>} */
+/**
+ * @type {Readonly<{
+ *   bg: string;
+ *   surface: string;
+ *   border: string;
+ *   text: string;
+ *   textMuted: string;
+ *   accent: string;
+ *   success: string;
+ *   warning: string;
+ *   danger: string;
+ *   info: string;
+ * }>}
+ *
+ * AI-NOTE: `accent` must match web `statusColors.success` / `--c-accent`
+ * (#10b981, emerald-500) so that Sergeant's brand accent is identical
+ * cross-platform. Keep `success` / `warning` / `danger` / `info` aligned
+ * with `statusColors` in `./tokens.js`.
+ */
 export const colors = Object.freeze({
   bg: "#0b0d10",
   surface: "#13161b",
   border: "#1f242c",
   text: "#f2f4f7",
   textMuted: "#8a94a6",
-  accent: "#7c5cff",
+  accent: "#10b981",
+  success: "#10b981",
+  warning: "#f59e0b",
   danger: "#ef4444",
+  info: "#0ea5e9",
 });
 
 /** @type {Readonly<{ xs: number; sm: number; md: number; lg: number; xl: number; xxl: number; }>} */


### PR DESCRIPTION
## What changed

- `packages/design-tokens/mobile.js`: mobile accent `#7c5cff` (фіолетовий) → `#10b981` (emerald-500, ідентичний web `brand-500` / `statusColors.success` / `--c-accent`).
- `packages/design-tokens/mobile.js`: додано `success` / `warning` / `danger` / `info` у `colors` — дзеркало `statusColors` з `./tokens.js`, щоб mobile mirror повну web-статус-палітру.
- `packages/design-tokens/mobile.d.ts`: `MobileColor` розширено на нові ключі.
- `apps/mobile/global.css`: додано `--c-accent: 16 185 129` у `.dark` блок (раніше існував лише у `:root`; тепер явний у обох темах, без fallback-залежності).
- Додано `AI-NOTE` коментар у `mobile.js` поряд із `accent`, фіксуючи контракт "mobile accent = web brand".

## Why

Ранніше mobile-акцент був фіолетовий (`#7c5cff`), а web-бренд — emerald (`#10b981`). Коли mobile виросте до повноцінних branded surfaces (PR 10, PR 9), цей розрив давав би когнітивний дисонанс: tab bar, sign-in CTA, `colors.accent` у всіх `_layout.tsx` навігаторах — фіолетові, а на web та в онбордингу — зелені.

Це PR 2 з 15-кроковою серією `design-system-review-2026-04` (P0, §3 Mobile accent disconnect).

## How to test

- Відкрити mobile (Expo) — перевірити, що `tabBarActiveTintColor`, header tint, sign-in/sign-up CTA, spinner у `auth/callback`, `<ModuleStub>` — усі emerald, не фіолетові.
- `grep -r "#7c5cff" apps/ packages/` → 0 збігів.
- `pnpm --filter @sergeant/mobile typecheck` → green (тип `MobileColor` уже працює як object-key у `colors`).
- Порівняти `packages/design-tokens/mobile.js` `colors` і `tokens.js` `statusColors` — `success` / `warning` / `danger` / `info` мають бути однаковими.

---

## How AI-tested this PR

- [x] Manual smoke: грепнув за `colors.accent` — 14 call sites, усі отримають новий emerald автоматично.
- [x] Vitest passes: `pnpm --filter @sergeant/mobile typecheck` → 0 errors. `@sergeant/design-tokens` не має vitest-тестів (PR 14 це закриє).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
