### PR TITLE
feat(web): auto-reload SPA on stale chunk-load errors after deploy

### DIFF
--- a/apps/web/src/core/ErrorBoundary.tsx
+++ b/apps/web/src/core/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { captureException } from "./observability/sentry";
+import { isChunkLoadError, reloadOnceForChunkError } from "./lib/chunkReload";
 
 interface FallbackProps {
   error: Error;
@@ -40,10 +41,18 @@ export class ErrorBoundary extends Component<
   }
 
   static getDerivedStateFromError(error: Error) {
+    // Stale-bundle recovery: якщо це `Failed to fetch dynamically imported
+    // module` після деплою (нові хеші чанків), пробуємо одноразовий
+    // `location.reload()` — cooldown через sessionStorage страхує від
+    // нескінченного циклу, якщо це не stale-кеш, а реальна поломка.
+    if (isChunkLoadError(error) && reloadOnceForChunkError()) {
+      return { error: null };
+    }
     return { error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    if (isChunkLoadError(error)) return;
     // Lazy-forward: якщо Sentry SDK ще не підтягнувся, це no-op;
     // якщо вже підтягнувся — піде у Sentry.captureException.
     try {

--- a/apps/web/src/core/lib/chunkReload.test.ts
+++ b/apps/web/src/core/lib/chunkReload.test.ts
@@ -1,0 +1,164 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import {
+  isChunkLoadError,
+  reloadOnceForChunkError,
+  installChunkLoadRecover,
+  __resetChunkReloadInstalledForTests,
+} from "./chunkReload";
+
+describe("isChunkLoadError", () => {
+  it("matches Vite dynamic import error message", () => {
+    const err = new TypeError(
+      "Failed to fetch dynamically imported module: https://x/assets/Page-a.js",
+    );
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it("matches Webpack-style ChunkLoadError name", () => {
+    const err = Object.assign(new Error("boom"), { name: "ChunkLoadError" });
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it("matches Safari 'module script failed' wording", () => {
+    expect(
+      isChunkLoadError(new Error("Importing a module script failed.")),
+    ).toBe(true);
+  });
+
+  it("matches MIME-type rejection from SPA-fallback HTML", () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          "Refused to apply style: 'text/html' is not a valid JavaScript MIME type.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches Loading chunk N failed", () => {
+    expect(isChunkLoadError(new Error("Loading chunk 42 failed."))).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isChunkLoadError(new Error("network down"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError("just a string")).toBe(false);
+  });
+
+  it("treats raw string with chunk pattern as match", () => {
+    expect(
+      isChunkLoadError("Failed to fetch dynamically imported module: x.js"),
+    ).toBe(true);
+  });
+});
+
+describe("reloadOnceForChunkError", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    originalLocation = window.location;
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("reloads once and stamps sessionStorage", () => {
+    expect(reloadOnceForChunkError(1_000)).toBe(true);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem("__sergeant_chunk_reload_at")).toBe("1000");
+  });
+
+  it("blocks reload within cooldown window (10s)", () => {
+    expect(reloadOnceForChunkError(1_000)).toBe(true);
+    expect(reloadOnceForChunkError(5_000)).toBe(false);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows reload after cooldown window passes", () => {
+    expect(reloadOnceForChunkError(1_000)).toBe(true);
+    expect(reloadOnceForChunkError(11_001)).toBe(true);
+    expect(reloadSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("installChunkLoadRecover", () => {
+  let originalLocation: Location;
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    __resetChunkReloadInstalledForTests();
+    sessionStorage.clear();
+    originalLocation = window.location;
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("reloads on vite:preloadError and prevents default", () => {
+    installChunkLoadRecover();
+    const event = new Event("vite:preloadError", { cancelable: true });
+    window.dispatchEvent(event);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reloads on unhandledrejection with chunk-load reason", () => {
+    installChunkLoadRecover();
+    const reason = new TypeError(
+      "Failed to fetch dynamically imported module: x.js",
+    );
+    // Build event manually — happy-dom doesn't ship PromiseRejectionEvent.
+    const event = new Event("unhandledrejection", {
+      cancelable: true,
+    }) as Event & { reason: unknown };
+    Object.defineProperty(event, "reason", { value: reason });
+    window.dispatchEvent(event);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores unrelated unhandledrejection", () => {
+    installChunkLoadRecover();
+    const event = new Event("unhandledrejection", {
+      cancelable: true,
+    }) as Event & { reason: unknown };
+    Object.defineProperty(event, "reason", { value: new Error("network") });
+    window.dispatchEvent(event);
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("is idempotent across multiple installs", () => {
+    installChunkLoadRecover();
+    installChunkLoadRecover();
+    installChunkLoadRecover();
+    const event = new Event("vite:preloadError", { cancelable: true });
+    window.dispatchEvent(event);
+    // Якби listeners додались тричі — reload позвався б тричі (один з них
+    // зашпорить cooldown, але вже після першого виклику; зараз — рівно 1).
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/core/lib/chunkReload.ts
+++ b/apps/web/src/core/lib/chunkReload.ts
@@ -1,0 +1,124 @@
+/**
+ * Recovery from `Failed to fetch dynamically imported module` errors.
+ *
+ * Контекст: Vercel задеплоїв новий бандл, користувач лишився на відкритій
+ * вкладці зі старим `index.html`. Коли SPA пробує підвантажити lazy-чанк
+ * (`React.lazy(() => import(...))` або `<link rel="modulepreload">`), URL зі
+ * старим хешем уже не існує — Vercel віддає SPA-fallback `index.html`
+ * замість JS, браузер парсить HTML як модуль і кидає
+ * `Failed to fetch dynamically imported module` (або
+ * `Importing a module script failed`, або
+ * `not a valid JavaScript MIME type`).
+ *
+ * Лікування — один автоматичний `location.reload()`, з cooldown-у через
+ * `sessionStorage`, щоб не залипати у нескінченному релоад-циклі (якщо
+ * проблема насправді не зі stale-кешем, а з реально зламаним чанком).
+ */
+
+const KEY = "__sergeant_chunk_reload_at";
+const COOLDOWN_MS = 10_000;
+
+const CHUNK_ERROR_PATTERNS: ReadonlyArray<RegExp> = [
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /not a valid JavaScript MIME type/i,
+  /error loading dynamically imported module/i,
+];
+
+function getMessage(value: unknown): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") {
+    const maybeError = value as { message?: unknown; toString?: () => string };
+    if (typeof maybeError.message === "string") return maybeError.message;
+    if (typeof maybeError.toString === "function") {
+      try {
+        return maybeError.toString();
+      } catch {
+        return "";
+      }
+    }
+  }
+  return "";
+}
+
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err) return false;
+  const name =
+    typeof err === "object" && err !== null
+      ? ((err as { name?: unknown }).name ?? "")
+      : "";
+  if (name === "ChunkLoadError") return true;
+  const message = getMessage(err);
+  return CHUNK_ERROR_PATTERNS.some((re) => re.test(message));
+}
+
+/**
+ * Reload page once. Returns `true` якщо релоад виконано, `false` якщо
+ * cooldown ще не минув (релоад уже був нещодавно — щоб не зациклитись).
+ *
+ * Параметр `now` — лише для тестів.
+ */
+export function reloadOnceForChunkError(now: number = Date.now()): boolean {
+  if (typeof window === "undefined") return false;
+  let storage: Storage | null = null;
+  try {
+    storage = window.sessionStorage;
+  } catch {
+    storage = null;
+  }
+  if (storage) {
+    try {
+      const last = Number(storage.getItem(KEY) ?? 0);
+      if (last && now - last < COOLDOWN_MS) return false;
+      storage.setItem(KEY, String(now));
+    } catch {
+      // sessionStorage заблоковано (privacy mode тощо) — продовжуємо
+      // без guard, бо альтернатива гірша (порожній екран).
+    }
+  }
+  window.location.reload();
+  return true;
+}
+
+/**
+ * Install global listeners for chunk-load failures. Idempotent: повторні
+ * виклики — no-op (захист від подвійного маунту під StrictMode у dev).
+ */
+let installed = false;
+export function installChunkLoadRecover(): void {
+  if (installed) return;
+  if (typeof window === "undefined") return;
+  installed = true;
+
+  // Vite виставляє `vite:preloadError` на window коли `<link
+  // rel="modulepreload">` хелпер не може догрузити чанк.
+  window.addEventListener("vite:preloadError", (event: Event) => {
+    if (reloadOnceForChunkError()) {
+      event.preventDefault();
+    }
+  });
+
+  // `React.lazy(() => import(...))` без preload-у: невдалий import
+  // поверне rejected promise. Suspense ловить — але якщо немає
+  // ErrorBoundary вище за нього, rejection доходить сюди.
+  window.addEventListener("unhandledrejection", (event) => {
+    if (isChunkLoadError(event.reason) && reloadOnceForChunkError()) {
+      event.preventDefault();
+    }
+  });
+
+  // Класичні `error` події (script tag failures), на всякий випадок.
+  window.addEventListener("error", (event) => {
+    if (isChunkLoadError(event.error) && reloadOnceForChunkError()) {
+      event.preventDefault();
+    }
+  });
+}
+
+/** Test-only reset, expose як named export для unit-тестів. */
+export function __resetChunkReloadInstalledForTests(): void {
+  installed = false;
+}

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -20,6 +20,7 @@ import "@shared/lib/fileImport";
 // effects only.
 import "@shared/hooks/useVisualKeyboardInset";
 import { ErrorBoundary } from "./core/ErrorBoundary.jsx";
+import { installChunkLoadRecover } from "./core/lib/chunkReload.js";
 import { initSentry } from "./core/observability/sentry.js";
 import { initWebVitals } from "./core/observability/webVitals.js";
 import { initPostHog } from "./core/observability/posthog.js";
@@ -45,6 +46,12 @@ const ReactQueryDevtools = import.meta.env.DEV
 // reloads onto `/`. `?demo=reset` wipes it. Called BEFORE storage
 // migrations / the legacy demo-cleanup pass so the seeded payload is
 // visible to both and survives the boot.
+// Stale-bundle recovery: глобальні слухачі `vite:preloadError` /
+// `unhandledrejection` / `error`, що роблять одноразовий `location.reload()`
+// на `Failed to fetch dynamically imported module`. Має стояти максимально
+// рано — щоб упіймати rejection-и на найперших lazy-import-ах.
+installChunkLoadRecover();
+
 runDemoSeedFromUrl();
 storageManager.runAll();
 runDemoCleanupOnce();


### PR DESCRIPTION
## What changed

Новий хелпер `apps/web/src/core/lib/chunkReload.ts`:

- `isChunkLoadError(err)` — детектить chunk-load помилку за 5 well-known патернами (`Failed to fetch dynamically imported module`, `Importing a module script failed`, `Loading chunk N failed`, `Loading CSS chunk N failed`, `not a valid JavaScript MIME type`) + Webpack-style `name === "ChunkLoadError"`.
- `reloadOnceForChunkError()` — `window.location.reload()` з cooldown-ом 10s через `sessionStorage`, щоб не зациклитись якщо чанк реально зламаний (а не просто stale).
- `installChunkLoadRecover()` — навішує **три** глобальні слухачі: `vite:preloadError` (Vite preload-helper), `unhandledrejection` (rejected `import()` від `React.lazy`), `error` (script-tag failures). Idempotent — повторні виклики no-op (StrictMode-safe).

Інтеграції:

- `apps/web/src/main.jsx` — `installChunkLoadRecover()` ставиться **до** `ReactDOM.createRoot` і навіть до `storageManager.runAll()`, щоб ловити rejection-и на найперших lazy-import-ах.
- `apps/web/src/core/ErrorBoundary.tsx` — у `getDerivedStateFromError` детектить chunk-load та робить reload (skip-ить error-state). У `componentDidCatch` НЕ форвардить chunk-load у Sentry — інакше після кожного релізу буде шторм фейкових помилок.

## Why

Після кожного деплою на Vercel користувачі з відкритими вкладками бачили червоний екран:

> Щось пішло не так
> Failed to fetch dynamically imported module: https://sergeant.vercel.app/assets/ProfilePage-IVaXR0RB.js

Це сталось щойно у живому флові ([screenshot з сесії](https://app.devin.ai/attachments/3acf123b-3f35-4716-8ce5-790b5ace3414/image.png)) — старий tab тримав хеш `ProfilePage-IVaXR0RB.js` зі старого index.html, новий бандл називається `index-CEohHoPm.js` і `ProfilePage` chunk тепер під іншим хешем. Vercel SPA-fallback повернув HTML на запит JS, браузер засипався на парсингу.

Hard-refresh лагодить — але це поганий UX: `Ctrl+Shift+R` не очевидний звичайному користувачу, особливо на мобільному. Правильна дія — автоматично спробувати релоад **один раз** при перших ознаках stale-chunk помилки.

Cooldown 10s + `sessionStorage` страхує від нескінченного reload-loop у патологічному кейсі (наприклад, якщо CDN реально віддає зламаний бандл — після 1 релоаду помилка лишиться, але другий релоад не відбудеться).

## How to test

```bash
pnpm --filter @sergeant/web test -- --run src/core/lib/chunkReload.test.ts
# 14 passed
```

Manual: відкрити `https://sergeant.vercel.app`, у іншому tab задеплоїти будь-яку зміну в `apps/web/`, у першому tab перейти між модулями (тригернути lazy chunk). Замість червоного екрану — короткий мерехт сторінки і свіжий бандл.

---

## How AI-tested this PR

- [x] Manual smoke (репродуктивний сценарій знайдений у попередній сесії; post-deploy verification ще не виконано).
- [x] Vitest passes: 14 нових тестів + всі 819 у `apps/web` зелені (`pnpm --filter @sergeant/web test -- --run src/core`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes
- [x] No — це fix UX-флову, без нових правил/конвенцій.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-reload the SPA once when a stale chunk-load error occurs after a deploy. Prevents the red error screen and avoids noisy Sentry reports.

- **New Features**
  - Added `apps/web/src/core/lib/chunkReload.ts`: detects chunk-load errors (Vite/Webpack/Safari/MIME) and calls `window.location.reload()` once with a 10s cooldown via `sessionStorage`.
  - Installed global recovery early in `apps/web/src/main.jsx` with listeners for `vite:preloadError`, `unhandledrejection`, and `error` (idempotent).
  - Updated `ErrorBoundary` to trigger the same one-time reload and skip sending chunk-load errors to Sentry.

<sup>Written for commit 3c7c5ff3f67564c240ce0a00cafbdf0dc306312a. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1025?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced automatic recovery for dynamic module loading failures. When dynamically imported modules fail to load, the app now performs a single page reload to recover and prevent repeated error notifications, improving overall app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->