### PR TITLE
chore(server): explicit strict: true (no implicit inheritance)

### DIFF
--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@sergeant/config/tsconfig.node.json",
   "compilerOptions": {
+    "strict": true,
     "allowJs": true,
     "checkJs": false,
     "paths": {


### PR DESCRIPTION
## What changed

Added explicit `"strict": true` to `apps/server/tsconfig.json` `compilerOptions`.

## Why

Audit item **PR-6.D** (`docs/audits/2026-04-26-sergeant-audit-devin.md`, §6 «Type safety»).

`apps/server` already inherits `strict: true` via the chain:
`@sergeant/config/tsconfig.node.json` → `tsconfig.base.json` (where `strict: true` lives).

However, this is invisible from the file itself, making it vulnerable to accidental override or misconfiguration. Making it explicit is a zero-risk hardening change.

## How to test

```bash
pnpm --filter @sergeant/server typecheck   # passes (no new errors — strict was already active)
pnpm --filter @sergeant/server build       # passes
```

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): N/A — config-only change, no runtime behavior affected.
- [x] Vitest passes: `typecheck` and `build` both green locally.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal TypeScript configuration to improve code quality and development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->