### PR TITLE
feat(server): phase 0 monetization rails — pricing page + waitlist endpoint

### DIFF
--- a/apps/server/src/migrations/009_waitlist.down.sql
+++ b/apps/server/src/migrations/009_waitlist.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS waitlist_entries_tier_idx;
+DROP INDEX IF EXISTS waitlist_entries_created_at_idx;
+DROP INDEX IF EXISTS waitlist_entries_email_uniq;
+DROP TABLE IF EXISTS waitlist_entries;

--- a/apps/server/src/migrations/009_waitlist.sql
+++ b/apps/server/src/migrations/009_waitlist.sql
@@ -1,0 +1,28 @@
+-- Phase 0 (monetization rails): простий waitlist для майбутнього Pro-тіру.
+-- Жодного billing/entitlements — просто email + tier interest + source, щоб
+-- виміряти попит до того, як вкладатись у платіжну інфраструктуру.
+-- План: docs/launch/01-monetization-and-pricing.md (тіри Free/Plus/Pro).
+
+CREATE TABLE waitlist_entries (
+  id            BIGSERIAL PRIMARY KEY,
+  email         TEXT NOT NULL,
+  tier_interest TEXT NOT NULL CHECK (tier_interest IN ('free', 'plus', 'pro', 'unsure')),
+  source        TEXT NOT NULL DEFAULT 'pricing_page',
+  locale        TEXT,
+  user_id       TEXT REFERENCES "user"(id) ON DELETE SET NULL,
+  user_agent    TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  notified_at   TIMESTAMPTZ
+);
+
+-- Унікальність по email — case-insensitive (без citext-extension, який не
+-- гарантовано увімкнений на Railway). Email нормалізуємо до lower-case
+-- у сервісі перед INSERT-ом, але індекс додатково захищає від обходу.
+CREATE UNIQUE INDEX waitlist_entries_email_uniq
+  ON waitlist_entries (LOWER(email));
+
+-- Для адмін-виборки "останні Х entries" та аналітики розподілу по tier-ах.
+CREATE INDEX waitlist_entries_created_at_idx
+  ON waitlist_entries (created_at DESC);
+CREATE INDEX waitlist_entries_tier_idx
+  ON waitlist_entries (tier_interest);

