### PR TITLE
feat(server): activate Anthropic prompt caching metrics (PR-12.A)

### DIFF
--- a/apps/server/src/lib/anthropic.ts
+++ b/apps/server/src/lib/anthropic.ts
@@ -2,6 +2,7 @@ import {
   aiRequestDurationMs,
   aiRequestsTotal,
   aiTokensTotal,
+  anthropicPromptCacheHitTotal,
   externalHttpDurationMs,
   externalHttpRequestsTotal,
 } from "../obs/metrics.js";
@@ -18,6 +19,12 @@ export interface AnthropicCallOptions {
    * caller вирішив перервати.
    */
   signal?: AbortSignal;
+  /**
+   * Версія system prompt (SYSTEM_PROMPT_VERSION). Якщо передано, `recordUsage`
+   * інкрементує `anthropic_prompt_cache_hit_total{version, outcome}` —
+   * per-request лічильник cache hit/miss.
+   */
+  promptVersion?: string;
 }
 
 /**
@@ -112,7 +119,11 @@ interface AnthropicResponseData {
   [key: string]: unknown;
 }
 
-function recordUsage(model: string, data: AnthropicResponseData | null): void {
+function recordUsage(
+  model: string,
+  data: AnthropicResponseData | null,
+  promptVersion?: string,
+): void {
   try {
     const usage = data?.usage;
     if (!usage) return;
@@ -144,6 +155,14 @@ function recordUsage(model: string, data: AnthropicResponseData | null): void {
         usage.cache_read_input_tokens,
       );
     }
+    // Per-request cache outcome counter for Grafana dashboards.
+    if (promptVersion) {
+      const cacheRead = usage.cache_read_input_tokens ?? 0;
+      anthropicPromptCacheHitTotal.inc({
+        version: promptVersion,
+        outcome: cacheRead > 0 ? "hit" : "miss",
+      });
+    }
   } catch {
     /* ignore */
   }
