### PR TITLE
fix(web): use hapticError instead of missing triggerHaptic export

### DIFF
--- a/apps/web/src/shared/hooks/useFormValidation.ts
+++ b/apps/web/src/shared/hooks/useFormValidation.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import { triggerHaptic } from "../lib/haptic";
+import { hapticError } from "../lib/haptic";
 
 type ValidationRule<T> = {
   validate: (value: T) => boolean;
@@ -96,7 +96,7 @@ export function useFormValidation<T extends Record<string, unknown>>(
     }
 
     // Trigger haptic feedback
-    triggerHaptic("error");
+    hapticError();
 
     // Start shake
     setFields((prev) => ({


### PR DESCRIPTION
## What changed

`apps/web/src/shared/hooks/useFormValidation.ts` was importing a non-existent `triggerHaptic` symbol from `apps/web/src/shared/lib/haptic.ts`. That module only exports the named-event functions bound to the `@sergeant/shared` haptic contract (`hapticTap`, `hapticSuccess`, `hapticWarning`, `hapticError`, `hapticCancel`, `hapticPattern`).

Replaced the import + call site to use `hapticError()` directly — matching every other call site in `apps/web` (`undoToast.tsx`, `VoiceMicButton.tsx`, `FeatureSpotlight.tsx`, `RoutineApp.tsx`, `HabitQuickCreateDialog.tsx`, `AddMealSheet.tsx`, `WorkoutJournalSection.tsx`, `ManualExpenseSheet.tsx`, `HubSearch.tsx`).

## Why

Production Vercel build was failing on `main` with:

```
[vite-plugin-pwa:build] There was an error during the build:
  src/shared/hooks/useFormValidation.ts (2:9): "triggerHaptic" is not exported
  by "src/shared/lib/haptic.ts", imported by "src/shared/hooks/useFormValidation.ts".
```

Blocking deploys.

## How to test

```
pnpm install --frozen-lockfile
pnpm --filter @sergeant/web build
```

Build now completes ("✓ built in ~13s") and the PWA service worker is generated successfully.

---

## How AI-tested this PR

- [x] Manual smoke (`pnpm --filter @sergeant/web build`): passes locally with the same Vite/Rollup pipeline used by Vercel.
- [ ] Vitest passes: not run (single import-name change; no behaviour change worth reverifying).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` — n/a (no docs touched).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/f69a8c5b234d4a8c8128f4d8600c49bd
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Vercel build by replacing the non-existent `triggerHaptic` import with `hapticError()` in the form validation hook. This aligns with other web call sites and unblocks `@sergeant/web` deploys.

<sup>Written for commit a5ef89bb2efd022ab4011d8cfc0ea869c9e5d020. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1055?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

