### PR TITLE
feat(web): posthog $pageview tracking with sensitive-query sanitizer

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -39,6 +39,7 @@ import { useHubNavigation } from "./hooks/useHubNavigation";
 import { useHubUIState } from "./hooks/useHubUIState";
 import { usePwaActions, type PwaAction } from "./hooks/usePwaActions";
 import { ShellDeepLinkBridge } from "./app/ShellDeepLinkBridge";
+import { PageviewTracker } from "./observability/PageviewTracker";
 import { HintsOrchestrator } from "./hints/HintsOrchestrator";
 
 const AuthPage = lazy(() =>
@@ -92,6 +93,12 @@ export default function App() {
           /reset-password, /design тощо) — deep link може прилетіти у
           будь-який із цих станів. */}
       <ShellDeepLinkBridge />
+      {/* PostHog `$pageview` tracker: монтуємо тут (всередині
+          BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
+          в unauthenticated-шляхах (`/sign-in`, `/welcome`,
+          `/reset-password`) — без цього onboarding / auth funnels
+          у PostHog були б сліпими перед login-ом. */}
+      <PageviewTracker />
       <ApiClientProvider client={apiClient}>
         <AuthProvider>
           <AppInner />

--- a/apps/web/src/core/observability/PageviewTracker.test.tsx
+++ b/apps/web/src/core/observability/PageviewTracker.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+
+const captureMock = vi.fn<(name: string, payload?: object) => void>();
+
+vi.mock("./posthog", () => ({
+  capturePostHogEvent: (name: string, payload?: object) =>
+    captureMock(name, payload),
+}));
+
+import { PageviewTracker } from "./PageviewTracker";
+
+beforeEach(() => {
+  captureMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PageviewTracker", () => {
+  it("шле $pageview при першому маунті", () => {
+    render(
+      <MemoryRouter initialEntries={["/welcome"]}>
+        <PageviewTracker />
+      </MemoryRouter>,
+    );
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = captureMock.mock.calls[0];
+    expect(eventName).toBe("$pageview");
+    expect((payload as { $pathname: string }).$pathname).toBe("/welcome");
+    expect(typeof (payload as { $current_url: string }).$current_url).toBe(
+      "string",
+    );
+  });
+
+  it("шле новий $pageview на зміну pathname", () => {
+    function Nav() {
+      const navigate = useNavigate();
+      useEffect(() => {
+        navigate("/hub");
+      }, [navigate]);
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/welcome"]}>
+        <PageviewTracker />
+        <Routes>
+          <Route path="/welcome" element={<Nav />} />
+          <Route path="/hub" element={<div>hub</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const paths = captureMock.mock.calls.map(
+      ([, payload]) => (payload as { $pathname: string }).$pathname,
+    );
+    expect(paths).toEqual(["/welcome", "/hub"]);
+  });
+
+  it("НЕ шле pageview на зміну тільки query-string", () => {
+    function Nav() {
+      const navigate = useNavigate();
+      useEffect(() => {
+        navigate("/hub?filter=week");
+      }, [navigate]);
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/hub"]}>
+        <PageviewTracker />
+        <Routes>
+          <Route path="/hub" element={<Nav />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("стрипає чутливий token у $current_url", () => {
+    // jsdom — `window.location.href` читаємо з JSDOM URL; встановлюємо
+    // через history API (MemoryRouter не чіпає window.location).
+    window.history.replaceState(
+      {},
+      "",
+      "/auth/callback?token=SECRET123&email=u%40x",
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth/callback"]}>
+        <PageviewTracker />
+      </MemoryRouter>,
+    );
+
+    const [, payload] = captureMock.mock.calls[0];
+    const url = (payload as { $current_url: string }).$current_url;
+    expect(url).not.toContain("SECRET123");
+    expect(url).toContain("token=%5Bredacted%5D");
+  });
+});

--- a/apps/web/src/core/observability/PageviewTracker.tsx
+++ b/apps/web/src/core/observability/PageviewTracker.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { capturePostHogEvent } from "./posthog";
+import { sanitizeUrl } from "./sanitizeUrl";
+
+/**
+ * Side-effect-only компонент, який шле `$pageview` у PostHog на кожну
+ * зміну `pathname`. Монтується всередині `<BrowserRouter>` один раз
+ * (`apps/web/src/core/App.tsx`), повертає `null`.
+ *
+ * Чому власний тречер замість `capture_pageview: true` у `posthog.init`:
+ *
+ *   1. `$current_url` прокидаємо через `sanitizeUrl()` — magic-link
+ *      токени / OAuth-коди не попадають у event-props (той самий патерн,
+ *      що й `beforeSend` для cookies у `sentry.ts`).
+ *   2. Тригеримо тільки на зміну `pathname` — не на кожну мутацію
+ *      query-рядка (фільтри, модалки), щоб не роздувати funnel drop-offs
+ *      шумом.
+ *   3. Залишаємо `capture_pageleave: false`: Sergeant живе як SPA з
+ *      довгими сесіями на одній сторінці (onboarding wizard, Hub dash),
+ *      `$pageleave` дав би гіршу апроксимацію engagement, ніж явний
+ *      `first_real_entry` + retention-events.
+ *
+ * Без `VITE_POSTHOG_KEY` — повний no-op (див. `capturePostHogEvent`):
+ * ефект викликається, але SDK не підтягується, queue не росте.
+ */
+export function PageviewTracker(): null {
+  const location = useLocation();
+  // Guard від подвійного fire при React 18 StrictMode-mount-у: ефект
+  // виконується двічі з тим самим `pathname`, SDK сприйняв би це як
+  // два окремі pageview-и однієї сторінки.
+  const lastPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const path = location.pathname;
+    if (lastPathRef.current === path) return;
+    lastPathRef.current = path;
+
+    const $current_url = sanitizeUrl(window.location.href);
+    capturePostHogEvent("$pageview", {
+      $current_url,
+      $pathname: path,
+    });
+  }, [location.pathname]);
+
+  return null;
+}

--- a/apps/web/src/core/observability/sanitizeUrl.test.ts
+++ b/apps/web/src/core/observability/sanitizeUrl.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUrl } from "./sanitizeUrl";
+
+describe("sanitizeUrl", () => {
+  it("повертає URL без змін, коли немає чутливих query-params", () => {
+    expect(sanitizeUrl("https://sergeant.vercel.app/welcome")).toBe(
+      "https://sergeant.vercel.app/welcome",
+    );
+    expect(
+      sanitizeUrl("https://sergeant.vercel.app/hub?vibe=finyk&step=2"),
+    ).toBe("https://sergeant.vercel.app/hub?vibe=finyk&step=2");
+  });
+
+  it("стрипає magic-link токен", () => {
+    const out = sanitizeUrl(
+      "https://sergeant.vercel.app/auth/callback?token=abc123def&email=u%40x",
+    );
+    expect(out).toContain("token=%5Bredacted%5D");
+    expect(out).not.toContain("abc123def");
+    // Інші парами зберігаються.
+    expect(out).toContain("email=u%40x");
+  });
+
+  it("стрипає OAuth `code` і `state`", () => {
+    const out = sanitizeUrl(
+      "https://sergeant.vercel.app/oauth/callback?code=SECRET&state=STATEVAL&scope=read",
+    );
+    expect(out).toContain("code=%5Bredacted%5D");
+    expect(out).toContain("state=%5Bredacted%5D");
+    expect(out).not.toContain("SECRET");
+    expect(out).not.toContain("STATEVAL");
+    expect(out).toContain("scope=read");
+  });
+
+  it("стрипає access_token / refresh_token в різних регістрах", () => {
+    const out = sanitizeUrl(
+      "https://sergeant.vercel.app/cb?ACCESS_TOKEN=aaa&Refresh_Token=bbb",
+    );
+    expect(out).not.toContain("aaa");
+    expect(out).not.toContain("bbb");
+  });
+
+  it("редактує всі дублікати ключа", () => {
+    const out = sanitizeUrl(
+      "https://sergeant.vercel.app/x?token=a&token=b&token=c",
+    );
+    expect(out).not.toContain("=a");
+    expect(out).not.toContain("=b");
+    expect(out).not.toContain("=c");
+    // URLSearchParams.set зливає дублікати в один запис.
+    expect(out.match(/token=/g)?.length).toBe(1);
+  });
+
+  it("зберігає hash", () => {
+    const out = sanitizeUrl(
+      "https://sergeant.vercel.app/hub?token=abc#section",
+    );
+    expect(out.endsWith("#section")).toBe(true);
+  });
+
+  it("повертає входовий рядок, якщо URL невалідний", () => {
+    expect(sanitizeUrl("not a url")).toBe("not a url");
+    expect(sanitizeUrl("")).toBe("");
+  });
+});

--- a/apps/web/src/core/observability/sanitizeUrl.ts
+++ b/apps/web/src/core/observability/sanitizeUrl.ts
@@ -1,0 +1,66 @@
+/**
+ * Стрипає чутливі query-params з URL перед відправкою у PostHog як
+ * `$current_url`. Без цього magic-link токени (`?token=…`), OAuth-коди
+ * (`?code=…`, `?state=…`), refresh-токени і т.п. осідали б у event-props
+ * і в дашбордах PostHog — це technically PII / auth material, доступний
+ * будь-кому з read-правами на project.
+ *
+ * Ключі матчаться case-insensitive і з підтримкою звичайних варіантів
+ * (`access_token`, `accessToken`, `apikey`, `api_key` — усі стрипаються
+ * однаково).
+ *
+ * Hash (`#…`) не чіпаємо — у Sergeant ми не тримаємо там авторизаційних
+ * артефактів, а пейджвю по анкор-секціях все ж корисно бачити у funnels.
+ *
+ * Невалідний URL повертаємо як є (без `throw`), щоб телеметрія ніколи
+ * не валила роутинг.
+ */
+
+const SENSITIVE_QUERY_KEYS = new Set([
+  "token",
+  "access_token",
+  "accesstoken",
+  "refresh_token",
+  "refreshtoken",
+  "id_token",
+  "idtoken",
+  "code",
+  "state",
+  "magic",
+  "auth",
+  "password",
+  "secret",
+  "api_key",
+  "apikey",
+]);
+
+const REDACTED = "[redacted]";
+
+export function sanitizeUrl(href: string): string {
+  if (!href || typeof href !== "string") return href;
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  let mutated = false;
+  const params = url.searchParams;
+  // Збираємо ключі до replace, щоб не мутувати колекцію під час ітерації.
+  const keysToRedact: string[] = [];
+  for (const key of params.keys()) {
+    if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+      keysToRedact.push(key);
+    }
+  }
+  for (const key of keysToRedact) {
+    // `set` переписує всі значення ключа однією парою — саме те що треба:
+    // дублікати типу `?token=a&token=b` обидва стають `[redacted]`.
+    params.set(key, REDACTED);
+    mutated = true;
+  }
+
+  if (!mutated) return href;
+  return url.toString();
+}

--- a/docs/observability/frontend.md
+++ b/docs/observability/frontend.md
@@ -183,6 +183,28 @@ Init-конфіг (`posthog.init`):
 Super-properties, що додаються автоматично: `platform` (`web`/`ios`/`android`)
 і `is_capacitor` (boolean) — теж через `@sergeant/shared`.
 
+### Pageviews
+
+**Файл:** `apps/web/src/core/observability/PageviewTracker.tsx`.
+
+`capture_pageview: false` у `posthog.init` свідомий — PostHog дефолтний
+auto-pageview стріляє на будь-яку мутацію URL (включно з query-params) і
+записує повний `window.location.href` як `$current_url`. Для Sergeant це
+означало б:
+
+1. Magic-link токени (`?token=…`), OAuth-коди (`?code=…&state=…`), PWA-action
+   параметри просочувались би у event-props як частина `$current_url`.
+2. Кожен клік по filter-у чи відкриття модалки через query-param був би
+   окремим `$pageview` — шум у funnels і retention.
+
+Замість цього окремий `<PageviewTracker />` (монтується у `core/App.tsx`
+всередині `<BrowserRouter>`) слухає `useLocation().pathname` і явно викликає
+`capturePostHogEvent("$pageview", { $current_url, $pathname })` тільки на
+зміну pathname. `$current_url` прокидається через `sanitizeUrl()` —
+чутливі query-ключі (`token`, `code`, `state`, `access_token`,
+`refresh_token`, `magic`, `auth`, `password`, `secret`, `api_key`)
+редактуються до `[redacted]`. Без `VITE_POSTHOG_KEY` ефект no-op.
+
 ### Identify / reset
 
 `AuthContext` слухає `user?.id` і викликає:


### PR DESCRIPTION
## What changed

- Додано новий `<PageviewTracker />` у `apps/web/src/core/observability/PageviewTracker.tsx`. Компонент слухає `useLocation().pathname` і стріляє `capturePostHogEvent("$pageview", { $current_url, $pathname })` тільки на зміну `pathname` (а не на кожну мутацію query-рядка).
- Додано утиліту `sanitizeUrl()` у `apps/web/src/core/observability/sanitizeUrl.ts`, яка редактує чутливі query-ключі (`token`, `code`, `state`, `access_token`, `refresh_token`, `id_token`, `magic`, `auth`, `password`, `secret`, `api_key`, `apikey` — case-insensitive) у `$current_url` перед відправкою в PostHog.
- `<PageviewTracker />` змонтовано у `apps/web/src/core/App.tsx` поруч з `<ShellDeepLinkBridge />` — всередині `<BrowserRouter>`, але поза `<AuthProvider>`, щоб pageview-и фіксувались і в unauthenticated-шляхах (`/sign-in`, `/welcome`, `/reset-password`).
- Оновлено `docs/observability/frontend.md` — додано секцію "Pageviews" з поясненням чому власний трекер, а не `capture_pageview: true`.

`posthog.init` config **не міняється** (`capture_pageview: false` залишається). Існуючі іменовані події (`onboarding_*`, `ftux_*`, `expense_added`, …) не торкаються — продовжують йти через `trackEvent()`.

## Why

До цього PR-а PostHog був сліпий до навігації між роутами, тому в UI не працювали:

- URL-based funnels (`/welcome → /onboarding → /hub`),
- Web Analytics insight (вкладка в лівому меню PostHog),
- "Paths" insight (sankey користувацької навігації),
- breakdown метрик по роуту/сторінці.

Дефолтний `capture_pageview: true` не підходить з двох причин:

1. **Витік секретів у event-props.** PostHog автоматично кладе `window.location.href` як `$current_url`. У Sergeant ми маємо `?token=…` на magic-link callback (`/auth/callback`), `?code=…&state=…` на OAuth callback (Mono, Google), PWA-action query-params — усе це потрапляло б у PostHog і було б доступне будь-кому з read-правами на project.
2. **Шум у funnels.** Auto-pageview стріляє на будь-яку мутацію URL (включно з query), тому кожен клік по filter-у чи відкриття модалки через `?modal=…` був би окремим `$pageview`. Retention і funnel drop-offs забруднилися б.

Власний трекер + `sanitizeUrl()` розвʼязує обидва — і не чіпає вже узгоджений контракт `posthog.ts` (lazy load, `identified_only`, super-properties, buffer до init).

## How to test

Локально:

```bash
pnpm --filter @sergeant/web test -- --run src/core/observability/
pnpm --filter @sergeant/web typecheck
```

Обидва мають пройти (43 observability-тести, з них 11 нових).

Manual smoke (потрібен `VITE_POSTHOG_KEY`):

1. `pnpm --filter @sergeant/web dev` → відкрити DevTools → Network → фільтр `posthog`.
2. Перейти `/` → `/welcome` → `/sign-in` → бачити `/e/` POST із `event: "$pageview"` для кожної зміни pathname.
3. Перейти `/hub?filter=week` → `/hub?filter=month` — **нового** `$pageview` бути НЕ повинно (query змінився, pathname — ні).
4. Відкрити `/auth/callback?token=ANY_SECRET&email=u%40x` → у payload POST-у перевірити `$current_url` — має бути `…?token=[redacted]&email=u%40x`.
5. У PostHog UI → Activity → нові `$pageview` події зі sanitized URL.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): не виконувався у цій сесії — потрібен `VITE_POSTHOG_KEY` і живий dev-server. Дії з пункту "How to test" рекомендовано проробити локально.
- [x] Vitest passes: `pnpm --filter @sergeant/web test -- --run src/core/observability/` → 43 passed (6 файлів, у т.ч. `sanitizeUrl.test.ts` 7 тестів і `PageviewTracker.test.tsx` 4 тести).
- [x] Typecheck passes: `pnpm --filter @sergeant/web typecheck` → exit 0 (4 tsconfig-и).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — нова секція в `docs/observability/frontend.md` українською, JSDoc у нових файлах теж.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/4b8b665710b54beab9b0479c398d7e70
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
