### PR TITLE
ci(ci): add posthog-release-annotation workflow

### DIFF
--- a/.github/workflows/posthog-release-annotation.yml
+++ b/.github/workflows/posthog-release-annotation.yml
@@ -1,0 +1,55 @@
+name: PostHog release annotation
+
+# Постить release annotation у PostHog після кожного merge у `main` —
+# момент, коли Vercel (frontend) і Railway (backend) тригерять
+# production deploy. Анотація відмалюється вертикальною лінією поверх
+# усіх PostHog-дашбордів (DAU, retention, paywall, error-rate), щоб
+# дроп/спайк після релізу одразу мав підпис «Release abc1234 …».
+#
+# Якщо `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` секрети не
+# виставлені (наприклад, у форках) — скрипт завершиться з exit 0
+# (graceful no-op), workflow не червонітиме.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Тільки логувати payload, без HTTP-виклику"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: posthog-release-annotation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  annotate:
+    name: Post release annotation
+    runs-on: ubuntu-latest
+    # Не блокуємо CI: workflow самостійний, не входить у required-checks.
+    timeout-minutes: 5
+    steps:
+      # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "20"
+
+      - name: Post release annotation to PostHog
+        run: node scripts/ci/posthog-release-annotation.mjs
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          POSTHOG_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}


### PR DESCRIPTION
## What changed

Додає `.github/workflows/posthog-release-annotation.yml` — компаньйон-workflow до скрипту `scripts/ci/posthog-release-annotation.mjs`, що пішов у main у PR #992. Тригери:

- `push` у `main` — після кожного merge постить release annotation у PostHog (`POST {host}/api/projects/{id}/annotations/`).
- `workflow_dispatch` (з `dry_run` опцією) — для smoke-перевірок без HTTP-виклику.

`actions/checkout` і `actions/setup-node` SHA-pinned (v6.0.2 / v6.4.0). Concurrency-група `posthog-release-annotation-${{ github.ref }}` без cancel-in-progress, щоб двох merge-ів поспіль не з'їдало одне одного.

## Why

PR #992 додав сам скрипт + 32 vitest-теста + docs у `docs/observability/frontend.md`, але `.github/workflows/*.yml` не вдалося пушнути через стандартний Devin GitHub App proxy без `workflow` OAuth scope. Цей PR закриває цей gap (запушений напряму через Contents API з PAT, який має `workflow` scope).

Без секретів `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` workflow завершується з exit 0 (graceful no-op у скрипті), тому форки і preview-середовища не червоніють.

## How to test

1. Після merge — на наступному push у `main` workflow-job "Post release annotation" запуститься у Actions; без секретів він має лог `[posthog-release-annotation] POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID не виставлені — пропускаю (no-op).` і exit 0.
2. Додати repo secrets (`Settings → Secrets and variables → Actions`):
   - `POSTHOG_PERSONAL_API_KEY` — Personal API key (`phx_…`), scope `annotation:write` + `project:read`.
   - `POSTHOG_PROJECT_ID` — числовий id з URL у PostHog UI.
   - `POSTHOG_HOST` (опц.) — дефолт `https://eu.posthog.com`.
3. Тригернути `workflow_dispatch` з `dry_run=true` — у логах має бути `[posthog-release-annotation] DRY RUN → https://…/annotations/ {…payload…}`, без HTTP-виклику.
4. Тригернути `workflow_dispatch` з `dry_run=false` (або зробити merge у main) — у PostHog UI: будь-який insight з time-axis отримує вертикальну лінію `Release <sha>: <commit subject>`; запис також видно у `Project → Annotations`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): локально прогнав workflow YAML через `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/posthog-release-annotation.yml'))"` (валідується), і протестував сам скрипт у PR #992 (graceful no-op + dry-run).
- [x] Vitest passes: тести скрипта вже у main з PR #992 (32/32).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — у PR #992 уже додано рядок про `posthog-release-annotation.yml` у "CI workflows" таблицю.
- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/b76b8ea36784472798cbb8982f5776e6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
