### PR TITLE
feat(web): chooser sheet for Почати тренування (template vs ad-hoc picks)

### DIFF
--- a/apps/web/src/modules/fizruk/components/workouts/QuickStartSheet.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/QuickStartSheet.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
+import { Sheet } from "@shared/components/ui/Sheet";
+import { cn } from "@shared/lib/cn";
+import { useVisualKeyboardInset } from "@sergeant/shared";
+
+/**
+ * Two-step launcher for a new workout. Replaces the old standalone
+ * "Тренування за шаблоном" tile + immediate "Почати тренування" CTA
+ * combo on the Workouts landing.
+ *
+ *   step "choose" — user picks the path:
+ *     • "За шаблоном"     → caller routes to the templates view.
+ *     • "Підібрати вправи" → switches to step "pick".
+ *
+ *   step "pick"   — user multi-selects from the catalogue and confirms.
+ *     The session (and its timer) is created by the caller only after
+ *     `onConfirmExercises` fires, so the timer never starts before the
+ *     user has at least one exercise lined up.
+ *
+ * Header/title updates per step so screen readers announce the change.
+ */
+
+export function QuickStartSheet({
+  open,
+  onClose,
+  exercises,
+  search,
+  onPickTemplate,
+  onConfirmExercises,
+}) {
+  const [step, setStep] = useState("choose");
+  const [q, setQ] = useState("");
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const kbInsetPx = useVisualKeyboardInset(open && step === "pick");
+
+  // Reset to the chooser whenever the sheet is reopened.
+  useEffect(() => {
+    if (!open) {
+      setStep("choose");
+      setQ("");
+      setSelectedIds(new Set());
+    }
+  }, [open]);
+
+  const list = useMemo(() => {
+    if (step !== "pick") return [];
+    return search(q).slice(0, 60);
+  }, [search, q, step]);
+
+  const byId = useMemo(() => {
+    const m = new Map();
+    for (const ex of exercises || []) {
+      if (ex?.id) m.set(ex.id, ex);
+    }
+    return m;
+  }, [exercises]);
+
+  const selectedCount = selectedIds.size;
+
+  const toggle = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    if (selectedCount === 0) return;
+    const picks = [];
+    for (const id of selectedIds) {
+      const ex = byId.get(id);
+      if (ex) picks.push(ex);
+    }
+    if (picks.length === 0) return;
+    onConfirmExercises(picks);
+  };
+
+  if (step === "choose") {
+    return (
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title="Почати тренування"
+        description="Обери шаблон або підбери вправи разово — таймер запуститься після вибору."
+        closeLabel="Закрити вибір"
+        panelClassName="fizruk-sheet"
+        zIndex={90}
+      >
+        <div className="grid grid-cols-1 gap-2 pb-2">
+          <button
+            type="button"
+            onClick={() => {
+              onClose();
+              onPickTemplate();
+            }}
+            className="rounded-2xl border border-line bg-panelHi p-4 text-left hover:border-muted active:scale-[0.99] transition"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl" aria-hidden>
+                📋
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-semibold text-text">
+                  За шаблоном
+                </div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Готовий набір вправ — старт із заповненим списком.
+                </div>
+              </div>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setStep("pick")}
+            className="rounded-2xl border border-line bg-panelHi p-4 text-left hover:border-muted active:scale-[0.99] transition"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-2xl" aria-hidden>
+                💪
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-semibold text-text">
+                  Підібрати вправи
+                </div>
+                <div className="text-xs text-subtle mt-0.5">
+                  Обери вправи зараз і почни — без збереження шаблону.
+                </div>
+              </div>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
+            </div>
+          </button>
+        </div>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title="Підібрати вправи"
+      description={
+        selectedCount > 0
+          ? `Обрано: ${selectedCount} · натисни «Почати», щоб запустити таймер.`
+          : "Познач хоча б одну вправу — таймер запуститься після старту."
+      }
+      closeLabel="Закрити підбір"
+      kbInsetPx={kbInsetPx}
+      panelClassName="fizruk-sheet"
+      zIndex={90}
+      headerRight={
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 min-h-[44px]"
+          onClick={() => setStep("choose")}
+          aria-label="Повернутись до вибору способу"
+        >
+          ← Назад
+        </Button>
+      }
+      footer={
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Button
+            variant="ghost"
+            className="h-12 min-h-[44px] sm:flex-1"
+            onClick={onClose}
+          >
+            Скасувати
+          </Button>
+          <Button
+            className="h-12 min-h-[44px] sm:flex-1"
+            onClick={handleConfirm}
+            disabled={selectedCount === 0}
+          >
+            ▶︎ Почати
+            {selectedCount > 0 ? ` · ${selectedCount}` : ""}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <Input
+          placeholder="Пошук вправи…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          aria-label="Пошук вправи в каталозі"
+        />
+
+        {list.length === 0 ? (
+          <div className="rounded-xl border border-line bg-panelHi p-4 text-center text-xs text-subtle">
+            {q.trim()
+              ? "Нічого не знайдено за цим запитом."
+              : "Каталог поки що порожній."}
+          </div>
+        ) : (
+          <ul className="space-y-1.5">
+            {list.map((ex) => {
+              const id = ex.id;
+              const active = selectedIds.has(id);
+              const name = ex?.name?.uk || ex?.name?.en || id;
+              return (
+                <li key={id}>
+                  <button
+                    type="button"
+                    onClick={() => toggle(id)}
+                    aria-pressed={active}
+                    className={cn(
+                      "w-full text-left rounded-xl border p-3 min-h-[52px] flex items-center gap-3 transition-colors",
+                      active
+                        ? "border-brand-500 bg-brand-500/10"
+                        : "border-line bg-bg hover:border-muted",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full border text-[11px] font-bold",
+                        active
+                          ? "bg-brand-strong border-brand-strong text-white"
+                          : "border-line text-subtle",
+                      )}
+                      aria-hidden
+                    >
+                      {active ? "✓" : ""}
+                    </span>
+                    <span className="text-sm text-text truncate flex-1">
+                      {name}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </Sheet>
+  );
+}

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -12,6 +12,7 @@ import { AddExerciseSheet } from "../components/workouts/AddExerciseSheet";
 import { ExerciseDetailSheet } from "../components/workouts/ExerciseDetailSheet";
 import { WorkoutJournalSection } from "../components/workouts/WorkoutJournalSection";
 import { WorkoutCatalogSection } from "../components/workouts/WorkoutCatalogSection";
+import { QuickStartSheet } from "../components/workouts/QuickStartSheet";
 import { useExerciseCatalog } from "../hooks/useExerciseCatalog";
 import { useRecovery } from "../hooks/useRecovery";
 import { useWorkoutTemplates } from "../hooks/useWorkoutTemplates";
@@ -135,6 +136,7 @@ export function Workouts() {
   const [riskyTemplateConfirm, setRiskyTemplateConfirm] = useState(null); // stores template when risky
   const [now, setNow] = useState(Date.now());
   const [retroOpen, setRetroOpen] = useState(false);
+  const [quickStartOpen, setQuickStartOpen] = useState(false);
   const [retroDate, setRetroDate] = useState(() => {
     const x = new Date();
     return `${x.getFullYear()}-${String(x.getMonth() + 1).padStart(2, "0")}-${String(x.getDate()).padStart(2, "0")}`;
@@ -473,12 +475,11 @@ export function Workouts() {
             activeWorkout={activeWorkout}
             activeDuration={activeDuration}
             recentWorkouts={recentWorkouts}
-            createWorkout={createWorkout}
-            setActiveWorkoutId={setActiveWorkoutId}
             onOpenSession={() => setView("log")}
             onOpenCatalog={() => setView("catalog")}
             onOpenTemplates={() => setView("templates")}
             onOpenJournal={() => setView("log")}
+            onRequestStart={() => setQuickStartOpen(true)}
             onOpenRetro={() => {
               setRetroOpen(true);
               setView("log");
@@ -590,6 +591,43 @@ export function Workouts() {
           addExercise={addExercise}
         />
 
+        <QuickStartSheet
+          open={quickStartOpen}
+          onClose={() => setQuickStartOpen(false)}
+          exercises={exercises}
+          search={search}
+          onPickTemplate={() => {
+            setQuickStartOpen(false);
+            setView("templates");
+          }}
+          onConfirmExercises={(picks) => {
+            // Build a fresh ad-hoc session and pre-load the picked
+            // exercises before flipping the active flag — that way the
+            // session-level live timer (`activeWorkout.startedAt`) is
+            // only created after the user confirmed their selection,
+            // matching the user-stated requirement that the timer must
+            // not start before exercises are lined up.
+            const w = createWorkout();
+            for (const ex of picks) {
+              const isCardio = ex.primaryGroup === "cardio";
+              addItem(w.id, {
+                exerciseId: ex.id,
+                nameUk: ex?.name?.uk || ex?.name?.en,
+                primaryGroup: ex.primaryGroup,
+                musclesPrimary: ex?.muscles?.primary || [],
+                musclesSecondary: ex?.muscles?.secondary || [],
+                type: isCardio ? "distance" : "strength",
+                sets: isCardio ? undefined : [{ weightKg: 0, reps: 0 }],
+                durationSec: isCardio ? 0 : 0,
+                distanceM: isCardio ? 0 : 0,
+              });
+            }
+            setActiveWorkoutId(w.id);
+            setQuickStartOpen(false);
+            setView("log");
+          }}
+        />
+
         <RestTimerOverlay
           restTimer={restTimer}
           onCancel={() => setRestTimer(null)}
@@ -687,12 +725,17 @@ interface WorkoutsHomeProps {
     endedAt?: string | null;
     items?: ReadonlyArray<unknown>;
   }>;
-  createWorkout: () => { id: string };
-  setActiveWorkoutId: (id: string | null) => void;
   onOpenSession: () => void;
   onOpenCatalog: () => void;
   onOpenTemplates: () => void;
   onOpenJournal: () => void;
+  /**
+   * Opens the start chooser (`QuickStartSheet`) instead of immediately
+   * spinning up an empty session — the chooser itself is responsible
+   * for creating the workout once the user picked a template or a set
+   * of exercises.
+   */
+  onRequestStart: () => void;
   onOpenRetro: () => void;
 }
 
@@ -700,21 +743,14 @@ function WorkoutsHome({
   activeWorkout,
   activeDuration,
   recentWorkouts,
-  createWorkout,
-  setActiveWorkoutId,
   onOpenSession,
   onOpenCatalog,
   onOpenTemplates,
   onOpenJournal,
+  onRequestStart,
   onOpenRetro,
 }: WorkoutsHomeProps) {
   const hasActive = !!activeWorkout && !activeWorkout.endedAt;
-
-  const handleStart = () => {
-    const w = createWorkout();
-    setActiveWorkoutId(w.id);
-    onOpenSession();
-  };
 
   return (
     <div className="space-y-4">
@@ -742,21 +778,11 @@ function WorkoutsHome({
             Немає активного тренування
           </div>
           <div className="text-xs text-subtle mt-1">
-            Почни нове, обери шаблон або внеси проведене заняття заднім числом.
+            Почни нове — обереш шаблон або підбереш вправи перед стартом.
           </div>
-          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <Button
-              className="h-12 text-base sm:col-span-2"
-              onClick={handleStart}
-            >
+          <div className="mt-3 grid grid-cols-1 gap-2">
+            <Button className="h-12 text-base" onClick={onRequestStart}>
               ▶︎ Почати тренування
-            </Button>
-            <Button
-              variant="ghost"
-              className="h-12 text-base"
-              onClick={onOpenTemplates}
-            >
-              📋 Тренування за шаблоном →
             </Button>
             <Button
               variant="ghost"


### PR DESCRIPTION
## What changed

- New `QuickStartSheet` (bottom sheet, two steps) on the Workouts landing in Фізрук:
  - **Step 1 — chooser:** "📋 За шаблоном" or "💪 Підібрати вправи".
  - **Step 2 — pick:** search + multi-select catalogue list with a sticky "▶︎ Почати · N" footer button.
- "▶︎ Почати тренування" no longer creates an empty session immediately; it opens the chooser sheet, and the workout (and its live timer) is only created **after** the user picked a template OR confirmed at least one exercise.
- Removed the standalone "📋 Тренування за шаблоном →" button from the Workouts empty-state hero. Templates are still discoverable via the "Шаблони" tile under "Довідники", and now also via the chooser.
- Empty-state copy refreshed to match the new flow: "Почни нове — обереш шаблон або підбереш вправи перед стартом."

## Why

Previous behaviour: tapping "Почати тренування" instantly created an empty workout and dropped the user on the running-timer screen with no exercises lined up; "Тренування за шаблоном" was a separate sibling button that did the right thing but was easy to miss. User feedback (`@andrijvigrav`): «Може прибрати кнопку почати з шаблону і внести її у вибір коли натискається почати тренування? Бо воно одразу стартує, а так юзер міг би обрати чи шаблон чи одноразово підібрати вправи і тоді вже почати, а не додавати коли вже таймер пішов.»

The chooser sheet folds both paths into a single explicit decision and defers session/timer creation until exercises are actually selected.

Existing flows are unchanged:
- Active-workout state still surfaces the "Активне тренування · Відкрити" bar.
- Retro logging (`✏️ Внести проведене заняття`) is still a peer button in the empty-state — different semantics, intentionally not folded into the start-now chooser.
- `executeTemplateStart` / risky-recovery dialog flow on the templates view is untouched.

## How to test

1. Open Фізрук → Тренування with no active workout.
2. Verify the empty-state hero now shows two buttons: "▶︎ Почати тренування" and "✏️ Внести проведене заняття" (no "Тренування за шаблоном" sibling).
3. Tap "▶︎ Почати тренування" → chooser sheet appears with two large options.
4. Pick "📋 За шаблоном" → sheet closes, view switches to the templates list. Existing template-start flow (incl. recovery confirm) still works end-to-end.
5. Reopen the chooser → pick "💪 Підібрати вправи" → search + tick a couple of exercises → footer enables ("Почати · 2"). Tap "Почати":
   - new workout is created **with** the picked exercises pre-loaded,
   - timer starts (`activeWorkout.startedAt` = "now"),
   - view switches to "log" with the active session panel.
6. Cancel buttons + scrim dismiss reset the chooser back to step 1 on reopen.
7. With an active workout, the hero shows "Активне · Відкрити →" exactly as before — the chooser path is gated behind `!hasActive`.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web typecheck` — clean.
- [x] `pnpm --filter @sergeant/web exec eslint` on the touched files (`Workouts.tsx`, `QuickStartSheet.tsx`) — clean. (Pre-existing Button.tsx WCAG-AA lint errors on `main` are unrelated to this PR and predate it.)
- [x] `pnpm exec vitest run src/modules/fizruk` — 7 files / 44 tests passing (HeroCard, KpiRow, RecentWorkoutsSection, WorkoutTemplates, fizrukStorage, useWorkouts, WorkoutJournalSection.finish).
- [ ] Manual smoke in the deployed preview — pending review.
- [x] No new `AI-DANGER` markers added.
- [x] User-facing strings are in Ukrainian.

## AGENTS.md updated?

- [x] No — this PR doesn't introduce any permanent rules; it's a product UX change scoped to one Фізрук surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
