### PR TITLE
feat(web): add `weight` prop to SectionHeading

### DIFF
--- a/apps/web/src/shared/components/ui/SectionHeading.test.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.test.tsx
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { SectionHeading } from "./SectionHeading";
+
+afterEach(cleanup);
+
+/**
+ * Contract tests for the DS SectionHeading primitive. Focus: size-driven
+ * defaults, `weight` override, variant override, and the `action` slot
+ * wrapper.
+ */
+describe("SectionHeading", () => {
+  it("default size='xs' renders as <h3> with bold + uppercase + text-subtle", () => {
+    const { container } = render(<SectionHeading>Розділ</SectionHeading>);
+    const el = container.querySelector("h3")!;
+    expect(el).not.toBeNull();
+    expect(el.className).toContain("text-2xs");
+    expect(el.className).toContain("uppercase");
+    expect(el.className).toContain("tracking-widest");
+    expect(el.className).toContain("font-bold");
+    expect(el.className).toContain("text-subtle");
+  });
+
+  it("size='md' drops the uppercase/tracking treatment and uses font-semibold", () => {
+    const { container } = render(
+      <SectionHeading size="md">Розділ</SectionHeading>,
+    );
+    const el = container.querySelector("h3")!;
+    expect(el.className).toContain("text-sm");
+    expect(el.className).toContain("font-semibold");
+    expect(el.className).not.toContain("uppercase");
+  });
+
+  it("weight='semibold' overrides default bold on eyebrow sizes", () => {
+    const { container } = render(
+      <SectionHeading weight="semibold">Розділ</SectionHeading>,
+    );
+    const el = container.querySelector("h3")!;
+    expect(el.className).toContain("font-semibold");
+    expect(el.className).not.toContain("font-bold");
+  });
+
+  it("weight='extrabold' lets callers promote an xs eyebrow to heavier", () => {
+    const { container } = render(
+      <SectionHeading size="xs" weight="extrabold">
+        Розділ
+      </SectionHeading>,
+    );
+    expect(container.querySelector("h3")!.className).toContain(
+      "font-extrabold",
+    );
+  });
+
+  it("variant='finyk' applies the finyk module tint (light + dark)", () => {
+    const { container } = render(
+      <SectionHeading variant="finyk">Фінік</SectionHeading>,
+    );
+    const cls = container.querySelector("h3")!.className;
+    expect(cls).toContain("text-finyk-strong");
+    expect(cls).toContain("dark:text-finyk/70");
+  });
+
+  it("action prop wraps the heading in a flex-row with a trailing slot", () => {
+    const { container, getByText } = render(
+      <SectionHeading action={<button type="button">Більше</button>}>
+        Заголовок
+      </SectionHeading>,
+    );
+    // The outer wrapper contains the heading + an extra <div> with the button.
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.tagName).toBe("DIV");
+    expect(wrapper.className).toContain("flex");
+    expect(wrapper.className).toContain("justify-between");
+    expect(getByText("Більше").tagName).toBe("BUTTON");
+  });
+
+  it("as='h2' renders the requested semantic tag", () => {
+    const { container } = render(
+      <SectionHeading as="h2">Розділ</SectionHeading>,
+    );
+    expect(container.querySelector("h2")).not.toBeNull();
+    expect(container.querySelector("h3")).toBeNull();
+  });
+});

--- a/apps/web/src/shared/components/ui/SectionHeading.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.tsx
@@ -30,12 +30,37 @@ export type SectionHeadingVariant =
   | "routine"
   | "nutrition";
 
