### PR TITLE
feat(design-tokens): mobile `*Strong` colour parity with web `-strong` tier

### DIFF
--- a/packages/design-tokens/__snapshots__/tokens.test.js.snap
+++ b/packages/design-tokens/__snapshots__/tokens.test.js.snap
@@ -3,15 +3,20 @@
 exports[`@sergeant/design-tokens — mobile.js > mobile.colors matches the canonical web moduleColors + statusColors 1`] = `
 {
   "accent": "#10b981",
+  "accentStrong": "#047857",
   "bg": "#0b0d10",
   "border": "#1f242c",
   "danger": "#ef4444",
+  "dangerStrong": "#b91c1c",
   "info": "#0ea5e9",
+  "infoStrong": "#0369a1",
   "success": "#10b981",
+  "successStrong": "#047857",
   "surface": "#13161b",
   "text": "#f2f4f7",
   "textMuted": "#8a94a6",
   "warning": "#f59e0b",
+  "warningStrong": "#b45309",
 }
 `;
 

--- a/packages/design-tokens/mobile.d.ts
+++ b/packages/design-tokens/mobile.d.ts
@@ -15,7 +15,14 @@ export type MobileColor =
   | "success"
   | "warning"
   | "danger"
-  | "info";
+  | "info"
+  // WCAG-AA companions sized for light surfaces. See `mobile.js` AI-CONTEXT
+  // for when to use these (only on light-mode rendering paths).
+  | "accentStrong"
+  | "successStrong"
+  | "warningStrong"
+  | "dangerStrong"
+  | "infoStrong";
 
 /** Mobile spacing scale identifiers (pixel values defined in `mobile.js`). */
 export type MobileSpacing = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";

--- a/packages/design-tokens/mobile.js
+++ b/packages/design-tokens/mobile.js
@@ -21,12 +21,36 @@
  *   warning: string;
  *   danger: string;
  *   info: string;
