### PR TITLE
feat(server): wire Google OAuth provider into Better Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,16 @@ BETTER_AUTH_SECRET=change_me_to_a_long_random_string_32chars
 # Від кого (має бути з верифікованого домену в Resend; для тесту — onboarding@resend.dev)
 # RESEND_FROM=Sergeant <noreply@yourdomain.com>
 
+# Google OAuth (Better Auth socialProviders.google).
+# Активує кнопку «Увійти через Google» на AuthPage. Без обох змінних
+# socialProviders.google не вмикається і клік повертає
+# `Provider not configured` у `authError`.
+# Створення клієнта: https://console.cloud.google.com/auth/clients/create
+# Authorized redirect URIs мають містити <BETTER_AUTH_URL>/api/auth/callback/google
+# (локально http://localhost:5000/..., у проді https://<railway-api>/...).
+# GOOGLE_CLIENT_ID=...apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=GOCSPX-...
+
 # ── Anthropic Claude API ──────────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-api03-...
 

--- a/apps/server/src/auth.test.ts
+++ b/apps/server/src/auth.test.ts
@@ -58,6 +58,47 @@ describe("auth config — bearer plugin інтегрований у Better Auth"
     expect(options.emailAndPassword?.enabled).toBe(true);
   });
 
+  /**
+   * `socialProviders.google` має вмикатися ТІЛЬКИ коли пара
+   * `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` обидві задані.
+   * У тестовому середовищі ці env-и порожні — тож конфіг має
+   * стартувати без `socialProviders`, інакше Better Auth впав би
+   * на старті з валідаційною помилкою.
+   */
+  it("без env-ів socialProviders НЕ передається у Better Auth", () => {
+    const options = (
+      auth as unknown as { options: { socialProviders?: unknown } }
+    ).options;
+    expect(options.socialProviders).toBeUndefined();
+  });
+
+  it("із заданими GOOGLE_CLIENT_ID/SECRET вмикається google-провайдер", async () => {
+    vi.resetModules();
+    vi.stubEnv("GOOGLE_CLIENT_ID", "test-client-id.apps.googleusercontent.com");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "GOCSPX-test-secret");
+    try {
+      const { auth: authWithGoogle } = await import("./auth.js");
+      const options = (
+        authWithGoogle as unknown as {
+          options: {
+            socialProviders?: {
+              google?: { clientId?: string; clientSecret?: string };
+            };
+          };
+        }
+      ).options;
+      expect(options.socialProviders?.google?.clientId).toBe(
+        "test-client-id.apps.googleusercontent.com",
+      );
+      expect(options.socialProviders?.google?.clientSecret).toBe(
+        "GOCSPX-test-secret",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
   it("налаштовані sendResetPassword та emailVerification (Resend у рантаймі)", () => {
     const options = (
       auth as unknown as {

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -57,6 +57,33 @@ function getAdvancedCookieOptions(): AdvancedCookieOptions | null {
 
 const advancedCookies = getAdvancedCookieOptions();
 
+/**
+ * Збираємо `socialProviders` тільки коли пара
+ * `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` обидві задані. Якщо
+ * хоча б одна порожня — кидати конфіг до Better Auth не можна
+ * (він зразу падає при старті, бо валідатор сприймає це як
+ * misconfigured provider). Тому у dev/CI без credentials просто не
+ * вмикаємо провайдера: фронтова кнопка отримає `Provider not
+ * configured` через стандартний `authError` (див. `loginWithGoogle`
+ * у `apps/web/src/core/auth/AuthContext.tsx`), а сервер стартує без
+ * сюрпризів.
+ */
+function getSocialProviders():
+  | { google: { clientId: string; clientSecret: string } }
+  | undefined {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return undefined;
+  return {
+    google: {
+      clientId,
+      clientSecret,
+    },
+  };
+}
+
+const socialProviders = getSocialProviders();
+
 export const auth = betterAuth({
   database: pool,
   baseURL: getBaseURL(),
@@ -66,6 +93,7 @@ export const auth = betterAuth({
       enabled: true,
     },
   },
+  ...(socialProviders ? { socialProviders } : {}),
   emailAndPassword: {
     enabled: true,
     // NIST SP 800-63B рекомендує мінімум 8 символів; 10 — розумний trade-off,


### PR DESCRIPTION
## What changed

- **`apps/server/src/auth.ts`** — додав `socialProviders.google` у Better Auth конфіг, активується **тільки** коли обидві env vars задані (`GOOGLE_CLIENT_ID` і `GOOGLE_CLIENT_SECRET`). Якщо хоча б одна порожня — `socialProviders` взагалі не передається у `betterAuth({...})` (інакше валідатор Better Auth впав би на старті з помилкою про misconfigured provider).
- **`apps/server/src/auth.test.ts`** — два нові тести: (a) у тестовому середовищі без env-ів `options.socialProviders === undefined`; (b) із заданими env-ами `options.socialProviders.google.{clientId,clientSecret}` мають коректні значення (використовую `vi.stubEnv` + `vi.resetModules` + динамічний `import("./auth.js")`).
- **`.env.example`** — додав закоментований блок `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` з посиланням на Google Cloud Console і нагадуванням про формат `Authorized redirect URIs` (`<BETTER_AUTH_URL>/api/auth/callback/google`).

## Why

Парний серверний фікс до #1011: фронтова кнопка тепер реально клікається й кличе `signIn.social({ provider: "google" })`, але до цього моменту бекенд не знав, що таке провайдер `google`, і Better Auth повертав помилку. Цей PR закриває контур — після додавання змінних у Railway кнопка дає end-to-end OAuth flow (`/api/auth/sign-in/social` → Google consent → `/api/auth/callback/google` → сесія + me-кеш інвалідація через існуючий `loginWithGoogle` в AuthContext).

Чому опційно (через env-gate), а не безумовно: dev/CI без credentials мають стартувати без сюрпризів. Коментар у `auth.ts` пояснює це поведінку.

## How to test

### Юніт (CI)
```bash
pnpm --filter @sergeant/server test -- --run src/auth.test.ts
# 6/6 passed (4 існуючих + 2 нових)
```

### Інтеграційно (після мерджу обох PR і Railway deploy)
1. У Google Cloud Console: створити OAuth Client (Web application) з:
   - Authorized JS origins: `http://localhost:5000`, `http://localhost:5173`, `https://sergeant.vercel.app`, `https://sergeant-production.up.railway.app`
   - Authorized redirect URIs: `http://localhost:5000/api/auth/callback/google`, `https://sergeant-production.up.railway.app/api/auth/callback/google`
2. У Railway → API сервіс → Variables додати `GOOGLE_CLIENT_ID` і `GOOGLE_CLIENT_SECRET`. Дочекатися redeploy.
3. На `https://sergeant.vercel.app` → Auth-сторінка → клік «Увійти через Google» → редирект на Google → consent → повернення на `sergeant.vercel.app` уже залогіненим.

### Локально
1. `cp .env.example .env` і вставити свої значення `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` (можна окремий test-app у Google Cloud з redirect URI `http://localhost:5000/api/auth/callback/google`).
2. `pnpm dev:server` + `pnpm dev:web`, відкрити `http://localhost:5173`, клік на кнопку.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/server test -- --run src/auth.test.ts` — 6/6.
- [x] Lint clean (`eslint src/auth.ts src/auth.test.ts`) і Prettier clean.
- [ ] Manual smoke (OAuth round-trip): не виконував — потребує реальних `GOOGLE_CLIENT_*` у Railway, що додаватиме @Skords-01 у рамках цього ж тікета.
- [x] No new `AI-DANGER` markers added.
- [x] Docs/коментарі — українською, як просить AGENTS.md.

> Pre-existing CI: `Test coverage (vitest)` і `check` зараз червоні на `main` через `apps/server/src/openapi/registry.ts:128` (`PushSendSummarySchema` does not exist) — регрес від щойно мерженого #1009. Цей PR не торкається openapi/voice, тож успадкує ту саму поломку до окремого фіксу.

## AGENTS.md updated?

- [ ] Yes
- [x] No — нових постійних правил немає (поведінка задокументована у `.env.example` і JSDoc-коментарі).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
