### PR TITLE
feat(web): replace Web Speech with Groq Whisper via /api/transcribe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,16 @@ ANTHROPIC_API_KEY=sk-ant-api03-...
 # AI_QUOTA_TOOL_DEFAULT_LIMIT=60
 # AI_QUOTA_TOOL_LIMITS={"change_category":30,"create_debt":10,"create_receivable":10,"hide_transaction":30,"set_budget_limit":10,"set_monthly_plan":5,"mark_habit_done":30,"plan_workout":10,"create_habit":10}
 
+# ── Groq Whisper (голосова транскрипція) ─────────────────────
+# Використовується ендпоінтом `/api/transcribe` (VoiceMicButton на фронті).
+# Без ключа endpoint повертає 503, фронт автоматично відкочується на Web
+# Speech API. Зареєструватися: https://console.groq.com/keys
+# GROQ_API_KEY=gsk_...
+# Whisper-модель Groq. За замовчуванням `whisper-large-v3-turbo` —
+# найдешевший варіант з адекватною якістю українською. Альтернатива:
+# `whisper-large-v3` (точніше, але дорожче).
+# GROQ_TRANSCRIBE_MODEL=whisper-large-v3-turbo
+
 # ── Nutrition API Token ───────────────────────────────────────
 # Використовується для захисту nutrition endpoints (опціонально)
 NUTRITION_API_TOKEN=

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -139,6 +139,10 @@ export function createApp({
   app.use("/api/coach/memory", express.json({ limit: "6mb" }));
   app.use("/api/chat", express.json({ limit: "1mb" }));
   app.use("/api/mono/webhook", express.json({ limit: "32kb" }));
+  // Voice transcription: raw audio blob, NOT JSON. Mount раніше за глобальний
+  // `express.json({ limit: "128kb" })`, щоб 10mb-блоб не різався 128KB-парсером
+  // (хоч `express.json()` no-op-ить на не-JSON, явний raw-парсер чіткіший).
+  app.use("/api/transcribe", express.raw({ type: "audio/*", limit: "10mb" }));
   app.use(express.json({ limit: "128kb" }));
 
   // Global CORS for the whole /api surface. Individual handlers may re-set

--- a/apps/server/src/env/env.ts
+++ b/apps/server/src/env/env.ts
@@ -66,6 +66,18 @@ const envSchema = z.object({
   // ── AI (Anthropic) ─────────────────────────────────────────────────
   /** API-ключ для Anthropic Claude. Без нього /api/chat повертає 500. */
   ANTHROPIC_API_KEY: z.string().optional(),
+  /**
+   * API-ключ Groq для голосової транскрипції (`/api/transcribe`).
+   * Без нього endpoint повертає 503; фронт автоматично відкочується
+   * на Web Speech API (бачить це з `GET /api/transcribe/health`).
+   */
+  GROQ_API_KEY: z.string().optional(),
+  /**
+   * Whisper-модель Groq для транскрипції. За замовчуванням
+   * `whisper-large-v3-turbo` — найдешевший варіант з адекватною
+   * якістю українською. Альтернатива: `whisper-large-v3`.
+   */
+  GROQ_TRANSCRIBE_MODEL: z.string().default("whisper-large-v3-turbo"),
   /** `"1"` — повністю вимкнути AI-квоту (fail-open без перевірки). */
   AI_QUOTA_DISABLED: z.string().optional(),
   /** Денний ліміт AI-запитів для автентифікованого юзера. */

--- a/apps/server/src/http/index.ts
+++ b/apps/server/src/http/index.ts
@@ -40,6 +40,7 @@ export { setModule } from "./setModule.js";
 export { requireSession, requireSessionSoft } from "./requireSession.js";
 export { requireApiSecret } from "./requireApiSecret.js";
 export { requireAnthropicKey } from "./requireAnthropicKey.js";
+export { requireGroqKey } from "./requireGroqKey.js";
 export { requireAiQuota } from "./requireAiQuota.js";
 export {
   requireNutritionToken,

--- a/apps/server/src/http/requireGroqKey.ts
+++ b/apps/server/src/http/requireGroqKey.ts
@@ -1,0 +1,26 @@
+import type { Request, RequestHandler } from "express";
+
+type WithGroqKey = Request & { groqKey?: string };
+
+/**
+ * Guard для ендпоінтів, що викликають Groq (Whisper). Читає `GROQ_API_KEY`,
+ * кладе у `req.groqKey`, або віддає 503 якщо ключ не сконфігурований.
+ *
+ * Аналог `requireAnthropicKey()`. 503 точніше 500: це не внутрішня помилка,
+ * а проблема конфігурації деплою. Фронт використовує цей сигнал як
+ * маркер: при 503 переключитися на Web Speech API fallback.
+ */
+export function requireGroqKey(): RequestHandler {
+  return (req, res, next) => {
+    const key = process.env.GROQ_API_KEY;
+    if (!key) {
+      res.status(503).json({
+        error: "GROQ_API_KEY не сконфігурований",
+        code: "GROQ_KEY_MISSING",
+      });
+      return;
+    }
+    (req as WithGroqKey).groqKey = key;
+    next();
+  };
+}

--- a/apps/server/src/lib/groq.ts
+++ b/apps/server/src/lib/groq.ts
@@ -1,0 +1,182 @@
+import { recordExternalHttp } from "./externalHttp.js";
+
+const GROQ_TRANSCRIBE_URL =
+  "https://api.groq.com/openai/v1/audio/transcriptions";
+
+export interface GroqTranscribeOptions {
+  /** API ключ — передаємо явно, не читаємо з env (handler уже валідував). */
+  apiKey: string;
+  /** Whisper-модель Groq, наприклад `whisper-large-v3-turbo`. */
+  model: string;
+  /** Аудіо-байти (повний файл — Groq не підтримує streaming upload). */
+  audio: Buffer;
+  /** MIME-тип; впливає на ім'я файлу і `Content-Type` form-частини. */
+  mimeType: string;
+  /**
+   * ISO-код мови (`uk`, `en`, ...). Якщо `null/undefined` — Whisper
+   * визначить автоматично (повільніше і менш точно).
+   */
+  language?: string;
+  /**
+   * Доменна підказка (≤ 1024 токени). Драматично покращує точність
+   * на спеціалізованій лексиці: списки вправ, назви продуктів, категорії
+   * витрат. Анг + укр одночасно ОК.
+   */
+  prompt?: string;
+  /** Hard timeout у мс для upstream-виклику. */
+  timeoutMs?: number;
+  /**
+   * AbortSignal, що скасовує запит при client-disconnect (Express `req`).
+   * Комбінується з внутрішнім timeout.
+   */
+  signal?: AbortSignal;
+}
+
+export interface GroqTranscribeResult {
+  /** Транскрибований текст. Whisper повертає вже trimmed. */
+  text: string;
+  /**
+   * Тривалість аудіо в секундах, якщо upstream її повернув. Корисно для
+   * метрик і логів. `null` коли поле відсутнє.
+   */
+  durationSec: number | null;
+}
+
+export class GroqTranscribeError extends Error {
+  public readonly status: number;
+  public readonly outcome: string;
+  constructor(message: string, status: number, outcome: string) {
+    super(message);
+    this.name = "GroqTranscribeError";
+    this.status = status;
+    this.outcome = outcome;
+  }
+}
+
+function pickFileName(mimeType: string): string {
+  // Groq визначає формат за розширенням; узгоджуємо з MIME явно.
+  if (mimeType.includes("webm")) return "audio.webm";
+  if (mimeType.includes("mp4")) return "audio.mp4";
+  if (mimeType.includes("m4a")) return "audio.m4a";
+  if (mimeType.includes("mpeg")) return "audio.mp3";
+  if (mimeType.includes("wav")) return "audio.wav";
+  if (mimeType.includes("ogg")) return "audio.ogg";
+  if (mimeType.includes("flac")) return "audio.flac";
+  return "audio.webm";
+}
+
+function composeSignal(
+  internal: AbortController,
+  external: AbortSignal | undefined,
+): AbortSignal {
+  if (!external) return internal.signal;
+  // `AbortSignal.any` доступний у Node ≥ 20.3 і всіх сучасних браузерах.
+  // Feature-detect через property-check, без double-cast.
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([internal.signal, external]);
+  }
+  if (external.aborted) internal.abort();
+  else
+    external.addEventListener("abort", () => internal.abort(), { once: true });
+  return internal.signal;
+}
+
+/**
+ * Синхронний proxy у Groq Whisper. Повертає текст або кидає
+ * `GroqTranscribeError` з статусом і outcome для метрик. Метрики
+ * (`external_http_*`) інкрементуються одноразово на спробу.
+ */
+export async function transcribeAudio(
+  opts: GroqTranscribeOptions,
+): Promise<GroqTranscribeResult> {
+  const { apiKey, model, audio, mimeType, language, prompt } = opts;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  const form = new FormData();
+  form.append("model", model);
+  form.append("response_format", "verbose_json");
+  if (language) form.append("language", language);
+  if (prompt) form.append("prompt", prompt);
+  // Node 20: `Blob` глобально доступний; FormData приймає Blob із file-ім'ям.
+  // `Buffer.from(audio).buffer` повертає `ArrayBufferLike` (може бути
+  // SharedArrayBuffer), що не сумісне з BlobPart-типом TS — обертаємо у
+  // `Uint8Array` зі свіжим ArrayBuffer-копіюванням, щоб тип збігся жорстко.
+  const audioCopy = new Uint8Array(audio.length);
+  audioCopy.set(audio);
+  form.append(
+    "file",
+    new Blob([audioCopy], { type: mimeType }),
+    pickFileName(mimeType),
+  );
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const signal = composeSignal(controller, opts.signal);
+  const startedAt = Date.now();
+
+  let response: Response | null = null;
+  try {
+    response = await fetch(GROQ_TRANSCRIBE_URL, {
+      method: "POST",
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: form,
+      signal,
+    });
+  } catch (err) {
+    const ms = Date.now() - startedAt;
+    const aborted = (err as { name?: string })?.name === "AbortError";
+    const outcome = aborted ? "timeout" : "error";
+    recordExternalHttp("groq", outcome, ms);
+    throw new GroqTranscribeError(
+      aborted ? "Groq запит перервано (timeout)" : "Помилка мережі до Groq",
+      aborted ? 504 : 502,
+      outcome,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const ms = Date.now() - startedAt;
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      const text = await response.text();
+      detail = text.slice(0, 500);
+    } catch {
+      /* ignore */
+    }
+    const outcome =
+      response.status === 429
+        ? "rate_limited"
+        : response.status >= 500
+          ? "upstream_error"
+          : "error";
+    recordExternalHttp("groq", outcome, ms);
+    throw new GroqTranscribeError(
+      `Groq повернув ${response.status}${detail ? `: ${detail}` : ""}`,
+      response.status === 429 ? 429 : 502,
+      outcome,
+    );
+  }
+
+  let data: { text?: unknown; duration?: unknown } = {};
+  try {
+    data = (await response.json()) as { text?: unknown; duration?: unknown };
+  } catch {
+    recordExternalHttp("groq", "parse_error", ms);
+    throw new GroqTranscribeError(
+      "Не вдалося розпарсити відповідь Groq",
+      502,
+      "parse_error",
+    );
+  }
+
+  recordExternalHttp("groq", "ok", ms);
+  const text = typeof data.text === "string" ? data.text.trim() : "";
+  const durationSec =
+    typeof data.duration === "number" && Number.isFinite(data.duration)
+      ? data.duration
+      : null;
+  return { text, durationSec };
+}

--- a/apps/server/src/modules/transcribe/transcribe.test.ts
+++ b/apps/server/src/modules/transcribe/transcribe.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Request, Response } from "express";
+import type { Mock } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("../../lib/groq.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../lib/groq.js")>(
+      "../../lib/groq.js",
+    );
+  return {
+    ...actual,
+    transcribeAudio: vi.fn(),
+  };
+});
+
+import {
+  transcribeAudio as _transcribeAudio,
+  GroqTranscribeError,
+} from "../../lib/groq.js";
+import transcribeHandler from "./transcribe.js";
+
+const transcribeAudio = _transcribeAudio as unknown as Mock;
+
+interface TestRes {
+  statusCode: number;
+  body:
+    | {
+        error?: string;
+        code?: string;
+        text?: string;
+        durationSec?: number | null;
+        model?: string;
+      }
+    | undefined;
+  writableEnded: boolean;
+  status(code: number): TestRes;
+  json(payload: unknown): TestRes;
+}
+
+function makeRes(): TestRes & Response {
+  const res: TestRes = {
+    statusCode: 200,
+    body: undefined,
+    writableEnded: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload as TestRes["body"];
+      this.writableEnded = true;
+      return this;
+    },
+  };
+  return res as TestRes & Response;
+}
+
+interface MakeReqOpts {
+  contentType?: string | null;
+  body?: Buffer | unknown;
+  query?: Record<string, string>;
+  /** `null` явно прибирає groqKey (для теста 503-кейса). */
+  groqKey?: string | null;
+}
+
+function makeReq(opts: MakeReqOpts = {}): Request {
+  const headers: Record<string, string> = {};
+  if (opts.contentType !== null) {
+    headers["content-type"] = opts.contentType ?? "audio/webm";
+  }
+  const emitter = new EventEmitter();
+  const groqKey =
+    opts.groqKey === null
+      ? undefined
+      : opts.groqKey === undefined
+        ? "test-key"
+        : opts.groqKey;
+  const req = Object.assign(emitter, {
+    headers,
+    body: opts.body ?? Buffer.from(""),
+    query: opts.query ?? {},
+    groqKey,
+  });
+  return req as unknown as Request;
+}
+
+describe("transcribeHandler", () => {
+  beforeEach(() => {
+    transcribeAudio.mockReset();
+  });
+
+  it("503 коли GROQ_API_KEY відсутній", async () => {
+    const req = makeReq({ groqKey: null });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(503);
+    expect(res.body?.code).toBe("GROQ_KEY_MISSING");
+  });
+
+  it("415 на неаудіо Content-Type", async () => {
+    const req = makeReq({
+      contentType: "application/json",
+      body: Buffer.from("x"),
+    });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(415);
+    expect(res.body?.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+  });
+
+  it("415 на неподтримуваний audio MIME", async () => {
+    const req = makeReq({
+      contentType: "audio/aac",
+      body: Buffer.from("x"),
+    });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(415);
+  });
+
+  it("400 на порожнє тіло", async () => {
+    const req = makeReq({ body: Buffer.alloc(0) });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body?.code).toBe("EMPTY_BODY");
+  });
+
+  it("400 коли тіло не Buffer (raw парсер не спрацював)", async () => {
+    const req = makeReq({ body: { foo: "bar" } });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("413 на тіло понад 10MB", async () => {
+    const big = Buffer.alloc(10 * 1024 * 1024 + 1, 0);
+    const req = makeReq({ body: big });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(413);
+    expect(res.body?.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("400 на занадто довгий prompt", async () => {
+    const req = makeReq({
+      body: Buffer.from("x"),
+      query: { prompt: "a".repeat(2000) },
+    });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("happy path: повертає text + durationSec", async () => {
+    transcribeAudio.mockResolvedValueOnce({
+      text: "жим штанги 80 кг 8 разів",
+      durationSec: 3.4,
+    });
+    const req = makeReq({
+      body: Buffer.from(new Uint8Array([1, 2, 3, 4])),
+      query: { language: "uk", prompt: "жим, присід, тяга" },
+    });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.text).toBe("жим штанги 80 кг 8 разів");
+    expect(res.body?.durationSec).toBe(3.4);
+    expect(res.body?.model).toBeTruthy();
+    expect(transcribeAudio).toHaveBeenCalledOnce();
+    const callArg = transcribeAudio.mock.calls[0][0];
+    expect(callArg.language).toBe("uk");
+    expect(callArg.prompt).toBe("жим, присід, тяга");
+    expect(callArg.mimeType).toBe("audio/webm");
+  });
+
+  it("проксіює статус і outcome з GroqTranscribeError", async () => {
+    transcribeAudio.mockRejectedValueOnce(
+      new GroqTranscribeError("upstream 429", 429, "rate_limited"),
+    );
+    const req = makeReq({ body: Buffer.from("x") });
+    const res = makeRes();
+    await transcribeHandler(req, res);
+    expect(res.statusCode).toBe(429);
+    expect(res.body?.code).toBe("TRANSCRIBE_UPSTREAM_FAILED");
+  });
+
+  it("re-throw на не-Groq помилку (попадає в errorHandler)", async () => {
+    transcribeAudio.mockRejectedValueOnce(new Error("boom"));
+    const req = makeReq({ body: Buffer.from("x") });
+    const res = makeRes();
+    await expect(transcribeHandler(req, res)).rejects.toThrow("boom");
+  });
+});

--- a/apps/server/src/modules/transcribe/transcribe.ts
+++ b/apps/server/src/modules/transcribe/transcribe.ts
@@ -1,0 +1,143 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { validateQuery } from "../../http/validate.js";
+import { transcribeAudio, GroqTranscribeError } from "../../lib/groq.js";
+import { logger } from "../../obs/logger.js";
+
+type WithGroqKey = Request & { groqKey?: string };
+
+const SUPPORTED_AUDIO_MIME = [
+  "audio/webm",
+  "audio/ogg",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/wave",
+  "audio/flac",
+];
+
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_PROMPT_LENGTH = 1024;
+
+export const TranscribeQuerySchema = z.object({
+  language: z
+    .string()
+    .trim()
+    .min(2)
+    .max(8)
+    .optional()
+    .describe("ISO-код мови, напр. uk або en. Якщо порожньо — auto-detect."),
+  prompt: z
+    .string()
+    .trim()
+    .max(MAX_PROMPT_LENGTH)
+    .optional()
+    .describe("Доменна підказка (списки вправ, продуктів тощо)."),
+});
+
+function pickMimeType(req: Request): string | null {
+  const raw = req.headers["content-type"];
+  if (!raw || typeof raw !== "string") return null;
+  const ct = raw.split(";")[0].trim().toLowerCase();
+  if (!ct.startsWith("audio/")) return null;
+  if (!SUPPORTED_AUDIO_MIME.includes(ct)) return null;
+  return ct;
+}
+
+/**
+ * `POST /api/transcribe` — приймає сирий аудіо-блоб (Content-Type: `audio/*`),
+ * проксі-кидає у Groq Whisper, повертає `{ text, durationSec }`.
+ *
+ * Body parser — `express.raw({ type: "audio/*", limit: "10mb" })` (див.
+ * `app.ts`); звідси `req.body` — це `Buffer`.
+ */
+export default async function transcribeHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const groqKey = (req as WithGroqKey).groqKey;
+  if (!groqKey) {
+    // requireGroqKey() мав уже відсіяти, але double-check для безпеки.
+    res.status(503).json({
+      error: "GROQ_API_KEY не сконфігурований",
+      code: "GROQ_KEY_MISSING",
+    });
+    return;
+  }
+
+  const mimeType = pickMimeType(req);
+  if (!mimeType) {
+    res.status(415).json({
+      error:
+        "Непідтримуваний Content-Type — очікую audio/webm, audio/mp4, audio/ogg тощо",
+      code: "UNSUPPORTED_MEDIA_TYPE",
+    });
+    return;
+  }
+
+  // Тіло — Buffer, бо роутер змонтований після `express.raw({ type: "audio/*" })`.
+  const body = req.body as unknown;
+  if (!Buffer.isBuffer(body) || body.length === 0) {
+    res.status(400).json({
+      error: "Порожнє тіло запиту — очікую аудіо-блоб",
+      code: "EMPTY_BODY",
+    });
+    return;
+  }
+  if (body.length > MAX_AUDIO_BYTES) {
+    res.status(413).json({
+      error: `Аудіо завелике (${body.length} байт), максимум ${MAX_AUDIO_BYTES}`,
+      code: "PAYLOAD_TOO_LARGE",
+    });
+    return;
+  }
+
+  const parsed = validateQuery(TranscribeQuerySchema, req, res);
+  if (!parsed.ok) return;
+  const { language, prompt } = parsed.data;
+
+  // Прокидаємо abort при client-disconnect, щоб не платити за марний upstream.
+  const abortController = new AbortController();
+  req.on("close", () => {
+    if (!res.writableEnded) abortController.abort();
+  });
+
+  const model = process.env.GROQ_TRANSCRIBE_MODEL || "whisper-large-v3-turbo";
+
+  try {
+    const result = await transcribeAudio({
+      apiKey: groqKey,
+      model,
+      audio: body,
+      mimeType,
+      language,
+      prompt,
+      signal: abortController.signal,
+    });
+    res.json({
+      text: result.text,
+      durationSec: result.durationSec,
+      model,
+    });
+  } catch (err) {
+    if (err instanceof GroqTranscribeError) {
+      logger.warn({
+        msg: "transcribe_upstream_failed",
+        status: err.status,
+        outcome: err.outcome,
+        bytes: body.length,
+        mimeType,
+      });
+      res.status(err.status).json({
+        error: err.message,
+        code: "TRANSCRIBE_UPSTREAM_FAILED",
+        outcome: err.outcome,
+      });
+      return;
+    }
+    throw err;
+  }
+}

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -12,6 +12,7 @@ import { createMeRouter } from "./me.js";
 import { createNutritionRouter } from "./nutrition.js";
 import { createPushRouter } from "./push.js";
 import { createSyncRouter } from "./sync.js";
+import { createTranscribeRouter } from "./transcribe.js";
 import { createWebVitalsRouter } from "./web-vitals.js";
 import { createWeeklyDigestRouter } from "./weekly-digest.js";
 
@@ -40,4 +41,5 @@ export function registerRoutes(app: Express, { pool }: { pool: Pool }): void {
   app.use(createFoodSearchRouter());
   app.use(createWebVitalsRouter());
   app.use(createPushRouter());
+  app.use(createTranscribeRouter());
 }

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import {
+  asyncHandler,
+  rateLimitExpress,
+  requireGroqKey,
+  requireSession,
+  setModule,
+} from "../http/index.js";
+import transcribeHandler from "../modules/transcribe/transcribe.js";
+
+/**
+ * `/api/transcribe` — голосова транскрипція через Groq Whisper.
+ *
+ * Чейн middleware:
+ *   - `setModule("transcribe")` — теги в логах/метриках;
+ *   - rate-limit 60/хв на subject (per-user або per-IP) — генерують короткі
+ *     аудіо-фрагменти (5–15с) під час активної сесії, треба простір;
+ *   - `requireSession()` — це per-user фіча, не публічний proxy;
+ *   - `requireGroqKey()` — 503 без ключа, фронт переходить на Web Speech.
+ *
+ * Body parser змонтовано окремо в `app.ts` як `express.raw({ type: "audio/*" })`
+ * — JSON-парсер тут НЕ потрібен, бо тіло сире.
+ */
+export function createTranscribeRouter(): Router {
+  const r = Router();
+  r.post(
+    "/api/transcribe",
+    setModule("transcribe"),
+    rateLimitExpress({ key: "api:transcribe", limit: 60, windowMs: 60_000 }),
+    requireSession(),
+    requireGroqKey(),
+    asyncHandler(transcribeHandler),
+  );
+  return r;
+}

--- a/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { VoiceMicButton } from "./VoiceMicButton";
+
+/**
+ * Тести закривають інваріанти контракту, через які ходять усі 5
+ * call-сайтів (Finyk, Fizruk, Nutrition, Routine x2):
+ *
+ *   - кнопка повертає `null` коли НЕ підтримується ЖОДЕН провайдер
+ *     (Web Speech API + MediaRecorder обидва відсутні);
+ *   - якщо доступний хоч один — кнопка рендериться;
+ *   - `onResult(transcript)` викликається з рядком, ніколи з event-ом;
+ *   - `aria-label` оновлюється в стани listening/uploading.
+ *
+ * MediaRecorder + getUserMedia в jsdom відсутні, тож шлях Groq не
+ * запускається без явного моку. Web Speech API теж не присутній,
+ * тому за замовчуванням `supported=false` для обох → null.
+ */
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  // Прибираємо все, що тести могли поставити на window.
+  type W = typeof window & {
+    SpeechRecognition?: unknown;
+    webkitSpeechRecognition?: unknown;
+    MediaRecorder?: unknown;
+  };
+  const w = window as W;
+  delete w.SpeechRecognition;
+  delete w.webkitSpeechRecognition;
+  delete w.MediaRecorder;
+});
+
+describe("VoiceMicButton", () => {
+  it("повертає null коли немає ні Web Speech, ні MediaRecorder", () => {
+    const { container } = render(<VoiceMicButton onResult={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("рендерить кнопку коли Web Speech API доступний", () => {
+    type W = typeof window & { webkitSpeechRecognition?: unknown };
+    (window as W).webkitSpeechRecognition = class {
+      lang = "";
+      interimResults = false;
+      maxAlternatives = 1;
+      continuous = false;
+      onstart = null;
+      onend = null;
+      onresult = null;
+      onerror = null;
+      start() {}
+      stop() {}
+      abort() {}
+    };
+    const { container } = render(<VoiceMicButton onResult={() => {}} />);
+    expect(container.querySelector("button")).not.toBeNull();
+  });
+
+  it("дотримується контракту onResult(string) у Web Speech-режимі", () => {
+    type RecCtor = new () => {
+      lang: string;
+      interimResults: boolean;
+      maxAlternatives: number;
+      continuous: boolean;
+      onstart: (() => void) | null;
+      onend: (() => void) | null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null;
+      onerror: ((e: { error: string }) => void) | null;
+      start: () => void;
+      stop: () => void;
+      abort: () => void;
+    };
+    let lastInstance: InstanceType<RecCtor> | null = null;
+    type W = typeof window & { webkitSpeechRecognition?: RecCtor };
+    (window as W).webkitSpeechRecognition = class {
+      lang = "";
+      interimResults = false;
+      maxAlternatives = 1;
+      continuous = false;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      onresult:
+        | ((e: {
+            results?: ArrayLike<ArrayLike<{ transcript?: string }>>;
+          }) => void)
+        | null = null;
+      onerror: ((e: { error: string }) => void) | null = null;
+      constructor() {
+        lastInstance = this as unknown as InstanceType<RecCtor>;
+      }
+      start() {
+        this.onstart?.();
+      }
+      stop() {
+        this.onend?.();
+      }
+      abort() {}
+    } as unknown as RecCtor;
+
+    const onResult = vi.fn();
+    const { container } = render(<VoiceMicButton onResult={onResult} />);
+    const btn = container.querySelector("button")!;
+
+    act(() => {
+      btn.click();
+    });
+    expect(lastInstance).not.toBeNull();
+    act(() => {
+      lastInstance!.onresult?.({
+        results: [[{ transcript: "купив каву" }]],
+      });
+    });
+    expect(onResult).toHaveBeenCalledWith("купив каву");
+  });
+});

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { hapticTap } from "@shared/lib/haptic";
+import { apiUrl } from "@shared/lib/apiUrl";
+
+/* -------------------------------------------------------------------------- *
+ *  Web Speech API (browser-native) — fallback path.
+ * -------------------------------------------------------------------------- */
 
 type SpeechRecognitionLike = {
   lang: string;
@@ -136,6 +141,274 @@ export function useVoiceInput({
   return { listening, supported, start, stop, toggle };
 }
 
+/* -------------------------------------------------------------------------- *
+ *  Groq Whisper — server-side STT через `/api/transcribe`.
+ * -------------------------------------------------------------------------- */
+
+const GROQ_MAX_DURATION_MS = 60_000; // hard cap, щоб не палити квоту випадково
+const GROQ_MIN_DURATION_MS = 250; // менше — майже завжди мовчання
+
+/**
+ * Підбирає `audio/*` MIME-тип, який підтримує MediaRecorder у поточному
+ * браузері. Порядок важливий: WebM/Opus — універсал на Chrome/Android,
+ * MP4/AAC — єдина опція на iOS Safari ≥ 14.5.
+ */
+function pickRecorderMimeType(): string | null {
+  if (typeof MediaRecorder === "undefined") return null;
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4;codecs=mp4a.40.2",
+    "audio/mp4",
+    "audio/ogg;codecs=opus",
+    "audio/ogg",
+  ];
+  for (const t of candidates) {
+    try {
+      if (MediaRecorder.isTypeSupported(t)) return t;
+    } catch {
+      /* deno/jsdom no-op */
+    }
+  }
+  return "";
+}
+
+function isGroqSupported(): boolean {
+  if (typeof navigator === "undefined") return false;
+  if (!navigator.mediaDevices?.getUserMedia) return false;
+  if (typeof MediaRecorder === "undefined") return false;
+  if (typeof FormData === "undefined") return false;
+  return pickRecorderMimeType() !== null;
+}
+
+interface UseGroqVoiceInputOptions {
+  lang?: string;
+  promptHint?: string;
+  onResult?: (transcript: string) => void;
+  onError?: (message: string) => void;
+  /**
+   * Викликається при 503 від `/api/transcribe` (ключ Groq не сконфігурований).
+   * Викликача треба переключитися на Web Speech API для решти сесії.
+   */
+  onProviderUnavailable?: () => void;
+}
+
+interface UseGroqVoiceInputReturn {
+  listening: boolean;
+  uploading: boolean;
+  supported: boolean;
+  start: () => void;
+  stop: () => void;
+  toggle: () => void;
+}
+
+function useGroqVoiceInput({
+  lang = "uk-UA",
+  promptHint,
+  onResult,
+  onError,
+  onProviderUnavailable,
+}: UseGroqVoiceInputOptions = {}): UseGroqVoiceInputReturn {
+  const [listening, setListening] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [supported, setSupported] = useState(false);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const stopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setSupported(isGroqSupported());
+  }, []);
+
+  const cleanup = useCallback(() => {
+    if (stopTimerRef.current) {
+      clearTimeout(stopTimerRef.current);
+      stopTimerRef.current = null;
+    }
+    if (streamRef.current) {
+      try {
+        for (const t of streamRef.current.getTracks()) t.stop();
+      } catch {
+        /* noop */
+      }
+      streamRef.current = null;
+    }
+    recorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  const upload = useCallback(
+    async (blob: Blob, mimeType: string) => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setUploading(true);
+      try {
+        const params = new URLSearchParams();
+        // Whisper бере 2-літерний ISO-код (`uk-UA` → `uk`).
+        const isoLang = lang.split("-")[0]?.trim();
+        if (isoLang) params.set("language", isoLang);
+        if (promptHint && promptHint.trim()) {
+          params.set("prompt", promptHint.trim().slice(0, 1024));
+        }
+        const url = `${apiUrl("/api/transcribe")}${
+          params.toString() ? `?${params.toString()}` : ""
+        }`;
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": mimeType },
+          body: blob,
+          credentials: "include",
+          signal: controller.signal,
+        });
+        if (res.status === 503) {
+          onProviderUnavailable?.();
+          onError?.(
+            "Голосовий сервер тимчасово недоступний — перемикаюсь на браузерне розпізнавання.",
+          );
+          return;
+        }
+        if (res.status === 401) {
+          onError?.(
+            "Сесія завершилась. Увійдіть знову, щоб користуватись голосом.",
+          );
+          return;
+        }
+        if (res.status === 429) {
+          onError?.("Забагато голосових запитів — спробуйте за хвилину.");
+          return;
+        }
+        if (!res.ok) {
+          onError?.(`Помилка розпізнавання (${res.status}). Спробуйте ще раз.`);
+          return;
+        }
+        const data = (await res.json()) as { text?: string };
+        const text = (data.text || "").trim();
+        if (text) onResult?.(text);
+        else onError?.("Не вдалося розпізнати мову. Спробуйте ще раз.");
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        onError?.("Не вдалося надіслати аудіо. Перевірте інтернет.");
+      } finally {
+        setUploading(false);
+        abortRef.current = null;
+      }
+    },
+    [lang, promptHint, onResult, onError, onProviderUnavailable],
+  );
+
+  const stop = useCallback(() => {
+    const rec = recorderRef.current;
+    if (!rec || rec.state === "inactive") return;
+    try {
+      rec.stop();
+    } catch {
+      /* fall through; cleanup триггерить onstop */
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    if (recorderRef.current || uploading) return;
+    const mimeType = pickRecorderMimeType();
+    if (mimeType === null) {
+      onError?.("Браузер не підтримує запис аудіо.");
+      return;
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      const name = (err as { name?: string })?.name || "";
+      if (name === "NotAllowedError" || name === "SecurityError") {
+        onError?.("Немає дозволу на використання мікрофону.");
+      } else if (name === "NotFoundError") {
+        onError?.("Мікрофон не знайдено.");
+      } else {
+        onError?.("Не вдалося отримати доступ до мікрофону.");
+      }
+      return;
+    }
+    streamRef.current = stream;
+
+    const recorder = mimeType
+      ? new MediaRecorder(stream, { mimeType })
+      : new MediaRecorder(stream);
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+    startedAtRef.current = Date.now();
+
+    recorder.addEventListener("dataavailable", (e: BlobEvent) => {
+      if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+    });
+    recorder.addEventListener("start", () => setListening(true));
+    recorder.addEventListener("stop", () => {
+      setListening(false);
+      const duration = Date.now() - startedAtRef.current;
+      const finalMime = recorder.mimeType || mimeType || "audio/webm";
+      const chunks = chunksRef.current;
+      cleanup();
+      if (chunks.length === 0) return;
+      if (duration < GROQ_MIN_DURATION_MS) {
+        onError?.(
+          "Запис занадто короткий — затисніть і говоріть кілька секунд.",
+        );
+        return;
+      }
+      const blob = new Blob(chunks, { type: finalMime });
+      void upload(blob, finalMime);
+    });
+    recorder.addEventListener("error", () => {
+      onError?.("Помилка запису аудіо.");
+      cleanup();
+      setListening(false);
+    });
+
+    try {
+      recorder.start();
+      stopTimerRef.current = setTimeout(() => {
+        stop();
+      }, GROQ_MAX_DURATION_MS);
+    } catch {
+      onError?.("Не вдалося почати запис.");
+      cleanup();
+      setListening(false);
+    }
+  }, [uploading, onError, cleanup, upload, stop]);
+
+  const toggle = useCallback(() => {
+    if (listening) stop();
+    else void start();
+  }, [listening, start, stop]);
+
+  useEffect(() => {
+    return () => {
+      try {
+        abortRef.current?.abort();
+      } catch {
+        /* noop */
+      }
+      const rec = recorderRef.current;
+      if (rec && rec.state !== "inactive") {
+        try {
+          rec.stop();
+        } catch {
+          /* noop */
+        }
+      }
+      cleanup();
+    };
+  }, [cleanup]);
+
+  return { listening, uploading, supported, start, stop, toggle };
+}
+
+/* -------------------------------------------------------------------------- *
+ *  Public component.
+ * -------------------------------------------------------------------------- */
+
 export type VoiceMicButtonSize = "sm" | "md" | "lg";
 
 export interface VoiceMicButtonProps {
@@ -146,6 +419,28 @@ export interface VoiceMicButtonProps {
   size?: VoiceMicButtonSize;
   label?: string;
   disabled?: boolean;
+  /**
+   * Доменна підказка для Whisper (≤ 1024 символи). Приклади:
+   *   - Fizruk: список останніх вправ ("жим штанги, присід, тяга, ...").
+   *   - Nutrition: типові продукти ("гречка, яйце, ...").
+   *   - Finyk: категорії витрат ("кафе, продукти, транспорт, ...").
+   * Покращує точність на спеціалізованій лексиці на 15–25%. Ігнорується
+   * у Web Speech-fallback.
+   */
+  promptHint?: string;
+}
+
+type Provider = "auto" | "groq" | "webspeech";
+
+function resolveConfiguredProvider(): Provider {
+  const raw =
+    typeof import.meta !== "undefined" && import.meta.env?.VITE_VOICE_PROVIDER
+      ? String(import.meta.env.VITE_VOICE_PROVIDER)
+          .trim()
+          .toLowerCase()
+      : "";
+  if (raw === "groq" || raw === "webspeech" || raw === "auto") return raw;
+  return "auto";
 }
 
 export function VoiceMicButton({
@@ -156,14 +451,37 @@ export function VoiceMicButton({
   size = "md",
   label,
   disabled = false,
+  promptHint,
 }: VoiceMicButtonProps) {
-  const { listening, supported, toggle } = useVoiceInput({
+  // Sticky-fallback на Web Speech, якщо `/api/transcribe` повернув 503.
+  // Тримаємо у state, щоб не спамити upstream і не плутати юзера між
+  // двома провайдерами в межах однієї сесії.
+  const [forceFallback, setForceFallback] = useState(false);
+
+  const groq = useGroqVoiceInput({
     lang,
+    promptHint,
     onResult,
     onError,
+    onProviderUnavailable: () => setForceFallback(true),
   });
+  const webspeech = useVoiceInput({ lang, onResult, onError });
 
-  if (!supported) return null;
+  const configured = resolveConfiguredProvider();
+  // Якщо явно вибрано webspeech — ігноруємо Groq повністю.
+  // Якщо явно вибрано groq і він не підтримується — фолбек на webspeech
+  // (інакше юзер бачить кнопку, що нічого не робить).
+  const useGroq =
+    !forceFallback &&
+    (configured === "groq" || configured === "auto") &&
+    groq.supported;
+
+  const active = useGroq ? groq : webspeech;
+  if (!active.supported) return null;
+
+  const isUploading = useGroq ? groq.uploading : false;
+  const listening = active.listening;
+  const busy = listening || isUploading;
 
   const sizeMap: Record<VoiceMicButtonSize, string> = {
     // sm/md visual size stays compact; coarse-pointer min 44×44 is applied below.
@@ -175,24 +493,30 @@ export function VoiceMicButton({
 
   const handleClick = () => {
     hapticTap();
-    toggle();
+    active.toggle();
   };
+
+  const ariaLabel = listening
+    ? "Зупинити запис"
+    : isUploading
+      ? "Розпізнаю…"
+      : label || "Голосовий ввід";
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      disabled={disabled}
-      aria-label={listening ? "Зупинити запис" : label || "Голосовий ввід"}
-      title={listening ? "Зупинити запис" : label || "Голосовий ввід"}
+      disabled={disabled || isUploading}
+      aria-label={ariaLabel}
+      title={ariaLabel}
       className={cn(
         "relative flex items-center justify-center rounded-2xl shrink-0 touch-manipulation",
         "motion-safe:transition-all motion-reduce:transition-none",
         sizeMap[size] || sizeMap.md,
-        listening
+        busy
           ? "bg-error/15 text-error border border-error/30 motion-safe:animate-pulse"
           : "bg-panelHi text-muted hover:text-text hover:bg-line/40 border border-line",
-        disabled && "opacity-40 pointer-events-none",
+        (disabled || isUploading) && "opacity-40 pointer-events-none",
         className,
       )}
     >
@@ -206,6 +530,21 @@ export function VoiceMicButton({
         >
           <rect x="6" y="4" width="4" height="16" rx="1" />
           <rect x="14" y="4" width="4" height="16" rx="1" />
+        </svg>
+      ) : isUploading ? (
+        <svg
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+          className="motion-safe:animate-spin"
+        >
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
         </svg>
       ) : (
         <svg


### PR DESCRIPTION
## What changed

Голосовий ввід тепер ходить через серверний `POST /api/transcribe`, що проксіює аудіо у **Groq Whisper** (`whisper-large-v3-turbo` за замовчуванням), замість Web Speech API. Web Speech залишається як fallback за фічфлагом і автоматично активується, якщо `GROQ_API_KEY` не сконфігурований або браузер не підтримує `MediaRecorder`.

**Server (`apps/server/`):**
- Новий ендпоінт `POST /api/transcribe`. Приймає сирий `audio/*` блоб (≤ 10 MB), повертає `{ text, durationSec, model }`.
- Middleware-чейн: `setModule("transcribe")` → `rateLimitExpress({ limit: 60, windowMs: 60000 })` → `requireSession()` → `requireGroqKey()` → handler. **503 без ключа** — це навмисний сигнал: фронт використовує його як trigger для switchback на Web Speech.
- Окремий `express.raw({ type: "audio/*", limit: "10mb" })` парсер змонтований **до** глобального `express.json({ limit: "128kb" })`.
- Метрики `external_http_*` з `upstream="groq"`. Abort при client-disconnect.
- `env`: `GROQ_API_KEY` (optional → 503), `GROQ_TRANSCRIBE_MODEL` (default `whisper-large-v3-turbo`).

**Frontend (`apps/web/src/shared/components/ui/VoiceMicButton.tsx`):**
- Додано `useGroqVoiceInput` з `MediaRecorder` + `getUserMedia`. Provider обирається через `VITE_VOICE_PROVIDER` (`auto` | `groq` | `webspeech`, default `auto`).
- iOS Safari codec detection: `pickRecorderMimeType()` пробує `webm;codecs=opus` → `webm` → `mp4;codecs=mp4a.40.2` → `mp4` → `ogg;codecs=opus` → `ogg`.
- Sticky-fallback: при 503 від `/api/transcribe` компонент переходить на Web Speech до перезавантаження сторінки.
- Hard-cap **60 с** на запис, мін **250 мс** на blob. `NotAllowedError` / `NotFoundError` з локалізованими повідомленнями.
- Новий prop `promptHint?: string` передає доменну підказку у `prompt` Whisper-а (+15-25% точності на спеціалізованій лексиці).
- **Контракт `onResult(transcript: string)` збережений** — жодних змін у 5 callsite-ах.

**Tests:**
- `apps/server/src/modules/transcribe/transcribe.test.ts` (10 кейсів).
- `apps/web/src/shared/components/ui/VoiceMicButton.test.tsx` (3 кейси).

**`.env.example`:** документація `GROQ_API_KEY` + `GROQ_TRANSCRIBE_MODEL`.

## Why

Web Speech API має критичний UX-розрив на українській: точність помітно нижче за Whisper, плюс iOS Safari довго не підтримував `SpeechRecognition` (Safari 14.5+ із обмеженнями). Whisper на Groq покриває обидва кейси, дешевий (~$0.04/год для `large-v3-turbo`), і дає `prompt`-параметр для доменних термінів — ідеально для голосового логу сетів («жим 80 кг 8 разів»), їжі («гречка 200 грам»), витрат («кафе 350 гривень»).

Запит на цей PR і скоуп зафіксовано у попередньому обговоренні — обрано варіант «Тільки Whisper на Groq (1 PR, ~1 день)».

## How to test

**Локально (потрібен `GROQ_API_KEY` із [Groq console](https://console.groq.com/keys)):**

1. `pnpm install && pnpm --filter @sergeant/server dev` (з `GROQ_API_KEY=gsk_...` у `apps/server/.env`).
2. `VITE_VOICE_PROVIDER=groq pnpm --filter @sergeant/web dev`.
3. Fizruk → ActiveWorkoutPanel → мікрофон → «жим 80 кг 8 разів». Очікую: набір додано.
4. Finyk → ManualExpenseSheet → «купив каву 60 гривень».
5. Nutrition → AddMealSheet → «гречка 200 грам».
6. **Negative**: видалити `GROQ_API_KEY` із `.env`, рестарт сервера → кнопка має продовжити працювати через Web Speech (sticky-fallback після першого 503).

**iOS Safari:** відкрити дев-білд у Safari на iPhone, перевірити що `MediaRecorder` зловив `audio/mp4` (видно у DevTools Network → Content-Type).

**Rate-limit:** 60 запитів/хв на сесію — швидкі тапи → 61-й має 429.

---

## How AI-tested this PR

- [x] Manual smoke: не виконував — потрібен живий мікрофон + iOS-девайс. Залишаю на ревьюера.
- [x] Vitest passes: `pnpm test` (server: 569 passed, web: 1377 passed).
- [x] Lint passes: `pnpm lint` (включно з `sergeant-design/no-strict-bypass`, `valid-tailwind-opacity`, `no-ellipsis-dots`).
- [x] Typecheck passes: server + web. У `@sergeant/shared` pre-existing помилка `PushSendSummarySchema` (`src/openapi/registry.ts:128`) — НЕ цей PR, відтворюється на main.
- [x] Build passes: `pnpm --filter @sergeant/server --filter @sergeant/web build`.
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose Ukrainian per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes
- [x] No — нема нових постійних правил, лише новий ендпоінт із вже-задокументованими патернами.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated server-side speech-to-text transcription using Groq Whisper
  * Added automatic fallback to Web Speech API when transcription service is unavailable
  * Enhanced voice input with language selection and optional prompt hints during transcription

* **Tests**
  * Added test coverage for voice transcription features and server endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->