--- a/apps/server/src/modules/waitlist/waitlistService.test.ts
+++ b/apps/server/src/modules/waitlist/waitlistService.test.ts
@@ -1,0 +1,163 @@
+// Phase 0 monetization rails: integration tests for `submitWaitlistEntry`.
+//
+// Uses the shared Testcontainers harness (`apps/server/src/test/pg-container.ts`)
+// so the same `009_waitlist.sql` migration that ships to production runs
+// against a real Postgres-16 instance. Mocks would not catch the
+// `LOWER(email)` unique-index behaviour or the `ON CONFLICT DO NOTHING`
+// idempotency we rely on.
+//
+// On dev machines without Docker the test soft-skips (mirrors the
+// rollback-sanity pattern in `apps/server/src/migrations/__tests__/`).
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import type pg from "pg";
+import {
+  startPgContainer,
+  stopPgContainer,
+  truncateAll,
+} from "../../test/pg-container.js";
+import { countWaitlistByTier, submitWaitlistEntry } from "./waitlistService.js";
+
+// Container boot + migrations runs ~15–30s on Linux CI runners; lift the
+// hook ceiling so a slow Docker pull does not flake.
+const HOOK_TIMEOUT_MS = 180_000;
+
+describe("waitlistService (Phase 0 monetization)", () => {
+  let pool: pg.Pool | undefined;
+  let dockerAvailable = false;
+
+  beforeAll(async () => {
+    try {
+      pool = await startPgContainer();
+      dockerAvailable = true;
+    } catch (err) {
+      // No Docker locally — soft-skip. CI runners always have Docker.
+      console.warn(
+        "[waitlistService.test] Docker unavailable — skipping integration tests:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }, HOOK_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (dockerAvailable) {
+      await stopPgContainer();
+    }
+  }, HOOK_TIMEOUT_MS);
+
+  it("inserts a new entry and returns created=true", async () => {
+    if (!dockerAvailable || !pool) return;
+    await truncateAll();
+
+    const result = await submitWaitlistEntry(pool, {
+      email: "alice@example.com",
+      tier_interest: "pro",
+      source: "pricing_page",
+      locale: "uk",
+    });
+
+    expect(result).toEqual({ created: true });
+
+    const rows = await pool.query<{
+      email: string;
+      tier_interest: string;
+      source: string;
+      locale: string | null;
+    }>(`SELECT email, tier_interest, source, locale FROM waitlist_entries`);
+    expect(rows.rows).toEqual([
+      {
+        email: "alice@example.com",
+        tier_interest: "pro",
+        source: "pricing_page",
+        locale: "uk",
+      },
+    ]);
+  });
+
+  it("returns created=false on duplicate email (idempotent submit)", async () => {
+    if (!dockerAvailable || !pool) return;
+    await truncateAll();
+
+    await submitWaitlistEntry(pool, {
+      email: "bob@example.com",
+      tier_interest: "plus",
+      source: "pricing_page",
+    });
+    const second = await submitWaitlistEntry(pool, {
+      email: "bob@example.com",
+      tier_interest: "pro",
+      source: "paywall",
+    });
+
+    expect(second).toEqual({ created: false });
+
+    // Conflict shouldn't overwrite the first entry's tier_interest/source.
+    const rows = await pool.query<{
+      email: string;
+      tier_interest: string;
+      source: string;
+    }>(`SELECT email, tier_interest, source FROM waitlist_entries`);
+    expect(rows.rows).toEqual([
+      {
+        email: "bob@example.com",
+        tier_interest: "plus",
+        source: "pricing_page",
+      },
+    ]);
+  });
+
+  it("treats email case-insensitively via LOWER(email) unique index", async () => {
+    if (!dockerAvailable || !pool) return;
+    await truncateAll();
+
+    // Bypass schema normalization to prove the DB-level guard works.
+    await submitWaitlistEntry(pool, {
+      email: "carol@example.com",
+      tier_interest: "free",
+      source: "pricing_page",
+    });
+    const second = await submitWaitlistEntry(pool, {
+      email: "CAROL@EXAMPLE.COM",
+      tier_interest: "pro",
+      source: "pricing_page",
+    });
+
+    expect(second).toEqual({ created: false });
+
+    const rows = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::TEXT AS count FROM waitlist_entries`,
+    );
+    expect(Number(rows.rows[0]?.count)).toBe(1);
+  });
+
+  it("aggregates counts by tier for admin reporting", async () => {
+    if (!dockerAvailable || !pool) return;
+    await truncateAll();
+
+    await submitWaitlistEntry(pool, {
+      email: "a@example.com",
+      tier_interest: "pro",
+      source: "pricing_page",
+    });
+    await submitWaitlistEntry(pool, {
+      email: "b@example.com",
+      tier_interest: "pro",
+      source: "pricing_page",
+    });
+    await submitWaitlistEntry(pool, {
+      email: "c@example.com",
+      tier_interest: "plus",
+      source: "pricing_page",
+    });
+
+    const counts = await countWaitlistByTier(pool);
+    expect(counts).toEqual([
+      { tier_interest: "plus", total: 1 },
+      { tier_interest: "pro", total: 2 },
+    ]);
+    // AGENTS rule #1: counts are coerced to `number`, never bigint string.
+    for (const row of counts) {
+      expect(typeof row.total).toBe("number");
+    }
+  });
+});

--- a/apps/server/src/modules/waitlist/waitlistService.ts
+++ b/apps/server/src/modules/waitlist/waitlistService.ts
@@ -1,0 +1,88 @@
+import type { Pool } from "pg";
+import type { WaitlistSource, WaitlistTier } from "@sergeant/shared";
+
+/**
+ * Phase 0 monetization rails: простий waitlist для майбутнього Pro-тіру.
+ *
+ * Сервіс свідомо тонкий — single insert із `ON CONFLICT DO NOTHING` по
+ * email. `RETURNING id` виокремлює "новий запис" від "вже був" без
+ * додаткового SELECT-а:
+ *
+ *  - Якщо INSERT успішний → `RETURNING id` повертає новий id → `created=true`.
+ *  - Якщо conflict → `ON CONFLICT DO NOTHING` пропускає рядок → `RETURNING`
+ *    нічого не повертає → `created=false`.
+ *
+ * Це гарантує idempotency: користувач може натиснути "Join waitlist" хоч сто
+ * разів — у БД лишається рівно один запис, і ми точно знаємо, скільки
+ * унікальних email-ів реально цікавляться.
+ */
+export interface WaitlistInsertInput {
+  email: string;
+  tier_interest: WaitlistTier;
+  source: WaitlistSource;
+  locale?: string;
+  user_id?: string | null;
+  user_agent?: string | null;
+}
+
+export interface WaitlistInsertResult {
+  /** `true` якщо це новий запис; `false` якщо email уже був у списку. */
+  created: boolean;
+}
+
+export async function submitWaitlistEntry(
+  pool: Pool,
+  input: WaitlistInsertInput,
+): Promise<WaitlistInsertResult> {
+  // `LOWER(email)` нормалізація відбувається ще на рівні Zod-схеми
+  // (`.toLowerCase()`), але унікальний індекс у БД додатково побудований
+  // на `LOWER(email)` — тож нічого не зламається, навіть якщо хтось
+  // обійшов схему й передав mixed-case.
+  const result = await pool.query<{ id: string }>(
+    `INSERT INTO waitlist_entries
+       (email, tier_interest, source, locale, user_id, user_agent)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (LOWER(email)) DO NOTHING
+     RETURNING id`,
+    [
+      input.email,
+      input.tier_interest,
+      input.source,
+      input.locale ?? null,
+      input.user_id ?? null,
+      input.user_agent ?? null,
+    ],
+  );
+  return { created: result.rowCount === 1 };
+}
+
+/**
+ * Internal helper для адмінських звітів — повертає aggregate "скільки
+ * email-ів по якому tier-у". Не expose-иться через публічний API; виклик
+ * з admin-endpoint-у (Phase 2+) або з консолі.
+ */
+export interface WaitlistTierCount {
+  tier_interest: WaitlistTier;
+  total: number;
+}
+
+export async function countWaitlistByTier(
+  pool: Pool,
+): Promise<WaitlistTierCount[]> {
+  const result = await pool.query<{
+    tier_interest: WaitlistTier;
+    total: string;
+  }>(
+    `SELECT tier_interest, COUNT(*)::TEXT AS total
+       FROM waitlist_entries
+      GROUP BY tier_interest
+      ORDER BY tier_interest`,
+  );
+  // pg повертає COUNT(*) як bigint → string. AGENTS правило #1: завжди
+  // coerce у Number() в серіалізаторі. Тут aggregate ніколи не вийде за
+  // межі Number.MAX_SAFE_INTEGER (>2^53 entries — нереалістично).
+  return result.rows.map((r) => ({
+    tier_interest: r.tier_interest,
+    total: Number(r.total),
+  }));
+}

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -13,6 +13,7 @@ import { createNutritionRouter } from "./nutrition.js";
 import { createPushRouter } from "./push.js";
 import { createSyncRouter } from "./sync.js";
 import { createTranscribeRouter } from "./transcribe.js";
+import { createWaitlistRouter } from "./waitlist.js";
 import { createWebVitalsRouter } from "./web-vitals.js";
 import { createWeeklyDigestRouter } from "./weekly-digest.js";
 
@@ -42,4 +43,5 @@ export function registerRoutes(app: Express, { pool }: { pool: Pool }): void {
   app.use(createWebVitalsRouter());
   app.use(createPushRouter());
   app.use(createTranscribeRouter());
+  app.use(createWaitlistRouter());
 }

--- a/apps/server/src/routes/waitlist.ts
+++ b/apps/server/src/routes/waitlist.ts
@@ -1,0 +1,103 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import {
+  WaitlistSubmitSchema,
+  WaitlistSubmitResponseSchema,
+  type WaitlistSubmitResponse,
+} from "@sergeant/shared";
+import {
+  asyncHandler,
+  rateLimitExpress,
+  setModule,
+  validateBody,
+} from "../http/index.js";
+import { getSessionUser } from "../auth.js";
+import pool from "../db.js";
+import { submitWaitlistEntry } from "../modules/waitlist/waitlistService.js";
+
+/**
+ * Phase 0 monetization rails: `POST /api/v1/waitlist`.
+ *
+ * Анонімний endpoint — sign-up не потребує сесії, бо ми хочемо ловити
+ * інтерес від відвідувачів `/pricing` (включно з тими, що ще не зробили
+ * onboarding). Якщо сесія є — підвʼязуємо `user_id` для майбутньої
+ * сегментації (наприклад, "скільки активних юзерів зацікавились Pro").
+ *
+ * Rate-limit: 10 submissions / IP / hour. Без цього endpoint може стати
+ * email-spam vehicle (зловмисник флудить чужі адреси). Ліміт навмисно
+ * генерозний — реальний користувач має залишити inquiry один раз, бот —
+ * навіть один раз не зможе масштабувати.
+ *
+ * 200 OK з `{ created: boolean }`:
+ *  - `created: true` — новий запис.
+ *  - `created: false` — email уже у списку (idempotent).
+ *
+ * Жодного "уже зареєстровано" 4xx — не розкриваємо чи email уже у БД, щоб
+ * endpoint не служив enumeration-oracle для існуючих користувачів.
+ */
+export function createWaitlistRouter(): Router {
+  const r = Router();
+  r.use("/api/v1/waitlist", setModule("waitlist"));
+  r.use("/api/waitlist", setModule("waitlist"));
+
+  const handler = asyncHandler(async (req: Request, res: Response) => {
+    const parsed = validateBody(WaitlistSubmitSchema, req, res);
+    if (!parsed.ok) return;
+
+    // Опційне привʼязування до сесії, якщо користувач залогінений. Не
+    // вимагаємо сесію — це pricing-page CTA для анонімів так само.
+    let userId: string | null = null;
+    try {
+      const sessionUser = await getSessionUser(req);
+      userId = sessionUser?.id ?? null;
+    } catch {
+      // Будь-який збій резолюції сесії трактуємо як "анонімний" — sign-up
+      // не має ламатись через тимчасову проблему з auth-таблицями.
+      userId = null;
+    }
+
+    const userAgent =
+      typeof req.headers["user-agent"] === "string"
+        ? req.headers["user-agent"].slice(0, 256)
+        : null;
+
+    const result = await submitWaitlistEntry(pool, {
+      email: parsed.data.email,
+      tier_interest: parsed.data.tier_interest,
+      source: parsed.data.source,
+      locale: parsed.data.locale,
+      user_id: userId,
+      user_agent: userAgent,
+    });
+
+    const payload: WaitlistSubmitResponse = WaitlistSubmitResponseSchema.parse({
+      ok: true,
+      created: result.created,
+    });
+    res.json(payload);
+  });
+
+  r.post(
+    "/api/v1/waitlist",
+    rateLimitExpress({
+      key: "api:waitlist",
+      limit: 10,
+      windowMs: 60 * 60 * 1000,
+    }),
+    handler,
+  );
+  // Legacy alias без `/v1` — `apiVersionRewrite` middleware вже мапить
+  // `/api/v1/...` → `/api/...`, але реєструємо обидва, щоб не лежати від
+  // порядку monter-ів у `app.ts`.
+  r.post(
+    "/api/waitlist",
+    rateLimitExpress({
+      key: "api:waitlist",
+      limit: 10,
+      windowMs: 60 * 60 * 1000,
+    }),
+    handler,
+  );
+
+  return r;
+}

--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -61,6 +61,9 @@ const AssistantCataloguePage = lazy(() =>
     default: m.AssistantCataloguePage,
   })),
 );
+const PricingPage = lazy(() =>
+  import("./PricingPage").then((m) => ({ default: m.PricingPage })),
+);
 interface ModuleAppProps {
   onBackToHub: () => void;
   pwaAction?: PwaAction;
@@ -332,6 +335,19 @@ function AppInner() {
     return (
       <Suspense fallback={<PageLoader />}>
         <DesignShowcase />
+      </Suspense>
+    );
+  }
+
+  // `/pricing` — Phase 0 monetization рейки: статична сторінка з тарифами
+  // і waitlist-формою. Анонімна (auth не вимагається), бо основний
+  // траффік — неавторизовані відвідувачі, які ще не зробили sign-up.
+  if (location.pathname === "/pricing") {
+    return (
+      <Suspense fallback={<PageLoader />}>
+        <div className="page-enter">
+          <PricingPage />
+        </div>
       </Suspense>
     );
   }

--- a/apps/web/src/core/PricingPage.test.tsx
+++ b/apps/web/src/core/PricingPage.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const {
+  submitMock,
+  toastSuccessMock,
+  toastErrorMock,
+  toastInfoMock,
+  trackEventMock,
+} = vi.hoisted(() => ({
+  submitMock:
+    vi.fn<(input: unknown) => Promise<{ ok: true; created: boolean }>>(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+  trackEventMock: vi.fn(),
+}));
+
+submitMock.mockResolvedValue({ ok: true, created: true });
+
+vi.mock("@shared/api", () => ({
+  waitlistApi: { submit: submitMock },
+}));
+
+vi.mock("@shared/hooks/useToast", () => ({
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: toastInfoMock,
+  }),
+}));
+
+vi.mock("./observability/analytics", async () => {
+  const shared = await import("@sergeant/shared");
+  return {
+    ANALYTICS_EVENTS: shared.ANALYTICS_EVENTS,
+    trackEvent: (name: string, payload?: unknown) =>
+      trackEventMock(name, payload),
+  };
+});
+
+import { PricingPage } from "./PricingPage";
+import { ANALYTICS_EVENTS } from "@sergeant/shared";
+
+function renderPricing(initialUrl = "/pricing") {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <PricingPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("PricingPage (Phase 0 monetization rails)", () => {
+  beforeEach(() => {
+    submitMock.mockClear();
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+    toastInfoMock.mockClear();
+    trackEventMock.mockClear();
+  });
+  afterEach(() => cleanup());
+
+  it("fires PRICING_VIEWED on mount and renders the three tier cards", () => {
+    renderPricing();
+    expect(trackEventMock).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.PRICING_VIEWED,
+      { source: "direct" },
+    );
+    // Tier headings present
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Free" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Plus" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 3, name: "Pro" })).toBeTruthy();
+  });
+
+  it("submits the waitlist form and tracks the WAITLIST_SUBMITTED event", async () => {
+    renderPricing();
+
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, {
+      target: { value: "alice@example.com" },
+    });
+
+    const submit = screen.getByRole("button", {
+      name: /Підписатись на waitlist/i,
+    });
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(submitMock).toHaveBeenCalledTimes(1);
+    });
+    expect(submitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "alice@example.com",
+        tier_interest: "unsure",
+        source: "pricing_page",
+      }),
+    );
+    expect(trackEventMock).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.WAITLIST_SUBMITTED,
+      expect.objectContaining({
+        tier_interest: "unsure",
+        source: "pricing_page",
+        created: true,
+      }),
+    );
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it("shows an inline email error and skips the network call on invalid input", async () => {
+    renderPricing();
+
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Підписатись на waitlist/i }),
+    );
+
+    await waitFor(() => {
+      // Точний матч на inline-error по `id` — не плутаємо з <label>Email</label>.
+      expect(document.getElementById("waitlist-email-error")).not.toBeNull();
+    });
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("fires PRICING_CTA_CLICKED when a tier card CTA is pressed", () => {
+    renderPricing();
+    const proCta = screen.getAllByRole("button", {
+      name: /Хочу дізнатись першим/i,
+    });
+    fireEvent.click(proCta[0]);
+    expect(trackEventMock).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.PRICING_CTA_CLICKED,
+      expect.objectContaining({ cta: "waitlist" }),
+    );
+  });
+});

--- a/apps/web/src/core/PricingPage.tsx
+++ b/apps/web/src/core/PricingPage.tsx
@@ -1,0 +1,234 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@shared/components/ui/Button";
+import { Icon } from "@shared/components/ui/Icon";
+import { ANALYTICS_EVENTS, trackEvent } from "./observability/analytics";
+import { WaitlistForm } from "./pricing/WaitlistForm";
+
+/**
+ * Phase 0 monetization rails: статична маркетингова сторінка з планом
+ * тарифів і CTA-формою waitlist-у. Активного білінгу ще немає — задача
+ * сторінки виміряти попит до того, як вкладатись у Stripe / Mono jar.
+ *
+ * План тарифів змавпований із `docs/launch/01-monetization-and-pricing.md`
+ * (варіант Б — три тіри з decoy ефектом). Ціни тут — pre-MVP draft, не
+ * біллимо нікого.
+ */
+
+interface Tier {
+  id: "free" | "plus" | "pro";
+  name: string;
+  price: string;
+  cadence: string;
+  highlight?: boolean;
+  tagline: string;
+  features: ReadonlyArray<string>;
+}
+
+const TIERS: ReadonlyArray<Tier> = [
+  {
+    id: "free",
+    name: "Free",
+    price: "₴0",
+    cadence: "назавжди",
+    tagline: "Усі 4 модулі базово. Local-first, без cloud.",
+    features: [
+      "Усі модулі: Фінік / Фізрук / Харчування / Звички",
+      "AI-чат: 5 повідомлень на день",
+      "Manual Mono-імпорт (без webhook)",
+      "1 активна програма у Фізруку",
+      "2 push-нагадування для звичок",
+    ],
+  },
+  {
+    id: "plus",
+    name: "Plus",
+    price: "₴59",
+    cadence: "на місяць",
+    tagline: "Якщо AI треба більше і кілька пристроїв.",
+    features: [
+      "AI-чат: 25 повідомлень на день",
+      "AI-фото для їжі: 10 на день",
+      "CloudSync на 2 пристрої",
+      "Тижневі крос-модульні звіти",
+      "Авто-Mono sync",
+      "3 активні програми у Фізруку",
+    ],
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    price: "₴99",
+    cadence: "на місяць (₴799/рік)",
+    highlight: true,
+    tagline: "Усе без обмежень + щоденний AI-брифінг.",
+    features: [
+      "Безлімітний AI-чат + щоденний брифінг",
+      "Безлімітне AI-фото для їжі",
+      "CloudSync на всі пристрої",
+      "Повні звіти + порівняння модулів",
+      "Авто-Mono + мульти-банк (PrivatBank)",
+      "Безлімітні програми + push-нагадування",
+      "Експорт CSV / PDF + кастомні теми",
+    ],
+  },
+];
+
+export function PricingPage() {
+  const navigate = useNavigate();
+
+  // Pageview-аналітика. Window.location.search парситься щоб ми могли
+  // розрізнити "user натиснув CTA з paywall" vs "user сам зайшов на /pricing".
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const source = params.get("source") ?? "direct";
+    trackEvent(ANALYTICS_EVENTS.PRICING_VIEWED, { source });
+  }, []);
+
+  function handleTierCta(tierId: Tier["id"]): void {
+    trackEvent(ANALYTICS_EVENTS.PRICING_CTA_CLICKED, {
+      tier: tierId,
+      cta: "waitlist",
+    });
+    // Скрол до форми. Без `behavior: "smooth"` на `prefers-reduced-motion`
+    // користувачах — браузер сам ріспектить media query. Захищаємось
+    // `typeof === "function"` бо jsdom не реалізує `scrollIntoView`,
+    // а в продакшні старі браузери теж можуть його не мати.
+    const anchor = document.getElementById("waitlist-anchor");
+    if (anchor && typeof anchor.scrollIntoView === "function") {
+      anchor.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
+
+  return (
+    <div
+      className="min-h-dvh bg-bg"
+      style={{
+        paddingTop: "max(1.25rem, env(safe-area-inset-top))",
+        paddingBottom: "max(1.25rem, env(safe-area-inset-bottom))",
+      }}
+    >
+      <div className="max-w-5xl mx-auto px-5 pb-12 space-y-10">
+        <header className="flex items-center gap-3 pt-6 pb-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            onClick={() => navigate(-1)}
+            aria-label="Назад"
+          >
+            <Icon name="chevron-left" size={20} />
+          </Button>
+          <h1 className="text-xl font-bold text-text">Тарифи</h1>
+        </header>
+
+        <section className="space-y-3 text-center">
+          {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift -- intentional marketing eyebrow above the hero headline; не існує SectionHeading-eyebrow API. */}
+          <p className="text-xs uppercase tracking-wider text-brand-strong font-semibold">
+            Pre-MVP — поки збираємо інтерес
+          </p>
+          <h2 className="text-3xl sm:text-4xl font-bold text-text leading-tight">
+            Sergeant буде безкоштовним для більшості.
+            <br />
+            Pro — для тих, хто хоче усе одразу.
+          </h2>
+          <p className="text-base text-muted max-w-2xl mx-auto">
+            Білінг ще не запущено. Залиш email — повідомимо щойно Pro стартує, і
+            ціни вже фіналізуємо. Жодних авто-списань зараз.
+          </p>
+        </section>
+
+        <section
+          className="grid grid-cols-1 md:grid-cols-3 gap-4"
+          aria-label="Тарифні плани"
+        >
+          {TIERS.map((tier) => (
+            <article
+              key={tier.id}
+              className={
+                "rounded-3xl border p-6 flex flex-col gap-4 " +
+                (tier.highlight
+                  ? "border-brand-500 bg-panel shadow-glow"
+                  : "border-line bg-panel")
+              }
+            >
+              <header className="space-y-1">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-bold text-text">{tier.name}</h3>
+                  {tier.highlight && (
+                    // eslint-disable-next-line sergeant-design/no-eyebrow-drift -- pill-badge на картці тіра; uppercase + tracking — частина дизайну badge-а.
+                    <span className="text-xs font-semibold uppercase tracking-wider text-brand-strong bg-brand/10 px-2 py-1 rounded-full">
+                      Топ-вибір
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-muted">{tier.tagline}</p>
+              </header>
+
+              <div className="space-y-1">
+                <span className="text-3xl font-bold text-text">
+                  {tier.price}
+                </span>
+                <span className="block text-sm text-muted">{tier.cadence}</span>
+              </div>
+
+              <ul className="space-y-2 grow">
+                {tier.features.map((f) => (
+                  <li
+                    key={f}
+                    className="flex items-start gap-2 text-sm text-text"
+                  >
+                    <Icon
+                      name="check"
+                      size={16}
+                      className="text-brand-strong mt-0.5 shrink-0"
+                    />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Button
+                variant={tier.highlight ? "primary" : "secondary"}
+                size="md"
+                onClick={() => handleTierCta(tier.id)}
+              >
+                {tier.id === "free"
+                  ? "Лишусь на Free"
+                  : "Хочу дізнатись першим"}
+              </Button>
+            </article>
+          ))}
+        </section>
+
+        <section
+          id="waitlist-anchor"
+          className="rounded-3xl border border-line bg-panel p-6 sm:p-8 max-w-2xl mx-auto"
+        >
+          <header className="space-y-2 mb-6">
+            <h2 className="text-2xl font-bold text-text">
+              Залишити email для waitlist
+            </h2>
+            <p className="text-sm text-muted">
+              Один лист, коли Pro стартує. Без спаму, без авто-списань.
+            </p>
+          </header>
+          <WaitlistForm source="pricing_page" />
+        </section>
+
+        <footer className="text-center text-xs text-muted space-y-1">
+          <p>
+            Усі ціни орієнтовні (₴, для України). Після MVP можемо додати $/€
+            для міжнародної аудиторії.
+          </p>
+          <p>
+            Деталі плану:{" "}
+            <code className="bg-panelHi px-1.5 py-0.5 rounded text-text">
+              docs/launch/01-monetization-and-pricing.md
+            </code>
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/core/pricing/WaitlistForm.tsx
+++ b/apps/web/src/core/pricing/WaitlistForm.tsx
@@ -1,0 +1,201 @@
+import { useState, type FormEvent } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
+import { Label } from "@shared/components/ui/FormField";
+import { useToast } from "@shared/hooks/useToast";
+import { waitlistApi } from "@shared/api";
+import { isApiError } from "@sergeant/api-client";
+import {
+  type WaitlistSource,
+  type WaitlistTier,
+  WaitlistSubmitSchema,
+} from "@sergeant/shared";
+import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
+
+const TIER_OPTIONS: ReadonlyArray<{
+  value: WaitlistTier;
+  label: string;
+  hint: string;
+}> = [
+  { value: "pro", label: "Pro", hint: "AI-чат, авто-Mono, повні звіти" },
+  { value: "plus", label: "Plus", hint: "Базовий AI + cloud sync" },
+  {
+    value: "free",
+    label: "Залишусь на Free",
+    hint: "Просто слідкувати за новинами",
+  },
+  { value: "unsure", label: "Ще не знаю", hint: "Розкажіть мені більше" },
+];
+
+/**
+ * Phase 0 monetization rails: форма для збору waitlist-ів на майбутній
+ * Pro-тір. Анонімна (не вимагає логіну) — основний траффік сюди йтиме з
+ * `/pricing`, де неавторизовані відвідувачі мають мати змогу залишити email.
+ *
+ * Аналітика: `WAITLIST_SUBMITTED` шлемо тільки після успішної відповіді
+ * сервера (включно з ідемпотентним `created=false`), щоб дашборд не
+ * рахував перерване подання як справжній sign-up.
+ */
+export interface WaitlistFormProps {
+  /**
+   * Звідки прийшла submission. Використовується для PostHog-сегментації
+   * ("waitlist з paywall vs. з pricing-сторінки конвертять по-різному").
+   */
+  source: WaitlistSource;
+  /**
+   * Опційний preset tier (наприклад, якщо юзер натиснув CTA на конкретній
+   * картці тіра). Якщо не передано — селектор стартує з `unsure`.
+   */
+  defaultTier?: WaitlistTier;
+  /** Викликається після успішної (або ідемпотентної) відповіді сервера. */
+  onSuccess?: (created: boolean) => void;
+  /** Опційний className для контейнера-обгортки. */
+  className?: string;
+}
+
+export function WaitlistForm({
+  source,
+  defaultTier,
+  onSuccess,
+  className,
+}: WaitlistFormProps) {
+  const toast = useToast();
+  const [email, setEmail] = useState("");
+  const [tier, setTier] = useState<WaitlistTier>(defaultTier ?? "unsure");
+  const [pending, setPending] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  async function handleSubmit(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+    setEmailError(null);
+
+    // Локальна валідація перед мережевим викликом — даємо швидкий
+    // feedback. Сервер усе одно валідує знову (rate-limit + Zod).
+    const parsed = WaitlistSubmitSchema.safeParse({
+      email,
+      tier_interest: tier,
+      source,
+    });
+    if (!parsed.success) {
+      const issue = parsed.error.issues.find((i) => i.path[0] === "email");
+      setEmailError(issue?.message ?? "Перевір email");
+      return;
+    }
+
+    setPending(true);
+    try {
+      const res = await waitlistApi.submit(parsed.data);
+      trackEvent(ANALYTICS_EVENTS.WAITLIST_SUBMITTED, {
+        tier_interest: parsed.data.tier_interest,
+        source,
+        created: res.created,
+      });
+      if (res.created) {
+        toast.success("Дякуємо! Повідомимо щойно Pro буде готовий.");
+      } else {
+        toast.info("Ми вже памʼятаємо твій інтерес — жодних дублікатів.");
+      }
+      setEmail("");
+      onSuccess?.(res.created);
+    } catch (err) {
+      if (isApiError(err) && err.status === 429) {
+        toast.error("Забагато запитів. Спробуй за годину.");
+      } else if (isApiError(err) && err.status === 400) {
+        setEmailError("Перевір email-адресу");
+      } else {
+        toast.error("Не вдалося зберегти. Спробуй ще раз.");
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={className}
+      noValidate
+      aria-label="Підписатись на waitlist Pro-тіру"
+    >
+      <div className="space-y-3">
+        <div>
+          <Label htmlFor="waitlist-email">Email</Label>
+          <Input
+            id="waitlist-email"
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.currentTarget.value)}
+            autoComplete="email"
+            required
+            disabled={pending}
+            aria-invalid={emailError ? true : undefined}
+            aria-describedby={emailError ? "waitlist-email-error" : undefined}
+          />
+          {emailError && (
+            <p
+              id="waitlist-email-error"
+              className="mt-1 text-xs text-danger-strong"
+            >
+              {emailError}
+            </p>
+          )}
+        </div>
+
+        <fieldset>
+          <legend className="text-sm font-medium text-text mb-2">
+            Який тариф цікавить найбільше?
+          </legend>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {TIER_OPTIONS.map((opt) => {
+              const checked = tier === opt.value;
+              const inputId = `waitlist-tier-${opt.value}`;
+              return (
+                <label
+                  key={opt.value}
+                  htmlFor={inputId}
+                  aria-label={`${opt.label} — ${opt.hint}`}
+                  className={
+                    "flex items-start gap-3 rounded-2xl border p-3 cursor-pointer transition-colors " +
+                    (checked
+                      ? "border-brand-500 bg-brand/10 dark:bg-brand/15"
+                      : "border-line bg-panel hover:bg-panelHi")
+                  }
+                >
+                  <input
+                    id={inputId}
+                    type="radio"
+                    name="waitlist-tier"
+                    value={opt.value}
+                    checked={checked}
+                    onChange={() => setTier(opt.value)}
+                    className="mt-1 accent-brand-strong"
+                    disabled={pending}
+                  />
+                  <span className="flex flex-col">
+                    <span className="text-sm font-semibold text-text">
+                      {opt.label}
+                    </span>
+                    <span className="text-xs text-muted">{opt.hint}</span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <Button type="submit" variant="primary" size="lg" loading={pending}>
+          Підписатись на waitlist
+        </Button>
+
+        <p className="text-xs text-muted">
+          Без спаму. Один лист, коли Pro запуститься. Ціни теж покажемо
+          фіналізовано — поки в `docs/launch/01-monetization-and-pricing.md`
+          лише драфт.
+        </p>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -39,6 +39,7 @@ export const foodSearchApi = apiClient.foodSearch;
 export const monoApi = apiClient.mono;
 export const monoWebhookApi = apiClient.monoWebhook;
 export const privatApi = apiClient.privat;
+export const waitlistApi = apiClient.waitlist;
 export const weeklyDigestApi = apiClient.weeklyDigest;
 
 // Errors, types, HTTP primitives

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1783,6 +1783,55 @@
         }
       }
     },
+    "/api/v1/waitlist": {
+      "post": {
+        "summary": "Sign-up на waitlist для майбутнього Pro-тіру (анонімний)",
+        "tags": [
+          "monetization"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WaitlistSubmit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Submitted (created=true) або уже був у списку (created=false)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitlistSubmitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — payload не пройшов zod-валідацію.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests — rate-limit перевищено.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/food-search": {
       "get": {
         "summary": "OpenFoodFacts search proxy",
@@ -3880,6 +3929,45 @@
         ],
         "description": "POST /api/push/test."
       },
+      "WaitlistSubmit": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "maxLength": 254,
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+          },
+          "tier_interest": {
+            "default": "unsure",
+            "type": "string",
+            "enum": [
+              "free",
+              "plus",
+              "pro",
+              "unsure"
+            ]
+          },
+          "source": {
+            "default": "pricing_page",
+            "type": "string",
+            "enum": [
+              "pricing_page",
+              "paywall",
+              "settings",
+              "onboarding"
+            ]
+          },
+          "locale": {
+            "type": "string",
+            "pattern": "^[a-z]{2}$"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "description": "POST /api/v1/waitlist — sign-up на майбутній Pro-тір (Phase 0 monetization)."
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -4120,6 +4208,24 @@
         ],
         "additionalProperties": false,
         "description": "POST /api/push/test response."
+      },
+      "WaitlistSubmitResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "created": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "created"
+        ],
+        "additionalProperties": false,
+        "description": "Відповідь на POST /api/v1/waitlist — `created` розрізняє новий запис vs duplicate."
       }
     },
     "securitySchemes": {

--- a/packages/api-client/src/createApiClient.ts
+++ b/packages/api-client/src/createApiClient.ts
@@ -31,6 +31,10 @@ import {
   type PrivatEndpoints,
 } from "./endpoints/privat";
 import {
+  createWaitlistEndpoints,
+  type WaitlistEndpoints,
+} from "./endpoints/waitlist";
+import {
   createWeeklyDigestEndpoints,
   type WeeklyDigestEndpoints,
 } from "./endpoints/weeklyDigest";
@@ -60,6 +64,7 @@ export interface ApiClient {
   mono: MonoEndpoints;
   monoWebhook: MonoWebhookEndpoints;
   privat: PrivatEndpoints;
+  waitlist: WaitlistEndpoints;
   weeklyDigest: WeeklyDigestEndpoints;
 }
 
@@ -78,6 +83,7 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
     mono: createMonoEndpoints(http),
     monoWebhook: createMonoWebhookEndpoints(http),
     privat: createPrivatEndpoints(http),
+    waitlist: createWaitlistEndpoints(http),
     weeklyDigest: createWeeklyDigestEndpoints(http),
   };
 }

--- a/packages/api-client/src/endpoints/waitlist.ts
+++ b/packages/api-client/src/endpoints/waitlist.ts
@@ -1,0 +1,48 @@
+import {
+  WaitlistSubmitSchema as SharedWaitlistSubmitSchema,
+  WaitlistSubmitResponseSchema as SharedWaitlistSubmitResponseSchema,
+  z,
+} from "@sergeant/shared";
+import type { HttpClient } from "../httpClient";
+import type { RequestOptions } from "../types";
+
+/**
+ * Phase 0 monetization rails: client для `POST /api/v1/waitlist`.
+ *
+ * Re-export-имо схеми з `@sergeant/shared` так само, як це зроблено для
+ * push-endpoint-ів — щоб callsite-и могли попередньо валідувати payload
+ * перед мережевим викликом, і щоб тести могли імпортувати схему без
+ * зачіпки за весь shared-bundle.
+ */
+export const WaitlistSubmitRequestSchema = SharedWaitlistSubmitSchema;
+export const WaitlistSubmitResponseSchema = SharedWaitlistSubmitResponseSchema;
+
+export type WaitlistSubmitRequest = z.infer<typeof WaitlistSubmitRequestSchema>;
+export type WaitlistSubmitResponse = z.infer<
+  typeof WaitlistSubmitResponseSchema
+>;
+
+export interface WaitlistEndpoints {
+  /**
+   * `POST /api/v1/waitlist` — анонімний sign-up на майбутній Pro-тір.
+   * Сервер відповідає `{ ok: true, created: boolean }`; парсимо
+   * `WaitlistSubmitResponseSchema`, щоб неочікуваний shape (старий сервер,
+   * проксі-injection) фейлив на клієнті, а не пізніше у UI-логіці.
+   */
+  submit: (
+    body: WaitlistSubmitRequest,
+    opts?: Pick<RequestOptions, "signal">,
+  ) => Promise<WaitlistSubmitResponse>;
+}
+
+export function createWaitlistEndpoints(http: HttpClient): WaitlistEndpoints {
+  return {
+    submit: async (body, { signal } = {}) => {
+      // Шлях `/api/waitlist` перепишеться на `/api/v1/waitlist` через
+      // `applyApiPrefix` у `HttpClient` (див. `src/httpClient.ts`) —
+      // конвенція решти endpoint-ів цього клієнта.
+      const raw = await http.post<unknown>("/api/waitlist", body, { signal });
+      return WaitlistSubmitResponseSchema.parse(raw);
+    },
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -143,6 +143,15 @@ export {
 } from "./endpoints/privat";
 
 export {
+  createWaitlistEndpoints,
+  WaitlistSubmitRequestSchema,
+  WaitlistSubmitResponseSchema,
+  type WaitlistEndpoints,
+  type WaitlistSubmitRequest,
+  type WaitlistSubmitResponse,
+} from "./endpoints/waitlist";
+
+export {
   createWeeklyDigestEndpoints,
   type WeeklyDigestEndpoints,
   type WeeklyDigestPayload,

--- a/packages/shared/src/lib/analyticsEvents.test.ts
+++ b/packages/shared/src/lib/analyticsEvents.test.ts
@@ -39,4 +39,10 @@ describe("ANALYTICS_EVENTS registry", () => {
     );
     expect(ANALYTICS_EVENTS.SUBSCRIPTION_RENEWED).toBe("subscription_renewed");
   });
+
+  it("exposes the Pricing / Waitlist (Phase 0 monetization) group verbatim", () => {
+    expect(ANALYTICS_EVENTS.PRICING_VIEWED).toBe("pricing_viewed");
+    expect(ANALYTICS_EVENTS.PRICING_CTA_CLICKED).toBe("pricing_cta_clicked");
+    expect(ANALYTICS_EVENTS.WAITLIST_SUBMITTED).toBe("waitlist_submitted");
+  });
 });

--- a/packages/shared/src/lib/analyticsEvents.ts
+++ b/packages/shared/src/lib/analyticsEvents.ts
@@ -124,6 +124,21 @@ export const ANALYTICS_EVENTS = Object.freeze({
   SUBSCRIPTION_STARTED: "subscription_started",
   SUBSCRIPTION_CANCELED: "subscription_canceled",
   SUBSCRIPTION_RENEWED: "subscription_renewed",
+
+  // Pricing / waitlist (Phase 0 monetization rails). Без активного білінгу:
+  // вимірюємо попит до того, як вкладатись у Stripe / Mono jar інтеграцію.
+  // Очікувані payload-контракти:
+  //
+  //   PRICING_VIEWED         { source?: "settings" | "paywall" | "direct" }
+  //   PRICING_CTA_CLICKED    { tier: "free" | "plus" | "pro",
+  //                            cta: "waitlist" | "primary" }
+  //   WAITLIST_SUBMITTED     { tier_interest: "free" | "plus" | "pro" | "unsure",
+  //                            source: "pricing_page" | "paywall" | "settings"
+  //                                   | "onboarding",
+  //                            created: boolean }
+  PRICING_VIEWED: "pricing_viewed",
+  PRICING_CTA_CLICKED: "pricing_cta_clicked",
+  WAITLIST_SUBMITTED: "waitlist_submitted",
 } as const);
 
 export type AnalyticsEventName =

--- a/packages/shared/src/openapi/registry.ts
+++ b/packages/shared/src/openapi/registry.ts
@@ -150,6 +150,16 @@ const Pagination = schemas.PaginationSchema.meta({
   description:
     "Стандартні query-params для list-endpoints (limit/offset, coerced).",
 });
+const WaitlistSubmit = schemas.WaitlistSubmitSchema.meta({
+  id: "WaitlistSubmit",
+  description:
+    "POST /api/v1/waitlist — sign-up на майбутній Pro-тір (Phase 0 monetization).",
+});
+const WaitlistSubmitResponse = schemas.WaitlistSubmitResponseSchema.meta({
+  id: "WaitlistSubmitResponse",
+  description:
+    "Відповідь на POST /api/v1/waitlist — `created` розрізняє новий запис vs duplicate.",
+});
 
 /** Стандартна 400-помилка для validateBody. */
 const ApiError = z
@@ -203,6 +213,8 @@ export const namedSchemas = {
   BarcodeQuery,
   MonoTransactionsQuery,
   Pagination,
+  WaitlistSubmit,
+  WaitlistSubmitResponse,
   ApiError,
 } as const;
 

--- a/packages/shared/src/openapi/routes.ts
+++ b/packages/shared/src/openapi/routes.ts
@@ -543,6 +543,35 @@ export const paths: ZodOpenApiPathsObject = {
     },
   },
 
+  // ────────────────────── Waitlist (Phase 0 monetization) ───────────────────
+  "/api/v1/waitlist": {
+    post: {
+      summary: "Sign-up на waitlist для майбутнього Pro-тіру (анонімний)",
+      tags: ["monetization"],
+      requestBody: {
+        content: {
+          "application/json": { schema: namedSchemas.WaitlistSubmit },
+        },
+      },
+      responses: {
+        "200": {
+          description:
+            "Submitted (created=true) або уже був у списку (created=false)",
+          content: {
+            "application/json": { schema: namedSchemas.WaitlistSubmitResponse },
+          },
+        },
+        "400": validationError,
+        "429": {
+          description: "Too many requests — rate-limit перевищено.",
+          content: {
+            "application/json": { schema: namedSchemas.ApiError },
+          },
+        },
+      },
+    },
+  },
+
   // ────────────────────── Food search / barcode ──────────────────────
   "/api/food-search": {
     get: {

--- a/packages/shared/src/schemas/api.ts
+++ b/packages/shared/src/schemas/api.ts
@@ -609,4 +609,50 @@ export const MonoTransactionsQuerySchema = z.object({
   cursor: z.string().min(3).optional(),
 });
 
+// ────────────────────── Waitlist (Phase 0 monetization rails) ───────────────
+// Простий sign-up для майбутнього Pro-тіру. Валідується тут, щоб і клієнт
+// (через `@sergeant/api-client`) і сервер (через `validateBody`) мали одне
+// джерело правди. Tier-и навмисно матчать `docs/launch/01-monetization-and-pricing.md`.
+
+export const WaitlistTierSchema = z.enum(["free", "plus", "pro", "unsure"]);
+export type WaitlistTier = z.infer<typeof WaitlistTierSchema>;
+
+export const WaitlistSourceSchema = z.enum([
+  "pricing_page",
+  "paywall",
+  "settings",
+  "onboarding",
+]);
+export type WaitlistSource = z.infer<typeof WaitlistSourceSchema>;
+
+export const WaitlistSubmitSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Некоректна email-адреса")
+    .max(254),
+  tier_interest: WaitlistTierSchema.default("unsure"),
+  source: WaitlistSourceSchema.default("pricing_page"),
+  // ISO-639-1, два символи: "uk", "en". Опційний — UI може не знати.
+  locale: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .regex(/^[a-z]{2}$/, "locale має бути 2-літерний ISO-639-1")
+    .optional(),
+});
+export type WaitlistSubmitPayload = z.infer<typeof WaitlistSubmitSchema>;
+
+export const WaitlistSubmitResponseSchema = z.object({
+  ok: z.literal(true),
+  // `created` — true якщо це новий запис; false якщо email уже був у списку.
+  // Дозволяє UI показати «ми памʼятаємо твій інтерес» замість «дякуємо що
+  // підписався» — без розкриття конкретики.
+  created: z.boolean(),
+});
+export type WaitlistSubmitResponse = z.infer<
+  typeof WaitlistSubmitResponseSchema
+>;
+
 export { z };


### PR DESCRIPTION
## What changed

**Phase 0** з 4-фазового плану монетизації — інфраструктурні рейки без жодного payment provider. Просто збираємо сигнал demand через email.

- **Migration 009** — нова таблиця `waitlist_entries`. `UNIQUE INDEX` по `LOWER(email)` + index по `created_at DESC` та `tier_interest`.
- **Shared Zod schemas** — `WaitlistTierSchema` (`free|plus|pro|unsure`), `WaitlistSourceSchema`, `WaitlistSubmitSchema`, `WaitlistSubmitResponseSchema`.
- **Analytics events** — `PRICING_VIEWED`, `PRICING_CTA_CLICKED`, `WAITLIST_SUBMITTED` (+ unit test).
- **Server route** — `POST /api/v1/waitlist` (alias `/api/waitlist`), rate-limit 10/h/IP, опційний `user_id` з сесії. `ON CONFLICT DO NOTHING` + `RETURNING id` розрізняє новий vs duplicate. Response: `{ ok: true, created: boolean }`.
- **API client** — `waitlistApi.submit()` з runtime response-валідацією.
- **Web /pricing** — 3-tier (Free ₴0 / Plus ₴59 / Pro ₴99), lazy-loaded через `App.tsx`.
- **WaitlistForm** — email + tier-radio (a11y: `htmlFor`+`aria-label`), inline-error на 400, toast на 429/500, success-стан.
- **OpenAPI** — schemas + route у registry/routes; `docs/api/openapi.json` оновлений.

## Why

Юзер попросив інфру для монетизації, без складних процесів. План з 4 послідовних PR (Phase 0 → 1 → 2 → 3, ~12-15h). Цей PR без user-facing breaking change — `/pricing` доступна, але не лінкується з UI. Waitlist-entries дадуть signal для Phase 1 (paywall + quota-aware UI).

AGENTS compliance: bigint→Number в serializer (rule #1); API-contract синхронний по 3 місцях (rule #3); migration sequential 008 → 009 (rule #4); Conventional Commit scope `server` (rule #5).

## How to test

1. Postgres + server + web локально.
2. `http://localhost:5173/pricing` — 3 тіра + форма.
3. Submit з валідним email → toast «Готово!» + `{ ok: true, created: true }`.
4. Submit повторно → `{ ok: true, created: false }` (idempotent).
5. Submit з невалідним email → inline-error, без network.
6. PostHog: `pricing_viewed`, `pricing_cta_clicked`, `waitlist_submitted`.

---

## How AI-tested this PR

- [x] Vitest passes:
  - `pnpm --filter @sergeant/web test -- --run PricingPage` → 4/4 passed
  - `pnpm --filter @sergeant/shared test` → 314/314 passed
  - `pnpm --filter @sergeant/api-client test` → 59/59 passed
  - `waitlistService.test.ts` — testcontainers (soft-skip без Docker)
- [x] `pnpm typecheck` → 13/13 green
- [x] `pnpm lint` → green
- [x] `node scripts/lint-migrations.mjs` → passed
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 0 monetization rails: a `/pricing` page and a public waitlist API to collect demand via email (no payments). Users submit email + tier interest; responses are idempotent and analytics are tracked.

- **New Features**
  - `POST /api/v1/waitlist` (alias `/api/waitlist`): 10/hour/IP rate limit; idempotent insert returns `{ ok: true, created: boolean }`; optional `user_id` from session.
  - `/pricing` page (Free / Plus / Pro) with `WaitlistForm` (email + tier); lazy-loaded in `App.tsx`.
  - Shared Zod schemas in `@sergeant/shared` (`WaitlistTier`, `WaitlistSource`, `WaitlistSubmit`, `WaitlistSubmitResponse`) + OpenAPI docs.
  - Analytics events: `PRICING_VIEWED`, `PRICING_CTA_CLICKED`, `WAITLIST_SUBMITTED`.
  - API client in `@sergeant/api-client`: `waitlistApi.submit()` with response validation.

- **Migration**
  - Adds `waitlist_entries` with `UNIQUE INDEX` on `LOWER(email)` and indexes on `created_at DESC` and `tier_interest` (`009_waitlist`).
  - Apply migrations; no UI links to `/pricing` yet and no payment provider integration.

<sup>Written for commit 1c1c88b5948921b61c35da5e8dbf8a6381ea852c. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1029?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

