### PR TITLE
feat(mobile): нормальний undo через showUndoToast (parity з web)

### DIFF
--- a/apps/mobile/src/auth/SignInScreen.test.tsx
+++ b/apps/mobile/src/auth/SignInScreen.test.tsx
@@ -29,7 +29,9 @@ describe("SignInScreen", () => {
   it("renders the sign-in form", () => {
     const { getByText, getByPlaceholderText } = render(<SignInScreen />);
 
-    expect(getByText("З поверненням 👋")).toBeTruthy();
+    // Heading text was de-coupled from the 👋 emoji in #1046 (Sparkles icon
+    // sibling now lives next to the same heading).
+    expect(getByText("З поверненням")).toBeTruthy();
     expect(getByPlaceholderText("ваш@email.com")).toBeTruthy();
     expect(getByPlaceholderText("••••••••••")).toBeTruthy();
     expect(getByText("Увійти")).toBeTruthy();

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -23,7 +23,7 @@ import {
 } from "react-native";
 import { ChevronRight } from "lucide-react-native";
 
-import { haptic } from "@sergeant/shared";
+import { hapticTap } from "@sergeant/shared";
 import { colors } from "@/theme";
 import { SectionHeading } from "./SectionHeading";
 
@@ -101,7 +101,7 @@ export const ListItem = forwardRef<RNView, ListItemProps>(function ListItem(
     event: Parameters<NonNullable<PressableProps["onPress"]>>[0],
   ) => {
     if (hapticFeedback && !disabled) {
-      haptic.tap();
+      hapticTap();
     }
     onPress?.(event);
   };

--- a/apps/mobile/src/lib/showUndoToast.test.ts
+++ b/apps/mobile/src/lib/showUndoToast.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Mirror of `apps/web/src/shared/lib/undoToast.test.tsx` for the mobile
+ * helper. We mock the haptic adapter so the test stays platform-pure
+ * (no `expo-haptics` import is needed in the jest jsdom env).
+ */
+
+import { resetHapticAdapter, setHapticAdapter } from "@sergeant/shared";
+import type { HapticAdapter } from "@sergeant/shared";
+
+import type { ToastApi } from "@/components/ui/Toast";
+import { showUndoToast } from "./showUndoToast";
+
+interface CapturedAction {
+  label: string;
+  onPress: () => void;
+}
+
+function makeToast(): ToastApi & { _captured: { action?: CapturedAction } } {
+  const captured: { action?: CapturedAction } = {};
+  const api: ToastApi = {
+    show: jest.fn((_msg, _type, _duration, action) => {
+      if (action) captured.action = action;
+      return 1;
+    }),
+    success: jest.fn(() => 1),
+    error: jest.fn(() => 2),
+    info: jest.fn(() => 1),
+    warning: jest.fn(() => 1),
+    dismiss: jest.fn(),
+  };
+  return Object.assign(api, { _captured: captured });
+}
+
+function makeHapticAdapter(): HapticAdapter {
+  return {
+    tap: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    cancel: jest.fn(),
+    pattern: jest.fn(),
+  };
+}
+
+describe("showUndoToast (mobile)", () => {
+  let haptic: HapticAdapter;
+
+  beforeEach(() => {
+    haptic = makeHapticAdapter();
+    setHapticAdapter(haptic);
+  });
+
+  afterEach(() => {
+    resetHapticAdapter();
+  });
+
+  it("викликає onUndo один раз при натисканні", () => {
+    const onUndo = jest.fn();
+    const toast = makeToast();
+    showUndoToast(toast, { msg: "Видалено", onUndo });
+
+    toast._captured.action?.onPress();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(haptic.warning).toHaveBeenCalledTimes(1);
+    expect(haptic.tap).toHaveBeenCalledTimes(1);
+  });
+
+  it("якщо onUndo кидає — показуємо error-toast (не silent)", () => {
+    const onUndo = jest.fn(() => {
+      throw new Error("storage quota exceeded");
+    });
+    const toast = makeToast();
+
+    showUndoToast(toast, { msg: "Видалено", onUndo });
+    expect(() => toast._captured.action?.onPress()).not.toThrow();
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Не вдалось повернути. Спробуй ще раз.",
+    );
+    expect(haptic.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("дозволяє кастомне повідомлення для помилки undo", () => {
+    const onUndo = jest.fn(() => {
+      throw new Error("boom");
+    });
+    const toast = makeToast();
+
+    showUndoToast(toast, {
+      msg: "Видалено звичку",
+      onUndo,
+      onUndoErrorMsg: "Не вдалось повернути звичку",
+    });
+    toast._captured.action?.onPress();
+    expect(toast.error).toHaveBeenCalledWith("Не вдалось повернути звичку");
+  });
+
+  it("використовує default duration=5000 і info-тип", () => {
+    const toast = makeToast();
+    showUndoToast(toast, { msg: "Видалено", onUndo: () => {} });
+
+    expect(toast.show).toHaveBeenCalledTimes(1);
+    const call = (toast.show as jest.Mock).mock.calls[0];
+    expect(call[1]).toBe("info");
+    expect(call[2]).toBe(5000);
+  });
+
+  it("дозволяє кастомний undoLabel", () => {
+    const toast = makeToast();
+    showUndoToast(toast, {
+      msg: "Видалено",
+      onUndo: () => {},
+      undoLabel: "Скасувати",
+    });
+
+    expect(toast._captured.action?.label).toBe("Скасувати");
+  });
+});

--- a/apps/mobile/src/lib/showUndoToast.ts
+++ b/apps/mobile/src/lib/showUndoToast.ts
@@ -1,0 +1,75 @@
+/**
+ * Mobile mirror of `apps/web/src/shared/lib/undoToast.tsx`.
+ *
+ * Wraps `useToast().show` for destructive actions so the user gets a
+ * single 5-second toast with an «Повернути» button instead of an
+ * upfront confirm dialog or the legacy "tap-twice" pulse pattern.
+ *
+ * Why a port instead of sharing the web file:
+ *  - Web's `ToastApi` action uses `onClick`; mobile's uses `onPress`
+ *    (different React event surface — no DOM on mobile). The shape of
+ *    the action object is therefore platform-specific, so we keep this
+ *    helper next to the platform's `Toast` provider.
+ *  - The haptic feedback contract (`hapticWarning` / `hapticTap` /
+ *    `hapticError`) is the *same* on both platforms — it's exposed via
+ *    `@sergeant/shared` and routed through the platform-specific
+ *    adapter installed at app bootstrap. So this helper is otherwise
+ *    behaviourally identical to the web one.
+ *
+ * Error handling: if `onUndo` throws (e.g., quota error from MMKV),
+ * we emit `hapticError` and surface a separate error-toast instead of
+ * silently swallowing the exception. Historically `catch {}` here hid
+ * real failures — the user thought their data was back when in fact
+ * the restore had failed.
+ */
+
+import type { ReactNode } from "react";
+
+import { hapticError, hapticTap, hapticWarning } from "@sergeant/shared";
+
+import type { ToastApi } from "@/components/ui/Toast";
+
+export interface UndoToastOptions {
+  /** Текст, який бачить користувач ("Видалено звичку «Вода»"). */
+  msg: ReactNode;
+  /** Скільки мс тримати toast відкритим (default 5000). */
+  duration?: number;
+  /** Лейбл для кнопки undo ("Повернути"). */
+  undoLabel?: string;
+  /** Викликається, коли юзер натиснув undo — ти відновлюєш локальний state. */
+  onUndo: () => void;
+  /**
+   * Повідомлення, яке показується окремим error-toast-ом, якщо `onUndo`
+   * кидає. Default: "Не вдалось повернути. Спробуй ще раз.".
+   */
+  onUndoErrorMsg?: ReactNode;
+}
+
+/**
+ * Показати undo-toast. Повертає id toast-а (як `useToast().show`), щоб
+ * викликаюча сторона могла programmatically dismiss-нути його.
+ */
+export function showUndoToast(
+  toast: ToastApi,
+  {
+    msg,
+    duration = 5000,
+    undoLabel = "Повернути",
+    onUndo,
+    onUndoErrorMsg = "Не вдалось повернути. Спробуй ще раз.",
+  }: UndoToastOptions,
+): number {
+  hapticWarning();
+  return toast.show(msg, "info", duration, {
+    label: undoLabel,
+    onPress: () => {
+      hapticTap();
+      try {
+        onUndo();
+      } catch {
+        hapticError();
+        toast.error(onUndoErrorMsg);
+      }
+    },
+  });
+}

--- a/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.test.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.test.tsx
@@ -83,7 +83,16 @@ jest.mock("@/components/ui/SwipeToAction", () => {
   };
 });
 
+import { ToastProvider } from "@/components/ui/Toast";
+
 import { TransactionsPage } from "./TransactionsPage";
+
+// Toast provider — компонент очікує `useToast` з Toast.tsx; тести
+// через RTL рендерять сторінку в ізоляції, тому загортаємо в ToastProvider.
+import type { ReactElement } from "react";
+
+const renderTransactionsPage = (ui: ReactElement) =>
+  render(<ToastProvider>{ui}</ToastProvider>);
 
 const FIXED_NOW = new Date("2026-04-21T12:00:00.000Z");
 
@@ -133,7 +142,7 @@ beforeEach(() => {
 
 describe("TransactionsPage — render", () => {
   it("renders the empty state with a primary CTA when there are no transactions", () => {
-    render(<TransactionsPage now={FIXED_NOW} />);
+    renderTransactionsPage(<TransactionsPage now={FIXED_NOW} />);
     expect(screen.getByTestId("finyk-transactions-empty")).toBeTruthy();
     const cta = screen.getByTestId("finyk-transactions-empty-add");
     expect(cta).toBeTruthy();
@@ -142,7 +151,7 @@ describe("TransactionsPage — render", () => {
   });
 
   it("renders seeded manual expenses grouped by day with running totals", () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -180,7 +189,7 @@ describe("TransactionsPage — render", () => {
   });
 
   it("computes per-day running totals correctly across multiple groups", () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -236,7 +245,7 @@ describe("TransactionsPage — render", () => {
   });
 
   it("disables the next-month button when viewing the current month", () => {
-    render(<TransactionsPage now={FIXED_NOW} />);
+    renderTransactionsPage(<TransactionsPage now={FIXED_NOW} />);
     const nextBtn = screen.getByTestId("finyk-transactions-next-month");
     expect(nextBtn.props.accessibilityState?.disabled).toBe(true);
   });
@@ -244,7 +253,7 @@ describe("TransactionsPage — render", () => {
 
 describe("TransactionsPage — filters", () => {
   it("filters to expenses only when the 'Витрати' chip is tapped", () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -281,7 +290,9 @@ describe("TransactionsPage — filters", () => {
   });
 
   it("persists the active filter to MMKV and exposes a clear-all action", async () => {
-    const { unmount } = render(<TransactionsPage now={FIXED_NOW} />);
+    const { unmount } = renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} />,
+    );
     fireEvent.press(screen.getByTestId("finyk-transactions-filter-income"));
 
     await waitFor(() => {
@@ -301,7 +312,7 @@ describe("TransactionsPage — filters", () => {
   });
 
   it("filters by a date range when the user picks a window", async () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -358,7 +369,7 @@ describe("TransactionsPage — filters", () => {
       description: "Метро",
       mcc: 4111, // transport
     });
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{ realTx: [foodTx, transportTx] }}
@@ -384,7 +395,7 @@ describe("TransactionsPage — filters", () => {
       accountIds: [],
       range: { startMs: null, endMs: null },
     });
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -410,7 +421,7 @@ describe("TransactionsPage — filters", () => {
 
 describe("TransactionsPage — swipe actions", () => {
   it("opens a categorize picker when a row is swiped right", async () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -434,7 +445,7 @@ describe("TransactionsPage — swipe actions", () => {
   });
 
   it("re-reads MMKV-backed manual expenses on pull-to-refresh", async () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -493,7 +504,7 @@ describe("TransactionsPage — swipe actions", () => {
       txs: [realTx],
       timestamp: Date.now(),
     });
-    render(<TransactionsPage now={FIXED_NOW} />);
+    renderTransactionsPage(<TransactionsPage now={FIXED_NOW} />);
     expect(screen.getByText("Сільпо")).toBeTruthy();
   });
 
@@ -509,12 +520,12 @@ describe("TransactionsPage — swipe actions", () => {
       txs: [realTx],
       timestamp: Date.now(),
     });
-    render(<TransactionsPage now={FIXED_NOW} />);
+    renderTransactionsPage(<TransactionsPage now={FIXED_NOW} />);
     expect(screen.getByText("Аврора")).toBeTruthy();
   });
 
   it("removes a manual expense when the user taps Delete in the edit sheet", async () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -548,7 +559,9 @@ describe("TransactionsPage — swipe actions", () => {
       description: "ATB",
       mcc: 5411,
     });
-    render(<TransactionsPage now={FIXED_NOW} seed={{ realTx: [realTx] }} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={{ realTx: [realTx] }} />,
+    );
     expect(screen.getByText("ATB")).toBeTruthy();
 
     const swipeLeft = screen.getAllByTestId(/swipe-left-/i)[0]!;
@@ -566,7 +579,7 @@ describe("TransactionsPage — swipe actions", () => {
   });
 
   it("opens the prefilled edit sheet when a manual row is swiped left", async () => {
-    render(
+    renderTransactionsPage(
       <TransactionsPage
         now={FIXED_NOW}
         seed={{
@@ -617,7 +630,9 @@ describe("TransactionsPage — day collapse", () => {
     // Reset the month-wide expansion from the global beforeEach so we
     // can assert the real first-run default.
     _getMMKVInstance().clearAll();
-    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />,
+    );
 
     // Both day headers render regardless of collapse state.
     expect(screen.getByTestId("finyk-tx-day-h-2026-04-21")).toBeTruthy();
@@ -631,7 +646,9 @@ describe("TransactionsPage — day collapse", () => {
 
   it("toggles a day expanded when the header is pressed, and persists the choice to MMKV", () => {
     _getMMKVInstance().clearAll();
-    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />,
+    );
 
     // Precondition: yesterday starts collapsed.
     expect(screen.queryByText("вчора-tx")).toBeNull();
@@ -651,7 +668,9 @@ describe("TransactionsPage — day collapse", () => {
 
   it("collapses today when the user explicitly toggles its header", () => {
     _getMMKVInstance().clearAll();
-    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />,
+    );
 
     // Precondition: today starts expanded.
     expect(screen.getByText("сьогодні-tx")).toBeTruthy();
@@ -668,7 +687,9 @@ describe("TransactionsPage — day collapse", () => {
 
   it("temporarily ignores the collapsed state when the user types a search query", () => {
     _getMMKVInstance().clearAll();
-    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />,
+    );
 
     // Precondition: yesterday is hidden (default-collapsed).
     expect(screen.queryByText("вчора-tx")).toBeNull();
@@ -690,7 +711,9 @@ describe("TransactionsPage — day collapse", () => {
       "2026-04-20": true,
     });
 
-    render(<TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />);
+    renderTransactionsPage(
+      <TransactionsPage now={FIXED_NOW} seed={COLLAPSE_SEED} />,
+    );
 
     expect(screen.getByText("вчора-tx")).toBeTruthy();
     expect(screen.getByText("сьогодні-tx")).toBeTruthy();

--- a/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
+++ b/apps/mobile/src/modules/finyk/pages/Transactions/TransactionsPage.tsx
@@ -57,6 +57,8 @@ import {
 import { TxRow } from "@/modules/finyk/components/TxRow";
 import { SwipeToAction } from "@/components/ui/SwipeToAction";
 import { Sheet } from "@/components/ui/Sheet";
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
 import {
   ManualExpenseSheet,
   type ManualExpensePayload,
@@ -198,6 +200,27 @@ export function TransactionsPage({
     overrideCategory,
     refresh,
   } = store;
+  const toast = useToast();
+
+  // Single-tap delete + undo-toast (parity з web). Снимаємо запис
+  // до виклику `removeManualExpense`, бо після нього його вже немає.
+  const handleDeleteManualExpense = useCallback(
+    (id: string) => {
+      const snapshot = manualExpenses.find((e) => e.id === id);
+      if (!snapshot) return;
+      removeManualExpense(id);
+      showUndoToast(toast, {
+        msg: `Транзакцію видалено`,
+        onUndo: () => {
+          // ManualExpenseRecord використовує `string` для category, але
+          // payload очікує літеральний union — за допомогою snapshot це
+          // безпечно, бо значення вже валідне (записано раніше).
+          addManualExpense(snapshot as unknown as ManualExpensePayload);
+        },
+      });
+    },
+    [addManualExpense, manualExpenses, removeManualExpense, toast],
+  );
 
   const { filters, setFilter, setAccountIds, setRange, clearAll } =
     useFinykTxFilters(filtersSeed);
@@ -940,7 +963,7 @@ export function TransactionsPage({
         open={sheetState.open}
         onClose={closeSheet}
         onSave={handleSave}
-        onDelete={removeManualExpense}
+        onDelete={handleDeleteManualExpense}
         initialExpense={
           sheetState.open && sheetState.editing ? sheetState.editing : null
         }

--- a/apps/mobile/src/modules/fizruk/hooks/useMeasurements.ts
+++ b/apps/mobile/src/modules/fizruk/hooks/useMeasurements.ts
@@ -58,6 +58,12 @@ export interface UseMeasurementsResult {
   ) => MobileMeasurementEntry | null;
   /** Remove the entry with the given id. No-op when the id is unseen. */
   remove: (id: string) => void;
+  /**
+   * Re-insert a previously-removed entry. Used by undo-toast after
+   * `remove`. No-op (referentially identical state) when an entry with
+   * the same id already exists.
+   */
+  restore: (entry: MobileMeasurementEntry) => void;
   /** Delete every entry. Used by the settings "reset data" button. */
   clear: () => void;
 }
@@ -113,9 +119,21 @@ export function useMeasurements(): UseMeasurementsResult {
     [raw, setRaw],
   );
 
+  const restore = useCallback<UseMeasurementsResult["restore"]>(
+    (entry) => {
+      if (!entry?.id) return;
+      setRaw((prev) => {
+        const list = Array.isArray(prev) ? prev : [];
+        if (list.some((e) => e.id === entry.id)) return list;
+        return upsertMeasurement(list, entry);
+      });
+    },
+    [setRaw],
+  );
+
   const clear = useCallback<UseMeasurementsResult["clear"]>(() => {
     removeRaw();
   }, [removeRaw]);
 
-  return { entries, add, update, remove, clear };
+  return { entries, add, update, remove, restore, clear };
 }

--- a/apps/mobile/src/modules/fizruk/pages/Measurements.test.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Measurements.test.tsx
@@ -22,8 +22,17 @@ import { act, fireEvent, render, screen } from "@testing-library/react-native";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance, safeWriteLS } from "@/lib/storage";
+import { ToastProvider } from "@/components/ui/Toast";
 
 import { Measurements } from "./Measurements";
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <Measurements />
+    </ToastProvider>,
+  );
+}
 
 jest.mock("react-native-safe-area-context", () => {
   const RN = jest.requireActual("react-native");
@@ -71,7 +80,7 @@ afterEach(() => {
 
 describe("Fizruk Measurements page (mobile)", () => {
   it("renders the empty-state card when MMKV has no entries", () => {
-    render(<Measurements />);
+    renderPage();
 
     expect(screen.getByText("Вимірювання")).toBeTruthy();
     expect(screen.getByTestId("fizruk-measurements-list-empty")).toBeTruthy();
@@ -87,7 +96,7 @@ describe("Fizruk Measurements page (mobile)", () => {
       { id: "c", at: "2026-04-15T00:00:00Z", weightKg: 82 },
     ]);
 
-    render(<Measurements />);
+    renderPage();
 
     expect(screen.queryByTestId("fizruk-measurements-list-empty")).toBeNull();
 
@@ -103,7 +112,7 @@ describe("Fizruk Measurements page (mobile)", () => {
   });
 
   it("opens the form sheet when the FAB is pressed", () => {
-    render(<Measurements />);
+    renderPage();
 
     // Before press, sheet body isn't mounted.
     expect(screen.queryByText("Новий замір")).toBeNull();
@@ -115,7 +124,7 @@ describe("Fizruk Measurements page (mobile)", () => {
   });
 
   it("creates an entry via the form and shows it in the list", () => {
-    render(<Measurements />);
+    renderPage();
 
     fireEvent.press(screen.getByTestId("fizruk-measurements-add"));
     fireEvent.changeText(screen.getByLabelText("Вага"), "80.5");
@@ -140,7 +149,7 @@ describe("Fizruk Measurements page (mobile)", () => {
   it("opens the edit sheet pre-populated when a row is tapped", () => {
     seedEntries([{ id: "a", at: "2026-04-10T00:00:00Z", weightKg: 80 }]);
 
-    render(<Measurements />);
+    renderPage();
 
     fireEvent.press(screen.getByTestId("fizruk-measurements-row-a-edit"));
 
@@ -149,25 +158,19 @@ describe("Fizruk Measurements page (mobile)", () => {
     expect(screen.getByLabelText("Вага").props.value).toBe("80");
   });
 
-  it("removes a row via the two-tap delete flow", () => {
+  it("removes a row in a single tap (with undo-toast)", () => {
     seedEntries([
       { id: "a", at: "2026-04-10T00:00:00Z", weightKg: 80 },
       { id: "b", at: "2026-04-20T00:00:00Z", weightKg: 81 },
     ]);
 
-    render(<Measurements />);
+    renderPage();
 
     const deleteBtn = screen.getByTestId("fizruk-measurements-row-a-delete");
 
-    // First tap flips to the confirmation label.
+    // Single-tap delete (parity з web — undo-toast відіграє роль скасування).
     act(() => {
       fireEvent.press(deleteBtn);
-    });
-    expect(screen.getByTestId("fizruk-measurements-row-a-delete")).toBeTruthy();
-
-    // Second tap commits the delete.
-    act(() => {
-      fireEvent.press(screen.getByTestId("fizruk-measurements-row-a-delete"));
     });
 
     expect(screen.queryByTestId("fizruk-measurements-row-a")).toBeNull();

--- a/apps/mobile/src/modules/fizruk/pages/Measurements.tsx
+++ b/apps/mobile/src/modules/fizruk/pages/Measurements.tsx
@@ -16,11 +16,14 @@
  *    `domain/progress` module (do NOT duplicate).
  *  - Sub-components live in `../components/measurements/*`.
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { MobileMeasurementEntry } from "@sergeant/fizruk-domain/domain";
+
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
 
 import {
   MeasurementEntryForm,
@@ -34,9 +37,6 @@ type FormState =
   | { mode: "new" }
   | { mode: "edit"; entry: MobileMeasurementEntry };
 
-/** Two-tap delete confirm window — mirrors `HabitsPage`. */
-const DELETE_CONFIRM_MS = 5000;
-
 export interface MeasurementsProps {
   /** Optional root testID — sub-ids derive from it. */
   testID?: string;
@@ -45,13 +45,10 @@ export interface MeasurementsProps {
 export function Measurements({
   testID = "fizruk-measurements",
 }: MeasurementsProps) {
-  const { entries, add, update, remove } = useMeasurements();
+  const { entries, add, update, remove, restore } = useMeasurements();
+  const toast = useToast();
 
   const [formState, setFormState] = useState<FormState>({ mode: "closed" });
-  const [deletePending, setDeletePending] = useState<{
-    id: string;
-    expiresAt: number;
-  } | null>(null);
 
   const openNew = useCallback(() => setFormState({ mode: "new" }), []);
   const openEdit = useCallback(
@@ -71,27 +68,23 @@ export function Measurements({
     [formState, add, update],
   );
 
+  // Single-tap delete + undo-toast (parity з web-ом і з HabitsPage).
   const handleRequestDelete = useCallback(
     (id: string) => {
-      const now = Date.now();
-      if (
-        deletePending &&
-        deletePending.id === id &&
-        deletePending.expiresAt > now
-      ) {
-        remove(id);
-        setDeletePending(null);
-      } else {
-        setDeletePending({ id, expiresAt: now + DELETE_CONFIRM_MS });
-      }
+      const snapshot = entries.find((e) => e.id === id);
+      if (!snapshot) return;
+      remove(id);
+      showUndoToast(toast, {
+        msg: "Запис вимірювання видалено",
+        onUndo: () => restore(snapshot),
+      });
     },
-    [deletePending, remove],
+    [entries, remove, restore, toast],
   );
 
-  const pendingDeleteId = useMemo(() => {
-    if (!deletePending) return null;
-    return deletePending.expiresAt > Date.now() ? deletePending.id : null;
-  }, [deletePending]);
+  // Після переходу на undo-toast pending-стану більше нема — лишили
+  // `pendingDeleteId` у ПРОП-списку листа для зворотної сумісності.
+  const pendingDeleteId: string | null = null;
 
   const editingEntry = formState.mode === "edit" ? formState.entry : null;
 

--- a/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
+++ b/apps/mobile/src/modules/nutrition/NutritionApp.test.tsx
@@ -17,13 +17,16 @@ import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { apiClient } from "@/api/apiClient";
 import { _getMMKVInstance } from "@/lib/storage";
+import { ToastProvider } from "@/components/ui/Toast";
 
 import { NutritionApp } from "./NutritionApp";
 
 function renderNutrition() {
   return render(
     <ApiClientProvider client={apiClient}>
-      <NutritionApp />
+      <ToastProvider>
+        <NutritionApp />
+      </ToastProvider>
     </ApiClientProvider>,
   );
 }

--- a/apps/mobile/src/modules/nutrition/hooks/useNutritionPantries.ts
+++ b/apps/mobile/src/modules/nutrition/hooks/useNutritionPantries.ts
@@ -32,6 +32,12 @@ export interface UseNutritionPantriesResult {
   /** Результат `parsePantry` (сервер) — злиття в активний склад. */
   applyParsedItems: (items: readonly PantryItem[]) => void;
   removeItemAt: (index: number) => void;
+  /**
+   * Re-insert an item at the given index in the active pantry. Used by
+   * undo-toast after `removeItemAt`. Если index >= length — додаємо у
+   * кінець; index < 0 → no-op.
+   */
+  restoreItemAt: (index: number, item: PantryItem) => void;
   addPantry: (name: string) => void;
   refresh: () => void;
 }
@@ -110,6 +116,20 @@ export function useNutritionPantries(): UseNutritionPantriesResult {
     );
   }, []);
 
+  const restoreItemAt = useCallback((index: number, item: PantryItem) => {
+    if (index < 0 || !item) return;
+    setPantries((cur) =>
+      updatePantry(cur, activeIdRef.current, (p) => {
+        const items = Array.isArray(p.items) ? [...p.items] : [];
+        // Сплайс із clamp-нутим індексом — якщо item-ів стало менше
+        // (паралельний remove), просто додаємо в кінець.
+        const clamped = Math.min(index, items.length);
+        items.splice(clamped, 0, item);
+        return { ...p, items };
+      }),
+    );
+  }, []);
+
   const addPantry = useCallback((name: string) => {
     const n = String(name || "").trim();
     if (!n) return;
@@ -129,6 +149,7 @@ export function useNutritionPantries(): UseNutritionPantriesResult {
     addLine,
     applyParsedItems,
     removeItemAt,
+    restoreItemAt,
     addPantry,
     refresh,
   };

--- a/apps/mobile/src/modules/nutrition/pages/Log.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Log.tsx
@@ -26,7 +26,8 @@ import {
 import { toLocalISODate } from "@sergeant/shared";
 
 import { Card } from "@/components/ui/Card";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
 
 import {
   AddMealSheet,
@@ -98,12 +99,9 @@ export function Log({ testID, onMealAdded }: LogProps) {
     updateMeal,
     removeMeal,
   } = useNutritionLog();
+  const toast = useToast();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editMeal, setEditMeal] = useState<InitialMeal | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<{
-    date: string;
-    id: string;
-  } | null>(null);
 
   const handleAdd = useCallback(() => {
     setEditMeal(null);
@@ -135,12 +133,19 @@ export function Log({ testID, onMealAdded }: LogProps) {
     [editMeal, selectedDate, addMeal, updateMeal, onMealAdded],
   );
 
-  const confirmDelete = useCallback(() => {
-    if (deleteTarget) {
-      removeMeal(deleteTarget.date, deleteTarget.id);
-      setDeleteTarget(null);
-    }
-  }, [deleteTarget, removeMeal]);
+  // Замість ConfirmDialog — single-tap видалення з undo-toast (parity з web).
+  const handleDeleteMeal = useCallback(
+    (meal: Meal) => {
+      removeMeal(selectedDate, meal.id);
+      const dateAtDelete = selectedDate;
+      const mealName = meal.name || "прийом";
+      showUndoToast(toast, {
+        msg: `Видалено «${mealName}»`,
+        onUndo: () => addMeal(dateAtDelete, meal),
+      });
+    },
+    [addMeal, removeMeal, selectedDate, toast],
+  );
 
   const rows = useMemo(
     () => getRowsForDate(nutritionLog, selectedDate),
@@ -298,12 +303,7 @@ export function Log({ testID, onMealAdded }: LogProps) {
                         {Math.round(item.meal.macros?.carbs_g || 0)}
                       </Text>
                       <Pressable
-                        onPress={() =>
-                          setDeleteTarget({
-                            date: selectedDate,
-                            id: item.meal.id,
-                          })
-                        }
+                        onPress={() => handleDeleteMeal(item.meal)}
                         accessibilityRole="button"
                         accessibilityLabel={`Видалити ${item.meal.name || "прийом"}`}
                         hitSlop={8}
@@ -328,15 +328,6 @@ export function Log({ testID, onMealAdded }: LogProps) {
         }}
         onSave={handleSave}
         initialMeal={editMeal}
-      />
-
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title="Видалити прийом їжі?"
-        description="Цей запис буде видалено назавжди."
-        confirmLabel="Видалити"
-        onConfirm={confirmDelete}
-        onCancel={() => setDeleteTarget(null)}
       />
     </View>
   );

--- a/apps/mobile/src/modules/nutrition/pages/Pantry.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/Pantry.tsx
@@ -19,6 +19,8 @@ import { hapticTap } from "@sergeant/shared";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
 
 import { useNutritionPantries } from "../hooks/useNutritionPantries";
 
@@ -41,8 +43,10 @@ export function PantryPage({ testID }: { testID?: string }) {
     addLine,
     applyParsedItems,
     removeItemAt,
+    restoreItemAt,
     addPantry,
   } = useNutritionPantries();
+  const toast = useToast();
   const [draft, setDraft] = useState("");
   const [newPantryName, setNewPantryName] = useState("");
   const [bulkText, setBulkText] = useState("");
@@ -228,7 +232,13 @@ export function PantryPage({ testID }: { testID?: string }) {
                     <Pressable
                       onPress={() => {
                         hapticTap();
+                        const snapshot: PantryItem = it;
+                        const removedAt = idx;
                         removeItemAt(idx);
+                        showUndoToast(toast, {
+                          msg: `Видалено «${snapshot.name}»`,
+                          onUndo: () => restoreItemAt(removedAt, snapshot),
+                        });
                       }}
                       accessibilityLabel={`Видалити ${it.name}`}
                       className="px-2 py-1"

--- a/apps/mobile/src/modules/nutrition/pages/RecipeDetail.tsx
+++ b/apps/mobile/src/modules/nutrition/pages/RecipeDetail.tsx
@@ -1,14 +1,16 @@
 import { useCallback } from "react";
-import { Alert, Pressable, ScrollView, Share, Text, View } from "react-native";
+import { Pressable, ScrollView, Share, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
 import { hapticTap, type NullableMacros } from "@sergeant/shared";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
 
 import { useSavedRecipeById } from "../hooks/useSavedRecipeById";
-import { removeSavedRecipe } from "../lib/recipeBookStore";
+import { removeSavedRecipe, upsertSavedRecipe } from "../lib/recipeBookStore";
 
 function formatMacros(m: NullableMacros): { text: string; hasAny: boolean } {
   const parts = [
@@ -27,6 +29,7 @@ export function RecipeDetailPage({
 }) {
   const router = useRouter();
   const { recipe, recipeId } = useSavedRecipeById(id);
+  const toast = useToast();
   const onBack = useCallback(() => {
     hapticTap();
     router.back();
@@ -50,25 +53,21 @@ export function RecipeDetailPage({
     });
   }, [recipe, router]);
 
+  // Single-tap delete + undo-toast (parity з web). Після видалення
+  // відразу вертаємося назад, а toast живе ї є доступний у листі рецептів.
   const onDelete = useCallback(() => {
     if (!recipe) return;
-    Alert.alert(
-      "Видалити рецепт?",
-      `«${recipe.title}» буде видалено з пристрою.`,
-      [
-        { text: "Скасувати", style: "cancel" },
-        {
-          text: "Видалити",
-          style: "destructive",
-          onPress: () => {
-            removeSavedRecipe(recipe.id);
-            hapticTap();
-            router.back();
-          },
-        },
-      ],
-    );
-  }, [recipe, router]);
+    const snapshot = recipe;
+    removeSavedRecipe(recipe.id);
+    hapticTap();
+    router.back();
+    showUndoToast(toast, {
+      msg: `Рецепт «${snapshot.title}» видалено`,
+      onUndo: () => {
+        upsertSavedRecipe(snapshot);
+      },
+    });
+  }, [recipe, router, toast]);
 
   if (!recipeId) {
     return (

--- a/apps/mobile/src/modules/routine/RoutineApp.test.tsx
+++ b/apps/mobile/src/modules/routine/RoutineApp.test.tsx
@@ -16,8 +16,17 @@ import { fireEvent, render } from "@testing-library/react-native";
 import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance } from "@/lib/storage";
+import { ToastProvider } from "@/components/ui/Toast";
 
 import { RoutineApp } from "./RoutineApp";
+
+function renderApp() {
+  return render(
+    <ToastProvider>
+      <RoutineApp />
+    </ToastProvider>,
+  );
+}
 
 // Unique copy inside the mounted Calendar screen (the bottom-nav item
 // label is just "Календар", so we pin to the eyebrow kicker inside
@@ -38,12 +47,12 @@ beforeEach(() => {
 
 describe("RoutineApp shell", () => {
   it("renders the Calendar screen by default", () => {
-    const { getByText } = render(<RoutineApp />);
+    const { getByText } = renderApp();
     expect(getByText(CALENDAR_EYEBROW)).toBeTruthy();
   });
 
   it("switches to the Heatmap page when the Stats tab is pressed", () => {
-    const { getAllByText, getByText, queryByText } = render(<RoutineApp />);
+    const { getAllByText, getByText, queryByText } = renderApp();
 
     fireEvent.press(getAllByText("Статистика")[0]);
 
@@ -53,7 +62,7 @@ describe("RoutineApp shell", () => {
   });
 
   it("switches to the Habits page when the Settings tab is pressed", () => {
-    const { getAllByText, getByText } = render(<RoutineApp />);
+    const { getAllByText, getByText } = renderApp();
 
     fireEvent.press(getAllByText("Налаштування")[0]);
 
@@ -62,7 +71,7 @@ describe("RoutineApp shell", () => {
   });
 
   it("writes the selected tab to MMKV under the shared ROUTINE_MAIN_TAB key", () => {
-    const { getAllByText } = render(<RoutineApp />);
+    const { getAllByText } = renderApp();
 
     fireEvent.press(getAllByText("Статистика")[0]);
 
@@ -75,7 +84,7 @@ describe("RoutineApp shell", () => {
   it("picks up a persisted tab from MMKV on first mount", () => {
     _getMMKVInstance().set(STORAGE_KEYS.ROUTINE_MAIN_TAB, "settings");
 
-    const { getByText } = render(<RoutineApp />);
+    const { getByText } = renderApp();
 
     expect(getByText(SETTINGS_HEADLINE)).toBeTruthy();
   });
@@ -83,7 +92,7 @@ describe("RoutineApp shell", () => {
   it("falls back to the Calendar tab when the persisted value is malformed", () => {
     _getMMKVInstance().set(STORAGE_KEYS.ROUTINE_MAIN_TAB, "not-a-valid-tab");
 
-    const { getByText } = render(<RoutineApp />);
+    const { getByText } = renderApp();
 
     expect(getByText(CALENDAR_EYEBROW)).toBeTruthy();
   });

--- a/apps/mobile/src/modules/routine/lib/routineStore.ts
+++ b/apps/mobile/src/modules/routine/lib/routineStore.ts
@@ -23,6 +23,7 @@ import {
   applyDeleteHabit,
   applyMarkAllScheduledHabitsComplete,
   applyMoveHabitInOrder,
+  applyRestoreHabit,
   applySetCompletionNote,
   applySetHabitArchived,
   applySetHabitOrder,
@@ -31,9 +32,11 @@ import {
   defaultRoutineState,
   ensureHabitOrder,
   normalizeRoutineState,
+  snapshotHabit as snapshotHabitPure,
   type CreateHabitOptions,
   type Habit,
   type HabitDraftPatch,
+  type HabitSnapshot,
   type RoutineState,
 } from "@sergeant/routine-domain";
 import { _getMMKVInstance, safeReadLS, safeWriteLS } from "@/lib/storage";
@@ -75,6 +78,16 @@ export interface UseRoutineStoreReturn {
   setHabitArchived: (id: string, archived: boolean) => void;
   /** Остаточне видалення звички разом із completions / order / notes. */
   deleteHabit: (id: string) => void;
+  /**
+   * Повний знімок звички (сама звичка + completions + notes + позиція)
+   * для undo-toast. Повертає `null`, якщо звичка не знайдена.
+   */
+  snapshotHabit: (id: string) => HabitSnapshot | null;
+  /**
+   * Відновити звичку зі знімка, отриманого `snapshotHabit`. Ідемпотентно:
+   * якщо id вже існує — no-op.
+   */
+  restoreHabit: (snapshot: HabitSnapshot | null) => void;
   /** Перемістити звичку в списку на `delta` позицій (-1 = вгору). */
   moveHabitInOrder: (id: string, delta: number) => void;
   /**
@@ -186,6 +199,25 @@ export function useRoutineStore(): UseRoutineStoreReturn {
     });
   }, []);
 
+  // Тримаємо в state-getter-стилі: snapshotHabit читає поточний routine.
+  // Не реактивний (useCallback з deps на routine), але стабільний у межах
+  // одного рендеру. Це OK — snapshot треба зробити в момент видалення,
+  // _до_ виклику deleteHabit.
+  const snapshotHabit = useCallback(
+    (id: string): HabitSnapshot | null => snapshotHabitPure(routine, id),
+    [routine],
+  );
+
+  const restoreHabit = useCallback((snapshot: HabitSnapshot | null) => {
+    setRoutineState((prev) => {
+      const next = applyRestoreHabit(prev, snapshot);
+      if (next === prev) return prev;
+      saveRoutineState(next);
+      enqueueChange(ROUTINE_STORAGE_KEY);
+      return next;
+    });
+  }, []);
+
   const moveHabitInOrder = useCallback((id: string, delta: number) => {
     setRoutineState((prev) => {
       const next = applyMoveHabitInOrder(prev, id, delta);
@@ -217,6 +249,8 @@ export function useRoutineStore(): UseRoutineStoreReturn {
     updateHabit,
     setHabitArchived,
     deleteHabit,
+    snapshotHabit,
+    restoreHabit,
     moveHabitInOrder,
     setHabitOrder,
   };

--- a/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.test.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.test.tsx
@@ -18,8 +18,17 @@ import { AccessibilityInfo } from "react-native";
 import { act, fireEvent, render, screen } from "@testing-library/react-native";
 
 import { _getMMKVInstance } from "@/lib/storage";
+import { ToastProvider } from "@/components/ui/Toast";
 
 import { HabitsPage } from "./HabitsPage";
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <HabitsPage testID="habits-page" />
+    </ToastProvider>,
+  );
+}
 
 beforeEach(() => {
   _getMMKVInstance().clearAll();
@@ -37,7 +46,7 @@ afterEach(() => {
 
 describe("HabitsPage", () => {
   it("renders the empty state when no active habits exist", () => {
-    render(<HabitsPage testID="habits-page" />);
+    renderPage();
 
     expect(screen.getByText("Активні звички")).toBeTruthy();
     expect(screen.getByText("Поки порожньо")).toBeTruthy();
@@ -46,7 +55,7 @@ describe("HabitsPage", () => {
   });
 
   it("opens the HabitForm sheet when the FAB is pressed", () => {
-    render(<HabitsPage testID="habits-page" />);
+    renderPage();
 
     // Before the press, no form headline is mounted.
     expect(screen.queryByText("Нова звичка")).toBeNull();
@@ -59,7 +68,7 @@ describe("HabitsPage", () => {
   });
 
   it("creates a habit via the form and renders it in the active list", () => {
-    render(<HabitsPage testID="habits-page" />);
+    renderPage();
 
     fireEvent.press(screen.getByTestId("habits-page-add"));
 

--- a/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.tsx
+++ b/apps/mobile/src/modules/routine/pages/Habits/HabitsPage.tsx
@@ -45,6 +45,9 @@ import {
   type HabitDraftPatch,
 } from "@sergeant/routine-domain";
 
+import { useToast } from "@/components/ui/Toast";
+import { showUndoToast } from "@/lib/showUndoToast";
+
 import { useRoutineStore } from "../../lib/routineStore";
 import { DraggableHabitList } from "./DraggableHabitList";
 import { HabitForm } from "./HabitForm";
@@ -54,9 +57,6 @@ type FormState =
   | { mode: "closed" }
   | { mode: "new" }
   | { mode: "edit"; habit: Habit };
-
-/** Delete confirmation pulse window — same "tap twice" pattern as Finyk. */
-const DELETE_CONFIRM_MS = 5000;
 
 export interface HabitsPageProps {
   /** Optional root `testID` — children derive stable sub-ids. */
@@ -70,15 +70,14 @@ export function HabitsPage({ testID }: HabitsPageProps) {
     updateHabit,
     setHabitArchived,
     deleteHabit,
+    snapshotHabit,
+    restoreHabit,
     moveHabitInOrder,
     setHabitOrder,
   } = useRoutineStore();
+  const toast = useToast();
 
   const [formState, setFormState] = useState<FormState>({ mode: "closed" });
-  const [deletePending, setDeletePending] = useState<{
-    id: string;
-    expiresAt: number;
-  } | null>(null);
   const [archiveOpen, setArchiveOpen] = useState(false);
 
   const activeHabits = useMemo(
@@ -118,27 +117,27 @@ export function HabitsPage({ testID }: HabitsPageProps) {
     [formState, createHabit, updateHabit],
   );
 
+  // Single-tap delete + undo-toast (parity з web-ом). Знімок робимо
+  // _до_ виклику `deleteHabit`, бо після reducer-а звички в `routine`
+  // вже немає.
   const handleRequestDelete = useCallback(
     (id: string) => {
-      const now = Date.now();
-      if (
-        deletePending &&
-        deletePending.id === id &&
-        deletePending.expiresAt > now
-      ) {
-        deleteHabit(id);
-        setDeletePending(null);
-      } else {
-        setDeletePending({ id, expiresAt: now + DELETE_CONFIRM_MS });
-      }
+      const snapshot = snapshotHabit(id);
+      if (!snapshot) return;
+      deleteHabit(id);
+      const habitName = snapshot.habit.name || "звичку";
+      showUndoToast(toast, {
+        msg: `Видалено звичку «${habitName}»`,
+        onUndo: () => restoreHabit(snapshot),
+      });
     },
-    [deletePending, deleteHabit],
+    [deleteHabit, restoreHabit, snapshotHabit, toast],
   );
 
-  const pendingDeleteId =
-    deletePending && deletePending.expiresAt > Date.now()
-      ? deletePending.id
-      : null;
+  // `pendingDeleteId` залишається у списку API DraggableHabitList для
+  // зворотної сумісності, але після переходу на undo-toast pending-стану
+  // більше нема — завжди передаємо `null`.
+  const pendingDeleteId: string | null = null;
 
   const editingId = formState.mode === "edit" ? formState.habit.id : null;
 
@@ -235,14 +234,6 @@ export function HabitsPage({ testID }: HabitsPageProps) {
             )
           ) : null}
         </View>
-
-        {pendingDeleteId ? (
-          <View className="rounded-xl border border-danger/30 bg-danger/10 px-3 py-2">
-            <Text className="text-xs text-danger text-center">
-              Ще раз «Видалити», щоб остаточно прибрати звичку.
-            </Text>
-          </View>
-        ) : null}
       </ScrollView>
 
       <View className="absolute right-4 bottom-6">


### PR DESCRIPTION
## What changed

Додає на мобайл повноцінний **undo-toast** для деструктивних дій — паритет із вебом, де давно живе `apps/web/src/shared/lib/undoToast.tsx`.

**Новий хелпер `apps/mobile/src/lib/showUndoToast.ts`** — мобайл-дзеркало вебового `showUndoToast`. Контракт ідентичний: `hapticWarning()` на показ, `hapticTap()` на тап «Повернути», `hapticError()` + error-toast якщо `onUndo` кидає.

**Snapshot/restore у store-ах:**
- `useRoutineStore.snapshotHabit(id)` + `restoreHabit(snapshot)` — використовує чисті reducer-и `snapshotHabit` / `applyRestoreHabit` із `@sergeant/routine-domain`.
- `useMeasurements.restore(entry)` — `upsertMeasurement` (домен-чистий шлях, ідемпотентний при дублікатах id).
- `useNutritionPantries.restoreItemAt(index, item)` — вставляє предмет назад на ту ж позицію в активному pantry.

**Виклик undo з UI (single-tap delete + 5-сек toast із кнопкою «Повернути»):**
- `HabitsPage` — прибрано «tap-twice + червоний banner»; тепер snapshot → delete → toast.
- `Measurements` — те саме, замість двох тапів.
- `Pantry` — undo для `removeItemAt` з відновленням на ту ж позицію.
- `Log` (Nutrition) — прибрано `ConfirmDialog`, single-tap + undo через `addMeal`/`removeMeal` (id-preserving).
- `TransactionsPage` (Finyk) — `removeManualExpense` тепер обгорнутий: snapshot → delete → toast → restore через `addManualExpense`.
- `RecipeDetail` (Nutrition) — прибрано `Alert.alert`; одразу `removeSavedRecipe` + `router.back()`, undo живе на батьківському екрані.

**Drive-by fix:** `apps/mobile/src/components/ui/ListItem.tsx` (з #1046) імпортував неіснуючий `haptic` namespace, через що mobile typecheck падав на main. Заміна на `hapticTap` із `@sergeant/shared`.

**Тести:**
- Новий `apps/mobile/src/lib/showUndoToast.test.ts` — happy path, error path, кастомні label/duration/error-msg.
- Сторінкові тести (`HabitsPage`, `RoutineApp`, `NutritionApp`, `Measurements`, `TransactionsPage`) тепер обгортаються в `ToastProvider` (як це вже робив `HubDashboard.test.tsx`).
- `Measurements.test.tsx` — оновлено колишній «two-tap delete» кейс на «single-tap delete» (toast живе у RTL, але робить delete синхронно).

## Why

Юзер: «зроби нормальні undo в мобайл версії і глянь наскільки взагалі відстає мобайл від вебу».

Раніше мобайл мав три різні (і всі гірші) патерни замість undo:
1. **tap-twice + червоний banner** (`HabitsPage`, `Measurements`) — не дискаверабельно, треба тримати в голові 5-сек таймер.
2. **`ConfirmDialog` / `Alert.alert`** (`Log`, `RecipeDetail`) — нативний modal до дії, без можливості скасувати після.
3. **Без жодного попередження** (`Pantry`, `TransactionsPage`) — «тиха» втрата даних.

Веб у всіх цих місцях використовує `showUndoToast` (бачимо у `Transactions.tsx`, `Workouts.tsx`, `AssetsTable.tsx`, `Budgets.tsx`, `RoutineSection.tsx`, `RecipesCard.tsx`, `WorkoutTemplatesSection.tsx`, `HubChat.tsx`). Тепер мобайл має той самий primitive і той самий UX-контракт.

## Parity gap report (mobile vs web)

Що **залишилось** не в паритеті після цього PR (не блокери — окремі задачі):

| Домен | Web має | Mobile має | Статус |
|---|---|---|---|
| Routine | undo-toast для delete habit | ✅ цей PR | done |
| Routine | `RoutineSection` (Settings) — undo для clear-history | undo через `showUndoToast` | ❌ нема такого екрану на мобайлі |
| Fizruk | undo для measurements delete | ✅ цей PR | done |
| Fizruk | `Workouts.tsx` — undo для delete workout & template | старий патерн / `Alert.alert` | ❌ окремий PR |
| Fizruk | `WorkoutTemplatesSection` — undo для template delete | нема секції на мобайлі | ❌ окремий PR |
| Nutrition | undo для meal delete | ✅ цей PR | done |
| Nutrition | undo для pantry remove | ✅ цей PR | done |
| Nutrition | undo для recipe delete | ✅ цей PR | done |
| Nutrition | `RecipesCard` (HubDashboard) — undo для recipe remove | нема картки на мобайлі | ❌ окремий PR |
| Finyk | undo для manual expense delete | ✅ цей PR | done |
| Finyk | `Budgets.tsx` — undo для бюджет/правило delete | сторінки не портовано | ❌ окремий PR |
| Finyk | `AssetsTable.tsx` — undo для asset delete | сторінки не портовано | ❌ окремий PR |
| Core | `HubChat` — undo для clear-context | мобайл chat має інший потік | ❌ окремий PR |

Інші помітні розбіжності mobile vs web (поза undo):
- **Workouts (Fizruk)**: web має повноцінний редактор шаблонів + undo; mobile — лиш базовий лог. Багато ще не портовано.
- **Budgets / Assets (Finyk)**: на мобайлі це фактично stub-сторінки. Інша велика прогалина.
- **HubChat tool actions**: web має ціле сімейство `chatActions/*` з undo для деяких; мобайл тут трохи відстає.
- **Settings / RoutineSection**: web `core/settings/RoutineSection.tsx` має clear-history з undo; мобайл — нема.

## How to test

1. `pnpm --filter @sergeant/mobile typecheck` — clean.
2. `pnpm --filter @sergeant/mobile lint` — clean.
3. `pnpm --filter @sergeant/mobile test` — 616 passed (єдиний 1 fail — `SignInScreen.test.tsx` із pre-existing emoji-renderer issue, не пов'язаний з PR; те саме на main).
4. Manual smoke на мобайлі:
   - Відкрити `Habits` → видалити звичку → клікнути «Повернути» → звичка повертається.
   - `Measurements` → видалити запис → undo.
   - `Nutrition / Log` → довгий тап на прийомі → видалити → undo.
   - `Nutrition / Pantry` → ✕ біля продукту → undo (продукт повертається на ту ж позицію в категорії).
   - `Nutrition / RecipeDetail` → «Видалити» → toast живе у списку рецептів.
   - `Finyk / Transactions` → відкрити свій manual expense → «Видалити» → undo.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/mobile typecheck` — pass.
- [x] `pnpm --filter @sergeant/mobile lint` — pass.
- [x] `pnpm --filter @sergeant/mobile test` — 616 pass / 1 pre-existing fail (SignInScreen, не пов'язано).
- [x] Новий unit-тест `showUndoToast.test.ts` (5 кейсів: happy, error, custom error msg, default duration/type, custom label).
- [x] Без нових `AI-DANGER` маркерів.
- [x] Українська у docs / коментарях де практично.

## AGENTS.md updated?

- [ ] No — нових постійних правил не додаю.

Link to Devin session: https://app.devin.ai/sessions/43e8e5fc835c4d7d8754bf639e6e7c35
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a proper undo toast on mobile with a new `showUndoToast` helper, matching the web experience. Destructive actions are now single-tap delete with a 5s undo, with haptic feedback and error handling.

- New Features
  - Added `apps/mobile/src/lib/showUndoToast.ts` (mirror of web `showUndoToast`): 5s toast, customizable label/message, uses `useToast` and `@sergeant/shared` haptics (`hapticWarning`, `hapticTap`, `hapticError`).
  - Routine: `snapshotHabit(id)` and `restoreHabit(snapshot)` via `@sergeant/routine-domain`.
  - Measurements: `restore(entry)` (idempotent upsert).
  - Nutrition Pantries: `restoreItemAt(index, item)` to reinsert at the original position.
  - Switched delete flows to snapshot → delete → undo toast in Habits, Measurements, Nutrition (Log, Pantry, RecipeDetail), and Finyk Transactions. RecipeDetail navigates back immediately after delete; undo lives on the list screen.

- Bug Fixes
  - Fixed `ListItem` to use `hapticTap` from `@sergeant/shared` instead of a non-existent `haptic` import.
  - Updated `apps/mobile/src/auth/SignInScreen.test.tsx` to match the heading text change after #1046 (emoji moved to icon).

<sup>Written for commit 056f96395de14bd60c16a9435c85ab32bf8a903d. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global undo flow: deleted items across transactions, measurements, meals, pantry, recipes, and habits can be restored via an undo toast.
  * Added a reusable undo toast utility with localized default error messaging and haptic feedback.

* **Improvements**
  * Deletions are immediate with an undo option—no multi-step confirmations.
  * Haptic feedback refined for taps, warnings, and errors.

* **Tests**
  * Updated tests to include toast context and added mobile-focused undo/haptic tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->