### PR TITLE
test(server): add SSE end-to-end harness for chat streaming

### DIFF
--- a/apps/server/src/modules/chat.stream.test.ts
+++ b/apps/server/src/modules/chat.stream.test.ts
@@ -1,0 +1,737 @@
+/**
+ * SSE end-to-end harness для `streamAnthropicToSse` / `streamOneIterationToSse`.
+ *
+ * Покриває untested-шлях у `chat.ts`: коли клієнт запитує `stream: true` разом
+ * із `tool_results + tool_calls_raw`, сервер відкриває upstream-стрім до
+ * Anthropic і форвардить text-дельти у `data: {"t":"…"}\n\n` події. Цей файл
+ * мокає `anthropicMessagesStream` фейковою `Response` із `ReadableStream`-боді,
+ * а Express-`Response` — об'єктом, що збирає все, що пишуть у `res.write()`,
+ * щоб можна було асертити саме SSE-протокол (а не лише фінальний текст).
+ *
+ * Тести покривають:
+ * - простий стрім: text-дельти → data-події → `[DONE]`;
+ * - авто-continuation на `stop_reason: "max_tokens"` (другий upstream-виклик
+ *   з накопиченим assistant-text як останнім повідомленням);
+ * - cap (`MAX_TEXT_CONTINUATIONS = 3`) на runaway-генерацію;
+ * - graceful degradation коли continuation повертає !ok / кидає виняток
+ *   (юзер бачить partial text + `err`-подію + `[DONE]`);
+ * - upstream-помилку на першому виклику (JSON-помилка, без SSE-заголовків);
+ * - reassembly SSE-подій, розрізаних по chunk-боундарі;
+ * - skip некоректного JSON у data-лінії (без падіння стріму);
+ * - skip non-text content_block_delta (input_json_delta тощо);
+ * - prompt-cache-метрика: `cache_read>0` → `hit`, `0` → `miss`.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Request, Response } from "express";
+import type { Mock } from "vitest";
+
+vi.mock("../lib/anthropic.js", () => ({
+  anthropicMessages: vi.fn(),
+  anthropicMessagesStream: vi.fn(),
+  extractAnthropicText: vi.fn(),
+}));
+
+vi.mock("../obs/metrics.js", () => ({
+  anthropicPromptCacheHitTotal: { inc: vi.fn() },
+  aiRequestDurationMs: { observe: vi.fn() },
+  aiRequestsTotal: { inc: vi.fn() },
+  aiTokensTotal: { inc: vi.fn() },
+  externalHttpDurationMs: { observe: vi.fn() },
+  externalHttpRequestsTotal: { inc: vi.fn() },
+}));
+
+import { anthropicMessagesStream as _anthropicMessagesStream } from "../lib/anthropic.js";
+import { anthropicPromptCacheHitTotal as _cacheMetric } from "../obs/metrics.js";
+import handler from "./chat.js";
+
+const anthropicMessagesStream = _anthropicMessagesStream as unknown as Mock;
+const cacheMetricInc = (_cacheMetric as unknown as { inc: Mock }).inc;
+
+interface SseEvent {
+  type: string;
+  delta?: { type?: string; text?: string; stop_reason?: string };
+  message?: { usage?: Record<string, number> };
+  // input_json_delta тощо — лишаємо як index signature
+  [key: string]: unknown;
+}
+
+/**
+ * Серіалізує масив подій у єдину raw SSE-строку: `data: <json>\n\n` ×N.
+ * Окрема функція на випадок, якщо тест хоче розрізати її по власних
+ * boundaries (див. `makeChunkedUpstream`).
+ */
+function eventsToSseString(events: SseEvent[]): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+}
+
+/**
+ * Будує fetch-`Response` з body-`ReadableStream`, який віддає всю serialized
+ * SSE-строку одним chunk-ом. Під капотом сервер усе одно прокачує через
+ * `getReader().read()` циклом, тому одно/багатоchunk-овий boundary тестується
+ * `makeChunkedUpstream` нижче.
+ */
+function makeUpstreamSse(
+  events: SseEvent[],
+  init: { ok?: boolean; status?: number } = {},
+): globalThis.Response {
+  const status = init.status ?? 200;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(eventsToSseString(events)));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/**
+ * Будує fetch-`Response`, де body віддає кілька raw-chunk-ів у вказаному
+ * порядку. Дозволяє розрізати SSE-події посеред JSON-літерала чи між
+ * `\n` і `\n` — стрес-тест на line-buffer reassembly у
+ * `streamOneIterationToSse`.
+ */
+function makeChunkedUpstream(
+  rawChunks: string[],
+  init: { status?: number } = {},
+): globalThis.Response {
+  const status = init.status ?? 200;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of rawChunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status });
+}
+
+interface SseRes {
+  statusCode: number;
+  body: unknown;
+  writes: string[];
+  headers: Record<string, string>;
+  status(code: number): SseRes;
+  json(payload: unknown): SseRes;
+  setHeader(k: string, v: string): void;
+  write(s: string): boolean;
+  end(): void;
+  on(): void;
+  readonly writableEnded: boolean;
+}
+
+/**
+ * Express-Response мок, спеціально під SSE: `setHeader` + `write` + `end`.
+ * Зберігає всі writes окремими строчками, щоб тест бачив порядок подій.
+ */
+function makeSseRes(): SseRes & Response {
+  const writes: string[] = [];
+  const headers: Record<string, string> = {};
+  let writableEnded = false;
+  const res: SseRes = {
+    statusCode: 200,
+    body: undefined,
+    writes,
+    headers,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    write(s: string) {
+      if (writableEnded) return false;
+      writes.push(s);
+      return true;
+    },
+    end() {
+      writableEnded = true;
+    },
+    on() {
+      /* no-op: chat.ts слухає 'close', але в тестах не emit-имо */
+    },
+    get writableEnded() {
+      return writableEnded;
+    },
+  };
+  return res as unknown as SseRes & Response;
+}
+
+function makeReq(body: unknown): Request {
+  return { anthropicKey: "sk-test", body } as unknown as Request;
+}
+
+/**
+ * Streaming-шлях у `chat.ts` живе саме в гілці tool-result (line ~341), тому
+ * тести треба проганяти через payload із `tool_results + tool_calls_raw`. Цей
+ * helper будує мінімальний валідний body, лишаючи тестам лише декларацію
+ * stream-сценарію.
+ */
+function makeStreamReqBody(): Record<string, unknown> {
+  return {
+    stream: true,
+    messages: [{ role: "user", content: "довгий брифінг" }],
+    tool_calls_raw: [
+      {
+        type: "tool_use",
+        id: "toolu_x",
+        name: "noop",
+        input: {},
+      },
+    ],
+    tool_results: [{ tool_use_id: "toolu_x", content: "ok" }],
+  };
+}
+
+/** Витягує всі data-payload-и (без префікса `data: ` і термінатора `\n\n`). */
+function dataPayloads(writes: string[]): string[] {
+  return writes
+    .filter((w) => w.startsWith("data: "))
+    .map((w) => w.slice("data: ".length).replace(/\n\n$/, ""));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  anthropicMessagesStream.mockReset();
+  cacheMetricInc.mockReset();
+});
+
+describe("chat handler — SSE streaming (basic forwarding)", () => {
+  it("форвардить text-дельти як data-події і завершує [DONE]", async () => {
+    const events: SseEvent[] = [
+      {
+        type: "message_start",
+        message: { usage: { cache_read_input_tokens: 0 } },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Привіт" },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: ", як " },
+      },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "справи?" },
+      },
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+    ];
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse(events),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    const payloads = dataPayloads(res.writes);
+    // Кожен text_delta стає окремою `data: {"t":"…"}` подією у тому ж порядку.
+    expect(payloads).toEqual([
+      JSON.stringify({ t: "Привіт" }),
+      JSON.stringify({ t: ", як " }),
+      JSON.stringify({ t: "справи?" }),
+      "[DONE]",
+    ]);
+    // SSE-протокольні заголовки виставлені.
+    expect(res.headers["Content-Type"]).toBe(
+      "text/event-stream; charset=utf-8",
+    );
+    expect(res.headers["Cache-Control"]).toBe("no-cache, no-transform");
+    expect(res.headers["X-Accel-Buffering"]).toBe("no");
+    expect(res.writableEnded).toBe(true);
+  });
+
+  it("HE відкриває continuation коли stop_reason='end_turn'", async () => {
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse([
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "Готово." },
+        },
+        { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(anthropicMessagesStream).toHaveBeenCalledTimes(1);
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "Готово." }),
+      "[DONE]",
+    ]);
+  });
+
+  it("ігнорує не-text content_block_delta (input_json_delta тощо)", async () => {
+    // Anthropic емітить input_json_delta для tool_use; SSE-форвард має пропустити.
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse([
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "видимий " },
+        },
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "input_json_delta",
+            partial_json: '{"x":1',
+          } as unknown as SseEvent["delta"],
+        },
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "текст" },
+        },
+        { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "видимий " }),
+      JSON.stringify({ t: "текст" }),
+      "[DONE]",
+    ]);
+  });
+});
+
+describe("chat handler — SSE auto-continuation на stop_reason=max_tokens", () => {
+  it("робить другий upstream-виклик з накопиченим assistant-text", async () => {
+    anthropicMessagesStream
+      .mockResolvedValueOnce({
+        response: makeUpstreamSse([
+          {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Перша частина… " },
+          },
+          { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+        ]),
+        recordStreamEnd: vi.fn(),
+      })
+      .mockResolvedValueOnce({
+        response: makeUpstreamSse([
+          {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "друга частина — кінець." },
+          },
+          { type: "message_delta", delta: { stop_reason: "end_turn" } },
+        ]),
+        recordStreamEnd: vi.fn(),
+      });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(anthropicMessagesStream).toHaveBeenCalledTimes(2);
+    // Continuation отримує partial-text як останнє assistant-повідомлення
+    // (Anthropic вимагає user/assistant alternation).
+    const secondPayload = anthropicMessagesStream.mock.calls[1][1] as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    const last = secondPayload.messages[secondPayload.messages.length - 1];
+    expect(last).toEqual({
+      role: "assistant",
+      content: "Перша частина… ",
+    });
+    // Endpoint-розмітка для другого виклику — `chat-tool-result-cont`,
+    // щоб latency-метрики розрізняли continuation від першого виклику.
+    const secondOpts = anthropicMessagesStream.mock.calls[1][2] as {
+      endpoint: string;
+    };
+    expect(secondOpts.endpoint).toBe("chat-tool-result-cont");
+
+    // Юзер бачить обидва chunk-и склеєними у одному SSE-потоці без маркерів
+    // continuation.
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "Перша частина… " }),
+      JSON.stringify({ t: "друга частина — кінець." }),
+      "[DONE]",
+    ]);
+  });
+
+  it("обмежує кількість continuation викликів cap-ом MAX_TEXT_CONTINUATIONS=3", async () => {
+    // Runaway: модель щоразу повертає max_tokens. Cap=3 → загалом 1+3=4 upstream.
+    const partial = (i: number) => ({
+      response: makeUpstreamSse([
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: `c${i} ` },
+        },
+        { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+    anthropicMessagesStream
+      .mockResolvedValueOnce(partial(1))
+      .mockResolvedValueOnce(partial(2))
+      .mockResolvedValueOnce(partial(3))
+      .mockResolvedValueOnce(partial(4))
+      .mockResolvedValueOnce(partial(5)); // зайвий — не має бути спожитим
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(anthropicMessagesStream).toHaveBeenCalledTimes(4);
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "c1 " }),
+      JSON.stringify({ t: "c2 " }),
+      JSON.stringify({ t: "c3 " }),
+      JSON.stringify({ t: "c4 " }),
+      "[DONE]",
+    ]);
+  });
+
+  it("у 2-му continuation messages мають user/assistant alternation (не два assistant поспіль)", async () => {
+    const partial = (i: number) => ({
+      response: makeUpstreamSse([
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: `p${i} ` },
+        },
+        { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+    anthropicMessagesStream
+      .mockResolvedValueOnce(partial(1))
+      .mockResolvedValueOnce(partial(2))
+      .mockResolvedValueOnce({
+        response: makeUpstreamSse([
+          {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "p3" },
+          },
+          { type: "message_delta", delta: { stop_reason: "end_turn" } },
+        ]),
+        recordStreamEnd: vi.fn(),
+      });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(anthropicMessagesStream).toHaveBeenCalledTimes(3);
+    const thirdPayload = anthropicMessagesStream.mock.calls[2][1] as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    // Останнім має бути ОДИН assistant-msg із усім накопиченим текстом ("p1 p2 ").
+    const last = thirdPayload.messages[thirdPayload.messages.length - 1];
+    expect(last).toEqual({ role: "assistant", content: "p1 p2 " });
+    // Sanity: жодних двох однакових ролей поспіль.
+    const roles = thirdPayload.messages.map((m) => m.role);
+    for (let k = 1; k < roles.length; k++) {
+      expect(roles[k]).not.toBe(roles[k - 1]);
+    }
+  });
+});
+
+describe("chat handler — SSE graceful degradation на continuation-помилці", () => {
+  it("continuation повертає !ok → пише err-подію, лишає partial-text, завершує [DONE]", async () => {
+    anthropicMessagesStream
+      .mockResolvedValueOnce({
+        response: makeUpstreamSse([
+          {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Перша частина… " },
+          },
+          { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+        ]),
+        recordStreamEnd: vi.fn(),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ error: "upstream 500" }), {
+          status: 500,
+        }),
+        recordStreamEnd: vi.fn(),
+      });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    const payloads = dataPayloads(res.writes);
+    // Перший chunk дійшов до клієнта, далі err-подія, далі [DONE].
+    expect(payloads[0]).toBe(JSON.stringify({ t: "Перша частина… " }));
+    expect(payloads).toContain(
+      JSON.stringify({ err: "AI continuation failed" }),
+    );
+    expect(payloads[payloads.length - 1]).toBe("[DONE]");
+    expect(res.writableEnded).toBe(true);
+    // Перший виклик уже виставив SSE-заголовки — fallback не повертає JSON-помилку.
+    expect(res.headers["Content-Type"]).toBe(
+      "text/event-stream; charset=utf-8",
+    );
+  });
+
+  it("continuation кидає виняток → пише err-подію, не падає, [DONE]", async () => {
+    anthropicMessagesStream
+      .mockResolvedValueOnce({
+        response: makeUpstreamSse([
+          {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "часткова… " },
+          },
+          { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+        ]),
+        recordStreamEnd: vi.fn(),
+      })
+      .mockRejectedValueOnce(new Error("network down"));
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    const payloads = dataPayloads(res.writes);
+    expect(payloads).toContain(JSON.stringify({ t: "часткова… " }));
+    expect(payloads).toContain(JSON.stringify({ err: "network down" }));
+    expect(payloads[payloads.length - 1]).toBe("[DONE]");
+  });
+});
+
+describe("chat handler — SSE first-call upstream errors", () => {
+  it("перший upstream !ok → JSON-помилка зі статусом, БЕЗ SSE-заголовків і БЕЗ data-подій", async () => {
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({ error: { message: "rate limited" } }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect(res.body).toEqual({ error: "rate limited" });
+    expect(res.writes).toHaveLength(0);
+    expect(res.headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("перший upstream !ok з не-JSON боді → дефолтний 'AI error' (документує quirk fetch API)", async () => {
+    // `firstResponse.json()` спочатку реджектиться (не JSON), AЛЕ це
+    // одночасно консьюмить body-стрім. Коли catch-гілка робить
+    // `firstResponse.text()`, body вже вичерпано — отримуємо порожній
+    // рядок або throw, тож логіка падає на дефолтний `errMsg = "AI error"`.
+    // Тест фіксує цю поведінку, щоб майбутні рефактори не зламали статус-код,
+    // не звертаючи уваги на повідомлення (chat.ts:582-592).
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: new Response("Service Unavailable", {
+        status: 503,
+        headers: { "content-type": "text/plain" },
+      }),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect((res.body as { error: string }).error).toBe("AI error");
+    // SSE-заголовки НЕ виставлені (помилкова гілка віддає JSON, а не event-stream).
+    expect(res.headers["Content-Type"]).toBeUndefined();
+  });
+});
+
+describe("chat handler — SSE protocol robustness", () => {
+  it("reassembly: SSE-подія, розрізана по chunk-боундарі (raw chunk-ів багато)", async () => {
+    // Розриваємо рівно посеред JSON-літерала і навіть посеред термінатора \n\n.
+    const json = JSON.stringify({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: "одна-довга-репліка" },
+    });
+    const stop = JSON.stringify({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+    });
+    const fullPayload = `data: ${json}\n\ndata: ${stop}\n\n`;
+    // Шматуємо по 7 байтів — гарантовано б'є по середині `data: `, JSON, та між \n\n.
+    const chunks: string[] = [];
+    for (let i = 0; i < fullPayload.length; i += 7) {
+      chunks.push(fullPayload.slice(i, i + 7));
+    }
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeChunkedUpstream(chunks),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "одна-довга-репліка" }),
+      "[DONE]",
+    ]);
+  });
+
+  it("малформований JSON у data-лінії — пропускається без падіння", async () => {
+    // Anthropic іноді в edge-cases шле некоректні фрейми; стрім має толерувати.
+    const chunks = [
+      "data: not-a-json{broken\n\n",
+      `data: ${JSON.stringify({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "після битої" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+      })}\n\n`,
+    ];
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeChunkedUpstream(chunks),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "після битої" }),
+      "[DONE]",
+    ]);
+  });
+
+  it("non-data рядки (`event:`, `: ping`) ігноруються", async () => {
+    const chunks = [
+      "event: message_start\n",
+      ": ping\n\n",
+      `data: ${JSON.stringify({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "видимий" },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+      })}\n\n`,
+    ];
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeChunkedUpstream(chunks),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "видимий" }),
+      "[DONE]",
+    ]);
+  });
+
+  it("`data: [DONE]` від upstream сприймається як end-of-stream без зайвої події у клієнта", async () => {
+    // Upstream може закрити стрім явним `[DONE]`-маркером. Сервер має його
+    // не форвардити як text-дельту і завершити власним `[DONE]` у кінці.
+    const chunks = [
+      `data: ${JSON.stringify({
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "ok" },
+      })}\n\n`,
+      "data: [DONE]\n\n",
+    ];
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeChunkedUpstream(chunks),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(dataPayloads(res.writes)).toEqual([
+      JSON.stringify({ t: "ok" }),
+      "[DONE]",
+    ]);
+  });
+});
+
+describe("chat handler — SSE prompt-cache metric", () => {
+  it("cache_read_input_tokens > 0 → outcome=hit, інакше miss", async () => {
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse([
+        {
+          type: "message_start",
+          message: { usage: { cache_read_input_tokens: 4096 } },
+        },
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ok" },
+        },
+        { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(cacheMetricInc).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "hit" }),
+    );
+  });
+
+  it("cache_read_input_tokens=0 → outcome=miss", async () => {
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse([
+        {
+          type: "message_start",
+          message: { usage: { cache_read_input_tokens: 0 } },
+        },
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ok" },
+        },
+        { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(cacheMetricInc).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "miss" }),
+    );
+  });
+
+  it("без message_start usage → метрика не інкрементиться", async () => {
+    anthropicMessagesStream.mockResolvedValueOnce({
+      response: makeUpstreamSse([
+        {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ok" },
+        },
+        { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ]),
+      recordStreamEnd: vi.fn(),
+    });
+
+    const req = makeReq(makeStreamReqBody());
+    const res = makeSseRes();
+    await handler(req, res);
+
+    expect(cacheMetricInc).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

Новий тестовий файл `apps/server/src/modules/chat.stream.test.ts` (17 тестів, 5 describe-блоків) покриває untested-шлях у `chat.ts` — `streamAnthropicToSse` / `streamOneIterationToSse`. До цього PR streaming-гілка (~250 рядків нетривіальної логіки) не мала жодного тесту, попри те що це critical path для tool-result-чату з SSE.

Тести інстанціюють `chat` handler із замоканим `anthropicMessagesStream` (`vi.mock(../lib/anthropic.js)`), де upstream-`Response` будується поверх `ReadableStream` із заданим набором SSE-подій. Express-`Response` — мок, що збирає всі `write()` як список рядків, тож можна асертити саме SSE-протокол (порядок подій, заголовки, термінатори).

Покриті сценарії:

**Basic forwarding** (3 тести)
- text-дельти стають `data: {"t":"…"}` подіями у тому ж порядку, в кінці `[DONE]`;
- `Content-Type: text/event-stream`, `Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no` виставлені;
- continuation НЕ запускається, коли `stop_reason: "end_turn"`;
- `input_json_delta` (tool_use partial-input) і інші не-text content_block_delta події ігноруються.

**Auto-continuation на `stop_reason: "max_tokens"`** (3 тести)
- другий upstream-виклик отримує накопичений assistant-text як останнє повідомлення (Anthropic вимагає user/assistant alternation);
- `endpoint` другого виклику = `chat-tool-result-cont` (для метрик);
- cap `MAX_TEXT_CONTINUATIONS=3`: runaway-генерація, де модель щоразу віддає `max_tokens`, обмежується на 1+3=4 upstream-виклики;
- у 2-му continuation messages мають user/assistant alternation (не два assistant поспіль).

**Graceful degradation** (2 тести)
- continuation повертає `!ok` → пише `data: {"err":"AI continuation failed"}\n\n`, лишає вже стрімнутий partial-text, завершує `[DONE]`;
- continuation кидає виняток → пише `data: {"err":"<message>"}\n\n`, не падає, завершує `[DONE]`.

**First-call upstream errors** (2 тести)
- перший upstream `!ok` → JSON-помилка зі статусом, БЕЗ SSE-заголовків, БЕЗ data-подій;
- non-JSON боді → дефолтне `"AI error"` (документує quirk: `firstResponse.json()` консьюмить body-стрім, fallback на `.text()` у `chat.ts:582-592` фактично недосяжний; тест фіксує реальну поведінку).

**SSE protocol robustness** (4 тести)
- reassembly: SSE-подія, нарізана по 7 байтів (рве по середині `data: `, JSON, `\n\n`) — line-buffer склеює коректно;
- малформований JSON у `data: …` лінії — пропускається без падіння стріму;
- non-data рядки (`event: …`, `: ping`) ігноруються;
- `data: [DONE]` від upstream сприймається як end-of-stream, не форвардиться як зайва подія.

**Prompt-cache metric** (3 тести)
- `cache_read_input_tokens > 0` → `anthropicPromptCacheHitTotal.inc({outcome: "hit"})`;
- `cache_read_input_tokens === 0` → `outcome: "miss"`;
- без `message_start.usage` метрика взагалі не інкрементиться.

## Why

Це закриває аудитний пункт **PR-4.A** із `docs/audits/2026-04-26-sergeant-audit-devin.md`: «test(server,chat): SSE end-to-end harness — асерти на: сплітинг по chunk, tool_use boundary, auto-continuation при stop_reason: max_tokens». Streaming-гілка `chat.ts` — це shipping critical path (HubChat в продакшні стрімить через нього), а тестове покриття там було нульове. Будь-який рефактор `streamOneIterationToSse` (наприклад, переїзд на native EventSource-парсер) міг тихо зламати line-buffer-reassembly або continuation-роутинг — клієнт побачив би «зависло» або обрізану відповідь, без жодного сигналу в CI.

Testcontainers + Postgres з аудитного формулювання навмисне НЕ використовувались: streaming-гілка `chat.ts:341` не звертається до БД (квота-middleware та tool-handler-и виконуються у `apps/web` поверх `tool_calls_raw`/`tool_results`, які приходять у payload). Mocking-only підхід дає 17 тестів за <1с, тоді як real-Postgres harness додав би 30-60с CI без додаткової коректності.

## How to test

```bash
pnpm --filter=@sergeant/server exec vitest run src/modules/chat.stream.test.ts
# 17 passed (17), ~900ms
pnpm typecheck --filter=@sergeant/server
pnpm test --filter=@sergeant/server
# 471 passed (471), 38 test files
```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прогнав `vitest run src/modules/chat.stream.test.ts` локально — всі 17 пройшли.
- [x] Vitest passes: `pnpm test --filter=@sergeant/server` → 471/471 pass (38 файлів). Жоден існуючий тест не зачеплений.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — коментарі у тестах і describe-блоки українською, як у `chat.test.ts`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/ab4c882831fe4f7e8be76bea4b29939d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for the chat streaming route, validating SSE framing, payload semantics, auto-continuation behavior, error handling, and cache metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->