### PR TITLE
fix(migrations): renumber duplicate 009 mono_mcc_categorization to 010

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -461,7 +461,6 @@
 - [istanbul-lib-instrument@5.2.1](https://istanbul.js.org/) - BSD-3-Clause
 - [jackspeak@3.4.3](https://github.com/isaacs/jackspeak#readme) - BlueOak-1.0.0
 - [jimp-compact@0.16.1](https://github.com/nuxt-community/jimp-compact#readme) - MIT
-- [jiti@1.21.7](https://github.com/unjs/jiti#readme) - MIT
 - [jiti@2.6.1](https://github.com/unjs/jiti#readme) - MIT
 - [join-component@1.1.0](undefined) - MIT
 - [jose@6.2.2](https://github.com/panva/jose) - MIT

--- a/apps/server/src/migrations/010_mono_mcc_categorization.down.sql
+++ b/apps/server/src/migrations/010_mono_mcc_categorization.down.sql
@@ -1,4 +1,4 @@
--- Rollback for 009_mono_mcc_categorization.sql. DEV-only — production never
+-- Rollback for 010_mono_mcc_categorization.sql. DEV-only — production never
 -- runs `down.sql` (див. AGENTS.md rule #4 / docs/database.md). Видаляє індекс
 -- і обидві колонки. Користувацькі override-категорії втрачаються —
 -- забекапь їх перед rollback-ом, якщо це не локальна БД.

--- a/apps/server/src/migrations/010_mono_mcc_categorization.sql
+++ b/apps/server/src/migrations/010_mono_mcc_categorization.sql
@@ -16,7 +16,7 @@
 -- етапі це всі рядки, але умова страхує повторне виконання після
 -- `down`/`up` циклу в dev).
 --
--- Ідемпотентно (`IF NOT EXISTS`). Rollback — `009_mono_mcc_categorization.down.sql`.
+-- Ідемпотентно (`IF NOT EXISTS`). Rollback — `010_mono_mcc_categorization.down.sql`.
 
 ALTER TABLE mono_transaction
   ADD COLUMN IF NOT EXISTS category_slug TEXT,

--- a/docs/integrations/monobank-roadmap.md
+++ b/docs/integrations/monobank-roadmap.md
@@ -14,7 +14,7 @@
 | ----- | ------------------------------------ | --------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **A** | Cleanup legacy polling               | (невидимий)           | низька     | низький  | ⏳ pending — `useMonobankLegacy()` живий у `apps/web/src/modules/finyk/hooks/useMonobank.ts:171`; `useFlag("mono_webhook")` все ще викликається у `FinykApp.tsx:45` і `useMonobank.ts:161`.                                                                                                                       |
 | **B** | Backfill UX (Діагностика + progress) | плюс                  | низька     | низький  | ⏳ pending — `apps/server/src/modules/mono/backfill.ts` без progress-DTO; блок «🔧 Діагностика» у `FinykSection.tsx` не доданий.                                                                                                                                                                                  |
-| **C** | Auto-categorization по MCC           | плюс плюс             | середня    | середній | ⏳ pending — `apps/server/src/modules/mono/mccCategories.ts` не існує; міграція `009_mono_mcc_categorization.sql` не створена.                                                                                                                                                                                    |
+| **C** | Auto-categorization по MCC           | плюс плюс             | середня    | середній | ⏳ pending — `apps/server/src/modules/mono/mccCategories.ts` не існує; міграція `010_mono_mcc_categorization.sql` не створена.                                                                                                                                                                                    |
 | **D** | Push-нотифікації                     | плюс плюс плюс        | висока     | середній | ✅ done — `apps/server/src/modules/mono/webhook.ts` після UPSERT викликає `void sendToUserQuietly(userId, payload, { module: "mono" })` з `RETURNING (xmax = 0) AS inserted` для де-дупу retry-доставок. Покриття: `webhook.test.ts` — 4 нові кейси (insert→push, update→no-push, hold-marker, idempotent retry). |
 | **E** | Webhook secret rotation              | (захист)              | низька     | низький  | ⏳ pending — `webhook.ts` робить lookup `WHERE webhook_secret = $1` без версіонування / rotation flow.                                                                                                                                                                                                            |
 
@@ -177,7 +177,7 @@ END)
 WHERE category_overridden = FALSE AND category_slug IS NULL;
 ```
 
-Запустити як SQL-міграцію `009_mono_mcc_categorization.sql`.
+Запустити як SQL-міграцію `010_mono_mcc_categorization.sql`.
 
 ### Edge cases
 


### PR DESCRIPTION
## What changed

- Renamed `apps/server/src/migrations/009_mono_mcc_categorization.sql` (and its `.down.sql`) → `010_*.sql`. Updated the inline `Rollback — …` note inside both files and the single doc reference (`docs/integrations/monobank-roadmap.md` lines 17 & 180).
- Regenerated `THIRD_PARTY_LICENSES.md` via `pnpm licenses:gen` — drops the stale `jiti@1.21.7` entry (the dep graph now ships only `jiti@2.6.1`).

## Why

Two PRs both shipped a migration numbered `009` and landed on main back-to-back:

- #1029 (phase 0 monetization rails, merged 2026-04-28 03:27 +0300) → `009_waitlist.sql`
- #1033 (mono MCC auto-categorization, merged 2026-04-28 10:55 +0300) → `009_mono_mcc_categorization.sql`

`pnpm db:migrate` applies migrations by lexicographic filename order, so the duplicate is silently tolerated at runtime, but it violates **AGENTS.md rule #4** (sequential, no gaps, no duplicates) and the **`Migration lint (AGENTS rule #4)`** CI job has been failing on every PR since the second 009 landed (e.g. #1038).

The **`License policy check`** CI job has likewise been failing on main since `jiti@1.21.7` was dropped from the lockfile but `THIRD_PARTY_LICENSES.md` was never regenerated. Folded into this same PR because both are pre-existing CI failures on `main` that block every downstream PR's required-checks gate.

#1029 (waitlist) merged first, so it keeps `009`; the later #1033 (mono_mcc_categorization) is renumbered to `010`.

## How to test

1. `node scripts/lint-migrations.mjs` → `✅ Migration lint passed.`
2. `pnpm exec node scripts/generate-licenses.mjs check` → `License policy check OK: 930 shipped packages …`
3. Inspect `apps/server/src/migrations/` — sequence is now `001 … 008, 009_waitlist, 010_mono_mcc_categorization`, no duplicates, no gaps.
4. Open the renamed `.sql` and `.down.sql` and confirm the inline rollback note references `010_mono_mcc_categorization.down.sql` (not the stale `009_…`).

### Production safety on rename

Railway's pre-deploy migration runner records applied migrations in `schema_migrations` keyed by filename, so renaming a file the runner has already applied makes it attempt to re-apply it under the new name. Mitigated here because the migration is **fully idempotent** — every `ADD COLUMN` and `CREATE INDEX` uses `IF NOT EXISTS`, and the backfill `UPDATE` is gated on `category_overridden = FALSE AND category_slug IS NULL`, so re-running on an environment where 009 was already applied is a no-op. The `.down.sql` is dev-only (production never runs `down.sql`) and unaffected by the rename. No data loss, no downtime.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): ran `node scripts/lint-migrations.mjs` (green), `pnpm exec node scripts/generate-licenses.mjs check` (green) locally on the branch.
- [x] Vitest passes: no test changes, scope is migrations + SBOM only. `pnpm --filter @sergeant/server test --run modules/waitlist` confirms unrelated waitlist tests still reference `009_waitlist.sql` and remain green.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (the single roadmap line touched stays Ukrainian).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — this PR enforces an existing rule (#4 — sequential migration numbering), no new permanent rules.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered the duplicate migration `009_mono_mcc_categorization` to `010` to restore sequential order and fix the migration lint. Regenerated `THIRD_PARTY_LICENSES.md` to remove stale `jiti@1.21.7`, unblocking the license policy check.

- **Bug Fixes**
  - Renamed to `apps/server/src/migrations/010_mono_mcc_categorization.sql` and `.down.sql`; updated inline rollback notes and the doc references in `docs/integrations/monobank-roadmap.md`.
  - Safe to deploy: the migration uses `IF NOT EXISTS` and gated updates, so re-run after rename is a no-op.

- **Dependencies**
  - Ran `pnpm licenses:gen`; SBOM now reflects only `jiti@2.6.1` (removed `jiti@1.21.7`).

<sup>Written for commit 32e3bed95b6472c115f2ba289a62a87551c02b3d. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1039?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete dependency from license records
  * Corrected migration documentation and script references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->