### PR TITLE
docs(docs): polish docs/launch/02-go-to-market.md

### DIFF
--- a/docs/launch/02-go-to-market.md
+++ b/docs/launch/02-go-to-market.md
@@ -1,49 +1,77 @@
 # 02. Go-to-market: запуск, промоутинг, growth
 
-> Pre-MVP draft. Цифри trafic/CPA/reach — оцінкові, для брейнштормінгу.
-> Джерело: `sergeant-monetization-plan.md` (ч.2), `sergeant-launch-checklist.md` (§7–§9), `sergeant-toolstack.md` (§5–§7, §11).
+> Pre-MVP draft. Цифри traffic/CPA/reach — оцінкові, для брейнштормінгу.
+> Джерело: `sergeant-monetization-plan.md` (ч.2), `sergeant-launch-checklist.md` (§7–§9),
+> `sergeant-toolstack.md` (§5–§7, §11).
 
 ---
 
 ## 1. Стратегія запуску: фази
 
 ```
-ФАЗА 0: Pre-launch (2-4 тижні до запуску)
+ФАЗА 0: Pre-launch (T-4 … T-2 тижні)
   │
-ФАЗА 1: Soft launch / Closed beta (2-4 тижні)
+ФАЗА 1: Soft launch / Closed beta (2–4 тижні)
   │
 ФАЗА 2: Public launch (тиждень запуску)
   │
 ФАЗА 3: Growth (ongoing)
   │
-ФАЗА 4: Expansion (3-6 місяців після)
+ФАЗА 4: Expansion (3–6 місяців після)
 ```
 
 ---
 
 ## 2. ФАЗА 0 — Pre-launch
 
-**Мета:** зібрати waitlist 500–1000 людей до запуску.
+**Мета:** зібрати waitlist 500–1 000 людей до запуску.
 
-### Landing page
+### 2.1 Pre-launch checklist
+
+| #   | Дія                                                      | Дедлайн   | Відповідальний |
+| --- | -------------------------------------------------------- | --------- | -------------- |
+| 1   | Зареєструвати домен `sergeant.com.ua`                    | T-28 днів | Засновник      |
+| 2   | Задеплоїти landing page (Astro або Vite static build)    | T-25 днів | Засновник      |
+| 3   | Підключити email-збір (Loops або ConvertKit free tier)   | T-25 днів | Засновник      |
+| 4   | Створити Telegram-канал «Sergeant 🎖️» + бот для підписки | T-24 дні  | Засновник      |
+| 5   | Опублікувати перший Build-in-Public пост (Twitter/X)     | T-21 день | Засновник      |
+| 6   | Написати founder's story для DOU.ua (див. §4.3 нижче)    | T-18 днів | Засновник      |
+| 7   | Запустити опитування «Які модулі найважливіші?» (Tally)  | T-17 днів | Засновник      |
+| 8   | Провести 10–15 custdev-інтерв'ю з target-юзерами         | T-14 днів | Засновник      |
+| 9   | Підготувати Product Hunt assets (демо-відео, скріни)     | T-10 днів | Засновник      |
+| 10  | Зібрати 20+ PH-хантерів / early supporters               | T-7 днів  | Засновник      |
+| 11  | Фіналізувати share-card генератор (OG images)            | T-5 днів  | Засновник      |
+| 12  | Dry-run launch day: перевірити всі лінки, CTA, analytics | T-2 дні   | Засновник      |
+
+> **T** = дата public launch (ФАЗА 2). Всі дедлайни — від цієї дати назад.
+
+### 2.2 Landing page
 
 - Окремий лендінг: «Sergeant — один додаток замість п'яти».
 - Email-збір: «Отримай ранній доступ + пожиттєву знижку».
 - Таймер зворотного відліку.
-- **Інструменти:** сам Sergeant web (Vite), або Carrd/Framer/Astro для швидкості.
+- **Інструменти:** Sergeant web (Vite SSG build) або Astro/Framer для швидкості.
+- **URL-стратегія:**
 
-### Build in Public
+```
+sergeant.com.ua                → Landing page (маркетинг)
+app.sergeant.com.ua            → PWA-додаток
+sergeant.com.ua/blog           → SEO-блог (Astro SSG)
+```
 
-- **Twitter/X:** щоденні/щотижневі апдейти, скрін нових фіч, цифри («AI-розпізнавання їжі — точність 87 %»), behind-the-scenes.
+### 2.3 Build in Public
+
+- **Twitter/X:** щоденні/щотижневі апдейти, скріни фіч, цифри
+  («AI-розпізнавання їжі — точність 87 %»), behind-the-scenes.
 - **Threads:** для UA-аудиторії (зростаюча платформа).
-- **DOU.ua:** «Як я будую all-in-one life tracker на React».
+- **DOU.ua:** «Як я будую all-in-one life tracker на React» (див. §4.3).
 - **Indie Hackers:** journey + revenue goals.
 
-### Збір фідбеку
+### 2.4 Збір фідбеку
 
 - Tally / Typeform: «Які модулі вам найважливіші?»
 - Telegram-канал/група для ранніх адоптерів.
