### PR TITLE
fix(web): handle Whisper word-form numbers + reject empty workout sets

### DIFF
--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -367,6 +367,7 @@ export function ManualExpenseSheet({
             <VoiceMicButton
               size="md"
               label="Сказати голосом"
+              promptHint="Витрата у гривнях: кава 60 гривень, продукти 350 грн, таксі 200, обід 150."
               onResult={(transcript) => {
                 const parsed = parseExpenseSpeech(transcript);
                 if (!parsed) return;

--- a/apps/web/src/modules/finyk/pages/AssetsForm.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsForm.tsx
@@ -305,6 +305,7 @@ export function DebtForm({
         <VoiceMicButton
           size="md"
           label="Голосовий ввід"
+          promptHint="Пасив у гривнях: кредит 50000, борг 12000, іпотека."
           onResult={(transcript) => {
             const parsed = parseExpenseVoice(transcript);
             if (!parsed) return;

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutItemCard.tsx
@@ -276,9 +276,28 @@ export function WorkoutItemCard({
               <VoiceMicButton
                 size="md"
                 label="Голосовий ввід підходу"
+                // Domain prompt steers Whisper toward the canonical
+                // weight/reps shape ("80 кг 8 разів"). Without it Whisper
+                // tends to spell short numbers out ("вісімдесят кілограмів"),
+                // which the parser handles too — but digits are easier to
+                // confirm visually when the user replays the transcript.
+                promptHint="Вправа з вагою та повтореннями: жим штанги 80 кг 8 разів, присідання 100 кг 5 повторень."
                 onResult={(transcript) => {
                   const parsed = parseWorkoutSetSpeech(transcript);
-                  if (!parsed) return;
+                  // Refuse to add an empty set: parser returns a truthy
+                  // object with all-null metrics whenever nothing usable
+                  // was understood (see speechParsers.ts contract). Without
+                  // this guard the user sees a 0×0 set + rest timer and no
+                  // explanation — surprising at best, data-corrupting at
+                  // worst (silently logged by the cloud-sync queue).
+                  if (
+                    !parsed ||
+                    (parsed.weight == null &&
+                      parsed.reps == null &&
+                      parsed.sets == null)
+                  ) {
+                    return;
+                  }
                   const newSet = {
                     weightKg: parsed.weight ?? 0,
                     reps: parsed.reps ?? 0,

--- a/apps/web/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/NameTimeRow.tsx
@@ -61,6 +61,7 @@ export function NameTimeRow({ form, field, setForm }: NameTimeRowProps) {
               onResult={handleVoiceMeal}
               onError={(e) => setForm((s) => ({ ...s, err: e }))}
               label="Голосовий ввід страви"
+              promptHint="Прийом їжі: гречка 200 грам 180 ккал, овочевий салат 150 г 45 калорій, омлет 250 грам 30 г білка."
             />
           </SectionHeading>
           <Input

--- a/apps/web/src/modules/routine/components/settings/HabitForm.tsx
+++ b/apps/web/src/modules/routine/components/settings/HabitForm.tsx
@@ -243,6 +243,7 @@ export function HabitForm({
               setHabitDraft((d) => ({ ...d, name: t }));
             }}
             label="Голосовий ввід назви звички"
+            promptHint="Назва звички українською: пити воду, медитувати, ранкова пробіжка, читати книгу."
             className="shrink-0"
           />
         </div>

--- a/packages/shared/src/utils/speechParsers.test.ts
+++ b/packages/shared/src/utils/speechParsers.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeUaNumbers,
+  parseExpenseSpeech,
+  parseMealSpeech,
+  parseUaNumber,
+  parseWorkoutSetSpeech,
+} from "./speechParsers";
+
+describe("parseUaNumber", () => {
+  it("parses pure digits", () => {
+    expect(parseUaNumber("80")).toBe(80);
+    expect(parseUaNumber("80.5")).toBe(80.5);
+    expect(parseUaNumber("80,5")).toBe(80.5);
+  });
+
+  it("parses single Ukrainian word", () => {
+    expect(parseUaNumber("вісімдесят")).toBe(80);
+    expect(parseUaNumber("п'ять")).toBe(5);
+  });
+
+  it("parses compound Ukrainian numbers", () => {
+    expect(parseUaNumber("сто двадцять п'ять")).toBe(125);
+    expect(parseUaNumber("двісті п'ятдесят")).toBe(250);
+    expect(parseUaNumber("одна тисяча двісті")).toBe(1200);
+    expect(parseUaNumber("дві тисячі триста сорок")).toBe(2340);
+  });
+
+  it("returns null on non-numeric input", () => {
+    expect(parseUaNumber("кава")).toBeNull();
+    expect(parseUaNumber("")).toBeNull();
+    expect(parseUaNumber("   ")).toBeNull();
+  });
+
+  it("normalizes typographic apostrophes", () => {
+    // typographic right-quote and ASCII single-quote both map to the same key
+    expect(parseUaNumber("п’ять")).toBe(5);
+    expect(parseUaNumber("дев’яносто")).toBe(90);
+  });
+});
+
+describe("normalizeUaNumbers", () => {
+  it("replaces a single word number with digits", () => {
+    expect(normalizeUaNumbers("вісімдесят кілограмів")).toBe("80 кілограмів");
+  });
+
+  it("replaces compound words with a single digit token", () => {
+    expect(normalizeUaNumbers("сто двадцять п'ять гривень")).toBe(
+      "125 гривень",
+    );
+    expect(normalizeUaNumbers("одна тисяча двісті")).toBe("1200");
+  });
+
+  it("preserves digit tokens unchanged", () => {
+    expect(normalizeUaNumbers("80 кг 8 разів")).toBe("80 кг 8 разів");
+  });
+
+  it("handles multiple separate runs", () => {
+    expect(normalizeUaNumbers("жим вісімдесят кілограмів вісім разів")).toBe(
+      "жим 80 кілограмів 8 разів",
+    );
+  });
+
+  it("preserves trailing punctuation on the last run word", () => {
+    expect(normalizeUaNumbers("Жим, вісімдесят, вісім разів.")).toContain(
+      "80,",
+    );
+    expect(normalizeUaNumbers("Жим, вісімдесят, вісім разів.")).toContain(
+      "8 разів.",
+    );
+  });
+
+  it("leaves non-number words untouched", () => {
+    expect(normalizeUaNumbers("кава смачна")).toBe("кава смачна");
+  });
+});
+
+describe("parseExpenseSpeech", () => {
+  it("returns null on empty input", () => {
+    expect(parseExpenseSpeech("")).toBeNull();
+    expect(parseExpenseSpeech("   ")).toBeNull();
+  });
+
+  it("parses digit + currency", () => {
+    const r = parseExpenseSpeech("кава 60 гривень");
+    expect(r).not.toBeNull();
+    expect(r?.amount).toBe(60);
+    expect(r?.name).toMatch(/кава/i);
+  });
+
+  it("parses inflected currency form (гривень)", () => {
+    expect(parseExpenseSpeech("таксі 250 гривень")?.amount).toBe(250);
+    // Some Russian-Ukrainian transliterations Whisper emits
+    expect(parseExpenseSpeech("таксі 250 гривен")?.amount).toBe(250);
+  });
+
+  it("parses word-form numbers", () => {
+    const r = parseExpenseSpeech("кава шістдесят гривень");
+    expect(r?.amount).toBe(60);
+    expect(r?.name).toMatch(/кава/i);
+  });
+
+  it("parses compound word-form numbers", () => {
+    const r = parseExpenseSpeech("продукти триста двадцять п'ять гривень");
+    expect(r?.amount).toBe(325);
+    expect(r?.name).toMatch(/продукти/i);
+  });
+
+  it("falls back to bare number when no currency unit", () => {
+    expect(parseExpenseSpeech("кава 60")?.amount).toBe(60);
+  });
+});
+
+describe("parseWorkoutSetSpeech", () => {
+  it("returns null on empty input", () => {
+    expect(parseWorkoutSetSpeech("")).toBeNull();
+  });
+
+  it("parses digit form (canonical)", () => {
+    const r = parseWorkoutSetSpeech("жим 80 кг 8 разів");
+    expect(r?.weight).toBe(80);
+    expect(r?.reps).toBe(8);
+    expect(r?.exerciseName).toMatch(/жим/i);
+  });
+
+  it("parses Ukrainian word-form numbers (Whisper short-utterance habit)", () => {
+    const r = parseWorkoutSetSpeech("жим вісімдесят кілограмів вісім разів");
+    expect(r?.weight).toBe(80);
+    expect(r?.reps).toBe(8);
+  });
+
+  it("parses inflected unit forms", () => {
+    expect(parseWorkoutSetSpeech("жим 80 кілограмів")?.weight).toBe(80);
+    expect(parseWorkoutSetSpeech("жим 80 кілограм")?.weight).toBe(80);
+    expect(parseWorkoutSetSpeech("жим 80 кг")?.weight).toBe(80);
+    expect(parseWorkoutSetSpeech("8 повторень")?.reps).toBe(8);
+    expect(parseWorkoutSetSpeech("8 повторів")?.reps).toBe(8);
+    expect(parseWorkoutSetSpeech("8 повторення")?.reps).toBe(8);
+    expect(parseWorkoutSetSpeech("8 разів")?.reps).toBe(8);
+    expect(parseWorkoutSetSpeech("8 раз")?.reps).toBe(8);
+  });
+
+  it("parses English form", () => {
+    const r = parseWorkoutSetSpeech("bench press 80 kg 8 reps");
+    expect(r?.weight).toBe(80);
+    expect(r?.reps).toBe(8);
+  });
+
+  it("parses lbs and converts to kg", () => {
+    const r = parseWorkoutSetSpeech("bench press 180 lbs 8 reps");
+    expect(r?.weight).toBe(82); // 180 * 0.453592 ≈ 81.65 → rounded
+    expect(r?.reps).toBe(8);
+  });
+
+  it("returns parsed object with all-null metrics when nothing matches (caller must guard)", () => {
+    const r = parseWorkoutSetSpeech("ой не виходить нічого");
+    expect(r).not.toBeNull();
+    expect(r?.weight).toBeNull();
+    expect(r?.reps).toBeNull();
+    expect(r?.sets).toBeNull();
+  });
+});
+
+describe("parseMealSpeech", () => {
+  it("returns null on empty input", () => {
+    expect(parseMealSpeech("")).toBeNull();
+  });
+
+  it("parses digit form", () => {
+    const r = parseMealSpeech("гречка 200 грам 180 ккал");
+    expect(r?.grams).toBe(200);
+    expect(r?.kcal).toBe(180);
+    expect(r?.name).toMatch(/гречка/i);
+  });
+
+  it("parses word-form numbers (Whisper short-utterance habit)", () => {
+    const r = parseMealSpeech("гречка двісті грамів");
+    expect(r?.grams).toBe(200);
+    expect(r?.name).toMatch(/гречка/i);
+  });
+
+  it("parses inflected unit forms", () => {
+    expect(parseMealSpeech("гречка 200 грамів")?.grams).toBe(200);
+    expect(parseMealSpeech("гречка 200 грама")?.grams).toBe(200);
+    expect(parseMealSpeech("гречка 200 г")?.grams).toBe(200);
+    expect(parseMealSpeech("курка 180 калорій")?.kcal).toBe(180);
+    expect(parseMealSpeech("курка 180 кілокалорій")?.kcal).toBe(180);
+  });
+
+  it("parses combined kcal + grams", () => {
+    const r = parseMealSpeech("омлет двісті грамів триста ккал");
+    expect(r?.grams).toBe(200);
+    expect(r?.kcal).toBe(300);
+  });
+});

--- a/packages/shared/src/utils/speechParsers.ts
+++ b/packages/shared/src/utils/speechParsers.ts
@@ -1,15 +1,30 @@
 /**
  * Speech-to-structured-data parsers for each module's entry format.
  * Supports Ukrainian and English input.
+ *
+ * Voice flow: VoiceMicButton → Groq Whisper → text → these parsers →
+ * domain object. Whisper has a strong tendency to write Ukrainian numbers
+ * in word form on short utterances ("вісімдесят кілограмів" rather than
+ * "80 кг"), so every parser normalizes word-form numbers to digits before
+ * regex matching. We also accept inflected forms ("кілограмів", "грамів",
+ * "разів", "повторень", "гривень") via prefix-matching alternations
+ * without `\b` anchors.
  */
-
-// ── Finyk: expense parser ──────────────────────────────────────────────────
-// e.g. "кава 45 гривень", "продукти 320 грн", "таксі двісті п'ятдесят"
+//
+// ── Ukrainian number-words → digits ────────────────────────────────────────
+//
+// Used by both `parseUaNumber` (single-number parse) and `normalizeUaNumbers`
+// (token-stream rewrite). Inflections are deliberately NOT included here
+// because they only ever appear as the trailing word of a phrase like
+// "вісімдесятьох кілограмів" — the digit comes from "вісімдесят", and the
+// case ending lives on the unit, which the regex tolerates separately.
 
 const UA_NUMBER_WORDS: Record<string, number> = {
   нуль: 0,
   один: 1,
   одна: 1,
+  одне: 1,
+  одно: 1,
   два: 2,
   дві: 2,
   три: 3,
@@ -51,16 +66,44 @@ const UA_NUMBER_WORDS: Record<string, number> = {
   тисяч: 1000,
 };
 
-function parseUaNumber(text: string): number | null {
-  const lower = text.toLowerCase();
+// Apostrophes Whisper emits vary: ASCII `'`, typographic `’`, modifier `ʼ`.
+// Normalize to ASCII before lookup so "п'ять" / "п’ять" / "пʼять" all hit.
+// (Combining marks like U+0301 are deliberately excluded — character-class
+// linters flag them, and Whisper does not emit them in this position.)
+function normalizeApostrophes(s: string): string {
+  return s.replace(/[\u2019\u02BC]/g, "'");
+}
+
+function stripWordPunctuation(token: string): string {
+  return token
+    .replace(/[.,!?;:()«»"'`]+$/g, "")
+    .replace(/^[.,!?;:()«»"'`]+/g, "");
+}
+
+/**
+ * Parse a single number expressed as Ukrainian words OR digits.
+ * Returns null when the input contains no recognizable number.
+ *
+ * Examples:
+ *   "вісімдесят" → 80
+ *   "сто двадцять п'ять" → 125
+ *   "одна тисяча двісті" → 1200
+ *   "80,5" → 80.5
+ *   "кава" → null
+ */
+export function parseUaNumber(text: string): number | null {
+  const lower = normalizeApostrophes(text.toLowerCase());
   const parsed = parseFloat(lower.replace(",", "."));
   if (!isNaN(parsed)) return parsed;
   let total = 0;
   let current = 0;
+  let matched = false;
   const words = lower.split(/\s+/);
-  for (const w of words) {
+  for (const raw of words) {
+    const w = stripWordPunctuation(raw);
     const v = UA_NUMBER_WORDS[w];
     if (v == null) continue;
+    matched = true;
     if (v === 1000) {
       total += (current || 1) * 1000;
       current = 0;
@@ -69,8 +112,69 @@ function parseUaNumber(text: string): number | null {
     }
   }
   total += current;
-  return total > 0 ? total : null;
+  return matched ? total : null;
 }
+
+/**
+ * Walk the input as whitespace-separated words and replace every maximal
+ * run of UA number-words with the computed digit form. Punctuation between
+ * consecutive number-words breaks the run, so "вісімдесят, вісім" stays
+ * 80 + 8 instead of collapsing to 88. Output is whitespace-normalised
+ * (single spaces); parsers do not depend on the original spacing.
+ *
+ * "жим вісімдесят кілограмів вісім разів"
+ *   → "жим 80 кілограмів 8 разів"
+ *
+ * "сто двадцять п'ять гривень"
+ *   → "125 гривень"
+ *
+ * Once normalized, the existing digit-based regexes in each parser can
+ * extract weights / reps / amounts unchanged.
+ */
+export function normalizeUaNumbers(text: string): string {
+  const normalized = normalizeApostrophes(text);
+  const words = normalized.split(/\s+/).filter((w) => w.length > 0);
+  const out: string[] = [];
+  const PUNCT_BREAK = /[.,;:!?)»]$/;
+  let i = 0;
+  while (i < words.length) {
+    const clean = stripWordPunctuation(words[i]).toLowerCase();
+    if (UA_NUMBER_WORDS[clean] == null) {
+      out.push(words[i]);
+      i++;
+      continue;
+    }
+    // Collect a contiguous run of number-words, breaking at punctuation
+    // attached to a previous word in the run.
+    const runWords: string[] = [clean];
+    let j = i + 1;
+    while (j < words.length) {
+      // If the previous word ended with separator punctuation, stop the run
+      // here so that "вісімдесят, вісім" produces 80 + 8 (two numbers) rather
+      // than the merged "вісімдесят вісім" = 88.
+      if (PUNCT_BREAK.test(words[j - 1])) break;
+      const c = stripWordPunctuation(words[j]).toLowerCase();
+      if (UA_NUMBER_WORDS[c] == null) break;
+      runWords.push(c);
+      j++;
+    }
+    const n = parseUaNumber(runWords.join(" "));
+    if (n != null) {
+      // Preserve trailing punctuation on the last word of the run
+      // (e.g. "вісімдесят," → "80,").
+      const lastRaw = words[j - 1];
+      const trailingPunct = lastRaw.match(/[.,!?;:)»]+$/)?.[0] ?? "";
+      out.push(String(n) + trailingPunct);
+    } else {
+      for (let k = i; k < j; k++) out.push(words[k]);
+    }
+    i = j;
+  }
+  return out.join(" ");
+}
+
+// ── Finyk: expense parser ──────────────────────────────────────────────────
+// e.g. "кава 45 гривень", "продукти 320 грн", "таксі двісті п'ятдесят"
 
 export interface ParsedExpense {
   name: string;
@@ -81,25 +185,29 @@ export interface ParsedExpense {
 export function parseExpenseSpeech(text: string): ParsedExpense | null {
   if (!text?.trim()) return null;
 
-  const lower = text.toLowerCase().replace(/[,]/g, ".");
+  const norm = normalizeUaNumbers(text);
+  const lower = norm.toLowerCase().replace(/[,]/g, ".");
 
   const amountMatch =
-    lower.match(/(\d+(?:\.\d+)?)\s*(?:грн?|гривень|гривні|гривня|₴|uah)/i) ||
-    lower.match(/(\d+(?:\.\d+)?)/);
+    lower.match(
+      /(\d+(?:\.\d+)?)\s*(?:грн?|гривень|гривні|гривня|гривен|₴|uah)/iu,
+    ) || lower.match(/(\d+(?:\.\d+)?)/u);
 
   let amount: number | null = null;
   if (amountMatch) {
     amount = parseFloat(amountMatch[1]);
   }
 
+  // Belt-and-suspenders fallback for inputs the normalizer happened to miss
+  // (e.g. unusual case forms not in the lookup).
   if (amount == null) {
     amount = parseUaNumber(text);
   }
 
-  const currencyRe = /\b(?:грн?|гривень|гривні|гривня|₴|uah)\b/i;
-  let name = text
+  const currencyRe = /\b(?:грн?|гривень|гривні|гривня|гривен|₴|uah)\b/iu;
+  let name = norm
     .replace(
-      /(\d+(?:[.,]\d+)?)\s*(?:грн?|гривень|гривні|гривня|₴|uah)?\b/gi,
+      /(\d+(?:[.,]\d+)?)\s*(?:грн?|гривень|гривні|гривня|гривен|₴|uah)?\b/giu,
       " ",
     )
     .replace(currencyRe, " ")
@@ -117,7 +225,8 @@ export function parseExpenseSpeech(text: string): ParsedExpense | null {
 }
 
 // ── Fizruk: workout set parser ─────────────────────────────────────────────
-// e.g. "bench press 80 kg 8 reps", "присідання 100 кг 5 повторень"
+// e.g. "bench press 80 kg 8 reps", "присідання 100 кг 5 повторень",
+//       "жим вісімдесят кілограмів вісім разів"
 
 export interface ParsedWorkoutSet {
   exerciseName: string | null;
@@ -127,22 +236,35 @@ export interface ParsedWorkoutSet {
   raw: string;
 }
 
+/**
+ * Parse a workout-set utterance. Returns:
+ *   - `null` when the input is empty / whitespace-only
+ *   - an object with `weight`/`reps`/`sets` populated to the extent recognized
+ *
+ * NOTE: callers should refuse to act on the result when *all three* of
+ * `weight`, `reps`, and `sets` are `null` — the parser still returns the
+ * trimmed `exerciseName` in that case so the caller can use it as a free-form
+ * label, but it does NOT mean a numeric set was understood. See the
+ * `WorkoutItemCard` callsite for the canonical guard.
+ */
 export function parseWorkoutSetSpeech(text: string): ParsedWorkoutSet | null {
   if (!text?.trim()) return null;
 
-  const lower = text.toLowerCase();
+  const norm = normalizeUaNumbers(text);
+  const lower = norm.toLowerCase();
 
   const weightMatch =
-    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:кг|kg|кілограм|килограм)/i) ||
-    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:lb|lbs|фунт)/i);
+    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:кг|kg|кілограм|килограм)/iu) ||
+    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:lb|lbs|фунт)/iu);
 
   const repsMatch =
-    lower.match(/(\d+)\s*(?:повт|повторень|повторів|reps?|раз|разів)/i) ||
-    lower.match(/(?:повт|reps?)\s*(\d+)/i);
+    lower.match(
+      /(\d+)\s*(?:повт|повторень|повторів|повторення|reps?|разів|раз)/iu,
+    ) || lower.match(/(?:повт|reps?)\s*(\d+)/iu);
 
   const setsMatch =
-    lower.match(/(\d+)\s*(?:підходів|підхід|sets?)/i) ||
-    lower.match(/(?:підхід|sets?)\s*(\d+)/i);
+    lower.match(/(\d+)\s*(?:підходів|підхід|sets?)/iu) ||
+    lower.match(/(?:підхід|sets?)\s*(\d+)/iu);
 
   let weight: number | null = null;
   if (weightMatch) {
@@ -157,10 +279,13 @@ export function parseWorkoutSetSpeech(text: string): ParsedWorkoutSet | null {
   let sets: number | null = null;
   if (setsMatch) sets = parseInt(setsMatch[1] || setsMatch[2], 10);
 
-  let exerciseName: string | null = text
-    .replace(/(\d+(?:[.,]\d+)?)\s*(?:кг|kg|кілограм|lb|lbs|фунт)?\b/gi, " ")
+  let exerciseName: string | null = norm
     .replace(
-      /(\d+)\s*(?:повт|повторень|повторів|reps?|раз|разів|підходів|підхід|sets?)\b/gi,
+      /(\d+(?:[.,]\d+)?)\s*(?:кг|kg|кілограм|килограм|lb|lbs|фунт)?\b/giu,
+      " ",
+    )
+    .replace(
+      /(\d+)\s*(?:повт|повторень|повторів|повторення|reps?|разів|раз|підходів|підхід|sets?)\b/giu,
       " ",
     )
     .replace(/\s+/g, " ")
@@ -180,7 +305,8 @@ export function parseWorkoutSetSpeech(text: string): ParsedWorkoutSet | null {
 }
 
 // ── Nutrition: meal parser ─────────────────────────────────────────────────
-// e.g. "гречка 200 грам 180 ккал", "овочевий салат 150г 45 калорій"
+// e.g. "гречка 200 грам 180 ккал", "овочевий салат 150г 45 калорій",
+//      "омлет двісті п'ятдесят грамів"
 
 export interface ParsedMeal {
   name: string;
@@ -193,18 +319,26 @@ export interface ParsedMeal {
 export function parseMealSpeech(text: string): ParsedMeal | null {
   if (!text?.trim()) return null;
 
-  const lower = text.toLowerCase();
+  const norm = normalizeUaNumbers(text);
+  const lower = norm.toLowerCase();
 
   const kcalMatch =
-    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:ккал|кілокалор|калор|kcal|cal)/i) ||
-    lower.match(/(?:ккал|kcal)\s*(\d+(?:[.,]\d+)?)/i);
+    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:ккал|кілокалор|калор|kcal|cal)/iu) ||
+    lower.match(/(?:ккал|kcal)\s*(\d+(?:[.,]\d+)?)/iu);
 
+  // Prefer multi-letter alternations first; "гр"/"г" alone use a Cyrillic-aware
+  // negative lookahead so they don't gobble "гречка". JS `\b` is ASCII-only and
+  // doesn't fire between two Cyrillic chars even with the /u flag.
+  const CYR = /[а-яА-ЯёЁєЄіІїЇґҐ]/.source;
+  const gramsRe = new RegExp(
+    `(\\d+(?:[.,]\\d+)?)\\s*(?:грам|гр(?!${CYR})|г(?!${CYR})|g\\b|ml|мл)`,
+    "iu",
+  );
   const gramsMatch =
-    lower.match(/(\d+(?:[.,]\d+)?)\s*(?:грам|гр|г\b|g\b|ml|мл)/i) ||
-    lower.match(/(?:грам|гр)\s*(\d+(?:[.,]\d+)?)/i);
+    lower.match(gramsRe) || lower.match(/(?:грам|гр)\s*(\d+(?:[.,]\d+)?)/iu);
 
   const proteinMatch = lower.match(
-    /(\d+(?:[.,]\d+)?)\s*(?:г\s*білка|г\s*протеїну|g\s*protein|protein)/i,
+    /(\d+(?:[.,]\d+)?)\s*(?:г\s*білка|г\s*протеїну|g\s*protein|protein)/iu,
   );
 
   let kcal: number | null = null;
@@ -217,10 +351,16 @@ export function parseMealSpeech(text: string): ParsedMeal | null {
   let protein: number | null = null;
   if (proteinMatch) protein = parseFloat(proteinMatch[1].replace(",", "."));
 
-  let name = text
-    .replace(/(\d+(?:[.,]\d+)?)\s*(?:ккал|кілокалор|калор|kcal|cal)?\b/gi, " ")
-    .replace(/(\d+(?:[.,]\d+)?)\s*(?:грам|гр|г\b|g\b|ml|мл)?\b/gi, " ")
-    .replace(/(\d+(?:[.,]\d+)?)\s*(?:г\s*білка|g\s*protein)?\b/gi, " ")
+  // Strip recognized number-units from the name. Same Cyrillic-aware
+  // lookahead trick for "гр"/"г" so we don't munch food-name prefixes.
+  const stripGramsRe = new RegExp(
+    `(\\d+(?:[.,]\\d+)?)\\s*(?:грам|гр(?!${CYR})|г(?!${CYR})|g\\b|ml|мл)?\\b`,
+    "giu",
+  );
+  let name = norm
+    .replace(/(\d+(?:[.,]\d+)?)\s*(?:ккал|кілокалор|калор|kcal|cal)?\b/giu, " ")
+    .replace(stripGramsRe, " ")
+    .replace(/(\d+(?:[.,]\d+)?)\s*(?:г\s*білка|g\s*protein)?\b/giu, " ")
     .replace(/\s+/g, " ")
     .trim();
 


### PR DESCRIPTION
## What changed

Three connected fixes for the Groq Whisper voice flow shipped in #1009:

1. **Empty-set guard in `WorkoutItemCard`.** The parser's contract returns a truthy `ParsedWorkoutSet` with all-`null` metrics whenever it cannot extract weight/reps/sets — the existing `if (!parsed) return` guard accepted that case and committed a 0×0 set + rest timer. Now the callsite refuses to act unless at least one of weight/reps/sets is populated.

2. **Whisper-aware normalisation in `speechParsers.ts`.** On short Ukrainian utterances Groq Whisper writes numbers in word form ("вісімдесят кілограмів вісім разів") instead of digits. Added `normalizeUaNumbers()` which rewrites contiguous runs of UA number-words to digits before regex matching, with punctuation acting as a run boundary so "вісімдесят, вісім" stays 80 + 8 (not 88). Also extracted `parseUaNumber` for reuse, normalised typographic apostrophes (`’`/`ʼ` → `'`), and switched all unit regexes to `/u` so Cyrillic word boundaries fire (fixes "200 г" → `grams=null` on the meal parser; latent bug pre-dating Whisper).

3. **Domain `promptHint` per callsite.** Every `<VoiceMicButton>` now passes a short example string to Whisper via the `prompt` query param. This biases recognition toward digit-form numbers and the canonical `weight кг N разів` / `name N грн` shapes, making transcripts both more accurate on domain vocabulary and easier for the parser to consume.

## Why

Live test on iOS Safari (PWA, prod) showed `POST /api/v1/transcribe` returning **HTTP 200** but the workout silently gained an **empty set + rest timer** instead of the spoken numbers. Root cause was diagnosed in two places: (a) the parser tolerated all-null metrics and the callsite blindly trusted it, (b) Whisper's strong tendency to spell short Ukrainian numbers in word form made the digit-only regex miss everything. Fixing both keeps the contract `onResult(text)` stable for all 5 callsites while making the voice flow work end-to-end.

## How to test

```bash
pnpm --filter @sergeant/shared test src/utils/speechParsers
# 29 tests covering: digit form, word-form numbers (single + compound),
# Ukrainian inflections (кілограмів, грамів, повторень, гривень, калорій),
# apostrophe variants (’/ʼ → '), the empty-set contract.
```

End-to-end smoke (any browser, prod or local with `GROQ_API_KEY` set):
1. Active workout → tap the mic on a set card → say «жим штанги вісімдесят кілограмів вісім разів» → set with `weightKg=80, reps=8` should be appended (not 0×0).
2. Same flow with «жим 80 кг 8 разів» → still works (digit path).
3. Say something nonsensical like «ой не виходить» → **no set is added**, no rest timer fires.
4. Finyk ManualExpense: «кава шістдесят гривень» → amount 60.
5. Nutrition AddMeal: «гречка двісті грамів триста ккал» → grams 200, kcal 300.

---

## How AI-tested this PR

- [x] Manual smoke (parser): live `pnpm test` against new + existing cases passes 29/29.
- [x] Vitest passes: `pnpm -r test` — all packages green except the **pre-existing** `PushSendSummarySchema` failure on `main` (unrelated; same red as #1009).
- [x] Lint passes: `pnpm lint` clean.
- [x] Typecheck: clean **except** the same pre-existing `PushSendSummarySchema doesn't exist` error in `packages/shared/src/openapi/registry.ts:128`, present on `main` since before #1009 — not introduced here.
- [x] Build: `pnpm build` green.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian where practical (comments mostly EN per existing convention; user-visible prompts UA).

## AGENTS.md updated?

- [x] No — no new permanent rules. Conformant to existing rule #5 (`web` scope, dual-scope explanation in commit body).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example prompts to voice input for expenses, debts, workouts, meals, and habits.

* **Improvements**
  * Enhanced Ukrainian voice parsing for numbers, currency, and measurement units across all voice-input features.
  * Improved validation to prevent adding incomplete workout sets via voice input.

* **Tests**
  * Added comprehensive test suite for speech parsing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->