### PR TITLE
docs(security): vulnerability SLA matrix + nightly reminder workflow

### DIFF
--- a/.github/workflows/security-sla-reminder.yml
+++ b/.github/workflows/security-sla-reminder.yml
@@ -1,0 +1,91 @@
+name: Security SLA breach reminder
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: security-sla-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sla-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v4.3.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # actions/github-script v7.0.1 (SHA-pinned for supply-chain hardening)
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const SLA_DAYS = {
+              'security:critical': 1,
+              'security:high': 14,
+              'security:medium': 30,
+            };
+
+            const MARKER = '<!-- sla-breach-marker -->';
+            const now = new Date();
+
+            for (const [label, deadline] of Object.entries(SLA_DAYS)) {
+              const issues = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: label,
+                state: 'open',
+                per_page: 100,
+              });
+
+              for (const issue of issues.data) {
+                const createdAt = new Date(issue.created_at);
+                const ageDays = Math.floor((now - createdAt) / (1000 * 60 * 60 * 24));
+
+                if (ageDays <= deadline) continue;
+
+                // Idempotency: check if we already commented this week
+                const comments = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 20,
+                });
+
+                const startOfWeek = new Date(now);
+                startOfWeek.setDate(now.getDate() - now.getDay());
+                startOfWeek.setHours(0, 0, 0, 0);
+
+                const alreadyCommented = comments.data.some(
+                  (c) =>
+                    c.body.includes(MARKER) &&
+                    new Date(c.created_at) >= startOfWeek
+                );
+
+                if (alreadyCommented) continue;
+
+                const severity = label.replace('security:', '');
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    MARKER,
+                    `> **SLA breach:** ${severity} issue is **${ageDays}** days old (deadline: ${deadline} days).`,
+                    '',
+                    `See [vulnerability SLA policy](../docs/security/vulnerability-sla.md) for escalation steps.`,
+                  ].join('\n'),
+                });
+
+                core.warning(
+                  `SLA breach: #${issue.number} "${issue.title}" — ${severity}, ${ageDays}d old (limit ${deadline}d)`
+                );
+              }
+            }
+
+            core.info('Security SLA reminder check complete.');

