### PR TITLE
docs(obs): fix dashboard JSON imports — __inputs, timezone, datasource refs

### DIFF
--- a/docs/observability/dashboards/ai-cost.json
+++ b/docs/observability/dashboards/ai-cost.json
@@ -1,9 +1,22 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for Sergeant server metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -45,15 +58,25 @@
     {
       "title": "Token rate by model (prompt + completion)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
-            "stacking": { "mode": "normal" },
+            "stacking": {
+              "mode": "normal"
+            },
             "lineWidth": 1
           },
           "unit": "ops"
@@ -66,7 +89,9 @@
           "placement": "bottom",
           "calcs": ["mean", "max"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -80,25 +105,44 @@
       "title": "Estimated daily spend (USD)",
       "description": "Estimated daily cost. Adjust $usd_per_1m_tokens variable to match your Anthropic pricing tier.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 5 },
-              { "color": "red", "value": 20 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "textMode": "value_and_name",
         "colorMode": "background"
       },
@@ -114,9 +158,17 @@
       "title": "Cache-hit ratio (1h window)",
       "description": "Anthropic prompt cache hit ratio. Target line at 0.5 per PR-12.A.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -130,24 +182,41 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "target (0.5)" },
+            "matcher": {
+              "id": "byName",
+              "options": "target (0.5)"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               },
               {
                 "id": "custom.lineStyle",
-                "value": { "fill": "dash", "dash": [10, 10] }
+                "value": {
+                  "fill": "dash",
+                  "dash": [10, 10]
+                }
               },
-              { "id": "custom.fillOpacity", "value": 0 }
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -166,24 +235,40 @@
       "title": "AI quota blocks",
       "description": "Requests refused by AI quota. Any value > 0 means users are being rate-limited.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "textMode": "value_and_name",
         "colorMode": "background",
         "graphMode": "area"
@@ -200,24 +285,40 @@
       "title": "AI quota fail-open (CRITICAL)",
       "description": "Quota store unavailable, requests passing through without limit check. Any value > 0 is a billing risk.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
       "id": 5,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "textMode": "value_and_name",
         "colorMode": "background",
         "graphMode": "area"
@@ -233,15 +334,25 @@
     {
       "title": "AI request outcomes",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 6,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
-            "stacking": { "mode": "normal" },
+            "stacking": {
+              "mode": "normal"
+            },
             "lineWidth": 1
           },
           "unit": "ops"
@@ -254,7 +365,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -267,9 +380,17 @@
     {
       "title": "AI p95 latency by endpoint",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 7,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -281,9 +402,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 10000 },
-              { "color": "red", "value": 30000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "red",
+                "value": 30000
+              }
             ]
           }
         },