-const sizes: Record<SectionHeadingSize, string> = {
-  xs: "text-2xs font-bold uppercase tracking-widest",
-  sm: "text-xs font-bold uppercase tracking-widest",
-  md: "text-sm font-semibold",
-  lg: "text-lg font-extrabold leading-tight",
-  xl: "text-xl font-extrabold leading-tight",
+/**
+ * Font-weight override. Default is size-dependent (eyebrow sizes bold,
+ * md semibold, lg/xl extrabold). Primary use-case is the Finyk drift
+ * "text-xs text-muted uppercase tracking-wide font-semibold" — after this
+ * prop exists, call-sites can opt-in via `<SectionHeading weight="semibold">`
+ * and drop their raw-className eslint-disable.
+ */
+export type SectionHeadingWeight = "semibold" | "bold" | "extrabold";
+
+// Size-only tokens (font-scale + casing + tracking). Weight is applied
+// separately so `weight` prop overrides can compose cleanly.
+const sizeTokens: Record<SectionHeadingSize, string> = {
+  xs: "text-2xs uppercase tracking-widest",
+  sm: "text-xs uppercase tracking-widest",
+  md: "text-sm",
+  lg: "text-lg leading-tight",
+  xl: "text-xl leading-tight",
+};
+
+const weightTokens: Record<SectionHeadingWeight, string> = {
+  semibold: "font-semibold",
+  bold: "font-bold",
+  extrabold: "font-extrabold",
+};
+
+const defaultWeightForSize: Record<SectionHeadingSize, SectionHeadingWeight> = {
+  xs: "bold",
+  sm: "bold",
+  md: "semibold",
+  lg: "extrabold",
+  xl: "extrabold",
 };
 
 const variants: Record<SectionHeadingVariant, string> = {
@@ -68,6 +93,12 @@ export interface SectionHeadingProps extends HTMLAttributes<HTMLElement> {
   size?: SectionHeadingSize;
   /** Colour variant. Defaults to `subtle` for xs/sm and `text` for md+. */
   variant?: SectionHeadingVariant;
+  /**
+   * Font-weight override. Defaults to `bold` for xs/sm (eyebrow),
+   * `semibold` for md, and `extrabold` for lg/xl. Use `semibold` to
+   * match the Finyk eyebrow tone on neutral cards.
+   */
+  weight?: SectionHeadingWeight;
   as?: ElementType;
   /** Optional right-aligned slot for actions/links. */
   action?: ReactNode;
@@ -82,13 +113,19 @@ export function SectionHeading({
   className,
   size = "xs",
   variant,
+  weight,
   as: Component = "h3",
   action,
   children,
   ...props
 }: SectionHeadingProps) {
   const resolvedVariant = variant ?? defaultVariantForSize[size];
-  const base = cn(sizes[size], variants[resolvedVariant]);
+  const resolvedWeight = weight ?? defaultWeightForSize[size];
+  const base = cn(
+    sizeTokens[size],
+    weightTokens[resolvedWeight],
+    variants[resolvedVariant],
+  );
 
   if (action) {
     return (


### PR DESCRIPTION
## What changed

Вводимо новий `weight?: 'semibold' | 'bold' | 'extrabold'` prop до `<SectionHeading>` разом з default-мапою за розміром:

| size | default weight |
|------|----------------|
| `xs` | `bold`         |
| `sm` | `bold`         |
| `md` | `semibold`     |
| `lg` | `extrabold`    |
| `xl` | `extrabold`    |

Імплементація: `sizes: Record<size, string>` (який раніше пакував scale + uppercase + tracking **і** font-weight в один клас) розбито на:

- **`sizeTokens`** — лише scale + casing + tracking (`text-2xs uppercase tracking-widest` для xs).
- **`weightTokens`** — окремо `font-bold` / `font-semibold` / `font-extrabold`, вибирається за `weight ?? defaultWeightForSize[size]`.

```tsx
// До: eyebrow-drift з raw className + eslint-disable
// eslint-disable-next-line sergeant-design/no-eyebrow-drift -- Finyk eyebrow тон
<h3 className="text-xs text-muted uppercase tracking-wide font-semibold">Останні транзакції</h3>

// Після: канонічний SectionHeading з weight override
<SectionHeading size="sm" variant="muted" weight="semibold">Останні транзакції</SectionHeading>
```

## Why

**PR 13 з `design-system-review-2026-04.md §6` — "eyebrow drift → SectionHeading (+ weight prop)"**.

До цього PR-у всі eyebrow-drift call-sites у коді мали `eslint-disable-next-line sergeant-design/no-eyebrow-drift` з причинами типу "Finyk тон" або "/70 routine tint". Додавання `weight` прибирає _один_ з трьох вимірів drift-у (font-scale → size, colour → variant, weight → weight). Решту (custom tint, `text-3xs`) еслint-disable залишає legit.

**Переваги:**
- Немає класового дублювання `sizes[size] + font-semibold` — Tailwind-merge у `cn()` не філтрує ці утиліти, бо вони не конфліктують за групою, але тепер API явне.
- Call-sites можуть перейти на `<SectionHeading weight="semibold">` у наступних PR-ах і зняти свої eslint-disable (це done окремим подальшим патчем).
- Default behaviour без змін: xs/sm → bold, тож existing consumers не торкаються.

## Tests

Додано **`SectionHeading.test.tsx`** (7 контрактних тестів):

1. Default `size='xs'` → `<h3>` + `text-2xs font-bold uppercase tracking-widest text-subtle`.
2. `size='md'` → без uppercase/tracking + `font-semibold`.
3. `weight='semibold'` — override `font-bold` → `font-semibold` на eyebrow.
4. `weight='extrabold'` — promote xs eyebrow до heavier.
5. `variant='finyk'` → `text-finyk-strong dark:text-finyk/70`.
6. `action` prop — wrapper `<div flex justify-between>` + trailing slot.
7. `as='h2'` → семантичний tag overrides default `<h3>`.

Усі проходять локально: `7 tests passed, 1 file`.

## How to test

```bash
pnpm --filter @sergeant/web lint       # 0 errors
pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/SectionHeading.test.tsx
# 7 tests passed, 1 file
```

Runtime smoke: відкрити будь-який модуль (Finyk home, Routine calendar) — eyebrow-заголовки не змінились, бо default weight залишається `bold` для xs/sm.

---

## How AI-tested this PR

- [x] Manual smoke: грепом по `SectionHeading` — немає call-site, який передавав би `weight` (default behaviour збережено).
- [x] Vitest passes: `7/7 passing`.
- [x] `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.

## AGENTS.md updated?

- [ ] Yes
- [x] No — `weight` prop задокументовано у JSDoc компонента; у `AGENTS.md` не згадувалося `SectionHeading` API. Окремий follow-up PR може оновити `docs/COMPONENT_API.md` якщо потрібно.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
