### PR TITLE
feat(web): wrap onboarding goal questions in module-soft cards

### DIFF
--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { cn } from "@shared/lib/cn";
 import { Button } from "@shared/components/ui/Button";
+import { Card, type CardVariant } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { BrandLogo } from "../app/BrandLogo";
 import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
@@ -463,6 +464,33 @@ const GOAL_KEY_MAP: Record<string, keyof OnboardingGoals> = {
   nutrition_goal: "nutritionGoal",
 };
 
+/** Per-module card style hooks for the goal-step soft cards. */
+const GOAL_MODULE_STYLES: Record<
+  string,
+  { variant: CardVariant; iconBg: string; iconColor: string }
+> = {
+  finyk: {
+    variant: "finyk-soft",
+    iconBg: "bg-finyk/15",
+    iconColor: "text-finyk",
+  },
+  fizruk: {
+    variant: "fizruk-soft",
+    iconBg: "bg-fizruk/15",
+    iconColor: "text-fizruk",
+  },
+  routine: {
+    variant: "routine-soft",
+    iconBg: "bg-routine/15",
+    iconColor: "text-routine",
+  },
+  nutrition: {
+    variant: "nutrition-soft",
+    iconBg: "bg-nutrition/15",
+    iconColor: "text-nutrition",
+  },
+};
+
 function GoalsStep({
   picks,
   goals,
@@ -493,13 +521,15 @@ function GoalsStep({
       </div>
 
       {hasQuestions && (
-        <div className="w-full space-y-4 text-left">
+        <div className="w-full space-y-2.5 text-left">
           {questions.map((q) => {
             const goalKey = GOAL_KEY_MAP[q.id];
-            if (q.type === "radio") {
-              return (
+            const style = GOAL_MODULE_STYLES[q.module];
+            const moduleIcon = ONBOARDING_VIBE_ICONS[q.module];
+            const moduleLabel = MODULE_LABELS[q.module];
+            const inner =
+              q.type === "radio" ? (
                 <GoalRadioGroup
-                  key={q.id}
                   question={q}
                   value={(goals[goalKey] as string | null) ?? null}
                   onChange={(v) => {
@@ -511,22 +541,45 @@ function GoalsStep({
                     });
                   }}
                 />
+              ) : (
+                <GoalSlider
+                  question={q}
+                  value={(goals[goalKey] as number | null) ?? null}
+                  onChange={(v) => {
+                    onSetGoal(goalKey, v);
+                    trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
+                      module: q.module,
+                      goalType: q.id,
+                      value: v,
+                    });
+                  }}
+                />
               );
-            }
             return (
-              <GoalSlider
+              <Card
                 key={q.id}
-                question={q}
-                value={(goals[goalKey] as number | null) ?? null}
-                onChange={(v) => {
-                  onSetGoal(goalKey, v);
-                  trackEvent(ANALYTICS_EVENTS.ONBOARDING_GOAL_SET, {
-                    module: q.module,
-                    goalType: q.id,
-                    value: v,
-                  });
-                }}
-              />
+                variant={style?.variant ?? "flat"}
+                radius="md"
+                padding="sm"
+                className="space-y-2.5"
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "shrink-0 w-7 h-7 rounded-lg flex items-center justify-center",
+                      style?.iconBg ?? "bg-panelHi",
+                      style?.iconColor ?? "text-muted",
+                    )}
+                    aria-hidden
+                  >
+                    <Icon name={moduleIcon} size={14} strokeWidth={2.25} />
+                  </span>
+                  <span className="text-xs font-semibold text-subtle">
+                    {moduleLabel}
+                  </span>
+                </div>
+                {inner}
+              </Card>
             );
           })}
         </div>

--- a/ops/n8n-workflows/06-mono-webhook-enrichment.json
+++ b/ops/n8n-workflows/06-mono-webhook-enrichment.json
@@ -37,7 +37,10 @@
       "typeVersion": 4.2,
       "position": [460, 300],
       "credentials": {
-        "httpHeaderAuth": { "id": "CONFIGURE_ME", "name": "Anthropic (x-api-key)" }
+        "httpHeaderAuth": {
+          "id": "CONFIGURE_ME",
+          "name": "Anthropic (x-api-key)"
+        }
       }
     },
     {
@@ -121,5 +124,10 @@
     }
   },
   "settings": { "executionOrder": "v1", "timezone": "Europe/Kyiv" },
-  "tags": [{ "name": "finyk" }, { "name": "mono" }, { "name": "ai" }, { "name": "budget" }]
+  "tags": [
+    { "name": "finyk" },
+    { "name": "mono" },
+    { "name": "ai" },
+    { "name": "budget" }
+  ]
 }


### PR DESCRIPTION
## What changed

PR 3/6 у серії «прибираємо вигляд сирого продукту». Сам `OnboardingWizard` уже рендериться у панелі (`bg-panel border border-line rounded-3xl`), і **welcome / modules / permissions** кроки структуровані. Але крок **goals** ("Твої цілі") стек 1–4 запитань (Finyk бюджет, Nutrition мета, Fizruk тижнева ціль, Routine перша звичка) рендерив прямо як текст + чіпи на панелі — без жодних меж між запитаннями. З 3+ обраними модулями всі ці групи злипалися в одну стіну.

