### PR TITLE
fix(web): pass token (not id) when revoking a Better Auth session

### DIFF
--- a/apps/web/src/core/profile/SessionsSection.test.tsx
+++ b/apps/web/src/core/profile/SessionsSection.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// Regression test for the production toast
+// `[body.token] Invalid input: expected string, received undefined`
+// that the user reported when clicking "Завершити" in profile sessions.
+//
+// Better Auth's `/revoke-session` endpoint validates the body with
+// `z.object({ token: z.string() })` (see
+// `node_modules/better-auth/dist/api/routes/session.mjs`). The component
+// previously passed `{ id }`, which lands as `body.token === undefined`
+// and surfaces as the user-visible toast above. We pin the contract here
+// so a future refactor cannot regress to `{ id }` silently.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const listSessionsMock = vi.fn<() => Promise<{ data: unknown[] }>>();
+const revokeSessionMock = vi.fn<(d: unknown) => Promise<{ error: null }>>();
+
+vi.mock("../auth/authClient.js", () => ({
+  listSessions: () => listSessionsMock(),
+  revokeSession: (data: unknown) => revokeSessionMock(data),
+}));
+
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+vi.mock("@shared/hooks/useToast", () => ({
+  useToast: () => ({ success: toastSuccessMock, error: toastErrorMock }),
+}));
+
+import { SessionsSection } from "./SessionsSection";
+
+const SAMPLE_SESSION = {
+  id: "sess_abc",
+  token: "tok_def",
+  userId: "u-1",
+  expiresAt: new Date(Date.now() + 86_400_000),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ipAddress: "127.0.0.1",
+  userAgent: "Safari/604.1",
+};
+
+describe("SessionsSection — revoke flow", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    listSessionsMock.mockResolvedValue({ data: [SAMPLE_SESSION] });
+    revokeSessionMock.mockResolvedValue({ error: null });
+  });
+
+  it("calls revokeSession with the session token (NOT the id)", async () => {
+    render(<SessionsSection online={true} />);
+
+    // Wait for listSessions to populate the row.
+    const revokeButton = await screen.findByRole("button", {
+      name: /Завершити/i,
+    });
+
+    fireEvent.click(revokeButton);
+
+    await waitFor(() => expect(revokeSessionMock).toHaveBeenCalledTimes(1));
+    expect(revokeSessionMock).toHaveBeenCalledWith({ token: "tok_def" });
+    // Critical contract pin — `id` must NOT be passed.
+    expect(revokeSessionMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.anything() }),
+    );
+  });
+
+  it("removes the session from the list and shows a success toast on success", async () => {
+    render(<SessionsSection online={true} />);
+
+    const revokeButton = await screen.findByRole("button", {
+      name: /Завершити/i,
+    });
+
+    fireEvent.click(revokeButton);
+
+    await waitFor(() =>
+      expect(toastSuccessMock).toHaveBeenCalledWith("Сесію завершено"),
+    );
+    // After success the row is gone — fallback empty-state copy renders.
+    expect(await screen.findByText(/Немає сесій/i)).toBeTruthy();
+  });
+
+  it("surfaces server error message in a toast on failure", async () => {
+    revokeSessionMock.mockResolvedValueOnce({
+      error: { message: "boom" },
+    } as never);
+    render(<SessionsSection online={true} />);
+
+    const revokeButton = await screen.findByRole("button", {
+      name: /Завершити/i,
+    });
+
+    fireEvent.click(revokeButton);
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("boom"));
+  });
+});

--- a/apps/web/src/core/profile/SessionsSection.tsx
+++ b/apps/web/src/core/profile/SessionsSection.tsx
@@ -42,10 +42,17 @@ export function SessionsSection({ online }: { online: boolean }) {
     load();
   }, [load]);
 
-  const handleRevoke = async (id: string) => {
+  const handleRevoke = async (id: string, token: string) => {
     setRevoking(id);
     try {
-      const res = await revokeSession({ id });
+      // Better Auth's `/revoke-session` endpoint validates the body with
+      // `z.object({ token: z.string() })` (see
+      // `node_modules/better-auth/dist/api/routes/session.mjs`). Passing
+      // `{ id }` lands as `body.token === undefined` and surfaces as a
+      // user-visible toast: `[body.token] Invalid input: expected
+      // string, received undefined`. We use the session's `token`
+      // (already returned by `listSessions`) as the identifier.
+      const res = await revokeSession({ token });
       if (res.error) {
         toast.error(res.error.message ?? "Не вдалося завершити сесію");
         return;
@@ -112,7 +119,7 @@ export function SessionsSection({ online }: { online: boolean }) {
                     size="xs"
                     disabled={revoking === s.id}
                     loading={revoking === s.id}
-                    onClick={() => handleRevoke(s.id)}
+                    onClick={() => handleRevoke(s.id, s.token)}
                   >
                     Завершити
                   </Button>


### PR DESCRIPTION
## What changed

`apps/web/src/core/profile/SessionsSection.tsx` — the `handleRevoke` handler now passes `{ token }` to `revokeSession` instead of `{ id }`. New regression test in `SessionsSection.test.tsx` pins the contract.

## Why

User-visible production bug: clicking **«Завершити»** on any active session in profile settings fires the toast

> `[body.token] Invalid input: expected string, received undefined`

…and the session is never actually revoked.

Root cause: Better Auth's `/revoke-session` endpoint validates the body with `z.object({ token: z.string() })` (`node_modules/better-auth/dist/api/routes/session.mjs`). The Sergeant client was passing `{ id: s.id }`, so `body.token` arrived as `undefined`, the Zod refinement bounced the request as a 400, and the user saw the validation message verbatim through `res.error.message`.

`SessionItem` already exposes the per-session `token` returned by `listSessions` — we just weren't using it. The `id` is still kept for client-side state book-keeping (filtering the row out of the list and the `revoking` busy flag), but the network call carries the token.

## How to test

```sh
# Targeted regression
pnpm --filter @sergeant/web exec vitest run \
  src/core/profile/SessionsSection.test.tsx
# 3 tests, all pass; the first one explicitly forbids {id} from being
# passed and asserts {token: \"tok_def\"}.

# Full web suite
pnpm --filter @sergeant/web test
```

Manual verification on a deployed build: open profile settings → \"Активні сесії\" → click \"Завершити\" on any row. Expected: toast \"Сесію завершено\" and the row disappears, no `[body.token]` error.

---

## How AI-tested this PR

- [x] Vitest passes (`SessionsSection.test.tsx` — 3 / 3 incl. negative `not.toHaveBeenCalledWith({ id })`).
- [x] `pnpm --filter @sergeant/web typecheck` clean.
- [x] `pnpm --filter @sergeant/web lint` clean; Prettier --check clean.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules. Just aligning the call site with Better Auth's existing endpoint contract.

---

Devin run: https://app.devin.ai/sessions/52faa029f506462798edc133bb7c5d6b
Requested by: Андрій (@Skords-01)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
