### PR TITLE
feat(web): posthog identify traits (vibe, plan, locale, signup_date)

### DIFF
--- a/apps/server/src/routes/me.ts
+++ b/apps/server/src/routes/me.ts
@@ -9,7 +9,22 @@ type AuthedUser = {
   name?: string;
   image?: string | null;
   emailVerified?: boolean;
+  // Better Auth повертає `createdAt` як `Date`; нормалізуємо у ISO-рядок
+  // нижче (схема `UserSchema` очікує `string | null`). Допускаємо `string`
+  // на випадок, якщо адаптер сесії віддасть уже серіалізоване значення.
+  createdAt?: Date | string;
 };
+
+function toIsoOrNull(value: Date | string | undefined): string | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  return null;
+}
 
 /**
  * `/api/me` — уніфікований endpoint "хто я" для web cookie-сесій та
@@ -49,6 +64,7 @@ export function createMeRouter(): Router {
           name: user.name ?? null,
           image: user.image ?? null,
           emailVerified: Boolean(user.emailVerified),
+          createdAt: toIsoOrNull(user.createdAt),
         },
       });
       res.json(payload);

--- a/apps/web/src/core/auth/AuthContext.test.tsx
+++ b/apps/web/src/core/auth/AuthContext.test.tsx
@@ -73,6 +73,7 @@ interface UseUserState {
           name: string | null;
           image: string | null;
           emailVerified: boolean;
+          createdAt: string | null;
         };
       }
     | undefined;
@@ -109,6 +110,7 @@ const SAMPLE_USER = {
   name: "A",
   image: null,
   emailVerified: true,
+  createdAt: "2026-01-15T08:30:00.000Z",
 };
 
 describe("AuthContext", () => {

--- a/apps/web/src/core/auth/AuthContext.tsx
+++ b/apps/web/src/core/auth/AuthContext.tsx
@@ -13,6 +13,7 @@ import { useUser, apiQueryKeys } from "@sergeant/api-client/react";
 import type { User } from "@sergeant/shared";
 import { signIn, signUp, signOut, forgetPassword } from "./authClient";
 import { identifyPostHogUser, resetPostHog } from "../observability/posthog";
+import { buildIdentifyTraits } from "../observability/identifyTraits";
 
 /**
  * AuthContext — єдине джерело правди «хто я» для веб-додатку.
@@ -145,17 +146,35 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Привʼязуємо/відвʼязуємо аналітику до userId. Ref тримає попередній
   // userId, щоб `reset()` викликався тільки на реальному переході
   // authenticated → unauthenticated, а не при першому mount з `null`.
+  // Traits (vibe / plan / locale / signup_date) збираються у
+  // `buildIdentifyTraits()` — див. JSDoc у `identifyTraits.ts` про
+  // джерела і поведінку при відсутності localStorage / navigator.
   const lastIdentifiedUserIdRef = useRef<string | null>(null);
   useEffect(() => {
     const currentId = user?.id ?? null;
     const prevId = lastIdentifiedUserIdRef.current;
-    if (currentId && currentId !== prevId) {
-      identifyPostHogUser(currentId);
+    if (currentId && user && currentId !== prevId) {
+      // Cast у `Record<string, unknown>` — `IdentifyTraits` має іменовані
+      // опціональні поля без index-signature, тому TS не звужує його до
+      // record-у автоматично. Контракт `identifyPostHogUser` приймає
+      // довільний bag-of-properties — типи трейтів захищає сам
+      // `buildIdentifyTraits`.
+      identifyPostHogUser(
+        currentId,
+        buildIdentifyTraits(user) as Record<string, unknown>,
+      );
       lastIdentifiedUserIdRef.current = currentId;
     } else if (!currentId && prevId) {
       resetPostHog();
       lastIdentifiedUserIdRef.current = null;
     }
+    // `user` навмисно НЕ в deps: traits, які залежать від `user`
+    // (signup_date), стабільні на час життя ідентифікованої сесії, а
+    // решта (vibe / plan / locale) тягнеться з зовнішніх джерел —
+    // localStorage і `navigator`. Перезапуск ефекту на кожен новий
+    // `user`-референс (наприклад, після refetch `/api/v1/me`)
+    // спричинив би зайві identify-виклики при тому самому id.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id]);
 
   // Request a password reset email via Better Auth. Returns `true` when

--- a/apps/web/src/core/observability/identifyTraits.test.ts
+++ b/apps/web/src/core/observability/identifyTraits.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { User } from "@sergeant/shared";
+
+const getVibePicksMock = vi.fn();
+
+vi.mock("../onboarding/vibePicks", async () => {
+  const actual = await vi.importActual<
+    typeof import("../onboarding/vibePicks")
+  >("../onboarding/vibePicks");
+  return {
+    ...actual,
+    getVibePicks: () => getVibePicksMock(),
+  };
+});
+
+import { buildIdentifyTraits } from "./identifyTraits";
+
+const BASE_USER: User = {
+  id: "user-123",
+  email: "test@example.com",
+  name: "Тест",
+  image: null,
+  emailVerified: true,
+  createdAt: "2026-01-15T08:30:00.000Z",
+};
+
+beforeEach(() => {
+  getVibePicksMock.mockReset().mockReturnValue([]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildIdentifyTraits", () => {
+  it("повертає всі чотири трейти, коли всі джерела доступні", () => {
+    getVibePicksMock.mockReturnValue(["finyk", "fizruk"]);
+    vi.stubGlobal("navigator", { language: "uk-UA" });
+
+    const traits = buildIdentifyTraits(BASE_USER);
+
+    expect(traits).toEqual({
+      vibe: ["finyk", "fizruk"],
+      plan: "free",
+      locale: "uk-UA",
+      signup_date: "2026-01-15",
+    });
+  });
+
+  it("`signup_date` — це YYYY-MM-DD у UTC, не в локальному TZ", () => {
+    // 2026-01-15 02:30 UTC = 2026-01-15 04:30 у Києві (UTC+2 взимку),
+    // але також 2026-01-15 у Лос-Анджелесі (UTC-8) — там було б
+    // 2026-01-14. Тест фіксує саме UTC-зріз.
+    const traits = buildIdentifyTraits({
+      ...BASE_USER,
+      createdAt: "2026-01-15T02:30:00.000Z",
+    });
+    expect(traits.signup_date).toBe("2026-01-15");
+  });
+
+  it("опускає `vibe`, якщо vibe-picks порожні", () => {
+    getVibePicksMock.mockReturnValue([]);
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits).not.toHaveProperty("vibe");
+  });
+
+  it("опускає `vibe`, якщо `getVibePicks` кинув (наприклад quota)", () => {
+    getVibePicksMock.mockImplementation(() => {
+      throw new Error("quota");
+    });
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits).not.toHaveProperty("vibe");
+  });
+
+  it("опускає `signup_date`, якщо `createdAt` = null", () => {
+    const traits = buildIdentifyTraits({ ...BASE_USER, createdAt: null });
+    expect(traits).not.toHaveProperty("signup_date");
+  });
+
+  it("опускає `signup_date`, якщо `createdAt` зіпсований", () => {
+    const traits = buildIdentifyTraits({
+      ...BASE_USER,
+      createdAt: "not-a-date",
+    });
+    expect(traits).not.toHaveProperty("signup_date");
+  });
+
+  it("обрізає `locale` до 16 символів (узгоджено з `Locale` schema)", () => {
+    vi.stubGlobal("navigator", {
+      language: "x".repeat(64),
+    });
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits.locale).toHaveLength(16);
+  });
+
+  it("опускає `locale`, якщо `navigator.language` порожній", () => {
+    vi.stubGlobal("navigator", { language: "   " });
+    const traits = buildIdentifyTraits(BASE_USER);
+    expect(traits).not.toHaveProperty("locale");
+  });
+
+  it("`plan` завжди `free` до запуску підписок", () => {
+    expect(buildIdentifyTraits(BASE_USER).plan).toBe("free");
+  });
+});

--- a/apps/web/src/core/observability/identifyTraits.ts
+++ b/apps/web/src/core/observability/identifyTraits.ts
@@ -1,0 +1,98 @@
+import type { User } from "@sergeant/shared";
+import { getVibePicks, type HubModuleId } from "../onboarding/vibePicks";
+
+/**
+ * Person properties (traits), які прокидаються в PostHog `identify(distinctId, traits)`
+ * з `AuthContext` після переходу у `authenticated`. Усі поля опціональні —
+ * якщо джерело недоступне (наприклад, `localStorage` у Capacitor у
+ * cold-start, або `navigator.language` у не-DOM-середовищі), трейт
+ * просто не потрапляє у payload, замість того щоб ламати identify.
+ *
+ * Контракт навмисно вузький:
+ *   - `vibe` — масив id вкладок ("finyk", "fizruk", …) з онбордингу.
+ *     Сегментуємо ретеншн і funnel-и за тим, який модуль користувач
+ *     обрав на старті. Якщо vibe-picks порожні — поле опускаємо.
+ *   - `plan` — поточний tier підписки. Поки що Stripe/billing немає
+ *     (див. `docs/launch/01-monetization-and-pricing.md`), тому всі
+ *     ідентифіковані юзери `"free"`. Коли підписки з'являться, цей
+ *     модуль буде єдине місце, де треба підставити реальне джерело.
+ *   - `locale` — `navigator.language` без подальшої нормалізації,
+ *     обрізаний до 16 символів (узгоджено з `Locale` schema в
+ *     `packages/shared/src/schemas/api.ts`).
+ *   - `signup_date` — `YYYY-MM-DD` у UTC з `user.createdAt`. Дата без
+ *     часу свідома: дозволяє "за днем життя акаунта" сегментацію без
+ *     зайвого PII (точна година реєстрації нікому не потрібна для
+ *     funnels).
+ */
+export interface IdentifyTraits {
+  vibe?: HubModuleId[];
+  plan?: "free" | "pro";
+  locale?: string;
+  signup_date?: string;
+}
+
+const MAX_LOCALE_LENGTH = 16;
+
+function safeNavigatorLanguage(): string | null {
+  try {
+    if (typeof navigator === "undefined") return null;
+    const lang = navigator.language;
+    if (typeof lang !== "string") return null;
+    const trimmed = lang.trim();
+    if (!trimmed) return null;
+    return trimmed.slice(0, MAX_LOCALE_LENGTH);
+  } catch {
+    return null;
+  }
+}
+
+function safeVibePicks(): HubModuleId[] {
+  try {
+    return getVibePicks();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Перетворює ISO-рядок з `user.createdAt` у `YYYY-MM-DD` (UTC). Будь-яке
+ * не-ISO значення → `null` (а не throw): identify навмисно толерантний
+ * до зіпсованих legacy-юзерів.
+ */
+function toSignupDate(createdAt: string | null | undefined): string | null {
+  if (!createdAt) return null;
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Поточний підписковий tier. До реальних підписок завжди `"free"` —
+ * див. JSDoc `IdentifyTraits.plan`.
+ */
+function currentPlan(): "free" | "pro" {
+  return "free";
+}
+
+/**
+ * Будує traits-обʼєкт для PostHog `identify`. Опускає поля, у яких
+ * джерело недоступне, щоб не перетирати раніше встановлені person
+ * properties у PostHog порожнім значенням.
+ */
+export function buildIdentifyTraits(user: User): IdentifyTraits {
+  const traits: IdentifyTraits = { plan: currentPlan() };
+
+  const vibe = safeVibePicks();
+  if (vibe.length > 0) traits.vibe = vibe;
+
+  const locale = safeNavigatorLanguage();
+  if (locale) traits.locale = locale;
+
+  const signupDate = toSignupDate(user.createdAt);
+  if (signupDate) traits.signup_date = signupDate;
+
+  return traits;
+}

--- a/apps/web/src/core/profile/ProfilePage.test.tsx
+++ b/apps/web/src/core/profile/ProfilePage.test.tsx
@@ -62,6 +62,7 @@ const mockUser = {
   name: "Тест",
   image: null as string | null,
   emailVerified: true,
+  createdAt: "2026-01-15T08:30:00.000Z" as string | null,
 };
 const refreshMock = vi.fn(async () => undefined);
 const logoutMock = vi.fn(async () => undefined);

--- a/docs/observability/frontend.md
+++ b/docs/observability/frontend.md
@@ -209,12 +209,31 @@ auto-pageview стріляє на будь-яку мутацію URL (включ
 
 `AuthContext` слухає `user?.id` і викликає:
 
-- `identifyPostHogUser(userId)` — при переході у `authenticated`.
+- `identifyPostHogUser(userId, traits)` — при переході у `authenticated`.
 - `resetPostHog()` — при переході `authenticated → unauthenticated`.
 
 Виклики fire-and-forget; події, що прилетіли до завершення init,
 буферизуються (до 100) і flush-ляться після завантаження SDK. Buffer
 відкидається, якщо `VITE_POSTHOG_KEY` не виставлений.
+
+#### Person traits
+
+`buildIdentifyTraits(user)` (`apps/web/src/core/observability/identifyTraits.ts`)
+збирає person properties для `identify` payload-у:
+
+| Trait         | Джерело                                                        | Формат                 | Примітки                                                                                                            |
+| ------------- | -------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `vibe`        | `getVibePicks()` (localStorage `hub_onboarding_vibes_v1`)      | `DashboardModuleId[]`  | Опускається, якщо vibe-picks порожні або `localStorage` недоступний. Сегментуємо ретеншн і funnel-и за вкладкою.    |
+| `plan`        | константа `"free"`                                             | `"free" \| "pro"`      | До запуску підписок (Stripe / LiqPay) завжди `"free"`. `identifyTraits.ts` — єдине місце, де треба підставити tier. |
+| `locale`      | `navigator.language`                                           | string ≤ 16 chars      | Узгоджено з `Locale` schema у `packages/shared/src/schemas/api.ts`. Опускається, якщо `navigator` недоступний.      |
+| `signup_date` | `user.createdAt` з `/api/v1/me` (Better Auth `user.createdAt`) | `YYYY-MM-DD` у **UTC** | Лише дата, без часу — без зайвого PII. Опускається, якщо `createdAt` = null або зіпсована.                          |
+
+Контракт навмисно **толерантний**: будь-яке з джерел може мовчазно
+відмовитись (Capacitor cold-start без localStorage, SSR-середовище без
+`navigator`, legacy-юзери з `createdAt = null`) — `identify` все одно
+виконається з тими трейтами, що доступні. Це краще, ніж ламати
+identify повністю або перетирати раніше встановлений person property
+порожнім значенням.
 
 ### ENV
 

--- a/packages/api-client/src/endpoints/me.test.ts
+++ b/packages/api-client/src/endpoints/me.test.ts
@@ -40,6 +40,7 @@ describe("createMeEndpoints", () => {
         name: "Тест",
         image: null,
         emailVerified: true,
+        createdAt: "2026-01-15T08:30:00.000Z",
       },
     });
 
@@ -54,6 +55,7 @@ describe("createMeEndpoints", () => {
         name: "Тест",
         image: null,
         emailVerified: true,
+        createdAt: "2026-01-15T08:30:00.000Z",
       },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -80,6 +82,7 @@ describe("createMeEndpoints", () => {
         name: null,
         image: null,
         emailVerified: false,
+        createdAt: null,
       },
     });
     const me = createMeEndpoints(createHttpClient());
@@ -94,6 +97,7 @@ describe("createMeEndpoints", () => {
         name: null,
         image: null,
         emailVerified: false,
+        createdAt: null,
       },
     });
     const me = createMeEndpoints(createHttpClient());

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -24,6 +24,12 @@ export const UserSchema = z.object({
   name: z.string().nullable(),
   image: z.string().nullable(),
   emailVerified: z.boolean(),
+  // Better Auth's `user.createdAt` (час реєстрації акаунта) — ISO-8601
+  // рядок. Потрібен PostHog `identify` для трейту `signup_date` і для
+  // майбутніх "за днем життя акаунта" сегментацій. Nullable, бо для
+  // legacy-юзерів, у яких поле відсутнє у БД, краще лишити null, ніж
+  // валити `/api/v1/me` для всієї сесії.
+  createdAt: z.string().datetime({ offset: true }).nullable(),
 });
 export type User = z.infer<typeof UserSchema>;
 

--- a/packages/shared/src/schemas/me.test.ts
+++ b/packages/shared/src/schemas/me.test.ts
@@ -10,6 +10,7 @@ describe("UserSchema", () => {
         name: "Ім'я",
         image: null,
         emailVerified: true,
+        createdAt: "2026-01-15T08:30:00.000Z",
       }),
     ).toEqual({
       id: "u-1",
@@ -17,6 +18,7 @@ describe("UserSchema", () => {
       name: "Ім'я",
       image: null,
       emailVerified: true,
+      createdAt: "2026-01-15T08:30:00.000Z",
     });
   });
 
@@ -28,8 +30,9 @@ describe("UserSchema", () => {
         name: null,
         image: null,
         emailVerified: false,
+        createdAt: null,
       }),
-    ).toMatchObject({ email: null, name: null, image: null });
+    ).toMatchObject({ email: null, name: null, image: null, createdAt: null });
   });
 
   it.each(["", " ", "bad-email"])("падає на невалідному email %p", (email) => {
@@ -40,6 +43,7 @@ describe("UserSchema", () => {
         name: null,
         image: null,
         emailVerified: false,
+        createdAt: null,
       }),
     ).toThrow();
   });
