### PR TITLE
refactor(server): extract OFF/USDA/Mono normalizers into lib/normalizers/

### DIFF
--- a/apps/server/src/lib/normalizers/index.ts
+++ b/apps/server/src/lib/normalizers/index.ts
@@ -1,0 +1,29 @@
+export {
+  normalizeOFFBarcode,
+  normalizeOFFSearch,
+  type OFFProduct,
+  type OFFSearchProduct,
+  type NormalizedOFFBarcode,
+  type NormalizedOFFSearch,
+} from "./off.js";
+
+export {
+  normalizeUSDABarcode,
+  normalizeUSDASearch,
+  FDC_NUTRIENT,
+  type USDAFood,
+  type USDAFoodNutrient,
+  type USDASearchFood,
+  type NormalizedUSDABarcode,
+  type NormalizedUSDASearch,
+} from "./usda.js";
+
+export {
+  toNumberOrNull,
+  normalizeMonoAccount,
+  normalizeMonoTransaction,
+  type MonoAccountRow,
+  type MonoTransactionRow,
+  type NormalizedMonoAccount,
+  type NormalizedMonoTransaction,
+} from "./mono.js";

--- a/apps/server/src/lib/normalizers/mono.test.ts
+++ b/apps/server/src/lib/normalizers/mono.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import {
+  toNumberOrNull,
+  normalizeMonoAccount,
+  normalizeMonoTransaction,
+} from "./mono.js";
+
+// ─── toNumberOrNull ──────────────────────────────────────────────────────────
+
+describe("toNumberOrNull", () => {
+  it("returns number as-is", () => {
+    expect(toNumberOrNull(42)).toBe(42);
+    expect(toNumberOrNull(0)).toBe(0);
+    expect(toNumberOrNull(-100)).toBe(-100);
+  });
+
+  it("coerces string to number", () => {
+    expect(toNumberOrNull("123")).toBe(123);
+    expect(toNumberOrNull("0")).toBe(0);
+    expect(toNumberOrNull("-50")).toBe(-50);
+  });
+
+  it("coerces bigint to number", () => {
+    expect(toNumberOrNull(42n)).toBe(42);
+    expect(toNumberOrNull(0n)).toBe(0);
+  });
+
+  it("returns null for null", () => {
+    expect(toNumberOrNull(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(toNumberOrNull(undefined)).toBeNull();
+  });
+
+  it("returns null for non-coercible types", () => {
+    expect(toNumberOrNull({})).toBeNull();
+    expect(toNumberOrNull([])).toBeNull();
+    expect(toNumberOrNull(true)).toBeNull();
+  });
+});
+
+// ─── normalizeMonoAccount ────────────────────────────────────────────────────
+
+describe("normalizeMonoAccount", () => {
+  it("happy path: coerces bigint balance/creditLimit, serializes Date", () => {
+    const result = normalizeMonoAccount({
+      userId: "u1",
+      monoAccountId: "acc1",
+      sendId: "s1",
+      type: "black",
+      currencyCode: 980,
+      cashbackType: "UAH",
+      maskedPan: ["4444****1111"],
+      iban: "UA123",
+      balance: "10000",
+      creditLimit: "0",
+      lastSeenAt: new Date("2026-04-26T12:00:00Z"),
+    });
+    expect(result.balance).toBe(10000);
+    expect(result.creditLimit).toBe(0);
+    expect(result.lastSeenAt).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("handles null maskedPan by defaulting to empty array", () => {
+    const result = normalizeMonoAccount({
+      userId: "u1",
+      monoAccountId: "acc1",
+      sendId: null,
+      type: "black",
+      currencyCode: 980,
+      cashbackType: null,
+      maskedPan: null,
+      iban: null,
+      balance: 5000,
+      creditLimit: null,
+      lastSeenAt: null,
+    });
+    expect(result.maskedPan).toEqual([]);
+    expect(result.creditLimit).toBeNull();
+    expect(result.lastSeenAt).toBeNull();
+  });
+
+  it("handles string lastSeenAt (ISO string from DB)", () => {
+    const result = normalizeMonoAccount({
+      userId: "u1",
+      monoAccountId: "acc1",
+      sendId: null,
+      type: "black",
+      currencyCode: 980,
+      cashbackType: null,
+      maskedPan: [],
+      iban: null,
+      balance: 0,
+      creditLimit: 0,
+      lastSeenAt: "2026-04-26T12:00:00.000Z",
+    });
+    expect(result.lastSeenAt).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("handles bigint balance from pg driver (string '0')", () => {
+    const result = normalizeMonoAccount({
+      userId: "u1",
+      monoAccountId: "acc1",
+      sendId: null,
+      type: "black",
+      currencyCode: 980,
+      cashbackType: null,
+      maskedPan: [],
+      iban: null,
+      balance: "0",
+      creditLimit: "0",
+      lastSeenAt: null,
+    });
+    expect(result.balance).toBe(0);
+    expect(result.creditLimit).toBe(0);
+  });
+});
+
+// ─── normalizeMonoTransaction ────────────────────────────────────────────────
+
+describe("normalizeMonoTransaction", () => {
+  const baseRow = {
+    userId: "u1",
+    monoAccountId: "acc1",
+    monoTxId: "tx1",
+    time: new Date("2026-04-26T10:00:00Z"),
+    amount: "-5000",
+    operationAmount: "-5000",
+    currencyCode: 980,
+    mcc: 5411,
+    originalMcc: null,
+    hold: false,
+    description: "Сільпо",
+    comment: null,
+    cashbackAmount: "50",
+    commissionRate: "0",
+    balance: "100000",
+    receiptId: null,
+    invoiceId: null,
+    counterEdrpou: null,
+    counterIban: null,
+    counterName: null,
+    source: "webhook",
+    receivedAt: new Date("2026-04-26T10:00:01Z"),
+  };
+
+  it("happy path: coerces numeric fields and serializes dates", () => {
+    const result = normalizeMonoTransaction(baseRow);
+    expect(result.amount).toBe(-5000);
+    expect(result.operationAmount).toBe(-5000);
+    expect(result.cashbackAmount).toBe(50);
+    expect(result.commissionRate).toBe(0);
+    expect(result.balance).toBe(100000);
+    expect(result.time).toBe("2026-04-26T10:00:00.000Z");
+    expect(result.receivedAt).toBe("2026-04-26T10:00:01.000Z");
+  });
+
+  it("defaults amount and operationAmount to 0 when null", () => {
+    const result = normalizeMonoTransaction({
+      ...baseRow,
+      amount: null,
+      operationAmount: null,
+    });
+    expect(result.amount).toBe(0);
+    expect(result.operationAmount).toBe(0);
+  });
+
+  it("handles string time (already ISO from DB)", () => {
+    const result = normalizeMonoTransaction({
+      ...baseRow,
+      time: "2026-04-26T10:00:00.000Z",
+      receivedAt: "2026-04-26T10:00:01.000Z",
+    });
+    expect(result.time).toBe("2026-04-26T10:00:00.000Z");
+    expect(result.receivedAt).toBe("2026-04-26T10:00:01.000Z");
+  });
+
+  it("handles null optional numeric fields gracefully", () => {
+    const result = normalizeMonoTransaction({
+      ...baseRow,
+      cashbackAmount: null,
+      commissionRate: null,
+      balance: null,
+    });
+    expect(result.cashbackAmount).toBeNull();
+    expect(result.commissionRate).toBeNull();
+    expect(result.balance).toBeNull();
+  });
+
+  it("preserves non-numeric fields unchanged", () => {
+    const result = normalizeMonoTransaction(baseRow);
+    expect(result.userId).toBe("u1");
+    expect(result.monoAccountId).toBe("acc1");
+    expect(result.monoTxId).toBe("tx1");
+    expect(result.mcc).toBe(5411);
+    expect(result.description).toBe("Сільпо");
+    expect(result.source).toBe("webhook");
+  });
+});

--- a/apps/server/src/lib/normalizers/mono.ts
+++ b/apps/server/src/lib/normalizers/mono.ts
@@ -1,0 +1,132 @@
+/**
+ * Monobank DB-row normalizers.
+ *
+ * `node-postgres` returns Postgres `bigint` (int8) columns as **strings**.
+ * These helpers coerce numeric columns to plain `number` in API responses,
+ * keeping values within JavaScript's safe-integer range (Monobank balances
+ * are denominated in kopecks, max ≈ 9 × 10¹⁵). See AGENTS.md rule #1.
+ */
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+export function toNumberOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === "number") return v;
+  if (typeof v === "string" || typeof v === "bigint") return Number(v);
+  return null;
+}
+
+// ── Account row normalizer ───────────────────────────────────────────────────
+
+export interface MonoAccountRow {
+  userId: string;
+  monoAccountId: string;
+  sendId: string | null;
+  type: string;
+  currencyCode: number;
+  cashbackType: string | null;
+  maskedPan: string[] | null;
+  iban: string | null;
+  balance: unknown;
+  creditLimit: unknown;
+  lastSeenAt: Date | string | null;
+}
+
+export interface NormalizedMonoAccount {
+  userId: string;
+  monoAccountId: string;
+  sendId: string | null;
+  type: string;
+  currencyCode: number;
+  cashbackType: string | null;
+  maskedPan: string[];
+  iban: string | null;
+  balance: number | null;
+  creditLimit: number | null;
+  lastSeenAt: string | null;
+}
+
+export function normalizeMonoAccount(
+  row: MonoAccountRow,
+): NormalizedMonoAccount {
+  return {
+    ...row,
+    balance: toNumberOrNull(row.balance),
+    creditLimit: toNumberOrNull(row.creditLimit),
+    maskedPan: row.maskedPan ?? [],
+    lastSeenAt:
+      row.lastSeenAt instanceof Date
+        ? row.lastSeenAt.toISOString()
+        : row.lastSeenAt,
+  };
+}
+
+// ── Transaction row normalizer ───────────────────────────────────────────────
+
+export interface MonoTransactionRow {
+  userId: string;
+  monoAccountId: string;
+  monoTxId: string;
+  time: Date | string;
+  amount: unknown;
+  operationAmount: unknown;
+  currencyCode: number;
+  mcc: number | null;
+  originalMcc: number | null;
+  hold: boolean | null;
+  description: string | null;
+  comment: string | null;
+  cashbackAmount: unknown;
+  commissionRate: unknown;
+  balance: unknown;
+  receiptId: string | null;
+  invoiceId: string | null;
+  counterEdrpou: string | null;
+  counterIban: string | null;
+  counterName: string | null;
+  source: string;
+  receivedAt: Date | string;
+}
+
+export interface NormalizedMonoTransaction {
+  userId: string;
+  monoAccountId: string;
+  monoTxId: string;
+  time: string;
+  amount: number;
+  operationAmount: number;
+  currencyCode: number;
+  mcc: number | null;
+  originalMcc: number | null;
+  hold: boolean | null;
+  description: string | null;
+  comment: string | null;
+  cashbackAmount: number | null;
+  commissionRate: number | null;
+  balance: number | null;
+  receiptId: string | null;
+  invoiceId: string | null;
+  counterEdrpou: string | null;
+  counterIban: string | null;
+  counterName: string | null;
+  source: string;
+  receivedAt: string;
+}
+
+export function normalizeMonoTransaction(
+  row: MonoTransactionRow,
+): NormalizedMonoTransaction {
+  return {
+    ...row,
+    amount: toNumberOrNull(row.amount) ?? 0,
+    operationAmount: toNumberOrNull(row.operationAmount) ?? 0,
+    cashbackAmount: toNumberOrNull(row.cashbackAmount),
+    commissionRate: toNumberOrNull(row.commissionRate),
+    balance: toNumberOrNull(row.balance),
+    time: row.time instanceof Date ? row.time.toISOString() : String(row.time),
+    receivedAt:
+      row.receivedAt instanceof Date
+        ? row.receivedAt.toISOString()
+        : String(row.receivedAt),
+  };
+}

--- a/apps/server/src/lib/normalizers/off.test.ts
+++ b/apps/server/src/lib/normalizers/off.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOFFBarcode, normalizeOFFSearch } from "./off.js";
+
+function stableId(
+  prefix: string,
+  _parts: Array<string | null | undefined>,
+): string {
+  return `${prefix}_stub`;
+}
+
+// ─── normalizeOFFBarcode ─────────────────────────────────────────────────────
+
+describe("normalizeOFFBarcode", () => {
+  const nutriments = {
+    "energy-kcal_100g": 250,
+    proteins_100g: 3.2,
+    fat_100g: 1.1,
+    carbohydrates_100g: 52,
+  };
+
+  it("happy path: returns normalized product with all fields", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Nutella",
+      brands: "Ferrero",
+      nutriments,
+      serving_size: "15 g",
+      serving_quantity: 15,
+    });
+    expect(result).toEqual({
+      name: "Nutella",
+      brand: "Ferrero",
+      kcal_100g: 250,
+      protein_100g: 3.2,
+      fat_100g: 1.1,
+      carbs_100g: 52,
+      servingSize: "15 g",
+      servingGrams: 15,
+      source: "off",
+    });
+  });
+
+  it("prefers product_name_uk over product_name", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Milk",
+      product_name_uk: "Молоко",
+      nutriments,
+    });
+    expect(result!.name).toBe("Молоко");
+  });
+
+  it("takes only the first brand from comma-separated list", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "X",
+      brands: "Alpha, Beta, Gamma",
+      nutriments,
+    });
+    expect(result!.brand).toBe("Alpha");
+  });
+
+  it("returns null when product is null", () => {
+    expect(normalizeOFFBarcode(null)).toBeNull();
+  });
+
+  it("returns null when product is undefined", () => {
+    expect(normalizeOFFBarcode(undefined)).toBeNull();
+  });
+
+  it("returns null when name is missing", () => {
+    expect(normalizeOFFBarcode({ nutriments })).toBeNull();
+  });
+
+  it("returns null when all macros are missing", () => {
+    expect(
+      normalizeOFFBarcode({ product_name: "Empty", nutriments: {} }),
+    ).toBeNull();
+  });
+
+  it("rounds macros to 1 decimal place", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Test",
+      nutriments: { "energy-kcal_100g": 99.87 },
+    });
+    expect(result!.kcal_100g).toBe(99.9);
+  });
+
+  it("handles malformed nutriment values gracefully", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Test",
+      nutriments: {
+        "energy-kcal_100g": "not-a-number",
+        proteins_100g: 5,
+      },
+    });
+    expect(result!.kcal_100g).toBeNull();
+    expect(result!.protein_100g).toBe(5);
+  });
+
+  it("falls back to energy-kcal when energy-kcal_100g is absent", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Test",
+      nutriments: { "energy-kcal": 120 },
+    });
+    expect(result!.kcal_100g).toBe(120);
+  });
+
+  it("handles serving_quantity as string", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Test",
+      nutriments,
+      serving_quantity: "30",
+    });
+    expect(result!.servingGrams).toBe(30);
+  });
+
+  it("handles non-finite serving_quantity", () => {
+    const result = normalizeOFFBarcode({
+      product_name: "Test",
+      nutriments,
+      serving_quantity: "abc",
+    });
+    expect(result!.servingGrams).toBeNull();
+  });
+});
+
+// ─── normalizeOFFSearch ──────────────────────────────────────────────────────
+
+describe("normalizeOFFSearch", () => {
+  const nutriments = {
+    "energy-kcal_100g": 250,
+    proteins_100g: 3.2,
+    fat_100g: 1.1,
+    carbohydrates_100g: 52,
+  };
+
+  it("happy path: returns normalized search product with code-based id", () => {
+    const result = normalizeOFFSearch(
+      {
+        code: "3017620422003",
+        product_name: "Nutella",
+        brands: "Ferrero",
+        nutriments,
+      },
+      stableId,
+    );
+    expect(result).toEqual({
+      id: "off_3017620422003",
+      name: "Nutella",
+      brand: "Ferrero",
+      source: "off",
+      per100: { kcal: 250, protein_g: 3.2, fat_g: 1.1, carbs_g: 52 },
+      defaultGrams: 100,
+    });
+  });
+
+  it("strips leading zeros from code but keeps single 0", () => {
+    const result = normalizeOFFSearch(
+      { code: "000012345", product_name: "X", nutriments },
+      stableId,
+    );
+    expect(result!.id).toBe("off_12345");
+
+    const zero = normalizeOFFSearch(
+      { code: "0000", product_name: "Z", nutriments },
+      stableId,
+    );
+    expect(zero!.id).toBe("off_0");
+  });
+
+  it("falls back to stableId when code is absent", () => {
+    const result = normalizeOFFSearch(
+      { product_name_uk: "Молоко", brands: "Галичина", nutriments },
+      stableId,
+    );
+    expect(result!.id).toBe("off_stub");
+  });
+
+  it("prefers Ukrainian name", () => {
+    const result = normalizeOFFSearch(
+      { product_name: "Milk", product_name_uk: "Молоко", nutriments },
+      stableId,
+    );
+    expect(result!.name).toBe("Молоко");
+  });
+
+  it("accepts Latin name with digits and punctuation", () => {
+    const result = normalizeOFFSearch(
+      { product_name: "Greek Yogurt 2.5% (500 g)", nutriments },
+      stableId,
+    );
+    expect(result!.name).toBe("Greek Yogurt 2.5% (500 g)");
+  });
+
+  it("rejects product_name with control characters", () => {
+    expect(
+      normalizeOFFSearch(
+        { product_name: "bad\u0000name", nutriments },
+        stableId,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(normalizeOFFSearch(null, stableId)).toBeNull();
+  });
+
+  it("returns null when all macros are missing", () => {
+    expect(
+      normalizeOFFSearch({ product_name: "Empty", nutriments: {} }, stableId),
+    ).toBeNull();
+  });
+
+  it("fills missing macros with 0 in per100", () => {
+    const result = normalizeOFFSearch(
+      { product_name: "X", nutriments: { "energy-kcal_100g": 100 } },
+      stableId,
+    );
+    expect(result!.per100).toEqual({
+      kcal: 100,
+      protein_g: 0,
+      fat_g: 0,
+      carbs_g: 0,
+    });
+  });
+
+  it("uses serving_quantity as defaultGrams when present", () => {
+    const result = normalizeOFFSearch(
+      { product_name: "X", nutriments, serving_quantity: 250 },
+      stableId,
+    );
+    expect(result!.defaultGrams).toBe(250);
+  });
+
+  it("defaults defaultGrams to 100 when serving_quantity is absent", () => {
+    const result = normalizeOFFSearch(
+      { product_name: "X", nutriments },
+      stableId,
+    );
+    expect(result!.defaultGrams).toBe(100);
+  });
+});

--- a/apps/server/src/lib/normalizers/off.ts
+++ b/apps/server/src/lib/normalizers/off.ts
@@ -1,0 +1,173 @@
+/**
+ * Open Food Facts (OFF) response normalizers.
+ *
+ * Two entry-points:
+ * - `normalizeOFFBarcode` — single-product barcode lookup (product page API)
+ * - `normalizeOFFSearch`  — multi-product search result
+ *
+ * Both consume the same raw OFF product shape and apply shared nutriment
+ * extraction, differing only in the output contract (barcode returns serving
+ * info, search returns an id + per-100 g macros + default grams).
+ */
+
+// ── Raw upstream types ───────────────────────────────────────────────────────
+
+export interface OFFProduct {
+  product_name?: string;
+  product_name_uk?: string;
+  brands?: string;
+  nutriments?: Record<string, unknown>;
+  serving_size?: string;
+  serving_quantity?: number | string;
+}
+
+export interface OFFSearchProduct {
+  code?: string;
+  product_name?: string;
+  product_name_uk?: string;
+  brands?: string;
+  nutriments?: Record<string, unknown>;
+  serving_quantity?: number | string;
+}
+
+// ── Normalized output types ──────────────────────────────────────────────────
+
+export interface NormalizedOFFBarcode {
+  name: string;
+  brand: string | null;
+  kcal_100g: number | null;
+  protein_100g: number | null;
+  fat_100g: number | null;
+  carbs_100g: number | null;
+  servingSize: string | null;
+  servingGrams: number | null;
+  source: "off";
+}
+
+export interface NormalizedOFFSearch {
+  id: string;
+  name: string;
+  brand: string | null;
+  source: "off";
+  per100: {
+    kcal: number;
+    protein_g: number;
+    fat_g: number;
+    carbs_g: number;
+  };
+  defaultGrams: number;
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+function round1(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n * 10) / 10 : null;
+}
+
+function firstBrand(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  return String(raw).split(",")[0].trim() || null;
+}
+
+interface ExtractedMacros {
+  kcal: number | null;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
+}
+
+function extractNutriments(
+  nutriments: Record<string, unknown> | undefined | null,
+): ExtractedMacros {
+  const n = (nutriments || {}) as Record<string, unknown>;
+  return {
+    kcal: round1(n["energy-kcal_100g"] ?? n["energy-kcal"] ?? null),
+    protein: round1(n["proteins_100g"] ?? null),
+    fat: round1(n["fat_100g"] ?? null),
+    carbs: round1(n["carbohydrates_100g"] ?? null),
+  };
+}
+
+function hasSomeMacro(m: ExtractedMacros): boolean {
+  return (
+    m.kcal != null || m.protein != null || m.fat != null || m.carbs != null
+  );
+}
+
+// ── Barcode normalizer ───────────────────────────────────────────────────────
+
+export function normalizeOFFBarcode(
+  product: OFFProduct | null | undefined,
+): NormalizedOFFBarcode | null {
+  if (!product) return null;
+
+  const name = product.product_name_uk || product.product_name || null;
+  if (!name) return null;
+
+  const macros = extractNutriments(product.nutriments);
+  if (!hasSomeMacro(macros)) return null;
+
+  const servingSize = product.serving_size
+    ? String(product.serving_size)
+    : null;
+  const servingGrams =
+    product.serving_quantity != null &&
+    Number.isFinite(Number(product.serving_quantity))
+      ? Number(product.serving_quantity)
+      : null;
+
+  return {
+    name,
+    brand: firstBrand(product.brands),
+    kcal_100g: macros.kcal,
+    protein_100g: macros.protein,
+    fat_100g: macros.fat,
+    carbs_100g: macros.carbs,
+    servingSize,
+    servingGrams,
+    source: "off",
+  };
+}
+
+// ── Search normalizer ────────────────────────────────────────────────────────
+
+export function normalizeOFFSearch(
+  product: OFFSearchProduct | null | undefined,
+  stableId: (prefix: string, parts: Array<string | null | undefined>) => string,
+): NormalizedOFFSearch | null {
+  if (!product) return null;
+
+  const name =
+    product.product_name_uk ||
+    (product.product_name &&
+    /^[\u0020-\u024F\u0400-\u04FF]+$/.test(product.product_name)
+      ? product.product_name
+      : null) ||
+    null;
+  if (!name) return null;
+
+  const macros = extractNutriments(product.nutriments);
+  if (!hasSomeMacro(macros)) return null;
+
+  const brand = firstBrand(product.brands);
+
+  return {
+    id: product.code
+      ? `off_${String(product.code).replace(/^0+/, "") || "0"}`
+      : stableId("off", [name, brand]),
+    name,
+    brand,
+    source: "off",
+    per100: {
+      kcal: macros.kcal ?? 0,
+      protein_g: macros.protein ?? 0,
+      fat_g: macros.fat ?? 0,
+      carbs_g: macros.carbs ?? 0,
+    },
+    defaultGrams: product.serving_quantity
+      ? Math.round(Number(product.serving_quantity))
+      : 100,
+  };
+}

--- a/apps/server/src/lib/normalizers/usda.test.ts
+++ b/apps/server/src/lib/normalizers/usda.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUSDABarcode, normalizeUSDASearch } from "./usda.js";
+
+function stableId(
+  prefix: string,
+  _parts: Array<string | null | undefined>,
+): string {
+  return `${prefix}_stub`;
+}
+
+// ─── normalizeUSDABarcode ────────────────────────────────────────────────────
+
+describe("normalizeUSDABarcode", () => {
+  const foodNutrients = [
+    { nutrientId: 1008, value: 64 },
+    { nutrientId: 1003, value: 3.4 },
+    { nutrientId: 1004, value: 3.6 },
+    { nutrientId: 1005, value: 4.8 },
+  ];
+
+  it("happy path: returns normalized product with all fields", () => {
+    const result = normalizeUSDABarcode({
+      description: "Milk, whole",
+      brandOwner: "Dairy Co",
+      foodNutrients,
+      servingSize: 244,
+      servingSizeUnit: "g",
+    });
+    expect(result).toEqual({
+      name: "Milk, whole",
+      brand: "Dairy Co",
+      kcal_100g: 64,
+      protein_100g: 3.4,
+      fat_100g: 3.6,
+      carbs_100g: 4.8,
+      servingSize: "244 g",
+      servingGrams: 244,
+      source: "usda",
+    });
+  });
+
+  it("prefers brandOwner over brandName", () => {
+    const result = normalizeUSDABarcode({
+      description: "X",
+      brandOwner: "Owner",
+      brandName: "Name",
+      foodNutrients,
+    });
+    expect(result!.brand).toBe("Owner");
+  });
+
+  it("falls back to brandName when brandOwner is missing", () => {
+    const result = normalizeUSDABarcode({
+      description: "X",
+      brandName: "FallbackBrand",
+      foodNutrients,
+    });
+    expect(result!.brand).toBe("FallbackBrand");
+  });
+
+  it("handles nutrient.id nested in nutrient object", () => {
+    const result = normalizeUSDABarcode({
+      description: "X",
+      foodNutrients: [
+        { nutrient: { id: 1008 }, amount: 200 },
+        { nutrient: { id: 1003 }, amount: 10 },
+      ],
+    });
+    expect(result!.kcal_100g).toBe(200);
+    expect(result!.protein_100g).toBe(10);
+  });
+
+  it("returns null when food is null", () => {
+    expect(normalizeUSDABarcode(null)).toBeNull();
+  });
+
+  it("returns null when food is undefined", () => {
+    expect(normalizeUSDABarcode(undefined)).toBeNull();
+  });
+
+  it("returns null when description is empty", () => {
+    expect(normalizeUSDABarcode({ description: "", foodNutrients })).toBeNull();
+  });
+
+  it("returns null when description is missing", () => {
+    expect(normalizeUSDABarcode({ foodNutrients })).toBeNull();
+  });
+
+  it("returns null when all nutrients are missing", () => {
+    expect(
+      normalizeUSDABarcode({ description: "X", foodNutrients: [] }),
+    ).toBeNull();
+  });
+
+  it("rounds nutrient values to 1 decimal place", () => {
+    const result = normalizeUSDABarcode({
+      description: "Test",
+      foodNutrients: [{ nutrientId: 1008, value: 99.87 }],
+    });
+    expect(result!.kcal_100g).toBe(99.9);
+  });
+
+  it("handles malformed nutrient values gracefully", () => {
+    const result = normalizeUSDABarcode({
+      description: "Test",
+      foodNutrients: [
+        { nutrientId: 1008, value: NaN },
+        { nutrientId: 1003, value: 5 },
+      ],
+    });
+    expect(result!.kcal_100g).toBeNull();
+    expect(result!.protein_100g).toBe(5);
+  });
+
+  it("sets servingSize to null when servingSizeUnit is missing", () => {
+    const result = normalizeUSDABarcode({
+      description: "Test",
+      foodNutrients,
+      servingSize: 100,
+    });
+    expect(result!.servingSize).toBeNull();
+    expect(result!.servingGrams).toBe(100);
+  });
+});
+
+// ─── normalizeUSDASearch ─────────────────────────────────────────────────────
+
+describe("normalizeUSDASearch", () => {
+  const foodNutrients = [
+    { nutrientId: 1008, value: 64 },
+    { nutrientId: 1003, value: 3.4 },
+    { nutrientId: 1004, value: 3.6 },
+    { nutrientId: 1005, value: 4.8 },
+  ];
+
+  it("happy path: returns normalized search product with fdcId", () => {
+    const result = normalizeUSDASearch(
+      { fdcId: 170290, description: "Milk, whole", foodNutrients },
+      stableId,
+    );
+    expect(result).toEqual({
+      id: "usda_170290",
+      name: "Milk, whole",
+      brand: null,
+      source: "usda",
+      per100: { kcal: 64, protein_g: 3.4, fat_g: 3.6, carbs_g: 4.8 },
+      defaultGrams: 100,
+    });
+  });
+
+  it("falls back to stableId when fdcId is missing", () => {
+    const result = normalizeUSDASearch(
+      { description: "Custom food", foodNutrients },
+      stableId,
+    );
+    expect(result!.id).toBe("usda_stub");
+  });
+
+  it("returns null for null input", () => {
+    expect(normalizeUSDASearch(null, stableId)).toBeNull();
+  });
+
+  it("returns null when description is empty", () => {
+    expect(
+      normalizeUSDASearch({ description: "", foodNutrients }, stableId),
+    ).toBeNull();
+  });
+
+  it("returns null when all nutrients are missing", () => {
+    expect(
+      normalizeUSDASearch({ description: "X", foodNutrients: [] }, stableId),
+    ).toBeNull();
+  });
+
+  it("fills missing nutrients with 0 in per100", () => {
+    const result = normalizeUSDASearch(
+      {
+        fdcId: 1,
+        description: "Partial",
+        foodNutrients: [{ nutrientId: 1008, value: 100 }],
+      },
+      stableId,
+    );
+    expect(result!.per100).toEqual({
+      kcal: 100,
+      protein_g: 0,
+      fat_g: 0,
+      carbs_g: 0,
+    });
+  });
+
+  it("maps the four tracked nutrient ids correctly", () => {
+    const result = normalizeUSDASearch(
+      { fdcId: 1, description: "X", foodNutrients },
+      stableId,
+    );
+    expect(result!.per100).toEqual({
+      kcal: 64,
+      protein_g: 3.4,
+      fat_g: 3.6,
+      carbs_g: 4.8,
+    });
+  });
+});

--- a/apps/server/src/lib/normalizers/usda.ts
+++ b/apps/server/src/lib/normalizers/usda.ts
@@ -1,0 +1,191 @@
+/**
+ * USDA FoodData Central response normalizers.
+ *
+ * Two entry-points:
+ * - `normalizeUSDABarcode` — single-product barcode lookup (Branded Foods API)
+ * - `normalizeUSDASearch`  — multi-product search result
+ *
+ * Both consume raw USDA food shapes and apply shared nutrient-ID mapping,
+ * differing only in the output contract.
+ */
+
+// ── Raw upstream types ───────────────────────────────────────────────────────
+
+export interface USDAFoodNutrient {
+  nutrientId?: number;
+  nutrient?: { id?: number };
+  value?: number;
+  amount?: number;
+}
+
+export interface USDAFood {
+  description?: string;
+  brandOwner?: string;
+  brandName?: string;
+  foodNutrients?: USDAFoodNutrient[];
+  servingSize?: number;
+  servingSizeUnit?: string;
+  gtinUpc?: string;
+}
+
+export interface USDASearchFood {
+  fdcId?: number;
+  description?: string;
+  foodNutrients?: Array<{ nutrientId?: number; value?: number }>;
+}
+
+// ── Normalized output types ──────────────────────────────────────────────────
+
+export interface NormalizedUSDABarcode {
+  name: string;
+  brand: string | null;
+  kcal_100g: number | null;
+  protein_100g: number | null;
+  fat_100g: number | null;
+  carbs_100g: number | null;
+  servingSize: string | null;
+  servingGrams: number | null;
+  source: "usda";
+}
+
+export interface NormalizedUSDASearch {
+  id: string;
+  name: string;
+  brand: string | null;
+  source: "usda";
+  per100: {
+    kcal: number;
+    protein_g: number;
+    fat_g: number;
+    carbs_g: number;
+  };
+  defaultGrams: number;
+}
+
+// ── Nutrient ID constants ────────────────────────────────────────────────────
+
+export const FDC_NUTRIENT = {
+  kcal: 1008,
+  protein: 1003,
+  fat: 1004,
+  carbs: 1005,
+} as const;
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+interface ExtractedMacros {
+  kcal: number | null;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
+}
+
+function hasSomeMacro(m: ExtractedMacros): boolean {
+  return (
+    m.kcal != null || m.protein != null || m.fat != null || m.carbs != null
+  );
+}
+
+function extractBarcodeNutrients(
+  nutrients: USDAFoodNutrient[] | undefined | null,
+): ExtractedMacros {
+  const nutrientMap: Record<number, number> = {};
+  for (const n of nutrients || []) {
+    const id = n.nutrientId ?? n.nutrient?.id;
+    const value = n.value ?? n.amount;
+    if (id != null && value != null && Number.isFinite(Number(value))) {
+      nutrientMap[id] = Math.round(Number(value) * 10) / 10;
+    }
+  }
+  return {
+    kcal: nutrientMap[FDC_NUTRIENT.kcal] ?? null,
+    protein: nutrientMap[FDC_NUTRIENT.protein] ?? null,
+    fat: nutrientMap[FDC_NUTRIENT.fat] ?? null,
+    carbs: nutrientMap[FDC_NUTRIENT.carbs] ?? null,
+  };
+}
+
+function extractSearchNutrients(
+  nutrients: Array<{ nutrientId?: number; value?: number }> | undefined | null,
+): ExtractedMacros {
+  const arr = Array.isArray(nutrients) ? nutrients : [];
+  const round1 = (v: unknown): number | null =>
+    v != null && Number.isFinite(Number(v))
+      ? Math.round(Number(v) * 10) / 10
+      : null;
+  const get = (id: number): number | null => {
+    const n = arr.find((x) => x.nutrientId === id);
+    return n?.value != null ? round1(n.value) : null;
+  };
+  return {
+    kcal: get(FDC_NUTRIENT.kcal),
+    protein: get(FDC_NUTRIENT.protein),
+    fat: get(FDC_NUTRIENT.fat),
+    carbs: get(FDC_NUTRIENT.carbs),
+  };
+}
+
+// ── Barcode normalizer ───────────────────────────────────────────────────────
+
+export function normalizeUSDABarcode(
+  food: USDAFood | null | undefined,
+): NormalizedUSDABarcode | null {
+  if (!food) return null;
+  const name = food.description || null;
+  if (!name) return null;
+
+  const brand = food.brandOwner || food.brandName || null;
+  const macros = extractBarcodeNutrients(food.foodNutrients);
+
+  const servingGrams =
+    food.servingSize != null && Number.isFinite(Number(food.servingSize))
+      ? Number(food.servingSize)
+      : null;
+  const servingUnit = food.servingSizeUnit || null;
+  const servingSize =
+    servingGrams && servingUnit ? `${servingGrams} ${servingUnit}` : null;
+
+  if (!hasSomeMacro(macros)) return null;
+
+  return {
+    name,
+    brand,
+    kcal_100g: macros.kcal,
+    protein_100g: macros.protein,
+    fat_100g: macros.fat,
+    carbs_100g: macros.carbs,
+    servingSize,
+    servingGrams,
+    source: "usda",
+  };
+}
+
+// ── Search normalizer ────────────────────────────────────────────────────────
+
+export function normalizeUSDASearch(
+  food: USDASearchFood | null | undefined,
+  stableId: (prefix: string, parts: Array<string | null | undefined>) => string,
+): NormalizedUSDASearch | null {
+  const name = food?.description;
+  if (!name) return null;
+
+  const macros = extractSearchNutrients(food?.foodNutrients);
+  if (!hasSomeMacro(macros)) return null;
+
+  return {
+    id:
+      food?.fdcId != null
+        ? `usda_${String(food.fdcId)}`
+        : stableId("usda", [name]),
+    name,
+    brand: null,
+    source: "usda",
+    per100: {
+      kcal: macros.kcal ?? 0,
+      protein_g: macros.protein ?? 0,
+      fat_g: macros.fat ?? 0,
+      carbs_g: macros.carbs ?? 0,
+    },
+    defaultGrams: 100,
+  };
+}

--- a/apps/server/src/modules/barcode.ts
+++ b/apps/server/src/modules/barcode.ts
@@ -3,6 +3,12 @@ import { recordExternalHttp } from "../lib/externalHttp.js";
 import { BarcodeQuerySchema } from "../http/schemas.js";
 import { validateQuery } from "../http/validate.js";
 import { barcodeLookupsTotal } from "../obs/metrics.js";
+import {
+  normalizeOFFBarcode,
+  normalizeUSDABarcode,
+  type OFFProduct,
+  type USDAFood,
+} from "../lib/normalizers/index.js";
 
 interface NormalizedProduct {
   name: string;
@@ -128,31 +134,7 @@ export function __barcodeTestHooks(): BarcodeTestHooks {
   };
 }
 
-interface OFFProduct {
-  product_name?: string;
-  product_name_uk?: string;
-  brands?: string;
-  nutriments?: Record<string, unknown>;
-  serving_size?: string;
-  serving_quantity?: number | string;
-}
-
-interface USDAFoodNutrient {
-  nutrientId?: number;
-  nutrient?: { id?: number };
-  value?: number;
-  amount?: number;
-}
-
-interface USDAFood {
-  description?: string;
-  brandOwner?: string;
-  brandName?: string;
-  foodNutrients?: USDAFoodNutrient[];
-  servingSize?: number;
-  servingSizeUnit?: string;
-  gtinUpc?: string;
-}
+// Raw upstream types imported from ../lib/normalizers/index.js
 
 function hasErrorName(e: unknown, name: string): boolean {
   return !!e && typeof e === "object" && (e as { name?: string }).name === name;
@@ -187,47 +169,7 @@ const OFF_FIELDS =
 function normalizeOFF(
   product: OFFProduct | null | undefined,
 ): NormalizedProduct | null {
-  const n = (product?.nutriments || {}) as Record<string, unknown>;
-  const name = product?.product_name_uk || product?.product_name || null;
-  const brand = product?.brands
-    ? String(product.brands).split(",")[0].trim()
-    : null;
-
-  const round1 = (v: unknown): number | null =>
-    v != null && Number.isFinite(Number(v))
-      ? Math.round(Number(v) * 10) / 10
-      : null;
-
-  const kcal = round1(n["energy-kcal_100g"] ?? n["energy-kcal"] ?? null);
-  const protein = round1(n["proteins_100g"] ?? null);
-  const fat = round1(n["fat_100g"] ?? null);
-  const carbs = round1(n["carbohydrates_100g"] ?? null);
-
-  const servingSize = product?.serving_size
-    ? String(product.serving_size)
-    : null;
-  const servingGrams =
-    product?.serving_quantity != null &&
-    Number.isFinite(Number(product.serving_quantity))
-      ? Number(product.serving_quantity)
-      : null;
-
-  if (!name) return null;
-  // require at least one macro to avoid returning empty shells
-  if (kcal == null && protein == null && fat == null && carbs == null)
-    return null;
-
-  return {
-    name,
-    brand,
-    kcal_100g: kcal,
-    protein_100g: protein,
-    fat_100g: fat,
-    carbs_100g: carbs,
-    servingSize,
-    servingGrams,
-    source: "off",
-  };
+  return normalizeOFFBarcode(product);
 }
 
 async function lookupOFF(barcode: string): Promise<NormalizedProduct | null> {
@@ -270,60 +212,10 @@ async function lookupOFF(barcode: string): Promise<NormalizedProduct | null> {
 // ──────────────────────────────────────────────────────────────────────────────
 const FDC_BASE = "https://api.nal.usda.gov/fdc/v1";
 
-// Nutrient IDs in USDA FoodData Central
-const FDC_NUTRIENT = {
-  kcal: 1008,
-  protein: 1003,
-  fat: 1004,
-  carbs: 1005,
-} as const;
-
 function normalizeUSDA(
   food: USDAFood | null | undefined,
 ): NormalizedProduct | null {
-  if (!food) return null;
-  const name = food.description || null;
-  if (!name) return null;
-
-  const brand = food.brandOwner || food.brandName || null;
-
-  const nutrientMap: Record<number, number> = {};
-  for (const n of food.foodNutrients || []) {
-    const id = n.nutrientId ?? n.nutrient?.id;
-    const value = n.value ?? n.amount;
-    if (id != null && value != null && Number.isFinite(Number(value))) {
-      nutrientMap[id] = Math.round(Number(value) * 10) / 10;
-    }
-  }
-
-  const kcal = nutrientMap[FDC_NUTRIENT.kcal] ?? null;
-  const protein = nutrientMap[FDC_NUTRIENT.protein] ?? null;
-  const fat = nutrientMap[FDC_NUTRIENT.fat] ?? null;
-  const carbs = nutrientMap[FDC_NUTRIENT.carbs] ?? null;
-
-  // Serving size from USDA householdServingFullText + servingSize in grams
-  const servingGrams =
-    food.servingSize != null && Number.isFinite(Number(food.servingSize))
-      ? Number(food.servingSize)
-      : null;
-  const servingUnit = food.servingSizeUnit || null;
-  const servingSize =
-    servingGrams && servingUnit ? `${servingGrams} ${servingUnit}` : null;
-
-  if (kcal == null && protein == null && fat == null && carbs == null)
-    return null;
-
-  return {
-    name,
-    brand,
-    kcal_100g: kcal,
-    protein_100g: protein,
-    fat_100g: fat,
-    carbs_100g: carbs,
-    servingSize,
-    servingGrams,
-    source: "usda",
-  };
+  return normalizeUSDABarcode(food);
 }
 
 async function lookupUSDA(barcode: string): Promise<NormalizedProduct | null> {

--- a/apps/server/src/modules/food-search.ts
+++ b/apps/server/src/modules/food-search.ts
@@ -1,26 +1,17 @@
 import type { Request, Response } from "express";
 import { FoodSearchQuerySchema } from "../http/schemas.js";
 import { validateQuery } from "../http/validate.js";
+import {
+  normalizeOFFSearch,
+  normalizeUSDASearch,
+  type OFFSearchProduct,
+  type USDASearchFood,
+} from "../lib/normalizers/index.js";
 
 const OFF_SEARCH = "https://world.openfoodfacts.org/api/v2/search";
 const OFF_FIELDS =
   "code,product_name,product_name_uk,brands,nutriments,serving_quantity";
 const USDA_SEARCH = "https://api.nal.usda.gov/fdc/v1/foods/search";
-
-interface OFFSearchProduct {
-  code?: string;
-  product_name?: string;
-  product_name_uk?: string;
-  brands?: string;
-  nutriments?: Record<string, unknown>;
-  serving_quantity?: number | string;
-}
-
-interface USDASearchFood {
-  fdcId?: number;
-  description?: string;
-  foodNutrients?: Array<{ nutrientId?: number; value?: number }>;
-}
 
 // Deterministic fallback id based on product content — used when the upstream
 // record has no stable code (OFF `code` / USDA `fdcId`). Avoids embedding
@@ -169,102 +160,14 @@ function translateFirstToken(query: string): string | null {
 export function normalizeOFFProduct(
   product: OFFSearchProduct | null | undefined,
 ): NormalizedSearchProduct | null {
-  const n = (product?.nutriments || {}) as Record<string, unknown>;
-
-  const round1 = (v: unknown): number | null =>
-    v != null && Number.isFinite(Number(v))
-      ? Math.round(Number(v) * 10) / 10
-      : null;
-
-  // Дозволяємо друковані символи латиниці + кирилиця (без керуючих символів).
-  // \u0020-\u024F вже охоплює ASCII-цифри та пунктуацію, тож окремих
-  // \d.,()\-/ у діапазоні не треба.
-  const name =
-    product?.product_name_uk ||
-    (product?.product_name &&
-    /^[\u0020-\u024F\u0400-\u04FF]+$/.test(product.product_name)
-      ? product.product_name
-      : null) ||
-    null;
-  if (!name) return null;
-
-  const brand = product?.brands
-    ? String(product.brands).split(",")[0].trim()
-    : null;
-
-  const kcal = round1(n["energy-kcal_100g"] ?? n["energy-kcal"] ?? null);
-  const protein = round1(n["proteins_100g"] ?? null);
-  const fat = round1(n["fat_100g"] ?? null);
-  const carbs = round1(n["carbohydrates_100g"] ?? null);
-
-  if (kcal == null && protein == null && fat == null && carbs == null) {
-    return null;
-  }
-
-  return {
-    id: product?.code
-      ? `off_${String(product.code).replace(/^0+/, "") || "0"}`
-      : stableId("off", [name, brand]),
-    name,
-    brand,
-    source: "off",
-    per100: {
-      kcal: kcal ?? 0,
-      protein_g: protein ?? 0,
-      fat_g: fat ?? 0,
-      carbs_g: carbs ?? 0,
-    },
-    defaultGrams: product?.serving_quantity
-      ? Math.round(Number(product.serving_quantity))
-      : 100,
-  };
+  return normalizeOFFSearch(product, stableId);
 }
 
 // USDA nutrient IDs: 1008=Energy(kcal), 1003=Protein, 1004=Fat, 1005=Carbs
 export function normalizeUSDAProduct(
   food: USDASearchFood | null | undefined,
 ): NormalizedSearchProduct | null {
-  const name = food?.description;
-  if (!name) return null;
-
-  const round1 = (v: unknown): number | null =>
-    v != null && Number.isFinite(Number(v))
-      ? Math.round(Number(v) * 10) / 10
-      : null;
-
-  const nutrients = Array.isArray(food?.foodNutrients)
-    ? food.foodNutrients
-    : [];
-  const get = (id: number): number | null => {
-    const n = nutrients.find((x) => x.nutrientId === id);
-    return n?.value != null ? Number(n.value) : null;
-  };
-
-  const kcal = round1(get(1008));
-  const protein = round1(get(1003));
-  const fat = round1(get(1004));
-  const carbs = round1(get(1005));
-
-  if (kcal == null && protein == null && fat == null && carbs == null) {
-    return null;
-  }
-
-  return {
-    id:
-      food?.fdcId != null
-        ? `usda_${String(food.fdcId)}`
-        : stableId("usda", [name]),
-    name,
-    brand: null,
-    source: "usda",
-    per100: {
-      kcal: kcal ?? 0,
-      protein_g: protein ?? 0,
-      fat_g: fat ?? 0,
-      carbs_g: carbs ?? 0,
-    },
-    defaultGrams: 100,
-  };
+  return normalizeUSDASearch(food, stableId);
 }
 
 async function fetchOFF(

--- a/apps/server/src/modules/mono/read.ts
+++ b/apps/server/src/modules/mono/read.ts
@@ -2,38 +2,20 @@ import type { Request, Response } from "express";
 import { query } from "../../db.js";
 import { validateQuery } from "../../http/validate.js";
 import { MonoTransactionsQuerySchema } from "../../http/schemas.js";
+import {
+  normalizeMonoAccount,
+  normalizeMonoTransaction,
+  type MonoAccountRow,
+  type MonoTransactionRow,
+} from "../../lib/normalizers/index.js";
 
 interface AuthedRequest extends Request {
   user?: { id: string };
 }
 
 // AI-NOTE: coerce bigint→number here; pg returns int8 as string, breaking `!a.creditLimit` checks. See AGENTS.md rule #1.
-/**
- * `node-postgres` returns Postgres `bigint` (int8) columns as **strings**
- * by default — losing precision is impossible, but JavaScript boolean
- * coercion of a non-empty string `"0"` is `true`, breaking client-side
- * predicates like `!a.creditLimit`. We coerce to plain numbers because
- * Monobank balances are denominated in cents and stay well within the
- * safe-integer range (≤ 9 × 10¹⁵).
- *
- * ### Coerced BIGINT fields by handler
- *
- * **accountsHandler** — `balance`, `creditLimit`
- *
- * **transactionsHandler** — `amount`, `operationAmount`, `cashbackAmount`,
- * `commissionRate`, `balance`
- *
- * Fields that remain strings intentionally:
- * `monoAccountId`, `monoTxId`, `sendId`, `iban`, `receiptId`, `invoiceId`,
- * `counterEdrpou`, `counterIban`, `counterName` — these are TEXT columns,
- * not numeric.
- */
-function toNumberOrNull(v: unknown): number | null {
-  if (v == null) return null;
-  if (typeof v === "number") return v;
-  if (typeof v === "string" || typeof v === "bigint") return Number(v);
-  return null;
-}
+// Coercion helpers extracted to lib/normalizers/mono.ts — toNumberOrNull,
+// normalizeMonoAccount, normalizeMonoTransaction.
 
 /**
  * GET /api/mono/accounts — returns user's Monobank accounts from DB.
@@ -68,18 +50,7 @@ export async function accountsHandler(
     { op: "mono_accounts_read" },
   );
 
-  res.json(
-    rows.map((r) => ({
-      ...r,
-      balance: toNumberOrNull(r.balance),
-      creditLimit: toNumberOrNull(r.creditLimit),
-      maskedPan: r.maskedPan ?? [],
-      lastSeenAt:
-        r.lastSeenAt instanceof Date
-          ? r.lastSeenAt.toISOString()
-          : r.lastSeenAt,
-    })),
-  );
+  res.json(rows.map((r) => normalizeMonoAccount(r as MonoAccountRow)));
 }
 
 /**
@@ -203,17 +174,9 @@ export async function transactionsHandler(
   const hasMore = rows.length > limit;
   const items = hasMore ? rows.slice(0, limit) : rows;
 
-  const result = items.map((r) => ({
-    ...r,
-    amount: toNumberOrNull(r.amount) ?? 0,
-    operationAmount: toNumberOrNull(r.operationAmount) ?? 0,
-    cashbackAmount: toNumberOrNull(r.cashbackAmount),
-    commissionRate: toNumberOrNull(r.commissionRate),
-    balance: toNumberOrNull(r.balance),
-    time: r.time instanceof Date ? r.time.toISOString() : r.time,
-    receivedAt:
-      r.receivedAt instanceof Date ? r.receivedAt.toISOString() : r.receivedAt,
-  }));
+  const result = items.map((r) =>
+    normalizeMonoTransaction(r as MonoTransactionRow),
+  );
 
   if (hasMore) {
     const last = result[result.length - 1];


### PR DESCRIPTION
## What changed

Extracted inline normalization logic from three handler files into dedicated, reusable modules under `apps/server/src/lib/normalizers/`:

| New file | Exports | Replaces inline code in |
|----------|---------|------------------------|
| `off.ts` | `normalizeOFFBarcode`, `normalizeOFFSearch` + raw/normalized types | `modules/barcode.ts` (`normalizeOFF`), `modules/food-search.ts` (`normalizeOFFProduct`) |
| `usda.ts` | `normalizeUSDABarcode`, `normalizeUSDASearch`, `FDC_NUTRIENT` + types | `modules/barcode.ts` (`normalizeUSDA`), `modules/food-search.ts` (`normalizeUSDAProduct`) |
| `mono.ts` | `toNumberOrNull`, `normalizeMonoAccount`, `normalizeMonoTransaction` + row/output types | `modules/mono/read.ts` (inline `toNumberOrNull` + spread-map serialization) |
| `index.ts` | Re-exports all of the above | — |

Original handlers now delegate to the extracted functions via thin wrappers, preserving their existing signatures and external behaviour.

## Why

- **Audit item [PR-4.C](docs/audits/2026-04-26-sergeant-audit-devin.md)** — extract OFF/USDA/Mono normalizers with unit tests.
- **[`docs/backend-tech-debt.md`](docs/backend-tech-debt.md)** — "Дублювання логіки: OFF/USDA нормалізатори … повторюються у 2–3 файлах" (Середній).
- Shared nutriment extraction (OFF `energy-kcal_100g` fallback, USDA nutrient-ID mapping, Mono bigint→number coercion) was copy-pasted across `barcode.ts`, `food-search.ts`, and `mono/read.ts`. Extracting removes duplication and makes normalizers independently testable.

## How to test

```bash
# All 454 tests pass (397 existing + 57 new normalizer tests)
pnpm --filter @sergeant/server test

# Typecheck
pnpm --filter @sergeant/server typecheck

# Lint
pnpm --filter @sergeant/server lint
```

---

## How AI-tested this PR

- [x] Vitest passes: 454/454 (all existing 397 tests pass unmodified + 57 new)
- [x] `pnpm --filter @sergeant/server typecheck` — clean
- [x] `pnpm --filter @sergeant/server lint` — clean
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules

---

[Devin session](https://app.devin.ai/sessions/da00b8ae2e4c412bbe620a805569a48b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data normalization logic for Open Food Facts, USDA, and Monobank integrations into reusable modules, improving consistency and maintainability across product and financial data handling.

* **Tests**
  * Added comprehensive test coverage for data normalization workflows to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->