### PR TITLE
feat(mobile): add module dark-mode CSS tokens + color-scheme

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -37,6 +37,8 @@
   }
 
   .dark {
+    color-scheme: dark;
+
     --c-bg: 23 20 18;
     --c-panel: 32 28 25;
     --c-panel-hi: 48 42 37;
@@ -50,5 +52,25 @@
     --c-warning-soft: 146 64 14;
     --c-danger-soft: 153 27 27;
     --c-info-soft: 7 89 133;
+
+    /* ───────────────────────────────────────────────────────────────────
+       MODULE DARK SURFACES & BORDERS — mirrors apps/web/src/index.css
+       Premixed accents tuned for use over the dark `panel` background.
+       Decoupled from the live `--c-finyk` / `--c-routine` / … accents so
+       the visual proportions of `bg-<m>-surface-dark/N` and
+       `border-<m>-border-dark/N` opacity tints don't silently drift if a
+       module's primary colour is later retuned. Initial RGB values
+       mirror the corresponding `moduleColors.<m>.primary` from
+       `packages/design-tokens/tokens.js` — change them here
+       independently when dark-mode tints need their own treatment.
+       ─────────────────────────────────────────────────────────────────── */
+    --c-finyk-surface-dark: 16 185 129; /* emerald-500 */
+    --c-finyk-border-dark: 16 185 129; /* emerald-500 */
+    --c-fizruk-surface-dark: 20 184 166; /* teal-500 */
+    --c-fizruk-border-dark: 20 184 166; /* teal-500 */
+    --c-routine-surface-dark: 249 112 102; /* coral-500 */
+    --c-routine-border-dark: 249 112 102; /* coral-500 */
+    --c-nutrition-surface-dark: 146 204 23; /* lime-500 */
+    --c-nutrition-border-dark: 146 204 23; /* lime-500 */
   }
 }


### PR DESCRIPTION
## What changed

Додаю відсутні module-brand dark surface/border tokens + `color-scheme: dark` до `apps/mobile/global.css`. Дзеркало web-конфігу з `apps/web/src/index.css §MODULE DARK SURFACES & BORDERS`.

```diff
   .dark {
+    color-scheme: dark;
+
     --c-bg: 23 20 18;
     ...
     --c-info-soft: 7 89 133;
+
+    --c-finyk-surface-dark: 16 185 129;
+    --c-finyk-border-dark: 16 185 129;
+    --c-fizruk-surface-dark: 20 184 166;
+    --c-fizruk-border-dark: 20 184 166;
+    --c-routine-surface-dark: 249 112 102;
+    --c-routine-border-dark: 249 112 102;
+    --c-nutrition-surface-dark: 146 204 23;
+    --c-nutrition-border-dark: 146 204 23;
   }
```

## Why

**PR 10 з `design-system-review-2026-04.md §9.2` — "mobile module dark tokens".**

`packages/design-tokens/tailwind-preset.js` **вже** реєструє утиліти `bg-finyk-surface-dark`, `border-finyk-border-dark` (та аналоги для fizruk/routine/nutrition) — вони оглашені у preset через `rgb(var(--c-finyk-surface-dark) / <alpha>)`. На web-апці відповідні CSS-змінні задані у `apps/web/src/index.css §181-198`, тому утіліти працюють. На mobile вони **до цього PR-у були undefined**, внаслідок чого NativeWind резолвила їх у `rgba(0 0 0 / alpha)` — модульні bento-tiles у dark-режимі виглядали як transparent/чорні замість emerald/teal/coral/lime tint.

**Додатково**: `color-scheme: dark` у `.dark` блоці — стандартний web-hint, який підказує браузеру (а в RN — embedded WebView) темне значення `form-control`, `scrollbar`, `system-ui` typography. На web воно є (index.css:141), на mobile було пропущено.

## How to test

```bash
pnpm --filter @sergeant/mobile typecheck  # 0 errors (passed)
```

Візуальний smoke (у Metro з dark-режимом увімкнено):
1. `pnpm --filter @sergeant/mobile start`.
2. Відкрити будь-який екран, що використовує `bg-finyk-surface-dark/15` / `border-fizruk-border-dark/30` — наприклад, фінансовий summary-тайл.
3. Переключитись у dark (через settings). Тайли повинні показати правильний module-brand tint замість чорного кольору.

---

## How AI-tested this PR

- [x] Manual smoke: порівняння 1:1 з `apps/web/src/index.css` — значення RGB ідентичні (тож parity збережено).
- [x] `pnpm --filter @sergeant/mobile typecheck` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian; коментар у CSS пояснює decoupling від live `--c-finyk` / `--c-routine` (щоб dark tint не drift-ив при retune основного кольору модуля).

## AGENTS.md updated?

- [ ] Yes
- [x] No — зміна виключно у CSS-tokens; `packages/design-tokens/tailwind-preset.js` документація (яка вже посилається на ці tokens) актуальна.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
