### PR TITLE
feat(web): deep-link Fizruk plan hint to Routine calendar tab

### DIFF
--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.test.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import { PlanCalendar } from "./PlanCalendar";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlanCalendar", () => {
+  it("опускає підказку у звичайний параграф, якщо onOpenRoutine не передано", () => {
+    render(<PlanCalendar />);
+
+    const hint = screen.getByText(
+      /Заплановані тренування відображатимуться у календарі модуля «Рутина»/,
+    );
+    // Без callback-а — це звичайний `<p>`, без role=button
+    expect(hint.tagName).toBe("P");
+    expect(
+      screen.queryByRole("button", { name: /Заплановані тренування/ }),
+    ).toBeNull();
+  });
+
+  it("робить підказку клікабельним діп-лінком на календар Рутини", () => {
+    const onOpenRoutine = vi.fn();
+    render(<PlanCalendar onOpenRoutine={onOpenRoutine} />);
+
+    const link = screen.getByRole("button", {
+      name: /Заплановані тренування відображатимуться у календарі модуля «Рутина»/,
+    });
+    expect(link.tagName).toBe("BUTTON");
+
+    fireEvent.click(link);
+    expect(onOpenRoutine).toHaveBeenCalledTimes(1);
+  });
+
+  it("кнопка «Запланувати тренування» теж викликає onOpenRoutine", () => {
+    const onOpenRoutine = vi.fn();
+    render(<PlanCalendar onOpenRoutine={onOpenRoutine} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Запланувати тренування" }),
+    );
+    expect(onOpenRoutine).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
+++ b/apps/web/src/modules/fizruk/pages/PlanCalendar.tsx
@@ -27,9 +27,23 @@ export function PlanCalendar({
               Запланувати тренування
             </Button>
           )}
-          <p className="text-xs text-subtle text-center leading-snug">
-            Заплановані тренування відображатимуться у календарі модуля «Рутина»
-          </p>
+          {onOpenRoutine ? (
+            <button
+              type="button"
+              onClick={onOpenRoutine}
+              className="block w-full text-xs text-subtle hover:text-text text-center leading-snug min-h-[44px] px-2 py-2 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-routine"
+            >
+              Заплановані тренування відображатимуться у{" "}
+              <span className="underline underline-offset-2">
+                календарі модуля «Рутина»
+              </span>
+            </button>
+          ) : (
+            <p className="text-xs text-subtle text-center leading-snug">
+              Заплановані тренування відображатимуться у календарі модуля
+              «Рутина»
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
+++ b/apps/web/src/modules/fizruk/shell/FizrukRouter.tsx
@@ -53,7 +53,9 @@ export function FizrukRouter({
       return (
         <PlanCalendar
           onOpenRoutine={
-            onOpenModule ? () => onOpenModule("routine") : undefined
+            onOpenModule
+              ? () => onOpenModule("routine", { hash: "calendar" })
+              : undefined
           }
         />
       );

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -198,6 +198,31 @@ export default function RoutineApp({
       validate: (v): v is RoutineMainTab => v === "calendar" || v === "stats",
     },
   );
+
+  // Deep-link: коли модуль відкритий з hash `#calendar` чи `#stats`
+  // (напр. з Fizruk → «Запланувати тренування»), форсуємо вкладку
+  // незалежно від попередньо збереженої у localStorage. Прибираємо
+  // hash після застосування, щоб back-навігація / refresh не
+  // повторювали стрибок.
+  useEffect(() => {
+    let raw = "";
+    try {
+      raw = (window.location.hash || "").replace(/^#\/?/, "").toLowerCase();
+    } catch {
+      return;
+    }
+    if (raw !== "calendar" && raw !== "stats") return;
+    setMainTab(raw);
+    try {
+      const next = `${window.location.pathname}${window.location.search}`;
+      window.history.replaceState(null, "", next);
+    } catch {
+      /* noop */
+    }
+    // Один раз на mount — наступні переходи між вкладками — через
+    // RoutineBottomNav, без url hash.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [timeMode, setTimeMode] = useState<RoutineTimeMode>("today");
   const now = todayDate();
   const [monthCursor, setMonthCursor] = useState<MonthCursor>(() => ({


### PR DESCRIPTION
## What changed

На екрані **Fizruk → План** підказка «Заплановані тренування відображатимуться у календарі модуля «Рутина»» тепер є клікабельним діп-лінком — тап відкриває модуль **Рутина** одразу на вкладці **Календар**, незалежно від останньої вибраної вкладки користувачем.

- `apps/web/src/modules/fizruk/pages/PlanCalendar.tsx` — підказка перетворена з `<p>` на `<button>` з a11y-required `min-h-[44px]`, focus-ring на `ring-routine` і підкресленою фразою «календарі модуля «Рутина»». Якщо `onOpenRoutine` не передано — рендериться попередній `<p>` (без зміни поведінки в інших шеллах).
- `apps/web/src/modules/fizruk/shell/FizrukRouter.tsx` — `onOpenRoutine` тепер передає `{ hash: "calendar" }` через `onOpenModule`. Це впливає і на сусідню кнопку «Запланувати тренування» — обидві ведуть у той самий контекст календаря Рутини.
- `apps/web/src/modules/routine/RoutineApp.tsx` — на mount читаємо `window.location.hash`. Якщо це `#calendar` чи `#stats`, форсуємо `mainTab` (перекриваючи попереднє значення з localStorage) і чистимо hash через `history.replaceState`, щоб back-нав / refresh не повторювали стрибок. Той самий шаблон, що й для існуючого `?routineDay=…` параметра.

## Why

Запит від @andrijvigrav (скріншот: Fizruk → План). Користувач хоче напряму потрапити у календар Рутини з фрази-підказки, а не шукати модуль через Hub і потім перемикати вкладку — особливо, коли в Рутині востаннє був відкритий «Stats» tab.

Pattern узгоджений з існуючим `apps/web/src/modules/finyk/pages/AssetsTable.tsx:108` (`openHubModule("routine", "")`) — лише замість бульбашкової події використано вже-прокинутий `onOpenModule`-проп Fizruk-роутера, щоб не плодити додатковий канал.

## How to test

1. У Рутині перемкнути вкладку на **Stats**, повернутися в Hub.
2. Перейти у **Fizruk → План**.
3. Тапнути по тексту-підказці внизу («Заплановані тренування відображатимуться у календарі модуля «Рутина»»).
4. Очікувано: відкривається Рутина, активна вкладка — **Календар**, URL hash прибраний.
5. Те ж саме — для кнопки «Запланувати тренування» зверху: тепер вона теж форсує Календар.

---

## How AI-tested this PR

- [x] Vitest passes locally на змінених шляхах:
  - `pnpm --filter @sergeant/web exec vitest run src/modules/fizruk src/modules/routine` → 100 тестів пройшли.
  - Нові кейси: `apps/web/src/modules/fizruk/pages/PlanCalendar.test.tsx` (3 тести: підказка-як-`<p>` без callback-а, клік по підказці викликає `onOpenRoutine`, кнопка «Запланувати тренування» теж викликає його).
- [x] `pnpm --filter @sergeant/web typecheck` — clean.
- [x] `pnpm --filter @sergeant/web lint` — лишилися 6 pre-existing помилок у `shared/components/ui/Button.tsx` (`bg-brand-500` + `text-white`, не пов'язані з цим PR — вже на main).
- [ ] Manual smoke: не тестувалось у браузері (зміна 100% TS / RTL-coverable; готовий зробити запис, якщо потрібно).
- [x] No new `AI-DANGER` markers added.
- [x] Прокинутий коментар у `RoutineApp.tsx` — українською (відповідає AGENTS.md).

## AGENTS.md updated?

- [x] No — no new permanent rules. Pattern узгоджується з існуючим `routineDay` query-param + `openHubModule(..., hash)`-каналом.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
