### PR TITLE
feat(shared,web,mobile): respect onboarding module picks on Hub dashboard

### DIFF
--- a/apps/mobile/src/core/dashboard/DraggableDashboard.tsx
+++ b/apps/mobile/src/core/dashboard/DraggableDashboard.tsx
@@ -109,6 +109,12 @@ export interface DraggableDashboardProps {
    * module.
    */
   previews?: DashboardModulePreviews;
+  /**
+   * Module ids that should render in the muted/greyed-out "inactive"
+   * state. Driven by the user's onboarding picks; rows not in this
+   * set render normally.
+   */
+  inactiveModules?: ReadonlySet<DashboardModuleId>;
   testID?: string;
 }
 
@@ -121,6 +127,7 @@ interface DraggableRowProps {
   onLayoutHeight: (index: number, height: number) => void;
   reduceMotionRef: React.MutableRefObject<boolean>;
   preview?: ModulePreview | null;
+  inactive?: boolean;
   testID?: string;
 }
 
@@ -133,6 +140,7 @@ const DraggableRow = memo(function DraggableRow({
   onLayoutHeight,
   reduceMotionRef,
   preview,
+  inactive,
   testID,
 }: DraggableRowProps) {
   const translationY = useSharedValue(0);
@@ -201,6 +209,7 @@ const DraggableRow = memo(function DraggableRow({
           id={id}
           onPress={onOpenModule}
           preview={preview}
+          inactive={inactive}
           testID={testID ? `${testID}-${id}` : undefined}
         />
       </Animated.View>
@@ -213,6 +222,7 @@ export function DraggableDashboard({
   onReorder,
   onOpenModule,
   previews,
+  inactiveModules,
   testID,
 }: DraggableDashboardProps) {
   const orderRef = useRef<DashboardModuleId[]>([...modules]);
@@ -289,6 +299,7 @@ export function DraggableDashboard({
           onLayoutHeight={handleLayoutHeight}
           reduceMotionRef={reduceMotionRef}
           preview={previews?.[id] ?? null}
+          inactive={inactiveModules?.has(id) ?? false}
           testID={testID ?? "dashboard-module-row"}
         />
       ))}

--- a/apps/mobile/src/core/dashboard/HubDashboard.tsx
+++ b/apps/mobile/src/core/dashboard/HubDashboard.tsx
@@ -36,15 +36,22 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useUser } from "@sergeant/api-client/react";
 import {
+  getActiveModules,
+  getHideInactiveModules,
+  isActiveModule,
   isFirstActionPending,
   isFirstRealEntryDone,
   isSoftAuthDismissed,
+  setHideInactiveModules,
   type DashboardModuleId,
   type KVStore,
 } from "@sergeant/shared";
 
 import { DraggableDashboard } from "./DraggableDashboard";
-import { DASHBOARD_MODULE_ROUTES } from "./dashboardModuleConfig";
+import {
+  DASHBOARD_MODULE_ROUTES,
+  VISIBLE_DASHBOARD_MODULES,
+} from "./dashboardModuleConfig";
 import { FirstActionHeroCard } from "./FirstActionHeroCard";
 import { HubInsightsPanel, type InsightItem } from "./HubInsightsPanel";
 import { SoftAuthPromptCard } from "./SoftAuthPromptCard";
@@ -121,9 +128,51 @@ export function HubDashboard() {
     enabled: signedIn,
   });
 
-  const { visibleOrder, reorderVisible } = useDashboardOrder();
+  // Active vs. inactive modules — driven by the user's onboarding
+  // "vibe picks". Inactive modules render greyed-out (or hidden when
+  // the user has flipped the `hideInactive` toggle below). Computed
+  // before `useDashboardOrder` so the visibility filter can drop
+  // inactive ids when the toggle is on.
+  const activeModules = useMemo(() => getActiveModules(mmkvStore), []);
+  const [hideInactive, setHideInactive] = useState(() =>
+    getHideInactiveModules(mmkvStore),
+  );
+  const toggleHideInactive = useCallback(() => {
+    setHideInactive((prev) => {
+      const next = !prev;
+      setHideInactiveModules(mmkvStore, next);
+      return next;
+    });
+  }, []);
+  const dashboardVisibleIds = useMemo(
+    () =>
+      hideInactive
+        ? VISIBLE_DASHBOARD_MODULES.filter((id) =>
+            isActiveModule(activeModules, id),
+          )
+        : VISIBLE_DASHBOARD_MODULES,
+    [hideInactive, activeModules],
+  );
+
+  const { visibleOrder, reorderVisible } =
+    useDashboardOrder(dashboardVisibleIds);
   const { focus, rest, dismiss: dismissFocus } = useDashboardFocus();
   const previews = useModulePreviews();
+
+  const inactiveModuleSet = useMemo(
+    () =>
+      new Set<DashboardModuleId>(
+        visibleOrder.filter((id) => !isActiveModule(activeModules, id)),
+      ),
+    [visibleOrder, activeModules],
+  );
+  const hasInactive = useMemo(
+    () =>
+      VISIBLE_DASHBOARD_MODULES.some(
+        (id) => !isActiveModule(activeModules, id),
+      ),
+    [activeModules],
+  );
 
   const runDigest = useCallback(() => {
     void generate();
@@ -269,7 +318,27 @@ export function HubDashboard() {
             onReorder={reorderVisible}
             onOpenModule={openModule}
             previews={previews}
+            inactiveModules={inactiveModuleSet}
           />
+          {hasInactive ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                hideInactive
+                  ? "Показати неактивні модулі"
+                  : "Приховати неактивні модулі"
+              }
+              onPress={toggleHideInactive}
+              className="mt-1 self-center px-2 py-1 active:opacity-70"
+              testID="dashboard-toggle-hide-inactive"
+            >
+              <Text className="text-[11px] text-fg-muted underline">
+                {hideInactive
+                  ? "Показати неактивні модулі"
+                  : "Приховати неактивні модулі"}
+              </Text>
+            </Pressable>
+          ) : null}
           <Text className="mt-1 text-[11px] leading-snug text-fg-subtle">
             Утримай і потягни, щоб змінити порядок модулів. Порядок
             синхронізується з вебом.

--- a/apps/mobile/src/core/dashboard/StatusRow.tsx
+++ b/apps/mobile/src/core/dashboard/StatusRow.tsx
@@ -39,6 +39,12 @@ export interface StatusRowProps {
    * gaps.
    */
   preview?: ModulePreview | null;
+  /**
+   * When `true`, the row is rendered in a muted/greyed-out state and
+   * the preview block is replaced by a hint pointing the user at Hub
+   * Settings. Driven by the user's onboarding "vibe picks".
+   */
+  inactive?: boolean;
 }
 
 /** Clamp a loose percentage to the [0, 100] bounds used by the bar. */
@@ -62,35 +68,58 @@ export const StatusRow = memo(function StatusRow({
   disabled,
   testID,
   preview,
+  inactive,
 }: StatusRowProps) {
   const config = DASHBOARD_MODULE_RENDER[id];
-  const showPreview = hasPreviewContent(preview);
+  const showPreview = !inactive && hasPreviewContent(preview);
   const showProgress = showPreview && typeof preview?.progress === "number";
 
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`${config.label}: ${config.description}`}
+      accessibilityLabel={
+        inactive
+          ? `${config.label} — неактивний. Увімкнути в налаштуваннях.`
+          : `${config.label}: ${config.description}`
+      }
       accessibilityHint="Двічі торкнись, щоб відкрити модуль. Утримай і потягни, щоб змінити порядок."
       accessibilityState={{ disabled: Boolean(disabled) }}
       onPress={() => onPress?.(id)}
       disabled={disabled}
       testID={testID ?? `dashboard-row-${id}`}
-      className="flex-row items-stretch overflow-hidden rounded-2xl border border-cream-300 bg-cream-50 active:opacity-80"
+      className={`flex-row items-stretch overflow-hidden rounded-2xl border border-cream-300 bg-cream-50 active:opacity-80 ${
+        inactive ? "opacity-60" : ""
+      }`}
     >
-      <View className={`w-1.5 ${config.accentClass}`} />
+      <View
+        className={`w-1.5 ${inactive ? "bg-cream-300" : config.accentClass}`}
+      />
       <View className="flex-1 flex-row items-center gap-3 px-3 py-3">
         <View
-          className={`h-11 w-11 items-center justify-center rounded-xl ${config.iconBgClass}`}
+          className={`h-11 w-11 items-center justify-center rounded-xl ${
+            inactive ? "bg-cream-100" : config.iconBgClass
+          }`}
         >
           <Text className="text-xl">{config.glyph}</Text>
         </View>
         <View className="flex-1">
-          <Text className="text-base font-semibold text-fg" numberOfLines={1}>
+          <Text
+            className={`text-base font-semibold ${
+              inactive ? "text-fg-muted" : "text-fg"
+            }`}
+            numberOfLines={1}
+          >
             {config.label}
           </Text>
-          <Text className="text-xs text-fg-muted" numberOfLines={1}>
-            {config.description}
+          <Text
+            className={`text-xs ${
+              inactive ? "text-fg-subtle" : "text-fg-muted"
+            }`}
+            numberOfLines={1}
+          >
+            {inactive
+              ? "Неактивний — увімкнути в налаштуваннях"
+              : config.description}
           </Text>
           {showProgress ? (
             <View

--- a/apps/mobile/src/core/settings/GeneralSection.test.tsx
+++ b/apps/mobile/src/core/settings/GeneralSection.test.tsx
@@ -72,7 +72,7 @@ describe("GeneralSection", () => {
   });
 
   it("expands to reveal active toggles, dashboard reorder list, and deferred sub-group notices", () => {
-    const { getByText, getByTestId } = render(<GeneralSection />);
+    const { getByText, getAllByText, getByTestId } = render(<GeneralSection />);
 
     fireEvent.press(getByText("Загальні"));
 
@@ -80,17 +80,20 @@ describe("GeneralSection", () => {
     expect(getByText("Показувати AI-коуч")).toBeTruthy();
 
     expect(getByText("Дашборд")).toBeTruthy();
+    expect(getByText("Активні модулі")).toBeTruthy();
     expect(getByText("Упорядкувати модулі")).toBeTruthy();
     expect(getByText("Хмарна синхронізація")).toBeTruthy();
     expect(getByText("Резервна копія Hub")).toBeTruthy();
 
-    // Dashboard reorder list renders the three visible module labels
-    // (Nutrition is hidden until Phase 7) and the ↑/↓ controls.
-    expect(getByText("Фінік")).toBeTruthy();
-    expect(getByText("Фізрук")).toBeTruthy();
-    expect(getByText("Рутина")).toBeTruthy();
+    // Module labels render in both "Active modules" and the reorder
+    // list, so they appear at least twice (Nutrition only in active).
+    expect(getAllByText("Фінік").length).toBeGreaterThanOrEqual(2);
+    expect(getAllByText("Фізрук").length).toBeGreaterThanOrEqual(2);
+    expect(getAllByText("Рутина").length).toBeGreaterThanOrEqual(2);
     expect(getByTestId("dashboard-reorder-down-finyk")).toBeTruthy();
     expect(getByTestId("dashboard-reorder-up-routine")).toBeTruthy();
+    expect(getByTestId("general-active-module-finyk")).toBeTruthy();
+    expect(getByTestId("general-hide-inactive-toggle")).toBeTruthy();
   });
 
   it("rewrites the dashboard order when the reorder ▼ button is pressed", () => {

--- a/apps/mobile/src/core/settings/GeneralSection.tsx
+++ b/apps/mobile/src/core/settings/GeneralSection.tsx
@@ -46,11 +46,17 @@
 import { useState } from "react";
 import { DeviceEventEmitter, Pressable, Text, View } from "react-native";
 import {
+  ALL_MODULES,
   DASHBOARD_MODULE_LABELS,
   downloadJson,
+  getActiveModules,
+  getHideInactiveModules,
   pickJson,
   resetOnboardingState,
+  setActiveModules,
+  setHideInactiveModules,
   STORAGE_KEYS,
+  type DashboardModuleId,
   type KVStore,
 } from "@sergeant/shared";
 
@@ -193,6 +199,31 @@ export function GeneralSection() {
   const dark = prefs.darkMode === true;
   const showHints = prefs.showHints !== false;
 
+  const [activeModules, setActiveModulesState] = useState<DashboardModuleId[]>(
+    () => getActiveModules(mmkvStore),
+  );
+  const [hideInactive, setHideInactiveState] = useState(() =>
+    getHideInactiveModules(mmkvStore),
+  );
+  const toggleActive = (id: DashboardModuleId) => {
+    setActiveModulesState((prev) => {
+      const isActive = prev.includes(id);
+      if (isActive && prev.length === 1) {
+        toast.error("Щонайменше один модуль має бути активним");
+        return prev;
+      }
+      const next = isActive
+        ? prev.filter((x) => x !== id)
+        : ALL_MODULES.filter((x) => prev.includes(x) || x === id);
+      setActiveModules(mmkvStore, next);
+      return next;
+    });
+  };
+  const toggleHideInactive = (next: boolean) => {
+    setHideInactiveState(next);
+    setHideInactiveModules(mmkvStore, next);
+  };
+
   const handleExport = async () => {
     try {
       const payload = buildHubBackupPayload();
@@ -265,6 +296,51 @@ export function GeneralSection() {
         >
           Перезапустити онбординг
         </Button>
+      </SettingsSubGroup>
+      <SettingsSubGroup title="Активні модулі">
+        <Text className="text-xs text-fg-muted leading-snug">
+          Неактивні модулі відображаються на дашборді приглушено — без кнопки
+          швидкого додавання. Чонайменше один модуль має залишатися активним.
+        </Text>
+        <View className="overflow-hidden rounded-xl border border-cream-300">
+          {ALL_MODULES.map((id, index) => {
+            const checked = activeModules.includes(id);
+            const label = DASHBOARD_MODULE_LABELS[id];
+            return (
+              <Pressable
+                key={id}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked }}
+                accessibilityLabel={label}
+                onPress={() => toggleActive(id)}
+                className={`flex-row items-center gap-3 bg-cream-50 px-3 py-3 active:bg-cream-100 ${
+                  index === 0 ? "" : "border-t border-cream-300"
+                }`}
+                testID={`general-active-module-${id}`}
+              >
+                <View
+                  className={`h-5 w-5 items-center justify-center rounded border ${
+                    checked
+                      ? "border-primary bg-primary"
+                      : "border-cream-300 bg-cream-50"
+                  }`}
+                >
+                  {checked ? (
+                    <Text className="text-[11px] font-bold text-bg">✓</Text>
+                  ) : null}
+                </View>
+                <Text className="flex-1 text-sm text-fg">{label}</Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <ToggleRow
+          label="Приховати неактивні модулі"
+          description="Повністю ховає неактивні плитки з дашборду."
+          checked={hideInactive}
+          onChange={toggleHideInactive}
+          testID="general-hide-inactive-toggle"
+        />
       </SettingsSubGroup>
       <SettingsSubGroup title="Упорядкувати модулі">
         <ModuleReorderList />

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -2,9 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import {
   countRealEntries,
+  getActiveModules,
   getActiveNudge,
+  getHideInactiveModules,
   getVibePicks,
+  isActiveModule,
   recordLastActiveDate,
+  setHideInactiveModules,
   shouldShowReengagement,
   type User,
 } from "@sergeant/shared";
@@ -119,6 +123,32 @@ export function HubDashboard({
     });
   }, [sessionDays, nudgeDismissed]);
 
+  // Active vs. inactive modules — driven by the user's onboarding
+  // "vibe picks". Inactive modules render greyed-out (or hidden when
+  // the user has flipped the `hideInactive` toggle below).
+  const activeModules = useMemo(() => getActiveModules(localStorageStore), []);
+  const [hideInactive, setHideInactive] = useState(() =>
+    getHideInactiveModules(localStorageStore),
+  );
+  const toggleHideInactive = useCallback(() => {
+    setHideInactive((prev) => {
+      const next = !prev;
+      setHideInactiveModules(localStorageStore, next);
+      return next;
+    });
+  }, []);
+  const hasInactive = useMemo(
+    () => order.some((id) => !isActiveModule(activeModules, id)),
+    [order, activeModules],
+  );
+  const visibleOrder = useMemo(
+    () =>
+      hideInactive
+        ? order.filter((id) => isActiveModule(activeModules, id))
+        : order,
+    [order, activeModules, hideInactive],
+  );
+
   const { focus, rest, dismiss } = useDashboardFocus();
 
   // Insights з deep-link (`actionHash`) повинні відкрити модуль рівно
@@ -161,7 +191,12 @@ export function HubDashboard({
   const quickAddByModule = useMemo(() => {
     const map: Record<string, { label: string; run: () => void } | undefined> =
       {};
+    const activeSet = new Set<string>(activeModules);
     for (const id of modulesWithSignal) {
+      // Suppress quick-add for inactive modules — the BentoCard
+      // already hides the affordance, but skipping here keeps the
+      // registry tidy and avoids accidental wiring downstream.
+      if (!activeSet.has(id)) continue;
       const quick = getModulePrimaryAction(id);
       if (!quick) continue;
       map[id] = {
@@ -174,7 +209,7 @@ export function HubDashboard({
       };
     }
     return map;
-  }, [modulesWithSignal]);
+  }, [modulesWithSignal, activeModules]);
 
   const handleDragEnd = useCallback(
     (event: {
@@ -287,19 +322,35 @@ export function HubDashboard({
             collisionDetection={closestCenter}
             onDragEnd={handleDragEnd}
           >
-            <SortableContext items={order} strategy={rectSortingStrategy}>
+            <SortableContext
+              items={visibleOrder}
+              strategy={rectSortingStrategy}
+            >
               <div className="grid grid-cols-2 gap-3">
-                {order.map((id) => (
+                {visibleOrder.map((id) => (
                   <SortableCard
                     key={id}
                     id={id as ModuleId}
                     onOpenModule={onOpenModule}
                     quickAdd={quickAddByModule[id] || null}
+                    inactive={!isActiveModule(activeModules, id)}
                   />
                 ))}
               </div>
             </SortableContext>
           </DndContext>
+
+          {hasInactive && (
+            <button
+              type="button"
+              onClick={toggleHideInactive}
+              className="mx-auto mt-2 block text-2xs text-muted underline-offset-2 hover:text-text hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            >
+              {hideInactive
+                ? "Показати неактивні модулі"
+                : "Приховати неактивні модулі"}
+            </button>
+          )}
         </section>
       </StaggerChild>
 

--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -23,6 +23,13 @@ export interface BentoCardProps {
   primaryRef?: (node: HTMLButtonElement | null) => void;
   primaryProps?: Record<string, unknown>;
   isDragging?: boolean;
+  /**
+   * When `true`, the card is rendered in a muted/greyed-out state
+   * because the user did not mark this module as important during
+   * onboarding. Quick-add is suppressed and a hint pointing at Hub
+   * Settings is shown in place of the preview numbers.
+   */
+  inactive?: boolean;
 }
 
 /**
@@ -41,25 +48,45 @@ export const BentoCard = memo(function BentoCard({
   primaryRef,
   primaryProps,
   isDragging,
+  inactive,
 }: BentoCardProps) {
   const preview = config.getPreview();
   const showProgress =
-    config.hasGoal && preview.progress !== undefined && preview.progress > 0;
+    !inactive &&
+    config.hasGoal &&
+    preview.progress !== undefined &&
+    preview.progress > 0;
   const hasData = !!(preview.main || preview.sub);
+  // Inactive modules suppress quick-add to avoid implying parity with
+  // active modules — the user has to reactivate them in Hub Settings
+  // before a quick-add affordance reappears.
+  const showQuickAdd = !inactive && !!onQuickAdd;
 
   return (
-    <div className={cn("relative", isDragging && "opacity-70 z-50")}>
+    <div
+      className={cn(
+        "relative",
+        isDragging && "opacity-70 z-50",
+        inactive && "opacity-60",
+      )}
+    >
       <button
         ref={primaryRef}
         type="button"
         onClick={onClick}
         {...primaryProps}
+        aria-label={
+          inactive
+            ? `${config.label} — неактивний модуль. Увімкнути в налаштуваннях Hub.`
+            : undefined
+        }
+        data-inactive={inactive ? "true" : undefined}
         className={cn(
           "group relative flex flex-col w-full rounded-3xl border border-line p-3.5",
           "shadow-card transition-all duration-200 text-left",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
           "active:scale-[0.98]",
-          config.cardBg,
+          inactive ? "bg-panel grayscale" : config.cardBg,
           isDragging && "shadow-float cursor-grabbing",
         )}
       >
@@ -67,7 +94,7 @@ export const BentoCard = memo(function BentoCard({
           <div
             className={cn(
               "w-7 h-7 rounded-lg flex items-center justify-center shrink-0",
-              config.iconClass,
+              inactive ? "bg-line/40 text-muted" : config.iconClass,
             )}
           >
             {config.icon}
@@ -76,14 +103,23 @@ export const BentoCard = memo(function BentoCard({
           {/* Layout placeholder for the absolutely-positioned quick-add
               sibling — keeps the label centred consistently regardless of
               whether the module exposes a quick-add action. */}
-          {onQuickAdd && <span aria-hidden className="w-6 h-6 shrink-0" />}
+          {showQuickAdd && <span aria-hidden className="w-6 h-6 shrink-0" />}
         </div>
 
-        <span className="text-xs font-semibold text-text">
+        <span
+          className={cn(
+            "text-xs font-semibold",
+            inactive ? "text-muted" : "text-text",
+          )}
+        >
           {config.emoji} {config.label}
         </span>
 
-        {hasData ? (
+        {inactive ? (
+          <span className="text-2xs text-muted mt-1 leading-snug">
+            Неактивний — увімкнути в налаштуваннях
+          </span>
+        ) : hasData ? (
           <>
             {preview.main && (
               <span className="text-lg font-bold text-text tabular-nums mt-1 truncate">
@@ -116,7 +152,7 @@ export const BentoCard = memo(function BentoCard({
         )}
       </button>
 
-      {onQuickAdd && (
+      {showQuickAdd && onQuickAdd && (
         <button
           type="button"
           onClick={(e) => {
@@ -144,6 +180,7 @@ export interface SortableCardProps {
   id: ModuleId;
   onOpenModule: (id: ModuleId) => void;
   quickAdd?: { label: string; run: () => void } | null;
+  inactive?: boolean;
 }
 
 /**
@@ -155,6 +192,7 @@ export const SortableCard = memo(function SortableCard({
   id,
   onOpenModule,
   quickAdd,
+  inactive,
 }: SortableCardProps) {
   const {
     attributes,
@@ -198,6 +236,7 @@ export const SortableCard = memo(function SortableCard({
         primaryRef={setActivatorNodeRef}
         primaryProps={primaryProps}
         isDragging={isDragging}
+        inactive={inactive}
       />
     </div>
   );

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -1,9 +1,19 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
-import { resetOnboardingState, type KVStore } from "@sergeant/shared";
+import {
+  ALL_MODULES,
+  DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
+  getActiveModules,
+  getHideInactiveModules,
+  resetOnboardingState,
+  setActiveModules,
+  setHideInactiveModules,
+  type DashboardModuleId,
+  type KVStore,
+} from "@sergeant/shared";
 import { HubBackupPanel } from "../hub/HubBackupPanel";
 import {
   swClearCaches,
@@ -98,29 +108,64 @@ export function GeneralSection({
   const toast = useToast();
   const [swBusy, setSwBusy] = useState(false);
 
-  const localStorageStore: KVStore = {
-    getString(key) {
-      try {
-        return localStorage.getItem(key);
-      } catch {
-        return null;
-      }
+  const localStorageStore: KVStore = useMemo(
+    () => ({
+      getString(key) {
+        try {
+          return localStorage.getItem(key);
+        } catch {
+          return null;
+        }
+      },
+      setString(key, value) {
+        try {
+          localStorage.setItem(key, value);
+        } catch {
+          /* noop */
+        }
+      },
+      remove(key) {
+        try {
+          localStorage.removeItem(key);
+        } catch {
+          /* noop */
+        }
+      },
+    }),
+    [],
+  );
+  const [activeModules, setActiveModulesState] = useState<DashboardModuleId[]>(
+    () => getActiveModules(localStorageStore),
+  );
+  const [hideInactive, setHideInactiveState] = useState(() =>
+    getHideInactiveModules(localStorageStore),
+  );
+  const toggleActive = useCallback(
+    (id: DashboardModuleId) => {
+      setActiveModulesState((prev) => {
+        const isActive = prev.includes(id);
+        // Keep at least one module active so the dashboard never
+        // collapses to an empty grid.
+        if (isActive && prev.length === 1) {
+          toast.error("Щонайменше один модуль має бути активним");
+          return prev;
+        }
+        const next = isActive
+          ? prev.filter((x) => x !== id)
+          : ALL_MODULES.filter((x) => prev.includes(x) || x === id);
+        setActiveModules(localStorageStore, next);
+        return next;
+      });
     },
-    setString(key, value) {
-      try {
-        localStorage.setItem(key, value);
-      } catch {
-        /* noop */
-      }
+    [localStorageStore, toast],
+  );
+  const toggleHideInactive = useCallback(
+    (next: boolean) => {
+      setHideInactiveState(next);
+      setHideInactiveModules(localStorageStore, next);
     },
-    remove(key) {
-      try {
-        localStorage.removeItem(key);
-      } catch {
-        /* noop */
-      }
-    },
-  };
+    [localStorageStore],
+  );
 
   const handleMove = useCallback((index: number, direction: -1 | 1) => {
     setOrder((prev) => {
@@ -226,6 +271,38 @@ export function GeneralSection({
             Скинути кеш PWA
           </Button>
         </div>
+      </SettingsSubGroup>
+      <SettingsSubGroup title="Активні модулі">
+        <p className="text-xs text-subtle leading-snug">
+          Неактивні модулі відображаються на дашборді приглушено — без кнопки
+          швидкого додавання. Чонайменше один модуль має залишатися активним.
+        </p>
+        <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
+          {ALL_MODULES.map((id) => {
+            const checked = activeModules.includes(id);
+            return (
+              <li key={id} className="px-3 py-2 bg-panel">
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleActive(id)}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  <span className="flex-1 text-sm text-text">
+                    {SHARED_DASHBOARD_MODULE_LABELS[id]}
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+        <ToggleRow
+          label="Приховати неактивні модулі"
+          description="Повністю ховає неактивні плитки з дашборду."
+          checked={hideInactive}
+          onChange={(e) => toggleHideInactive(e.target.checked)}
+        />
       </SettingsSubGroup>
       <SettingsSubGroup title="Упорядкувати модулі">
         <p className="text-xs text-subtle leading-snug">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,9 @@ export * from "./lib/kvStore";
 // Onboarding "vibe picks" state + FTUX time-to-value helpers.
 export * from "./lib/vibePicks";
 
+// Active-modules helpers (derived from vibe picks) + hide-inactive toggle.
+export * from "./lib/activeModules";
+
 // Onboarding gate helpers (first-launch detection, done flag, splash taxonomy).
 export * from "./lib/onboarding";
 

--- a/packages/shared/src/lib/activeModules.test.ts
+++ b/packages/shared/src/lib/activeModules.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { createMemoryKVStore } from "./kvStore";
+import {
+  HIDE_INACTIVE_MODULES_KEY,
+  getActiveModules,
+  getHideInactiveModules,
+  isActiveModule,
+  setActiveModules,
+  setHideInactiveModules,
+  toggleHideInactiveModules,
+} from "./activeModules";
+import { ALL_MODULES, VIBE_PICKS_KEY, saveVibePicks } from "./vibePicks";
+
+describe("activeModules — getActiveModules", () => {
+  it("falls back to ALL_MODULES on a fresh store", () => {
+    const store = createMemoryKVStore();
+    expect(getActiveModules(store)).toEqual([...ALL_MODULES]);
+  });
+
+  it("returns the saved subset when the user picked modules", () => {
+    const store = createMemoryKVStore();
+    saveVibePicks(store, ["finyk", "routine"]);
+    expect(getActiveModules(store)).toEqual(["finyk", "routine"]);
+  });
+
+  it("falls back to ALL_MODULES when stored picks are empty", () => {
+    const store = createMemoryKVStore();
+    saveVibePicks(store, []);
+    expect(getActiveModules(store)).toEqual([...ALL_MODULES]);
+  });
+
+  it("filters unknown ids out via sanitization", () => {
+    const store = createMemoryKVStore();
+    store.setString(VIBE_PICKS_KEY, JSON.stringify(["finyk", "bogus"]));
+    expect(getActiveModules(store)).toEqual(["finyk"]);
+  });
+});
+
+describe("activeModules — setActiveModules", () => {
+  it("persists the selection", () => {
+    const store = createMemoryKVStore();
+    setActiveModules(store, ["fizruk"]);
+    expect(getActiveModules(store)).toEqual(["fizruk"]);
+  });
+
+  it("an empty selection falls back to ALL_MODULES on read", () => {
+    const store = createMemoryKVStore();
+    setActiveModules(store, ["finyk"]);
+    setActiveModules(store, []);
+    expect(getActiveModules(store)).toEqual([...ALL_MODULES]);
+  });
+});
+
+describe("activeModules — isActiveModule", () => {
+  it("returns true when the id is in the active list", () => {
+    expect(isActiveModule(["finyk", "routine"], "finyk")).toBe(true);
+  });
+
+  it("returns false when the id is missing", () => {
+    expect(isActiveModule(["finyk", "routine"], "fizruk")).toBe(false);
+  });
+});
+
+describe("activeModules — hide-inactive toggle", () => {
+  it("defaults to false", () => {
+    const store = createMemoryKVStore();
+    expect(getHideInactiveModules(store)).toBe(false);
+  });
+
+  it("setHideInactiveModules(true) persists '1'", () => {
+    const store = createMemoryKVStore();
+    setHideInactiveModules(store, true);
+    expect(store.getString(HIDE_INACTIVE_MODULES_KEY)).toBe("1");
+    expect(getHideInactiveModules(store)).toBe(true);
+  });
+
+  it("setHideInactiveModules(false) removes the key", () => {
+    const store = createMemoryKVStore();
+    setHideInactiveModules(store, true);
+    setHideInactiveModules(store, false);
+    expect(store.getString(HIDE_INACTIVE_MODULES_KEY)).toBeNull();
+    expect(getHideInactiveModules(store)).toBe(false);
+  });
+
+  it("toggleHideInactiveModules flips the flag and returns the new value", () => {
+    const store = createMemoryKVStore();
+    expect(toggleHideInactiveModules(store)).toBe(true);
+    expect(getHideInactiveModules(store)).toBe(true);
+    expect(toggleHideInactiveModules(store)).toBe(false);
+    expect(getHideInactiveModules(store)).toBe(false);
+  });
+});

--- a/packages/shared/src/lib/activeModules.ts
+++ b/packages/shared/src/lib/activeModules.ts
@@ -1,0 +1,94 @@
+/**
+ * Active modules — derived from the user's onboarding "vibe picks"
+ * plus a "hide inactive" UI toggle.
+ *
+ * The onboarding wizard step 2 ("Що тобі важливо?") writes the user's
+ * selection to {@link VIBE_PICKS_KEY}. Any module not in that list is
+ * considered *inactive* on the Hub dashboard:
+ *  - it still renders, but in a muted/greyed-out state;
+ *  - its quick-add affordance is suppressed;
+ *  - a hint points the user at Hub Settings to reactivate it.
+ *
+ * If the persisted picks list is missing or empty (e.g. fresh install,
+ * cleared storage, or the user tapped through the wizard without
+ * selecting anything — see `buildFinalPicks`'s ALL_MODULES fallback),
+ * we fall back to "all modules active" so existing accounts behave
+ * identically to before this feature landed.
+ *
+ * The {@link HIDE_INACTIVE_MODULES_KEY} toggle (default: `false`)
+ * lets the user collapse the inactive tiles entirely instead of
+ * showing them muted.
+ *
+ * DOM-free: callers wire the platform-specific {@link KVStore}
+ * (localStorage on web, MMKV on mobile).
+ */
+
+import { type DashboardModuleId } from "./dashboard";
+import { type KVStore } from "./kvStore";
+import { ALL_MODULES, getVibePicks, saveVibePicks } from "./vibePicks";
+
+/**
+ * localStorage / MMKV key for the "hide inactive modules" boolean
+ * toggle. Stored as the literal string `"1"` when on; absent or any
+ * other value means off.
+ */
+export const HIDE_INACTIVE_MODULES_KEY = "hub_hide_inactive_modules_v1";
+
+/**
+ * Return the set of modules the user marked as active during
+ * onboarding (or via Hub Settings). Falls back to {@link ALL_MODULES}
+ * when the picks list is missing or empty so legacy accounts and
+ * fresh installs render every module by default.
+ */
+export function getActiveModules(store: KVStore): DashboardModuleId[] {
+  const picks = getVibePicks(store);
+  return picks.length > 0 ? picks : [...ALL_MODULES];
+}
+
+/**
+ * Persist the user's active-module selection. A no-op-style empty
+ * input is intentionally allowed — `getActiveModules` will then fall
+ * back to "all modules" until the user picks again.
+ */
+export function setActiveModules(
+  store: KVStore,
+  ids: readonly DashboardModuleId[],
+): void {
+  saveVibePicks(store, ids);
+}
+
+/** True when {@link id} is in the user's active-module list. */
+export function isActiveModule(
+  active: readonly DashboardModuleId[],
+  id: DashboardModuleId,
+): boolean {
+  return active.includes(id);
+}
+
+/** True when the user has opted to hide inactive modules entirely. */
+export function getHideInactiveModules(store: KVStore): boolean {
+  return store.getString(HIDE_INACTIVE_MODULES_KEY) === "1";
+}
+
+/**
+ * Persist the "hide inactive modules" toggle. `true` writes `"1"`,
+ * `false` removes the key so a future read returns the default
+ * (`false`).
+ */
+export function setHideInactiveModules(store: KVStore, hide: boolean): void {
+  if (hide) {
+    store.setString(HIDE_INACTIVE_MODULES_KEY, "1");
+  } else {
+    store.remove(HIDE_INACTIVE_MODULES_KEY);
+  }
+}
+
+/**
+ * Flip the "hide inactive modules" toggle. Returns the new value so
+ * callers can update local component state without a second read.
+ */
+export function toggleHideInactiveModules(store: KVStore): boolean {
+  const next = !getHideInactiveModules(store);
+  setHideInactiveModules(store, next);
+  return next;
+}


### PR DESCRIPTION
placeholder — will update via git_pr.update
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect onboarding “vibe picks” on the Hub dashboard across web and mobile. Inactive modules now appear muted (or can be hidden), quick‑add is suppressed, and Settings lets users manage active modules.

- **New Features**
  - Shared (`@sergeant/shared`): added `activeModules` helpers (`getActiveModules`, `setActiveModules`, `isActiveModule`) and a persisted `hide inactive` toggle.
  - Web dashboard: inactive tiles render greyed out with a settings hint; quick‑add is hidden; optional “hide inactive” control below the grid; drag context uses the filtered order.
  - Mobile dashboard: same behavior; `DraggableDashboard` passes an `inactiveModules` set; `StatusRow` shows muted styles with a settings hint; toggle to show/hide inactive below the list.
  - Settings (web + mobile): new “Active modules” group with per‑module checkboxes and a “Hide inactive modules” toggle; enforces at least one active module; shares state with onboarding.

<sup>Written for commit e6d6dbeedd02ebb545495b3b00f08d718c954c3e. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1042?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Dashboard module management in settings—users can now enable/disable which modules appear on the dashboard
* Toggle to hide inactive modules from the dashboard view  
* Inactive modules display in a muted, greyed-out state when visible
* At least one module must remain active at all times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->