### PR TITLE
feat(web): wrap fizruk workouts sections in cards

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
+import { Card } from "@shared/components/ui/Card";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { useToast } from "@shared/hooks/useToast";
@@ -796,15 +797,15 @@ function WorkoutsHome({
         </div>
       )}
 
-      <div>
-        <div className="flex items-center justify-between px-1 mb-2">
-          <h2 className="text-sm font-semibold text-text/80">
+      <Card as="section" radius="lg" aria-label="Останні тренування">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-text">
             Останні тренування
           </h2>
           {recentWorkouts.length > 0 ? (
             <button
               type="button"
-              className="text-xs font-semibold text-teal-700 hover:underline"
+              className="text-xs font-semibold text-fizruk-strong hover:underline active:opacity-70"
               onClick={onOpenJournal}
             >
               Всі →
@@ -812,41 +813,43 @@ function WorkoutsHome({
           ) : null}
         </div>
         {recentWorkouts.length > 0 ? (
-          <ul className="space-y-2">
+          <ul className="flex flex-col gap-2">
             {recentWorkouts.map((w) => (
               <li key={w.id}>
                 <button
                   type="button"
-                  className="w-full text-left rounded-xl border border-border bg-surface-2 px-3 py-3 flex items-center justify-between hover:bg-surface-3"
+                  className="w-full text-left rounded-xl border border-line bg-bg px-3 py-3 flex items-center justify-between hover:bg-panelHi transition-colors"
                   onClick={onOpenJournal}
                 >
                   <RecentWorkoutSummary workout={w} />
-                  <span className="text-subtle">›</span>
+                  <span className="text-subtle" aria-hidden>
+                    ›
+                  </span>
                 </button>
               </li>
             ))}
           </ul>
         ) : (
-          <div className="rounded-xl border border-border bg-surface-2 p-4 text-xs text-subtle">
+          <div className="rounded-2xl border border-dashed border-line p-4 text-xs text-subtle text-center">
             Після першого завершеного тренування тут з&apos;являться останні
             сесії.
           </div>
         )}
-      </div>
+      </Card>
 
-      <div>
-        <h2 className="text-sm font-semibold text-text/80 px-1 mb-2">
-          Довідники
-        </h2>
+      <Card as="section" radius="lg" aria-label="Довідники">
+        <h2 className="text-sm font-semibold text-text mb-3">Довідники</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           <button
             type="button"
-            className="rounded-xl border border-border bg-surface-2 p-4 text-left hover:bg-surface-3"
+            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
             onClick={onOpenCatalog}
           >
             <div className="flex items-center gap-3">
-              <span className="text-2xl">📚</span>
-              <div className="flex-1">
+              <span className="text-2xl" aria-hidden>
+                📚
+              </span>
+              <div className="flex-1 min-w-0">
                 <div className="text-sm font-semibold text-text">
                   Каталог вправ
                 </div>
@@ -854,27 +857,33 @@ function WorkoutsHome({
                   Пошук · групи м&apos;язів · своя вправа
                 </div>
               </div>
-              <span className="text-subtle">›</span>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
             </div>
           </button>
           <button
             type="button"
-            className="rounded-xl border border-border bg-surface-2 p-4 text-left hover:bg-surface-3"
+            className="rounded-2xl border border-line bg-bg p-4 text-left hover:bg-panelHi transition-colors"
             onClick={onOpenTemplates}
           >
             <div className="flex items-center gap-3">
-              <span className="text-2xl">📋</span>
-              <div className="flex-1">
+              <span className="text-2xl" aria-hidden>
+                📋
+              </span>
+              <div className="flex-1 min-w-0">
                 <div className="text-sm font-semibold text-text">Шаблони</div>
                 <div className="text-xs text-subtle mt-0.5">
                   Збережені набори вправ на швидкий старт
                 </div>
               </div>
-              <span className="text-subtle">›</span>
+              <span className="text-subtle" aria-hidden>
+                ›
+              </span>
             </div>
           </button>
         </div>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/ops/n8n-workflows/06-mono-webhook-enrichment.json
+++ b/ops/n8n-workflows/06-mono-webhook-enrichment.json
@@ -37,7 +37,10 @@
       "typeVersion": 4.2,
       "position": [460, 300],
       "credentials": {
-        "httpHeaderAuth": { "id": "CONFIGURE_ME", "name": "Anthropic (x-api-key)" }
+        "httpHeaderAuth": {
+          "id": "CONFIGURE_ME",
+          "name": "Anthropic (x-api-key)"
+        }
       }
     },
     {
@@ -121,5 +124,10 @@
     }
   },
   "settings": { "executionOrder": "v1", "timezone": "Europe/Kyiv" },
-  "tags": [{ "name": "finyk" }, { "name": "mono" }, { "name": "ai" }, { "name": "budget" }]
+  "tags": [
+    { "name": "finyk" },
+    { "name": "mono" },
+    { "name": "ai" },
+    { "name": "budget" }
+  ]
 }


### PR DESCRIPTION
## What changed

Останній PR (6/6) у серії «прибираємо вигляд сирого продукту». Я переглянув усі модульні дашборди (Фінік, Фізрук, Рутина, Харчування) і їхні внутрішні таби — більшість уже в порядку. Єдина помітно сира ділянка — це **Фізрук → таб «Тренування»**: дві підсекції (`Останні тренування` і `Довідники`) рендерилися як голі `h2`-лейбли з контентом прямо на фоні сторінки.

Що особливо неконсистентно: на табі **«Сьогодні»** ця ж сама секція (`RecentWorkoutsSection`) уже обгорнута у `<Card>`. Тобто дашборд читався як полірований UI, а Тренування-таб — як unfinished list of items.

### Зміни в `apps/web/src/modules/fizruk/pages/Workouts.tsx`

1. **`Останні тренування`** → обгорнуто у `<Card as="section" radius="lg" aria-label="Останні тренування">`. h2 тепер коректний card-header. Empty-state рядок став dashed-border zone (як у dashboard-варіанті). Список має ті самі inner-row borders, що й dashboard.

2. **`Довідники`** (Каталог вправ + Шаблони) → також у `<Card as="section" radius="lg" aria-label="Довідники">`. Inner buttons (catalog/templates) перенесено з legacy-токенів `border-border bg-surface-2 hover:bg-surface-3` на канонічні design-system токени `border-line bg-bg hover:bg-panelHi`. `rounded-xl` → `rounded-2xl` (узгоджено з рештою картковості модуля).

3. **`text-teal-700`** на «Всі →» CTA → `text-fizruk-strong` (модульний tinted strong-token, сумісний з WCAG AA — rule #9).

### Не змінено

- `onOpenJournal`, `onOpenCatalog`, `onOpenTemplates`, `onRequestStart`, `onOpenRetro`, `onOpenSession` — props/handlers недоторкані.
- DOM-порядок секцій (`active/empty card → recent → довідники`) — той самий.
- `RecentWorkoutSummary` (внутрішній компонент) — без змін.
- Юніт-тести `RecentWorkoutsSection.test.tsx` (на дашборд-варіант) залишаються зеленими, бо ця зміна — у `pages/Workouts.tsx`, не в dashboard-секції.
- Active workout state (`Активне тренування` зі лічильником) — без змін.
- Emoji-іконки (📚, 📋) і їхній стиль — той самий.

### Drive-by

Додав `chore(ci): apply prettier to n8n mono-webhook workflow` (другий комміт у PR) — той самий prettier-фікс на `ops/n8n-workflows/06-mono-webhook-enrichment.json`, що в PR #1031 / #1032 / #1035, щоб `pnpm format:check` проходив на цій гілці. Сам JSON-вміст без змін, лише форматування.

Файли: `apps/web/src/modules/fizruk/pages/Workouts.tsx` (+31 / −22), `ops/n8n-workflows/06-mono-webhook-enrichment.json` (whitespace-only).

### Скріни (Фізрук → Тренування таб)

**Before** — `Останні тренування` і `Довідники` як голі h2-лейбли, kontent на bg-bg:

![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvN2JjN2FiNzYtMjM0My00NmQzLTgxYTctNGNlNGYwNjE4NjAyIiwiaWF0IjoxNzc3MzM3NjAyLCJleHAiOjE3Nzc5NDI0MDIsImZpbGVuYW1lIjoic2NyZWVuc2hvdF83ZWU4Y2UwNzkxNzI0MDZjODU0NzJlNzlmYjc4MWQ3OC5wbmcifQ.idupdsgbxP9T-kF5fNMEdi43gfQE6sXGLF6lJGBl3Nk)

**After** — обидві секції у Cards, ритм карток узгоджений з табом «Сьогодні»:

![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGJmNDFlNTY2ZDMwNGViZWEzMmRlNjVkYzZlZmMzZjIvMGMxZTE2MDUtZDBjMy00YWUwLWEyY2MtYmQ1YjgwNWZjMTUzIiwiaWF0IjoxNzc3MzM3NjAyLCJleHAiOjE3Nzc5NDI0MDIsImZpbGVuYW1lIjoic2NyZWVuc2hvdF9hM2ZhOGViZWE0ODE0NmNmYjkwY2JjNDRiNzAxZDRjNy5wbmcifQ.wOepFuNhANVabQDZA44T2iPt4J8SVc-RLUWGOwUbjXQ)

## Why

Завершує серію PR #1026 / #1028 / #1031 / #1032 / #1035. Користувач писав, що «більшість сторінок» виглядають як «текст на тлі без карток». Я переглянув кожен модульний дашборд і їхні підтаби; це залишилось єдиним помітно сирим екраном, що варто було полірнути.

## How to test

1. `pnpm --filter @sergeant/web dev` → відкрити Hub.
2. Перейти **Фізрук** → таб **Тренування** (`/?module=fizruk#workouts`).
3. Переконатися, що:
   - `Останні тренування` рендериться у Card з заголовком всередині й бордером навколо. Empty-state — dashed border центрований.
   - `Довідники` рендериться у Card; `Каталог вправ` і `Шаблони` — два rounded-2xl кнопок-картки в 2 колонки на sm+.
   - `Всі →` (коли є тренування) має fizruk-strong tint, не teal-700 (raw teal не змінювався у dark, тут стало консистентно).
4. Натиснути `Каталог вправ` / `Шаблони` / `Всі →` — навігація працює як раніше (callback prop-ів не міняли).
5. Перемкнутися на таб **Сьогодні** — переконатися, що там нічого не змінилось (фікс лише у `pages/Workouts.tsx`, не зачіпає `dashboard/RecentWorkoutsSection.tsx`).
6. Запустити `pnpm --filter @sergeant/web test -- Workouts` (або `RecentWorkoutsSection`) — `RecentWorkoutsSection.test.tsx` (4 tests) і пов'язані тести залишаються зеленими.

---

## How AI-tested this PR

- [x] Manual smoke (`/?module=fizruk#workouts`): дві секції візуально перевірено, Card-borders і inner-buttons рендеряться, dashed-border empty-state на місці. Інші таби (Сьогодні / План / Прогрес / Тіло) — без регресій.
- [x] Vitest passes: `pnpm --filter @sergeant/web test -- Workouts` → 11 passed (3 файли). `RecentWorkoutsSection.test.tsx` (4 tests) зачепити цією зміною неможливо, бо це інший компонент.
- [x] Lint + typecheck чисті: `pnpm --filter @sergeant/web lint && … typecheck`.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules. Дотримано наявних: rule #5 scope `web`, rule #7 (Husky/lint-staged без `--no-verify`), rule #8 не застосовно (нові opacity-кроки не вводились), rule #9 — `text-fizruk-strong` замість legacy `text-teal-700` саме і є compliance-фіксом для WCAG-AA брендового тинту.

Link to Devin session: https://app.devin.ai/sessions/b6d7c5e627ea4d9dbde7573f13a284d5
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped the Fizruk → Workouts tab sections in cards to match the “Сьогодні” tab and clean up the UI. Migrated inner styles to design-system tokens; no logic or behavior changes.

- **Refactors**
  - Wrapped “Останні тренування” and “Довідники” in Card sections with headers.
  - Replaced legacy classes with design-system tokens: `border-line`, `bg-bg`, `hover:bg-panelHi`, `text-fizruk-strong`; updated to `rounded-2xl`; empty state now uses a dashed border.
  - Minor a11y polish (aria-hidden on decorative glyphs).
  - Callbacks and DOM order unchanged; tests unaffected.
  - CI: Prettier-only reformat of `ops/n8n-workflows/06-mono-webhook-enrichment.json` so `pnpm format:check` passes.

<sup>Written for commit 1ee354c351ed0f93885a6b36af5eb6e9155efc36. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1036?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Redesigned recent workouts and reference sections with card-based layout for better visual organization
  * Updated spacing, typography, and styling for improved readability and user experience
  * Enhanced accessibility with improved screen reader support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->