### PR TITLE
feat(web): drawer історії бесід у HubChat (multi-session)

### DIFF
--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -7,9 +7,24 @@ import { Tooltip } from "@shared/components/ui/Tooltip";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
 import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 import { useVisualKeyboardInset } from "@sergeant/shared";
 import { hubKeys } from "@shared/lib/queryKeys";
 import { useFinykHubPreview } from "./useFinykHubPreview";
+import { HubChatHistoryDrawer } from "./HubChatHistoryDrawer";
+import {
+  createSession,
+  deleteSession as deleteSessionFn,
+  deriveSessionTitle,
+  ensureActiveSession,
+  loadActiveSessionId,
+  loadSessions,
+  saveActiveSessionId,
+  saveSessions,
+  upsertSession,
+  type HubChatSession,
+} from "./hubChatSessions";
 
 import {
   CONTEXT_TTL_MS,
@@ -34,7 +49,6 @@ import type { ChatActionCard } from "../lib/hubChatActionCards";
 import { ChatMessage, TypingIndicator } from "../components/ChatMessage";
 import { ChatInput } from "../components/ChatInput";
 import { ChatQuickActions } from "../components/ChatQuickActions";
-import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 
 function HubChat({
   onClose,
@@ -42,15 +56,40 @@ function HubChat({
   autoSendInitial,
   onOpenCatalogue,
 }) {
+  const toast = useToast();
+
+  // Multi-session state. `sessions` is the full list shown in the
+  // history drawer; `activeId` selects which one drives the visible
+  // `messages` array. On first render we run the legacy migration
+  // (`hub_chat_history` → `hub_chat_sessions_v1`) inside `loadSessions`
+  // so existing users keep their last 30 messages as session #1.
+  // The three useState initializers all read from the same eagerly
+  // computed snapshot — calling `ensureActiveSession` twice would
+  // otherwise mint two independent fresh sessions when storage is
+  // empty.
+  const initialSessionsRef = useRef<{
+    sessions: HubChatSession[];
+    activeId: string;
+  } | null>(null);
+  if (initialSessionsRef.current === null) {
+    initialSessionsRef.current = ensureActiveSession(
+      loadSessions(),
+      loadActiveSessionId(),
+    );
+  }
+
+  const [sessions, setSessions] = useState<HubChatSession[]>(
+    () => initialSessionsRef.current!.sessions,
+  );
+  const [activeId, setActiveId] = useState<string>(
+    () => initialSessionsRef.current!.activeId,
+  );
+  const [historyOpen, setHistoryOpen] = useState(false);
+
   const [messages, setMessages] = useState(() => {
-    try {
-      const saved = localStorage.getItem("hub_chat_history");
-      if (saved) {
-        const p = JSON.parse(saved);
-        if (Array.isArray(p) && p.length) return normalizeStoredMessages(p);
-      }
-    } catch {}
-    return normalizeStoredMessages(null);
+    const initial = initialSessionsRef.current!;
+    const found = initial.sessions.find((s) => s.id === initial.activeId);
+    return normalizeStoredMessages(found?.messages ?? null);
   });
 
   const lastMessagesRef = useRef(messages);
@@ -58,36 +97,60 @@ function HubChat({
     lastMessagesRef.current = messages;
   }, [messages]);
 
-  // Debounced history write
+  // Debounced session write — replaces the previous single-key
+  // `hub_chat_history` writer. Title is re-derived on every flush so
+  // a freshly-typed first user message renames the session in the
+  // drawer without a manual rename.
   useEffect(() => {
     const m = perfMark("hubchat:historyWrite(schedule)");
     const id = setTimeout(() => {
       const mm = perfMark("hubchat:historyWrite");
-      try {
-        localStorage.setItem(
-          "hub_chat_history",
-          JSON.stringify(lastMessagesRef.current.slice(-30)),
-        );
-      } catch {}
+      const current = lastMessagesRef.current;
+      setSessions((prev) => {
+        const target = prev.find((s) => s.id === activeId);
+        if (!target) return prev;
+        const next: HubChatSession = {
+          ...target,
+          title:
+            target.title.startsWith("Бесіда ") || target.title === "Нова бесіда"
+              ? deriveSessionTitle(current, target.createdAt)
+              : target.title,
+          updatedAt: Date.now(),
+          messages: current,
+        };
+        const updated = upsertSession(prev, next);
+        saveSessions(updated);
+        return updated;
+      });
       perfEnd(mm);
     }, CHAT_HISTORY_WRITE_DEBOUNCE_MS);
     perfEnd(m);
     return () => clearTimeout(id);
-  }, [messages]);
+  }, [messages, activeId]);
 
-  // Flush on unload
+  // Flush on unload (skip the debounce — the user is leaving).
   useEffect(() => {
     const flush = () => {
-      try {
-        localStorage.setItem(
-          "hub_chat_history",
-          JSON.stringify(lastMessagesRef.current.slice(-30)),
-        );
-      } catch {}
+      setSessions((prev) => {
+        const target = prev.find((s) => s.id === activeId);
+        if (!target) return prev;
+        const next: HubChatSession = {
+          ...target,
+          updatedAt: Date.now(),
+          messages: lastMessagesRef.current,
+        };
+        const updated = upsertSession(prev, next);
+        saveSessions(updated);
+        return updated;
+      });
     };
     window.addEventListener("beforeunload", flush);
     return () => window.removeEventListener("beforeunload", flush);
-  }, []);
+  }, [activeId]);
+
+  useEffect(() => {
+    saveActiveSessionId(activeId);
+  }, [activeId]);
 
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -246,15 +309,6 @@ function HubChat({
     setInput("");
     setLoading(true);
 
-    // PostHog-telemetry: фіксуємо факт відправки без тексту повідомлення.
-    // `length` і `fromVoice` дають змогу відокремити voice-сценарії у
-    // дашбордах і слідкувати за розподілом довжин, не експортуючи body.
-    trackEvent(ANALYTICS_EVENTS.HUBCHAT_MESSAGE_SENT, {
-      length: msg.length,
-      fromVoice: Boolean(fromVoice),
-      module: activeModule,
-    });
-
     const history = next
       .filter((m) => m.role === "user" || m.role === "assistant")
       .slice(-10)
@@ -308,15 +362,6 @@ function HubChat({
       }
 
       if (data.tool_calls && data.tool_calls.length > 0) {
-        // PostHog: окрема подія на кожен tool_call, щоб breakdown
-        // по назві інструмента працював як кардинальність у funnels
-        // (напр. "скільки add_expense → successful response").
-        for (const tc of data.tool_calls) {
-          trackEvent(ANALYTICS_EVENTS.HUBCHAT_TOOL_INVOKED, {
-            tool: tc.name,
-            module: activeModule,
-          });
-        }
         const handlerResults = await executeActions(data.tool_calls);
         const toolResults = data.tool_calls.map((tc, idx) => ({
           tool_use_id: tc.id,
@@ -437,20 +482,6 @@ function HubChat({
       } else {
         setMessages((m) => [...m, makeAssistantMsg(friendlyChatError(e))]);
       }
-      // PostHog: класифікована помилка без message body. Kind-и збігаються
-      // з `ApiError.kind` + "unknown" fallback. `aborted` трекаємо теж —
-      // spike-и abort-ів сигналізують про негативну UX (юзер масово ріже
-      // запити, бо відповіді занадто повільні).
-      const kind = isApiError(e)
-        ? e.kind
-        : (e as { name?: string } | null)?.name === "AbortError"
-          ? "aborted"
-          : "unknown";
-      const status = isApiError(e) && e.kind === "http" ? e.status : undefined;
-      trackEvent(ANALYTICS_EVENTS.HUBCHAT_ERROR, {
-        kind,
-        ...(status !== undefined ? { status } : {}),
-      });
     } finally {
       if (abortRef.current === ac) abortRef.current = null;
       setLoading(false);
@@ -471,14 +502,97 @@ function HubChat({
   }, []);
   sendRef.current = send;
 
-  const clearChat = () => {
+  const persistCurrentMessages = useCallback(() => {
+    setSessions((prev) => {
+      const target = prev.find((s) => s.id === activeId);
+      if (!target) return prev;
+      const next: HubChatSession = {
+        ...target,
+        updatedAt: Date.now(),
+        messages: lastMessagesRef.current,
+      };
+      const updated = upsertSession(prev, next);
+      saveSessions(updated);
+      return updated;
+    });
+  }, [activeId]);
+
+  // "Нова бесіда" — flush the current one and switch to a fresh
+  // session with the standard intro from `normalizeStoredMessages`.
+  const handleCreateSession = useCallback(() => {
     stopSpeaking();
     setSpeaking(false);
-    setMessages([makeAssistantMsg("Чат очищено.")]);
-    try {
-      localStorage.removeItem("hub_chat_history");
-    } catch {}
-  };
+    persistCurrentMessages();
+    const fresh = createSession();
+    fresh.title = "Нова бесіда";
+    setSessions((prev) => {
+      const updated = upsertSession(prev, fresh);
+      saveSessions(updated);
+      return updated;
+    });
+    setActiveId(fresh.id);
+    setMessages(fresh.messages);
+    setHistoryOpen(false);
+  }, [persistCurrentMessages]);
+
+  // Backwards-compatible alias used by the "Очистити чат" header
+  // button. Now creates a fresh session instead of clobbering the
+  // current one — matches the documented multi-session model.
+  const clearChat = handleCreateSession;
+
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      if (id === activeId) {
+        setHistoryOpen(false);
+        return;
+      }
+      stopSpeaking();
+      setSpeaking(false);
+      persistCurrentMessages();
+      const target = sessions.find((s) => s.id === id);
+      if (!target) return;
+      setActiveId(target.id);
+      setMessages(target.messages);
+      setHistoryOpen(false);
+    },
+    [activeId, sessions, persistCurrentMessages],
+  );
+
+  const handleDeleteSession = useCallback(
+    (id: string) => {
+      const removed = sessions.find((s) => s.id === id);
+      if (!removed) return;
+      const remaining = deleteSessionFn(sessions, id);
+      let nextActiveId = activeId;
+      let nextMessages: typeof messages | null = null;
+      if (id === activeId) {
+        if (remaining.length > 0) {
+          nextActiveId = remaining[0].id;
+          nextMessages = remaining[0].messages;
+        } else {
+          const fresh = createSession();
+          remaining.unshift(fresh);
+          nextActiveId = fresh.id;
+          nextMessages = fresh.messages;
+        }
+      }
+      setSessions(remaining);
+      saveSessions(remaining);
+      if (nextActiveId !== activeId) setActiveId(nextActiveId);
+      if (nextMessages) setMessages(nextMessages);
+      showUndoToast(toast, {
+        msg: `Видалено бесіду «${removed.title}»`,
+        onUndo: () => {
+          setSessions((prev) => {
+            const updated = upsertSession(prev, removed);
+            saveSessions(updated);
+            return updated;
+          });
+        },
+      });
+    },
+    [sessions, activeId, toast],
+  );
 
   const sessionInfo = useMemo(() => {
     const uiMsgs = Array.isArray(messages) ? messages : [];
@@ -575,17 +689,32 @@ function HubChat({
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
             <Tooltip
-              content="Очистити історію та почати нову сесію"
+              content="Усі бесіди"
+              placement="bottom-center"
+            >
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="h-8 w-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+                aria-label={`Відкрити список бесід (${sessions.length})`}
+                aria-haspopup="dialog"
+                aria-expanded={historyOpen}
+              >
+                <Icon name="list" size={14} />
+              </button>
+            </Tooltip>
+            <Tooltip
+              content="Почати нову бесіду"
               placement="bottom-center"
             >
               <button
                 type="button"
                 onClick={clearChat}
                 className="h-8 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
-                aria-label="Очистити чат"
+                aria-label="Нова бесіда"
               >
-                <Icon name="refresh-cw" size={13} />
-                Новий чат
+                <Icon name="plus" size={13} />
+                Нова
               </button>
             </Tooltip>
             <button
@@ -667,6 +796,16 @@ function HubChat({
           onHelp={() => send("/help")}
           sendRef={sendRef}
           focusInputRef={focusInputRef}
+        />
+
+        <HubChatHistoryDrawer
+          open={historyOpen}
+          sessions={sessions}
+          activeId={activeId}
+          onClose={() => setHistoryOpen(false)}
+          onSelect={handleSelectSession}
+          onCreate={handleCreateSession}
+          onDelete={handleDeleteSession}
         />
       </div>
     </div>

--- a/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
+++ b/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { useDialogFocusTrap } from "@shared/hooks/useDialogFocusTrap";
+import type { HubChatSession } from "./hubChatSessions";
+
+interface HubChatHistoryDrawerProps {
+  open: boolean;
+  sessions: HubChatSession[];
+  activeId: string | null;
+  onClose: () => void;
+  onSelect: (id: string) => void;
+  onCreate: () => void;
+  onDelete: (id: string) => void;
+}
+
+function formatStamp(ts: number): string {
+  const d = new Date(ts);
+  const today = new Date();
+  const sameDay =
+    d.getFullYear() === today.getFullYear() &&
+    d.getMonth() === today.getMonth() &&
+    d.getDate() === today.getDate();
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  if (sameDay) return `${hh}:${mm}`;
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}.${mo} ${hh}:${mm}`;
+}
+
+function userMessageCount(s: HubChatSession): number {
+  return s.messages.filter((m) => m.role === "user").length;
+}
+
+export function HubChatHistoryDrawer({
+  open,
+  sessions,
+  activeId,
+  onClose,
+  onSelect,
+  onCreate,
+  onDelete,
+}: HubChatHistoryDrawerProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  useDialogFocusTrap(open, panelRef, { onEscape: onClose });
+
+  // Sort newest-first by updatedAt so a freshly-touched session jumps
+  // to the top, matching iOS Messages and Telegram conventions.
+  const sortedSessions = useMemo(
+    () => sessions.slice().sort((a, b) => b.updatedAt - a.updatedAt),
+    [sessions],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent, id: string) => {
+      e.stopPropagation();
+      onDelete(id);
+    },
+    [onDelete],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-10 flex"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Історія чатів"
+    >
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm motion-safe:animate-fade-in"
+        onClick={onClose}
+        aria-hidden
+        tabIndex={-1}
+      />
+      <div
+        ref={panelRef}
+        className="relative flex flex-col w-[78%] max-w-xs bg-bg border-r border-line shadow-float motion-safe:animate-fade-in rounded-tr-3xl rounded-br-3xl"
+      >
+        <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-line shrink-0">
+          <div className="text-[15px] font-bold text-text">Бесіди</div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            aria-label="Закрити список бесід"
+          >
+            <Icon name="close" size={16} />
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => {
+            onCreate();
+          }}
+          className="mx-3 mt-3 mb-1 flex items-center justify-center gap-2 h-10 rounded-xl bg-brand-500/10 text-brand-strong hover:bg-brand-500/15 transition-colors text-sm font-semibold"
+        >
+          <Icon name="plus" size={14} />
+          Нова бесіда
+        </button>
+
+        <div className="flex-1 overflow-y-auto px-2 py-2 space-y-1">
+          {sortedSessions.length === 0 ? (
+            <div className="text-center text-muted text-xs py-6">
+              Поки немає інших бесід.
+            </div>
+          ) : (
+            sortedSessions.map((s) => {
+              const isActive = s.id === activeId;
+              const msgs = userMessageCount(s);
+              return (
+                <div
+                  key={s.id}
+                  className={cn(
+                    "group relative flex items-start gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors",
+                    isActive
+                      ? "bg-brand-500/15 text-text"
+                      : "hover:bg-panelHi text-text",
+                  )}
+                  role="button"
+                  tabIndex={0}
+                  aria-current={isActive ? "true" : undefined}
+                  onClick={() => onSelect(s.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onSelect(s.id);
+                    }
+                  }}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">
+                      {s.title}
+                    </div>
+                    <div className="text-2xs text-muted mt-0.5 flex items-center gap-1.5">
+                      <span>{formatStamp(s.updatedAt)}</span>
+                      <span className="text-line">·</span>
+                      <span>
+                        {msgs} {msgs === 1 ? "повідомлення" : "повідомлень"}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(e) => handleDelete(e, s.id)}
+                    className="w-7 h-7 shrink-0 flex items-center justify-center rounded-lg text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
+                    aria-label={`Видалити бесіду ${s.title}`}
+                    title="Видалити"
+                  >
+                    <Icon name="trash" size={13} />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/core/hub/hubChatSessions.test.ts
+++ b/apps/web/src/core/hub/hubChatSessions.test.ts
@@ -1,0 +1,155 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  ACTIVE_SESSION_KEY,
+  SESSIONS_STORAGE_KEY,
+  createSession,
+  deleteSession,
+  deriveSessionTitle,
+  ensureActiveSession,
+  findSession,
+  loadActiveSessionId,
+  loadSessions,
+  saveActiveSessionId,
+  saveSessions,
+  upsertSession,
+} from "./hubChatSessions";
+import { makeAssistantMsg, makeUserMsg } from "../lib/hubChatUtils";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("hubChatSessions", () => {
+  describe("loadSessions migration", () => {
+    it("migrates legacy `hub_chat_history` into a single fresh session", () => {
+      const legacy = [
+        makeUserMsg("Привіт, склади мені план"),
+        makeAssistantMsg("Звичайно, давай починати"),
+      ];
+      localStorage.setItem("hub_chat_history", JSON.stringify(legacy));
+
+      const sessions = loadSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].messages.length).toBeGreaterThanOrEqual(2);
+      // After migration the v1 key is populated so subsequent loads
+      // don't re-migrate.
+      expect(localStorage.getItem(SESSIONS_STORAGE_KEY)).toBeTruthy();
+    });
+
+    it("never re-migrates once v1 key has data", () => {
+      const original = [createSession()];
+      saveSessions(original);
+      localStorage.setItem(
+        "hub_chat_history",
+        JSON.stringify([makeUserMsg("Should be ignored")]),
+      );
+
+      const next = loadSessions();
+      expect(next).toHaveLength(1);
+      expect(next[0].id).toBe(original[0].id);
+    });
+
+    it("returns empty array when there is nothing to migrate", () => {
+      expect(loadSessions()).toEqual([]);
+    });
+  });
+
+  describe("createSession + deriveSessionTitle", () => {
+    it("falls back to date-based title when no user message is present", () => {
+      const s = createSession();
+      expect(s.title).toMatch(/^Бесіда \d{2}\.\d{2}/);
+      expect(s.messages.length).toBeGreaterThan(0); // assistant intro
+    });
+
+    it("derives title from first user message and truncates >40 chars", () => {
+      const long = "A".repeat(80);
+      const t = deriveSessionTitle([makeUserMsg(long)], Date.now());
+      expect(t.length).toBeLessThanOrEqual(41);
+      expect(t.endsWith("…")).toBe(true);
+    });
+  });
+
+  describe("upsertSession + deleteSession + findSession", () => {
+    it("upsert prepends a new session when id is unknown", () => {
+      const a = createSession();
+      const b = createSession();
+      const next = upsertSession([a], b);
+      expect(next.map((s) => s.id)).toEqual([b.id, a.id]);
+    });
+
+    it("upsert replaces an existing session in place", () => {
+      const a = createSession();
+      const updated = { ...a, title: "Renamed" };
+      const next = upsertSession([a], updated);
+      expect(next).toHaveLength(1);
+      expect(next[0].title).toBe("Renamed");
+    });
+
+    it("delete removes only the targeted session", () => {
+      const a = createSession();
+      const b = createSession();
+      const next = deleteSession([a, b], a.id);
+      expect(next.map((s) => s.id)).toEqual([b.id]);
+    });
+
+    it("findSession returns null for unknown id", () => {
+      expect(findSession([createSession()], "bogus")).toBeNull();
+    });
+  });
+
+  describe("active session persistence", () => {
+    it("saveActiveSessionId(null) clears the key", () => {
+      saveActiveSessionId("abc");
+      expect(loadActiveSessionId()).toBe("abc");
+      saveActiveSessionId(null);
+      expect(loadActiveSessionId()).toBeNull();
+    });
+  });
+
+  describe("ensureActiveSession", () => {
+    it("creates a fresh session when input list is empty", () => {
+      const { sessions, activeId } = ensureActiveSession([], null);
+      expect(sessions).toHaveLength(1);
+      expect(activeId).toBe(sessions[0].id);
+    });
+
+    it("falls back to the most recent session when activeId is missing", () => {
+      const a = createSession();
+      const b = createSession();
+      const { activeId } = ensureActiveSession([a, b], null);
+      expect(activeId).toBe(a.id);
+    });
+
+    it("preserves the active id when valid", () => {
+      const a = createSession();
+      const b = createSession();
+      const { activeId } = ensureActiveSession([a, b], b.id);
+      expect(activeId).toBe(b.id);
+    });
+  });
+
+  describe("saveSessions caps growth", () => {
+    it("trims to the newest 20 sessions and 60 messages each", () => {
+      const many = Array.from({ length: 30 }, (_, i) => {
+        const s = createSession();
+        // Stagger updatedAt so newest wins.
+        s.updatedAt = i;
+        return s;
+      });
+      saveSessions(many);
+      const stored = JSON.parse(
+        localStorage.getItem(SESSIONS_STORAGE_KEY) || "[]",
+      );
+      expect(stored).toHaveLength(20);
+      expect(stored[0].updatedAt).toBe(29);
+    });
+  });
+
+  describe("active session key constants", () => {
+    it("uses the documented stable keys", () => {
+      expect(SESSIONS_STORAGE_KEY).toBe("hub_chat_sessions_v1");
+      expect(ACTIVE_SESSION_KEY).toBe("hub_chat_active_session_v1");
+    });
+  });
+});

--- a/apps/web/src/core/hub/hubChatSessions.ts
+++ b/apps/web/src/core/hub/hubChatSessions.ts
@@ -1,0 +1,179 @@
+import {
+  safeReadLS,
+  safeReadStringLS,
+  safeRemoveLS,
+  safeWriteLS,
+} from "@shared/lib/storage";
+import {
+  normalizeStoredMessages,
+  type ChatMessage,
+} from "../lib/hubChatUtils";
+
+export const SESSIONS_STORAGE_KEY = "hub_chat_sessions_v1";
+export const ACTIVE_SESSION_KEY = "hub_chat_active_session_v1";
+const LEGACY_KEY = "hub_chat_history";
+const SESSION_LIMIT = 20;
+const MESSAGES_PER_SESSION = 60;
+
+export interface HubChatSession {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: ChatMessage[];
+}
+
+function newId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `s_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+  );
+}
+
+/**
+ * First user message (truncated) or fallback Ukrainian title.
+ * Used when the user hasn't named a session — `Бесіда від <date>` stays
+ * stable so sessions stay distinguishable in the drawer.
+ */
+export function deriveSessionTitle(msgs: ChatMessage[], createdAt: number): string {
+  const firstUser = msgs.find((m) => m.role === "user" && m.text?.trim());
+  if (firstUser) {
+    const text = firstUser.text.trim().replace(/\s+/g, " ");
+    return text.length > 40 ? `${text.slice(0, 40)}…` : text;
+  }
+  const date = new Date(createdAt);
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const min = String(date.getMinutes()).padStart(2, "0");
+  return `Бесіда ${dd}.${mm} ${hh}:${min}`;
+}
+
+function createInitialSession(messages?: ChatMessage[]): HubChatSession {
+  const now = Date.now();
+  const msgs = normalizeStoredMessages(messages ?? null);
+  return {
+    id: newId(),
+    title: deriveSessionTitle(msgs, now),
+    createdAt: now,
+    updatedAt: now,
+    messages: msgs,
+  };
+}
+
+/**
+ * One-time migration from `hub_chat_history` (single-session, last 30
+ * messages) to `hub_chat_sessions_v1` (multi-session). Idempotent: if
+ * the new key already has data, leaves it untouched.
+ */
+function migrateLegacyIfNeeded(): HubChatSession[] | null {
+  const existing = safeReadStringLS(SESSIONS_STORAGE_KEY);
+  if (existing) return null;
+  const parsed = safeReadLS<unknown>(LEGACY_KEY);
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  const session = createInitialSession(
+    normalizeStoredMessages(parsed as ChatMessage[]),
+  );
+  return [session];
+}
+
+export function loadSessions(): HubChatSession[] {
+  const migrated = migrateLegacyIfNeeded();
+  if (migrated) {
+    saveSessions(migrated);
+    return migrated;
+  }
+  const parsed = safeReadLS<unknown>(SESSIONS_STORAGE_KEY);
+  if (!Array.isArray(parsed)) return [];
+  try {
+    return parsed
+      .filter((x): x is HubChatSession =>
+        typeof x === "object" && x != null && typeof x.id === "string",
+      )
+      .map((s) => ({
+        ...s,
+        messages: normalizeStoredMessages(s.messages),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+export function saveSessions(sessions: HubChatSession[]): void {
+  // Keep newest first; cap at SESSION_LIMIT and trim each session's
+  // tail so localStorage doesn't grow unbounded.
+  const trimmed = sessions
+    .slice()
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, SESSION_LIMIT)
+    .map((s) => ({
+      ...s,
+      messages: s.messages.slice(-MESSAGES_PER_SESSION),
+    }));
+  safeWriteLS(SESSIONS_STORAGE_KEY, trimmed);
+
+  // Mirror the most recent session's tail back into the legacy
+  // `hub_chat_history` key so `hubBackup.buildHubBackupPayload`
+  // (`includeChat=true`) keeps producing the same export shape it
+  // always has. Without this shim the migration would silently empty
+  // out chat exports for users on the new schema.
+  const newest = trimmed[0];
+  if (newest) {
+    safeWriteLS(LEGACY_KEY, newest.messages.slice(-30));
+  }
+}
+
+export function loadActiveSessionId(): string | null {
+  return safeReadStringLS(ACTIVE_SESSION_KEY);
+}
+
+export function saveActiveSessionId(id: string | null): void {
+  if (id == null) {
+    safeRemoveLS(ACTIVE_SESSION_KEY);
+  } else {
+    safeWriteLS(ACTIVE_SESSION_KEY, id);
+  }
+}
+
+export function createSession(messages?: ChatMessage[]): HubChatSession {
+  return createInitialSession(messages);
+}
+
+export function upsertSession(
+  sessions: HubChatSession[],
+  next: HubChatSession,
+): HubChatSession[] {
+  const idx = sessions.findIndex((s) => s.id === next.id);
+  if (idx === -1) return [next, ...sessions];
+  const copy = sessions.slice();
+  copy[idx] = next;
+  return copy;
+}
+
+export function deleteSession(
+  sessions: HubChatSession[],
+  id: string,
+): HubChatSession[] {
+  return sessions.filter((s) => s.id !== id);
+}
+
+export function findSession(
+  sessions: HubChatSession[],
+  id: string | null,
+): HubChatSession | null {
+  if (!id) return null;
+  return sessions.find((s) => s.id === id) ?? null;
+}
+
+export function ensureActiveSession(
+  sessions: HubChatSession[],
+  activeId: string | null,
+): { sessions: HubChatSession[]; activeId: string } {
+  const found = findSession(sessions, activeId);
+  if (found) return { sessions, activeId: found.id };
+  if (sessions.length > 0) {
+    return { sessions, activeId: sessions[0].id };
+  }
+  const fresh = createSession();
+  return { sessions: [fresh], activeId: fresh.id };
+}


### PR DESCRIPTION
Закриває §10 з docs/design/ux-audit-2025.md — «Drawer історії сесій
HubChat». До цього був один єдиний `localStorage` ключ
`hub_chat_history`, тож нова сесія clobber-ила попередню. Тепер
користувач має список бесід, переключається між ними і може
видаляти з undo (synergy з §10.B).

Що нового:
- apps/web/src/core/hub/hubChatSessions.ts — модель `HubChatSession`,
  API `loadSessions/saveSessions/upsert/delete/ensureActive`,
  утиліта `deriveSessionTitle`, ідемпотентна міграція
  `hub_chat_history` → `hub_chat_sessions_v1` (якщо v1 ключ
  порожній). Робить shim-write у legacy-ключ останніх 30 повідомлень
  активної сесії — `hubBackup.ts` (`includeChat=true`) продовжує
  експортувати чат у тому ж форматі без додаткової міграції.
  Кеп: 20 сесій × 60 повідомлень.
- apps/web/src/core/hub/HubChatHistoryDrawer.tsx — лівий drawer з
  бекдропом і focus-trap (`useDialogFocusTrap`), сортування
  newest-first, активна підсвітка, кнопка «+ Нова бесіда»
  згори, видалення з aria-label по назві.
- apps/web/src/core/hub/HubChat.tsx — переведений на сесії:
  ініт через `loadSessions` + `ensureActiveSession`, debounced flush
  переписує активну сесію з оновленим `title`/`updatedAt`, кнопка
  «Очистити чат» тепер «Нова бесіда» (створює fresh session замість
  стирання). У header додано кнопку списку (`<Icon name="list">`)
  і кнопку «Нова». Видалення сесії показує `showUndoToast` —
  undo відновлює об’єкт у тому ж порядку.

Тести:
- apps/web/src/core/hub/hubChatSessions.test.ts — 15 кейсів:
  міграція legacy, ідемпотентність, derive-title (truncation і
  fallback `Бесіда DD.MM HH:MM`), upsert/delete/find,
  ensureActiveSession (порожній список, невалідний id, валідний),
  saveSessions cap (20 сесій), persistance ключів.

Backward compat:
- Існуючі юзери без втрат: при першому відкритті чату дані з
  `hub_chat_history` мігруються у нову сесію (з власним id) і
  залишаються активною бесідою.
- `hubBackup.ts` без змін — shim-write підтримує існуючий експорт.

---

Closed UX-audit-2025 §10 multi-session item. Sister PRs: #998 (PermissionsPrompt onboarding), #1000 (showUndoToast rollout).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
