### PR TITLE
feat(design-tokens): WCAG-AA `-strong` companions for brand + status

### DIFF
--- a/docs/brand-palette-wcag-aa-proposal.md
+++ b/docs/brand-palette-wcag-aa-proposal.md
@@ -126,10 +126,12 @@ The four module colours already have a `strong` field on the
 `semanticVariants` block in
 [`tailwind-preset.js`](../packages/design-tokens/tailwind-preset.js)
 (lines 119–124 for `finyk`, identical pattern for the rest). Today
-those are populated with `brandColors.{family}[700]` and exposed as
-`text-finyk-strong`, etc. They are used by soft Badge variants
-(`bg-finyk-soft text-finyk-strong border-finyk-ring/50`) and in
-`StatCard` headlines.
+those are populated with `brandColors.{family}[700]` for `finyk` /
+`fizruk` / `routine` and `brandColors.lime[800]` for `nutrition`
+(lime-700 was too thin a margin against the cream `bg-bg`, see
+§ 2.1 below), and exposed as `text-finyk-strong`, etc. They are used
+by soft Badge variants (`bg-finyk-soft text-finyk-strong
+border-finyk-ring/50`) and in `StatCard` headlines.
 
 Extend the convention to the other six tokens:
 
@@ -161,15 +163,15 @@ warning:        statusColors.warning,           // unchanged: #f59e0b
 Computed contrast at 14 px regular against the cream `--c-bg`
 (`#fdf9f3`):
 
-| Token                   | Hex                     | Ratio on `bg-bg` | WCAG AA 14 px   |
-| ----------------------- | ----------------------- | ---------------: | --------------- |
-| `text-success-strong`   | `#047857` (emerald-700) |     **5.23 : 1** | ✓ Pass          |
-| `text-fizruk-strong`    | `#0f766e` (teal-700)    |     **5.22 : 1** | ✓ Pass          |
-| `text-routine-strong`   | `#c23a3a` (coral-700)   |     **5.06 : 1** | ✓ Pass          |
-| `text-nutrition-strong` | `#567c0f` (lime-700)    |     **4.67 : 1** | ✓ Pass (margin) |
-| `text-warning-strong`   | `#b45309` (amber-700)   |     **4.83 : 1** | ✓ Pass          |
-| `text-danger-strong`    | `#b91c1c` (red-700)     |     **6.17 : 1** | ✓ Pass          |
-| `text-info-strong`      | `#0369a1` (sky-700)     |     **5.66 : 1** | ✓ Pass          |
+| Token                   | Hex                     | Ratio on `bg-bg` | WCAG AA 14 px |
+| ----------------------- | ----------------------- | ---------------: | ------------- |
+| `text-success-strong`   | `#047857` (emerald-700) |     **5.23 : 1** | ✓ Pass        |
+| `text-fizruk-strong`    | `#0f766e` (teal-700)    |     **5.22 : 1** | ✓ Pass        |
+| `text-routine-strong`   | `#c23a3a` (coral-700)   |     **5.06 : 1** | ✓ Pass        |
+| `text-nutrition-strong` | `#466212` (lime-800)    |     **6.64 : 1** | ✓ Pass        |
+| `text-warning-strong`   | `#b45309` (amber-700)   |     **4.83 : 1** | ✓ Pass        |
+| `text-danger-strong`    | `#b91c1c` (red-700)     |     **6.17 : 1** | ✓ Pass        |
+| `text-info-strong`      | `#0369a1` (sky-700)     |     **5.66 : 1** | ✓ Pass        |
 
 And `text-white` against the corresponding `bg-{c}-strong` solid — the
 other half of the symmetric pair, used by `Button` / `Badge` solid
@@ -180,15 +182,20 @@ tones:
 | `text-white` on `bg-success-strong` (emerald-700) | **5.48 : 1** | ✓ Pass        |
 | `text-white` on `bg-fizruk-strong` (teal-700)     | **5.47 : 1** | ✓ Pass        |
 | `text-white` on `bg-routine-strong` (coral-700)   | **5.30 : 1** | ✓ Pass        |