--- a/docs/security/vulnerability-sla.md
+++ b/docs/security/vulnerability-sla.md
@@ -1,0 +1,49 @@
+# Політика часу реакції на вразливості (Vulnerability SLA)
+
+> **Last reviewed:** 2026-04-27 | **Reviewer:** @Skords-01
+
+## SLA-матриця
+
+| Severity | CVSS       | Реакція (acknowledge) | Дедлайн усунення / mitigation  | Ескалація                                                |
+| -------- | ---------- | --------------------- | ------------------------------ | -------------------------------------------------------- |
+| Critical | >= 9.0     | Того ж дня            | 24 години (fix або mitigation) | Sentry critical incident + PagerDuty (placeholder)       |
+| High     | 7.0 -- 8.9 | <= 24 години          | <= 14 днів                     | GitHub issue з label `security:high`, assignee = on-call |
+| Medium   | 4.0 -- 6.9 | <= 72 години          | <= 30 днів                     | Label `security:medium`, batched у наступний спринт      |
+| Low      | < 4.0      | Best-effort           | <= 90 днів або risk-accept     | Label `security:low`                                     |
+
+## Як визначаємо severity
+
+Базова оцінка -- CVSS v3.1. Допускається product-context override:
+
+- Вразливість із CVSS High у dev-only залежності може бути знижена до Medium, якщо вона не потрапляє в production bundle.
+- Override фіксується в GitHub issue коментарем із обгрунтуванням та посиланням на цю політику.
+
+## Escape hatch
+
+Якщо SLA не може бути дотриманий з обгрунтованих причин (складність фіксу, відсутність upstream patch тощо), виняток оформлюється згідно з [docs/security/audit-exceptions.md](./audit-exceptions.md).
+
+## Як файлити вразливість
+
+1. **GitHub Security Advisory** (preferred) -- для responsible disclosure.
+2. **Private issue** з label `security:*` відповідного рівня.
+3. Автоматичний triage: workflow `.github/workflows/security-sla-reminder.yml` щотижня перевіряє відкриті security-issues та коментує при порушенні SLA.
+
+## Автоматичний SLA reminder
+
+Workflow `security-sla-reminder.yml` запускається щопонеділка о 08:00 UTC. Для кожного відкритого issue з label `security:critical`, `security:high` або `security:medium`, що перевищує дедлайн з матриці вище, додається коментар з попередженням. Коментар -- idempotent (один раз на тиждень, перевіряється через HTML-маркер).
+
+## Owners
+
+Maintainers [@Skords-01](https://github.com/Skords-01).
+
+## Метрики
+
+- `count(open security issues)` by severity.
+- Oldest age (днів від створення).
+- Placeholder: Prometheus metric `security_open_issues{severity="..."}` для моніторингу в бек-логу.
+
+## Cross-references
+
+- [docs/security/audit-exceptions.md](./audit-exceptions.md) -- винятки з політик безпеки.
+- [docs/governance/policy-review.md](../governance/policy-review.md) -- загальний процес перегляду політик.
+- AGENTS.md rule #6 -- no force push to main/master.


### PR DESCRIPTION
## What changed

**PR-9.C** from `docs/audits/2026-04-26-sergeant-audit-devin.md` (~line 284).

Two new files:

1. **`docs/security/vulnerability-sla.md`** — vulnerability response-time policy with SLA matrix:
   - Critical (CVSS >= 9.0): same-day acknowledge, 24h fix/mitigation
   - High (7.0–8.9): <= 24h acknowledge, <= 14 days
   - Medium (4.0–6.9): <= 72h acknowledge, <= 30 days
   - Low (< 4.0): best-effort, <= 90 days or risk-accept
   - Severity determination via CVSS v3.1 with product-context override
   - Cross-references to `audit-exceptions.md`, `policy-review.md`, AGENTS.md rule #6

2. **`.github/workflows/security-sla-reminder.yml`** — weekly SLA breach reminder:
   - Trigger: `schedule` (Monday 08:00 UTC) + `workflow_dispatch`
   - Scans open issues with `security:critical`, `security:high`, `security:medium` labels
   - Comments on issues that exceed their SLA deadline
   - Idempotent: one comment per issue per week (HTML marker `<!-- sla-breach-marker -->`)
   - Minimal permissions: `issues: write`, `contents: read`
   - All actions SHA-pinned per AGENTS.md security practice

### Scope reduction

- `scripts/security-triage.mjs` — triage logic inlined in the workflow `github-script` step (simpler, no extra file to maintain).

### Manual steps required post-merge

- Create labels `security:critical`, `security:high`, `security:medium`, `security:low` in the repo (not created via API to avoid permission issues).
- Optionally: open a test issue with `security:medium` label and trigger the workflow via `workflow_dispatch` to smoke-test.

## Why

Last missing piece of the security audit trio (PR-9.A audit-blocking, PR-9.B gitleaks, PR-9.D no-anthropic-key-in-logs already merged). Formalises vulnerability response times and adds automation to detect SLA breaches.

## How to test

1. Review `docs/security/vulnerability-sla.md` for policy completeness.
2. Review `.github/workflows/security-sla-reminder.yml` for correctness of:
   - SLA day thresholds matching the matrix
   - Idempotency logic (weekly marker check)
   - SHA-pinned actions
3. Post-merge: create a `security:medium` label, open a test issue with that label (backdated or old enough), trigger `workflow_dispatch`, verify comment appears.

---

## How AI-tested this PR

- [x] `prettier --check` on both files: pass
- [x] Workflow YAML parsed successfully by prettier (valid YAML)
- [x] Commit messages validated by husky/commitlint hooks (both commits passed)
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`
- [ ] Manual smoke (post-merge): maintainer to trigger `workflow_dispatch` with a test issue
- [x] No new `AI-DANGER` markers added

## AGENTS.md updated?

- [ ] No — no new permanent rules

## Commits

1. `docs(docs): add vulnerability SLA matrix`
2. `ci(ci): add weekly security SLA breach reminder workflow`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
