### PR TITLE
feat(eslint-plugins): add no-strict-bypass rule (forbid new ts-expect-error/as-any)

### DIFF
--- a/docs/frontend-tech-debt.md
+++ b/docs/frontend-tech-debt.md
@@ -272,6 +272,42 @@ Ref: PR-6.F (sergeant-audit-devin.md).
   - `core/lib/chatActions/fizrukActions.ts` — 7 raw calls → `safeReadLS` + `readWorkouts()` helper
   - `core/hub/HubDashboard.tsx` — вже використовував `localStorageStore` (KVStore adapter), прибрано з allowlist
 
+---
+
+### `no-strict-bypass` — TODO files
+
+**PR-6.E:** додано ESLint-правило
+[`sergeant-design/no-strict-bypass`](../packages/eslint-plugin-sergeant-design/index.js)
+зі scope `apps/web/src/**` + `apps/server/src/**`. Ловить 4 патерни:
+`// @ts-expect-error`, `// @ts-ignore`, `as any`, `as unknown as X`.
+
+Тести (`**/*.test.*`, `**/__tests__/**`, `**/*.spec.*`) — повний opt-out.
+
+На момент введення правила (2026-04-26) в production-коді знайдено
+**11 файлів** з `as unknown as X` (інших патернів — 0). Файли додані
+до allowlist у `eslint.config.js`. Міграція файла = видалення рядка
+з allowlist.
+
+| Файл                                                                | Патерн          | Кількість |
+| ------------------------------------------------------------------- | --------------- | --------- |
+| `apps/web/src/shared/components/ui/VoiceMicButton.tsx`              | `as unknown as` | 2         |
+| `apps/web/src/modules/fizruk/pages/Workouts.tsx`                    | `as unknown as` | 1         |
+| `apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts`         | `as unknown as` | 1         |
+| `apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts` | `as unknown as` | 1         |
+| `apps/web/src/modules/finyk/hooks/useFinykPersonalization.ts`       | `as unknown as` | 6         |
+| `apps/web/src/core/lib/hubChatUtils.ts`                             | `as unknown as` | 2         |
+| `apps/web/src/core/App.tsx`                                         | `as unknown as` | 3         |
+| `apps/server/src/modules/chat.ts`                                   | `as unknown as` | 1         |
+| `apps/server/src/lib/anthropic.ts`                                  | `as unknown as` | 1         |
+| `apps/server/src/lib/bankProxy.ts`                                  | `as unknown as` | 1         |
+| `apps/server/src/lib/webpushSend.ts`                                | `as unknown as` | 1         |
+
+**Fix recipe:** більшість `as unknown as X` замінюються правильним generic
+type parameter, type guard (`if ('prop' in obj)`), або `satisfies` +
+explicit return type.
+
+---
+
 ## Recommended next steps
 
 1. **Міграція TODO-списку `no-raw-local-storage`** — пріоритетно файли з

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -363,5 +363,42 @@ export default [
       "sergeant-design/no-anthropic-key-in-logs": "error",
     },
   },
