### PR TITLE
feat(server): truncate-aware tool_result handler with Sentry breadcrumb

### DIFF
--- a/apps/server/src/modules/chat.test.ts
+++ b/apps/server/src/modules/chat.test.ts
@@ -166,6 +166,86 @@ describe("chat handler — tool_use parsing", () => {
     });
   });
 
+  it("великий tool_result truncate-ається перед відправкою в Anthropic", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Готово." }] },
+    });
+
+    // 5000-char tool_result blob (як briefing з RoutineSync або digest)
+    const bigBlob = "BIG_RESULT_START " + "x".repeat(4970) + " BIG_RESULT_END";
+    const req = makeReq({
+      messages: [{ role: "user", content: "Дай брифінг" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_briefing",
+          name: "briefing",
+          input: {},
+        },
+      ],
+      tool_results: [{ tool_use_id: "toolu_briefing", content: bigBlob }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+
+    const payload = anthropicMessages.mock.calls[0][1] as {
+      messages: Array<{
+        role: string;
+        content: Array<{
+          type: string;
+          tool_use_id?: string;
+          content?: string;
+        }>;
+      }>;
+    };
+    const sentToolResult = payload.messages[2].content[0];
+    expect(sentToolResult.type).toBe("tool_result");
+    // Контент скоротився
+    expect(sentToolResult.content).toBeDefined();
+    expect((sentToolResult.content as string).length).toBeLessThan(
+      bigBlob.length / 2,
+    );
+    // Маркер truncation присутній
+    expect(sentToolResult.content).toContain("[…truncated");
+    // Head/tail збереглися
+    expect(sentToolResult.content).toContain("BIG_RESULT_START");
+    expect(sentToolResult.content).toContain("BIG_RESULT_END");
+  });
+
+  it("малий tool_result проходить без truncation", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Ок." }] },
+    });
+
+    const smallContent = "Транзакцію m_xyz видалено успішно";
+    const req = makeReq({
+      messages: [{ role: "user", content: "Видали m_xyz" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_small",
+          name: "delete_transaction",
+          input: { tx_id: "m_xyz" },
+        },
+      ],
+      tool_results: [{ tool_use_id: "toolu_small", content: smallContent }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    const payload = anthropicMessages.mock.calls[0][1] as {
+      messages: Array<{
+        role: string;
+        content: Array<{ type: string; content?: string }>;
+      }>;
+    };
+    expect(payload.messages[2].content[0].content).toBe(smallContent);
+  });
+
   it("400 коли немає повідомлень", async () => {
     const req = makeReq({ messages: [] });
     const res = makeRes();

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -13,7 +13,9 @@ import {
 } from "../lib/anthropic.js";
 import type { WithAiQuotaRefund } from "./aiQuota.js";
 import { TOOLS, SYSTEM_PREFIX, SYSTEM_PROMPT_VERSION } from "./chat/tools.js";
+import { truncateToolResults } from "./chat/toolResultTruncation.js";
 import { anthropicPromptCacheHitTotal } from "../obs/metrics.js";
+import { als } from "../obs/requestContext.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
 
@@ -302,10 +304,17 @@ export default async function handler(
 
   // Другий крок: клієнт виконав tool calls і повертає результати
   if (tool_results && tool_calls_raw) {
-    const toolResultMessages = tool_results.map((r) => ({
+    // Великі `tool_result`-блоби (брифінги, місячні digest-и) з'їдають
+    // бюджет вхідних токенів і зривають continuation. Truncate на сервері,
+    // повний blob — у Sentry breadcrumb для debug-у.
+    const requestId = als.getStore()?.requestId ?? undefined;
+    const normalizedToolResults = truncateToolResults(tool_results, {
+      requestId,
+    });
+    const toolResultMessages = normalizedToolResults.map((r) => ({
       type: "tool_result" as const,
       tool_use_id: r.tool_use_id,
-      content: String(r.content ?? "ok"),
+      content: r.content,
     }));
 
     // Беремо лише останнє user-повідомлення (питання що спричинило tool call)

--- a/apps/server/src/modules/chat/toolResultTruncation.test.ts
+++ b/apps/server/src/modules/chat/toolResultTruncation.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit-тести для truncate-aware tool_result helper.
+ *
+ * Покриває:
+ * - non-truncated path: контент ≤ threshold проходить як є.
+ * - truncated path: контент > threshold → summary з head/tail/marker, повний
+ *   blob у breadcrumb, метрика інкрементиться.
+ * - non-string content: number/boolean/null/undefined/object → string.
+ * - threshold override.
+ * - requestId прокидається у breadcrumb-data.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  truncateToolResults,
+  TOOL_RESULT_TRUNCATE_THRESHOLD,
+  type RawToolResult,
+} from "./toolResultTruncation.js";
+
+describe("truncateToolResults — short content (≤ threshold)", () => {
+  it("повертає контент as-is, breadcrumb та метрику не викликає", () => {
+    const addBreadcrumb = vi.fn();
+    const recordMetric = vi.fn();
+    const out = truncateToolResults(
+      [{ tool_use_id: "toolu_1", content: "Транзакцію видалено" }],
+      { addBreadcrumb, recordMetric },
+    );
+    expect(out).toEqual([
+      { tool_use_id: "toolu_1", content: "Транзакцію видалено" },
+    ]);
+    expect(addBreadcrumb).not.toHaveBeenCalled();
+    expect(recordMetric).not.toHaveBeenCalled();
+  });
+
+  it("обробляє number/boolean/null/undefined → строки", () => {
+    const out = truncateToolResults([
+      { tool_use_id: "n", content: 42 },
+      { tool_use_id: "b", content: true },
+      { tool_use_id: "u", content: undefined },
+      { tool_use_id: "z", content: null },
+    ]);
+    expect(out).toEqual([
+      { tool_use_id: "n", content: "42" },
+      { tool_use_id: "b", content: "true" },
+      { tool_use_id: "u", content: "ok" },
+      { tool_use_id: "z", content: "ok" },
+    ]);
+  });
+
+  it("серіалізує object content через JSON.stringify", () => {
+    const out = truncateToolResults([
+      { tool_use_id: "obj", content: { ok: true, count: 3 } },
+    ]);
+    expect(out[0].content).toBe('{"ok":true,"count":3}');
+  });
+
+  it("обробляє content рівно на межі threshold (=2000) — не truncate", () => {
+    const exact = "a".repeat(TOOL_RESULT_TRUNCATE_THRESHOLD);
+    const addBreadcrumb = vi.fn();
+    const out = truncateToolResults([{ tool_use_id: "edge", content: exact }], {
+      addBreadcrumb,
+    });
+    expect(out[0].content).toBe(exact);
+    expect(addBreadcrumb).not.toHaveBeenCalled();
+  });
+});
+
+describe("truncateToolResults — long content (> threshold)", () => {
+  function bigContent(): string {
+    // 5000 chars, де перші 600 — "HEAD…", останні 400 — "…TAIL", середина — заповнення
+    const head =
+      "HEAD_START " +
+      "h".repeat(600 - "HEAD_START ".length - "_HEAD_END".length) +
+      "_HEAD_END";
+    const tail =
+      "TAIL_START_" +
+      "t".repeat(400 - "TAIL_START_".length - "_TAIL_END".length) +
+      "_TAIL_END";
+    const middle = "X".repeat(5000 - 600 - 400);
+    return head + middle + tail;
+  }
+
+  it("замінює content на summary з head + marker + tail", () => {
+    const content = bigContent();
+    const addBreadcrumb = vi.fn();
+    const recordMetric = vi.fn();
+    const out = truncateToolResults([{ tool_use_id: "big", content }], {
+      addBreadcrumb,
+      recordMetric,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].tool_use_id).toBe("big");
+    const summary = out[0].content;
+    // Head зберігся
+    expect(summary).toContain("HEAD_START");
+    expect(summary).toContain("_HEAD_END");
+    // Tail зберігся
+    expect(summary).toContain("TAIL_START_");
+    expect(summary).toContain("_TAIL_END");
+    // Маркер
+    expect(summary).toContain("[…truncated");
+    expect(summary).toContain("original 5000 chars");
+    // Сильно коротший за оригінал
+    expect(summary.length).toBeLessThan(content.length / 2);
+  });
+
+  it("шле повний blob у Sentry breadcrumb з category=chat.tool_result", () => {
+    const content = bigContent();
+    const addBreadcrumb = vi.fn();
+    truncateToolResults([{ tool_use_id: "big", content }], {
+      addBreadcrumb,
+      recordMetric: vi.fn(),
+    });
+
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1);
+    const bc = addBreadcrumb.mock.calls[0][0];
+    expect(bc.category).toBe("chat.tool_result");
+    expect(bc.level).toBe("info");
+    expect(bc.message).toMatch(/truncated/i);
+    expect(bc.data.tool_use_id).toBe("big");
+    expect(bc.data.original_length).toBe(content.length);
+    expect(bc.data.threshold).toBe(TOOL_RESULT_TRUNCATE_THRESHOLD);
+    expect(bc.data.full).toBe(content);
+  });
+
+  it("інкрементить метрику з reason=size_threshold за кожен truncate", () => {
+    const recordMetric = vi.fn();
+    truncateToolResults(
+      [
+        { tool_use_id: "a", content: bigContent() },
+        { tool_use_id: "b", content: "ok" }, // не truncate
+        { tool_use_id: "c", content: bigContent() },
+      ],
+      { addBreadcrumb: vi.fn(), recordMetric },
+    );
+    expect(recordMetric).toHaveBeenCalledTimes(2);
+    expect(recordMetric).toHaveBeenNthCalledWith(1, {
+      reason: "size_threshold",
+    });
+    expect(recordMetric).toHaveBeenNthCalledWith(2, {
+      reason: "size_threshold",
+    });
+  });
+
+  it("прокидає requestId у breadcrumb data, якщо переданий", () => {
+    const addBreadcrumb = vi.fn();
+    truncateToolResults([{ tool_use_id: "x", content: bigContent() }], {
+      addBreadcrumb,
+      recordMetric: vi.fn(),
+      requestId: "req-123",
+    });
+    expect(addBreadcrumb.mock.calls[0][0].data.request_id).toBe("req-123");
+  });
+
+  it("без requestId — поле request_id у breadcrumb відсутнє", () => {
+    const addBreadcrumb = vi.fn();
+    truncateToolResults([{ tool_use_id: "x", content: bigContent() }], {
+      addBreadcrumb,
+      recordMetric: vi.fn(),
+    });
+    expect(addBreadcrumb.mock.calls[0][0].data.request_id).toBeUndefined();
+  });
+
+  it("кастомний threshold — нижчий за стандарт — truncate-ає менші тексти", () => {
+    const addBreadcrumb = vi.fn();
+    const out = truncateToolResults(
+      [{ tool_use_id: "small", content: "x".repeat(1500) }],
+      { addBreadcrumb, recordMetric: vi.fn(), threshold: 500 },
+    );
+    expect(out[0].content).toContain("[…truncated");
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+
+  it("серіалізує великий object через JSON, потім truncate-ає", () => {
+    const items = Array.from({ length: 200 }, (_, i) => ({
+      id: i,
+      label: `item-${i}-with-some-padding`,
+    }));
+    const addBreadcrumb = vi.fn();
+    const out = truncateToolResults([{ tool_use_id: "obj", content: items }], {
+      addBreadcrumb,
+      recordMetric: vi.fn(),
+    });
+    expect(out[0].content).toMatch(/^\[\{"id":0/); // head зберігся
+    expect(out[0].content).toContain("[…truncated");
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("truncateToolResults — порядок і стійкість", () => {
+  it("зберігає порядок tool_use_id у вихідному масиві", () => {
+    const out = truncateToolResults([
+      { tool_use_id: "first", content: "a" },
+      { tool_use_id: "second", content: "b" },
+      { tool_use_id: "third", content: "c" },
+    ]);
+    expect(out.map((r) => r.tool_use_id)).toEqual(["first", "second", "third"]);
+  });
+
+  it("приймає порожній масив", () => {
+    const out = truncateToolResults([] as RawToolResult[]);
+    expect(out).toEqual([]);
+  });
+
+  it("default-моки на breadcrumb/metric не падають, коли не передані", () => {
+    // Без addBreadcrumb/recordMetric helper має не кидати, навіть якщо
+    // Sentry/prom-client не ініціалізовані у test-env.
+    expect(() =>
+      truncateToolResults([{ tool_use_id: "x", content: "a".repeat(3000) }]),
+    ).not.toThrow();
+  });
+});

--- a/apps/server/src/modules/chat/toolResultTruncation.ts
+++ b/apps/server/src/modules/chat/toolResultTruncation.ts
@@ -1,0 +1,160 @@
+/**
+ * Truncate-aware tool_result helper.
+ *
+ * Контекст: на другому кроці `/api/chat` клієнт надсилає `tool_results`
+ * (масив `{ tool_use_id, content }`) — це сирі результати, які client
+ * зібрав під час виконання tool-call-у (briefing-блоби з RoutineSync,
+ * Finyk-витрати-за-місяць, Fizruk-progress-блоки тощо). Великий
+ * `tool_result` контент (>≈ 2 000 chars) має 3 побічних ефекти:
+ *
+ * 1. Anthropic API рахує його як вхідні токени — кешуючи їх не
+ *    допомагає, бо `tool_result`-content ніколи не потрапляє у
+ *    cache-prefix.
+ * 2. Через `max_tokens=2500` cap на відповідь, велика вхідна
+ *    `tool_result`-секція з'їдає бюджет токенів і модель не встигає
+ *    закінчити саму відповідь — у `chat.ts::streamOneIterationToSse`
+ *    включається `auto-continuation`, але якщо кожне `iteration` знов
+ *    тягне ту ж саму tool_result, обриваємось на cap-у
+ *    `MAX_TEXT_CONTINUATIONS=3` без фіналу.
+ * 3. У snapshot-боксах (Sentry, log-replay) повний blob "забруднює"
+ *    індекс, ускладнюючи debugging.
+ *
+ * Рішення (PR-12.E): якщо `content` довший за поріг
+ * `TOOL_RESULT_TRUNCATE_THRESHOLD`, замінюємо його на короткий summary
+ * (`head` + `tail` + size), а ПОВНИЙ blob кладемо в Sentry-breadcrumb
+ * категорії `chat.tool_result`, де він залишається для debug-у, але не
+ * вилазить у HTTP-payload до Anthropic.
+ *
+ * Клієнтська схема `ToolResult.content` уже капнута на 8 000 chars
+ * (`packages/shared/src/schemas/api.ts`). Цей helper працює всередині
+ * того cap-у — тобто валідація на ingress лишається попередньою лінією
+ * захисту, а truncation — другою (для випадків, коли клієнт навмисно
+ * шле великий blob, бо «це ж дозволений ліміт»).
+ */
+import { Sentry } from "../../sentry.js";
+import { chatToolResultTruncatedTotal } from "../../obs/metrics.js";
+
+/** Максимальний розмір (chars) для того, щоб НЕ зачіпати content. */
+export const TOOL_RESULT_TRUNCATE_THRESHOLD = 2000;
+
+/** Скільки лишаємо з початку при truncate-і. */
+const HEAD_BYTES = 600;
+/** Скільки лишаємо з кінця при truncate-і. */
+const TAIL_BYTES = 400;
+
+export interface RawToolResult {
+  tool_use_id: string;
+  content?: unknown;
+}
+
+export interface NormalizedToolResult {
+  tool_use_id: string;
+  content: string;
+}
+
+/**
+ * Серіалізує `content`-будь-що-non-string у короткий рядок, який модель
+ * зможе зрозуміти. Числа/булеві → toString. `null`/`undefined` → "ok"
+ * (історично fallback у chat.ts перед цим refactor-ом).
+ */
+function stringifyContent(content: unknown): string {
+  if (content == null) return "ok";
+  if (typeof content === "string") return content;
+  if (typeof content === "number" || typeof content === "boolean") {
+    return String(content);
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return "ok";
+  }
+}
+
+/**
+ * Стискає content на рівні символів (не байтів — для UA-тексту різниця
+ * у 2-3× буде, але саме символи — те що кеш Anthropic-у рахує). Зберігає
+ * head + tail, посередині додає маркер з повним розміром.
+ */
+function summarize(content: string): string {
+  const total = content.length;
+  if (total <= HEAD_BYTES + TAIL_BYTES) return content;
+  const head = content.slice(0, HEAD_BYTES).trimEnd();
+  const tail = content.slice(total - TAIL_BYTES).trimStart();
+  return `${head}\n\n[…truncated ${total - HEAD_BYTES - TAIL_BYTES} chars; original ${total} chars sent to Sentry breadcrumb…]\n\n${tail}`;
+}
+
+/**
+ * Опційний `breadcrumb`-callback. У production — `Sentry.addBreadcrumb`,
+ * у тестах — мок. Через це helper testable без дотику до глобального
+ * Sentry-стану.
+ */
+export interface TruncateOptions {
+  threshold?: number;
+  addBreadcrumb?: (b: {
+    category: string;
+    level: "info" | "warning";
+    message: string;
+    data: Record<string, unknown>;
+  }) => void;
+  recordMetric?: (labels: { reason: string }) => void;
+  /**
+   * Optional request-id, який потрапить у breadcrumb-data для зручного
+   * grep-у в Sentry. Якщо нема — пишемо без поля (Sentry-side ALS уже
+   * прикріплює `requestId`-tag через `beforeSend` у sentry.ts, але
+   * breadcrumbs йдуть до `beforeSend` не завжди).
+   */
+  requestId?: string;
+}
+
+/**
+ * Нормалізує + truncate-ає масив `tool_results`. Повертає НЕ-порожні
+ * результати (`{ tool_use_id, content: string }`), готові для Anthropic
+ * `tool_result`-блоків.
+ */
+export function truncateToolResults(
+  raw: ReadonlyArray<RawToolResult>,
+  opts: TruncateOptions = {},
+): NormalizedToolResult[] {
+  const threshold = opts.threshold ?? TOOL_RESULT_TRUNCATE_THRESHOLD;
+  const addBreadcrumb =
+    opts.addBreadcrumb ??
+    ((b) => {
+      try {
+        Sentry.addBreadcrumb(b);
+      } catch {
+        /* Sentry не ініціалізований у деяких env — no-op */
+      }
+    });
+  const recordMetric =
+    opts.recordMetric ??
+    ((labels) => {
+      try {
+        chatToolResultTruncatedTotal.inc(labels);
+      } catch {
+        /* prom-client не ініціалізований у тестах — no-op */
+      }
+    });
+
+  return raw.map((r) => {
+    const original = stringifyContent(r.content);
+    if (original.length <= threshold) {
+      return { tool_use_id: r.tool_use_id, content: original };
+    }
+    const summarized = summarize(original);
+    addBreadcrumb({
+      category: "chat.tool_result",
+      level: "info",
+      message: "tool_result truncated for Anthropic payload",
+      data: {
+        tool_use_id: r.tool_use_id,
+        original_length: original.length,
+        summary_length: summarized.length,
+        threshold,
+        ...(opts.requestId ? { request_id: opts.requestId } : {}),
+        full: original,
+      },
+    });
+    recordMetric({ reason: "size_threshold" });
+    return { tool_use_id: r.tool_use_id, content: summarized };
+  });
+}

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -102,6 +102,13 @@ export const anthropicPromptCacheHitTotal = new client.Counter({
   registers: [register],
 });
 
+export const chatToolResultTruncatedTotal = new client.Counter({
+  name: "chat_tool_result_truncated_total",
+  help: "tool_result content truncated server-side before Anthropic call",
+  labelNames: ["reason"], // reason=size_threshold
+  registers: [register],
+});
+
 export const aiQuotaBlocksTotal = new client.Counter({
   name: "ai_quota_blocks_total",
   help: "AI quota refusals",

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -359,7 +359,7 @@
 - `PR-12.B` ✅ closed — [#885](https://github.com/Skords-01/Sergeant/pull/885) `test(web): contract tests for all hubChatActions handlers (happy + error path)`.
 - `PR-12.C` — `feat(server,chat): per-tool metrics (tool_invocations_total{tool=,outcome=}) → SLO dashboard`.
 - `PR-12.D` — `docs(ai): tool lifecycle model (proposal → safety review → rollout → KPIs)` — як одно-сторінковий ADR.
-- `PR-12.E` — `feat(server,chat): truncate-aware tool_result handler` — якщо `tool_result` >N токенів, серверна частина серіалізує summary + повний blob у Sentry breadcrumb. Закриває edge case, де великі briefing/digest вибивають continuation.
+- `PR-12.E` ✅closed — `feat(server,chat): truncate-aware tool_result handler` — якщо `tool_result` >N токенів, серверна частина серіалізує summary + повний blob у Sentry breadcrumb. Закриває edge case, де великі briefing/digest вибивають continuation. Реалізовано: `apps/server/src/modules/chat/toolResultTruncation.ts` (threshold 2 000 chars, head 600 + tail 400 + marker), wired у `chat.ts` перед `tool_result`-payload-ом, `chat_tool_result_truncated_total{reason}` метрика, 14 unit + 2 integration тестів.
 
 ---
 


### PR DESCRIPTION
## What changed

Закриває **PR-12.E** з аудиту `docs/audits/2026-04-26-sergeant-audit-devin.md` — server-side truncation великих `tool_result` payload-ів перед другим викликом Anthropic у `/api/chat`.

- **Новий helper:** `apps/server/src/modules/chat/toolResultTruncation.ts`
  - `truncateToolResults(rawResults, opts)` нормалізує content (string/number/boolean/null/object→JSON), і якщо довжина > `TOOL_RESULT_TRUNCATE_THRESHOLD = 2000` chars — стискає до `head(600) + marker + tail(400)`, а повний blob кладе у Sentry-breadcrumb категорії `chat.tool_result` (level: info, data: tool_use_id, original/summary length, threshold, requestId, full).
  - Метрика `chat_tool_result_truncated_total{reason=size_threshold}` інкрементиться за кожен truncate.
  - DI на `addBreadcrumb`/`recordMetric` через opts — для testability.
- **Wiring:** `chat.ts` тягне `requestId` з ALS, прокидає у helper перед побудовою `tool_result`-блоків. Поведінка для малих payload-ів незмінна (`String(content ?? "ok")` ефективно зберігся).
- **Метрика** зареєстрована у `apps/server/src/obs/metrics.ts` поряд із `anthropic_prompt_cache_hit_total`.

## Why

Аудит відмітив edge case: великі `tool_result` (briefing, monthly digest, місячна finyk-розшифровка) — попри cap у Zod-схемі `z.string().max(8000)` — фактично з'їдали бюджет вхідних токенів і запускали `streamOneIterationToSse` continuation-цикл, який обривався на `MAX_TEXT_CONTINUATIONS=3`, не дописавши відповідь. Truncate на сервері:

1. Звільняє бюджет токенів — модель встигає закінчити відповідь у `max_tokens=2500`.
2. Не втрачаємо debug-trace: повний blob лишається у Sentry breadcrumb (з retention за конфігом), не в Anthropic-payload-і.
3. Метрика дає видимість "як часто і скільки байт ми скидаємо" → можна тюнити threshold за реальними даними.

## How to test

```bash
cd apps/server
pnpm exec vitest run src/modules/chat/toolResultTruncation.test.ts  # 14/14
pnpm exec vitest run src/modules/chat.test.ts                        # 22/22 (20 старих + 2 нові integration)
pnpm exec vitest run                                                 # 527/527
pnpm exec tsc --noEmit                                               # clean
```

Manual: на `/api/chat` другому кроці клієнт надсилає `tool_results: [{ tool_use_id, content: "<5000-char briefing>" }]`. У логах Sentry зʼявиться breadcrumb `chat.tool_result` з повним blob-ом; в Anthropic пейлоаді content скоротиться до summary з маркером `[…truncated N chars; original M chars sent to Sentry breadcrumb…]`. У Prometheus `chat_tool_result_truncated_total{reason="size_threshold"}` +1.

---

## How AI-tested this PR

- [x] Manual smoke: розширив `chat.test.ts` 5000-char blob → assert truncated content has `[…truncated`, head+tail markers, length < original/2.
- [x] Vitest passes: 527/527 у `apps/server`, 14/14 на новий `toolResultTruncation.test.ts` (включно з edge на межі threshold, default-моки no-throw, requestId-проброс, JSON-серіалізація об'єктів).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian (коментарі в helper-і + JSDoc).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic truncation for oversized tool results to prevent payload overload, with preserved beginning and end sections plus a truncation summary.
  * Added metric tracking to monitor tool result truncation events.

* **Tests**
  * Expanded test coverage for truncation behavior with both small and large tool result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->