### PR TITLE
fix(web): finyk budget detail — red networth on negative + respect hide-balance everywhere

### DIFF
--- a/apps/web/src/modules/finyk/components/DebtCard.tsx
+++ b/apps/web/src/modules/finyk/components/DebtCard.tsx
@@ -32,6 +32,7 @@ interface DebtCardProps {
   linkedCount?: number;
   isReceivable?: boolean;
   dueDate?: string | null;
+  showBalance?: boolean;
 }
 
 // Чиста картка боргу / заборгованості — рендер повністю керується пропсами,
@@ -47,6 +48,7 @@ function DebtCardComponent({
   linkedCount,
   isReceivable,
   dueDate,
+  showBalance = true,
 }: DebtCardProps) {
   const pct = total > 0 ? Math.min(100, Math.round((paid / total) * 100)) : 0;
   const dueText = formatDueDate(dueDate);
@@ -65,8 +67,9 @@ function DebtCardComponent({
               isReceivable ? "text-success" : "text-danger",
             )}
           >
-            {isReceivable ? "+" : "−"}
-            {remaining.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴
+            {showBalance
+              ? `${isReceivable ? "+" : "−"}${remaining.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} ₴`
+              : "••••"}
           </span>
           {onDelete && (
             <button
@@ -89,8 +92,9 @@ function DebtCardComponent({
       </div>
       <div className="text-xs text-subtle mt-2">
         {isReceivable ? "Отримано" : "Сплачено"}{" "}
-        {paid.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} з{" "}
-        {total.toLocaleString("uk-UA")} ₴
+        {showBalance
+          ? `${paid.toLocaleString("uk-UA", { maximumFractionDigits: 0 })} з ${total.toLocaleString("uk-UA")} ₴`
+          : "••••"}
       </div>
       {dueText && (
         <div

--- a/apps/web/src/modules/finyk/components/SubCard.tsx
+++ b/apps/web/src/modules/finyk/components/SubCard.tsx
@@ -36,6 +36,7 @@ function SubCardComponent({
   onDelete,
   onEdit,
   onLinkTransactions,
+  showBalance = true,
 }) {
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState({
@@ -188,8 +189,9 @@ function SubCardComponent({
       <div className="flex flex-col items-end gap-1 shrink-0">
         {amount != null ? (
           <div className="text-sm font-bold">
-            {amount.toLocaleString("uk-UA", { maximumFractionDigits: 2 })}
-            {currency}
+            {showBalance
+              ? `${amount.toLocaleString("uk-UA", { maximumFractionDigits: 2 })}${currency}`
+              : "••••"}
           </div>
         ) : (
           <div className="text-xs text-subtle">ще не списувалось</div>

--- a/apps/web/src/modules/finyk/pages/AssetsTable.test.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTable.test.tsx
@@ -54,4 +54,31 @@ describe("AssetsNetworthCard", () => {
     const nonLucideBars = Array.from(bars).filter((el) => !el.closest("svg"));
     expect(nonLucideBars.length).toBe(0);
   });
+
+  it("colours networth red when negative", () => {
+    const { container } = render(
+      <AssetsNetworthCard
+        networth={-68499}
+        totalAssets={12555}
+        totalDebt={81054}
+        showBalance={true}
+      />,
+    );
+    const valueEl = container.querySelector(".text-danger-strong");
+    expect(valueEl).not.toBeNull();
+    expect(valueEl?.textContent).toContain("-68");
+  });
+
+  it("colours networth in finyk tone when non-negative", () => {
+    const { container } = render(
+      <AssetsNetworthCard
+        networth={12345}
+        totalAssets={15000}
+        totalDebt={2655}
+        showBalance={true}
+      />,
+    );
+    expect(container.querySelector(".text-finyk-strong")).not.toBeNull();
+    expect(container.querySelector(".text-danger-strong")).toBeNull();
+  });
 });

--- a/apps/web/src/modules/finyk/pages/AssetsTable.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTable.tsx
@@ -43,19 +43,30 @@ export function AssetsNetworthCard({
   totalDebt,
   showBalance,
 }: Pick<State, "networth" | "totalAssets" | "totalDebt" | "showBalance">) {
+  const isNegative = networth < 0;
   return (
     <div className="rounded-3xl bg-finyk/[.06] dark:bg-finyk-surface-dark/10 border border-finyk/[.14] dark:border-finyk-border-dark/20 p-5 mb-3 shadow-card">
       <p className="text-sm text-muted">Загальний нетворс</p>
       <div
         className={cn(
-          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums text-finyk-strong dark:text-finyk",
+          "text-[40px] font-bold tracking-tight leading-tight mt-2 tabular-nums",
+          isNegative
+            ? "text-danger-strong dark:text-danger"
+            : "text-finyk-strong dark:text-finyk",
           !showBalance && "tracking-widest",
         )}
       >
         {showBalance ? (
           <>
             {networth.toLocaleString("uk-UA", { maximumFractionDigits: 0 })}
-            <span className="text-2xl font-semibold text-finyk/60 ml-1">₴</span>
+            <span
+              className={cn(
+                "text-2xl font-semibold ml-1",
+                isNegative ? "text-danger/60" : "text-finyk/60",
+              )}
+            >
+              ₴
+            </span>
           </>
         ) : (
           "\u2022\u2022\u2022\u2022\u2022\u2022"
@@ -100,6 +111,7 @@ export function AssetsSubscriptionsSection({ state }: { state: State }) {
     newSub,
     setNewSub,
     setTxPicker,
+    showBalance,
   } = state;
   const toast = useToast();
 
@@ -121,6 +133,7 @@ export function AssetsSubscriptionsSection({ state }: { state: State }) {
           key={sub.id}
           sub={sub}
           transactions={transactions}
+          showBalance={showBalance}
           onDelete={() => {
             const removed = sub;
             const removedIdx = i;
@@ -190,6 +203,7 @@ export function AssetsAssetsSection({ state }: { state: State }) {
     assetFormRef,
     assetNameInputRef,
     setTxPicker,
+    showBalance,
   } = state;
 
   return (
@@ -217,14 +231,17 @@ export function AssetsAssetsSection({ state }: { state: State }) {
               <div>
                 <div className="text-sm font-medium">{getAccountLabel(a)}</div>
                 <div className="text-xs text-subtle mt-0.5">
-                  {(a.balance / 100).toLocaleString("uk-UA", {
-                    minimumFractionDigits: 2,
-                  })}{" "}
-                  {a.currencyCode === 980
-                    ? "₴"
-                    : a.currencyCode === 840
-                      ? "$"
-                      : "€"}
+                  {showBalance
+                    ? `${(a.balance / 100).toLocaleString("uk-UA", {
+                        minimumFractionDigits: 2,
+                      })} ${
+                        a.currencyCode === 980
+                          ? "₴"
+                          : a.currencyCode === 840
+                            ? "$"
+                            : "€"
+                      }`
+                    : "\u2022\u2022\u2022\u2022"}
                 </div>
               </div>
             </div>
@@ -247,6 +264,7 @@ export function AssetsAssetsSection({ state }: { state: State }) {
           total={getReceivableEffectiveTotal(r, transactions)}
           dueDate={r.dueDate}
           isReceivable
+          showBalance={showBalance}
           onDelete={() => {
             const removed = r;
             setReceivables((rs) => rs.filter((x) => x.id !== removed.id));
@@ -312,12 +330,15 @@ export function AssetsAssetsSection({ state }: { state: State }) {
           </div>
           <div className="flex items-center gap-2">
             <span className="text-sm font-bold text-success">
-              {Number(a.amount).toLocaleString("uk-UA")}{" "}
-              {a.currency === "UAH"
-                ? "₴"
-                : a.currency === "USD"
-                  ? "$"
-                  : a.currency}
+              {showBalance
+                ? `${Number(a.amount).toLocaleString("uk-UA")} ${
+                    a.currency === "UAH"
+                      ? "₴"
+                      : a.currency === "USD"
+                        ? "$"
+                        : a.currency
+                  }`
+                : "\u2022\u2022\u2022\u2022"}
             </span>
             <button
               onClick={() => {
@@ -364,6 +385,7 @@ export function AssetsLiabilitiesSection({ state }: { state: State }) {
     debtFormRef,
     debtNameInputRef,
     setTxPicker,
+    showBalance,
   } = state;
 
   return (
@@ -400,6 +422,7 @@ export function AssetsLiabilitiesSection({ state }: { state: State }) {
             remaining={remaining}
             paid={paidFromLinked}
             total={volatileTotal}
+            showBalance={showBalance}
             onLink={() => setTxPicker({ id: a.id, type: "monoDebt" })}
             linkedCount={linkedIds.length}
           />
@@ -414,6 +437,7 @@ export function AssetsLiabilitiesSection({ state }: { state: State }) {
           paid={getDebtPaid(d, transactions)}
           total={getDebtEffectiveTotal(d, transactions)}
           dueDate={d.dueDate}
+          showBalance={showBalance}
           onDelete={() => {
             const removed = d;
             setManualDebts((ds) => ds.filter((x) => x.id !== removed.id));
@@ -520,9 +544,13 @@ export function AssetsTable({ state }: { state: State }) {
         title="Активи"
         iconName="trending-up"
         iconTone="success"
-        summary={`+${totalAssets.toLocaleString("uk-UA", {
-          maximumFractionDigits: 0,
-        })} ₴`}
+        summary={
+          showBalance
+            ? `+${totalAssets.toLocaleString("uk-UA", {
+                maximumFractionDigits: 0,
+              })} ₴`
+            : "\u2022\u2022\u2022\u2022"
+        }
         open={open.assets}
         onToggle={() => setOpen((v) => ({ ...v, assets: !v.assets }))}
       />
@@ -533,9 +561,13 @@ export function AssetsTable({ state }: { state: State }) {
         title="Пасиви"
         iconName="trending-down"
         iconTone="danger"
-        summary={`\u2212${totalDebt.toLocaleString("uk-UA", {
-          maximumFractionDigits: 0,
-        })} ₴`}
+        summary={
+          showBalance
+            ? `\u2212${totalDebt.toLocaleString("uk-UA", {
+                maximumFractionDigits: 0,
+              })} ₴`
+            : "\u2022\u2022\u2022\u2022"
+        }
         open={open.liabilities}
         onToggle={() => setOpen((v) => ({ ...v, liabilities: !v.liabilities }))}
       />


### PR DESCRIPTION
## What changed

На сторінці **ФІНІК → Активи / Бюджети**:

1. **Колір нетворсу.** `AssetsNetworthCard` тепер червоний (`text-danger-strong dark:text-danger`), коли `networth < 0`, — так само, як головна `HeroCard` (`apps/web/src/modules/finyk/pages/overview/HeroCard.tsx:33-46`). Раніше суму завжди фарбували у фірмовий `text-finyk-strong`, навіть при мінусовому балансі.

2. **Режим приховування сум.** Всі грошові значення на цій сторінці тепер маскуються до `••••`, коли `showBalance === false`. Раніше тогл «око» приховував лише число у героїчній картці; решта значень (саммарі секцій, картки рахунків, інлайн-картки боргів і підписок) показувалися завжди:
   - Саммарі `SectionBar` для **Активи** і **Пасиви** (`+12 555 ₴` / `−81 054 ₴`).
   - Баланси Monobank-карток у списку **Картки Monobank**.
   - Суми ручних активів у списку **Інші активи**.
   - `DebtCard` (борги, мені винні) — додано пропс `showBalance`, маскується сума заборгованості та рядок «Сплачено / Отримано X з Y».
   - `SubCard` (підписки) — додано пропс `showBalance`, маскується сума останнього списання.

## Why

Фідбек користувача (скріншот): на сторінці бюджетів нетворс −68 499 ₴ показано фірмовим зеленим, хоча на головній «нетворс на першій сторінці червоний бо мінусовий». Плюс «режим оце ховати цифри деякі сторінки походу ігнорує» — на цій сторінці лишалися видимими саммарі секцій і вкладені картки.

## How to test

1. Відкрити **ФІНІК → Активи** з мінусовим нетворсом → заголовок суми має бути червоним (`text-danger-strong`), `₴` теж червоного відтінку.
2. Натиснути іконку «око» у хедері (`setShowBalance` toggle):
   - Саммарі «Активи» / «Пасиви» поряд з `Розкласти ↓` показують `••••`.
   - Розкласти «Активи» → баланси Monobank-карток і ручні активи теж `••••`; картки «Мені винні» (`DebtCard` з `isReceivable`) маскують суму та `Отримано X з Y`.
   - Розкласти «Пасиви» → `DebtCard` для Mono-боргів та ручних боргів маскує суму та `Сплачено X з Y`.
   - Розкласти «Підписки» → `SubCard` показує `••••` замість грошової суми.
3. Назад увімкнути `showBalance` → значення повертаються.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прочитано рендер-шлях `FinykApp → Assets → AssetsTable → {Networth, Section bodies}`, перевірено всі місця, де формується грошовий рядок, і пройдено токеном `showBalance` зверху вниз.
- [x] Vitest passes: `pnpm --filter @sergeant/web test -- run finyk` → 18 файлів / 182 тести passed; додано 2 нових кейси у `AssetsTable.test.tsx` (`colours networth red when negative`, `colours networth in finyk tone when non-negative`).
- [x] `pnpm --filter @sergeant/web lint` → clean.
- [x] `pnpm --filter @sergeant/web typecheck` → clean (всі 4 tsconfig-режими).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (поведінковий баг-фікс, без зміни конвенцій)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added balance visibility toggle: users can now hide monetary amounts across assets, liabilities, and subscriptions (displays masked placeholders when hidden)
  * Negative networth values now display with distinct danger coloring to highlight losses at a glance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->