### PR TITLE
fix(web): restore web typecheck

### DIFF
--- a/apps/web/src/core/DesignShowcase.tsx
+++ b/apps/web/src/core/DesignShowcase.tsx
@@ -1100,36 +1100,12 @@ export function DesignShowcase() {
 
           <Group label="ProgressRing">
             <div className="flex flex-wrap items-end gap-6">
-              {(["xs", "sm", "md", "lg", "xl"] as const).map((size) => (
-                <ProgressRing
-                  key={size}
-                  size={size}
-                  value={65}
-                  max={100}
-                  showValue
-                />
+              {(["sm", "md", "lg", "xl"] as const).map((size) => (
+                <ProgressRing key={size} size={size} value={65} max={100} />
               ))}
-              <ProgressRing
-                size="lg"
-                value={100}
-                max={100}
-                variant="success"
-                showValue
-              />
-              <ProgressRing
-                size="lg"
-                value={30}
-                max={100}
-                variant="warning"
-                showValue
-              />
-              <ProgressRing
-                size="lg"
-                value={15}
-                max={100}
-                variant="danger"
-                showValue
-              />
+              <ProgressRing size="lg" value={100} max={100} variant="success" />
+              <ProgressRing size="lg" value={30} max={100} variant="warning" />
+              <ProgressRing size="lg" value={15} max={100} variant="danger" />
             </div>
           </Group>
 
@@ -1158,22 +1134,22 @@ export function DesignShowcase() {
 
           <Group label="Tooltip">
             <div className="flex flex-wrap items-center gap-4">
-              <Tooltip content="Підказка зверху" placement="top">
+              <Tooltip content="Підказка зверху" placement="top-center">
                 <Button variant="secondary" size="sm">
                   Top
                 </Button>
               </Tooltip>
-              <Tooltip content="Підказка знизу" placement="bottom">
+              <Tooltip content="Підказка знизу" placement="bottom-center">
                 <Button variant="secondary" size="sm">
                   Bottom
                 </Button>
               </Tooltip>
-              <Tooltip content="Підказка зліва" placement="left">
+              <Tooltip content="Підказка зліва" placement="left-center">
                 <Button variant="secondary" size="sm">
                   Left
                 </Button>
               </Tooltip>
-              <Tooltip content="Підказка справа" placement="right">
+              <Tooltip content="Підказка справа" placement="right-center">
                 <Button variant="secondary" size="sm">
                   Right
                 </Button>
@@ -1244,7 +1220,7 @@ export function DesignShowcase() {
                 id="demo-spotlight-top"
                 title="Підказка зверху"
                 description="Це демо підказки з позицією top"
-                position="top"
+                placement="top"
               >
                 <Button variant="secondary" size="sm">
                   Hover me (top)
@@ -1254,7 +1230,7 @@ export function DesignShowcase() {
                 id="demo-spotlight-bottom"
                 title="Підказка знизу"
                 description="Це демо підказки з позицією bottom"
-                position="bottom"
+                placement="bottom"
               >
                 <Button variant="secondary" size="sm">
                   Hover me (bottom)

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -33,7 +33,7 @@ export function HubFloatingActions({ hidden = false, onOpenChat }) {
         id="hub-assistant-fab"
         title="AI-асистент"
         description="Запитай будь-що про фінанси, тренування, харчування чи рутину"
-        position="left"
+        placement="left"
         showOnce
         delay={3000}
       >

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -116,7 +116,7 @@ export function HubHeader({
             id="hub-search-button"
             title="Глобальний пошук"
             description="Знаходь транзакції, тренування та їжу. Також Cmd+K"
-            position="bottom"
+            placement="bottom"
             showOnce
             delay={5000}
           >

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -216,7 +216,7 @@ export function GeneralSection({
           label="Показувати підказки"
           description="Короткі підказки в моменті (без спаму)."
           checked={showHints !== false}
-          onChange={(checked) => setShowHints(checked)}
+          onChange={setShowHints}
         />
       </SettingsSubGroup>
       <SettingsSubGroup title="Щільність дашборду">
@@ -357,7 +357,7 @@ export function GeneralSection({
           label="Приховати неактивні модулі"
           description="Повністю ховає неактивні плитки з дашборду."
           checked={hideInactive}
-          onChange={(checked) => toggleHideInactive(checked)}
+          onChange={toggleHideInactive}
         />
       </SettingsSubGroup>
       <SettingsSubGroup title="Упорядкувати модулі">

--- a/apps/web/src/core/settings/NotificationsSection.tsx
+++ b/apps/web/src/core/settings/NotificationsSection.tsx
@@ -155,7 +155,7 @@ export function NotificationsSection() {
           label="Нагадування про звички"
           description="Спрацьовує у встановлений в кожній звичці час, навіть коли застосунок закрито."
           checked={routine.prefs?.routineRemindersEnabled === true}
-          onChange={(checked) => handleRoutineToggle(checked)}
+          onChange={handleRoutineToggle}
         />
       </SettingsSubGroup>
 
@@ -164,7 +164,7 @@ export function NotificationsSection() {
           label="Нагадування про тренування"
           description="Надсилається о вказаній годині, якщо на сьогодні призначено тренування."
           checked={monthlyPlan.reminderEnabled}
-          onChange={(checked) => handleFizrukToggle(checked)}
+          onChange={handleFizrukToggle}
         />
         {monthlyPlan.reminderEnabled && (
           <label className="flex items-center gap-2 text-sm">
@@ -187,7 +187,7 @@ export function NotificationsSection() {
           label="Нагадування про їжу"
           description="Щоденне нагадування записати прийоми їжі, навіть коли застосунок закрито."
           checked={Boolean(nutritionPrefs.reminderEnabled)}
-          onChange={(checked) => handleNutritionToggle(checked)}
+          onChange={handleNutritionToggle}
         />
         {nutritionPrefs.reminderEnabled && (
           <label className="flex items-center gap-2 text-sm">

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { FeatureSpotlight } from "./FeatureSpotlight";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("FeatureSpotlight", () => {
+  it("keeps wrapped target visible and opens the spotlight after delay", () => {
+    vi.useFakeTimers();
+
+    const { getByRole, queryByRole, getByText } = render(
+      <FeatureSpotlight
+        id="assistant-fab-test"
+        title="AI-асистент"
+        description="Швидкий вхід у чат"
+        placement="left"
+        delay={100}
+        skipPersist
+      >
+        <button type="button">Асистент</button>
+      </FeatureSpotlight>,
+    );
+
+    expect(getByRole("button", { name: "Асистент" })).not.toBeNull();
+    expect(queryByRole("dialog")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(queryByRole("dialog")).not.toBeNull();
+    expect(getByText("AI-асистент")).not.toBeNull();
+  });
+});

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
@@ -82,6 +82,9 @@ export function FeatureSpotlight({
   title,
   description,
   placement = "bottom",
+  position,
+  delay = 500,
+  showOnce,
   actionText = "Зрозуміло",
   onDismiss,
   skipPersist = false,
@@ -89,18 +92,22 @@ export function FeatureSpotlight({
 }: FeatureSpotlightProps) {
   const [visible, setVisible] = useState(false);
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const targetRef = useRef<HTMLSpanElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const effectivePlacement = position ?? placement;
+  const persistDismissal = showOnce ?? !skipPersist;
 
   // Check if already dismissed
   useEffect(() => {
-    if (!skipPersist && isDismissed(id)) {
+    if (persistDismissal && isDismissed(id)) {
       return;
     }
 
     // Find target element
     const findTarget = () => {
-      if (!targetSelector) return;
-      const target = document.querySelector(targetSelector);
+      const target = targetSelector
+        ? document.querySelector(targetSelector)
+        : targetRef.current;
       if (target) {
         setTargetRect(target.getBoundingClientRect());
         setVisible(true);
@@ -108,17 +115,18 @@ export function FeatureSpotlight({
     };
 
     // Delay slightly to ensure DOM is ready
-    const timer = setTimeout(findTarget, 500);
+    const timer = setTimeout(findTarget, delay);
     return () => clearTimeout(timer);
-  }, [id, targetSelector, skipPersist]);
+  }, [delay, id, persistDismissal, targetSelector]);
 
   // Update position on scroll/resize
   useEffect(() => {
     if (!visible) return;
 
     const updatePosition = () => {
-      if (!targetSelector) return;
-      const target = document.querySelector(targetSelector);
+      const target = targetSelector
+        ? document.querySelector(targetSelector)
+        : targetRef.current;
       if (target) {
         setTargetRect(target.getBoundingClientRect());
       }
@@ -135,19 +143,25 @@ export function FeatureSpotlight({
   const handleDismiss = useCallback(() => {
     hapticTap();
     setVisible(false);
-    if (!skipPersist) {
+    if (persistDismissal) {
       markDismissed(id);
     }
     onDismiss?.();
-  }, [id, skipPersist, onDismiss]);
+  }, [id, persistDismissal, onDismiss]);
 
-  if (!visible || !targetRect) return null;
+  const target = children ? (
+    <span ref={targetRef} className="inline-flex">
+      {children}
+    </span>
+  ) : null;
+
+  if (!visible || !targetRect) return target;
 
   // Calculate tooltip position
   const padding = 12;
   const tooltipStyle: CSSProperties = {};
 
-  switch (placement) {
+  switch (effectivePlacement) {
     case "top":
       tooltipStyle.bottom = window.innerHeight - targetRect.top + padding;
       tooltipStyle.left = targetRect.left + targetRect.width / 2;
@@ -181,71 +195,73 @@ export function FeatureSpotlight({
   };
 
   return (
-    <div className="fixed inset-0 z-[1000]" role="dialog" aria-modal="true">
-      {/* Overlay with cutout */}
-      <svg
-        className="absolute inset-0 w-full h-full"
-        onClick={handleDismiss}
-        aria-hidden="true"
-      >
-        <defs>
-          <mask id={`spotlight-mask-${id}`}>
-            <rect x="0" y="0" width="100%" height="100%" fill="white" />
-            <rect
-              x={spotlightRect.left}
-              y={spotlightRect.top}
-              width={spotlightRect.width}
-              height={spotlightRect.height}
-              rx={spotlightRect.borderRadius}
-              fill="black"
-            />
-          </mask>
-        </defs>
-        <rect
-          x="0"
-          y="0"
-          width="100%"
-          height="100%"
-          fill="rgba(0, 0, 0, 0.6)"
-          mask={`url(#spotlight-mask-${id})`}
-          className="motion-safe:animate-fade-in"
+    <>
+      {target}
+      <div className="fixed inset-0 z-[1000]" role="dialog" aria-modal="true">
+        {/* Overlay with cutout */}
+        <svg
+          className="absolute inset-0 w-full h-full"
+          onClick={handleDismiss}
+          aria-hidden="true"
+        >
+          <defs>
+            <mask id={`spotlight-mask-${id}`}>
+              <rect x="0" y="0" width="100%" height="100%" fill="white" />
+              <rect
+                x={spotlightRect.left}
+                y={spotlightRect.top}
+                width={spotlightRect.width}
+                height={spotlightRect.height}
+                rx={spotlightRect.borderRadius}
+                fill="black"
+              />
+            </mask>
+          </defs>
+          <rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            fill="rgba(0, 0, 0, 0.6)"
+            mask={`url(#spotlight-mask-${id})`}
+            className="motion-safe:animate-fade-in"
+          />
+        </svg>
+
+        {/* Spotlight ring */}
+        <div
+          className={cn(
+            "absolute pointer-events-none",
+            "rounded-xl ring-2 ring-brand-500 ring-offset-2 ring-offset-transparent",
+            "motion-safe:animate-pulse",
+          )}
+          style={{
+            top: spotlightRect.top,
+            left: spotlightRect.left,
+            width: spotlightRect.width,
+            height: spotlightRect.height,
+          }}
+          aria-hidden="true"
         />
-      </svg>
 
-      {/* Spotlight ring */}
-      <div
-        className={cn(
-          "absolute pointer-events-none",
-          "rounded-xl ring-2 ring-brand-500 ring-offset-2 ring-offset-transparent",
-          "motion-safe:animate-pulse",
-        )}
-        style={{
-          top: spotlightRect.top,
-          left: spotlightRect.left,
-          width: spotlightRect.width,
-          height: spotlightRect.height,
-        }}
-        aria-hidden="true"
-      />
-
-      {/* Tooltip */}
-      <div
-        ref={tooltipRef}
-        className={cn(
-          "fixed w-72 p-4 rounded-2xl",
-          "bg-panel border border-line shadow-float",
-          "motion-safe:animate-slide-up",
-        )}
-        style={tooltipStyle}
-      >
-        <h3 className="text-base font-bold text-text mb-1">{title}</h3>
-        <p className="text-sm text-muted mb-4">{description}</p>
-        {children}
-        <Button size="sm" onClick={handleDismiss} className="w-full">
-          {actionText}
-        </Button>
+        {/* Tooltip */}
+        <div
+          ref={tooltipRef}
+          className={cn(
+            "fixed w-72 p-4 rounded-2xl",
+            "bg-panel border border-line shadow-float",
+            "motion-safe:animate-slide-up",
+          )}
+          style={tooltipStyle}
+        >
+          <h3 className="text-base font-bold text-text mb-1">{title}</h3>
+          <p className="text-sm text-muted mb-4">{description}</p>
+          <Button size="sm" onClick={handleDismiss} className="w-full">
+            {actionText}
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/shared/hooks/useFormValidation.ts
+++ b/apps/web/src/shared/hooks/useFormValidation.ts
@@ -99,17 +99,21 @@ export function useFormValidation<T extends Record<string, unknown>>(
     hapticError();
 
     // Start shake
-    setFields((prev) => ({
-      ...prev,
-      [name]: { ...prev[name], shaking: true },
-    }));
+    setFields(
+      (prev): FormState<T> => ({
+        ...prev,
+        [name]: { ...prev[name], shaking: true },
+      }),
+    );
 
     // Stop shake after animation completes
     const timeout = setTimeout(() => {
-      setFields((prev) => ({
-        ...prev,
-        [name]: { ...prev[name], shaking: false },
-      }));
+      setFields(
+        (prev): FormState<T> => ({
+          ...prev,
+          [name]: { ...prev[name], shaking: false },
+        }),
+      );
       shakeTimeouts.current.delete(name);
     }, 500);
 
@@ -123,10 +127,12 @@ export function useFormValidation<T extends Record<string, unknown>>(
 
       for (const rule of fieldConfig.rules) {
         if (!rule.validate(value)) {
-          setFields((prev) => ({
-            ...prev,
-            [name]: { ...prev[name], error: rule.message, touched: true },
-          }));
+          setFields(
+            (prev): FormState<T> => ({
+              ...prev,
+              [name]: { ...prev[name], error: rule.message, touched: true },
+            }),
+          );
           return false;
         }
       }
@@ -194,10 +200,12 @@ export function useFormValidation<T extends Record<string, unknown>>(
         error: !!field?.error,
         className: field?.shaking ? "animate-shake" : "",
         onBlur: () => {
-          setFields((prev) => ({
-            ...prev,
-            [name]: { ...prev[name], touched: true },
-          }));
+          setFields(
+            (prev): FormState<T> => ({
+              ...prev,
+              [name]: { ...prev[name], touched: true },
+            }),
+          );
         },
       };
     },

--- a/apps/web/src/shared/lib/export.ts
+++ b/apps/web/src/shared/lib/export.ts
@@ -35,13 +35,10 @@ export function arrayToCSV<T extends Record<string, unknown>>(
 
   for (const row of data) {
     const values = columns.map((col) => {
+      const value = getColumnValue(row, col.key);
       if (col.format) {
-        return escapeCSV(col.format(row[col.key as keyof T], row));
+        return escapeCSV(col.format(value, row));
       }
-      const keyStr = String(col.key);
-      const value = keyStr.includes(".")
-        ? getNestedValue(row, keyStr)
-        : row[col.key as keyof T];
       return escapeCSV(value);
     });
     lines.push(values.join(separator));
@@ -60,6 +57,16 @@ function getNestedValue<T extends Record<string, unknown>>(
     }
     return undefined;
   }, obj);
+}
+
+function getColumnValue<T extends Record<string, unknown>>(
+  row: T,
+  key: ExportColumn<T>["key"],
+): unknown {
+  if (typeof key === "string" && key.includes(".")) {
+    return getNestedValue(row, key);
+  }
+  return row[key as keyof T];
 }
 
 /**
@@ -283,16 +290,9 @@ export function dataToHTMLTable<T extends Record<string, unknown>>(
 
   const rows = data.map((row) => {
     const cells = columns.map((col) => {
-      let value: unknown;
+      const value = getColumnValue(row, col.key);
       if (col.format) {
-        value = col.format(row[col.key as keyof T], row);
-      } else {
-        const keyStr = String(col.key);
-        if (keyStr.includes(".")) {
-          value = getNestedValue(row, keyStr);
-        } else {
-          value = row[col.key as keyof T];
-        }
+        return `<td>${col.format(value, row)}</td>`;
       }
       return `<td>${value ?? ""}</td>`;
     });


### PR DESCRIPTION
## What changed

- Restored compatibility between `FeatureSpotlight` and its wrapped-target call sites in the hub chrome/design showcase.
- Updated `DesignShowcase` to use the current `ProgressRing` and `Tooltip` APIs.
- Aligned `ToggleRow` with the new boolean `Switch.onChange` contract and updated settings sections.
- Fixed typed column access in CSV/PDF export helpers.
- Added explicit generic state updater return types in `useFormValidation` to satisfy `noImplicitAny`.
- Added a regression test for wrapped `FeatureSpotlight` targets staying rendered while the spotlight opens after its delay.

## Why

`main` was failing `@sergeant/web` typecheck after the recent UX/UI work because several call sites still used old prop names/contracts (`position`, `showValue`, short tooltip placements, event-based switch toggles). Once those were fixed, the stricter web config exposed one additional `noImplicitAny` return-type issue in `useFormValidation`.

## How to test

```bash
pnpm typecheck
pnpm --filter @sergeant/web lint
pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/FeatureSpotlight.test.tsx src/shared/components/ui/ProgressRing.test.tsx src/shared/components/ui/Tooltip.test.tsx
pnpm --filter @sergeant/web build
```

## How AI-tested this PR

- [x] Monorepo typecheck passes: `13 successful, 13 total`.
- [x] Web lint passes.
- [x] Targeted UI tests pass: `3 passed`, `15 tests passed`.
- [x] Web production build passes and PWA service worker is generated.
- [x] Pre-commit hook passed (`eslint --fix --max-warnings=0`, `prettier --write`).
- [x] No new `AI-DANGER` markers added.

## AGENTS.md updated?

- [x] No — no new permanent rules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `@sergeant/web` typecheck by aligning UI component APIs and fixing strict TypeScript issues. Upgrades `FeatureSpotlight` to support wrapped targets, delayed opening, and one-time prompts, with a regression test.

- **Bug Fixes**
  - `FeatureSpotlight`: wrapped targets via `children`; adds `placement` (alias `position`), `delay`, `showOnce`/`skipPersist`; keeps target visible while opening; improved scroll/resize; adds test.
  - `DesignShowcase` and hub: update to new `Tooltip` placements and `FeatureSpotlight.placement`; `ProgressRing` no longer uses `showValue`.
  - Settings: toggles now use boolean `onChange` handlers to match `Switch.onChange`.
  - Export helpers: correct typed column access (incl. nested) and pass proper value to `format` for CSV/HTML table.
  - `useFormValidation`: explicit generic updater return types to satisfy `noImplicitAny`.

<sup>Written for commit a08bfe86fe536e6075e06d9abaf9203f71be1b0b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `FeatureSpotlight` with configurable delay, optional target selection, and persistent dismissal control.

* **Bug Fixes**
  * Updated `Tooltip` placement values to centered variants for better positioning.
  * Refined `ProgressRing` showcase display.

* **Refactor**
  * Simplified toggle handlers across settings sections.
  * Extracted shared utility for improved code reusability.

* **Tests**
  * Added test coverage for `FeatureSpotlight` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->