### PR TITLE
feat(shared): add remaining UX plan phases - design tokens, animation…

### DIFF
--- a/apps/mobile/app/(tabs)/finyk/_layout.tsx
+++ b/apps/mobile/app/(tabs)/finyk/_layout.tsx
@@ -39,9 +39,14 @@ export default function FinykStackLayout() {
           headerTitleStyle: { color: colors.text },
           headerTintColor: colors.accent,
           contentStyle: { backgroundColor: colors.bg },
+          animation: "slide_from_right",
+          animationDuration: 250,
         }}
       >
-        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="index"
+          options={{ headerShown: false, animation: "fade" }}
+        />
         <Stack.Screen name="transactions" options={{ title: "Операції" }} />
         <Stack.Screen name="budgets" options={{ title: "Планування" }} />
         <Stack.Screen name="analytics" options={{ title: "Аналітика" }} />

--- a/apps/mobile/app/(tabs)/fizruk/_layout.tsx
+++ b/apps/mobile/app/(tabs)/fizruk/_layout.tsx
@@ -23,8 +23,14 @@ import { Stack } from "expo-router";
 
 export default function FizrukStackLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="index" />
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: "slide_from_right",
+        animationDuration: 250,
+      }}
+    >
+      <Stack.Screen name="index" options={{ animation: "fade" }} />
       <Stack.Screen name="workouts" />
       <Stack.Screen name="exercise" />
       <Stack.Screen name="programs" />

--- a/apps/mobile/app/(tabs)/nutrition/_layout.tsx
+++ b/apps/mobile/app/(tabs)/nutrition/_layout.tsx
@@ -23,9 +23,14 @@ export default function NutritionStackLayout() {
           headerTitleStyle: { color: colors.text },
           headerTintColor: colors.accent,
           contentStyle: { backgroundColor: colors.bg },
+          animation: "slide_from_right",
+          animationDuration: 250,
         }}
       >
-        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="index"
+          options={{ headerShown: false, animation: "fade" }}
+        />
         <Stack.Screen name="scan" options={{ title: "Сканер" }} />
         <Stack.Screen
           name="pantry"

--- a/apps/mobile/app/(tabs)/routine/_layout.tsx
+++ b/apps/mobile/app/(tabs)/routine/_layout.tsx
@@ -28,9 +28,14 @@ export default function RoutineStackLayout() {
           headerTitleStyle: { color: colors.text },
           headerTintColor: colors.accent,
           contentStyle: { backgroundColor: colors.bg },
+          animation: "slide_from_right",
+          animationDuration: 250,
         }}
       >
-        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="index"
+          options={{ headerShown: false, animation: "fade" }}
+        />
         <Stack.Screen name="habit/[id]" options={{ title: "Звичка" }} />
       </Stack>
     </ModuleErrorBoundary>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -42,11 +42,26 @@ function RootShell() {
 
   return (
     <View style={{ flex: 1 }}>
-      <Stack screenOptions={{ headerShown: false }}>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          animation: "fade",
+          animationDuration: 250,
+        }}
+      >
         <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="(auth)" options={{ presentation: "modal" }} />
-        <Stack.Screen name="settings" options={{ presentation: "modal" }} />
-        <Stack.Screen name="assistant" options={{ presentation: "modal" }} />
+        <Stack.Screen
+          name="(auth)"
+          options={{ presentation: "modal", animation: "slide_from_bottom" }}
+        />
+        <Stack.Screen
+          name="settings"
+          options={{ presentation: "modal", animation: "slide_from_bottom" }}
+        />
+        <Stack.Screen
+          name="assistant"
+          options={{ presentation: "modal", animation: "slide_from_bottom" }}
+        />
         <Stack.Screen name="auth/callback" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -34,6 +34,15 @@
     --c-warning-soft: 254 243 199;
     --c-danger-soft: 254 226 226;
     --c-info-soft: 224 242 254;
