### PR TITLE
docs(docs): mark superpowers specs with status + move vercel hotfix

### DIFF
--- a/docs/superpowers/hotfixes/2026-04-26-vercel-root-directory-hotfix.md
+++ b/docs/superpowers/hotfixes/2026-04-26-vercel-root-directory-hotfix.md
@@ -1,5 +1,13 @@
 # Hotfix Vercel Root Directory
 
+> **Status:** shipped (PR [#803](https://github.com/Skords-01/Sergeant/pull/803)).
+> `apps/web/vercel.json` додано з тими ж production settings (pnpm 9.15.1, build
+> `@sergeant/web`, `outputDirectory: ../server/dist`, headers, SPA rewrites,
+> `.well-known` exclusions).
+>
+> Раніше лежало у `docs/superpowers/specs/`; перенесено сюди як incident-runbook,
+> бо це не дизайн модуля, а one-off operations fix.
+
 ## Проблема
 
 Production `sergeant.vercel.app` повертає Vercel `404: NOT_FOUND`. Vercel project має Root Directory `apps/web`, а поточний Vercel config лежить у корені репозиторію. Project config читається з project root directory, тому root-level `vercel.json` може не застосовуватись до `apps/web` project.

--- a/docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md
+++ b/docs/superpowers/specs/2026-04-24-assistant-quick-actions-v1-design.md
@@ -1,5 +1,12 @@
 # Assistant Quick Actions v1 — дизайн-спек
 
+> **Status:** shipped (PR [#743](https://github.com/Skords-01/Sergeant/pull/743)) — **superseded by**
+> [`2026-04-25-assistant-capability-catalogue-design.md`](./2026-04-25-assistant-capability-catalogue-design.md).
+> Quick action chips, `RISKY_TOOLS` і action cards живі (`apps/web/src/core/components/ChatQuickActions.tsx`,
+> `apps/web/src/core/lib/hubChatActionCards.ts`), але `hubChatQuickActions.ts` тепер тонкий
+> back-compat shim над `ASSISTANT_CAPABILITIES`. Документ лишається як історичний
+> контекст; усі майбутні зміни surface-ів — у capability-catalogue spec-у.
+
 ## Контекст
 
 HubChat уже має сильну технічну основу: Anthropic tool-use, SSE-стрімінг, голосовий ввід/озвучення, локальну історію, контекст усіх 4 модулів і 60 синхронізованих tool definitions між сервером та клієнтським `executeAction`.

--- a/docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md
+++ b/docs/superpowers/specs/2026-04-25-assistant-capability-catalogue-design.md
@@ -1,5 +1,20 @@
 # Assistant Capability Catalogue — дизайн-спек
 
+> **Status:** shipped (PR [#795](https://github.com/Skords-01/Sergeant/pull/795) +
+> follow-ups [#798](https://github.com/Skords-01/Sergeant/pull/798),
+> [#799](https://github.com/Skords-01/Sergeant/pull/799),
+> [#800](https://github.com/Skords-01/Sergeant/pull/800),
+> [#805](https://github.com/Skords-01/Sergeant/pull/805),
+> [#812](https://github.com/Skords-01/Sergeant/pull/812),
+> [#839](https://github.com/Skords-01/Sergeant/pull/839)).
+> Реджистр живе у `packages/shared/src/lib/assistantCatalogue.ts`; UI — у
+> `apps/web/src/core/AssistantCataloguePage.tsx` + `CapabilityDetailModal.tsx`;
+> server system prompt будується з реджистру через `buildModuleToolList()` у
+> `apps/server/src/modules/chat/toolDefs/systemPrompt.ts` (`SYSTEM_PROMPT_VERSION = "v6"`);
+> `/help` редіректить на каталог через `onOpenCatalogue` у `HubChat.tsx`.
+> Залишковий борг: видалити back-compat shim `apps/web/src/core/lib/hubChatQuickActions.ts`
+> після міграції `ChatQuickActions.tsx` на пряме читання `getQuickActionCapabilities()`.
+
 ## Контекст
 
 HubChat має 60 серверних tool definitions, ~50-рядковий `HELP_TEXT` і 10 quick action chips — три **повністю незалежних** списки можливостей, кожен підтримується вручну. Конкретний стан до цього спека:

--- a/docs/superpowers/specs/2026-04-26-finyk-chat-tools-design.md
+++ b/docs/superpowers/specs/2026-04-26-finyk-chat-tools-design.md
@@ -1,5 +1,10 @@
 # Finyk HubChat Tools — `find_transaction` + `batch_categorize`
 
+> **Status:** shipped (PR [#794](https://github.com/Skords-01/Sergeant/pull/794)).
+> Серверні tool defs — `apps/server/src/modules/chat/toolDefs/finyk.ts`; client
+> handlers — `apps/web/src/core/lib/chatActions/finykActions.ts`; обидва tools є у
+> `KNOWN_TOOLS` і `RISKY_TOOLS` (`hubChatActionCards.ts`).
+
 ## Контекст
 
 PR 5 додає два Фінік tools у HubChat. Сервер лише описує tools для Anthropic, а side effects виконуються на клієнті через `executeAction`, тому перша версія працює з локальними Finyk даними (`finyk_manual_expenses_v1`, `finyk_tx_cache`, `finyk_tx_cats`, hidden ids і transaction context, який уже є у клієнта).

--- a/docs/superpowers/specs/2026-04-26-routine-chat-schedule-pause-design.md
+++ b/docs/superpowers/specs/2026-04-26-routine-chat-schedule-pause-design.md
@@ -1,6 +1,13 @@
 # Routine chat tools: `set_habit_schedule` + `pause_habit`
 
-> Status: design
+> **Status:** shipped (PR [#797](https://github.com/Skords-01/Sergeant/pull/797),
+> catalogue rows у [#798](https://github.com/Skords-01/Sergeant/pull/798),
+> dedup у [#800](https://github.com/Skords-01/Sergeant/pull/800)).
+> `paused` доданий у `packages/routine-domain` (`types.ts`, `schedule.ts`,
+> `domain/reminders/weekday.ts`); серверні tool defs — `apps/server/src/modules/chat/toolDefs/routine.ts`;
+> client handlers — `apps/web/src/core/lib/chatActions/routineActions.ts`;
+> `SYSTEM_PROMPT_VERSION = "v6"`; cards мають `set_habit_schedule` / `pause_habit`.
+>
 > Authors: Devin (session: dbc81f8c) for @Skords-01
 > Created: 2026-04-26
 


### PR DESCRIPTION
## What changed

Гігієна `docs/superpowers/`:

- **Spec 1** (`assistant-quick-actions-v1`) — додано шапку `> Status: shipped (PR #743) — superseded by …capability-catalogue…`. Документ лишається як історичний контекст.
- **Spec 2** (`assistant-capability-catalogue`) — додано шапку `> Status: shipped` зі списком follow-up PR-ів (#795, #798, #799, #800, #805, #812, #839) і коротким резюме, що реалізовано і де живе. Зафіксовано залишковий борг: видалити back-compat shim `hubChatQuickActions.ts` після міграції `ChatQuickActions.tsx`.
- **Spec 3** (`finyk-chat-tools`) — додано `> Status: shipped (PR #794)` з посиланням на серверні tool defs і клієнтські handlers.
- **Spec 4** (`routine-chat-schedule-pause`) — попередній маркер `> Status: design` замінено на `> Status: shipped (PR #797 + #798 + #800)` з посиланням на domain/server/client/cards.
- **Vercel hotfix** — перенесено з `docs/superpowers/specs/` у новий `docs/superpowers/hotfixes/2026-04-26-vercel-root-directory-hotfix.md` (drop `-design` суфікс), додано `> Status: shipped (PR #803)`. Це operations runbook на ~30 рядків, а не дизайн-док модуля, тому розділив його зі specs/.

## Why

Усі 5 файлів описують вже виконану роботу, але без жодного маркера статусу читач (агент чи людина) не може швидко зрозуміти, чи це активний дизайн чи реалізована фіча. Spec 1 і Spec 2 описують один surface; без позначки superseded виглядають як два паралельних плани.

Коротко — папка тепер самодокументована: design-specs у `specs/`, incident-runbooks у `hotfixes/`, кожен файл починається з `> Status: …`.

## How to test

Ці зміни тільки markdown. Перевірка:

- візуально подивитися 5 файлів — кожен починається з `> **Status:** …` блоку;
- перевірити, що `docs/superpowers/hotfixes/2026-04-26-vercel-root-directory-hotfix.md` існує, а файл із суфіксом `-design.md` зник зі specs/;
- `grep -r vercel-root-directory-hotfix` — інших посилань на старий шлях у репо нема (перевірив локально).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прочитав усі 5 файлів через `git diff`, перевірив, що жоден інший файл у репо не посилається на стару назву `vercel-root-directory-hotfix-design.md`.
- [ ] Vitest passes: n/a — markdown-only.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
