### PR TITLE
docs(docs): audit — PR-8.C formally closed as duplicate of PR-12.A

### DIFF
--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial)**
+> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial, +PR-8.C duplicate)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -34,6 +34,7 @@
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
 | PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#963](https://github.com/Skords-01/Sergeant/pull/963)                                                                 |
 | PR-11.C  | ADR template + README index                                            | 🟡 partial | template+README зроблено, retroactive ADRs ⏳                                                                          |
+| PR-8.C   | SYSTEM_PROMPT_VERSION + cache-hit metric                               | 🔄 duplicate | by PR-12.A ([#864](https://github.com/Skords-01/Sergeant/pull/864))                                                    |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -262,7 +263,7 @@
 
 - `PR-8.A` — `docs(obs): error-budget policy` — який тип фіч freeze, коли HTTP API budget вигорає; які ні (security fixes, hotfixes).
 - `PR-8.B` — `feat(obs): expose Prometheus /metrics from apps/server` (якщо ще не) + Grafana dashboard import JSON у `docs/observability/dashboards/`.
-- `PR-8.C` — `feat(server,chat): SYSTEM_PROMPT_VERSION constant + cache-hit metric` — підготовка до prompt-cache rollout.
+- `PR-8.C` 🔄 duplicate — closed as duplicate of [PR-12.A](#12-продуктова-масштабованість-та-ai-напрям) ([#864](https://github.com/Skords-01/Sergeant/pull/864)). PR-12.A уже реалізував усе, що описувалось у PR-8.C: `SYSTEM_PROMPT_VERSION` константу, активацію prompt-caching для `SYSTEM_PREFIX` через `cache_control: ephemeral`, per-request метрику `anthropic_prompt_cache_hit_total{version, outcome}` (включно зі streaming-шляхом).
 
 ---
 


### PR DESCRIPTION
## What changed

Formally marked `PR-8.C` as a duplicate of `PR-12.A` in the audit document `docs/audits/2026-04-26-sergeant-audit-devin.md`:

1. **§8 (Observability)** — replaced the `PR-8.C` PR-idea entry with a `🔄 duplicate` annotation referencing PR-12.A ([#864](https://github.com/Skords-01/Sergeant/pull/864)) and describing the scope already delivered.
2. **TL;DR status table** — added a `PR-8.C | 🔄 duplicate` row before the "Інші" catch-all row.
3. **Revision header** — bumped to "п'ята ревізія: +PR-8.C duplicate".

## Why

PR-12.A ([#864](https://github.com/Skords-01/Sergeant/pull/864)) already implemented everything described in PR-8.C:
- `SYSTEM_PROMPT_VERSION` constant
- Prompt-caching activation for `SYSTEM_PREFIX` via `cache_control: ephemeral`
- Per-request metric `anthropic_prompt_cache_hit_total{version, outcome}` (including streaming path)

A separate PR for PR-8.C is therefore unnecessary. This change formalises the duplicate status in the audit document.

## How to test

```bash
grep -n 'PR-8.C' docs/audits/2026-04-26-sergeant-audit-devin.md
```
Should show updated entries (duplicate annotation in §8, row in TL;DR table, revision header).

No code changes — only a docs-only markdown update.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): verified `git diff main..HEAD` shows changes only in `docs/audits/2026-04-26-sergeant-audit-devin.md`
- [x] Vitest passes: N/A — docs-only change
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated duplicate work items and updated the audit status to reflect consolidation.
  * Revised the progress table to mark the duplicate entry and point to the resolving item.
  * Updated the observability roadmap to mark the item closed and list implemented metrics, including prompt-cache and per-request cache-hit coverage (including streaming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->