### PR TITLE
fix(web): restore monotonic darkening on Button primary/module variants

### DIFF
--- a/apps/web/src/shared/components/ui/Button.test.tsx
+++ b/apps/web/src/shared/components/ui/Button.test.tsx
@@ -57,6 +57,40 @@ describe("Button", () => {
     expect(cls).toContain("text-white");
   });
 
+  it("primary hover/active are monotonically darker than the -strong base", () => {
+    // Regression guard: when the primary base was promoted to `bg-brand-strong`
+    // (= emerald-700), the old `hover:bg-brand-600 active:bg-brand-700`
+    // classes turned the interaction inverted (hover lighter than base) and
+    // dropped the active state (700 = base, no visible change). Pin the
+    // corrected progression so the inversion can't silently come back.
+    const { getByRole } = render(<Button variant="primary">Go</Button>);
+    const cls = getByRole("button").className;
+    expect(cls).toContain("hover:bg-brand-800");
+    expect(cls).toContain("active:bg-brand-900");
+    expect(cls).not.toContain("hover:bg-brand-600");
+    expect(cls).not.toContain("active:bg-brand-700");
+  });
+
+  it.each([
+    ["finyk", "hover:bg-emerald-800", "active:bg-emerald-900"],
+    ["fizruk", "hover:bg-teal-800", "active:bg-teal-900"],
+    ["routine", "hover:bg-coral-800", "active:bg-coral-900"],
+    // nutrition's `-strong` is lime-800 already, so hover only goes to lime-900.
+    ["nutrition", "hover:bg-lime-900", null],
+  ] as const)(
+    "%s variant darkens monotonically from -strong (no inverted hover)",
+    (variant, hoverCls, activeCls) => {
+      const { getByRole } = render(<Button variant={variant}>Go</Button>);
+      const cls = getByRole("button").className;
+      expect(cls).toContain(`bg-${variant}-strong`);
+      expect(cls).toContain(hoverCls);
+      if (activeCls) expect(cls).toContain(activeCls);
+      // The pre-fix tokens (`*-hover` = -600 step) would lighten the button
+      // on hover relative to a -strong (700+) base.
+      expect(cls).not.toContain(`hover:bg-${variant}-hover`);
+    },
+  );
+
   it("applies size classes distinctly for md vs xs", () => {
     const { getByRole, rerender } = render(<Button size="xs">X</Button>);
     expect(getByRole("button").className).toMatch(/\bh-8\b/);

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -43,7 +43,7 @@ export type ButtonSize = "xs" | "sm" | "md" | "lg" | "xl";
 const variants: Record<ButtonVariant, string> = {
   // Core variants
   primary:
-    "bg-brand-strong text-white shadow-sm hover:bg-brand-600 hover:shadow-glow active:bg-brand-700 active:scale-[0.98]",
+    "bg-brand-strong text-white shadow-sm hover:bg-brand-800 hover:shadow-glow active:bg-brand-900 active:scale-[0.98]",
   secondary:
     "bg-panel text-text border border-line shadow-sm hover:bg-panelHi hover:border-brand-200 active:scale-[0.98]",
   ghost:
@@ -57,13 +57,13 @@ const variants: Record<ButtonVariant, string> = {
 
   // Module-specific branded buttons
   finyk:
-    "bg-finyk-strong text-white shadow-sm hover:bg-finyk-hover hover:shadow-glow active:scale-[0.98]",
+    "bg-finyk-strong text-white shadow-sm hover:bg-emerald-800 hover:shadow-glow active:bg-emerald-900 active:scale-[0.98]",
   fizruk:
-    "bg-fizruk-strong text-white shadow-sm hover:bg-fizruk-hover hover:shadow-glow-teal active:scale-[0.98]",
+    "bg-fizruk-strong text-white shadow-sm hover:bg-teal-800 hover:shadow-glow-teal active:bg-teal-900 active:scale-[0.98]",
   routine:
-    "bg-routine-strong text-white shadow-sm hover:bg-routine-hover hover:shadow-glow-coral active:scale-[0.98]",
+    "bg-routine-strong text-white shadow-sm hover:bg-coral-800 hover:shadow-glow-coral active:bg-coral-900 active:scale-[0.98]",
   nutrition:
-    "bg-nutrition-strong text-white shadow-sm hover:bg-nutrition-hover hover:shadow-glow-lime active:scale-[0.98]",
+    "bg-nutrition-strong text-white shadow-sm hover:bg-lime-900 hover:shadow-glow-lime active:scale-[0.98]",
 
   // Soft module variants (for secondary actions within modules).
   // Dark mode swaps the light pastel surface for the saturated accent at


### PR DESCRIPTION
## What changed

Retunes the `hover:` / `active:` background steps on five Button variants — `primary`, `finyk`, `fizruk`, `routine`, `nutrition` — so the interaction state is *darker* than the resting `-strong` base (was: lighter on hover, no visible press in module variants).

| Variant     | Base                          | Hover (was → is)                                                  | Active (was → is)                                       |
| ----------- | ----------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
| `primary`   | `bg-brand-strong` (emerald-700) | `hover:bg-brand-600` (lighter ❌) → `hover:bg-brand-800`           | `active:bg-brand-700` (= base ❌) → `active:bg-brand-900` |
| `finyk`     | `bg-finyk-strong` (emerald-700) | `hover:bg-finyk-hover` (emerald-600 ❌) → `hover:bg-emerald-800`   | (none) → `active:bg-emerald-900`                        |
| `fizruk`    | `bg-fizruk-strong` (teal-700)   | `hover:bg-fizruk-hover` (teal-600 ❌) → `hover:bg-teal-800`        | (none) → `active:bg-teal-900`                           |
| `routine`   | `bg-routine-strong` (coral-700) | `hover:bg-routine-hover` (coral-600 ❌) → `hover:bg-coral-800`     | (none) → `active:bg-coral-900`                          |
| `nutrition` | `bg-nutrition-strong` (lime-800)| `hover:bg-nutrition-hover` (lime-600 ❌) → `hover:bg-lime-900`     | (none, existing `active:scale-[0.98]` retained)         |

`destructive` is intentionally left as-is — it uses `hover:brightness-110` which lightens, but that's a pre-existing choice unrelated to this regression. `secondary` / `ghost` / `success` / `*-soft` don't sit behind `text-white` and are unaffected.

## Why

PR #855 (and follow-ups #857 + commit `702471ca`) promoted these six variants from the saturated DEFAULT/-500 step to the `-strong` companion (-700, nutrition = -800) to satisfy the `sergeant-design/no-low-contrast-text-on-fill` rule (AGENTS.md rule #9 — see `docs/design/BRANDBOOK.md` → "WCAG-AA `-strong` Tier"). The hover/active tokens, however, were left at the *old* offsets (`-600` / `-hover` / `-700`), so:

1. **Inverted hover** — `bg-brand-600` (= emerald-600) is *lighter* than `bg-brand-strong` (= emerald-700). Buttons brighten on hover instead of darkening — the opposite of every other interactive surface in the app.
2. **Dead active state on `primary`** — `active:bg-brand-700` collapses onto the base step (`bg-brand-strong` = emerald-700). There's no colour delta on press; the only feedback is the existing `active:scale-[0.98]`.
3. **No active state at all on the four module variants** — they shipped only `active:scale-[0.98]`, so the brightening-on-hover regression is even more visible there.

The fix applies the reviewer's suggested progression (`hover:bg-brand-800` + `active:bg-brand-900`) to `primary`, and propagates the same logic — using direct palette tokens, since the `finyk/fizruk/routine/nutrition` Tailwind sub-trees don't expose a numeric scale — to all four module variants. Steps 800/900 are explicitly allow-listed by `no-low-contrast-text-on-fill` (rule allows `>=700`), so they comfortably clear WCAG AA against `text-white`.

The `nutrition` variant has a one-step ceiling (`-strong` = lime-800; only lime-900 is darker), so it gets `hover:bg-lime-900` and continues to rely on the existing `active:scale-[0.98]` for press feedback. That's fine — the visible state difference between hover (-900) and base (-800) is wider than between any two adjacent shades on the other variants.

## How to test

1. Open `/design` in the running app.
2. Hover and press each of: primary, finyk, fizruk, routine, nutrition CTA.
3. Each should now visibly *darken* on hover (not brighten) and darken further on press.
4. `pnpm --filter @sergeant/web test src/shared/components/ui/Button` → 12 passes (was 7); five new regression-guard tests pin `hover:bg-brand-800` / `active:bg-brand-900` and the equivalent module-palette steps, and explicitly forbid `hover:bg-brand-600` and `hover:bg-{module}-hover` from coming back.
5. `pnpm --filter @sergeant/web lint` → clean.

---

## How AI-tested this PR

- [x] Manual smoke: not run in browser; verified via class-name pinning in vitest. Behaviour is purely a CSS class swap with no JS or layout impact.
- [x] Vitest passes: `pnpm --filter @sergeant/web test src/shared/components/ui/Button` — 12/12 green (5 new regression tests).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`. (PR description in English to match the original `702471ca` commit thread; commit message in English for consistency with the design-system PR series.)

## AGENTS.md updated?

- [x] No — no new permanent rules. The fix is purely token-step retuning inside an existing primitive; no new lint rule, no new convention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inverted hover and missing press feedback on `Button` primary and module variants by making hover/active backgrounds darker than the `-strong` base. Adds tests to pin the progression.

- **Bug Fixes**
  - Darkening progression: base `-strong` → `hover:-800` → `active:-900` for `primary`, `finyk` (emerald), `fizruk` (teal), `routine` (coral); `nutrition`: base lime-800 → `hover:lime-900` (keeps `active:scale-[0.98]`).
  - Regression tests added to pin new classes and forbid `hover:bg-brand-600` / `hover:bg-{module}-hover`.
  - `destructive`, `secondary`, and `ghost` remain unchanged.

<sup>Written for commit 043691524fc00ed8389291148bd3c76d19f84cc4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1019?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