@@ -295,7 +425,9 @@
           "placement": "bottom",
           "calcs": ["mean", "max"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -323,19 +455,32 @@
         "type": "datasource"
       },
       {
-        "current": { "selected": false, "text": "3.00", "value": "3.00" },
+        "current": {
+          "selected": false,
+          "text": "3.00",
+          "value": "3.00"
+        },
         "hide": 0,
         "name": "usd_per_1m_tokens",
-        "options": [{ "selected": true, "text": "3.00", "value": "3.00" }],
+        "options": [
+          {
+            "selected": true,
+            "text": "3.00",
+            "value": "3.00"
+          }
+        ],
         "query": "3.00",
         "type": "textbox",
         "label": "USD per 1M tokens"
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "Europe/Kyiv",
   "title": "Sergeant — AI Cost",
   "uid": "sergeant-ai-cost",
   "version": 1

--- a/docs/observability/dashboards/auth.json
+++ b/docs/observability/dashboards/auth.json
@@ -1,9 +1,22 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for Sergeant server metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -45,15 +58,25 @@
     {
       "title": "Auth outcomes",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
-            "stacking": { "mode": "normal" },
+            "stacking": {
+              "mode": "normal"
+            },
             "lineWidth": 1
           },
           "unit": "ops"
@@ -66,7 +89,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -79,9 +104,17 @@
     {
       "title": "Session lookup p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -93,17 +126,31 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 50 },
-              { "color": "red", "value": 100 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -116,9 +163,17 @@
     {
       "title": "Rate-limit hits on api:auth:sensitive",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -136,7 +191,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -149,25 +206,44 @@
     {
       "title": "Sign-in success rate",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.9 },
-              { "color": "green", "value": 0.95 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "textMode": "value_and_name",
         "colorMode": "background"
       },
@@ -198,9 +274,12 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "Europe/Kyiv",
   "title": "Sergeant — Auth",
   "uid": "sergeant-auth",
   "version": 1

--- a/docs/observability/dashboards/frontend-cwv.json
+++ b/docs/observability/dashboards/frontend-cwv.json
@@ -1,9 +1,22 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for Sergeant server metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -46,52 +59,85 @@
       "title": "LCP — rating distribution",
       "description": "Largest Contentful Paint. Thresholds: good ≤2500ms, needs-improvement ≤4000ms, poor >4000ms. Baseline mode — no SLO threshold lines.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "percent" },
+            "stacking": {
+              "mode": "percent"
+            },
             "lineWidth": 1
           },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "good" },
+            "matcher": {
+              "id": "byName",
+              "options": "good"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "needs-improvement" },
+            "matcher": {
+              "id": "byName",
+              "options": "needs-improvement"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "yellow", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "poor" },
+            "matcher": {
+              "id": "byName",
+              "options": "poor"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -104,9 +150,17 @@
     {
       "title": "LCP p75",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -119,8 +173,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -134,52 +193,85 @@
       "title": "INP — rating distribution",
       "description": "Interaction to Next Paint. Thresholds: good ≤200ms, needs-improvement ≤500ms, poor >500ms.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "percent" },
+            "stacking": {
+              "mode": "percent"
+            },
             "lineWidth": 1
           },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "good" },
+            "matcher": {
+              "id": "byName",
+              "options": "good"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "needs-improvement" },
+            "matcher": {
+              "id": "byName",
+              "options": "needs-improvement"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "yellow", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "poor" },
+            "matcher": {
+              "id": "byName",
+              "options": "poor"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -192,9 +284,17 @@
     {
       "title": "INP p75",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -207,8 +307,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -222,52 +327,85 @@
       "title": "FCP — rating distribution",
       "description": "First Contentful Paint. Thresholds: good ≤1800ms, needs-improvement ≤3000ms, poor >3000ms.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 5,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "percent" },
+            "stacking": {
+              "mode": "percent"
+            },
             "lineWidth": 1
           },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "good" },
+            "matcher": {
+              "id": "byName",
+              "options": "good"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "needs-improvement" },
+            "matcher": {
+              "id": "byName",
+              "options": "needs-improvement"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "yellow", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "poor" },
+            "matcher": {
+              "id": "byName",
+              "options": "poor"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -280,9 +418,17 @@
     {
       "title": "FCP p75",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 6,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -295,8 +441,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -310,52 +461,85 @@
       "title": "TTFB — rating distribution",
       "description": "Time to First Byte. Thresholds: good ≤800ms, needs-improvement ≤1800ms, poor >1800ms.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
       "id": 7,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "percent" },
+            "stacking": {
+              "mode": "percent"
+            },
             "lineWidth": 1
           },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "good" },
+            "matcher": {
+              "id": "byName",
+              "options": "good"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "needs-improvement" },
+            "matcher": {
+              "id": "byName",
+              "options": "needs-improvement"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "yellow", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "poor" },
+            "matcher": {
+              "id": "byName",
+              "options": "poor"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -368,9 +552,17 @@
     {
       "title": "TTFB p75",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
       "id": 8,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -383,8 +575,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -398,52 +595,85 @@
       "title": "CLS — rating distribution",
       "description": "Cumulative Layout Shift (unitless). Thresholds: good ≤0.1, needs-improvement ≤0.25, poor >0.25. Separate histogram (web_vitals_cls).",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
       "id": 9,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "percent" },
+            "stacking": {
+              "mode": "percent"
+            },
             "lineWidth": 1
           },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "good" },
+            "matcher": {
+              "id": "byName",
+              "options": "good"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "needs-improvement" },
+            "matcher": {
+              "id": "byName",
+              "options": "needs-improvement"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "yellow", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "poor" },
+            "matcher": {
+              "id": "byName",
+              "options": "poor"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -456,9 +686,17 @@
     {
       "title": "CLS p75",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
       "id": 10,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -472,8 +710,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
@@ -502,9 +745,12 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "Europe/Kyiv",
   "title": "Sergeant — Frontend CWV",
   "uid": "sergeant-frontend-cwv",
   "version": 1

--- a/docs/observability/dashboards/hubchat.json
+++ b/docs/observability/dashboards/hubchat.json
@@ -1,9 +1,22 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for Sergeant server metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -45,24 +58,40 @@
     {
       "title": "Tool invocation leaderboard (proposed, top-N, 1h)",
       "type": "bargauge",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "blue", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "displayMode": "gradient",
         "orientation": "horizontal"
       },
@@ -71,12 +100,19 @@
           "id": "sortBy",
           "options": {
             "fields": {},
-            "sort": [{ "field": "Value", "desc": true }]
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
           }
         },
         {
           "id": "limit",
-          "options": { "limitField": 15 }
+          "options": {
+            "limitField": 15
+          }
         }
       ],
       "targets": [
@@ -92,9 +128,17 @@
       "title": "Executed / proposed ratio by tool",
       "description": "Ratio of executed to proposed tool invocations. Dead tools (proposed=0) and flaky tools (executed << proposed) stand out.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -114,7 +158,9 @@
           "placement": "bottom",
           "calcs": ["mean"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -128,24 +174,40 @@
       "title": "unknown_tool invocations",
       "description": "Must be 0 everywhere. Any non-zero value indicates a client↔server contract violation. Alert threshold: > 0.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
         "textMode": "value_and_name",
         "colorMode": "background",
         "graphMode": "area"
@@ -161,15 +223,25 @@
     {
       "title": "Tool result truncations by reason",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
-            "stacking": { "mode": "normal" },
+            "stacking": {
+              "mode": "normal"
+            },
             "lineWidth": 1
           },
           "unit": "ops"
@@ -182,7 +254,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -211,7 +285,10 @@
       },
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(chat_tool_invocations_total, tool)",
         "hide": 0,
         "includeAll": true,
@@ -227,9 +304,12 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "Europe/Kyiv",
   "title": "Sergeant — HubChat Tools",
   "uid": "sergeant-hubchat",
   "version": 1

--- a/docs/observability/dashboards/sync.json
+++ b/docs/observability/dashboards/sync.json
@@ -1,9 +1,22 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource for Sergeant server metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -45,15 +58,25 @@
     {
       "title": "Sync outcomes (stacked)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
-            "stacking": { "mode": "normal" },
+            "stacking": {
+              "mode": "normal"
+            },
             "lineWidth": 1
           },
           "unit": "ops"
@@ -66,7 +89,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -79,9 +104,17 @@
     {
       "title": "p95 sync duration",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -93,9 +126,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1500 },
-              { "color": "red", "value": 2500 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1500
+              },
+              {
+                "color": "red",
+                "value": 2500
+              }
             ]
           }
         },
