### PR TITLE
test(web): add design-showcase page to axe-core CI accessibility scan

### DIFF
--- a/apps/web/tests/a11y/axe.spec.ts
+++ b/apps/web/tests/a11y/axe.spec.ts
@@ -45,6 +45,11 @@ const SURFACES: Array<{ name: string; path: string }> = [
   { name: "fizruk-dashboard", path: "/?module=fizruk" },
   { name: "nutrition-dashboard", path: "/?module=nutrition" },
   { name: "routine-dashboard", path: "/?module=routine" },
+  // Design-system showcase page — renders the full catalogue of Sergeant
+  // primitives in every variant × tone × size combination. Running axe
+  // here catches a11y regressions at the primitive level (before they
+  // propagate into module surfaces).
+  { name: "design-showcase", path: "/design" },
 ];
 
 for (const { name, path } of SURFACES) {


### PR DESCRIPTION
## What changed

Розширюю `apps/web/tests/a11y/axe.spec.ts` — додаю `/design` (DesignShowcase) сторінку до списку SURFACES, які сканує axe-core у CI.

```diff
 const SURFACES: Array<{ name: string; path: string }> = [
   { name: "hub-root", path: "/" },
   { name: "finyk-overview", path: "/?module=finyk" },
   { name: "fizruk-dashboard", path: "/?module=fizruk" },
   { name: "nutrition-dashboard", path: "/?module=nutrition" },
   { name: "routine-dashboard", path: "/?module=routine" },
+  // Design-system showcase page — renders the full catalogue of Sergeant
+  // primitives in every variant × tone × size combination. Running axe
+  // here catches a11y regressions at the primitive level (before they
+  // propagate into module surfaces).
+  { name: "design-showcase", path: "/design" },
 ];
```

## Why

**PR 15 з `design-system-review-2026-04.md §11.2` — "CI axe-audit для DesignShowcase"**.

PR 15 з дизайн-ревʼю просив: _"Додати `@axe-core/playwright` для автоматичного сканування DesignShowcase page. Порогове значення: 0 серйозних violations."_

**Ключове відкриття:** у кодовій базі **уже** існує:

- `apps/web/tests/a11y/axe.spec.ts` з 5 SURFACES (hub + 4 модулі).
- `@axe-core/playwright: ^4.11.2` у `apps/web/package.json`.
- `pnpm test:a11y` скрипт.
- GitHub Actions CI job `a11y: Accessibility (axe-core)` у `.github/workflows/ci.yml:121-157` — запускається у **кожному** PR-і, завантажує playwright-report як артефакт на 7 днів.

Це PR додає бракуючий елемент — скан **DesignShowcase** page. Оскільки ця сторінка рендерить повний каталог primitives (`<Button>` × всіх variant/tone/size, `<Badge>` × всіх tone, `<Card>` × radius × variant, тощо), axe на неї ловить a11y-регресії на **рівні primitives** — перш ніж вони потрапляють у модульні сторінки.

**Threshold поведінка:** existing test suite вже має `0 serious/critical violations` як hard-блокер (див. `apps/web/tests/a11y/axe.spec.ts:100-110`). Minor/moderate violations позначаються soft-сигналом через `test.info().annotations`. Це PR просто додає ще одну surface до цього списку — нічого не змінює у thresholds / reporting.

## How to test

```bash
pnpm --filter @sergeant/web lint        # 0 errors (passed)
pnpm --filter @sergeant/web typecheck   # 0 errors (passed)
```

Локальний axe-run (вимагає `vite preview` або живий dev server):

```bash
cd apps/web
pnpm dev  # у другому терміналі
pnpm test:a11y -g "design-showcase"
```

У CI:
- PR → GitHub Actions → `a11y` job → спробує завантажити `/design` → запустить axe → якщо `design-showcase` має serious/critical violations → CI fail.
- Artifact `playwright-a11y-report` upload-иться у всіх випадках (successful + failed) на 7 днів.

---

## How AI-tested this PR

- [x] Manual smoke: `/design` route verified у `apps/web/src/core/App.tsx:324-330` — рендериться через `<Suspense><DesignShowcase /></Suspense>`.
- [x] `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] `pnpm --filter @sergeant/web typecheck` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.
- [ ] Vitest passes — a11y spec використовує Playwright (не Vitest); тести запустяться у CI `a11y` job після merge.

## AGENTS.md updated?

- [ ] Yes
- [x] No — a11y harness вже задокументовано у `docs/a11y-audit.md` + коментарях `apps/web/tests/a11y/axe.spec.ts:1-30`; зміна виключно додавання елемента у масив SURFACES.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
