### PR TITLE
fix(ci): pin pnpm@9.15.1 in macOS workflows so cache step doesn't crash

### DIFF
--- a/.github/workflows/detox-ios.yml
+++ b/.github/workflows/detox-ios.yml
@@ -59,8 +59,13 @@ jobs:
       # actions/checkout v6.0.2 (SHA-pinned for supply-chain hardening)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening)
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening).
+      # `version:` mirrors `packageManager` in root package.json — without
+      # it the action defaults to pnpm@latest (10.x, needs Node ≥22.13)
+      # which crashes setup-node `cache: pnpm` on macOS runners.
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
+        with:
+          version: 9.15.1
 
       # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/mobile-shell-ios-release.yml
+++ b/.github/workflows/mobile-shell-ios-release.yml
@@ -92,10 +92,15 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # pnpm/action-setup v4.1.0 (SHA-pinned)
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening).
+      # `version:` mirrors `packageManager` in root package.json — without
+      # it the action defaults to pnpm@latest (10.x, needs Node ≥22.13)
+      # which crashes setup-node `cache: pnpm` on macOS runners.
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
+        with:
+          version: 9.15.1
 
-      # actions/setup-node v4.4.0 (SHA-pinned)
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "20"

--- a/.github/workflows/mobile-shell-ios.yml
+++ b/.github/workflows/mobile-shell-ios.yml
@@ -56,10 +56,18 @@ jobs:
       # actions/checkout v4.3.1 (SHA-pinned)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # pnpm/action-setup v4.1.0 (SHA-pinned)
+      # pnpm/action-setup v6.0.3 (SHA-pinned for supply-chain hardening).
+      # `version:` mirrors `packageManager` in root package.json. Without
+      # an explicit pin the action defaults to pnpm@latest (currently 10.x)
+      # which requires Node ≥22.13 — see
+      # https://github.com/pnpm/action-setup#inputs and PR #990 CI logs.
+      # The macOS runner image's bootstrap node trips this earlier than
+      # Linux ones (where the cache step is skipped on miss).
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
+        with:
+          version: 9.15.1
 
-      # actions/setup-node v4.4.0 (SHA-pinned)
+      # actions/setup-node v6.4.0 (SHA-pinned for supply-chain hardening)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "20"


### PR DESCRIPTION
GitHub Actions on macOS runners crashes the setup-node `cache: pnpm` step with:

  warn: This version of pnpm requires at least Node.js v22.13
  warn: The current version of Node.js is v20.20.2
  Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite

`pnpm/action-setup@903f9c1a` (v6.0.3) without an explicit `version:` input does not pick up the `packageManager: pnpm@9.15.1` field on the macOS runner image, so it falls back to pnpm@latest (currently 10.x), which dropped support for Node 20. `setup-node`'s built-in pnpm cache then invokes `pnpm store path` against Node 20 → ERR_UNKNOWN_BUILTIN_MODULE.

Pinning `version: 9.15.1` in the action mirrors the repo's `packageManager` declaration and is bulletproof regardless of how the action resolves defaults on each runner image.

Applies to all three macOS workflows that share the same broken pattern:
- mobile-shell-ios.yml (PR-time iOS Simulator build)
- mobile-shell-ios-release.yml (tag-time TestFlight upload)
- detox-ios.yml (E2E)

Linux workflows already work because their bootstrap node is newer; the fix doesn't need to change anything on Linux.

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
