### PR TITLE
fix(web): narrow AssetsProps.storage to slice actually used

### DIFF
--- a/apps/web/src/modules/finyk/pages/useAssetsState.test.ts
+++ b/apps/web/src/modules/finyk/pages/useAssetsState.test.ts
@@ -19,7 +19,7 @@ function makeStorage(overrides = {}) {
     addSubscriptionFromRecurring: vi.fn(),
     dismissedRecurring: [],
     dismissRecurring: vi.fn(),
-    excludedTxIds: [],
+    excludedTxIds: new Set<string>(),
     monoDebtLinkedTxIds: {},
     toggleMonoDebtTx: vi.fn(),
     customCategories: [],

--- a/apps/web/src/modules/finyk/pages/useAssetsState.ts
+++ b/apps/web/src/modules/finyk/pages/useAssetsState.ts
@@ -13,9 +13,36 @@ import type { Tx } from "@sergeant/finyk-domain/domain/debtEngine";
 // AI-NOTE: Props mirror the original Assets component signature from FinykApp.
 // The original component was untyped; we use loose structural types here to
 // preserve backwards compatibility without introducing strict coupling.
+//
+// `storage` lists only the slice of `useStorage()` that this hook actually
+// destructures — keeping the prop honest about its real surface and letting
+// tests / alternate callers supply lightweight stand-ins without satisfying
+// the full 47-field hook signature.
+type StorageSlice = Pick<
+  ReturnType<typeof import("../hooks/useStorage").useStorage>,
+  | "hiddenAccounts"
+  | "manualAssets"
+  | "setManualAssets"
+  | "manualDebts"
+  | "setManualDebts"
+  | "receivables"
+  | "setReceivables"
+  | "toggleLinkedTx"
+  | "subscriptions"
+  | "setSubscriptions"
+  | "updateSubscription"
+  | "addSubscriptionFromRecurring"
+  | "dismissedRecurring"
+  | "dismissRecurring"
+  | "excludedTxIds"
+  | "monoDebtLinkedTxIds"
+  | "toggleMonoDebtTx"
+  | "customCategories"
+>;
+
 export type AssetsProps = {
   mono: { accounts: MonoAccount[]; transactions: Tx[] };
-  storage: ReturnType<typeof import("../hooks/useStorage").useStorage>;
+  storage: StorageSlice;
   showBalance?: boolean;
   initialOpenDebt?: boolean;
 };


### PR DESCRIPTION
## What changed

`apps/web/src/modules/finyk/pages/useAssetsState.ts:18`: тип `AssetsProps.storage` був `ReturnType<typeof useStorage>` (47 полів). `useAssetsState` фактично деструктурує лише 18 із них. У тесті `useAssetsState.test.ts` `makeStorage()` мокав саме цю 18-польну форму, тому `tsc` валився з 9× `TS2740`.

Два дрібних зміни:
- Винесено `StorageSlice = Pick<ReturnType<typeof useStorage>, …>` тільки з тих 18 ключів, які hook реально юзає; `AssetsProps.storage: StorageSlice`. Код hook-а не торкався.
- `useAssetsState.test.ts:21`: `excludedTxIds` тепер `new Set<string>()` (відповідає реальній формі `useStorage`), не `[]`.

## Why

Після мерджу [#887](https://github.com/Skords-01/Sergeant/pull/887) (decompose Assets.tsx) `pnpm -F @sergeant/web typecheck` падає на `main`. Через це **`check` job червоний на всіх PR** (наприклад, [#892](https://github.com/Skords-01/Sergeant/pull/892), [#894](https://github.com/Skords-01/Sergeant/pull/894), і будь-яких майбутніх). Прибираю блокер локалізованим способом, без переписування тестів і без розширення моків до 47 полів.

Архітектурно це чесніше: `AssetsProps.storage` тепер документує саме той зріз даних, який hook реально потребує — і альтернативні call-site / тести можуть легко надавати lightweight stand-in без сатисфакції повної 47-польної сигнатури hook-а.

## How to test

```
pnpm -F @sergeant/web typecheck
pnpm -F @sergeant/web test -- --run useAssetsState
```

До: 9× `error TS2740`, 0/9 vitest run.
Після: typecheck clean, vitest 9/9 pass.

---

## How AI-tested this PR

- [x] Manual smoke: typecheck + 9/9 vitest на `useAssetsState.test.ts` локально.
- [x] Vitest passes.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
