### PR TITLE
docs(docs): mark PR-7.B (#904) and PR-9.C (#902) as merged in audit

### DIFF
--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (третя ревізія: +#897 +#898)**
+> **Статус виконання — оновлено 2026-04-27 (четверта ревізія: +#902 +#904)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -28,6 +28,8 @@
 | PR-3.B   | decompose `Assets.tsx` (1147 LOC) into smaller modules                 | ✅ closed  | [#887](https://github.com/Skords-01/Sergeant/pull/887)                                                                 |
 | PR-9.B   | gitleaks SHA-pinned secret-scan blocking job in CI                     | ✅ closed  | [#897](https://github.com/Skords-01/Sergeant/pull/897)                                                                 |
 | PR-3.C   | split `seedFoodsUk.ts` (1614 LOC) by category into `seeds/*`           | ✅ closed  | [#898](https://github.com/Skords-01/Sergeant/pull/898)                                                                 |
+| PR-9.C   | vulnerability SLA matrix + weekly breach-reminder workflow             | ✅ closed  | [#902](https://github.com/Skords-01/Sergeant/pull/902)                                                                 |
+| PR-7.B   | cloud-sync offline-queue + replay-on-reconnect integration tests       | ✅ closed  | [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                                 |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -232,7 +234,7 @@
 **PR-ідеї:**
 
 - `PR-7.A` ✅ closed — [#886](https://github.com/Skords-01/Sergeant/pull/886) `test(web): unit + integration tests for recommendationEngine and TodayFocusCard`.
-- `PR-7.B` — `test(web,cloud-sync): integration tests for offline queue + replay on reconnect` (через MSW з offline-mode + RTL).
+- `PR-7.B` ✅ closed — [#904](https://github.com/Skords-01/Sergeant/pull/904) `test(web,cloud-sync): integration tests for offline queue + replay on reconnect` — 17 тестів, 4 сценарії (coalesce, happy replay, server-error, MAX_OFFLINE_QUEUE overflow).
 - `PR-7.C` — `test(web,reports): HubReports aggregation snapshot tests` для крос-модульних звітів.
 - `PR-7.D` — `ci(test): add weekly flaky-tests dashboard` (GitHub Action, що збирає `vitest --reporter json` за 7 днів і публікує markdown trend в artifact).
 - `PR-7.E` — `test(mobile): triage 3 known flaky tests one-by-one (each in own PR), document fixes`.
@@ -283,7 +285,7 @@
 
 - `PR-9.A` ✅ closed — [#862](https://github.com/Skords-01/Sergeant/pull/862) `ci(security): make pnpm audit --audit-level=high blocking by default + escape hatch via labeled PR (e.g. label "audit-exception")`. Це міняє default на «потрібно явно дозволити», а не «потрібно явно заблокувати».
 - `PR-9.B` ✅ closed — [#897](https://github.com/Skords-01/Sergeant/pull/897) `ci(security): add gitleaks step (SHA-pinned)` — окремий blocking `Secret scan (gitleaks)` job, паралельний з `check`/`coverage`.
-- `PR-9.C` ⏳ pending — `docs(security): vulnerability SLA matrix (critical: same-day; high: ≤14 days; med: ≤30 days)` + автоматичний reminder action.
+- `PR-9.C` ✅ closed — [#902](https://github.com/Skords-01/Sergeant/pull/902) `docs(security): vulnerability SLA matrix (critical: same-day; high: ≤14 days; med: ≤30 days)` + weekly `security-sla-reminder.yml` workflow з idempotent breach-comments.
 - `PR-9.D` ✅ closed — [#871](https://github.com/Skords-01/Sergeant/pull/871) `feat(eslint-plugins): no-anthropic-key-in-logs` (AST + heuristic-rule на `console.log`/`logger.*`/`pino.*` з `process.env.ANTHROPIC_API_KEY` або secret-identifier у scope з імпортом `@anthropic-ai/sdk`).
 
 ---
@@ -397,7 +399,7 @@
 | 8   | `PR-2.B` — `no-bigint-string` ESLint rule               | 1-2 д  | автоматизує rule #1   | ✅ [#868](https://github.com/Skords-01/Sergeant/pull/868)                                                                              |
 | 9   | `PR-2.C` — `rq-keys-only-from-factory`                  | 1-2 д  | автоматизує rule #2   | ✅ [#869](https://github.com/Skords-01/Sergeant/pull/869)                                                                              |
 | 10  | `PR-12.B` — chatActions contract tests                  | 2 д    | safety net на tools   | ✅ [#885](https://github.com/Skords-01/Sergeant/pull/885)                                                                              |
-| 11  | `PR-7.A` + `PR-7.B` — recommendation + cloud-sync tests | 3 д    | critical paths        | `PR-7.A` ✅ [#886](https://github.com/Skords-01/Sergeant/pull/886); `PR-7.B` ⏳ pending                                                |
+| 11  | `PR-7.A` + `PR-7.B` — recommendation + cloud-sync tests | 3 д    | critical paths        | `PR-7.A` ✅ [#886](https://github.com/Skords-01/Sergeant/pull/886); `PR-7.B` ✅ [#904](https://github.com/Skords-01/Sergeant/pull/904) |
 | 12  | `PR-5.A` — migration linter                             | 1 д    | автоматизує rule #4   | ✅ [#863](https://github.com/Skords-01/Sergeant/pull/863)                                                                              |
 
 ### Спринт 3-6 (2-3 місяці) — «масштабування»


### PR DESCRIPTION
## What changed

Четверта ревізія `docs/audits/2026-04-26-sergeant-audit-devin.md`:

- **PR-7.B** → ✅ closed [#904](https://github.com/Skords-01/Sergeant/pull/904) (cloud-sync offline-queue replay integration tests, 17 тестів, 4 сценарії).
- **PR-9.C** → ✅ closed [#902](https://github.com/Skords-01/Sergeant/pull/902) (vulnerability SLA matrix + weekly breach-reminder workflow).
- Оновлено заголовок ревізії, статус-таблицю, inline-секції (7-Тестова стратегія, 9-Безпека) і Sprint-1-2 таблицю.

## Why

Обидва PR щойно змержені. Без синхронізації документа батьківські сесії можуть знову призначити ту саму роботу.

## How to test

```bash
grep -E "PR-(7\.B|9\.C)" docs/audits/2026-04-26-sergeant-audit-devin.md
# обидва рядки мають містити ✅ closed і посилання на #902/#904
```

---

## How AI-tested this PR

- [x] Manual smoke: GitHub API підтвердив merged=true для #902 та #904.
- [x] Vitest passes: docs-only PR, тести не торкаються.
- [x] No new AI-DANGER markers.
- [x] Docs prose українською.

## AGENTS.md updated?

- [x] No — no new permanent rules

> Note: `check` job на main зараз червоний через pre-existing Prettier issue у `apps/web/src/modules/finyk/FinykApp.tsx` (з коміту `94149801 style: design handoff v2`). Окремий 1-line fix відкритий у [#906](https://github.com/Skords-01/Sergeant/pull/906) і повинен бути змержений ПЕРЕД цим PR, інакше CI цього docs-PR теж буде червоним на `check`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
