### PR TITLE
test(web): align SectionHeading xs assertion with design-handoff-v2 tokens

### DIFF
--- a/apps/web/src/shared/components/ui/SectionHeading.test.tsx
+++ b/apps/web/src/shared/components/ui/SectionHeading.test.tsx
@@ -15,9 +15,12 @@ describe("SectionHeading", () => {
     const { container } = render(<SectionHeading>Розділ</SectionHeading>);
     const el = container.querySelector("h3")!;
     expect(el).not.toBeNull();
-    expect(el.className).toContain("text-2xs");
+    // Pinned to the design-handoff-v2 tokens (commit 94149801,
+    // "④ SectionHeading xs: text-2xs tracking-widest → text-xs tracking-wider").
+    // Source of truth: `sizeTokens.xs` in `SectionHeading.tsx`.
+    expect(el.className).toContain("text-xs");
     expect(el.className).toContain("uppercase");
-    expect(el.className).toContain("tracking-widest");
+    expect(el.className).toContain("tracking-wider");
     expect(el.className).toContain("font-bold");
     expect(el.className).toContain("text-subtle");
   });


### PR DESCRIPTION
## What changed

`apps/web/src/shared/components/ui/SectionHeading.test.tsx` — the `default size='xs'` contract test now expects `text-xs` + `tracking-wider` instead of `text-2xs` + `tracking-widest`. Added a comment pointing at the originating design commit so the next tweak knows to bump both files together.

## Why

Commit `94149801` ("design handoff v2") intentionally swapped the xs size on `SectionHeading`:

> ④ SectionHeading xs: `text-2xs tracking-widest` → `text-xs tracking-wider`

The component (`SectionHeading.tsx`) was updated, but the contract test in the same directory was not. As a result, `pnpm test:coverage` (`@sergeant/web`) has been red on every PR since — example failure on PR #918's CI:

```
FAIL src/shared/components/ui/SectionHeading.test.tsx > SectionHeading > default size='xs' renders as <h3> with bold + uppercase + text-subtle
AssertionError: expected 'text-xs uppercase tracking-wider font…' to contain 'text-2xs'
```

This is the textbook "test forgot to follow design change" case — the source of truth is `sizeTokens.xs` in `SectionHeading.tsx`, and the test is now aligned with it.

## How to test

```sh
pnpm --filter @sergeant/web exec vitest run \
  src/shared/components/ui/SectionHeading.test.tsx
# 7 tests / all pass
```

---

## How AI-tested this PR

- [x] Vitest passes locally (7/7 SectionHeading tests).
- [x] `git log` confirms the design intent (commit 94149801).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (n/a — file is test code).

## AGENTS.md updated?

- [x] No — no new permanent rules. Just realigning a stale assertion with the source of truth.

---

Devin run: https://app.devin.ai/sessions/52faa029f506462798edc133bb7c5d6b
Requested by: Андрій (@Skords-01)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Updated SectionHeading component test specifications to reflect design token updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->