### PR TITLE
feat(web): redesign chat history drawer as full-height side sheet

### DIFF
--- a/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
+++ b/apps/web/src/core/hub/HubChatHistoryDrawer.tsx
@@ -74,48 +74,64 @@ export function HubChatHistoryDrawer({
 
   return (
     <div
-      className="absolute inset-0 z-10 flex"
+      className="fixed inset-0 z-[60] flex safe-area-pt-pb"
       role="dialog"
       aria-modal="true"
       aria-label="Історія чатів"
     >
       <div
-        className="absolute inset-0 bg-black/40 backdrop-blur-sm motion-safe:animate-fade-in"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm motion-safe:animate-fade-in"
         onClick={onClose}
         aria-hidden
         tabIndex={-1}
       />
       <div
         ref={panelRef}
-        className="relative flex flex-col w-[78%] max-w-xs bg-bg border-r border-line shadow-float motion-safe:animate-fade-in rounded-tr-3xl rounded-br-3xl"
+        className="relative flex flex-col w-[85%] max-w-sm h-full bg-bg border-r border-line shadow-float motion-safe:animate-fade-in"
       >
-        <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-line shrink-0">
-          <div className="text-[15px] font-bold text-text">Бесіди</div>
+        <div className="flex items-center justify-between gap-3 px-4 h-14 border-b border-line shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <div
+              className="w-8 h-8 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0"
+              aria-hidden
+            >
+              <Icon name="sparkle" size={15} className="text-brand-500" />
+            </div>
+            <div className="text-[15px] font-bold text-text">Бесіди</div>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+            className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
             aria-label="Закрити список бесід"
           >
-            <Icon name="close" size={16} />
+            <Icon name="close" size={18} />
           </button>
         </div>
 
-        <button
-          type="button"
-          onClick={() => {
-            onCreate();
-          }}
-          className="mx-3 mt-3 mb-1 flex items-center justify-center gap-2 h-10 rounded-xl bg-brand-500/10 text-brand-strong hover:bg-brand-500/15 transition-colors text-sm font-semibold"
-        >
-          <Icon name="plus" size={14} />
-          Нова бесіда
-        </button>
+        <div className="px-3 pt-3 pb-2 shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              onCreate();
+            }}
+            className="w-full flex items-center justify-center gap-2 h-11 rounded-2xl border border-dashed border-line text-text hover:bg-panelHi hover:border-brand-500/40 hover:text-brand-strong transition-colors text-sm font-semibold"
+          >
+            <Icon name="plus" size={15} />
+            Нова бесіда
+          </button>
+        </div>
 
-        <div className="flex-1 overflow-y-auto px-2 py-2 space-y-1">
+        <div className="flex-1 overflow-y-auto px-2 pb-3 space-y-1">
           {sortedSessions.length === 0 ? (
-            <div className="text-center text-muted text-xs py-6">
-              Поки немає інших бесід.
+            <div className="flex flex-col items-center justify-center gap-2 text-center text-muted text-xs py-10 px-4">
+              <div
+                className="w-12 h-12 rounded-2xl bg-panelHi flex items-center justify-center"
+                aria-hidden
+              >
+                <Icon name="sparkle" size={20} className="text-subtle" />
+              </div>
+              <div>Поки немає інших бесід.</div>
             </div>
           ) : (
             sortedSessions.map((s) => {
@@ -125,7 +141,7 @@ export function HubChatHistoryDrawer({
                 <div
                   key={s.id}
                   className={cn(
-                    "group relative flex items-start gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors",
+                    "group relative flex items-center gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors",
                     isActive
                       ? "bg-brand-500/15 text-text"
                       : "hover:bg-panelHi text-text",
@@ -147,7 +163,9 @@ export function HubChatHistoryDrawer({
                     </div>
                     <div className="text-2xs text-muted mt-0.5 flex items-center gap-1.5">
                       <span>{formatStamp(s.updatedAt)}</span>
-                      <span className="text-line">·</span>
+                      <span className="text-line" aria-hidden>
+                        ·
+                      </span>
                       <span>
                         {msgs} {msgs === 1 ? "повідомлення" : "повідомлень"}
                       </span>
@@ -156,11 +174,11 @@ export function HubChatHistoryDrawer({
                   <button
                     type="button"
                     onClick={(e) => handleDelete(e, s.id)}
-                    className="w-7 h-7 shrink-0 flex items-center justify-center rounded-lg text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
+                    className="w-9 h-9 shrink-0 flex items-center justify-center rounded-lg text-subtle/60 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 hover:text-danger hover:bg-danger/10 transition-[color,background-color,opacity]"
                     aria-label={`Видалити бесіду ${s.title}`}
                     title="Видалити"
                   >
-                    <Icon name="trash" size={13} />
+                    <Icon name="trash" size={14} />
                   </button>
                 </div>
               );


### PR DESCRIPTION
## What changed

Reworked the HubChat conversations drawer (`apps/web/src/core/hub/HubChatHistoryDrawer.tsx`) so it always renders as a viewport-level, full-height left side sheet instead of being clipped to the parent chat sheet.

- Container moved from `absolute inset-0 z-10` (constrained by the chat bottom sheet) to `fixed inset-0 z-[60] safe-area-pt-pb` (viewport-level overlay)
- Panel widened from `w-[78%] max-w-xs` to `w-[85%] max-w-sm` and now uses `h-full`; dropped the rounded-right corners since the drawer reaches both edges
- Header gets a sparkle glyph for visual continuity with the chat header; close button bumped to a 36x36 hit target
- Нова бесіда CTA reworked from a filled brand pill to a dashed-border button so it stops competing with the active-session highlight
- Empty state now has an icon medallion above the Поки немає інших бесід. copy
- Trash button promoted to a 36x36 hit target

## Why

The user reported the conversations modal looks ugly on mobile. The root cause: `HubChatHistoryDrawer` used `absolute inset-0`, so its height tracked the parent `<HubChat>` panel — which is a content-sized bottom sheet (`mt-auto … max-h-[92dvh]`). When the chat had few/no messages the parent sheet was short, so the drawer collapsed into a stubby card pinned to the bottom-left of the viewport.

Switching to `fixed inset-0` decouples the drawer from the chat sheet height and matches the existing `ModuleSettingsDrawer` pattern.

## How to test

1. Open the web app, launch HubChat.
2. Before sending any messages, tap the list icon in the chat header to open Бесіди.
3. Verify the drawer fills the full viewport height, anchored to the left, ~85% width on a phone.
4. Verify Нова бесіда looks like a dashed-border secondary CTA.
5. Tap the close (X), the scrim, or press Escape — drawer dismisses.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web typecheck` passes
- [x] `pnpm --filter @sergeant/web lint` passes
- [x] `pnpm prettier --check apps/web/src/core/hub/HubChatHistoryDrawer.tsx` passes
- [ ] Manual smoke not yet run.
- [x] No new AI-DANGER markers added.
- [x] Tailwind opacity steps used are on the registered scale.

## AGENTS.md updated?

- [x] No — pure visual refinement.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the HubChat conversations drawer into a full-height, viewport-level left side sheet for a consistent mobile experience. Polished the header, actions, and empty state with larger, easier-to-tap controls.

- **Bug Fixes**
  - Switched the drawer container to a fixed overlay (`fixed inset-0 z-[60] safe-area-pt-pb`) so it no longer collapses with the chat bottom sheet on short chats.

- **New Features**
  - Wider panel (`w-[85%] max-w-sm h-full`) with a stronger scrim for focus.
  - Branded header with a sparkle icon; close button increased to 36×36.
  - "Нова бесіда" is now a full-width, dashed-border secondary button.
  - Empty state includes an icon medallion; delete button hit target increased to 36×36.

<sup>Written for commit 6de705d78935d47f718b9ddd9db880923ef604c4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1037?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated drawer UI with improved positioning, z-index layering, and enhanced backdrop styling.
  * Redesigned header layout with new icon styling and improved sizing controls.
  * Refreshed action button with full-width dashed border design.
  * Enhanced empty state presentation with improved visual spacing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->