### PR TITLE
feat(ui): design improvements — filled chip nav, module header tint, …

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -238,6 +238,7 @@ export default function App({
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       <ModuleHeader
+        module="finyk"
         left={
           typeof onBackToHub === "function" ? (
             <ModuleHeaderBackButton onClick={onBackToHub} />

--- a/apps/web/src/modules/finyk/pages/Overview.tsx
+++ b/apps/web/src/modules/finyk/pages/Overview.tsx
@@ -405,6 +405,8 @@ export function Overview({ mono, storage, onNavigate, showBalance = true }) {
           firstName={firstName}
           dateLabel={dateLabel}
           showBalance={showBalance}
+          dayBudget={dayBudget}
+          spendPlanRatio={spendPlanRatio}
         />
 
         <p className="text-xs text-subtle px-1 -mt-1 leading-relaxed">

--- a/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { cn } from "@shared/lib/cn";
 
 /**
- * Верхня градієнтна картка з нетворсом, balance-of-the-month і breakdown-ом
+ * Верхня картка з нетворсом, balance-of-the-month і breakdown-ом
  * (картки / борги / місяць). Чисто презентаційна — усі значення обчислює
  * Overview.
  */
@@ -14,27 +14,29 @@ const HeroCardImpl = function HeroCard({
   firstName,
   dateLabel,
   showBalance = true,
+  dayBudget = 0,
+  spendPlanRatio = 0,
 }) {
   return (
-    <div className="rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-700 to-emerald-900 text-white p-5 shadow-float border border-white/10">
+    <div className="rounded-3xl bg-finyk/[.06] dark:bg-finyk-surface-dark/10 border border-finyk/[.14] dark:border-finyk-border-dark/20 p-5 shadow-card">
       <div className="flex items-start justify-between gap-2">
         <div>
-          <p className="text-emerald-100/90 text-sm">Загальний нетворс</p>
-          <p className="text-xs text-emerald-200/70 mt-0.5">
+          <p className="text-sm text-muted">Загальний нетворс</p>
+          <p className="text-xs text-subtle mt-0.5">
             {firstName} · {dateLabel}
           </p>
         </div>
       </div>
       <div
         className={cn(
-          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums",
+          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums text-finyk-strong dark:text-finyk",
           !showBalance && "tracking-widest",
         )}
       >
         {showBalance ? (
           <>
             {networth.toLocaleString("uk-UA", { maximumFractionDigits: 0 })}
-            <span className="text-2xl font-semibold text-emerald-100 ml-1">
+            <span className="text-2xl font-semibold text-finyk/60 ml-1">
               ₴
             </span>
           </>
@@ -42,7 +44,7 @@ const HeroCardImpl = function HeroCard({
           "••••••"
         )}
       </div>
-      <div className="flex items-center gap-2 mt-3 text-emerald-100">
+      <div className="flex items-center gap-2 mt-3 text-finyk">
         <svg
           width="18"
           height="18"
@@ -58,31 +60,47 @@ const HeroCardImpl = function HeroCard({
           <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
           <polyline points="17 6 23 6 23 12" />
         </svg>
-        <span className="text-sm">
+        <span className="text-sm text-muted">
           {showBalance
             ? `Баланс місяця: ${monthBalance >= 0 ? "+" : "−"}${Math.abs(monthBalance).toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
             : "••••"}
         </span>
       </div>
-      <div className="flex flex-wrap gap-x-4 gap-y-2 mt-4 pt-4 border-t border-white/20 text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-2 mt-4 pt-4 border-t border-finyk/20 text-sm">
         <div>
-          <div className="text-xs text-emerald-200/80 mb-0.5">На картках</div>
-          <div className="font-semibold tabular-nums text-emerald-50">
+          <div className="text-xs text-subtle mb-0.5">На картках</div>
+          <div className="font-semibold tabular-nums text-text">
             {showBalance
               ? `+${monoTotal.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
               : "••••"}
           </div>
         </div>
-        <div className="w-px bg-white/25 hidden sm:block self-stretch min-h-[2.5rem]" />
+        <div className="w-px bg-finyk/20 hidden sm:block self-stretch min-h-[2.5rem]" />
         <div>
-          <div className="text-xs text-emerald-200/80 mb-0.5">Борги</div>
-          <div className="font-semibold tabular-nums text-emerald-50">
+          <div className="text-xs text-subtle mb-0.5">Борги</div>
+          <div className="font-semibold tabular-nums text-text">
             {showBalance
               ? `−${totalDebt.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
               : "••••"}
           </div>
         </div>
       </div>
+      {dayBudget > 0 && (
+        <div className="mt-3 px-3 py-2.5 rounded-2xl bg-finyk/[.06] border border-finyk/[.14]">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted font-medium">Бюджет на день</span>
+            <span className="text-base font-extrabold text-finyk-strong dark:text-finyk">
+              {Math.round(dayBudget).toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
+            </span>
+          </div>
+          <div className="mt-1.5 h-1 rounded-full bg-finyk/[.15] overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-brand-400 to-brand-500"
+              style={{ width: `${Math.min(100, spendPlanRatio * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukHeader.tsx
@@ -106,6 +106,7 @@ export function FizrukHeader({
 
   return (
     <ModuleHeader
+      module={showChevronBack ? undefined : "fizruk"}
       left={left}
       title={titleFor(page)}
       subtitle={showChevronBack ? undefined : subtitleFor(page, activeProgram)}

--- a/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
+++ b/apps/web/src/modules/nutrition/components/NutritionHeader.tsx
@@ -45,5 +45,5 @@ export function NutritionHeader({ busy: _busy, onBackToHub }) {
       <AppleBadge />
     );
 
-  return <ModuleHeader left={left} title="ХАРЧУВАННЯ" subtitle="Мій раціон" />;
+  return <ModuleHeader module="nutrition" left={left} title="ХАРЧУВАННЯ" subtitle="Мій раціон" />;
 }

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -480,6 +480,7 @@ export default function RoutineApp({
   return (
     <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
       <ModuleHeader
+        module="routine"
         left={
           typeof onBackToHub === "function" ? (
             <ModuleHeaderBackButton onClick={onBackToHub} />

--- a/apps/web/src/shared/components/layout/ModuleHeader.tsx
+++ b/apps/web/src/shared/components/layout/ModuleHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -29,8 +30,20 @@ export interface ModuleHeaderProps {
   right?: ReactNode;
   /** Override the default title/eyebrow/subtitle body entirely. */
   titleSlot?: ReactNode;
+  /** Optional: when provided the header gets a module-colored gradient tint and subtitle uses the module color. */
+  module?: ModuleAccent;
   className?: string;
 }
+
+const MODULE_HEADER_TOKENS: Record<
+  ModuleAccent,
+  { gradient: string; border: string; subtitle: string }
+> = {
+  finyk:     { gradient: "from-finyk/[.06]",     border: "border-finyk/[.14]",     subtitle: "text-finyk-strong dark:text-finyk/70" },
+  fizruk:    { gradient: "from-fizruk/[.06]",    border: "border-fizruk/[.14]",    subtitle: "text-fizruk-strong dark:text-fizruk/70" },
+  routine:   { gradient: "from-routine/[.06]",   border: "border-routine/[.14]",   subtitle: "text-routine-strong dark:text-routine/70" },
+  nutrition: { gradient: "from-nutrition/[.06]", border: "border-nutrition/[.14]", subtitle: "text-nutrition-strong dark:text-nutrition/70" },
+};
 
 export function ModuleHeader({
   title,
@@ -39,12 +52,18 @@ export function ModuleHeader({
   left,
   right,
   titleSlot,
+  module,
   className,
 }: ModuleHeaderProps) {
+  const mt = module ? MODULE_HEADER_TOKENS[module] : null;
+
   return (
     <div
       className={cn(
-        "shrink-0 bg-panel/95 backdrop-blur-md border-b border-line z-40 relative safe-area-pt",
+        "shrink-0 backdrop-blur-md z-40 relative safe-area-pt",
+        mt
+          ? cn("bg-gradient-to-b to-panel/95", mt.gradient, mt.border, "border-b")
+          : "bg-panel/95 border-b border-line",
         className,
       )}
     >
@@ -65,7 +84,10 @@ export function ModuleHeader({
                 </span>
               ) : null}
               {subtitle ? (
-                <span className="text-2xs text-subtle font-medium truncate">
+                <span className={cn(
+                  "text-2xs font-medium truncate",
+                  mt ? mt.subtitle : "text-subtle",
+                )}>
                   {subtitle}
                 </span>
               ) : null}

--- a/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
+++ b/apps/web/src/shared/components/ui/ModuleBottomNav.tsx
@@ -52,6 +52,7 @@ export interface ModuleBottomNavProps {
 type ColorTokens = {
   text: string;
   pill: string;
+  chipBg: string;
   glow: string;
   badge: string;
 };
@@ -60,24 +61,28 @@ const COLORS: Record<ModuleNavColor, ColorTokens> = {
   finyk: {
     text: "text-finyk",
     pill: "bg-gradient-to-r from-brand-400 to-brand-500",
+    chipBg: "bg-finyk/[.12]",
     glow: "drop-shadow-module-nav-finyk",
     badge: "bg-finyk",
   },
   fizruk: {
     text: "text-fizruk",
     pill: "bg-gradient-to-r from-teal-400 to-teal-500",
+    chipBg: "bg-fizruk/[.12]",
     glow: "drop-shadow-module-nav-fizruk",
     badge: "bg-fizruk",
   },
   routine: {
     text: "text-routine",
     pill: "bg-gradient-to-r from-coral-400 to-coral-500",
+    chipBg: "bg-routine/[.12]",
     glow: "drop-shadow-module-nav-routine",
     badge: "bg-routine",
   },
   nutrition: {
     text: "text-nutrition",
     pill: "bg-gradient-to-r from-lime-400 to-lime-500",
+    chipBg: "bg-nutrition/[.12]",
     glow: "drop-shadow-module-nav-nutrition",
     badge: "bg-nutrition",
   },
@@ -129,19 +134,11 @@ export function ModuleBottomNav({
                 active ? "text-text" : "text-muted hover:text-text/70",
               )}
             >
-              {active && (
-                <span
-                  className={cn(
-                    "absolute top-0 left-1/2 -translate-x-1/2",
-                    "w-10 h-1 rounded-full shadow-sm",
-                    tokens.pill,
-                  )}
-                  aria-hidden
-                />
-              )}
               <span
                 className={cn(
-                  "relative transition-[background-color,color,opacity,transform] duration-200",
+                  "relative flex items-center justify-center w-10 h-[26px] rounded-[13px]",
+                  "transition-[background-color,color,opacity,transform] duration-200",
+                  active ? tokens.chipBg : "bg-transparent",
                   active && tokens.text,
                   active && tokens.glow,
                 )}


### PR DESCRIPTION
…HeroCard refresh

① ModuleBottomNav: replace top-pill active indicator with a filled chip
  (w-10 h-[26px] rounded-[13px]) wrapping the icon, colored at 12% module
  opacity. Added `chipBg` to ColorTokens and COLORS for all 4 modules.

② ModuleHeader: add optional `module?: ModuleAccent` prop. When present,
  the header background becomes a gradient tint (from-{module}/[.06] →
  panel/95) with a module-colored border and subtitle rendered in
  text-{module}-strong / dark:text-{module}/70.
  Updated call sites: FinykApp, RoutineApp, FizrukHeader, NutritionHeader.

③ HeroCard (Finyk): convert from dark emerald gradient to light finyk-tinted
  panel (bg-finyk/[.06]). Balance rendered in text-finyk-strong /
  dark:text-finyk. Added day budget tile with progress bar; Overview now
  passes dayBudget and spendPlanRatio props.

https://claude.ai/code/session_01VinkitojMAa2e4G4mbukcz

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
