### PR TITLE
fix(eslint-plugins): add FIZRUK_DAILY_LOG to TRACKED_STORAGE_KEY_NAMES

### DIFF
--- a/packages/eslint-plugin-sergeant-design/index.js
+++ b/packages/eslint-plugin-sergeant-design/index.js
@@ -182,6 +182,7 @@ const TRACKED_STORAGE_KEY_NAMES = new Set([
   "FIZRUK_PLAN_TEMPLATE",
   "FIZRUK_MONTHLY_PLAN",
   "FIZRUK_WELLBEING",
+  "FIZRUK_DAILY_LOG",
   // routine
   "ROUTINE",
   // nutrition
@@ -225,6 +226,7 @@ const TRACKED_STORAGE_KEY_VALUES = new Set([
   "fizruk_plan_template_v1",
   "fizruk_monthly_plan_v1",
   "fizruk_wellbeing_v1",
+  "fizruk_daily_log_v1",
   // routine
   "hub_routine_v1",
   // nutrition


### PR DESCRIPTION
## What changed

Дві однорядкові правки у `packages/eslint-plugin-sergeant-design/index.js`:

1. `TRACKED_STORAGE_KEY_NAMES` ← додано `"FIZRUK_DAILY_LOG"` (line ~185).
2. `TRACKED_STORAGE_KEY_VALUES` ← додано `"fizruk_daily_log_v1"` (line ~229).

## Why

`FIZRUK_DAILY_LOG` був доданий у `SYNC_MODULES` (`apps/mobile/src/sync/config.ts:54`) у PR з портуванням `useDailyLog`/`useRecovery` на mobile. Парність-тест `packages/eslint-plugin-sergeant-design/__tests__/no-raw-tracked-storage.parity.test.mjs` тоді не оновили, тому `pnpm lint:plugins` падав на main із:

```
not ok 2 - rule's TRACKED_STORAGE_KEY_NAMES matches SYNC_MODULES exactly
  error: |-
    Rule's TRACKED_STORAGE_KEY_NAMES drifted from SYNC_MODULES.
    + missing: [ 'FIZRUK_DAILY_LOG' ]
not ok 3 - rule's TRACKED_STORAGE_KEY_VALUES matches the resolved STORAGE_KEYS values
  error: |-
    Rule's TRACKED_STORAGE_KEY_VALUES drifted.
    + missing: [ 'fizruk_daily_log_v1' ]
```

CI-`check`-job через це постійно червоний на всіх PR-ах (наприклад, в PR #900). Це формально не блокує merge, але псує сигнал — реальні поломки тонуть у пре-існуючому червоному.

Парність-комент у самому файлі (рядки 144–150) явно вимагає синхронізації: «Tracked names + values are mirrored verbatim from `apps/mobile/src/sync/config.ts` and `packages/shared/src/lib/storageKeys.ts`. The companion test … fails CI if the rule's set drifts from them, so a new tracked key cannot be added to `SYNC_MODULES` without updating the rule (or vice versa).» — у попередньому PR-і це правило обійшли, цей PR ремонтує парність, нічого не змінюючи у поведінці rule-у для існуючих ключів.

Обидва Set-и треба тримати в синхронізації з реальним сторадж-ключем, інакше rule `no-raw-tracked-storage` не зможе ловити прямі `localStorage.setItem('fizruk_daily_log_v1', …)` у консьюмерах — це фактичний security-net регрес, який поточний red-status маскує.

## How to test

```bash
pnpm lint:plugins
# tests 173, pass 173, fail 0  (на main: pass 171, fail 2)
```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прогнав `pnpm lint:plugins` локально — обидва раніше-failing підтести (`TRACKED_STORAGE_KEY_NAMES matches SYNC_MODULES`, `TRACKED_STORAGE_KEY_VALUES matches STORAGE_KEYS`) тепер ok. Усі 173 тести зеленими.
- [x] Vitest passes: N/A — це `node --test`-плагінні тести (`packages/eslint-plugin-sergeant-design/__tests__/*.mjs`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/ab4c882831fe4f7e8be76bea4b29939d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
