### PR TITLE
docs(docs): add frontend (web+mobile) observability guide

### DIFF
--- a/docs/observability/frontend.md
+++ b/docs/observability/frontend.md
@@ -1,0 +1,316 @@
+# Frontend Observability — Web & Mobile
+
+> Last reviewed: 2026-04-27.
+
+Observability-стек для web- і mobile-клієнтів Sergeant: error tracking,
+session replay, Core Web Vitals, product analytics, ErrorBoundary-конвенції.
+Серверний observability — [`SLO.md`](./SLO.md), [`runbook.md`](./runbook.md),
+[`dashboards.md`](./dashboards.md); тут лише точки з'єднання (§7).
+
+---
+
+## 1. Огляд стеку
+
+| Шар                             | Інструмент                                                 | Env-flag                                      | Статус                                                    |
+| ------------------------------- | ---------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| Web — Sentry (errors + tracing) | `@sentry/react` (lazy `import()`)                          | `VITE_SENTRY_DSN`                             | **Prod-ready**                                            |
+| Web — Replay                    | `@sentry/react` `replayIntegration`                        | `VITE_SENTRY_REPLAY_SAMPLE_RATE`              | **Prod-ready** (default session=0, error=1.0)             |
+| Web — Core Web Vitals           | `web-vitals` → `POST /api/metrics/web-vitals` → Prometheus | `VITE_WEB_VITALS_ENDPOINT` (`=0` kill-switch) | **Prod-ready** (baseline, SLO не зафіксовано — SLO.md §8) |
+| Mobile — Sentry                 | `@sentry/react-native` (planned)                           | `EXPO_PUBLIC_SENTRY_DSN` (зарезервовано)      | **TODO (Phase 10)**                                       |
+| Capacitor shell                 | Web Sentry з tag `is_capacitor=true`                       | `VITE_SENTRY_*`                               | **Prod-ready**                                            |
+| Server — Sentry                 | `@sentry/node`                                             | `SENTRY_DSN`                                  | **Prod-ready** (детально — інші docs)                     |
+
+---
+
+## 2. Web — Sentry
+
+**Файл:** `apps/web/src/core/observability/sentry.ts`
+
+### Lazy dynamic-import
+
+`initSentry()` завантажує `@sentry/react` через `await import("@sentry/react")`.
+~30–40 KB gzip не потрапляє у головний бандл — error tracking не блокує
+hydration (правило 2.3 — «Defer Non-Critical Third-Party Libraries»).
+
+### DSN gating
+
+Без `VITE_SENTRY_DSN` — early return, жодного чанку не підтягується. Локальна
+розробка і staging без DSN працюють із zero overhead.
+
+### Env-flags
+
+| Змінна                           | Опис                       | Дефолт                  |
+| -------------------------------- | -------------------------- | ----------------------- |
+| `VITE_SENTRY_DSN`                | DSN. Без неї — no-op       | —                       |
+| `VITE_SENTRY_ENVIRONMENT`        | `environment` tag          | `MODE` / `"production"` |
+| `VITE_SENTRY_RELEASE`            | Release tag (source maps)  | —                       |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | `tracesSampleRate`         | `0.1`                   |
+| `VITE_SENTRY_REPLAY_SAMPLE_RATE` | `replaysSessionSampleRate` | `0`                     |
+
+### `beforeSend` — стрип cookies
+
+Видаляє `event.request.cookies` перед відправкою — session-токени не
+потрапляють у Sentry (`sentry.ts:53–55`).
+
+### Tags: `platform` і `is_capacitor`
+
+- **`platform`** — `getPlatform()` з `@sergeant/shared` (`"web"` / `"ios"` / `"android"`).
+- **`is_capacitor`** — `"true"` / `"false"`.
+
+Тріаж: native-specific баги (safe-area, keyboard resize, cookie/storage)
+фільтруються через `is_capacitor:true` (`sentry.ts:61–62`).
+
+### Replay
+
+```
+maskAllText: false    — текст видно (для дебагу UX)
+blockAllMedia: true   — медіа заблоковані (PII/розмір)
+```
+
+- `replaysSessionSampleRate = 0` — повноцінний запис вимкнений.
+- `replaysOnErrorSampleRate = 1.0` — **кожна** помилка з replay.
+- Prod-дебаг: тимчасово підняти `VITE_SENTRY_REPLAY_SAMPLE_RATE` (наприклад, `0.1`).
+
+---
+
+## 3. Web — Core Web Vitals
+
+**Файл:** `apps/web/src/core/observability/webVitals.ts`
+
+### Метрики
+
+П'ять CWV через `web-vitals` npm (~1 KB gzip):
+
+| Метрика | Тип         | Prometheus histogram                           |
+| ------- | ----------- | ---------------------------------------------- |
+| LCP     | timing (ms) | `web_vitals_duration_ms{metric="LCP",rating}`  |
+| INP     | timing (ms) | `web_vitals_duration_ms{metric="INP",rating}`  |
+| FCP     | timing (ms) | `web_vitals_duration_ms{metric="FCP",rating}`  |
+| TTFB    | timing (ms) | `web_vitals_duration_ms{metric="TTFB",rating}` |
+| CLS     | unitless    | `web_vitals_cls{rating}`                       |
+
+`rating`: `"good"` / `"needs-improvement"` / `"poor"` (пороги Google CWV).
+
+### Батч + `navigator.sendBeacon`
+
+Метрики буферизуються (до `MAX_BATCH = 10`) і відправляються:
+
+1. `navigator.sendBeacon` на `visibilitychange=hidden` та `pagehide` —
+   єдиний надійний спосіб на unload (`fetch keepalive` ненадійний на mobile
+   Safari; синхронний XHR блокує закриття).
+2. **Fallback**: `fetch(..., { keepalive: true })`.
+3. Мікро-дебаунс: `Promise.resolve().then(flush)`.
+
+### Endpoint
+
+`POST /api/metrics/web-vitals` (`apps/server/src/routes/web-vitals.ts`):
+
+- **Rate limit**: 60 req/min/IP.
+- **Відповідь**: завжди `204 No Content` (sendBeacon ігнорує body).
+- **Валідація**: Zod (`apps/server/src/modules/web-vitals.ts:36–49`):
+  timing — `0..120_000 ms`, CLS — `0..10`.
+- **Payload**: `{ metrics: [{ name, value, rating }] }` (1..10 items).
+- Невалідні записи логуються з `sample=1%`.
+
+### Kill-switch
+
+`VITE_WEB_VITALS_ENDPOINT=0` — no-op: `web-vitals` chunk не підтягується.
+
+### Серверні метрики
+
+- `web_vitals_duration_ms{metric, rating}` — бакети
+  `[50, 100, 250, 500, 800, 1200, 1800, 2500, 4000, 6000, 10000]`
+  (`apps/server/src/obs/metrics.ts:286–291`).
+- `web_vitals_cls{rating}` — бакети `[0.01, 0.05, 0.1, 0.15, 0.25, 0.5, 1]`
+  (`apps/server/src/obs/metrics.ts:296–301`).
+
+PromQL: `sum by (rating) (rate(web_vitals_duration_ms_count{metric="LCP"}[5m]))`
+→ readout good / needs-improvement / poor. Детальніше — [SLO.md §8](./SLO.md).
+
+### Capacitor exclusion
+
+`initWebVitals()` робить ранній return для `isCapacitor()` — CWV у Capacitor
+WebView є шумом (інший cold-start, JS engine), що отруює RUM-дашборди
+(`webVitals.ts:136–138`).
+
+### Бот-spam
+
+Endpoint анонімний. Rate-limiter мітігує масовий spam, але не розподілений
+трафік. Якщо стане проблемою — [SLO.md §8](./SLO.md).
+
+---
+
+## 4. Web — analytics.ts
+
+**Файл:** `apps/web/src/core/observability/analytics.ts`
+
+Lightweight product analytics sink: **console logger + localStorage ring-buffer**
+(`hub_analytics_log_v1`, max 200 подій). `trackEvent(name, payload?)` —
+fire-and-forget, ніколи не кидає.
+
+**Event names** визначені в `@sergeant/shared` →
+`packages/shared/src/lib/analyticsEvents.ts` → `ANALYTICS_EVENTS` (~40 подій:
+onboarding, finyk, FTUX, auth, nudges, hints). Typo не компілюється.
+
+**Sentry зв'язок**: analytics не емітить breadcrumbs напряму, але
+`console.log("[analytics]", event)` потрапляє у Sentry console-breadcrumbs
+автоматично.
+
+**Додавання events**:
+
+1. Ключ у `ANALYTICS_EVENTS` (`packages/shared/src/lib/analyticsEvents.ts`).
+2. `trackEvent(ANALYTICS_EVENTS.MY_EVENT, { ...payload })`.
+3. Payload — plain object **без PII**.
+
+**Майбутнє**: PostHog / Amplitude / proxy — зміниться тільки цей файл.
+
+---
+
+## 5. Mobile — Sentry status
+
+### Поточний стан
+
+- **DSN accessor** є: `apps/mobile/src/lib/observability/env.ts` →
+  `getSentryDsn()` читає `process.env.EXPO_PUBLIC_SENTRY_DSN`.
+- **`@sentry/react-native` не встановлений.** ErrorBoundary і
+  ModuleErrorBoundary використовують `console.error`.
+- `TODO(phase-10)` в `ModuleErrorBoundary.tsx:74`.
+
+### Plan (Phase 10+)
+
+1. Встановити `@sentry/react-native`.
+2. `EXPO_PUBLIC_SENTRY_DSN` зарезервовано. Expo babel-preset інлайнить
+   `process.env.EXPO_PUBLIC_*` у runtime bundle at build time.
+3. Замінити `console.error` → `Sentry.captureException` в ErrorBoundary /
+   ModuleErrorBoundary.
+4. `Sentry.init()` з DSN gating (аналогічно web).
+
+### Чому `env.ts` окремий модуль
+
+Для `jest.mock("@/lib/observability/env")` — тестування обох гілок (DSN-set /
+DSN-absent) в одному файлі (`env.ts:1–6`).
+
+---
+
+## 6. Capacitor shell
+
+**Директорія:** `apps/mobile-shell/`
+
+Web Sentry працює з тегом `is_capacitor=true` (`sentry.ts:62`) — всі
+browser-errors з Capacitor WebView маркуються.
+
+**Native-specific класи багів** (фільтр `is_capacitor:true`):
+
+- **Safe-area insets** — notch / Dynamic Island.
+- **Keyboard resize** — різна поведінка `resize` залежно від
+  `android:windowSoftInputMode`.
+- **Cookie / third-party storage** — обмежений доступ; `SameSite=None` може
+  не працювати.
+- **Deep-link cold-start buffer** — URL доступний після ініціалізації
+  Capacitor bridge.
+
+Фільтрація в Sentry:
+
+```
+is_capacitor:true     — Capacitor-специфічні помилки
+platform:ios          — iOS WebView
+platform:android      — Android WebView
+```
+
+---
+
+## 7. Server-side coupling
+
+### Cross-reference: web error → server log
+
+Web-клієнт включає `requestId` у API-помилках
+(`apps/web/src/shared/lib/apiErrorFormat.ts`). Якщо `requestId` присутній —
+шукайте у серверних логах (Pino) для кореляції.
+
+> **TODO**: додати `x-request-id` header у fetch-клієнт — наразі `requestId`
+> є тільки у відповідях сервера, не як outgoing header.
+
+### Sentry events не з'єднані
+
+Web і server Sentry events **не зв'язані** через distributed tracing (різні
+DSN/проєкти). Дебаг-flow:
+
+1. Web Sentry event → `requestId` з breadcrumbs / error message.
+2. Шукати `requestId` у серверних логах або server Sentry.
+
+---
+
+## 8. Env-flags reference
+
+### Web (`apps/web`)
+
+| Змінна                           | Призначення                 | Дефолт                  |
+| -------------------------------- | --------------------------- | ----------------------- |
+| `VITE_SENTRY_DSN`                | Sentry DSN; без неї — no-op | —                       |
+| `VITE_SENTRY_ENVIRONMENT`        | environment tag             | `MODE` / `"production"` |
+| `VITE_SENTRY_RELEASE`            | release (source maps)       | —                       |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | tracing sample rate         | `0.1`                   |
+| `VITE_SENTRY_REPLAY_SAMPLE_RATE` | session replay sample rate  | `0`                     |
+| `VITE_WEB_VITALS_ENDPOINT`       | kill-switch: `"0"` = no-op  | увімкнено               |
+
+### Mobile (`apps/mobile`) — planned
+
+| Змінна                   | Призначення                  | Дефолт |
+| ------------------------ | ---------------------------- | ------ |
+| `EXPO_PUBLIC_SENTRY_DSN` | Mobile Sentry DSN (Phase 10) | —      |
+
+### Server (для повноти; детально в інших docs)
+
+| Змінна                      | Призначення                 |
+| --------------------------- | --------------------------- |
+| `SENTRY_DSN`                | Server Sentry DSN           |
+| `SENTRY_ENVIRONMENT`        | environment tag             |
+| `SENTRY_RELEASE`            | release                     |
+| `SENTRY_TRACES_SAMPLE_RATE` | tracing sample rate         |
+| `METRICS_TOKEN`             | Bearer token для `/metrics` |
+| `LOG_LEVEL`                 | Pino log level              |
+| `LOG_PRETTY`                | Pino pretty-print (dev)     |
+
+---
+
+## 9. ErrorBoundary conventions
+
+### Web — `ErrorBoundary`
+
+**Файл:** `apps/web/src/core/ErrorBoundary.tsx`
+
+Кореневий boundary. **Lazy bridge** до `captureException` з
+`./observability/sentry.ts` — no-op поки SDK не завантажений, тому
+ErrorBoundary в критичному шляху без витягування Sentry у головний бандл.
+
+- `componentDidCatch` → `captureException(error, { contexts: { react: { componentStack } } })`.
+- `fallback`: `ReactNode` або render-prop `({error, resetError}) => ReactNode`.
+  Без prop — `null`.
+
+### Web — `ModuleErrorBoundary`
+
+**Файл:** `apps/web/src/core/ModuleErrorBoundary.tsx`
+
+Ізолює падіння lazy-модуля від решти хабу:
+
+- **"Спробувати ще"** — `retryRev++` як React `key` → force remount піддерева.
+- **"До вибору модуля"** — `onBackToHub` callback.
+
+Обгортайте кожен lazy-loaded модуль (Фінік, Фізрук, Рутина, Нутриція), щоб
+краш одного не зносив навігацію.
+
+### Mobile — `ErrorBoundary`
+
+**Файл:** `apps/mobile/src/core/ErrorBoundary.tsx`
+
+Порт web boundary. `console.error` + `captureError` (fallback на `console.error`
+до Phase 10). Default fallback: `Card` + `Button` (`"Щось пішло не так"` /
+`"Перезавантажити"`), reset + `router.replace("/")`. NativeWind semantic tokens.
+
+### Mobile — `ModuleErrorBoundary`
+
+**Файл:** `apps/mobile/src/core/ModuleErrorBoundary.tsx`
+
+Порт web `ModuleErrorBoundary`. Додатковий prop `moduleName?: string` —
+контекстуалізує заголовок (`"Модуль {moduleName} не вдалося завантажити"`).
+Телеметрія: `console.error` (TODO Phase 10). `retryRev` key — ідентично web.


