### PR TITLE
ci(ci): add migration-lint CI job enforcing AGENTS.md rule #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,3 +258,23 @@ jobs:
           path: apps/web/playwright-report
           if-no-files-found: ignore
           retention-days: 7
+
+  migration-lint:
+    name: Migration lint (AGENTS rule #4)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+
+      - name: Lint migration files
+        run: node scripts/lint-migrations.mjs
+        env:
+          BASE_REF: ${{ github.base_ref }}

--- a/docs/playbooks/add-sql-migration.md
+++ b/docs/playbooks/add-sql-migration.md
@@ -79,6 +79,33 @@ pnpm db:migrate
 - [ ] Bigint→number coercion у serializer (rule #1)
 - [ ] Типи в `packages/api-client` оновлені (rule #3)
 - [ ] `pnpm db:migrate` працює локально
+- [ ] `pnpm lint:migrations` — green (CI: `migration-lint` job)
+
+## CI: Migration lint (`migration-lint` job)
+
+The `migration-lint` CI job (runs on every PR) enforces AGENTS.md rule #4 automatically:
+
+1. **No unguarded `DROP COLUMN` / `DROP TABLE`** in new or changed `*.sql` files (`.down.sql` is exempt).
+2. **Sequential numbering** — no gaps, no duplicates across all migration files.
+
+If the job fails because your migration contains a legitimate DROP:
+
+- Ensure the column/table is already unused in code (deployed in a **previous, merged** PR).
+- Add an escape-hatch comment anywhere in the migration file:
+  ```sql
+  -- ALLOW_DROP: column unused since PR #NNN (due: YYYY-MM-DD)
+  ```
+  The `due:` date is an audit reminder — choose a date ~30 days out.
+
+Run locally:
+
+```bash
+pnpm lint:migrations
+# or directly:
+BASE_REF=main node scripts/lint-migrations.mjs
+```
+
+Script: [`scripts/lint-migrations.mjs`](../../scripts/lint-migrations.mjs) | Tests: `node --test scripts/__tests__/lint-migrations.test.mjs`
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "preview": "pnpm --filter @sergeant/web preview",
     "lint": "turbo run lint && node scripts/check-imports.mjs && pnpm lint:plugins",
     "lint:imports": "node scripts/check-imports.mjs",
+    "lint:migrations": "node scripts/lint-migrations.mjs",
     "lint:plugins": "node --test packages/eslint-plugin-sergeant-design/__tests__/*.test.mjs",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",

--- a/scripts/__tests__/lint-migrations.test.mjs
+++ b/scripts/__tests__/lint-migrations.test.mjs
@@ -1,0 +1,299 @@
+// scripts/__tests__/lint-migrations.test.mjs
+//
+// Unit tests for the migration linter (AGENTS.md rule #4).
+// Run with: node --test scripts/__tests__/lint-migrations.test.mjs
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  isCommentLine,
+  findDropLines,
+  hasAllowDropEscapeHatch,
+  checkSequentialNumbers,
+  run,
+} from "../lint-migrations.mjs";
+
+// ── isCommentLine ────────────────────────────────────────────────────────────
+
+describe("isCommentLine", () => {
+  it("returns true for lines starting with --", () => {
+    assert.equal(isCommentLine("-- this is a comment"), true);
+    assert.equal(isCommentLine("  -- indented comment"), true);
+    assert.equal(isCommentLine("--no space"), true);
+  });
+
+  it("returns false for non-comment lines", () => {
+    assert.equal(isCommentLine("DROP TABLE foo;"), false);
+    assert.equal(isCommentLine("ALTER TABLE foo DROP COLUMN bar;"), false);
+    assert.equal(isCommentLine("SELECT '--not a comment';"), false);
+    assert.equal(isCommentLine(""), false);
+  });
+});
+
+// ── findDropLines ────────────────────────────────────────────────────────────
+
+describe("findDropLines", () => {
+  it("finds DROP TABLE statements", () => {
+    const content = "CREATE TABLE foo;\nDROP TABLE bar;\nSELECT 1;";
+    const result = findDropLines(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].lineNumber, 2);
+    assert.ok(result[0].text.includes("DROP TABLE"));
+  });
+
+  it("finds DROP COLUMN statements", () => {
+    const content = "ALTER TABLE foo\n  DROP COLUMN bar;";
+    const result = findDropLines(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].lineNumber, 2);
+  });
+
+  it("ignores comment lines containing DROP", () => {
+    const content = "-- DROP TABLE old_table;\nSELECT 1;";
+    const result = findDropLines(content);
+    assert.equal(result.length, 0);
+  });
+
+  it("is case-insensitive", () => {
+    const lines = [
+      "drop table foo;",
+      "Drop Column bar;",
+      "DROP   TABLE baz;",
+      "DROP\tCOLUMN qux;",
+    ];
+    for (const line of lines) {
+      const result = findDropLines(line);
+      assert.equal(result.length, 1, `Expected match for: ${line}`);
+    }
+  });
+
+  it("returns empty for clean SQL", () => {
+    const content =
+      "CREATE TABLE foo (id INT);\nALTER TABLE foo ADD COLUMN bar TEXT;";
+    assert.equal(findDropLines(content).length, 0);
+  });
+
+  it("finds multiple DROP statements in one file", () => {
+    const content = "DROP TABLE a;\nSELECT 1;\nALTER TABLE b DROP COLUMN c;";
+    assert.equal(findDropLines(content).length, 2);
+  });
+});
+
+// ── hasAllowDropEscapeHatch ──────────────────────────────────────────────────
+
+describe("hasAllowDropEscapeHatch", () => {
+  it("returns true when ALLOW_DROP comment exists", () => {
+    const content =
+      "-- ALLOW_DROP: legacy cleanup (due: 2026-06-01)\nDROP TABLE foo;";
+    assert.equal(hasAllowDropEscapeHatch(content), true);
+  });
+
+  it("returns true for minimal ALLOW_DROP", () => {
+    assert.equal(
+      hasAllowDropEscapeHatch("-- ALLOW_DROP: reason\nDROP TABLE x;"),
+      true,
+    );
+  });
+
+  it("returns false when no ALLOW_DROP comment", () => {
+    assert.equal(hasAllowDropEscapeHatch("DROP TABLE foo;"), false);
+  });
+
+  it("returns false for ALLOW_DROP without reason", () => {
+    assert.equal(
+      hasAllowDropEscapeHatch("-- ALLOW_DROP:\nDROP TABLE x;"),
+      false,
+    );
+  });
+
+  it("returns false for ALLOW_DROP in non-comment context", () => {
+    assert.equal(
+      hasAllowDropEscapeHatch("SELECT 'ALLOW_DROP: reason';"),
+      false,
+    );
+  });
+});
+
+// ── checkSequentialNumbers ───────────────────────────────────────────────────
+
+describe("checkSequentialNumbers", () => {
+  it("passes for sequential files", () => {
+    const files = ["001_init.sql", "002_foo.sql", "003_bar.sql"];
+    const { gaps, duplicates } = checkSequentialNumbers(files);
+    assert.deepEqual(gaps, []);
+    assert.deepEqual(duplicates, []);
+  });
+
+  it("detects gaps", () => {
+    const files = ["001_init.sql", "003_bar.sql"];
+    const { gaps } = checkSequentialNumbers(files);
+    assert.deepEqual(gaps, [2]);
+  });
+
+  it("detects multiple gaps", () => {
+    const files = ["001_init.sql", "005_bar.sql"];
+    const { gaps } = checkSequentialNumbers(files);
+    assert.deepEqual(gaps, [2, 3, 4]);
+  });
+
+  it("detects duplicates", () => {
+    const files = ["001_init.sql", "001_other.sql", "002_bar.sql"];
+    const { duplicates } = checkSequentialNumbers(files);
+    assert.deepEqual(duplicates, [1]);
+  });
+
+  it("ignores .down.sql files in numbering", () => {
+    const files = [
+      "001_init.sql",
+      "001_init.down.sql",
+      "002_bar.sql",
+      "002_bar.down.sql",
+    ];
+    const { gaps, duplicates } = checkSequentialNumbers(files);
+    assert.deepEqual(gaps, []);
+    assert.deepEqual(duplicates, []);
+  });
+
+  it("ignores non-migration files", () => {
+    const files = ["README.md", "001_init.sql", "002_bar.sql"];
+    const { gaps, duplicates, numbers } = checkSequentialNumbers(files);
+    assert.deepEqual(numbers, [1, 2]);
+    assert.deepEqual(gaps, []);
+    assert.deepEqual(duplicates, []);
+  });
+
+  it("handles empty list", () => {
+    const { gaps, duplicates, numbers } = checkSequentialNumbers([]);
+    assert.deepEqual(numbers, []);
+    assert.deepEqual(gaps, []);
+    assert.deepEqual(duplicates, []);
+  });
+});
+
+// ── run() integration tests (with temp dirs) ────────────────────────────────
+
+describe("run() — integration", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "migration-lint-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("happy path — clean migrations pass", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "CREATE TABLE foo (id INT);\n");
+    writeFileSync(
+      join(tmpDir, "002_add_bar.sql"),
+      "ALTER TABLE foo ADD COLUMN bar TEXT;\n",
+    );
+
+    const { ok, errors } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "002_add_bar.sql")],
+    });
+    assert.equal(ok, true);
+    assert.equal(errors.length, 0);
+  });
+
+  it("fails when DROP TABLE found without escape-hatch", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "CREATE TABLE foo (id INT);\n");
+    writeFileSync(join(tmpDir, "002_drop_foo.sql"), "DROP TABLE foo;\n");
+
+    const { ok, errors } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "002_drop_foo.sql")],
+    });
+    assert.equal(ok, false);
+    assert.ok(errors.some((e) => e.includes("DROP TABLE")));
+    assert.ok(errors.some((e) => e.includes("AGENTS.md rule #4")));
+  });
+
+  it("fails when DROP COLUMN found without escape-hatch", () => {
+    writeFileSync(
+      join(tmpDir, "001_init.sql"),
+      "CREATE TABLE foo (id INT, bar TEXT);\n",
+    );
+    writeFileSync(
+      join(tmpDir, "002_drop_col.sql"),
+      "ALTER TABLE foo DROP COLUMN bar;\n",
+    );
+
+    const { ok, errors } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "002_drop_col.sql")],
+    });
+    assert.equal(ok, false);
+    assert.ok(errors.some((e) => e.includes("DROP COLUMN")));
+  });
+
+  it("passes when DROP has ALLOW_DROP escape-hatch", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "CREATE TABLE foo (id INT);\n");
+    writeFileSync(
+      join(tmpDir, "002_drop_foo.sql"),
+      "-- ALLOW_DROP: column unused since PR #500 (due: 2026-06-01)\nDROP TABLE foo;\n",
+    );
+
+    const { ok } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "002_drop_foo.sql")],
+    });
+    assert.equal(ok, true);
+  });
+
+  it("allows DROP in .down.sql files", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "CREATE TABLE foo (id INT);\n");
+    writeFileSync(join(tmpDir, "001_init.down.sql"), "DROP TABLE foo;\n");
+
+    const { ok } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "001_init.down.sql")],
+    });
+    assert.equal(ok, true);
+  });
+
+  it("ignores DROP inside SQL comments", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "CREATE TABLE foo (id INT);\n");
+    writeFileSync(
+      join(tmpDir, "002_note.sql"),
+      "-- Note: we will DROP TABLE foo later in a separate migration\nSELECT 1;\n",
+    );
+
+    const { ok } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [join(tmpDir, "002_note.sql")],
+    });
+    assert.equal(ok, true);
+  });
+
+  it("fails on gaps in migration numbering", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "SELECT 1;\n");
+    writeFileSync(join(tmpDir, "003_skip.sql"), "SELECT 1;\n");
+
+    const { ok, errors } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [],
+    });
+    assert.equal(ok, false);
+    assert.ok(errors.some((e) => e.includes("gaps")));
+  });
+
+  it("fails on duplicate migration numbers", () => {
+    writeFileSync(join(tmpDir, "001_init.sql"), "SELECT 1;\n");
+    writeFileSync(join(tmpDir, "001_other.sql"), "SELECT 1;\n");
+    writeFileSync(join(tmpDir, "002_bar.sql"), "SELECT 1;\n");
+
+    const { ok, errors } = run({
+      migrationsDir: tmpDir,
+      changedFiles: [],
+    });
+    assert.equal(ok, false);
+    assert.ok(errors.some((e) => e.includes("Duplicate")));
+  });
+});

