### PR TITLE
feat(web): polish finyk Assets page — typed mono card chips, empty states, row unification

### DIFF
--- a/apps/web/src/modules/finyk/components/DebtCard.tsx
+++ b/apps/web/src/modules/finyk/components/DebtCard.tsx
@@ -58,7 +58,8 @@ function DebtCardComponent({
     <div className="bg-panel border border-line rounded-xl p-4 mb-3">
       <div className="flex items-start justify-between mb-3">
         <span className="text-sm font-semibold leading-snug">
-          {emoji} {name}
+          {emoji ? `${emoji} ` : ""}
+          {name}
         </span>
         <div className="flex items-center gap-2 shrink-0 ml-2">
           <span

--- a/apps/web/src/modules/finyk/lib/accountVisual.ts
+++ b/apps/web/src/modules/finyk/lib/accountVisual.ts
@@ -1,0 +1,107 @@
+import type { IconName } from "@shared/components/ui/Icon";
+import type { MonoAccount } from "@sergeant/finyk-domain/lib/accounts";
+
+/**
+ * Derive the visual treatment for a Monobank account: an icon glyph, a tone
+ * class set for the chip (surface + icon colour), and a clean human label
+ * without the leading emoji that `getAccountLabel` prepends.
+ *
+ * Keeping this on the web side (rather than in `@sergeant/finyk-domain`) is
+ * intentional — `tone` is Tailwind-only and would leak design-token coupling
+ * into a platform-agnostic package. The domain helper `getAccountLabel` still
+ * remains the source of truth for the text label.
+ */
+
+interface AccountLike {
+  type?: string;
+  creditLimit?: number;
+}
+
+export interface AccountVisual {
+  iconName: IconName;
+  /** Tailwind classes for the chip surface + icon colour. Uses design tokens only. */
+  tone: string;
+  /** Label without the leading emoji (e.g. "Біла картка" instead of "⬜ Біла картка"). */
+  name: string;
+}
+
+const TONE_NEUTRAL =
+  "bg-surface-muted text-muted dark:bg-surface-muted dark:text-muted";
+const TONE_BLACK = "bg-text text-bg dark:bg-text dark:text-bg";
+const TONE_WHITE =
+  "bg-bg text-text border border-line dark:bg-panel dark:text-text dark:border-line";
+const TONE_CREDIT =
+  "bg-warning-soft text-warning-strong dark:bg-warning/15 dark:text-warning";
+const TONE_PLATINUM =
+  "bg-info-soft text-info-strong dark:bg-info/15 dark:text-info";
+const TONE_IRON = "bg-panelHi text-muted dark:bg-panelHi dark:text-muted";
+const TONE_FOP =
+  "bg-finyk/10 text-finyk-strong dark:bg-finyk/15 dark:text-finyk";
+const TONE_EAID =
+  "bg-info-soft text-info-strong dark:bg-info/15 dark:text-info";
+
+const LABEL_BY_TYPE: Record<string, string> = {
+  eAid: "Єпідтримка",
+  black: "Чорна картка",
+  white: "Біла картка",
+  platinum: "Платинова",
+  iron: "Залізна",
+  fop: "ФОП",
+};
+
+export function getAccountVisual(acc: AccountLike): AccountVisual {
+  const isCredit = (acc.creditLimit ?? 0) > 0;
+
+  if (acc.type === "eAid") {
+    return { iconName: "hand-coins", tone: TONE_EAID, name: "Єпідтримка" };
+  }
+  if (isCredit && acc.type === "black") {
+    return {
+      iconName: "credit-card",
+      tone: TONE_CREDIT,
+      name: "Кредитна картка",
+    };
+  }
+  if (isCredit) {
+    return { iconName: "credit-card", tone: TONE_CREDIT, name: "Кредит" };
+  }
+  if (acc.type === "black") {
+    return {
+      iconName: "credit-card",
+      tone: TONE_BLACK,
+      name: LABEL_BY_TYPE.black,
+    };
+  }
+  if (acc.type === "white") {
+    return {
+      iconName: "credit-card",
+      tone: TONE_WHITE,
+      name: LABEL_BY_TYPE.white,
+    };
+  }
+  if (acc.type === "platinum") {
+    return {
+      iconName: "credit-card",
+      tone: TONE_PLATINUM,
+      name: LABEL_BY_TYPE.platinum,
+    };
+  }
+  if (acc.type === "iron") {
+    return {
+      iconName: "credit-card",
+      tone: TONE_IRON,
+      name: LABEL_BY_TYPE.iron,
+    };
+  }
+  if (acc.type === "fop") {
+    return { iconName: "archive", tone: TONE_FOP, name: LABEL_BY_TYPE.fop };
+  }
+  return { iconName: "credit-card", tone: TONE_NEUTRAL, name: "Картка" };
+}
+
+/**
+ * `MonoAccount` is the canonical type used by callers; re-export the narrow
+ * surface we actually touch so the helper can be called with a bare `type` +
+ * `creditLimit` pair in tests without requiring the full shape.
+ */
+export type AccountVisualInput = Pick<MonoAccount, "type" | "creditLimit">;

--- a/apps/web/src/modules/finyk/pages/AssetsTable.tsx
+++ b/apps/web/src/modules/finyk/pages/AssetsTable.tsx
@@ -4,7 +4,6 @@ import { RecurringSuggestions } from "../components/RecurringSuggestions";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Icon } from "@shared/components/ui/Icon";
 import {
-  getAccountLabel,
   getMonoDebt,
   getDebtPaid,
   getRecvPaid,
@@ -13,6 +12,7 @@ import {
   getDebtEffectiveTotal,
   getReceivableEffectiveTotal,
 } from "../utils";
+import { getAccountVisual } from "../lib/accountVisual";
 import { cn } from "@shared/lib/cn";
 import { openHubModule } from "@shared/lib/hubNav";
 import { useToast } from "@shared/hooks/useToast";
@@ -216,37 +216,48 @@ export function AssetsAssetsSection({ state }: { state: State }) {
       </SectionHeading>
       {accounts
         .filter((a) => !hiddenAccounts.includes(a.id))
-        .map((a, i) => (
-          <div
-            key={i}
-            className="flex items-center justify-between py-2.5 px-1 border-b border-line last:border-0"
-          >
-            <div className="flex items-center gap-3">
-              <span
-                className="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-surface-muted text-muted"
-                aria-hidden
-              >
-                <Icon name="credit-card" size={16} />
-              </span>
-              <div>
-                <div className="text-sm font-medium">{getAccountLabel(a)}</div>
-                <div className="text-xs text-subtle mt-0.5">
+        .map((a, i) => {
+          const visual = getAccountVisual(a);
+          const currencySymbol =
+            a.currencyCode === 980
+              ? "\u20B4"
+              : a.currencyCode === 840
+                ? "$"
+                : "\u20AC";
+          return (
+            <div
+              key={i}
+              className="flex items-center justify-between gap-3 rounded-xl border border-line bg-panel/60 p-3 hover:bg-panelHi transition-colors"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span
+                  className={cn(
+                    "inline-flex h-10 w-10 items-center justify-center rounded-xl shrink-0",
+                    visual.tone,
+                  )}
+                  aria-hidden
+                >
+                  <Icon name={visual.iconName} size={18} />
+                </span>
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold truncate">
+                    {visual.name}
+                  </div>
+                  <div className="text-[11px] text-subtle mt-0.5">Monobank</div>
+                </div>
+              </div>
+              <div className="text-right shrink-0">
+                <div className="text-sm font-bold tabular-nums text-text">
                   {showBalance
                     ? `${(a.balance / 100).toLocaleString("uk-UA", {
                         minimumFractionDigits: 2,
-                      })} ${
-                        a.currencyCode === 980
-                          ? "₴"
-                          : a.currencyCode === 840
-                            ? "$"
-                            : "€"
-                      }`
+                      })} ${currencySymbol}`
                     : "\u2022\u2022\u2022\u2022"}
                 </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
 
       <SectionHeading as="div" size="sm" className="pt-2">
         <span className="inline-flex items-center gap-1.5">
@@ -254,6 +265,12 @@ export function AssetsAssetsSection({ state }: { state: State }) {
           Мені винні
         </span>
       </SectionHeading>
+      {receivables.length === 0 && !showRecvForm && (
+        <p className="text-xs text-muted px-1">
+          Зберігайте облік боргів і дат повернення — прив&apos;язуйте вхідні
+          транзакції, щоб автоматично рахувати повернене.
+        </p>
+      )}
       {receivables.map((r) => (
         <DebtCard
           key={r.id}
@@ -299,6 +316,30 @@ export function AssetsAssetsSection({ state }: { state: State }) {
           Інші активи
         </span>
       </SectionHeading>
+      {manualAssets.length === 0 && !showAssetForm && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted px-1">
+            Готівка, заощадження, депозит, інвестиції, нерухомість, авто — усе,
+            що не на картці Monobank.
+          </p>
+          <div className="flex flex-wrap gap-1.5 px-1">
+            {[
+              "\uD83D\uDCB5 Готівка",
+              "\uD83C\uDFE6 Депозит",
+              "\uD83D\uDCC8 Інвестиції",
+              "\uD83C\uDFE0 Нерухомість",
+              "\uD83D\uDE97 Авто",
+            ].map((chip) => (
+              <span
+                key={chip}
+                className="inline-flex items-center text-[11px] text-muted bg-panelHi border border-line rounded-full px-2 py-0.5"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
       {showAssetForm ? (
         <AssetForm
           newAsset={newAsset}
@@ -319,21 +360,26 @@ export function AssetsAssetsSection({ state }: { state: State }) {
       {manualAssets.map((a, i) => (
         <div
           key={i}
-          className="flex items-center justify-between py-2.5 border-b border-text"
+          className="flex items-center justify-between gap-3 rounded-xl border border-line bg-panel/60 p-3 hover:bg-panelHi transition-colors"
         >
-          <div className="flex items-center gap-3">
-            <span className="text-xl leading-none">{a.emoji}</span>
-            <div>
-              <div className="text-sm font-medium">{a.name}</div>
-              <div className="text-xs text-subtle">{a.currency}</div>
+          <div className="flex items-center gap-3 min-w-0">
+            <span
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-panelHi text-xl leading-none shrink-0"
+              aria-hidden
+            >
+              {a.emoji}
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold truncate">{a.name}</div>
+              <div className="text-[11px] text-subtle mt-0.5">{a.currency}</div>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-bold text-success">
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-sm font-bold tabular-nums text-success">
               {showBalance
                 ? `${Number(a.amount).toLocaleString("uk-UA")} ${
                     a.currency === "UAH"
-                      ? "₴"
+                      ? "\u20B4"
                       : a.currency === "USD"
                         ? "$"
                         : a.currency
@@ -388,8 +434,35 @@ export function AssetsLiabilitiesSection({ state }: { state: State }) {
     showBalance,
   } = state;
 
+  const liabilitiesEmpty =
+    monoDebtAccounts.length === 0 && manualDebts.length === 0 && !showDebtForm;
+
   return (
     <div className="mb-3 space-y-0">
+      {liabilitiesEmpty && (
+        <div className="space-y-2 mb-3">
+          <p className="text-xs text-muted px-1">
+            Кредити, розстрочки, позики, комунальні борги — додавайте з датою
+            повернення, прив&apos;язуйте транзакції-платежі, і картка сама
+            покаже прогрес «Сплачено N з M».
+          </p>
+          <div className="flex flex-wrap gap-1.5 px-1">
+            {[
+              "\uD83D\uDCB3 Кредит",
+              "\uD83D\uDCC5 Розстрочка",
+              "\uD83E\uDD1D Позика",
+              "\uD83D\uDCA1 Комуналка",
+            ].map((chip) => (
+              <span
+                key={chip}
+                className="inline-flex items-center text-[11px] text-muted bg-panelHi border border-line rounded-full px-2 py-0.5"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
       {showDebtForm ? (
         <DebtForm
           newDebt={newDebt}
@@ -414,11 +487,12 @@ export function AssetsLiabilitiesSection({ state }: { state: State }) {
           .reduce((s, t) => s + Math.abs(t.amount / 100), 0);
         const remaining = getMonoDebt(a);
         const volatileTotal = paidFromLinked + remaining;
+        const visual = getAccountVisual(a);
         return (
           <DebtCard
             key={i}
-            name={getAccountLabel(a)}
-            emoji={"\u{1F5A4}"}
+            name={visual.name}
+            emoji={"\u{1F4B3}"}
             remaining={remaining}
             paid={paidFromLinked}
             total={volatileTotal}


### PR DESCRIPTION
## What changed

ФІНІК → вкладка **«Активи»** у мобільному вигляді виглядала «голо та сиро». PR полірує її у тому самому напрямі, що і попередні polish-PR-и (#1036 modules-polish, `feat(web): wrap fizruk workouts sections in cards`, `wrap onboarding goal questions in module-soft cards`):

1. **Картки Monobank**
   Раніше — бліді рядки з `border-b border-line` та єдиним візуальним маркером у вигляді емоджі-літери з `getAccountLabel`, включно з `⬜`, що на багатьох платформах рендериться як сірий квадратик. Відрізнити white / black / credit / fop / eAid на око майже неможливо.

   Тепер — `rounded-xl` рядки на `border-line bg-panel/60 hover:bg-panelHi transition-colors` з кольоровою плиткою-аватаром 40×40 за типом картки + ім'я без провідної емоджі + підлейбл «Monobank» та сума справа у `tabular-nums`.

2. **Новий хелпер `apps/web/src/modules/finyk/lib/accountVisual.ts`**
   Web-тільки `getAccountVisual(acc)` → `{ iconName, tone, name }`. Мапить `MonoAccount` на `Icon` (`credit-card` / `archive` / `hand-coins`), chip-tone на design-tokens (усі на дозволеній Tailwind-opacity шкалі з `AGENTS.md` rule #8) та текст без емоджі. Доменний `getAccountLabel` у `packages/finyk-domain` **не чіпаємо**.

3. **Фікс дубля `🖤 🖤 Кредитна картка` у секції Пасиви**
   `AssetsLiabilitiesSection` передавав `DebtCard` одночасно `name={getAccountLabel(a)}` (уже містить `🖤 `) і `emoji="🖤"`. Тепер `name={visual.name}` + `emoji="💳"` → просто «💳 Кредитна картка». `DebtCard` також коректно обробляє порожній `emoji=""`.

4. **Manual asset row (Інші активи)** — замість `border-b border-text` (важка темна лінія повз design tokens) той самий `rounded-xl border-line bg-panel/60 hover:bg-panelHi` шаблон, що і в Monobank-рядках.

5. **Empty states**
   - «Мені винні»: пояснювальний рядок про прив'язку вхідних транзакцій.
   - «Інші активи»: опис + chips (`💵 Готівка`, `🏦 Депозит`, `📈 Інвестиції`, `🏠 Нерухомість`, `🚗 Авто`).
   - «Пасиви»: опис + chips (`💳 Кредит`, `📅 Розстрочка`, `🤝 Позика`, `💡 Комуналка`).

Без змін логіки стану, селекторів тестів, API-контрактів, публічних сигнатур.

## Why

Продовження серії polish-PR-ів модулів. Користувач повідомив, що «активи якісь теж голі та сирі виглядають» у мобільному viewport через mobile-shell.

## How to test

1. ФІНІК → таб **Активи** → блок **«Картки Monobank»** рендериться як rounded-xl картки з кольоровими chip-аватарами per type, hover додає `bg-panelHi`.
2. Розгорнути **Пасиви** з Monobank-кредиткою → без дубль-серця.
3. Сценарій порожнього стану → pretty empty states у всіх трьох секціях.
4. Ручний актив рендериться у тому самому rounded-xl шаблоні, без темної `border-b` лінії.
5. Dark mode — tone-класи мають `dark:` варіанти.

---

## How AI-tested this PR

- [x] Manual smoke: надішлю скріншоти у коментарі після локальної перевірки в браузері (mobile viewport).
- [x] Vitest passes: `pnpm --filter @sergeant/web test` → **1381 passed / 1381**; фокусні `AssetsTable`, `AssetsForm`, `useAssetsState` → 21/21.
- [x] Typecheck passes: `pnpm --filter @sergeant/web typecheck` (усі 4 tsconfig-и).
- [x] Lint passes: `pnpm --filter @sergeant/web lint` — після фіксу eyebrow-drift-правила на підлейблах.
- [x] No new `AI-DANGER` markers.
- [x] Docs prose — українською.

## AGENTS.md updated?

- [x] No — no new permanent rules (це чистий UI polish без зміни інваріантів).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Finyk Assets page: Monobank accounts are now clear, color‑coded cards with readable labels, plus useful empty states and unified row styles. Also fixes the duplicate emoji in liabilities; no state or API changes.

- **New Features**
  - Monobank accounts render as rounded cards with a 40×40 colored chip by type, clean label (no leading emoji), “Monobank” sublabel, and tabular-nums amount.
  - Added web-only `getAccountVisual(acc)` → `{ iconName, tone, name }`; domain `getAccountLabel` in `@sergeant/finyk-domain` stays unchanged.
  - Manual asset rows use the same rounded card template and hover as Monobank rows.
  - Empty states for Receivables, Manual assets, and Liabilities with short copy and hint chips.

- **Bug Fixes**
  - Removed duplicated emoji in Monobank credit liabilities by using `visual.name` and `💳`; `DebtCard` now tolerates empty `emoji` without a stray space.

<sup>Written for commit 49f7813778057997f2aa07a152c5d67a9551efff. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1040?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

