### PR TITLE
fix(web/a11y): focus-visible rings on legacy h-11 rounded-xl interactive elements

### DIFF
--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -221,6 +221,7 @@ function DigestContent({
             "dark:from-brand-600 dark:via-brand-500 dark:to-teal-500",
             "shadow-card hover:brightness-110 active:scale-[0.98] transition-[box-shadow,filter,opacity,transform]",
             "flex items-center justify-center gap-2",
+            "focus-ring",
           )}
         >
           <svg

--- a/apps/web/src/core/settings/FinykSection.tsx
+++ b/apps/web/src/core/settings/FinykSection.tsx
@@ -442,7 +442,10 @@ export function FinykSection() {
                 <button
                   type="button"
                   onClick={() => setShowWebhookToken((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-text"
+                  className="focus-ring absolute right-3 top-1/2 -translate-y-1/2 rounded-md text-subtle hover:text-text"
+                  aria-label={
+                    showWebhookToken ? "Приховати токен" : "Показати токен"
+                  }
                 >
                   {showWebhookToken ? "\u{1F648}" : "\u{1F441}"}
                 </button>
@@ -643,7 +646,7 @@ export function FinykSection() {
                   <button
                     type="button"
                     onClick={() => setShowPrivatToken((v) => !v)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-text"
+                    className="focus-ring absolute right-3 top-1/2 -translate-y-1/2 rounded-md text-subtle hover:text-text"
                     aria-label={showPrivatToken ? "Приховати" : "Показати"}
                   >
                     {showPrivatToken ? "🙈" : "👁"}

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -303,7 +303,7 @@ export default function App({
             <button
               type="button"
               onClick={() => setShowBalance((v) => !v)}
-              className="w-11 h-11 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors"
+              className="focus-ring w-11 h-11 flex items-center justify-center rounded-xl text-subtle hover:text-text hover:bg-panelHi transition-colors"
               aria-label={showBalance ? "Приховати суми" : "Показати суми"}
               title={showBalance ? "Приховати суми" : "Показати суми"}
             >

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -466,7 +466,7 @@ export function Body({ onOpenMeasurements }) {
             <button
               type="submit"
               className={cn(
-                "w-full py-3 rounded-xl font-semibold text-sm transition-[background-color,box-shadow,opacity,transform]",
+                "focus-ring w-full py-3 rounded-xl font-semibold text-sm transition-[background-color,box-shadow,opacity,transform]",
                 submitSuccess
                   ? "bg-success-strong text-white"
                   : "bg-success-strong text-white active:scale-[0.98]",

--- a/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
+++ b/apps/web/src/modules/routine/components/HabitQuickCreateDialog.tsx
@@ -175,7 +175,7 @@ export function HabitQuickCreateDialog({
           <button
             type="button"
             onClick={onClose}
-            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="focus-ring w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
             aria-label="Закрити"
           >
             <svg

--- a/apps/web/src/modules/routine/components/WeekDayStrip.tsx
+++ b/apps/web/src/modules/routine/components/WeekDayStrip.tsx
@@ -33,7 +33,7 @@ export function WeekDayStrip({
     <div className="flex items-center gap-1.5 sm:gap-2">
       <button
         type="button"
-        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
+        className="focus-ring shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
         onClick={() => onShiftWeek(-1)}
         aria-label="Попередній тиждень"
       >
@@ -50,7 +50,7 @@ export function WeekDayStrip({
               type="button"
               onClick={() => onSelectDay(k)}
               className={cn(
-                "flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-xs",
+                "focus-ring flex min-h-[44px] flex-col items-center justify-center rounded-xl border py-1 text-2xs font-semibold transition-colors sm:text-xs",
                 isSel
                   ? "border-routine-ring dark:border-routine-border-dark/40 bg-routine-surface2 dark:bg-routine-surface-dark/15 text-text shadow-sm ring-1 ring-routine-line/50 dark:ring-routine-border-dark/30"
                   : "border-transparent bg-panelHi/50 text-muted hover:bg-panelHi hover:text-text",
@@ -70,7 +70,7 @@ export function WeekDayStrip({
       </div>
       <button
         type="button"
-        className="shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
+        className="focus-ring shrink-0 flex h-11 w-9 items-center justify-center rounded-xl border border-line bg-panel/90 text-lg text-muted transition-colors hover:bg-panelHi hover:text-text"
         onClick={() => onShiftWeek(1)}
         aria-label="Наступний тиждень"
       >

--- a/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
+++ b/apps/web/src/shared/components/layout/ModuleSettingsDrawer.tsx
@@ -59,7 +59,7 @@ export function ModuleSettingsDrawer({
           <button
             type="button"
             onClick={onClose}
-            className="w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="focus-ring w-11 h-11 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
             aria-label="Закрити"
           >
             <Icon name="close" size={22} />


### PR DESCRIPTION
## What changed

`apps/web/src` — додаю `focus-ring` утиліту (визначена у
`src/index.css`: `outline-none focus-visible:ring-2
focus-visible:ring-accent/60 focus-visible:ring-offset-2
focus-visible:ring-offset-surface`) на сім legacy `h-11 rounded-xl`
інтерактивних елементів, які донині рендерилися без видимого кільця
для клавіатурної навігації:

| Файл | Елемент |
| --- | --- |
| `core/insights/WeeklyDigestCard.tsx` | CTA «Переглянути як сторіс» |
| `modules/finyk/FinykApp.tsx` | toggle «Показати/Приховати суми» |
| `modules/routine/components/HabitQuickCreateDialog.tsx` | close (`×`) |
| `shared/components/layout/ModuleSettingsDrawer.tsx` | close (`×`) |
| `modules/routine/components/WeekDayStrip.tsx` | prev/next-week + 7 day tiles |
| `modules/fizruk/pages/Body.tsx` | submit «Записати» |
| `core/settings/FinykSection.tsx` | Mono/Privat eye-toggles (+`aria-label` на Mono) |

Усі точки знайшов через `grep "h-11.*rounded-xl|rounded-xl.*h-11"` +
ручний відсів `<input>` з `input-focus-*` (вони вже мають
focus-visible через @apply у тому ж `index.css`).

## Why

Follow-up `docs/design/ux-audit-2025.md` §10 («Не увійшло»):
> Audit focus rings у застарілих компонентах (`h-11 rounded-xl` tokens) для follow-up.

Дизайн-система вже містить готову утиліту `.focus-ring` у
`src/index.css` (lines 261-269), створену саме під цей кейс — але
жодне місце в коді її не використовувало. Цей PR робить її першим
консьюмером. Інтерактивні елементи без видимого focus-ring ламають
клавіатурну навігацію (WCAG 2.1 § 2.4.7 Focus Visible — рівень AA).

Без bundle-impact: клас уже визначений @apply у `index.css`, цей PR
лише вмикає його на місцях, де він був забутий. Додатково додаю
`aria-label` на Mono eye-toggle (Privat вже мав).

## How to test

1. `pnpm --filter @sergeant/web vitest run` — нічого не повинно
   попсуватися (зміни тільки у className strings, без логіки).
2. `pnpm --filter @sergeant/web lint` — `sergeant-design/*` правила
   жодне не зачіпаю; перевірка має лишатися такою як на main.
3. Manual: на `/`, `/?module=finyk`, `/?module=routine`, `/?module=fizruk`
   — `Tab` через інтерфейс і переконатися, що щойно перелічені
   елементи показують зелене кільце з offset на `:focus-visible` (а
   на mouse-click — ні, бо `focus-visible:` не реагує на мишу).
4. Axe a11y gate (`apps/web/tests/a11y/axe.spec.ts`) — `/design`
   surface вже включений; має лишатися зеленим (зміни не на
   `/design`).

---

## How AI-tested this PR

- [x] Сканер `h-11.*rounded-xl|rounded-xl.*h-11` по `apps/web/src` дав 11 файлів; з них 7 виявилися інтерактивними елементами без `focus-visible:` поруч (інші 4 — це або `<input>` з `input-focus-*`, або `h-11` всередині декоративного `w-11` icon-контейнера).
- [x] Diff чистий: 7 файлів, +13 / −9 (тільки `className` strings + один новий `aria-label`).
- [x] Bundle-impact: нульовий — `.focus-ring` уже @apply'нуто у `index.css:266`.
- [ ] Vitest: лок CI запустить (на VM немає `pnpm install`-ed `node_modules`).
- [ ] Visual smoke: лишаю reviewer-у — у мене немає доступу до dev-сервера.
- [x] No new `AI-DANGER` markers added.
- [x] Українська у PR-описі (та у commit-message), згідно з AGENTS.md.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules; це просто wiring існуючої `.focus-ring` утиліти на місця, де вона була пропущена.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
