### PR TITLE
fix(web): use -strong companions on Button saturated brand fills

### DIFF
--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -163,7 +163,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
                     setForgotEmail((cur) => cur || email || "");
                     setShowForgot((v) => !v);
                   }}
-                  className="text-xs text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
+                  className="text-xs text-brand-strong dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
                 >
                   Забули пароль?
                 </button>
@@ -344,7 +344,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
           <button
             type="button"
             onClick={switchMode}
-            className="text-sm text-brand-600 dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+            className="text-sm text-brand-strong dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
           >
             {mode === "login"
               ? "Немає акаунту? Зареєструватися"

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -49,7 +49,7 @@ const variants: Record<ButtonVariant, string> = {
   ghost:
     "bg-transparent text-muted hover:bg-panelHi hover:text-text active:bg-line/50",
   danger:
-    "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
+    "bg-danger-soft text-danger-strong border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
     "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -43,7 +43,7 @@ export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 const variants: Record<ButtonVariant, string> = {
   // Core variants
   primary:
-    "bg-brand-500 text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-700 active:scale-[0.98]",
+    "bg-brand-strong text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-800 active:scale-[0.98]",
   secondary:
     "bg-panel text-text border border-line shadow-sm hover:bg-panelHi hover:border-brand-200 active:scale-[0.98]",
   ghost:
@@ -51,19 +51,19 @@ const variants: Record<ButtonVariant, string> = {
   danger:
     "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
   destructive:
-    "bg-danger text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
+    "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:
     "bg-brand-50 text-brand-700 border border-brand-200/50 hover:bg-brand-100 dark:bg-brand-500/15 dark:text-brand-300 dark:border-brand-500/30 dark:hover:bg-brand-500/25 active:scale-[0.98]",
 
   // Module-specific branded buttons
   finyk:
-    "bg-finyk text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
+    "bg-finyk-strong text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
   fizruk:
-    "bg-fizruk text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
+    "bg-fizruk-strong text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
   routine:
-    "bg-routine text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
+    "bg-routine-strong text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
   nutrition:
-    "bg-nutrition text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
+    "bg-nutrition-strong text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
 
   // Soft module variants (for secondary actions within modules).
   // Dark mode swaps the light pastel surface for the saturated accent at


### PR DESCRIPTION
## What changed

Варіанти `primary`, `destructive`, `finyk`, `fizruk`, `routine`, `nutrition` у `apps/web/src/shared/components/ui/Button.tsx` тепер рендерять `-strong` (≈ `-700`, для `nutrition` — `-800`) замість насиченого `-500` за `text-white`. Hover-стани (`-hover` ≈ `-600`) і active (`active:bg-brand-800`) лишаються.

## Why

Текст `text-white` поверх `bg-brand-500` / `bg-{name}` / `bg-danger` дає ~2.4–2.8 : 1 — нижче WCAG 2.1 AA-порогу 4.5 : 1. Це ловить `sergeant-design/no-low-contrast-text-on-fill` (6 errors на main, бачили на CI у PR #982).

`-strong` — це вже задокументована WCAG-AA-companion для саме такого юзкейсу (див. `docs/design/BRANDBOOK.md` → 'WCAG-AA `-strong` Tier' і `docs/design/brand-palette-wcag-aa-proposal.md`). Той самий шаблон уже застосовано у `Badge.tsx`, `Segmented.tsx`, `Toast.tsx`, `PantryManagerSheet.tsx`, `NutritionDashboard.tsx`, `PushupsWidget.tsx`, `MealTypePicker.tsx`, `FoodPickerSection.tsx`, `FromPantryRow.tsx`, `routineConstants.ts` — тому `Button.tsx` був останньою саме-такою регресією.

## How to test

1. `pnpm --filter @sergeant/web lint` — раніше 6 errors у `Button.tsx`, тепер clean.
2. `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Button.test.tsx` — `applies variant classes (primary → bg-brand-strong text-white)` тепер зелений.
3. Візуально: `Storybook`/Hub-дашборд → primary-кнопки тепер на крок темніші (emerald-700 замість emerald-500). Hover іде до emerald-600 (як було), active — до emerald-800 (раніше було emerald-700). Brand-cohesion узгоджено з Badge / Segmented / Toast.

---

## How AI-tested this PR

- [x] Vitest passes:
  - `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Button.test.tsx` — 7/7 pass.
- [x] `pnpm --filter @sergeant/web lint` — clean (раніше 6 errors саме у цьому файлі).
- [x] `pnpm --filter @sergeant/web typecheck` — clean.
- [ ] Manual smoke: візуально не пере-перевірено в браузері (зміна — заміна 6 Tailwind-токенів у Record, без зміни API).
- [x] No new `AI-DANGER` markers added.
- [x] Pattern узгоджується з вже існуючим `-strong`-rollout (Badge / Segmented / Toast / Pantry / NutritionDashboard / PushupsWidget).

## AGENTS.md updated?

- [x] No — правило вже задокументоване (Hard rule #9, AGENTS.md `Saturated brand fills behind text-white must use the -strong companion`). Цей PR — просто послідовне дотримання.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button styling to use stronger color variants across primary, danger/destructive, and module-specific buttons for improved contrast and visual hierarchy.
  * Adjusted auth page buttons to use a stronger brand text color (dark-mode appearance unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->