### PR TITLE
test(design-tokens): refresh mobile.colors snapshot

### DIFF
--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -2,13 +2,16 @@
 
 exports[`@sergeant/design-tokens — mobile.js > mobile.colors matches the canonical web moduleColors + statusColors 1`] = `
 {
-  "accent": "#7c5cff",
+  "accent": "#10b981",
   "bg": "#0b0d10",
   "border": "#1f242c",
   "danger": "#ef4444",
+  "info": "#0ea5e9",
+  "success": "#10b981",
   "surface": "#13161b",
   "text": "#f2f4f7",
   "textMuted": "#8a94a6",
+  "warning": "#f59e0b",
 }
 `;
 


### PR DESCRIPTION
## What changed

Оновлено `packages/design-tokens/__snapshots__/tokens.test.js.snap` (4 рядки) — snapshot тесту `mobile.colors matches the canonical web moduleColors + statusColors` тепер відповідає поточному `mobile.js`.

```diff
  {
-   "accent": "#7c5cff",
+   "accent": "#10b981",
    "bg": "#0b0d10",
    "border": "#1f242c",
    "danger": "#ef4444",
+   "info": "#0ea5e9",
+   "success": "#10b981",
    "surface": "#13161b",
    "text": "#f2f4f7",
    "textMuted": "#8a94a6",
+   "warning": "#f59e0b",
  }
```

## Why

Регресія між двома PR на main:
- **#833 (`mobile-accent-emerald`)** вирівняв `mobile.colors` з web `statusColors`: `accent` violet → emerald (`#7c5cff` → `#10b981`), додав `info` / `success` / `warning`.
- **#845 (`design-tokens-snapshot-tests`)** додав сам snapshot-тест, але snap-файл ще тримав значення *до* #833.

Результат — `@sergeant/design-tokens:test` фейлив на main → `check` job червоніє у кожному наступному PR (зокрема цей фейл блокував #846 axe-фікси, поки той не зрегджили admin-override).

## How to test

```
cd packages/design-tokens && pnpm exec vitest run
```
Очікувано: `9 passed`, `0 snapshots written/failed`. Регенерувати snap наново через `vitest -u` дає той самий вміст, що в цьому PR.

Компонентної поведінки snapshot не змінює — це тільки оновлення чекера-інваріанту.

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web test` — 927 passed (jest snap не зачеплено).
- [x] `cd packages/design-tokens && pnpm exec vitest run` — `9 passed`.
- [x] `pnpm lint`, `pnpm typecheck` — clean.
- [x] No new AI-DANGER markers.
- [x] Без змін у будь-якому web/mobile рантаймі.

## AGENTS.md updated?

- [x] No — суто синхронізація snapshot з реальним експортом.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
