### PR TITLE
fix(finyk-domain): enable noImplicitAny in @sergeant/finyk-domain [PR-6.B]

### DIFF
--- a/packages/finyk-domain/tsconfig.json
+++ b/packages/finyk-domain/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@sergeant/config/tsconfig.base.json",
   "compilerOptions": {
+    "noImplicitAny": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "rootDir": "./src",


### PR DESCRIPTION
## What changed

Added `"noImplicitAny": true` to `packages/finyk-domain/tsconfig.json` compilerOptions.

## Why

Part of the gradual TypeScript migration plan documented in `docs/backend-tech-debt.md`. Explicitly enabling `noImplicitAny` in `@sergeant/finyk-domain` locks the flag at the package level so it cannot regress if the base config ever changes.

The base config (`packages/config/tsconfig.base.json`) already has `strict: true` which implies `noImplicitAny`, so all existing code was already properly typed — zero type errors, zero code changes needed.

## How to test

```bash
pnpm --filter @sergeant/finyk-domain typecheck   # 0 errors
pnpm typecheck                                    # full monorepo — 0 errors
pnpm --filter @sergeant/finyk-domain lint         # clean
pnpm --filter @sergeant/finyk-domain test         # 224 tests pass
```

---

## How AI-tested this PR

- [x] Vitest passes: 224 tests, 14 test files — all green
- [x] Full monorepo typecheck (`pnpm typecheck`) — all 14 packages pass
- [x] Package lint (`pnpm --filter @sergeant/finyk-domain lint`) — clean
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules

---

[Devin session](https://app.devin.ai/sessions/bfb55488cb414da6bbb2cd7756485927)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
