### PR TITLE
V0/skords 01 bdc35813

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -478,22 +478,6 @@ function AppInner() {
           onCloseSearch={ui.closeSearch}
           onOpenModule={openModule}
         />
-        {/* Assistant FAB — persistent across all module views so the user
-          can reach the AI chat without navigating back to the hub first. */}
-        <HubFloatingActions onOpenChat={ui.openChat} />
-        <HubModals
-          chatOpen={ui.chatOpen}
-          onCloseChat={ui.closeChat}
-          chatInitialMessage={ui.chatInitialMessage}
-          chatAutoSend={ui.chatAutoSend}
-          onOpenCatalogue={() => {
-            ui.closeChat();
-            navigate(ASSISTANT_PATH);
-          }}
-          searchOpen={ui.searchOpen}
-          onCloseSearch={ui.closeSearch}
-          onOpenModule={openModule}
-        />
         <KeyboardShortcutsModal
           open={keyboardShortcuts.open}
           onClose={keyboardShortcuts.onClose}
@@ -578,6 +562,22 @@ function AppInner() {
           );
         })()}
       </Suspense>
+      {/* Assistant FAB — available in all module views so the user can
+          reach the AI chat without navigating back to the hub first. */}
+      <HubFloatingActions onOpenChat={ui.openChat} />
+      <HubModals
+        chatOpen={ui.chatOpen}
+        onCloseChat={ui.closeChat}
+        chatInitialMessage={ui.chatInitialMessage}
+        chatAutoSend={ui.chatAutoSend}
+        onOpenCatalogue={() => {
+          ui.closeChat();
+          navigate(ASSISTANT_PATH);
+        }}
+        searchOpen={ui.searchOpen}
+        onCloseSearch={ui.closeSearch}
+        onOpenModule={openModule}
+      />
       <KeyboardShortcutsModal
         open={keyboardShortcuts.open}
         onClose={keyboardShortcuts.onClose}

--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -478,6 +478,22 @@ function AppInner() {
           onCloseSearch={ui.closeSearch}
           onOpenModule={openModule}
         />
+        {/* Assistant FAB — persistent across all module views so the user
+          can reach the AI chat without navigating back to the hub first. */}
+        <HubFloatingActions onOpenChat={ui.openChat} />
+        <HubModals
+          chatOpen={ui.chatOpen}
+          onCloseChat={ui.closeChat}
+          chatInitialMessage={ui.chatInitialMessage}
+          chatAutoSend={ui.chatAutoSend}
+          onOpenCatalogue={() => {
+            ui.closeChat();
+            navigate(ASSISTANT_PATH);
+          }}
+          searchOpen={ui.searchOpen}
+          onCloseSearch={ui.closeSearch}
+          onOpenModule={openModule}
+        />
         <KeyboardShortcutsModal
           open={keyboardShortcuts.open}
           onClose={keyboardShortcuts.onClose}


### PR DESCRIPTION
## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores assistant chat access in all module views. Users can open the chat without leaving Finyk, Fizruk, Routine, or Nutrition.

- **Bug Fixes**
  - Mounted `HubFloatingActions` in module views to trigger `ui.openChat`.
  - Added `HubModals` in module views with chat/search handlers and module navigation; `onOpenCatalogue` routes to `ASSISTANT_PATH`.

<sup>Written for commit 5a8682cc5480057caf9788b576402b96d4d61e87. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