@@ -156,6 +175,7 @@ export async function anthropicMessages(
     timeoutMs = 20000,
     endpoint = "unknown",
     signal: externalSignal,
+    promptVersion,
   }: AnthropicCallOptions = {},
 ): Promise<AnthropicMessagesResult> {
   const maxAttempts = 3;
@@ -205,7 +225,7 @@ export async function anthropicMessages(
       const ms = Number(process.hrtime.bigint() - overallStart) / 1e6;
       if (response.ok) {
         recordOutcome("ok", { model, endpoint, ms });
-        recordUsage(model, data);
+        recordUsage(model, data, promptVersion);
       } else {
         recordOutcome(response.status === 429 ? "rate_limited" : "error", {
           model,

--- a/apps/server/src/modules/chat.test.ts
+++ b/apps/server/src/modules/chat.test.ts
@@ -384,6 +384,50 @@ describe("chat handler — system payload (prompt caching)", () => {
     expect(Array.isArray(payload.system)).toBe(true);
     expect(payload.system[0].cache_control).toEqual({ type: "ephemeral" });
   });
+
+  it("два послідовні запити обидва шлють cache_control на system block", async () => {
+    anthropicMessages
+      .mockResolvedValueOnce({
+        response: { ok: true, status: 200 },
+        data: { content: [{ type: "text", text: "Ок 1." }] },
+      })
+      .mockResolvedValueOnce({
+        response: { ok: true, status: 200 },
+        data: { content: [{ type: "text", text: "Ок 2." }] },
+      });
+
+    const req1 = makeReq({
+      messages: [{ role: "user", content: "перший запит" }],
+      context: "[Дані] баланс 1000₴",
+    });
+    const res1 = makeRes();
+    await handler(req1, res1);
+
+    const req2 = makeReq({
+      messages: [{ role: "user", content: "другий запит" }],
+      context: "[Дані] баланс 1000₴",
+    });
+    const res2 = makeRes();
+    await handler(req2, res2);
+
+    expect(anthropicMessages).toHaveBeenCalledTimes(2);
+
+    for (let call = 0; call < 2; call++) {
+      const payload = anthropicMessages.mock.calls[call][1] as {
+        system: Array<{
+          type: string;
+          text: string;
+          cache_control?: { type: string };
+        }>;
+        tools: Array<{ cache_control?: { type: string } }>;
+      };
+      expect(Array.isArray(payload.system)).toBe(true);
+      expect(payload.system[0].cache_control).toEqual({ type: "ephemeral" });
+      expect(payload.system[0].text).toMatch(/^Ти персональний асистент/);
+      const lastTool = payload.tools[payload.tools.length - 1];
+      expect(lastTool.cache_control).toEqual({ type: "ephemeral" });
+    }
+  });
 });
 
 describe("chat handler — auto-continuation на stop_reason=max_tokens", () => {

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -12,7 +12,8 @@ import {
   extractAnthropicText,
 } from "../lib/anthropic.js";
 import type { WithAiQuotaRefund } from "./aiQuota.js";
-import { TOOLS, SYSTEM_PREFIX } from "./chat/tools.js";
+import { TOOLS, SYSTEM_PREFIX, SYSTEM_PROMPT_VERSION } from "./chat/tools.js";
+import { anthropicPromptCacheHitTotal } from "../obs/metrics.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
 
@@ -116,9 +117,17 @@ interface ClientChatMessage {
   content: string;
 }
 
+interface StreamUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
 interface StreamEvent {
   type: string;
   delta?: { type?: string; text?: string; stop_reason?: string };
+  message?: { usage?: StreamUsage };
 }
 
 /**
@@ -152,6 +161,7 @@ async function callAnthropicWithContinuation(
     timeoutMs?: number;
     endpoint: string;
     signal?: AbortSignal;
+    promptVersion?: string;
   },
 ): Promise<{
   response: FetchResponse | null;
@@ -336,6 +346,7 @@ export default async function handler(
         payload,
         "chat-tool-result",
         clientAbort.signal,
+        SYSTEM_PROMPT_VERSION,
       );
       return;
     }
@@ -349,6 +360,7 @@ export default async function handler(
           timeoutMs: 30000,
           endpoint: "chat-tool-result",
           signal: clientAbort.signal,
+          promptVersion: SYSTEM_PROMPT_VERSION,
         },
       ));
     } catch (e) {
@@ -392,7 +404,12 @@ export default async function handler(
         tools: TOOLS_WITH_CACHE,
         messages: cleaned,
       },
-      { timeoutMs: 30000, endpoint: "chat", signal: clientAbort.signal },
+      {
+        timeoutMs: 30000,
+        endpoint: "chat",
+        signal: clientAbort.signal,
+        promptVersion: SYSTEM_PROMPT_VERSION,
+      },
     ));
   } catch (e) {
     await refundQuotaOnUpstreamFailure(req);
@@ -448,6 +465,7 @@ interface StreamIterationResult {
   outcome: "ok" | "error";
   stopReason: string | null;
   accumulatedText: string;
+  usage: StreamUsage | null;
 }
 
 /**
@@ -464,7 +482,12 @@ async function streamOneIterationToSse(
 ): Promise<StreamIterationResult> {
   const reader = upstream.body?.getReader();
   if (!reader) {
-    return { outcome: "error", stopReason: null, accumulatedText: "" };
+    return {
+      outcome: "error",
+      stopReason: null,
+      accumulatedText: "",
+      usage: null,
+    };
   }
 
   const decoder = new TextDecoder();
@@ -472,6 +495,7 @@ async function streamOneIterationToSse(
   let accumulatedText = "";
   let stopReason: string | null = null;
   let outcome: "ok" | "error" = "ok";
+  let usage: StreamUsage | null = null;
 
   try {
     while (true) {
@@ -503,6 +527,8 @@ async function streamOneIterationToSse(
           }
         } else if (ev.type === "message_delta" && ev.delta?.stop_reason) {
           stopReason = ev.delta.stop_reason;
+        } else if (ev.type === "message_start" && ev.message?.usage) {
+          usage = ev.message.usage;
         }
       }
     }
@@ -514,7 +540,7 @@ async function streamOneIterationToSse(
     }
   }
 
-  return { outcome, stopReason, accumulatedText };
+  return { outcome, stopReason, accumulatedText, usage };
 }
 
 /**
@@ -535,6 +561,7 @@ async function streamAnthropicToSse(
   payload: Record<string, unknown>,
   endpoint: string = "chat",
   abortSignal?: AbortSignal,
+  promptVersion?: string,
 ): Promise<void> {
   let firstResponse: FetchResponse;
   let firstRecordEnd: (outcome?: string) => void;
@@ -589,6 +616,18 @@ async function streamAnthropicToSse(
       const iter = await streamOneIterationToSse(res, currentResponse);
       currentRecordEnd(iter.outcome);
       if (iter.accumulatedText) accumulatedAllText += iter.accumulatedText;
+
+      if (promptVersion && iter.usage) {
+        const cacheRead = iter.usage.cache_read_input_tokens ?? 0;
+        try {
+          anthropicPromptCacheHitTotal.inc({
+            version: promptVersion,
+            outcome: cacheRead > 0 ? "hit" : "miss",
+          });
+        } catch {
+          /* metrics must never break a request */
+        }
+      }
 
       if (
         iter.outcome === "error" ||

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -91,7 +91,14 @@ export const dbPoolWaiting = new client.Gauge({
 export const aiTokensTotal = new client.Counter({
   name: "ai_tokens_total",
   help: "AI tokens consumed",
-  labelNames: ["provider", "model", "kind"], // kind=prompt|completion
+  labelNames: ["provider", "model", "kind"], // kind=prompt|completion|cache_write|cache_read
+  registers: [register],
+});
+
+export const anthropicPromptCacheHitTotal = new client.Counter({
+  name: "anthropic_prompt_cache_hit_total",
+  help: "Anthropic prompt cache hit/miss per request",
+  labelNames: ["version", "outcome"], // outcome=hit|miss
   registers: [register],
 });
 

--- a/docs/playbooks/enable-prompt-caching.md
+++ b/docs/playbooks/enable-prompt-caching.md
@@ -1,5 +1,7 @@
 # Playbook: Enable Anthropic Prompt Caching
 
+**Status:** ✅ active (PR-12.A, Sprint 0)
+
 **Trigger:** «Зменшити cost Anthropic» / «Anthropic API занадто дорогий» / `aiTokensTotal{kind="prompt"}` росте лінійно з трафіком, бо стабільні `SYSTEM_PREFIX` і `TOOLS` повторюються на кожному запиті.
 
 ---
@@ -244,6 +246,34 @@ ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @sergeant/server dev
 - **TTL ephemeral кешу — ~5 хв** з останнього read. Для sparse трафіку (юзер заходить раз на годину) prompt caching не дасть значної економії; має сенс для активних сесій / інтенсивного chat-flow.
 - **Cache key чутливий побайтно.** Невидимий whitespace-diff, BOM, нерозривні пробіли — все робить cache miss. Не редагуй `SYSTEM_PREFIX` у редакторі без unicode-aware diff.
 - **Minimum length failures silent.** Якщо prompt нижче порогу моделі, request успішний, але `cache_creation_input_tokens` і `cache_read_input_tokens` лишаються 0.
+
+## Моніторинг (як перевірити в production)
+
+### Prometheus метрики
+
+1. **Token-level** (наявні): `aiTokensTotal{kind="cache_write"}` / `aiTokensTotal{kind="cache_read"}` — кількість токенів записаних / прочитаних з кешу.
+2. **Request-level** (новий): `anthropic_prompt_cache_hit_total{version="<SYSTEM_PROMPT_VERSION>", outcome="hit|miss"}` — кількість запитів з cache hit / miss. Outcome `hit` якщо `cache_read_input_tokens > 0`.
+
+### Grafana queries
+
+```promql
+# Cache hit rate (%)
+sum(rate(anthropic_prompt_cache_hit_total{outcome="hit"}[5m]))
+/
+sum(rate(anthropic_prompt_cache_hit_total[5m]))
+
+# Token savings from cache reads
+sum(rate(ai_tokens_total{kind="cache_read"}[5m]))
+
+# Cache invalidation спалахи (після бампу SYSTEM_PROMPT_VERSION)
+sum(rate(anthropic_prompt_cache_hit_total{outcome="miss"}[5m])) by (version)
+```
+
+### Після деплою
+
+- Перші ~5 хв — очікувані cache miss-и для всіх юзерів.
+- Через 5–15 хв: `anthropic_prompt_cache_hit_total{outcome="hit"}` має зростати.
+- Якщо `outcome="hit"` лишається на 0 — див. секцію "Manual verification у dev".
 
 ## See also
 


### PR DESCRIPTION
## What changed

Add per-request Prometheus counter `anthropic_prompt_cache_hit_total{version, outcome}` and streaming cache usage tracking for the Anthropic prompt caching system.

### Code changes

- **`apps/server/src/obs/metrics.ts`**: New counter `anthropic_prompt_cache_hit_total` with labels `version` (from `SYSTEM_PROMPT_VERSION`) and `outcome` (`hit`/`miss`).
- **`apps/server/src/lib/anthropic.ts`**: `promptVersion` option in `AnthropicCallOptions`; `recordUsage()` now increments the cache counter when `promptVersion` is provided (outcome = `hit` when `cache_read_input_tokens > 0`).
- **`apps/server/src/modules/chat.ts`**:
  - Import `SYSTEM_PROMPT_VERSION` and pass it via `promptVersion` on all Anthropic call paths.
  - Capture `message_start` SSE usage in `streamOneIterationToSse` for streaming cache tracking.
  - Increment `anthropicPromptCacheHitTotal` after each streaming iteration.
- **`apps/server/src/modules/chat.test.ts`**: New test — two consecutive requests both send `cache_control` on system block and last tool.
- **`docs/playbooks/enable-prompt-caching.md`**: Status → `active`, added monitoring section with PromQL queries for Grafana.

### What was already in place (audit findings)

The core caching infrastructure was already implemented:
- `buildSystem(context)` wraps `SYSTEM_PREFIX` with `cache_control: { type: "ephemeral" }`, dynamic `context` as separate uncached block.
- `applyToolsCacheBreakpoint()` adds `cache_control` to last tool (practical breakpoint for real cache hits since SYSTEM_PREFIX alone is ~987 tokens, below Sonnet 1024 minimum).
- `SYSTEM_PROMPT_VERSION = "v6"` already exists.
- `recordUsage()` already records `cache_write`/`cache_read` token counts.

## Why

Audit task PR-12.A (Sprint 0): activate and instrument Anthropic prompt caching for `SYSTEM_PREFIX`. Expected effect: -30..50% Anthropic costs + reduced latency for active chat sessions.

The missing piece was a **per-request** cache outcome counter for Grafana dashboards (existing metrics only tracked raw token counts) and streaming path coverage.

## How to test

1. `pnpm --filter @sergeant/server exec vitest run src/modules/chat` — all 33 tests pass.
2. After deploy, monitor `anthropic_prompt_cache_hit_total{outcome="hit"}` in Grafana — should rise within 5–15 min of active traffic.
3. See `docs/playbooks/enable-prompt-caching.md` → "Моніторинг" section for PromQL queries.

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): N/A (metrics-only change, no user-facing behavior change)
- [x] Vitest passes: 33/33 tests green (including new consecutive-request cache_control test)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

---

[Devin session](https://app.devin.ai/sessions/8cfd9ce75786483d82a21bb22daf5b89)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added monitoring for Anthropic prompt cache performance, tracking hit/miss rates by prompt version.
  * New cache performance metrics now available for production observability.

* **Documentation**
  * Added comprehensive playbook for monitoring prompt caching with metrics queries and troubleshooting guidance.

* **Tests**
  * Added unit test coverage for prompt caching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->