### PR TITLE
feat(web): expand design system, FeatureSpotlight, haptics

### DIFF
--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 import {
+  Avatar,
   Badge,
   Banner,
   Button,
@@ -16,6 +17,7 @@ import {
   ICON_NAMES,
   IconButton,
   Input,
+  ProgressRing,
   SectionHeading,
   Segmented,
   Select,
@@ -23,8 +25,12 @@ import {
   SkeletonText,
   Spinner,
   Stat,
+  Switch,
   Tabs,
   Textarea,
+  Tooltip,
+  useCelebration,
+  FeatureSpotlight,
 } from "@shared/components/ui";
 import { Modal } from "@shared/components/ui/Modal";
 import { Sheet } from "@shared/components/ui/Sheet";
@@ -107,6 +113,8 @@ const NAV_SECTIONS = [
   { id: "navigation", label: "Навігація" },
   { id: "overlays", label: "Overlays" },
   { id: "feedback", label: "Фідбек" },
+  { id: "celebration", label: "Святкування" },
+  { id: "onboarding", label: "Онбординг" },
 ] as const;
 
 // ─── Main ──────────────────────────────────────────────────────────────────
@@ -119,6 +127,9 @@ export function DesignShowcase() {
   const [modal, setModal] = useState<"sm" | "md" | "lg" | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [switchOn, setSwitchOn] = useState(false);
+  const { success, achievement, confetti, goalCompleted, streak } =
+    useCelebration();
 
   return (
     <div className="min-h-dvh bg-bg">
@@ -1073,6 +1084,182 @@ export function DesignShowcase() {
                 </div>
                 <span className="text-xs text-muted font-mono">check-pop</span>
               </div>
+            </div>
+          </Group>
+
+          <Group label="Avatar">
+            <div className="flex flex-wrap items-end gap-4">
+              {(["xs", "sm", "md", "lg", "xl"] as const).map((size) => (
+                <Avatar key={size} size={size} name="Сергій Коваленко" src="" />
+              ))}
+              <Avatar size="lg" name="Онлайн" status="online" />
+              <Avatar size="lg" name="Офлайн" status="offline" />
+              <Avatar size="lg" name="Зайнятий" status="busy" />
+            </div>
+          </Group>
+
+          <Group label="ProgressRing">
+            <div className="flex flex-wrap items-end gap-6">
+              {(["xs", "sm", "md", "lg", "xl"] as const).map((size) => (
+                <ProgressRing
+                  key={size}
+                  size={size}
+                  value={65}
+                  max={100}
+                  showValue
+                />
+              ))}
+              <ProgressRing
+                size="lg"
+                value={100}
+                max={100}
+                variant="success"
+                showValue
+              />
+              <ProgressRing
+                size="lg"
+                value={30}
+                max={100}
+                variant="warning"
+                showValue
+              />
+              <ProgressRing
+                size="lg"
+                value={15}
+                max={100}
+                variant="danger"
+                showValue
+              />
+            </div>
+          </Group>
+
+          <Group label="Switch">
+            <div className="flex flex-wrap items-center gap-6">
+              <Switch
+                checked={switchOn}
+                onChange={setSwitchOn}
+                label="Увімкнено"
+              />
+              <Switch checked={false} onChange={() => {}} label="Вимкнено" />
+              <Switch
+                checked={true}
+                onChange={() => {}}
+                disabled
+                label="Disabled on"
+              />
+              <Switch
+                checked={false}
+                onChange={() => {}}
+                disabled
+                label="Disabled off"
+              />
+            </div>
+          </Group>
+
+          <Group label="Tooltip">
+            <div className="flex flex-wrap items-center gap-4">
+              <Tooltip content="Підказка зверху" placement="top">
+                <Button variant="secondary" size="sm">
+                  Top
+                </Button>
+              </Tooltip>
+              <Tooltip content="Підказка знизу" placement="bottom">
+                <Button variant="secondary" size="sm">
+                  Bottom
+                </Button>
+              </Tooltip>
+              <Tooltip content="Підказка зліва" placement="left">
+                <Button variant="secondary" size="sm">
+                  Left
+                </Button>
+              </Tooltip>
+              <Tooltip content="Підказка справа" placement="right">
+                <Button variant="secondary" size="sm">
+                  Right
+                </Button>
+              </Tooltip>
+            </div>
+          </Group>
+        </Sec>
+
+        {/* ── 11. CELEBRATION ─────────────────────────────────────── */}
+        <Sec id="celebration" title="Святкування">
+          <Group label="CelebrationModal">
+            <div className="flex flex-wrap gap-3">
+              <Button
+                variant="success"
+                size="sm"
+                onClick={() => success("Збережено!", "Дані успішно оновлено")}
+              >
+                Success
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() =>
+                  achievement(
+                    "Перша транзакція!",
+                    "Ти зробив перший крок до фінансової свободи",
+                    [
+                      { icon: "💰", label: "Фінансист" },
+                      { icon: "📊", label: "Аналітик" },
+                    ],
+                  )
+                }
+              >
+                Achievement
+              </Button>
+              <Button
+                variant="finyk"
+                size="sm"
+                onClick={() =>
+                  confetti("Вітаю!", "Ти досяг нового рівня!", "high")
+                }
+              >
+                Confetti
+              </Button>
+              <Button
+                variant="fizruk"
+                size="sm"
+                onClick={() => goalCompleted("Тренування", 45, "хв", "fizruk")}
+              >
+                Goal
+              </Button>
+              <Button
+                variant="routine"
+                size="sm"
+                onClick={() => streak(7, "7 днів поспіль!")}
+              >
+                Streak
+              </Button>
+            </div>
+          </Group>
+        </Sec>
+
+        {/* ── 12. ONBOARDING ──────────────────────────────────────── */}
+        <Sec id="onboarding" title="Онбординг">
+          <Group label="FeatureSpotlight">
+            <div className="flex flex-wrap gap-4">
+              <FeatureSpotlight
+                id="demo-spotlight-top"
+                title="Підказка зверху"
+                description="Це демо підказки з позицією top"
+                position="top"
+              >
+                <Button variant="secondary" size="sm">
+                  Hover me (top)
+                </Button>
+              </FeatureSpotlight>
+              <FeatureSpotlight
+                id="demo-spotlight-bottom"
+                title="Підказка знизу"
+                description="Це демо підказки з позицією bottom"
+                position="bottom"
+              >
+                <Button variant="secondary" size="sm">
+                  Hover me (bottom)
+                </Button>
+              </FeatureSpotlight>
             </div>
           </Group>
         </Sec>

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@shared/components/ui/Icon";
+import { FeatureSpotlight } from "@shared/components/ui/FeatureSpotlight";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -28,25 +29,34 @@ export function HubFloatingActions({ hidden = false, onOpenChat }) {
       className="fixed right-5 z-40 flex flex-col items-end gap-2 pointer-events-none"
       style={{ bottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))" }}
     >
-      <button
-        type="button"
-        onClick={() => onOpenChat()}
-        aria-label="Відкрити AI-асистента"
-        title="Асистент"
-        className={cn(
-          "pointer-events-auto h-14 pl-4 pr-5 flex items-center justify-center gap-2 rounded-full",
-          // brand-700 (not brand-500) — needed for WCAG AA contrast against
-          // `text-white` at 14px regular weight (≥4.5:1).
-          "bg-brand-700 text-white shadow-float",
-          "hover:bg-brand-800 hover:shadow-glow active:scale-95 transition-[background-color,box-shadow,opacity,transform]",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-        )}
+      <FeatureSpotlight
+        id="hub-assistant-fab"
+        title="AI-асистент"
+        description="Запитай будь-що про фінанси, тренування, харчування чи рутину"
+        position="left"
+        showOnce
+        delay={3000}
       >
-        <Icon name="sparkle" size={22} strokeWidth={2.2} />
-        <span className="text-sm font-semibold whitespace-nowrap">
-          Асистент
-        </span>
-      </button>
+        <button
+          type="button"
+          onClick={() => onOpenChat()}
+          aria-label="Відкрити AI-асистента"
+          title="Асистент"
+          className={cn(
+            "pointer-events-auto h-14 pl-4 pr-5 flex items-center justify-center gap-2 rounded-full",
+            // brand-700 (not brand-500) — needed for WCAG AA contrast against
+            // `text-white` at 14px regular weight (≥4.5:1).
+            "bg-brand-700 text-white shadow-float",
+            "hover:bg-brand-800 hover:shadow-glow active:scale-95 transition-[background-color,box-shadow,opacity,transform]",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          )}
+        >
+          <Icon name="sparkle" size={22} strokeWidth={2.2} />
+          <span className="text-sm font-semibold whitespace-nowrap">
+            Асистент
+          </span>
+        </button>
+      </FeatureSpotlight>
     </div>
   );
 }

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Tooltip } from "@shared/components/ui/Tooltip";
+import { FeatureSpotlight } from "@shared/components/ui/FeatureSpotlight";
 import { useScrollHeader } from "@shared/hooks/useScrollHeader";
 import { BrandLogo } from "./BrandLogo";
 import { DarkModeToggle } from "./DarkModeToggle";
@@ -111,16 +112,25 @@ export function HubHeader({
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          <Tooltip content="Пошук по всіх модулях" placement="bottom-center">
-            <button
-              type="button"
-              onClick={onOpenSearch}
-              aria-label="Пошук"
-              className={ICON_BUTTON_CLS}
-            >
-              <Icon name="search" size={20} />
-            </button>
-          </Tooltip>
+          <FeatureSpotlight
+            id="hub-search-button"
+            title="Глобальний пошук"
+            description="Знаходь транзакції, тренування та їжу. Також Cmd+K"
+            position="bottom"
+            showOnce
+            delay={5000}
+          >
+            <Tooltip content="Пошук по всіх модулях" placement="bottom-center">
+              <button
+                type="button"
+                onClick={onOpenSearch}
+                aria-label="Пошук"
+                className={ICON_BUTTON_CLS}
+              >
+                <Icon name="search" size={20} />
+              </button>
+            </Tooltip>
+          </FeatureSpotlight>
 
           {user ? (
             <UserMenuButton

--- a/apps/web/src/shared/components/ui/Segmented.tsx
+++ b/apps/web/src/shared/components/ui/Segmented.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
+import { hapticTap } from "@shared/lib/haptic";
 
 /**
  * Sergeant Design System — Segmented
@@ -115,7 +116,12 @@ export function Segmented<V extends string = string>({
             aria-selected={isActive}
             aria-label={item.ariaLabel}
             title={item.title}
-            onClick={() => onChange(item.value)}
+            onClick={() => {
+              if (item.value !== value) {
+                hapticTap();
+                onChange(item.value);
+              }
+            }}
             className={cn(
               "rounded-full border font-semibold transition-[background-color,border-color,color,box-shadow,opacity]",
               SIZE[size],

--- a/apps/web/src/shared/components/ui/Switch.tsx
+++ b/apps/web/src/shared/components/ui/Switch.tsx
@@ -1,10 +1,12 @@
 import { cn } from "@shared/lib/cn";
+import { hapticTap } from "@shared/lib/haptic";
 import type { ChangeEvent } from "react";
 
 export interface SwitchProps {
   checked: boolean;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange: (checked: boolean) => void;
   disabled?: boolean;
+  label?: string;
   className?: string;
 }
 
@@ -22,37 +24,47 @@ export function Switch({
   checked,
   onChange,
   disabled = false,
+  label,
   className,
 }: SwitchProps) {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
+    hapticTap();
+    onChange(e.target.checked);
+  };
+
   return (
-    <span
+    <label
       className={cn(
-        "relative inline-flex items-center cursor-pointer select-none",
+        "relative inline-flex items-center cursor-pointer select-none gap-2",
         disabled && "opacity-50 cursor-not-allowed",
         className,
       )}
     >
-      <input
-        type="checkbox"
-        className="sr-only peer"
-        checked={checked}
-        onChange={onChange}
-        disabled={disabled}
-      />
-      <span
-        className={cn(
-          "block w-[44px] h-[26px] rounded-full transition-colors duration-200",
-          "bg-line peer-checked:bg-brand-500",
-          "peer-focus-visible:ring-2 peer-focus-visible:ring-brand-500/45 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-bg",
-        )}
-      />
-      <span
-        className={cn(
-          "absolute left-[3px] top-[3px] block w-5 h-5 rounded-full bg-panel shadow-card",
-          "transition-transform duration-200",
-          "peer-checked:translate-x-[18px]",
-        )}
-      />
-    </span>
+      <span className="relative inline-flex">
+        <input
+          type="checkbox"
+          className="sr-only peer"
+          checked={checked}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+        <span
+          className={cn(
+            "block w-[44px] h-[26px] rounded-full transition-colors duration-200",
+            "bg-line peer-checked:bg-brand-500",
+            "peer-focus-visible:ring-2 peer-focus-visible:ring-brand-500/45 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-bg",
+          )}
+        />
+        <span
+          className={cn(
+            "absolute left-[3px] top-[3px] block w-5 h-5 rounded-full bg-panel shadow-card",
+            "transition-transform duration-200",
+            "peer-checked:translate-x-[18px]",
+          )}
+        />
+      </span>
+      {label && <span className="text-sm text-text">{label}</span>}
+    </label>
   );
 }


### PR DESCRIPTION
- Add Avatar, ProgressRing, Switch, Tooltip, CelebrationModal, FeatureSpotlight sections to DesignShowcase
- Integrate FeatureSpotlight in HubFloatingActions and HubHeader
- Add haptic feedback to Switch and Segmented components
- Verified: axe a11y tests, ProfilePage with avatar, design primitives

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the design system with Avatar, ProgressRing, Switch, Tooltip, CelebrationModal, and FeatureSpotlight. Add feature spotlights to Hub search and the assistant FAB, and add haptic feedback to Switch and Segmented.

- New Features
  - DesignShowcase: added sections for Avatar, ProgressRing, Switch, Tooltip, CelebrationModal, and FeatureSpotlight.
  - HubFloatingActions: wrapped assistant FAB with FeatureSpotlight (left, showOnce, delayed).
  - HubHeader: wrapped search button with FeatureSpotlight (bottom, showOnce, delayed).
  - Haptics: added tap feedback to Switch and Segmented. Axe a11y checks pass.

- Migration
  - Switch onChange now receives a boolean (checked) instead of the event. Update usages to onChange={(v) => setState(v)}.
  - Switch accepts an optional label prop for inline text.

<sup>Written for commit 1461d203d065a146718ff75e23af5a4397a5ccf4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1056?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