Тепер кожне goal-запитання обгорнуто у per-module **soft card** (`Card variant="{module}-soft" radius="md" padding="sm"`) з маленьким хедером — іконка модуля у тонкому круглому контейнері + label (Фінік / Фізрук / Рутина / Харчування). Кожен модуль використовує свій бренд-токен як легкий tint (`{module}-soft` → `bg-{family}-50/50` light, `bg-{family}-500/10` dark), що візуально прив'язує запитання до відповідного модуля і збігається з ритмом permissions-step (де теж row-картки).

Без змін: логіка `wizardReducer`, аналітика (`ONBOARDING_GOAL_SET`, `ONBOARDING_STEP_VIEWED`, …), форма даних `OnboardingGoals`, ключі `GOAL_KEY_MAP`, навігація між кроками, test-id у `PermissionsPrompt.test.tsx`.

Файл: `apps/web/src/core/onboarding/OnboardingWizard.tsx`.

### Скріни

**Before** — 3 запитання як одна стіна тексту:

![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvYWQ3ZmMwYWMtZTdkNS00YzhlLTkyMGMtYjdjYjY1MDVmNjNiIiwiaWF0IjoxNzc3MzM2MDY2LCJleHAiOjE3Nzc5NDA4NjYsImZpbGVuYW1lIjoic2NyZWVuc2hvdF8wYWY1NDEyOTEwM2Y0ZTc5YmU3ZWI2OTc2MzgxNWI1MC5wbmcifQ.1DCihvLiRKV0PqDACe5gmv8M_vYpZREDeKVe47KC5yI)

**After** — кожне запитання у власній module-soft картці з іконкою модуля:

![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvOThjNzEzMDQtMjdhNS00MDIzLTljNWUtZGRkMGE0Njg1MDMzIiwiaWF0IjoxNzc3MzM2MDY2LCJleHAiOjE3Nzc5NDA4NjYsImZpbGVuYW1lIjoic2NyZWVuc2hvdF80YmZmYWRlZGQ3YWU0ODMwYmM4NGNiN2Y1ODdkNmI4YS5wbmcifQ.JtAGFxHtl4IuVphz4NGH4-AVBX2BpTWS81qrc1Rjt20)

## Why

Користувач писав, що «більшість сторінок» виглядають як «текст на тлі». Goals-step онбордингу — найбільш помітний кейс цього всередині OnboardingWizard, який сам по собі вже у Card. Косметичний фікс, який не торкається даних, аналітики, persistence або навігації.

## How to test

1. `pnpm --filter @sergeant/web dev` → відкрити `/welcome` (свіжий localStorage або `localStorage.clear()`).
2. Welcome → Далі → у Modules вибрати **усі 4 модулі** (щоб побачити всі 4 goal-картки) → Далі.
3. На «Твої цілі» переконатися, що кожне запитання у своїй module-soft картці з іконкою + label-ом модуля. Слайдер Фініка має тягнутися й оновлювати число в правому верхньому куті, радіо-чіпи Nutrition обираються коректно, чіпи Fizruk теж.
4. Натиснути «Відкрити Sergeant» → модуль `routine_first_habit` (radio) теж має бути показаний у Routine-картці, якщо обрана Routine.
5. Dark mode (`document.documentElement.classList.add('dark')`) — soft-картки мають видно tint-ще-помітніше за рахунок dark-варіантів `{family}-soft`.
6. Mobile width (375px) — картки не вилазять, кнопки доступні.

---

## How AI-tested this PR

- [x] Manual smoke (`/welcome` happy path → modules → goals → permissions → Hub): візуально кожна модульна картка читається, slider/radio зберігають значення, переходи кроками працюють.
- [x] Vitest passes: `pnpm --filter @sergeant/web test -- onboarding` → `PermissionsPrompt` (6 тестів) zelene; OnboardingWizard сам по собі покритий e2e-flow, не unit, тож регресій selectors немає.
- [x] Lint + typecheck: `pnpm --filter @sergeant/web lint` та `… typecheck` чисті (одну `sergeant-design/no-eyebrow-drift` помилку перевиправлено — eyebrow → нормальний `text-xs font-semibold`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. Дотримано наявних: rule #5 (scope `web`), rule #7 (Husky/lint-staged без `--no-verify`), rule #8 (opacity `/15` — на дозволеній шкалі), rule #9 (saturated `text-white` фонів не додавали — `*-soft` варіанти Card вже сумісні з AA для тексту всередині).

Link to Devin session: https://app.devin.ai/sessions/b6d7c5e627ea4d9dbde7573f13a284d5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped each onboarding goals question in a per‑module soft `Card` with a small icon + label header using `variant='{module}-soft'` to match Modules/Permissions; logic and analytics are unchanged. Also formatted `ops/n8n-workflows/06-mono-webhook-enrichment.json` with Prettier to fix CI format‑check.

<sup>Written for commit 541a0a2eaf99d383a7b54056cf6e9d4230ab37d9. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1031?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