--- a/scripts/lint-migrations.mjs
+++ b/scripts/lint-migrations.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// scripts/lint-migrations.mjs
+//
+// CI lint: enforces AGENTS.md rule #4 —
+//   • sequential migration numbering (no gaps, no duplicates)
+//   • two-phase DROP (no DROP COLUMN / DROP TABLE without escape-hatch)
+//
+// Usage:
+//   BASE_REF=main node scripts/lint-migrations.mjs
+//   node scripts/lint-migrations.mjs          # defaults BASE_REF to "main"
+//
+// The script exits 1 when violations are found.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIGRATIONS_DIR = "apps/server/src/migrations";
+const MIGRATION_FILE_RE = /^(\d{3})_.+\.sql$/;
+const DOWN_FILE_RE = /\.down\.sql$/;
+const DROP_RE = /\bDROP\s+(COLUMN|TABLE)\b/i;
+const ALLOW_DROP_RE = /^--[ \t]*ALLOW_DROP:[ \t]*\S.*/m;
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────────
+
+/** True when the trimmed line is a SQL single-line comment (`-- …`). */
+export function isCommentLine(line) {
+  return line.trimStart().startsWith("--");
+}
+
+/**
+ * Returns `{ lineNumber, text }[]` for every non-comment line in `content`
+ * that contains `DROP COLUMN` or `DROP TABLE` (case-insensitive).
+ */
+export function findDropLines(content) {
+  return content
+    .split("\n")
+    .map((text, i) => ({ lineNumber: i + 1, text }))
+    .filter(({ text }) => !isCommentLine(text) && DROP_RE.test(text));
+}
+
+/**
+ * Returns `true` when the file content contains at least one
+ * `-- ALLOW_DROP: <reason>` comment (the escape-hatch).
+ */
+export function hasAllowDropEscapeHatch(content) {
+  return ALLOW_DROP_RE.test(content);
+}
+
+/**
+ * Given an array of migration filenames (basenames), returns
+ * `{ numbers, gaps, duplicates }` where:
+ * - `numbers` — sorted array of migration prefix numbers
+ * - `gaps`    — missing numbers in the sequence
+ * - `duplicates` — numbers that appear more than once
+ *
+ * `.down.sql` files are excluded from the count.
+ */
+export function checkSequentialNumbers(filenames) {
+  const numbers = filenames
+    .filter((f) => !DOWN_FILE_RE.test(f))
+    .map((f) => {
+      const m = f.match(MIGRATION_FILE_RE);
+      return m ? Number(m[1]) : null;
+    })
+    .filter((n) => n !== null)
+    .sort((a, b) => a - b);
+
+  const seen = new Set();
+  const duplicates = [];
+  for (const n of numbers) {
+    if (seen.has(n)) {
+      if (!duplicates.includes(n)) duplicates.push(n);
+    }
+    seen.add(n);
+  }
+
+  const gaps = [];
+  if (numbers.length > 0) {
+    for (let i = numbers[0]; i <= numbers[numbers.length - 1]; i++) {
+      if (!seen.has(i)) gaps.push(i);
+    }
+  }
+
+  return {
+    numbers: [...new Set(numbers)].sort((a, b) => a - b),
+    gaps,
+    duplicates,
+  };
+}
+
+// ── CLI runner ───────────────────────────────────────────────────────────────
+
+export function run({
+  migrationsDir = MIGRATIONS_DIR,
+  changedFiles = null,
+} = {}) {
+  const baseRef = process.env.BASE_REF || "main";
+  const errors = [];
+
+  // 1. Determine which migration files are new/changed in this PR
+  if (changedFiles === null) {
+    try {
+      const diff = execSync(
+        `git diff --name-only --diff-filter=ACM origin/${baseRef} -- "${migrationsDir}"`,
+        { encoding: "utf8" },
+      ).trim();
+      changedFiles = diff ? diff.split("\n") : [];
+    } catch {
+      console.warn(
+        `⚠ Could not diff against origin/${baseRef}; checking all migration files.`,
+      );
+      changedFiles = readdirSync(migrationsDir)
+        .filter((f) => MIGRATION_FILE_RE.test(f))
+        .map((f) => join(migrationsDir, f));
+    }
+  }
+
+  // 2. Check DROP statements in new/changed files (skip .down.sql)
+  for (const filePath of changedFiles) {
+    const name = basename(filePath);
+
+    if (DOWN_FILE_RE.test(name)) continue;
+
+    let content;
+    try {
+      content = readFileSync(filePath, "utf8");
+    } catch {
+      // File might have been deleted in diff — skip
+      continue;
+    }
+
+    const dropLines = findDropLines(content);
+    if (dropLines.length > 0 && !hasAllowDropEscapeHatch(content)) {
+      for (const { lineNumber, text } of dropLines) {
+        errors.push(
+          [
+            `❌ ${filePath}:${lineNumber}: "${text.trim()}"`,
+            `   AGENTS.md rule #4 requires two-phase DROP:`,
+            `   1. First PR: deploy code that stops using the column/table.`,
+            `   2. Second PR: DROP in a new migration (only after phase 1 is live).`,
+            `   Escape hatch: add a comment to the file:`,
+            `     -- ALLOW_DROP: <reason> (due: YYYY-MM-DD)`,
+            `   Ref: https://github.com/Skords-01/Sergeant/blob/main/AGENTS.md#4-sql-migrations-sequential-no-gaps-two-phase-for-drop`,
+          ].join("\n"),
+        );
+      }
+    }
+  }
+
+  // 3. Check sequential numbering across ALL migration files
+  const allFiles = readdirSync(migrationsDir);
+  const { gaps, duplicates } = checkSequentialNumbers(allFiles);
+
+  if (gaps.length > 0) {
+    const padded = gaps.map((n) => String(n).padStart(3, "0")).join(", ");
+    errors.push(
+      `❌ Migration numbering has gaps: ${padded}.\n` +
+        `   AGENTS.md rule #4: sequential, no gaps.`,
+    );
+  }
+
+  if (duplicates.length > 0) {
+    const padded = duplicates.map((n) => String(n).padStart(3, "0")).join(", ");
+    errors.push(
+      `❌ Duplicate migration numbers: ${padded}.\n` +
+        `   AGENTS.md rule #4: no duplicates.`,
+    );
+  }
+
+  // 4. Report
+  if (errors.length > 0) {
+    console.error("\n🚫 Migration lint failed:\n");
+    for (const e of errors) console.error(e + "\n");
+    return { ok: false, errors };
+  }
+
+  console.log("✅ Migration lint passed.");
+  return { ok: true, errors: [] };
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  const { ok } = run();
+  if (!ok) process.exit(1);
+}


