### PR TITLE
ci(ci): fix pipeline-duration-summary needs (smoke-e2e -> critical-flow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
     name: Pipeline duration (p95 trend)
     runs-on: ubuntu-latest
     # Run after all main jobs; report even when some fail.
-    needs: [check, coverage, a11y, smoke-e2e]
+    needs: [check, coverage, a11y, critical-flow]
     if: always()
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fix the pre-existing `Invalid workflow file` error that's blocking **every** push and PR on `main` since 2026-04-27 12:39 UTC.

### Root cause

PR #951 made two changes ~11 minutes apart that didn't synchronise:

| Commit | What |
|--------|------|
| [`813cf326`](https://github.com/Skords-01/Sergeant/commit/813cf326) (12:28 UTC) — `ci(ci): split smoke-e2e into critical-flow + nightly extended-flow` | Removed the `smoke-e2e` job from `ci.yml`; renamed it to `critical-flow`. |
| [`d25b950a`](https://github.com/Skords-01/Sergeant/commit/d25b950a) (12:39 UTC) — `ci(ci): add p95 pipeline-duration metric to CI summary` | Added `pipeline-duration-summary` with `needs: [check, coverage, a11y, smoke-e2e]` — referencing the job that had just been removed. |

GitHub Actions validates `needs:` dependencies before scheduling any job, so the workflow file is rejected as invalid:

```
Invalid workflow file: .github/workflows/ci.yml#L345
(Line: 345, Col: 36): Job 'pipeline-duration-summary' depends on unknown job 'smoke-e2e'.
```

The result: every workflow run since 12:39 UTC completes in ~0s with `conclusion: failure` and **zero** jobs executed. Visible on:
- `main` itself (merge commit `2c0c8653`, run `25002...`)
- PR #968 (`devin/1777301489-docs-align-agents-contributing`)
- The other open PR `devin/1777301475-hosting-evolution-doc`

### Fix

One-line: rename `smoke-e2e` → `critical-flow` in `pipeline-duration-summary.needs`.

```diff
-    needs: [check, coverage, a11y, smoke-e2e]
+    needs: [check, coverage, a11y, critical-flow]
```

This preserves the original intent (`pipeline-duration-summary` runs only after the heavy E2E job finishes) without introducing any other change.

## Review & Testing Checklist for Human

Risk: **yellow** — surgical CI fix, but it unblocks the entire CI pipeline so worth a careful eyeball.

- [ ] Confirm `critical-flow` is the correct successor — i.e. the job that should gate `pipeline-duration-summary` (it has no `needs:` of its own and runs Playwright critical-flow E2E in 8 min).
- [ ] After merge, watch a fresh CI run (any push or PR) and verify all 8 jobs execute and `pipeline-duration-summary` reports the p95 metric. The first successful run after merge should be observable on the merge commit itself.
- [ ] Confirm `nightly-audit.yml` is unrelated to this failure (it has its own jobs and was failing for a different reason — track separately if needed).

Test plan: GitHub Actions will validate the workflow on push/PR; if the YAML parses and jobs schedule, we're green.

### Notes

- Discovered while validating PR #968 — both PRs are blocked on this fix landing first.
- Conventional Commits scope `ci(ci)` per `AGENTS.md` hard rule #5 / `commitlint.config.js`.
- Commit was authored via the GitHub Git Database REST API (git CLI auth through the Devin proxy is currently broken for this repo).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to optimize workflow sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->