### PR DESCRIPTION
## What changed

New file `docs/observability/frontend.md` — comprehensive guide for the frontend (web + mobile) observability stack in Sergeant.

Covers all 9 sections requested:
1. Stack overview table (layer → tool → env-flag → status)
2. Web Sentry (lazy import, DSN gating, env-flags, beforeSend, tags, Replay)
3. Web Core Web Vitals (metrics, sendBeacon batching, endpoint, kill-switch, server metrics)
4. Web analytics.ts (lightweight sink, event names, Sentry breadcrumb link)
5. Mobile Sentry status (DSN accessor exists, SDK not installed, Phase 10 plan)
6. Capacitor shell (is_capacitor tag, native-specific bug classes, filtering)
7. Server-side coupling (requestId cross-reference, no automatic distributed tracing)
8. Env-flags reference table (web, mobile planned, server for completeness)
9. ErrorBoundary conventions (web + mobile, root + module boundaries)

## Why

Frontend observability was only mentioned in one paragraph in SLO.md §8 (Frontend CWV). This standalone doc provides a full reference for the stack.

## How to test

- Verify markdown renders correctly on GitHub.
- Cross-check code references against source files mentioned in each section.

## TODO / planned gaps (docs ↔ code)

The following items are documented as **planned / TODO** — they reflect real gaps between the docs and the current codebase:

- **Mobile Sentry (Phase 10)**: `@sentry/react-native` is **not installed**. DSN accessor (`env.ts`) and env-flag (`EXPO_PUBLIC_SENTRY_DSN`) are reserved but unused. `ErrorBoundary.tsx` and `ModuleErrorBoundary.tsx` use `console.error` only — `TODO(phase-10)` markers in code.
- **`x-request-id` outgoing header**: `requestId` appears in server responses and error formatting, but the web fetch client does not yet send an `x-request-id` header for full end-to-end tracing.
- **Distributed tracing**: Web and server Sentry events are in separate projects and not linked automatically.

---

## How AI-tested this PR

- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.
- [x] All code file paths and line references verified against current source.
- [x] No code changes — docs only.
- [x] Husky pre-commit (lint-staged) passed.

## AGENTS.md updated?

- [ ] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/b28a210e12ba424aac7ae8a177e324dc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
