### PR TITLE
docs(docs): re-sync audit doc with merged PRs (PR-7.D/8.B/10.A/11.A/1…

### DIFF
--- a/docs/audits/2026-04-26-sergeant-audit-devin.md
+++ b/docs/audits/2026-04-26-sergeant-audit-devin.md
@@ -4,7 +4,7 @@
 **Скоуп:** репо `Skords-01/Sergeant` (default branch на момент клонування).
 **Метод:** репозиторний прохід — структура, конфіги, `AGENTS.md`/`CONTRIBUTING.md`/`README.md`, `docs/*` (roadmap, tech-debt, observability, playbooks), `.github/workflows/ci.yml`, `eslint.config.js`, `packages/eslint-plugin-sergeant-design/`, `apps/*/tsconfig.json`, міграції в `apps/server/src/migrations/`. Без виконання CI/тестів.
 
-> **Статус виконання — оновлено 2026-04-27 (шоста ревізія: +PR-11.C partial)**
+> **Статус виконання — оновлено 2026-04-27 (сьома ревізія: re-sync з реальним станом коду)**
 > Поки документ жив в attachments, частина PR-ідей з нього вже відпрацьована
 > через дочерні Devin-сесії. Узагальнений знімок прогресу:
 
@@ -33,8 +33,14 @@
 | PR-5.B   | rollback sanity для `*.down.sql` міграцій (Testcontainers)             | ✅ closed  | [#918](https://github.com/Skords-01/Sergeant/pull/918)                                                                 |
 | PR-6.B   | `noImplicitAny` phase 2 — routine + shared + nutrition (3 з 6)         | 🟡 partial | [#923](https://github.com/Skords-01/Sergeant/pull/923), [#934](https://github.com/Skords-01/Sergeant/pull/934)         |
 | PR-7.E   | de-flake `OnboardingWizard.test.tsx` (1/3 flaky triage)                | ✅ closed  | [#963](https://github.com/Skords-01/Sergeant/pull/963)                                                                 |
-| PR-11.C  | ADR template + README index                                            | 🟡 partial | template+README зроблено, retroactive ADRs ⏳                                                                          |
+| PR-11.C  | ADR template + README index + retroactive ADRs (3 з 5: Better Auth / Capacitor / Anthropic) | 🟡 partial | template+README ✅; ADR-0007/0010/0005 ✅ via [#958](https://github.com/Skords-01/Sergeant/pull/958), [#956](https://github.com/Skords-01/Sergeant/pull/956), [#962](https://github.com/Skords-01/Sergeant/pull/962); ⏳ turbo + monorepo split |
 | PR-8.A   | `docs(obs): error-budget policy`                                       | ✅ closed  | [#942](https://github.com/Skords-01/Sergeant/pull/942)                                                                 |
+| PR-7.D   | weekly flaky-tests dashboard workflow                                  | ✅ closed  | [#945](https://github.com/Skords-01/Sergeant/pull/945)                                                                 |
+| PR-8.B   | Prometheus `/metrics` endpoint + Grafana dashboards JSON               | ✅ closed  | [#946](https://github.com/Skords-01/Sergeant/pull/946), [#948](https://github.com/Skords-01/Sergeant/pull/948), [#953](https://github.com/Skords-01/Sergeant/pull/953) |
+| PR-10.A  | p95 pipeline-duration metric у CI summary                              | ✅ closed  | [#951](https://github.com/Skords-01/Sergeant/pull/951), доробка [#970](https://github.com/Skords-01/Sergeant/pull/970), [#971](https://github.com/Skords-01/Sergeant/pull/971) |
+| PR-11.A  | freshness badges для топ-документів + nightly overdue-doc workflow     | ✅ closed  | [#952](https://github.com/Skords-01/Sergeant/pull/952)                                                                 |
+| PR-11.B  | top-5 playbooks → decision-tree формат + `_TEMPLATE-decision-tree.md`  | ✅ closed  | [#955](https://github.com/Skords-01/Sergeant/pull/955)                                                                 |
+| PR-6.D   | `apps/server` strict TS — explicit `"strict": true`                    | ✅ closed  | [#937](https://github.com/Skords-01/Sergeant/pull/937)                                                                 |
 | Інші     | див. inline-теги нижче                                                 | ⏳ pending | —                                                                                                                      |
 
 > Sprint-таблиці нижче (`Спринт 0`, `Спринт 1-2`, `Спринт 3-6`) також оновлені
@@ -51,7 +57,7 @@
 | Блок                         | Оцінка Васі | Моя оцінка | Чому інша                                                                                                                                                                                 |
 | ---------------------------- | ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 3. Frontend platform         | 8/10        | **7.5/10** | Великих файлів (>600 LOC) **25, не 10**. Топ — 1614 LOC (`seedFoodsUk.ts`). Storage migration ще на 55 файлів у TODO. Це більший regression-surface, ніж видається.                       |
-| 6. Type safety               | 7.5/10      | **6.5/10** | `strict: true` ввімкнений у `tsconfig.base`, але **`apps/web` і `apps/server` його перевизначають на `false`** + `allowJs: true, checkJs: false`. Це не «pending», це активне regression. |
+| 6. Type safety               | 7.5/10      | **6.5/10** | `strict: true` ввімкнений у `tsconfig.base`. `apps/server` уже на `"strict": true"` (PR-6.D, [#937](https://github.com/Skords-01/Sergeant/pull/937)), але `apps/web` досі перевизначає на `false` + `allowJs: true, checkJs: false`. Це не «pending», це активне regression. |
 | 11. Документація / playbooks | 9/10        | **9.5/10** | 23 playbooks з конкретними кроками + структурований AI-marker система (`AI-NOTE`/`AI-CONTEXT`/`AI-DANGER`/`AI-LEGACY`) + `eslint-plugin-sergeant-design` з 6 кастомних правил. Виняткове. |
 
 **Чого не вистачає в аудиті Васі (мої додаткові спостереження):**
@@ -241,8 +247,8 @@
 - `PR-7.A` ✅ closed — [#886](https://github.com/Skords-01/Sergeant/pull/886) `test(web): unit + integration tests for recommendationEngine and TodayFocusCard`.
 - `PR-7.B` ✅ closed — [#904](https://github.com/Skords-01/Sergeant/pull/904) `test(web,cloud-sync): integration tests for offline queue + replay on reconnect` — 17 тестів, 4 сценарії (coalesce, happy replay, server-error, MAX_OFFLINE_QUEUE overflow).
 - `PR-7.C` ✅ closed — [#913](https://github.com/Skords-01/Sergeant/pull/913) `test(web): hub-reports aggregation snapshot tests` — витягнуто 4 чисті агрегатори з inline-замикань `useReportData` у `apps/web/src/core/hub/hubReports.aggregation.ts`; 44 snapshot-тести покривають date-helpers, per-module aggregators і повний cross-module звіт із усіма 4 модулями заповненими.
-- `PR-7.D` — `ci(test): add weekly flaky-tests dashboard` (GitHub Action, що збирає `vitest --reporter json` за 7 днів і публікує markdown trend в artifact).
-- `PR-7.E` — `test(mobile): triage 3 known flaky tests one-by-one (each in own PR), document fixes`.
+- `PR-7.D` ✅ closed — [#945](https://github.com/Skords-01/Sergeant/pull/945) `ci(test): weekly flaky-tests dashboard workflow + aggregator script`. Реалізовано як `.github/workflows/flaky-tests-dashboard.yml` з cron-розкладом і markdown trend в artifact.
+- `PR-7.E` 🟡 partial (1/3) — [#963](https://github.com/Skords-01/Sergeant/pull/963) de-flake `OnboardingWizard.test.tsx`. Залишилося 2/3: `WeeklyDigestFooter.test.tsx`, `HubSettingsPage.test.tsx` (як зафіксовано в `AGENTS.md` «Pre-existing flaky tests»).
 
 ---
 
@@ -262,8 +268,8 @@
 **PR-ідеї:**
 
 - `PR-8.A` ✅ closed — [#942](https://github.com/Skords-01/Sergeant/pull/942) `docs(obs): error-budget policy` — який тип фіч freeze, коли HTTP API budget вигорає; які ні (security fixes, hotfixes).
-- `PR-8.B` — `feat(obs): expose Prometheus /metrics from apps/server` (якщо ще не) + Grafana dashboard import JSON у `docs/observability/dashboards/`.
-- `PR-8.C` — `feat(server,chat): SYSTEM_PROMPT_VERSION constant + cache-hit metric` — підготовка до prompt-cache rollout.
+- `PR-8.B` ✅ closed — [#946](https://github.com/Skords-01/Sergeant/pull/946) `feat(server): Prometheus /metrics endpoint on apps/server`, [#948](https://github.com/Skords-01/Sergeant/pull/948) Grafana dashboard JSON files, [#953](https://github.com/Skords-01/Sergeant/pull/953) `docs(obs): metrics catalog`. `apps/server/src/routes/health.ts` реєструє `r.get("/metrics", metricsHandler)` (виключений з auth/CORS ланцюжка).
+- `PR-8.C` ✅ closed — реалізовано в межах PR-12.A ([#864](https://github.com/Skords-01/Sergeant/pull/864)): `SYSTEM_PROMPT_VERSION` const + `anthropic_prompt_cache_hit_total{version, outcome}` (вкл. streaming-шлях).
 
 ---
 
@@ -314,7 +320,7 @@
 
 **PR-ідеї:**
 
-- `PR-10.A` — `ci: add p95 pipeline-duration metric to CI summary` (script, що читає GitHub Actions API і публікує trend у PR як коментар).
+- `PR-10.A` ✅ closed — [#951](https://github.com/Skords-01/Sergeant/pull/951) `ci: p95 pipeline-duration metric у CI summary`, доробка [#970](https://github.com/Skords-01/Sergeant/pull/970)/[#971](https://github.com/Skords-01/Sergeant/pull/971) (`needs:` fix після розділення smoke-e2e → critical-flow). Реалізовано як job `pipeline-duration-summary` у `ci.yml`.
 - `PR-10.B` — `ci: split smoke-e2e into critical-flow (must-pass) + extended-flow (nightly)`. ✅ closed
 - `PR-10.C` — `ci: nightly job for full audit (critical+high blocking) + dependency-check (snyk або osv-scanner)`. Nightly не блокує PR, але дає трендовий сигнал. ✅ closed — [#944](https://github.com/Skords-01/Sergeant/pull/944)
 
@@ -336,9 +342,14 @@
 
 **PR-ідеї:**
 
-- `PR-11.A` — `docs(meta): freshness badge for top-10 docs` — простий header `**Last validated:** YYYY-MM-DD by @user. **Next review:** YYYY-MM-DD.` + nightly script, що відкриває issue, якщо `Next review` пройшов.
-- `PR-11.B` — `docs(playbooks): convert top-5 playbooks to "decision tree" format` (`when ... do X, else Y`).
-- `PR-11.C` 🟡 partial — ADR практика "живе": `docs/adr/0001-monetization-architecture.md` ([#912](https://github.com/Skords-01/Sergeant/pull/912)) і `docs/adr/0002-tool-lifecycle.md` ([#926](https://github.com/Skords-01/Sergeant/pull/926)) уже існують. Цим PR-ом формалізовано: `docs/adr/TEMPLATE.md` (1-page MADR-adapted skeleton із secção Status / Context / Considered options / Decision / Consequences / Compliance / Links) і `docs/adr/README.md` (index, naming convention, lifecycle, посилання на TEMPLATE). **Залишилось ⏳:** retroactive ADRs для turbo / Better Auth / monorepo split / Capacitor wrapper / Anthropic tool-on-client architecture (5 шт., по PR на кожен).
+- `PR-11.A` ✅ closed — [#952](https://github.com/Skords-01/Sergeant/pull/952) `docs(docs): freshness badges for top-10 docs + nightly overdue-doc issue workflow`. `**Last validated:**` бейдж додано на 11+ топ-документів, `.github/workflows/docs-freshness.yml` + `scripts/docs/check-freshness.mjs` відкриває issue на overdue.
+- `PR-11.B` ✅ closed — [#955](https://github.com/Skords-01/Sergeant/pull/955) `docs(docs): convert top-5 playbooks to decision-tree format`. Додано `docs/playbooks/_TEMPLATE-decision-tree.md` і конвертовано: `debug-chat-tool.md`, `hotfix-prod-regression.md`, `investigate-alert.md`, `rotate-secrets.md`, `stabilize-flaky-test.md`.
+- `PR-11.C` 🟡 partial (3/5) — ADR template + README ✅ ([#938](https://github.com/Skords-01/Sergeant/pull/938)) + retroactive batches:
+  - `docs/adr/0007-better-auth-choice-and-session-model.md` (Better Auth) ✅ ([#962](https://github.com/Skords-01/Sergeant/pull/962))
+  - `docs/adr/0010-mobile-dual-track-capacitor-expo.md` (Capacitor wrapper) ✅ ([#956](https://github.com/Skords-01/Sergeant/pull/956))
+  - `docs/adr/0005-anthropic-model-and-caching.md` (Anthropic tool-on-client) ✅ ([#958](https://github.com/Skords-01/Sergeant/pull/958))
+  - **Залишилось ⏳:** retroactive ADRs для `turbo` (monorepo runner) і `monorepo split` (apps/* + packages/*) — 2 шт.
+  - **Caveat:** паралельні ADR-пакети #956/#961/#962 створили колізії номерів 0003-0012 (10 пар файлів з однаковим NNNN). Розв'язується окремим PR-ом `docs(adr): resolve numbering collisions`.
 
 ---
 
@@ -412,11 +423,11 @@
 | #   | PR                                                       | Effort    | Імпакт               | Status                                                                                            |
 | --- | -------------------------------------------------------- | --------- | -------------------- | ------------------------------------------------------------------------------------------------- |
 | 13  | `PR-6.C` — strict: true full + remove allowJs            | 1 тиждень | strict TS done       | ⏳ pending                                                                                        |
-| 14  | `PR-4.D` — zod-to-openapi для api-client                 | 1 тиждень | автоматизує rule #3  |
-| 15  | `PR-8.A` + `PR-8.C` — error-budget policy + tool metrics | 3-5 д     | operational maturity |
+| 14  | `PR-4.D` — zod-to-openapi для api-client                 | 1 тиждень | автоматизує rule #3  | ⏳ pending |
+| 15  | `PR-8.A` + `PR-8.C` — error-budget policy + tool metrics | 3-5 д     | operational maturity | `PR-8.A` ✅ [#942](https://github.com/Skords-01/Sergeant/pull/942); `PR-8.C` ✅ через PR-12.A [#864](https://github.com/Skords-01/Sergeant/pull/864) |
 | 16  | `PR-10.B` + `PR-10.C` — split smoke-e2e + nightly audit  | 2-3 д     | CI scaling           | `PR-10.B` ✅ closed; `PR-10.C` ✅ closed — [#944](https://github.com/Skords-01/Sergeant/pull/944) |
-| 17  | `PR-11.A` + `PR-11.C` — freshness badges + ADR template  | 1 тиждень | doc lifecycle        |
-| 18  | `PR-3.B/C` next 5 — file decomposition next wave         | 1-2 тижні | regression-surface   |
+| 17  | `PR-11.A` + `PR-11.C` — freshness badges + ADR template  | 1 тиждень | doc lifecycle        | `PR-11.A` ✅ [#952](https://github.com/Skords-01/Sergeant/pull/952); `PR-11.C` 🟡 partial (3/5) |
+| 18  | `PR-3.B/C` next 5 — file decomposition next wave         | 1-2 тижні | regression-surface   | ⏳ pending |
 
 ### Поза 6 місяців
 


### PR DESCRIPTION
…1.B/8.C/6.D)

Updates the 2026-04-26 audit document to reflect the actual state of the codebase. Several PR-ideas listed only as 'PR-ideas' in section bodies (without progress-table entries) had already been merged but were not tracked in the top progress table:

- PR-7.D weekly flaky-tests dashboard (#945)
- PR-8.B Prometheus /metrics + Grafana dashboards (#946, #948, #953)
- PR-10.A p95 pipeline-duration metric (#951, #970, #971)
- PR-11.A freshness badges + nightly overdue-doc workflow (#952)
- PR-11.B top-5 playbooks decision-tree conversion (#955)
- PR-8.C SYSTEM_PROMPT_VERSION + cache-hit metric (already in PR-12.A #864)
- PR-6.D apps/server explicit strict:true (#937)

Also corrects the TL;DR section: section 0 said 'apps/web AND apps/server override strict to false' — apps/server already has strict:true (#937); only apps/web is still false.

For PR-11.C, 3 of 5 retroactive ADRs already exist (Better Auth #962, Capacitor #956, Anthropic #958). Only turbo + monorepo split remain. Notes the side-issue: parallel ADR PRs (#956/#961/#962) created numbering collisions on 0003-0012, to be resolved in a follow-up PR.

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