@@ -107,7 +149,9 @@
           "placement": "bottom",
           "calcs": ["mean", "max"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -120,9 +164,17 @@
     {
       "title": "Payload bytes p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -140,7 +192,9 @@
           "placement": "bottom",
           "calcs": ["mean", "max"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -153,9 +207,17 @@
     {
       "title": "Conflict ratio (push/push_all)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -168,8 +230,13 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -183,9 +250,17 @@
       "title": "SLO burn-rate — Sync error ratio",
       "description": "Multi-window burn-rate for Sync SLO (99.5%). Budget = 0.005. Page threshold: 14.4×0.005 = 0.072. Ticket threshold: 6×0.005 = 0.03.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
       "id": 5,
-      "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -198,38 +273,67 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "page threshold (0.072)" },
+            "matcher": {
+              "id": "byName",
+              "options": "page threshold (0.072)"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               },
               {
                 "id": "custom.lineStyle",
-                "value": { "fill": "dash", "dash": [10, 10] }
+                "value": {
+                  "fill": "dash",
+                  "dash": [10, 10]
+                }
               },
-              { "id": "custom.fillOpacity", "value": 0 }
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "ticket threshold (0.03)" },
+            "matcher": {
+              "id": "byName",
+              "options": "ticket threshold (0.03)"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "orange", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               },
               {
                 "id": "custom.lineStyle",
-                "value": { "fill": "dash", "dash": [10, 10] }
+                "value": {
+                  "fill": "dash",
+                  "dash": [10, 10]
+                }
               },
-              { "id": "custom.fillOpacity", "value": 0 }
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -278,7 +382,10 @@
       },
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "$DS_PROMETHEUS" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(sync_operations_total, module)",
         "hide": 0,
         "includeAll": true,
@@ -294,9 +401,12 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "Europe/Kyiv",
   "title": "Sergeant — Sync",
   "uid": "sergeant-sync",
   "version": 1


### PR DESCRIPTION
## What changed

Follow-up to #948. Fixes three issues found by Devin Review in the 5 new dashboard JSONs (`ai-cost.json`, `auth.json`, `frontend-cwv.json`, `hubchat.json`, `sync.json`):

1. **Added `__inputs` section** — required for Grafana's import dialog to prompt for the Prometheus datasource. Matches the convention in `http-red.json`, `db-use.json`, `slo-burn-rate.json`.
2. **Set `timezone` to `Europe/Kyiv`** — was `""` (browser default). Now matches existing dashboards and the `AGENTS.md` domain invariant ("Single source of truth: Europe/Kyiv").
3. **Changed `$DS_PROMETHEUS` → `${DS_PROMETHEUS}`** — curly-brace syntax matches existing dashboards and is the standard Grafana convention for datasource variable references.

## Why

Devin Review on #948 flagged these as functional issues:
- Missing `__inputs` breaks the one-click import workflow documented in `dashboards/README.md`
- Inconsistent timezone causes day-boundary drift across team members
- Bare `$` vs `${}` datasource refs may cause issues in some Grafana versions

## How to test

```bash
jq empty docs/observability/dashboards/*.json          # syntax valid
jq '.__inputs[0].name' docs/observability/dashboards/{ai-cost,auth,frontend-cwv,hubchat,sync}.json  # "DS_PROMETHEUS"
jq '.timezone' docs/observability/dashboards/{ai-cost,auth,frontend-cwv,hubchat,sync}.json          # "Europe/Kyiv"
grep -c '\\${DS_PROMETHEUS}' docs/observability/dashboards/{ai-cost,auth,frontend-cwv,hubchat,sync}.json  # all > 0
```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `jq empty` on all JSON files, verified `__inputs`, `timezone`, and `${DS_PROMETHEUS}` refs
- [ ] Vitest passes: N/A (docs-only change)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/b6a5008100574297b1c3d2f01fa02ee4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