### PR DESCRIPTION
## What changed

New `migration-lint` CI job that automatically enforces AGENTS.md rule #4 (sequential migrations + two-phase DROP). Adds:

- **`scripts/lint-migrations.mjs`** — Node.js linter that:
  - Finds new/changed `apps/server/src/migrations/*.sql` files relative to `origin/${BASE_REF}`
  - Detects `DROP COLUMN` / `DROP TABLE` statements (case-insensitive, ignoring SQL comment lines `--`)
  - Skips `.down.sql` files (DROP in rollback migrations is expected)
  - Validates sequential numbering — no gaps, no duplicates
  - Supports `-- ALLOW_DROP: <reason> (due: YYYY-MM-DD)` escape-hatch comment
- **`scripts/__tests__/lint-migrations.test.mjs`** — 28 unit tests (`node:test`): happy path, fail cases, escape-hatch, `.down.sql` exemption, gaps, duplicates
- **`migration-lint` job** in `.github/workflows/ci.yml` — runs on PRs only, SHA-pinned actions, `fetch-depth: 0` for diff
- **`pnpm lint:migrations`** script for local runs
- Updated **`docs/playbooks/add-sql-migration.md`** with CI section explaining how to handle failures and the escape-hatch

## Why

PR-5.A audit task (Sprint 1): rule #4 compliance was enforced only by code review. This CI step makes it a blocking check, preventing accidental single-phase DROPs from being merged.

## How to test

1. **Unit tests**: `node --test scripts/__tests__/lint-migrations.test.mjs` — 28 tests pass
2. **Local run against existing migrations**: `pnpm lint:migrations` — passes (no false positives on 001–008)
3. **Simulate a violation**: create a file like `009_test.sql` with `DROP TABLE foo;` → script fails with AGENTS rule #4 message
4. **Escape-hatch**: add `-- ALLOW_DROP: test (due: 2026-06-01)` to the same file → script passes
5. **CI**: the `migration-lint` job runs on this PR

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `pnpm lint:migrations` against existing migrations — passes with no false positives
- [x] Vitest passes: n/a (uses `node:test`); all 28 tests pass
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules (the CI job enforces an existing rule)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI validation for SQL database migrations that enforces sequential, gap-free numbering across all migration files.
  * Implemented linting rules preventing unguarded `DROP COLUMN` and `DROP TABLE` statements in migrations, with an escape-hatch mechanism for legitimate drops.
  * Added `pnpm lint:migrations` command to run validation locally.

* **Documentation**
  * Updated migration playbook with CI verification requirements and guidelines for handling column/table drops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->