### PR TITLE
feat(web): enable noImplicitAny on routine + shared modules

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "build:analyze": "cross-env ANALYZE=1 vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit && tsc -p tsconfig.strict.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sw.json --noEmit && tsc -p tsconfig.strict.json --noEmit && tsc -p tsconfig.noimplicitany.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
+++ b/apps/web/src/modules/fizruk/hooks/useExerciseCatalog.ts
@@ -6,7 +6,9 @@ import {
   serializeCustomExercisesToStorage,
 } from "@sergeant/fizruk-domain";
 
-function norm(s) {
+type RawExerciseDef = FizrukData.RawExerciseDef;
+
+function norm(s: unknown) {
   return (s || "").toString().trim().toLowerCase();
 }
 
@@ -17,7 +19,7 @@ function norm(s) {
  */
 export function useExerciseCatalog() {
   const catalogData = FizrukData.EXERCISE_CATALOG;
-  const [customExercises, setCustomExercises] = useState([]);
+  const [customExercises, setCustomExercises] = useState<RawExerciseDef[]>([]);
 
   const primaryGroupsUk = FizrukData.PRIMARY_GROUPS_UK;
   const equipmentUk = FizrukData.EQUIPMENT_UK;
@@ -28,11 +30,11 @@ export function useExerciseCatalog() {
     try {
       const raw = localStorage.getItem(CUSTOM_EXERCISES_KEY);
       const parsed = parseCustomExercisesFromStorage(raw);
-      if (Array.isArray(parsed)) setCustomExercises(parsed);
+      if (Array.isArray(parsed)) setCustomExercises(parsed as RawExerciseDef[]);
     } catch {}
   }, []);
 
-  const persistCustom = useCallback((next) => {
+  const persistCustom = useCallback((next: RawExerciseDef[]) => {
     setCustomExercises(next);
     try {
       localStorage.setItem(
@@ -49,7 +51,7 @@ export function useExerciseCatalog() {
   );
 
   const search = useCallback(
-    (query) => {
+    (query: string) => {
       const q = norm(query);
       if (!q) return exercises;
 
@@ -74,7 +76,7 @@ export function useExerciseCatalog() {
   );
 
   const addExercise = useCallback(
-    (ex) => {
+    (ex: RawExerciseDef) => {
       if (!ex?.id) throw new Error("id is required");
       if (!ex?.name?.uk) throw new Error("name.uk is required");
       const next = [
@@ -87,7 +89,7 @@ export function useExerciseCatalog() {
   );
 
   const removeExercise = useCallback(
-    (id) => {
+    (id: string) => {
       if (!id) return false;
       const next = customExercises.filter((x) => x?.id !== id);
       if (next.length === customExercises.length) return false;

--- a/apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts
+++ b/apps/web/src/modules/fizruk/hooks/useMonthlyPlan.ts
@@ -4,6 +4,17 @@ import { MONTHLY_PLAN_STORAGE_KEY } from "@sergeant/fizruk-domain";
 
 const STORAGE_KEY = MONTHLY_PLAN_STORAGE_KEY;
 
+interface DayEntry {
+  templateId: string;
+}
+
+interface MonthlyPlanState {
+  reminderEnabled: boolean;
+  reminderHour: number;
+  reminderMinute: number;
+  days: Record<string, DayEntry>;
+}
+
 function todayKey() {
   const d = new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -36,7 +47,7 @@ function loadState() {
   }
 }
 
-function saveState(s) {
+function saveState(s: MonthlyPlanState) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
     window.dispatchEvent(new CustomEvent("fizruk-storage-monthly-plan"));
@@ -48,7 +59,7 @@ export function useMonthlyPlan() {
 
   useEffect(() => {
     const sync = () => setState(loadState());
-    const onStorage = (e) => {
+    const onStorage = (e: StorageEvent) => {
       if (e.key === STORAGE_KEY || e.key === null) sync();
     };
     window.addEventListener("storage", onStorage);
@@ -59,7 +70,7 @@ export function useMonthlyPlan() {
     };
   }, []);
 
-  const setReminder = useCallback((hour, minute) => {
+  const setReminder = useCallback((hour: number, minute: number) => {
     setState((prev) => {
       const next = {
         ...prev,
@@ -71,7 +82,7 @@ export function useMonthlyPlan() {
     });
   }, []);
 
-  const setReminderEnabled = useCallback((enabled) => {
+  const setReminderEnabled = useCallback((enabled: boolean) => {
     setState((prev) => {
       const next = { ...prev, reminderEnabled: !!enabled };
       saveState(next);
@@ -79,22 +90,25 @@ export function useMonthlyPlan() {
     });
   }, []);
 
-  const setDayTemplate = useCallback((dateKey, templateId) => {
-    setState((prev) => {
-      const days = { ...prev.days };
-      if (templateId == null || templateId === "") {
-        delete days[dateKey];
-      } else {
-        days[dateKey] = { templateId };
-      }
-      const next = { ...prev, days };
-      saveState(next);
-      return next;
-    });
-  }, []);
+  const setDayTemplate = useCallback(
+    (dateKey: string, templateId: string | null) => {
+      setState((prev) => {
+        const days = { ...prev.days };
+        if (templateId == null || templateId === "") {
+          delete days[dateKey];
+        } else {
+          days[dateKey] = { templateId };
+        }
+        const next = { ...prev, days };
+        saveState(next);
+        return next;
+      });
+    },
+    [],
+  );
 
   const getTemplateForDate = useCallback(
-    (dateKey) => state.days[dateKey]?.templateId ?? null,
+    (dateKey: string) => state.days[dateKey]?.templateId ?? null,
     [state.days],
   );
 

--- a/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.test.tsx
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.test.tsx
@@ -87,7 +87,10 @@ describe("useWorkoutTemplates", () => {
       result.current.restoreTemplate(null, 0);
     });
     act(() => {
-      result.current.restoreTemplate({ id: "" }, 0);
+      result.current.restoreTemplate(
+        { id: "" } as Parameters<typeof result.current.restoreTemplate>[0],
+        0,
+      );
     });
     expect(result.current.templates).toHaveLength(0);
   });

--- a/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.ts
+++ b/apps/web/src/modules/fizruk/hooks/useWorkoutTemplates.ts
@@ -4,22 +4,36 @@ import { STORAGE_KEYS } from "@sergeant/shared";
 
 const KEY = STORAGE_KEYS.FIZRUK_TEMPLATES;
 
+export interface WorkoutTemplate {
+  id: string;
+  name: string;
+  exerciseIds: string[];
+  groups: unknown[];
+  updatedAt?: string;
+  lastUsedAt?: string;
+  [key: string]: unknown;
+}
+
+type TemplatesUpdater =
+  | WorkoutTemplate[]
+  | ((prev: WorkoutTemplate[]) => WorkoutTemplate[]);
+
 function uid() {
   return `tpl_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export function useWorkoutTemplates() {
-  const [templates, setTemplates] = useState([]);
+  const [templates, setTemplates] = useState<WorkoutTemplate[]>([]);
 
   useEffect(() => {
     const parsed = safeReadLS(KEY, []);
-    if (Array.isArray(parsed)) setTemplates(parsed);
+    if (Array.isArray(parsed)) setTemplates(parsed as WorkoutTemplate[]);
   }, []);
 
   // Функціональний updater через setTemplates, щоб уникнути stale closure:
   // колбеки в undo-toast можуть викликатись після того, як state оновився
   // (див. AGENTS.md §5.11).
-  const persist = useCallback((updater) => {
+  const persist = useCallback((updater: TemplatesUpdater) => {
     setTemplates((prev) => {
       const next = typeof updater === "function" ? updater(prev) : updater;
       safeWriteLS(KEY, next);
@@ -50,7 +64,7 @@ export function useWorkoutTemplates() {
   );
 
   const updateTemplate = useCallback(
-    (id, patch) => {
+    (id: string, patch: Partial<WorkoutTemplate>) => {
       persist((prev) =>
         prev.map((t) =>
           t.id === id
@@ -63,14 +77,14 @@ export function useWorkoutTemplates() {
   );
 
   const removeTemplate = useCallback(
-    (id) => {
+    (id: string) => {
       persist((prev) => prev.filter((t) => t.id !== id));
     },
     [persist],
   );
 
   const restoreTemplate = useCallback(
-    (template, atIndex) => {
+    (template: WorkoutTemplate | null | undefined, atIndex?: number) => {
       if (!template || !template.id) return;
       persist((prev) => {
         if (prev.some((t) => t.id === template.id)) return prev;
@@ -87,7 +101,7 @@ export function useWorkoutTemplates() {
   );
 
   const markTemplateUsed = useCallback(
-    (id) => {
+    (id: string) => {
       persist((prev) =>
         prev.map((t) =>
           t.id === id ? { ...t, lastUsedAt: new Date().toISOString() } : t,

--- a/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
+++ b/apps/web/src/modules/routine/components/FizrukDayPlanSheet.tsx
@@ -9,6 +9,13 @@ import { useWorkoutTemplates } from "../../fizruk/hooks/useWorkoutTemplates";
 import { useExerciseCatalog } from "../../fizruk/hooks/useExerciseCatalog";
 import { parseDateKey } from "../lib/hubCalendarAggregate";
 
+interface CatalogExercise {
+  id: string;
+  name?: { uk?: string; en?: string };
+  primaryGroup?: string;
+  primaryGroupUk?: string;
+}
+
 export interface FizrukDayPlanSheetProps {
   dateKey: string | null;
   onClose: () => void;
@@ -32,11 +39,13 @@ export function FizrukDayPlanSheet({
     [currentTemplateId, templates],
   );
 
-  const exerciseList = useMemo(() => {
+  const exerciseList = useMemo<CatalogExercise[]>(() => {
     if (!currentTemplate) return [];
-    return (currentTemplate.exerciseIds || [])
-      .map((id: string) => exercises.find((e) => e.id === id))
-      .filter(Boolean);
+    return ((currentTemplate.exerciseIds || []) as string[])
+      .map((id: string) =>
+        (exercises as CatalogExercise[]).find((e) => e.id === id),
+      )
+      .filter((e): e is CatalogExercise => Boolean(e));
   }, [currentTemplate, exercises]);
 
   const dateLabel = dateKey

--- a/apps/web/src/modules/routine/lib/routineStorage.extended.test.ts
+++ b/apps/web/src/modules/routine/lib/routineStorage.extended.test.ts
@@ -522,7 +522,7 @@ describe("edge cases: loadRoutineState sanitization", () => {
   it("коерсить completions як не-об'єкт у порожню мапу", () => {
     const raw = {
       schemaVersion: 3,
-      habits: [],
+      habits: [] as unknown[],
       completions: "not-an-object",
     };
     localStorage.setItem(ROUTINE_STORAGE_KEY, JSON.stringify(raw));

--- a/apps/web/src/shared/hooks/usePushNotifications.test.tsx
+++ b/apps/web/src/shared/hooks/usePushNotifications.test.tsx
@@ -93,7 +93,7 @@ function makeMockPushSubscription(args: {
     endpoint: args.endpoint,
     expirationTime: null,
     options: {} as PushSubscriptionOptions,
-    getKey: () => null,
+    getKey: (): ArrayBuffer | null => null,
     toJSON: () => ({
       endpoint: args.endpoint,
       keys: { p256dh: args.p256dh, auth: args.auth },

--- a/apps/web/src/shared/lib/createModuleStorage.test.ts
+++ b/apps/web/src/shared/lib/createModuleStorage.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createModuleStorage } from "./createModuleStorage";
 
-let storage;
+let storage: ReturnType<typeof createModuleStorage>;
 
 beforeEach(() => {
   localStorage.clear();

--- a/apps/web/tsconfig.noimplicitany.json
+++ b/apps/web/tsconfig.noimplicitany.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["src/shared/**/*", "src/modules/routine/**/*", "src/test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What changed

- Додано **scoped `apps/web/tsconfig.noimplicitany.json`** (аналогічно до вже існуючого `tsconfig.strict.json` для `strictNullChecks`), який вмикає `noImplicitAny: true` для:
  - `src/shared/**/*`
  - `src/modules/routine/**/*`
  - `src/test/**/*` (для підтягування `@testing-library/jest-dom` типів у тести)
- Цей чек додано у `pnpm typecheck` — CI тепер фейлиться на будь-якому новому implicit-any у цих шляхах.
- Виправлено **25 помилок** у routine+shared (param/destructure/variable без типу).
- Бонусом виправлено **29 transitive implicit-any помилок** у трьох `fizruk/hooks` файлах, які імпортуються з routine (`useExerciseCatalog`, `useMonthlyPlan`, `useWorkoutTemplates`) — без цього cross-module type-check з routine не зеленіє. Додано `WorkoutTemplate`-інтерфейс, `MonthlyPlanState`-інтерфейс, перевикористано `RawExerciseDef` з `@sergeant/fizruk-domain` замість локального дубля.

## Why

Частина audit-roadmap пункту `PR-6.B` (TypeScript strict phase 2, noImplicitAny) з `docs/audits/2026-04-26-sergeant-audit-devin.md`.

Повний `noImplicitAny` на `apps/web` — це **1,480 помилок у ~120 файлах** (перевірено `tsc --noImplicitAny`). Робити одним PR — високий ризик конфліктів і погано ревʼюїться (`AGENTS.md` → "Prefer minimal, focused edits"). Тому це PR #2.1 у серії:

| Крок | Модуль | Помилок |
|---|---|---:|
| **#2.1 (цей PR)** | **routine + shared** (+ transitive з fizruk/hooks) | **25 + 29** |
| #2.2 | `core/**` | 238 |
| #2.3 | `nutrition/**` | 309 |
| #2.4 | `fizruk/**` (решта) | ~381 |
| #2.5 | `finyk/**` + перенос прапорця в root `tsconfig.json` | 499 |

Після мержу всіх 5 — прапорець стане глобальним для `apps/web`, а `tsconfig.noimplicitany.json` і `tsconfig.strict.json` можна буде прибрати.

## How to test

```bash
# Усі чотири tsc-проекти мають пройти
cd apps/web && pnpm typecheck

# Повний vitest
pnpm --filter @sergeant/web test

# Наочна перевірка: новий файл у routine/** або shared/** без типу має впасти
echo 'export function foo(x) { return x; }' > apps/web/src/modules/routine/tmp.ts
cd apps/web && pnpm exec tsc -p tsconfig.noimplicitany.json --noEmit
# → error TS7006: Parameter 'x' implicitly has an 'any' type.
rm apps/web/src/modules/routine/tmp.ts
```

Smoke в UI не потрібен — зміни чисто типові (runtime-поведінка незмінна, тільки signatures і `as` касти у тестах). Всі 1315 тестів локально зелені.

---

## How AI-tested this PR

- [x] Manual smoke: не потрібен (runtime незмінний; тести 1315 passed)
- [x] Vitest passes: `pnpm --filter @sergeant/web test` — 116 files / 1315 tests passed
- [x] `pnpm typecheck` (усі 4 проекти tsc) — exit 0
- [x] `pnpm lint` (apps/web) — 0 errors
- [x] `pnpm exec prettier --check apps/web/` — OK
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (це тактичний tsconfig-чек, який буде видалено після #2.5)


Link to Devin session: https://app.devin.ai/sessions/0113661fc7e64ae9a55ba94314b4242b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
