### PR TITLE
fix(web): show negative networth in danger color on Finyk Overview

### DIFF
--- a/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
+++ b/apps/web/src/modules/finyk/pages/overview/HeroCard.tsx
@@ -29,14 +29,24 @@ const HeroCardImpl = function HeroCard({
       </div>
       <div
         className={cn(
-          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums text-finyk-strong dark:text-finyk",
+          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums",
+          networth < 0
+            ? "text-danger-strong dark:text-danger"
+            : "text-finyk-strong dark:text-finyk",
           !showBalance && "tracking-widest",
         )}
       >
         {showBalance ? (
           <>
             {networth.toLocaleString("uk-UA", { maximumFractionDigits: 0 })}
-            <span className="text-2xl font-semibold text-finyk/60 ml-1">₴</span>
+            <span
+              className={cn(
+                "text-2xl font-semibold ml-1",
+                networth < 0 ? "text-danger/60" : "text-finyk/60",
+              )}
+            >
+              ₴
+            </span>
           </>
         ) : (
           "••••••"


### PR DESCRIPTION
## What changed

`apps/web/src/modules/finyk/pages/overview/HeroCard.tsx` — when `networth < 0`, the big amount + the trailing ₴ glyph now render in `text-danger-strong dark:text-danger` instead of the always-emerald `text-finyk-strong`. Positive/zero networth is unchanged.

## Why

Андрій помітив, що "Загальний нетворс −68 278 ₴" малюється зеленим — візуально читається як "все добре", хоча насправді людина в мінусі. Червоний на відʼємному значенні відповідає семантиці danger/негативного балансу, узгоджується з тим, як `monthBalance < 0` вже малюється в інших місцях (`text-danger`, `text-rose-300`), і не зачіпає happy-path.

Скрін, з якого виник репорт:

![current behaviour: -68 278 ₴ rendered in emerald](https://app.devin.ai/attachments/3bcbb8f1-e955-4adc-b1ab-c3e73efc9c0f/IMG_2134.png)

## How to test

1. `pnpm --filter @sergeant/web dev`, відкрити Finyk → Огляд.
2. Зробити total networth відʼємним (наприклад додати борг більший за активи). Велика сума + ₴ повинні бути червоними (`text-danger-strong`, в dark — `text-danger`).
3. Повернути networth в плюс — повертається до зеленого `text-finyk-strong`.
4. Toggle "приховати баланс" (`showBalance=false`) → бульки рендеряться без зміни кольору, що очікувано.

---

## How AI-tested this PR

- [x] Vitest passes: `npx vitest run src/modules/finyk/pages` — 25/25 pass (no HeroCard test exists; знакові тести в Overview не торкаються кольору).
- [x] Typecheck: `npx tsc --noEmit` clean.
- [x] Lint: `npx eslint src/modules/finyk/pages/overview/HeroCard.tsx` clean (зокрема `sergeant-design/valid-tailwind-opacity` — `/60` на дозволеній шкалі).
- [ ] Manual smoke: not run — суто візуальна зміна, прев'ю Vercel в PR-checks дасть фактичний рендер.
- [x] No new `AI-DANGER` markers added.
- [x] Ukrainian prose in PR body.

## AGENTS.md updated?

- [x] No — no new permanent rules. `text-danger-strong dark:text-danger` дзеркалить існуючий патерн `text-finyk-strong dark:text-finyk` і вже використовується в інших finyk-екранах (Analytics, AssetsTxPickerView).

## Notes / out of scope

- Mobile (`apps/mobile/src/modules/finyk/pages/Overview/HeroCard.tsx`) — RN-варіант рендериться поверх `bg-emerald-700` solid surface, тож просто перекрасити цифру в червоний поверх зеленого фону виглядатиме гірше, ніж зараз. Якщо хочеш — окремим PR можу або (а) фліпнути всю картку на rose-700 при відʼємному, або (б) портнути web-стиль soft-background → tinted text. Скажи, який варіант тобі ближче.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