-- 10–15 інтерв'ю з потенційними юзерами.
+- 10–15 інтерв'ю з потенційними юзерами (Calendly + Google Meet).
 
 ---
 
@@ -51,55 +79,189 @@
 
 **Мета:** 100–200 активних тестерів, сигнали Product-Market Fit.
 
-### Інвайт-система
+### 3.1 Інвайт-система
 
 - Кожен бета-юзер отримує 3–5 інвайтів.
 - «Приведи друга — отримай +1 місяць Pro безкоштовно».
 - Створює exclusivity + word-of-mouth.
 
-### Фідбек-лупи
+### 3.2 Фідбек-лупи
 
 - In-app feedback widget («Є ідея / Знайшов баг»).
 - Щотижневий email-дайджест: «Що ми зробили цього тижня за вашим фідбеком».
 - NPS опитування після 7 днів використання.
 
-### Ключові метрики бети
+### 3.3 Ключові метрики бети
 
-- **D1 retention:** >40 % (хороший), >60 % (відмінний).
-- **D7 retention:** >20 %.
-- **WAU/MAU:** >50 % (sticky product).
-- **Activation rate:** % юзерів, які додали запис у 2+ модулях за 3 дні.
+| Метрика             | Прийнятно | Добре  | Відмінно |
+| ------------------- | --------- | ------ | -------- |
+| **D1 retention**    | > 30 %    | > 40 % | > 60 %   |
+| **D7 retention**    | > 15 %    | > 20 % | > 30 %   |
+| **WAU/MAU**         | > 40 %    | > 50 % | > 65 %   |
+| **Activation rate** | > 25 %    | > 40 % | > 60 %   |
+
+> **Activation** = юзер додав запис у 2+ модулях за перші 3 дні.
+> Джерело retention/activation бенчмарків: [01-monetization-and-pricing.md](./01-monetization-and-pricing.md) §7.
 
 ---
 
 ## 4. ФАЗА 2 — Public launch
 
-**Мета:** 1000–5000 юзерів за перший тиждень.
+**Мета:** 1 000–5 000 юзерів за перший тиждень.
 
-### Product Hunt
+### 4.1 Product Hunt playbook
 
-- **Коли:** вівторок або середа (найкращі дні).
-- Підготувати: демо-відео 2 хв, скріншоти, description.
-- Заголовок: «Sergeant — Personal life hub: finance + fitness + habits + nutrition with AI».
-- Попросити бета-юзерів upvote + залишити review.
-- **Target:** Top-5 Product of the Day.
+#### Таймлайн
 
-### Українські канали
+| Коли            | Дія                                                               |
+| --------------- | ----------------------------------------------------------------- |
+| T-14 днів       | Створити PH draft, завантажити логотип, скріни, short description |
+| T-10 днів       | Записати демо-відео (2 хв макс., див. сценарій нижче)             |
+| T-7 днів        | Знайти Hunter (топ-хантер або @chrismessina рівня)                |
+| T-3 дні         | Написати 20+ людям у LinkedIn/Twitter з проханням підтримати      |
+| T-1 день        | Фіналізувати description, перший коментар, перевірити лінки       |
+| **Launch day**  | Опублікувати о 00:01 PST (10:01 Київ). Моніторити коментарі       |
+| Launch + 1 день | Подякувати всім, хто upvote. Шерити результат у Telegram/Twitter  |
 
-| Канал                                    | Формат                     | Очікуваний reach |
-| ---------------------------------------- | -------------------------- | ---------------- |
-| **DOU.ua**                               | Стаття «Як я побудував…»   | 5K–20K читачів   |
-| **AIN.ua**                               | Прес-реліз / стаття        | 10K–50K          |
-| **Telegram: «Українські стартапи»**      | Пост + лінк                | 5K–15K           |
-| **Telegram: фін-канали** (Mono, фінанси) | Пост про Фінік             | 10K–30K          |
-| **Telegram: фітнес-канали**              | Пост про Фізрук+Харчування | 5K–20K           |
-| **Threads UA**                           | Серія постів               | 1K–10K           |
-| **Reddit: r/ukraine, r/productivity**    | Пост                       | 2K–10K           |
-| **Instagram Reels / TikTok**             | Демо-відео 30–60 с         | 5K–100K (вірус)  |
+#### Headline-формули (обрати одну)
 