-| `text-white` on `bg-nutrition-strong` (lime-700)  | **4.90 : 1** | ✓ Pass        |
+| `text-white` on `bg-nutrition-strong` (lime-800)  | **6.96 : 1** | ✓ Pass        |
 | `text-white` on `bg-warning-strong` (amber-700)   | **5.02 : 1** | ✓ Pass        |
 | `text-white` on `bg-danger-strong` (red-700)      | **6.47 : 1** | ✓ Pass        |
 | `text-white` on `bg-info-strong` (sky-700)        | **5.93 : 1** | ✓ Pass        |
 
-The `nutrition-strong` / lime-700 pair clears 4.5 : 1 by a thin (~ 0.17)
-margin. If type ramps drop below 14 px we may need to step it down to
-`lime-800` (`#466212`, ratio 6.31 : 1 on cream) for body sizes; the
-numeric callouts (≥24 px bold) clear at 3 : 1 either way.
+All seven `-strong` tokens land comfortably above the 4.5 : 1 floor.
+`nutrition-strong` is the only family that _isn't_ `[700]` — the
+existing preset already bumped it to `lime-800` (`#466212`) because
+`lime-700` (`#567c0f`) only clears 4.67 : 1 on cream, well below the
+5–6 : 1 headroom the other modules enjoy. The implementation PR
+_keeps_ the lime-800 choice as-is. The other six tokens (success /
+warning / danger / info / brand / accent) follow the `[700]`
+convention. Numeric callouts (≥24 px bold) clear the WCAG AA 3 : 1
+large-text rule at any of these tiers.
 
 ### 2.2 Component-level usage rules
 

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -81,6 +81,12 @@ const preset = {
           light: brandColors.emerald[400],
           dark: brandColors.emerald[600],
           subtle: brandColors.emerald[50],
+          // `strong` is the WCAG-AA companion to `DEFAULT` — emerald-700
+          // clears 4.5:1 against the cream `bg-bg` and against `text-white`
+          // when used as a solid fill. Use `bg-brand-strong text-white` on
+          // primary CTAs and `text-brand-strong` for body-sized brand text.
+          // See docs/brand-palette-wcag-aa-proposal.md.
+          strong: brandColors.emerald[700],
           ...brandColors.emerald,
         },
         teal: brandColors.teal,
