### PR TITLE
feat(web): add UI/UX improvements and new components

### DIFF
--- a/apps/web/src/core/hub/dashboard/BentoCard.tsx
+++ b/apps/web/src/core/hub/dashboard/BentoCard.tsx
@@ -85,8 +85,11 @@ export const BentoCard = memo(function BentoCard({
           "group relative flex flex-col w-full rounded-3xl border border-line",
           "p-3.5 [@media(pointer:coarse)]:p-4",
           "min-h-[120px] [@media(pointer:coarse)]:min-h-[132px]",
-          "shadow-card transition-all duration-200 text-left",
+          "shadow-card transition-interactive text-left",
           "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2",
+          // Hover effect for desktop - lift and glow
+          "[@media(pointer:fine)]:hover:shadow-float [@media(pointer:fine)]:hover:-translate-y-0.5",
+          "[@media(pointer:fine)]:hover:border-brand-200/50 dark:[@media(pointer:fine)]:hover:border-line/80",
           "active:scale-[0.98] [@media(pointer:coarse)]:active:scale-[0.97]",
           inactive ? "bg-panel grayscale" : config.cardBg,
           isDragging && "shadow-float cursor-grabbing",

--- a/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
+++ b/apps/web/src/core/hub/dashboard/moduleConfigs.tsx
@@ -56,7 +56,7 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     iconClass: "bg-finyk-soft text-finyk dark:bg-finyk-surface-dark/15",
     accentClass: "bg-finyk",
     cardBg:
-      "bg-finyk-soft/40 dark:bg-finyk-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-finyk-soft/40 dark:bg-finyk-surface-dark/10 dark:border-finyk-border-dark/25",
     description: "Транзакції та бюджети",
     hasGoal: false,
     emptyLabel: "Почни тут \u2192",
@@ -89,7 +89,7 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
     iconClass: "bg-fizruk-soft text-fizruk dark:bg-fizruk-surface-dark/15",
     accentClass: "bg-fizruk",
     cardBg:
-      "bg-fizruk-soft/40 dark:bg-fizruk-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-fizruk-soft/40 dark:bg-fizruk-surface-dark/10 dark:border-fizruk-border-dark/25",
     description: "Тренування та прогрес",
     hasGoal: false,
     emptyLabel: "Почни тут \u2192",
@@ -122,7 +122,7 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
       "bg-routine-surface text-routine dark:bg-routine-surface-dark/15",
     accentClass: "bg-routine",
     cardBg:
-      "bg-routine-surface/40 dark:bg-routine-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-routine-surface/40 dark:bg-routine-surface-dark/10 dark:border-routine-border-dark/25",
     description: "Звички та щоденні цілі",
     hasGoal: true,
     emptyLabel: "Почни тут \u2192",
@@ -156,7 +156,7 @@ export const MODULE_CONFIGS: Record<ModuleId, ModuleConfig> = {
       "bg-nutrition-soft text-nutrition dark:bg-nutrition-surface-dark/15",
     accentClass: "bg-nutrition",
     cardBg:
-      "bg-nutrition-soft/40 dark:bg-nutrition-surface-dark/8 hover:shadow-float hover:-translate-y-0.5",
+      "bg-nutrition-soft/40 dark:bg-nutrition-surface-dark/10 dark:border-nutrition-border-dark/25",
     description: "КБЖВ та раціон",
     hasGoal: true,
     emptyLabel: "Почни тут \u2192",

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -101,6 +101,8 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: ButtonSize;
   iconOnly?: boolean;
   loading?: boolean;
+  /** Progress value 0-100 for determinate loading state */
+  progress?: number;
   children?: ReactNode;
 }
 
@@ -113,6 +115,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       type = "button",
       iconOnly = false,
       loading = false,
+      progress,
       disabled,
       children,
       ...props
@@ -120,6 +123,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) {
     const isDisabled = disabled || loading;
+    const hasProgress = typeof progress === "number" && progress >= 0;
     const needsCoarseMinTarget = iconOnly || size === "xs" || size === "sm";
 
     return (
@@ -149,13 +153,21 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {loading ? (
           <>
-            <LoadingSpinner className="motion-safe:animate-spin" />
+            {hasProgress ? (
+              <ProgressSpinner progress={progress} className="shrink-0" />
+            ) : (
+              <LoadingSpinner className="motion-safe:animate-spin" />
+            )}
             {!iconOnly && (
               <span className="opacity-0" aria-hidden="true">
                 {children}
               </span>
             )}
-            <span className="sr-only">Завантаження…</span>
+            <span className="sr-only">
+              {hasProgress
+                ? `Завантаження ${Math.round(progress)}%`
+                : "Завантаження…"}
+            </span>
           </>
         ) : (
           children
@@ -180,6 +192,53 @@ function LoadingSpinner({ className }: { className?: string }) {
       strokeLinecap="round"
     >
       <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+    </svg>
+  );
+}
+
+// Determinate progress spinner with circular progress ring
+function ProgressSpinner({
+  progress,
+  className,
+}: {
+  progress: number;
+  className?: string;
+}) {
+  const radius = 7;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference - (progress / 100) * circumference;
+
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      className={cn("h-4 w-4", className)}
+      viewBox="0 0 18 18"
+    >
+      {/* Background circle */}
+      <circle
+        cx="9"
+        cy="9"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        opacity="0.25"
+      />
+      {/* Progress circle */}
+      <circle
+        cx="9"
+        cy="9"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={strokeDashoffset}
+        transform="rotate(-90 9 9)"
+        className="transition-[stroke-dashoffset] duration-200 ease-out"
+      />
     </svg>
   );
 }

--- a/apps/web/src/shared/components/ui/EmptyStateIllustrations.tsx
+++ b/apps/web/src/shared/components/ui/EmptyStateIllustrations.tsx
@@ -1,0 +1,408 @@
+import { memo } from "react";
+import { cn } from "@shared/lib/cn";
+
+interface IllustrationProps {
+  className?: string;
+  size?: number;
+}
+
+/**
+ * Module-specific empty state illustrations.
+ * SVG-based, responsive, and theme-aware.
+ */
+
+export const FinykEmptyIllustration = memo(function FinykEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-finyk", className)}
+      aria-hidden="true"
+    >
+      {/* Wallet base */}
+      <rect
+        x="20"
+        y="35"
+        width="80"
+        height="55"
+        rx="12"
+        className="fill-finyk-soft dark:fill-finyk/10 stroke-finyk/30"
+        strokeWidth="2"
+      />
+      {/* Wallet flap */}
+      <path
+        d="M20 47C20 40.373 25.373 35 32 35H88C94.627 35 100 40.373 100 47V55H20V47Z"
+        className="fill-finyk/20 dark:fill-finyk/15"
+      />
+      {/* Card slot */}
+      <rect
+        x="70"
+        y="60"
+        width="20"
+        height="14"
+        rx="3"
+        className="fill-panel stroke-finyk/40"
+        strokeWidth="1.5"
+      />
+      {/* Coins floating */}
+      <circle
+        cx="35"
+        cy="25"
+        r="10"
+        className="fill-brand-100 dark:fill-brand/20 stroke-brand-400"
+        strokeWidth="2"
+      />
+      <text
+        x="35"
+        y="29"
+        textAnchor="middle"
+        className="fill-brand-600 dark:fill-brand text-[10px] font-bold"
+      >
+        $
+      </text>
+      <circle
+        cx="55"
+        cy="18"
+        r="8"
+        className="fill-teal-100 dark:fill-teal-500/20 stroke-teal-400"
+        strokeWidth="1.5"
+        opacity="0.7"
+      />
+      {/* Sparkles */}
+      <path
+        d="M85 25L87 22L89 25L87 28L85 25Z"
+        className="fill-brand-400 motion-safe:animate-pulse"
+      />
+      <path
+        d="M25 70L26.5 68L28 70L26.5 72L25 70Z"
+        className="fill-brand-300 motion-safe:animate-pulse"
+        style={{ animationDelay: "0.5s" }}
+      />
+    </svg>
+  );
+});
+
+export const FizrukEmptyIllustration = memo(function FizrukEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-fizruk", className)}
+      aria-hidden="true"
+    >
+      {/* Dumbbell bar */}
+      <rect
+        x="25"
+        y="55"
+        width="70"
+        height="10"
+        rx="5"
+        className="fill-line dark:fill-line/60"
+      />
+      {/* Left weight */}
+      <rect
+        x="15"
+        y="40"
+        width="18"
+        height="40"
+        rx="4"
+        className="fill-fizruk-soft dark:fill-fizruk/15 stroke-fizruk/40"
+        strokeWidth="2"
+      />
+      <rect
+        x="8"
+        y="45"
+        width="12"
+        height="30"
+        rx="3"
+        className="fill-fizruk/30 dark:fill-fizruk/20 stroke-fizruk/30"
+        strokeWidth="1.5"
+      />
+      {/* Right weight */}
+      <rect
+        x="87"
+        y="40"
+        width="18"
+        height="40"
+        rx="4"
+        className="fill-fizruk-soft dark:fill-fizruk/15 stroke-fizruk/40"
+        strokeWidth="2"
+      />
+      <rect
+        x="100"
+        y="45"
+        width="12"
+        height="30"
+        rx="3"
+        className="fill-fizruk/30 dark:fill-fizruk/20 stroke-fizruk/30"
+        strokeWidth="1.5"
+      />
+      {/* Sweat drops */}
+      <ellipse
+        cx="60"
+        cy="35"
+        rx="3"
+        ry="5"
+        className="fill-teal-300 dark:fill-teal-400/50 motion-safe:animate-bounce"
+        style={{ animationDuration: "2s" }}
+      />
+      <ellipse
+        cx="50"
+        cy="30"
+        rx="2"
+        ry="3.5"
+        className="fill-teal-200 dark:fill-teal-400/30 motion-safe:animate-bounce"
+        style={{ animationDuration: "2.3s", animationDelay: "0.3s" }}
+      />
+      {/* Floor line */}
+      <path
+        d="M10 95H110"
+        className="stroke-line dark:stroke-line/40"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray="4 4"
+      />
+    </svg>
+  );
+});
+
+export const RoutineEmptyIllustration = memo(function RoutineEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn("text-routine", className)}
+      aria-hidden="true"
+    >
+      {/* Clipboard */}
+      <rect
+        x="25"
+        y="20"
+        width="70"
+        height="85"
+        rx="8"
+        className="fill-panel stroke-line"
+        strokeWidth="2"
+      />
+      {/* Clipboard top */}
+      <rect
+        x="40"
+        y="12"
+        width="40"
+        height="16"
+        rx="4"
+        className="fill-routine-surface dark:fill-routine/15 stroke-routine/40"
+        strokeWidth="2"
+      />
+      <circle cx="60" cy="20" r="4" className="fill-routine/50" />
+      {/* Empty checklist lines */}
+      <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+        <rect x="35" y="40" width="14" height="14" rx="3" />
+        <line x1="55" y1="47" x2="85" y2="47" strokeLinecap="round" />
+        <rect x="35" y="62" width="14" height="14" rx="3" />
+        <line x1="55" y1="69" x2="80" y2="69" strokeLinecap="round" />
+        <rect x="35" y="84" width="14" height="14" rx="3" />
+        <line x1="55" y1="91" x2="75" y2="91" strokeLinecap="round" />
+      </g>
+      {/* Decorative star */}
+      <path
+        d="M100 30L102 26L104 30L100 32L96 30L100 26L100 30Z"
+        className="fill-routine/50 motion-safe:animate-pulse"
+      />
+    </svg>
+  );
+});
+
+export const NutritionEmptyIllustration = memo(
+  function NutritionEmptyIllustration({
+    className,
+    size = 120,
+  }: IllustrationProps) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 120 120"
+        fill="none"
+        className={cn("text-nutrition", className)}
+        aria-hidden="true"
+      >
+        {/* Plate */}
+        <ellipse
+          cx="60"
+          cy="75"
+          rx="45"
+          ry="20"
+          className="fill-nutrition-soft dark:fill-nutrition/10 stroke-nutrition/30"
+          strokeWidth="2"
+        />
+        <ellipse
+          cx="60"
+          cy="75"
+          rx="35"
+          ry="14"
+          className="fill-panel stroke-line dark:stroke-line/60"
+          strokeWidth="1.5"
+        />
+        {/* Fork */}
+        <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+          <line x1="25" y1="40" x2="25" y2="65" strokeLinecap="round" />
+          <line x1="20" y1="40" x2="20" y2="52" strokeLinecap="round" />
+          <line x1="30" y1="40" x2="30" y2="52" strokeLinecap="round" />
+          <path d="M20 52H30" strokeLinecap="round" />
+        </g>
+        {/* Knife */}
+        <g className="stroke-line dark:stroke-line/60" strokeWidth="2">
+          <line x1="95" y1="40" x2="95" y2="65" strokeLinecap="round" />
+          <path d="M95 40C100 40 100 50 95 52" strokeLinecap="round" />
+        </g>
+        {/* Leaf garnish */}
+        <path
+          d="M55 55C55 50 60 45 65 45C65 50 60 55 55 55Z"
+          className="fill-nutrition/40 dark:fill-nutrition/30"
+        />
+        <path
+          d="M60 55L62 48"
+          className="stroke-nutrition/60"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        {/* Steam/aroma lines */}
+        <path
+          d="M50 35C50 32 53 32 53 35C53 38 50 38 50 35Z"
+          className="stroke-muted/40 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+        />
+        <path
+          d="M60 30C60 27 63 27 63 30C63 33 60 33 60 30Z"
+          className="stroke-muted/30 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+          style={{ animationDelay: "0.3s" }}
+        />
+        <path
+          d="M70 35C70 32 73 32 73 35C73 38 70 38 70 35Z"
+          className="stroke-muted/40 motion-safe:animate-pulse"
+          strokeWidth="1.5"
+          fill="none"
+          style={{ animationDelay: "0.6s" }}
+        />
+      </svg>
+    );
+  },
+);
+
+/**
+ * Generic empty state illustration for non-module contexts.
+ */
+export const GenericEmptyIllustration = memo(function GenericEmptyIllustration({
+  className,
+  size = 120,
+}: IllustrationProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="none"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      {/* Box */}
+      <rect
+        x="25"
+        y="35"
+        width="70"
+        height="55"
+        rx="8"
+        className="fill-panelHi stroke-line"
+        strokeWidth="2"
+      />
+      {/* Box opening */}
+      <path
+        d="M25 50L60 35L95 50"
+        className="stroke-line"
+        strokeWidth="2"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path
+        d="M60 35V55"
+        className="stroke-line/50"
+        strokeWidth="1.5"
+        strokeDasharray="3 3"
+      />
+      {/* Dust particles */}
+      <circle
+        cx="45"
+        cy="70"
+        r="2"
+        className="fill-muted/30 motion-safe:animate-pulse"
+      />
+      <circle
+        cx="75"
+        cy="65"
+        r="1.5"
+        className="fill-muted/20 motion-safe:animate-pulse"
+        style={{ animationDelay: "0.5s" }}
+      />
+      <circle
+        cx="60"
+        cy="75"
+        r="1"
+        className="fill-muted/25 motion-safe:animate-pulse"
+        style={{ animationDelay: "1s" }}
+      />
+    </svg>
+  );
+});
+
+export type ModuleIllustration =
+  | "finyk"
+  | "fizruk"
+  | "routine"
+  | "nutrition"
+  | "generic";
+
+const ILLUSTRATIONS: Record<
+  ModuleIllustration,
+  React.ComponentType<IllustrationProps>
+> = {
+  finyk: FinykEmptyIllustration,
+  fizruk: FizrukEmptyIllustration,
+  routine: RoutineEmptyIllustration,
+  nutrition: NutritionEmptyIllustration,
+  generic: GenericEmptyIllustration,
+};
+
+export interface ModuleEmptyIllustrationProps extends IllustrationProps {
+  module: ModuleIllustration;
+}
+
+/**
+ * Convenience component that renders the appropriate illustration
+ * based on the module name.
+ */
+export const ModuleEmptyIllustration = memo(function ModuleEmptyIllustration({
+  module,
+  ...props
+}: ModuleEmptyIllustrationProps) {
+  const Component = ILLUSTRATIONS[module] || ILLUSTRATIONS.generic;
+  return <Component {...props} />;
+});

