### PR TITLE
ci(metrics): track strict TS coverage % per package

### DIFF
--- a/docs/frontend-tech-debt.md
+++ b/docs/frontend-tech-debt.md
@@ -242,6 +242,25 @@ Production код чистий. Тестові `any` — фабрики фікт
 
 ---
 
+### 12. Strict TS coverage tracking (CI)
+
+**Скрипт:** [`scripts/strict-coverage.mjs`](../scripts/strict-coverage.mjs) —
+сканує всі `tsconfig.json` у `apps/*/` та `packages/*/`, резолвить `extends`
+ланцюги, виводить markdown-таблицю з прапорами `strict`, `strictNullChecks`,
+`noImplicitAny`, `allowJs` для кожного пакету.
+
+**CI:** job `strict-coverage` у `.github/workflows/ci.yml` — інформативний
+(не блокує CI), пише результат у `$GITHUB_STEP_SUMMARY`. Видно на вкладці
+Summary кожного workflow run.
+
+**Локально:** `pnpm strict:coverage` або `node scripts/strict-coverage.mjs --json`.
+
+**Тести:** `node --test scripts/__tests__/strict-coverage.test.mjs`.
+
+Ref: PR-6.F (sergeant-audit-devin.md).
+
+---
+
 ## Recently completed
 
 - ✅ Vitest path aliases — 80/80 файлів зелені

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db:migrate": "pnpm --filter @sergeant/server db:migrate",
     "licenses:gen": "node scripts/generate-licenses.mjs",
     "licenses:check": "node scripts/generate-licenses.mjs check",
+    "strict:coverage": "node scripts/strict-coverage.mjs",
     "dead-code:packages": "node scripts/ts-prune-packages.mjs",
     "knip": "knip",
     "depcheck:all": "pnpm -r exec depcheck --ignore-patterns=dist,dist-server,coverage,.turbo",

--- a/scripts/__tests__/strict-coverage.test.mjs
+++ b/scripts/__tests__/strict-coverage.test.mjs
@@ -1,0 +1,126 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scanStrictCoverage, formatMarkdown } from "../strict-coverage.mjs";
+
+function createTmpRepo(structure) {
+  const root = mkdtempSync(join(tmpdir(), "strict-cov-test-"));
+  for (const [relPath, content] of Object.entries(structure)) {
+    const fullPath = join(root, relPath);
+    mkdirSync(join(fullPath, ".."), { recursive: true });
+    writeFileSync(fullPath, JSON.stringify(content, null, 2));
+  }
+  return root;
+}
+
+describe("scanStrictCoverage", () => {
+  test("detects strict: true from direct config", () => {
+    const root = createTmpRepo({
+      "apps/web/tsconfig.json": {
+        compilerOptions: { strict: true },
+      },
+      "packages/shared/tsconfig.json": {
+        compilerOptions: { strict: false, strictNullChecks: true },
+      },
+    });
+
+    try {
+      const result = scanStrictCoverage(root);
+      assert.equal(result.packages.length, 2);
+
+      const web = result.packages.find((p) => p.name === "apps/web");
+      assert.equal(web.strict, true);
+      assert.equal(web.strictNullChecks, true);
+      assert.equal(web.noImplicitAny, true);
+
+      const shared = result.packages.find((p) => p.name === "packages/shared");
+      assert.equal(shared.strict, false);
+      assert.equal(shared.strictNullChecks, true);
+      assert.equal(shared.noImplicitAny, false);
+
+      assert.equal(result.summary.total, 2);
+      assert.equal(result.summary.strictCount, 1);
+      assert.equal(result.summary.pct, 50);
+    } finally {
+      rmSync(root, { recursive: true });
+    }
+  });
+
+  test("resolves extends from relative path", () => {
+    const root = createTmpRepo({
+      "packages/config/tsconfig.base.json": {
+        compilerOptions: { strict: true, allowJs: true },
+      },
+      "packages/shared/tsconfig.json": {
+        extends: "../../packages/config/tsconfig.base.json",
+        compilerOptions: {},
+      },
+    });
+
+    try {
+      const result = scanStrictCoverage(root);
+      const shared = result.packages.find((p) => p.name === "packages/shared");
+      assert.equal(shared.strict, true);
+      assert.equal(shared.allowJs, true);
+    } finally {
+      rmSync(root, { recursive: true });
+    }
+  });
+
+  test("override in child takes precedence over extends", () => {
+    const root = createTmpRepo({
+      "packages/config/tsconfig.base.json": {
+        compilerOptions: { strict: true },
+      },
+      "apps/web/tsconfig.json": {
+        extends: "../../packages/config/tsconfig.base.json",
+        compilerOptions: { strict: false, allowJs: true },
+      },
+    });
+
+    try {
+      const result = scanStrictCoverage(root);
+      const web = result.packages.find((p) => p.name === "apps/web");
+      assert.equal(web.strict, false);
+      assert.equal(web.strictNullChecks, false);
+      assert.equal(web.allowJs, true);
+    } finally {
+      rmSync(root, { recursive: true });
+    }
+  });
+});
+
+describe("formatMarkdown", () => {
+  test("produces valid markdown table", () => {
+    const result = {
+      packages: [
+        {
+          name: "apps/web",
+          path: "apps/web/tsconfig.json",
+          strict: false,
+          strictNullChecks: true,
+          noImplicitAny: false,
+          allowJs: true,
+        },
+        {
+          name: "packages/shared",
+          path: "packages/shared/tsconfig.json",
+          strict: true,
+          strictNullChecks: true,
+          noImplicitAny: true,
+          allowJs: false,
+        },
+      ],
+      summary: { total: 2, strictCount: 1, pct: 50 },
+    };
+
+    const md = formatMarkdown(result);
+    assert.ok(md.includes("## Strict TypeScript Coverage"));
+    assert.ok(md.includes("1 / 2 packages"));
+    assert.ok(md.includes("50%"));
+    assert.ok(md.includes("| apps/web |"));
+    assert.ok(md.includes("| packages/shared |"));
+  });
+});

