### PR TITLE
fix(shared): enable noImplicitAny in @sergeant/shared [PR-6.B]

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@sergeant/config/tsconfig.base.json",
   "compilerOptions": {
+    "noImplicitAny": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": "./src",


### PR DESCRIPTION
## What changed

Added `"noImplicitAny": true` to `packages/shared/tsconfig.json` compiler options.

## Why

Part of the gradual TypeScript strictness migration plan documented in `docs/backend-tech-debt.md`. This explicitly enables the `noImplicitAny` check in `@sergeant/shared`, making the requirement visible in the package's own config rather than relying solely on the base config's `strict: true`.

The base config (`packages/config/tsconfig.base.json`) already has `strict: true` which implies `noImplicitAny`, so all existing code was already compliant — zero type errors, zero runtime changes.

## How to test

1. `pnpm --filter @sergeant/shared typecheck` → passes (0 errors)
2. `pnpm typecheck` → full monorepo typecheck passes
3. `pnpm --filter @sergeant/shared test` → all 273 tests pass
4. `pnpm --filter @sergeant/shared lint` → clean

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/shared test` — 22 test files, 273 tests, all green
- [x] Full monorepo typecheck: `pnpm typecheck` — all 14 packages pass
- [x] `@sergeant/shared` lint: clean
- [x] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
