### PR TITLE
ci(ci): make pnpm audit --audit-level=high blocking with audit-exception escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,13 @@ jobs:
       - name: Audit (critical only)
         run: pnpm audit --audit-level=critical --prod
 
-      - name: Audit (high, non-blocking)
-        run: pnpm audit --audit-level=high --prod || true
+      - name: Audit (high, production)
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'audit-exception') }}
+        run: pnpm audit --audit-level=high --prod
 
-      - name: Audit full tree (non-blocking)
-        run: pnpm audit --audit-level=high || true
+      - name: Audit full tree (high)
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'audit-exception') }}
+        run: pnpm audit --audit-level=high
 
       - name: License policy check (production tree)
         # Validates that every package in the production dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,7 @@ Every push/PR triggers `.github/workflows/ci.yml`.
 ### CI gotchas
 
 - `pnpm audit --audit-level=critical --prod` is blocking.
-- `pnpm audit --audit-level=high --prod` and full-tree high audit are non-blocking but should still be reviewed.
+- `pnpm audit --audit-level=high --prod` and full-tree `--audit-level=high` are **blocking**. If a PR carries the `audit-exception` label both steps are skipped (see [Audit exception workflow](#audit-exception-workflow) below).
 - `pnpm licenses:check` is blocking and requires `THIRD_PARTY_LICENSES.md` to match the lockfile.
 - `pnpm --filter @sergeant/web exec size-limit` is blocking.
 - `a11y` installs Playwright Chromium with system dependencies.
@@ -253,6 +253,16 @@ These three tests fail on `main` and **should not block merge** if your PR does 
 - `apps/mobile/src/core/OnboardingWizard.test.tsx`
 - `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
 - `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
+
+### Audit exception workflow
+
+When `pnpm audit --audit-level=high` fails in CI due to a vulnerability with no available fix:
+
+1. **Document** the vulnerability in [`docs/security/audit-exceptions.md`](docs/security/audit-exceptions.md) — include advisory link, affected package, severity, reason, mitigation, due date, and owner.
+2. **Add the `audit-exception` label** to the PR. This skips the two high-severity audit steps while keeping the critical-only audit blocking.
+3. **Remove the label** once the vulnerability is resolved and the entry is cleared from the exceptions file.
+
+> The `audit-exception` label is an escape hatch, not a blank cheque. Every exception must be tracked in `docs/security/audit-exceptions.md` with a due date so it does not drift indefinitely.
 
 ---
 

--- a/docs/security/audit-exceptions.md
+++ b/docs/security/audit-exceptions.md
@@ -1,0 +1,39 @@
+# Audit Exceptions
+
+> Tracked vulnerabilities that are temporarily accepted via the `audit-exception` PR label.
+
+## How this file works
+
+When `pnpm audit --audit-level=high` reports a vulnerability that cannot be fixed immediately (e.g. no patch available, upstream issue), document it here so the team has visibility. Add the `audit-exception` label to the PR to bypass the blocking audit step in CI.
+
+Each entry must include:
+
+| Field          | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| **Advisory**   | Link to the npm/GitHub advisory                                 |
+| **Package**    | Affected package name and installed version                     |
+| **Severity**   | `high` or `critical`                                            |
+| **Reason**     | Why it cannot be fixed right now                                |
+| **Mitigation** | What reduces the risk (e.g. not used in prod, input validation) |
+| **Due date**   | When the exception must be re-evaluated or resolved             |
+| **Owner**      | Who is responsible for tracking the fix                         |
+
+## Current exceptions
+
+_None — as of 2026-04-26, `pnpm audit --audit-level=high` passes cleanly._
+
+<!-- Template for adding a new exception:
+
+### <Advisory title>
+
+| Field       | Value                                       |
+| ----------- | ------------------------------------------- |
+| Advisory    | https://github.com/advisories/GHSA-xxxx     |
+| Package     | `some-package@1.2.3`                        |
+| Severity    | high                                        |
+| Reason      | No patch available; upstream PR pending      |
+| Mitigation  | Dev-only dependency, not in production build |
+| Due date    | YYYY-MM-DD                                  |
+| Owner       | @username                                   |
+
+-->


### PR DESCRIPTION
## What changed

- **`.github/workflows/ci.yml`**: removed `|| true` from both high-severity audit steps (`Audit (high, production)` and `Audit full tree (high)`), making them CI-blocking. Added a `contains(github.event.pull_request.labels.*.name, 'audit-exception')` condition so PRs with the `audit-exception` label skip these two steps. The critical-only audit remains unconditionally blocking.
- **`docs/security/audit-exceptions.md`** (new): tracking template for temporarily accepted vulnerabilities — advisory link, package, severity, reason, mitigation, due date, and owner.
- **`CONTRIBUTING.md`**: updated "CI gotchas" to reflect the new blocking behaviour; added "Audit exception workflow" section documenting when and how to use the `audit-exception` label.

## Why

PR-9.A (Sprint 0 security audit): the previous `|| true` pattern silently swallowed high-severity vulnerabilities — the team had no CI signal and high-vulns could drift for weeks. This change surfaces them as build failures while providing a documented escape hatch for cases where no fix is available yet.

## How to test

1. Verify CI passes on this PR — `pnpm audit --audit-level=high` currently reports 0 high-severity findings (only 1 moderate).
2. Confirm the two audit steps in `.github/workflows/ci.yml` no longer have `|| true`.
3. Confirm the `if:` condition references the `audit-exception` label correctly.
4. Review `docs/security/audit-exceptions.md` template and `CONTRIBUTING.md` "Audit exception workflow" section for clarity.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `pnpm audit --audit-level=high --prod` and `pnpm audit --audit-level=high` locally — both exit 0 (only 1 moderate vuln, no high).
- [x] Vitest passes: N/A — no application code changed, only CI config and docs.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules (docs changes are in CONTRIBUTING.md where the CI gotchas section already lived).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security audit exception documentation and workflow for managing unfixable vulnerabilities.
  * Updated contribution guidelines with audit exception process details.

* **Chores**
  * Enhanced CI to enforce security audits as blocking checks by default, with conditional bypass via label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->