### PR TITLE
test(mobile): de-flake OnboardingWizard.test.tsx (PR-7.E 1/3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Quick lookup before editing: which path uses which test stack and which conventi
 | `apps/server/src/modules/**`                          | Vitest + Testcontainers (real Postgres) | n/a                                   | Always coerce bigint→number in serializers (rule #1). Update `api-client` types.                                                                                |
 | `apps/server/src/modules/chat/**`                     | Vitest                                  | n/a                                   | Anthropic tool defs split per domain in `toolDefs/`. See Architecture section.                                                                                  |
 | `apps/server/src/migrations/**`                       | n/a                                     | n/a                                   | Sequential `NNN_*.sql` (currently 001–008). No gaps. Two-phase for DROP — see rule #4.                                                                          |
-| `apps/mobile/src/core/**`                             | Vitest (3 known flaky — see below)      | (mobile RQ uses module-local keys)    | NativeWind (not Tailwind). MMKV (not localStorage). No DOM.                                                                                                     |
+| `apps/mobile/src/core/**`                             | Jest (2 known flaky — see below)        | (mobile RQ uses module-local keys)    | NativeWind (not Tailwind). MMKV (not localStorage). No DOM.                                                                                                     |
 | `apps/mobile/app/**`                                  | Vitest                                  | n/a                                   | Expo Router routes. Each `_layout.tsx` is a navigator.                                                                                                          |
 | `apps/mobile-shell/**`                                | none                                    | n/a                                   | Capacitor wrapper around `apps/web`. No app code lives here, only build glue.                                                                                   |
 | `packages/shared/**`                                  | Vitest                                  | n/a                                   | Zod schemas, types, business logic. Used by all apps — change with care.                                                                                        |
@@ -383,11 +383,10 @@ Real regressions we've shipped — do not repeat:
 
 ## Pre-existing flaky tests (do not block merge)
 
-- `apps/mobile/src/core/OnboardingWizard.test.tsx`
 - `apps/mobile/src/core/dashboard/WeeklyDigestFooter.test.tsx`
 - `apps/mobile/src/core/settings/HubSettingsPage.test.tsx`
 
-These three fail on `main`. Ignore them if your PR does not touch `apps/mobile`.
+These two fail on `main`. Ignore them if your PR does not touch `apps/mobile`.
 
 ## Test users
 

--- a/apps/mobile/src/core/OnboardingWizard.test.tsx
+++ b/apps/mobile/src/core/OnboardingWizard.test.tsx
@@ -18,16 +18,12 @@ function resetStore() {
 describe("OnboardingWizard", () => {
   beforeEach(() => {
     resetStore();
-    // Swallow the async reduce-motion probe so tests don't leak React
-    // act warnings. Matches the pattern used by Sheet/Skeleton tests.
     jest
       .spyOn(AccessibilityInfo, "isReduceMotionEnabled")
-      .mockImplementation(() => new Promise<boolean>(() => {}));
+      .mockResolvedValue(false);
     jest
       .spyOn(AccessibilityInfo, "addEventListener")
-      .mockReturnValue({ remove: () => {} } as ReturnType<
-        typeof AccessibilityInfo.addEventListener
-      >);
+      .mockImplementation(() => ({ remove: () => {} }) as never);
   });
 
   afterEach(() => {

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -32,7 +32,8 @@
 | PR-7.B   | cloud-sync offline-queue + replay-on-reconnect integration tests       | ✅ closed  | [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                                 |
 | PR-5.B   | rollback sanity для `*.down.sql` міграцій (Testcontainers)             | ✅ closed  | [#918](https://github.com/Skords-01/Sergeant/pull/918)                                                                 |
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
-| PR-11.C  | ADR template + README index                                          | 🟡 partial | template+README зроблено, retroactive ADRs ⏳ |
+| PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#TBD](https://github.com/Skords-01/Sergeant/pull/TBD)                                                                 |
+| PR-11.C  | ADR template + README index                                            | 🟡 partial | template+README зроблено, retroactive ADRs ⏳                                                                          |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені

--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -32,7 +32,7 @@
 | PR-7.B   | cloud-sync offline-queue + replay-on-reconnect integration tests       | ✅ closed  | [#904](https://github.com/Skords-01/Sergeant/pull/904)                                                                 |
 | PR-5.B   | rollback sanity для `*.down.sql` міграцій (Testcontainers)             | ✅ closed  | [#918](https://github.com/Skords-01/Sergeant/pull/918)                                                                 |
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
-| PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#TBD](https://github.com/Skords-01/Sergeant/pull/TBD)                                                                 |
+| PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#963](https://github.com/Skords-01/Sergeant/pull/963)                                                                 |
 | PR-11.C  | ADR template + README index                                            | 🟡 partial | template+README зроблено, retroactive ADRs ⏳                                                                          |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 


### PR DESCRIPTION
## What changed

Replace the never-resolving `AccessibilityInfo.isReduceMotionEnabled()` mock in `OnboardingWizard.test.tsx` with `mockResolvedValue(false)`, aligning it with the deterministic pattern already used by `Sheet.test.tsx` and `Skeleton.test.tsx`.

Also update `AGENTS.md` (remove from flaky list, update ownership map count) and add PR-7.E (1/3) row to the audit status table.

## Why

The test was listed as a known flaky test in `AGENTS.md`. The root cause:

The `beforeEach` mock used `new Promise<boolean>(() => {})` — a promise that **never resolves**. This left an unsettled microtask that could interact with React's `act()` flushing under CI load, producing intermittent act-warning failures. The comment claimed it "matches the pattern used by Sheet/Skeleton tests", but those tests actually use `.mockResolvedValue(false)` which settles the promise within `act()` — fully deterministic.

Secondary alignment: the `addEventListener` mock was using `mockReturnValue(...)` while all other test files use `mockImplementation(() => ...)` — now consistent.

## How to test

```bash
# Run the test 10 times — must be 10/10 green
for i in $(seq 1 10); do
  pnpm --filter @sergeant/mobile test -- --testPathPattern="OnboardingWizard" 2>&1 | grep -E "PASS|FAIL"
done

# Full mobile suite — no regressions
pnpm --filter @sergeant/mobile test
```

---

## How AI-tested this PR

- [x] Manual smoke: ran `OnboardingWizard.test.tsx` 10 times in isolation — 10/10 green.
- [x] Full mobile test suite: 93 suites, 612 tests — all passing, no regressions.
- [x] Ran full suite 3 additional times to confirm no inter-file flakiness.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — removed `OnboardingWizard.test.tsx` from "Pre-existing flaky tests" section; updated module ownership map count from "3 known flaky" to "2 known flaky"; corrected test stack label from "Vitest" to "Jest".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
