### PR TITLE
feat(web): track hubchat and cloudsync events + subscription placeholders

### DIFF
--- a/apps/web/src/core/cloudSync/engine/initialSync.ts
+++ b/apps/web/src/core/cloudSync/engine/initialSync.ts
@@ -1,4 +1,5 @@
 import { syncApi } from "@shared/api";
+import { trackEvent, ANALYTICS_EVENTS } from "../../observability/analytics";
 import { SYNC_MODULES } from "../config";
 import { isModulePushSuccess } from "../conflict/pushSuccess";
 import { resolveInitialSync } from "../conflict/resolver";
@@ -102,6 +103,13 @@ async function applyMerge(
       "[cloudSync] initialSync.merge: server rejected push for modules (kept dirty for retry)",
       conflicted,
     );
+    // Окрема подія для initial-merge гілки: сигналізує про збіг dirty-flag
+    // і cloud-snapshot, який свіжіший за локальну версію — типово трапляється
+    // коли користувач вмикає синк на другому пристрої.
+    trackEvent(ANALYTICS_EVENTS.SYNC_CONFLICT_RESOLVED, {
+      kind: "initial-merge",
+      modules: conflicted.length,
+    });
   }
 }
 

--- a/apps/web/src/core/cloudSync/engine/push.test.ts
+++ b/apps/web/src/core/cloudSync/engine/push.test.ts
@@ -29,6 +29,16 @@ vi.mock("./replay", () => ({
   replayOfflineQueue: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../observability/analytics", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../observability/analytics")
+  >("../../observability/analytics");
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  };
+});
+
 import { syncApi } from "@shared/api";
 import { buildModulesPayload } from "./buildPayload";
 import { addToOfflineQueue } from "../queue/offlineQueue";
@@ -37,7 +47,10 @@ import {
   markModuleDirty,
   getDirtyModules,
 } from "../state/dirtyModules";
+import { trackEvent, ANALYTICS_EVENTS } from "../../observability/analytics";
 import { pushDirty, pushAll } from "./push";
+
+const mockedTrackEvent = trackEvent as unknown as ReturnType<typeof vi.fn>;
 
 const mockedBuild = buildModulesPayload as unknown as ReturnType<typeof vi.fn>;
 const mockedPushAllApi = syncApi.pushAll as unknown as ReturnType<typeof vi.fn>;
@@ -228,5 +241,31 @@ describe("pushAll", () => {
     expect(onError).not.toHaveBeenCalled();
     // finyk — очищений, routine — лишився dirty до наступного push-у.
     expect(getDirtyModules()).toEqual({ routine: true });
+
+    // PostHog sync_conflict_resolved фіксуємо рівно один раз з
+    // правильним лічильником модулів (routine) і kind="push" —
+    // дашборди для виявлення regression-ів LWW-guard-а очікують саме цю форму.
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.SYNC_CONFLICT_RESOLVED,
+      { kind: "push", modules: 1 },
+    );
+  });
+
+  it("does not fire sync_conflict_resolved when all modules succeed cleanly", async () => {
+    markModuleDirty("finyk");
+    mockedBuild.mockReturnValueOnce({
+      finyk: { data: { a: 1 }, clientUpdatedAt: "2025-01-01T00:00:00.000Z" },
+    });
+    mockedPushAllApi.mockResolvedValueOnce({
+      results: { finyk: { ok: true, version: 42 } },
+    });
+
+    const { args } = makeArgs();
+    await pushAll(args);
+
+    const conflictCalls = mockedTrackEvent.mock.calls.filter(
+      (c) => c[0] === ANALYTICS_EVENTS.SYNC_CONFLICT_RESOLVED,
+    );
+    expect(conflictCalls).toHaveLength(0);
   });
 });

--- a/apps/web/src/core/cloudSync/engine/push.ts
+++ b/apps/web/src/core/cloudSync/engine/push.ts
@@ -1,4 +1,5 @@
 import { syncApi } from "@shared/api";
+import { trackEvent, ANALYTICS_EVENTS } from "../../observability/analytics";
 import { SYNC_MODULES } from "../config";
 import { isModulePushSuccess } from "../conflict/pushSuccess";
 import { addToOfflineQueue } from "../queue/offlineQueue";