@@ -52,6 +56,20 @@ describe("UserSchema", () => {
         name: null,
         image: null,
         emailVerified: false,
+        createdAt: null,
+      }),
+    ).toThrow();
+  });
+
+  it("падає на не-ISO createdAt", () => {
+    expect(() =>
+      UserSchema.parse({
+        id: "u-5",
+        email: null,
+        name: null,
+        image: null,
+        emailVerified: false,
+        createdAt: "yesterday",
       }),
     ).toThrow();
   });
@@ -70,8 +88,10 @@ describe("MeResponseSchema", () => {
         name: "A",
         image: "https://x.test/avatar.png",
         emailVerified: true,
+        createdAt: "2026-01-15T08:30:00.000Z",
       },
     });
     expect(parsed.user.id).toBe("u-4");
+    expect(parsed.user.createdAt).toBe("2026-01-15T08:30:00.000Z");
   });
 });


### PR DESCRIPTION
## What changed

- Доданий хелпер `apps/web/src/core/observability/identifyTraits.ts` з функцією `buildIdentifyTraits(user)`, що збирає person properties для PostHog `identify`:
  - `vibe` — масив `DashboardModuleId` з `getVibePicks()` (localStorage `hub_onboarding_vibes_v1`); опускається, якщо vibe-picks порожні або `localStorage` недоступний.
  - `plan` — поки що завжди `"free"` (Stripe/LiqPay не підключений; `identifyTraits.ts` — єдине місце, де треба підставити реальний tier коли підписки запустяться).
  - `locale` — `navigator.language`, обрізаний до 16 символів (узгоджено з `Locale` schema у `packages/shared/src/schemas/api.ts`).
  - `signup_date` — `YYYY-MM-DD` у UTC з `user.createdAt`. Лише дата без часу, щоб не тягнути зайвий PII.