--- a/scripts/strict-coverage.mjs
+++ b/scripts/strict-coverage.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * strict-coverage.mjs
+ *
+ * Scans all tsconfig.json files in apps/* and packages/* and reports
+ * strict TypeScript coverage per package. Resolves `extends` chains
+ * naïvely (following local paths and @sergeant/config presets).
+ *
+ * Usage: node scripts/strict-coverage.mjs [--json] [--root <dir>]
+ *
+ * Outputs a markdown table to stdout (suitable for $GITHUB_STEP_SUMMARY).
+ * With --json, outputs machine-readable JSON instead.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+
+// --- Helpers ---
+
+// Strip JSON comments (single-line and block) and trailing commas,
+// respecting string boundaries so "//" inside strings is preserved.
+function stripJsonComments(text) {
+  let result = "";
+  let i = 0;
+  while (i < text.length) {
+    // String literal — pass through unchanged
+    if (text[i] === '"') {
+      result += '"';
+      i++;
+      while (i < text.length && text[i] !== '"') {
+        if (text[i] === "\\") {
+          result += text[i] + (text[i + 1] || "");
+          i += 2;
+        } else {
+          result += text[i];
+          i++;
+        }
+      }
+      if (i < text.length) {
+        result += '"';
+        i++;
+      }
+    }
+    // Single-line comment
+    else if (text[i] === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++;
+    }
+    // Block comment
+    else if (text[i] === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+    } else {
+      result += text[i];
+      i++;
+    }
+  }
+  // Remove trailing commas before } or ]
+  result = result.replace(/,\s*([\]}])/g, "$1");
+  return result;
+}
+
+/** Parse a tsconfig-like JSON file (with comments/trailing commas). */
+function parseTsconfig(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  return JSON.parse(stripJsonComments(raw));
+}
+
+/**
+ * Resolve `extends` to a file path.
+ * Handles relative paths and package references.
+ */
+function resolveExtends(extendsValue, fromDir, rootDir) {
+  if (extendsValue.startsWith(".")) {
+    const resolved = resolve(fromDir, extendsValue);
+    if (existsSync(resolved)) return resolved;
+    if (existsSync(resolved + ".json")) return resolved + ".json";
+    return null;
+  }
+
+  // Package reference — try node_modules resolution
+  const candidates = [
+    join(rootDir, "node_modules", extendsValue),
+    join(rootDir, "node_modules", extendsValue + ".json"),
+    join(fromDir, "node_modules", extendsValue),
+    join(fromDir, "node_modules", extendsValue + ".json"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Resolve compilerOptions by following the `extends` chain (max 5 levels).
+ * Returns merged compilerOptions.
+ */
+function resolveCompilerOptions(filePath, rootDir, depth = 0) {
+  if (depth > 5 || !existsSync(filePath)) return {};
+
+  const config = parseTsconfig(filePath);
+  let parentOpts = {};
+
+  if (config.extends) {
+    const parentPath = resolveExtends(
+      config.extends,
+      dirname(filePath),
+      rootDir,
+    );
+    if (parentPath) {
+      parentOpts = resolveCompilerOptions(parentPath, rootDir, depth + 1);
+    }
+  }
+
+  return { ...parentOpts, ...(config.compilerOptions || {}) };
+}
+
+// --- Glob helper ---
+
+// Find files matching "baseDir/*/suffix" pattern.
+function findFilesInSubdirs(baseDir, filename) {
+  if (!existsSync(baseDir)) return [];
+
+  const entries = readdirSync(baseDir, { withFileTypes: true });
+  const results = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const candidate = join(baseDir, entry.name, filename);
+      if (existsSync(candidate)) {
+        results.push(candidate);
+      }
+    }
+  }
+  return results;
+}
+
+// --- Main ---
+
+/**
+ * Scan the repo and return strict coverage info.
+ * @param {string} rootDir - repo root
+ * @returns {{ packages: Array<{name: string, path: string, strict: boolean, strictNullChecks: boolean, noImplicitAny: boolean, allowJs: boolean}>, summary: {total: number, strictCount: number, pct: number} }}
+ */
+export function scanStrictCoverage(rootDir) {
+  const tsconfigPaths = [
+    ...findFilesInSubdirs(join(rootDir, "apps"), "tsconfig.json"),
+    ...findFilesInSubdirs(join(rootDir, "packages"), "tsconfig.json"),
+  ].sort();
+
+  const packages = [];
+
+  for (const tsconfigPath of tsconfigPaths) {
+    const opts = resolveCompilerOptions(tsconfigPath, rootDir);
+    const relPath = tsconfigPath.replace(rootDir + "/", "");
+    const name = relPath.replace("/tsconfig.json", "");
+
+    const strict = opts.strict === true;
+    const strictNullChecks = strict || opts.strictNullChecks === true;
+    const noImplicitAny = strict || opts.noImplicitAny === true;
+    const allowJs = opts.allowJs === true;
+
+    packages.push({
+      name,
+      path: relPath,
+      strict,
+      strictNullChecks,
+      noImplicitAny,
+      allowJs,
+    });
+  }
+
+  const total = packages.length;
+  const strictCount = packages.filter((p) => p.strict).length;
+  const pct = total > 0 ? Math.round((strictCount / total) * 100) : 0;
+
+  return { packages, summary: { total, strictCount, pct } };
+}
+
+/** Format results as a markdown table. */
+export function formatMarkdown(result) {
+  const { packages, summary } = result;
+  const lines = [];
+
+  lines.push("## Strict TypeScript Coverage");
+  lines.push("");
+  lines.push(
+    `**Summary:** ${summary.strictCount} / ${summary.total} packages have full \`strict: true\` (${summary.pct}%)`,
+  );
+  lines.push("");
+  lines.push(
+    "| Package | strict | strictNullChecks | noImplicitAny | allowJs |",
+  );
+  lines.push(
+    "| ------- | ------ | ---------------- | ------------- | ------- |",
+  );
+
+  for (const pkg of packages) {
+    const row = [
+      pkg.name,
+      pkg.strict ? "✅" : "❌",
+      pkg.strictNullChecks ? "✅" : "❌",
+      pkg.noImplicitAny ? "✅" : "❌",
+      pkg.allowJs ? "⚠️" : "—",
+    ];
+    lines.push(`| ${row.join(" | ")} |`);
+  }
+
+  lines.push("");
+  lines.push(
+    `> strict TS coverage: ${summary.strictCount} / ${summary.total} packages (${summary.pct}%)`,
+  );
+
+  return lines.join("\n");
+}
+
+// --- CLI entrypoint ---
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes("--json");
+  const rootIdx = args.indexOf("--root");
+  const rootDir =
+    rootIdx !== -1 && args[rootIdx + 1]
+      ? resolve(args[rootIdx + 1])
+      : resolve(import.meta.dirname, "..");
+
+  const result = scanStrictCoverage(rootDir);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatMarkdown(result));
+  }
+}
+
+// Run if invoked directly
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("strict-coverage.mjs");
+
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
## What changed

