### PR TITLE
fix(web): use Edge Middleware for /api proxy (fixes OAuth callback 404)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,11 +38,13 @@ BETTER_AUTH_SECRET=change_me_to_a_long_random_string_32chars
 # Створення клієнта: https://console.cloud.google.com/auth/clients/create
 #
 # Authorized redirect URIs мають містити <BETTER_AUTH_URL>/api/auth/callback/google.
-# У production з Vercel-проксі (`apps/web/vercel.json` rewrites `/api/*`
-# на Railway) це домен фронта — наприклад
+# У production фронт `sergeant.vercel.app` проксує `/api/*` на Railway через
+# Vercel Edge Middleware (`apps/web/middleware.ts`, активується env-ом
+# `BACKEND_URL` на Vercel) — тож redirect URI має бути на домені фронта:
 # `https://sergeant.vercel.app/api/auth/callback/google`. Використовувати
 # домен фронта обов'язково: інакше state-cookie ставиться на API-домен як
-# 3rd-party і Chrome її ріже → callback повертається з `error=state_mismatch`.
+# 3rd-party, Safari ITP / Chrome Tracking Protection її ріже → callback
+# повертається з `error=state_mismatch`.
 # Локально — `http://localhost:5000/api/auth/callback/google`.
 # GOOGLE_CLIENT_ID=...apps.googleusercontent.com
 # GOOGLE_CLIENT_SECRET=GOCSPX-...
@@ -98,13 +100,20 @@ ALLOWED_ORIGINS=http://localhost:5173
 # ── Порт Express ─────────────────────────────────────────────
 PORT=3000
 
+# ── Vercel Edge Middleware (server-side, без префіксу VITE_) ──
+# `BACKEND_URL` — base URL Railway-API, який `apps/web/middleware.ts`
+# проксує під `/api/*` на домен фронта. Має бути виставлений у Vercel
+# Production env, інакше middleware no-op і фронт б'є на пусто (відносні
+# `/api/...` без бекенду). Без проксі OAuth ламається на 3rd-party cookie.
+# BACKEND_URL=https://sergeant-production.up.railway.app
+
 # ── Vite (frontend, змінні з VITE_ — у клієнтському бандлі) ────
 # Базова URL API. ⚠️ У production на Vercel ЗАЛИШИТИ ПОРОЖНІМ або не