-### Запускова акція
+```
+Формула А: "[Назва] — [What] for [Who]"
+→ "Sergeant — All-in-one life hub for finance, fitness, habits & nutrition"
 
-- **«Founder's Deal»:** перші 100 підписників — Lifetime Pro за ₴999 (замість ₴799/рік).
+Формула Б: "[Action verb] your [outcome] with [differentiator]"
+→ "Track your money, workouts, habits & meals — one app, AI-powered"
+
+Формула В: "[Number] apps replaced by one"
+→ "Replace 5 apps with one — finance, fitness, habits, nutrition + AI coach"
+```
+
+> Заголовок ≤ 60 символів. Перший рядок — найважливіший.
+
+#### Демо-відео сценарій (90–120 с)
+
+```
+[0:00–0:05]  Hook: «Скільки додатків ви використовуєте щодня для фінансів,
+              фітнесу, звичок і їжі? А якщо все це — в одному?»
+[0:05–0:20]  Огляд Dashboard: 4 модулі на одному екрані.
+[0:20–0:40]  Фінік: додати транзакцію → Mono sync → AI-інсайт.
+[0:40–0:55]  Фізрук: почати тренування → логування сетів → AI workout summary.
+[0:55–1:05]  Рутина: чекнути 3 звички → стрік 14 днів → heatmap.
+[1:05–1:20]  Харчування: сфотографувати їжу → AI-розпізнавання → калорії.
+[1:20–1:35]  AI-чат: «Сержанте, що мені порадиш?» → крос-модульний інсайт.
+[1:35–1:45]  CTA: «Спробуй безкоштовно — sergeant.com.ua».
+[1:45–1:50]  Логотип + посилання.
+```
+
+> Записувати: OBS Studio (безкоштовно) або Loom.
+> Формат: 1920×1080, .mp4, субтитри вшити (для autoplay без звуку).
+
+#### Hunter strategy
+
+1. **Ідеальний hunter** — людина з 1 000+ followers на PH, яка вже хантила
+   productivity/finance/health продукти.
+2. **Де шукати:** [producthunt.com/directory/upcoming](https://producthunt.com/directory/upcoming),
+   Twitter-пошук `"product hunt" "looking for products"`.
+3. **Як підійти:** коротке DM (LinkedIn або Twitter) з demo-лінком + одне речення
+   чому це релевантно їхній аудиторії.
+4. **Якщо не знайшли hunter:** self-launch — це ОК. Фокус на якості першого
+   коментаря важливіший за ім'я hunter.
+
+#### Перший коментар (maker comment template)
+
+```
+👋 Привіт, Product Hunt! Я [Ім'я], засновник Sergeant.
+
+Sergeant — це один додаток замість п'яти: фінанси, фітнес, звички,
+харчування + AI-асистент, що бачить повну картину твого дня.
+
+Чому я це побудував:
+- Я використовував 5 різних додатків і жоден не знав про інші.
+- Мій фітнес-трекер не знав, що я на дієті. Мій бюджет-додаток
+  не знав, що я витратив ₴2K на спортзал.
+- Sergeant це виправляє: AI бачить все і дає розумні поради.
+
+🇺🇦 Зроблений в Україні. Працює офлайн. Дані на пристрої.
+
+Буду радий фідбеку — що додати першим?
+```
+
+### 4.2 Українські канали
+
+#### Telegram-канали (конкретні, з оцінкою аудиторії)
+
+| Канал (Telegram handle)                | Тематика              | Підписники (орієнтовно) | Формат посту                 |
+| -------------------------------------- | --------------------- | ----------------------- | ---------------------------- |
+| **@monobankukraine**                   | Фінанси, monobank     | ~600K                   | Пост про інтеграцію Фініка   |
+| **@oaboronov** (Олег Гороховський)     | Фінтех, бізнес        | ~700K                   | Колаборація, згадка продукту |
+| **@investory_ua**                      | Інвестиції, фінанси   | ~120K                   | Огляд фін-модуля             |
+| **@groshi_ua**                         | Фінансова грамотність | ~80K                    | Спонсорський пост            |
+| **@startupukraine**                    | Стартапи              | ~25K                    | Founder's story              |
+| **@ain_ua**                            | Технології, стартапи  | ~90K                    | Прес-реліз / огляд           |
+| **@daboronov** (Моно фінансові поради) | Особисті фінанси      | ~150K                   | Пост про бюджетування        |
+| **@fitness_ua_channel**                | Фітнес                | ~45K                    | Пост про Фізрук-модуль       |
+| **@zozh_ukraine**                      | ЗОЖ, здоров'я         | ~60K                    | Огляд харчування + фітнес    |
+| **@productivity_ua**                   | Продуктивність        | ~35K                    | Огляд all-in-one трекера     |
+| **@digitalnomad_ua**                   | Фріланс, IT           | ~40K                    | Build in public story        |
+
+> Підписники — оцінка на базі TGStat (uk.tgstat.com), квітень 2026.
+> Стратегія: почати з безкоштовних згадок (DOU, стартапи), потім бартер
+> (Pro за пост), потім платна реклама у великих каналах (₴2K–5K за пост).
+
+#### Інші українські платформи
+
+| Канал                                 | Формат                   | Очікуваний reach |
+| ------------------------------------- | ------------------------ | ---------------- |
+| **DOU.ua**                            | Стаття «Як я побудував…» | 5K–20K читачів   |
+| **AIN.ua**                            | Прес-реліз / стаття      | 10K–50K          |
+| **Threads UA**                        | Серія постів             | 1K–10K           |
+| **Reddit: r/ukraine, r/productivity** | Пост                     | 2K–10K           |
+| **Instagram Reels / TikTok**          | Демо-відео 30–60 с       | 5K–100K (вірус)  |
+
+### 4.3 DOU.ua / AIN.ua — founder's story template
+
+Структура статті для DOU.ua (лонгрід 1 500–2 500 слів):
+
+```
+Заголовок-формула: «Як я побудував [що] — [результат] за [час]»
+→ «Як я побудував all-in-one life tracker на React — від ідеї до 200 бета-юзерів за 3 місяці»
+
+Секції:
+
+1. HOOK (100 слів)
+   Проблема → біль → «я використовував 5 додатків і збожеволів».
+
+2. РІШЕННЯ (200 слів)
+   Що таке Sergeant, одне речення positioning. Скріншот dashboard.
+
+3. ТЕХНОЛОГІЯ (400 слів)
+   Стек: React 19, Vite, Express, PostgreSQL, Expo, Capacitor.
+   Чому PWA, чому offline-first, чому AI (Anthropic Claude).
+   Код-фрагмент або архітектурна діаграма (developers = аудиторія DOU).
+
+4. ВИКЛИКИ (300 слів)
+   3 найбільші проблеми: sync conflicts, AI cost, mono-інтеграція.
+   Чесно — що не вийшло з першого разу.
+
+5. МЕТРИКИ (200 слів)
+   Beta-результати: D1/D7 retention, NPS, кількість тестерів.
+   Скріншот PostHog або графіка.
+
+6. МОНЕТИЗАЦІЯ (200 слів)
+   Freemium модель, ціни, чому ₴99/міс — конкурентно.
+   Посилання на 01-monetization-and-pricing.md (внутрішнє).
+
+7. CTA (100 слів)
+   «Спробуй безкоштовно» + лінк + QR-код + Telegram-канал.
+```
+
+> **Для AIN.ua:** коротша версія (600–800 слів), фокус на продукт + ринок,
+> менше коду. Формат прес-релізу: «Український розробник запустив…».
+
+### 4.4 Запускова акція
+
+- **«Founder's Deal»:** перші 100 підписників — Lifetime Pro за ₴999
+  (замість ₴799/рік).
 - **«Перший місяць безкоштовно»** для всіх, хто зареєструється на launch-week.
 - **Referral:** «Приведи 3 друзів → Pro на 3 місяці».
 
@@ -116,71 +278,150 @@
 | «Як рахувати калорії без зусиль»         | рахувати калорії додаток | TOFU        |
 | «Monobank аналітика: як бачити більше»   | monobank аналітика       | MOFU        |
 | «Програма тренувань вдома безкоштовно»   | тренування вдома         | TOFU        |
-| «Sergeant vs MyFitnessPal: порівняння»   | сержант vs               | BOFU        |
+| «Sergeant vs MyFitnessPal: порівняння»   | sergeant vs mfp          | BOFU        |
 | «Як я скинув 10 кг з трекером»           | user story               | TOFU        |
 
-> Блог на `sergeant.2dmanager.com.ua/blog` — дає SEO juice основному домену.
+> Блог на `sergeant.com.ua/blog` (Astro SSG) — дає SEO juice основному домену.
+> Інструменти для контенту/SEO → [03-services-and-toolstack.md](./03-services-and-toolstack.md) §6.5–§6.6.
 
 ### 5.2 Реферальна програма
 
-```
-Рівні:
-  1 друг   → +1 тиждень Pro
-  3 друзі  → +1 місяць Pro
-  5 друзів → +3 місяці Pro
-  10 друзів → Lifetime Pro
+#### Тарифна сітка
 
-Механіка:
-  - Унікальне посилання для кожного юзера
-  - In-app таблиця лідерів (gamification)
-  - Push-нотифікація: «Твій друг Олена приєдналась!»
+| Рівень    | Нагорода referrer | Нагорода referee  |
+| --------- | ----------------- | ----------------- |
+| 1 друг    | +1 тиждень Pro    | +7 днів Pro trial |
+| 3 друзі   | +1 місяць Pro     | +7 днів Pro trial |
+| 5 друзів  | +3 місяці Pro     | +7 днів Pro trial |
+| 10 друзів | Lifetime Pro      | +7 днів Pro trial |
+
+**Cap:** максимум 12 місяців Pro через referrals (крім рівня Lifetime).
+
+#### Unit economics рефералу
+
+```
+Вхідні дані:
+  Pro ARPU           = ₴99/міс
+  Avg. lifetime      = 6 міс → LTV = ₴594
+  Free → Pro conv.   = 5 %
+  LTV per install    = ₴594 × 5 % = ₴29.70
+
+Вартість рефералу для маркетингу:
+  Referrer reward    = 7 днів Pro = ₴99 ÷ 30 × 7 ≈ ₴23
+  Referee reward     = 7 днів Pro trial = ₴0 (trial, не revenue loss)
+  Ефективний CAC     = ₴23 за реферала
+
+Висновок:
+  CAC (₴23) < LTV per install (₴29.70) → юніт-економіка позитивна.
+  Маркетинг готовий «платити» до ₴25 за рефералового юзера.
+  При 10 друзів (Lifetime Pro = ₴799 value) → CAC/реферал = ₴80.
+  Окупається якщо 3+ з 10 рефералів конвертнуться в Pro.
 ```
 
-### Технічна імплементація
+#### Механіка
+
+- Унікальне посилання для кожного юзера.
+- In-app таблиця лідерів (gamification).
+- Push-нотифікація: «Твій друг Олена приєдналась!»
+
+#### Технічна імплементація
 
 ```
 Потрібно:
   1. Таблиця referrals (referrer_id, referee_id, status, reward_applied)
   2. Унікальний referral code per user (8-char alphanumeric)
-  3. /api/referral/code → GET свій код
-  4. /api/referral/apply → POST при реєстрації (з query param ?ref=ABC123)
+  3. GET  /api/referral/code     → повертає код юзера
+  4. POST /api/referral/apply    → при реєстрації (з ?ref=ABC123)
   5. Landing: sergeant.com.ua/?ref=ABC123 → cookie → при signup apply
-
-Rewards:
-  Referrer: +7 днів Pro за кожного реферала
-  Referee:  +7 днів Pro trial
-  Cap: max 12 місяців Pro через referrals
 ```
 
-### 5.3 Вірусні петлі (viral loops)
+### 5.3 Share cards
+
+#### Формати та розміри
+
+| Платформа                  | Розмір (px)   | Aspect ratio | Де використовується     |
+| -------------------------- | ------------- | ------------ | ----------------------- |
+| Open Graph (Facebook, X)   | 1 200 × 630   | 1.91:1       | Посилання у соцмережах  |
+| Instagram / Telegram Story | 1 080 × 1 920 | 9:16         | Stories, прямий шерінг  |
+| Telegram-пост preview      | 1 200 × 630   | 1.91:1       | Preview у чатах/каналах |
+| Twitter card (summary)     | 800 × 418     | 1.91:1       | Twitter link preview    |
+
+#### Ескізи (ASCII)
+
+**OG-карточка (1 200 × 630):**
+
+```
+┌──────────────────────────────────────────────────┐
+│  [Sergeant Logo]          sergeant.com.ua        │
+│                                                  │
+│  🔥 14-денний стрік у Sergeant!                   │
+│                                                  │
+│  ┌──┬──┬──┬──┬──┬──┬──┐                          │
+│  │░░│░░│██│██│██│██│██│  ← heatmap               │
+│  │░░│██│██│██│██│██│██│    (green squares)        │
+│  └──┴──┴──┴──┴──┴──┴──┘                          │
+│                                                  │
+│  [QR-code]  «Приєднуйся → sergeant.com.ua»       │
+└──────────────────────────────────────────────────┘
+```
+
+**Story-карточка (1 080 × 1 920):**
+
+```
+┌────────────────────────┐
+│   [Sergeant Logo]      │
+│                        │
+│   Тренування           │
+│   завершено! 💪        │
+│                        │
+│   ┌──────────────────┐ │
+│   │ Chest Day        │ │
+│   │ 45 хв · 12 вправ │ │
+│   │ Tonnage: 4 200 кг│ │
+│   └──────────────────┘ │
+│                        │
+│   ┌──────────────────┐ │
+│   │   [QR-CODE]      │ │
+│   │                  │ │
+│   └──────────────────┘ │
+│                        │
+│  sergeant.com.ua       │
+└────────────────────────┘
+```
+
+#### Бібліотеки для генерації
+
+| Бібліотека       | Підхід                 | Плюси                                | Мінуси                         |
+| ---------------- | ---------------------- | ------------------------------------ | ------------------------------ |
+| **@vercel/og**   | Edge runtime + Satori  | JSX-шаблони, zero config на Vercel   | Тільки Vercel Edge             |
+| **Satori**       | JSX → SVG → PNG        | Standalone, будь-який Node.js сервер | Потрібен resvg для PNG         |
+| **node-canvas**  | Canvas API на сервері  | Повний контроль, шрифти, градієнти   | Нативна залежність (C++ build) |
+| **Puppeteer/PW** | Headless Chrome render | Pixel-perfect HTML → PNG             | Важкий, повільний, не для Edge |
+| **Sharp**        | Image compositing      | Швидкий, composite з шарів           | Не підтримує text layout       |
+
+> **Рекомендація:** `@vercel/og` (Satori) для OG-images на Vercel Edge,
+> `node-canvas` для server-side share cards на Railway.
+> Детальніше про інструменти → [03-services-and-toolstack.md](./03-services-and-toolstack.md) §6.5.
+
+#### Модулі для share cards
+
+| Модуль        | Контент карточки                                         |
+| ------------- | -------------------------------------------------------- |
+| **Routine**   | Стрік + heatmap calendar (green squares)                 |
+| **Fizruk**    | «Тренування завершено: chest day, 45 хв, 12 вправ, 4.2T» |
+| **Finyk**     | «Цього місяця зекономив ₴2 400» (без sensitive деталей)  |
+| **Nutrition** | «7 днів підряд < 2 000 kcal — ціль досягнута!»           |
+| **Weekly AI** | AI-згенерована інфографіка тижня (всі модулі)            |
+
+### 5.4 Вірусні петлі (viral loops)
 
 1. **Порівняння тижнів** — генерує красиву карточку → Share в соцмережі.
 2. **Стрік-бейджі** — «30 днів без пропуску рутини 🔥» → Share.
 3. **Workout complete** — «Тренування завершено: 45 хв, 12 вправ» → Share card.
-4. **Фінансовий звіт** — «Цього місяця зекономив ₴2,400» → Share (анонімізовано).
+4. **Фінансовий звіт** — «Цього місяця зекономив ₴2 400» → Share (анонімізовано).
 5. **AI-інсайт** — щотижневі інсайти, які хочеться показати друзям.
 
-**Share cards (найшвидший quick win):**
-
-```
-Генерувати OG-image (canvas або server-side) з результатами:
-
-"🔥 14-денний стрік у Sergeant!"
-[Heatmap календар з green squares]
-[QR-code або лінк на landing]
-
-Юзер шерить у Stories/Telegram → друг бачить → лінк на landing → registers
-```
-
-Модулі для share cards:
-
-- **Routine:** стрік + heatmap.
-- **Fizruk:** «Тренування завершено: chest day, 45 хв, 12 вправ».
-- **Finyk:** «Цього місяця зекономив ₴2,400» (без sensitive деталей).
-- **Nutrition:** «7 днів підряд < 2000 kcal».
-- **Weekly digest:** AI-згенерована інфографіка тижня.
-
-### 5.4 Community-led growth
+### 5.5 Community-led growth
 
 - **Telegram-спільнота** «Sergeant Community 🎖️»:
   - Щоденні челенджі: «Сьогодні ходимо 10K кроків».
@@ -189,7 +430,7 @@ Rewards:
   - Ексклюзивні бета-фічі для активних учасників.
 - **Discord** (для tech-аудиторії).
 
-### 5.5 Партнерства
+### 5.6 Партнерства
 
 | Партнер                    | Формат                                   | Взаємна вигода               |
 | -------------------------- | ---------------------------------------- | ---------------------------- |
@@ -199,7 +440,33 @@ Rewards:
 | **Telegram-блогери**       | Реклама / бартер (Pro за пост)           | Reach                        |
 | **Корпоративний wellness** | B2B-пакет для компаній                   | Великі контракти             |
 
-### 5.6 Paid acquisition (якщо є бюджет)
+> Деталі legal/ops для партнерств → [04-launch-readiness.md](./04-launch-readiness.md).
+
+### 5.7 Paid acquisition (якщо є бюджет)
+
+#### Benchmark CPA: UA-ринок productivity/health/finance apps (2025–2026)
+
+| Категорія         | Глобальний CPI (Android) | Глобальний CPI (iOS) | UA-ринок (оцінка, Android) |
+| ----------------- | ------------------------ | -------------------- | -------------------------- |
+| Health & Fitness  | $1.20–2.50               | $3.00–5.00           | ₴15–40 (≈ $0.35–0.95)      |
+| Finance / Fintech | $2.00–4.00               | $4.50–8.00           | ₴25–60 (≈ $0.60–1.45)      |
+| Productivity      | $1.50–3.00               | $3.50–6.00           | ₴20–50 (≈ $0.48–1.20)      |
+
+> Джерела: Sensor Tower State of Mobile 2026, AppFillip CPI Benchmark Q1 2025,
+> Adjust State of App Growth 2026.
+> UA-ринок — Tier 2 регіон, CPI на 60–80 % нижче за US.
+
+#### Конкуренти: benchmark CPI
+
+| Додаток (категорія)       | Платформа   | CPI орієнтовний (US)    | Примітка                    |
+| ------------------------- | ----------- | ----------------------- | --------------------------- |
+| **MyFitnessPal** (health) | iOS         | $3.50–5.00              | Категорія H&F, висока конк. |
+| **YNAB** (finance)        | iOS         | $5.00–8.00              | Premium фін-аудиторія       |
+| **Fealthy** (finance, UA) | Android     | ~₴15–25 (organic-first) | UA-ринок, менша конкуренція |
+| **Fabulous** (habits)     | Android     | $1.50–2.50              | Subscription H&F            |
+| **Sergeant** (all-in-one) | PWA/Android | **Target: ₴15–30**      | Cross-category, UA-first    |
+
+#### Канали та бюджети
 
 | Канал                       | Бюджет/міс | CPA target          |
 | --------------------------- | ---------- | ------------------- |
@@ -208,9 +475,13 @@ Rewards:
 | Telegram Ads                | ₴2K–5K     | ₴10–25              |
 | TikTok (UGC-стиль)          | ₴3K–8K     | ₴5–15               |
 
-> **Unit economics check:** Pro = ₴99/міс, lifetime ~6 міс → LTV = ₴594. При конверсії free→Pro 5 % → LTV per install = ₴30. CPA повинен бути < ₴30.
+> **Unit economics check:** Pro = ₴99/міс, avg. lifetime ≈ 6 міс → LTV = ₴594.
+> При конверсії free → Pro 5 % → LTV per install = ₴29.70.
+> CPA повинен бути < ₴25 для здорової юніт-економіки (LTV/CPA ≥ 3:1 ідеально).
 
-> **Підхід:** не запускати рекламу до Product-Market Fit. Спочатку organic (Telegram, DOU, Product Hunt), потім paid.
+> **Підхід:** не запускати рекламу до Product-Market Fit. Спочатку organic
+> (Telegram, DOU, Product Hunt), потім paid.
+> Інструменти реклами → [03-services-and-toolstack.md](./03-services-and-toolstack.md) §6.7.
 
 ---
 
@@ -268,23 +539,17 @@ Positioning statement:
 - [ ] **Store screenshots** — 5–8 штук для Play Store (кожен модуль + AI chat + dashboard).
 - [ ] **Feature graphic** — 1024×500 банер для Play Store.
 - [ ] **Demo video** — 30–60 с для Store + landing.
-- [ ] **Open Graph images** — для шерінгу лінків (sergeant.2dmanager.com.ua).
+- [ ] **Open Graph images** — для шерінгу лінків (sergeant.com.ua).
 - [ ] **Favicon / PWA icons** — перевірити всі розміри (192, 512, maskable).
 
 ### 7.3 Landing page
 
-Зараз web app = landing (юзер одразу бачить додаток). Для маркетингу краще мати **окремий лендінг**:
+Зараз web app = landing (юзер одразу бачить додаток). Для маркетингу краще мати
+**окремий лендінг**:
 
 ```
-sergeant.2dmanager.com.ua/         → Landing page (маркетинг)
-sergeant.2dmanager.com.ua/app      → Додаток (PWA)
-```
-
-або:
-
-```
-sergeant.com.ua                    → Landing page
-app.sergeant.com.ua                → Додаток
+sergeant.com.ua                → Landing page (маркетинг)
+app.sergeant.com.ua            → Додаток (PWA)
 ```
 
 Landing має містити:
@@ -301,7 +566,7 @@ Landing має містити:
 
 PWA SEO складніший (SPA = один HTML), але можна:
 
-- [ ] **Pre-rendering** для landing (Vite SSG або окремий Next.js / Astro site).
+- [ ] **Pre-rendering** для landing (Vite SSG або Astro site).
 - [ ] **Meta tags** — title, description, OG image для кожної маркетингової сторінки.
 - [ ] **Structured data** — JSON-LD для SoftwareApplication (schema.org).
 - [ ] **Sitemap.xml** — для landing і блогу.
@@ -318,16 +583,63 @@ PWA SEO складніший (SPA = один HTML), але можна:
 | Phase 2 | 🇬🇧 Англійська | Product Hunt, Reddit, intl |
 | Phase 3 | 🇵🇱 Польська   | 1M+ українців у Польщі     |
 
-**Підготовка зараз:**
+### 8.1 Підготовка зараз
 
-- [ ] Не hardcode-ити українські рядки в UI. Виносити у constants/копі-файли.
-- [ ] Для AI prompts — додати language param для multi-lang.
+- [ ] Не hardcode-ити українські рядки в UI. Виносити у constants / копі-файли.
+- [ ] Для AI prompts — додати `language` param для multi-lang.
 - [ ] `assistantCatalogue.ts` — рядки готові до externalization (архітектурно).
+
+### 8.2 i18n-ready checklist для `apps/web`
+
+Нижче — конкретний checklist, що потрібно переробити в кодовій базі `apps/web`,
+щоб рядки були vendor-agnostic і готові до підключення бібліотеки i18n
+(react-intl, i18next або lingui):
+
+| #   | Файл / Патерн                                 | Що зробити                                                       | Пріоритет |
+| --- | --------------------------------------------- | ---------------------------------------------------------------- | --------- |
+| 1   | `apps/web/src/**/*.tsx` — inline strings      | Витягнути всі user-facing рядки (label, placeholder, title,      | 🔴 High   |
+|     |                                               | toast, error message) у централізований файл `messages/uk.ts`    |           |
+| 2   | `apps/web/src/core/lib/assistantCatalogue.ts` | Замінити hardcoded UA-промпти на шаблони з `{locale}` параметром | 🔴 High   |
+| 3   | `apps/web/src/shared/constants/*.ts`          | Перевірити: назви модулів, label, units — винести у messages     | 🟡 Medium |
+| 4   | `packages/shared/src/**`                      | Zod error messages — зробити locale-aware або залишити EN-only   | 🟡 Medium |
+| 5   | `apps/web/src/modules/*/components/**`        | Перевірити hardcoded `"₴"` → використовувати Intl.NumberFormat   | 🟡 Medium |
+| 6   | `apps/web/public/manifest.json`               | `name`, `short_name`, `description` — параметризувати для locale | 🟢 Low    |
+| 7   | `apps/web/index.html`                         | `<html lang="uk">` → динамічний `lang` атрибут                   | 🟢 Low    |
+| 8   | Дати / числа / валюта                         | Використовувати `Intl.DateTimeFormat`, `Intl.NumberFormat`       | 🟡 Medium |
+|     |                                               | замість hardcoded форматів                                       |           |
+
+> **Крок 1 (мінімум для запуску):** винести рядки у `messages/uk.ts` +
+> зробити `useTranslation()` wrapper. Можна без бібліотеки — простий
+> `Record<string, string>` map + React context.
+>
+> **Крок 2 (Phase 2):** підключити `react-intl` або `i18next`, додати `en.ts`.
+>
+> **Крок 3 (Phase 3):** додати `pl.ts`, language switcher в Settings.
+
+---
+
+## Appendix A: SEO — meta title / description для top keyword pages
+
+| Сторінка (URL path)              | Meta title (≤ 60 символів)                        | Meta description (≤ 155 символів)                                                                    |
+| -------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `/`                              | Sergeant — фінанси, фітнес, звички, їжа в одному  | Безкоштовний трекер фінансів, тренувань, звичок і харчування з AI. Працює офлайн. Зроблений в 🇺🇦.    |
+| `/blog/kontrol-vytrat`           | Як контролювати витрати в Україні 2026 · Sergeant | Покроковий гайд по контролю витрат: Monobank sync, бюджети, AI-поради. Безкоштовний додаток.         |
+| `/blog/treker-zvychok`           | Найкращі трекери звичок українською · Sergeant    | Порівняння трекерів звичок: Streaks, Fabulous, Sergeant. Стріки, heatmap, нагадування — українською. |
+| `/blog/rahuvaty-kalorii`         | Як рахувати калорії без зусиль · Sergeant         | AI розпізнає їжу з фото, сканер штрих-кодів, база 500K+ продуктів. Спробуй безкоштовно.              |
+| `/blog/monobank-analityka`       | Monobank аналітика: як бачити більше · Sergeant   | Підключи Mono до Sergeant — автоматичні категорії, бюджети, тренди витрат. Безкоштовно.              |
+| `/blog/trenuvannya-vdoma`        | Програма тренувань вдома безкоштовно · Sergeant   | Готові програми тренувань + логування сетів + AI-рекомендації. Без абонементу в зал.                 |
+| `/blog/sergeant-vs-myfitnesspal` | Sergeant vs MyFitnessPal: порівняння 2026         | Sergeant = фітнес + фінанси + звички + їжа. MFP = тільки їжа і фітнес. Повне порівняння.             |
+
+> **Формула:** `{Primary keyword} · Sergeant` для title, value prop + CTA для description.
+> OG-image: автогенерація через `@vercel/og` з title + branding (див. §5.3).
+> Structured data: `SoftwareApplication` JSON-LD на `/`, `BlogPosting` на `/blog/*`.
 
 ---
 
 ## Pointers
 
 - Бізнес-модель і paywall → [01-monetization-and-pricing.md](./01-monetization-and-pricing.md).
-- Інструменти SMM/SEO/контенту/реклами зі статусом і цінами → [03-services-and-toolstack.md](./03-services-and-toolstack.md) (§5 SMM, §6 SEO, §7 ADS).
-- Метрики успіху, unit economics, ризики, повний pre-launch чеклист → [04-launch-readiness.md](./04-launch-readiness.md).
+- Інструменти SMM/SEO/контенту/реклами зі статусом і цінами →
+  [03-services-and-toolstack.md](./03-services-and-toolstack.md) (§5 SMM, §6 SEO, §7 ADS).
+- Метрики успіху, unit economics, ризики, повний pre-launch чеклист →
+  [04-launch-readiness.md](./04-launch-readiness.md).


### PR DESCRIPTION
## What changed

Comprehensive polish of `docs/launch/02-go-to-market.md` — the GTM strategy document for Sergeant. Turned general brainstorming notes into actionable, concrete playbooks.

### Key additions:
- **Phase 0 pre-launch checklist** with 12 concrete actions and T-minus deadlines
- **Product Hunt playbook**: headline formulas, 90-second demo-video script, hunter strategy, maker comment template
- **DOU.ua / AIN.ua founder's story template** with 7 structured sections and headline formula
- **Concrete UA Telegram channels** with subscriber counts (~600K @monobankukraine, ~700K @oaboronov, ~120K @investory_ua, etc.) sourced from TGStat
- **Share cards**: ASCII wireframes for OG (1200×630) and Story (1080×1920) formats, plus library comparison (Satori, @vercel/og, node-canvas, Puppeteer, Sharp)
- **Referral unit economics**: CAC ₴23 vs LTV per install ₴29.70 breakdown, marketing willingness-to-pay thresholds
- **Paid ads CPA benchmarks** from Sensor Tower 2026, AppFillip Q1 2025, Adjust 2026 — by category (H&F, Finance, Productivity) for both global and UA market
- **SEO appendix**: meta title/description for top 7 keyword pages with ≤60/≤155 char limits
- **i18n-ready checklist** for `apps/web`: 8 concrete items (inline strings, currency hardcodes, manifest.json, Intl APIs)
- Improved metrics table for beta phase (3-tier: acceptable/good/excellent)

## Why

Polish session to make the GTM doc actionable for a founder + future marketer audience. Previous version had general notes; this version has templates, benchmarks, and checklists you can execute.

## How to test

1. Open `docs/launch/02-go-to-market.md` and verify readability, structure, and cross-references to 01/03/04 docs.
2. Check that Prettier formatting passes: `pnpm exec prettier --check docs/launch/02-go-to-market.md`.

---

## How AI-tested this PR

- [x] Manual smoke: verified markdown renders correctly, all internal links point to valid files.
- [x] Prettier: ran `npx prettier --write` before commit — formatting is clean.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
