### PR TITLE
ci: add codeowner-blocking guard for tsconfig strict [PR-1.A]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,13 @@
 # tsconfig strict guard — require review for files that affect TypeScript
-# strictness inheritance. See docs/playbooks/tsconfig-strict-guard.md.
-apps/*/tsconfig.json               @Skords-01
-packages/config/**                 @Skords-01
-tools/tsconfig-guard/**            @Skords-01
+# strictness inheritance. See docs/backend-tech-debt.md.
+#
+# GitHub requires at least one approval from a CODEOWNER before merging
+# any PR that touches these paths (when the branch-protection rule
+# "Require review from Code Owners" is enabled).
+
+apps/web/tsconfig.json             @Skords-01
+apps/server/tsconfig.json          @Skords-01
+packages/config/tsconfig.base.json @Skords-01
+packages/config/tsconfig.node.json @Skords-01
+packages/config/tsconfig.react.json @Skords-01
+scripts/check-tsconfig-strict.mjs  @Skords-01

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:web": "pnpm --filter @sergeant/web build",
     "build:analyze": "pnpm --filter @sergeant/web build:analyze",
     "preview": "pnpm --filter @sergeant/web preview",
-    "lint": "turbo run lint && node scripts/check-imports.mjs && pnpm lint:plugins && pnpm lint:tech-debt-freshness",
+    "lint": "turbo run lint && node scripts/check-imports.mjs && node scripts/check-tsconfig-strict.mjs && pnpm lint:plugins && pnpm lint:tech-debt-freshness",
     "lint:imports": "node scripts/check-imports.mjs",
     "lint:migrations": "node scripts/lint-migrations.mjs",
     "lint:tech-debt-freshness": "node scripts/check-tech-debt-freshness.mjs",

--- a/scripts/check-tsconfig-strict.mjs
+++ b/scripts/check-tsconfig-strict.mjs
@@ -1,0 +1,121 @@
+/**
+ * CI guard: ensures tsconfig strict settings are not accidentally weakened.
+ *
+ * For each monitored tsconfig the script verifies:
+ *   1. compilerOptions.strict is explicitly `true`.
+ *   2. allowJs is NOT `true` in apps/web (optional, warn-only).
+ *
+ * When strict is not yet enabled (e.g. apps/web during migration) the
+ * check emits a warning instead of failing so the guard can be merged
+ * before the migration PR lands.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(process.cwd());
+
+// ── files to check ──────────────────────────────────────────────────
+const STRICT_REQUIRED = [
+  { file: "apps/server/tsconfig.json", warnOnly: false },
+  { file: "apps/web/tsconfig.json", warnOnly: true },
+];
+
+const DISALLOW_ALLOWJS = [{ file: "apps/web/tsconfig.json" }];
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/** Strip JSON5-style comments while preserving string contents intact. */
+function stripJsonComments(text) {
+  let out = "";
+  let i = 0;
+  while (i < text.length) {
+    // strings — copy verbatim
+    if (text[i] === '"') {
+      let j = i + 1;
+      while (j < text.length && text[j] !== '"') {
+        if (text[j] === "\\") j++; // skip escaped char
+        j++;
+      }
+      out += text.slice(i, j + 1);
+      i = j + 1;
+      continue;
+    }
+    // single-line comment
+    if (text[i] === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++;
+      continue;
+    }
+    // multi-line comment
+    if (text[i] === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    out += text[i++];
+  }
+  return out;
+}
+
+function readJson(relPath) {
+  const abs = path.join(repoRoot, relPath);
+  if (!fs.existsSync(abs)) return null;
+  const raw = fs.readFileSync(abs, "utf8");
+  return JSON.parse(stripJsonComments(raw));
+}
+
+// ── checks ──────────────────────────────────────────────────────────
+
+const errors = [];
+const warnings = [];
+
+for (const { file, warnOnly } of STRICT_REQUIRED) {
+  const json = readJson(file);
+  if (!json) {
+    errors.push(`${file}: file not found`);
+    continue;
+  }
+
+  const strict = json.compilerOptions?.strict;
+
+  if (strict !== true) {
+    const msg = `${file}: compilerOptions.strict must be \`true\` (got ${JSON.stringify(strict)})`;
+    if (warnOnly) {
+      warnings.push(`${msg} [warn-only — migration pending]`);
+    } else {
+      errors.push(msg);
+    }
+  }
+}
+
+for (const { file } of DISALLOW_ALLOWJS) {
+  const json = readJson(file);
+  if (!json) continue;
+
+  if (json.compilerOptions?.allowJs === true) {
+    warnings.push(
+      `${file}: compilerOptions.allowJs is \`true\` — remove once JS→TS migration completes`,
+    );
+  }
+}
+
+// ── output ──────────────────────────────────────────────────────────
+
+if (warnings.length) {
+  console.warn(
+    "⚠️  tsconfig-strict warnings:\n" +
+      warnings.map((w) => `  - ${w}`).join("\n"),
+  );
+}
+
+if (errors.length) {
+  console.error(
+    "❌ tsconfig-strict check FAILED:\n" +
+      errors.map((e) => `  - ${e}`).join("\n") +
+      "\n\nDo not remove or override `strict: true` in these files.\n",
+  );
+  process.exit(1);
+} else {
+  console.log("✅ tsconfig-strict check passed.");
+}


### PR DESCRIPTION
- Update .github/CODEOWNERS to require @Skords-01 review for all tsconfig files that affect strict-mode inheritance
- Add scripts/check-tsconfig-strict.mjs CI guard that verifies compilerOptions.strict is true in apps/server and apps/web tsconfigs
- apps/web strict check is warn-only until migration completes
- Optionally warns if allowJs is true in apps/web
- Integrate guard into root pnpm lint pipeline

Refs: PR-1.A

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
