### PR TITLE
fix(web): restore WCAG AA on auth + design-showcase (axe color-contrast)

### DIFF
--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -179,7 +179,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
                     setForgotEmail((cur) => cur || email || "");
                     setShowForgot((v) => !v);
                   }}
-                  className="text-xs text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
+                  className="text-xs text-brand-strong dark:text-brand-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 rounded"
                 >
                   Забули пароль?
                 </button>
@@ -359,7 +359,7 @@ export function AuthPage({ onContinueWithoutAccount }) {
           <button
             type="button"
             onClick={switchMode}
-            className="text-sm text-brand-600 dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
+            className="text-sm text-brand-strong dark:text-brand-400 hover:underline px-2 py-1 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45"
           >
             {mode === "login"
               ? "Немає акаунту? Зареєструватися"

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -49,7 +49,7 @@ const variants: Record<ButtonVariant, string> = {
   ghost:
     "bg-transparent text-muted hover:bg-panelHi hover:text-text active:bg-line/50",
   danger:
-    "bg-danger-soft text-danger border border-danger/30 hover:bg-danger/15 hover:border-danger/50 active:scale-[0.98]",
+    "bg-danger-soft text-danger-strong border border-danger/30 hover:bg-danger/15 hover:border-danger/50 dark:text-red-200 active:scale-[0.98]",
   destructive:
     "bg-danger-strong text-white shadow-sm hover:brightness-110 hover:shadow-[0_0_0_3px_rgba(239,68,68,0.15)] active:scale-[0.98]",
   success:


### PR DESCRIPTION
## What changed

Axe-core знайшов 2 serious/critical **color-contrast** порушення на `/sign-in` і `/design`. Виправлено по патерну AGENTS.md rule #9 (`-strong` companion).

| Поверхня | Елемент | Було | Стало | Контраст (до → після) |
| --- | --- | --- | --- | --- |
| `/sign-in` | `Забули пароль?` (link-button) | `text-brand-600 dark:text-brand-400` | `text-brand-strong dark:text-brand-400` | 3.59:1 → **5.38:1** |
| `/sign-in` | `Немає акаунту? Зареєструватися` (link-button) | `text-brand-600 dark:text-brand-400` | `text-brand-strong dark:text-brand-400` | 3.59:1 → **5.38:1** |
| `/design` | `Button variant="danger"` × 5 ghost-destructive (`bg-danger-soft text-danger`) | `text-danger` | `text-danger-strong dark:text-red-200` | 3.08:1 → **6.17:1** |

AA-поріг для normal-size тексту: 4.5:1. Фон у обох випадках — світлий cream / danger-soft; -500 емеральд/ред занадто світлі. `-strong` — це -700 шейд, уже зареєстрований в `packages/design-tokens/tailwind-preset.js` саме для цього кейсу (див. коментар під `brand.strong` і `*-strong` запис).

Патерн `text-danger-strong dark:text-red-200` копіюється з `Badge.tsx:60` (danger-soft варіант), щоб dark-mode не регресував.

## Why

Ці порушення були pre-existing на `main`, але раніше їх «приховував» flaky `needs: check` на a11y-джобі — він скіпався на PR-ах, де падав job `check`. Після того як #1013 стабілізував docs-only CI, a11y-джоб вперше реально запустився на чистому PR і показав #ef4444 + #059669 на світлих поверхнях.

Це також пояснює, чому **5/7 a11y-сценаріїв продовжували бути зеленими** (хаб + модулі) — там `-strong` вже скрізь застосовано після [#854](https://github.com/Skords-01/Sergeant/pull/854) / [#855](https://github.com/Skords-01/Sergeant/pull/855) / [#857](https://github.com/Skords-01/Sergeant/pull/857). Залишився authentication flow і design-showcase (саме той екран, що показує усі варіанти кнопок — тому там `Button variant="danger"` підсвітився 5 разів поспіль).

## How to test

```
pnpm --filter @sergeant/web test:a11y
# експектд: 14 passed (axe.spec × 7 + ds-visual-qa × 6 + sw-smoke × 1)

pnpm lint
# експектд: 0 errors, 173/173 plugin tests

pnpm --filter @sergeant/web vitest run src/shared/components/ui/Button.test.tsx src/core/auth
# експектд: 20/20 tests pass
```

Локально: 14/14 a11y, 20/20 unit, lint зелений.

---

## How AI-tested this PR

- [x] A11y: локально пройшов `pnpm --filter @sergeant/web test:a11y` → 14/14 passed (включно з 7 axe-scans, 6 ds-visual-qa, 1 sw-smoke).
- [x] Unit: `Button.test.tsx` + `AuthContext.test.tsx` = 20/20 pass.
- [x] Lint: `pnpm lint` = 0 errors, 173/173 plugin tests pass.
- [x] Патерн відповідає AGENTS.md rule #9 + `docs/design/brand-palette-wcag-aa-proposal.md`.
- [x] Контрасти підраховані axe-core (значення в таблиці вище — з axe `failureSummary`).

## AGENTS.md updated?

- [x] No — слідує існуючим правилам (#9), нових конвенцій не вводить.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two axe color-contrast violations on `/sign-in` and `/design` by switching to strong text colors so all UI meets WCAG AA, including in dark mode.

- **Bug Fixes**
  - Auth links on `/sign-in` (“Forgot password?”, “No account? Sign up”): `text-brand-600` → `text-brand-strong` (3.59:1 → 5.38:1) with `dark:text-brand-400` kept.
  - `Button` `variant="danger"` (ghost/outlined on danger-soft): `text-danger` → `text-danger-strong` with `dark:text-red-200` (3.08:1 → 6.17:1).
  - Follows AGENTS.md rule #9 using existing `*-strong` tokens; no behavior or layout changes.

<sup>Written for commit 408ff77f78357829fa27651c9c9e6672485e4372. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

