### PR TITLE
feat(mobile): port Badge / SectionHeading / Stat / Tabs primitives to RN

### DIFF
--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -1,0 +1,218 @@
+/**
+ * Sergeant Design System — Badge (React Native)
+ *
+ * Mobile port of the web `Badge` primitive. Compact pill for status,
+ * counts and labels.
+ *
+ * @see apps/web/src/shared/components/ui/Badge.tsx — canonical source of truth
+ *
+ * Parity notes:
+ * - Same `BadgeVariant` enum (neutral/accent/success/warning/danger/info +
+ *   four module brand colours).
+ * - Same `BadgeTone` (soft / solid / outline) and `BadgeSize` (xs/sm/md).
+ * - Same API surface: `variant`, `tone`, `size`, `dot`, `className`, children.
+ *
+ * Differences from web (intentional):
+ * - Wraps `<View>` + inner `<Text>` (NativeWind cannot colour-inherit
+ *   through nested Text on RN, so callers pass plain strings — we wrap
+ *   them ourselves). JSX children (e.g. leading icon) render as siblings.
+ * - Dot is a plain `<View>` with `bg-current` approximation via the
+ *   variant's text tint (drops back to the shared tone-fg palette).
+ * - Status bg-*-soft tokens resolve through the same semantic CSS
+ *   variables as web (see `apps/mobile/global.css`).
+ */
+
+import type { ReactNode } from "react";
+import { Text, View, type ViewProps } from "react-native";
+
+export type BadgeVariant =
+  | "neutral"
+  | "accent"
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type BadgeTone = "soft" | "solid" | "outline";
+
+export type BadgeSize = "xs" | "sm" | "md";
+
+const solidVariants: Record<BadgeVariant, string> = {
+  neutral: "bg-fg-muted/90",
+  accent: "bg-accent",
+  success: "bg-success",
+  warning: "bg-warning",
+  danger: "bg-danger",
+  info: "bg-info",
+  finyk: "bg-finyk",
+  fizruk: "bg-fizruk",
+  routine: "bg-routine",
+  nutrition: "bg-nutrition",
+};
+
+const softVariants: Record<BadgeVariant, string> = {
+  neutral: "bg-surface-muted border border-line",
+  accent: "bg-success-soft border border-success/30",
+  success: "bg-success-soft border border-success/30",
+  warning: "bg-warning-soft border border-warning/30",
+  danger: "bg-danger-soft border border-danger/30",
+  info: "bg-info-soft border border-info/30",
+  finyk: "bg-finyk-soft border border-finyk/30",
+  fizruk: "bg-fizruk-soft border border-fizruk/30",
+  routine: "bg-routine-surface border border-routine/30",
+  nutrition: "bg-nutrition-soft border border-nutrition/30",
+};
+
+const outlineVariants: Record<BadgeVariant, string> = {
+  neutral: "border border-line bg-transparent",
+  accent: "border border-accent/60 bg-transparent",
+  success: "border border-success/60 bg-transparent",
+  warning: "border border-warning/60 bg-transparent",
+  danger: "border border-danger/60 bg-transparent",
+  info: "border border-info/60 bg-transparent",
+  finyk: "border border-finyk/60 bg-transparent",
+  fizruk: "border border-fizruk/60 bg-transparent",
+  routine: "border border-routine/60 bg-transparent",
+  nutrition: "border border-nutrition/60 bg-transparent",
+};
+
+const solidText: Record<BadgeVariant, string> = {
+  neutral: "text-surface",
+  accent: "text-white",
+  success: "text-white",
+  warning: "text-white",
+  danger: "text-white",
+  info: "text-white",
+  finyk: "text-white",
+  fizruk: "text-white",
+  routine: "text-white",
+  nutrition: "text-white",
+};
+
+const softText: Record<BadgeVariant, string> = {
+  neutral: "text-fg-muted",
+  accent: "text-success",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  info: "text-info",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+const outlineText: Record<BadgeVariant, string> = softText;
+
+const sizes: Record<BadgeSize, string> = {
+  xs: "h-5 px-1.5 rounded-md",
+  sm: "h-6 px-2 rounded-lg",
+  md: "h-7 px-2.5 rounded-xl",
+};
+
+const textSizes: Record<BadgeSize, string> = {
+  xs: "text-2xs",
+  sm: "text-xs",
+  md: "text-xs",
+};
+
+const dotSizes: Record<BadgeSize, string> = {
+  xs: "w-1.5 h-1.5 mr-1",
+  sm: "w-1.5 h-1.5 mr-1",
+  md: "w-2 h-2 mr-1.5",
+};
+
+// RN has no CSS `currentColor`, so the leading status dot uses an
+// explicit bg per variant. Solid tone shows a contrasting dot (white on
+// filled bg); soft/outline render the variant's accent tint.
+const solidDot: Record<BadgeVariant, string> = {
+  neutral: "bg-surface",
+  accent: "bg-white",
+  success: "bg-white",
+  warning: "bg-white",
+  danger: "bg-white",
+  info: "bg-white",
+  finyk: "bg-white",
+  fizruk: "bg-white",
+  routine: "bg-white",
+  nutrition: "bg-white",
+};
+
+const softDot: Record<BadgeVariant, string> = {
+  neutral: "bg-fg-muted",
+  accent: "bg-success",
+  success: "bg-success",
+  warning: "bg-warning",
+  danger: "bg-danger",
+  info: "bg-info",
+  finyk: "bg-finyk",
+  fizruk: "bg-fizruk",
+  routine: "bg-routine",
+  nutrition: "bg-nutrition",
+};
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface BadgeProps extends ViewProps {
+  variant?: BadgeVariant;
+  tone?: BadgeTone;
+  size?: BadgeSize;
+  /** Leading dot (useful for status indicators). */
+  dot?: boolean;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function Badge({
+  variant = "neutral",
+  tone = "soft",
+  size = "sm",
+  dot = false,
+  className,
+  children,
+  ...props
+}: BadgeProps) {
+  const containerMap =
+    tone === "solid"
+      ? solidVariants
+      : tone === "outline"
+        ? outlineVariants
+        : softVariants;
+  const textMap =
+    tone === "solid" ? solidText : tone === "outline" ? outlineText : softText;
+  const dotMap = tone === "solid" ? solidDot : softDot;
+
+  return (
+    <View
+      className={cx(
+        "flex-row items-center self-start",
+        sizes[size],
+        containerMap[variant],
+        className,
+      )}
+      {...props}
+    >
+      {dot && (
+        <View
+          accessibilityElementsHidden
+          className={cx("rounded-full", dotSizes[size], dotMap[variant])}
+        />
+      )}
+      {typeof children === "string" || typeof children === "number" ? (
+        <Text
+          className={cx("font-semibold", textSizes[size], textMap[variant])}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ui/SectionHeading.tsx
+++ b/apps/mobile/src/components/ui/SectionHeading.tsx
@@ -1,0 +1,128 @@
+/**
+ * Sergeant Design System — SectionHeading (React Native)
+ *
+ * Mobile port of the web `SectionHeading` primitive.
+ *
+ * @see apps/web/src/shared/components/ui/SectionHeading.tsx — canonical source of truth
+ *
+ * Parity notes:
+ * - Same `SectionHeadingSize` (xs/sm/md/lg/xl) and `SectionHeadingVariant`
+ *   (subtle/muted/text/accent + four module tints).
+ * - Same `weight` prop (semibold/bold/extrabold) with the same size-keyed
+ *   defaults.
+ *
+ * Differences from web (intentional):
+ * - Renders as a single `<Text>` (RN has no semantic heading tag; screen
+ *   readers announce the `accessibilityRole="header"` supplied here).
+ * - No `as` / `action` slot — RN callers compose the trailing action in
+ *   their own <View className="flex-row"> sibling if needed.
+ */
+
+import type { ReactNode } from "react";
+import { Text, type TextProps } from "react-native";
+
+export type SectionHeadingSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export type SectionHeadingVariant =
+  | "subtle"
+  | "muted"
+  | "text"
+  | "accent"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type SectionHeadingWeight = "semibold" | "bold" | "extrabold";
+
+// This IS the SectionHeading primitive itself — canonical owner of the
+// uppercase + tracking + text-* eyebrow combo. Raw-className call-sites
+// elsewhere must still go through <SectionHeading>.
+const sizeTokens: Record<SectionHeadingSize, string> = {
+  // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- primitive owner
+  xs: "text-2xs uppercase tracking-widest",
+  // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- primitive owner
+  sm: "text-xs uppercase tracking-widest",
+  md: "text-sm",
+  lg: "text-lg leading-tight",
+  xl: "text-xl leading-tight",
+};
+
+const weightTokens: Record<SectionHeadingWeight, string> = {
+  semibold: "font-semibold",
+  bold: "font-bold",
+  extrabold: "font-extrabold",
+};
+
+const defaultWeightForSize: Record<SectionHeadingSize, SectionHeadingWeight> = {
+  xs: "bold",
+  sm: "bold",
+  md: "semibold",
+  lg: "extrabold",
+  xl: "extrabold",
+};
+
+const variants: Record<SectionHeadingVariant, string> = {
+  subtle: "text-subtle",
+  muted: "text-muted",
+  text: "text-text",
+  accent: "text-accent",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+const defaultVariantForSize: Record<SectionHeadingSize, SectionHeadingVariant> =
+  {
+    xs: "subtle",
+    sm: "subtle",
+    md: "text",
+    lg: "text",
+    xl: "text",
+  };
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface SectionHeadingProps extends TextProps {
+  size?: SectionHeadingSize;
+  variant?: SectionHeadingVariant;
+  weight?: SectionHeadingWeight;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function SectionHeading({
+  size = "xs",
+  variant,
+  weight,
+  className,
+  children,
+  ...props
+}: SectionHeadingProps) {
+  const resolvedVariant = variant ?? defaultVariantForSize[size];
+  const resolvedWeight = weight ?? defaultWeightForSize[size];
+
+  return (
+    <Text
+      accessibilityRole="header"
+      className={cx(
+        sizeTokens[size],
+        weightTokens[resolvedWeight],
+        variants[resolvedVariant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}
+
+export const SectionHeader = SectionHeading;
+export type SectionHeaderProps = SectionHeadingProps;
+export type SectionHeaderSize = SectionHeadingSize;
+export type SectionHeaderVariant = SectionHeadingVariant;
+export type SectionHeaderWeight = SectionHeadingWeight;

--- a/apps/mobile/src/components/ui/Stat.tsx
+++ b/apps/mobile/src/components/ui/Stat.tsx
@@ -1,0 +1,120 @@
+/**
+ * Sergeant Design System — Stat (React Native)
+ *
+ * Mobile port of the web `Stat` primitive.
+ *
+ * @see apps/web/src/shared/components/ui/Stat.tsx — canonical source of truth
+ *
+ * The canonical "eyebrow + big number + sublabel" triple that repeats
+ * across dashboards. `variant` tints the value; `size` picks the number
+ * typography.
+ *
+ * Differences from web (intentional):
+ * - Renders as `<View>` with three `<Text>` rows instead of semantic
+ *   div+heading markup. Header uses a SectionHeading (mobile port).
+ * - Leading `icon` renders as a `<Text>` sibling next to the value; an
+ *   emoji string or any ReactNode works.
+ */
+
+import type { ReactNode } from "react";
+import { Text, View } from "react-native";
+import { SectionHeading } from "./SectionHeading";
+
+export type StatVariant =
+  | "default"
+  | "success"
+  | "warning"
+  | "danger"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type StatSize = "sm" | "md" | "lg";
+
+const variantClass: Record<StatVariant, string> = {
+  default: "text-text",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+const valueSize: Record<StatSize, string> = {
+  sm: "text-lg font-extrabold",
+  md: "text-2xl font-extrabold",
+  lg: "text-3xl font-black",
+};
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface StatProps {
+  label: ReactNode;
+  value: ReactNode;
+  sublabel?: ReactNode;
+  variant?: StatVariant;
+  size?: StatSize;
+  icon?: ReactNode;
+  align?: "left" | "center" | "right";
+  className?: string;
+}
+
+export function Stat({
+  label,
+  value,
+  sublabel,
+  variant = "default",
+  size = "md",
+  icon,
+  align = "left",
+  className,
+}: StatProps) {
+  const rowAlign =
+    align === "center"
+      ? "justify-center"
+      : align === "right"
+        ? "justify-end"
+        : "justify-start";
+  const textAlign =
+    align === "center"
+      ? "text-center"
+      : align === "right"
+        ? "text-right"
+        : "text-left";
+
+  return (
+    <View className={cx(className)}>
+      <SectionHeading size="xs" className={textAlign}>
+        {label}
+      </SectionHeading>
+      <View className={cx("mt-1 flex-row items-baseline", rowAlign)}>
+        {icon != null &&
+          (typeof icon === "string" || typeof icon === "number" ? (
+            <Text className="text-base mr-1.5">{icon}</Text>
+          ) : (
+            <View className="mr-1.5">{icon}</View>
+          ))}
+        {typeof value === "string" || typeof value === "number" ? (
+          <Text className={cx(valueSize[size], variantClass[variant])}>
+            {value}
+          </Text>
+        ) : (
+          value
+        )}
+      </View>
+      {sublabel != null &&
+        (typeof sublabel === "string" || typeof sublabel === "number" ? (
+          <Text className={cx("text-xs text-subtle mt-1", textAlign)}>
+            {sublabel}
+          </Text>
+        ) : (
+          <View className="mt-1">{sublabel}</View>
+        ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ui/Tabs.tsx
+++ b/apps/mobile/src/components/ui/Tabs.tsx
@@ -1,0 +1,159 @@
+/**
+ * Sergeant Design System — Tabs (React Native)
+ *
+ * Mobile port of the web `Tabs` primitive. Provides a tablist with a
+ * controlled `value` + `onChange` API across both style treatments
+ * (`underline` and `pill`) and the module variant palette.
+ *
+ * @see apps/web/src/shared/components/ui/Tabs.tsx — canonical source of truth
+ *
+ * Differences from web (intentional):
+ * - No roving-tabindex or arrow-key navigation (RN relies on touch /
+ *   VoiceOver / TalkBack swipe navigation; the underlying tab array is
+ *   flat with individual Pressable elements).
+ * - Scrollable row uses a plain `<View>` (callers wrap in a
+ *   `ScrollView horizontal` if they expect overflow).
+ */
+
+import type { ReactNode } from "react";
+import { Pressable, Text, View } from "react-native";
+
+export type TabsVariant =
+  | "accent"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type TabsStyle = "underline" | "pill";
+
+export type TabsSize = "sm" | "md";
+
+export interface TabsItem<Value extends string = string> {
+  value: Value;
+  label: ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps<Value extends string = string> {
+  items: ReadonlyArray<TabsItem<Value>>;
+  value: Value;
+  onChange: (next: Value) => void;
+  variant?: TabsVariant;
+  style?: TabsStyle;
+  size?: TabsSize;
+  className?: string;
+}
+
+const pillActive: Record<TabsVariant, string> = {
+  accent: "bg-success-soft",
+  finyk: "bg-finyk-soft",
+  fizruk: "bg-fizruk-soft",
+  routine: "bg-routine-surface",
+  nutrition: "bg-nutrition-soft",
+};
+
+const pillActiveText: Record<TabsVariant, string> = {
+  accent: "text-success",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+const underlineActiveBorder: Record<TabsVariant, string> = {
+  accent: "border-b-2 border-accent",
+  finyk: "border-b-2 border-finyk",
+  fizruk: "border-b-2 border-fizruk",
+  routine: "border-b-2 border-routine",
+  nutrition: "border-b-2 border-nutrition",
+};
+
+const underlineActiveText: Record<TabsVariant, string> = pillActiveText;
+
+const sizes: Record<TabsSize, string> = {
+  sm: "h-9 px-3",
+  md: "h-11 px-4",
+};
+
+const textSizes: Record<TabsSize, string> = {
+  sm: "text-xs",
+  md: "text-sm",
+};
+
+function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function Tabs<Value extends string = string>({
+  items,
+  value,
+  onChange,
+  variant = "accent",
+  style: tabStyle = "underline",
+  size = "md",
+  className,
+}: TabsProps<Value>) {
+  return (
+    <View
+      accessibilityRole="tablist"
+      className={cx(
+        "flex-row items-center",
+        tabStyle === "pill" ? "bg-surface-muted rounded-xl p-1 gap-1" : "gap-1",
+        tabStyle === "underline" ? "border-b border-line" : undefined,
+        className,
+      )}
+    >
+      {items.map((item) => {
+        const isActive = item.value === value;
+        const activeCls =
+          tabStyle === "pill"
+            ? cx(pillActive[variant], pillActiveText[variant])
+            : cx(underlineActiveBorder[variant], underlineActiveText[variant]);
+        const inactiveCls = cx(
+          tabStyle === "pill"
+            ? undefined
+            : "-mb-px border-b-2 border-transparent",
+          "text-fg-muted",
+        );
+        return (
+          <Pressable
+            key={item.value}
+            accessibilityRole="tab"
+            accessibilityState={{
+              selected: isActive,
+              disabled: Boolean(item.disabled),
+            }}
+            disabled={item.disabled}
+            onPress={() => onChange(item.value)}
+            className={cx(
+              "items-center justify-center rounded-lg",
+              sizes[size],
+              isActive ? activeCls : inactiveCls,
+              item.disabled ? "opacity-50" : undefined,
+            )}
+          >
+            {typeof item.label === "string" ||
+            typeof item.label === "number" ? (
+              <Text
+                className={cx(
+                  "font-semibold",
+                  textSizes[size],
+                  isActive
+                    ? tabStyle === "pill"
+                      ? pillActiveText[variant]
+                      : underlineActiveText[variant]
+                    : "text-fg-muted",
+                )}
+              >
+                {item.label}
+              </Text>
+            ) : (
+              item.label
+            )}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}


### PR DESCRIPTION
## What changed

Додаю 4 нові UI-примітиви до `apps/mobile/src/components/ui/`, щоб звузити web↔mobile parity gap, виявлений у `design-system-review-2026-04.md §9`. Кожен — сумісний API з web-аналогом:

| Файл | Стан до | Стан після |
|------|---------|------------|
| `Badge.tsx`         | ❌ відсутній | 10 variants × 3 tones × 3 sizes + `dot` |
| `SectionHeading.tsx`| ❌ відсутній | size (xs…xl) × variant × `weight` prop (mirror PR 13) |
| `Stat.tsx`          | ❌ відсутній | eyebrow + value + sublabel, 8 variants, 3 sizes |
| `Tabs.tsx`          | ❌ відсутній | controlled value/onChange, 5 variants × 2 styles × 2 sizes, disabled, a11y tablist |

## Why

До цього `apps/mobile/src/components/ui/` мав **9 примітивів** (Banner, Button, Card, ConfirmDialog, Input, Sheet, Skeleton, SwipeToAction, Toast) проти **~30+ на web**. Це змушувало mobile-ки hand-rolled-ити власні pill-и, eyebrow-и, stat-triples — з окремим drift-ом колонки в дизайн-токени.

**Зараз parity покрито для 4 найчастіше-використовуваних примітивів:**

- **Badge** — pill для лічильників, статусів, модульних labels (у Finyk транзакційні теги, Fizruk muscle groups, Routine frequency).
- **SectionHeading** — канонічний eyebrow-heading (розділи dashboard / list).
- **Stat** — eyebrow + big number + sublabel (пульс, вага, добовий сумнар витрат).
- **Tabs** — underline або pill-style табсет (Day/Week/Month, module-scoped bookmarks).

Усі 4 — шляхом копіювання API web-аналогу 1:1 з мінімальними RN-адаптаціями (див. нижче).

## Parity notes

**Що спільне з web:**
- Енуми `BadgeVariant`, `BadgeTone`, `BadgeSize`; `SectionHeadingSize`, `SectionHeadingVariant`, `SectionHeadingWeight`; `StatVariant`, `StatSize`; `TabsVariant`, `TabsStyle`, `TabsSize`.
- Props: `variant`, `tone`, `size`, `weight`, `dot`, `children`, `className`.
- Семантичні токени (`text-subtle`, `bg-surface-muted`, `text-finyk-strong` тощо) — NativeWind processes один і той самий `@sergeant/design-tokens/tailwind-preset`.
- Size/variant-maps віддзеркалюють web-значення (включно з `font-extrabold` / `tabular-nums` семантикою).

**Що інакше (intentional):**
- `<View>` / `<Text>` / `<Pressable>` замість `<span>` / `<div>` / `<button>`.
- `accessibilityRole` / `accessibilityState` замість `role` / `aria-*`.
- Badge leading-dot використовує explicit `bg-<variant>` map (RN не має CSS `currentColor`). Solid tone контрастний dot (white); soft/outline — variant tint.
- Tabs без roving-tabindex / arrow-key nav — RN делегує це на touch / VoiceOver / TalkBack swipe-навігацію.
- SectionHeading рендериться як `<Text accessibilityRole="header">` (RN не має `<h3>`).
- Stat без `tabular-nums` (RN 0.76 відсутня прямa tailwind-утиліта для `font-variant-numeric`; еквівалент — `style={{fontVariant: ['tabular-nums']}}` як follow-up, або per-call кастомний font).

## ESLint

- `apps/mobile/src/components/ui/SectionHeading.tsx` містить саме той `uppercase + tracking + text-*` combo, який еслинт-правило `sergeant-design/no-eyebrow-drift` забороняє — але саме цей файл є каноническим owner-ом eyebrow-токенів. Два `// eslint-disable-next-line` коментарі ставляться над `xs` / `sm` мапою.
- Правило для інших call-sites ЗБЕРЕЖЕНО (raw-className eyebrow-и у модулях все ще заборонено).

## How to test

```bash
pnpm --filter @sergeant/mobile lint       # 0 errors (passed)
pnpm --filter @sergeant/mobile typecheck  # 0 errors (passed)
```

Візуальний smoke (у Metro):
1. Запусти `pnpm --filter @sergeant/mobile start`.
2. Імпортуй новий primitive у будь-яку debug-екран (`app/(tabs)/settings.tsx`):
```tsx
import { Badge } from "@/src/components/ui/Badge";

<Badge variant="finyk" tone="soft" dot>3 транзакції</Badge>
```
3. Перевір темно-/світло-режим через settings toggle.

---

## How AI-tested this PR

- [x] Manual smoke: typecheck + lint — без помилок.
- [ ] Vitest passes — тести для нових RN primitives не додано у цьому PR (follow-up: RN-test harness з `@testing-library/react-native` наразі використовується тільки для Banner/Card/ConfirmDialog/Input/Sheet/Skeleton/Toast).
- [x] `pnpm --filter @sergeant/mobile lint` → 0 errors.
- [x] `pnpm --filter @sergeant/mobile typecheck` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.

## AGENTS.md updated?

- [ ] Yes
- [x] No — нові файли слідують існуючій конвенції (mirror web primitive + JSDoc link back). Окрема документаційна секція `apps/mobile/src/components/ui/` не існує; follow-up може створити `docs/mobile-primitives.md` якщо потрібно.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new UI components to the mobile design system: Badge, SectionHeading, Stat, and Tabs for enhanced interface consistency and richer functionality across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->