### PR TITLE
ci(mobile): bake detox `--headless --record-logs all` into dedicated `:ci` scripts

### DIFF
--- a/.github/workflows/detox-android.yml
+++ b/.github/workflows/detox-android.yml
@@ -168,7 +168,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           working-directory: apps/mobile
-          script: pnpm e2e:test:android -- --headless --record-logs all
+          script: pnpm e2e:test:android:ci
 
       - name: Upload Detox artefacts on failure
         if: always()

--- a/.github/workflows/detox-ios.yml
+++ b/.github/workflows/detox-ios.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run Detox iOS suite
         working-directory: apps/mobile
-        run: pnpm e2e:test:ios -- --headless --record-logs all
+        run: pnpm e2e:test:ios:ci
 
       - name: Upload Detox artefacts on failure
         if: always()

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,8 +15,10 @@
     "test": "jest --passWithNoTests",
     "e2e:build:ios": "detox build --configuration ios.sim.debug",
     "e2e:test:ios": "detox test --configuration ios.sim.debug",
+    "e2e:test:ios:ci": "detox test --configuration ios.sim.debug --headless --record-logs all",
     "e2e:build:android": "detox build --configuration android.emu.debug",
-    "e2e:test:android": "detox test --configuration android.emu.debug"
+    "e2e:test:android": "detox test --configuration android.emu.debug",
+    "e2e:test:android:ci": "detox test --configuration android.emu.debug --headless --record-logs all"
   },
   "dependencies": {
     "@better-auth/expo": "^1.6.5",


### PR DESCRIPTION
## What changed

Follow-up to #1052. After the prebuild + Gradle plugin fixes the detox jobs got far enough to actually try running `detox test`, which immediately fell over on argument parsing. This is the next pre-existing CI bug, not anything we introduced.

- `apps/mobile/package.json` — add `e2e:test:ios:ci` and `e2e:test:android:ci` that include `--headless --record-logs all` directly in detox's argv.
- `.github/workflows/detox-ios.yml` — call `pnpm e2e:test:ios:ci`.
- `.github/workflows/detox-android.yml` — call `pnpm e2e:test:android:ci`.

No behavioural change for local `pnpm e2e:test:ios` / `pnpm e2e:test:android` — those stay interactive.

## Why

The workflows ran:

```yaml
run: pnpm e2e:test:ios -- --headless --record-logs all
```

pnpm's `--` forwards everything after it verbatim to the underlying script command, so the actual argv becomes:

```
detox test --configuration ios.sim.debug -- --headless --record-logs all
```

In detox CLI semantics the standalone `--` separates **detox flags** (left) from **jest flags** (right) — everything past it is forwarded directly to the jest runner. jest doesn't know `--headless` or `--record-logs` and aborts at startup:

```
● Unrecognized CLI Parameters:

  Following options were not recognized:
  ["headless", "record-logs"]

 ELIFECYCLE  Command failed with exit code 1.
12:28:40.961 detox[53680] E Command failed with exit code = 1:
jest --config e2e/jest.config.js --headless --record-logs all
```

This bug has existed on `main` since detox was added; the original `tar`-import crash in `expo prebuild` masked it because the build step died before `detox test` ever ran. With #1052 unblocking prebuild, detox now reaches the real flag bug — visible in the latest detox-ios run on PR #1052 (https://github.com/Skords-01/Sergeant/actions/runs/25051992982/job/73382010622) and detox-android (https://github.com/Skords-01/Sergeant/actions/runs/25051993068/job/73381995419).

Moving the flags into the script bypasses pnpm's argv quirk entirely:

```diff
+    "e2e:test:ios:ci": "detox test --configuration ios.sim.debug --headless --record-logs all",
+    "e2e:test:android:ci": "detox test --configuration android.emu.debug --headless --record-logs all"
```

Detox now sees its own flags as detox flags (no `--` in the way), and jest sees only `--config e2e/jest.config.js` as detox normally invokes it.

## How to test

Locally we can verify the script string composes correctly without running the simulator:

```bash
cd apps/mobile
pnpm run --silent e2e:test:ios:ci --help 2>&1 | head -1
# detox test [-h] [--configuration <name>] …  ← detox parsed flags ok
```

Real verification is on CI: re-run `detox-ios` / `detox-android (34)` against this PR — they should now actually execute the test suite instead of dying on `Unrecognized CLI Parameters`.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Inspected the merged commands; verified detox argv shape against detox v20 docs.
- [x] Vitest passes: untouched code paths.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Detox CI by moving `--headless --record-logs all` into dedicated `:ci` scripts, so the flags are parsed by `detox` instead of being forwarded to Jest. CI jobs now run headless with logs; local `pnpm e2e:test:*` remains interactive.

- **Bug Fixes**
  - Added `e2e:test:ios:ci` and `e2e:test:android:ci` in `apps/mobile/package.json` with Detox flags baked in.
  - Updated `.github/workflows/detox-ios.yml` and `.github/workflows/detox-android.yml` to call the new scripts.

<sup>Written for commit 4ba95f9b8c82cf45182448c38e41bcfff19f4022. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1057?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
