### PR TITLE
docs(docs): formalize ADR template + index README (audit PR-11.C)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,35 +6,46 @@
 
 ADR (Architecture Decision Record) — короткий документ, який фіксує **архітектурне рішення з контекстом і альтернативами**, щоб через рік не довелось гадати «чому ми тут зробили так, а не інакше».
 
-Кожен ADR має:
+Заводимо ADR коли рішення стосується архітектури, вибору технології, зовнішніх інтеграцій, або суттєво впливає на структуру коду / DX / operational процеси. Не заводимо для дрібних рефакторингів, bug-фіксів або стилістичних змін.
 
-- **Status** — `proposed` / `accepted` / `superseded by ADR-NNNN` / `deprecated`.
-- **Context** — що ми вирішуємо і чому це питання взагалі виникло.
-- **Decision** — який варіант ми обрали.
-- **Consequences** — що з цього випливає (як добрі, так і погані).
-- **Alternatives considered** — інші варіанти, чому не вони.
-
-## Конвенції файлів
+## Naming convention
 
 ```
 docs/adr/
 ├── README.md                    ← ви тут
+├── TEMPLATE.md                  ← шаблон для нових ADR
 ├── 0001-monetization-architecture.md
-├── 0002-...
-└── NNNN-<short-kebab-title>.md
+├── 0002-tool-lifecycle.md
+└── NNNN-kebab-case-title.md
 ```
 
-- Номери послідовні, без пропусків (`0001`, `0002`, ...).
-- Якщо ADR замінює попередній — старий помічається `superseded by ADR-NNNN`, новий лінкує `supersedes ADR-MMMM`.
+- Формат: `NNNN-kebab-case-title.md` — 4-значний sequential номер, без пропусків (`0001`, `0002`, ...).
+- Для нового ADR: скопіюй [`TEMPLATE.md`](./TEMPLATE.md), перейменуй у `NNNN-kebab-case-title.md`, заповни секції.
 - ADR ніколи не видаляються — лише `deprecated`.
+
+## Lifecycle
+
+```
+Proposed → Accepted → (Deprecated | Superseded by ADR-XXXX)
+```
+
+| Статус                   | Коли                                                              |
+| ------------------------ | ----------------------------------------------------------------- |
+| `Proposed`               | ADR створено, PR відкритий, рішення ще не затверджене.            |
+| `Accepted`               | PR змерджено, рішення діє.                                        |
+| `Deprecated`             | Рішення більше не актуальне (технологія відмовлена, тощо).        |
+| `Superseded by ADR-NNNN` | Нове рішення замінює це; новий ADR лінкує `Supersedes: ADR-MMMM`. |
+
+Зміна статусу — **окремим PR-ом** (щоб бачити чому і коли рішення було переглянуто).
 
 ## Як створити новий ADR
 
-1. Скопіюй останній ADR як шаблон, інкрементуй номер.
-2. Заповни секції Status / Context / Decision / Consequences / Alternatives.
-3. Status = `proposed` поки PR не змерджений.
-4. При мерджі — `accepted` + дата.
+1. Скопіюй [`TEMPLATE.md`](./TEMPLATE.md), перейменуй у `NNNN-kebab-case-title.md` (інкрементуй номер).
+2. Заповни секції: Context and Problem Statement / Considered Options / Decision / Rationale / Consequences / Compliance.
+3. Status = `Proposed` поки PR не змерджений.
+4. При мерджі — `Accepted` + дата.
 5. Лінкуй ADR з відповідних дизайн-документів (`docs/launch/06-*`, `docs/audits/*`).
