### PR TITLE
feat(web): improve onboarding wizard UX and auth page

### DIFF
--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -1,9 +1,41 @@
 import { useState } from "react";
+import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { useToast } from "@shared/hooks/useToast";
 import { BrandLogo } from "../app/BrandLogo";
 import { useAuth } from "./AuthContext";
+
+function PasswordStrengthBar({ password }: { password: string }) {
+  if (!password) return null;
+  const len = password.length;
+  const level = len < 6 ? 0 : len < 10 ? 1 : 2;
+  const widths = ["w-1/3", "w-2/3", "w-full"];
+  const colors = ["bg-error", "bg-amber-400", "bg-brand-500"];
+  const labels = ["Слабкий", "Середній", "Надійний"];
+  const labelColors = [
+    "text-error",
+    "text-amber-500",
+    "text-brand-600 dark:text-brand-400",
+  ];
+
+  return (
+    <div className="mt-1.5 space-y-1">
+      <div className="h-1 rounded-full bg-line overflow-hidden">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all duration-300",
+            widths[level],
+            colors[level],
+          )}
+        />
+      </div>
+      <p className={cn("text-[11px] font-medium", labelColors[level])}>
+        {labels[level]}
+      </p>
+    </div>
+  );
+}
 
 export function AuthPage({ onContinueWithoutAccount }) {
   const { login, register, requestPasswordReset, authError, setAuthError } =
@@ -14,6 +46,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [showForgot, setShowForgot] = useState(false);
   // "idle" → the panel renders the reset form; "sending" disables the
   // button while the request flies; "sent" replaces the form with a
@@ -136,20 +169,45 @@ export function AuthPage({ onContinueWithoutAccount }) {
                 </button>
               )}
             </div>
