### PR TITLE
docs(docs): expand postmortem template with metadata, detection, root-cause split

### DIFF
--- a/docs/postmortems/TEMPLATE.md
+++ b/docs/postmortems/TEMPLATE.md
@@ -1,53 +1,97 @@
 # Postmortem: [INCIDENT TITLE]
 
-> Date: YYYY-MM-DD · Severity: page/ticket · Duration: Xh Ym
+> **This is a blameless postmortem.** Focus on systems and processes, not on individuals. The goal is to learn and prevent recurrence, not to assign blame.
+
+|                        |                             |
+| ---------------------- | --------------------------- |
+| **Incident ID**        | INC-YYYY-NNN                |
+| **Date**               | YYYY-MM-DD                  |
+| **Severity**           | SEV1 / SEV2 / SEV3 / SEV4   |
+| **Status**             | Draft / In review / Final   |
+| **Duration**           | Xh Ym (detected → resolved) |
+| **Authors**            | @handle                     |
+| **Incident commander** | @handle                     |
+| **On-call**            | @handle                     |
+| **Reviewers**          | @handle, @handle            |
+
+> **Severity guide:** SEV1 — full outage / data loss · SEV2 — major degradation, many users affected · SEV3 — partial degradation, workaround exists · SEV4 — minor, internal-only.
 
 ## Summary
 
-<!-- 1-2 sentences: what happened and user impact -->
-
-## Timeline (UTC)
-
-| Time  | Event                    |
-| ----- | ------------------------ |
-| HH:MM | Alert fired: `AlertName` |
-| HH:MM | On-call acknowledged     |
-| HH:MM | Root cause identified    |
-| HH:MM | Mitigation applied       |
-| HH:MM | Resolved                 |
-
-## Root cause
-
-<!-- What broke and why -->
+_2–4 sentences a stakeholder can read in 30 seconds. What happened, who was affected, how it ended._
 
 ## Impact
 
-- **Users affected:** ~N
-- **Duration:** Xh Ym
+- **Users affected:** ~N (% of active users)
+- **Customer-facing duration:** Xh Ym
+- **Requests failed / data lost:** N requests · N records
 - **SLO budget consumed:** X %
+- **Revenue / contractual impact:** $ / none
+- **Public communication:** status page · email · none
 
-## Mitigation
+## Detection
 
-<!-- What was done to stop the bleeding -->
+- **Detected at:** HH:MM UTC
+- **Time to detect (TTD):** Xm (incident start → first signal)
+- **How:** alert `AlertName` · customer report · internal report · dashboard
+- **Was the alert appropriate?** yes / no — _why_
+
+## Timeline (UTC)
+
+| Time  | Event                                |
+| ----- | ------------------------------------ |
+| HH:MM | Change deployed / inciting event     |
+| HH:MM | Alert fired: `AlertName`             |
+| HH:MM | On-call acknowledged                 |
+| HH:MM | Incident channel opened (`#inc-...`) |
+| HH:MM | Hypothesis: ...                      |
+| HH:MM | Mitigation applied: ...              |
+| HH:MM | User-facing impact ended             |
+| HH:MM | Resolved · all-clear                 |
+
+## Trigger
+
+_The specific event that started the incident (deploy, config change, traffic spike, dependency failure)._
+
+## Root cause
+
+_The underlying reason the trigger caused an incident. Use 5 whys if helpful — go past the symptom to the system property that allowed this._
+
+## Contributing factors
+
+_Things that didn't cause the incident on their own but made it worse, longer, or harder to detect (missing alert, stale runbook, single point of failure, recent process change)._
+
+## Mitigation & resolution
+
+- **Mitigation steps:** _what stopped the bleeding (rollback, feature flag off, scale up, restart, ...)._
+- **Resolution steps:** _what made the system fully healthy again._
+- **Time to mitigate (TTM):** Xm · **Time to resolve (TTR):** Xm
+
+## What went well
+
+-
+
+## What went wrong / where we got lucky
+
+-
 
 ## Action items
 