+6. Додай рядок у таблицю «Поточні ADR» нижче.
 
 ## Поточні ADR
 

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,60 @@
+# ADR-NNNN: Title
+
+- **Status:** Proposed <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
+- **Date:** YYYY-MM-DD
+- **Deciders:** @Skords-01 <!-- GitHub handles of people who approved the decision -->
+- **Supersedes:** — <!-- ADR-MMMM if this replaces an older record, otherwise — -->
+- **Related:**
+  - <!-- e.g. [`docs/launch/06-monetization-architecture.md`](../launch/06-monetization-architecture.md) -->
+
+---
+
+## Context and Problem Statement
+
+<!-- What is the issue that we're seeing that is motivating this decision or change?
+     Include enough background so a new team member understands the trade-off space. -->
+
+## Considered Options
+
+<!-- List every realistic alternative, including "do nothing".
+     One sentence per option is enough; detail goes into Decision / Rationale. -->
+
+1. **Option A** — <!-- brief description -->
+2. **Option B** — <!-- brief description -->
+3. **Do nothing / status quo** — <!-- why this is or isn't acceptable -->
+
+## Decision
+
+<!-- Which option did we choose and what does it mean concretely for the codebase?
+     Be specific: name files, modules, environment variables, migration steps. -->
+
+## Rationale
+
+<!-- Why this option over the others?
+     Link to benchmarks, proof-of-concepts, external docs if available. -->
+
+## Consequences
+
+### Positive
+
+<!-- e.g. simpler API surface, fewer runtime dependencies, better DX -->
+
+### Negative
+
+<!-- e.g. migration effort, new dependency, learning curve -->
+
+### Neutral
+
+<!-- e.g. no change to CI pipeline, unchanged public API -->
+
+## Compliance
+
+<!-- How do we verify that the decision is being followed?
+     Examples: ESLint rule `sergeant-design/no-xyz`, CI job `migration-lint`,
+     playbook `docs/playbooks/add-hubchat-tool.md`, manual review checklist. -->
+
+## Links
+
+<!-- Optional. PRs, issues, external articles, RFCs that informed this decision. -->
+
+- <!-- e.g. [#862](https://github.com/Skords-01/Sergeant/pull/862) — initial implementation -->

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (пʼята ревізія: +#918 +#923 +#934)**
+> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -32,6 +32,7 @@
 | PR-7.B   | cloud-sync offline-queue + replay-on-reconnect integration tests       | ✅ closed  | [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                                 |
 | PR-5.B   | rollback sanity для `*.down.sql` міграцій (Testcontainers)             | ✅ closed  | [#918](https://github.com/Skords-01/Sergeant/pull/918)                                                                 |
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
+| PR-11.C  | ADR template + README index                                          | 🟡 partial | template+README зроблено, retroactive ADRs ⏳ |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -335,7 +336,7 @@
 
 - `PR-11.A` — `docs(meta): freshness badge for top-10 docs` — простий header `**Last validated:** YYYY-MM-DD by @user. **Next review:** YYYY-MM-DD.` + nightly script, що відкриває issue, якщо `Next review` пройшов.
 - `PR-11.B` — `docs(playbooks): convert top-5 playbooks to "decision tree" format` (`when ... do X, else Y`).
-- `PR-11.C` — `docs(adr): introduce lightweight ADR template` (`docs/adr/NNNN-title.md`, 1 page) і занести 5 retroactive ADRs (вибір turbo, choice of Better Auth, monorepo split, Capacitor wrapper, Anthropic tool-on-client architecture).
+- `PR-11.C` 🟡 partial — ADR практика "живе": `docs/adr/0001-monetization-architecture.md` ([#912](https://github.com/Skords-01/Sergeant/pull/912)) і `docs/adr/0002-tool-lifecycle.md` ([#926](https://github.com/Skords-01/Sergeant/pull/926)) уже існують. Цим PR-ом формалізовано: `docs/adr/TEMPLATE.md` (1-page MADR-adapted skeleton із secção Status / Context / Considered options / Decision / Consequences / Compliance / Links) і `docs/adr/README.md` (index, naming convention, lifecycle, посилання на TEMPLATE). **Залишилось ⏳:** retroactive ADRs для turbo / Better Auth / monorepo split / Capacitor wrapper / Anthropic tool-on-client architecture (5 шт., по PR на кожен).
 
 ---
 


### PR DESCRIPTION
## What changed

- **New** `docs/adr/TEMPLATE.md` — 1-page MADR-adapted ADR skeleton with sections: Status / Context and Problem Statement / Considered Options / Decision / Rationale / Consequences (positive / negative / neutral) / Compliance / Links. Inline placeholder comments in each section.
- **Updated** `docs/adr/README.md` — added naming convention (`NNNN-kebab-case-title.md`), explicit lifecycle diagram (`Proposed → Accepted → Deprecated | Superseded`), link to `TEMPLATE.md`, step-by-step creation guide, and "when to create an ADR" guidance.
- **Updated** `docs/audits/2026-04-26-sergeant-audit-devin.md` — marked `PR-11.C` as 🟡 partial in §11 inline entry and TL;DR status table; bumped revision header.

## Why

Closes audit item `PR-11.C` (partial): the ADR practice already "lives" with `0001-monetization-architecture.md` ([#912](https://github.com/Skords-01/Sergeant/pull/912)) and `0002-tool-lifecycle.md` ([#926](https://github.com/Skords-01/Sergeant/pull/926)), but there was no formalized template or index README.

**Remaining ⏳:** 5 retroactive ADRs (turbo / Better Auth / monorepo split / Capacitor wrapper / Anthropic tool-on-client architecture) — one PR each.

## How to test

1. Open `docs/adr/TEMPLATE.md` — verify it has all required sections with placeholder comments.
2. Open `docs/adr/README.md` — verify naming convention, lifecycle table, link to `TEMPLATE.md`, and the existing ADR index table.
3. `grep -n 'PR-11.C' docs/audits/2026-04-26-sergeant-audit-devin.md` — should return updated inline entry (§11) and TL;DR table row.
4. `pnpm lint` passes.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): verified `git status` shows exactly 3 expected files; `grep -n PR-11.C` returns updated entries.
- [x] `pnpm lint` passes (ESLint, plugins, tech-debt freshness — all green).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized Architecture Decision Record (ADR) template with structured metadata and narrative sections
  * Updated ADR guidelines defining creation scope and naming conventions
  * Introduced ADR lifecycle model with clear status progression: Proposed → Accepted → Superseded or Deprecated
  * Enhanced ADR creation documentation with streamlined process steps
  * Updated project audit documentation reflecting ADR implementation progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->