### PR TITLE
fix(web): migrate raw bg-{family} text-white call-sites to -strong tier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,32 @@ Any other step (`/7`, `/9`, `/12`, `/18`, …) is **silently dropped** — Tailw
 
 Enforced by `sergeant-design/valid-tailwind-opacity` (`error`). To add a new step, extend the `opacity` map in the preset **and** the `ALLOWED_TAILWIND_OPACITY_STEPS` constant in `packages/eslint-plugin-sergeant-design/index.js` — they must stay in sync.
 
+### 9. Saturated brand fills behind `text-white` must use the `-strong` companion
+
+Every saturated brand colour (`brand`, `accent`, `success`, `warning`, `danger`, `info`, `finyk`, `fizruk`, `routine`, `nutrition`) ships with a `-strong` companion (typically the `-700` step; `nutrition` uses `-800`) that clears WCAG 2.1 AA 4.5 : 1 against `text-white`. The saturated `-500` shades regress to ~2.4–2.8 : 1 against white — see `docs/BRANDBOOK.md` → "WCAG-AA `-strong` Tier" for the full per-family contrast table and `docs/brand-palette-wcag-aa-proposal.md` for the migration history (PRs [#854](https://github.com/Skords-01/Sergeant/pull/854) / [#855](https://github.com/Skords-01/Sergeant/pull/855) / [#857](https://github.com/Skords-01/Sergeant/pull/857)).
+
+```tsx
+// ❌ BAD — saturated brand fill behind white text fails WCAG AA at body sizes.
+<button className="bg-brand text-white">…</button>
+<button className="bg-brand-500 text-white">…</button>
+<span className="bg-fizruk text-white">…</span>
+
+// ✅ GOOD — strong companion clears AA (5.2 – 6.6 : 1).
+<button className="bg-brand-strong text-white">…</button>
+<span className="bg-fizruk-strong text-white">…</span>
+```
+
+The rule deliberately does **not** fire on:
+
+- `bg-{family}-strong text-white` — the canonical fix.
+- `bg-{family}-{700,800,900}` — explicit dark steps already clear AA.
+- `bg-{family}/N` — opacity-tinted soft washes; the foreground is `text-{family}-strong`, not white.
+- `bg-[#hex] text-white` — arbitrary values; deliberate one-off opt-out.
+- `dark:bg-{family} text-white` — on dark surfaces emerald-500 vs. white passes ~5.4 : 1; the strong tier would actually regress contrast.
+- `hover:bg-{family} text-white` — hover-only saturated bg if the base state is fine.
+
+Enforced by `sergeant-design/no-low-contrast-text-on-fill` (`error`). The four saturated `*-500` brand-identity tokens in `packages/design-tokens/tokens.js` remain unchanged — they're still the canonical brand colours for logos, marketing assets, and dark-mode bento surfaces. The strong tier is purely additive and only required for text/fill-behind-text contexts.
+
 ## AI markers
 
 Structured comments for AI-agent context. Enforced by ESLint rule `sergeant-design/ai-marker-syntax` (warn).

--- a/apps/web/src/core/app/ActiveWorkoutBanner.tsx
+++ b/apps/web/src/core/app/ActiveWorkoutBanner.tsx
@@ -42,7 +42,7 @@ export function ActiveWorkoutBanner({ hidden = false }: { hidden?: boolean }) {
           aria-hidden
         >
           <Icon name="dumbbell" size={16} strokeWidth={2.25} />
-          <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-success ring-2 ring-fizruk motion-safe:animate-pulse" />
+          <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-success ring-2 ring-fizruk-strong motion-safe:animate-pulse" />
         </span>
         <span className="text-sm font-semibold whitespace-nowrap">
           Тренування триває

--- a/apps/web/src/core/app/ActiveWorkoutBanner.tsx
+++ b/apps/web/src/core/app/ActiveWorkoutBanner.tsx
@@ -34,7 +34,7 @@ export function ActiveWorkoutBanner({ hidden = false }: { hidden?: boolean }) {
       <button
         type="button"
         onClick={() => openHubModule("fizruk", "#workouts")}
-        className="pointer-events-auto flex items-center gap-2.5 h-12 pl-3 pr-4 rounded-full bg-fizruk text-white shadow-float hover:brightness-110 transition-[filter,box-shadow,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        className="pointer-events-auto flex items-center gap-2.5 h-12 pl-3 pr-4 rounded-full bg-fizruk-strong text-white shadow-float hover:brightness-110 transition-[filter,box-shadow,opacity] focus:outline-none focus-visible:ring-2 focus-visible:ring-fizruk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         aria-label="Повернутись до активного тренування"
       >
         <span

--- a/apps/web/src/core/app/BrandLogo.tsx
+++ b/apps/web/src/core/app/BrandLogo.tsx
@@ -131,7 +131,7 @@ export function BrandLogo({
     >
       <span
         aria-hidden="true"
-        className="inline-flex items-center justify-center bg-brand-500 text-white shadow-[0_1px_2px_rgba(16,185,129,0.25),0_4px_12px_-2px_rgba(16,185,129,0.35)]"
+        className="inline-flex items-center justify-center bg-brand-strong text-white shadow-[0_1px_2px_rgba(16,185,129,0.25),0_4px_12px_-2px_rgba(16,185,129,0.35)]"
         style={{
           width: badgePx,
           height: badgePx,

--- a/apps/web/src/core/app/OfflineBanner.tsx
+++ b/apps/web/src/core/app/OfflineBanner.tsx
@@ -27,7 +27,7 @@ export function OfflineBanner() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed top-0 left-0 right-0 z-[300] flex items-center justify-center gap-2 px-4 py-2 bg-warning text-white text-xs font-semibold safe-area-pt shadow-soft"
+      className="fixed top-0 left-0 right-0 z-[300] flex items-center justify-center gap-2 px-4 py-2 bg-warning-strong text-white text-xs font-semibold safe-area-pt shadow-soft"
     >
       <Icon name="wifi-off" size={14} strokeWidth={2.5} aria-hidden />
       <span className="truncate max-w-[min(92vw,40rem)]">{label}</span>

--- a/apps/web/src/core/components/ChatInput.tsx
+++ b/apps/web/src/core/components/ChatInput.tsx
@@ -155,7 +155,7 @@ export function ChatInput({
           className={cn(
             "w-11 h-11 rounded-full flex items-center justify-center shrink-0 transition-[background-color,border-color,color,opacity] border focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel",
             listening
-              ? "bg-danger text-white border-danger motion-safe:animate-pulse"
+              ? "bg-danger-strong text-white border-danger-strong motion-safe:animate-pulse"
               : "bg-panel border-line text-muted hover:text-text hover:border-muted",
           )}
           title={listening ? "Зупинити запис" : "Голосовий ввід"}

--- a/apps/web/src/core/hub/HubReports.tsx
+++ b/apps/web/src/core/hub/HubReports.tsx
@@ -436,7 +436,7 @@ export function HubReports() {
               className={cn(
                 "px-3 py-1.5 text-xs font-medium transition-colors",
                 period === p
-                  ? "bg-brand-500 text-white"
+                  ? "bg-brand-strong text-white"
                   : "text-muted hover:text-text hover:bg-panelHi",
               )}
             >

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -210,7 +210,7 @@ function ModuleCard({
       )}
     >
       {active && (
-        <span className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-500 text-white flex items-center justify-center">
+        <span className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-strong text-white flex items-center justify-center">
           <Icon name="check" size={12} strokeWidth={3} />
         </span>
       )}

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -401,7 +401,7 @@ export default function App({
             setEditingManualExpenseId(null);
             setShowExpenseSheet(true);
           }}
-          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-[background-color,box-shadow,opacity,transform] duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
+          className="fixed bottom-[calc(60px+env(safe-area-inset-bottom,0px)+16px)] right-4 w-12 h-12 rounded-full bg-finyk-strong text-white shadow-float flex items-center justify-center text-2xl hover:bg-finyk-hover hover:shadow-glow hover:scale-105 active:scale-95 transition-[background-color,box-shadow,opacity,transform] duration-200 ease-smooth z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finyk/45 focus-visible:ring-offset-2 focus-visible:ring-offset-panel"
           aria-label="Додати витрату"
         >
           +

--- a/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
+++ b/apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx
@@ -56,7 +56,7 @@ function AddBudgetFormComponent({
           className={cn(
             "flex-1 py-2 text-sm font-semibold rounded-xl border transition-colors",
             formType === "goal"
-              ? "bg-success border-success text-white"
+              ? "bg-success-strong border-success-strong text-white"
               : "border-line text-subtle",
           )}
         >

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -403,7 +403,7 @@ export function WorkoutTemplatesSection({
                 {typeof onStartTemplate === "function" && (
                   <Button
                     size="sm"
-                    className="h-10 min-h-[44px] px-3 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk/90"
+                    className="h-10 min-h-[44px] px-3 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk-strong/90"
                     onClick={() => onStartTemplate(t)}
                     disabled={!(t.exerciseIds || []).length}
                   >

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -260,7 +260,7 @@ export function WorkoutTemplatesSection({
                       {groupSelectMode && (
                         <button
                           type="button"
-                          className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success border-success text-white" : "border-line bg-bg"}`}
+                          className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
                           onClick={() => handleToggleGroupSelect(id)}
                         >
                           {isSelected && (
@@ -403,7 +403,7 @@ export function WorkoutTemplatesSection({
                 {typeof onStartTemplate === "function" && (
                   <Button
                     size="sm"
-                    className="h-10 min-h-[44px] px-3 bg-fizruk text-white border-fizruk hover:bg-fizruk/90"
+                    className="h-10 min-h-[44px] px-3 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk/90"
                     onClick={() => onStartTemplate(t)}
                     disabled={!(t.exerciseIds || []).length}
                   >

--- a/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -162,7 +162,7 @@ export function ExerciseDetailSheet({
       {mode === "log" && (
         <Button
           type="button"
-          className="w-full h-12 mt-5 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk/90"
+          className="w-full h-12 mt-5 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk-strong/90"
           onClick={() => {
             if (!activeWorkoutId) {
               toast?.warning("Спочатку натисни «+ Нове» у блоці вище.");

--- a/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx
@@ -162,7 +162,7 @@ export function ExerciseDetailSheet({
       {mode === "log" && (
         <Button
           type="button"
-          className="w-full h-12 mt-5 bg-fizruk text-white border-fizruk hover:bg-fizruk/90"
+          className="w-full h-12 mt-5 bg-fizruk-strong text-white border-fizruk-strong hover:bg-fizruk/90"
           onClick={() => {
             if (!activeWorkoutId) {
               toast?.warning("Спочатку натисни «+ Нове» у блоці вище.");

--- a/apps/web/src/modules/fizruk/components/workouts/WarmupCooldownChecklist.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WarmupCooldownChecklist.tsx
@@ -55,7 +55,7 @@ export function WarmupCooldownChecklist({
           <li key={item.id} className="flex items-center gap-2">
             <button
               type="button"
-              className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${item.done ? "bg-success border-success text-white" : "border-line bg-bg"}`}
+              className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${item.done ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
               onClick={() => onToggle(item.id)}
               aria-label={
                 item.done

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
@@ -83,7 +83,7 @@ export function WorkoutItemCard({
             {groupSelectMode && (
               <button
                 type="button"
-                className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success border-success text-white" : "border-line bg-bg"}`}
+                className={`w-5 h-5 rounded-md border flex items-center justify-center flex-shrink-0 transition-colors ${isSelected ? "bg-success-strong border-success-strong text-white" : "border-line bg-bg"}`}
                 onClick={() => onToggleGroupSelect(it.id)}
               >
                 {isSelected && (

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -174,7 +174,7 @@ function ScoreButton({ value, selected, onClick, label }) {
       className={cn(
         "flex-1 flex flex-col items-center gap-1 py-2.5 rounded-xl border text-xs font-semibold transition-[background-color,border-color,color,opacity]",
         selected
-          ? "bg-success text-white border-success"
+          ? "bg-success-strong text-white border-success-strong"
           : "border-line text-subtle hover:border-success/50 hover:text-text",
       )}
       aria-pressed={selected}
@@ -468,8 +468,8 @@ export function Body({ onOpenMeasurements }) {
               className={cn(
                 "w-full py-3 rounded-xl font-semibold text-sm transition-[background-color,box-shadow,opacity,transform]",
                 submitSuccess
-                  ? "bg-success text-white"
-                  : "bg-success text-white active:scale-[0.98]",
+                  ? "bg-success-strong text-white"
+                  : "bg-success-strong text-white active:scale-[0.98]",
               )}
             >
               {submitSuccess ? "Записано ✓" : "Записати"}

--- a/apps/web/src/modules/fizruk/pages/Dashboard.tsx
+++ b/apps/web/src/modules/fizruk/pages/Dashboard.tsx
@@ -379,7 +379,7 @@ export function Dashboard({
             {todaySession && (
               <button
                 type="button"
-                className="w-full py-3 rounded-xl bg-fizruk text-white font-semibold text-sm transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
+                className="w-full py-3 rounded-xl bg-fizruk-strong text-white font-semibold text-sm transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
                 onClick={() => {
                   const session =
                     activeProgram.sessions?.[todaySession.sessionKey];

--- a/apps/web/src/modules/fizruk/pages/Exercise.tsx
+++ b/apps/web/src/modules/fizruk/pages/Exercise.tsx
@@ -624,7 +624,7 @@ export function Exercise({ exerciseId }) {
           <div className="mt-3">
             <button
               type="button"
-              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white"
+              className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white"
               onClick={() => (window.location.hash = "#workouts")}
             >
               Перейти до журналу

--- a/apps/web/src/modules/fizruk/pages/Measurements.tsx
+++ b/apps/web/src/modules/fizruk/pages/Measurements.tsx
@@ -135,7 +135,7 @@ export function Measurements() {
           <div className="mt-3">
             <button
               type="button"
-              className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
+              className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
               onClick={() => {
                 const payload = {};
                 for (const f of MEASURE_FIELDS) {

--- a/apps/web/src/modules/fizruk/pages/Programs.tsx
+++ b/apps/web/src/modules/fizruk/pages/Programs.tsx
@@ -94,7 +94,7 @@ export function Programs({
                             "flex-1 text-center rounded py-1 text-3xs font-bold transition-colors",
                             hasSession
                               ? isToday && isActive
-                                ? "bg-success text-white"
+                                ? "bg-success-strong text-white"
                                 : "bg-success/15 text-success"
                               : "bg-line/30 text-subtle/40",
                           )}
@@ -109,7 +109,7 @@ export function Programs({
                     {!isActive ? (
                       <button
                         type="button"
-                        className="flex-1 py-2.5 rounded-xl bg-success text-white text-sm font-semibold transition-[background-color,opacity,transform] active:scale-[0.98]"
+                        className="flex-1 py-2.5 rounded-xl bg-success-strong text-white text-sm font-semibold transition-[background-color,opacity,transform] active:scale-[0.98]"
                         onClick={() => activateProgram(prog.id)}
                       >
                         Активувати
@@ -119,7 +119,7 @@ export function Programs({
                         {todaySession && onStartWorkout && (
                           <button
                             type="button"
-                            className="flex-1 py-2.5 rounded-xl bg-fizruk text-white text-sm font-semibold transition-[background-color,opacity,transform] active:scale-[0.98]"
+                            className="flex-1 py-2.5 rounded-xl bg-fizruk-strong text-white text-sm font-semibold transition-[background-color,opacity,transform] active:scale-[0.98]"
                             onClick={() => {
                               const session =
                                 prog.sessions[todaySession.sessionKey];

--- a/apps/web/src/modules/fizruk/pages/Progress.tsx
+++ b/apps/web/src/modules/fizruk/pages/Progress.tsx
@@ -544,7 +544,7 @@ export function Progress() {
                     className={cn(
                       "shrink-0 px-3 h-7 rounded-full text-xs font-semibold transition-colors border",
                       prFilter === "all"
-                        ? "bg-fizruk text-white border-fizruk"
+                        ? "bg-fizruk-strong text-white border-fizruk-strong"
                         : "bg-panel border-line text-subtle hover:text-text",
                     )}
                   >
@@ -558,7 +558,7 @@ export function Progress() {
                       className={cn(
                         "shrink-0 px-3 h-7 rounded-full text-xs font-semibold transition-colors border whitespace-nowrap",
                         prFilter === g
-                          ? "bg-fizruk text-white border-fizruk"
+                          ? "bg-fizruk-strong text-white border-fizruk-strong"
                           : "bg-panel border-line text-subtle hover:text-text",
                       )}
                     >
@@ -649,7 +649,7 @@ export function Progress() {
           </SectionHeading>
           <button
             type="button"
-            className="w-full py-4 rounded-full font-bold text-base bg-fizruk text-white mb-2 transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
+            className="w-full py-4 rounded-full font-bold text-base bg-fizruk-strong text-white mb-2 transition-[background-color,box-shadow,opacity,transform] active:scale-[0.98]"
             onClick={exportJson}
           >
             Експорт (backup)

--- a/apps/web/src/modules/routine/lib/routineConstants.ts
+++ b/apps/web/src/modules/routine/lib/routineConstants.ts
@@ -57,7 +57,7 @@ export const ROUTINE_THEME = {
 
   // Primary button
   primary:
-    "bg-routine hover:bg-routine-hover text-white border-0 shadow-sm transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-200 active:scale-[0.98]",
+    "bg-routine-strong hover:bg-routine-hover text-white border-0 shadow-sm transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-200 active:scale-[0.98]",
   primarySoft:
     "bg-routine-surface hover:bg-coral-100 text-routine-strong dark:text-routine border border-routine-ring/50 transition-[background-color,border-color,color,box-shadow,opacity,transform] duration-200",
 

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -3,8 +3,8 @@ import { cn } from "@shared/lib/cn";
 
 const VARIANT: Record<ToastType, string> = {
   success: "bg-brand-700 text-white",
-  error: "bg-danger text-white",
-  warning: "bg-warning text-white",
+  error: "bg-danger-strong text-white",
+  warning: "bg-warning-strong text-white",
   info: "bg-primary text-bg",
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,12 +77,11 @@ export default [
       // utility paired with `text-white` regresses to ~2.4–2.8 : 1
       // contrast (the bug class fixed in PRs #854 / #855). The fix is
       // `bg-{family}-strong text-white`. See docs/BRANDBOOK.md →
-      // "WCAG-AA `-strong` Tier" for the full mapping. Set to "warn"
-      // initially (same staged-migration pattern as ai-marker-syntax)
-      // because ~28 pre-existing call-sites in app/component code
-      // currently violate it; promote to "error" once a follow-up
-      // cleanup PR migrates the call-sites to the `-strong` tokens.
-      "sergeant-design/no-low-contrast-text-on-fill": "warn",
+      // "WCAG-AA `-strong` Tier" for the full mapping. Promoted from
+      // "warn" to "error" once the cleanup PR migrated the last 28
+      // call-sites — the codebase is now clean against this rule, and
+      // any new violation must be intentional.
+      "sergeant-design/no-low-contrast-text-on-fill": "error",
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-unused-vars": [
         "error",


### PR DESCRIPTION
## What changed

Cleanup PR closing the brand-palette → WCAG-AA migration ([#854](https://github.com/Skords-01/Sergeant/pull/854) / [#855](https://github.com/Skords-01/Sergeant/pull/855) / [#857](https://github.com/Skords-01/Sergeant/pull/857)) and the guardrail rule ([#859](https://github.com/Skords-01/Sergeant/pull/859)) that landed at `"warn"`. Three things here:

1. **Migrate 29 raw `bg-{family} text-white` call-sites to `bg-{family}-strong text-white`** — every place that bypassed the migrated primitives in [#855](https://github.com/Skords-01/Sergeant/pull/855) and inlined the saturated brand colour behind white text. Where a saturated `border-{family}` was paired with the fill (the "selected pill" / "checked checkbox" pattern in `Body` / `WarmupCooldownChecklist` / `WorkoutItemCard` / `WorkoutTemplatesSection` / `Progress` filter pills / `AddBudgetForm`), the border also moves to `-strong` so fill and border stay visually matched. `hover:bg-{family}` / `hover:bg-{family}/N` are preserved — the rule already ignores hover state, and brightening to the saturated tone on hover is intentional.

2. **Promote `sergeant-design/no-low-contrast-text-on-fill` from `"warn"` → `"error"`** in `eslint.config.js`. Codebase is now clean against the rule; any new violation must be intentional and explicit (arbitrary `bg-[#hex]`, dark-mode-only variant, or hover-only saturated bg — all already excluded).

3. **Add § 9 to AGENTS.md** alongside § 8 (`valid-tailwind-opacity`). Documents the BAD/GOOD pattern, the explicit non-fired shapes (`-strong`, `-{700,800,900}`, `bg-{family}/N`, arbitrary values, `dark:bg-{family}`, `hover:bg-{family}`), and cross-references the brandbook + proposal + migration PRs.

### Migrated call-sites (29 total)

| File | Family | Notes |
| --- | --- | --- |
| `apps/web/src/core/app/ActiveWorkoutBanner.tsx` | `fizruk` | |
| `apps/web/src/core/app/BrandLogo.tsx` | `brand-500` → `brand-strong` | |
| `apps/web/src/core/app/OfflineBanner.tsx` | `warning` | |
| `apps/web/src/core/components/ChatInput.tsx` | `danger` | + matching border |
| `apps/web/src/core/hub/HubReports.tsx` | `brand-500` → `brand-strong` | |
| `apps/web/src/core/onboarding/OnboardingWizard.tsx` | `brand-500` → `brand-strong` | |
| `apps/web/src/modules/finyk/FinykApp.tsx` | `finyk` | |
| `apps/web/src/modules/finyk/components/budgets/AddBudgetForm.tsx` | `success` | + matching border |
| `apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx` | `success` + `fizruk` | ×2 (checkbox fill + button fill) |
| `apps/web/src/modules/fizruk/components/workouts/ExerciseDetailSheet.tsx` | `fizruk` | + matching border |
| `apps/web/src/modules/fizruk/components/workouts/WarmupCooldownChecklist.tsx` | `success` | + matching border |
| `apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx` | `success` | + matching border |
| `apps/web/src/modules/fizruk/pages/Body.tsx` | `success` | ×3 (segmented + 2 submit states) |
| `apps/web/src/modules/fizruk/pages/Dashboard.tsx` | `fizruk` | |
| `apps/web/src/modules/fizruk/pages/Exercise.tsx` | `fizruk` | |
| `apps/web/src/modules/fizruk/pages/Measurements.tsx` | `fizruk` | |
| `apps/web/src/modules/fizruk/pages/Programs.tsx` | `success` + `fizruk` | ×3 (×2 reported + ×1 surfaced after rule promotion) |
| `apps/web/src/modules/fizruk/pages/Progress.tsx` | `fizruk` | ×3 (filter pill ×2 + export button) |
| `apps/web/src/modules/routine/lib/routineConstants.ts` | `routine` | primary button preset |
| `apps/web/src/shared/components/ui/Toast.tsx` | `danger` + `warning` | ×2 (`error` / `warning` variants) |

The 29th violation in `Programs.tsx:97` (the active-program weekly-day chip on `today`) was caught by the `"error"` flip after promoting the rule — confirms the staged migration pattern works as designed.

## Why

The `"warn"` setting in [#859](https://github.com/Skords-01/Sergeant/pull/859) was deliberate so the rule could ship without blocking CI on pre-existing violations. The `"error"` flip is the second half of that staged migration: now that the call-sites are clean, regressions must trip CI. Without this, raw `bg-brand text-white` could silently land again — exactly the bug class that prompted the migration to begin with (~2.4–2.8 : 1 contrast against WCAG AA's 4.5 : 1 floor).

§ 9 in AGENTS.md gives future agents a plain-language reason **why** the rule exists and **when** it deliberately doesn't fire, so they don't redundantly try to "fix" excluded shapes (e.g. dark-mode-only variants or opacity washes).

## How to test

```bash
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web test
pnpm lint:plugins
```

To confirm the rule now blocks regressions, temporarily revert any one call-site:

```bash
git diff main -- apps/web/src/core/app/OfflineBanner.tsx | git apply -R
pnpm --filter @sergeant/web lint   # → exits 1 with bg-warning + text-white error
```

## Visual

No visual regression vs. [#855](https://github.com/Skords-01/Sergeant/pull/855). Buttons / FABs / checkmarks / banners that bypassed the primitives are now visually consistent with the primitives — saturated → `-strong` (typically `-700`; `nutrition` already used `-800`). Difference is only perceptible side-by-side.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): N/A — pure className token replacement; no behaviour change. Smoke covered by 937 vitest cases.
- [x] Vitest passes: `pnpm --filter @sergeant/web test` → 105 files / 937 tests pass (no snapshot drift).
- [x] Plugin tests pass: `pnpm lint:plugins` → 67/67 pass (no regression of the rule's own fixtures).
- [x] Web lint clean: `pnpm --filter @sergeant/web lint` → 0 errors, 0 warnings.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — § 9 added at lines 198–222 of `AGENTS.md` ("Saturated brand fills behind `text-white` must use the `-strong` companion"). Sits in the Hard rules section alongside § 8 (`valid-tailwind-opacity`).

Link to Devin session: https://app.devin.ai/sessions/cf17a97b88c7475db936f10cafe42ab3
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated visual appearance of buttons and interactive controls throughout the entire application. Action buttons, toggle controls, status indicators, and form elements now display stronger background color variants when selected or in an active state. Changes impact workout features, budget management forms, report views, progress tracking sections, and notification displays across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->