-# виставляти: фронт ходить через відносні `/api/...`, які Vercel
-# проксує на Railway (див. `apps/web/vercel.json` → rewrites). Це робить
-# auth-cookie 1st-party до домену фронта і лагодить OAuth-флов
-# (Better Auth state cookie + cross-site cookie restrictions).
-# Заповнюйте лише якщо фронт хоститься поза Vercel і не може проксувати.
+# виставляти: фронт ходить через відносні `/api/...`, які Vercel Edge
+# Middleware проксує на Railway (див. `apps/web/middleware.ts` +
+# `BACKEND_URL` вище). Це робить auth-cookie 1st-party до домену фронта
+# і лагодить OAuth-флов (Better Auth state cookie + cross-site cookie
+# restrictions). Заповнюйте лише якщо фронт хоститься поза Vercel.
 # VITE_API_BASE_URL=https://your-api.railway.app
 
 # Якщо увімкнено NUTRITION_API_TOKEN на бекенді — той самий токен (публічний для клієнта)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,15 +1,22 @@
 /**
  * Vercel Edge Middleware — проксіює `/api/*` запити на бекенд (Railway).
  *
- * Safari (ITP) блокує third-party cookie, коли фронт і API на різних доменах
- * (sergeant.vercel.app ↔ sergeant-production.up.railway.app). Проксі робить
- * cookie same-origin — Safari їх зберігає.
+ * Третьосторонні cookie (фронт `sergeant.vercel.app` ↔ API
+ * `sergeant-production.up.railway.app`) блокуються Safari ITP та Chrome
+ * Tracking Protection — це ламає Better Auth state-cookie у Google OAuth
+ * флові (callback читає її з upstream-домена і отримує `state_mismatch`).
+ * Проксі робить запит first-party до домена фронта — cookie зберігається.
+ *
+ * `redirect: "manual"` критичний для OAuth: Better Auth callback редіректить
+ * на сторінку помилок/успіху, і ми ОБОВ'ЯЗКОВО мусимо віддати 3xx-відповідь
+ * назад у браузер (а не слідувати редіректу серверно). Інакше fetch піде по
+ * upstream-Location, відносні `Location: /?error=...` зрезолвляться відносно
+ * домена Railway, який не сервить `/`, → 404 «Cannot GET /».
  *
  * Конфігурація:
- *   - `BACKEND_URL` (Vercel env) — base URL бекенду, напр.
- *     `https://sergeant-production.up.railway.app`. Без неї middleware — no-op
- *     (запити проходять далі без проксі, що зручно для dev-режимів, де API
- *     подається Vite proxy або тим самим процесом).
+ *   - `BACKEND_URL` (Vercel env, без префіксу VITE_) — base URL бекенду,
+ *     напр. `https://sergeant-production.up.railway.app`. Без неї
+ *     middleware — no-op, запит йде далі (зручно для dev/preview без API).
  */
 
 export const config = {
@@ -32,9 +39,19 @@ export default async function middleware(
   const hasBody = request.method !== "GET" && request.method !== "HEAD";
   const body = hasBody ? await request.arrayBuffer() : undefined;
 
-  return fetch(target.toString(), {
+  const upstream = await fetch(target.toString(), {
     method: request.method,
     headers,
     body,
+    redirect: "manual",
+  });
+
+  // `fetch(..., { redirect: "manual" })` у Vercel Edge runtime повертає
+  // звичайний Response з оригінальним статусом і `Location`, тож можна
+  // напряму репропагувати у відповідь.
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: upstream.headers,
   });
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -51,10 +51,6 @@
   ],
   "rewrites": [
     {
-      "source": "/api/:path*",
-      "destination": "https://sergeant-production.up.railway.app/api/:path*"
-    },
-    {
       "source": "/((?!api/|\\.well-known/).*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## What changed

- `apps/web/vercel.json` — прибрано rewrite `/api/:path*` → Railway, доданий у #1018. Він шейдив наявний Edge Middleware і ламав OAuth callback.
- `apps/web/middleware.ts` — додано `redirect: "manual"` у `fetch` і перепакування `Response`, щоб 3xx-відповіді upstream проходили браузеру без серверного слідування.
- `.env.example` — задокументовано `BACKEND_URL` (Vercel server-side env, без префіксу `VITE_`) і вирівняно нотатку про `VITE_API_BASE_URL` під middleware-проксі.

## Why

Після #1018 OAuth callback повертав `404 Cannot GET /` після вибору профіля Google (https://app.devin.ai/attachments/2cde201e-4272-40a8-9cc3-71fb5e29bd3c/image.png). Корінь — Vercel **зовнішній** rewrite (`destination: https://railway.app/...`) **серверно слідує за upstream-редіректами**:

```
1. Vercel rewrite: /api/auth/callback/google?... → Railway /api/auth/callback/google?...
2. Better Auth: 302 Location: https://sergeant.vercel.app/api/auth/error?...
3. Vercel слідує внутрішньо → re-rewrite → Railway /api/auth/error?...
4. Better Auth: 302 Location: /?error=... (relative)
5. Vercel резолвить relative проти upstream → https://sergeant-production.up.railway.app/?error=...
6. Railway не сервить /, → Express 404 "Cannot GET /"
7. Vercel повертає це 404 клієнту
```

Емпіричне підтвердження:

```bash
# 200 (немає редіректу на upstream)
curl -sSi https://sergeant.vercel.app/api/auth/ok

# 302 на Railway напряму
curl -sSi https://sergeant-production.up.railway.app/api/auth/callback/google?state=zzz\&code=zzz

# 404 'Cannot GET /' через Vercel rewrite — баг
curl -sSi https://sergeant.vercel.app/api/auth/callback/google?state=zzz\&code=zzz
```

У репо вже жив Edge Middleware (`apps/web/middleware.ts` — додано в #856 / `50ede886`) саме для цього проксі, але він був no-op, бо `BACKEND_URL` ніколи не виставлявся на Vercel. PR #1018 "замінив" його зовнішнім rewrite-ом, не помітивши що той ламає 3xx-флов.

`redirect: "manual"` у Vercel Edge runtime повертає звичайний `Response` зі статусом і `Location` (на відміну від WHATWG-spec-poведінки в браузері, де response opaque). Перепакування у `new Response(upstream.body, ...)` пропагує статус і всі заголовки (включно з `Set-Cookie`) клієнту. Браузер сам резолвить `Location: /?error=...` відносно своєї адреси (`sergeant.vercel.app`) — точно як треба.

## How to test

Після мерджу адміну треба зробити **один крок**:

- На Vercel: Project → Settings → Environment Variables → додати `BACKEND_URL=https://sergeant-production.up.railway.app` (Production scope, без префіксу `VITE_`). Redeploy Production.

Перевірити через curl (через 1-2 хв після redeploy):

```bash
# Має бути 302 (а не 404 "Cannot GET /")
curl -sSi 'https://sergeant.vercel.app/api/auth/callback/google?state=zzz&code=zzz' | head -3
# Має бути 302 з Location до /?error=...
curl -sSi 'https://sergeant.vercel.app/api/auth/error?error=test' | head -3
# Sanity: існуючі ендпоінти лишаються живими
curl -sSi 'https://sergeant.vercel.app/api/auth/ok'
```

Після цього клац «Увійти через Google» → Google → вибір акаунту → має повернутись на фронт залогіненим без `state_mismatch` чи `Cannot GET /`.

---

## How AI-tested this PR

- [x] Manual smoke (verified the upstream-redirect-following bug end-to-end з curl, локалізовано до `redirect: "follow"` у Vercel zovnishnix rewrites; live verification — після redeploy + `BACKEND_URL`).
- [x] Vitest passes: lint+typecheck `@sergeant/web` чисті.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes
- [x] No — інфраструктурний фікс одного флоу, без нових правил.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth configuration guidance with clarified redirect URI requirements and third-party cookie blocking impacts.
  * Added new backend URL configuration option.

* **Bug Fixes**
  * Improved OAuth redirect handling in production environments with better proxy behavior management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth callback 404 by proxying `/api/*` through Vercel Edge Middleware instead of an external rewrite, and forwarding 3xx responses to the browser. OAuth now resolves on the app domain with first‑party cookies.

- **Bug Fixes**
  - Removed the `vercel.json` external rewrite for `/api/:path*` that followed upstream redirects and produced 404s.
  - Updated `apps/web/middleware.ts` to use `redirect: "manual"` and rebuild the `Response` so 3xx and headers (incl. `Set-Cookie`) reach the browser intact.
  - Documented `BACKEND_URL` in `.env.example` and clarified `VITE_API_BASE_URL` guidance for Vercel.

- **Migration**
  - In Vercel → Project Settings → Environment Variables, set `BACKEND_URL=https://sergeant-production.up.railway.app` (Production). Redeploy.

<sup>Written for commit 875b35221557440bdb8ab30b22a5c9f8521588ea. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1023?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

