### PR TITLE
docs(docs): audit — PR-3.A formally subsumed by PR-6.A/6.B/6.C

### DIFF
--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial)**
+> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial, +PR-3.A subsumed)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -34,6 +34,7 @@
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
 | PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#963](https://github.com/Skords-01/Sergeant/pull/963)                                                                 |
 | PR-11.C  | ADR template + README index                                            | 🟡 partial | template+README зроблено, retroactive ADRs ⏳                                                                          |
+| PR-3.A   | strict + noImplicitAny на apps/web (phase 1: shared/+core/)            | 🔄 subsumed | by PR-6.A/6.B/6.C — окремого PR не буде                                                                                |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -131,7 +132,7 @@
 
 **PR-ідеї:**
 
-- `PR-3.A` — `feat(web,tsconfig): enable strict + noImplicitAny on apps/web (phase 1: shared/+ core/)` із expected baseline error-count і `// @ts-expect-error` baseline-файлом. Конкретно: спершу strict тільки в `apps/web/src/shared/**` і `apps/web/src/core/lib/**` через project references.
+- `PR-3.A` 🔄 subsumed — closed without separate PR. Phase-by-phase strict rollout було перенесено у §6 і виконується через PR-6.A ([#870](https://github.com/Skords-01/Sergeant/pull/870), strictNullChecks на shared/), PR-6.B ([#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934), noImplicitAny на shared/routine/nutrition; залишилось core/finyk/fizruk), PR-6.C (фінал: `strict: true` + remove `allowJs`). Окремого PR-3.A не буде.
 - `PR-3.B` ✅ closed — [#887](https://github.com/Skords-01/Sergeant/pull/887) `refactor(web,finyk): decompose Assets.tsx (1147 LOC) into smaller modules` — пілот для top-10 list.
 - `PR-3.C` ✅ closed — [#898](https://github.com/Skords-01/Sergeant/pull/898) `refactor(web,nutrition): split seedFoodsUk.ts (1614 LOC) by category (meat/fish/dairy/grains/...)` — чисто data-split, 19 per-category файлів, всі 390 елементів структурно ідентичні.
 - `PR-3.D` ✅ closed — [#865](https://github.com/Skords-01/Sergeant/pull/865) `chore(web,storage): migrate top-3 high-call-site localStorage files to safe wrappers` (`core/settings/FinykSection.tsx` -20, `core/lib/chatActions/fizrukActions.ts` -7, `core/hub/HubDashboard.tsx` -5) — burn-down list.


### PR DESCRIPTION
## What changed

Marked audit item `PR-3.A` (`feat(web,tsconfig): enable strict + noImplicitAny on apps/web (phase 1: shared/+core/)`) as 🔄 **subsumed** in `docs/audits/2026-04-26-sergeant-audit-devin.md`.

Three edits:

1. **§3 PR-ideas list** (line 130) — replaced the original `PR-3.A` bullet with a subsumed note referencing PR-6.A ([#870](https://github.com/Skords-01/Sergeant/pull/870)), PR-6.B ([#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)), and upcoming PR-6.C.
2. **TL;DR status table** — added a `| PR-3.A | … | 🔄 subsumed | by PR-6.A/6.B/6.C |` row after PR-7.B.
3. **Revision header** — bumped to `шоста ревізія: +PR-3.A subsumed`.

## Why

PR-3.A scope (strict + noImplicitAny on `apps/web`, phase 1: `shared/` + `core/`) is fully covered by the phase-by-phase rollout in §6:
- PR-6.A ([#870](https://github.com/Skords-01/Sergeant/pull/870)) — `strictNullChecks` on `shared/`
- PR-6.B ([#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)) — `noImplicitAny` on `shared/routine/nutrition`; remaining: `core/finyk/fizruk`
- PR-6.C (upcoming) — final `strict: true` + remove `allowJs`

A separate PR-3.A would only duplicate work already tracked in §6.

## How to test

1. `grep -n PR-3.A docs/audits/2026-04-26-sergeant-audit-devin.md` — should show 3 hits (header, table, §3 bullet), all with 🔄 subsumed.
2. `pnpm lint:tech-debt-freshness` — should pass.
3. `git diff main..HEAD --stat` — only `docs/audits/2026-04-26-sergeant-audit-devin.md` changed.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): verified `grep PR-3.A` shows 3 correct hits, `pnpm lint:tech-debt-freshness` passes, `git diff --stat` confirms single-file change.
- [x] Vitest passes: N/A — docs-only change.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal audit documentation to reflect progress tracking changes and consolidation of TypeScript configuration initiatives into existing development series.

---

**Note:** This release contains no user-facing changes or code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->