+ *   accentStrong: string;
+ *   successStrong: string;
+ *   warningStrong: string;
+ *   dangerStrong: string;
+ *   infoStrong: string;
  * }>}
  *
  * AI-NOTE: `accent` must match web `statusColors.success` / `--c-accent`
  * (#10b981, emerald-500) so that Sergeant's brand accent is identical
  * cross-platform. Keep `success` / `warning` / `danger` / `info` aligned
  * with `statusColors` in `./tokens.js`.
+ *
+ * AI-CONTEXT: `*Strong` companions mirror the web `*-strong` Tailwind
+ * tokens introduced in PR #854 / docs/brand-palette-wcag-aa-proposal.md.
+ * On the current *dark-only* mobile theme the saturated `*` shades already
+ * clear WCAG AA against `bg` / `surface` (emerald-500 ≈ 5.4:1, amber-500
+ * ≈ 8.3:1, etc.) — `*Strong` is **not** required there, and using it on
+ * dark surfaces would actually regress contrast (emerald-700 ≈ 2.0:1 on
+ * `#13161b`). The fields are exported now so RN primitives can adopt the
+ * same naming the web uses, and so when mobile gains a *light* theme
+ * (`darkMode: "class"` is already wired in `apps/mobile/tailwind.config.js`)
+ * the strong shades become the correct on-cream choice without another
+ * token migration. Components rendering on the current dark theme should
+ * keep using the saturated `*` value; switch to `*Strong` only inside
+ * code paths gated on the light scheme.
+ *
+ * NativeWind utilities `bg-{c}-strong` / `text-{c}-strong` are already
+ * available via `tailwind-preset.js` — these JS exports cover the
+ * StyleSheet-based consumers (`StyleSheet.create({ color: colors.* })`)
+ * that don't go through NativeWind's class-name interop.
  */
 export const colors = Object.freeze({
   bg: "#0b0d10",
@@ -39,6 +63,13 @@ export const colors = Object.freeze({
   warning: "#f59e0b",
   danger: "#ef4444",
   info: "#0ea5e9",
+  // WCAG-AA companions for light surfaces (see AI-CONTEXT above).
+  // emerald-700 / amber-700 / red-700 / sky-700.
+  accentStrong: "#047857",
+  successStrong: "#047857",
+  warningStrong: "#b45309",
+  dangerStrong: "#b91c1c",
+  infoStrong: "#0369a1",
 });
 
 /** @type {Readonly<{ xs: number; sm: number; md: number; lg: number; xl: number; xxl: number; }>} */


### PR DESCRIPTION
## What changed

Adds the five `*Strong` companions to `@sergeant/design-tokens/mobile` so RN consumers that style through `StyleSheet.create({ color: colors.* })` (the path that **doesn't** go through NativeWind's class-name interop) can reach the same WCAG-AA tier the web tailwind preset already exposes.

| Mobile key       | Hex       | Web equivalent          | Comment |
| ---------------- | --------- | ----------------------- | ------- |
| `accentStrong`   | `#047857` | `text-brand-strong`     | emerald-700 |
| `successStrong`  | `#047857` | `text-success-strong`   | emerald-700 |
| `warningStrong`  | `#b45309` | `text-warning-strong`   | amber-700 |
| `dangerStrong`   | `#b91c1c` | `text-danger-strong`    | red-700 |
| `infoStrong`     | `#0369a1` | `text-info-strong`      | sky-700 |

NativeWind class-name companions (`bg-{c}-strong` / `text-{c}-strong`) were already exposed cross-platform through `packages/design-tokens/tailwind-preset.js` in [#854](https://github.com/Skords-01/Sergeant/pull/854) — this PR closes the gap for the imperative `StyleSheet.create` path.

Files touched:

- `packages/design-tokens/mobile.js` — five new freezable entries + an `AI-CONTEXT` block explaining usage.
- `packages/design-tokens/mobile.d.ts` — `MobileColor` union extended (mirror-rule with `mobile.js`).
- `packages/design-tokens/__snapshots__/tokens.test.js.snap` — re-recorded so the public-API snapshot reflects the new keys.

## Why

The current `apps/mobile` theme is **dark-only**. On the dark surfaces (`bg = #0b0d10`, `surface = #13161b`) the saturated `*` shades already clear WCAG AA comfortably:

| Token   | Hex       | Contrast vs `surface` |
| ------- | --------- | --------------------- |
| accent  | `#10b981` | ~5.4 : 1 |
| success | `#10b981` | ~5.4 : 1 |
| warning | `#f59e0b` | ~8.3 : 1 |
| danger  | `#ef4444` | ~5.7 : 1 |
| info    | `#0ea5e9` | ~6.2 : 1 |

Using `*Strong` on those surfaces would actually **regress** legibility (emerald-700 ≈ 2.0 : 1 on `#13161b`). So the new tokens are deliberately **forward-looking**:

1. RN primitives can adopt the same naming the web uses (less cognitive load when porting components).
2. When mobile gains a light theme (`darkMode: "class"` is already wired in `apps/mobile/tailwind.config.js`) the strong shades become the correct on-cream choice without another token migration.

The JSDoc on `colors` and an `AI-CONTEXT` marker spell out the dark-vs-light rule so RN authors don't reach for the strong shade on dark today.

This closes Step 4 ("mobile parity") of the migration plan in `docs/brand-palette-wcag-aa-proposal.md`. Steps 1–3 landed in [#854](https://github.com/Skords-01/Sergeant/pull/854) and [#855](https://github.com/Skords-01/Sergeant/pull/855).

## How to test

```bash
pnpm --filter @sergeant/design-tokens exec vitest run
pnpm --filter @sergeant/mobile exec tsc --noEmit
```

Local results: 9/9 vitest pass, mobile typecheck clean.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): N/A — pure additive token export. Snapshot diff shows the five new entries inserted alphabetically; no existing key changed.
- [x] Vitest passes: full `@sergeant/design-tokens` suite green (9 / 9); `mobile.colors` snapshot re-recorded; mobile typecheck clean.
- [x] No new `AI-DANGER` markers added without justification. Added one `AI-CONTEXT` because the dark-vs-light rule is the kind of thing a future AI agent would get wrong without the breadcrumb.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. The new comments are inline JSDoc / `AI-NOTE` / `AI-CONTEXT` blocks following the surrounding English convention of the file.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — additive token export, no new permanent rule. Tracked under the `docs/brand-palette-wcag-aa-proposal.md` migration plan (Step 4: mobile parity).

Link to Devin session: https://app.devin.ai/sessions/cf17a97b88c7475db936f10cafe42ab3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new strong color variants for mobile applications: Accent Strong, Success Strong, Warning Strong, Danger Strong, and Info Strong. These semantic color tokens are WCAG-AA compliant and optimized for light-mode rendering in mobile user interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->