@@ -131,6 +132,13 @@ export async function pushAll(args: PushArgs): Promise<void> {
         "[cloudSync] pushAll: server rejected push for modules (kept dirty)",
         conflicted,
       );
+      // PostHog: spike-и conflict-ів — сигнал регресії LWW-guard-а або
+      // clock-drift-у. `modules` — лічильник, не імена, щоб не тягнути
+      // module-level кардинальність у події.
+      trackEvent(ANALYTICS_EVENTS.SYNC_CONFLICT_RESOLVED, {
+        kind: "push",
+        modules: conflicted.length,
+      });
     }
     onSuccess(new Date());
   } catch (err) {

--- a/apps/web/src/core/cloudSync/hook/useSyncCallbacks.ts
+++ b/apps/web/src/core/cloudSync/hook/useSyncCallbacks.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { trackEvent, ANALYTICS_EVENTS } from "../../observability/analytics";
 import { updateDebugSnapshot } from "../debugState";
 import { toSyncError } from "../errorNormalizer";
 import { syncLog } from "../logger";
@@ -156,6 +157,10 @@ export function useSyncCallbacks(): SyncLifecycle {
         value: undefined,
         set: false,
       };
+      // Захоплюємо старт у закритті, щоб кожен bound-callback-set мав
+      // власний таймер — не ділили timestamp з іншим sync-id, навіть
+      // якщо два runExclusive-и накладаються через `runBypassed`.
+      let startedAt: number | null = null;
       return {
         onStart: () => {
           if (!isActive()) {
@@ -175,6 +180,8 @@ export function useSyncCallbacks(): SyncLifecycle {
             syncId,
           });
           setState("syncing", syncId);
+          startedAt = Date.now();
+          trackEvent(ANALYTICS_EVENTS.SYNC_STARTED, {});
         },
         onSuccess: (when: Date) => {
           if (!isActive()) {
@@ -193,6 +200,10 @@ export function useSyncCallbacks(): SyncLifecycle {
             lastError: null,
           });
           setState("success", syncId);
+          const durationMs = startedAt !== null ? Date.now() - startedAt : 0;
+          trackEvent(ANALYTICS_EVENTS.SYNC_SUCCEEDED, {
+            duration_ms: durationMs,
+          });
         },
         onErrorRaw: (err: unknown) => {
           // Stash the raw error so the subsequent `onError(message)`
@@ -220,6 +231,12 @@ export function useSyncCallbacks(): SyncLifecycle {
           setSyncErrorDetail(detail);
           updateDebugSnapshot({ lastError: detail, lastAction: "error" });
           setState("error", syncId);
+          const durationMs = startedAt !== null ? Date.now() - startedAt : 0;
+          trackEvent(ANALYTICS_EVENTS.SYNC_FAILED, {
+            error_type: detail.type,
+            retryable: detail.retryable,
+            duration_ms: durationMs,
+          });
         },
         onSettled: () => {
           // Always release the guard, even for superseded callbacks — a

--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -34,6 +34,7 @@ import type { ChatActionCard } from "../lib/hubChatActionCards";
 import { ChatMessage, TypingIndicator } from "../components/ChatMessage";
 import { ChatInput } from "../components/ChatInput";
 import { ChatQuickActions } from "../components/ChatQuickActions";
+import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 
 function HubChat({
   onClose,
@@ -245,6 +246,15 @@ function HubChat({
     setInput("");
     setLoading(true);
 
+    // PostHog-telemetry: фіксуємо факт відправки без тексту повідомлення.
+    // `length` і `fromVoice` дають змогу відокремити voice-сценарії у
+    // дашбордах і слідкувати за розподілом довжин, не експортуючи body.
+    trackEvent(ANALYTICS_EVENTS.HUBCHAT_MESSAGE_SENT, {
+      length: msg.length,
+      fromVoice: Boolean(fromVoice),
+      module: activeModule,
+    });
+
     const history = next
       .filter((m) => m.role === "user" || m.role === "assistant")
       .slice(-10)
@@ -298,6 +308,15 @@ function HubChat({
       }
 
       if (data.tool_calls && data.tool_calls.length > 0) {
+        // PostHog: окрема подія на кожен tool_call, щоб breakdown
+        // по назві інструмента працював як кардинальність у funnels
+        // (напр. "скільки add_expense → successful response").
+        for (const tc of data.tool_calls) {
+          trackEvent(ANALYTICS_EVENTS.HUBCHAT_TOOL_INVOKED, {
+            tool: tc.name,
+            module: activeModule,
+          });
+        }
         const handlerResults = await executeActions(data.tool_calls);
         const toolResults = data.tool_calls.map((tc, idx) => ({
           tool_use_id: tc.id,
@@ -418,6 +437,20 @@ function HubChat({
       } else {
         setMessages((m) => [...m, makeAssistantMsg(friendlyChatError(e))]);
       }
+      // PostHog: класифікована помилка без message body. Kind-и збігаються
+      // з `ApiError.kind` + "unknown" fallback. `aborted` трекаємо теж —
+      // spike-и abort-ів сигналізують про негативну UX (юзер масово ріже
+      // запити, бо відповіді занадто повільні).
+      const kind = isApiError(e)
+        ? e.kind
+        : (e as { name?: string } | null)?.name === "AbortError"
+          ? "aborted"
+          : "unknown";
+      const status = isApiError(e) && e.kind === "http" ? e.status : undefined;
+      trackEvent(ANALYTICS_EVENTS.HUBCHAT_ERROR, {
+        kind,
+        ...(status !== undefined ? { status } : {}),
+      });
     } finally {
       if (abortRef.current === ac) abortRef.current = null;
       setLoading(false);

--- a/docs/observability/frontend.md
+++ b/docs/observability/frontend.md
@@ -149,8 +149,9 @@ Lightweight product analytics sink: **console logger + localStorage ring-buffer*
 fire-and-forget, ніколи не кидає.
 
 **Event names** визначені в `@sergeant/shared` →
-`packages/shared/src/lib/analyticsEvents.ts` → `ANALYTICS_EVENTS` (~40 подій:
-onboarding, finyk, FTUX, auth, nudges, hints). Typo не компілюється.
+`packages/shared/src/lib/analyticsEvents.ts` → `ANALYTICS_EVENTS` (~50 подій:
+onboarding, finyk, FTUX, auth, nudges, hints, hubchat, cloudsync, subscription).
+Typo не компілюється.
 
 **Sentry зв'язок**: analytics не емітить breadcrumbs напряму, але
 `console.log("[analytics]", event)` потрапляє у Sentry console-breadcrumbs
@@ -204,6 +205,72 @@ auto-pageview стріляє на будь-яку мутацію URL (включ
 чутливі query-ключі (`token`, `code`, `state`, `access_token`,
 `refresh_token`, `magic`, `auth`, `password`, `secret`, `api_key`)
 редактуються до `[redacted]`. Без `VITE_POSTHOG_KEY` ефект no-op.
+
+### HubChat events
+
+**Файл:** `apps/web/src/core/hub/HubChat.tsx`.
+
+Трекаємо факт взаємодії з асистентом, НЕ текст повідомлень. Три події:
+
+| Event                  | Коли                                              | Payload                                                                        |
+| ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `hubchat_message_sent` | Юзер відправив повідомлення (після всіх guard-ів) | `{ length, fromVoice, module? }`                                               |
+| `hubchat_tool_invoked` | На кожен `tool_call` із відповіді LLM             | `{ tool, module? }`                                                            |
+| `hubchat_error`        | Будь-яка помилка у `send()` catch-блоці           | `{ kind, status? }` де `kind ∈ http \| parse \| aborted \| network \| unknown` |
+
+`length` — кількість символів, не текст; `fromVoice: boolean` — дає розділити
+voice vs typed сценарії у funnels; `tool` — канонічне ім'я `ChatAction`
+(напр. `add_expense`, `log_workout`). Для `hubchat_error` `status` заповнюється
+тільки для `kind=http` (HTTP-код сервера), щоб алерт-и ловили spike-и 5xx
+окремо від 4xx.
+
+### CloudSync events
+
+**Файл:** `apps/web/src/core/cloudSync/hook/useSyncCallbacks.ts` — lifecycle
+(start/success/fail). **Файли:** `engine/push.ts`, `engine/initialSync.ts` —
+conflict-резолюція.
+
+| Event                    | Коли                                                      | Payload                                        |
+| ------------------------ | --------------------------------------------------------- | ---------------------------------------------- |
+| `sync_started`           | `onStart` у `makeBoundCallbacks`                          | `{}`                                           |
+| `sync_succeeded`         | `onSuccess` — успішний прогін `runExclusive`              | `{ duration_ms }`                              |
+| `sync_failed`            | `onError` — після класифікації `toSyncError`              | `{ error_type, retryable, duration_ms }`       |
+| `sync_conflict_resolved` | `conflicted.length > 0` у `pushAll` / `initialSync.merge` | `{ kind: "push" \| "initial-merge", modules }` |
+
+`error_type` — категорія з `SyncError["type"]` (`network` / `auth` / `conflict`
+/ `validation` / `unknown`). `retryable` — boolean з того самого normalizer-а;
+дозволяє відокремити транзієнтні помилки від терміналу (4xx без авто-retry).
+`modules` у `sync_conflict_resolved` — лічильник, не імена модулів: кардинальність
+у PostHog залишається маленькою, але spike-и LWW-loss детектуються.
+
+### Subscription events (placeholders)
+
+Білінг ще не підключений, але канонічні імена вже зафіксовані в
+`ANALYTICS_EVENTS` (`SUBSCRIPTION_STARTED`, `SUBSCRIPTION_CANCELED`,
+`SUBSCRIPTION_RENEWED`) — щоб у момент підключення Stripe/IAP не винаходити
+нові імена і не розвалити PostHog-funnel-и між першим і другим релізом.
+Очікувані payload-и (для майбутнього implementor-а):
+
+```ts
+trackEvent(ANALYTICS_EVENTS.SUBSCRIPTION_STARTED, {
+  plan: "monthly" | "yearly",
+  source: "paywall" | "deeplink" | "cta",
+  price_cents: number,
+  currency: string, // ISO-4217, "UAH" / "USD" / …
+});
+trackEvent(ANALYTICS_EVENTS.SUBSCRIPTION_CANCELED, {
+  plan: string,
+  reason: "user" | "billing" | "expired",
+});
+trackEvent(ANALYTICS_EVENTS.SUBSCRIPTION_RENEWED, {
+  plan: string,
+  period: number, // кількість успішних renewal-ів
+});
+```
+
+Revenue-аналітика (MRR/ARR у PostHog) рахується через super-property
+`$revenue` на `subscription_started` / `subscription_renewed` — окремий
+task коли білінг оживе.
 
 ### Identify / reset
 

--- a/packages/shared/src/lib/analyticsEvents.test.ts
+++ b/packages/shared/src/lib/analyticsEvents.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { ANALYTICS_EVENTS } from "./analyticsEvents";
+
+describe("ANALYTICS_EVENTS registry", () => {
+  it("is frozen so callsites cannot mutate event names at runtime", () => {
+    expect(Object.isFrozen(ANALYTICS_EVENTS)).toBe(true);
+  });
+
+  it("keeps all event names unique (no accidental duplicates)", () => {
+    const values = Object.values(ANALYTICS_EVENTS);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it("keeps event strings snake_case and stable", () => {
+    for (const value of Object.values(ANALYTICS_EVENTS)) {
+      expect(value).toMatch(/^[a-z][a-z0-9]*(_[a-z0-9]+)*$/);
+    }
+  });
+
+  // Canonical event names — if any of these change, dashboards / funnels in
+  // PostHog must move with them in the same PR. The registry is the source
+  // of truth, but this assertion makes a rename impossible by accident.
+  it("exposes the HubChat / CloudSync / Subscription groups verbatim", () => {
+    expect(ANALYTICS_EVENTS.HUBCHAT_MESSAGE_SENT).toBe("hubchat_message_sent");
+    expect(ANALYTICS_EVENTS.HUBCHAT_TOOL_INVOKED).toBe("hubchat_tool_invoked");
+    expect(ANALYTICS_EVENTS.HUBCHAT_ERROR).toBe("hubchat_error");
+
+    expect(ANALYTICS_EVENTS.SYNC_STARTED).toBe("sync_started");
+    expect(ANALYTICS_EVENTS.SYNC_SUCCEEDED).toBe("sync_succeeded");
+    expect(ANALYTICS_EVENTS.SYNC_FAILED).toBe("sync_failed");
+    expect(ANALYTICS_EVENTS.SYNC_CONFLICT_RESOLVED).toBe(
+      "sync_conflict_resolved",
+    );
+
+    expect(ANALYTICS_EVENTS.SUBSCRIPTION_STARTED).toBe("subscription_started");
+    expect(ANALYTICS_EVENTS.SUBSCRIPTION_CANCELED).toBe(
+      "subscription_canceled",
+    );
+    expect(ANALYTICS_EVENTS.SUBSCRIPTION_RENEWED).toBe("subscription_renewed");
+  });
+});

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -67,6 +67,63 @@ export const ANALYTICS_EVENTS = Object.freeze({
   HINT_CLICKED: "hint_clicked",
   HINT_DISMISSED: "hint_dismissed",
   HINT_COMPLETED: "hint_completed",
+
+  // HubChat — AI conversational assistant.
+  //
+  // Трекаємо факт взаємодії, НЕ текст повідомлень. Payload-контракти:
+  //
+  //   HUBCHAT_MESSAGE_SENT   { length: number, fromVoice: boolean,
+  //                            hasQuickAction?: boolean, module?: string }
+  //   HUBCHAT_TOOL_INVOKED   { tool: string, module: string,
+  //                            success: boolean, latency_ms: number }
+  //   HUBCHAT_ERROR          { kind: "http" | "parse" | "aborted" | "network"
+  //                                 | "unknown",
+  //                            status?: number }
+  //
+  // `tool` — канонічне ім'я ChatAction (напр. `add_expense`, `log_workout`).
+  // Body повідомлень / tool_input НЕ потрапляють у payload — лише counts
+  // + latency + провайдер/модуль, щоб дашборди працювали без експорту PII.
+  HUBCHAT_MESSAGE_SENT: "hubchat_message_sent",
+  HUBCHAT_TOOL_INVOKED: "hubchat_tool_invoked",
+  HUBCHAT_ERROR: "hubchat_error",
+
+  // CloudSync — local-first replication engine (`apps/web/src/core/cloudSync`).
+  //
+  //   SYNC_STARTED            { trigger?: "manual" | "auto" | "initial" }
+  //   SYNC_SUCCEEDED          { duration_ms: number, modules?: number }
+  //   SYNC_FAILED             { error_type: SyncError["type"],
+  //                             retryable: boolean, duration_ms?: number }
+  //   SYNC_CONFLICT_RESOLVED  { kind: "push" | "initial-merge",
+  //                             modules: number }
+  //
+  // `SYNC_CONFLICT_RESOLVED.modules` — кількість модулів, для яких LWW
+  // guard на бекенді повернув `conflict: true` (push) або локальні
+  // dirty-зміни переважили cloud-snapshot (initial-merge). Дозволяє
+  // алерт-ити spike-и conflict-ів без експорту body.
+  SYNC_STARTED: "sync_started",
+  SYNC_SUCCEEDED: "sync_succeeded",
+  SYNC_FAILED: "sync_failed",
+  SYNC_CONFLICT_RESOLVED: "sync_conflict_resolved",
+
+  // Subscription / billing — placeholders. Білінг поки не підключено;
+  // константи зафіксовані тут, щоб майбутні callsite-и не винаходили
+  // власні імена і дашборд-funnel-и у PostHog не розвалилися між
+  // першим і другим релізом білінгу. Коли IAP / Stripe-інтеграція
+  // оживе, payload-контракти очікуються такі:
+  //
+  //   SUBSCRIPTION_STARTED   { plan: "monthly" | "yearly",
+  //                            source: "paywall" | "deeplink" | "cta",
+  //                            price_cents: number, currency: string }
+  //   SUBSCRIPTION_CANCELED  { plan: string, reason?: "user" | "billing"
+  //                                                  | "expired" }
+  //   SUBSCRIPTION_RENEWED   { plan: string, period: number }
+  //
+  // Revenue-аналітика (MRR / ARR) рахується у PostHog через
+  // `$revenue` super-property на `SUBSCRIPTION_STARTED` /
+  // `SUBSCRIPTION_RENEWED` (task TBD коли буде білінг).
+  SUBSCRIPTION_STARTED: "subscription_started",
+  SUBSCRIPTION_CANCELED: "subscription_canceled",
+  SUBSCRIPTION_RENEWED: "subscription_renewed",
 } as const);
 
 export type AnalyticsEventName =


### PR DESCRIPTION
## What changed

Розширено `ANALYTICS_EVENTS` (`packages/shared/src/lib/analyticsEvents.ts`) трьома групами канонічних імен і підключено `trackEvent(…)` у реальні callsite-и:

- **HubChat** — `hubchat_message_sent`, `hubchat_tool_invoked`, `hubchat_error` у `apps/web/src/core/hub/HubChat.tsx` (на send-entry, на кожен `tool_call`, у catch-блоці з класифікацією `kind`).
- **CloudSync** — `sync_started`, `sync_succeeded`, `sync_failed`, `sync_conflict_resolved` у `apps/web/src/core/cloudSync/hook/useSyncCallbacks.ts` (lifecycle: start/success/fail з `duration_ms`) + `apps/web/src/core/cloudSync/engine/push.ts` і `initialSync.ts` (LWW-conflict).
- **Subscription placeholders** — `subscription_started`, `subscription_canceled`, `subscription_renewed` як константи з JSDoc-контрактом payload. Callsite-ів поки немає — білінг не підключений, але імена зафіксовані, щоб перший PostHog-funnel після підключення Stripe/IAP не треба було переписувати.

Оновлено таксономію подій у `docs/observability/frontend.md` (секції HubChat events / CloudSync events / Subscription events).

## Why

§10 з плану PostHog-observability ([посилання в попередньому PR #980](https://github.com/Skords-01/Sergeant/pull/980)) — додаткові групи подій для:
- HubChat voice-vs-typed розподіл + spike-и 5xx / parse-помилок у assistant-flow.
- CloudSync — середня тривалість sync-у, rate-и `error_type=network` / `retryable=false`, spike-и `sync_conflict_resolved` як сигнал LWW-регресії або clock-drift.
- Subscription — зафіксувати naming щоб уникнути drift-у між релізами білінгу.

Без PII: body повідомлень / tool_input / назви модулів-конфліктів не потрапляють у payload — тільки counts, latency, тип помилки.

## How to test

1. Локально у devtools з `VITE_POSTHOG_KEY` виставленим:
   - Надіслати повідомлення у HubChat → `console.log("[analytics]", { eventName: "hubchat_message_sent", payload: { length, fromVoice: false, module } })`.
   - Якщо LLM повертає `tool_call` → додатково `hubchat_tool_invoked` з `{ tool, module }`.
   - Вимкнути мережу і надіслати → `hubchat_error` з `kind: "network"`.
2. Сховати напис у sync-панелі, почати sync → `sync_started` → `sync_succeeded` з `duration_ms`.
3. Якщо сервер повертає `{ ok: true, conflict: true }` на push → `sync_conflict_resolved` з `kind: "push"` і лічильником модулів.

## How AI-tested this PR

- [x] Vitest passes:
  - `pnpm --filter @sergeant/shared test -- --run` → 277 passed (включно з 4 новими для `ANALYTICS_EVENTS` registry).
  - `pnpm --filter @sergeant/web test -- --run` → 1342 passed (включно з 1 новим regression-тестом на `sync_conflict_resolved` у `push.test.ts`).
- [x] Typecheck:
  - `pnpm --filter @sergeant/web typecheck` → 0 errors.
  - `pnpm --filter @sergeant/shared typecheck` → 0 errors.
- [x] Lint: `pnpm --filter @sergeant/web lint` → 0 errors.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian (taxonomy tables у `docs/observability/frontend.md`).

## AGENTS.md updated?

- [ ] Yes
- [x] No — no new permanent rules (конвенції PostHog-трекінгу вже зафіксовані у попередніх PR-ах і в `docs/observability/frontend.md`).


Link to Devin session: https://app.devin.ai/sessions/4b8b665710b54beab9b0479c398d7e70
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
