### PR TITLE
feat(web): PermissionsPrompt onboarding step (push / mic / camera)

### DIFF
--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -21,6 +21,7 @@ import {
   markOnboardingDone,
   shouldShowOnboarding as sharedShouldShowOnboarding,
 } from "./onboardingGate";
+import { PermissionsPrompt } from "./PermissionsPrompt";
 import { MODULE_LABELS } from "@shared/lib/moduleLabels";
 import {
   ONBOARDING_MODULE_DESCRIPTIONS,
@@ -593,6 +594,7 @@ export function OnboardingWizard({
     goals: { ...EMPTY_GOALS },
     stepStartedAt: Date.now(),
   });
+  const [showPermissions, setShowPermissions] = useState(false);
 
   // Track wizard start
   useEffect(() => {
@@ -671,10 +673,8 @@ export function OnboardingWizard({
     );
 
     // Track completion
-    const duration = Date.now() - state.stepStartedAt;
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
-      step: "goals",
-      durationMs: duration,
+      step: "permissions",
     });
     trackEvent(ANALYTICS_EVENTS.ONBOARDING_VIBE_PICKED, {
       picks: chosen,
@@ -690,7 +690,7 @@ export function OnboardingWizard({
     markFirstActionPending();
     markOnboardingDone();
     onDone(null, { intent: "vibe_empty", picks: chosen });
-  }, [state.picks, state.goals, state.stepStartedAt, onDone]);
+  }, [state.picks, state.goals, onDone]);
 
   const stepIdx = ONBOARDING_STEPS.indexOf(state.step);
 
@@ -710,22 +710,43 @@ export function OnboardingWizard({
     handleBack();
   }, [handleBack]);
 
-  const animatedFinish = useCallback(() => {
+  const goToPermissions = useCallback(() => {
+    setDirection("forward");
+    stepKeyRef.current += 1;
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_COMPLETED, {
+      step: "goals",
+      durationMs: Date.now() - state.stepStartedAt,
+    });
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, { step: "permissions" });
+    setShowPermissions(true);
+  }, [state.stepStartedAt]);
+
+  const finishFromPermissions = useCallback(() => {
     setDirection("forward");
     finish();
   }, [finish]);
+
+  const backFromPermissions = useCallback(() => {
+    setDirection("backward");
+    stepKeyRef.current += 1;
+    setShowPermissions(false);
+  }, []);
 
   const transitionClass =
     direction === "forward"
       ? "motion-safe:animate-step-forward"
       : "motion-safe:animate-step-backward";
 
+  const totalSteps = ONBOARDING_STEPS.length + 1;
+  const currentStepIdx = showPermissions ? ONBOARDING_STEPS.length : stepIdx;
   const content = (
     <div className="space-y-4">
-      <StepIndicator current={stepIdx} total={ONBOARDING_STEPS.length} />
+      <StepIndicator current={currentStepIdx} total={totalSteps} />
       <div key={stepKeyRef.current} className={transitionClass}>
-        {state.step === "welcome" && <WelcomeStep onContinue={animatedNext} />}
-        {state.step === "modules" && (
+        {!showPermissions && state.step === "welcome" && (
+          <WelcomeStep onContinue={animatedNext} />
+        )}
+        {!showPermissions && state.step === "modules" && (
           <ModulesStep
             picks={state.picks}
             togglePick={togglePick}
@@ -733,13 +754,19 @@ export function OnboardingWizard({
             onBack={animatedBack}
           />
         )}
-        {state.step === "goals" && (
+        {!showPermissions && state.step === "goals" && (
           <GoalsStep
             picks={state.picks}
             goals={state.goals}
             onSetGoal={setGoal}
-            onFinish={animatedFinish}
+            onFinish={goToPermissions}
             onBack={animatedBack}
+          />
+        )}
+        {showPermissions && (
+          <PermissionsPrompt
+            onComplete={finishFromPermissions}
+            onBack={backFromPermissions}
           />
         )}
       </div>

--- a/apps/web/src/core/onboarding/PermissionsPrompt.test.tsx
+++ b/apps/web/src/core/onboarding/PermissionsPrompt.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { PermissionsPrompt } from "./PermissionsPrompt";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const ANALYTICS_CALLS: Array<{ name: string; props?: Record<string, unknown> }> = [];
+
+vi.mock("../observability/analytics", () => ({
+  trackEvent: (name: string, props?: Record<string, unknown>) => {
+    ANALYTICS_CALLS.push({ name, props });
+  },
+  ANALYTICS_EVENTS: {
+    PERMISSION_REQUESTED: "permission_requested",
+    PERMISSION_GRANTED: "permission_granted",
+    PERMISSION_DENIED: "permission_denied",
+  },
+}));
+
+beforeEach(() => {
+  ANALYTICS_CALLS.length = 0;
+});
+
+describe("PermissionsPrompt", () => {
+  it("renders all three permission rows with explanations", () => {
+    const { getByText } = render(
+      <PermissionsPrompt onComplete={() => {}} onBack={() => {}} />,
+    );
+    expect(getByText("Сповіщення")).not.toBeNull();
+    expect(getByText("Мікрофон")).not.toBeNull();
+    expect(getByText("Камера")).not.toBeNull();
+    // "Пропустити" button is always visible — user can never get stuck.
+    expect(getByText("Пропустити")).not.toBeNull();
+  });
+
+  it("Skip calls onComplete with empty granted list and never asks the browser", () => {
+    const onComplete = vi.fn();
+    const requestPermission = vi.fn();
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: { requestPermission },
+    });
+
+    const { getByText } = render(
+      <PermissionsPrompt onComplete={onComplete} onBack={() => {}} />,
+    );
+    fireEvent.click(getByText("Пропустити"));
+    expect(onComplete).toHaveBeenCalledWith([]);
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("Allow → granted updates the row to show 'Готово' and tracks analytics", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: { requestPermission },
+    });
+
+    const onComplete = vi.fn();
+    const { getByLabelText, findByText } = render(
+      <PermissionsPrompt onComplete={onComplete} onBack={() => {}} />,
+    );
+    fireEvent.click(getByLabelText("Дозволити сповіщення"));
+
+    await findByText("Готово");
+    expect(requestPermission).toHaveBeenCalledOnce();
+    const names = ANALYTICS_CALLS.map((c) => c.name);
+    expect(names).toContain("permission_requested");
+    expect(names).toContain("permission_granted");
+  });
+
+  it("Allow → denied marks the row as 'Заблоковано' and emits PERMISSION_DENIED", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("denied");
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: { requestPermission },
+    });
+
+    const { getByLabelText, findByText } = render(
+      <PermissionsPrompt onComplete={() => {}} onBack={() => {}} />,
+    );
+    fireEvent.click(getByLabelText("Дозволити сповіщення"));
+
+    await findByText("Заблоковано");
+    expect(ANALYTICS_CALLS.map((c) => c.name)).toContain("permission_denied");
+  });
+
+  it("onComplete receives only the permissions that were granted", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: { requestPermission },
+    });
+
+    const onComplete = vi.fn();
+    const { getByLabelText, getByText, findByText } = render(
+      <PermissionsPrompt onComplete={onComplete} onBack={() => {}} />,
+    );
+    fireEvent.click(getByLabelText("Дозволити сповіщення"));
+    await findByText("Готово");
+
+    fireEvent.click(getByText("Продовжити"));
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    expect(onComplete).toHaveBeenCalledWith(["push"]);
+  });
+
+  it("Back button invokes onBack without continuing", () => {
+    const onBack = vi.fn();
+    const onComplete = vi.fn();
+    const { getByLabelText } = render(
+      <PermissionsPrompt onComplete={onComplete} onBack={onBack} />,
+    );
+    fireEvent.click(getByLabelText("Назад"));
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/core/onboarding/PermissionsPrompt.tsx
+++ b/apps/web/src/core/onboarding/PermissionsPrompt.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { cn } from "@shared/lib/cn";
+import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
+
+/**
+ * PermissionsPrompt — фінальний інтерстиціал онбордингу. Пояснює, які
+ * дозволи браузера буде використовувати Sergeant і коли. Запит дозволу
+ * робиться інлайново (Notification.requestPermission, getUserMedia
+ * audio/video) — кожен браузерний модальник з\'являється лише після
+ * явного "Дозволити", щоб не був заблокований heuristic-ами Chrome
+ * проти запитів одразу при завантаженні сторінки.
+ *
+ * Контракт із гайдлайнами:
+ * - Skip-кнопка завжди доступна; PR не блокує користувача.
+ * - Запит фактично робиться через рідні Web API (browser drives the
+ *   prompt UI). Ми лише трекаємо PERMISSION_REQUESTED / GRANTED / DENIED.
+ * - У capacitor-білді (`VITE_TARGET === "capacitor"`) Web API недоступні
+ *   або поводяться інакше, тож кнопки рендеряться, але повертають
+ *   "denied"-fallback без помилки. Native push має інший шлях
+ *   (registerPush у mobile-shell), яким керує `usePushNotifications`.
+ */
+
+type PermissionId = "push" | "microphone" | "camera";
+type PermissionUiState = "idle" | "asking" | "granted" | "denied" | "unsupported";
+
+interface PermissionRowMeta {
+  id: PermissionId;
+  title: string;
+  reason: string;
+  icon: React.ReactNode;
+}
+
+const ROWS: readonly PermissionRowMeta[] = [
+  {
+    id: "push",
+    title: "Сповіщення",
+    reason:
+      "Нагадування про звички, тренування та щотижневий дайджест. Без цього нагадування не приходитимуть.",
+    icon: <Icon name="bell" size={22} aria-hidden />,
+  },
+  {
+    id: "microphone",
+    title: "Мікрофон",
+    reason:
+      "Голосове введення в чаті і швидке додавання витрат / їжі без клавіатури.",
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+        <path d="M19 10v1a7 7 0 0 1-14 0v-1" />
+        <line x1="12" y1="18" x2="12" y2="22" />
+        <line x1="8" y1="22" x2="16" y2="22" />
+      </svg>
+    ),
+  },
+  {
+    id: "camera",
+    title: "Камера",
+    reason:
+      "Сканер штрихкодів продуктів і фото страв для AI-аналізу калорій.",
+    icon: (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+        <circle cx="12" cy="13" r="4" />
+      </svg>
+    ),
+  },
+];
+
+async function requestPushPermission(): Promise<PermissionUiState> {
+  if (typeof Notification === "undefined") return "unsupported";
+  try {
+    const r = await Notification.requestPermission();
+    if (r === "granted") return "granted";
+    return "denied";
+  } catch {
+    return "denied";
+  }
+}
+
+async function requestMediaPermission(
+  kind: "audio" | "video",
+): Promise<PermissionUiState> {
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia)
+    return "unsupported";
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia(
+      kind === "audio" ? { audio: true } : { video: true },
+    );
+    // Release immediately — onboarding не записує, лише питає дозвіл.
+    stream.getTracks().forEach((t) => t.stop());
+    return "granted";
+  } catch {
+    return "denied";
+  }
+}
+
+async function requestPermission(id: PermissionId): Promise<PermissionUiState> {
+  switch (id) {
+    case "push":
+      return requestPushPermission();
+    case "microphone":
+      return requestMediaPermission("audio");
+    case "camera":
+      return requestMediaPermission("video");
+  }
+}
+
+export function PermissionsPrompt({
+  onComplete,
+  onBack,
+}: {
+  onComplete: (granted: PermissionId[]) => void;
+  onBack: () => void;
+}) {
+  const [states, setStates] = useState<Record<PermissionId, PermissionUiState>>({
+    push: "idle",
+    microphone: "idle",
+    camera: "idle",
+  });
+
+  const handleAllow = useCallback(async (id: PermissionId) => {
+    setStates((s) => ({ ...s, [id]: "asking" }));
+    trackEvent(ANALYTICS_EVENTS.PERMISSION_REQUESTED, { permission: id });
+    const next = await requestPermission(id);
+    setStates((s) => ({ ...s, [id]: next }));
+    if (next === "granted") {
+      trackEvent(ANALYTICS_EVENTS.PERMISSION_GRANTED, { permission: id });
+    } else if (next === "denied") {
+      trackEvent(ANALYTICS_EVENTS.PERMISSION_DENIED, { permission: id });
+    }
+  }, []);
+
+  const handleContinue = useCallback(() => {
+    const granted = (Object.keys(states) as PermissionId[]).filter(
+      (id) => states[id] === "granted",
+    );
+    onComplete(granted);
+  }, [states, onComplete]);
+
+  return (
+    <div className="flex flex-col items-center text-center space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-xl font-bold text-text">Дозволи</h2>
+        <p className="text-xs text-muted leading-relaxed max-w-xs mx-auto">
+          Щоб усе працювало, Sergeant може попросити кілька дозволів
+          браузера. Можна пропустити — увімкнеш у налаштуваннях, коли
+          знадобиться.
+        </p>
+      </div>
+
+      <ul className="w-full space-y-2 text-left" role="list">
+        {ROWS.map((row) => {
+          const state = states[row.id];
+          return (
+            <li
+              key={row.id}
+              className="flex items-start gap-3 p-3 rounded-2xl border border-line bg-panelHi"
+            >
+              <div className="w-10 h-10 shrink-0 rounded-xl bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center">
+                {row.icon}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-semibold text-text">
+                  {row.title}
+                </div>
+                <div className="text-xs text-muted mt-0.5 leading-snug">
+                  {row.reason}
+                </div>
+              </div>
+              <div className="shrink-0 self-center">
+                {state === "granted" ? (
+                  <span
+                    className="inline-flex items-center gap-1 text-xs font-semibold text-success-strong"
+                    aria-live="polite"
+                  >
+                    <Icon name="check" size={14} aria-hidden />
+                    Готово
+                  </span>
+                ) : state === "denied" ? (
+                  <span
+                    className="text-xs font-semibold text-muted"
+                    aria-live="polite"
+                  >
+                    Заблоковано
+                  </span>
+                ) : state === "unsupported" ? (
+                  <span className="text-xs text-subtle">—</span>
+                ) : (
+                  <Button
+                    type="button"
+                    onClick={() => handleAllow(row.id)}
+                    variant="primary"
+                    size="sm"
+                    disabled={state === "asking"}
+                    className={cn(state === "asking" && "opacity-60")}
+                    aria-label={`Дозволити ${row.title.toLowerCase()}`}
+                  >
+                    {state === "asking" ? "..." : "Дозволити"}
+                  </Button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="w-full flex gap-2">
+        <Button
+          type="button"
+          onClick={onBack}
+          variant="ghost"
+          size="lg"
+          className="w-auto px-4"
+          aria-label="Назад"
+        >
+          <Icon name="chevron-left" size={16} />
+        </Button>
+        <Button
+          type="button"
+          onClick={handleContinue}
+          variant="primary"
+          size="lg"
+          className="flex-1"
+        >
+          Продовжити
+          <Icon name="chevron-right" size={16} />
+        </Button>
+      </div>
+      <button
+        type="button"
+        onClick={handleContinue}
+        className="w-full text-xs text-muted hover:text-text transition-colors py-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
+      >
+        Пропустити
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

Додано `PermissionsPrompt.tsx` як 4-й крок онбордингу — пояснення +
запит дозволів на push-сповіщення, мікрофон і камеру через рідні Web
API. Виклик відбувається лише по `«Дозволити»`; `«Пропустити»` ніколи
не блокує користувача.

## Why

Закриває §10 з `docs/design/ux-audit-2025.md` («`PermissionsPrompt` у
онбординг (push / speech / camera)») — це останній не закритий пункт
follow-up списку поряд з focus-rings (#988). Контекстних запитів
(сканер штрихкоду, голосовий ввід) недостатньо, тому що багато
користувачів так і не доходять до них. Едукативний крок у онбордингу
дає шанс ввімкнути все одразу і пояснити «навіщо».

## How to test

1. У DevTools → Application → Local Storage очисти `hub_onboarding_done_v1`.
2. Reload `/` — пройди welcome → modules → goals.
3. На 4-му кроці натисни «Дозволити» в кожному рядку — браузер показує
   нативний модальник; allow → бачиш «Готово», deny → «Заблоковано».
4. Кнопка «Продовжити» закриває онбординг і викликає `onDone`.
5. Назад повертає у Goals без втрати введеного.
6. У DevTools → Network/Console дивись `permission_*` події аналітики.

## How AI-tested this PR

- [x] Manual smoke (which flow?): онбординг з нуля, перевірка кожного
      пермішена + skip + back. Описано в How to test.
- [x] Vitest passes: новий `PermissionsPrompt.test.tsx` (6 кейсів) —
      рендер, skip без запиту, granted/denied, granted-list, back.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
