### PR TITLE
fix(web): wire Google OAuth button to signIn.social

### DIFF
--- a/apps/web/src/core/auth/AuthContext.test.tsx
+++ b/apps/web/src/core/auth/AuthContext.test.tsx
@@ -14,6 +14,11 @@ const signInEmail: ReturnType<
     (args: { email: string; password: string }) => Promise<AuthResult>
   >
 > = vi.fn(async () => ok());
+const signInSocial: ReturnType<
+  typeof vi.fn<
+    (args: { provider: string; callbackURL?: string }) => Promise<AuthResult>
+  >
+> = vi.fn(async () => ok());
 const signUpEmail: ReturnType<
   typeof vi.fn<
     (args: {
@@ -35,6 +40,8 @@ const forgetPassword: ReturnType<
 vi.mock("./authClient.js", () => ({
   signIn: {
     email: (args: { email: string; password: string }) => signInEmail(args),
+    social: (args: { provider: string; callbackURL?: string }) =>
+      signInSocial(args),
   },
   signUp: {
     email: (args: { email: string; password: string; name: string }) =>
@@ -116,6 +123,7 @@ const SAMPLE_USER = {
 describe("AuthContext", () => {
   beforeEach(() => {
     signInEmail.mockClear();
+    signInSocial.mockClear();
     signUpEmail.mockClear();
     signOut.mockClear();
     forgetPassword.mockClear();
@@ -241,6 +249,41 @@ describe("AuthContext", () => {
     expect(invalidateSpy).not.toHaveBeenCalledWith({
       queryKey: apiQueryKeys.me.current(),
     });
+  });
+
+  it("loginWithGoogle delegates to signIn.social with provider=google", async () => {
+    setUser({ data: undefined });
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const okResult = await result.current.loginWithGoogle();
+      expect(okResult).toBe(true);
+    });
+    expect(signInSocial).toHaveBeenCalledWith({
+      provider: "google",
+      callbackURL: "/",
+    });
+    // Successful social sign-in normally redirects to the provider; the
+    // me-cache will be re-fetched after the OAuth callback round-trips,
+    // not here. Invalidation explicitly should NOT happen on the kickoff.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: apiQueryKeys.me.current(),
+    });
+  });
+
+  it("loginWithGoogle surfaces provider errors via authError", async () => {
+    setUser({ data: undefined });
+    signInSocial.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Provider not configured" },
+    } as unknown as Awaited<ReturnType<typeof signInSocial>>);
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+    await act(async () => {
+      const okResult = await result.current.loginWithGoogle();
+      expect(okResult).toBe(false);
+    });
+    expect(result.current.authError).toBe("Provider not configured");
   });
 
   it("useAuth() throws when used outside AuthProvider", () => {

--- a/apps/web/src/core/auth/AuthContext.tsx
+++ b/apps/web/src/core/auth/AuthContext.tsx
@@ -46,6 +46,7 @@ interface AuthContextValue {
   authError: string | null;
   setAuthError: (msg: string | null) => void;
   login: (email: string, password: string) => Promise<boolean>;
+  loginWithGoogle: () => Promise<boolean>;
   register: (email: string, password: string, name: string) => Promise<boolean>;
   logout: () => Promise<void>;
   requestPasswordReset: (email: string) => Promise<boolean>;
@@ -108,6 +109,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
     },
     [invalidateMe],
   );
+
+  // Better Auth `signIn.social` ініціює OAuth-редирект на провайдера —
+  // у разі успіху сторінка переходить на Google і керування назад
+  // повертається через `callbackURL`, тож resolve тут зазвичай не
+  // настає. Помилки (provider не сконфігуровано на сервері, мережа,
+  // CSRF) повертаються синхронно через `result.error` — піднімаємо їх
+  // у `authError`, щоб користувач отримав фідбек замість мовчазного
+  // нічого.
+  const loginWithGoogle = useCallback(async () => {
+    setAuthError(null);
+    try {
+      const result = await signIn.social({
+        provider: "google",
+        callbackURL: "/",
+      });
+      if (result?.error) {
+        setAuthError(
+          translateAuthError(
+            result.error.message || "Не вдалося увійти через Google",
+          ),
+        );
+        return false;
+      }
+      return true;
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Не вдалося увійти через Google";
+      setAuthError(message);
+      return false;
+    }
+  }, []);
 
   const register = useCallback(
     async (email: string, password: string, name: string) => {
@@ -211,6 +243,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       authError,
       setAuthError,
       login,
+      loginWithGoogle,
       register,
       logout,
       requestPasswordReset,
@@ -222,6 +255,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       status,
       authError,
       login,
+      loginWithGoogle,
       register,
       logout,
       requestPasswordReset,

--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -38,14 +38,21 @@ function PasswordStrengthBar({ password }: { password: string }) {
 }
 
 export function AuthPage({ onContinueWithoutAccount }) {
-  const { login, register, requestPasswordReset, authError, setAuthError } =
-    useAuth();
+  const {
+    login,
+    loginWithGoogle,
+    register,
+    requestPasswordReset,
+    authError,
+    setAuthError,
+  } = useAuth();
   const toast = useToast();
   const [mode, setMode] = useState("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showForgot, setShowForgot] = useState(false);
   // "idle" → the panel renders the reset form; "sending" disables the
@@ -73,6 +80,15 @@ export function AuthPage({ onContinueWithoutAccount }) {
     setForgotState("sending");
     const ok = await requestPasswordReset(target);
     setForgotState(ok ? "sent" : "idle");
+  };
+
+  const handleGoogleSignIn = async () => {
+    setGoogleLoading(true);
+    await loginWithGoogle();
+    // У сценарії success браузер вже перейшов на Google і цей код не
+    // виконається. Скидаємо локальний спіннер тільки на випадок, якщо
+    // OAuth не запустився (помилка вже в `authError`).
+    setGoogleLoading(false);
   };
 
   const handleSubmit = async (e) => {
@@ -314,10 +330,9 @@ export function AuthPage({ onContinueWithoutAccount }) {
           variant="secondary"
           size="lg"
           className="w-full"
-          onClick={() => {
-            // TODO: initiate Google OAuth via better-auth
-            // authClient.signIn.social({ provider: "google" })
-          }}
+          loading={googleLoading}
+          disabled={loading || googleLoading}
+          onClick={handleGoogleSignIn}
         >
           <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
             <path


### PR DESCRIPTION
## What changed

- **`apps/web/src/core/auth/AuthContext.tsx`** — додав `loginWithGoogle()` action, що викликає `signIn.social({ provider: "google", callbackURL: "/" })` і піднімає помилки через існуючий `authError` (з тим же `translateAuthError` мапінгом, що й `login`/`register`).
- **`apps/web/src/core/auth/AuthPage.tsx`** — кнопка «Увійти через Google» (рядки 312–321 у попередньому стані) тепер має реальний `onClick={handleGoogleSignIn}`, окремий `googleLoading` state і коректно блокує форму під час OAuth-редиректу. TODO-коментар прибрано.
- **`apps/web/src/core/auth/AuthContext.test.tsx`** — мок `signIn.social` додано до існуючого стабу `authClient`, плюс два нові тести: щасливий шлях (виклик з `provider: "google"`, без інвалідації me-кеша до повернення з callback) і помилка від провайдера → потрапляє в `authError`.

## Why

Кнопка Google OAuth рендерилась, але `onClick` був порожньою стрілкою з TODO-коментарем — клік нічого не робив, що відчувалось як зламаний UX (особливо що поряд `Увійти` працює). Better Auth уже має `signIn.social()`; на фронт-енді бракувало тільки тонкого враппера навколо нього.

> ⚠️ **Бекенд side-config.** На сервері (`apps/server/src/auth.ts`) поки немає `socialProviders.google` — це окрема задача (потрібні `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` env-и + рядок у `betterAuth({ socialProviders: { google: {...} } })`). До того часу клік по кнопці тригерне виклик і отримає помилку від Better Auth — її буде показано у вже наявному `authError`-блоці замість мовчазного нічого. Це фіксить саме UX-баг, описаний у тікеті, не змінюючи інфраструктури.

## How to test

1. `pnpm --filter @sergeant/web test -- src/core/auth/AuthContext.test.tsx` → 13 passed (2 нові).
2. Manual: відкрити Auth-сторінку → клік по «Увійти через Google» → бачимо спіннер, далі або редирект на Google (коли provider буде сконфігуровано), або повідомлення в `authError` під формою.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web test -- src/core/auth/AuthContext.test.tsx` — 13/13.
- [x] Lint clean (`eslint src/core/auth`) і Prettier clean (`prettier --check src/core/auth`).
- [x] No new `AI-DANGER` markers added.
- [x] Docs/коментарі — українською, як просить AGENTS.md.
- [ ] Manual smoke (UI click): не виконував — required server-side `socialProviders.google`, якого ще немає, тож ручна перевірка показала б очікувану помилку Better Auth, а не успішний редирект.

> Pre-existing: `pnpm --filter @sergeant/web typecheck` падає у `src/shared/components/ui/VoiceMicButton.test.tsx` (TS2790 / TS7008) — помилки існували до цього PR (відтворюються з `git stash` моїх змін; зʼявились у щойно змерженому #1009). Не входить у скоуп цієї правки.

## AGENTS.md updated?

- [ ] Yes
- [x] No — нових постійних правил немає.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Sign-In authentication, allowing users to securely authenticate using their Google account as an alternative to standard credentials. Includes loading states and error handling for a seamless user experience.

* **Tests**
  * Added comprehensive test coverage for the new Google authentication feature, validating successful sign-in flows and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->