### PR TITLE
docs: correct routine-strong hex + warning/danger/info contrast ratios in BRANDBOOK

### DIFF
--- a/docs/BRANDBOOK.md
+++ b/docs/BRANDBOOK.md
@@ -92,12 +92,12 @@ colour is rendered as text or as the fill behind `text-white`.**
 | --------- | ------------------ | ---------------------------------------------------------- | --------- | ------------------- | ------------------------ |
 | brand     | `#10b981`          | `bg-brand-strong` / `text-brand-strong` (= emerald-700)    | `#047857` | 5.23 : 1            | 5.48 : 1                 |
 | success   | `#10b981`          | `bg-success-strong` / `text-success-strong` (emerald-700)  | `#047857` | 5.23 : 1            | 5.48 : 1                 |
-| warning   | `#f59e0b`          | `bg-warning-strong` / `text-warning-strong` (amber-700)    | `#b45309` | 5.16 : 1            | 5.40 : 1                 |
-| danger    | `#ef4444`          | `bg-danger-strong` / `text-danger-strong` (red-700)        | `#b91c1c` | 6.43 : 1            | 6.74 : 1                 |
-| info      | `#0ea5e9`          | `bg-info-strong` / `text-info-strong` (sky-700)            | `#0369a1` | 6.59 : 1            | 6.91 : 1                 |
+| warning   | `#f59e0b`          | `bg-warning-strong` / `text-warning-strong` (amber-700)    | `#b45309` | 4.83 : 1            | 5.02 : 1                 |
+| danger    | `#ef4444`          | `bg-danger-strong` / `text-danger-strong` (red-700)        | `#b91c1c` | 6.17 : 1            | 6.47 : 1                 |
+| info      | `#0ea5e9`          | `bg-info-strong` / `text-info-strong` (sky-700)            | `#0369a1` | 5.66 : 1            | 5.93 : 1                 |
 | finyk     | `#10b981`          | `bg-finyk-strong` / `text-finyk-strong` (emerald-700)      | `#047857` | 5.23 : 1            | 5.48 : 1                 |
-| fizruk    | `#14b8a6`          | `bg-fizruk-strong` / `text-fizruk-strong` (teal-700)       | `#0f766e` | 5.21 : 1            | 5.47 : 1                 |
-| routine   | `#f97066`          | `bg-routine-strong` / `text-routine-strong` (coral-700)    | `#b62b1e` | 6.10 : 1            | 6.39 : 1                 |
+| fizruk    | `#14b8a6`          | `bg-fizruk-strong` / `text-fizruk-strong` (teal-700)       | `#0f766e` | 5.22 : 1            | 5.47 : 1                 |
+| routine   | `#f97066`          | `bg-routine-strong` / `text-routine-strong` (coral-700)    | `#c23a3a` | 5.06 : 1            | 5.30 : 1                 |
 | nutrition | `#92cc17`          | `bg-nutrition-strong` / `text-nutrition-strong` (lime-800) | `#466212` | 6.64 : 1            | 6.96 : 1                 |
 
 > **Note on nutrition.** Lime is exceptionally light at every step;


### PR DESCRIPTION
## What changed

Fixes two factual errors that Devin Review caught in the merged [#857](https://github.com/Skords-01/Sergeant/pull/857) — the WCAG-AA `-strong` Tier table in `docs/BRANDBOOK.md` had a wrong hex for `routine-strong` and overstated contrast ratios for `warning` / `danger` / `info`.

### 1. `routine-strong` hex was `#b62b1e` — wrong

Actual `brandColors.coral[700]` is `#c23a3a` ([`packages/design-tokens/tokens.js:61`](https://github.com/Skords-01/Sergeant/blob/main/packages/design-tokens/tokens.js#L61)). The contrast ratios listed (6.10 : 1 / 6.39 : 1) followed from the wrong hex; with the correct `#c23a3a` they are 5.06 : 1 / 5.30 : 1 — exactly what `docs/brand-palette-wcag-aa-proposal.md` already documented.

This is the same lookup mistake the proposal review caught earlier for `nutrition` (`lime-700` vs `lime-800`) — the BRANDBOOK now lines up with both the proposal doc and the Tailwind preset.

### 2. `warning` / `danger` / `info` ratios overstated by 0.3–0.9

The proposal table gives (verified by Node script using WCAG 2.1 § 1.4.3 formula):

| Token   | Hex       | bg-bg (was → is) | text-white (was → is) |
| ------- | --------- | ---------------: | --------------------: |
| warning | `#b45309` | 5.16 → **4.83**  | 5.40 → **5.02**       |
| danger  | `#b91c1c` | 6.43 → **6.17**  | 6.74 → **6.47**       |
| info    | `#0369a1` | 6.59 → **5.66**  | 6.91 → **5.93**       |

`warning`'s margin is genuinely thin (clears by 0.33, not 0.66) — worth knowing if anyone tries the strong tier on a darker cream surface; the previous overstatement obscured that signal.

Also bumped `fizruk` from 5.21 : 1 → 5.22 : 1 to match the proposal's single-decimal-shift figure (no behavioural change).

### Not changed

- `success` 5.23 / 5.48 — already correct (matches proposal).
- `brand` 5.23 / 5.48 — same colour as success, already correct.
- `finyk` 5.23 / 5.48 — same colour as success, already correct.
- `nutrition` 6.64 / 6.96 — already correct.

All seven families still clear WCAG AA 4.5 : 1; no token, primitive, or test logic moves. Docs-only correction.

## Why

`docs/BRANDBOOK.md` is the canonical reference designers and engineers reach for; if the hex or ratio numbers there don't match the actual tokens, anyone implementing a `StyleSheet`-based mobile component (which the doc itself suggests at lines 134-137) will pick up the wrong colour. The BRANDBOOK should mirror the proposal doc exactly for the families it covers.

## How to test

Visually inspect the rendered Markdown table at `docs/BRANDBOOK.md` lines 91-101. Compare against `docs/brand-palette-wcag-aa-proposal.md` lines 165-188 (verified equal). Run `git diff main -- docs/BRANDBOOK.md` to see the exact substitutions.

No code, no tokens, no tests change.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): cross-checked every modified row against `docs/brand-palette-wcag-aa-proposal.md` (lines 165-188) and `packages/design-tokens/tokens.js` (line 61 for `coral[700]`). All six new numbers + the corrected hex match the source.
- [x] Vitest passes: N/A — docs-only.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. The brandbook itself is in English (consistent with the surrounding sections); the PR body / commit narrative leans on the proposal doc that already documented the correct numbers.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — fix-forward of a docs-only error introduced in #857. AGENTS.md unaffected.

Link to Devin session: https://app.devin.ai/sessions/cf17a97b88c7475db936f10cafe42ab3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated brand guidelines with revised WCAG-AA-strong tier contrast mappings for warning, danger, and info semantic families.
  * Refreshed color specifications and contrast ratios for routine and fizruk semantic families to ensure accurate brand documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->