### PR TITLE
docs(docs): додати рядок про docs/api/ в індекс docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,23 +7,24 @@
 
 ## Структура
 
-| Розділ                                | Призначення                                                                   |
-| ------------------------------------- | ----------------------------------------------------------------------------- |
-| [`adr/`](./adr/README.md)             | Architecture Decision Records — `чому` обрано конкретні архітектурні рішення. |
-| [`architecture/`](./architecture)     | Огляд системи: статус-матриця, фронтенд-overview, API-контракт, платформи.    |
-| [`audits/`](./audits)                 | Періодичні аудити коду / архітектури.                                         |
-| [`design/`](./design)                 | Брендбук, дизайн-токени, UX-аудит, palette / WCAG.                            |
-| [`governance/`](./governance)         | Cadence policies (freshness, policy review).                                  |
-| [`integrations/`](./integrations)     | Сторонні сервіси: Railway+Vercel, Renovate, Monobank.                         |
-| [`launch/`](./launch/README.md)       | Запуск продукту: монетизація, GTM, операції.                                  |
-| [`mobile/`](./mobile)                 | Мобільні додатки: Expo overview, Capacitor shell, deep-links, RN-міграція.    |
-| [`observability/`](./observability)   | SLO, runbook, dashboards, prometheus rules, on-call.                          |
-| [`planning/`](./planning)             | Roadmap-и: dev-stack, AI-coding, structure-refactor.                          |
-| [`playbooks/`](./playbooks/README.md) | Покрокові how-to для типових змін у репо.                                     |
-| [`postmortems/`](./postmortems)       | Постмортеми інцидентів.                                                       |
-| [`security/`](./security)             | Аудит-винятки, vulnerability SLA, нічний скан.                                |
-| [`superpowers/`](./superpowers)       | Specs та hotfix-нотатки для Devin Superpowers.                                |
-| [`tech-debt/`](./tech-debt)           | Frontend / Backend tech-debt registries.                                      |
+| Розділ                                | Призначення                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------ |
+| [`adr/`](./adr/README.md)             | Architecture Decision Records — `чому` обрано конкретні архітектурні рішення.  |
+| [`api/`](./api/README.md)             | OpenAPI 3.1 spec (`openapi.json`), згенерований із zod-схем `packages/shared`. |
+| [`architecture/`](./architecture)     | Огляд системи: статус-матриця, фронтенд-overview, API-контракт, платформи.     |
+| [`audits/`](./audits)                 | Періодичні аудити коду / архітектури.                                          |
+| [`design/`](./design)                 | Брендбук, дизайн-токени, UX-аудит, palette / WCAG.                             |
+| [`governance/`](./governance)         | Cadence policies (freshness, policy review).                                   |
+| [`integrations/`](./integrations)     | Сторонні сервіси: Railway+Vercel, Renovate, Monobank.                          |
+| [`launch/`](./launch/README.md)       | Запуск продукту: монетизація, GTM, операції.                                   |
+| [`mobile/`](./mobile)                 | Мобільні додатки: Expo overview, Capacitor shell, deep-links, RN-міграція.     |
+| [`observability/`](./observability)   | SLO, runbook, dashboards, prometheus rules, on-call.                           |
+| [`planning/`](./planning)             | Roadmap-и: dev-stack, AI-coding, structure-refactor.                           |
+| [`playbooks/`](./playbooks/README.md) | Покрокові how-to для типових змін у репо.                                      |
+| [`postmortems/`](./postmortems)       | Постмортеми інцидентів.                                                        |
+| [`security/`](./security)             | Аудит-винятки, vulnerability SLA, нічний скан.                                 |
+| [`superpowers/`](./superpowers)       | Specs та hotfix-нотатки для Devin Superpowers.                                 |
+| [`tech-debt/`](./tech-debt)           | Frontend / Backend tech-debt registries.                                       |
 
 ## Швидкі лінки
 


### PR DESCRIPTION
## What changed

Додано рядок `[`api/`](./api/README.md)` у таблицю «Структура» в `docs/README.md`. Інших змін нема.

## Why

Папка `docs/api/` (`README.md` + `openapi.json`) існує і на неї посилаються AGENTS.md (правило #3) та `docs/api/README.md` сам, але в індексі `docs/README.md` рядка для цього розділу не було — на відміну від усіх інших підкаталогів `docs/`. Згідно секції «Як додати документ» («оновлюй цей індекс в одному PR з самим документом») це прогалина, яку видно в одному рядку.

## How to test

- Відкрити `docs/README.md` → у таблиці «Структура» між `adr/` і `architecture/` тепер є рядок про `api/`, лінк `./api/README.md` веде на існуючий файл.
- Жодних code-змін, lint-стейджед хук пройшов локально (Prettier --write + ESLint --fix).

---

## How AI-tested this PR

- [x] Manual smoke: `pnpm exec prettier --check docs/README.md` зелений після правки. `lint-staged` пройшов на pre-commit.
- [ ] Vitest passes: не запускав — зміна суто в `docs/`, тестового surface нема.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Session: https://app.devin.ai/sessions/5b9f631a26a24028bed2a8107438aa7a
Requested by: Андрій Виграв (andrijvigrav@gmail.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `api/` to the “Структура” table in `docs/README.md`, linking to `./api/README.md`, so the existing API docs are visible and consistent with other `docs/` sections.

<sup>Written for commit 237924753cabde0113fb3152214b41e71ef48edc. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1072?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
