### PR TITLE
fix(web): proxy /api/* through Vercel to fix Google OAuth state_mismatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,14 @@ BETTER_AUTH_SECRET=change_me_to_a_long_random_string_32chars
 # socialProviders.google не вмикається і клік повертає
 # `Provider not configured` у `authError`.
 # Створення клієнта: https://console.cloud.google.com/auth/clients/create
-# Authorized redirect URIs мають містити <BETTER_AUTH_URL>/api/auth/callback/google
-# (локально http://localhost:5000/..., у проді https://<railway-api>/...).
+#
+# Authorized redirect URIs мають містити <BETTER_AUTH_URL>/api/auth/callback/google.
+# У production з Vercel-проксі (`apps/web/vercel.json` rewrites `/api/*`
+# на Railway) це домен фронта — наприклад
+# `https://sergeant.vercel.app/api/auth/callback/google`. Використовувати
+# домен фронта обов'язково: інакше state-cookie ставиться на API-домен як
+# 3rd-party і Chrome її ріже → callback повертається з `error=state_mismatch`.
+# Локально — `http://localhost:5000/api/auth/callback/google`.
 # GOOGLE_CLIENT_ID=...apps.googleusercontent.com
 # GOOGLE_CLIENT_SECRET=GOCSPX-...
 
@@ -93,8 +99,13 @@ ALLOWED_ORIGINS=http://localhost:5173
 PORT=3000
 
 # ── Vite (frontend, змінні з VITE_ — у клієнтському бандлі) ────
-# Базова URL API для продакшн (якщо фронтенд і API на різних доменах)
-VITE_API_BASE_URL=https://your-api.railway.app
+# Базова URL API. ⚠️ У production на Vercel ЗАЛИШИТИ ПОРОЖНІМ або не
+# виставляти: фронт ходить через відносні `/api/...`, які Vercel
+# проксує на Railway (див. `apps/web/vercel.json` → rewrites). Це робить
+# auth-cookie 1st-party до домену фронта і лагодить OAuth-флов
+# (Better Auth state cookie + cross-site cookie restrictions).
+# Заповнюйте лише якщо фронт хоститься поза Vercel і не може проксувати.
+# VITE_API_BASE_URL=https://your-api.railway.app
 
 # Якщо увімкнено NUTRITION_API_TOKEN на бекенді — той самий токен (публічний для клієнта)
 VITE_NUTRITION_API_TOKEN=

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -51,6 +51,10 @@
   ],
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "https://sergeant-production.up.railway.app/api/:path*"
+    },
+    {
       "source": "/((?!api/|\\.well-known/).*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## What changed

- `apps/web/vercel.json` — додано rewrite `/api/:path*` → `https://sergeant-production.up.railway.app/api/:path*` **перед** SPA-fallback, тож `/api/*` запити з фронта йдуть через Vercel, який проксує їх на Railway-сервіс.
- `.env.example` — оновлено коментарі:
  - `VITE_API_BASE_URL` — у production з Vercel-проксі залишати порожнім (`apiUrl()` повертатиме відносні шляхи).
  - Google OAuth блок — пояснення, чому `Authorized redirect URI` має використовувати домен фронта (`https://sergeant.vercel.app/...`), а не API.

## Why

Користувач натискав «Увійти через Google» → редірект на Google → вибір профілю → callback повертав `error=state_mismatch` (плюс `Cannot GET /` на корені Railway, бо API там не сервить SPA).

Корінь: фронт (`sergeant.vercel.app`) і API (Railway) — різні eTLD+1, тож:

1. POST `/api/auth/sign-in/social` йшов крос-оріджном на Railway → response ставив `Set-Cookie: better-auth.state=…; SameSite=None; Secure` на домен Railway як **3rd-party** cookie.
2. Chrome (з дефолтним Tracking Protection) **не зберігав цей cookie** — навіть з `SameSite=None; Secure`.
3. Google повертав юзера на Railway-callback зі `state` у query, але cookie на Railway не було → `state_mismatch`.
4. Better Auth після помилки робив redirect на корінь свого `BETTER_AUTH_URL` — отримуємо `Cannot GET /` від Railway, який не має маршруту на `/`.

Після проксі фронт ходить на `sergeant.vercel.app/api/...` — same-origin, cookie стає 1st-party до домену фронта, Google callback URL живе на тому самому домені → state валідується нормально, помилкові редіректи теж віддаються SPA-фронтом.

## How to test

Автоматичних тестів цей фікс не вимагає (це rewrite-конфіг + docs). Перевірка вручну після мерджу:

1. Адмін: на Vercel прибрати/зачистити `VITE_API_BASE_URL` для Production env, дочекатися redeploy.
2. Адмін: на Railway виставити `BETTER_AUTH_URL=https://sergeant.vercel.app`, redeploy.
3. Адмін: у Google Cloud OAuth client додати Authorized redirect URI `https://sergeant.vercel.app/api/auth/callback/google` (старий railway-варіант можна видалити).
4. Перевірити: відкрити `https://sergeant.vercel.app`, натиснути «Увійти через Google», обрати акаунт → має повернути на фронт залогіненим, без `state_mismatch`.

Sanity check на існуючі ендпоінти:

```bash
# обидва мають повертати 200 з ідентичним JSON:
curl -i https://sergeant.vercel.app/api/v1/health
curl -i https://sergeant-production.up.railway.app/api/v1/health
```

---

## How AI-tested this PR

- [x] Manual smoke (verified rewrite shape locally; live test will run after Vercel redeploy + Railway env update).
- [x] Vitest passes: existing auth tests лишаються зеленими (зміни лише у `vercel.json` + `.env.example`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes
- [x] No — це інфраструктурний фікс конкретного flow, без нових постійних правил.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy `/api/*` through Vercel to the Railway API to fix Google OAuth state_mismatch by making the Better Auth state cookie first‑party and aligning the callback origin.

- **Bug Fixes**
  - Added rewrite in `apps/web/vercel.json` (before SPA fallback): `/api/:path*` → `https://sergeant-production.up.railway.app/api/:path*`.
  - Resolves Chrome dropping the 3rd‑party state cookie by keeping auth on `sergeant.vercel.app`.

- **Migration**
  - Leave `VITE_API_BASE_URL` empty in Vercel production (use relative `/api/*`).
  - Set `BETTER_AUTH_URL=https://sergeant.vercel.app` on Railway.
  - In Google OAuth, set Authorized redirect URI to `https://sergeant.vercel.app/api/auth/callback/google`.

<sup>Written for commit f916e35b1c01c4b4b8329ca55cd78e78962c6df3. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1018?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration guidance for OAuth and API endpoint setup.
  * Implemented API request routing configuration for cloud deployments to properly forward requests to backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->