### PR TITLE
chore(web,tsconfig): enable strictNullChecks (phase 1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "build:analyze": "cross-env ANALYZE=1 vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit && tsc -p tsconfig.strict.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/web/src/shared/lib/createModuleStorage.test.ts
+++ b/apps/web/src/shared/lib/createModuleStorage.test.ts
@@ -55,7 +55,7 @@ describe("createModuleStorage: debounce + skip-if-equal", () => {
     storage.writeJSONDebounced("k", { a: 1 }, 200);
     expect(localStorage.getItem("k")).toBeNull();
     vi.advanceTimersByTime(201);
-    expect(JSON.parse(localStorage.getItem("k"))).toEqual({ a: 1 });
+    expect(JSON.parse(localStorage.getItem("k")!)).toEqual({ a: 1 });
 
     const spy = vi.spyOn(Storage.prototype, "setItem");
     storage.writeJSONDebounced("k", { a: 1 }, 200);
@@ -70,7 +70,7 @@ describe("createModuleStorage: debounce + skip-if-equal", () => {
     storage.writeJSONDebounced("q", 2, 300);
     storage.writeJSONDebounced("q", 3, 300);
     vi.advanceTimersByTime(301);
-    expect(JSON.parse(localStorage.getItem("q"))).toBe(3);
+    expect(JSON.parse(localStorage.getItem("q")!)).toBe(3);
   });
 
   it("flushPendingWrites одразу скидає буфер", () => {
@@ -78,7 +78,7 @@ describe("createModuleStorage: debounce + skip-if-equal", () => {
     storage.writeJSONDebounced("p", "v", 500);
     expect(localStorage.getItem("p")).toBeNull();
     storage.flushPendingWrites();
-    expect(JSON.parse(localStorage.getItem("p"))).toBe("v");
+    expect(JSON.parse(localStorage.getItem("p")!)).toBe("v");
   });
 
   it("removeItem скасовує pending write", () => {
@@ -100,7 +100,7 @@ describe("createModuleStorage: ізоляція між модулями", () => 
     // b перезапише a, бо ключ один — але pending-стан ізольований.
     vi.advanceTimersByTime(101);
     // Останнє застосоване = B (оскільки обидва записали).
-    expect(JSON.parse(localStorage.getItem("same"))).toBe("B");
+    expect(JSON.parse(localStorage.getItem("same")!)).toBe("B");
     a.flushPendingWrites();
     b.flushPendingWrites();
   });

--- a/apps/web/src/shared/lib/storage.test.ts
+++ b/apps/web/src/shared/lib/storage.test.ts
@@ -61,7 +61,7 @@ describe("shared storage helpers", () => {
 
   it("safeWriteLS serializes objects and returns true on success", () => {
     expect(safeWriteLS("obj", { x: 1 })).toBe(true);
-    expect(JSON.parse(localStorage.getItem("obj"))).toEqual({ x: 1 });
+    expect(JSON.parse(localStorage.getItem("obj")!)).toEqual({ x: 1 });
   });
 
   it("safeWriteLS stores raw strings without double-quoting", () => {

--- a/apps/web/src/shared/lib/typedStore.test.ts
+++ b/apps/web/src/shared/lib/typedStore.test.ts
@@ -42,7 +42,7 @@ describe("typedStore", () => {
       defaultValue: { count: 0, name: "" },
     });
     store.set({ count: 5, name: "a" });
-    const raw = JSON.parse(globalThis.localStorage.getItem("test"));
+    const raw = JSON.parse(globalThis.localStorage.getItem("test")!);
     expect(raw).toEqual({ __v: 2, data: { count: 5, name: "a" } });
     expect(store.get()).toEqual({ count: 5, name: "a" });
   });
@@ -122,7 +122,7 @@ describe("typedStore", () => {
       schema,
       defaultValue: { count: 0, name: "" },
     });
-    let seen = null;
+    let seen: { count: number; name: string } | null = null;
     const off = store.subscribe((v) => {
       seen = v;
     });

--- a/apps/web/tsconfig.strict.json
+++ b/apps/web/tsconfig.strict.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "noEmit": true
+  },
+  "include": ["src/shared/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/frontend-tech-debt.md
+++ b/docs/frontend-tech-debt.md
@@ -207,6 +207,41 @@ Production код чистий. Тестові `any` — фабрики фікт
 
 ---
 
+### 11. Strict TypeScript rollout — Phase 1 (`strictNullChecks`) in progress
+
+**Контекст:** `apps/web/tsconfig.json` має `strict: false` + `allowJs: true`.
+Базовий `packages/config/tsconfig.base.json` — `strict: true`, але web-app
+перевизначає його. Це regression risk на найбільшому production surface.
+
+**Триетапний план:**
+
+| Phase | Прапор                                      | Скоуп                          | Статус      |
+| ----- | ------------------------------------------- | ------------------------------ | ----------- |
+| 1     | `strictNullChecks`                          | `src/shared/**`                | ✅ Виконано |
+| 2     | `strictNullChecks`                          | `src/core/lib/**` + розширення | TODO        |
+| 3     | повний `strict: true` + видалення `allowJs` | всі файли                      | TODO        |
+
+**Phase 1 деталі (цей PR — PR-6.A):**
+
+- Додано `apps/web/tsconfig.strict.json` — extends основний tsconfig,
+  додає `strictNullChecks: true`, includes тільки `src/shared/**`.
+- Typecheck script оновлено: `tsc -p tsconfig.strict.json --noEmit` додано
+  до pipeline.
+- **Baseline error count (з `strictNullChecks` на весь `apps/web`):** 518 помилок.
+  - `src/shared/**` — 7 помилок → виправлено (non-null assertions у тестах).
+  - `src/core/lib/**` — 16 помилок → TODO Phase 2.
+  - Інші модулі (`modules/`, `core/` без lib) — ~495 помилок → Phase 3.
+- Жодних `@ts-expect-error` або runtime-змін не додано.
+
+**Phase 2 (наступний PR):** розширити `tsconfig.strict.json` include на
+`src/core/lib/**`. Виправити 16 помилок (4 у production-коді
+`hubChatContext.ts`, решта в тестах).
+
+**Phase 3:** увімкнути `strict: true` у головному `tsconfig.json`, видалити
+`allowJs`, виправити всі залишкові помилки.
+
+---
+
 ## Recently completed
 
 - ✅ Vitest path aliases — 80/80 файлів зелені


### PR DESCRIPTION
## What changed

Enable `strictNullChecks: true` for `apps/web/src/shared/**` via a dedicated `tsconfig.strict.json`, as the first phase of a strict TypeScript rollout.

**Changes:**
- Added `apps/web/tsconfig.strict.json` — extends main tsconfig, adds `strictNullChecks: true`, scoped to `src/shared/**`
- Updated `apps/web/package.json` typecheck script to include `tsc -p tsconfig.strict.json --noEmit`
- Fixed 7 null-check type errors in test files (non-null assertions on `localStorage.getItem()` in test assertions)
- Updated `docs/frontend-tech-debt.md` — new section #11 documenting the strict TS rollout plan and Phase 1 status

## Why

Ref: **PR-6.A** from the independent audit (`docs/sergeant-audit-devin.md`, Sprint 0 #3).

`apps/web/tsconfig.json` overrides the base `strict: true` with `strict: false`. This is an active regression risk on the largest production surface (434 source files, 87k lines).

**Baseline error count** (with `strictNullChecks` on all of `apps/web`): **518 errors**.
Since this exceeds the 50-error threshold, scope is narrowed to `src/shared/**` only (7 errors → all fixed).

**Remaining TODO:**
- Phase 2: extend to `src/core/lib/**` (16 errors — 4 in production code, 12 in tests)
- Phase 3: full `strict: true` + remove `allowJs`

## How to test

```bash
cd apps/web
pnpm exec tsc -p tsconfig.strict.json --noEmit   # should pass (0 errors)
pnpm typecheck                                     # full pipeline passes
pnpm exec vitest run                              # 105 test files / 937 tests pass
pnpm lint                                          # no lint errors
```

---

## How AI-tested this PR

- [x] Vitest passes: 105 test files, 937 tests all green
- [x] `pnpm typecheck` (all 3 tsconfigs): 0 errors
- [x] `pnpm lint`: clean
- [x] No new `AI-DANGER` markers added
- [x] No `@ts-expect-error` directives added
- [x] No runtime logic changes — only non-null assertions in test files
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/29ae0ff360eb40088331f6f74bca6c12
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
