### PR TITLE
fix(server): clone Response before .json() in /api/chat SSE error path

### DIFF
--- a/apps/server/src/modules/chat.stream.test.ts
+++ b/apps/server/src/modules/chat.stream.test.ts
@@ -525,13 +525,11 @@ describe("chat handler — SSE first-call upstream errors", () => {
     expect(res.headers["Content-Type"]).toBeUndefined();
   });
 
-  it("перший upstream !ok з не-JSON боді → дефолтний 'AI error' (документує quirk fetch API)", async () => {
-    // `firstResponse.json()` спочатку реджектиться (не JSON), AЛЕ це
-    // одночасно консьюмить body-стрім. Коли catch-гілка робить
-    // `firstResponse.text()`, body вже вичерпано — отримуємо порожній
-    // рядок або throw, тож логіка падає на дефолтний `errMsg = "AI error"`.
-    // Тест фіксує цю поведінку, щоб майбутні рефактори не зламали статус-код,
-    // не звертаючи уваги на повідомлення (chat.ts:582-592).
+  it("перший upstream !ok з не-JSON боді → fallback на raw text() через clone()", async () => {
+    // `firstResponse.json()` консьюмить body-стрім. Щоб після failed-`.json()`
+    // мати можливість прочитати raw-text, у chat.ts тримаємо `clone()` ДО
+    // першої спроби — інакше `.text()` поверне нічого і ми втратимо edge-case
+    // 5xx без application/json (Cloudflare/Railway-edge "Service Unavailable").
     anthropicMessagesStream.mockResolvedValueOnce({
       response: new Response("Service Unavailable", {
         status: 503,
@@ -545,7 +543,7 @@ describe("chat handler — SSE first-call upstream errors", () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(503);
-    expect((res.body as { error: string }).error).toBe("AI error");
+    expect((res.body as { error: string }).error).toBe("Service Unavailable");
     // SSE-заголовки НЕ виставлені (помилкова гілка віддає JSON, а не event-stream).
     expect(res.headers["Content-Type"]).toBeUndefined();
   });

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -579,13 +579,21 @@ async function streamAnthropicToSse(
 
   if (!firstResponse.ok) {
     await refundQuotaOnUpstreamFailure(req);
+    // Body — одноразовий стрім: `await response.json()` його консьюмить, тож
+    // `response.text()` після failed-`.json()` нічого не поверне (тіло вже
+    // прочитане). Робимо `clone()` ДО першої спроби, щоб мати можливість
+    // прочитати raw text fallback-ом для не-JSON 5xx (наприклад "Service
+    // Unavailable" від Cloudflare/Railway-edge без application/json
+    // content-type).
+    const errClone = firstResponse.clone();
     let errMsg = "AI error";
     try {
       const j = (await firstResponse.json()) as AnthropicMessagesResponseData;
       errMsg = j?.error?.message || errMsg;
     } catch {
       try {
-        errMsg = await firstResponse.text();
+        const text = await errClone.text();
+        if (text) errMsg = text;
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## What changed

`apps/server/src/modules/chat.ts:580-603` — у `streamAnthropicToSse`, коли upstream-`firstResponse.ok` false, тримаємо `firstResponse.clone()` перед `.json()`-спробою. Якщо парс реджектиться (не-JSON боді), читаємо raw text із clone-оваго response.

`apps/server/src/modules/chat.stream.test.ts` — тест «перший upstream !ok з не-JSON боді…» оновлено, щоб асертити реальний text-меседж (`"Service Unavailable"`), а не дефолтне `"AI error"`.

## Why

Discovered під час написання SSE-харнесу у [#900](https://github.com/Skords-01/Sergeant/pull/900): `Response.json()` (і `.text()`) — обидва консьюмлять body-стрім, бо це ReadableStream. Поточний код:

```ts
try {
  const j = await firstResponse.json();    // консьюмить body
  errMsg = j?.error?.message || errMsg;
} catch {
  try {
    errMsg = await firstResponse.text();   // body вже спожитий — кидає або порожньо
  } catch { /* ignore */ }
}
```

…має фактично недосяжний text-fallback. Якщо Anthropic upstream (або edge-проксі — Cloudflare, Railway) віддасть не-JSON 5xx (`Service Unavailable`, `Bad Gateway`, raw stack), юзер у логах сервера й у `res.body.error` бачить дефолтне `"AI error"` замість реального upstream-повідомлення. Це робить інциденти типу «AI впав уночі» на порядок складнішими дебажити: треба грепати raw upstream-логи замість читати `errMsg` з нашого JSON-у.

Fix мінімальний — `clone()` ДО першої спроби, далі та сама try/catch-структура, fallback читає `errClone.text()`. Семантика для JSON-помилок (нормальний випадок Anthropic) повністю зберігається — `firstResponse.json()` працює як раніше, clone не торкається.

## How to test

```bash
pnpm --filter=@sergeant/server exec vitest run \
  src/modules/chat.stream.test.ts src/modules/chat.test.ts
# 35 passed (35)
pnpm typecheck --filter=@sergeant/server
```

Конкретно тест-кейс «перший upstream !ok з не-JSON боді → fallback на raw text() через clone()» падав би до фіксу (`expected 'AI error' to be 'Service Unavailable'`), зеленіє після.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прогнав `vitest run src/modules/chat.{stream.,}test.ts` — 35/35 ok. Tests, що перевіряють JSON-error path (`upstream 500` з `application/json`), теж зелені — тобто немає регресії на нормальному шляху.
- [x] Vitest passes: `pnpm test --filter=@sergeant/server` локально — без регресій (запущу повторно після push, разом з CI).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/ab4c882831fe4f7e8be76bea4b29939d
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
