### PR TITLE
test(web): add unit & integration tests for recommendationEngine and TodayFocusCard

### DIFF
--- a/apps/web/src/core/insights/TodayFocusCard.test.tsx
+++ b/apps/web/src/core/insights/TodayFocusCard.test.tsx
@@ -1,30 +1,617 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { TodayFocusCard } from "./TodayFocusCard";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { TodayFocusCard, useDashboardFocus } from "./TodayFocusCard";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the recommendation engine so we control what recs are returned
+const generateRecommendationsMock = vi.fn<
+  () => Array<{
+    id: string;
+    module: string;
+    priority: number;
+    severity?: string;
+    icon: string;
+    title: string;
+    body: string;
+    action: string;
+    pwaAction?: string;
+  }>
+>(() => []);
+
+vi.mock("../lib/recommendationEngine", () => ({
+  generateRecommendations: (...args: unknown[]) =>
+    generateRecommendationsMock(...(args as [])),
+}));
+
+// Mock hubNav so we can verify dispatches without real DOM events
+const openHubModuleWithActionMock = vi.fn();
+vi.mock("@shared/lib/hubNav", () => ({
+  openHubModule: vi.fn(),
+  openHubModuleWithAction: (...args: unknown[]) =>
+    openHubModuleWithActionMock(...args),
+  HUB_OPEN_MODULE_EVENT: "hub:open-module",
+}));
+
+// Mock moduleQuickActions
+vi.mock("@shared/lib/moduleQuickActions", () => ({
+  MODULE_PRIMARY_ACTION: {
+    finyk: {
+      label: "Додати витрату",
+      shortLabel: "+ Витрата",
+      action: "add_expense",
+    },
+    fizruk: {
+      label: "Почати тренування",
+      shortLabel: "+ Тренування",
+      action: "start_workout",
+    },
+    routine: {
+      label: "Додати звичку",
+      shortLabel: "+ Звичка",
+      action: "add_habit",
+    },
+    nutrition: {
+      label: "Додати прийом їжі",
+      shortLabel: "+ Їжа",
+      action: "add_meal",
+    },
+  },
+  getModulePrimaryAction: (moduleId: string) => {
+    const map: Record<
+      string,
+      { label: string; shortLabel: string; action: string }
+    > = {
+      finyk: {
+        label: "Додати витрату",
+        shortLabel: "+ Витрата",
+        action: "add_expense",
+      },
+      fizruk: {
+        label: "Почати тренування",
+        shortLabel: "+ Тренування",
+        action: "start_workout",
+      },
+      routine: {
+        label: "Додати звичку",
+        shortLabel: "+ Звичка",
+        action: "add_habit",
+      },
+      nutrition: {
+        label: "Додати прийом їжі",
+        shortLabel: "+ Їжа",
+        action: "add_meal",
+      },
+    };
+    return map[moduleId] || null;
+  },
+}));
+
+// Stub Icon and SectionHeading to simplify rendering
+vi.mock("@shared/components/ui/Icon", () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+vi.mock("@shared/components/ui/SectionHeading", () => ({
+  SectionHeading: ({
+    children,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    as?: string;
+    size?: string;
+    variant?: string;
+    className?: string;
+  }) => (
+    <span data-testid="section-heading" {...rest}>
+      {children}
+    </span>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// TodayFocusCard — component rendering tests
+// ---------------------------------------------------------------------------
 
 describe("TodayFocusCard", () => {
-  it("uses danger styling for over-budget recommendations", () => {
-    const { container } = render(
+  const onAction = vi.fn();
+  const onDismiss = vi.fn();
+
+  beforeEach(() => {
+    localStorage.clear();
+    generateRecommendationsMock.mockReturnValue([]);
+    onAction.mockClear();
+    onDismiss.mockClear();
+    openHubModuleWithActionMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty state
+  // -----------------------------------------------------------------------
+
+  it("рендерить порожній стан (EmptyFocus) коли focus=null", () => {
+    render(
+      <TodayFocusCard focus={null} onAction={onAction} onDismiss={onDismiss} />,
+    );
+
+    expect(screen.getByText("Що зафіксуємо?")).toBeTruthy();
+    expect(
+      screen.getByText("Один тап — один запис. Обери модуль і продовжуй."),
+    ).toBeTruthy();
+  });
+
+  it("EmptyFocus показує 4 quick-add чипи для модулів", () => {
+    render(
+      <TodayFocusCard focus={null} onAction={onAction} onDismiss={onDismiss} />,
+    );
+
+    // Check for module quick-add buttons by role
+    const buttons = screen.getAllByRole("button");
+    const labels = buttons.map((b) => b.textContent?.trim());
+    expect(labels).toContain("Витрата");
+    expect(labels).toContain("Тренування");
+    expect(labels).toContain("Звичка");
+    expect(labels).toContain("Їжа");
+  });
+
+  it("click на quick-add чип запускає openHubModuleWithAction", () => {
+    render(
+      <TodayFocusCard focus={null} onAction={onAction} onDismiss={onDismiss} />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const finykBtn = buttons.find((b) => b.textContent?.trim() === "Витрата");
+    expect(finykBtn).toBeDefined();
+    fireEvent.click(finykBtn!);
+    expect(openHubModuleWithActionMock).toHaveBeenCalledWith(
+      "finyk",
+      "add_expense",
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Focus card with recommendation
+  // -----------------------------------------------------------------------
+
+  it("рендерить фокус-картку з title та body рекомендації", () => {
+    const focus = {
+      id: "budget_over_food",
+      module: "finyk" as const,
+      severity: "danger" as const,
+      title: 'Бюджет "Продукти" перевищено на 80%',
+      body: "Витрачено 900 ₴ з 500 ₴",
+      icon: "💸",
+      action: "finyk",
+      pwaAction: "add_expense" as const,
+    };
+
+    render(
       <TodayFocusCard
-        focus={{
-          id: "budget_over_smoking",
-          module: "finyk",
-          severity: "danger",
-          icon: "💸",
-          title: 'Бюджет "smoking" перевищено на 18%',
-          body: "Витрачено 590 ₴ з 500 ₴",
-          action: "finyk",
-        }}
-        onAction={vi.fn()}
-        onDismiss={vi.fn()}
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
       />,
     );
 
-    expect(container.firstElementChild).toHaveClass(
-      "bg-danger-soft/70",
-      "border-danger/30",
+    expect(
+      screen.getByText(/Бюджет "Продукти" перевищено на 80%/),
+    ).toBeTruthy();
+    expect(screen.getByText("Витрачено 900 ₴ з 500 ₴")).toBeTruthy();
+  });
+
+  it("danger severity додає відповідне стилізування", () => {
+    const focus = {
+      id: "budget_over_food",
+      module: "finyk" as const,
+      severity: "danger" as const,
+      title: "Бюджет перевищено",
+      body: "Дані",
+      icon: "💸",
+      action: "finyk",
+    };
+
+    const { container } = render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
     );
-    expect(screen.getByText("Зараз")).toHaveClass("text-danger");
+
+    // The card should have danger-themed wash class
+    const card = container.firstElementChild;
+    expect(card?.className).toContain("bg-danger");
+  });
+
+  it("warning severity застосовує warning стилізування", () => {
+    const focus = {
+      id: "budget_warn_cafe",
+      module: "finyk" as const,
+      severity: "warning" as const,
+      title: "Ліміт майже вичерпано",
+      body: "95% бюджету",
+      icon: "⚠️",
+      action: "finyk",
+    };
+
+    const { container } = render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const card = container.firstElementChild;
+    expect(card?.className).toContain("bg-warning");
+  });
+
+  it("рендерить іконку рекомендації", () => {
+    const focus = {
+      id: "fizruk_long_break",
+      module: "fizruk" as const,
+      title: "10 днів без тренування",
+      body: "Пора відновити активність!",
+      icon: "🏋️",
+      action: "fizruk",
+      pwaAction: "start_workout" as const,
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText("🏋️")).toBeTruthy();
+  });
+
+  // -----------------------------------------------------------------------
+  // CTA buttons
+  // -----------------------------------------------------------------------
+
+  it("click на primary CTA з pwaAction запускає openHubModuleWithAction", () => {
+    const focus = {
+      id: "fizruk_long_break",
+      module: "fizruk" as const,
+      title: "10 днів без тренування",
+      body: "Пора тренуватися",
+      icon: "🏋️",
+      action: "fizruk",
+      pwaAction: "start_workout" as const,
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    // Primary CTA — find button that contains the CTA label (not secondary)
+    const buttons = screen.getAllByRole("button");
+    const primaryBtn = buttons.find((b) =>
+      b.textContent?.includes("Почати тренування"),
+    );
+    expect(primaryBtn).toBeDefined();
+    fireEvent.click(primaryBtn!);
+    expect(openHubModuleWithActionMock).toHaveBeenCalledWith(
+      "fizruk",
+      "start_workout",
+    );
+  });
+
+  it("click на primary CTA без pwaAction запускає onAction", () => {
+    const focus = {
+      id: "spending_velocity_high",
+      module: "finyk" as const,
+      title: "Витрати на 50% вище",
+      body: "За такий же проміжок",
+      icon: "📈",
+      action: "finyk",
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const primaryBtn = buttons.find((b) =>
+      b.textContent?.includes("Відкрити Фінік"),
+    );
+    expect(primaryBtn).toBeDefined();
+    fireEvent.click(primaryBtn!);
+    expect(onAction).toHaveBeenCalledWith("finyk");
+  });
+
+  it("рекомендація з pwaAction показує secondary кнопку 'Відкрити <модуль>'", () => {
+    const focus = {
+      id: "nutrition_no_meals",
+      module: "nutrition" as const,
+      title: "Немає записів",
+      body: "Зафіксуй їжу",
+      icon: "🥗",
+      action: "nutrition",
+      pwaAction: "add_meal" as const,
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const secondaryBtn = screen.getByText("Відкрити Харчування");
+    fireEvent.click(secondaryBtn);
+    expect(onAction).toHaveBeenCalledWith("nutrition");
+  });
+
+  it("кнопка 'Пізніше' дисмісить рекомендацію", () => {
+    const focus = {
+      id: "routine_evening_reminder",
+      module: "routine" as const,
+      title: "2 звичок ще не виконано",
+      body: "Вечір — ще не пізно",
+      icon: "✅",
+      action: "routine",
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const dismissBtn = buttons.find((b) => b.textContent?.trim() === "Пізніше");
+    expect(dismissBtn).toBeDefined();
+    fireEvent.click(dismissBtn!);
+    expect(onDismiss).toHaveBeenCalledWith("routine_evening_reminder");
+  });
+
+  // -----------------------------------------------------------------------
+  // Module-specific rendering
+  // -----------------------------------------------------------------------
+
+  it("рендерить fizruk рекомендацію з правильним module accent", () => {
+    const focus = {
+      id: "fizruk_muscle_chest",
+      module: "fizruk" as const,
+      title: "Груди не тренували 12 днів",
+      body: "Включи вправи на ці мʼязи",
+      icon: "💪",
+      action: "fizruk",
+      pwaAction: "start_workout" as const,
+    };
+
+    const { container } = render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    // Accent bar should use fizruk module color
+    const accentBar = container.querySelector('[aria-hidden="true"]');
+    expect(accentBar?.className).toContain("bg-fizruk");
+  });
+
+  it("рендерить routine рекомендацію", () => {
+    const focus = {
+      id: "routine_streak_7",
+      module: "routine" as const,
+      title: "7 днів поспіль! Вогонь!",
+      body: "Неймовірна серія!",
+      icon: "🔥",
+      action: "routine",
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText(/7 днів поспіль/)).toBeTruthy();
+    expect(screen.getByText("🔥")).toBeTruthy();
+  });
+
+  it("рендерить nutrition рекомендацію з add_meal action", () => {
+    const focus = {
+      id: "nutrition_kcal_low",
+      module: "nutrition" as const,
+      title: "Лише 400 ккал з 2000 ккал цілі",
+      body: "Недостатнє споживання калорій",
+      icon: "⚡",
+      action: "nutrition",
+      pwaAction: "add_meal" as const,
+    };
+
+    render(
+      <TodayFocusCard
+        focus={focus}
+        onAction={onAction}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText(/400 ккал/)).toBeTruthy();
+    const buttons = screen.getAllByRole("button");
+    const primaryBtn = buttons.find((b) =>
+      b.textContent?.includes("Додати прийом їжі"),
+    );
+    expect(primaryBtn).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useDashboardFocus — hook integration tests
+// ---------------------------------------------------------------------------
+
+describe("useDashboardFocus", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    generateRecommendationsMock.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("повертає focus=null та rest=[] при порожніх рекомендаціях", () => {
+    generateRecommendationsMock.mockReturnValue([]);
+
+    const { result } = renderHook(() => useDashboardFocus());
+
+    expect(result.current.focus).toBeNull();
+    expect(result.current.rest).toEqual([]);
+  });
+
+  it("повертає найвищий priority рекомендацію як focus", () => {
+    generateRecommendationsMock.mockReturnValue([
+      {
+        id: "r1",
+        module: "finyk",
+        priority: 90,
+        icon: "💸",
+        title: "High priority",
+        body: "body",
+        action: "finyk",
+      },
+      {
+        id: "r2",
+        module: "fizruk",
+        priority: 50,
+        icon: "🏋️",
+        title: "Low priority",
+        body: "body",
+        action: "fizruk",
+      },
+    ]);
+
+    const { result } = renderHook(() => useDashboardFocus());
+
+    expect(result.current.focus?.id).toBe("r1");
+    expect(result.current.rest).toHaveLength(1);
+    expect(result.current.rest[0].id).toBe("r2");
+  });
+
+  it("dismiss приховує рекомендацію", () => {
+    generateRecommendationsMock.mockReturnValue([
+      {
+        id: "r1",
+        module: "finyk",
+        priority: 90,
+        icon: "💸",
+        title: "Rec 1",
+        body: "body",
+        action: "finyk",
+      },
+      {
+        id: "r2",
+        module: "fizruk",
+        priority: 50,
+        icon: "🏋️",
+        title: "Rec 2",
+        body: "body",
+        action: "fizruk",
+      },
+    ]);
+
+    const { result } = renderHook(() => useDashboardFocus());
+
+    expect(result.current.focus?.id).toBe("r1");
+
+    act(() => {
+      result.current.dismiss("r1");
+    });
+
+    // After dismiss, r2 becomes focus
+    expect(result.current.focus?.id).toBe("r2");
+    expect(result.current.rest).toHaveLength(0);
+  });
+
+  it("dismiss зберігає стан у localStorage", () => {
+    generateRecommendationsMock.mockReturnValue([
+      {
+        id: "r1",
+        module: "finyk",
+        priority: 90,
+        icon: "💸",
+        title: "Rec 1",
+        body: "body",
+        action: "finyk",
+      },
+    ]);
+
+    const { result } = renderHook(() => useDashboardFocus());
+
+    act(() => {
+      result.current.dismiss("r1");
+    });
+
+    const stored = JSON.parse(
+      localStorage.getItem("hub_recs_dismissed_v1") || "{}",
+    );
+    expect(stored["r1"]).toBeDefined();
+    expect(typeof stored["r1"]).toBe("number");
+  });
+
+  it("dismissed рекомендації не зʼявляються повторно", () => {
+    // Pre-set dismissed state
+    localStorage.setItem(
+      "hub_recs_dismissed_v1",
+      JSON.stringify({ r1: Date.now() }),
+    );
+
+    generateRecommendationsMock.mockReturnValue([
+      {
+        id: "r1",
+        module: "finyk",
+        priority: 90,
+        icon: "💸",
+        title: "Should be hidden",
+        body: "body",
+        action: "finyk",
+      },
+      {
+        id: "r2",
+        module: "fizruk",
+        priority: 50,
+        icon: "🏋️",
+        title: "Visible",
+        body: "body",
+        action: "fizruk",
+      },
+    ]);
+
+    const { result } = renderHook(() => useDashboardFocus());
+
+    expect(result.current.focus?.id).toBe("r2");
+    expect(result.current.rest).toHaveLength(0);
   });
 });

--- a/apps/web/src/core/lib/recommendationEngine.test.ts
+++ b/apps/web/src/core/lib/recommendationEngine.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { generateRecommendations } from "./recommendationEngine";
 
-function setLS(key, value) {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setLS(key: string, value: unknown) {
   localStorage.setItem(key, JSON.stringify(value));
 }
 
@@ -10,9 +14,20 @@ function clearAll() {
   localStorage.clear();
 }
 
+// ---------------------------------------------------------------------------
+// generateRecommendations – structural guarantees
+// ---------------------------------------------------------------------------
+
 describe("generateRecommendations", () => {
   beforeEach(clearAll);
-  afterEach(clearAll);
+  afterEach(() => {
+    clearAll();
+    vi.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic contract
+  // -----------------------------------------------------------------------
 
   it("повертає масив навіть при порожньому localStorage", () => {
     const result = generateRecommendations();
@@ -37,15 +52,42 @@ describe("generateRecommendations", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("виявляє перевищення бюджету", () => {
+  it("повертає рекомендації відсортовані за спаданням priority", () => {
+    // Seed data for multiple modules to get several recs
     const now = new Date();
-    // Транзакція поточного місяця: витрата 1000 грн * 100 (копійки) у категорії food
     const ts = Math.floor(now.getTime() / 1000);
     setLS("finyk_tx_cache", {
       txs: [{ id: "tx1", amount: -100000, time: ts, description: "Продукти" }],
     });
     setLS("finyk_tx_cats", { tx1: "food" });
-    // Ліміт 500 грн (50% від фактичних витрат → 200% → перевищення)
+    setLS("finyk_budgets", [
+      { id: "b1", type: "limit", categoryId: "food", limit: 500 },
+    ]);
+
+    const recs = generateRecommendations();
+    for (let i = 1; i < recs.length; i++) {
+      expect(recs[i - 1].priority).toBeGreaterThanOrEqual(recs[i].priority);
+    }
+  });
+
+  it("дедуплікує id — перша зустріч лишається", () => {
+    // This tests the deduplication filter in generateRecommendations
+    const result = generateRecommendations();
+    const ids = result.map((r) => r.id);
+    expect(ids.length).toBe(new Set(ids).size);
+  });
+
+  // -----------------------------------------------------------------------
+  // Finance (Finyk) — budget over/warn
+  // -----------------------------------------------------------------------
+
+  it("виявляє перевищення бюджету", () => {
+    const now = new Date();
+    const ts = Math.floor(now.getTime() / 1000);
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "tx1", amount: -100000, time: ts, description: "Продукти" }],
+    });
+    setLS("finyk_tx_cats", { tx1: "food" });
     setLS("finyk_budgets", [
       { id: "b1", type: "limit", categoryId: "food", limit: 500 },
     ]);
@@ -53,9 +95,9 @@ describe("generateRecommendations", () => {
     const recs = generateRecommendations();
     const budgetRec = recs.find((r) => r.id === "budget_over_food");
     expect(budgetRec).toBeDefined();
-    expect(budgetRec.module).toBe("finyk");
-    expect(budgetRec.priority).toBeGreaterThanOrEqual(80);
-    expect(budgetRec.severity).toBe("danger");
+    expect(budgetRec!.module).toBe("finyk");
+    expect(budgetRec!.priority).toBeGreaterThanOrEqual(80);
+    expect(budgetRec!.severity).toBe("danger");
   });
 
   it("показує попередження якщо бюджет майже вичерпано (90%+)", () => {
@@ -80,7 +122,6 @@ describe("generateRecommendations", () => {
   it("враховує txSplits при обчисленні бюджетних витрат", () => {
     const now = new Date();
     const ts = Math.floor(now.getTime() / 1000);
-    // Одна транзакція -20000 коп (-200 грн), розбита: 120 грн smoking + 80 грн food
     setLS("finyk_tx_cache", {
       txs: [{ id: "tx_s", amount: -20000, time: ts, description: "Магазин" }],
     });
@@ -102,8 +143,52 @@ describe("generateRecommendations", () => {
     expect(overRec!.severity).toBe("danger");
   });
 
-  it("генерує рекомендацію про тренування якщо тиждень без тренувань", () => {
-    // Останнє тренування > 7 днів тому
+  it("не генерує бюджетні рекомендації коли ліміт = 0 або відсутній categoryId", () => {
+    setLS("finyk_budgets", [
+      { id: "b1", type: "limit", categoryId: null, limit: 100 },
+      { id: "b2", type: "limit", categoryId: "food", limit: 0 },
+    ]);
+    setLS("finyk_tx_cache", {
+      txs: [
+        {
+          id: "tx1",
+          amount: -50000,
+          time: Math.floor(Date.now() / 1000),
+          description: "Їжа",
+        },
+      ],
+    });
+    setLS("finyk_tx_cats", { tx1: "food" });
+
+    const recs = generateRecommendations();
+    const budgetRecs = recs.filter(
+      (r) => r.id.startsWith("budget_over_") || r.id.startsWith("budget_warn_"),
+    );
+    expect(budgetRecs).toHaveLength(0);
+  });
+
+  it("не генерує бюджетних рекомендацій якщо витрати менші за 90% ліміту", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    setLS("finyk_tx_cache", {
+      txs: [{ id: "tx1", amount: -10000, time: ts, description: "Кафе" }],
+    });
+    setLS("finyk_tx_cats", { tx1: "cafe" });
+    setLS("finyk_budgets", [
+      { id: "b1", type: "limit", categoryId: "cafe", limit: 5000 },
+    ]);
+
+    const recs = generateRecommendations();
+    const budgetRecs = recs.filter(
+      (r) => r.id.startsWith("budget_over_") || r.id.startsWith("budget_warn_"),
+    );
+    expect(budgetRecs).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Fizruk — workout recs
+  // -----------------------------------------------------------------------
+
+  it("генерує рекомендацію про тренування якщо більше 5 днів без тренувань", () => {
     const oldDate = new Date();
     oldDate.setDate(oldDate.getDate() - 10);
     setLS("fizruk_workouts_v1", {
@@ -119,7 +204,832 @@ describe("generateRecommendations", () => {
     });
 
     const recs = generateRecommendations();
-    const fitnessRec = recs.find((r) => r.module === "fizruk");
+    const fitnessRec = recs.find((r) => r.id === "fizruk_long_break");
     expect(fitnessRec).toBeDefined();
+    expect(fitnessRec!.module).toBe("fizruk");
+    expect(fitnessRec!.priority).toBe(85);
+    expect(fitnessRec!.title).toContain("днів без тренування");
+  });
+
+  it("не показує fizruk_long_break якщо тренувались менше 5 днів тому", () => {
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 2);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: recent.toISOString(),
+        endedAt: new Date(recent.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_long_break")).toBeUndefined();
+  });
+
+  it("визначає мʼязові групи за назвою вправи (regex)", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 12);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        endedAt: new Date(old.getTime() + 3600000).toISOString(),
+        items: [{ nameUk: "Жим лежачи" }, { nameUk: "Присідання зі штангою" }],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    // 12 days ≥ STALE_DAYS(8) → muscle recs for chest and legs
+    const chestRec = recs.find((r) => r.id === "fizruk_muscle_chest");
+    const legsRec = recs.find((r) => r.id === "fizruk_muscle_legs");
+    expect(chestRec).toBeDefined();
+    expect(chestRec!.title).toContain("Груди");
+    expect(legsRec).toBeDefined();
+    expect(legsRec!.title).toContain("Ноги");
+  });
+
+  it("визначає мʼязи через muscleGroups поле вправи", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 10);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        endedAt: new Date(old.getTime() + 3600000).toISOString(),
+        items: [{ name: "Custom Ex", muscleGroups: ["glutes", "hamstrings"] }],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_muscle_glutes")).toBeDefined();
+    expect(recs.find((r) => r.id === "fizruk_muscle_hamstrings")).toBeDefined();
+  });
+
+  it("не генерує мʼязові рекомендації для нещодавно тренованих мʼязів", () => {
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 3);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: recent.toISOString(),
+        endedAt: new Date(recent.getTime() + 3600000).toISOString(),
+        items: [{ nameUk: "Жим лежачи" }],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    // 3 days < STALE_DAYS(8) → no muscle stale rec
+    expect(recs.find((r) => r.id === "fizruk_muscle_chest")).toBeUndefined();
+  });
+
+  it("генерує fizruk_no_week_workout у середині тижня без тренувань", () => {
+    // Force a Wednesday or later date
+    vi.useFakeTimers();
+    // Wednesday 2026-04-29 15:00 UTC
+    vi.setSystemTime(new Date("2026-04-29T15:00:00Z"));
+
+    const old = new Date("2026-04-18T10:00:00Z"); // > 5 days ago
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        endedAt: new Date(old.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_no_week_workout")).toBeDefined();
+  });
+
+  it("НЕ генерує fizruk_no_week_workout на початку тижня (пн/вт)", () => {
+    vi.useFakeTimers();
+    // Monday 2026-04-27 10:00 UTC
+    vi.setSystemTime(new Date("2026-04-27T10:00:00Z"));
+
+    const old = new Date("2026-04-18T10:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        endedAt: new Date(old.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_no_week_workout")).toBeUndefined();
+  });
+
+  it("не генерує fizruk рекомендацій при порожніх тренуваннях", () => {
+    setLS("fizruk_workouts_v1", []);
+    const recs = generateRecommendations();
+    const fizrukRecs = recs.filter((r) => r.module === "fizruk");
+    expect(fizrukRecs).toHaveLength(0);
+  });
+
+  it("ігнорує незавершені тренування (без endedAt)", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 10);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        // no endedAt
+        items: [{ nameUk: "Присідання" }],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    const fizrukRecs = recs.filter((r) => r.module === "fizruk");
+    expect(fizrukRecs).toHaveLength(0);
+  });
+
+  it("parseFizrukWorkouts обробляє формат масиву напряму", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 10);
+    // Direct array (not wrapped in { workouts: [...] })
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: old.toISOString(),
+        endedAt: new Date(old.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_long_break")).toBeDefined();
+  });
+
+  it("parseFizrukWorkouts обробляє обгорнутий формат { workouts: […] }", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 10);
+    setLS("fizruk_workouts_v1", {
+      workouts: [
+        {
+          id: "w1",
+          startedAt: old.toISOString(),
+          endedAt: new Date(old.getTime() + 3600000).toISOString(),
+          items: [],
+        },
+      ],
+    });
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "fizruk_long_break")).toBeDefined();
+  });
+
+  it("parseFizrukWorkouts повертає [] при невалідному JSON", () => {
+    localStorage.setItem("fizruk_workouts_v1", "not-json{");
+    const recs = generateRecommendations();
+    const fizrukRecs = recs.filter((r) => r.module === "fizruk");
+    expect(fizrukRecs).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Routine — habits & streaks
+  // -----------------------------------------------------------------------
+
+  it("не генерує routine рекомендацій при порожньому стані", () => {
+    const recs = generateRecommendations();
+    const routineRecs = recs.filter((r) => r.module === "routine");
+    expect(routineRecs).toHaveLength(0);
+  });
+
+  it("не генерує routine рекомендацій якщо немає звичок", () => {
+    setLS("hub_routine_v1", { habits: [], completions: {} });
+    const recs = generateRecommendations();
+    const routineRecs = recs.filter((r) => r.module === "routine");
+    expect(routineRecs).toHaveLength(0);
+  });
+
+  it("не рахує архівовані звички", () => {
+    setLS("hub_routine_v1", {
+      habits: [{ id: "h1", archived: true }],
+      completions: {},
+    });
+    const recs = generateRecommendations();
+    const routineRecs = recs.filter((r) => r.module === "routine");
+    expect(routineRecs).toHaveLength(0);
+  });
+
+  it("генерує streak milestone рекомендацію для 7-денної серії", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    // 7 days streak: yesterday through 7 days ago (all complete)
+    completions["h1"] = [];
+    for (let i = 1; i <= 7; i++) {
+      const d = new Date("2026-04-27T12:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    const streakRec = recs.find((r) => r.id === "routine_streak_7");
+    expect(streakRec).toBeDefined();
+    expect(streakRec!.title).toContain("7 днів поспіль");
+    expect(streakRec!.priority).toBe(80);
+  });
+
+  it("генерує milestone для 3-денної серії", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    for (let i = 1; i <= 3; i++) {
+      const d = new Date("2026-04-27T12:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "routine_streak_3")).toBeDefined();
+  });
+
+  it("НЕ генерує milestone якщо серія не на спеціальному значенні (напр. 5)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    for (let i = 1; i <= 5; i++) {
+      const d = new Date("2026-04-27T12:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    // 5 is not in MILESTONE_STREAKS [3,7,14,30,60,100]
+    expect(recs.find((r) => r.id === "routine_streak_5")).toBeUndefined();
+  });
+
+  it("генерує вечірнє нагадування про незавершені звички після 18:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T19:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("hub_routine_v1", {
+      habits: [{ id: "h1" }, { id: "h2" }],
+      completions: { h1: [today] },
+    });
+
+    const recs = generateRecommendations();
+    const eveningRec = recs.find((r) => r.id === "routine_evening_reminder");
+    expect(eveningRec).toBeDefined();
+    expect(eveningRec!.title).toContain("1 звичок ще не виконано");
+    expect(eveningRec!.priority).toBe(65);
+  });
+
+  it("НЕ генерує вечірнє нагадування до 18:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("hub_routine_v1", {
+      habits: [{ id: "h1" }, { id: "h2" }],
+      completions: { h1: [today] },
+    });
+
+    const recs = generateRecommendations();
+    expect(
+      recs.find((r) => r.id === "routine_evening_reminder"),
+    ).toBeUndefined();
+  });
+
+  it("генерує streak_at_risk після 21:00 при серії 7+ і незавершених звичках", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    // 7-day streak — today NOT completed → streak at risk
+    for (let i = 1; i <= 7; i++) {
+      const d = new Date("2026-04-27T22:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    const atRisk = recs.find((r) => r.id === "routine_streak_at_risk");
+    expect(atRisk).toBeDefined();
+    expect(atRisk!.priority).toBe(95);
+    expect(atRisk!.title).toContain("під загрозою");
+  });
+
+  it("routine_streak_at_risk використовує правильну форму множини для 1 звички", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    for (let i = 1; i <= 7; i++) {
+      const d = new Date("2026-04-27T22:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    const atRisk = recs.find((r) => r.id === "routine_streak_at_risk");
+    expect(atRisk).toBeDefined();
+    // remaining === 1 → "звичка" (singular)
+    expect(atRisk!.body).toContain("1 звичка");
+  });
+
+  it("routine_streak_at_risk використовує множину для >1 звичок", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+
+    const habits = [{ id: "h1" }, { id: "h2" }, { id: "h3" }];
+    const completions: Record<string, string[]> = {};
+    for (const h of habits) {
+      completions[h.id] = [];
+      for (let i = 1; i <= 7; i++) {
+        const d = new Date("2026-04-27T22:00:00Z");
+        d.setDate(d.getDate() - i);
+        const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        completions[h.id].push(dk);
+      }
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    const atRisk = recs.find((r) => r.id === "routine_streak_at_risk");
+    expect(atRisk).toBeDefined();
+    // remaining === 3 → "звичок" (plural)
+    expect(atRisk!.body).toContain("3 звичок");
+  });
+
+  it("НЕ генерує streak_at_risk якщо серія < 7 днів", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T22:00:00Z"));
+
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    for (let i = 1; i <= 5; i++) {
+      const d = new Date("2026-04-27T22:00:00Z");
+      d.setDate(d.getDate() - i);
+      const dk = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "routine_streak_at_risk")).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Nutrition
+  // -----------------------------------------------------------------------
+
+  it("генерує nutrition_no_meals_today після 13:00 якщо немає записів", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T15:00:00Z"));
+
+    setLS("nutrition_log_v1", {});
+
+    const recs = generateRecommendations();
+    const noMeals = recs.find((r) => r.id === "nutrition_no_meals_today");
+    expect(noMeals).toBeDefined();
+    expect(noMeals!.module).toBe("nutrition");
+    expect(noMeals!.pwaAction).toBe("add_meal");
+  });
+
+  it("НЕ генерує nutrition_no_meals_today до 13:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T10:00:00Z"));
+
+    setLS("nutrition_log_v1", {});
+
+    const recs = generateRecommendations();
+    expect(
+      recs.find((r) => r.id === "nutrition_no_meals_today"),
+    ).toBeUndefined();
+  });
+
+  it("генерує nutrition_kcal_low якщо калорії < 50% після 18:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T19:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 400, protein_g: 30 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", { dailyTargetKcal: 2000 });
+
+    const recs = generateRecommendations();
+    const kcalLow = recs.find((r) => r.id === "nutrition_kcal_low");
+    expect(kcalLow).toBeDefined();
+    expect(kcalLow!.title).toContain("400");
+    expect(kcalLow!.title).toContain("2000");
+  });
+
+  it("НЕ генерує nutrition_kcal_low до 18:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 400, protein_g: 30 } }],
+      },
+    });
+
+    const recs = generateRecommendations();
+    expect(recs.find((r) => r.id === "nutrition_kcal_low")).toBeUndefined();
+  });
+
+  it("генерує nutrition_protein_low якщо білок < 60% після 16:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T17:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 1500, protein_g: 40 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", {
+      dailyTargetKcal: 2000,
+      dailyTargetProtein_g: 120,
+    });
+
+    const recs = generateRecommendations();
+    const proteinLow = recs.find((r) => r.id === "nutrition_protein_low");
+    expect(proteinLow).toBeDefined();
+    expect(proteinLow!.title).toContain("40г білка");
+  });
+
+  it("генерує nutrition_post_workout_protein після тренування з низьким білком", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T17:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 500, protein_g: 20 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", {
+      dailyTargetKcal: 2000,
+      dailyTargetProtein_g: 120,
+    });
+    // Recent workout (1 hour ago)
+    const recentWorkout = new Date("2026-04-27T16:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: recentWorkout.toISOString(),
+        endedAt: new Date(recentWorkout.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    const postWorkout = recs.find(
+      (r) => r.id === "nutrition_post_workout_protein",
+    );
+    expect(postWorkout).toBeDefined();
+    expect(postWorkout!.priority).toBe(88);
+  });
+
+  it("НЕ генерує nutrition_post_workout_protein якщо тренування було давно", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T17:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 500, protein_g: 20 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", {
+      dailyTargetKcal: 2000,
+      dailyTargetProtein_g: 120,
+    });
+    // Old workout (5 hours ago → > 2 threshold)
+    const oldWorkout = new Date("2026-04-27T12:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: oldWorkout.toISOString(),
+        endedAt: new Date(oldWorkout.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(
+      recs.find((r) => r.id === "nutrition_post_workout_protein"),
+    ).toBeUndefined();
+  });
+
+  it("використовує fallback значення при відсутності nutrition_prefs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T19:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 400, protein_g: 20 } }],
+      },
+    });
+    // No prefs → fallback to 2000 kcal / 120g protein
+
+    const recs = generateRecommendations();
+    const kcalLow = recs.find((r) => r.id === "nutrition_kcal_low");
+    expect(kcalLow).toBeDefined();
+    expect(kcalLow!.title).toContain("2000"); // default target
+  });
+
+  it("підтримує dailyTargetProtein (без _g) як fallback", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T17:00:00Z"));
+
+    const today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 1500, protein_g: 30 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", {
+      dailyTargetKcal: 2000,
+      dailyTargetProtein: 80,
+    });
+
+    const recs = generateRecommendations();
+    const proteinLow = recs.find((r) => r.id === "nutrition_protein_low");
+    expect(proteinLow).toBeDefined();
+    expect(proteinLow!.title).toContain("80г"); // uses dailyTargetProtein
+  });
+
+  it("обробляє порожні/null macros", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T19:00:00Z"));
+
+    const _today = "2026-04-27";
+    setLS("nutrition_log_v1", {
+      [_today]: {
+        meals: [{ macros: null }, { macros: {} }, {}],
+      },
+    });
+
+    const recs = generateRecommendations();
+    // Should handle gracefully; kcal = 0, might show kcal_low or no_meals
+    expect(Array.isArray(recs)).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Weekly digest
+  // -----------------------------------------------------------------------
+
+  it("генерує weekly_digest у понеділок 7-12 якщо є дані за минулий тиждень", () => {
+    vi.useFakeTimers();
+    // Monday 2026-04-27 09:00 UTC
+    vi.setSystemTime(new Date("2026-04-27T09:00:00Z"));
+
+    // Workout last week (Monday-Sunday: Apr 20-26)
+    const lastWeek = new Date("2026-04-23T10:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: lastWeek.toISOString(),
+        endedAt: new Date(lastWeek.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    const digest = recs.find((r) => r.id?.startsWith("weekly_digest_"));
+    expect(digest).toBeDefined();
+    expect(digest!.title).toBe("Підсумок минулого тижня");
+    expect(digest!.priority).toBe(92);
+    expect(digest!.body).toContain("1 трен.");
+  });
+
+  it("НЕ генерує weekly_digest у вівторок", () => {
+    vi.useFakeTimers();
+    // Tuesday 2026-04-28 09:00 UTC
+    vi.setSystemTime(new Date("2026-04-28T09:00:00Z"));
+
+    const lastWeek = new Date("2026-04-23T10:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: lastWeek.toISOString(),
+        endedAt: new Date(lastWeek.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(
+      recs.find((r) => r.id?.startsWith("weekly_digest_")),
+    ).toBeUndefined();
+  });
+
+  it("НЕ генерує weekly_digest у понеділок після 12:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T14:00:00Z"));
+
+    const lastWeek = new Date("2026-04-23T10:00:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: lastWeek.toISOString(),
+        endedAt: new Date(lastWeek.getTime() + 3600000).toISOString(),
+        items: [],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    expect(
+      recs.find((r) => r.id?.startsWith("weekly_digest_")),
+    ).toBeUndefined();
+  });
+
+  it("weekly_digest включає витрати та звички", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T09:00:00Z"));
+
+    // Mon prev = Apr 20, Sun prev = Apr 26 23:59:59
+    const txTime = Math.floor(
+      new Date("2026-04-22T12:00:00Z").getTime() / 1000,
+    );
+    setLS("finyk_tx_cache", {
+      txs: [
+        { id: "tx1", amount: -500000, time: txTime, description: "Покупки" },
+      ],
+    });
+    setLS("finyk_tx_cats", { tx1: "shopping" });
+
+    // Habits: 1 habit, completed all 7 days of last week
+    const habits = [{ id: "h1" }];
+    const completions: Record<string, string[]> = {};
+    completions["h1"] = [];
+    for (let i = 0; i < 7; i++) {
+      const _d = new Date("2026-04-20T12:00:00Z");
+      _d.setDate(_d.getDate() + i);
+      const dk = `${_d.getFullYear()}-${String(_d.getMonth() + 1).padStart(2, "0")}-${String(_d.getDate()).padStart(2, "0")}`;
+      completions["h1"].push(dk);
+    }
+    setLS("hub_routine_v1", { habits, completions });
+
+    const recs = generateRecommendations();
+    const digest = recs.find((r) => r.id?.startsWith("weekly_digest_"));
+    expect(digest).toBeDefined();
+    expect(digest!.body).toContain("₴"); // spending
+    expect(digest!.body).toContain("звички"); // habits
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases — corrupt/partial localStorage
+  // -----------------------------------------------------------------------
+
+  it("обробляє пошкоджений JSON у localStorage gracefully", () => {
+    localStorage.setItem("finyk_tx_cache", "{{not json}}");
+    localStorage.setItem("hub_routine_v1", "nope");
+    localStorage.setItem("nutrition_log_v1", "broken");
+
+    const recs = generateRecommendations();
+    expect(Array.isArray(recs)).toBe(true);
+  });
+
+  it("обробляє порожній масив транзакцій", () => {
+    setLS("finyk_tx_cache", { txs: [] });
+    setLS("finyk_budgets", [
+      { id: "b1", type: "limit", categoryId: "food", limit: 1000 },
+    ]);
+
+    const recs = generateRecommendations();
+    const budgetRecs = recs.filter(
+      (r) => r.id.startsWith("budget_over_") || r.id.startsWith("budget_warn_"),
+    );
+    expect(budgetRecs).toHaveLength(0);
+  });
+
+  it("обробляє finyk_tx_cache як масив напряму (не обгорнутий об'єкт)", () => {
+    const ts = Math.floor(Date.now() / 1000);
+    // Direct array format
+    setLS("finyk_tx_cache", [
+      { id: "tx1", amount: -200000, time: ts, description: "Покупки" },
+    ]);
+    setLS("finyk_tx_cats", { tx1: "food" });
+    setLS("finyk_budgets", [
+      { id: "b1", type: "limit", categoryId: "food", limit: 1000 },
+    ]);
+
+    const recs = generateRecommendations();
+    const budgetRec = recs.find((r) => r.id === "budget_over_food");
+    expect(budgetRec).toBeDefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Cross-module interaction
+  // -----------------------------------------------------------------------
+
+  it("крос-модульний: fizruk+nutrition → post_workout_protein", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T17:00:00Z"));
+
+    const today = "2026-04-27";
+    // Low protein
+    setLS("nutrition_log_v1", {
+      [today]: {
+        meals: [{ macros: { kcal: 500, protein_g: 10 } }],
+      },
+    });
+    setLS("nutrition_prefs_v1", {
+      dailyTargetKcal: 2000,
+      dailyTargetProtein_g: 120,
+    });
+
+    // Recent workout 30 min ago
+    const recentWorkout = new Date("2026-04-27T16:30:00Z");
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: recentWorkout.toISOString(),
+        endedAt: new Date(recentWorkout.getTime() + 1800000).toISOString(),
+        items: [{ nameUk: "Присідання зі штангою" }],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    const post = recs.find((r) => r.id === "nutrition_post_workout_protein");
+    expect(post).toBeDefined();
+    expect(post!.module).toBe("nutrition");
+    expect(post!.priority).toBe(88);
+  });
+
+  // -----------------------------------------------------------------------
+  // safeLS resilience
+  // -----------------------------------------------------------------------
+
+  it("safeLS повертає fallback при null localStorage", () => {
+    // getItem returns null for missing keys
+    const recs = generateRecommendations();
+    expect(Array.isArray(recs)).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Muscle label i18n
+  // -----------------------------------------------------------------------
+
+  it("мʼязові рекомендації використовують українські назви", () => {
+    const oldW = new Date();
+    oldW.setDate(oldW.getDate() - 12);
+    setLS("fizruk_workouts_v1", [
+      {
+        id: "w1",
+        startedAt: oldW.toISOString(),
+        endedAt: new Date(oldW.getTime() + 3600000).toISOString(),
+        items: [
+          { nameUk: "Тяга верхнього блоку" },
+          { nameUk: "Підйом на біцепс" },
+          { nameUk: "Розгинання на триципс" },
+          { nameUk: "Планка" },
+          { nameUk: "Розведення гантелей на плечей" },
+        ],
+      },
+    ]);
+
+    const recs = generateRecommendations();
+    const labels = recs
+      .filter((r) => r.id.startsWith("fizruk_muscle_"))
+      .map((r) => r.title);
+
+    // Verify Ukrainian labels are used
+    const allLabels = labels.join(" ");
+    expect(allLabels).toMatch(/Спина|Біцепс|Триципс|Прес|Плечі/);
   });
 });


### PR DESCRIPTION
## What changed

Added comprehensive test coverage for the recommendation engine (`recommendationEngine.ts`) and its dashboard display component (`TodayFocusCard.tsx`, formerly `HubRecommendations`).

**Unit tests — `recommendationEngine.test.ts` (54 tests):**
- **Finance (Finyk):** budget over/warn thresholds, txSplits accounting, edge cases (no limit, categoryId null, spending < 90%)
- **Fizruk:** long break (>5 days), muscle stale (≥8 days via regex + muscleGroups field), no week workout (mid-week only), incomplete workouts ignored
- **Routine:** streak milestones (3, 7 — not non-milestone values like 5), evening reminder (after 18:00 only), streak at risk (after 21:00 with 7+ streak)
- **Nutrition:** no meals today (after 13:00), kcal low (<50% after 18:00), protein low (<60% after 16:00), post-workout protein (within 2h window), fallback prefs
- **Weekly digest:** Monday 7–12 window only, body includes spending + habits
- **Edge cases:** corrupt JSON in localStorage, partial data, empty arrays, direct array vs wrapped object formats
- **Cross-module:** fizruk workout + nutrition protein → post_workout_protein rec
- **i18n:** Ukrainian plural forms verified (1 звичка / 3 звичок), muscle labels (Груди, Ноги, Спина, Біцепс, etc.)
- **parseFizrukWorkouts:** both array and `{ workouts: [] }` formats, invalid JSON graceful handling

**Integration RTL tests — `TodayFocusCard.test.tsx` (19 tests, 14+ scenarios):**
- **Empty state:** EmptyFocus renders with heading + subtitle, 4 quick-add chips (Витрата, Тренування, Звичка, Їжа), chip click dispatches `openHubModuleWithAction`
- **Focus card rendering:** title/body display, severity styling (danger → `bg-danger`, warning → `bg-warning`), icon rendering
- **CTA interactions:** pwaAction → `openHubModuleWithAction`, no pwaAction → `onAction` callback, secondary "Відкрити <модуль>" button, "Пізніше" dismiss button → `onDismiss(id)`
- **Module accents:** fizruk accent bar (`bg-fizruk`), routine/nutrition renders correctly
- **`useDashboardFocus` hook:** focus = highest priority, rest = remaining, dismiss filters & persists to localStorage, pre-dismissed items excluded

## Why

**Audit PR-7.A** from `docs/audits/2026-04-26-sergeant-audit-devin.md` (Block 7).

The recommendation engine is a critical user flow that was not covered by tests. This PR brings coverage from minimal (7 basic tests) to comprehensive (73 tests total), targeting ≥90% branch coverage for `recommendationEngine` and ≥3 mounted-render scenarios for the display component.

No production code was changed — tests only.

## How to test

```bash
# Run all new tests
pnpm --filter @sergeant/web test -- --run src/core/lib/recommendationEngine.test.ts src/core/insights/TodayFocusCard.test.tsx

# Run with coverage for recommendationEngine
pnpm --filter @sergeant/web test -- --run --coverage src/core/lib/recommendationEngine.test.ts
```

---

## How AI-tested this PR

- [x] Vitest passes: 73 tests (54 unit + 19 integration), all green
- [x] ESLint passes: 0 errors, 0 warnings
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] No production code changes — tests only

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for recommendation systems and focus card components with comprehensive validation of selection logic, dismissal behavior, time-gating rules, and UI interactions across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->