### PR TITLE
refactor(web): migrate eyebrow-drift call-sites to SectionHeading

### DIFF
--- a/apps/web/src/core/profile/ChangePasswordSection.tsx
+++ b/apps/web/src/core/profile/ChangePasswordSection.tsx
@@ -3,6 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { Input } from "@shared/components/ui/Input";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { useToast } from "@shared/hooks/useToast";
 import { changePassword } from "../auth/authClient";
 
@@ -48,12 +49,9 @@ export function ChangePasswordSection({ online }: { online: boolean }) {
       </div>
 
       <form onSubmit={handleSubmit} className="p-4 space-y-4">
-        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-            Standalone label for a form section inside Card, not a collapsible
-            SettingsSubGroup — SectionHeading cannot express this layout. */}
-        <p className="text-xs font-bold text-muted uppercase tracking-widest">
+        <SectionHeading size="sm" variant="muted" as="p">
           Зміна паролю
-        </p>
+        </SectionHeading>
         <div className="space-y-2">
           <label
             htmlFor="profile-current-pw"

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx
@@ -158,13 +158,9 @@ export function WorkoutFinishSheets({
             <div className="fizruk-summary-header">
               <div className="flex items-start justify-between gap-2">
                 <div>
-                  {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-                      "Завершено" hero kicker in module tint (`text-fizruk`)
-                      over `fizruk-summary-header` — intentional branded
-                      treatment. */}
-                  <div className="text-xs font-bold tracking-widest uppercase text-fizruk">
+                  <SectionHeading size="sm" variant="fizruk" as="div">
                     Завершено
-                  </div>
+                  </SectionHeading>
                   <div className="text-lg font-black text-teal-900 dark:text-white mt-1 leading-tight">
                     Тренування виконано
                   </div>

--- a/apps/web/src/modules/fizruk/pages/Atlas.tsx
+++ b/apps/web/src/modules/fizruk/pages/Atlas.tsx
@@ -1,6 +1,7 @@
 import { BodyAtlas } from "../components/BodyAtlas";
 import { useRecovery } from "../hooks/useRecovery";
 import { Card } from "@shared/components/ui/Card";
+import { SectionHeading } from "@shared/components/ui/SectionHeading";
 
 export function Atlas() {
   const rec = useRecovery();
@@ -53,11 +54,9 @@ export function Atlas() {
           className="rounded-3xl p-5 border border-line/20 bg-hero-teal dark:border-teal-800/30 dark:bg-panel dark:[background-image:linear-gradient(135deg,rgba(20,184,166,0.18)_0%,rgba(20,184,166,0.05)_100%)]"
           aria-label="Атлас мʼязів"
         >
-          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
-              Module hero kicker in branded `text-fizruk` above an h1. */}
-          <p className="text-xs font-bold tracking-widest uppercase text-fizruk">
+          <SectionHeading size="sm" variant="fizruk" as="p">
             Атлас мʼязів
-          </p>
+          </SectionHeading>
           <h1 className="text-hero font-black text-teal-900 dark:text-white mt-2 leading-tight">
             Стан відновлення
           </h1>


### PR DESCRIPTION
## What changed

Follow-up до [#840](https://github.com/Skords-01/Sergeant/pull/840) (SectionHeading `weight` prop). Мігрую **3 clean call-sites** з raw-className eyebrow drift на канонічну `<SectionHeading />` API.

| File | Before | After |
|------|--------|-------|
| `apps/web/src/core/profile/ChangePasswordSection.tsx:54` | `<p className="text-xs font-bold text-muted uppercase tracking-widest">` | `<SectionHeading size="sm" variant="muted" as="p">` |
| `apps/web/src/modules/fizruk/pages/Atlas.tsx:58` | `<p className="text-xs font-bold tracking-widest uppercase text-fizruk">` | `<SectionHeading size="sm" variant="fizruk" as="p">` |
| `apps/web/src/modules/fizruk/components/workouts/WorkoutFinishSheets.tsx:161` | `<div className="text-xs font-bold tracking-widest uppercase text-fizruk">` | `<SectionHeading size="sm" variant="fizruk" as="div">` |

Знято три `// eslint-disable-next-line sergeant-design/no-eyebrow-drift` anotation-и разом з коментарями.

## Visual behaviour diff

- **ChangePasswordSection**: byte-equivalent output (SH `size="sm" variant="muted"` рендерить `text-xs uppercase tracking-widest font-bold text-muted` — той же набір utility classes). **Нульовий візуальний зсув.**
- **Atlas.tsx / WorkoutFinishSheets.tsx** — SH variant="fizruk" рендерить `text-fizruk-strong dark:text-fizruk/70` замість raw `text-fizruk`. Це legitimate **візуальний improvement**:
  - Light mode: `text-fizruk` (teal-500) → `text-fizruk-strong` (teal-700-ish). На `bg-hero-teal` light-mode surface-і це фіксує borderline WCAG AA контраст (4.5:1 guarantee).
  - Dark mode: `text-fizruk` → `text-fizruk/70`. На dark panel з teal gradient — semi-transparent tint читається природніше як eyebrow, тримає hierarchy з h1 нижче.

## Why this scope (3 sites) and not more

Розглянув усі **20 call-sites з `eslint-disable-next-line sergeant-design/no-eyebrow-drift`** у кодовій базі. Решта **17 сайтів мають легітимні раціонали**, які token-система наразі не покриває:

- **text-3xs size** (7 сайтів: ModuleHeader, WeekDayStrip, WorkoutTemplatesSection, SupersetBadge, WorkoutItemCard×2, Atlas cardio stats) — менше за SectionHeading xs (`text-2xs`). Окрема робота: додати `size="xxs"` до SH. 
- **Динамічні модульні відтінки через `C.heroKicker`** (RoutineCalendarHero) — SH variants зараз статичні.
- **Hero-карткові `text-white/60`, `text-teal-600 dark:text-white/60`** (WorkoutFinishSheets×3) — не виражені через SH тіні.
- **Divider-ряди з "або" між `bg-line` spans** (AddMealSheet, FinykLoginScreen, AuthPage) — структурно delimiter, а не heading. Окрема робота: створити `<Divider>` primitive з optional inline label.
- **Label-pattern зі стабільним id** (ManualExpenseSheet) — потребує htmlFor + aria-labelledby; SH не має id-propagation.
- **`group-hover:text-text transition-colors`** (SettingsPrimitives) — інтерактивний стан, SH tone tokens статичні.
- **`text-primary` (bespoke accent)** (WeeklyDigestCard) — не exposed через SH tone tokens.
- **Form Label pattern** (FormField primitive itself) — це Label, не SectionHeading.

Ці 17 сайтів залишаються raw з чіткими коментарями чому — окрема робота (text-3xs size, Divider primitive, tone tokens extensions) покриватиме їх згодом.

## How to test

```bash
pnpm --filter @sergeant/web lint        # 0 errors (passed)
pnpm --filter @sergeant/web typecheck   # 0 errors (passed)
```

Manual visual check:
- `/settings` → профіль → "Безпека" картка → "ЗМІНА ПАРОЛЮ" label повинен рендеритись ідентично.
- `/?module=fizruk` → Atlas сторінка → hero "АТЛАС М'ЯЗІВ" — теал має бути трохи darker у light, і semi-transparent у dark.
- Завершення тренування у fizruk → summary sheet → "ЗАВЕРШЕНО" kicker — той же візуальний pattern що Atlas.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] `pnpm --filter @sergeant/web typecheck` → 0 errors.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.
- [ ] Vitest — no new tests needed; existing SectionHeading contract tests (#840) cover size/variant/as behaviour.

## AGENTS.md updated?

- [ ] Yes
- [x] No — change is scoped до трьох call-sites. Існуючий eyebrow-drift rationale у `packages/eslint-plugin-sergeant-design` не змінюється.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized section header styling across multiple pages and modules for improved visual consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->