### PR TITLE
fix(eslint-plugins): use ASCII spread in no-bigint-string spread-elements test

### DIFF
--- a/packages/eslint-plugin-sergeant-design/__tests__/no-bigint-string.test.mjs
+++ b/packages/eslint-plugin-sergeant-design/__tests__/no-bigint-string.test.mjs
@@ -215,9 +215,10 @@ describe("no-bigint-string – allows properly coerced values", () => {
   });
 
   it("does NOT flag spread elements", () => {
+    // eslint-disable-next-line sergeant-design/no-ellipsis-dots -- intentional spread `...` in JS source under test
     const messages = lint(`
       const data = result.rows.map((r) => ({
-        …r,
+        ...r,
         id: Number(r.id),
       }));
     `);


### PR DESCRIPTION
## What changed

Замінено `…r` (U+2026 horizontal ellipsis) на `...r` (ASCII spread) у тесті `__tests__/no-bigint-string.test.mjs:220` і додано `// eslint-disable-next-line sergeant-design/no-ellipsis-dots` щоб правило `no-ellipsis-dots` не auto-fix-ило назад.

## Why

Тест `'does NOT flag spread elements'` падає на `main` з моменту мерджу [#868](https://github.com/Skords-01/Sergeant/pull/868). Через це **`check` job червоний на всіх PR** (наприклад, [#892](https://github.com/Skords-01/Sergeant/pull/892) — суто docs-only PR). Корінь — у тому самому репо живе:

1. правило `no-ellipsis-dots`, яке під час `lint-staged --fix` пере-конвертує `...` усередині template literal у `…` (бо воно реагує на `TemplateElement.value.cooked`), і
2. тест `no-bigint-string`, у якому ASCII-spread `...r` є частиною JS-source-під-тест-ом усередині template literal.

Комбінація — правило autofix-ить тест свого «сусіда», ламає синтаксис у JS-source-під-тест-ом, і вже інше правило (`no-bigint-string`) реагує помилково (бо парсер не бачить spread, бачить ідентифікатор `…r`).

## How to test

```
cd packages/eslint-plugin-sergeant-design
node --test __tests__/no-bigint-string.test.mjs
```

До: `# fail 1`, `not ok 9 - does NOT flag spread elements` (`Expected: 0, actual: 1`).
Після: `# pass 23`, `# fail 0`.

Перераховано вручну на `main`:
```
$ git log --oneline -- packages/eslint-plugin-sergeant-design/__tests__/no-bigint-string.test.mjs
fa79703a feat(eslint-plugins): add no-bigint-string rule
```
Тест зламаний з самого комміту, який його ввів — це давно зайнятий зелений-але-fail-ить-все-інше patten.

---

## How AI-tested this PR

- [x] Manual smoke: `node --test __tests__/no-bigint-string.test.mjs` локально (23/23 pass).
- [x] Vitest passes: цей PR не торкається vitest-сумарного surface-у.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

_(Можливо варто винести цей edge case у `docs/playbooks/eslint-rule-self-conflict.md` як знахідку, але це окрема ітерація.)_

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
