### PR TITLE
fix(web): sync SectionHeading xs test with #901 design tokens

### DIFF
--- a/apps/web/src/shared/components/ui/SectionHeading.test.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.test.tsx
@@ -15,9 +15,9 @@ describe("SectionHeading", () => {
     const { container } = render(<SectionHeading>Розділ</SectionHeading>);
     const el = container.querySelector("h3")!;
     expect(el).not.toBeNull();
-    expect(el.className).toContain("text-2xs");
+    expect(el.className).toContain("text-xs");
     expect(el.className).toContain("uppercase");
-    expect(el.className).toContain("tracking-widest");
+    expect(el.className).toContain("tracking-wider");
     expect(el.className).toContain("font-bold");
     expect(el.className).toContain("text-subtle");
   });

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -281,7 +281,7 @@ Home/End, `role="tablist"`.
 
 | size | type-scale                                     | коли                    |
 | ---- | ---------------------------------------------- | ----------------------- |
-| `xs` | `text-2xs font-bold uppercase tracking-widest` | compact in-card eyebrow |
+| `xs` | `text-xs  font-bold uppercase tracking-wider`  | compact in-card eyebrow |
 | `sm` | `text-xs  font-bold uppercase tracking-widest` | standard section title  |
 | `md` | `text-sm font-semibold`                        | inline group heading    |
 | `lg` | `text-lg font-extrabold leading-tight`         | page sub-section        |


### PR DESCRIPTION
## What changed

- `apps/web/src/shared/components/ui/SectionHeading.test.tsx` — оновив default `xs` assertion: `text-2xs` → `text-xs`, `tracking-widest` → `tracking-wider`, щоб відповідало `sizeTokens.xs` після PR #901.
- `docs/design-system.md` — оновив рядок `xs` в канонічній таблиці size-токенів на новий формат.

## Why

PR #901 ("design handoff v2") свідомо змінив `SectionHeading.sizeTokens.xs`:
`text-2xs uppercase tracking-widest` → `text-xs uppercase tracking-wider`
([див. опис PR #901](https://github.com/Skords-01/Sergeant/pull/901) — пункт ④).

Але `SectionHeading.test.tsx` і `docs/design-system.md` не були оновлені разом із компонентом, тому з моменту merge #901 (commit `94149801`) **CI на `main` червоний** у обох ключових job-ах:

- `check` → `Format, lint, test, build` — https://github.com/Skords-01/Sergeant/actions/runs/24981031457/job/73143047726
- `Test coverage (vitest)`

Падає той самий ассершн:
```
src/shared/components/ui/SectionHeading.test.tsx > SectionHeading > default size='xs' …
AssertionError: expected 'text-xs uppercase tracking-wider font…' to contain 'text-2xs'
```

Без цього фіксу кожен наступний PR стартує на червоному main і ніколи не отримає зелений CI.

## How to test

```bash
pnpm --filter @sergeant/web test -- --run src/shared/components/ui/SectionHeading.test.tsx
# → 7/7 passed
```

Локально всі 7 тестів у `SectionHeading.test.tsx` проходять. Повний `pnpm check` на рівні монорепо запустить CI.

## Follow-up (поза цим PR, для обговорення)

- Зробити `check` і `Test coverage (vitest)` **required status checks** у branch protection на `main` — тоді такий drift не зміг би змержитися, навіть якщо перевірки тимчасово падають у PR.
- Додати в test-suite (або в `sergeant-design/valid-tailwind-opacity`-подібний кастом-ESLint-рул) lightweight контракт «токени в `sizeTokens` ↔ документовані в `design-system.md`», щоб уникнути дрифту доків ↔ коду при наступних handoff-ах.

---

## How AI-tested this PR

- [x] Manual smoke: `pnpm --filter @sergeant/web test -- --run src/shared/components/ui/SectionHeading.test.tsx` → 7/7 passed.
- [x] Vitest passes: `SectionHeading.test.tsx` — 7 passed.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules (це drift-fix, не нове правило).

Link to Devin session: https://app.devin.ai/sessions/0113661fc7e64ae9a55ba94314b4242b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