--- a/apps/web/src/shared/components/ui/ModulePageLoader.tsx
+++ b/apps/web/src/shared/components/ui/ModulePageLoader.tsx
@@ -1,0 +1,289 @@
+import { memo } from "react";
+import { cn } from "@shared/lib/cn";
+import { Skeleton, SkeletonText } from "./Skeleton";
+
+type ModuleType = "finyk" | "fizruk" | "routine" | "nutrition" | "generic";
+
+interface ModulePageLoaderProps {
+  module?: ModuleType;
+  className?: string;
+}
+
+/**
+ * Module-specific skeleton loader that mimics the actual page layout.
+ * Each module gets a unique skeleton structure that matches its UI.
+ */
+export const ModulePageLoader = memo(function ModulePageLoader({
+  module = "generic",
+  className,
+}: ModulePageLoaderProps) {
+  const Loader = LOADERS[module] || GenericLoader;
+  return (
+    <div
+      className={cn(
+        "p-4 space-y-4 motion-safe:animate-in motion-safe:fade-in",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Завантаження…"
+    >
+      <Loader />
+    </div>
+  );
+});
+
+/**
+ * Finyk loader - mimics transaction list with summary card
+ */
+const FinykLoader = memo(function FinykLoader() {
+  return (
+    <>
+      {/* Summary card */}
+      <div className="rounded-3xl border border-line bg-finyk-soft/20 dark:bg-finyk-surface-dark/10 p-5 space-y-3">
+        <div className="flex items-center justify-between">
+          <SkeletonText shimmer className="w-20" />
+          <Skeleton shimmer className="w-10 h-10 rounded-xl" />
+        </div>
+        <Skeleton shimmer className="h-8 w-32" />
+        <div className="flex gap-4">
+          <SkeletonText shimmer className="w-24" />
+          <SkeletonText shimmer className="w-24" />
+        </div>
+      </div>
+
+      {/* Chart placeholder */}
+      <Skeleton shimmer className="h-40 w-full rounded-2xl" />
+
+      {/* Transaction list header */}
+      <div className="flex items-center justify-between pt-2">
+        <SkeletonText shimmer className="w-28" />
+        <SkeletonText shimmer className="w-16" />
+      </div>
+
+      {/* Transaction items */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 p-3 rounded-2xl border border-line bg-panel"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <Skeleton shimmer className="w-11 h-11 rounded-xl shrink-0" />
+            <div className="flex-1 space-y-2">
+              <SkeletonText shimmer className="w-32" />
+              <SkeletonText shimmer className="w-20 h-2" />
+            </div>
+            <SkeletonText shimmer className="w-16" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+/**
+ * Fizruk loader - mimics workout cards layout
+ */
+const FizrukLoader = memo(function FizrukLoader() {
+  return (
+    <>
+      {/* Stats row */}
+      <div className="grid grid-cols-3 gap-3">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="rounded-2xl border border-line bg-fizruk-soft/20 dark:bg-fizruk-surface-dark/10 p-4 space-y-2"
+          >
+            <Skeleton shimmer className="w-8 h-8 rounded-lg" />
+            <Skeleton shimmer className="h-6 w-12" />
+            <SkeletonText shimmer className="w-full" />
+          </div>
+        ))}
+      </div>
+
+      {/* Section header */}
+      <div className="flex items-center justify-between pt-4">
+        <SkeletonText shimmer className="w-32" />
+        <Skeleton shimmer className="w-8 h-8 rounded-lg" />
+      </div>
+
+      {/* Workout cards */}
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="rounded-2xl border border-line bg-panel p-4 space-y-3"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <div className="flex items-center gap-3">
+              <Skeleton shimmer className="w-12 h-12 rounded-xl shrink-0" />
+              <div className="flex-1 space-y-2">
+                <SkeletonText shimmer className="w-40" />
+                <SkeletonText shimmer className="w-24 h-2" />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Skeleton shimmer className="h-7 w-16 rounded-full" />
+              <Skeleton shimmer className="h-7 w-20 rounded-full" />
+              <Skeleton shimmer className="h-7 w-14 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+/**
+ * Routine loader - mimics habit grid layout
+ */
+const RoutineLoader = memo(function RoutineLoader() {
+  return (
+    <>
+      {/* Progress ring / streak */}
+      <div className="flex items-center justify-center py-6">
+        <Skeleton shimmer className="w-28 h-28 rounded-full" />
+      </div>
+
+      {/* Date selector */}
+      <div className="flex justify-center gap-2 pb-4">
+        {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+          <Skeleton
+            key={i}
+            shimmer
+            className="w-10 h-14 rounded-xl"
+            style={{ animationDelay: `${i * 30}ms` }}
+          />
+        ))}
+      </div>
+
+      {/* Section header */}
+      <div className="flex items-center justify-between">
+        <SkeletonText shimmer className="w-24" />
+        <SkeletonText shimmer className="w-12" />
+      </div>
+
+      {/* Habit grid */}
+      <div className="grid grid-cols-2 gap-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="rounded-2xl border border-line bg-routine-surface/20 dark:bg-routine-surface-dark/10 p-4 space-y-3"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <div className="flex items-center gap-2">
+              <Skeleton shimmer className="w-8 h-8 rounded-lg shrink-0" />
+              <SkeletonText shimmer className="flex-1" />
+            </div>
+            <Skeleton shimmer className="h-2 w-full rounded-full" />
+            <SkeletonText shimmer className="w-16 h-2" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+/**
+ * Nutrition loader - mimics macro tracking layout
+ */
+const NutritionLoader = memo(function NutritionLoader() {
+  return (
+    <>
+      {/* Daily summary */}
+      <div className="rounded-3xl border border-line bg-nutrition-soft/20 dark:bg-nutrition-surface-dark/10 p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <SkeletonText shimmer className="w-32" />
+          <Skeleton shimmer className="w-10 h-10 rounded-xl" />
+        </div>
+        <div className="flex items-center justify-center py-4">
+          <Skeleton shimmer className="w-24 h-24 rounded-full" />
+        </div>
+        {/* Macro bars */}
+        <div className="grid grid-cols-4 gap-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="space-y-2 text-center">
+              <Skeleton shimmer className="h-2 w-full rounded-full" />
+              <SkeletonText shimmer className="w-8 mx-auto h-2" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Meals section header */}
+      <div className="flex items-center justify-between pt-2">
+        <SkeletonText shimmer className="w-20" />
+        <Skeleton shimmer className="w-8 h-8 rounded-lg" />
+      </div>
+
+      {/* Meal cards */}
+      <div className="space-y-3">
+        {["Сніданок", "Обід", "Вечеря"].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-2xl border border-line bg-panel p-4 space-y-3"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Skeleton shimmer className="w-10 h-10 rounded-xl shrink-0" />
+                <SkeletonText shimmer className="w-20" />
+              </div>
+              <SkeletonText shimmer className="w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+/**
+ * Generic loader - basic card list
+ */
+const GenericLoader = memo(function GenericLoader() {
+  return (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <SkeletonText shimmer className="w-32" />
+        <Skeleton shimmer className="w-10 h-10 rounded-xl" />
+      </div>
+
+      {/* Cards */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="rounded-2xl border border-line bg-panel p-4"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <div className="flex items-center gap-3">
+              <Skeleton shimmer className="w-11 h-11 rounded-xl shrink-0" />
+              <div className="flex-1 space-y-2">
+                <SkeletonText shimmer className="w-32" />
+                <SkeletonText shimmer className="w-full" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+const LOADERS: Record<ModuleType, React.ComponentType> = {
+  finyk: FinykLoader,
+  fizruk: FizrukLoader,
+  routine: RoutineLoader,
+  nutrition: NutritionLoader,
+  generic: GenericLoader,
+};
+
+export {
+  FinykLoader,
+  FizrukLoader,
+  RoutineLoader,
+  NutritionLoader,
+  GenericLoader,
+};

--- a/apps/web/src/shared/components/ui/PullToRefreshIndicator.tsx
+++ b/apps/web/src/shared/components/ui/PullToRefreshIndicator.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@shared/lib/cn";
+import type { PullToRefreshState } from "@shared/hooks/usePullToRefresh";
+
+export interface PullToRefreshIndicatorProps {
+  state: PullToRefreshState;
+  /** Module accent color variant */
+  variant?: "finyk" | "fizruk" | "routine" | "nutrition" | "default";
+  className?: string;
+}
+
+const VARIANT_COLORS = {
+  finyk: "text-finyk border-finyk/30",
+  fizruk: "text-fizruk border-fizruk/30",
+  routine: "text-routine border-routine/30",
+  nutrition: "text-nutrition border-nutrition/30",
+  default: "text-brand border-brand/30",
+};
+
+/**
+ * Pull-to-refresh indicator component.
+ * Shows a spinner that rotates based on pull progress.
+ * Pairs with `usePullToRefresh` hook.
+ */
+export function PullToRefreshIndicator({
+  state,
+  variant = "default",
+  className,
+}: PullToRefreshIndicatorProps) {
+  const { isPulling, isRefreshing, pullProgress, pullDistance, canRefresh } =
+    state;
+
+  if (!isPulling && !isRefreshing && pullDistance === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "absolute left-1/2 -translate-x-1/2 z-50 flex items-center justify-center",
+        "transition-[transform,opacity] duration-200 ease-out",
+        className,
+      )}
+      style={{
+        transform: `translateX(-50%) translateY(${pullDistance - 48}px)`,
+        opacity: Math.min(pullProgress * 1.5, 1),
+      }}
+    >
+      <div
+        className={cn(
+          "w-10 h-10 rounded-full bg-panel shadow-card border flex items-center justify-center",
+          VARIANT_COLORS[variant],
+          canRefresh && "scale-110",
+          "transition-transform duration-150",
+        )}
+      >
+        <svg
+          className={cn(
+            "w-5 h-5",
+            isRefreshing && "motion-safe:animate-pull-rotate",
+          )}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          style={{
+            transform: isRefreshing
+              ? undefined
+              : `rotate(${pullProgress * 360}deg)`,
+            transition: isRefreshing ? undefined : "transform 0.1s ease-out",
+          }}
+        >
+          <path d="M21 12a9 9 0 11-6.219-8.56" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/components/ui/StreakCelebration.tsx
+++ b/apps/web/src/shared/components/ui/StreakCelebration.tsx
@@ -1,0 +1,221 @@
+import { memo, useEffect, useState, useCallback } from "react";
+import { cn } from "@shared/lib/cn";
+
+interface ConfettiParticle {
+  id: number;
+  x: number;
+  y: number;
+  rotation: number;
+  color: string;
+  size: number;
+  delay: number;
+}
+
+const MILESTONE_COLORS = {
+  7: ["#10B981", "#14B8A6", "#059669"], // emerald/teal for 7 days
+  14: ["#F97066", "#FB923C", "#F59E0B"], // coral/orange for 14 days
+  30: ["#A855F7", "#EC4899", "#8B5CF6"], // purple/pink for 30 days
+  default: ["#10B981", "#F97066", "#84CC16"], // mixed for other milestones
+};
+
+const MILESTONE_MESSAGES: Record<number, string> = {
+  7: "Тиждень послідовності!",
+  14: "Два тижні! Неймовірно!",
+  21: "Три тижні сили волі!",
+  30: "Місяць! Ти легенда!",
+  60: "Два місяці! Вражаюче!",
+  90: "Три місяці! Майстер!",
+  100: "100 днів! Феноменально!",
+  365: "Рік! Ти неперевершений!",
+};
+
+function getMilestoneMessage(days: number): string | null {
+  if (MILESTONE_MESSAGES[days]) return MILESTONE_MESSAGES[days];
+  if (days > 0 && days % 100 === 0) return `${days} днів! Чемпіон!`;
+  return null;
+}
+
+function getColors(days: number): string[] {
+  if (days === 7) return MILESTONE_COLORS[7];
+  if (days === 14) return MILESTONE_COLORS[14];
+  if (days >= 30) return MILESTONE_COLORS[30];
+  return MILESTONE_COLORS.default;
+}
+
+export interface StreakCelebrationProps {
+  /** Current streak count */
+  streak: number;
+  /** Previous streak count (to detect milestone crossing) */
+  previousStreak?: number;
+  /** Called when celebration animation completes */
+  onComplete?: () => void;
+  /** Override visibility control */
+  show?: boolean;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Streak milestone celebration with confetti burst effect.
+ * Automatically detects milestone crossings (7, 14, 30, etc.) and shows
+ * a celebration overlay with confetti and congratulatory message.
+ */
+export const StreakCelebration = memo(function StreakCelebration({
+  streak,
+  previousStreak,
+  onComplete,
+  show: showOverride,
+  className,
+}: StreakCelebrationProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [particles, setParticles] = useState<ConfettiParticle[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const generateParticles = useCallback((count: number, colors: string[]) => {
+    const newParticles: ConfettiParticle[] = [];
+    for (let i = 0; i < count; i++) {
+      newParticles.push({
+        id: i,
+        x: 50 + (Math.random() - 0.5) * 60, // spread from center
+        y: 50 + (Math.random() - 0.5) * 40,
+        rotation: Math.random() * 360,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        size: 6 + Math.random() * 8,
+        delay: Math.random() * 0.3,
+      });
+    }
+    return newParticles;
+  }, []);
+
+  const triggerCelebration = useCallback(
+    (days: number) => {
+      const msg = getMilestoneMessage(days);
+      if (!msg) return;
+
+      const colors = getColors(days);
+      const particleCount = days >= 30 ? 40 : days >= 14 ? 30 : 20;
+
+      setMessage(msg);
+      setParticles(generateParticles(particleCount, colors));
+      setIsVisible(true);
+
+      // Auto-dismiss after animation
+      const timer = setTimeout(() => {
+        setIsVisible(false);
+        onComplete?.();
+      }, 2500);
+
+      return () => clearTimeout(timer);
+    },
+    [generateParticles, onComplete],
+  );
+
+  // Detect milestone crossing
+  useEffect(() => {
+    if (showOverride !== undefined) {
+      if (showOverride) triggerCelebration(streak);
+      else setIsVisible(false);
+      return;
+    }
+
+    // Check if we crossed a milestone
+    const milestones = [7, 14, 21, 30, 60, 90, 100, 365];
+    const crossedMilestone = milestones.find(
+      (m) =>
+        streak >= m && (previousStreak === undefined || previousStreak < m),
+    );
+
+    if (crossedMilestone) {
+      triggerCelebration(crossedMilestone);
+    }
+  }, [streak, previousStreak, showOverride, triggerCelebration]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-[9999] flex items-center justify-center pointer-events-none",
+        className,
+      )}
+      aria-live="polite"
+      role="alert"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/20 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-300" />
+
+      {/* Confetti particles */}
+      <div className="absolute inset-0 overflow-hidden">
+        {particles.map((p) => (
+          <div
+            key={p.id}
+            className="absolute motion-safe:animate-confetti"
+            style={{
+              left: `${p.x}%`,
+              top: `${p.y}%`,
+              width: p.size,
+              height: p.size,
+              backgroundColor: p.color,
+              borderRadius: Math.random() > 0.5 ? "50%" : "2px",
+              transform: `rotate(${p.rotation}deg)`,
+              animationDelay: `${p.delay}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Message card */}
+      <div
+        className={cn(
+          "relative z-10 flex flex-col items-center gap-3 px-8 py-6",
+          "bg-panel/95 backdrop-blur-xl rounded-3xl shadow-float",
+          "border border-line",
+          "motion-safe:animate-streak-milestone",
+        )}
+      >
+        <div className="text-4xl animate-streak-glow">
+          {streak >= 30 ? "🏆" : streak >= 14 ? "🔥" : "⭐"}
+        </div>
+        <div className="text-center">
+          <p className="text-2xl font-bold text-text tabular-nums">{streak}</p>
+          <p className="text-sm font-semibold text-muted">днів поспіль</p>
+        </div>
+        {message && (
+          <p className="text-base font-semibold text-brand-strong dark:text-brand text-center text-pretty">
+            {message}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Hook to manage streak celebration state.
+ * Returns a trigger function and the celebration component.
+ */
+export function useStreakCelebration() {
+  const [celebrationState, setCelebrationState] = useState<{
+    streak: number;
+    previousStreak?: number;
+  } | null>(null);
+
+  const trigger = useCallback((streak: number, previousStreak?: number) => {
+    setCelebrationState({ streak, previousStreak });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setCelebrationState(null);
+  }, []);
+
+  const CelebrationComponent = celebrationState ? (
+    <StreakCelebration
+      streak={celebrationState.streak}
+      previousStreak={celebrationState.previousStreak}
+      onComplete={dismiss}
+      show
+    />
+  ) : null;
+
+  return { trigger, dismiss, CelebrationComponent };
+}

--- a/apps/web/src/shared/components/ui/Toast.tsx
+++ b/apps/web/src/shared/components/ui/Toast.tsx
@@ -39,7 +39,7 @@ export function ToastContainer() {
           key={t.id}
           className={cn(
             "pointer-events-auto w-full px-4 py-3 rounded-2xl text-sm font-semibold shadow-float flex items-center gap-2.5",
-            "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200",
+            "motion-safe:animate-toast-enter",
             VARIANT[t.type] || VARIANT.info,
           )}
           role="alert"

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -53,3 +53,15 @@ export type {
 } from "./useToast";
 
 export { useWebVisualKeyboardInset } from "./useVisualKeyboardInset";
+
+export { useScrollHeader } from "./useScrollHeader";
+export type {
+  ScrollHeaderState,
+  UseScrollHeaderOptions,
+} from "./useScrollHeader";
+
+export { usePullToRefresh } from "./usePullToRefresh";
+export type {
+  PullToRefreshState,
+  UsePullToRefreshOptions,
+} from "./usePullToRefresh";

--- a/apps/web/src/shared/hooks/usePullToRefresh.ts
+++ b/apps/web/src/shared/hooks/usePullToRefresh.ts
@@ -1,0 +1,190 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export interface PullToRefreshState {
+  /** Whether currently pulling down */
+  isPulling: boolean;
+  /** Whether refresh is in progress */
+  isRefreshing: boolean;
+  /** Pull distance in pixels (0 to pullThreshold) */
+  pullDistance: number;
+  /** Pull progress (0 to 1) */
+  pullProgress: number;
+  /** Whether pull threshold has been exceeded (ready to refresh) */
+  canRefresh: boolean;
+}
+
+export interface UsePullToRefreshOptions {
+  /** Callback when refresh is triggered */
+  onRefresh: () => Promise<void>;
+  /** Pull distance required to trigger refresh (default: 80px) */
+  pullThreshold?: number;
+  /** Maximum pull distance (default: 120px) */
+  maxPullDistance?: number;
+  /** Resistance factor for pulling past threshold (default: 0.4) */
+  resistance?: number;
+  /** Whether pull-to-refresh is enabled (default: true) */
+  enabled?: boolean;
+  /** Ref to scrollable container (required) */
+  scrollRef: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Hook for native-like pull-to-refresh gesture.
+ * Only activates when at top of scroll container.
+ *
+ * Returns state for building custom pull-to-refresh UI:
+ * - isPulling: actively pulling
+ * - isRefreshing: refresh in progress
+ * - pullDistance: current pull distance
+ * - pullProgress: 0-1 progress toward threshold
+ * - canRefresh: threshold exceeded, will refresh on release
+ */
+export function usePullToRefresh(
+  options: UsePullToRefreshOptions,
+): PullToRefreshState {
+  const {
+    onRefresh,
+    pullThreshold = 80,
+    maxPullDistance = 120,
+    resistance = 0.4,
+    enabled = true,
+    scrollRef,
+  } = options;
+
+  const [state, setState] = useState<PullToRefreshState>({
+    isPulling: false,
+    isRefreshing: false,
+    pullDistance: 0,
+    pullProgress: 0,
+    canRefresh: false,
+  });
+
+  const touchStartY = useRef<number | null>(null);
+  const touchStartScrollTop = useRef<number>(0);
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || state.isRefreshing) return;
+
+      const scrollElement = scrollRef.current;
+      if (!scrollElement) return;
+
+      // Only activate if at top of scroll
+      if (scrollElement.scrollTop <= 0) {
+        touchStartY.current = e.touches[0].clientY;
+        touchStartScrollTop.current = scrollElement.scrollTop;
+      }
+    },
+    [enabled, state.isRefreshing, scrollRef],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || state.isRefreshing || touchStartY.current === null)
+        return;
+
+      const scrollElement = scrollRef.current;
+      if (!scrollElement) return;
+
+      const currentY = e.touches[0].clientY;
+      const deltaY = currentY - touchStartY.current;
+
+      // Only handle pull-down when at top
+      if (deltaY > 0 && scrollElement.scrollTop <= 0) {
+        // Apply resistance after threshold
+        let adjustedDelta = deltaY;
+        if (deltaY > pullThreshold) {
+          const overpull = deltaY - pullThreshold;
+          adjustedDelta = pullThreshold + overpull * resistance;
+        }
+
+        const pullDistance = Math.min(adjustedDelta, maxPullDistance);
+        const pullProgress = Math.min(pullDistance / pullThreshold, 1);
+        const canRefresh = pullDistance >= pullThreshold;
+
+        setState((prev) => ({
+          ...prev,
+          isPulling: true,
+          pullDistance,
+          pullProgress,
+          canRefresh,
+        }));
+
+        // Prevent scroll while pulling
+        if (pullDistance > 0) {
+          e.preventDefault();
+        }
+      }
+    },
+    [
+      enabled,
+      state.isRefreshing,
+      scrollRef,
+      pullThreshold,
+      maxPullDistance,
+      resistance,
+    ],
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!enabled || touchStartY.current === null) return;
+
+    touchStartY.current = null;
+
+    if (state.canRefresh && !state.isRefreshing) {
+      setState((prev) => ({
+        ...prev,
+        isPulling: false,
+        isRefreshing: true,
+        pullDistance: pullThreshold * 0.6, // Keep indicator visible
+        pullProgress: 0.6,
+        canRefresh: false,
+      }));
+
+      try {
+        await onRefresh();
+      } finally {
+        // Animate out
+        setState({
+          isPulling: false,
+          isRefreshing: false,
+          pullDistance: 0,
+          pullProgress: 0,
+          canRefresh: false,
+        });
+      }
+    } else {
+      // Reset without refresh
+      setState({
+        isPulling: false,
+        isRefreshing: false,
+        pullDistance: 0,
+        pullProgress: 0,
+        canRefresh: false,
+      });
+    }
+  }, [enabled, state.canRefresh, state.isRefreshing, pullThreshold, onRefresh]);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement || !enabled) return;
+
+    scrollElement.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    scrollElement.addEventListener("touchmove", handleTouchMove, {
+      passive: false,
+    });
+    scrollElement.addEventListener("touchend", handleTouchEnd, {
+      passive: true,
+    });
+
+    return () => {
+      scrollElement.removeEventListener("touchstart", handleTouchStart);
+      scrollElement.removeEventListener("touchmove", handleTouchMove);
+      scrollElement.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [scrollRef, enabled, handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  return state;
+}

--- a/apps/web/src/shared/hooks/useScrollHeader.ts
+++ b/apps/web/src/shared/hooks/useScrollHeader.ts
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export interface ScrollHeaderState {
+  /** Whether header should be hidden (user scrolling down) */
+  isHidden: boolean;
+  /** Whether header should be shrunk (scrolled past threshold) */
+  isShrunk: boolean;
+  /** Whether blur background should be applied */
+  hasBlur: boolean;
+  /** Current scroll position */
+  scrollY: number;
+  /** Scroll direction: 'up' | 'down' | null */
+  direction: "up" | "down" | null;
+}
+
+export interface UseScrollHeaderOptions {
+  /** Scroll distance before header shrinks (default: 50px) */
+  shrinkThreshold?: number;
+  /** Scroll distance before header hides (default: 100px) */
+  hideThreshold?: number;
+  /** Minimum scroll delta to trigger direction change (default: 10px) */
+  minDelta?: number;
+  /** Enable blur effect when scrolled (default: true) */
+  enableBlur?: boolean;
+  /** Ref to scrollable container (defaults to window) */
+  scrollRef?: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Hook for scroll-aware header behavior.
+ * Tracks scroll position and direction to enable:
+ * - Header shrink on scroll (compact mode)
+ * - Header hide on scroll down / show on scroll up
+ * - Blur background effect when scrolled
+ *
+ * Respects `prefers-reduced-motion` by disabling animations.
+ */
+export function useScrollHeader(
+  options: UseScrollHeaderOptions = {},
+): ScrollHeaderState {
+  const {
+    shrinkThreshold = 50,
+    hideThreshold = 100,
+    minDelta = 10,
+    enableBlur = true,
+    scrollRef,
+  } = options;
+
+  const [state, setState] = useState<ScrollHeaderState>({
+    isHidden: false,
+    isShrunk: false,
+    hasBlur: false,
+    scrollY: 0,
+    direction: null,
+  });
+
+  const lastScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  const updateScrollState = useCallback(() => {
+    const scrollElement = scrollRef?.current;
+    const currentScrollY = scrollElement
+      ? scrollElement.scrollTop
+      : window.scrollY;
+
+    const delta = currentScrollY - lastScrollY.current;
+    const absDelta = Math.abs(delta);
+
+    // Only update direction if delta exceeds minimum threshold
+    // to prevent jittery state changes on small scrolls
+    let direction = state.direction;
+    if (absDelta >= minDelta) {
+      direction = delta > 0 ? "down" : "up";
+    }
+
+    const isShrunk = currentScrollY > shrinkThreshold;
+    const hasBlur = enableBlur && currentScrollY > 0;
+
+    // Hide header when scrolling down past threshold, show when scrolling up
+    const isHidden =
+      direction === "down" &&
+      currentScrollY > hideThreshold &&
+      absDelta >= minDelta;
+
+    setState({
+      isHidden,
+      isShrunk,
+      hasBlur,
+      scrollY: currentScrollY,
+      direction,
+    });
+
+    lastScrollY.current = currentScrollY;
+    ticking.current = false;
+  }, [
+    scrollRef,
+    shrinkThreshold,
+    hideThreshold,
+    minDelta,
+    enableBlur,
+    state.direction,
+  ]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!ticking.current) {
+        requestAnimationFrame(updateScrollState);
+        ticking.current = true;
+      }
+    };
+
+    const scrollElement = scrollRef?.current;
+    const target = scrollElement || window;
+
+    target.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      target.removeEventListener("scroll", handleScroll);
+    };
+  }, [scrollRef, updateScrollState]);
+
+  return state;
+}

--- a/apps/web/src/styles/animations.css
+++ b/apps/web/src/styles/animations.css
@@ -239,6 +239,133 @@
   }
 }
 
+.animate-shimmer {
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+/* ── Page exit animations ────────────────────────────────────────────── */
+
+@keyframes module-slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-32px);
+  }
+}
+
+@keyframes hub-slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(32px);
+  }
+}
+
+@keyframes page-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+
+.module-exit {
+  animation: module-slide-out 0.2s ease-in forwards;
+}
+
+.hub-exit {
+  animation: hub-slide-out 0.2s ease-in forwards;
+}
+
+.page-exit {
+  animation: page-exit 0.15s ease-in forwards;
+}
+
+/* ── Toast animations ────────────────────────────────────────────────── */
+
+@keyframes toast-enter {
+  0% {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-exit {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.95);
+  }
+}
+
+.animate-toast-enter {
+  animation: toast-enter 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.animate-toast-exit {
+  animation: toast-exit 0.2s ease-in forwards;
+}
+
+/* ── Streak milestone celebration ────────────────────────────────────── */
+
+@keyframes streak-milestone-burst {
+  0% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 0 rgba(249, 112, 102, 0));
+  }
+  25% {
+    transform: scale(1.15);
+    filter: drop-shadow(0 0 12px rgba(249, 112, 102, 0.5));
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  75% {
+    transform: scale(1.1);
+    filter: drop-shadow(0 0 20px rgba(249, 112, 102, 0.3));
+  }
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 8px rgba(249, 112, 102, 0.2));
+  }
+}
+
+.animate-streak-milestone {
+  animation: streak-milestone-burst 0.8s cubic-bezier(0.34, 1.56, 0.64, 1)
+    forwards;
+}
+
+/* ── Pull to refresh ─────────────────────────────────────────────────── */
+
+@keyframes pull-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-pull-rotate {
+  animation: pull-rotate 0.8s linear infinite;
+}
+
 /* ── Number counter ticks ────────────────────────────────────────────── */
 
 @keyframes number-tick-up {


### PR DESCRIPTION
- add useScrollHeader hook for scroll-aware header behavior
- add usePullToRefresh hook with native-like gesture support
- add PullToRefreshIndicator component with module colors
- add StreakCelebration component with confetti for milestones
- add EmptyStateIllustrations SVGs for all modules
- add ModulePageLoader with module-specific skeletons
- add Button progress prop with determinate progress ring
- improve BentoCard hover effects for desktop
- improve dark mode borders in moduleConfigs
- improve Toast animations with bounce easing
- add exit animations for page transitions
- add animate-shimmer and other CSS utilities

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mobile-friendly interactions (pull-to-refresh, scroll-aware header) and visual polish across modules, plus new empty/skeleton components and a determinate progress button. Improves perceived performance and feedback, especially on touch devices.

- **New Features**
  - `useScrollHeader` for hide/shrink/blur header behavior based on scroll.
  - `usePullToRefresh` with native-like gesture and `PullToRefreshIndicator` (module color variants).
  - `StreakCelebration` with confetti and milestone messages (+ `useStreakCelebration` helper).
  - `EmptyStateIllustrations` (module SVGs) and `ModulePageLoader` (module-specific skeletons).
  - `Button` adds `progress` prop with circular determinate ring when `loading`.
  - UI polish: improved `BentoCard` hover (desktop), better dark-mode borders in `moduleConfigs`, smoother toast enter/exit, page exit animations, and `animate-shimmer` utilities.

- **Migration**
  - For determinate loading, set `loading` and pass `progress` (0–100) to `Button`.
  - To add pull-to-refresh, call `usePullToRefresh({ onRefresh, scrollRef })` and render `<PullToRefreshIndicator state={state} />` within the scroll container.
  - For a scroll-aware header, use `useScrollHeader()` and apply `isHidden`, `isShrunk`, and `hasBlur` to header classes.

<sup>Written for commit 1d443ac1593d4afb5381e4cf50fbc15a22314308. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1049?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

