### PR TITLE
docs(docs): audit sync v5 — PR-5.B closed, PR-6.B partial

### DIFF
--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (четверта ревізія: +#902 +#904)**
+> **Статус виконання — оновлено 2026-04-27 (пʼята ревізія: +#918 +#923 +#934)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -30,6 +30,8 @@
 | PR-3.C   | split `seedFoodsUk.ts` (1614 LOC) by category into `seeds/*`           | ✅ closed  | [#898](https://github.com/Skords-01/Sergeant/pull/898)                                                                 |
 | PR-9.C   | vulnerability SLA matrix + weekly breach-reminder workflow             | ✅ closed  | [#902](https://github.com/Skords-01/Sergeant/pull/902)                                                                 |
 | PR-7.B   | cloud-sync offline-queue + replay-on-reconnect integration tests       | ✅ closed  | [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                                 |
+| PR-5.B   | rollback sanity для `*.down.sql` міграцій (Testcontainers)             | ✅ closed  | [#918](https://github.com/Skords-01/Sergeant/pull/918)                                                                 |
+| PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -180,7 +182,7 @@
 **PR-ідеї:**
 
 - `PR-5.A` ✅ closed — [#863](https://github.com/Skords-01/Sergeant/pull/863) `ci(server): migration linter — fail PR if a NNN_*.sql contains DROP COLUMN/TABLE without a sibling NNN_*.add_*.sql in a previous merged PR`. Реалізація: Node-скрипт `scripts/lint-migrations.mjs` із escape-hatch коментарем `-- ALLOW_DROP: <reason> (due: YYYY-MM-DD)`.
-- `PR-5.B` — `ci(server): apply down.sql in test job after up.sql, then re-apply up.sql` (catch-all sanity check, що `down` принаймні виконується).
+- `PR-5.B` ✅ closed — [#918](https://github.com/Skords-01/Sergeant/pull/918) `test(server): rollback sanity for *.down.sql migrations`. `apps/server/src/migrations/__tests__/rollback-sanity.test.ts` піднімає `postgres:16-alpine` через Testcontainers і за цикл: (1) застосовує всі forward-міграції; (2) знімає schema-fingerprint (таблиці+індекси+стовпці); (3) прокатує всі `*.down.sql` у зворотньому порядку; (4) re-applies forward; (5) перевіряє рівність fingerprint-ів. Другий тест — двократний прокат `down.sql` як idempotency-guard для AGENTS rule #4.
 - `PR-5.C` ✅closed — `docs/playbooks/pre-merge-migration-checklist.md` — реалізовано: чек-лист на 10 секцій (numbering, two-phase DROP, bigint coercion, api-client sync, idempotency, performance, RLS, local & CI verification, rollout-readiness) + reviewer responsibilities + common mistakes table. Покликається з PR template для будь-якого PR з `apps/server/src/migrations/`.
 
 ---
@@ -208,7 +210,7 @@
 **PR-ідеї:**
 
 - `PR-6.A` ✅ closed — [#870](https://github.com/Skords-01/Sergeant/pull/870) `chore(web,tsconfig): enable strictNullChecks (phase 1)` — окремий PR, тільки `strictNullChecks: true`. Скоуп звужений до `apps/web/src/shared/**`.
-- `PR-6.B` ⏳ pending — `chore(web,tsconfig): enable noImplicitAny (phase 2)` — слідом, після того як phase 1 зеленіє.
+- `PR-6.B` 🟡 partial — `chore(web,tsconfig): enable noImplicitAny (phase 2)`. Реалізовано через scoped `apps/web/tsconfig.noimplicitany.json` (paralel з `tsconfig.strict.json` від PR-6.A) + wired у `pnpm typecheck`. Покриті модулі: `src/shared/**` ([#923](https://github.com/Skords-01/Sergeant/pull/923)), `src/modules/routine/**` ([#923](https://github.com/Skords-01/Sergeant/pull/923)), `src/modules/nutrition/**` ([#934](https://github.com/Skords-01/Sergeant/pull/934)). **Залишилось ⏳:** `src/core/**`, `src/modules/finyk/**`, `src/modules/fizruk/**` — кожен у своєму PR; після всіх — promote `noImplicitAny` у root `tsconfig.json`.
 - `PR-6.C` ⏳ pending — `chore(web,tsconfig): set strict: true (phase 3) + remove allowJs` — фінал. Орієнтовно через 4-6 тижнів від phase 1.
 - `PR-6.D` ⏳ pending — `chore(server,tsconfig): explicit strict: true (no implicit inheritance)`.
 - `PR-6.E` ✅ closed — [#877](https://github.com/Skords-01/Sergeant/pull/877) `feat(eslint-plugins): no-strict-bypass` (заборонити нові `// @ts-expect-error`, `// @ts-ignore`, `as any`, `as unknown as` поза тестами).
@@ -392,15 +394,15 @@
 ### Спринт 1-2 (3-4 тижні) — «закрити рутиний борг»
 
 | #   | PR                                                      | Effort | Імпакт                |
-| --- | ------------------------------------------------------- | ------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| 5   | `PR-6.B` — noImplicitAny phase 2                        | 3-5 д  | strict TS phase 2     | ⏳ pending                                                                                                                             |
-| 6   | `PR-3.D` — top-3 localStorage migration                 | 1 д    | burn-down             | ✅ [#865](https://github.com/Skords-01/Sergeant/pull/865)                                                                              |
-| 7   | `PR-3.B` + `PR-3.C` — Assets.tsx + seedFoodsUk split    | 2 д    | top-LOC decomposition | `PR-3.B` ✅ [#887](https://github.com/Skords-01/Sergeant/pull/887); `PR-3.C` ✅ [#898](https://github.com/Skords-01/Sergeant/pull/898) |
-| 8   | `PR-2.B` — `no-bigint-string` ESLint rule               | 1-2 д  | автоматизує rule #1   | ✅ [#868](https://github.com/Skords-01/Sergeant/pull/868)                                                                              |
-| 9   | `PR-2.C` — `rq-keys-only-from-factory`                  | 1-2 д  | автоматизує rule #2   | ✅ [#869](https://github.com/Skords-01/Sergeant/pull/869)                                                                              |
-| 10  | `PR-12.B` — chatActions contract tests                  | 2 д    | safety net на tools   | ✅ [#885](https://github.com/Skords-01/Sergeant/pull/885)                                                                              |
-| 11  | `PR-7.A` + `PR-7.B` — recommendation + cloud-sync tests | 3 д    | critical paths        | `PR-7.A` ✅ [#886](https://github.com/Skords-01/Sergeant/pull/886); `PR-7.B` ✅ [#904](https://github.com/Skords-01/Sergeant/pull/904) |
-| 12  | `PR-5.A` — migration linter                             | 1 д    | автоматизує rule #4   | ✅ [#863](https://github.com/Skords-01/Sergeant/pull/863)                                                                              |
+| --- | ------------------------------------------------------- | ------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5   | `PR-6.B` — noImplicitAny phase 2                        | 3-5 д  | strict TS phase 2     | 🟡 partial: `routine`+`shared` ✅ [#923](https://github.com/Skords-01/Sergeant/pull/923), `nutrition` ✅ [#934](https://github.com/Skords-01/Sergeant/pull/934); ⏳ `core`/`finyk`/`fizruk` |
+| 6   | `PR-3.D` — top-3 localStorage migration                 | 1 д    | burn-down             | ✅ [#865](https://github.com/Skords-01/Sergeant/pull/865)                                                                                                                                   |
+| 7   | `PR-3.B` + `PR-3.C` — Assets.tsx + seedFoodsUk split    | 2 д    | top-LOC decomposition | `PR-3.B` ✅ [#887](https://github.com/Skords-01/Sergeant/pull/887); `PR-3.C` ✅ [#898](https://github.com/Skords-01/Sergeant/pull/898)                                                      |
+| 8   | `PR-2.B` — `no-bigint-string` ESLint rule               | 1-2 д  | автоматизує rule #1   | ✅ [#868](https://github.com/Skords-01/Sergeant/pull/868)                                                                                                                                   |
+| 9   | `PR-2.C` — `rq-keys-only-from-factory`                  | 1-2 д  | автоматизує rule #2   | ✅ [#869](https://github.com/Skords-01/Sergeant/pull/869)                                                                                                                                   |
+| 10  | `PR-12.B` — chatActions contract tests                  | 2 д    | safety net на tools   | ✅ [#885](https://github.com/Skords-01/Sergeant/pull/885)                                                                                                                                   |
+| 11  | `PR-7.A` + `PR-7.B` — recommendation + cloud-sync tests | 3 д    | critical paths        | `PR-7.A` ✅ [#886](https://github.com/Skords-01/Sergeant/pull/886); `PR-7.B` ✅ [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                      |
+| 12  | `PR-5.A` — migration linter                             | 1 д    | автоматизує rule #4   | ✅ [#863](https://github.com/Skords-01/Sergeant/pull/863)                                                                                                                                   |
 
 ### Спринт 3-6 (2-3 місяці) — «масштабування»
 


### PR DESCRIPTION
## What changed

Доводимо `docs/audits/2026-04-26-sergeant-audit-devin.md` до актуального стану main:

- **PR-5.B** (`rollback sanity для *.down.sql`) — позначено як `✅ closed` через [#918](https://github.com/Skords-01/Sergeant/pull/918) у TL;DR-таблиці статусу та inline у §5 (Data layer). Раніше було `⏳ pending`.
- **PR-6.B** (`noImplicitAny` phase 2) — позначено як `🟡 partial`: вже покриті `src/shared/**` і `src/modules/routine/**` через [#923](https://github.com/Skords-01/Sergeant/pull/923) + `src/modules/nutrition/**` через [#934](https://github.com/Skords-01/Sergeant/pull/934). Залишилися: `core`, `finyk`, `fizruk`. Оновлено inline у §6 (Type safety) і таблицю «Спринт 1-2».
- Шапка статусу: `четверта ревізія: +#902 +#904` → `пʼята ревізія: +#918 +#923 +#934`.

## Why

Документ відставав від реального стану main: три merged PR (#918, #923, #934) безпосередньо закривають / частково закривають аудит-ID-и, але аудит про це не знав. Користувач просив звірити та підтягнути документ.

## How to test

- `grep -n "PR-5.B" docs/audits/2026-04-26-sergeant-audit-devin.md` — перший hit у TL;DR-таблиці зі статусом `✅ closed` і посиланням на #918, другий — у §5 із розгорнутим описом тесту rollback-sanity.
- `grep -n "PR-6.B" docs/audits/2026-04-26-sergeant-audit-devin.md` — статус `🟡 partial`, перелічені закриті модулі (routine/shared/nutrition) і pending модулі (core/finyk/fizruk).
- `git diff main..HEAD -- docs/audits/2026-04-26-sergeant-audit-devin.md` — лише doc-зміни, інших файлів не торкає.

---

## How AI-tested this PR

- [x] Manual smoke: звірка doc проти `git log` для PR #918, #923, #934 (підтверджено `merged_at`); звірка `apps/web/tsconfig.noimplicitany.json` `include` (`shared`, `routine`, `nutrition`, `test`); `apps/server/src/migrations/__tests__/rollback-sanity.test.ts` існує.
- [x] Vitest passes: doc-only зміна, тести не торкаються (lint-staged Prettier пройшов на pre-commit).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audit documentation to reflect current project execution status and completed implementation tracking
  * Enhanced sprint progress matrix with detailed implementation specifications, testing requirements, and validation protocols
  * Improved sprint planning table formatting to clarify task statuses and progress indicators for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->