+
+    /* Celebration / gamification tokens */
+    --c-celebration: 251 191 36; /* amber-400 */
+    --c-streak-glow: 249 112 102; /* coral-500 */
+    --c-xp: 139 92 246; /* violet-500 */
+
+    /* Enhanced focus ring */
+    --focus-ring-width: 3px;
+    --focus-ring-color: rgba(16, 185, 129, 0.4);
   }
 
   .dark {

--- a/apps/mobile/src/components/ui/KeyboardAccessory.tsx
+++ b/apps/mobile/src/components/ui/KeyboardAccessory.tsx
@@ -1,0 +1,228 @@
+/**
+ * Sergeant Design System — KeyboardAccessory (React Native)
+ *
+ * A compact chip bar rendered above the software keyboard that provides
+ * quick-fill actions for the currently focused input. Use cases:
+ *
+ *  - Finyk: frequently used amounts (100, 200, 500, 1000)
+ *  - Nutrition: common portion sizes (100g, 150g, 200g, 250g)
+ *  - Fizruk: common weights (10, 20, 30, 40, 50)
+ *  - Routine: water intake increments (+250ml, +500ml)
+ *
+ * The bar sits above the keyboard via `InputAccessoryView` on iOS and
+ * a bottom-anchored `Animated.View` on Android (since `InputAccessoryView`
+ * is iOS-only). Both implementations share the same chip rendering.
+ *
+ * @see docs/ux-enhancement-plan.md — Section 4.3 (Keyboard & Input)
+ */
+
+import { useCallback, type ReactNode } from "react";
+import {
+  InputAccessoryView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+
+export interface QuickFillChip {
+  /** Label displayed in the chip */
+  label: string;
+  /** Value to insert/apply when the chip is tapped */
+  value: string | number;
+}
+
+export interface KeyboardAccessoryProps {
+  /** Unique ID linking this accessory to an input via `inputAccessoryViewID` */
+  nativeID: string;
+  /** Quick-fill chips to display */
+  chips: QuickFillChip[];
+  /** Called when a chip is tapped. The consumer should update the input value. */
+  onChipPress: (chip: QuickFillChip) => void;
+  /** Optional "Done" button handler. Shows "Готово" when provided. */
+  onDone?: () => void;
+  /** Optional leading content (e.g. unit label) */
+  leading?: ReactNode;
+  /** Module color variant for active chips */
+  variant?: "default" | "finyk" | "fizruk" | "routine" | "nutrition";
+}
+
+const variantBg: Record<string, string> = {
+  default: "bg-brand/10",
+  finyk: "bg-finyk/10",
+  fizruk: "bg-fizruk/10",
+  routine: "bg-routine/10",
+  nutrition: "bg-nutrition/10",
+};
+
+const variantText: Record<string, string> = {
+  default: "text-brand",
+  finyk: "text-finyk",
+  fizruk: "text-fizruk",
+  routine: "text-routine",
+  nutrition: "text-nutrition",
+};
+
+function ChipBar({
+  chips,
+  onChipPress,
+  onDone,
+  leading,
+  variant = "default",
+}: Omit<KeyboardAccessoryProps, "nativeID">) {
+  return (
+    <View className="flex-row items-center bg-panel border-t border-line px-2 py-1.5">
+      {leading && <View className="mr-2">{leading}</View>}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="always"
+        contentContainerStyle={{ gap: 6, paddingRight: 8 }}
+        className="flex-1"
+      >
+        {chips.map((chip) => (
+          <Pressable
+            key={`${chip.label}-${chip.value}`}
+            accessibilityRole="button"
+            accessibilityLabel={`Вставити ${chip.label}`}
+            onPress={() => onChipPress(chip)}
+            className={`rounded-full px-3 py-1.5 ${variantBg[variant]} active:opacity-70`}
+          >
+            <Text className={`text-xs font-semibold ${variantText[variant]}`}>
+              {chip.label}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+      {onDone && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрити клавіатуру"
+          onPress={onDone}
+          className="ml-2 rounded-lg px-3 py-1.5 active:bg-panelHi"
+        >
+          <Text className="text-sm font-semibold text-brand">Готово</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+/**
+ * Keyboard accessory bar. On iOS, uses native `InputAccessoryView` for
+ * proper keyboard tracking. On Android, renders a simple bottom bar
+ * (consumers should position it above the keyboard via layout).
+ *
+ * Usage:
+ * ```tsx
+ * const AMOUNT_CHIPS = [
+ *   { label: "100", value: 100 },
+ *   { label: "200", value: 200 },
+ *   { label: "500", value: 500 },
+ * ];
+ *
+ * <TextInput inputAccessoryViewID="amount-input" ... />
+ * <KeyboardAccessory
+ *   nativeID="amount-input"
+ *   chips={AMOUNT_CHIPS}
+ *   onChipPress={(chip) => setValue(String(chip.value))}
+ *   onDone={() => Keyboard.dismiss()}
+ * />
+ * ```
+ */
+export function KeyboardAccessory({
+  nativeID,
+  chips,
+  onChipPress,
+  onDone,
+  leading,
+  variant = "default",
+}: KeyboardAccessoryProps) {
+  const handleChipPress = useCallback(
+    (chip: QuickFillChip) => {
+      onChipPress(chip);
+    },
+    [onChipPress],
+  );
+
+  if (Platform.OS === "ios") {
+    return (
+      <InputAccessoryView nativeID={nativeID}>
+        <ChipBar
+          chips={chips}
+          onChipPress={handleChipPress}
+          onDone={onDone}
+          leading={leading}
+          variant={variant}
+        />
+      </InputAccessoryView>
+    );
+  }
+
+  // Android: rendered inline; the consumer should position this component
+  // above the keyboard (e.g. using `useVisualKeyboardInset`).
+  return (
+    <ChipBar
+      chips={chips}
+      onChipPress={handleChipPress}
+      onDone={onDone}
+      leading={leading}
+      variant={variant}
+    />
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PRESET CHIP SETS — Reusable quick-fill chip arrays for common inputs
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/** Common UAH amounts for Finyk expense entry */
+export const AMOUNT_CHIPS_UAH: QuickFillChip[] = [
+  { label: "50", value: 50 },
+  { label: "100", value: 100 },
+  { label: "200", value: 200 },
+  { label: "500", value: 500 },
+  { label: "1000", value: 1000 },
+  { label: "2000", value: 2000 },
+];
+
+/** Common portion sizes for Nutrition */
+export const PORTION_CHIPS_GRAM: QuickFillChip[] = [
+  { label: "50g", value: 50 },
+  { label: "100g", value: 100 },
+  { label: "150g", value: 150 },
+  { label: "200g", value: 200 },
+  { label: "250g", value: 250 },
+  { label: "300g", value: 300 },
+];
+
+/** Common weight increments for Fizruk */
+export const WEIGHT_CHIPS_KG: QuickFillChip[] = [
+  { label: "5", value: 5 },
+  { label: "10", value: 10 },
+  { label: "15", value: 15 },
+  { label: "20", value: 20 },
+  { label: "25", value: 25 },
+  { label: "30", value: 30 },
+  { label: "40", value: 40 },
+  { label: "50", value: 50 },
+];
+
+/** Common rep counts for Fizruk */
+export const REP_CHIPS: QuickFillChip[] = [
+  { label: "5", value: 5 },
+  { label: "8", value: 8 },
+  { label: "10", value: 10 },
+  { label: "12", value: 12 },
+  { label: "15", value: 15 },
+  { label: "20", value: 20 },
+];
+
+/** Water intake increments for Routine */
+export const WATER_CHIPS_ML: QuickFillChip[] = [
+  { label: "+150ml", value: 150 },
+  { label: "+250ml", value: 250 },
+  { label: "+330ml", value: 330 },
+  { label: "+500ml", value: 500 },
+];

--- a/apps/mobile/src/components/ui/index.ts
+++ b/apps/mobile/src/components/ui/index.ts
@@ -179,3 +179,14 @@ export {
   type FABVariant,
   type FABSize,
 } from "./FloatingActionButton";
+
+export {
+  KeyboardAccessory,
+  AMOUNT_CHIPS_UAH,
+  PORTION_CHIPS_GRAM,
+  WEIGHT_CHIPS_KG,
+  REP_CHIPS,
+  WATER_CHIPS_ML,
+  type KeyboardAccessoryProps,
+  type QuickFillChip,
+} from "./KeyboardAccessory";

--- a/apps/mobile/src/core/settings/GeneralSection.tsx
+++ b/apps/mobile/src/core/settings/GeneralSection.tsx
@@ -48,6 +48,10 @@ import { DeviceEventEmitter, Pressable, Text, View } from "react-native";
 import {
   ALL_MODULES,
   DASHBOARD_MODULE_LABELS,
+  DASHBOARD_DENSITIES,
+  DASHBOARD_DENSITY_LABELS,
+  DASHBOARD_DENSITY_DESCRIPTIONS,
+  normalizeDashboardDensity,
   downloadJson,
   getActiveModules,
   getHideInactiveModules,
@@ -56,6 +60,7 @@ import {
   setActiveModules,
   setHideInactiveModules,
   STORAGE_KEYS,
+  type DashboardDensity,
   type DashboardModuleId,
   type KVStore,
 } from "@sergeant/shared";
@@ -198,6 +203,12 @@ export function GeneralSection() {
   const showCoach = prefs.showCoach !== false;
   const dark = prefs.darkMode === true;
   const showHints = prefs.showHints !== false;
+  const [density, setDensityState] = useLocalStorage<string>(
+    STORAGE_KEYS.DASHBOARD_DENSITY,
+    "comfortable",
+  );
+  const currentDensity = normalizeDashboardDensity(density) as DashboardDensity;
+  const handleDensityChange = (d: DashboardDensity) => setDensityState(d);
 
   const [activeModules, setActiveModulesState] = useState<DashboardModuleId[]>(
     () => getActiveModules(mmkvStore),
@@ -279,6 +290,42 @@ export function GeneralSection() {
           }
           testID="general-show-hints-toggle"
         />
+      </SettingsSubGroup>
+      <SettingsSubGroup title="Щільність дашборду">
+        <Text className="text-xs text-fg-muted leading-snug">
+          Скільки простору між картками на головному екрані.
+        </Text>
+        <View className="flex-row gap-2">
+          {DASHBOARD_DENSITIES.map((d) => (
+            <Pressable
+              key={d}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: d === currentDensity }}
+              accessibilityLabel={DASHBOARD_DENSITY_LABELS[d]}
+              onPress={() => handleDensityChange(d)}
+              className={`flex-1 rounded-xl border px-3 py-2.5 ${
+                d === currentDensity
+                  ? "border-brand bg-brand/8"
+                  : "border-cream-300 bg-cream-50 active:bg-cream-100"
+              }`}
+              testID={`dashboard-density-${d}`}
+            >
+              <Text
+                className={`text-sm font-medium ${
+                  d === currentDensity ? "text-brand" : "text-fg"
+                }`}
+              >
+                {DASHBOARD_DENSITY_LABELS[d]}
+              </Text>
+              <Text
+                className="text-[11px] text-fg-muted mt-0.5"
+                numberOfLines={2}
+              >
+                {DASHBOARD_DENSITY_DESCRIPTIONS[d]}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
       </SettingsSubGroup>
       <SettingsSubGroup title="Онбординг">
         <Text className="text-xs text-fg-muted leading-snug">

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -6,11 +6,18 @@ import { useToast } from "@shared/hooks/useToast";
 import {
   ALL_MODULES,
   DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
+  DASHBOARD_DENSITIES,
+  DASHBOARD_DENSITY_LABELS,
+  DASHBOARD_DENSITY_DESCRIPTIONS,
+  DEFAULT_DASHBOARD_DENSITY,
+  normalizeDashboardDensity,
+  STORAGE_KEYS,
   getActiveModules,
   getHideInactiveModules,
   resetOnboardingState,
   setActiveModules,
   setHideInactiveModules,
+  type DashboardDensity,
   type DashboardModuleId,
   type KVStore,
 } from "@sergeant/shared";
@@ -102,6 +109,23 @@ export function GeneralSection({
 }: GeneralSectionProps) {
   const [orderReset, setOrderReset] = useState(false);
   const [showHints, setShowHints] = useHubPref<boolean>("showHints", true);
+  const [density, setDensityState] = useState<DashboardDensity>(() => {
+    try {
+      return normalizeDashboardDensity(
+        localStorage.getItem(STORAGE_KEYS.DASHBOARD_DENSITY),
+      );
+    } catch {
+      return DEFAULT_DASHBOARD_DENSITY;
+    }
+  });
+  const handleDensityChange = useCallback((next: DashboardDensity) => {
+    setDensityState(next);
+    try {
+      localStorage.setItem(STORAGE_KEYS.DASHBOARD_DENSITY, next);
+    } catch {
+      /* noop */
+    }
+  }, []);
   const [order, setOrder] = useState<ModuleId[]>(
     () => loadDashboardOrder() as ModuleId[],
   );
@@ -194,6 +218,38 @@ export function GeneralSection({
           checked={showHints !== false}
           onChange={(e) => setShowHints(e.target.checked)}
         />
+      </SettingsSubGroup>
+      <SettingsSubGroup title="Щільність дашборду">
+        <p className="text-xs text-subtle leading-snug">
+          Скільки простору між картками на головному екрані.
+        </p>
+        <div className="flex gap-2">
+          {DASHBOARD_DENSITIES.map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => handleDensityChange(d)}
+              className={cn(
+                "flex-1 rounded-xl border px-3 py-2.5 text-left transition-colors",
+                d === density
+                  ? "border-brand bg-brand/8 ring-1 ring-brand/30"
+                  : "border-line bg-panel hover:bg-panelHi",
+              )}
+            >
+              <span
+                className={cn(
+                  "block text-sm font-medium",
+                  d === density ? "text-brand-strong" : "text-text",
+                )}
+              >
+                {DASHBOARD_DENSITY_LABELS[d]}
+              </span>
+              <span className="block text-xs text-muted mt-0.5">
+                {DASHBOARD_DENSITY_DESCRIPTIONS[d]}
+              </span>
+            </button>
+          ))}
+        </div>
       </SettingsSubGroup>
       <SettingsSubGroup title="Онбординг">
         <p className="text-xs text-subtle leading-snug">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -129,6 +129,41 @@
     --c-danger-soft: 254 226 226; /* red-100 */
     --c-info-soft: 224 242 254; /* sky-100 */
 
+    /* Celebration / gamification tokens */
+    --c-celebration: 251 191 36; /* amber-400 — confetti, stars, rewards */
+    --c-streak-glow: 249 112 102; /* coral-500 — streak flame glow */
+    --c-xp: 139 92 246; /* violet-500 — XP / level-up accent */
+
+    /* Module hero card gradients — delicate accent washes for top-of-page
+       hero cards. Semi-transparent so they layer over `bg-panel` or
+       module surfaces. */
+    --gradient-finyk: linear-gradient(
+      135deg,
+      rgba(16, 185, 129, 0.08) 0%,
+      rgba(20, 184, 166, 0.06) 100%
+    );
+    --gradient-fizruk: linear-gradient(
+      135deg,
+      rgba(20, 184, 166, 0.08) 0%,
+      rgba(200, 242, 100, 0.05) 100%
+    );
+    --gradient-routine: linear-gradient(
+      135deg,
+      rgba(249, 112, 102, 0.08) 0%,
+      rgba(255, 140, 120, 0.05) 100%
+    );
+    --gradient-nutrition: linear-gradient(
+      135deg,
+      rgba(146, 204, 23, 0.08) 0%,
+      rgba(176, 230, 54, 0.05) 100%
+    );
+
+    /* Enhanced focus ring — thicker, warmer, with offset for visibility.
+       Used via `focus-visible:ring` utilities that read the custom property. */
+    --focus-ring-width: 3px;
+    --focus-ring-offset: 2px;
+    --focus-ring-color: rgba(16, 185, 129, 0.4);
+
     /* Motion tokens — single source of truth for duration/easing. */
     --motion-duration-fast: 150ms;
     --motion-duration: 200ms;
@@ -137,6 +172,11 @@
     --motion-ease-smooth: cubic-bezier(0.25, 0.46, 0.45, 0.94);
     --motion-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
     --motion-ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+    /* Easing presets from the UX plan (Dodatok B) */
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
   /* ═══════════════════════════════════════════════════════════════════════
@@ -271,8 +311,23 @@
      token so light & dark themes stay in sync automatically.
      ═══════════════════════════════════════════════════════════════════════ */
   .focus-ring {
-    @apply outline-none focus-visible:ring-2 focus-visible:ring-accent/60
-           focus-visible:ring-offset-2 focus-visible:ring-offset-surface;
+    @apply outline-none focus-visible:ring-accent/60
+           focus-visible:ring-offset-surface;
+    --tw-ring-offset-width: var(--focus-ring-offset, 2px);
+  }
+  .focus-ring:focus-visible {
+    --tw-ring-shadow: 0 0 0 var(--focus-ring-width, 3px)
+      var(--focus-ring-color, rgba(16, 185, 129, 0.4));
+  }
+
+  /* Enhanced focus ring — thicker, with animation on keyboard focus.
+     Applies to all interactive elements that don't define their own ring. */
+  .focus-ring-enhanced {
+    @apply outline-none;
+    transition: box-shadow 0.15s ease-out;
+  }
+  .focus-ring-enhanced:focus-visible {
+    box-shadow: var(--shadow-focus-ring, 0 0 0 3px rgba(16, 185, 129, 0.4));
   }
 
   /* ═══════════════════════════════════════════════════════════════════════

--- a/apps/web/src/shared/components/ui/KeyboardAccessory.tsx
+++ b/apps/web/src/shared/components/ui/KeyboardAccessory.tsx
@@ -1,0 +1,156 @@
+/**
+ * Sergeant Design System — KeyboardAccessory (Web)
+ *
+ * A compact chip bar that renders inline below/above an input field
+ * for quick-fill actions. On web this is not a floating keyboard bar
+ * (no software keyboard on desktop), but a contextual chip row that
+ * appears alongside the input to speed up data entry.
+ *
+ * Parity with the mobile `KeyboardAccessory` — same `QuickFillChip`
+ * type and preset chip arrays so feature code can share chip sets.
+ *
+ * @see apps/mobile/src/components/ui/KeyboardAccessory.tsx
+ * @see docs/ux-enhancement-plan.md — Section 4.3 (Keyboard & Input)
+ */
+
+import { type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+export interface QuickFillChip {
+  /** Label displayed in the chip */
+  label: string;
+  /** Value to insert/apply when the chip is tapped */
+  value: string | number;
+}
+
+export interface KeyboardAccessoryProps {
+  /** Quick-fill chips to display */
+  chips: QuickFillChip[];
+  /** Called when a chip is clicked */
+  onChipPress: (chip: QuickFillChip) => void;
+  /** Optional leading content (e.g. unit label) */
+  leading?: ReactNode;
+  /** Module color variant */
+  variant?: "default" | "finyk" | "fizruk" | "routine" | "nutrition";
+  /** Additional className for the container */
+  className?: string;
+}
+
+const variantStyles: Record<string, { chip: string; chipHover: string }> = {
+  default: {
+    chip: "bg-brand/10 text-brand-strong",
+    chipHover: "hover:bg-brand/20",
+  },
+  finyk: {
+    chip: "bg-finyk/10 text-finyk-strong",
+    chipHover: "hover:bg-finyk/20",
+  },
+  fizruk: {
+    chip: "bg-fizruk/10 text-fizruk-strong",
+    chipHover: "hover:bg-fizruk/20",
+  },
+  routine: {
+    chip: "bg-routine/10 text-routine-strong",
+    chipHover: "hover:bg-routine/20",
+  },
+  nutrition: {
+    chip: "bg-nutrition/10 text-nutrition-strong",
+    chipHover: "hover:bg-nutrition/20",
+  },
+};
+
+/**
+ * Inline quick-fill chip bar for web inputs.
+ *
+ * Usage:
+ * ```tsx
+ * <Input value={amount} onChange={...} />
+ * <KeyboardAccessory
+ *   chips={AMOUNT_CHIPS_UAH}
+ *   onChipPress={(chip) => setAmount(String(chip.value))}
+ *   variant="finyk"
+ * />
+ * ```
+ */
+export function KeyboardAccessory({
+  chips,
+  onChipPress,
+  leading,
+  variant = "default",
+  className,
+}: KeyboardAccessoryProps) {
+  const style = variantStyles[variant] ?? variantStyles.default;
+
+  return (
+    <div
+      className={cn("flex items-center gap-1.5 flex-wrap", className)}
+      role="toolbar"
+      aria-label="Швидке заповнення"
+    >
+      {leading && <div className="mr-1">{leading}</div>}
+      {chips.map((chip) => (
+        <button
+          key={`${chip.label}-${chip.value}`}
+          type="button"
+          onClick={() => onChipPress(chip)}
+          className={cn(
+            "rounded-full px-2.5 py-1 text-xs font-semibold transition-colors",
+            style.chip,
+            style.chipHover,
+          )}
+        >
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PRESET CHIP SETS — same as mobile for cross-platform feature code
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export const AMOUNT_CHIPS_UAH: QuickFillChip[] = [
+  { label: "50", value: 50 },
+  { label: "100", value: 100 },
+  { label: "200", value: 200 },
+  { label: "500", value: 500 },
+  { label: "1000", value: 1000 },
+  { label: "2000", value: 2000 },
+];
+
+export const PORTION_CHIPS_GRAM: QuickFillChip[] = [
+  { label: "50g", value: 50 },
+  { label: "100g", value: 100 },
+  { label: "150g", value: 150 },
+  { label: "200g", value: 200 },
+  { label: "250g", value: 250 },
+  { label: "300g", value: 300 },
+];
+
+export const WEIGHT_CHIPS_KG: QuickFillChip[] = [
+  { label: "5", value: 5 },
+  { label: "10", value: 10 },
+  { label: "15", value: 15 },
+  { label: "20", value: 20 },
+  { label: "25", value: 25 },
+  { label: "30", value: 30 },
+  { label: "40", value: 40 },
+  { label: "50", value: 50 },
+];
+
+export const REP_CHIPS: QuickFillChip[] = [
+  { label: "5", value: 5 },
+  { label: "8", value: 8 },
+  { label: "10", value: 10 },
+  { label: "12", value: 12 },
+  { label: "15", value: 15 },
+  { label: "20", value: 20 },
+];
+
+export const WATER_CHIPS_ML: QuickFillChip[] = [
+  { label: "+150ml", value: 150 },
+  { label: "+250ml", value: 250 },
+  { label: "+330ml", value: 330 },
+  { label: "+500ml", value: 500 },
+];

--- a/apps/web/src/shared/components/ui/ScreenReaderAnnouncer.tsx
+++ b/apps/web/src/shared/components/ui/ScreenReaderAnnouncer.tsx
@@ -1,0 +1,117 @@
+/**
+ * Sergeant Design System — ScreenReaderAnnouncer
+ *
+ * An invisible `aria-live` region that announces dynamic content changes
+ * to screen readers. Useful for:
+ *  - Toast messages
+ *  - Loading state changes ("Loading complete")
+ *  - Counter updates ("Balance: 15,000 UAH")
+ *  - Action confirmations ("Transaction saved")
+ *
+ * Mount once at the root of the app. Use `announce()` imperatively
+ * from anywhere via the exported ref or `useAnnounce()` hook.
+ *
+ * @see docs/ux-enhancement-plan.md — Section 7.2 (Screen reader support)
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+type Politeness = "polite" | "assertive";
+
+interface AnnounceOptions {
+  /** How urgently to announce. Default: "polite" */
+  politeness?: Politeness;
+}
+
+interface AnnounceContextValue {
+  /** Announce a message to screen readers */
+  announce: (message: string, options?: AnnounceOptions) => void;
+}
+
+const AnnounceContext = createContext<AnnounceContextValue>({
+  announce: () => {
+    /* noop until provider mounts */
+  },
+});
+
+/**
+ * Hook to announce messages to screen readers.
+ *
+ * @example
+ * ```tsx
+ * const { announce } = useAnnounce();
+ * announce("Transaction saved successfully");
+ * announce("Error: invalid amount", { politeness: "assertive" });
+ * ```
+ */
+export function useAnnounce(): AnnounceContextValue {
+  return useContext(AnnounceContext);
+}
+
+/**
+ * Provider that renders two invisible `aria-live` regions (polite + assertive)
+ * and exposes the `announce()` function to descendants via context.
+ *
+ * Mount once at the app root, above any component that needs to announce.
+ */
+export function ScreenReaderAnnouncerProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [politeMessage, setPoliteMessage] = useState("");
+  const [assertiveMessage, setAssertiveMessage] = useState("");
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const announce = useCallback((message: string, options?: AnnounceOptions) => {
+    const { politeness = "polite" } = options ?? {};
+
+    // Clear current message first so repeated identical messages
+    // still trigger a DOM change that screen readers detect.
+    if (politeness === "assertive") {
+      setAssertiveMessage("");
+      requestAnimationFrame(() => setAssertiveMessage(message));
+    } else {
+      setPoliteMessage("");
+      requestAnimationFrame(() => setPoliteMessage(message));
+    }
+
+    // Auto-clear after 5s to avoid stale announcements
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    clearTimerRef.current = setTimeout(() => {
+      setPoliteMessage("");
+      setAssertiveMessage("");
+    }, 5000);
+  }, []);
+
+  return (
+    <AnnounceContext.Provider value={{ announce }}>
+      {children}
+      {/* Visually hidden but accessible to screen readers */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {politeMessage}
+      </div>
+      <div
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {assertiveMessage}
+      </div>
+    </AnnounceContext.Provider>
+  );
+}

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -210,3 +210,21 @@ export type {
   FABSize,
   FABVariant,
 } from "./FloatingActionButton";
+
+export {
+  KeyboardAccessory,
+  AMOUNT_CHIPS_UAH,
+  PORTION_CHIPS_GRAM,
+  WEIGHT_CHIPS_KG,
+  REP_CHIPS,
+  WATER_CHIPS_ML,
+} from "./KeyboardAccessory";
+export type {
+  KeyboardAccessoryProps,
+  QuickFillChip,
+} from "./KeyboardAccessory";
+
+export {
+  ScreenReaderAnnouncerProvider,
+  useAnnounce,
+} from "./ScreenReaderAnnouncer";

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -77,3 +77,5 @@ export type { DarkModeSchedule, UseDarkModeReturn } from "./useDarkMode";
 
 export { useHaptic } from "./useHaptic";
 export type { UseHapticReturn } from "./useHaptic";
+
+export { useReducedMotion } from "./useReducedMotion";

--- a/apps/web/src/shared/hooks/useReducedMotion.ts
+++ b/apps/web/src/shared/hooks/useReducedMotion.ts
@@ -1,0 +1,46 @@
+/**
+ * Sergeant Design System — useReducedMotion hook (Web)
+ *
+ * Returns `true` when the user has enabled "Reduce motion" in their OS
+ * accessibility settings. Components should respect this by:
+ *  - Skipping non-essential animations (confetti, celebrations, list stagger)
+ *  - Using instant transitions instead of timed ones
+ *  - Keeping functional animations (loading spinners) but simplifying them
+ *
+ * Subscribes to the `prefers-reduced-motion` media query and updates
+ * reactively if the user toggles the setting while the app is open.
+ *
+ * @see docs/ux-enhancement-plan.md — Section 7.2 (Reduced motion)
+ */
+
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * React hook that reactively tracks the user's reduced-motion preference.
+ *
+ * @returns `true` if the user prefers reduced motion, `false` otherwise.
+ *
+ * @example
+ * ```tsx
+ * const prefersReduced = useReducedMotion();
+ * const duration = prefersReduced ? 0 : 250;
+ * ```
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return reduced;
+}

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -215,6 +215,11 @@ const preset = {
           "rgb(var(--c-nutrition-surface-dark) / <alpha-value>)",
         "nutrition-border-dark":
           "rgb(var(--c-nutrition-border-dark) / <alpha-value>)",
+
+        // ─── Celebration / Gamification ──────────────────────────────────
+        celebration: "rgb(var(--c-celebration) / <alpha-value>)",
+        "streak-glow": "rgb(var(--c-streak-glow) / <alpha-value>)",
+        xp: "rgb(var(--c-xp) / <alpha-value>)",
       },
 
       // ═══════════════════════════════════════════════════════════════════
@@ -259,6 +264,15 @@ const preset = {
           "0 2px 4px rgba(13, 23, 38, 0.06), 0 12px 32px rgba(13, 23, 38, 0.12)",
         // Inner shadows for depth
         inner: "inset 0 2px 4px rgba(0, 0, 0, 0.05)",
+        // Celebration glow — warm amber for achievement moments
+        "celebration-glow":
+          "0 0 24px rgba(251, 191, 36, 0.3), 0 0 8px rgba(251, 191, 36, 0.2)",
+        // Streak glow — pulsing coral for active streaks
+        "streak-glow":
+          "0 0 16px rgba(249, 112, 102, 0.25), 0 0 4px rgba(249, 112, 102, 0.15)",
+        // Enhanced focus ring
+        "focus-ring":
+          "0 0 0 var(--focus-ring-width, 3px) var(--focus-ring-color, rgba(16, 185, 129, 0.4))",
       },
 
       // ═══════════════════════════════════════════════════════════════════

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -72,6 +72,9 @@ export * from "./lib/analyticsEvents";
 // DOM-free haptic contract (platform adapters register at app bootstrap).
 export * from "./lib/haptic";
 
+// Shared animation presets — timing, easing, spring configs, stagger helpers.
+export * from "./lib/animations";
+
 // Platform feature-detect (Capacitor WebView vs browser). DOM-free; reads
 // the `Capacitor` global injected by the native runtime, so `@sergeant/web`
 // can import it without pulling `@capacitor/*` into the browser bundle.

--- a/packages/shared/src/lib/animations.ts
+++ b/packages/shared/src/lib/animations.ts
@@ -1,0 +1,234 @@
+/**
+ * Sergeant Design System — Shared Animation Presets
+ *
+ * Single source of truth for animation timing, easing, and preset
+ * configurations used across web and mobile. Web consumers use the
+ * CSS easing strings directly; mobile consumers feed the spring
+ * configs into Reanimated / Animated.
+ *
+ * @see docs/ux-enhancement-plan.md — Section 6.1 (Animation Principles)
+ * @see packages/design-tokens/tailwind-preset.js — CSS variable counterparts
+ *
+ * Usage:
+ *   import { timing, easing, springConfig, presets } from "@sergeant/shared";
+ */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   TIMING — Duration constants (milliseconds)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export const timing = {
+  /** Hover states, micro-interactions, icon toggles */
+  fast: 150,
+  /** Standard transitions, reveals, content swaps */
+  normal: 250,
+  /** Page transitions, celebrations, modal entrance */
+  slow: 400,
+  /** Complex celebrations, confetti, level-up sequences */
+  slower: 600,
+} as const;
+
+export type TimingKey = keyof typeof timing;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   EASING — CSS cubic-bezier strings (web) + numeric arrays (RN Animated)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export const easing = {
+  /** Smooth exit — elements leaving or settling */
+  easeOut: "cubic-bezier(0.16, 1, 0.3, 1)",
+  /** Balanced — symmetric transitions */
+  easeInOut: "cubic-bezier(0.65, 0, 0.35, 1)",
+  /** Bouncy spring — playful entrance, checkbox bounce, FAB pop */
+  spring: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+  /** Smooth deceleration — standard Material-like ease */
+  smooth: "cubic-bezier(0.25, 0.46, 0.45, 0.94)",
+} as const;
+
+export type EasingKey = keyof typeof easing;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SPRING CONFIGS — React Native Reanimated `withSpring()` parameters
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export const springConfig = {
+  /** Default responsive spring — buttons, toggles, list items */
+  default: {
+    damping: 15,
+    stiffness: 150,
+    mass: 1,
+  },
+  /** Snappy — fast actions, checkbox check, icon press */
+  snappy: {
+    damping: 20,
+    stiffness: 300,
+    mass: 0.8,
+  },
+  /** Bouncy — celebrations, achievements, confetti */
+  bouncy: {
+    damping: 10,
+    stiffness: 120,
+    mass: 1,
+  },
+  /** Gentle — modals, sheets, page transitions */
+  gentle: {
+    damping: 20,
+    stiffness: 100,
+    mass: 1.2,
+  },
+  /** Heavy — drag-and-drop settle, destructive confirm */
+  heavy: {
+    damping: 25,
+    stiffness: 200,
+    mass: 1.5,
+  },
+} as const;
+
+export type SpringConfigKey = keyof typeof springConfig;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ANIMATION PRESETS — Reusable from/to configurations
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export interface AnimationPreset {
+  from: Record<string, number>;
+  to: Record<string, number>;
+  duration: number;
+  easing?: string;
+}
+
+export const presets = {
+  /** Simple opacity fade */
+  fadeIn: {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+    duration: timing.normal,
+    easing: easing.easeOut,
+  },
+
+  /** Slide up + fade — list items, cards, toasts */
+  slideUp: {
+    from: { opacity: 0, translateY: 20 },
+    to: { opacity: 1, translateY: 0 },
+    duration: timing.normal,
+    easing: easing.easeOut,
+  },
+
+  /** Slide down — dropdown menus, tooltips */
+  slideDown: {
+    from: { opacity: 0, translateY: -12 },
+    to: { opacity: 1, translateY: 0 },
+    duration: timing.fast,
+    easing: easing.easeOut,
+  },
+
+  /** Scale in — modals, celebrations, FAB items */
+  scaleIn: {
+    from: { opacity: 0, scale: 0.9 },
+    to: { opacity: 1, scale: 1 },
+    duration: timing.normal,
+    easing: easing.spring,
+  },
+
+  /** Bounce in — achievements, badges, confetti trigger */
+  bounceIn: {
+    from: { opacity: 0, scale: 0.5 },
+    to: { opacity: 1, scale: 1 },
+    duration: timing.slow,
+    easing: easing.spring,
+  },
+
+  /** Slide right — swipe actions reveal, sidebar entrance */
+  slideRight: {
+    from: { opacity: 0, translateX: -20 },
+    to: { opacity: 1, translateX: 0 },
+    duration: timing.normal,
+    easing: easing.easeOut,
+  },
+
+  /** Page exit — fade + slight shrink */
+  pageExit: {
+    from: { opacity: 1, scale: 1 },
+    to: { opacity: 0, scale: 0.97 },
+    duration: timing.fast,
+    easing: easing.easeInOut,
+  },
+
+  /** Page enter — subtle grow from slightly smaller */
+  pageEnter: {
+    from: { opacity: 0, scale: 0.98 },
+    to: { opacity: 1, scale: 1 },
+    duration: timing.normal,
+    easing: easing.easeOut,
+  },
+} as const;
+
+export type PresetKey = keyof typeof presets;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   STAGGER — Delay calculator for list entrance animations
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Calculate staggered delay for list item entrance animations.
+ * Caps the maximum delay so very long lists don't take forever.
+ *
+ * @param index — Item index in the list (0-based)
+ * @param staggerMs — Delay step per item (default: 50ms)
+ * @param maxMs — Maximum total delay cap (default: 500ms)
+ */
+export function staggerDelay(
+  index: number,
+  staggerMs = 50,
+  maxMs = 500,
+): number {
+  return Math.min(index * staggerMs, maxMs);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   CSS TRANSITION HELPERS — Build transition strings from presets
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Build a CSS `transition` string for common properties.
+ * Useful for inline styles when Tailwind utilities don't cover the case.
+ *
+ * @example
+ *   style={{ transition: cssTransition("all", "normal", "easeOut") }}
+ */
+export function cssTransition(
+  property = "all",
+  duration: TimingKey = "normal",
+  ease: EasingKey = "easeOut",
+): string {
+  return `${property} ${timing[duration]}ms ${easing[ease]}`;
+}
+
+/**
+ * Build a CSS `transition` string for multiple properties at once.
+ *
+ * @example
+ *   style={{ transition: cssTransitionMulti(["opacity", "transform"], "fast") }}
+ */
+export function cssTransitionMulti(
+  properties: string[],
+  duration: TimingKey = "normal",
+  ease: EasingKey = "easeOut",
+): string {
+  return properties
+    .map((prop) => `${prop} ${timing[duration]}ms ${easing[ease]}`)
+    .join(", ");
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   REDUCED MOTION — Helper to check user preference (web only)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Check if the user prefers reduced motion (web).
+ * Mobile consumers should use `AccessibilityInfo.isReduceMotionEnabled()`.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/packages/shared/src/lib/dashboard.ts
+++ b/packages/shared/src/lib/dashboard.ts
@@ -20,6 +20,67 @@
  * environment; storage I/O is the caller's responsibility.
  */
 
+/* ═══════════════════════════════════════════════════════════════════════════
+   Dashboard layout density — compact / comfortable / spacious.
+   Affects card padding, gap sizes, and font weights in the hub grid.
+   Persisted under `STORAGE_KEYS.DASHBOARD_DENSITY`.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+export const DASHBOARD_DENSITIES = [
+  "compact",
+  "comfortable",
+  "spacious",
+] as const;
+
+export type DashboardDensity = (typeof DASHBOARD_DENSITIES)[number];
+
+export const DEFAULT_DASHBOARD_DENSITY: DashboardDensity = "comfortable";
+
+export const DASHBOARD_DENSITY_LABELS: Record<DashboardDensity, string> = {
+  compact: "Компактно",
+  comfortable: "Комфортно",
+  spacious: "Просторо",
+};
+
+export const DASHBOARD_DENSITY_DESCRIPTIONS: Record<DashboardDensity, string> =
+  {
+    compact: "Більше інформації, менше простору",
+    comfortable: "Баланс між інформацією і повітрям",
+    spacious: "Великі картки, більше повітря",
+  };
+
+/** Spacing tokens (in Tailwind units) per density level. */
+export const DASHBOARD_DENSITY_SPACING: Record<
+  DashboardDensity,
+  {
+    /** Gap between cards (Tailwind: gap-N) */
+    cardGap: number;
+    /** Card internal padding (Tailwind: p-N) */
+    cardPadding: number;
+    /** Section vertical margin (Tailwind: my-N) */
+    sectionGap: number;
+  }
+> = {
+  compact: { cardGap: 2, cardPadding: 3, sectionGap: 3 },
+  comfortable: { cardGap: 3, cardPadding: 4, sectionGap: 5 },
+  spacious: { cardGap: 4, cardPadding: 5, sectionGap: 6 },
+};
+
+export function isDashboardDensity(value: unknown): value is DashboardDensity {
+  return (
+    typeof value === "string" &&
+    (DASHBOARD_DENSITIES as readonly string[]).includes(value)
+  );
+}
+
+export function normalizeDashboardDensity(raw: unknown): DashboardDensity {
+  return isDashboardDensity(raw) ? raw : DEFAULT_DASHBOARD_DENSITY;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Dashboard module ordering — pure helpers.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
 export const DASHBOARD_MODULE_IDS = [
   "finyk",
   "fizruk",

--- a/packages/shared/src/lib/storageKeys.ts
+++ b/packages/shared/src/lib/storageKeys.ts
@@ -16,6 +16,7 @@ export const STORAGE_KEYS = {
   DASHBOARD_ORDER: "hub_dashboard_order_v1",
   HUB_PREFS: "hub_prefs_v1",
   USER_PROFILE: "hub_user_profile_v1",
+  DASHBOARD_DENSITY: "hub_dashboard_density_v1",
 
   // Hub quick-stats previews rendered on the dashboard
   FINYK_QUICK_STATS: "finyk_quick_stats",


### PR DESCRIPTION
…s, layout, keyboard, a11y

- Celebration/streak-glow/xp color tokens (CSS vars + Tailwind)
- Shared animation presets library (timing, easing, spring configs, stagger)
- DashboardDensity type (compact/comfortable/spacious) + settings UI
- KeyboardAccessory component for both platforms with preset chip sets
- Mobile page transition animations (fade, slide_from_right, slide_from_bottom)
- useReducedMotion hook, ScreenReaderAnnouncerProvider, enhanced focus ring CSS

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the remaining UX plan pieces: celebration tokens, shared animation presets, dashboard density controls, a cross‑platform keyboard accessory, mobile page transitions, and accessibility utilities. This speeds up data entry, smooths navigation, and improves a11y.

- **New Features**
  - Design tokens: celebration/streak-glow/xp colors and enhanced focus rings; Tailwind preset updated for new colors, glows.
  - Animations: shared presets in `@sergeant/shared` (timing, easing, spring, stagger); mobile stack screens now use fade/slide transitions.
  - Dashboard layout: density (`compact`/`comfortable`/`spacious`) with storage key and settings UI on mobile and web.
  - Keyboard: `KeyboardAccessory` on mobile (iOS `InputAccessoryView`, Android inline) and web, plus preset chip sets (amounts, portions, weights, reps, water).
  - Accessibility: web `useReducedMotion`, `ScreenReaderAnnouncerProvider` + `useAnnounce`, and stronger focus ring styles.

- **Migration**
  - Mount `ScreenReaderAnnouncerProvider` at the web app root if you want live a11y announcements.
  - Respect `useReducedMotion` for non-essential animations; fall back to instant transitions when true.
  - To use the keyboard bar: on iOS set `inputAccessoryViewID` on your `TextInput` and pass the same `nativeID` to `KeyboardAccessory`; on Android/web render `KeyboardAccessory` near the input and wire `onChipPress`.

<sup>Written for commit 4614ea3c310bff439fa842e7bd850c3556c0e4c9. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1061?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

