### PR TITLE
feat(web): close undo-toast gaps for Fizruk + Memory Bank

### DIFF
--- a/apps/web/src/core/profile/MemoryBankSection.tsx
+++ b/apps/web/src/core/profile/MemoryBankSection.tsx
@@ -3,6 +3,7 @@ import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 import {
   CATEGORY_META,
   groupMemoryEntries,
@@ -36,10 +37,19 @@ export function MemoryBankSection() {
 
   const handleDelete = useCallback(
     (id: string) => {
+      const previous = entries;
+      const target = entries.find((e) => e.id === id);
       const result = removeMemoryEntry(entries, id);
       saveEntries(result.entries);
+      if (!target) return;
+      const factPreview =
+        target.fact.length > 60 ? `${target.fact.slice(0, 60)}…` : target.fact;
+      showUndoToast(toast, {
+        msg: `Запис «${factPreview}» видалено`,
+        onUndo: () => saveEntries(previous),
+      });
     },
-    [entries, saveEntries],
+    [entries, saveEntries, toast],
   );
 
   const openMemoryChat = useCallback(() => {

--- a/apps/web/src/core/profile/ProfilePage.test.tsx
+++ b/apps/web/src/core/profile/ProfilePage.test.tsx
@@ -52,8 +52,13 @@ vi.mock("@shared/hooks/useOnlineStatus", () => ({
 
 const toastSuccessMock = vi.fn();
 const toastErrorMock = vi.fn();
+const toastShowMock = vi.fn();
 vi.mock("@shared/hooks/useToast", () => ({
-  useToast: () => ({ success: toastSuccessMock, error: toastErrorMock }),
+  useToast: () => ({
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    show: toastShowMock,
+  }),
 }));
 
 const mockUser = {

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.finish.test.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.finish.test.tsx
@@ -95,6 +95,7 @@ function baseProps(
     })),
     submitRetroWorkout: vi.fn(),
     deleteWorkout: vi.fn(),
+    restoreWorkout: vi.fn(),
     ...overrides,
   };
 }

--- a/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/WorkoutJournalSection.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Button } from "@shared/components/ui/Button";
@@ -9,6 +9,7 @@ import { SectionErrorBoundary } from "@shared/components/ui/SectionErrorBoundary
 import { Card } from "@shared/components/ui/Card";
 import { useToast } from "@shared/hooks/useToast";
 import { hapticSuccess } from "@shared/lib/haptic";
+import { showUndoToast } from "@shared/lib/undoToast";
 
 function WorkoutRow({ w, activeWorkoutId, setActiveWorkoutId }) {
   // An ended workout is always "Завершене" — even if it happens to be the
@@ -89,9 +90,22 @@ export function WorkoutJournalSection({
   summarizeWorkoutForFinish,
   submitRetroWorkout,
   deleteWorkout,
+  restoreWorkout,
 }) {
   const toast = useToast();
   const workoutList = workouts || [];
+  const handleSwipeDelete = useCallback(
+    (id) => {
+      const snapshot = (workouts || []).find((w) => w.id === id);
+      if (!snapshot) return;
+      deleteWorkout(id);
+      showUndoToast(toast, {
+        msg: "Тренування видалено",
+        onUndo: () => restoreWorkout?.(snapshot),
+      });
+    },
+    [workouts, deleteWorkout, restoreWorkout, toast],
+  );
   const listHeight = Math.min(
     workoutList.length * JOURNAL_ITEM_HEIGHT,
     MAX_JOURNAL_HEIGHT,
@@ -295,7 +309,7 @@ export function WorkoutJournalSection({
                 key={w.id}
                 onSwipeLeft={
                   deleteWorkout && w.id !== activeWorkoutId
-                    ? () => deleteWorkout(w.id)
+                    ? () => handleSwipeDelete(w.id)
                     : undefined
                 }
                 rightLabel="🗑 Видалити"

--- a/apps/web/src/modules/fizruk/hooks/useDailyLog.ts
+++ b/apps/web/src/modules/fizruk/hooks/useDailyLog.ts
@@ -58,6 +58,20 @@ export function useDailyLog() {
     [entries, persist],
   );
 
+  /**
+   * Re-insert a previously deleted entry, preserving the original `id`,
+   * `at` timestamp and field values. Used by undo flows after `deleteEntry`.
+   */
+  const restoreEntry = useCallback(
+    (entry) => {
+      if (!entry || !entry.id) return;
+      persist(
+        entries.some((e) => e.id === entry.id) ? entries : [entry, ...entries],
+      );
+    },
+    [entries, persist],
+  );
+
   const sorted = useMemo(
     () => [...entries].sort((a, b) => (b.at || "").localeCompare(a.at || "")),
     [entries],
@@ -76,5 +90,12 @@ export function useDailyLog() {
   /** Latest single entry. */
   const latest = sorted[0] || null;
 
-  return { entries: sorted, latest, addEntry, deleteEntry, recentWith };
+  return {
+    entries: sorted,
+    latest,
+    addEntry,
+    deleteEntry,
+    restoreEntry,
+    recentWith,
+  };
 }

--- a/apps/web/src/modules/fizruk/hooks/useMeasurements.ts
+++ b/apps/web/src/modules/fizruk/hooks/useMeasurements.ts
@@ -54,9 +54,23 @@ export function useMeasurements() {
     [persist, entries],
   );
 
+  /**
+   * Re-insert a previously deleted measurement, preserving the original
+   * `id` and `at` timestamp. Used by undo flows after `deleteEntry`.
+   */
+  const restoreEntry = useCallback(
+    (entry) => {
+      if (!entry || !entry.id) return;
+      persist(
+        entries.some((e) => e.id === entry.id) ? entries : [entry, ...entries],
+      );
+    },
+    [persist, entries],
+  );
+
   const sorted = useMemo(() => {
     return [...entries].sort((a, b) => (b.at || "").localeCompare(a.at || ""));
   }, [entries]);
 
-  return { entries: sorted, addEntry, deleteEntry };
+  return { entries: sorted, addEntry, deleteEntry, restoreEntry };
 }

--- a/apps/web/src/modules/fizruk/pages/Body.tsx
+++ b/apps/web/src/modules/fizruk/pages/Body.tsx
@@ -7,6 +7,8 @@ import { cn } from "@shared/lib/cn";
 import { useDailyLog } from "../hooks/useDailyLog";
 import { Card } from "@shared/components/ui/Card";
 import { MiniLineChart } from "../components/MiniLineChart";
+import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 
 /**
  * Trend cards on this page used to be always-expanded, which meant four
@@ -419,7 +421,21 @@ function ScoreButton({ value, selected, onClick, label }) {
 }
 
 export function Body({ onOpenMeasurements }) {
-  const { entries, addEntry, deleteEntry, recentWith } = useDailyLog();
+  const { entries, addEntry, deleteEntry, restoreEntry, recentWith } =
+    useDailyLog();
+  const toast = useToast();
+  const handleDeleteJournalEntry = useCallback(
+    (id) => {
+      const snapshot = entries.find((e) => e.id === id);
+      if (!snapshot) return;
+      deleteEntry(id);
+      showUndoToast(toast, {
+        msg: "Запис журналу видалено",
+        onUndo: () => restoreEntry(snapshot),
+      });
+    },
+    [entries, deleteEntry, restoreEntry, toast],
+  );
 
   const [form, setForm] = useState({
     weightKg: "",
@@ -772,7 +788,7 @@ export function Body({ onOpenMeasurements }) {
           <JournalSection
             entries={entries.slice(0, 15)}
             totalCount={entries.length}
-            onDelete={deleteEntry}
+            onDelete={handleDeleteJournalEntry}
           />
         )}
       </div>

--- a/apps/web/src/modules/fizruk/pages/Measurements.tsx
+++ b/apps/web/src/modules/fizruk/pages/Measurements.tsx
@@ -1,16 +1,31 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { MEASURE_FIELDS, useMeasurements } from "../hooks/useMeasurements";
 import { Card } from "@shared/components/ui/Card";
 import { Stat } from "@shared/components/ui/Stat";
+import { useToast } from "@shared/hooks/useToast";
+import { showUndoToast } from "@shared/lib/undoToast";
 
 const inp =
   "input-focus-fizruk w-full h-11 rounded-2xl border border-line bg-panelHi px-4 text-text";
 
 export function Measurements() {
-  const { entries, addEntry, deleteEntry } = useMeasurements();
+  const { entries, addEntry, deleteEntry, restoreEntry } = useMeasurements();
+  const toast = useToast();
+  const handleDelete = useCallback(
+    (id) => {
+      const snapshot = entries.find((e) => e.id === id);
+      if (!snapshot) return;
+      deleteEntry(id);
+      showUndoToast(toast, {
+        msg: "Замір видалено",
+        onUndo: () => restoreEntry(snapshot),
+      });
+    },
+    [entries, deleteEntry, restoreEntry, toast],
+  );
   const [form, setForm] = useState(() =>
     Object.fromEntries(MEASURE_FIELDS.map((f) => [f.id, ""])),
   );
@@ -221,7 +236,7 @@ export function Measurements() {
                 </div>
                 <button
                   className="text-xs text-danger/80 hover:text-danger"
-                  onClick={() => deleteEntry(e.id)}
+                  onClick={() => handleDelete(e.id)}
                 >
                   Видалити
                 </button>

--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -104,6 +104,29 @@ export function Workouts() {
     updateItem,
     removeItem,
   } = useWorkouts();
+  const removeItemWithUndo = useCallback(
+    (workoutId, itemId) => {
+      const w = workouts.find((x) => x.id === workoutId);
+      if (!w) {
+        removeItem(workoutId, itemId);
+        return;
+      }
+      const snapshot = {
+        items: w.items || [],
+        groups: w.groups || [],
+      };
+      removeItem(workoutId, itemId);
+      showUndoToast(toast, {
+        msg: "Вправу видалено з тренування",
+        onUndo: () =>
+          updateWorkout(workoutId, {
+            items: snapshot.items,
+            groups: snapshot.groups,
+          }),
+      });
+    },
+    [workouts, removeItem, updateWorkout, toast],
+  );
   const templateApi = useWorkoutTemplates();
   const [q, setQ] = useState("");
   const [equipmentFilter, setEquipmentFilter] = useState<string[]>([]);
@@ -525,13 +548,14 @@ export function Workouts() {
             setRestTimer={setRestTimer}
             updateWorkout={updateWorkout}
             updateItem={updateItem}
-            removeItem={removeItem}
+            removeItem={removeItemWithUndo}
             setFinishFlash={setFinishFlash}
             endWorkout={endWorkout}
             setDeleteWorkoutConfirm={setDeleteWorkoutConfirm}
             summarizeWorkoutForFinish={summarizeWorkoutForFinish}
             submitRetroWorkout={submitRetroWorkout}
             deleteWorkout={deleteWorkout}
+            restoreWorkout={restoreWorkout}
           />
         )}
 

--- a/apps/web/src/shared/lib/undoToast.tsx
+++ b/apps/web/src/shared/lib/undoToast.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from "react";
 import type { ToastApi } from "@shared/hooks/useToast";
+import {
+  UNDO_TOAST_DEFAULT_DURATION_MS,
+  UNDO_TOAST_DEFAULT_ERROR_MSG,
+  UNDO_TOAST_DEFAULT_LABEL,
+} from "@sergeant/shared";
 import { hapticError, hapticTap, hapticWarning } from "./haptic";
 
 export interface UndoToastOptions {
@@ -47,10 +52,10 @@ export function showUndoToast(
   toast: ToastApi,
   {
     msg,
-    duration = 5000,
-    undoLabel = "Повернути",
+    duration = UNDO_TOAST_DEFAULT_DURATION_MS,
+    undoLabel = UNDO_TOAST_DEFAULT_LABEL,
     onUndo,
-    onUndoErrorMsg = "Не вдалось повернути. Спробуй ще раз.",
+    onUndoErrorMsg = UNDO_TOAST_DEFAULT_ERROR_MSG,
   }: UndoToastOptions,
 ): number {
   hapticWarning();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,6 +27,9 @@ export * from "./lib/vibePicks";
 // Active-modules helpers (derived from vibe picks) + hide-inactive toggle.
 export * from "./lib/activeModules";
 
+// Defaults shared by web/mobile undo-toast helpers.
+export * from "./lib/undoToast";
+
 // Onboarding gate helpers (first-launch detection, done flag, splash taxonomy).
 export * from "./lib/onboarding";
 

--- a/packages/shared/src/lib/undoToast.ts
+++ b/packages/shared/src/lib/undoToast.ts
@@ -1,0 +1,24 @@
+/**
+ * Defaults for the standardised "undo toast" pattern used after destructive
+ * actions (delete habit / transaction / set / memory entry / etc.).
+ *
+ * The actual `showUndoToast()` helper lives per-platform because the toast
+ * API differs (web's `useToast` exposes `show(msg, type, duration, action)`
+ * with `onClick`; React Native uses `onPress`). Both implementations import
+ * these constants so wording and timing stay in sync — see
+ * `apps/web/src/shared/lib/undoToast.tsx`.
+ */
+
+/** Default visible duration in ms (5 sec, matching the original product brief). */
+export const UNDO_TOAST_DEFAULT_DURATION_MS = 5_000;
+
+/** Default action-button label. */
+export const UNDO_TOAST_DEFAULT_LABEL = "Повернути";
+
+/**
+ * Default error message shown if the `onUndo` callback throws — historically
+ * a `catch {}` swallowed real failures (e.g. localStorage quota errors)
+ * and the user mistakenly assumed restore had succeeded.
+ */
+export const UNDO_TOAST_DEFAULT_ERROR_MSG =
+  "Не вдалось повернути. Спробуй ще раз.";


### PR DESCRIPTION
## What changed

Розширено `showUndoToast` на 5 точок видалення на web, які раніше виконували
`delete` без жодного шансу відмінити дію:

- **Fizruk → Body**: видалення запису денного журналу (вага / сон / енергія / нотатка).
  `useDailyLog` тепер експонує `restoreEntry(snapshot)`.
- **Fizruk → Measurements**: видалення заміру обхвату / складу.
  `useMeasurements` тепер експонує `restoreEntry(snapshot)`.
- **Fizruk → WorkoutJournalSection**: swipe-to-delete з історії тренувань.
  Використовує існуючий `restoreWorkout()` з `useWorkouts` (раніше використовувався
  лише для confirm-flow в `Workouts.tsx`).
- **Fizruk → ActiveWorkoutPanel/WorkoutItemCard**: видалення вправи з активного тренування.
  В `Workouts.tsx` додано `removeItemWithUndo`, який знімає snapshot `{ items, groups }` і
  відновлює через `updateWorkout()` — бо `removeItem` ще й чистить «розпавші» групи
  (суперсети), тож одного `insertItem` для повного відновлення недостатньо.
- **Profile → MemoryBankSection**: видалення запису з банку пам'яті ШІ.
  Snapshot цілого масиву + `saveEntries(previous)` зберігає оригінальний порядок
  у межах категорії.

### Shared scope

Винесено константи дефолтів у `@sergeant/shared` (`packages/shared/src/lib/undoToast.ts`):

- `UNDO_TOAST_DEFAULT_DURATION_MS` (5000)
- `UNDO_TOAST_DEFAULT_LABEL` (`"Повернути"`)
- `UNDO_TOAST_DEFAULT_ERROR_MSG` (`"Не вдалось повернути. Спробуй ще раз."`)

Web-обгортка в `apps/web/src/shared/lib/undoToast.tsx` тепер імпортує ці константи —
це підготовка до окремого PR із mobile-варіантом, щоб тексти й тайминги не розповзалися.

> Scope: PR зачіпає переважно `apps/web`, тому вибраний `web` як найвидиміший
> (per AGENTS.md rule #5: "use the most user-visible one and explain in the body").
> Зміни в `packages/shared` — винятково константи без логіки.

## Why

Користувацький аудит «Ундо тости у нас всюди вже є, де треба?» виявив 5 деструктивних
дій, де натискання видалення → миттєва втрата запису без жодного фідбеку для
відновлення. Інші модулі (Routine, Nutrition, Finyk Assets/Budgets/Transactions,
HubChat) уже мають undo-toast — цей PR закриває прогалини на web до того ж стандарту.

Mobile undo — свідомо окремий PR: на RN зараз немає `showUndoToast` helper-а взагалі,
хоча `Toast` компонент підтримує `label`+`onPress` (тест є). Зробимо коли цей зайде.

## How to test

1. **Fizruk → «Тіло» → Журнал** → видалити запис → toast «Запис журналу видалено» з
   кнопкою «Повернути» → натиснути «Повернути» → запис повертається з тим самим
   id/датою/значеннями.
2. **Fizruk → «Заміри»** → у списку «Останні» натиснути «Видалити» → toast «Замір
   видалено» → undo → запис повертається.
3. **Fizruk → «Тренування» → Журнал** → swipe вліво на завершеному тренуванні →
   toast «Тренування видалено» → undo → тренування повертається на правильне
   місце за `startedAt`.
4. **Fizruk → активне тренування** → натиснути ✕ біля вправи → toast «Вправу
   видалено з тренування» → undo → вправа і її група (якщо була у суперсеті)
   відновлюються.
5. **Профіль → Пам'ять ШІ** → натиснути ✕ біля запису → toast «Запис «...» видалено»
   → undo → запис повертається у ту саму категорію в тому ж порядку.
6. У всіх випадках, якщо не натиснути «Повернути» протягом 5 секунд — дія
   фінальна (як і було задумано).

---

## How AI-tested this PR

- [x] Manual smoke: n/a, web UI не запускався локально; покладаюсь на vitest + ручне тестування реквестера після зливу
- [x] Vitest web: `pnpm --filter @sergeant/web test -- --run` → 1381/1381
- [x] Vitest shared: `pnpm --filter @sergeant/shared test -- --run` → 326/326
- [x] Typecheck: `pnpm -r typecheck` → green
- [x] Lint: `pnpm -r lint` → green
- [x] Mobile jest: 611/612 (1 pre-existing fail у `SignInScreen.test.tsx` про "З поверненням 👋" не пов'язаний з цим PR)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds undo toast to all remaining destructive actions in Fizruk and Memory Bank on web, so users can quickly restore deletions. Centralizes undo-toast defaults in `@sergeant/shared` to keep labels and duration consistent.

- **New Features**
  - Fizruk → Body: undo on deleting daily log entries; `useDailyLog` now exposes `restoreEntry(snapshot)`.
  - Fizruk → Measurements: undo on deleting measurements; `useMeasurements` now exposes `restoreEntry(snapshot)`.
  - Fizruk → Workout journal: swipe-to-delete shows undo; uses existing `restoreWorkout()`.
  - Fizruk → Active workout: deleting an exercise shows undo; snapshot `{ items, groups }`, restore via `updateWorkout()`.
  - Profile → Memory Bank: deleting an entry shows undo; restore with `saveEntries(previous)` to keep category ordering.

- **Refactors**
  - Added shared defaults in `@sergeant/shared` for undo toasts: `UNDO_TOAST_DEFAULT_DURATION_MS`, `UNDO_TOAST_DEFAULT_LABEL`, `UNDO_TOAST_DEFAULT_ERROR_MSG`.
  - Web `showUndoToast` now imports these defaults.

<sup>Written for commit 147a6b47e43ecd35754b68409bcd673c89d2b84b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1047?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

