### PR TITLE
fix: unblock typecheck on main (PushSendSummarySchema + VoiceMicButton.test)

### DIFF
--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -572,6 +572,13 @@ export const PushTestResponseSchema = z.object({
   errors: z.array(PushSendErrorSchema),
 });
 
+// Same shape as PushTestResponseSchema — exported under a domain-neutral
+// name so non-test push fan-out endpoints (worker, internal /api/push/send)
+// can advertise it via the OpenAPI registry without coupling to the test
+// route. Kept as a re-export rather than a duplicate declaration so the two
+// are guaranteed to stay in lock-step.
+export const PushSendSummarySchema = PushTestResponseSchema;
+
 // ────────────────────── Pagination ──────────────────────
 // Переused у будь-якому endpoint-і, що повертає список. Query-params завжди
 // приходять рядками — `z.coerce.number()` конвертує "8" → 8 автоматично.


### PR DESCRIPTION
## What changed

Two small typecheck unblocks bundled in one PR — both surfaced on `main` simultaneously after the recent voice-Whisper merges (`a3e16705` + `0778cf24` → `a75dfd96`):

### 1. `packages/shared/src/schemas/api.ts` — add `PushSendSummarySchema`

```ts
export const PushSendSummarySchema = PushTestResponseSchema;
```

`packages/shared/src/openapi/registry.ts:128` references `schemas.PushSendSummarySchema`, and `packages/shared/src/openapi/routes.ts:451` advertises `namedSchemas.PushSendSummary` as the response of the worker push fan-out endpoint, but the schema was never exported from `api.ts` — only `PushSendSchema`, `PushSendErrorSchema`, `PushSendPlatformSchema`, and `PushTestResponseSchema` exist there.

`PushSendSummary` and `PushTestResponse` describe the **same** `{ delivered, cleaned, errors }` shape — `docs/api/openapi.json` documents both objects with byte-identical schemas (verified via `jq '.components.schemas.PushSendSummary'` vs. `.components.schemas.PushTestResponse`). Keeping it as a re-export (rather than a duplicate `z.object({…})`) guarantees they stay in lock-step if either ever evolves.

### 2. `apps/web/src/shared/components/ui/VoiceMicButton.test.tsx` — two TS errors

**(a) TS2790 — `delete w.MediaRecorder` on non-optional member.** `MediaRecorder` is non-optional on `Window` in `lib.dom.d.ts`. The local intersection type `typeof window & { MediaRecorder?: unknown }` does NOT propagate the optional flag through to the original DOM declaration. Fix: use `Reflect.deleteProperty(window, "…")`, which works against non-optional members.

**(b) TS7008 — `onstart = null` / `onend = null` / `onresult = null` / `onerror = null` implicit-any** on the inline `webkitSpeechRecognition` mock class. Flagged by `apps/web/tsconfig.noimplicitany.json` because the file lives under `src/shared/**`. Fix: annotate the mock fields with explicit function-or-null types matching the real `SpeechRecognition` callback shapes already used in the **second** test in the same file (lines 64–71).

## Why

`@sergeant/shared#typecheck` started failing on every PR (including doc-only PRs that touch zero TS code) after `PushSendSummarySchema` was referenced in the OpenAPI registry without ever being defined. Once that's fixed, `@sergeant/web#typecheck` then fails for the two reasons above. Both errors block:

- **`Test coverage (vitest)`** — its `pretest` step runs `pnpm typecheck` first.
- **`check`** — the catch-all CI job that runs `pnpm typecheck`.

So the **same single failure** (#1 alone, or #1 + #2 together depending on which package finishes first) is killing CI on every open PR right now. Reproduced on the latest `main` (a75dfd96): https://github.com/Skords-01/Sergeant/actions/runs/25021043697/job/73281313464

## How to test

```bash
pnpm install
pnpm --filter @sergeant/shared typecheck   # was: TS2551, now: clean
pnpm --filter @sergeant/web typecheck      # was: TS2790 + 4× TS7008, now: clean
pnpm typecheck                             # all 13 workspace projects clean
pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/VoiceMicButton.test.tsx
#                                          # 3 / 3 tests pass
pnpm api:check-openapi                     # `docs/api/openapi.json актуальна`
```

Locally on this branch:

- `pnpm typecheck` → `Tasks: 13 successful, 13 total`.
- `vitest run src/shared/components/ui/VoiceMicButton.test.tsx` → `Test Files: 1 passed, Tests: 3 passed`.
- `pnpm api:check-openapi` → «docs/api/openapi.json актуальна (≡ generator output).».

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `pnpm typecheck`, `pnpm api:check-openapi`, and `vitest run` for the affected file locally — all green.
- [x] Vitest passes: `VoiceMicButton.test.tsx` 3/3 still pass after the type annotations.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. (The added schema's inline comment is English because the surrounding schema comments in `api.ts` are English — house style of that file. The test-file delete-helper comment IS Ukrainian.)

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. Two direct fixes of pre-existing typecheck failures.