### PR TITLE
feat(server): deletePostHogPerson(userId) для ADR-0016 GDPR cleanup queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,17 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:3000
 # виставити `https://us.i.posthog.com`.
 # VITE_POSTHOG_HOST=https://eu.i.posthog.com
 
+# ── PostHog server-side (GDPR cleanup, ADR-0016 ADR-6.3) ──────
+# Personal API key із project-scope доступом до `persons` (write).
+# Використовується в `deletePostHogPerson(userId)` із cleanup-черги
+# при hard-delete акаунта. Без ключа cleanup-job скіпає PostHog
+# (outcome=skipped) — рекомендовано виставити у production.
+# POSTHOG_API_KEY=phx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Числовий ID проєкту (Settings → Project → ID).
+# POSTHOG_PROJECT_ID=12345
+# Host для server-side API. Default — EU Cloud, парний до VITE_POSTHOG_HOST.
+# POSTHOG_HOST=https://eu.i.posthog.com
+
 # ── CSP (опціонально, поступове розгортання) ──────────────────
 # CSP_REPORT_ONLY=1 → Content-Security-Policy-Report-Only (тільки логування).
 # CSP_DISABLE=1 → емердженсі-вимкнення без re-deploy.

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -114,6 +114,21 @@ const envSchema = z.object({
   LOG_PRETTY: z.string().optional(),
   /** Bearer token для захисту `GET /metrics`. */
   METRICS_TOKEN: z.string().optional(),
+  /**
+   * Personal API key для server-side PostHog cleanup (ADR-0016 ADR-6.3).
+   * Має project-level scope із write-доступом до `persons`. БЕЗ нього
+   * `deletePostHogPerson()` повертає `outcome: "skipped"` — GDPR worker
+   * markує row як completed (no-op).
+   */
+  POSTHOG_API_KEY: z.string().optional(),
+  /** Числовий ID PostHog-проєкту (Settings → Project → ID). */
+  POSTHOG_PROJECT_ID: z.string().optional(),
+  /**
+   * Server-side host для PostHog API. EU Cloud: `https://eu.i.posthog.com`
+   * (default), US: `https://us.i.posthog.com`, self-hosted: власна URL.
+   * Парний до клієнтського `VITE_POSTHOG_HOST`.
+   */
+  POSTHOG_HOST: z.string().optional(),
 
   // ── Security ───────────────────────────────────────────────────────
   /** `"1"` — вимкнути Content-Security-Policy (Replit dev). */

--- a/apps/server/src/lib/posthog.test.ts
+++ b/apps/server/src/lib/posthog.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { deletePostHogPerson } from "./posthog.js";
+import {
+  externalHttpRequestsTotal,
+  externalHttpDurationMs,
+  register,
+} from "../obs/metrics.js";
+
+function makeFetch(
+  impl: (url: string, init?: RequestInit) => Promise<Response>,
+) {
+  return vi.fn(impl) as unknown as typeof fetch;
+}
+
+function ok(status = 200): Response {
+  return new Response(null, { status });
+}
+
+function jsonError(status: number, body: string = ""): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("deletePostHogPerson — happy path", () => {
+  beforeEach(() => {
+    externalHttpRequestsTotal.reset();
+    externalHttpDurationMs.reset();
+  });
+
+  it("returns ok on 2xx and DELETEs to /api/projects/:id/persons/?distinct_id", async () => {
+    const fetchImpl = makeFetch(async () => ok(204));
+    const r = await deletePostHogPerson("user-123", {
+      apiKey: "phx_test",
+      projectId: "42",
+      host: "https://eu.i.posthog.com",
+      fetchImpl,
+    });
+
+    expect(r.outcome).toBe("ok");
+    expect(r.status).toBe(204);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }
+    ).mock.calls[0];
+    expect(url).toBe(
+      "https://eu.i.posthog.com/api/projects/42/persons/?distinct_id=user-123",
+    );
+    expect(init?.method).toBe("DELETE");
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer phx_test",
+    );
+  });
+
+  it("URL-encodes both projectId and userId", async () => {
+    const fetchImpl = makeFetch(async () => ok(204));
+    await deletePostHogPerson("user@example.com", {
+      apiKey: "k",
+      projectId: "proj id/with space",
+      host: "https://eu.i.posthog.com",
+      fetchImpl,
+    });
+    const [url] = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+      .calls[0];
+    expect(url).toContain("/api/projects/proj%20id%2Fwith%20space/persons/");
+    expect(url).toContain("?distinct_id=user%40example.com");
+  });
+
+  it("strips trailing slashes from custom host", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      host: "https://custom.posthog.example.com///",
+      fetchImpl,
+    });
+    const [url] = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://custom.posthog.example.com/api/projects/1/persons/?distinct_id=u1",
+    );
+  });
+});
+
+describe("deletePostHogPerson — outcome classification", () => {
+  it("404 → not_found (idempotent: already deleted)", async () => {
+    const fetchImpl = makeFetch(async () =>
+      jsonError(404, '{"detail":"not found"}'),
+    );
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("not_found");
+    expect(r.status).toBe(404);
+  });
+
+  it("429 → rate_limited", async () => {
+    const fetchImpl = makeFetch(async () => jsonError(429, "rate limited"));
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("rate_limited");
+    expect(r.status).toBe(429);
+  });
+
+  it("500 → error with status and body in result", async () => {
+    const fetchImpl = makeFetch(async () => jsonError(500, "internal"));
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("error");
+    expect(r.status).toBe(500);
+    expect(r.error).toMatch(/500/);
+  });
+
+  it("403 (auth/permissions) → error", async () => {
+    const fetchImpl = makeFetch(async () => jsonError(403, "forbidden"));
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("error");
+    expect(r.status).toBe(403);
+  });
+
+  it("network exception → error (not timeout)", async () => {
+    const fetchImpl = makeFetch(async () => {
+      throw new Error("ECONNRESET");
+    });
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("error");
+    expect(r.error).toBe("ECONNRESET");
+  });
+
+  it("AbortError → timeout", async () => {
+    const fetchImpl = makeFetch(async () => {
+      const e = new Error("aborted");
+      e.name = "AbortError";
+      throw e;
+    });
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("timeout");
+  });
+});
+
+describe("deletePostHogPerson — config gating", () => {
+  it("returns skipped without API key, never calling fetch", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    const r = await deletePostHogPerson("u1", {
+      apiKey: undefined,
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("skipped");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns skipped without project ID", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    const r = await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: undefined,
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("skipped");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to env vars when options omitted", async () => {
+    const prevKey = process.env.POSTHOG_API_KEY;
+    const prevProj = process.env.POSTHOG_PROJECT_ID;
+    const prevHost = process.env.POSTHOG_HOST;
+    process.env.POSTHOG_API_KEY = "phx_env";
+    process.env.POSTHOG_PROJECT_ID = "777";
+    process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+    try {
+      const fetchImpl = makeFetch(async () => ok(204));
+      const r = await deletePostHogPerson("u-env", { fetchImpl });
+      expect(r.outcome).toBe("ok");
+      const [url, init] = (
+        fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }
+      ).mock.calls[0];
+      expect(url).toBe(
+        "https://eu.i.posthog.com/api/projects/777/persons/?distinct_id=u-env",
+      );
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer phx_env",
+      );
+    } finally {
+      // process.env coerces values to string, so assigning `undefined`
+      // would set it literally to the string "undefined". `delete` is the
+      // only way to actually unset.
+      if (prevKey === undefined) delete process.env.POSTHOG_API_KEY;
+      else process.env.POSTHOG_API_KEY = prevKey;
+      if (prevProj === undefined) delete process.env.POSTHOG_PROJECT_ID;
+      else process.env.POSTHOG_PROJECT_ID = prevProj;
+      if (prevHost === undefined) delete process.env.POSTHOG_HOST;
+      else process.env.POSTHOG_HOST = prevHost;
+    }
+  });
+});
+
+describe("deletePostHogPerson — input validation", () => {
+  it("rejects empty userId", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    const r = await deletePostHogPerson("", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    expect(r.outcome).toBe("error");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("deletePostHogPerson — metrics", () => {
+  beforeEach(() => {
+    externalHttpRequestsTotal.reset();
+    externalHttpDurationMs.reset();
+  });
+
+  it("emits external_http_requests_total{upstream=posthog,outcome=ok} on 200", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    const text = await register.metrics();
+    expect(text).toMatch(
+      /external_http_requests_total\{upstream="posthog",outcome="ok"\} 1/,
+    );
+  });
+
+  it("emits outcome=not_found on 404", async () => {
+    const fetchImpl = makeFetch(async () => jsonError(404));
+    await deletePostHogPerson("u1", {
+      apiKey: "k",
+      projectId: "1",
+      fetchImpl,
+    });
+    const text = await register.metrics();
+    expect(text).toMatch(
+      /external_http_requests_total\{upstream="posthog",outcome="not_found"\} 1/,
+    );
+  });
+
+  it("emits outcome=skipped when config missing (no http roundtrip)", async () => {
+    const fetchImpl = makeFetch(async () => ok(200));
+    await deletePostHogPerson("u1", {
+      apiKey: undefined,
+      projectId: undefined,
+      fetchImpl,
+    });
+    const text = await register.metrics();
+    expect(text).toMatch(
+      /external_http_requests_total\{upstream="posthog",outcome="skipped"\} 1/,
+    );
+  });
+});

--- a/apps/server/src/lib/posthog.ts
+++ b/apps/server/src/lib/posthog.ts
@@ -1,0 +1,157 @@
+import { logger } from "../obs/logger.js";
+import { recordExternalHttp } from "./externalHttp.js";
+
+/**
+ * Server-side PostHog cleanup helper. Реалізує `deletePostHogPerson(userId)`
+ * для GDPR cleanup queue з ADR-0016 (ADR-6.3 — External services cleanup):
+ *
+ *   DELETE {host}/api/projects/{projectId}/persons/?distinct_id={userId}
+ *   Authorization: Bearer {POSTHOG_API_KEY}
+ *
+ * Поведінка ідемпотентна — повторний виклик на вже видалену person повертає
+ * 404 і ми класифікуємо його як `not_found` (caller → mark як completed).
+ *
+ * Відсутність config-у (`POSTHOG_API_KEY` / `POSTHOG_PROJECT_ID`) →
+ * `outcome: "skipped"`. Це зроблено навмисно: GDPR cleanup worker має
+ * можливість markувати row як completed навіть в dev/test, де PostHog
+ * не налаштований, інакше soft-deleted users застрягнуть назавжди.
+ *
+ * Не кидає помилок — повертає тегований union, який `gdpr_cleanup_queue`
+ * worker мапить на `completed_at` (ok/not_found/skipped) vs. `attempts++`
+ * (rate_limited/timeout/error).
+ */
+
+export type PostHogDeleteOutcome =
+  | "ok"
+  | "not_found"
+  | "rate_limited"
+  | "timeout"
+  | "skipped"
+  | "error";
+
+export interface PostHogDeletePersonResult {
+  outcome: PostHogDeleteOutcome;
+  status?: number;
+  error?: string;
+  ms?: number;
+}
+
+export interface PostHogDeletePersonOptions {
+  /** Personal API key (`POSTHOG_API_KEY`), Bearer-токен. */
+  apiKey?: string;
+  /** Числовий ID проєкту (`POSTHOG_PROJECT_ID`). */
+  projectId?: string;
+  /** Базовий host. Default — EU Cloud, як у клієнтському snippet (`POSTHOG_HOST`). */
+  host?: string;
+  /** Per-call timeout (мс). Default 10s — за ADR latency-budget ~1s + slack. */
+  timeoutMs?: number;
+  /** Inject-нутий fetch (для тестів). */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_HOST = "https://eu.i.posthog.com";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const UPSTREAM = "posthog";
+
+function elapsedMs(start: bigint): number {
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function isAbortError(e: unknown): boolean {
+  return (
+    !!e &&
+    typeof e === "object" &&
+    ((e as { name?: string }).name === "AbortError" ||
+      (e as { name?: string }).name === "TimeoutError")
+  );
+}
+
+export async function deletePostHogPerson(
+  userId: string,
+  options: PostHogDeletePersonOptions = {},
+): Promise<PostHogDeletePersonResult> {
+  if (typeof userId !== "string" || userId.length === 0) {
+    return { outcome: "error", error: "userId is required" };
+  }
+
+  const apiKey = options.apiKey ?? process.env.POSTHOG_API_KEY;
+  const projectId = options.projectId ?? process.env.POSTHOG_PROJECT_ID;
+  const host = (
+    options.host ??
+    process.env.POSTHOG_HOST ??
+    DEFAULT_HOST
+  ).replace(/\/+$/, "");
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  if (!apiKey || !projectId) {
+    logger.warn({
+      msg: "posthog_delete_person_skipped",
+      reason: "POSTHOG_API_KEY or POSTHOG_PROJECT_ID is not set",
+    });
+    recordExternalHttp(UPSTREAM, "skipped");
+    return { outcome: "skipped" };
+  }
+
+  const url =
+    `${host}/api/projects/${encodeURIComponent(projectId)}/persons/` +
+    `?distinct_id=${encodeURIComponent(userId)}`;
+
+  const start = process.hrtime.bigint();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(url, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+
+    const ms = elapsedMs(start);
+
+    if (response.ok) {
+      recordExternalHttp(UPSTREAM, "ok", ms);
+      return { outcome: "ok", status: response.status, ms };
+    }
+    if (response.status === 404) {
+      // Already deleted / unknown distinct_id → idempotent success.
+      recordExternalHttp(UPSTREAM, "not_found", ms);
+      return { outcome: "not_found", status: 404, ms };
+    }
+    if (response.status === 429) {
+      recordExternalHttp(UPSTREAM, "rate_limited", ms);
+      return { outcome: "rate_limited", status: 429, ms };
+    }
+
+    const bodyText = await response.text().catch(() => "");
+    recordExternalHttp(UPSTREAM, "error", ms);
+    logger.warn({
+      msg: "posthog_delete_person_failed",
+      status: response.status,
+      body: bodyText.slice(0, 500),
+    });
+    return {
+      outcome: "error",
+      status: response.status,
+      error: `posthog returned ${response.status}`,
+      ms,
+    };
+  } catch (e: unknown) {
+    const ms = elapsedMs(start);
+    const outcome: PostHogDeleteOutcome = isAbortError(e) ? "timeout" : "error";
+    recordExternalHttp(UPSTREAM, outcome, ms);
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn({
+      msg: "posthog_delete_person_exception",
+      outcome,
+      error: message,
+    });
+    return { outcome, error: message, ms };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## What changed

- New helper `apps/server/src/lib/posthog.ts` → `deletePostHogPerson(userId)`.
  Викликає `DELETE {host}/api/projects/{projectId}/persons/?distinct_id={userId}`
  з `Authorization: Bearer {POSTHOG_API_KEY}`. Повертає тегований union
  `{ outcome: "ok" | "not_found" | "rate_limited" | "timeout" | "skipped" | "error" }`,
  щоб GDPR cleanup worker знав, що мапити в `completed_at` vs. `attempts++`.
- Класифікація:
  - `2xx` → `ok`.
  - `404` → `not_found` (ідемпотентно: person вже видалена).
  - `429` → `rate_limited` (caller робить exponential backoff).
  - AbortError/TimeoutError → `timeout`.
  - 4xx (auth/permissions/validation), 5xx, network exception → `error`.
  - Відсутній `POSTHOG_API_KEY` або `POSTHOG_PROJECT_ID` → `skipped`
    (no-op, без HTTP-запиту), щоб non-prod/feature-disabled cleanup
    не зависав.
- Per-call `AbortController` таймаут (default 10s — за ADR latency-budget ~1s + slack).
- Метрики: `external_http_requests_total{upstream="posthog",outcome=...}`
  та `external_http_duration_ms{upstream="posthog",outcome=...}` через
  існуючий `recordExternalHttp()`.
- Env схема та `.env.example` доповнені трьома server-side змінними:
  `POSTHOG_API_KEY` (Bearer personal API key), `POSTHOG_PROJECT_ID`
  (числовий ID проєкту), `POSTHOG_HOST` (default `https://eu.i.posthog.com`,
  парний до клієнтського `VITE_POSTHOG_HOST`).
- Unit tests `apps/server/src/lib/posthog.test.ts` (16 кейсів):
  happy path, URL-encoding `userId`/`projectId`, host trailing-slash
  normalization, всі outcome-коди, fallback на env-змінні, валідація
  пустого `userId`, перевірка emit-у Prometheus-метрик.

## Why

ADR-0016 (`docs/adr/0016-user-deletion-and-pii-handling.md`), розділи
ADR-6.1 і **ADR-6.3 — External services cleanup queue**, вимагають
для повного покриття GDPR Art. 17 / ст. 8 ЗУ «Про захист персональних
даних» очищати дані юзера у зовнішніх сервісах (Stripe, Sentry,
PostHog, Resend) поза synchronous `DELETE /api/v1/me` хендлером —
через `gdpr_cleanup_queue` із background worker-ом.

PostHog — друга інтеграція з цього списку, для якої з'являється
server-side cleanup helper. Сама `gdpr_cleanup_queue` міграція й
worker — поза цим PR (підуть окремими §-кроками); цей PR доставляє
лише ізольовану функцію, яку worker викличе.

## How to test

```bash
pnpm --filter @sergeant/server test -- src/lib/posthog.test.ts
pnpm --filter @sergeant/server lint
pnpm --filter @sergeant/server typecheck
pnpm --filter @sergeant/server test         # повний прогон сервера, 559 тестів
```

Локальний smoke (опційно, з реальним PostHog):

```bash
export POSTHOG_API_KEY=phx_...
export POSTHOG_PROJECT_ID=12345
node --import tsx -e '
  import("./apps/server/src/lib/posthog.ts").then(async (m) => {
    console.log(await m.deletePostHogPerson("test-distinct-id"));
  });
'
```

Очікувані outcomes: `ok` (200/204), `not_found` (404 на повторний виклик),
`skipped` (без env-змінних).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): unit-тести покривають усі outcome-коди
      (ok / not_found / rate_limited / timeout / error / skipped) із
      mocked `fetch`. Метрики перевіряються через `register.metrics()`.
- [x] Vitest passes: `pnpm --filter @sergeant/server test` → 44 файли,
      559 тестів passed (16 нових для posthog).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/bbd4b2aaab954276b294d44f208aaacf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced user data deletion capability from PostHog with comprehensive error handling for rate limits, network timeouts, and configuration issues.
  * Supports configurable API host selection and customizable timeout settings.

* **Chores**
  * Added environment variables documentation for PostHog server-side API credentials and host configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->