### PR TITLE
feat(server): per-tool chat invocations metric (ADR-0002 PR-12.C)

### DIFF
--- a/apps/server/src/modules/chat.test.ts
+++ b/apps/server/src/modules/chat.test.ts
@@ -23,10 +23,21 @@ vi.mock("../lib/anthropic.js", () => ({
   ),
 }));
 
+// Мокаємо prometheus counter-и, щоб можна було перевірити виклики `inc()`
+// без тягнення глобального реєстру між тестами (prom-client Counter —
+// singleton у модулі). Ті метрики, які мають фактично інкрементуватися у
+// цьому тесті, присутні як `{ inc: vi.fn() }`; решта — фейки.
+vi.mock("../obs/metrics.js", () => ({
+  anthropicPromptCacheHitTotal: { inc: vi.fn() },
+  chatToolInvocationsTotal: { inc: vi.fn() },
+}));
+
 import { anthropicMessages as _anthropicMessages } from "../lib/anthropic.js";
+import { chatToolInvocationsTotal as _toolMetric } from "../obs/metrics.js";
 import handler from "./chat.js";
 
 const anthropicMessages = _anthropicMessages as unknown as Mock;
+const toolMetricInc = (_toolMetric as unknown as { inc: Mock }).inc;
 
 interface TestRes {
   statusCode: number;
@@ -64,6 +75,7 @@ beforeEach(() => {
   // Інакше leftover-моки з попереднього тесту (наприклад cap-тест queue-ить 5, а
   // консьюмить лише 4) залежать у наступному.
   anthropicMessages.mockReset();
+  toolMetricInc.mockReset();
 });
 
 describe("chat handler — tool_use parsing", () => {
@@ -737,5 +749,177 @@ describe("chat handler — auto-continuation на stop_reason=max_tokens", () =>
     expect(anthropicMessages).toHaveBeenCalledTimes(2);
     expect(res.statusCode).toBe(200);
     expect(asRec(res.body).text).toBe("Перша частина… ");
+  });
+});
+
+describe("chat handler — ADR-0002 tool_invocations metric", () => {
+  it("`proposed` — інкрементує per-tool коли модель повертає tool_use", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: {
+        content: [
+          { type: "text", text: "Виконую…" },
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "delete_transaction",
+            input: { tx_id: "m_1" },
+          },
+          {
+            type: "tool_use",
+            id: "toolu_2",
+            name: "briefing",
+            input: {},
+          },
+        ],
+      },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Видали транзакцію і дай брифінг" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(toolMetricInc).toHaveBeenCalledTimes(2);
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "delete_transaction",
+      outcome: "proposed",
+    });
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "briefing",
+      outcome: "proposed",
+    });
+  });
+
+  it("`proposed` — повний text-only response БЕЗ tool_use не інкрементує", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Просто текст" }] },
+    });
+
+    await handler(
+      makeReq({ messages: [{ role: "user", content: "Привіт" }] }),
+      makeRes(),
+    );
+
+    expect(toolMetricInc).not.toHaveBeenCalled();
+  });
+
+  it("`executed` — інкрементує per-tool коли клієнт повертає tool_results", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Готово" }] },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Видали m_abc" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "delete_transaction",
+          input: { tx_id: "m_abc" },
+        },
+      ],
+      tool_results: [{ tool_use_id: "toolu_1", content: "видалено" }],
+    });
+    await handler(req, makeRes());
+
+    expect(toolMetricInc).toHaveBeenCalledTimes(1);
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "delete_transaction",
+      outcome: "executed",
+    });
+  });
+
+  it('`executed` — tool_use_id без matching tool_use → tool="unknown"', async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Готово" }] },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "?" }],
+      // tool_calls_raw без `tool_use` блоку (тільки text) — не формує мапи.
+      tool_calls_raw: [{ type: "text", text: "something" }],
+      tool_results: [{ tool_use_id: "toolu_orphan", content: "result" }],
+    });
+    await handler(req, makeRes());
+
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "unknown",
+      outcome: "executed",
+    });
+  });
+
+  it("`executed` — кілька tool_results у батчі інкрементує по одному на кожен", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: true, status: 200 },
+      data: { content: [{ type: "text", text: "Готово" }] },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "Двома tools" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_a",
+          name: "delete_transaction",
+          input: { tx_id: "m_a" },
+        },
+        {
+          type: "tool_use",
+          id: "toolu_b",
+          name: "briefing",
+          input: {},
+        },
+      ],
+      tool_results: [
+        { tool_use_id: "toolu_a", content: "видалено" },
+        { tool_use_id: "toolu_b", content: "briefing text" },
+      ],
+    });
+    await handler(req, makeRes());
+
+    expect(toolMetricInc).toHaveBeenCalledTimes(2);
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "delete_transaction",
+      outcome: "executed",
+    });
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "briefing",
+      outcome: "executed",
+    });
+  });
+
+  it("`executed` інкрементується ДО Anthropic-виклику (навіть якщо другий крок зламається)", async () => {
+    anthropicMessages.mockResolvedValueOnce({
+      response: { ok: false, status: 500 },
+      data: { error: { message: "Anthropic 500" } },
+    });
+
+    const req = makeReq({
+      messages: [{ role: "user", content: "?" }],
+      tool_calls_raw: [
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "delete_transaction",
+          input: { tx_id: "m_1" },
+        },
+      ],
+      tool_results: [{ tool_use_id: "toolu_1", content: "ok" }],
+    });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    // Metric записана до Anthropic-виклику — не залежить від upstream-успіху.
+    expect(toolMetricInc).toHaveBeenCalledWith({
+      tool: "delete_transaction",
+      outcome: "executed",
+    });
   });
 });

