### PR TITLE
fix(web): adopt `-strong` tokens on primitives + re-arm `/design` axe gate

### DIFF
--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -1051,7 +1051,7 @@ export function DesignShowcase() {
                 variant="default"
                 padding="sm"
                 radius="lg"
-                className="motion-safe:animate-pulse-soft text-xs font-mono text-muted"
+                className="motion-safe:animate-pulse-soft text-xs font-mono text-text"
               >
                 pulse-soft
               </Card>

--- a/apps/web/src/shared/components/ui/Badge.test.tsx
+++ b/apps/web/src/shared/components/ui/Badge.test.tsx
@@ -19,14 +19,18 @@ describe("Badge", () => {
     expect(el.className).toContain("text-fg-muted");
   });
 
-  it("solid tone uses saturated accent + white text for variant='success'", () => {
+  it("solid tone uses WCAG-AA accent + white text for variant='success'", () => {
     const { container } = render(
       <Badge tone="solid" variant="success">
         OK
       </Badge>,
     );
     const el = container.querySelector("span")!;
-    expect(el.className).toContain("bg-brand-700");
+    // `bg-success-strong` (= emerald-700) clears 5.48:1 against
+    // text-white. The previous `bg-brand-700` resolved to the same hex,
+    // but the semantic name pairs better with the WCAG-AA contract in
+    // docs/brand-palette-wcag-aa-proposal.md.
+    expect(el.className).toContain("bg-success-strong");
     expect(el.className).toContain("text-white");
   });
 
@@ -38,7 +42,9 @@ describe("Badge", () => {
     );
     const el = container.querySelector("span")!;
     expect(el.className).toContain("bg-transparent");
-    expect(el.className).toContain("text-finyk");
+    // `text-finyk-strong` (= emerald-700) clears WCAG AA on cream `bg-bg`;
+    // the previous `text-finyk` (=emerald-500) only cleared ~2.4:1.
+    expect(el.className).toContain("text-finyk-strong");
     expect(el.className).toContain("border-finyk/60");
   });
 

--- a/apps/web/src/shared/components/ui/Badge.tsx
+++ b/apps/web/src/shared/components/ui/Badge.tsx
@@ -31,17 +31,21 @@ export type BadgeTone = "soft" | "solid" | "outline";
 
 export type BadgeSize = "xs" | "sm" | "md";
 
+// Solid tones use `bg-{c}-strong text-white` (5.0–7.0:1) so labels stay
+// readable at body sizes. The previous `bg-{c} text-white` failed WCAG
+// AA (~2.5:1) for every brand / status / module token. See
+// docs/brand-palette-wcag-aa-proposal.md § 2.2.
 const solidVariants: Record<BadgeVariant, string> = {
   neutral: "bg-fg-muted/90 text-surface border-transparent",
-  accent: "bg-accent text-white border-transparent",
-  success: "bg-brand-700 text-white border-transparent",
-  warning: "bg-warning text-white border-transparent",
-  danger: "bg-danger text-white border-transparent",
-  info: "bg-info text-white border-transparent",
-  finyk: "bg-finyk text-white border-transparent",
-  fizruk: "bg-fizruk text-white border-transparent",
-  routine: "bg-routine text-white border-transparent",
-  nutrition: "bg-nutrition text-white border-transparent",
+  accent: "bg-brand-strong text-white border-transparent",
+  success: "bg-success-strong text-white border-transparent",
+  warning: "bg-warning-strong text-white border-transparent",
+  danger: "bg-danger-strong text-white border-transparent",
+  info: "bg-info-strong text-white border-transparent",
+  finyk: "bg-finyk-strong text-white border-transparent",
+  fizruk: "bg-fizruk-strong text-white border-transparent",
+  routine: "bg-routine-strong text-white border-transparent",
+  nutrition: "bg-nutrition-strong text-white border-transparent",
 };
 
 const softVariants: Record<BadgeVariant, string> = {
@@ -53,7 +57,7 @@ const softVariants: Record<BadgeVariant, string> = {
   warning:
     "bg-amber-50 text-amber-700 border-amber-200/70 dark:bg-amber-500/15 dark:text-amber-300 dark:border-amber-500/30",
   danger:
-    "bg-danger-soft text-danger border-danger/30 dark:bg-danger/15 dark:border-danger/30",
+    "bg-danger-soft text-danger-strong border-danger/30 dark:bg-danger/15 dark:text-red-200 dark:border-danger/30",
   info: "bg-blue-50 text-blue-700 border-blue-200/70 dark:bg-info/15 dark:text-blue-300 dark:border-info/30",
   finyk:
     "bg-finyk-soft text-finyk-strong border-finyk-ring/50 dark:bg-finyk-surface-dark/15 dark:text-finyk dark:border-finyk-border-dark/30",
@@ -65,17 +69,21 @@ const softVariants: Record<BadgeVariant, string> = {
     "bg-nutrition-soft text-nutrition-strong border-nutrition-ring/50 dark:bg-nutrition-surface-dark/15 dark:text-nutrition dark:border-nutrition-border-dark/30",
 };
 
+// Outline tones place coloured text directly on the page background.
+// Borders aren't text, so the brand `*-500` shade stays at 60 % alpha
+// for the outline; the *label* uses `text-{c}-strong` (≥4.5:1 on
+// cream `bg-bg`).
 const outlineVariants: Record<BadgeVariant, string> = {
   neutral: "border-line text-fg-muted bg-transparent",
-  accent: "border-accent/60 text-accent bg-transparent",
-  success: "border-success/60 text-success bg-transparent",
-  warning: "border-warning/60 text-warning bg-transparent",
-  danger: "border-danger/60 text-danger bg-transparent",
-  info: "border-info/60 text-info bg-transparent",
-  finyk: "border-finyk/60 text-finyk bg-transparent",
-  fizruk: "border-fizruk/60 text-fizruk bg-transparent",
-  routine: "border-routine/60 text-routine bg-transparent",
-  nutrition: "border-nutrition/60 text-nutrition bg-transparent",
+  accent: "border-accent/60 text-brand-strong bg-transparent",
+  success: "border-success/60 text-success-strong bg-transparent",
+  warning: "border-warning/60 text-warning-strong bg-transparent",
+  danger: "border-danger/60 text-danger-strong bg-transparent",
+  info: "border-info/60 text-info-strong bg-transparent",
+  finyk: "border-finyk/60 text-finyk-strong bg-transparent",
+  fizruk: "border-fizruk/60 text-fizruk-strong bg-transparent",
+  routine: "border-routine/60 text-routine-strong bg-transparent",
+  nutrition: "border-nutrition/60 text-nutrition-strong bg-transparent",
 };
 
 const sizes: Record<BadgeSize, string> = {

--- a/apps/web/src/shared/components/ui/Button.test.tsx
+++ b/apps/web/src/shared/components/ui/Button.test.tsx
@@ -48,9 +48,13 @@ describe("Button", () => {
     expect(ref.current?.textContent).toBe("Ok");
   });
 
-  it("applies variant classes (primary → bg-brand-500)", () => {
+  it("applies variant classes (primary → bg-brand-strong text-white)", () => {
     const { getByRole } = render(<Button variant="primary">Go</Button>);
-    expect(getByRole("button").className).toContain("bg-brand-500");
+    const cls = getByRole("button").className;
+    // `bg-brand-strong` (= emerald-700) clears WCAG AA against text-white
+    // — see docs/brand-palette-wcag-aa-proposal.md.
+    expect(cls).toContain("bg-brand-strong");
+    expect(cls).toContain("text-white");
   });
 
   it("applies size classes distinctly for md vs xs", () => {

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -39,28 +39,36 @@ export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 const variants: Record<ButtonVariant, string> = {
   // Core variants
+  // `bg-brand-strong` = emerald-700 (5.48:1 vs text-white) — clears WCAG
+  // AA at body sizes. Saturated `bg-brand-500` failed at ~2.5:1; see
+  // docs/brand-palette-wcag-aa-proposal.md § 2.2.
   primary:
-    "bg-brand-500 text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-700 active:scale-[0.98]",
+    "bg-brand-strong text-white shadow-sm hover:bg-brand-800 hover:shadow-glow active:bg-brand-900 active:scale-[0.98]",
   secondary:
     "bg-panel text-text border border-line shadow-sm hover:bg-panelHi hover:border-brand-200 active:scale-[0.98]",
   ghost:
     "bg-transparent text-muted hover:bg-panelHi hover:text-text active:bg-line/50",
   danger:
-    "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
+    "bg-danger-soft text-danger-strong border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
-    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-danger-ring active:scale-[0.98]",
+    "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-danger-ring active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
 
-  // Module-specific branded buttons
+  // Module-specific branded buttons. `bg-{module}-strong` = the
+  // module's `[700]` (or lime-800 for nutrition) — clears WCAG AA on
+  // text-white (5.0–7.0:1). Hover stays at the existing `*-hover`
+  // shade (= brand-600) which is one step *lighter* than the new base;
+  // that’s the same hover-on-pressed pattern Apple/Material use for
+  // dark CTAs.
   finyk:
-    "bg-finyk text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
+    "bg-finyk-strong text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
   fizruk:
-    "bg-fizruk text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
+    "bg-fizruk-strong text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
   routine:
-    "bg-routine text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
+    "bg-routine-strong text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
   nutrition:
-    "bg-nutrition text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
+    "bg-nutrition-strong text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
 
   // Soft module variants (for secondary actions within modules).
   // Dark mode swaps the light pastel surface for the saturated accent at

--- a/apps/web/src/shared/components/ui/FormField.tsx
+++ b/apps/web/src/shared/components/ui/FormField.tsx
@@ -129,7 +129,7 @@ export function FormField({
       {hasError ? (
         <p
           id={`${controlId}-error`}
-          className="text-xs text-danger mt-1"
+          className="text-xs text-danger-strong mt-1"
           role="alert"
         >
           {error}

--- a/apps/web/src/shared/components/ui/SectionHeading.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.tsx
@@ -67,9 +67,12 @@ const variants: Record<SectionHeadingVariant, string> = {
   subtle: "text-subtle",
   muted: "text-muted",
   text: "text-text",
-  // `accent` uses the global --c-accent (emerald by default). Resolves
-  // per-module if a parent scopes the CSS variable.
-  accent: "text-accent",
+  // `accent` uses `text-brand-strong` (= emerald-700) instead of the
+  // global `--c-accent` token (= emerald-500). The latter only clears
+  // ~2.4:1 against the cream `bg-bg`; `-strong` clears 5.23:1. See
+  // docs/brand-palette-wcag-aa-proposal.md § 2.2 and the SectionHeading
+  // contract test that pins the className.
+  accent: "text-brand-strong",
   // Module-branded tints — normalised to /70 so callers don't drift
   // between /70, /80, /90.
   finyk: "text-finyk-strong dark:text-finyk/70",

--- a/apps/web/src/shared/components/ui/Segmented.test.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.test.tsx
@@ -57,7 +57,9 @@ describe("Segmented", () => {
       />,
     );
     const active = getAllByRole("tab")[0];
-    expect(active.className).toContain("bg-fizruk");
+    // `bg-fizruk-strong` (= teal-700) clears 5.47:1 against text-white.
+    // The previous `bg-fizruk` (= teal-500) only cleared ~2.5:1.
+    expect(active.className).toContain("bg-fizruk-strong");
     expect(active.className).toContain("text-white");
   });
 

--- a/apps/web/src/shared/components/ui/Segmented.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.tsx
@@ -53,12 +53,16 @@ export interface SegmentedProps<V extends string = string> {
   className?: string;
 }
 
+// Solid mode pairs `bg-{c}-strong text-white` (5.0–7.0:1) so the active
+// segment label stays readable at 12 px. Border keeps the brand `*-500`
+// for visual continuity with siblings; borders aren't text. See
+// docs/brand-palette-wcag-aa-proposal.md § 2.2.
 const VARIANT_SOLID: Record<SegmentedVariant, string> = {
-  brand: "bg-brand text-white border-brand",
-  fizruk: "bg-fizruk text-white border-fizruk",
-  routine: "bg-routine text-white border-routine",
-  nutrition: "bg-nutrition text-white border-nutrition",
-  finyk: "bg-finyk text-white border-finyk",
+  brand: "bg-brand-strong text-white border-brand",
+  fizruk: "bg-fizruk-strong text-white border-fizruk",
+  routine: "bg-routine-strong text-white border-routine",
+  nutrition: "bg-nutrition-strong text-white border-nutrition",
+  finyk: "bg-finyk-strong text-white border-finyk",
 };
 
 const VARIANT_SOFT: Record<SegmentedVariant, string> = {

--- a/apps/web/src/shared/components/ui/Stat.tsx
+++ b/apps/web/src/shared/components/ui/Stat.tsx
@@ -29,15 +29,21 @@ export type StatVariant =
 
 export type StatSize = "sm" | "md" | "lg";
 
+// `text-{c}-strong` (= `[700]`, lime-800 for nutrition) keeps Stat
+// numbers readable at body sizes against cream `bg-bg`. The previous
+// `text-{c}` (= `[500]`) only cleared ~2.4:1 — the `text-2xl` size
+// nominally exempts it from the 4.5:1 rule (large-text 3:1), but the
+// nested `<span>` value isn't `font-bold`, so axe applies the regular
+// threshold. See docs/brand-palette-wcag-aa-proposal.md.
 const variantClass: Record<StatVariant, string> = {
   default: "text-text",
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger",
-  finyk: "text-finyk",
-  fizruk: "text-fizruk",
-  routine: "text-routine",
-  nutrition: "text-nutrition",
+  success: "text-success-strong",
+  warning: "text-warning-strong",
+  danger: "text-danger-strong",
+  finyk: "text-finyk-strong",
+  fizruk: "text-fizruk-strong",
+  routine: "text-routine-strong",
+  nutrition: "text-nutrition-strong",
 };
 
 const valueSize: Record<StatSize, string> = {

--- a/apps/web/src/shared/components/ui/Tabs.test.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.test.tsx
@@ -98,7 +98,9 @@ describe("Tabs", () => {
     );
     const active = getAllByRole("tab")[0];
     expect(active.className).toContain("border-finyk");
-    expect(active.className).toContain("text-finyk");
+    // `text-finyk-strong` (=emerald-700) clears WCAG AA on cream `bg-bg`;
+    // the previous `text-finyk` (=emerald-500) only cleared ~2.4:1.
+    expect(active.className).toContain("text-finyk-strong");
   });
 
   it("omits aria-controls when no getPanelId is provided (avoids dangling IDREFs)", () => {

--- a/apps/web/src/shared/components/ui/Tabs.tsx
+++ b/apps/web/src/shared/components/ui/Tabs.tsx
@@ -74,12 +74,16 @@ export interface TabsProps<V extends string = string> {
   tabsClassName?: string;
 }
 
+// Active-tab text on the page background. The brand `*-500` shade only
+// clears ~2.5:1 on cream `bg-bg`; the `*-strong` companion (= `[700]`,
+// or lime-800 for nutrition) clears ≥4.5:1. See
+// docs/brand-palette-wcag-aa-proposal.md § 2.2.
 const VARIANT_TEXT: Record<TabsVariant, string> = {
-  brand: "text-brand",
-  finyk: "text-finyk",
-  fizruk: "text-fizruk",
-  routine: "text-routine",
-  nutrition: "text-nutrition",
+  brand: "text-brand-strong",
+  finyk: "text-finyk-strong",
+  fizruk: "text-fizruk-strong",
+  routine: "text-routine-strong",
+  nutrition: "text-nutrition-strong",
 };
 
 const VARIANT_UNDERLINE: Record<TabsVariant, string> = {

--- a/apps/web/tests/a11y/axe.spec.ts
+++ b/apps/web/tests/a11y/axe.spec.ts
@@ -45,28 +45,15 @@ const SURFACES: Array<{ name: string; path: string }> = [
   { name: "fizruk-dashboard", path: "/?module=fizruk" },
   { name: "nutrition-dashboard", path: "/?module=nutrition" },
   { name: "routine-dashboard", path: "/?module=routine" },
-  // NOTE: `/design` (DesignShowcase) is intentionally NOT in this list.
-  // The page renders the full primitive catalogue (every brand colour ×
-  // tone × variant × size), which surfaces ~70 axe violations that are
-  // systemic to the design tokens, not to this spec or the four module
-  // surfaces above:
-  //   - color-contrast (63 nodes, serious): brand palette (#10b981 emerald,
-  //     #14b8a6 teal, #92cc17 lime, #f97066 coral, #f59e0b warning, #0ea5e9
-  //     info) on `text-white` solids, plus `text-<accent>` labels rendered
-  //     ON the showcase background, fail WCAG 4.5:1. Fixing requires
-  //     re-tuning the design tokens (separate design-system PR).
-  //   - aria-valid-attr-value (6 nodes, critical): the Tabs primitive
-  //     emits `aria-controls={baseId}-panel-{value}` but consumers of the
-  //     showcase don't render matching panels, so the IDREF resolves to
-  //     nothing. Tracked as a follow-up to make `aria-controls` opt-in.
-  //   - select-name (4 nodes, critical): `<Select>` examples in the
-  //     showcase are rendered without surrounding `<FormField>`, so they
-  //     have no accessible name. Easy follow-up to add `aria-label`s to
-  //     the showcase examples.
-  // Re-add this entry once the contrast / Tabs / Select follow-ups land
-  // (so axe gates the primitives at the showcase level — same intent as
-  // commit 8e9d8833). For now the four module surfaces above already
-  // catch a11y regressions in production-shaped DOM.
+  // /design (DesignShowcase) renders the full primitive catalogue —
+  // every brand × tone × variant × size combination of Button / Badge /
+  // Tabs / Segmented / Stat / SectionHeading / Banner / FormField / etc.
+  // axe-gating it catches contrast & ARIA regressions at the *primitive*
+  // level before consumers do. Re-armed in PR #855 once Step 2 of the
+  // brand-palette WCAG-AA migration landed (Button/Badge/Tabs/Stat/
+  // Segmented/SectionHeading/FormField now use the `*-strong` companions
+  // documented in docs/brand-palette-wcag-aa-proposal.md).
+  { name: "design-showcase", path: "/design" },
 ];
 
 for (const { name, path } of SURFACES) {


### PR DESCRIPTION
## What changed

Steps 2 + 3 of the brand-palette WCAG-AA migration laid out in [`docs/brand-palette-wcag-aa-proposal.md`](https://github.com/Skords-01/Sergeant/blob/main/docs/brand-palette-wcag-aa-proposal.md). Step 1 ([#854](https://github.com/Skords-01/Sergeant/pull/854)) added the `*-strong` tokens **additively**; this PR flips the consumers and re-arms the `/design` axe gate that PR [#851](https://github.com/Skords-01/Sergeant/pull/851) had to drop.

**Primitive flips (`apps/web/src/shared/components/ui/`)**

| Component       | Change |
| --------------- | ------ |
| `Button`        | `primary` `bg-brand-500` → `bg-brand-strong` (5.48 : 1 vs white). `destructive` `bg-danger` → `bg-danger-strong`. `danger` soft text → `text-danger-strong`. `finyk` / `fizruk` / `routine` / `nutrition` solids → `bg-{c}-strong`. |
| `Badge`         | All `solid` / `soft` / `outline` tones for `accent` / `success` / `warning` / `danger` / `info` / `finyk` / `fizruk` / `routine` / `nutrition` → `*-strong` companions on the **text** side. Borders keep brand `*-500/60`. |
| `Tabs`          | `VARIANT_TEXT` (active-label colour, underline & pill styles) → `*-strong`. |
| `Segmented`     | `VARIANT_SOLID` → `bg-{c}-strong text-white`. Border stays at `*-500` (borders aren't text). |
| `Stat`          | `variantClass` for `success` / `warning` / `danger` / `finyk` / `fizruk` / `routine` / `nutrition` → `*-strong`. `text-2xl` qualifies for WCAG AA Large 3 : 1, but the inner `<span>` wrapping the numeric value isn't `font-bold`, so axe applies the regular 4.5 : 1 rule. |
| `SectionHeading`| `accent` variant → `text-brand-strong` (was `text-accent`, which resolved to emerald-500 / 2.4 : 1 on cream). |
| `FormField`     | Error message → `text-danger-strong`. |
| `DesignShowcase`| `pulse-soft` demo card → `text-text`. `text-muted` is fine for body sizes but only clears 4.02 : 1 at `text-xs` against `bg-panel`. |

**axe gate change**

`apps/web/tests/a11y/axe.spec.ts`: re-add `/design` to `SURFACES` as `design-showcase`. The placeholder doc-comment listing the blocking violations is removed and replaced with a brief note on what the surface gates now.

## Why

The merged proposal #853 codifies the strategy; #854 shipped the tokens; this PR closes the loop. With `/design` back in axe, every brand × tone × variant × size combination of every primitive is now contrast-gated in CI — regressions on brand-palette legibility get caught at the primitive level before any module surface notices.

Visual delta: brand CTAs and module-coloured solids are noticeably **darker** (emerald-500 → emerald-700, etc.). This is the documented trade-off in `docs/brand-palette-wcag-aa-proposal.md` § 2.2 — saturation for legibility.

## How to test

```bash
# UI primitive tests (88 specs, 13 files)
cd apps/web && pnpm vitest run src/shared/components/ui

# Full axe gate — all 6 surfaces including /design
pnpm exec playwright test tests/a11y/axe.spec.ts
```

Local results:

```
✓ a11y: hub-root has no serious/critical violations           (3.1s)
✓ a11y: finyk-overview has no serious/critical violations      (2.0s)
✓ a11y: fizruk-dashboard has no serious/critical violations    (2.1s)
✓ a11y: nutrition-dashboard has no serious/critical violations (2.3s)
✓ a11y: routine-dashboard has no serious/critical violations   (2.4s)
✓ a11y: design-showcase has no serious/critical violations     (4.8s)
6 passed (18.2s)

Test Files  13 passed (13)
     Tests  88 passed (88)
```

`pnpm --filter @sergeant/web lint` clean.

## How AI-tested this PR

- [x] Manual smoke (which flow?): rebuilt `apps/web`, ran the full axe spec against the preview server. Six surfaces (hub + 4 modules + `/design`) all green. Earlier debug runs against `/design` showed the violation count dropping 60 → 14 → 0 as each primitive was migrated, which confirmed the changes target the right surfaces.
- [x] Vitest passes: 88 UI primitive tests, including the updated assertions in `Button.test.tsx`, `Badge.test.tsx`, `Tabs.test.tsx`, `Segmented.test.tsx` that pin the new `*-strong` class names.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. (No prose changes in this PR — only inline code comments referencing the existing English design doc.)

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. The `/design` re-arm caps a multi-PR initiative whose contract already lives in `docs/brand-palette-wcag-aa-proposal.md`. AGENTS.md will be touched only if/when the optional `sergeant-design/no-low-contrast-text-on-fill` lint rule from § 4 of the proposal is implemented as a follow-up.

Link to Devin session: https://app.devin.ai/sessions/cf17a97b88c7475db936f10cafe42ab3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text contrast across UI components for better readability and WCAG AA accessibility compliance.
  * Enhanced color intensity for buttons, badges, form fields, tabs, segmented controls, and stat displays.
  * Strengthened error message colors for improved visibility in form validation feedback.

* **Tests**
  * Updated accessibility test coverage to include design system validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->