### PR TITLE
feat(eslint-plugins): add rq-keys-only-from-factory rule (automates AGENTS rule #2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -331,5 +331,21 @@ export default [
       "sergeant-design/no-bigint-string": "error",
     },
   },
+  // React Query keys factory guardrail — AGENTS.md hard rule #2: all
+  // `queryKey` / `mutationKey` values must come from the centralized
+  // factory in `apps/web/src/shared/lib/queryKeys.ts`. Inline array
+  // literals break bulk invalidation and let typos compile silently.
+  // The factory file itself is exempt (it defines the arrays).
+  {
+    files: ["apps/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "apps/web/src/shared/lib/queryKeys.ts",
+      "apps/web/src/**/*.test.{ts,tsx}",
+      "apps/web/src/**/__tests__/**",
+    ],
+    rules: {
+      "sergeant-design/rq-keys-only-from-factory": "error",
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/packages/eslint-plugin-sergeant-design/README.md
+++ b/packages/eslint-plugin-sergeant-design/README.md
@@ -92,6 +92,42 @@ return rows.map((r) => ({
 }));
 ```
 
+### `sergeant-design/rq-keys-only-from-factory`
+
+Forbids inline array literals for React Query `queryKey` / `mutationKey`. All keys must come from the centralized factory in `queryKeys.ts` ([AGENTS.md rule #2](../../AGENTS.md)). Severity: **error** (scoped to `apps/web/src/**`).
+
+The rule catches inline `ArrayExpression` in:
+
+- **RQ hooks:** `useQuery`, `useMutation`, `useInfiniteQuery`, `useSuspenseQuery`, `useSuspenseInfiniteQuery`
+- **QueryClient option methods:** `invalidateQueries`, `cancelQueries`, `removeQueries`, `fetchQuery`, `prefetchQuery`, `refetchQueries`, `resetQueries`
+- **QueryClient direct-key methods:** `getQueryData`, `setQueryData`, `getQueriesData`, `getQueryState`, `ensureQueryData`
+
+The factory file itself is always exempt — it legitimately defines the key arrays.
+
+#### Options
+
+| Option              | Type     | Default                                | Description                                                  |
+| ------------------- | -------- | -------------------------------------- | ------------------------------------------------------------ |
+| `factoryModulePath` | `string` | `apps/web/src/shared/lib/queryKeys.ts` | Path to the query keys factory file (relative to repo root). |
+
+#### Examples
+
+```ts
+// ❌ BAD — inline array literal drifts from the factory
+useQuery({ queryKey: ["finyk", "transactions", accountId], queryFn: fn });
+queryClient.invalidateQueries({ queryKey: ["finyk"] });
+queryClient.getQueryData(["finyk", "mono"]);
+
+// ✅ GOOD — factory key from queryKeys.ts
+import { finykKeys } from "@shared/lib/queryKeys";
+useQuery({
+  queryKey: finykKeys.monoTransactionsDb(from, to, accountId),
+  queryFn: fn,
+});
+queryClient.invalidateQueries({ queryKey: finykKeys.all });
+queryClient.getQueryData(finykKeys.mono);
+```
+
 ## Running tests
 
 ```sh

--- a/packages/eslint-plugin-sergeant-design/__tests__/rq-keys-only-from-factory.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/rq-keys-only-from-factory.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for the `sergeant-design/rq-keys-only-from-factory` rule.
+ *
+ * The rule enforces AGENTS.md hard rule #2: all React Query keys must
+ * come from the centralized factory in `queryKeys.ts`. Inline array
+ * literals for `queryKey` / `mutationKey` are forbidden.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/rq-keys-only-from-factory";
+
+function lint(code, filename = "apps/web/src/modules/finyk/hooks/useTx.js") {
+  return linter.verify(
+    code,
+    {
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: "error" },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    { filename },
+  );
+}
+
+// ─── Happy path: factory usage (no errors) ─────────────────────────────
+
+describe("rq-keys-only-from-factory — valid (factory keys)", () => {
+  it("allows useQuery with factory identifier key", () => {
+    const messages = lint(`
+      import { finykKeys } from "@shared/lib/queryKeys";
+      useQuery({ queryKey: finykKeys.all, queryFn: fetchAll });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows useQuery with factory function call key", () => {
+    const messages = lint(`
+      import { finykKeys } from "@shared/lib/queryKeys";
+      useQuery({ queryKey: finykKeys.monoStatement(accId, from, to), queryFn: fn });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows useMutation without mutationKey", () => {
+    const messages = lint(`
+      useMutation({ mutationFn: doSomething });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows useMutation with factory identifier key", () => {
+    const messages = lint(`
+      useMutation({ mutationKey: finykKeys.all, mutationFn: fn });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows queryClient.invalidateQueries with factory key", () => {
+    const messages = lint(`
+      queryClient.invalidateQueries({ queryKey: finykKeys.all });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows queryClient.getQueryData with factory key", () => {
+    const messages = lint(`
+      queryClient.getQueryData(finykKeys.mono);
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows queryClient.setQueryData with factory key", () => {
+    const messages = lint(`
+      queryClient.setQueryData(finykKeys.mono, newData);
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows spread in queryKey (not an array literal)", () => {
+    const messages = lint(`
+      const key = finykKeys.all;
+      useQuery({ queryKey: key, queryFn: fn });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows variable reference as queryKey", () => {
+    const messages = lint(`
+      const myKey = getKey();
+      useQuery({ queryKey: myKey, queryFn: fn });
+    `);
+    assert.equal(messages.length, 0);
+  });
+});
+
+// ─── Fail path: inline array literals ───────────────────────────────────
+
+describe("rq-keys-only-from-factory — invalid (inline arrays)", () => {
+  it("flags useQuery with inline array queryKey", () => {
+    const messages = lint(`
+      useQuery({ queryKey: ["finyk", "transactions", accountId], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.ok(messages[0].message.includes("queryKey"));
+  });
+
+  it("flags useMutation with inline array mutationKey", () => {
+    const messages = lint(`
+      useMutation({ mutationKey: ["finyk", "update"], mutationFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+    assert.ok(messages[0].message.includes("mutationKey"));
+  });
+
+  it("flags useInfiniteQuery with inline array queryKey", () => {
+    const messages = lint(`
+      useInfiniteQuery({ queryKey: ["items", page], queryFn: fn, getNextPageParam: p => p });
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags useSuspenseQuery with inline array queryKey", () => {
+    const messages = lint(`
+      useSuspenseQuery({ queryKey: ["data"], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.invalidateQueries with inline array", () => {
+    const messages = lint(`
+      queryClient.invalidateQueries({ queryKey: ["finyk"] });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.getQueryData with inline array", () => {
+    const messages = lint(`
+      queryClient.getQueryData(["finyk", "mono"]);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.setQueryData with inline array", () => {
+    const messages = lint(`
+      queryClient.setQueryData(["finyk", "mono"], newData);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.fetchQuery with inline array", () => {
+    const messages = lint(`
+      queryClient.fetchQuery({ queryKey: ["data"], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.prefetchQuery with inline array", () => {
+    const messages = lint(`
+      queryClient.prefetchQuery({ queryKey: ["data"], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.cancelQueries with inline array", () => {
+    const messages = lint(`
+      queryClient.cancelQueries({ queryKey: ["data"] });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags queryClient.removeQueries with inline array", () => {
+    const messages = lint(`
+      queryClient.removeQueries({ queryKey: ["data"] });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags empty inline array queryKey", () => {
+    const messages = lint(`
+      useQuery({ queryKey: [], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+  });
+});
+
+// ─── Edge cases ─────────────────────────────────────────────────────────
+
+describe("rq-keys-only-from-factory — edge cases", () => {
+  it("does NOT flag inside the factory file itself (.ts)", () => {
+    const messages = lint(
+      `export const finykKeys = { all: ["finyk"] };`,
+      "apps/web/src/shared/lib/queryKeys.js",
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag inside the factory file itself (exact path match)", () => {
+    const messages = lint(
+      `useQuery({ queryKey: ["finyk"], queryFn: fn });`,
+      "some/prefix/apps/web/src/shared/lib/queryKeys.js",
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag unrelated function calls with array arguments", () => {
+    const messages = lint(`
+      someOtherFunction({ queryKey: ["test"] });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag useQuery without queryKey property", () => {
+    const messages = lint(`
+      useQuery(someOptionsObject);
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("flags computed property name 'queryKey' with inline array", () => {
+    const messages = lint(`
+      useQuery({ ["queryKey"]: ["test"], queryFn: fn });
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("does NOT flag non-MemberExpression callee for QC methods", () => {
+    const messages = lint(`
+      invalidateQueries({ queryKey: ["test"] });
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag queryClient method with non-array first arg", () => {
+    const messages = lint(`
+      queryClient.getQueryData(finykKeys.all);
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("handles deeply nested useQuery call", () => {
+    const messages = lint(`
+      function useThing() {
+        return useQuery({
+          queryKey: ["deeply", "nested", id],
+          queryFn: () => fetch("/api"),
+          enabled: !!id,
+        });
+      }
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("does NOT flag array in other property of useQuery options", () => {
+    const messages = lint(`
+      useQuery({
+        queryKey: finykKeys.all,
+        queryFn: fn,
+        select: (data) => [data],
+      });
+    `);
+    assert.equal(messages.length, 0);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -939,6 +939,156 @@ const noBigintString = {
   },
 };
 
+// ─── rq-keys-only-from-factory ──────────────────────────────────────────
+//
+// AGENTS.md hard rule #2 — all React Query keys must come from the
+// centralized factory in `apps/web/src/shared/lib/queryKeys.ts`.
+// Inline array literals (`queryKey: ['something', id]`) drift from the
+// factory, break bulk invalidation, and let typos compile silently.
+//
+// The rule flags `queryKey` or `mutationKey` properties whose value is
+// an ArrayExpression in:
+//   - `useQuery({ queryKey: [...] })`
+//   - `useMutation({ mutationKey: [...] })`
+//   - `useInfiniteQuery({ queryKey: [...] })`
+//   - `queryClient.invalidateQueries({ queryKey: [...] })`
+//   - `queryClient.getQueryData([...])`
+//   - `queryClient.setQueryData([...], ...)`
+//   - `queryClient.cancelQueries({ queryKey: [...] })`
+//   - `queryClient.removeQueries({ queryKey: [...] })`
+//   - `queryClient.fetchQuery({ queryKey: [...] })`
+//   - `queryClient.prefetchQuery({ queryKey: [...] })`
+//   - `queryClient.refetchQueries({ queryKey: [...] })`
+//
+// The factory file itself is exempt (it legitimately defines the arrays).
+
+const RQ_HOOKS = new Set([
+  "useQuery",
+  "useMutation",
+  "useInfiniteQuery",
+  "useSuspenseQuery",
+  "useSuspenseInfiniteQuery",
+]);
+
+const QC_OPTION_METHODS = new Set([
+  "invalidateQueries",
+  "cancelQueries",
+  "removeQueries",
+  "fetchQuery",
+  "prefetchQuery",
+  "refetchQueries",
+  "resetQueries",
+  "isFetching",
+]);
+
+const QC_DIRECT_KEY_METHODS = new Set([
+  "getQueryData",
+  "getQueriesData",
+  "setQueryData",
+  "getQueryState",
+  "ensureQueryData",
+]);
+
+const DEFAULT_FACTORY_PATH = "apps/web/src/shared/lib/queryKeys.ts";
+
+const RQ_KEYS_MESSAGE =
+  "Inline array literal for `{{prop}}` — use a factory from `queryKeys.ts` instead (AGENTS.md rule #2). Inline keys drift from the factory, break bulk invalidation, and let typos compile.";
+
+const rqKeysOnlyFromFactory = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid inline array literals for React Query `queryKey` / `mutationKey`. All keys must come from the centralized factory in `queryKeys.ts` (AGENTS.md rule #2).",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          factoryModulePath: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: { inlineKey: RQ_KEYS_MESSAGE },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const factoryPath = options.factoryModulePath || DEFAULT_FACTORY_PATH;
+
+    const filename = context.filename || context.getFilename();
+    const normalizedFilename = filename.replace(/\\/g, "/");
+    const factoryBase = factoryPath.replace(/\\/g, "/").replace(/\.\w+$/, "");
+    const filenameBase = normalizedFilename.replace(/\.\w+$/, "");
+
+    if (filenameBase.endsWith(factoryBase)) {
+      return {};
+    }
+
+    function reportInlineArrayKey(node, propName) {
+      context.report({
+        node,
+        messageId: "inlineKey",
+        data: { prop: propName },
+      });
+    }
+
+    function checkOptionsObjectForInlineKey(arg) {
+      if (!arg || arg.type !== "ObjectExpression") return;
+      for (const prop of arg.properties) {
+        if (prop.type !== "Property") continue;
+        const keyName =
+          prop.key.type === "Identifier"
+            ? prop.key.name
+            : prop.key.type === "Literal"
+              ? prop.key.value
+              : null;
+        if (
+          (keyName === "queryKey" || keyName === "mutationKey") &&
+          prop.value.type === "ArrayExpression"
+        ) {
+          reportInlineArrayKey(prop.value, keyName);
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        // useQuery / useMutation / useInfiniteQuery / etc.
+        if (callee.type === "Identifier" && RQ_HOOKS.has(callee.name)) {
+          checkOptionsObjectForInlineKey(node.arguments[0]);
+          return;
+        }
+
+        // queryClient.invalidateQueries({ queryKey: [...] }) etc.
+        if (
+          callee.type === "MemberExpression" &&
+          !callee.computed &&
+          callee.property.type === "Identifier"
+        ) {
+          const methodName = callee.property.name;
+
+          if (QC_OPTION_METHODS.has(methodName)) {
+            checkOptionsObjectForInlineKey(node.arguments[0]);
+            return;
+          }
+
+          // queryClient.getQueryData([...]) — first arg is the key directly
+          if (QC_DIRECT_KEY_METHODS.has(methodName)) {
+            const firstArg = node.arguments[0];
+            if (firstArg && firstArg.type === "ArrayExpression") {
+              reportInlineArrayKey(firstArg, "queryKey");
+            }
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -949,6 +1099,7 @@ const plugin = {
     "valid-tailwind-opacity": validTailwindOpacity,
     "no-low-contrast-text-on-fill": noLowContrastTextOnFill,
     "no-bigint-string": noBigintString,
+    "rq-keys-only-from-factory": rqKeysOnlyFromFactory,
   },
 };
 
@@ -961,6 +1112,8 @@ export {
   TAILWIND_OPACITY_UTILITIES,
   STRONG_BG_FAMILIES,
   DEFAULT_NUMERIC_COLUMNS,
+  RQ_KEYS_MESSAGE,
+  DEFAULT_FACTORY_PATH,
 };
 
 export default plugin;


### PR DESCRIPTION
## What changed

Added a new ESLint rule `sergeant-design/rq-keys-only-from-factory` that enforces AGENTS.md hard rule #2: all React Query `queryKey` / `mutationKey` values must come from the centralized factory in `apps/web/src/shared/lib/queryKeys.ts`. Inline array literals are forbidden.

**Files changed:**

- `packages/eslint-plugin-sergeant-design/index.js` — new rule implementation
- `packages/eslint-plugin-sergeant-design/__tests__/rq-keys-only-from-factory.test.mjs` — 30 tests (valid/invalid/edge cases)
- `packages/eslint-plugin-sergeant-design/README.md` — added `rq-keys-only-from-factory` section (merged with `no-bigint-string` docs from #868)
- `eslint.config.js` — rule registered as `error` for `apps/web/src/**/*.{ts,tsx}`

### Rule semantics

The rule catches inline `ArrayExpression` for `queryKey` / `mutationKey` in:

- **RQ hooks:** `useQuery`, `useMutation`, `useInfiniteQuery`, `useSuspenseQuery`, `useSuspenseInfiniteQuery`
- **QueryClient option methods:** `invalidateQueries`, `cancelQueries`, `removeQueries`, `fetchQuery`, `prefetchQuery`, `refetchQueries`, `resetQueries`
- **QueryClient direct-key methods:** `getQueryData`, `setQueryData`, `getQueriesData`, `getQueryState`, `ensureQueryData`

**Exemptions:** the factory file itself (`queryKeys.ts`) and test files.

**Config option:** `factoryModulePath: string` (default: `apps/web/src/shared/lib/queryKeys.ts`).

### Examples

```ts
// ❌ BAD — inline array literal
useQuery({ queryKey: ["finyk", "transactions", accountId], queryFn: fn });
queryClient.invalidateQueries({ queryKey: ["finyk"] });
queryClient.getQueryData(["finyk", "mono"]);

// ✅ GOOD — factory from queryKeys.ts
import { finykKeys } from "@shared/lib/queryKeys";
useQuery({ queryKey: finykKeys.monoTransactionsDb(from, to, accountId), queryFn: fn });
queryClient.invalidateQueries({ queryKey: finykKeys.all });
queryClient.getQueryData(finykKeys.mono);
```

## Why

PR-2.C from the Sergeant audit (`docs/sergeant-audit-devin.md`, Sprint 1 #9). The codebase is already clean (no existing violations found), but the rule prevents future regressions mechanically instead of relying on code review alone.

## How to test

```bash
# Run plugin tests (30 new + 68 existing = 98 total)
pnpm lint:plugins

# Run full lint (confirms no false positives in the codebase)
pnpm lint

# Run typecheck
pnpm typecheck
```

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm lint:plugins` — 30/30 new tests pass for this rule
- [x] Full lint green: `pnpm lint` — no violations, no false positives from this rule
- [x] Typecheck green: `pnpm typecheck` — 13/13 packages pass
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

### CI note

The `check` job fails on `lint:plugins` due to a **pre-existing** test failure in `no-bigint-string.test.mjs` from PR #868 (the "does NOT flag spread elements" test uses `…r` Unicode ellipsis instead of `...r` three-dot spread — a syntax error in JS). This failure is present on `main` and is unrelated to this PR. The Vercel deployment failure is a rate limit, also unrelated.

## AGENTS.md updated?

- [ ] No — no new permanent rules (the rule enforces existing AGENTS.md rule #2)


Link to Devin session: https://app.devin.ai/sessions/39271e812f5a47f484d581070cd9bca7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