--- a/apps/server/src/modules/chat.ts
+++ b/apps/server/src/modules/chat.ts
@@ -14,7 +14,10 @@ import {
 import type { WithAiQuotaRefund } from "./aiQuota.js";
 import { TOOLS, SYSTEM_PREFIX, SYSTEM_PROMPT_VERSION } from "./chat/tools.js";
 import { truncateToolResults } from "./chat/toolResultTruncation.js";
-import { anthropicPromptCacheHitTotal } from "../obs/metrics.js";
+import {
+  anthropicPromptCacheHitTotal,
+  chatToolInvocationsTotal,
+} from "../obs/metrics.js";
 import { als } from "../obs/requestContext.js";
 
 type WithAnthropicKey = Request & { anthropicKey?: string };
@@ -79,6 +82,48 @@ function applyToolsCacheBreakpoint(
 }
 
 const TOOLS_WITH_CACHE = applyToolsCacheBreakpoint(TOOLS);
+
+/**
+ * Інкрементує `chat_tool_invocations_total` без шансу зламати запит.
+ * Anthropic іноді повертає tool_use без `name` (broken stream), і `unknown`
+ * label зберігає cardinality обмеженою — не дозволяємо сирому input потрапити
+ * у Prometheus-label.
+ */
+function recordToolInvocation(
+  tool: string | undefined,
+  outcome: "proposed" | "executed",
+): void {
+  try {
+    chatToolInvocationsTotal.inc({
+      tool: tool && tool.length > 0 ? tool : "unknown",
+      outcome,
+    });
+  } catch {
+    /* metrics must never break a request */
+  }
+}
+
+/**
+ * Map `tool_use_id` → `tool_use.name` із `tool_calls_raw`, які клієнт
+ * повернув разом з `tool_results`. Потрібно, щоб executed-метрика мала
+ * ідентичний `tool`-label з proposed-метрикою (інакше counter-и не сходяться
+ * у PromQL `sum by (tool)`).
+ */
+function buildToolUseIdToNameMap(
+  toolCallsRaw: unknown[] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!Array.isArray(toolCallsRaw)) return map;
+  for (const block of toolCallsRaw) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as { type?: unknown; id?: unknown; name?: unknown };
+    if (b.type !== "tool_use") continue;
+    if (typeof b.id !== "string" || !b.id) continue;
+    if (typeof b.name !== "string" || !b.name) continue;
+    map.set(b.id, b.name);
+  }
+  return map;
+}
 
 /**
  * Якщо Anthropic повернув не-2xx або виклик упав (timeout/abort), викликаємо
@@ -311,6 +356,15 @@ export default async function handler(
     const normalizedToolResults = truncateToolResults(tool_results, {
       requestId,
     });
+
+    // ADR-0002 tool lifecycle: `executed` — клієнт фактично повернув результат
+    // на конкретний `tool_use_id`. Це рахуємо ДО Anthropic-виклику, щоб
+    // сигнал не залежав від того, чи другий крок upstream зможе завершитися.
+    const toolUseIdToName = buildToolUseIdToNameMap(tool_calls_raw);
+    for (const r of normalizedToolResults) {
+      recordToolInvocation(toolUseIdToName.get(r.tool_use_id), "executed");
+    }
+
     const toolResultMessages = normalizedToolResults.map((r) => ({
       type: "tool_result" as const,
       tool_use_id: r.tool_use_id,
@@ -441,6 +495,12 @@ export default async function handler(
     .join("\n");
 
   if (toolUses.length > 0) {
+    // ADR-0002 tool lifecycle: `proposed` — модель запропонувала tool_use.
+    // Рахуємо окремо від `executed`: різниця (proposed - executed) — це
+    // `tool_rejected_rate` у KPI-панелі.
+    for (const t of toolUses) {
+      recordToolInvocation(t.name, "proposed");
+    }
     res.status(200).json({
       text: textParts || null,
       tool_calls: toolUses.map((t) => ({

--- a/apps/server/src/obs/metrics.ts
+++ b/apps/server/src/obs/metrics.ts
@@ -109,6 +109,24 @@ export const chatToolResultTruncatedTotal = new client.Counter({
   registers: [register],
 });
 
+// Per-tool lifecycle лічильник для ADR-0002 KPI-панелі:
+//   `tool_rejected_rate` = 1 - sum(outcome=executed) / sum(outcome=proposed)
+// на вікні 7 днів per-tool.
+//
+// Label `outcome`:
+//   - `proposed` — модель повернула `tool_use`-блок (перший крок chat-handler-а).
+//   - `executed` — клієнт повернув `tool_result` із `tool_use_id`, який
+//     матчиться з `tool_calls_raw` (другий крок). Це і є «пропозиція дійсно
+//     виконана».
+// `tool` label — `tool_use.name` (наприклад `delete_transaction`, `briefing`).
+// Unknown tool (rare: tool_result без matching tool_use) → `tool="unknown"`.
+export const chatToolInvocationsTotal = new client.Counter({
+  name: "chat_tool_invocations_total",
+  help: "HubChat tool lifecycle events (ADR-0002): proposed by model vs executed by client",
+  labelNames: ["tool", "outcome"], // outcome=proposed|executed
+  registers: [register],
+});
+
 export const aiQuotaBlocksTotal = new client.Counter({
   name: "ai_quota_blocks_total",
   help: "AI quota refusals",


### PR DESCRIPTION
## What changed

Закриває **PR-12.C** з `docs/audits/2026-04-26-sergeant-audit-devin.md` — `feat(server,chat): per-tool metrics (tool_invocations_total{tool,outcome}) → SLO dashboard`.

Додається лічильник `chat_tool_invocations_total{tool, outcome}` у Prometheus з двома outcome:
- `proposed` — модель повернула `tool_use`-блок (перший крок chat-handler-а).
- `executed` — клієнт повернув `tool_result` із `tool_use_id`, який матчиться з `tool_calls_raw` (другий крок).

Різниця між ними — це KPI `tool_rejected_rate` з ADR-0002 §KPIs (`docs/adr/0002-tool-lifecycle.md`), який тепер має реальний PromQL-шлях:
```promql
1 - (
  sum by (tool) (increase(chat_tool_invocations_total{outcome="executed"}[7d]))
  /
  sum by (tool) (increase(chat_tool_invocations_total{outcome="proposed"}[7d]))
)
```

## Why

ADR-0002 був змержений без цієї метрики, і секція «Rollout → KPIs» посилалася на ще не існуючий лічильник. Без PR-12.C весь rollout-процес (proposal → safety → rollout → KPIs) лишався без вимірюваного сигналу. Це blocker для decision-gating будь-якого нового tool-а.

## How

- **`apps/server/src/obs/metrics.ts`** — новий `chatToolInvocationsTotal` Counter з labels `tool` і `outcome`.
- **`apps/server/src/modules/chat.ts`**:
  - Helper `recordToolInvocation(tool, outcome)` — wrap `inc()` у try/catch, щоб метрики ніколи не ламали запит.
  - Helper `buildToolUseIdToNameMap(toolCallsRaw)` — реконструює мапу `tool_use_id → name` з raw-блоків, які клієнт echo-іть у другому кроці. Потрібно, щоб `executed` мала ідентичний `tool`-label з `proposed` (інакше PromQL не зшиє серії).
  - `proposed` інкрементуємо у першому кроці після фільтрації `content.filter(b => b.type === "tool_use")`.
  - `executed` інкрементуємо у другому кроці **до** Anthropic-виклику — сигнал не залежить від того, чи upstream другий крок вдасться.
  - Unknown `tool_use_id` (tool_result без matching tool_use у tool_calls_raw) → `tool="unknown"`, cardinality обмежена.
- **`apps/server/src/modules/chat.test.ts`** — `vi.mock('../obs/metrics.js')` + 6 нових тестів (`describe chat handler — ADR-0002 tool_invocations metric`).

## How to test

```bash
cd apps/server
pnpm vitest run src/modules/chat.test.ts
# 26 tests pass
pnpm typecheck
pnpm lint
```

Після rollout у prod: Grafana query `sum by (tool) (increase(chat_tool_invocations_total[24h]))` — має показати per-tool розподіл пропозицій і виконаних.

---

## How AI-tested this PR

- [x] Manual smoke: full `pnpm vitest run` в `apps/server` — 533/533 pass (з 26 у chat.test.ts).
- [x] Vitest passes: 6 нових тестів (proposed/executed/batch/unknown/upstream-failure).
- [x] `pnpm typecheck` + `pnpm lint` — clean.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian.

## AGENTS.md updated?

- [ ] Yes
- [x] No — no new permanent rules (метрика додається до існуючого inventory, без зміни policies).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
