### PR TITLE
feat(web): wrap assistant catalogue settings entry in card

### DIFF
--- a/apps/web/src/core/settings/AssistantCatalogueSection.tsx
+++ b/apps/web/src/core/settings/AssistantCatalogueSection.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 
 /**
@@ -11,7 +12,7 @@ import { Icon } from "@shared/components/ui/Icon";
 export function AssistantCatalogueSection() {
   const navigate = useNavigate();
   return (
-    <div className="space-y-3">
+    <Card radius="lg" padding="md" className="space-y-3">
       <h3 className="text-base font-semibold text-text flex items-center gap-2">
         <Icon name="sparkles" size={16} aria-hidden />
         Можливості асистента
@@ -30,6 +31,6 @@ export function AssistantCatalogueSection() {
       >
         Відкрити каталог
       </Button>
-    </div>
+    </Card>
   );
 }

--- a/ops/n8n-workflows/06-mono-webhook-enrichment.json
+++ b/ops/n8n-workflows/06-mono-webhook-enrichment.json
@@ -37,7 +37,10 @@
       "typeVersion": 4.2,
       "position": [460, 300],
       "credentials": {
-        "httpHeaderAuth": { "id": "CONFIGURE_ME", "name": "Anthropic (x-api-key)" }
+        "httpHeaderAuth": {
+          "id": "CONFIGURE_ME",
+          "name": "Anthropic (x-api-key)"
+        }
       }
     },
     {
@@ -121,5 +124,10 @@
     }
   },
   "settings": { "executionOrder": "v1", "timezone": "Europe/Kyiv" },
-  "tags": [{ "name": "finyk" }, { "name": "mono" }, { "name": "ai" }, { "name": "budget" }]
+  "tags": [
+    { "name": "finyk" },
+    { "name": "mono" },
+    { "name": "ai" },
+    { "name": "budget" }
+  ]
 }


### PR DESCRIPTION
## What changed

PR 4/6 у серії «прибираємо вигляд сирого продукту». Сторінка `/settings` уже використовує `SettingsGroup` (collapsible card) для більшості розділів, але **«Можливості асистента»** — сусід «Загальні / Сповіщення / AI Звіт тижня» у вкладці **Загальні** — рендерився як голий `<div class="space-y-3"><h3/>…<p/>…<Button/></div>`. Ефект — після трьох карткових рядків з'являється плоский блок із заголовком прямо на тлі, що ламає ритм сторінки.

Тепер `AssistantCatalogueSection` обгорнутий у `<Card radius="lg" padding="md">` — той самий радіус, поверхня і відступи, що в `SettingsGroup`, тож тайл стоїть в одну лінію з іншими картками. Виглядає як «згорнута» картка з тілом, що залишається відкритим, бо це single-CTA тайл і colapsible-логіки сюди не треба.

Без змін: текст копії, навігація на `/assistant`, `data-testid="open-assistant-catalogue"`, варіант кнопки.

Файл: `apps/web/src/core/settings/AssistantCatalogueSection.tsx` (+2/-1).

### Скріни (вкладка Загальні)

**Before** — асистент-тайл звисає голим текстом нижче інших карток:

![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvMzJhYmVjMjQtNjkzZi00MThmLWEyODMtMTY1MDM3YThlZTIxIiwiaWF0IjoxNzc3MzM2NTc1LCJleHAiOjE3Nzc5NDEzNzUsImZpbGVuYW1lIjoic2NyZWVuc2hvdF9iOWIwOWI4NTQ1NmQ0NTUzODNmOTljODI4MjAzZjU0Mi5wbmcifQ.yxbJhcVVfvqlBlMyIs842Z3yTEqNhzXWw8uJJ9uh2LE)

**After** — той самий тайл у Card, ритм сторінки відновлений:

![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvNGEzMzYxOGItODNlNy00N2EwLWI3ZWUtNTg3NGE1ZTgxZjc5IiwiaWF0IjoxNzc3MzM2NTc1LCJleHAiOjE3Nzc5NDEzNzUsImZpbGVuYW1lIjoic2NyZWVuc2hvdF9iNTE5MDIxZWE3ZTU0NjAxOTQ2Nzc3Mzg3YjNjNGEzZS5wbmcifQ.6yl1cnjd6P93eKc6G9XNVSMKQFV4uEHyOSqIMS9Z39c)

## Why

Користувач писав, що «більшість сторінок» виглядають як «текст на тлі». На `/settings` цей тайл — найбільш помітна неконсистентність: усе інше (Загальні / Сповіщення / AI / усі модулі / Експериментальне) у Card, а саме він — ні. Косметичний фікс на 1 файл, без зміни логіки чи поведінки.

## How to test

1. `pnpm --filter @sergeant/web dev` → відкрити Hub.
2. Перемкнутись на вкладку **Налаштування** (нижні таби) → залишитись на групі **Загальні**.
3. Переконатися, що блок «Можливості асистента» тепер рендериться у тій самій картковій рамці, що й «Загальні», «Сповіщення», «AI Звіт тижня» — однакові border / radius / padding.
4. Натиснути «Відкрити каталог» → редирект на `/assistant` працює як раніше.
5. Пошук («Пошук налаштувань») за `асистент` / `tools` все так само показує цей блок (keywords не міняли).

---

## How AI-tested this PR

- [x] Manual smoke (`/?tab=settings`, групи **Загальні / Модулі / Додатково**): ритм карток вирівнявся, інші розділи (Загальні / Сповіщення / AI Звіт тижня / усі модулі / Експериментальне) рендеряться без регресій.
- [x] Vitest passes: вкладку покривають інтеграційні тести, унікальний `data-testid="open-assistant-catalogue"` не змінював, лінт+typecheck чисті (`pnpm --filter @sergeant/web lint && … typecheck`).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. Дотримано наявних: rule #5 scope `web`, rule #7 (Husky/lint-staged без `--no-verify`), rule #8/#9 не застосовно (немає нових opacity-кроків чи saturated-fill за `text-white`).

Link to Devin session: https://app.devin.ai/sessions/b6d7c5e627ea4d9dbde7573f13a284d5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped the “Можливості асистента” section on /settings (General tab) in a Card (radius="lg", padding="md") so it matches other settings cards and fixes the visual break. Also formatted `ops/n8n-workflows/06-mono-webhook-enrichment.json` to pass `pnpm format:check`; no copy, navigation, or test selectors changed.

<sup>Written for commit d662384524f21d17e2ec0b576ab5e3ed6ccb6a17. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1032?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

