### PR TITLE
fix(web): a11y violations on hub-root flagged by axe-core

### DIFF
--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -35,8 +35,10 @@ export function HubFloatingActions({ hidden = false, onOpenChat }) {
         title="Асистент"
         className={cn(
           "pointer-events-auto h-14 pl-4 pr-5 flex items-center justify-center gap-2 rounded-full",
-          "bg-brand-500 text-white shadow-float",
-          "hover:bg-brand-600 hover:shadow-glow active:scale-95 transition-[background-color,box-shadow,opacity,transform]",
+          // brand-700 (not brand-500) — needed for WCAG AA contrast against
+          // `text-white` at 14px regular weight (≥4.5:1).
+          "bg-brand-700 text-white shadow-float",
+          "hover:bg-brand-800 hover:shadow-glow active:scale-95 transition-[background-color,box-shadow,opacity,transform]",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         )}
       >

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -136,7 +136,7 @@ export function HubHeader({
           aria-hidden="true"
           className="inline-block w-[3px] h-[14px] rounded-full bg-brand-500"
         />
-        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-brand-600 dark:text-brand-400 select-none">
+        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-brand-700 dark:text-brand-400 select-none">
           Оперативний центр
         </span>
       </div>

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -13,7 +13,15 @@ export interface BentoCardProps {
   config: ModuleConfig;
   onClick: () => void;
   onQuickAdd?: { label: string; run: () => void } | null;
-  dragProps?: Record<string, unknown>;
+  /**
+   * Ref/props applied to the inner primary `<button>` so dnd-kit can use it
+   * as the drag activator. Keeping the activator on the primary button (not
+   * the wrapper) allows the quick-add button to live as a sibling instead of
+   * a nested interactive control — see the `nested-interactive` axe rule
+   * (#839).
+   */
+  primaryRef?: (node: HTMLButtonElement | null) => void;
+  primaryProps?: Record<string, unknown>;
   isDragging?: boolean;
 }
 
@@ -22,15 +30,16 @@ export interface BentoCardProps {
  * the module emoji + label, latest preview numbers (`main`/`sub`) and a
  * progress bar when the module has a daily goal (`hasGoal`).
  *
- * Quick-add affordance (the small `+` button in the top-right corner) is
- * rendered only when the parent supplies an `onQuickAdd` action — keeps
- * dead pixels off the card for modules without a primary quick action.
+ * The card itself is the primary `<button>`; the small `+` quick-add affordance
+ * is rendered as an absolutely-positioned sibling button. They are siblings —
+ * not parent/child — so axe's `nested-interactive` rule passes.
  */
 export const BentoCard = memo(function BentoCard({
   config,
   onClick,
   onQuickAdd,
-  dragProps,
+  primaryRef,
+  primaryProps,
   isDragging,
 }: BentoCardProps) {
   const preview = config.getPreview();
@@ -39,93 +48,95 @@ export const BentoCard = memo(function BentoCard({
   const hasData = !!(preview.main || preview.sub);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "group relative flex flex-col w-full rounded-3xl border border-line p-3.5",
-        "shadow-card transition-all duration-200 text-left",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
-        "active:scale-[0.98]",
-        config.cardBg,
-        isDragging && "opacity-70 shadow-float z-50 cursor-grabbing",
-      )}
-      {...dragProps}
-    >
-      <div className="flex items-center justify-between mb-2">
-        <div
-          className={cn(
-            "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
-            config.iconClass,
-          )}
-        >
-          {config.icon}
-        </div>
-
-        {onQuickAdd && (
-          <span
-            role="button"
-            tabIndex={0}
-            onClick={(e) => {
-              e.stopPropagation();
-              onQuickAdd.run();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.stopPropagation();
-                e.preventDefault();
-                onQuickAdd.run();
-              }
-            }}
-            aria-label={onQuickAdd.label}
-            title={onQuickAdd.label}
-            className={cn(
-              "w-6 h-6 rounded-md flex items-center justify-center",
-              "text-text bg-panel/80 hover:bg-primary hover:text-bg",
-              "transition-colors",
-            )}
-          >
-            <Icon name="plus" size={13} strokeWidth={2.5} />
-          </span>
+    <div className={cn("relative", isDragging && "opacity-70 z-50")}>
+      <button
+        ref={primaryRef}
+        type="button"
+        onClick={onClick}
+        {...primaryProps}
+        className={cn(
+          "group relative flex flex-col w-full rounded-3xl border border-line p-3.5",
+          "shadow-card transition-all duration-200 text-left",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+          "active:scale-[0.98]",
+          config.cardBg,
+          isDragging && "shadow-float cursor-grabbing",
         )}
-      </div>
-
-      <span className="text-xs font-semibold text-text">
-        {config.emoji} {config.label}
-      </span>
-
-      {hasData ? (
-        <>
-          {preview.main && (
-            <span className="text-lg font-bold text-text tabular-nums mt-1 truncate">
-              {preview.main}
-            </span>
-          )}
-          {preview.sub && (
-            <span className="text-2xs text-muted mt-0.5 truncate">
-              {preview.sub}
-            </span>
-          )}
-        </>
-      ) : (
-        <span className="text-xs text-muted mt-1">{config.emptyLabel}</span>
-      )}
-
-      {showProgress && (
-        <div
-          className="w-full h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden mt-2"
-          aria-hidden
-        >
+      >
+        <div className="flex items-center justify-between mb-2">
           <div
             className={cn(
-              "h-full rounded-full transition-[width] duration-700 ease-out",
-              config.accentClass,
+              "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
+              config.iconClass,
             )}
-            style={{ width: `${Math.min(preview.progress ?? 0, 100)}%` }}
-          />
+          >
+            {config.icon}
+          </div>
+
+          {/* Layout placeholder for the absolutely-positioned quick-add
+              sibling — keeps the label centred consistently regardless of
+              whether the module exposes a quick-add action. */}
+          {onQuickAdd && <span aria-hidden className="w-6 h-6 shrink-0" />}
         </div>
+
+        <span className="text-xs font-semibold text-text">
+          {config.emoji} {config.label}
+        </span>
+
+        {hasData ? (
+          <>
+            {preview.main && (
+              <span className="text-lg font-bold text-text tabular-nums mt-1 truncate">
+                {preview.main}
+              </span>
+            )}
+            {preview.sub && (
+              <span className="text-2xs text-muted mt-0.5 truncate">
+                {preview.sub}
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="text-xs text-muted mt-1">{config.emptyLabel}</span>
+        )}
+
+        {showProgress && (
+          <div
+            className="w-full h-1 rounded-full bg-line/40 dark:bg-white/10 overflow-hidden mt-2"
+            aria-hidden
+          >
+            <div
+              className={cn(
+                "h-full rounded-full transition-[width] duration-700 ease-out",
+                config.accentClass,
+              )}
+              style={{ width: `${Math.min(preview.progress ?? 0, 100)}%` }}
+            />
+          </div>
+        )}
+      </button>
+
+      {onQuickAdd && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onQuickAdd.run();
+          }}
+          aria-label={onQuickAdd.label}
+          title={onQuickAdd.label}
+          className={cn(
+            "absolute top-3.5 right-3.5",
+            "w-6 h-6 rounded-md flex items-center justify-center",
+            "text-text bg-panel/80 hover:bg-primary hover:text-bg",
+            "transition-colors",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+          )}
+        >
+          <Icon name="plus" size={13} strokeWidth={2.5} />
+        </button>
       )}
-    </button>
+    </div>
   );
 });
 
@@ -149,6 +160,7 @@ export const SortableCard = memo(function SortableCard({
     attributes,
     listeners,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
     isDragging,
@@ -162,7 +174,12 @@ export const SortableCard = memo(function SortableCard({
     [transform, transition],
   );
 
-  const dragProps = useMemo(
+  // AI-NOTE: spread dnd-kit attributes/listeners on the *inner* primary button
+  // (via `primaryProps` + `setActivatorNodeRef`). Spreading them on the wrapper
+  // would either nest interactive controls (button-in-button with quick-add)
+  // or attach `role="button"` to a `<div>` whose only focusable child is the
+  // primary `<button>` — both fail axe a11y rules.
+  const primaryProps = useMemo(
     () => ({ ...attributes, ...listeners }),
     [attributes, listeners],
   );
@@ -178,8 +195,9 @@ export const SortableCard = memo(function SortableCard({
         config={cfg}
         onClick={handleClick}
         onQuickAdd={quickAdd}
+        primaryRef={setActivatorNodeRef}
+        primaryProps={primaryProps}
         isDragging={isDragging}
-        dragProps={dragProps}
       />
     </div>
   );

--- a/apps/web/src/core/insights/AssistantAdviceCard.tsx
+++ b/apps/web/src/core/insights/AssistantAdviceCard.tsx
@@ -85,7 +85,10 @@ export function AssistantAdviceCard({
         {!collapsed && (
           <div className="px-4 pb-3.5 -mt-0.5">
             {loading && !insight && (
-              <p className="text-sm text-muted motion-safe:animate-pulse">
+              <p
+                className="text-sm text-text/80 dark:text-text/90"
+                aria-live="polite"
+              >
                 Готую пораду…
               </p>
             )}


### PR DESCRIPTION
## What changed

Чотири точкових фікси на `/` (hub-root), які валили `Accessibility (axe-core)` job у CI:

| Місце | Правило | Було | Стало |
|---|---|---|---|
| `apps/web/src/core/hub/dashboard/BentoCard.tsx` | `nested-interactive` | `<span role="button" tabIndex={0}>` (quick-add `+`) всередині outer `<button>` картки модуля | quick-add винесено sibling-кнопкою; drag-активатор через `setActivatorNodeRef` на primary `<button>`, тож dnd-kit не накладає `role="button"` на wrapper-div |
| `apps/web/src/core/app/HubHeader.tsx` | `color-contrast` | `text-brand-600` (#059669) на `bg-paper`/#fdf9f3 → 3.59:1 | `text-brand-700` (#047857) → 5.13:1 |
| `apps/web/src/core/insights/AssistantAdviceCard.tsx` | `color-contrast` | `text-muted` + `motion-safe:animate-pulse` — opacity 1→0.5 cycle опускав ефективний контраст до ~3.0:1 | `text-text/80 dark:text-text/90`, без animation; додано `aria-live="polite"` для SR |
| `apps/web/src/core/app/HubFloatingActions.tsx` | `color-contrast` | `text-white` на `bg-brand-500` (#10b981) → 2.53:1 | `text-white` на `bg-brand-700` (#047857) → 5.49:1; hover → `bg-brand-800` |

## Why

Follow-up до #839: PR #839 з іконками каталогу був замерджений з пропуском axe-core. axe-job там фейлив на _existing_ serious violations на hub-root, які не стосувалися іконок (підтверджено локальним прогоном `pnpm test:a11y` на `cf8fcea4` ще до моїх змін). Цей PR закриває ті порушення, щоб job нарешті був зеленим без admin-override.

## How to test

```
CI=true pnpm --filter @sergeant/web test:a11y      # 12/12 passed (раніше 11/12)
pnpm --filter @sergeant/web test                   # 927 unit tests
pnpm lint && pnpm typecheck
```

Смок на `/`:
- Клац по картці `🥗Харчування` → відкривається модуль; drag-and-drop ліваркою лишається.
- `+` у правому верхньому куті відкриває `AddMealSheet`, не пропагує клік на картку.
- Tab-навігація: фокус послідовно на primary button картки, потім на quick-add (раніше span з `tabIndex={0}` — тепер справжній `<button>`).
- FAB `Асистент` — темно-смарагдовий, текст читабельний.

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web test:a11y` — `12 passed`.
- [x] `pnpm --filter @sergeant/web test` — `927 passed`.
- [x] `pnpm lint`, `pnpm typecheck` — clean.
- [x] No new AI-DANGER markers.

## AGENTS.md updated?

- [x] No — no new permanent rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
