### PR TITLE
fix(ci): respect explicit sub-flag overrides in strict-coverage

### DIFF
--- a/scripts/__tests__/strict-coverage.test.mjs
+++ b/scripts/__tests__/strict-coverage.test.mjs
@@ -90,6 +90,28 @@ describe("scanStrictCoverage", () => {
       rmSync(root, { recursive: true });
     }
   });
+
+  test("explicit sub-flag override takes precedence over strict: true", () => {
+    const root = createTmpRepo({
+      "apps/api/tsconfig.json": {
+        compilerOptions: {
+          strict: true,
+          strictNullChecks: false,
+          noImplicitAny: false,
+        },
+      },
+    });
+
+    try {
+      const result = scanStrictCoverage(root);
+      const api = result.packages.find((p) => p.name === "apps/api");
+      assert.equal(api.strict, true);
+      assert.equal(api.strictNullChecks, false);
+      assert.equal(api.noImplicitAny, false);
+    } finally {
+      rmSync(root, { recursive: true });
+    }
+  });
 });
 
 describe("formatMarkdown", () => {

--- a/scripts/strict-coverage.mjs
+++ b/scripts/strict-coverage.mjs
@@ -157,8 +157,12 @@ export function scanStrictCoverage(rootDir) {
     const name = relPath.replace("/tsconfig.json", "");
 
     const strict = opts.strict === true;
-    const strictNullChecks = strict || opts.strictNullChecks === true;
-    const noImplicitAny = strict || opts.noImplicitAny === true;
+    const strictNullChecks =
+      opts.strictNullChecks !== undefined
+        ? opts.strictNullChecks === true
+        : strict;
+    const noImplicitAny =
+      opts.noImplicitAny !== undefined ? opts.noImplicitAny === true : strict;
     const allowJs = opts.allowJs === true;
 
     packages.push({


### PR DESCRIPTION
## What changed

Fix `strictNullChecks`/`noImplicitAny` resolution in `scripts/strict-coverage.mjs` when an explicit sub-flag overrides `strict: true`.

**Before:** `const strictNullChecks = strict || opts.strictNullChecks === true` — short-circuits to `true` when `strict: true`, ignoring an explicit `strictNullChecks: false`.

**After:** `opts.strictNullChecks !== undefined ? opts.strictNullChecks === true : strict` — explicit sub-flag takes precedence, falling back to `strict` only when unset.

Added a test case covering the edge case (5 tests total now).

## Why

Flagged by Devin Review on PR #872. While no current repo tsconfig triggers this (`strict: true` + `strictNullChecks: false`), the pattern is valid TypeScript and the script should handle it correctly as a general-purpose tool.

## How to test

```bash
node --test scripts/__tests__/strict-coverage.test.mjs   # 5 tests pass
node scripts/strict-coverage.mjs                          # unchanged output (no current repo uses the edge case)
```

---

## How AI-tested this PR

- [x] Vitest passes: existing test suite unaffected
- [x] Custom tests pass: 5/5 green (`node --test`)
- [x] Script output unchanged for actual repo configs
- [x] No new `AI-DANGER` markers added

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/29ae0ff360eb40088331f6f74bca6c12
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