Add a Node script (`scripts/strict-coverage.mjs`) that scans all `tsconfig.json` files in `apps/*/` and `packages/*/`, resolves `extends` chains naïvely, and reports strict TypeScript coverage per package as a markdown table.

**Changes:**
- `scripts/strict-coverage.mjs` — scanner with `--json` and `--root` CLI flags
- `scripts/__tests__/strict-coverage.test.mjs` — 4 tests (direct config, extends resolution, override precedence, markdown format)
- `package.json` — added `"strict:coverage"` script
- `docs/frontend-tech-debt.md` — added section #12 "Strict TS coverage tracking (CI)"

**CI workflow change (manual step required):**
The OAuth token used by Devin does not have `workflow` scope, so the `.github/workflows/ci.yml` change cannot be pushed. Please add the following job to `ci.yml` (before `migration-lint`):

```yaml
  strict-coverage:
    name: Strict TS coverage (informational)
    runs-on: ubuntu-latest
    continue-on-error: true
    steps:
      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
        with:
          node-version: "20"
      - name: Report strict TS coverage
        run: node scripts/strict-coverage.mjs >> "$GITHUB_STEP_SUMMARY"
```

## Why

Ref: **PR-6.F** from the independent audit (`docs/sergeant-audit-devin.md`).

Provides visibility into the strict TypeScript rollout progress across all packages. Currently 10/11 packages (91%) have full `strict: true` — only `apps/web` remains at `strict: false`.

## How to test

```bash
# Run the script directly
node scripts/strict-coverage.mjs          # markdown table
node scripts/strict-coverage.mjs --json   # machine-readable JSON
pnpm strict:coverage                      # via package script

# Run tests
node --test scripts/__tests__/strict-coverage.test.mjs
```

---

## How AI-tested this PR

- [x] Vitest passes: existing test suite unaffected
- [x] `pnpm typecheck`: all packages pass
- [x] Script runs correctly: reports 10/11 packages strict (91%)
- [x] Custom tests pass: 4/4 green (`node --test`)
- [x] No new `AI-DANGER` markers added
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/29ae0ff360eb40088331f6f74bca6c12
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
