### PR TITLE
fix(mobile): token parity with web — Button/Stat/Badge/Input/Card/Tabs/Toast

### DIFF
--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -43,15 +43,15 @@ export type BadgeSize = "xs" | "sm" | "md";
 
 const solidVariants: Record<BadgeVariant, string> = {
   neutral: "bg-fg-muted/90",
-  accent: "bg-accent",
-  success: "bg-success",
-  warning: "bg-warning",
-  danger: "bg-danger",
-  info: "bg-info",
-  finyk: "bg-finyk",
-  fizruk: "bg-fizruk",
-  routine: "bg-routine",
-  nutrition: "bg-nutrition",
+  accent: "bg-brand-strong",
+  success: "bg-success-strong",
+  warning: "bg-warning-strong",
+  danger: "bg-danger-strong",
+  info: "bg-info-strong",
+  finyk: "bg-finyk-strong",
+  fizruk: "bg-fizruk-strong",
+  routine: "bg-routine-strong",
+  nutrition: "bg-nutrition-strong",
 };
 
 const softVariants: Record<BadgeVariant, string> = {
@@ -95,15 +95,15 @@ const solidText: Record<BadgeVariant, string> = {
 
 const softText: Record<BadgeVariant, string> = {
   neutral: "text-fg-muted",
-  accent: "text-success",
-  success: "text-success",
+  accent: "text-brand-700",
+  success: "text-brand-700",
   warning: "text-warning",
   danger: "text-danger",
   info: "text-info",
-  finyk: "text-finyk",
-  fizruk: "text-fizruk",
-  routine: "text-routine",
-  nutrition: "text-nutrition",
+  finyk: "text-finyk-strong",
+  fizruk: "text-fizruk-strong",
+  routine: "text-routine-strong",
+  nutrition: "text-nutrition-strong",
 };
 
 const outlineText: Record<BadgeVariant, string> = softText;
@@ -144,8 +144,8 @@ const solidDot: Record<BadgeVariant, string> = {
 
 const softDot: Record<BadgeVariant, string> = {
   neutral: "bg-fg-muted",
-  accent: "bg-success",
-  success: "bg-success",
+  accent: "bg-brand",
+  success: "bg-brand",
   warning: "bg-warning",
   danger: "bg-danger",
   info: "bg-info",

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -59,7 +59,7 @@ export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 // RN has no hover state and scale feedback is handled via `pressed` below.
 const variantContainer: Record<ButtonVariant, string> = {
   // Core variants
-  primary: "bg-brand-500",
+  primary: "bg-brand-strong",
   secondary: "bg-panel border border-line",
   ghost: "bg-transparent",
   danger: "bg-danger/10 border border-danger/30",
@@ -67,10 +67,10 @@ const variantContainer: Record<ButtonVariant, string> = {
   success: "bg-brand-50 border border-brand-200/50",
 
   // Module-specific
-  finyk: "bg-finyk",
-  fizruk: "bg-fizruk",
-  routine: "bg-routine",
-  nutrition: "bg-nutrition",
+  finyk: "bg-finyk-strong",
+  fizruk: "bg-fizruk-strong",
+  routine: "bg-routine-strong",
+  nutrition: "bg-nutrition-strong",
 
   // Soft module variants
   "finyk-soft": "bg-brand-50 border border-brand-200/50",

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -73,18 +73,18 @@ const radii: Record<CardRadius, string> = {
 // Module-branded variants bake `rounded-3xl` into their class string for
 // hero surfaces, matching the web component.
 const variantContainer: Record<CardVariant, string> = {
-  default: "bg-panel border border-line",
-  interactive: "bg-panel border border-line",
+  default: "bg-panel border border-line shadow-sm",
+  interactive: "bg-panel border border-line shadow-sm",
   flat: "bg-panel border border-line",
-  elevated: "bg-panel border border-line",
+  elevated: "bg-panel border border-line shadow-md",
   ghost: "bg-transparent border border-transparent",
 
   // Module hero cards — branded surface. Mobile strips the `dark:` modifiers
   // (no dark-mode plumbing yet) but keeps the branded border + solid token.
-  finyk: "rounded-3xl border border-brand-200/50 bg-finyk",
-  fizruk: "rounded-3xl border border-teal-200/50 bg-fizruk",
-  routine: "rounded-3xl border border-coral-200/50 bg-routine",
-  nutrition: "rounded-3xl border border-lime-200/50 bg-nutrition",
+  finyk: "rounded-3xl border border-brand-200/50 bg-finyk-soft",
+  fizruk: "rounded-3xl border border-teal-200/50 bg-fizruk-soft",
+  routine: "rounded-3xl border border-coral-200/50 bg-routine-surface",
+  nutrition: "rounded-3xl border border-lime-200/50 bg-nutrition-soft",
 
   // Soft module cards — less prominent tinted surface.
   "finyk-soft": "rounded-2xl border border-brand-100 bg-brand-50/50",

--- a/apps/mobile/src/components/ui/ConfirmDialog.test.tsx
+++ b/apps/mobile/src/components/ui/ConfirmDialog.test.tsx
@@ -74,7 +74,7 @@ describe("ConfirmDialog", () => {
     const pressables = UNSAFE_getAllByType(Pressable);
     expect(pressables.length).toBeGreaterThanOrEqual(3);
     const confirm = pressables[1];
-    expect(confirm.props.className).toContain("bg-brand-500");
+    expect(confirm.props.className).toContain("bg-brand-strong");
     expect(confirm.props.className).not.toContain("bg-danger");
   });
 });

--- a/apps/mobile/src/components/ui/Input.tsx
+++ b/apps/mobile/src/components/ui/Input.tsx
@@ -101,7 +101,7 @@ const sizes: Record<InputSize, string> = {
 };
 
 const variantBase: Record<InputVariant, string> = {
-  default: "bg-panel border border-line",
+  default: "bg-panelHi border border-line",
   filled: "bg-panelHi border border-transparent",
   ghost: "bg-transparent border border-transparent",
 };
@@ -189,14 +189,12 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
     spellCheck ?? (type && NON_PROSE_TYPES.has(type) ? false : undefined);
 
   const stateClass = error
-    ? "border-red-500"
+    ? "border-danger"
     : success
       ? "border-brand-400"
       : focused
         ? variantFocused[variant]
         : "";
-
-  const ringClass = focused && !error && !success ? "border-2" : "border";
 
   return (
     <View
@@ -205,7 +203,8 @@ export const Input = forwardRef<TextInput, InputProps>(function Input(
         sizes[size],
         variantBase[variant],
         stateClass,
-        ringClass,
+        "border",
+        focused && !error && !success ? "ring-2 ring-brand-400/40" : "",
         !editable && "opacity-50",
         containerClassName,
       )}
@@ -273,7 +272,7 @@ export const Textarea = forwardRef<TextInput, TextareaProps>(function Textarea(
   const [focused, setFocused] = useState(false);
 
   const stateClass = error
-    ? "border-red-500"
+    ? "border-danger"
     : focused
       ? variantFocused[variant]
       : "";

--- a/apps/mobile/src/components/ui/SectionHeading.tsx
+++ b/apps/mobile/src/components/ui/SectionHeading.tsx
@@ -40,7 +40,7 @@ export type SectionHeadingWeight = "semibold" | "bold" | "extrabold";
 // elsewhere must still go through <SectionHeading>.
 const sizeTokens: Record<SectionHeadingSize, string> = {
   // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- primitive owner
-  xs: "text-2xs uppercase tracking-widest",
+  xs: "text-xs uppercase tracking-wider",
   // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- primitive owner
   sm: "text-xs uppercase tracking-widest",
   md: "text-sm",
@@ -66,11 +66,11 @@ const variants: Record<SectionHeadingVariant, string> = {
   subtle: "text-subtle",
   muted: "text-muted",
   text: "text-text",
-  accent: "text-accent",
-  finyk: "text-finyk",
-  fizruk: "text-fizruk",
-  routine: "text-routine",
-  nutrition: "text-nutrition",
+  accent: "text-brand-strong",
+  finyk: "text-finyk-strong dark:text-finyk/70",
+  fizruk: "text-fizruk-strong dark:text-fizruk/70",
+  routine: "text-routine-strong dark:text-routine/70",
+  nutrition: "text-nutrition-strong dark:text-nutrition/70",
 };
 
 const defaultVariantForSize: Record<SectionHeadingSize, SectionHeadingVariant> =

--- a/apps/mobile/src/components/ui/Stat.tsx
+++ b/apps/mobile/src/components/ui/Stat.tsx
@@ -34,19 +34,19 @@ export type StatSize = "sm" | "md" | "lg";
 
 const variantClass: Record<StatVariant, string> = {
   default: "text-text",
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger",
-  finyk: "text-finyk",
-  fizruk: "text-fizruk",
-  routine: "text-routine",
-  nutrition: "text-nutrition",
+  success: "text-success-strong",
+  warning: "text-warning-strong",
+  danger: "text-danger-strong",
+  finyk: "text-finyk-strong",
+  fizruk: "text-fizruk-strong",
+  routine: "text-routine-strong",
+  nutrition: "text-nutrition-strong",
 };
 
 const valueSize: Record<StatSize, string> = {
-  sm: "text-lg font-extrabold",
-  md: "text-2xl font-extrabold",
-  lg: "text-3xl font-black",
+  sm: "text-lg font-extrabold tabular-nums",
+  md: "text-2xl font-extrabold tabular-nums",
+  lg: "text-3xl font-black tabular-nums",
 };
 
 function cx(...classes: Array<string | false | null | undefined>): string {

--- a/apps/mobile/src/components/ui/Tabs.tsx
+++ b/apps/mobile/src/components/ui/Tabs.tsx
@@ -46,7 +46,7 @@ export interface TabsProps<Value extends string = string> {
 }
 
 const pillActive: Record<TabsVariant, string> = {
-  accent: "bg-success-soft",
+  accent: "bg-brand-50",
   finyk: "bg-finyk-soft",
   fizruk: "bg-fizruk-soft",
   routine: "bg-routine-surface",
@@ -54,7 +54,7 @@ const pillActive: Record<TabsVariant, string> = {
 };
 
 const pillActiveText: Record<TabsVariant, string> = {
-  accent: "text-success",
+  accent: "text-brand-strong",
   finyk: "text-finyk",
   fizruk: "text-fizruk",
   routine: "text-routine",

--- a/apps/mobile/src/components/ui/Toast.tsx
+++ b/apps/mobile/src/components/ui/Toast.tsx
@@ -191,10 +191,10 @@ export function useToast(): ToastContextValue {
 }
 
 const VARIANT_BG: Record<ToastType, string> = {
-  success: "bg-brand-600",
+  success: "bg-brand-strong",
   error: "bg-red-600",
   warning: "bg-amber-500",
-  info: "bg-brand-500",
+  info: "bg-info",
 };
 
 // Unicode glyph placeholders until `react-native-svg` is wired in at


### PR DESCRIPTION
Button: primary → bg-brand-strong; module variants → *-strong fills
Stat: variantClass → *-strong; valueSize → tabular-nums
Badge: solidVariants → *-strong; softText accent/success → text-brand-700
SectionHeading: xs → text-xs tracking-wider; variants → *-strong + dark:
Input: border-red-500 → border-danger; bg-panel → bg-panelHi; ring fix
Toast: success → bg-brand-strong; info → bg-info
Tabs: accent → bg-brand-50 / text-brand-strong
Card: branded bgs → *-soft/*-surface; default/interactive shadow-sm
ConfirmDialog.test: update assertion bg-brand-500 → bg-brand-strong

https://claude.ai/code/session_01BDHNUzxqViHHTYjqGpFBbF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