- `apps/web/src/core/auth/AuthContext.tsx` — `useEffect`, що викликав `identifyPostHogUser(currentId)`, тепер прокидає traits: `identifyPostHogUser(currentId, buildIdentifyTraits(user))`. Deps лишилися `[user?.id]` — детальний коментар чому в коді (не хочемо зайвих identify на кожен новий `user`-референс після refetch `/api/v1/me`).
- `packages/shared/src/schemas/api.ts` — `UserSchema` отримав поле `createdAt: z.string().datetime({ offset: true }).nullable()`. Це єдине джерело правди для traits-у `signup_date`.
- `apps/server/src/routes/me.ts` — `/api/v1/me` тепер серіалізує `user.createdAt` (Better Auth повертає `Date`) у ISO-рядок через локальний хелпер `toIsoOrNull()`. Зіпсовані / відсутні значення → `null`, а не throw.
- Оновлені тестові фікстури під нову схему: `packages/api-client/src/endpoints/me.test.ts`, `packages/shared/src/schemas/me.test.ts` (+ новий тест на не-ISO `createdAt`), `apps/web/src/core/auth/AuthContext.test.tsx`, `apps/web/src/core/profile/ProfilePage.test.tsx`.
- Новий unit-suite `apps/web/src/core/observability/identifyTraits.test.ts` — 9 тестів: всі трейти разом, UTC-зріз `signup_date`, толерантність до зіпсованого `createdAt`, fallback при недоступному `localStorage`/`navigator`, обрізання `locale` до 16 символів, `plan === "free"`.
- `docs/observability/frontend.md` — додана таблиця "Person traits" у секції "Identify / reset" з джерелами, форматами і поведінкою при відсутності.

