### PR TITLE
ci(ci): add commitlint with scope enum from AGENTS.md rule #5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,31 @@ env:
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
+  commitlint:
+    name: Commit messages (commitlint)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      # pnpm/action-setup v4.1.0 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+
+      # actions/setup-node v4.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate PR commit messages
+        run: pnpm exec commitlint --from "origin/${{ github.base_ref }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec commitlint --edit $1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,28 @@ For UI changes, attach a screenshot or recording to the PR description when prac
 
 Hooks are installed by `pnpm install` via the `prepare` script. **Do not skip them**: `--no-verify` is forbidden per `AGENTS.md` hard rule #7.
 
+### Commit message lint (commitlint)
+
+The `commit-msg` hook runs [commitlint](https://commitlint.js.org/) to enforce Conventional Commits with the exact scope enum from `AGENTS.md` rule #5. A commit with an unknown scope or missing scope is rejected **before** it lands in history.
+
+#### Verify locally
+
+```bash
+# Lint the last commit
+pnpm exec commitlint --last
+
+# Lint a range (useful before pushing a stack)
+pnpm exec commitlint --from HEAD~3 --to HEAD
+```
+
+#### CI
+
+The `commitlint` job in `.github/workflows/ci.yml` validates every commit in a PR against `origin/<base>`. If any commit fails, the job fails.
+
+#### Bypassing
+
+You cannot bypass commitlint — `--no-verify` is forbidden (`AGENTS.md` hard rule #7). If the scope enum needs a new entry, update both `AGENTS.md` and `commitlint.config.js` in the same PR.
+
 ---
 
 ## Commit Messages
@@ -218,12 +240,13 @@ If a PR genuinely spans multiple scopes, use the most user-visible scope and exp
 
 Every push/PR triggers `.github/workflows/ci.yml`.
 
-| Job           | What                                                                                |
-| ------------- | ----------------------------------------------------------------------------------- |
-| **check**     | Install, audit, license policy check, `pnpm check`, bundle size guard               |
-| **coverage**  | `pnpm test:coverage`, coverage HTML/JSON artifacts                                  |
-| **a11y**      | Playwright Chromium install + axe-core accessibility checks                         |
-| **smoke-e2e** | Real Postgres service, migrations, API server, Vite preview, Playwright smoke suite |
+| Job            | What                                                                                |
+| -------------- | ----------------------------------------------------------------------------------- |
+| **commitlint** | Conventional Commits + scope enum validation (PR only)                              |
+| **check**      | Install, audit, license policy check, `pnpm check`, bundle size guard               |
+| **coverage**   | `pnpm test:coverage`, coverage HTML/JSON artifacts                                  |
+| **a11y**       | Playwright Chromium install + axe-core accessibility checks                         |
+| **smoke-e2e**  | Real Postgres service, migrations, API server, Vite preview, Playwright smoke suite |
 
 ### CI gotchas
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+/**
+ * Scope enum mirrors AGENTS.md hard rule #5.
+ * Keep this list in sync with the table there.
+ */
+const SCOPES = [
+  "web",
+  "server",
+  "mobile",
+  "mobile-shell",
+  "shared",
+  "api-client",
+  "finyk-domain",
+  "fizruk-domain",
+  "nutrition-domain",
+  "routine-domain",
+  "insights",
+  "design-tokens",
+  "config",
+  "eslint-plugins",
+  "migrations",
+  "deps",
+  "docs",
+  "ci",
+  "root",
+];
+
+/** @type {import('@commitlint/types').UserConfig} */
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "scope-enum": [2, "always", SCOPES],
+    "scope-empty": [2, "never"],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@commitlint/cli": "^20.5.2",
+    "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^9.15.0",
     "depcheck": "^1.4.7",
     "eslint": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,12 @@ overrides:
 importers:
   .:
     devDependencies:
+      "@commitlint/cli":
+        specifier: ^20.5.2
+        version: 20.5.2(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+      "@commitlint/config-conventional":
+        specifier: ^20.5.0
+        version: 20.5.0
       "@eslint/js":
         specifier: ^9.15.0
         version: 9.39.4
@@ -2184,6 +2190,126 @@ packages:
       }
     engines: { node: ">=0.1.90" }
 
+  "@commitlint/cli@20.5.2":
+    resolution:
+      {
+        integrity: sha512-IXr5xd3IX8SEG936P8gcpozRplkDeDSwJlt8UvoY1winwIy2udTbQ/cOCgbaaxcjdDqVoS29VUcz/wkwnSozbA==,
+      }
+    engines: { node: ">=v18" }
+    hasBin: true
+
+  "@commitlint/config-conventional@20.5.0":
+    resolution:
+      {
+        integrity: sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/config-validator@20.5.0":
+    resolution:
+      {
+        integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/ensure@20.5.0":
+    resolution:
+      {
+        integrity: sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/execute-rule@20.0.0":
+    resolution:
+      {
+        integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/format@20.5.0":
+    resolution:
+      {
+        integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/is-ignored@20.5.0":
+    resolution:
+      {
+        integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/lint@20.5.0":
+    resolution:
+      {
+        integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/load@20.5.2":
+    resolution:
+      {
+        integrity: sha512-zmr0RGDz7vThxW1I8ohb9yBjnGuH9mqwJpn21hInjGla+IlLOkS9ey0+dD5HlkzFlY0lX2NYdA2lDW6/0rO7Gw==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/message@20.4.3":
+    resolution:
+      {
+        integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/parse@20.5.0":
+    resolution:
+      {
+        integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/read@20.5.0":
+    resolution:
+      {
+        integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/resolve-extends@20.5.2":
+    resolution:
+      {
+        integrity: sha512-8EhSCU9eNos/5cI1yg64GW79UH1c64O69AfStCsj4zqy6An/qIphVEXj4/+2M6056T8coz00f+UXFn4WUUP1HQ==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/rules@20.5.0":
+    resolution:
+      {
+        integrity: sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/to-lines@20.0.0":
+    resolution:
+      {
+        integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/top-level@20.4.3":
+    resolution:
+      {
+        integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==,
+      }
+    engines: { node: ">=v18" }
+
+  "@commitlint/types@20.5.0":
+    resolution:
+      {
+        integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==,
+      }
+    engines: { node: ">=v18" }
+
   "@config-plugins/detox@9.0.0":
     resolution:
       {
@@ -2191,6 +2317,21 @@ packages:
       }
     peerDependencies:
       expo: ^52
+
+  "@conventional-changelog/git-client@2.7.0":
+    resolution:
+      {
+        integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
   "@csstools/color-helpers@6.0.2":
     resolution:
@@ -5017,6 +5158,20 @@ packages:
       react: "*"
       react-native: "*"
 
+  "@simple-libs/child-process-utils@1.0.2":
+    resolution:
+      {
+        integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==,
+      }
+    engines: { node: ">=18" }
+
+  "@simple-libs/stream-utils@1.2.0":
+    resolution:
+      {
+        integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==,
+      }
+    engines: { node: ">=18" }
+
   "@sinclair/typebox@0.27.10":
     resolution:
       {
@@ -6372,6 +6527,12 @@ packages:
         integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
       }
 
+  array-ify@1.0.0:
+    resolution:
+      {
+        integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==,
+      }
+
   array-includes@3.1.9:
     resolution:
       {
@@ -7680,6 +7841,12 @@ packages:
         integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==,
       }
 
+  compare-func@2.0.0:
+    resolution:
+      {
+        integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==,
+      }
+
   component-emitter@1.3.1:
     resolution:
       {
@@ -7740,6 +7907,28 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  conventional-changelog-angular@8.3.1:
+    resolution:
+      {
+        integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==,
+      }
+    engines: { node: ">=18" }
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution:
+      {
+        integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==,
+      }
+    engines: { node: ">=18" }
+
+  conventional-commits-parser@6.4.0:
+    resolution:
+      {
+        integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
   convert-source-map@2.0.0:
     resolution:
       {
@@ -7791,6 +7980,17 @@ packages:
         integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
       }
 
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution:
+      {
+        integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==,
+      }
+    engines: { node: ">=v18" }
+    peerDependencies:
+      "@types/node": "*"
+      cosmiconfig: ">=9"
+      typescript: ">=5"
+
   cosmiconfig@5.2.1:
     resolution:
       {
@@ -7804,6 +8004,18 @@ packages:
         integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==,
       }
     engines: { node: ">=10" }
+
+  cosmiconfig@9.0.1:
+    resolution:
+      {
+        integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==,
+      }
+    engines: { node: ">=14" }
+    peerDependencies:
+      typescript: ">=4.9.5"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cpu-features@0.0.10:
     resolution:
@@ -8457,6 +8669,13 @@ packages:
       {
         integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
       }
+
+  dot-prop@5.3.0:
+    resolution:
+      {
+        integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==,
+      }
+    engines: { node: ">=8" }
 
   dotenv-expand@11.0.7:
     resolution:
@@ -9898,6 +10117,14 @@ packages:
       }
     engines: { node: ">=6" }
 
+  git-raw-commits@5.0.1:
+    resolution:
+      {
+        integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -9963,6 +10190,13 @@ packages:
       }
     engines: { node: ">=12" }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global-directory@5.0.0:
+    resolution:
+      {
+        integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==,
+      }
+    engines: { node: ">=20" }
 
   global-modules@1.0.0:
     resolution:
@@ -10335,6 +10569,12 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
+  import-meta-resolve@4.2.0:
+    resolution:
+      {
+        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
+      }
+
   imurmurhash@0.1.4:
     resolution:
       {
@@ -10374,6 +10614,13 @@ packages:
         integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==,
       }
     engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
+
+  ini@6.0.0:
+    resolution:
+      {
+        integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   inline-style-parser@0.2.7:
     resolution:
@@ -10694,6 +10941,13 @@ packages:
         integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==,
       }
     engines: { node: ">=0.10.0" }
+
+  is-obj@2.0.0:
+    resolution:
+      {
+        integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==,
+      }
+    engines: { node: ">=8" }
 
   is-path-cwd@2.2.0:
     resolution:
@@ -11772,10 +12026,22 @@ packages:
         integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
       }
 
+  lodash.kebabcase@4.1.1:
+    resolution:
+      {
+        integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==,
+      }
+
   lodash.merge@4.6.2:
     resolution:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
+
+  lodash.mergewith@4.6.2:
+    resolution:
+      {
+        integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==,
       }
 
   lodash.once@4.1.1:
@@ -11784,16 +12050,34 @@ packages:
         integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
       }
 
+  lodash.snakecase@4.1.1:
+    resolution:
+      {
+        integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
+      }
+
   lodash.sortby@4.7.0:
     resolution:
       {
         integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==,
       }
 
+  lodash.startcase@4.4.0:
+    resolution:
+      {
+        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
+      }
+
   lodash.throttle@4.1.1:
     resolution:
       {
         integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==,
+      }
+
+  lodash.upperfirst@4.3.1:
+    resolution:
+      {
+        integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==,
       }
 
   lodash@4.18.1:
@@ -12017,6 +12301,13 @@ packages:
       {
         integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==,
       }
+
+  meow@13.2.0:
+    resolution:
+      {
+        integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+      }
+    engines: { node: ">=18" }
 
   merge-descriptors@1.0.3:
     resolution:
@@ -15597,6 +15888,13 @@ packages:
         integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
       }
 
+  tinyexec@1.1.1:
+    resolution:
+      {
+        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
+      }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.16:
     resolution:
       {
@@ -18309,10 +18607,132 @@ snapshots:
 
   "@colors/colors@1.6.0": {}
 
+  "@commitlint/cli@20.5.2(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)":
+    dependencies:
+      "@commitlint/format": 20.5.0
+      "@commitlint/lint": 20.5.0
+      "@commitlint/load": 20.5.2(@types/node@25.6.0)(typescript@6.0.3)
+      "@commitlint/read": 20.5.0(conventional-commits-parser@6.4.0)
+      "@commitlint/types": 20.5.0
+      tinyexec: 1.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@types/node"
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  "@commitlint/config-conventional@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      conventional-changelog-conventionalcommits: 9.3.1
+
+  "@commitlint/config-validator@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      ajv: 8.18.0
+
+  "@commitlint/ensure@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  "@commitlint/execute-rule@20.0.0": {}
+
+  "@commitlint/format@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      picocolors: 1.1.1
+
+  "@commitlint/is-ignored@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      semver: 7.7.4
+
+  "@commitlint/lint@20.5.0":
+    dependencies:
+      "@commitlint/is-ignored": 20.5.0
+      "@commitlint/parse": 20.5.0
+      "@commitlint/rules": 20.5.0
+      "@commitlint/types": 20.5.0
+
+  "@commitlint/load@20.5.2(@types/node@25.6.0)(typescript@6.0.3)":
+    dependencies:
+      "@commitlint/config-validator": 20.5.0
+      "@commitlint/execute-rule": 20.0.0
+      "@commitlint/resolve-extends": 20.5.2
+      "@commitlint/types": 20.5.0
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
+      is-plain-obj: 4.1.0
+      lodash.mergewith: 4.6.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - "@types/node"
+      - typescript
+
+  "@commitlint/message@20.4.3": {}
+
+  "@commitlint/parse@20.5.0":
+    dependencies:
+      "@commitlint/types": 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
+
+  "@commitlint/read@20.5.0(conventional-commits-parser@6.4.0)":
+    dependencies:
+      "@commitlint/top-level": 20.4.3
+      "@commitlint/types": 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      minimist: 1.2.8
+      tinyexec: 1.1.1
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  "@commitlint/resolve-extends@20.5.2":
+    dependencies:
+      "@commitlint/config-validator": 20.5.0
+      "@commitlint/types": 20.5.0
+      global-directory: 5.0.0
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  "@commitlint/rules@20.5.0":
+    dependencies:
+      "@commitlint/ensure": 20.5.0
+      "@commitlint/message": 20.4.3
+      "@commitlint/to-lines": 20.0.0
+      "@commitlint/types": 20.5.0
+
+  "@commitlint/to-lines@20.0.0": {}
+
+  "@commitlint/top-level@20.4.3":
+    dependencies:
+      escalade: 3.2.0
+
+  "@commitlint/types@20.5.0":
+    dependencies:
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
   "@config-plugins/detox@9.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))":
     dependencies:
       expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-build-properties: 0.13.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(graphql@16.13.2)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
+
+  "@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)":
+    dependencies:
+      "@simple-libs/child-process-utils": 1.0.2
+      "@simple-libs/stream-utils": 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
 
   "@csstools/color-helpers@6.0.2": {}
 
@@ -20337,6 +20757,12 @@ snapshots:
       recyclerlistview: 4.2.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
 
+  "@simple-libs/child-process-utils@1.0.2":
+    dependencies:
+      "@simple-libs/stream-utils": 1.2.0
+
+  "@simple-libs/stream-utils@1.2.0": {}
+
   "@sinclair/typebox@0.27.10": {}
 
   "@sinonjs/commons@3.0.1":
@@ -21261,6 +21687,8 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  array-ify@1.0.0: {}
+
   array-includes@3.1.9:
     dependencies:
       call-bind: 1.0.9
@@ -22067,6 +22495,11 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   component-emitter@1.3.1: {}
 
   component-type@1.2.2: {}
@@ -22112,6 +22545,19 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.4.0:
+    dependencies:
+      "@simple-libs/stream-utils": 1.2.0
+      meow: 13.2.0
+
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
@@ -22130,6 +22576,13 @@ snapshots:
 
   core-util-is@1.0.2: {}
 
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
+    dependencies:
+      "@types/node": 25.6.0
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      jiti: 2.6.1
+      typescript: 6.0.3
+
   cosmiconfig@5.2.1:
     dependencies:
       import-fresh: 2.0.0
@@ -22144,6 +22597,15 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.3
+
+  cosmiconfig@9.0.1(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   cpu-features@0.0.10:
     dependencies:
@@ -22570,6 +23032,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -23672,6 +24138,14 @@ snapshots:
 
   getenv@1.0.0: {}
 
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
+    dependencies:
+      "@conventional-changelog/git-client": 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -23731,6 +24205,10 @@ snapshots:
       inherits: 2.0.4
       minimatch: 5.1.9
       once: 1.4.0
+
+  global-directory@5.0.0:
+    dependencies:
+      ini: 6.0.0
 
   global-modules@1.0.0:
     dependencies:
@@ -23960,6 +24438,8 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -23974,6 +24454,8 @@ snapshots:
   ini@1.3.8: {}
 
   ini@4.1.3: {}
+
+  ini@6.0.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -24144,6 +24626,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-obj@2.0.0: {}
 
   is-path-cwd@2.2.0: {}
 
@@ -25050,13 +25534,23 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
+  lodash.kebabcase@4.1.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
 
   lodash.once@4.1.1: {}
 
+  lodash.snakecase@4.1.1: {}
+
   lodash.sortby@4.7.0: {}
 
+  lodash.startcase@4.4.0: {}
+
   lodash.throttle@4.1.1: {}
+
+  lodash.upperfirst@4.3.1: {}
 
   lodash@4.18.1: {}
 
@@ -25240,6 +25734,8 @@ snapshots:
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
+
+  meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -27784,6 +28280,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
## What changed

Automates AGENTS.md hard rule #5 (conventional-commit scope enum) via **commitlint**.

1. **`@commitlint/cli` + `@commitlint/config-conventional`** added as root devDependencies.
2. **`commitlint.config.js`** created with:
   - `extends: ['@commitlint/config-conventional']`
   - `scope-enum` rule — exact 20-scope enum from AGENTS.md rule #5
   - `scope-empty` rule — scope is mandatory (no scopeless commits)
3. **`.husky/commit-msg`** hook added — runs `pnpm exec commitlint --edit $1` on every commit locally.
4. **CI job `commitlint`** added to `.github/workflows/ci.yml` (PR-only) — validates all PR commits with `pnpm exec commitlint --from origin/$base --to $head_sha --verbose`.
5. **`CONTRIBUTING.md`** updated — new "Commit message lint (commitlint)" subsection with local verification commands, CI description, and explanation that bypassing is forbidden per rule #7.

## Why

PR-2.A audit task (Sprint 0). Previously the scope enum was only enforced manually in review. This automates enforcement both locally (commit-msg hook) and in CI (commitlint job on PRs).

## How to test

1. **Local hook:**
   ```bash
   pnpm install
   # Valid — should pass:
   echo "feat(web): test" | pnpm exec commitlint
   # Invalid scope — should fail:
   echo "feat(monorepo): test" | pnpm exec commitlint
   # Missing scope — should fail:
   echo "feat: test" | pnpm exec commitlint
   ```
2. **CI:** The `commitlint` job runs only on `pull_request` events. Check this PR's CI for the job.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Ran commitlint against valid scopes (`ci`, `web`, `root`), invalid scopes (`monorepo`, `all`, `app`, `core`), and scopeless commits — all validated correctly. Commit-msg hook ran successfully during the PR commit itself.
- [ ] Vitest passes: No test code changed — existing tests unaffected.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (this PR enforces existing rule #5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
