### PR TITLE
docs(docs): per-app status matrix + close PR-1.B/3.E/12.C in audit

### DIFF
--- a/docs/architecture/apps-status-matrix.md
+++ b/docs/architecture/apps-status-matrix.md
@@ -1,0 +1,65 @@
+# Apps & Packages Status Matrix
+
+> **Last revalidated: 2026-04-27.** Наступна ревалідація — 2026-07-27 (квартал).
+> Закриває audit PR-1.B. Перегляд при кожному додаванні / видаленні apps або
+> packages, і мінімум раз у квартал.
+
+Одна сторінка — хто живий, хто стабілізується, хто в міграції, хто legacy.
+Для кожного пакета: `status`, чим займається, куди копати глибше. Ніяких
+приватних деталей реалізації — для цього є per-module docs.
+
+## Легенда статусів
+
+| Status      | Що означає                                                                                            |
+| ----------- | ----------------------------------------------------------------------------------------------------- |
+| `active`    | Активно розвивається, часті зміни, PR-и йдуть щотижня.                                                |
+| `stabilize` | Контракт більш-менш заморожений, правки лише bugfix-и і maintenance. Breaking зміни — через ADR.      |
+| `migration` | У процесі переносу з / на іншу форму (наприклад web → RN, JS → TS). Очікується завершення зі строком. |
+| `legacy`    | Не видаляємо (ще є залежності), але нових фіч не додаємо. План виведення зафіксовано або TBD.         |
+
+---
+
+## Apps
+
+| Package                  | Path                | Status      | Опис                                                                                                                                          | Глибше                                                                                                                                                      |
+| ------------------------ | ------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@sergeant/web`          | `apps/web`          | `active`    | React 18 + Vite PWA — канонічна продакшн-апка (Vercel статика + Railway `/api`).                                                              | [`docs/platforms.md` §1](../platforms.md), [`docs/frontend-overview.md`](../frontend-overview.md), [`docs/frontend-tech-debt.md`](../frontend-tech-debt.md) |
+| `@sergeant/server`       | `apps/server`       | `active`    | Node 20 / TypeScript / Express `/api/v1/*`, Better Auth, Postgres, Anthropic tool-use.                                                        | [`docs/api-v1.md`](../api-v1.md), [`docs/backend-tech-debt.md`](../backend-tech-debt.md), [`AGENTS.md`](../../AGENTS.md)                                    |
+| `@sergeant/mobile`       | `apps/mobile`       | `active`    | Expo SDK 52 + Expo Router. Usе 4 модулі, native push (APNs/FCM), MMKV-офлайн. Internal dev-client.                                            | [`docs/mobile.md`](../mobile.md), [`docs/react-native-migration.md`](../react-native-migration.md), [`docs/platforms.md` §2](../platforms.md)               |
+| `@sergeant/mobile-shell` | `apps/mobile-shell` | `stabilize` | Capacitor 7 wrapper навколо `@sergeant/web` для Android / iOS. MVP-release флоу. Далі — лише maintenance, нові фічі уже в `@sergeant/mobile`. | [`docs/mobile-shell.md`](../mobile-shell.md), [`docs/capacitor-deep-links.md`](../capacitor-deep-links.md), [`docs/platforms.md` §3](../platforms.md)       |
+
+## Domain packages
+
+Бізнес-логіка модулів, pure TS без React. Імпортуються і web, і mobile.
+
+| Package                      | Path                        | Status   | Опис                                                                            | Глибше                                                                                                                         |
+| ---------------------------- | --------------------------- | -------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `@sergeant/finyk-domain`     | `packages/finyk-domain`     | `active` | Фінансова логіка (Monobank sync normalizers, бюджети, cashflow, активи, борги). | [`docs/frontend-overview.md` (Finyk)](../frontend-overview.md), [`packages/finyk-domain/src`](../../packages/finyk-domain/src) |
+| `@sergeant/fizruk-domain`    | `packages/fizruk-domain`    | `active` | Тренування, програми, прогрес, вимірювання.                                     | [`docs/frontend-overview.md` (Fizruk)](../frontend-overview.md)                                                                |
+| `@sergeant/routine-domain`   | `packages/routine-domain`   | `active` | Календар, звички, стріки, хітмеп.                                               | [`docs/frontend-overview.md` (Routine)](../frontend-overview.md)                                                               |
+| `@sergeant/nutrition-domain` | `packages/nutrition-domain` | `active` | Фото AI-аналіз нутрієнтів, лог їжі, штрихкоди, плани/покупки/комора/рецепти.    | [`docs/frontend-overview.md` (Nutrition)](../frontend-overview.md)                                                             |
+
+## Shared infra
+
+Пакети, які тримають контракт між поверхнями і підлогу під ногами.
+
+| Package                         | Path                                     | Status      | Опис                                                                                                       | Глибше                                                                                                                       |
+| ------------------------------- | ---------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `@sergeant/shared`              | `packages/shared`                        | `active`    | Спільні Zod-схеми API (`ChatRequestSchema`, `MeResponseSchema` та ін.), типи, утиліти.                     | [`packages/shared/src/schemas`](../../packages/shared/src/schemas)                                                           |
+| `@sergeant/api-client`          | `packages/api-client`                    | `stabilize` | Типізована обгортка над `/api/v1/*` для web + mobile. Контракт рівно відповідає `@sergeant/shared` схемам. | [`docs/api-v1.md`](../api-v1.md), [AGENTS.md rule #3](../../AGENTS.md)                                                       |
+| `@sergeant/design-tokens`       | `packages/design-tokens`                 | `stabilize` | Tailwind preset, кольори, типографія. Єдине джерело брендових токенів для web/mobile.                      | [`docs/BRANDBOOK.md`](../BRANDBOOK.md), [`docs/design-system.md`](../design-system.md)                                       |
+| `@sergeant/insights`            | `packages/insights`                      | `active`    | Pure-TS движок для weekly-digest / coach-insight (однаковий на сервері і клієнті).                         | [`packages/insights/src`](../../packages/insights/src)                                                                       |
+| `@sergeant/config`              | `packages/config`                        | `stabilize` | Спільний tsconfig/eslint-base. Апи інгерять через `extends`.                                               | [AGENTS.md rule #5](../../AGENTS.md), [PR-1.A](../audits/2026-04-26-sergeant-audit-devin.md) (pending)                       |
+| `eslint-plugin-sergeant-design` | `packages/eslint-plugin-sergeant-design` | `active`    | Custom ESLint rules (`no-raw-local-storage`, `rq-keys-only-from-factory`, `no-bigint-string`).             | [AGENTS.md rules](../../AGENTS.md), [`packages/eslint-plugin-sergeant-design`](../../packages/eslint-plugin-sergeant-design) |
+
+---
+
+## Чому ця сторінка існує
+
+Без central-matrix-у новий інженер мусить шукати по 10+ docs-файлах, що в репо
+`active` vs `stabilize`. Ця сторінка — короткий вхід у тему. Реальні деталі
+завжди живуть у per-module docs (посилання в колонці «Глибше»), а тут — лише
+«хто куди зараз рухається».
+
+Ревалідація — раз у квартал (наступна в заголовку). Якщо статус пакета
+змінюється у процесі PR — update цього файла в тому ж PR, не окремо.

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -80,7 +80,7 @@
 **PR-ідеї:**
 
 - `PR-1.A` — `chore(config): enforce inheritance of strict from tsconfig.base in apps/web,server (codeowner-blocking comment)`.
-- `PR-1.B` — `docs(architecture): per-app status matrix (active/stabilize/legacy/migration)` — на 1 сторінку, з датою останньої ревалідації.
+- `PR-1.B` ✅ closed — [#931](https://github.com/Skords-01/Sergeant/pull/931) `docs(docs): per-app status matrix` (`docs/architecture/apps-status-matrix.md`) — одна сторінка, 4 apps + 10 packages з `active/stabilize/migration/legacy`-легендою, дата ревалідації (`Last revalidated: 2026-04-27`, наступна — квартально).
 
 ---
 
@@ -131,7 +131,7 @@
 - `PR-3.B` ✅ closed — [#887](https://github.com/Skords-01/Sergeant/pull/887) `refactor(web,finyk): decompose Assets.tsx (1147 LOC) into smaller modules` — пілот для top-10 list.
 - `PR-3.C` ✅ closed — [#898](https://github.com/Skords-01/Sergeant/pull/898) `refactor(web,nutrition): split seedFoodsUk.ts (1614 LOC) by category (meat/fish/dairy/grains/...)` — чисто data-split, 19 per-category файлів, всі 390 елементів структурно ідентичні.
 - `PR-3.D` ✅ closed — [#865](https://github.com/Skords-01/Sergeant/pull/865) `chore(web,storage): migrate top-3 high-call-site localStorage files to safe wrappers` (`core/settings/FinykSection.tsx` -20, `core/lib/chatActions/fizrukActions.ts` -7, `core/hub/HubDashboard.tsx` -5) — burn-down list.
-- `PR-3.E` — `ci(web): add report on frontend-tech-debt freshness` (CI fail, якщо `frontend-tech-debt.md` не редагувався 60+ днів).
+- `PR-3.E` ✅ closed — [#907](https://github.com/Skords-01/Sergeant/pull/907) `ci(ci): freshness gate for docs/frontend-tech-debt.md` (`scripts/check-tech-debt-freshness.mjs`, wired у `pnpm lint:tech-debt-freshness` → root `pnpm lint`). Парсить `> **Оновлено YYYY-MM-DD.**` маркер, fail коли > `FRESHNESS_THRESHOLD_DAYS` (default 60). Маркер, а не git mtime, — тому format-only edit не «reset-ить» свіжість.
 
 ---
 
@@ -357,7 +357,7 @@
 
 - `PR-12.A` ✅ closed — [#864](https://github.com/Skords-01/Sergeant/pull/864) `feat(server,chat): activate prompt caching for SYSTEM_PREFIX (cache_control: ephemeral) + SYSTEM_PROMPT_VERSION constant` + per-request метрика `anthropic_prompt_cache_hit_total{version, outcome}` (включно зі streaming-шляхом). Очікуваний ефект: зниження Anthropic spend на 30-50% для повторних запитів.
 - `PR-12.B` ✅ closed — [#885](https://github.com/Skords-01/Sergeant/pull/885) `test(web): contract tests for all hubChatActions handlers (happy + error path)`.
-- `PR-12.C` — `feat(server,chat): per-tool metrics (tool_invocations_total{tool=,outcome=}) → SLO dashboard`.
+- `PR-12.C` ✅ closed — [#930](https://github.com/Skords-01/Sergeant/pull/930) `feat(server): per-tool chat invocations metric (ADR-0002 PR-12.C)` — `chat_tool_invocations_total{tool, outcome}` з outcome `proposed` (модель повернула `tool_use`) / `executed` (клієнт повернув `tool_result` з matching `tool_use_id`). Різниця — KPI `tool_rejected_rate` з ADR-0002. Recorded server-side до Anthropic-виклику (не залежить від upstream-успіху другого кроку). 6 нових vitest cases.
 - `PR-12.D` ✅closed — `docs(ai): tool lifecycle model (proposal → safety review → rollout → KPIs)` — реалізовано як [`docs/adr/0002-tool-lifecycle.md`](../adr/0002-tool-lifecycle.md): 4-фазний процес (Proposal/Safety/Rollout/KPIs) з checklist-ами для кожної фази, owner-domain map і KPI-thresholds на основі `chat_tool_invocations_total` (PR-12.C).
 - `PR-12.E` ✅closed — `feat(server,chat): truncate-aware tool_result handler` — якщо `tool_result` >N токенів, серверна частина серіалізує summary + повний blob у Sentry breadcrumb. Закриває edge case, де великі briefing/digest вибивають continuation. Реалізовано: `apps/server/src/modules/chat/toolResultTruncation.ts` (threshold 2 000 chars, head 600 + tail 400 + marker), wired у `chat.ts` перед `tool_result`-payload-ом, `chat_tool_result_truncated_total{reason}` метрика, 14 unit + 2 integration тестів.
 

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -80,7 +80,7 @@
 **PR-ідеї:**
 
 - `PR-1.A` — `chore(config): enforce inheritance of strict from tsconfig.base in apps/web,server (codeowner-blocking comment)`.
-- `PR-1.B` ✅ closed — [#931](https://github.com/Skords-01/Sergeant/pull/931) `docs(docs): per-app status matrix` (`docs/architecture/apps-status-matrix.md`) — одна сторінка, 4 apps + 10 packages з `active/stabilize/migration/legacy`-легендою, дата ревалідації (`Last revalidated: 2026-04-27`, наступна — квартально).
+- `PR-1.B` ✅ closed — [#932](https://github.com/Skords-01/Sergeant/pull/932) `docs(docs): per-app status matrix` (`docs/architecture/apps-status-matrix.md`) — одна сторінка, 4 apps + 10 packages з `active/stabilize/migration/legacy`-легендою, дата ревалідації (`Last revalidated: 2026-04-27`, наступна — квартально).
 
 ---
 


### PR DESCRIPTION
## What changed

Закриває **PR-1.B** з `docs/audits/2026-04-26-sergeant-audit-devin.md` — `docs(architecture): per-app status matrix (active/stabilize/legacy/migration)` — на 1 сторінку, з датою останньої ревалідації.

Додається `docs/architecture/apps-status-matrix.md` — єдиний вхід у питання «що в цьому монорепо зараз active, а що stabilize». 4 apps + 10 packages у трьох таблицях (Apps / Domain packages / Shared infra), кожен рядок: `Status`, `Опис`, `Глибше`-посилання.

Але цього мало, тому PR ще **закриває аудит-bookkeeping** на три вже-реалізовані PR, у яких аудит-файл лишався стале:

- **PR-1.B** ✅ (цим PR) — новий файл.
- **PR-3.E** ✅ — реально змерджено у [#907](https://github.com/Skords-01/Sergeant/pull/907) (`ci(ci): freshness gate for docs/frontend-tech-debt.md`, wired у `pnpm lint`). Аудит лишався неоновленим — тепер виправлено.
- **PR-12.C** ✅ — [#930](https://github.com/Skords-01/Sergeant/pull/930) (`feat(server): per-tool chat invocations metric`). Щойно закритий для закриття ADR-0002 KPI-контуру.

## Why

Людина, яка заходить у репо вперше, не знає чи `apps/mobile-shell` все ще активно розвивається (відповідь: ні, maintenance; нові мобайл-фічі — у `@sergeant/mobile`). І чи `packages/api-client` розвивається паралельно зі схемою (відповідь: stabilize — контракт синхронізований з `@sergeant/shared`). Без matrix це треба збирати по крихтах.

Side-effect: audit document більше не показує PR-3.E як open — що неправда, і створює видимість того, що freshness-gate ще треба зробити.

## How

- `docs/architecture/apps-status-matrix.md` — три таблиці:
  - **Apps**: web / server / mobile / mobile-shell.
  - **Domain packages**: finyk / fizruk / routine / nutrition.
  - **Shared infra**: shared / api-client / design-tokens / insights / config / eslint-plugin-sergeant-design.
- Легенда статусів (active / stabilize / migration / legacy) — в топі файла, щоб per-package рядки лишалися терсними.
- Header: `Last revalidated: 2026-04-27. Наступна — 2026-07-27 (квартально).` — синхронно з логікою `check-tech-debt-freshness.mjs` (PR-3.E), хоча freshness-gate поки тільки на frontend-tech-debt.md.
- `docs/audits/2026-04-26-sergeant-audit-devin.md`: PR-1.B, PR-3.E, PR-12.C помічено ✅ closed з лінками.

## How to test

```bash
# Перевір всі посилання в matrix-і коректні (відносні).
git grep -l "apps-status-matrix" docs/
```

Всі лінки перевірені вручну проти файлів, що справді існують у репо.

---

## How AI-tested this PR

- [x] Manual smoke: `node scripts/check-tech-debt-freshness.mjs` — pass (1 day ago, threshold 60).
- [x] Relative links in `apps-status-matrix.md` перевірено (`for f in …; do [ -e $f ]`).
- [x] Docs prose uses Ukrainian.
- [x] No new `AI-DANGER` markers.

## AGENTS.md updated?

- [ ] Yes
- [x] No — чиста docs-зміна, нових правил не додається.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
