### PR TITLE
fix(web): adopt -strong brand fills in Button primitive for WCAG AA

### DIFF
--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -43,7 +43,7 @@ export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 const variants: Record<ButtonVariant, string> = {
   // Core variants
   primary:
-    "bg-brand-500 text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-700 active:scale-[0.98]",
+    "bg-brand-strong text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-700 active:scale-[0.98]",
   secondary:
     "bg-panel text-text border border-line shadow-sm hover:bg-panelHi hover:border-brand-200 active:scale-[0.98]",
   ghost:
@@ -51,19 +51,19 @@ const variants: Record<ButtonVariant, string> = {
   danger:
     "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
-    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
+    "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
 
   // Module-specific branded buttons
   finyk:
-    "bg-finyk text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
+    "bg-finyk-strong text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
   fizruk:
-    "bg-fizruk text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
+    "bg-fizruk-strong text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
   routine:
-    "bg-routine text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
+    "bg-routine-strong text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
   nutrition:
-    "bg-nutrition text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
+    "bg-nutrition-strong text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
 
   // Soft module variants (for secondary actions within modules).
   // Dark mode swaps the light pastel surface for the saturated accent at


### PR DESCRIPTION
AGENTS.md rule #9 і ESLint `sergeant-design/no-low-contrast-text-on-fill` явно забороняють поєднання `bg-{brand,danger,finyk,fizruk,routine,nutrition}` (саме `-500` / DEFAULT) з `text-white` — контраст падає до ~2.4–2.8:1 проти WCAG AA 4.5:1.

Button primitive лишався з `bg-brand-500 text-white` на primary, і з DEFAULT-ами на danger/finyk/fizruk/routine/nutrition variant-ах. Тест Button.test.tsx вже очікував `bg-brand-strong`, але fix на компонент не довезли — через це на main червоніли і `lint`, і `test:coverage`.

Перемикаю base-fill-и 6 variant-ів на `-strong` companion (700/800-step, `-strong` токени вже задеклеровані в design-tokens preset). Hover- і active-state-и не торкаються — вони під variant prefix-ами і правило їх не ловить.

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
