### PR TITLE
feat(eslint-plugins): add no-anthropic-key-in-logs rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -347,5 +347,21 @@ export default [
       "sergeant-design/rq-keys-only-from-factory": "error",
     },
   },
+  // Anthropic key logging guardrail — prevents accidental logging of
+  // `process.env.ANTHROPIC_API_KEY` or secret-like identifiers via
+  // console.* / logger.* / pino.* / log.*. See AGENTS.md security rules.
+  // Scoped to both server (where the key lives) and web (defense in depth).
+  {
+    files: ["apps/server/src/**/*.{js,ts}", "apps/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "apps/server/src/**/*.test.{js,ts}",
+      "apps/server/src/**/__tests__/**",
+      "apps/web/src/**/*.test.{ts,tsx}",
+      "apps/web/src/**/__tests__/**",
+    ],
+    rules: {
+      "sergeant-design/no-anthropic-key-in-logs": "error",
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/packages/eslint-plugin-sergeant-design/README.md
+++ b/packages/eslint-plugin-sergeant-design/README.md
@@ -128,6 +128,46 @@ queryClient.invalidateQueries({ queryKey: finykKeys.all });
 queryClient.getQueryData(finykKeys.mono);
 ```
 
+### `sergeant-design/no-anthropic-key-in-logs`
+
+Forbids logging Anthropic API keys or secrets via `console.*`, `logger.*`, `pino.*`, or `log.*` methods. Catches `process.env.ANTHROPIC_API_KEY` passed as an argument (always), and secret-like identifiers (`apiKey`, `anthropicKey`, `secret`) when the file imports `@anthropic-ai/sdk`. Severity: **error** (scoped to `apps/server/src/**` and `apps/web/src/**`).
+
+#### Detection
+
+- **Always flagged:** `process.env.ANTHROPIC_API_KEY` as a direct argument, inside a template literal, or in string concatenation.
+- **Flagged with Anthropic import:** identifiers matching `/apiKey/i`, `/anthropicKey/`, `/secret/i` — only when the file imports `@anthropic-ai/sdk`.
+- **Not flagged:** string literals mentioning "ANTHROPIC_API_KEY" (e.g. error messages), non-logger function calls, unknown logger objects.
+
+#### Options
+
+```json
+{
+  "sergeant-design/no-anthropic-key-in-logs": [
+    "error",
+    {
+      "additionalSecretIdentifiers": ["Token$", "^credential"]
+    }
+  ]
+}
+```
+
+| Option                        | Type       | Default | Description                                     |
+| ----------------------------- | ---------- | ------- | ----------------------------------------------- |
+| `additionalSecretIdentifiers` | `string[]` | `[]`    | Extra regex patterns to match identifier names. |
+
+#### Examples
+
+```ts
+// ❌ BAD — logs the actual API key value
+console.log(process.env.ANTHROPIC_API_KEY);
+console.log(`Key is ${process.env.ANTHROPIC_API_KEY}`);
+logger.info(apiKey); // when file imports @anthropic-ai/sdk
+
+// ✅ GOOD — safe logging
+console.error("ANTHROPIC_API_KEY is not set");
+console.log(requestId);
+```
+
 ## Running tests
 
 ```sh

--- a/packages/eslint-plugin-sergeant-design/__tests__/no-anthropic-key-in-logs.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-anthropic-key-in-logs.test.mjs
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for the `sergeant-design/no-anthropic-key-in-logs` rule.
+ *
+ * The rule prevents accidental logging of Anthropic API keys (or any
+ * secret) via `console.*`, `logger.*`, `pino.*`, or `log.*` methods.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import plugin from "../index.js";
+
+const linter = new Linter();
+const RULE_ID = "sergeant-design/no-anthropic-key-in-logs";
+
+function lint(code, options) {
+  const ruleConfig = options ? ["error", options] : "error";
+  return linter.verify(code, {
+    plugins: { "sergeant-design": plugin },
+    rules: { [RULE_ID]: ruleConfig },
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  });
+}
+
+// ── BAD: should flag ────────────────────────────────────────────────────
+
+describe("no-anthropic-key-in-logs \u2014 flags secret logging", () => {
+  it("flags console.log(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`console.log(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].ruleId, RULE_ID);
+  });
+
+  it("flags console.error(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`console.error(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags console.warn(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`console.warn(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags console.info(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`console.info(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags console.debug(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`console.debug(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags logger.info(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`logger.info(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags pino.warn(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`pino.warn(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags log.error(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`log.error(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags logger.trace(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`logger.trace(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags logger.fatal(process.env.ANTHROPIC_API_KEY)", () => {
+    const messages = lint(`logger.fatal(process.env.ANTHROPIC_API_KEY);`);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags template literal with process.env.ANTHROPIC_API_KEY", () => {
+    const messages = lint(
+      "console.log(`Key is ${process.env.ANTHROPIC_API_KEY}`);",
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags string concatenation with process.env.ANTHROPIC_API_KEY", () => {
+    const messages = lint(
+      'console.log("Key: " + process.env.ANTHROPIC_API_KEY);',
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags ANTHROPIC_API_KEY identifier as second arg", () => {
+    const messages = lint(
+      'console.log("key:", process.env.ANTHROPIC_API_KEY);',
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags apiKey identifier with @anthropic-ai/sdk import", () => {
+    const messages = lint(`
+      import Anthropic from "@anthropic-ai/sdk";
+      const apiKey = getKey();
+      console.log(apiKey);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags anthropicKey identifier with @anthropic-ai/sdk import", () => {
+    const messages = lint(`
+      import Anthropic from "@anthropic-ai/sdk";
+      const anthropicKey = "sk-test";
+      console.log(anthropicKey);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags secret identifier with @anthropic-ai/sdk import", () => {
+    const messages = lint(`
+      import { Anthropic } from "@anthropic-ai/sdk";
+      const secret = getSecret();
+      logger.info(secret);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags obj.apiKey with @anthropic-ai/sdk import", () => {
+    const messages = lint(`
+      import Anthropic from "@anthropic-ai/sdk";
+      console.log(config.apiKey);
+    `);
+    assert.equal(messages.length, 1);
+  });
+
+  it("flags template literal interpolating apiKey with @anthropic-ai/sdk import", () => {
+    const messages = lint(
+      'import Anthropic from "@anthropic-ai/sdk";\nconsole.log(`key=${apiKey}`);',
+    );
+    assert.equal(messages.length, 1);
+  });
+});
+
+// ── GOOD: should NOT flag ───────────────────────────────────────────────
+
+describe("no-anthropic-key-in-logs \u2014 allows safe logging", () => {
+  it("allows console.log with a plain string", () => {
+    const messages = lint('console.log("Hello world");');
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows console.log with a number", () => {
+    const messages = lint("console.log(42);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows console.log with a non-secret variable", () => {
+    const messages = lint("const name = 'test';\nconsole.log(name);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag apiKey without @anthropic-ai/sdk import", () => {
+    const messages = lint("const apiKey = getKey();\nconsole.log(apiKey);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag secret without @anthropic-ai/sdk import", () => {
+    const messages = lint("const secret = 'x';\nlogger.info(secret);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag non-logger function call with key", () => {
+    const messages = lint("sendEmail(process.env.ANTHROPIC_API_KEY);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag myCustomLogger.info (unknown logger object)", () => {
+    const messages = lint(
+      "myCustomLogger.info(process.env.ANTHROPIC_API_KEY);",
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag console.table (not in CONSOLE_METHODS)", () => {
+    const messages = lint("console.table(process.env.ANTHROPIC_API_KEY);");
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows logging error messages that mention 'key' as a string literal", () => {
+    const messages = lint('console.error("ANTHROPIC_API_KEY is not set");');
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows using process.env.ANTHROPIC_API_KEY outside of log calls", () => {
+    const messages = lint(
+      "const key = process.env.ANTHROPIC_API_KEY;\nconst client = new Anthropic({ apiKey: key });",
+    );
+    assert.equal(messages.length, 0);
+  });
+});
+
+// ── Custom config ───────────────────────────────────────────────────────
+
+describe("no-anthropic-key-in-logs \u2014 custom additionalSecretIdentifiers", () => {
+  it("flags custom pattern from additionalSecretIdentifiers", () => {
+    const messages = lint(
+      `
+      import Anthropic from "@anthropic-ai/sdk";
+      const myCustomToken = "tok-123";
+      console.log(myCustomToken);
+    `,
+      { additionalSecretIdentifiers: ["Token$"] },
+    );
+    assert.equal(messages.length, 1);
+  });
+
+  it("does NOT flag unmatched custom pattern", () => {
+    const messages = lint(
+      `
+      import Anthropic from "@anthropic-ai/sdk";
+      const userId = "user-123";
+      console.log(userId);
+    `,
+      { additionalSecretIdentifiers: ["Token$"] },
+    );
+    assert.equal(messages.length, 0);
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -1089,6 +1089,211 @@ const rqKeysOnlyFromFactory = {
   },
 };
 
+// ─── no-anthropic-key-in-logs ────────────────────────────────────────────
+//
+// Prevents accidental logging of Anthropic API keys (or any secret) via
+// `console.*` or common logger methods (`logger.*`, `pino.*`, `log.*`).
+//
+// Detects:
+//   - `process.env.ANTHROPIC_API_KEY` passed as a log argument.
+//   - Identifiers matching secret-like names (`apiKey`, `anthropicKey`,
+//     `secret`, etc.) when the file imports `@anthropic-ai/sdk`.
+//   - Template literals that interpolate any of the above.
+//
+// Configurable via `additionalSecretIdentifiers: string[]` — extra
+// regex patterns to match against identifier names.
+
+const CONSOLE_METHODS = new Set(["log", "warn", "error", "info", "debug"]);
+const LOGGER_METHODS = new Set([
+  "log",
+  "warn",
+  "error",
+  "info",
+  "debug",
+  "trace",
+  "fatal",
+]);
+const LOGGER_OBJECTS = new Set(["logger", "pino", "log"]);
+
+const DEFAULT_SECRET_PATTERNS = [
+  /\bapi[_-]?key\b/i,
+  /\banthropicKey\b/,
+  /\bsecret\b/i,
+  /\bANTHROPIC_API_KEY\b/,
+];
+
+const NO_ANTHROPIC_KEY_MESSAGE =
+  "Do not log Anthropic API keys (or any secret). See AGENTS.md security rules.";
+
+function isConsoleLogCall(callee) {
+  if (callee.type !== "MemberExpression" || callee.computed) return false;
+  if (
+    callee.property.type !== "Identifier" ||
+    !CONSOLE_METHODS.has(callee.property.name)
+  ) {
+    return false;
+  }
+  return (
+    callee.object.type === "Identifier" && callee.object.name === "console"
+  );
+}
+
+function isLoggerCall(callee) {
+  if (callee.type !== "MemberExpression" || callee.computed) return false;
+  if (callee.property.type !== "Identifier") return false;
+  if (!LOGGER_METHODS.has(callee.property.name)) return false;
+  return (
+    callee.object.type === "Identifier" &&
+    LOGGER_OBJECTS.has(callee.object.name)
+  );
+}
+
+function isProcessEnvAnthropicKey(node) {
+  // process.env.ANTHROPIC_API_KEY
+  if (node.type !== "MemberExpression" || node.computed) return false;
+  if (
+    node.property.type !== "Identifier" ||
+    node.property.name !== "ANTHROPIC_API_KEY"
+  ) {
+    return false;
+  }
+  const obj = node.object;
+  if (obj.type !== "MemberExpression" || obj.computed) return false;
+  if (obj.property.type !== "Identifier" || obj.property.name !== "env") {
+    return false;
+  }
+  return obj.object.type === "Identifier" && obj.object.name === "process";
+}
+
+function matchesSecretPattern(name, patterns) {
+  for (const pat of patterns) {
+    if (pat.test(name)) return true;
+  }
+  return false;
+}
+
+function argumentContainsSecret(node, patterns, fileHasAnthropicImport) {
+  if (!node) return false;
+
+  // process.env.ANTHROPIC_API_KEY — always flag
+  if (isProcessEnvAnthropicKey(node)) return true;
+
+  // Identifier with a secret-like name
+  if (node.type === "Identifier") {
+    if (node.name === "ANTHROPIC_API_KEY") return true;
+    if (fileHasAnthropicImport && matchesSecretPattern(node.name, patterns)) {
+      return true;
+    }
+  }
+
+  // MemberExpression — check the property name
+  if (
+    node.type === "MemberExpression" &&
+    !node.computed &&
+    node.property.type === "Identifier"
+  ) {
+    if (isProcessEnvAnthropicKey(node)) return true;
+    if (
+      fileHasAnthropicImport &&
+      matchesSecretPattern(node.property.name, patterns)
+    ) {
+      return true;
+    }
+  }
+
+  // Template literal — check expressions
+  if (node.type === "TemplateLiteral") {
+    for (const expr of node.expressions) {
+      if (argumentContainsSecret(expr, patterns, fileHasAnthropicImport)) {
+        return true;
+      }
+    }
+  }
+
+  // String concatenation (BinaryExpression with +)
+  if (node.type === "BinaryExpression" && node.operator === "+") {
+    return (
+      argumentContainsSecret(node.left, patterns, fileHasAnthropicImport) ||
+      argumentContainsSecret(node.right, patterns, fileHasAnthropicImport)
+    );
+  }
+
+  return false;
+}
+
+const noAnthropicKeyInLogs = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid logging Anthropic API keys or secrets via console.* / logger.* / pino.* / log.*. See AGENTS.md security rules.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalSecretIdentifiers: {
+            type: "array",
+            items: { type: "string" },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: { noLogSecret: NO_ANTHROPIC_KEY_MESSAGE },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const extraPatterns = (options.additionalSecretIdentifiers || []).map(
+      (s) => new RegExp(s),
+    );
+    const allPatterns = [...DEFAULT_SECRET_PATTERNS, ...extraPatterns];
+
+    let fileHasAnthropicImport = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source &&
+          node.source.value &&
+          typeof node.source.value === "string" &&
+          node.source.value.includes("@anthropic-ai/sdk")
+        ) {
+          fileHasAnthropicImport = true;
+        }
+      },
+      // Also detect require("@anthropic-ai/sdk")
+      CallExpression(node) {
+        // Check for require("@anthropic-ai/sdk")
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "require" &&
+          node.arguments.length > 0 &&
+          node.arguments[0].type === "Literal" &&
+          typeof node.arguments[0].value === "string" &&
+          node.arguments[0].value.includes("@anthropic-ai/sdk")
+        ) {
+          fileHasAnthropicImport = true;
+        }
+
+        // Check log calls
+        const callee = node.callee;
+        if (!isConsoleLogCall(callee) && !isLoggerCall(callee)) return;
+
+        for (const arg of node.arguments) {
+          if (
+            argumentContainsSecret(arg, allPatterns, fileHasAnthropicImport)
+          ) {
+            context.report({ node, messageId: "noLogSecret" });
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -1100,6 +1305,7 @@ const plugin = {
     "no-low-contrast-text-on-fill": noLowContrastTextOnFill,
     "no-bigint-string": noBigintString,
     "rq-keys-only-from-factory": rqKeysOnlyFromFactory,
+    "no-anthropic-key-in-logs": noAnthropicKeyInLogs,
   },
 };
 
@@ -1114,6 +1320,7 @@ export {
   DEFAULT_NUMERIC_COLUMNS,
   RQ_KEYS_MESSAGE,
   DEFAULT_FACTORY_PATH,
+  NO_ANTHROPIC_KEY_MESSAGE,
 };
 
 export default plugin;


### PR DESCRIPTION
## What changed

New ESLint rule `sergeant-design/no-anthropic-key-in-logs` that prevents accidental logging of Anthropic API keys or other secrets via `console.*`, `logger.*`, `pino.*`, or `log.*` methods.

From audit item **PR-9.D** — defense-in-depth against secret leaks in log output.

## Why

Accidentally logging `process.env.ANTHROPIC_API_KEY` (or variables holding it) leaks the secret to stdout/stderr, log aggregators, and error-tracking services. This rule catches the pattern at lint time.

## Detection

- **Always flagged:** `process.env.ANTHROPIC_API_KEY` as a direct argument, inside a template literal, or via string concatenation.
- **Flagged with Anthropic import:** identifiers matching `/apiKey/i`, `/anthropicKey/`, `/secret/i` — only when the file imports `@anthropic-ai/sdk` (heuristic to avoid false positives in unrelated code).
- **Not flagged:** string literals mentioning "ANTHROPIC_API_KEY" (e.g. error messages), non-logger function calls, unknown logger objects.

### Examples

```ts
// ❌ BAD — logs the actual API key value
console.log(process.env.ANTHROPIC_API_KEY);
console.log(`Key is ${process.env.ANTHROPIC_API_KEY}`);
logger.info(apiKey); // when file imports @anthropic-ai/sdk

// ✅ GOOD — safe logging
console.error("ANTHROPIC_API_KEY is not set");
console.log(requestId);
```

### Config

Optional `additionalSecretIdentifiers: string[]` — extra regex patterns to match against identifier names.

## How to test

```sh
pnpm --filter eslint-plugin-sergeant-design exec node --test __tests__/no-anthropic-key-in-logs.test.mjs
```

30 test cases covering:
- All `console.*` methods + `logger.*`/`pino.*`/`log.*`
- Template literals and string concatenation
- Identifiers with/without `@anthropic-ai/sdk` import (heuristic)
- Custom `additionalSecretIdentifiers` config
- Non-logger calls (should NOT flag)
- String literal messages mentioning key names (should NOT flag)

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran all 30 rule tests locally — all pass
- [x] `pnpm typecheck` green (13/13 tasks)
- [x] `pnpm --filter eslint-plugin-sergeant-design exec node --test` green for new rule
- [x] No new `AI-DANGER` markers added without justification.
- [x] No existing violations in codebase (`apps/server/src/` and `apps/web/src/`)

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/c8fb80da727e45ff82393faa9cdc6c2a
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ESLint security rule that automatically detects and prevents accidental logging of Anthropic API keys and secrets
  * Scans logging statements across console, logger, pino, and log methods
  * Includes support for configurable custom secret identifier patterns to catch additional sensitive values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->