### PR TITLE
test(mobile): sync SignInScreen test with redesigned sign-in screen

### DIFF
--- a/apps/mobile/src/auth/SignInScreen.test.tsx
+++ b/apps/mobile/src/auth/SignInScreen.test.tsx
@@ -29,9 +29,9 @@ describe("SignInScreen", () => {
   it("renders the sign-in form", () => {
     const { getByText, getByPlaceholderText } = render(<SignInScreen />);
 
-    expect(getByText("З поверненням")).toBeTruthy();
-    expect(getByPlaceholderText("email@example.com")).toBeTruthy();
-    expect(getByPlaceholderText("пароль")).toBeTruthy();
+    expect(getByText("З поверненням 👋")).toBeTruthy();
+    expect(getByPlaceholderText("ваш@email.com")).toBeTruthy();
+    expect(getByPlaceholderText("••••••••••")).toBeTruthy();
     expect(getByText("Увійти")).toBeTruthy();
   });
 
@@ -41,10 +41,10 @@ describe("SignInScreen", () => {
     const { getByPlaceholderText, getByText } = render(<SignInScreen />);
 
     fireEvent.changeText(
-      getByPlaceholderText("email@example.com"),
+      getByPlaceholderText("ваш@email.com"),
       "test@example.com",
     );
-    fireEvent.changeText(getByPlaceholderText("пароль"), "password123");
+    fireEvent.changeText(getByPlaceholderText("••••••••••"), "password123");
     fireEvent.press(getByText("Увійти"));
 
     await waitFor(() => {
@@ -66,10 +66,10 @@ describe("SignInScreen", () => {
     );
 
     fireEvent.changeText(
-      getByPlaceholderText("email@example.com"),
+      getByPlaceholderText("ваш@email.com"),
       "bad@example.com",
     );
-    fireEvent.changeText(getByPlaceholderText("пароль"), "wrong");
+    fireEvent.changeText(getByPlaceholderText("••••••••••"), "wrong");
     fireEvent.press(getByText("Увійти"));
 
     const errorMsg = await findByText("Invalid credentials");


### PR DESCRIPTION
## What changed

Синхронізовано `apps/mobile/src/auth/SignInScreen.test.tsx` з поточним станом `apps/mobile/app/(auth)/sign-in.tsx`:

| Було у тесті | Стало (відповідає компоненту) |
|---|---|
| `getByText("З поверненням")` | `getByText("З поверненням 👋")` |
| `getByPlaceholderText("email@example.com")` | `getByPlaceholderText("ваш@email.com")` |
| `getByPlaceholderText("пароль")` | `getByPlaceholderText("••••••••••")` |

## Why

PR #914 (`feat(mobile): improve onboarding flow with welcome & slides screens`, merged as `eb4767b8`) переписав sign-in screen на design-system `Input`/`Button` з новим placeholder-ом `ваш@email.com`, заголовком `З поверненням 👋` (з emoji) і без окремого placeholder-а `"пароль"` — Label `"Пароль"` тепер зовнішній, а placeholder у password-інпуті — `"••••••••••"`. Тест не оновили разом із компонентом, тому `@sergeant/mobile#test` впав і залишив `main` червоним. Це блокує `check` job у всіх відкритих PR-ах.

Такий drift trifa за день — третій випадок (після PR #911 SectionHeading та PR #919/920 Prettier/WCAG). Варто зробити `check` та `Test coverage (vitest)` **required** у GitHub branch protection для `main`.

## How to test

```bash
pnpm --filter @sergeant/mobile test
# → 612 passed, 93 test suites, 0 failed
```

Runtime-поведінка не змінюється — лише тест-асершени.

---

## How AI-tested this PR

- [x] Vitest (jest-native) passes: `pnpm --filter @sergeant/mobile test` — 612 tests passed locally
- [x] No runtime / production code changed.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/0113661fc7e64ae9a55ba94314b4242b
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sign-in screen test assertions to reflect changes in greeting text and input field placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->