PostHog `posthog.ts` transport **не міняється**: контракт `identifyPostHogUser(userId, traits?)` уже існував (PR #972, де він був додав з `traits?: Record<string, unknown>`). Цей PR лише починає його використовувати.

## Why

До цього PR-а `identify` слав тільки `distinctId` без person properties, тому в PostHog UI неможливо було сегментувати за:

- **Vibe-онбордингом** — який модуль користувач обрав на старті (`finyk` / `fizruk` / …). Це найкорисніший зріз для retention curves: чи vibe `nutrition` тримається краще за `finyk` на 7-й день?
- **Locale** — україно-/англомовні юзери ведуть себе по-різному (особливо в HubChat).
- **Signup date** — "за днем життя акаунта" сегментація для funnel-ів і feature-flag rollouts (нові юзери проти сторожилів).
- **Plan** — поки що вироджений (всі `free`), але контракт уже на місці, щоб коли підписки запустяться (див. `docs/launch/01-monetization-and-pricing.md`), не довелось мігрувати історичні events.

Контракт навмисно толерантний: будь-яке з джерел може мовчазно відмовитись (Capacitor cold-start без `localStorage`, SSR без `navigator`, legacy-юзери з `createdAt = null`) — `identify` усе одно виконається з тими трейтами, що доступні. Це краще, ніж ламати identify повністю або перетирати раніше встановлений person property порожнім значенням.

## How to test

Локально:

```bash
pnpm --filter @sergeant/shared test -- --run
pnpm --filter @sergeant/api-client test -- --run
pnpm --filter @sergeant/web test -- --run src/core/observability/ src/core/auth/ src/core/profile/
pnpm --filter @sergeant/server test -- --run
pnpm --filter @sergeant/web typecheck
pnpm --filter @sergeant/server typecheck
pnpm lint
```

Усі мають пройти.

Manual smoke (потрібен `VITE_POSTHOG_KEY` і живий dev-server):

1. `pnpm --filter @sergeant/web dev` → відкрити DevTools → Network → фільтр `posthog`.
2. Залогінитись після проходження онбордингу з vibe-picks (наприклад, обрати `finyk` + `fizruk`).
3. У payload-і POST `/e/` події `$identify` має бути `properties.$set` з полями: `vibe: ["finyk","fizruk"]`, `plan: "free"`, `locale: "uk-UA"` (або як у браузері), `signup_date: "2026-..."`.
4. Logout → перейти у incognito, зареєструватися як новий юзер → identify знову вистрілює, `signup_date` — сьогоднішня дата.
5. У PostHog UI → Persons → відкрити свого юзера → у "Properties" мають зʼявитись `vibe`, `plan`, `locale`, `signup_date`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): не виконувався у цій сесії — потрібен `VITE_POSTHOG_KEY` і живий dev-server. Дії з пункту "How to test" рекомендовано проробити локально.
- [x] Vitest passes:
  - `pnpm --filter @sergeant/shared test -- --run` → 274 passed (22 файли, у т.ч. `me.test.ts` 9 тестів з новим case на не-ISO `createdAt`).
  - `pnpm --filter @sergeant/api-client test -- --run` → 59 passed.
  - `pnpm --filter @sergeant/web test -- --run` → 1350 passed (122 файли, у т.ч. новий `identifyTraits.test.ts` 9 тестів).
  - `pnpm --filter @sergeant/server test -- --run` → 543 passed (43 файли).
- [x] Typecheck passes: `pnpm --filter @sergeant/web typecheck`, `@sergeant/server typecheck`, `@sergeant/api-client typecheck` — exit 0.
- [x] Lint passes: `pnpm lint` — exit 0 (warnings, що залишилися — pre-existing tsconfig-strict migration warnings).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules. Контракт вже задокументований в `docs/observability/frontend.md` (нова секція "Person traits" з таблицею).

Link to Devin session: https://app.devin.ai/sessions/4dd4b802b5ec47deaaa4804beb2d1ed3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