+  // Type-safety bypass guardrail — PR-6.E: forbid new `@ts-expect-error`,
+  // `@ts-ignore`, `as any`, and `as unknown as X` in production code.
+  // These patterns erode type safety and make refactoring dangerous.
+  // Test files are exempt (they legitimately need type-level tricks).
+  //
+  // The `ignores` list below names every existing call-site as of the
+  // rule's introduction (see `docs/frontend-tech-debt.md` §no-strict-bypass).
+  // Migrate a file → drop it from the list.
+  {
+    files: ["apps/server/src/**/*.{js,ts}", "apps/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      // Tests can use type bypasses freely as fixtures.
+      "apps/server/src/**/*.test.{js,ts}",
+      "apps/server/src/**/__tests__/**",
+      "apps/web/src/**/*.test.{ts,tsx}",
+      "apps/web/src/**/__tests__/**",
+      "apps/web/src/**/test/**",
+      "apps/web/src/**/*.spec.{ts,tsx}",
+      // ── Existing `as unknown as` call-sites (do not add new ones) ──
+      // Web app
+      "apps/web/src/shared/components/ui/VoiceMicButton.tsx",
+      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
+      "apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts",
+      "apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts",
+      "apps/web/src/modules/finyk/hooks/useFinykPersonalization.ts",
+      "apps/web/src/core/lib/hubChatUtils.ts",
+      "apps/web/src/core/App.tsx",
+      // Server
+      "apps/server/src/modules/chat.ts",
+      "apps/server/src/lib/anthropic.ts",
+      "apps/server/src/lib/bankProxy.ts",
+      "apps/server/src/lib/webpushSend.ts",
+    ],
+    rules: {
+      "sergeant-design/no-strict-bypass": "error",
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/packages/eslint-plugin-sergeant-design/README.md
+++ b/packages/eslint-plugin-sergeant-design/README.md
@@ -168,6 +168,43 @@ console.error("ANTHROPIC_API_KEY is not set");
 console.log(requestId);
 ```
 
+### `sergeant-design/no-strict-bypass`
+
+Forbids type-safety bypasses in production code (PR-6.E). Catches four patterns:
+
+1. `// @ts-expect-error` comments
+2. `// @ts-ignore` comments
+3. `as any` casts
+4. `as unknown as X` double-casts
+
+Severity: **error** (scoped to `apps/web/src/**` and `apps/server/src/**`). Test files are exempt. Existing violations are allowlisted in `eslint.config.js` — see [`docs/frontend-tech-debt.md`](../../docs/frontend-tech-debt.md) §no-strict-bypass.
+
+#### Options
+
+| Option                         | Type      | Default | Description                          |
+| ------------------------------ | --------- | ------- | ------------------------------------ |
+| `forbidPatterns.tsExpectError` | `boolean` | `true`  | Flag `@ts-expect-error` comments.    |
+| `forbidPatterns.tsIgnore`      | `boolean` | `true`  | Flag `@ts-ignore` comments.          |
+| `forbidPatterns.asAny`         | `boolean` | `true`  | Flag `as any` casts.                 |
+| `forbidPatterns.asUnknownAs`   | `boolean` | `true`  | Flag `as unknown as X` double-casts. |
+
+#### Examples
+
+```ts
+// ❌ BAD — bypasses type system
+// @ts-expect-error
+const x = badCall();
+// @ts-ignore
+const y = badCall();
+const z = value as any;
+const w = window as unknown as { webkitAudioContext: typeof AudioContext };
+
+// ✅ GOOD — proper types
+const x: ReturnType<typeof badCall> = badCall();
+const z: SpecificType = value;
+const el = document.getElementById("foo") as HTMLDivElement;
+```
+
 ## Running tests
 
 ```sh

--- a/packages/eslint-plugin-sergeant-design/__tests__/no-strict-bypass.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-strict-bypass.test.mjs
@@ -1,0 +1,259 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Linter } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import plugin from "../index.js";
+
+const RULE_ID = "sergeant-design/no-strict-bypass";
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/** Lint JS code (comments only — no TS parser needed). */
+function lintJS(code, filename = "apps/web/src/modules/finyk/hooks/useTx.js") {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    {
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: "error" },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    { filename },
+  );
+}
+
+/** Lint TS code (uses @typescript-eslint/parser for TSAsExpression). */
+function lintTS(code, filename = "apps/web/src/modules/finyk/hooks/useTx.js") {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    {
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: "error" },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        parser: tsParser,
+      },
+    },
+    { filename },
+  );
+}
+
+/** Lint with specific forbidPatterns option. */
+function lintWithOptions(code, forbidPatterns, useTSParser = false) {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    {
+      plugins: { "sergeant-design": plugin },
+      rules: { [RULE_ID]: ["error", { forbidPatterns }] },
+      languageOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ...(useTSParser ? { parser: tsParser } : {}),
+      },
+    },
+    { filename: "apps/web/src/modules/test.js" },
+  );
+}
+
+// ── valid (no bypass) ───────────────────────────────────────────────────
+
+describe("no-strict-bypass — valid (clean code)", () => {
+  it("allows normal code without bypasses", () => {
+    const messages = lintJS(`
+      const x = 42;
+      const y = "hello";
+      function add(a, b) { return a + b; }
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows normal TS code with proper types", () => {
+    const messages = lintTS(`
+      const x: number = 42;
+      const y: string = "hello";
+      function greet(name: string): string { return name; }
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows `as unknown` without a second cast (NOT flagged)", () => {
+    const messages = lintTS(`
+      const x = someValue as unknown;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows generic type assertions `<T>value`", () => {
+    const messages = lintTS(`
+      const x = someValue as string;
+      const y = someValue as number;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows type assertions to concrete types", () => {
+    const messages = lintTS(`
+      const el = document.getElementById("foo") as HTMLDivElement;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("allows regular comments that mention ts-expect-error in prose", () => {
+    const messages = lintJS(`
+      // We removed the ts-expect-error from this line
+      const x = 42;
+    `);
+    assert.equal(messages.length, 0);
+  });
+});
+
+// ── invalid (all 4 patterns flagged) ────────────────────────────────────
+
+describe("no-strict-bypass — invalid (flags bypasses)", () => {
+  it("flags // @ts-expect-error", () => {
+    const messages = lintJS(`
+      // @ts-expect-error intentional
+      const x = badCall();
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "tsExpectError");
+  });
+
+  it("flags // @ts-ignore", () => {
+    const messages = lintJS(`
+      // @ts-ignore
+      const x = badCall();
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "tsIgnore");
+  });
+
+  it("flags `as any`", () => {
+    const messages = lintTS(`
+      const x = someValue as any;
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "asAny");
+  });
+
+  it("flags `as unknown as X` double-cast", () => {
+    const messages = lintTS(`
+      const x = someValue as unknown as string;
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "asUnknownAs");
+  });
+
+  it("flags multiple bypasses in the same file", () => {
+    const messages = lintTS(`
+      // @ts-expect-error
+      const a = bad1();
+      // @ts-ignore
+      const b = bad2();
+      const c = bad3 as any;
+      const d = bad4 as unknown as string;
+    `);
+    assert.equal(messages.length, 4);
+  });
+
+  it("flags @ts-expect-error with extra whitespace", () => {
+    const messages = lintJS(`
+      //   @ts-expect-error  some reason
+      const x = badCall();
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "tsExpectError");
+  });
+
+  it("flags @ts-ignore inside block comment", () => {
+    const messages = lintJS(`
+      /* @ts-ignore */
+      const x = badCall();
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "tsIgnore");
+  });
+
+  it("flags `as any` in function arguments", () => {
+    const messages = lintTS(`
+      doSomething(value as any);
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "asAny");
+  });
+
+  it("flags `as unknown as` with complex target type", () => {
+    const messages = lintTS(`
+      const x = window as unknown as { webkitAudioContext: typeof AudioContext };
+    `);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "asUnknownAs");
+  });
+});
+
+// ── edge cases ──────────────────────────────────────────────────────────
+
+describe("no-strict-bypass — edge cases", () => {
+  it("does NOT flag `as unknown` alone (single cast to unknown)", () => {
+    const messages = lintTS(`
+      const x = someValue as unknown;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag `as string` (specific type)", () => {
+    const messages = lintTS(`
+      const x = someValue as string;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("does NOT flag `as Record<string, unknown>`", () => {
+    const messages = lintTS(`
+      const x = someValue as Record<string, unknown>;
+    `);
+    assert.equal(messages.length, 0);
+  });
+
+  it("respects forbidPatterns config — disable tsExpectError", () => {
+    const messages = lintWithOptions(
+      `// @ts-expect-error disabled\nconst x = 1;`,
+      { tsExpectError: false },
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("respects forbidPatterns config — disable asAny", () => {
+    const messages = lintWithOptions(
+      `const x = value as any;`,
+      { asAny: false },
+      true,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("respects forbidPatterns config — disable asUnknownAs", () => {
+    const messages = lintWithOptions(
+      `const x = value as unknown as string;`,
+      { asUnknownAs: false },
+      true,
+    );
+    assert.equal(messages.length, 0);
+  });
+
+  it("respects forbidPatterns config — disable tsIgnore only", () => {
+    const messages = lintWithOptions(
+      `// @ts-ignore\nconst x = 1;\n// @ts-expect-error\nconst y = 2;`,
+      { tsIgnore: false },
+    );
+    // @ts-ignore should be allowed, but @ts-expect-error still flagged
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].messageId, "tsExpectError");
+  });
+});

--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -1294,6 +1294,116 @@ const noAnthropicKeyInLogs = {
   },
 };
 
+// ─── no-strict-bypass ───────────────────────────────────────────────────
+//
+// PR-6.E — forbid new type-safety bypasses in production code:
+//   1. `// @ts-expect-error` comments
+//   2. `// @ts-ignore` comments
+//   3. `as any` casts (TSAsExpression → TSAnyKeyword)
+//   4. `as unknown as X` double-casts (TSAsExpression wrapping another
+//      TSAsExpression whose typeAnnotation is TSUnknownKeyword)
+//
+// Test files are exempt via eslint.config.js `ignores`.
+// Existing violations are allowlisted (see docs/frontend-tech-debt.md).
+
+const NO_STRICT_BYPASS_MESSAGES = {
+  tsExpectError:
+    "`@ts-expect-error` bypasses type checking — fix the type error or add a proper type assertion instead.",
+  tsIgnore:
+    "`@ts-ignore` silently suppresses type errors — fix the type error or use a narrower workaround.",
+  asAny:
+    "`as any` erases type safety — use a specific type or a type guard instead.",
+  asUnknownAs:
+    "`as unknown as X` double-cast bypasses the type system — refactor to avoid the unsafe cast.",
+};
+
+const DEFAULT_FORBID_PATTERNS = {
+  tsExpectError: true,
+  tsIgnore: true,
+  asAny: true,
+  asUnknownAs: true,
+};
+
+const noStrictBypass = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid `@ts-expect-error`, `@ts-ignore`, `as any`, and `as unknown as X` in production code (PR-6.E).",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          forbidPatterns: {
+            type: "object",
+            properties: {
+              tsExpectError: { type: "boolean" },
+              tsIgnore: { type: "boolean" },
+              asAny: { type: "boolean" },
+              asUnknownAs: { type: "boolean" },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: NO_STRICT_BYPASS_MESSAGES,
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const forbid = { ...DEFAULT_FORBID_PATTERNS, ...options.forbidPatterns };
+
+    const listeners = {};
+
+    // ── Comment-based patterns ──────────────────────────────────────
+    if (forbid.tsExpectError || forbid.tsIgnore) {
+      listeners["Program:exit"] = function () {
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        for (const comment of sourceCode.getAllComments()) {
+          const text = comment.value.trim();
+          if (forbid.tsExpectError && /^@ts-expect-error\b/.test(text)) {
+            context.report({ node: comment, messageId: "tsExpectError" });
+          }
+          if (forbid.tsIgnore && /^@ts-ignore\b/.test(text)) {
+            context.report({ node: comment, messageId: "tsIgnore" });
+          }
+        }
+      };
+    }
+
+    // ── AST-based patterns (TS parser required) ─────────────────────
+    if (forbid.asAny || forbid.asUnknownAs) {
+      listeners["TSAsExpression"] = function (node) {
+        // `as any`
+        if (
+          forbid.asAny &&
+          node.typeAnnotation &&
+          node.typeAnnotation.type === "TSAnyKeyword"
+        ) {
+          context.report({ node, messageId: "asAny" });
+          return;
+        }
+
+        // `as unknown as X` — outer TSAsExpression whose inner expression
+        // is another TSAsExpression with TSUnknownKeyword.
+        if (
+          forbid.asUnknownAs &&
+          node.expression &&
+          node.expression.type === "TSAsExpression" &&
+          node.expression.typeAnnotation &&
+          node.expression.typeAnnotation.type === "TSUnknownKeyword"
+        ) {
+          context.report({ node, messageId: "asUnknownAs" });
+        }
+      };
+    }
+
+    return listeners;
+  },
+};
+
 const plugin = {
   rules: {
     "no-eyebrow-drift": noEyebrowDrift,
@@ -1306,6 +1416,7 @@ const plugin = {
     "no-bigint-string": noBigintString,
     "rq-keys-only-from-factory": rqKeysOnlyFromFactory,
     "no-anthropic-key-in-logs": noAnthropicKeyInLogs,
+    "no-strict-bypass": noStrictBypass,
   },
 };
 
@@ -1321,6 +1432,8 @@ export {
   RQ_KEYS_MESSAGE,
   DEFAULT_FACTORY_PATH,
   NO_ANTHROPIC_KEY_MESSAGE,
+  NO_STRICT_BYPASS_MESSAGES,
+  DEFAULT_FORBID_PATTERNS,
 };
 
 export default plugin;


### PR DESCRIPTION
## What changed

New ESLint rule `sergeant-design/no-strict-bypass` (PR-6.E from audit) that forbids four type-safety bypass patterns in production code:

1. `// @ts-expect-error` comments
2. `// @ts-ignore` comments
3. `as any` casts
4. `as unknown as X` double-casts

The rule is registered as `error` for `apps/server/src/**` and `apps/web/src/**`. Test files are exempt. All 11 existing `as unknown as X` violations are added to an allowlist in `eslint.config.js` — none are fixed in this PR (separate task).

## Why

PR-6.E from the Sergeant audit. These patterns silently bypass TypeScript's type system, making refactoring dangerous and hiding real type errors. The rule prevents new occurrences while documenting existing tech debt.

## Examples

```ts
// ❌ BAD — bypasses type system
// @ts-expect-error
const x = badCall();
// @ts-ignore
const y = badCall();
const z = value as any;
const w = window as unknown as { webkitAudioContext: typeof AudioContext };

// ✅ GOOD — proper types
const x: ReturnType<typeof badCall> = badCall();
const z: SpecificType = value;
const el = document.getElementById("foo") as HTMLDivElement;
const u = someValue as unknown; // single cast to unknown — OK
```

## How to test

```sh
# Plugin tests (22 tests: valid/invalid/edge cases)
pnpm --filter eslint-plugin-sergeant-design exec node --test

# Full lint (no new violations)
pnpm lint

# Typecheck
pnpm typecheck
```

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm typecheck` — 13/13 green
- [x] Plugin tests: 22/22 green (3 suites: valid, invalid, edge cases)
- [x] `pnpm lint` passes (pre-existing `no-bigint-string` spread test failure from main — not related)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

## Files changed

- `packages/eslint-plugin-sergeant-design/index.js` — rule implementation
- `packages/eslint-plugin-sergeant-design/__tests__/no-strict-bypass.test.mjs` — 22 tests
- `packages/eslint-plugin-sergeant-design/README.md` — rule documentation
- `eslint.config.js` — rule registration + allowlist (11 files)
- `docs/frontend-tech-debt.md` — §no-strict-bypass TODO files table


Link to Devin session: https://app.devin.ai/sessions/39271e812f5a47f484d581070cd9bca7
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
