### PR TITLE
fix(web): run prettier --write on AuthPage and OnboardingWizard

### DIFF
--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -188,26 +188,44 @@ export function AuthPage({ onContinueWithoutAccount }) {
               <button
                 type="button"
                 onClick={() => setShowPassword((v) => !v)}
-                aria-label={showPassword ? "Приховати пароль" : "Показати пароль"}
+                aria-label={
+                  showPassword ? "Приховати пароль" : "Показати пароль"
+                }
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-text transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
               >
                 {showPassword ? (
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94"/>
-                    <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19"/>
-                    <line x1="1" y1="1" x2="23" y2="23"/>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+                    <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
                   </svg>
                 ) : (
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-                    <circle cx="12" cy="12" r="3"/>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
                   </svg>
                 )}
               </button>
             </div>
-            {mode === "register" && (
-              <PasswordStrengthBar password={password} />
-            )}
+            {mode === "register" && <PasswordStrengthBar password={password} />}
           </div>
 
           {showForgot && (
@@ -302,10 +320,22 @@ export function AuthPage({ onContinueWithoutAccount }) {
           }}
         >
           <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
-            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
           </svg>
           Увійти через Google
         </Button>

--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -131,7 +131,12 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
     <div className="flex flex-col items-center text-center space-y-6">
       <div className="flex items-center gap-2">
         <div className="w-12 h-12 rounded-2xl bg-finyk/15 border border-finyk/30 flex items-center justify-center">
-          <Icon name="credit-card" size={22} className="text-finyk" aria-hidden />
+          <Icon
+            name="credit-card"
+            size={22}
+            className="text-finyk"
+            aria-hidden
+          />
         </div>
         <div className="w-12 h-12 rounded-2xl bg-fizruk/15 border border-fizruk/30 flex items-center justify-center">
           <Icon name="dumbbell" size={22} className="text-fizruk" aria-hidden />
@@ -140,7 +145,12 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
           <Icon name="check" size={22} className="text-routine" aria-hidden />
         </div>
         <div className="w-12 h-12 rounded-2xl bg-nutrition-soft border border-nutrition/30 flex items-center justify-center">
-          <Icon name="utensils" size={22} className="text-nutrition" aria-hidden />
+          <Icon
+            name="utensils"
+            size={22}
+            className="text-nutrition"
+            aria-hidden
+          />
         </div>
       </div>
       <div className="space-y-2">
@@ -190,11 +200,34 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
 // Step 2: Module selection (ModuleCards)
 // ---------------------------------------------------------------------------
 
-const MODULE_ACTIVE_CLASSES: Record<string, { border: string; bg: string; icon: string; check: string }> = {
-  finyk:     { border: "border-finyk/60",     bg: "bg-finyk/8",     icon: "bg-finyk/15 text-finyk",     check: "bg-finyk" },
-  fizruk:    { border: "border-fizruk/60",    bg: "bg-fizruk/8",    icon: "bg-fizruk/15 text-fizruk",    check: "bg-fizruk" },
-  routine:   { border: "border-routine/60",   bg: "bg-routine/8",   icon: "bg-routine/15 text-routine",   check: "bg-routine" },
-  nutrition: { border: "border-nutrition/60", bg: "bg-nutrition/8", icon: "bg-nutrition/15 text-nutrition", check: "bg-nutrition" },
+const MODULE_ACTIVE_CLASSES: Record<
+  string,
+  { border: string; bg: string; icon: string; check: string }
+> = {
+  finyk: {
+    border: "border-finyk/60",
+    bg: "bg-finyk/8",
+    icon: "bg-finyk/15 text-finyk",
+    check: "bg-finyk",
+  },
+  fizruk: {
+    border: "border-fizruk/60",
+    bg: "bg-fizruk/8",
+    icon: "bg-fizruk/15 text-fizruk",
+    check: "bg-fizruk",
+  },
+  routine: {
+    border: "border-routine/60",
+    bg: "bg-routine/8",
+    icon: "bg-routine/15 text-routine",
+    check: "bg-routine",
+  },
+  nutrition: {
+    border: "border-nutrition/60",
+    bg: "bg-nutrition/8",
+    icon: "bg-nutrition/15 text-nutrition",
+    check: "bg-nutrition",
+  },
 };
 
 const MODULE_CARDS = ALL_MODULES.map((id) => ({
@@ -235,10 +268,12 @@ function ModuleCard({
       )}
     >
       {active && (
-        <span className={cn(
-          "absolute top-2.5 right-2.5 w-5 h-5 rounded-full text-white flex items-center justify-center",
-          activeClasses.check,
-        )}>
+        <span
+          className={cn(
+            "absolute top-2.5 right-2.5 w-5 h-5 rounded-full text-white flex items-center justify-center",
+            activeClasses.check,
+          )}
+        >
           <Icon name="check" size={12} strokeWidth={3} />
         </span>
       )}


### PR DESCRIPTION
## What changed

Ran `pnpm exec prettier --write` on the two files flagged by `pnpm format:check`:

- `apps/web/src/core/auth/AuthPage.tsx`
- `apps/web/src/core/onboarding/OnboardingWizard.tsx`

No functional changes — only whitespace and line-break reformatting to match the repo's Prettier config.

## Why

`main` has been red since 07:40 UTC today (PR #915, `claude/improve-onboarding-auth-icT6W`) because those two files don't match Prettier's style. CI `check` fails at the first `pnpm format:check` step before it gets to `lint` / `typecheck` / `test` / `build`, which blocks **every** new PR (including in-flight ones from today).

The Devin-Review note on PR #915 explicitly called this out:
> The `check` job is failing because `apps/web/src/core/auth/AuthPage.tsx` and `apps/web/src/core/onboarding/OnboardingWizard.tsx` don't match Prettier's style.

This is the second main-breaking drift in ~1 hour (first was the SectionHeading test ↔ component drift from PR #901, fixed by #911). Long-term fix is the same: `check` needs to become a **required status check** in branch protection for `main`, so drift like this can't land on `main` even if the owner hits merge.

## How to test

```bash
pnpm exec prettier --check apps/web/src/core/auth/AuthPage.tsx apps/web/src/core/onboarding/OnboardingWizard.tsx
# → "All matched files use Prettier code style!"

pnpm format:check
# → passes (full repo)
```

Local `pnpm exec prettier --check` on both files passes after this diff.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm exec prettier --check` on both files before/after — before = `Code style issues found in 2 files`, after = clean.
- [x] Vitest passes: no behavioural changes; CI vitest job is the authority.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules.

Link to Devin session: https://app.devin.ai/sessions/0113661fc7e64ae9a55ba94314b4242b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
