### PR TITLE
fix(web): use -strong companions for onboarding module check badges

### DIFF
--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -208,25 +208,25 @@ const MODULE_ACTIVE_CLASSES: Record<
     border: "border-finyk/60",
     bg: "bg-finyk/8",
     icon: "bg-finyk/15 text-finyk",
-    check: "bg-finyk",
+    check: "bg-finyk-strong",
   },
   fizruk: {
     border: "border-fizruk/60",
     bg: "bg-fizruk/8",
     icon: "bg-fizruk/15 text-fizruk",
-    check: "bg-fizruk",
+    check: "bg-fizruk-strong",
   },
   routine: {
     border: "border-routine/60",
     bg: "bg-routine/8",
     icon: "bg-routine/15 text-routine",
-    check: "bg-routine",
+    check: "bg-routine-strong",
   },
   nutrition: {
     border: "border-nutrition/60",
     bg: "bg-nutrition/8",
     icon: "bg-nutrition/15 text-nutrition",
-    check: "bg-nutrition",
+    check: "bg-nutrition-strong",
   },
 };
 


### PR DESCRIPTION
## What changed

`MODULE_ACTIVE_CLASSES` in `apps/web/src/core/onboarding/OnboardingWizard.tsx` had `check: "bg-{module}"` for all four modules (finyk, fizruk, routine, nutrition). That class is applied to a `<span>` that also carries `text-white` (line 273), which violates **AGENTS.md rule #9** — saturated `-500` brand fills fail WCAG 2.1 AA 4.5:1 against white (~2.4–2.8:1). Replaced each with its `-strong` companion, which clears AA (5.2–6.6:1).

```diff
   finyk: {
     border: "border-finyk/60",
     bg: "bg-finyk/8",
     icon: "bg-finyk/15 text-finyk",
-    check: "bg-finyk",
+    check: "bg-finyk-strong",
   },
   // …same for fizruk, routine, nutrition
```

## Why

Flagged by **Devin Review on PR #919** (auto-fix suggestion). The fallback branch on line 254 already uses `bg-brand-strong`; this aligns the four module-specific entries with that canonical pattern and with the rest of the codebase (e.g. `ActiveWorkoutBanner.tsx:37`, nutrition surfaces).

**Why the ESLint rule missed this:** `sergeant-design/no-low-contrast-text-on-fill` inspects inline `className` strings. Here the offending class is stored indirectly in a `Record<string, { check: string }>` constant and interpolated via `activeClasses.check`, so the rule has no static className to flag. We may want to extend the rule to follow one-level constant-object lookups — tracking in a follow-up; this PR only fixes the site.

## How to test

1. Start the web app, open the onboarding wizard, advance to step 2 (module selection).
2. Click any module card to activate it.
3. Verify the small round "✓" badge in the top-right of the card has a noticeably darker brand background (the `-strong` tier) so the white checkmark has AA contrast against it.
4. Toggle across all four modules (finyk, fizruk, routine, nutrition) — each should use its own `-strong` shade.

```bash
pnpm --filter @sergeant/web exec eslint src/core/onboarding/OnboardingWizard.tsx
pnpm exec prettier --check apps/web/src/core/onboarding/OnboardingWizard.tsx
```

Both are clean.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Static review of the class names against AGENTS.md rule #9 allow/disallow matrix; confirmed each `-strong` companion is defined in `packages/design-tokens/tailwind-preset.js`.
- [x] Vitest passes: No behavioural changes; only className string values. CI vitest job is the authority.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules (this PR *enforces* an existing rule).


Link to Devin session: https://app.devin.ai/sessions/0113661fc7e64ae9a55ba94314b4242b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual prominence of active checkmarks in the onboarding experience by updating their background colors to stronger, more distinct variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->