### PR TITLE
fix(web): unify Finyk Assets-tab networth card with Overview HeroCard

### DIFF
--- a/apps/web/src/modules/finyk/pages/AssetsBars.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsBars.tsx
@@ -18,19 +18,16 @@ export function AssetsLiabilitiesBar({
   const assetsPct = Math.round((assets / total) * 100);
   const liabilitiesPct = 100 - assetsPct;
   return (
-    <div className="mt-3">
+    <div className="mt-4">
       <div
-        className="flex h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+        className="flex h-1.5 w-full overflow-hidden rounded-full bg-finyk/15"
         role="img"
         aria-label={`Активи ${assetsPct}% · Пасиви ${liabilitiesPct}%`}
       >
-        <div className="bg-emerald-300/90" style={{ width: `${assetsPct}%` }} />
-        <div
-          className="bg-rose-400/80"
-          style={{ width: `${liabilitiesPct}%` }}
-        />
+        <div className="bg-finyk-strong" style={{ width: `${assetsPct}%` }} />
+        <div className="bg-danger" style={{ width: `${liabilitiesPct}%` }} />
       </div>
-      <div className="flex justify-between text-[11px] text-emerald-100/80 mt-1.5">
+      <div className="flex justify-between text-[11px] text-muted mt-1.5">
         <span>Активи {assetsPct}%</span>
         <span>Пасиви {liabilitiesPct}%</span>
       </div>

--- a/apps/web/src/modules/finyk/pages/AssetsTable.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTable.tsx
@@ -42,35 +42,42 @@ export function AssetsNetworthCard({
   showBalance,
 }: Pick<State, "networth" | "totalAssets" | "totalDebt" | "showBalance">) {
   return (
-    <div className="bg-gradient-to-br from-emerald-600 via-emerald-700 to-emerald-900 text-white rounded-2xl p-5 mb-3 border border-white/10 shadow-float">
-      <div className="text-xs text-emerald-100/90 mb-1">Загальний нетворс</div>
+    <div className="rounded-3xl bg-finyk/[.06] dark:bg-finyk-surface-dark/10 border border-finyk/[.14] dark:border-finyk-border-dark/20 p-5 mb-3 shadow-card">
+      <p className="text-sm text-muted">Загальний нетворс</p>
       <div
         className={cn(
-          "text-3xl font-extrabold tracking-tight",
+          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums text-finyk-strong dark:text-finyk",
           !showBalance && "tracking-widest",
         )}
       >
-        {showBalance
-          ? `${networth.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
-          : "\u2022\u2022\u2022\u2022\u2022\u2022"}
-      </div>
-      <div className="text-xs text-emerald-100/85 mt-1">
         {showBalance ? (
           <>
-            Активи:{" "}
-            {totalAssets.toLocaleString("uk-UA", {
-              maximumFractionDigits: 0,
-            })}{" "}
-            ₴ · Пасиви: &minus;
-            {totalDebt.toLocaleString("uk-UA", {
-              maximumFractionDigits: 0,
-            })}{" "}
-            ₴
+            {networth.toLocaleString("uk-UA", { maximumFractionDigits: 0 })}
+            <span className="text-2xl font-semibold text-finyk/60 ml-1">₴</span>
           </>
         ) : (
-          "Суми приховано"
+          "\u2022\u2022\u2022\u2022\u2022\u2022"
         )}
       </div>
+      {showBalance ? (
+        <div className="flex flex-wrap gap-x-4 gap-y-2 mt-4 pt-4 border-t border-finyk/20 text-sm">
+          <div>
+            <div className="text-xs text-subtle mb-0.5">Активи</div>
+            <div className="font-semibold tabular-nums text-text">
+              {`+${totalAssets.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`}
+            </div>
+          </div>
+          <div className="w-px bg-finyk/20 hidden sm:block self-stretch min-h-[2.5rem]" />
+          <div>
+            <div className="text-xs text-subtle mb-0.5">Пасиви</div>
+            <div className="font-semibold tabular-nums text-text">
+              {`\u2212${totalDebt.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-muted mt-3">Суми приховано</p>
+      )}
       {showBalance && totalAssets + totalDebt > 0 && (
         <AssetsLiabilitiesBar assets={totalAssets} liabilities={totalDebt} />
       )}


### PR DESCRIPTION
## What changed

Сторінка **"Активи"** у Finyk показувала картку нетворсу із насиченим
emerald-600→900 градієнтом і білим текстом, тоді як ідентична за змістом
картка на сторінці **"Огляд"** (`HeroCard.tsx`) використовує мʼякий
mint-фон (`bg-finyk/[.06]`) з темним брендовим текстом
(`text-finyk-strong`). На сусідніх табах це виглядало як два різні стилі
дизайну — користувач [скаржиться у тікеті](https://app.devin.ai/sessions/ab4c882831fe4f7e8be76bea4b29939d).

| Було (Активи)                                                                                                              | Стало (Активи)                                                                                                                  |
| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| ![before](https://app.devin.ai/attachments/0ebbad82-b4ed-423f-8991-933f2eb77730/IMG_2130.png) | соевнает візуальний стиль із Overview HeroCard ↓ |

Скрін Overview-картки для довідки:
![overview-reference](https://app.devin.ai/attachments/2f2e0a75-91b3-4e67-89c5-74b3852849d0/IMG_2129.png)

### Зміни

- **`apps/web/src/modules/finyk/pages/AssetsTable.tsx`** —
  `AssetsNetworthCard` тепер 1:1 копіює оболонку Overview HeroCard:
  `rounded-3xl`, `bg-finyk/[.06] dark:bg-finyk-surface-dark/10`,
  `border-finyk/[.14]`, `shadow-card`. Заголовок у `text-muted`,
  цифра 40 px у `text-finyk-strong dark:text-finyk` із тонким `₴`-суфіксом
  (`text-2xl text-finyk/60`). Двоколонковий блок «Активи / Пасиви» з
  `<div className="w-px bg-finyk/20 …" />` vertical-divider — точно так
  само, як «На картках / Борги» в `HeroCard`.

- **`apps/web/src/modules/finyk/pages/AssetsBars.tsx`** —
  `AssetsLiabilitiesBar` був завʼязаний на dark-only кольори
  (`bg-white/10`, `bg-emerald-300/90`, `bg-rose-400/80`,
  `text-emerald-100/80`). На світлому mint-фоні це або зливалось, або
  давало несумісну палітру. Перевів на brand-токени:
  - track: `bg-finyk/15` (на зареєстрованому opacity-scale, AGENTS rule 8 ✅)
  - assets: `bg-finyk-strong`
  - liabilities: `bg-danger`
  - підписи `%`: `text-muted` (працює і на світлому, і на dark surface)

  Видимість на обох фонах однакова, темна тема нічого не втратила.

- Зберіг контент: розбивка «Активи / Пасиви» + progress-bar з % —
  унікальна для цього таба.

- `showBalance=false` гілка тепер показує «Суми приховано» у
  `text-muted` замість `text-emerald-100/85`, бо фон більше не
  emerald-700.

## Why

UI-консистентність: одна і та сама сутність (нетворс) повинна виглядати
однаково на всіх табах. Використання однакових brand-токенів робить
дизайн масштабованим: майбутній re-skin Finyk-палітри змінює один токен,
а не сім місць із hard-coded `emerald-*`.

## How to test

```bash
pnpm --filter=@sergeant/web exec vitest run src/modules/finyk/pages/AssetsTable.test.tsx
# → 4 passed (4)

pnpm --filter=@sergeant/web exec tsc --noEmit
pnpm --filter=@sergeant/web exec eslint src/modules/finyk/pages/AssetsTable.tsx src/modules/finyk/pages/AssetsBars.tsx
# → clean
```

UI smoke (manual):

1. Відкрийте Finyk → перемикніться між табами **Огляд** та **Активи**.
2. Переконайтесь, що картка нетворсу візуально ідентична: однаковий
   `bg-finyk/[.06]`, тонкий border, big-number з `₴`-суфіксом, divider
   перед двоколонковим блоком.
3. Натисніть «око» (showBalance toggle) — і там, і там «Суми приховано»
   читабельне.
4. Dark mode: переконайтесь, що картка лишається світлішою за фон і не
   зливається.

---

## How AI-tested this PR

- [x] Manual smoke (Activity tab): візуально звірив із референсним
      скріном Overview, який надав користувач.
- [x] Vitest passes: 4/4 на `AssetsTable.test.tsx`.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
