### PR TITLE
fix: unblock CI on main (PushSendSummarySchema + VoiceMicButton typecheck)

### DIFF
--- a/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.test.tsx
@@ -22,12 +22,15 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   // Прибираємо все, що тести могли поставити на window.
-  type W = typeof window & {
+  // `MediaRecorder` оголошений у lib.dom.d.ts як обовʼязковий → перетинна
+  // `& { MediaRecorder?: unknown }` його не послаблює. Використовуємо `Omit`
+  // щоб зробити поле опційним і дозволити `delete`.
+  type W = Omit<typeof window, "MediaRecorder"> & {
     SpeechRecognition?: unknown;
     webkitSpeechRecognition?: unknown;
     MediaRecorder?: unknown;
   };
-  const w = window as W;
+  const w = window as unknown as W;
   delete w.SpeechRecognition;
   delete w.webkitSpeechRecognition;
   delete w.MediaRecorder;
@@ -46,10 +49,10 @@ describe("VoiceMicButton", () => {
       interimResults = false;
       maxAlternatives = 1;
       continuous = false;
-      onstart = null;
-      onend = null;
-      onresult = null;
-      onerror = null;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      onresult: ((e: unknown) => void) | null = null;
+      onerror: ((e: unknown) => void) | null = null;
       start() {}
       stop() {}
       abort() {}

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -572,6 +572,12 @@ export const PushTestResponseSchema = z.object({
   errors: z.array(PushSendErrorSchema),
 });
 
+// `/api/push/send` (worker fan-out) повертає той самий summary, що й
+// `/api/push/test`. OpenAPI registry віддає їх як окремі іменовані схеми
+// `PushSendSummary` / `PushTestResponse`, тож тримаємо явний alias —
+// рефактор може розщепити їх у майбутньому без зміни контракту.
+export const PushSendSummarySchema = PushTestResponseSchema;
+
 // ────────────────────── Pagination ──────────────────────
 // Переused у будь-якому endpoint-і, що повертає список. Query-params завжди
 // приходять рядками — `z.coerce.number()` конвертує "8" → 8 автоматично.


### PR DESCRIPTION
## What changed

Два дрібні фікси які зараз тримають `check` / `Test coverage (vitest)` червоними на main і відповідно завалюють кожен Renovate-PR:

1. **`packages/shared/src/schemas/api.ts`** — додано `PushSendSummarySchema` як alias для `PushTestResponseSchema`. Обидва endpoint-и (`/api/push/send` worker і `/api/push/test` user-facing) повертають один і той самий summary-shape (`delivered` / `cleaned` / `errors`), а OpenAPI registry йшла по двох іменах: `PushSendSummary` і `PushTestResponse`. Реальний schema з ім'ям `Summary` ніколи не існував — тому `packages/shared/src/openapi/registry.ts:128` падав на `Property 'PushSendSummarySchema' does not exist`.
2. **`apps/web/src/shared/components/ui/VoiceMicButton.test.tsx`** — тест використовував `delete w.MediaRecorder`, але `MediaRecorder` оголошено як required у `lib.dom.d.ts`, і `& { MediaRecorder?: unknown }` його не послаблює. Замінив перетин на `Omit<typeof window, "MediaRecorder"> & {…}` + явні типи для `on{start,end,result,error}` (валилося на `noImplicitAny` tsconfig-у).

## Why

Це блокувало все:

- На main `pnpm typecheck` падає → `check` job червоний → жоден Renovate-PR не може автомерджитись.
- Цей баг описаний як pre-existing у [#1010](https://github.com/Skords-01/Sergeant/pull/1010) і [#1012](https://github.com/Skords-01/Sergeant/pull/1012), але досі не пофікшений.
- Без цього фікс auto-merge стратегії з PR #1012 нічого не дає — CI просто залишиться червоним.

## How to test

```bash
pnpm typecheck   # тепер зелений (раніше @sergeant/web падав на VoiceMicButton.test.tsx:33)
pnpm --filter @sergeant/shared typecheck
pnpm --filter @sergeant/web test -- src/shared/components/ui/VoiceMicButton.test.tsx --run
pnpm --filter @sergeant/shared test -- --run
pnpm format:check
pnpm lint
```

Усі команди локально пройшли.

---

## How AI-tested this PR

- [x] Vitest passes: `@sergeant/shared` (313/313), `@sergeant/web` VoiceMicButton (3/3)
- [x] Typecheck passes: `pnpm typecheck` зелений end-to-end
- [x] Lint + format clean
- [ ] Manual smoke: не потрібно — type-only зміна в shared + test-only зміна в web
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/cd652f0f6b7a4bd8b1a182adb13d5d35
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
