### PR TITLE
style(web): apply prettier to FinykApp.tsx (unblock check on main)

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -142,12 +142,28 @@ export default function App({
   const { clientInfo, connecting, error, authError, connect } = mono;
   const syncTone =
     mergedMono?.syncState?.status === "error"
-      ? { dot: "bg-danger",  text: "помилка",   pill: "bg-danger-soft  text-danger  border-danger/20"  }
+      ? {
+          dot: "bg-danger",
+          text: "помилка",
+          pill: "bg-danger-soft  text-danger  border-danger/20",
+        }
       : mergedMono?.syncState?.status === "partial"
-        ? { dot: "bg-warning", text: "частково", pill: "bg-warning/10   text-warning border-warning/20" }
+        ? {
+            dot: "bg-warning",
+            text: "частково",
+            pill: "bg-warning/10   text-warning border-warning/20",
+          }
         : mergedMono?.syncState?.status === "loading"
-          ? { dot: "bg-muted",   text: "оновлення",pill: "bg-panelHi     text-muted   border-line"       }
-          : { dot: "bg-success", text: "ок",        pill: "bg-success/10  text-success border-success/20" };
+          ? {
+              dot: "bg-muted",
+              text: "оновлення",
+              pill: "bg-panelHi     text-muted   border-line",
+            }
+          : {
+              dot: "bg-success",
+              text: "ок",
+              pill: "bg-success/10  text-success border-success/20",
+            };
 
   // Свайп між вкладками (без pull-to-refresh: скрол живе всередині сторінок, зовнішній scrollTop завжди 0)
   const touchStartX = useRef(null);
@@ -276,7 +292,12 @@ export default function App({
               )}
               aria-label={`Стан синхронізації: ${syncTone.text}`}
             >
-              <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", syncTone.dot)} />
+              <span
+                className={cn(
+                  "w-1.5 h-1.5 rounded-full shrink-0",
+                  syncTone.dot,
+                )}
+              />
               <span className="hidden sm:inline">{syncTone.text}</span>
             </div>
             <button


### PR DESCRIPTION
## What changed

Запустив `prettier --write apps/web/src/modules/finyk/FinykApp.tsx` — переформатував три chained-ternary `syncTone` об'єкти, які були в одному рядку з padding-spaces, але перевищували print-width і Prettier хоче їх розбити по рядках.

## Why

`check` job на main падає з:
```
[warn] apps/web/src/modules/finyk/FinykApp.tsx
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
ELIFECYCLE Command failed with exit code 1.
```

Це з'явилось у комміті `94149801 style: design handoff v2` і блокує CI на всіх PR-ах. Сьогоднішні #902/#904 пропустили це через manual override (їхні тести не зачіпали FinykApp.tsx, але `prettier --check .` бачить весь репо).

## How to test

```bash
npx prettier --check apps/web/src/modules/finyk/FinykApp.tsx
# повинен вийти без warnings
```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `npx prettier --check .` локально → exit 0.
- [x] Vitest passes: лише форматування, тести не торкаємо.
- [x] No new AI-DANGER markers added.
- [x] Docs prose українською у PR-body.

## AGENTS.md updated?

- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