@@ -92,7 +98,9 @@ const preset = {
         // STATUS COLORS — Consistent semantic meanings
         // Each status has a solid accent (for fills / icons / rings) plus a
         // `-soft` background token that resolves through CSS variables so
-        // dark mode works without bespoke dark: overrides.
+        // dark mode works without bespoke dark: overrides, and a `-strong`
+        // companion (text-on-cream / fill-with-white) that clears WCAG AA
+        // at body sizes. See docs/brand-palette-wcag-aa-proposal.md.
         // ═══════════════════════════════════════════════════════════════════
         success: statusColors.success,
         danger: statusColors.danger,
@@ -102,6 +110,12 @@ const preset = {
         "warning-soft": "rgb(var(--c-warning-soft) / <alpha-value>)",
         "danger-soft": "rgb(var(--c-danger-soft) / <alpha-value>)",
         "info-soft": "rgb(var(--c-info-soft) / <alpha-value>)",
+        // WCAG-AA companions: `text-{c}-strong` on cream / soft surfaces,
+        // `bg-{c}-strong text-white` on solid fills (Buttons, Badges, Tabs).
+        "success-strong": brandColors.emerald[700], // #047857 — 5.23:1 on cream / 5.48:1 on white
+        "warning-strong": "#b45309", // amber-700 — 4.83:1 on cream / 5.02:1 on white
+        "danger-strong": "#b91c1c", // red-700   — 6.17:1 on cream / 6.47:1 on white
+        "info-strong": "#0369a1", // sky-700   — 5.66:1 on cream / 5.93:1 on white
 
         // ═══════════════════════════════════════════════════════════════════
         // CHART PALETTE — For pie charts, graphs, data visualization


### PR DESCRIPTION
## What changed

Step 1 of the migration laid out in [`docs/brand-palette-wcag-aa-proposal.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/brand-palette-wcag-aa-proposal.md) (PR [#853](https://github.com/Skords-01/Sergeant/pull/853), merged). **Pure additive token PR — no consumer code, no snapshot churn.**

`packages/design-tokens/tailwind-preset.js`:

- `brand.strong = brandColors.emerald[700]` — opens up `text-brand-strong` / `bg-brand-strong`. Reachable as `bg-brand-700` already via the existing spread; the named alias pairs better with the Button/Badge primitives that Step 2 will flip.
- `success-strong = #047857` (emerald-700) — **5.23 : 1** on cream / **5.48 : 1** on white.
- `warning-strong = #b45309` (amber-700) — **4.83 : 1** / **5.02 : 1**.
- `danger-strong  = #b91c1c` (red-700)   — **6.17 : 1** / **6.47 : 1**.
- `info-strong    = #0369a1` (sky-700)   — **5.66 : 1** / **5.93 : 1**.

The four module colours (`finyk` / `fizruk` / `routine` / `nutrition`) already expose `.strong` on their nested objects — left untouched. `nutrition.strong` intentionally stays at `lime-800` (`#466212`, 6.64 : 1 on cream) per the existing preset choice; lime-700 only clears 4.67 : 1.

**Doc fix bundled in.** Addresses Devin Review finding on PR #853 ([comment 3144120301](https://github.com/Skords-01/Sergeant/pull/853#discussion_r3144120301)): the proposal table previously listed `text-nutrition-strong` as `lime-700` 4.67 : 1, but the preset has used `lime-800` 6.64 : 1 since before the proposal was written. Updated § 2.1 prose, both contrast tables, and the trailing margin note so the implementation PRs that follow this one don't accidentally regress nutrition contrast.

## Why

The merged proposal #853 codifies *what* needs to land; this PR ships the *first* mechanical step — token additions, no behavioural change. Splitting the migration into separate PRs (tokens / primitives / re-add `/design` to axe SURFACES) keeps each diff reviewable on its own and makes it obvious which step introduced any visual regression.

## How to test

```bash
pnpm --filter @sergeant/design-tokens test    # 9 passed (tokens.js + mobile.js snapshots untouched)
pnpm --filter @sergeant/web build              # succeeds
```

To eyeball the new tokens resolve correctly:

```bash
node --input-type=module -e "
import preset from './packages/design-tokens/tailwind-preset.js';
const c = preset.theme.extend.colors;
console.log({brand: c.brand.strong, s: c['success-strong'], w: c['warning-strong'], d: c['danger-strong'], i: c['info-strong']});
"
# → { brand: '#047857', s: '#047857', w: '#b45309', d: '#b91c1c', i: '#0369a1' }
```

Visual diff: **zero**, because no component uses the new utilities yet.

## How AI-tested this PR

- [x] Manual smoke (which flow?): N/A — additive token-only PR. Verified via `pnpm --filter @sergeant/design-tokens test` (9 passed) and `pnpm --filter @sergeant/web build` (clean). The `node -e` one-liner above confirms each new utility resolves to its expected hex.
- [x] Vitest passes: design-tokens snapshot suite unchanged (only `tailwind-preset.js` touched; it isn't snapshotted).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. (Doc edit is in `docs/brand-palette-wcag-aa-proposal.md` which is English by design — sibling to `BRANDBOOK.md` / `design-system.md`.)

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. AGENTS.md will be touched in Step 2 once the `Button` / `Badge` / `Tabs` flip + the optional `sergeant-design/no-low-contrast-text-on-fill` ESLint rule land.

Link to Devin session: https://app.devin.ai/sessions/cf17a97b88c7475db936f10cafe42ab3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
