### PR TITLE
refactor(web): replace native title tooltips with <Tooltip> primitive

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Icon } from "@shared/components/ui/Icon";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import { BrandLogo } from "./BrandLogo";
 import { DarkModeToggle } from "./DarkModeToggle";
 import { UserMenuButton } from "./UserMenuButton";
@@ -90,15 +91,16 @@ export function HubHeader({
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          <button
-            type="button"
-            onClick={onOpenSearch}
-            aria-label="Пошук"
-            title="Пошук по всіх модулях"
-            className={ICON_BUTTON_CLS}
-          >
-            <Icon name="search" size={20} />
-          </button>
+          <Tooltip content="Пошук по всіх модулях" placement="bottom-center">
+            <button
+              type="button"
+              onClick={onOpenSearch}
+              aria-label="Пошук"
+              className={ICON_BUTTON_CLS}
+            >
+              <Icon name="search" size={20} />
+            </button>
+          </Tooltip>
 
           {user ? (
             <UserMenuButton
@@ -115,15 +117,16 @@ export function HubHeader({
             <>
               <DarkModeToggle dark={dark} onToggle={onToggleDark} />
               {!authLoading && !hideAuthButton && (
-                <button
-                  type="button"
-                  onClick={onShowAuth}
-                  aria-label="Увійти в акаунт"
-                  title="Увійти"
-                  className={ICON_BUTTON_CLS}
-                >
-                  <Icon name="user" size={20} />
-                </button>
+                <Tooltip content="Увійти" placement="bottom-center">
+                  <button
+                    type="button"
+                    onClick={onShowAuth}
+                    aria-label="Увійти в акаунт"
+                    className={ICON_BUTTON_CLS}
+                  >
+                    <Icon name="user" size={20} />
+                  </button>
+                </Tooltip>
               )}
             </>
           )}

--- a/apps/web/src/core/components/ChatInput.tsx
+++ b/apps/web/src/core/components/ChatInput.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@shared/lib/cn";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import { stopSpeaking, unlockTTS } from "../lib/hubChatSpeech";
 import { useSpeech } from "../hooks/useSpeech";
 import {
@@ -83,30 +84,31 @@ export function ChatInput({
 
   return (
     <div className="flex gap-2 px-4 pt-2 pb-4 shrink-0">
-      <button
-        type="button"
-        onClick={onHelp}
-        className="w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-[background-color,border-color,color,opacity] border bg-panel border-line text-muted hover:text-text hover:border-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
-        title="Список команд (/help)"
-        aria-label="Показати список команд"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-          focusable="false"
+      <Tooltip content="Список команд (/help)" placement="top-center">
+        <button
+          type="button"
+          onClick={onHelp}
+          className="w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-[background-color,border-color,color,opacity] border bg-panel border-line text-muted hover:text-text hover:border-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          aria-label="Показати список команд"
         >
-          <circle cx="12" cy="12" r="10" />
-          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-          <line x1="12" y1="17" x2="12.01" y2="17" />
-        </svg>
-      </button>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            focusable="false"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+        </button>
+      </Tooltip>
       <input
         ref={inputRef}
         className="input-focus-finyk flex-1 bg-panel border border-line rounded-2xl px-4 py-3 text-sm text-text placeholder:text-subtle disabled:opacity-50"

--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ApiError, chatApi, isApiError } from "@shared/api";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
@@ -540,16 +541,20 @@ function HubChat({
             </div>
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
-            <button
-              type="button"
-              onClick={clearChat}
-              className="h-8 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
-              title="Очистити історію та почати нову сесію"
-              aria-label="Очистити чат"
+            <Tooltip
+              content="Очистити історію та почати нову сесію"
+              placement="bottom-center"
             >
-              <Icon name="refresh-cw" size={13} />
-              Новий чат
-            </button>
+              <button
+                type="button"
+                onClick={clearChat}
+                className="h-8 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
+                aria-label="Очистити чат"
+              >
+                <Icon name="refresh-cw" size={13} />
+                Новий чат
+              </button>
+            </Tooltip>
             <button
               type="button"
               onClick={onClose}
@@ -578,16 +583,17 @@ function HubChat({
           {loading && (
             <div className="flex items-center gap-2">
               <TypingIndicator />
-              <button
-                type="button"
-                onClick={cancelInFlight}
-                className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full bg-panelHi hover:bg-line/40 text-muted hover:text-text text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
-                aria-label="Скасувати поточний запит"
-                title="Скасувати (Esc)"
-              >
-                <Icon name="close" size={12} />
-                Скасувати
-              </button>
+              <Tooltip content="Скасувати (Esc)" placement="top-center">
+                <button
+                  type="button"
+                  onClick={cancelInFlight}
+                  className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full bg-panelHi hover:bg-line/40 text-muted hover:text-text text-2xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+                  aria-label="Скасувати поточний запит"
+                >
+                  <Icon name="close" size={12} />
+                  Скасувати
+                </button>
+              </Tooltip>
             </div>
           )}
         </div>

--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import {
   useWeeklyDigest,
   useDigestHistory,
@@ -411,15 +412,16 @@ export function WeeklyDigestCard({ onCollapse }: WeeklyDigestCardProps = {}) {
             </button>
           )}
           {onCollapse && (
-            <button
-              type="button"
-              onClick={onCollapse}
-              title="Згорнути"
-              aria-label="Згорнути звіт тижня"
-              className="w-7 h-7 flex items-center justify-center rounded-lg text-muted hover:text-text hover:bg-panelHi transition-colors"
-            >
-              <Icon name="chevron-up" size={15} strokeWidth={2.5} />
-            </button>
+            <Tooltip content="Згорнути" placement="top-center">
+              <button
+                type="button"
+                onClick={onCollapse}
+                aria-label="Згорнути звіт тижня"
+                className="w-7 h-7 flex items-center justify-center rounded-lg text-muted hover:text-text hover:bg-panelHi transition-colors"
+              >
+                <Icon name="chevron-up" size={15} strokeWidth={2.5} />
+              </button>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 
 // Презентаційна картка ліміту бюджету. Усі дані приходять готовими пропсами,
 // тому memo потрібен, щоб картка не перемальовувалась при змінах сусідніх
@@ -138,14 +139,18 @@ function LimitBudgetCardComponent({
                         />
                       </button>
                       {onDismissAdvice && (
-                        <button
-                          type="button"
-                          onClick={onDismissAdvice}
-                          className="px-3 text-xs text-muted hover:text-text border-l border-line transition-colors"
-                          title="Прибрати пораду до наступної генерації"
+                        <Tooltip
+                          content="Прибрати пораду до наступної генерації"
+                          placement="top-center"
                         >
-                          Зрозуміло
-                        </button>
+                          <button
+                            type="button"
+                            onClick={onDismissAdvice}
+                            className="px-3 text-xs text-muted hover:text-text border-l border-line transition-colors"
+                          >
+                            Зрозуміло
+                          </button>
+                        </Tooltip>
                       )}
                     </div>
                     {adviceOpen && (

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -4,6 +4,7 @@ import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
 
@@ -295,14 +296,19 @@ export function WorkoutTemplatesSection({
                         </span>
                       )}
                       {group && !groupSelectMode && (
-                        <button
-                          type="button"
-                          className="text-2xs text-danger/60 hover:text-danger px-1"
-                          title="Прибрати з групи"
-                          onClick={() => handleRemoveGroup(group.id)}
+                        <Tooltip
+                          content="Прибрати з групи"
+                          placement="top-center"
                         >
-                          ⊗
-                        </button>
+                          <button
+                            type="button"
+                            className="text-2xs text-danger/60 hover:text-danger px-1"
+                            aria-label="Прибрати з групи"
+                            onClick={() => handleRemoveGroup(group.id)}
+                          >
+                            ⊗
+                          </button>
+                        </Tooltip>
                       )}
                       {!groupSelectMode && (
                         <>

--- a/apps/web/src/modules/nutrition/components/PantryCard.tsx
+++ b/apps/web/src/modules/nutrition/components/PantryCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
 import { Icon } from "@shared/components/ui/Icon";
+import { Tooltip } from "@shared/components/ui/Tooltip";
 import { cn } from "@shared/lib/cn";
 import { groupItemsByCategory } from "../lib/foodCategories";
 import type { FoodCategory } from "../lib/foodCategories";
@@ -259,16 +260,17 @@ export function PantryCard({
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {typeof onScanBarcode === "function" && (
-              <button
-                type="button"
-                onClick={onScanBarcode}
-                disabled={busy}
-                className="w-8 h-8 rounded-xl bg-nutrition/10 text-nutrition-strong dark:text-nutrition border border-nutrition/30 hover:bg-nutrition/20 transition-colors disabled:opacity-50 flex items-center justify-center text-base"
-                aria-label="Сканувати штрих-код"
-                title="Сканувати штрих-код"
-              >
-                📷
-              </button>
+              <Tooltip content="Сканувати штрих-код" placement="bottom-center">
+                <button
+                  type="button"
+                  onClick={onScanBarcode}
+                  disabled={busy}
+                  className="w-8 h-8 rounded-xl bg-nutrition/10 text-nutrition-strong dark:text-nutrition border border-nutrition/30 hover:bg-nutrition/20 transition-colors disabled:opacity-50 flex items-center justify-center text-base"
+                  aria-label="Сканувати штрих-код"
+                >
+                  📷
+                </button>
+              </Tooltip>
             )}
             <div className="flex rounded-xl bg-panelHi border border-line p-0.5">
               {INPUT_MODES.map((m) => (


### PR DESCRIPTION
## What changed

Follow-up до [#843](https://github.com/Skords-01/Sergeant/pull/843) (Tooltip primitive). Мігрую **9 clean call-sites** з native HTML `title="..."` tooltip на `<Tooltip>` primitive.

### Migrated sites

| File:line | Button purpose |
|-----------|---------------|
| `apps/web/src/core/app/HubHeader.tsx:93` | Пошук по всіх модулях |
| `apps/web/src/core/app/HubHeader.tsx:118` | Увійти (auth button) |
| `apps/web/src/core/hub/HubChat.tsx:543` | Очистити історію чату |
| `apps/web/src/core/hub/HubChat.tsx:581` | Скасувати запит (Esc) |
| `apps/web/src/core/components/ChatInput.tsx:86` | Список команд (/help) |
| `apps/web/src/core/insights/WeeklyDigestCard.tsx:414` | Згорнути звіт тижня |
| `apps/web/src/modules/finyk/components/budgets/LimitBudgetCard.tsx:141` | Прибрати пораду |
| `apps/web/src/modules/nutrition/components/PantryCard.tsx:262` | Сканувати штрих-код |
| `apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx:298` | Прибрати з групи |

### Why Tooltip > native `title`

- **Keyboard accessibility**: native HTML `title` fires only on mouse hover. `<Tooltip>` fires on focus теж (keyboard users бачать хінт). A11y win.
- **Styled consistently**: native tooltip rendering залежить від браузера / OS. `<Tooltip>` — DS-tokens (panel bg, subtle border, text-2xs).
- **Delay control**: native title з'являється через ~2s (OS-залежно). `<Tooltip>` має `openDelay={150}` за замовчуванням — швидкий feedback.
- **Portal-based positioning**: `<Tooltip>` обходить overflow:hidden і z-index stacking issues.

### Duplicate `title` + `aria-label` handling

Частина кнопок мала обидва атрибути (`title` + `aria-label`). Після міграції:
- `aria-label` **залишається** на `<button>` (screen readers).
- `title` **переноситься** на `<Tooltip content="...">` (sighted users).

Текст може відрізнятись — `aria-label` короткий ("Пошук"), `Tooltip content` описовий ("Пошук по всіх модулях"). Legit — screen readers читають короткий label у контексті landmark-а, tooltip дає додатковий опис.

Для `WorkoutTemplatesSection` кнопки (`⊗` glyph, без label) — додав `aria-label="Прибрати з групи"`, бо раніше screen reader чув лише  `Circled Times`.

### Placement

- `top-center` — для bottom-of-viewport кнопок (HubChat cancel, ChatInput /help, WeeklyDigest collapse).
- `bottom-center` — для top-of-viewport кнопок (HubHeader search/auth, PantryCard scan).

### What was NOT migrated

**~160 інших `title="..."` occurrences** в `apps/web/src` — це React-component props, не native HTML tooltip-и:
```tsx
<Modal title="Видалити?">         // Modal prop — NOT native tooltip
<Sheet title="Новий запис">       // Sheet prop
<EmptyState title="Поки порожньо"> // EmptyState prop
<ConfirmDialog title="Видалити?">  // ConfirmDialog prop
```
Ці props — semantic heading, не tooltip поведінка, і вже правильно rendered як `<h2>` / `<h3>`.

**3 span-based native tooltips залишились як native** (legit: `<span>` не focusable за замовчуванням, тому `<Tooltip>` дасть inconsistent keyboard UX):
- `apps/web/src/modules/fizruk/components/workouts/WorkoutCatalogSection.tsx:140` — `<span>⚠</span>` warning icon.
- `apps/web/src/core/insights/TodayFocusCard.tsx:217` — reward pill `<span>`.
- `apps/web/src/core/hub/dashboard/dashboardCards.tsx:119` — streak pill `<span>`.

Для них окрема робота: або додати `role="img" aria-label`, або зробити pill focusable з `role="button"` + handler.

## How to test

```bash
pnpm --filter @sergeant/web lint        # 0 errors (passed)
pnpm --filter @sergeant/web typecheck   # 0 errors (passed)
```

Manual:
- Hub header → hover та tab до кнопки пошуку — tooltip "Пошук по всіх модулях" з'являється в обох режимах.
- HubChat → відкрити чат → Hover на "Новий чат" / Tab-фокус — tooltip.
- Почати запит → з'являється "Скасувати" — hover/focus tooltip з `(Esc)` hint.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] `pnpm --filter @sergeant/web typecheck` → 0 errors.
- [x] Existing Tooltip unit tests (#843) покривають render + placement + openDelay behaviours.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose Ukrainian.

## AGENTS.md updated?

- [ ] Yes
- [x] No — change is localized до 9 call-sites. Tooltip primitive rationale вже у PR #843.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
