### PR TITLE
ci(ci): split smoke-e2e into critical-flow + nightly extended-flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,13 +183,13 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  smoke-e2e:
-    name: Smoke E2E (Playwright)
+  critical-flow:
+    name: Critical-flow E2E (Playwright)
     runs-on: ubuntu-latest
     # No `needs:` — runs in parallel with other jobs so a lint/test failure in
     # `check` never causes this job to be skipped.  Previously `needs: check`
     # was the root cause of the job being skipped on most PRs.
-    timeout-minutes: 20
+    timeout-minutes: 8
 
     services:
       postgres:
@@ -269,8 +269,8 @@ jobs:
           timeout 60 bash -c 'until curl -sf http://127.0.0.1:4173 >/dev/null 2>&1; do sleep 2; done'
           echo "Both servers ready."
 
-      - name: Run smoke E2E suite
-        run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts
+      - name: Run critical-flow E2E suite
+        run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @critical
         env:
           CI: "true"
           PW_SKIP_WEBSERVER: "1"
@@ -281,7 +281,7 @@ jobs:
         # actions/upload-artifact v4.4.3 (SHA-pinned)
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
-          name: playwright-smoke-report
+          name: playwright-critical-flow-report
           path: apps/web/playwright-report
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/extended-e2e.yml
+++ b/.github/workflows/extended-e2e.yml
@@ -1,0 +1,149 @@
+name: Extended E2E (nightly)
+
+on:
+  schedule:
+    # 02:00 UTC daily (~05:00 Kyiv) — quiet hours.
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: extended-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  extended-flow:
+    name: Extended-flow E2E (Playwright)
+    runs-on: ubuntu-latest
+    # On pull_request, only run when the 'extended-e2e' label is present.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'extended-e2e')
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50
+        env:
+          POSTGRES_USER: hub
+          POSTGRES_PASSWORD: hub
+          POSTGRES_DB: hub
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U hub -d hub"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://hub:hub@127.0.0.1:5432/hub
+      BETTER_AUTH_SECRET: smoke_test_better_auth_secret_32_chars_min
+      AI_QUOTA_DISABLED: "1"
+      VITE_API_BASE_URL: http://127.0.0.1:3000
+      ALLOWED_ORIGINS: http://127.0.0.1:4173
+
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter @sergeant/web exec playwright --version | head -1)" >> "$GITHUB_OUTPUT"
+
+      # actions/cache v5.0.5 (SHA-pinned for supply-chain hardening)
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @sergeant/web exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browsers)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @sergeant/web exec playwright install-deps chromium
+
+      - name: Run database migrations
+        run: pnpm --filter @sergeant/server db:migrate:dev
+
+      - name: Build web app
+        run: pnpm --filter @sergeant/web build
+
+      - name: Start API server
+        run: pnpm --filter @sergeant/server dev &
+
+      - name: Start Vite preview server
+        run: pnpm --filter @sergeant/web preview -- --port 4173 --host 127.0.0.1 &
+
+      - name: Wait for servers
+        run: |
+          echo "Waiting for API server on :3000…"
+          timeout 60 bash -c 'until curl -sf http://127.0.0.1:3000/health >/dev/null 2>&1; do sleep 2; done'
+          echo "Waiting for preview server on :4173…"
+          timeout 60 bash -c 'until curl -sf http://127.0.0.1:4173 >/dev/null 2>&1; do sleep 2; done'
+          echo "Both servers ready."
+
+      - name: Run extended-flow E2E suite
+        run: pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @extended
+        env:
+          CI: "true"
+          PW_SKIP_WEBSERVER: "1"
+          PW_BASE_URL: http://127.0.0.1:4173
+
+      - name: Upload Playwright report
+        if: always()
+        # actions/upload-artifact v4.4.3 (SHA-pinned)
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: playwright-extended-flow-report
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+          retention-days: 14
+
+  notify-failure:
+    name: Create issue on failure
+    runs-on: ubuntu-latest
+    needs: extended-flow
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # actions/github-script v8.0.0 (SHA-pinned for supply-chain hardening)
+      - name: Create GitHub issue for nightly failure
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Extended E2E nightly failure — ${new Date().toISOString().slice(0, 10)}`,
+              body: `The nightly extended-flow E2E suite failed.\n\n**Run:** ${runUrl}\n\nPlease investigate and fix or mark as flaky.`,
+              labels: ['flaky-extended-e2e'],
+            });

--- a/apps/web/tests/smoke/auth.spec.ts
+++ b/apps/web/tests/smoke/auth.spec.ts
@@ -24,7 +24,9 @@ async function seedLocalStorage(page: Page) {
   }, SEEDED_LS);
 }
 
-test("auth: sign-up leads to authenticated hub surface", async ({ page }) => {
+test("@critical auth: sign-up leads to authenticated hub surface", async ({
+  page,
+}) => {
   await seedLocalStorage(page);
 
   const nonce = `${Date.now()}_${Math.random().toString(16).slice(2)}`;

--- a/apps/web/tests/smoke/dashboard-health.spec.ts
+++ b/apps/web/tests/smoke/dashboard-health.spec.ts
@@ -24,7 +24,9 @@ async function seedLocalStorage(page: Page) {
   }, SEEDED_LS);
 }
 
-test("dashboard: renders without console errors", async ({ page }) => {
+test("@critical dashboard: renders without console errors", async ({
+  page,
+}) => {
   await seedLocalStorage(page);
 
   const errors: string[] = [];
@@ -46,7 +48,9 @@ test("dashboard: renders without console errors", async ({ page }) => {
   expect(fatal, "Unexpected console errors on dashboard").toEqual([]);
 });
 
-test("dashboard: API health endpoint responds", async ({ request }) => {
+test("@critical dashboard: API health endpoint responds", async ({
+  request,
+}) => {
   const res = await request.get(
     (process.env.VITE_API_BASE_URL || "http://127.0.0.1:3000") + "/health",
   );

--- a/apps/web/tests/smoke/navigation-offline-sw.spec.ts
+++ b/apps/web/tests/smoke/navigation-offline-sw.spec.ts
@@ -24,7 +24,7 @@ async function seedLocalStorage(page: Page) {
   }, SEEDED_LS);
 }
 
-test("nav: module routes render (best-effort)", async ({ page }) => {
+test("@extended nav: module routes render (best-effort)", async ({ page }) => {
   await seedLocalStorage(page);
 
   for (const mod of ["finyk", "fizruk", "nutrition", "routine"] as const) {
@@ -33,7 +33,10 @@ test("nav: module routes render (best-effort)", async ({ page }) => {
   }
 });
 
-test("offline: shows OfflineBanner status", async ({ page, context }) => {
+test("@extended offline: shows OfflineBanner status", async ({
+  page,
+  context,
+}) => {
   await seedLocalStorage(page);
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
@@ -46,7 +49,7 @@ test("offline: shows OfflineBanner status", async ({ page, context }) => {
   await context.setOffline(false);
 });
 
-test("sw: debug roundtrip works (best-effort)", async ({ page }) => {
+test("@extended sw: debug roundtrip works (best-effort)", async ({ page }) => {
   await seedLocalStorage(page);
   await page.goto("/?sw=debug", { waitUntil: "domcontentloaded" });
 

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -310,7 +310,7 @@
 **PR-ідеї:**
 
 - `PR-10.A` — `ci: add p95 pipeline-duration metric to CI summary` (script, що читає GitHub Actions API і публікує trend у PR як коментар).
-- `PR-10.B` — `ci: split smoke-e2e into critical-flow (must-pass) + extended-flow (nightly)`.
+- `PR-10.B` — `ci: split smoke-e2e into critical-flow (must-pass) + extended-flow (nightly)`. ✅ closed
 - `PR-10.C` — `ci: nightly job for full audit (critical+high blocking) + dependency-check (snyk або osv-scanner)`. Nightly не блокує PR, але дає трендовий сигнал.
 
 ---
@@ -404,12 +404,12 @@
 
 ### Спринт 3-6 (2-3 місяці) — «масштабування»
 
-| #   | PR                                                       | Effort    | Імпакт               | Status     |
-| --- | -------------------------------------------------------- | --------- | -------------------- | ---------- |
-| 13  | `PR-6.C` — strict: true full + remove allowJs            | 1 тиждень | strict TS done       | ⏳ pending |
+| #   | PR                                                       | Effort    | Імпакт               | Status              |
+| --- | -------------------------------------------------------- | --------- | -------------------- | ------------------- |
+| 13  | `PR-6.C` — strict: true full + remove allowJs            | 1 тиждень | strict TS done       | ⏳ pending          |
 | 14  | `PR-4.D` — zod-to-openapi для api-client                 | 1 тиждень | автоматизує rule #3  |
 | 15  | `PR-8.A` + `PR-8.C` — error-budget policy + tool metrics | 3-5 д     | operational maturity |
-| 16  | `PR-10.B` + `PR-10.C` — split smoke-e2e + nightly audit  | 2-3 д     | CI scaling           |
+| 16  | `PR-10.B` + `PR-10.C` — split smoke-e2e + nightly audit  | 2-3 д     | CI scaling           | `PR-10.B` ✅ closed |
 | 17  | `PR-11.A` + `PR-11.C` — freshness badges + ADR template  | 1 тиждень | doc lifecycle        |
 | 18  | `PR-3.B/C` next 5 — file decomposition next wave         | 1-2 тижні | regression-surface   |
 

--- a/docs/playbooks/ci-e2e-split.md
+++ b/docs/playbooks/ci-e2e-split.md
@@ -1,0 +1,62 @@
+# CI E2E split: critical-flow vs extended-flow
+
+> Added by PR-10.B (audit item #16).
+
+## Two E2E buckets
+
+| Bucket            | Workflow                                 | Trigger                                                              | Timeout | Tests                          |
+| ----------------- | ---------------------------------------- | -------------------------------------------------------------------- | ------- | ------------------------------ |
+| **critical-flow** | `ci.yml` → `critical-flow` job           | every push / PR                                                      | 8 min   | `@critical`-tagged smoke tests |
+| **extended-flow** | `extended-e2e.yml` → `extended-flow` job | nightly 02:00 UTC, `workflow_dispatch`, PR with `extended-e2e` label | 30 min  | `@extended`-tagged smoke tests |
+
+## Test tagging convention
+
+Tests in `apps/web/tests/smoke/` use title-level tags:
+
+```ts
+test("@critical auth: sign-up leads to authenticated hub surface", …);
+test("@extended nav: module routes render (best-effort)", …);
+```
+
+Playwright `--grep @critical` / `--grep @extended` filters by these tags. Both buckets share the same `playwright.smoke.config.ts`.
+
+## Current test assignments
+
+### critical-flow (must-pass, every PR)
+
+| File                       | Test                             | Rationale            |
+| -------------------------- | -------------------------------- | -------------------- |
+| `auth.spec.ts`             | sign-up → authenticated hub      | Core auth journey    |
+| `dashboard-health.spec.ts` | dashboard renders without errors | SPA bootstrap health |
+| `dashboard-health.spec.ts` | API health endpoint responds     | Backend liveness     |
+
+### extended-flow (nightly)
+
+| File                            | Test                 | Rationale                         |
+| ------------------------------- | -------------------- | --------------------------------- |
+| `navigation-offline-sw.spec.ts` | module routes render | Multi-module navigation edge case |
+| `navigation-offline-sw.spec.ts` | OfflineBanner status | Offline mode, not merge-blocking  |
+| `navigation-offline-sw.spec.ts` | SW debug roundtrip   | Service worker internals          |
+
+## Adding new E2E tests
+
+1. Create the test in `apps/web/tests/smoke/`.
+2. Prefix the test title with `@critical` or `@extended`.
+3. **Rule of thumb:** if a failure means users cannot sign in or see the dashboard, it is `@critical`. Everything else starts as `@extended`.
+
+## Running locally
+
+```bash
+# critical only
+pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @critical
+
+# extended only
+pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @extended
+
+# all smoke tests (both buckets)
+pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts
+```
+
+## Nightly failure handling
+
+When the nightly extended-flow fails, a GitHub issue is created automatically with the `flaky-extended-e2e` label. Investigate via the linked Actions run, then either fix or mark the test as flaky (see `docs/playbooks/stabilize-flaky-test.md`).


### PR DESCRIPTION
## What changed

Split the monolithic `smoke-e2e` CI job into two distinct E2E buckets using Playwright `--grep` tag filtering:

| Bucket | Workflow | Trigger | Timeout | Tests |
|---|---|---|---|---|
| **critical-flow** | `ci.yml` → `critical-flow` job | every push / PR | 8 min | `@critical`-tagged tests (3) |
| **extended-flow** | `extended-e2e.yml` → `extended-flow` job | nightly 02:00 UTC, `workflow_dispatch`, PR with `extended-e2e` label | 30 min | `@extended`-tagged tests (3) |

### Approach: Variant A (tag-based, no file moves)

Tests stay in `apps/web/tests/smoke/` — each test title is prefixed with `@critical` or `@extended`. Both buckets use the same `playwright.smoke.config.ts`, filtered via `--grep`.

### Test bucket assignments

**critical-flow** (must-pass, every PR):

| File | Test | Rationale |
|---|---|---|
| `auth.spec.ts` | `@critical auth: sign-up leads to authenticated hub surface` | Core authentication journey |
| `dashboard-health.spec.ts` | `@critical dashboard: renders without console errors` | SPA bootstrap health |
| `dashboard-health.spec.ts` | `@critical dashboard: API health endpoint responds` | Backend liveness check |

**extended-flow** (nightly):

| File | Test | Rationale |
|---|---|---|
| `navigation-offline-sw.spec.ts` | `@extended nav: module routes render (best-effort)` | Multi-module navigation edge case |
| `navigation-offline-sw.spec.ts` | `@extended offline: shows OfflineBanner status` | Offline mode, not merge-blocking |
| `navigation-offline-sw.spec.ts` | `@extended sw: debug roundtrip works (best-effort)` | Service worker internals |

### CI changes

- `ci.yml`: renamed `smoke-e2e` → `critical-flow`, added `--grep @critical`, reduced `timeout-minutes: 20` → `8`
- New `extended-e2e.yml`: nightly schedule (02:00 UTC / ~05:00 Kyiv), `workflow_dispatch`, `pull_request` with `extended-e2e` label
- On nightly failure: auto-creates GitHub issue with `flaky-extended-e2e` label
- All actions remain SHA-pinned; Postgres image SHA-pinned (copied from `ci.yml`)

### Docs

- Added `docs/playbooks/ci-e2e-split.md` — explains both buckets, tagging convention, local run commands, failure handling
- Updated `docs/audits/2026-04-26-sergeant-audit-devin.md` lines 313 + 412 with `✅ closed`

## Why

Audit item PR-10.B (#16 in summary table). `smoke-e2e` had a 20-min timeout and ran all tests on every PR, slowing PR feedback. Splitting into critical (must-pass, ≤8 min) and extended (nightly) reduces the PR feedback loop while keeping full coverage via nightly runs.

## How to test

1. Verify `critical-flow` job runs on this PR and passes (only `@critical` tests execute)
2. After merge: trigger `extended-e2e.yml` via `workflow_dispatch` to verify extended tests run
3. Local verification:
   ```bash
   # critical only
   pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @critical
   # extended only
   pnpm --filter @sergeant/web exec playwright test -c playwright.smoke.config.ts --grep @extended
   ```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): verified Prettier formatting, YAML syntax validation, Husky pre-commit hooks pass
- [x] Vitest passes: not affected (no vitest changes)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules (docs added to `docs/playbooks/ci-e2e-split.md` instead)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
