### PR TITLE
feat(web): add ProgressRing primitive

### DIFF
--- a/apps/web/src/shared/components/ui/ProgressRing.test.tsx
+++ b/apps/web/src/shared/components/ui/ProgressRing.test.tsx
@@ -1,0 +1,75 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { ProgressRing } from "./ProgressRing";
+
+afterEach(cleanup);
+
+describe("ProgressRing", () => {
+  it("renders role=progressbar with aria-valuenow/min/max", () => {
+    const { getByRole } = render(<ProgressRing value={42} max={100} />);
+    const ring = getByRole("progressbar");
+    expect(ring.getAttribute("aria-valuenow")).toBe("42");
+    expect(ring.getAttribute("aria-valuemin")).toBe("0");
+    expect(ring.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  it("clamps value into [0, max] for aria-valuenow", () => {
+    const { getByRole, rerender } = render(
+      <ProgressRing value={-10} max={100} />,
+    );
+    expect(getByRole("progressbar").getAttribute("aria-valuenow")).toBe("0");
+
+    rerender(<ProgressRing value={200} max={100} />);
+    expect(getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("defaults showPercent=true — renders rounded %", () => {
+    const { getByRole } = render(<ProgressRing value={25} max={100} />);
+    const ring = getByRole("progressbar");
+    expect(ring.textContent).toBe("25%");
+  });
+
+  it("custom `label` overrides the percent text", () => {
+    const { getByRole } = render(
+      <ProgressRing value={3} max={10} label="3 з 10" />,
+    );
+    expect(getByRole("progressbar").textContent).toBe("3 з 10");
+  });
+
+  it("showPercent=false and no label — renders no text content", () => {
+    const { getByRole } = render(
+      <ProgressRing value={50} max={100} showPercent={false} />,
+    );
+    // Only the <svg> (aria-hidden) remains; no visible label span.
+    const ring = getByRole("progressbar");
+    const labelSpan = ring.querySelector("span");
+    expect(labelSpan).toBeNull();
+  });
+
+  it("variant applies the module colour class to the container", () => {
+    const { getByRole } = render(<ProgressRing value={50} variant="finyk" />);
+    expect(getByRole("progressbar").className).toContain("text-finyk");
+  });
+
+  it("size prop controls the outer diameter in px", () => {
+    const { getByRole, rerender } = render(
+      <ProgressRing value={50} size="sm" />,
+    );
+    expect(getByRole("progressbar").style.width).toBe("48px");
+
+    rerender(<ProgressRing value={50} size="xl" />);
+    expect(getByRole("progressbar").style.width).toBe("128px");
+  });
+
+  it("svg renders filled arc with dashoffset scaled to value/max", () => {
+    const { getByRole } = render(<ProgressRing value={50} max={100} />);
+    const circles = getByRole("progressbar").querySelectorAll("circle");
+    expect(circles.length).toBe(2);
+    const filled = circles[1];
+    const circumference = Number(filled.getAttribute("stroke-dasharray"));
+    const offset = Number(filled.getAttribute("stroke-dashoffset"));
+    // 50% → offset is ≈ circumference/2
+    expect(offset).toBeCloseTo(circumference / 2, 2);
+  });
+});

--- a/apps/web/src/shared/components/ui/ProgressRing.tsx
+++ b/apps/web/src/shared/components/ui/ProgressRing.tsx
@@ -1,0 +1,165 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+/**
+ * Sergeant Design System — ProgressRing
+ *
+ * Radial progress indicator built with an SVG stroke-dasharray trick.
+ * Used for KPI completion (Routine habit streaks, Fizruk workout goals,
+ * Nutrition daily macro rings, Finyk budget burn-down).
+ *
+ * Variants map to module / status semantic tokens so dark-mode works
+ * automatically via `stroke="currentColor"` + Tailwind `text-*` utility.
+ *
+ * API:
+ * - `value` — current progress, 0..`max` (clamped).
+ * - `max` — upper bound (default 100).
+ * - `size` — outer diameter in px (sm 48 / md 72 / lg 96 / xl 128).
+ * - `strokeWidth` — ring thickness in px; defaults to `size / 12`.
+ * - `variant` — colour token for the filled arc.
+ * - `label` — optional centred content (string / ReactNode). If omitted
+ *   we render `Math.round((value/max)*100)%`.
+ * - `showPercent` — force the default percent label even when `label`
+ *   is `undefined` (default `true`; pass `false` to hide text entirely).
+ *
+ * A11y:
+ * - `role="progressbar"` + `aria-valuenow` / `aria-valuemin` /
+ *   `aria-valuemax`. Pass `aria-label` or `aria-labelledby` via spread
+ *   props when the visual label is not descriptive.
+ * - `motion-safe:transition-all` on the filled arc — respects
+ *   `prefers-reduced-motion: reduce`.
+ */
+
+export type ProgressRingVariant =
+  | "accent"
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition";
+
+export type ProgressRingSize = "sm" | "md" | "lg" | "xl";
+
+const variantColor: Record<ProgressRingVariant, string> = {
+  accent: "text-accent",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+  info: "text-info",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+const sizePx: Record<ProgressRingSize, number> = {
+  sm: 48,
+  md: 72,
+  lg: 96,
+  xl: 128,
+};
+
+const labelTextSize: Record<ProgressRingSize, string> = {
+  sm: "text-xs",
+  md: "text-sm",
+  lg: "text-lg",
+  xl: "text-2xl",
+};
+
+export interface ProgressRingProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  value: number;
+  max?: number;
+  size?: ProgressRingSize;
+  strokeWidth?: number;
+  variant?: ProgressRingVariant;
+  label?: ReactNode;
+  showPercent?: boolean;
+}
+
+export function ProgressRing({
+  value,
+  max = 100,
+  size = "md",
+  strokeWidth,
+  variant = "accent",
+  label,
+  showPercent = true,
+  className,
+  ...props
+}: ProgressRingProps) {
+  const diameter = sizePx[size];
+  const stroke = strokeWidth ?? Math.max(2, Math.round(diameter / 12));
+  const radius = (diameter - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const safeMax = max > 0 ? max : 1;
+  const clamped = Math.max(0, Math.min(value, safeMax));
+  const pct = clamped / safeMax;
+  const dashOffset = circumference * (1 - pct);
+  const percentText = Math.round(pct * 100);
+
+  const displayLabel =
+    label !== undefined ? label : showPercent ? `${percentText}%` : null;
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={safeMax}
+      className={cn(
+        "relative inline-flex items-center justify-center",
+        variantColor[variant],
+        className,
+      )}
+      style={{ width: diameter, height: diameter }}
+      {...props}
+    >
+      <svg
+        width={diameter}
+        height={diameter}
+        viewBox={`0 0 ${diameter} ${diameter}`}
+        aria-hidden="true"
+        className="-rotate-90"
+      >
+        <circle
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity={0.15}
+          strokeWidth={stroke}
+        />
+        <circle
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          className="motion-safe:transition-all motion-safe:duration-300"
+        />
+      </svg>
+      {displayLabel != null && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute inset-0 flex items-center justify-center font-semibold tabular-nums text-text",
+            labelTextSize[size],
+          )}
+        >
+          {displayLabel}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -93,6 +93,13 @@ export type {
   PopoverProps,
 } from "./Popover";
 
+export { ProgressRing } from "./ProgressRing";
+export type {
+  ProgressRingProps,
+  ProgressRingSize,
+  ProgressRingVariant,
+} from "./ProgressRing";
+
 export { Skeleton, SkeletonText } from "./Skeleton";
 export type { SkeletonProps } from "./Skeleton";
 


### PR DESCRIPTION
## What changed

Додаю `<ProgressRing>` до `apps/web/src/shared/components/ui/` — SVG-based radial progress indicator для KPI completion (Routine streaks, Fizruk workout goals, Nutrition daily macros, Finyk budget burn-down).

```tsx
<ProgressRing
  value={7}
  max={10}
  variant="routine"
  size="md"
  aria-label="Звичка: ранковий біг"
/>
```

**API:**

| Prop          | Type                                                    | Default         |
|---------------|---------------------------------------------------------|-----------------|
| `value`       | `number` (0..max, clamped)                              | —               |
| `max`         | `number`                                                | `100`           |
| `size`        | `'sm' \| 'md' \| 'lg' \| 'xl'` (48/72/96/128 px)         | `'md'`          |
| `strokeWidth` | `number` (px)                                           | `size / 12`     |
| `variant`     | `accent \| success \| warning \| danger \| info \| finyk \| fizruk \| routine \| nutrition` | `'accent'` |
| `label`       | `ReactNode` (overrides %)                               | —               |
| `showPercent` | `boolean` (default label)                               | `true`          |

**Implementation:**

- Основний SVG `<circle stroke="currentColor"/>` з `stroke-dasharray=circumference` + `stroke-dashoffset = circumference * (1 - pct)`. Rotate `-90deg` на SVG, щоб arc починався з 12:00.
- Background track: другий `<circle>` з `strokeOpacity=0.15` (тойсамий currentColor, приглушений).
- `variant` мапиться у `text-finyk` / `text-success` / `text-accent` → SVG inherits через `currentColor` → і light, і dark автоматично.
- Overlay `<span aria-hidden>` з label (за замовчуванням — `{Math.round(pct * 100)}%`).
- `motion-safe:transition-all motion-safe:duration-300` — анімація зміни value; `prefers-reduced-motion: reduce` вимикає.

**A11y:**
- Wrapper: `role="progressbar"` + `aria-valuenow` / `aria-valuemin` / `aria-valuemax`.
- SVG: `aria-hidden` (не окремий landmark).
- Label span: `aria-hidden` (presentational). Screen-reader consumer повинен передавати `aria-label` / `aria-labelledby` явно через spread props.

## Why

**PR 12 з `design-system-review-2026-04.md §10.2` — "ProgressRing primitive"**.

До цього PR-у у кодовій базі було знайдено **кілька ad-hoc ring-компонентів** у модулях (Routine habit cards з hand-rolled `<svg>`, Fizruk workout summary), кожен з власним набором кольорів, розмірів, і стандартів a11y. Їх міграцію на канонічний primitive винесено у follow-up PR.

## Tests

Додано `ProgressRing.test.tsx` (8 контрактних тестів):

1. role=progressbar + aria-valuenow/min/max.
2. clamp `value` у `[0, max]` для aria-valuenow (-10 → 0, 200/100 → 100).
3. default `showPercent=true` → текст `25%` при value=25/max=100.
4. custom `label` override — `3 з 10` замість `30%`.
5. `showPercent=false` без label — панель без тексту.
6. `variant='finyk'` → `text-finyk` у wrapper className.
7. `size='sm'` → width=48px; `size='xl'` → width=128px.
8. SVG: два `<circle>`, filled arc has `stroke-dashoffset ≈ circumference/2` для value=50/max=100.

Усі проходять: `8 tests passed, 1 file`.

## How to test

```bash
pnpm --filter @sergeant/web lint                                               # 0 errors
pnpm --filter @sergeant/web typecheck                                          # 0 errors
pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/ProgressRing.test.tsx
# 8 tests passed
```

---

## How AI-tested this PR

- [x] Vitest: `8/8 passing`.
- [x] `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] `pnpm --filter @sergeant/web typecheck` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian у JSDoc.
- [x] motion-safe: guard присутній — WCAG 2.3.3 passed.

## AGENTS.md updated?

- [ ] Yes
- [x] No — JSDoc у компоненті документує повний API; follow-up PR з міграцією ad-hoc ring-ів у модулях оновить docs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ProgressRing` component—a reusable circular progress indicator with customizable sizes, color variants, and flexible label options (percentage or custom text). Includes full accessibility support for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->