-            <Input
-              id="auth-password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={mode === "register" ? 10 : 1}
-              placeholder={
-                mode === "register" ? "Мінімум 10 символів" : "Пароль"
-              }
-              autoComplete={
-                mode === "login" ? "current-password" : "new-password"
-              }
-            />
+            <div className="relative">
+              <Input
+                id="auth-password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={mode === "register" ? 10 : 1}
+                placeholder={
+                  mode === "register" ? "Мінімум 10 символів" : "Пароль"
+                }
+                autoComplete={
+                  mode === "login" ? "current-password" : "new-password"
+                }
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "Приховати пароль" : "Показати пароль"}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-text transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
+              >
+                {showPassword ? (
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94"/>
+                    <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19"/>
+                    <line x1="1" y1="1" x2="23" y2="23"/>
+                  </svg>
+                ) : (
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                    <circle cx="12" cy="12" r="3"/>
+                  </svg>
+                )}
+              </button>
+            </div>
+            {mode === "register" && (
+              <PasswordStrengthBar password={password} />
+            )}
           </div>
 
           {showForgot && (
@@ -222,6 +280,35 @@ export function AuthPage({ onContinueWithoutAccount }) {
                 : "Зареєструватися"}
           </Button>
         </form>
+
+        {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
+            Inline "або" divider between two <span> rules — structurally
+            a delimiter, not a heading, so SectionHeading is the wrong
+            abstraction. */}
+        <div className="my-6 flex items-center gap-3 text-xs text-muted uppercase tracking-wider">
+          <span className="flex-1 h-px bg-line" />
+          або
+          <span className="flex-1 h-px bg-line" />
+        </div>
+
+        <Button
+          type="button"
+          variant="secondary"
+          size="lg"
+          className="w-full"
+          onClick={() => {
+            // TODO: initiate Google OAuth via better-auth
+            // authClient.signIn.social({ provider: "google" })
+          }}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
+            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+          </svg>
+          Увійти через Google
+        </Button>
 
         <div className="mt-6 text-center">
           <button

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -129,8 +129,19 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
 function WelcomeStep({ onContinue }: { onContinue: () => void }) {
   return (
     <div className="flex flex-col items-center text-center space-y-6">
-      <div className="w-20 h-20 rounded-3xl bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center">
-        <Icon name="sparkle" size={40} strokeWidth={1.8} aria-hidden />
+      <div className="flex items-center gap-2">
+        <div className="w-12 h-12 rounded-2xl bg-finyk/15 border border-finyk/30 flex items-center justify-center">
+          <Icon name="credit-card" size={22} className="text-finyk" aria-hidden />
+        </div>
+        <div className="w-12 h-12 rounded-2xl bg-fizruk/15 border border-fizruk/30 flex items-center justify-center">
+          <Icon name="dumbbell" size={22} className="text-fizruk" aria-hidden />
+        </div>
+        <div className="w-12 h-12 rounded-2xl bg-routine-surface border border-routine/30 flex items-center justify-center">
+          <Icon name="check" size={22} className="text-routine" aria-hidden />
+        </div>
+        <div className="w-12 h-12 rounded-2xl bg-nutrition-soft border border-nutrition/30 flex items-center justify-center">
+          <Icon name="utensils" size={22} className="text-nutrition" aria-hidden />
+        </div>
       </div>
       <div className="space-y-2">
         <h2 className="text-2xl font-bold text-text">
@@ -179,6 +190,13 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
 // Step 2: Module selection (ModuleCards)
 // ---------------------------------------------------------------------------
 
+const MODULE_ACTIVE_CLASSES: Record<string, { border: string; bg: string; icon: string; check: string }> = {
+  finyk:     { border: "border-finyk/60",     bg: "bg-finyk/8",     icon: "bg-finyk/15 text-finyk",     check: "bg-finyk" },
+  fizruk:    { border: "border-fizruk/60",    bg: "bg-fizruk/8",    icon: "bg-fizruk/15 text-fizruk",    check: "bg-fizruk" },
+  routine:   { border: "border-routine/60",   bg: "bg-routine/8",   icon: "bg-routine/15 text-routine",   check: "bg-routine" },
+  nutrition: { border: "border-nutrition/60", bg: "bg-nutrition/8", icon: "bg-nutrition/15 text-nutrition", check: "bg-nutrition" },
+};
+
 const MODULE_CARDS = ALL_MODULES.map((id) => ({
   id,
   icon: ONBOARDING_VIBE_ICONS[id],
@@ -196,6 +214,13 @@ function ModuleCard({
   active: boolean;
   onToggle: () => void;
 }) {
+  const activeClasses = MODULE_ACTIVE_CLASSES[card.id] ?? {
+    border: "border-brand-500/60",
+    bg: "bg-brand-500/8",
+    icon: "bg-brand-500/15 text-brand-600 dark:text-brand-400",
+    check: "bg-brand-strong",
+  };
+
   return (
     <button
       type="button"
@@ -205,12 +230,15 @@ function ModuleCard({
         "relative w-full text-left p-3.5 rounded-2xl border transition-all duration-200",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
         active
-          ? "border-brand-500/60 bg-brand-500/8 shadow-card"
+          ? `${activeClasses.border} ${activeClasses.bg} shadow-card`
           : "border-line bg-panel hover:border-brand-500/30",
       )}
     >
       {active && (
-        <span className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-strong text-white flex items-center justify-center">
+        <span className={cn(
+          "absolute top-2.5 right-2.5 w-5 h-5 rounded-full text-white flex items-center justify-center",
+          activeClasses.check,
+        )}>
           <Icon name="check" size={12} strokeWidth={3} />
         </span>
       )}
@@ -218,9 +246,7 @@ function ModuleCard({
         <span
           className={cn(
             "shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-            active
-              ? "bg-brand-500/15 text-brand-600 dark:text-brand-400"
-              : "bg-panelHi text-muted",
+            active ? activeClasses.icon : "bg-panelHi text-muted",
           )}
           aria-hidden
         >
@@ -276,6 +302,11 @@ function ModulesStep({
           </div>
         ))}
       </div>
+      <p className="text-[11px] text-center text-muted min-h-[16px]">
+        {picks.length === 0
+          ? "Пропустиш вибір — отримаєш усі 4 модулі 🎉"
+          : `Обрано: ${picks.length} з ${ALL_MODULES.length}`}
+      </p>
       <div className="w-full flex gap-2">
         <Button
           type="button"
@@ -297,9 +328,6 @@ function ModulesStep({
           <Icon name="chevron-right" size={16} />
         </Button>
       </div>
-      {picks.length === 0 && (
-        <p className="text-[11px] text-muted">Без вибору — всі 4 модулі.</p>
-      )}
     </div>
   );
 }
@@ -485,10 +513,19 @@ function GoalsStep({
           size="lg"
           className="flex-1"
         >
-          Заповни мій хаб
+          Відкрити Sergeant
           <Icon name="chevron-right" size={16} />
         </Button>
       </div>
+      {hasQuestions && (
+        <button
+          type="button"
+          onClick={onFinish}
+          className="w-full text-xs text-muted hover:text-text transition-colors py-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
+        >
+          Пропустити налаштування
+        </button>
+      )}
     </div>
   );
 }
@@ -517,7 +554,7 @@ export function OnboardingWizard({
 }) {
   const [state, dispatch] = useReducer(wizardReducer, {
     step: "welcome",
-    picks: [...ALL_MODULES],
+    picks: [],
     goals: { ...EMPTY_GOALS },
     stepStartedAt: Date.now(),
   });


### PR DESCRIPTION
OnboardingWizard:
- WelcomeStep: replace single sparkle icon with 4 colored module icons (finyk/fizruk/routine/nutrition)
- ModuleCard: per-module active colors instead of uniform brand color
- ModulesStep: empty picks default (fallback to all 4 in finish()), add live counter
- GoalsStep: rename CTA to "Відкрити Sergeant", add "Пропустити налаштування" skip button

AuthPage:
- Add show/hide password toggle with eye icon
- Add PasswordStrengthBar indicator in register mode (weak/medium/strong)
- Add Google OAuth placeholder button with Google logo SVG

https://claude.ai/code/session_014YFC1c96nMUopHEcG34Yf9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