-| #   | Action | Owner | Deadline |
-| --- | ------ | ----- | -------- |
-| 1   |        |       |          |
+> Each item must have an owner, a deadline, and a tracking issue. `Type` = `prevent` (stops recurrence) · `detect` (finds it faster) · `mitigate` (reduces impact) · `process` (people / docs).
+
+| #   | Action | Type    | Priority | Owner   | Deadline   | Issue |
+| --- | ------ | ------- | -------- | ------- | ---------- | ----- |
+| 1   |        | prevent | P1       | @handle | YYYY-MM-DD | #123  |
 
 ## Lessons learned
 
-### What went well
-
--
-
-### What went wrong
-
--
+_1–3 paragraphs of generalizable takeaways — patterns that apply beyond this specific incident._
 
 ## References
 
+- Incident channel: `#inc-...`
 - Sentry issue: [link]
 - GitHub issue: [link]
 - Related PR: [link]
+- Dashboards / logs: [link]
+- Runbook used: [link]


### PR DESCRIPTION
## What changed

Розширено `docs/postmortems/TEMPLATE.md`, щоб шаблон форсував якісний розбір інцидентів, а не формальне заповнення:

- **Header metadata** — Incident ID, Severity, Status (Draft/In review/Final), Incident commander, On-call, Reviewers.
- **Severity scale** — стандартні `SEV1–SEV4` замість невиразного `page/ticket`.
- **Detection** — окрема секція з `Time to detect (TTD)` і питанням, чи спрацював правильний алерт (часта прогалина).
- **Trigger vs Root cause** — розділено: тригер (подія, що запустила) vs root cause (системна властивість, що дозволила це). Підказка про `5 whys`.
- **Contributing factors** — окрема секція для факторів, що погіршили інцидент (стейл runbook, відсутність алерту, SPOF тощо).
- **Impact** — додано Customer-facing duration, Requests failed / data lost, Revenue impact, Public communication.
- **Mitigation & resolution** — об'єднано з `TTM` / `TTR`.
- **Action items** — розширена таблиця: `Type` (prevent/detect/mitigate/process), `Priority`, `Issue` link. Без них список швидко стає мертвим.
- **Blameless reminder** — явне нагадування на самому початку.
- **References** — додано Incident channel, Dashboards/logs, Runbook used.

## Why

Користувач запитав, для чого існує цей файл і чи треба його покращувати. Поточний шаблон функціональний, але має кілька прогалин відносно сучасних практик (Google SRE, PagerDuty, Atlassian):

- немає метрик `TTD/TTM/TTR`, які є основою вимірювання якості реакції;
- `page/ticket` — нестандартна шкала severity;
- Trigger і Root cause злиті в одне поле, що схиляє автора зупинитись на симптомі;
- Action items без Type/Priority/Issue зазвичай не доводяться до завершення;
- немає явного blameless-нагадування — культурний сигнал, який легко втратити.

Це чисто docs-зміна, без впливу на код чи API.

## How to test

```bash
pnpm exec prettier --check docs/postmortems/TEMPLATE.md
```

Візуально відкрити файл у GitHub preview — переконатись, що таблиці рендеряться, severity guide читається, а заготовка готова до копіювання у `YYYY-MM-DD-<incident>.md`.

---

## How AI-tested this PR

- [x] `pnpm exec prettier --check docs/postmortems/TEMPLATE.md` passes.
- [x] No code changes — server/web/mobile/tests not affected.
- [x] No new `AI-DANGER` markers added.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md` — **навмисно англійською**: шаблон постмортему англомовний за конвенцією галузі (узгоджується з тоном існуючих секцій типу "Sentry issue", "SLO budget consumed"); готовий локалізувати, якщо хочете.

## AGENTS.md updated?

- [x] No — no new permanent rules. Це уточнення існуючого шаблону, а не нова конвенція для всього репо.


Link to Devin session: https://app.devin.ai/sessions/27fded7fc1ca46ec9ec467b841f9dcbc
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
