### PR TITLE
feat(web): polish onboarding with SpotlightQueue and CelebrationModal

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -46,6 +46,7 @@ import {
   KeyboardShortcutsModal,
   useKeyboardShortcutsModal,
 } from "@shared/components/ui/KeyboardShortcutsModal";
+import { SpotlightQueueProvider } from "@shared/components/ui/SpotlightQueue";
 
 const AuthPage = lazy(() =>
   import("./auth/AuthPage").then((m) => ({ default: m.AuthPage })),
@@ -94,24 +95,26 @@ const RoutineApp = lazy(
 export default function App() {
   return (
     <ToastProvider>
-      <ToastContainer />
-      {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
-          рендериться під <BrowserRouter>), але поза AppInner, щоб
-          bridge переживав ранні return-и в AppInner (/sign-in,
-          /reset-password, /design тощо) — deep link може прилетіти у
-          будь-який із цих станів. */}
-      <ShellDeepLinkBridge />
-      {/* PostHog `$pageview` tracker: монтуємо тут (всередині
-          BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
-          в unauthenticated-шляхах (`/sign-in`, `/welcome`,
-          `/reset-password`) — без цього onboarding / auth funnels
-          у PostHog були б сліпими перед login-ом. */}
-      <PageviewTracker />
-      <ApiClientProvider client={apiClient}>
-        <AuthProvider>
-          <AppInner />
-        </AuthProvider>
-      </ApiClientProvider>
+      <SpotlightQueueProvider>
+        <ToastContainer />
+        {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
+            рендериться під <BrowserRouter>), але поза AppInner, щоб
+            bridge переживав ранні return-и в AppInner (/sign-in,
+            /reset-password, /design тощо) — deep link може прилетіти у
+            будь-який із цих станів. */}
+        <ShellDeepLinkBridge />
+        {/* PostHog `$pageview` tracker: монтуємо тут (всередині
+            BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
+            в unauthenticated-шляхах (`/sign-in`, `/welcome`,
+            `/reset-password`) — без цього onboarding / auth funnels
+            у PostHog були б сліпими перед login-ом. */}
+        <PageviewTracker />
+        <ApiClientProvider client={apiClient}>
+          <AuthProvider>
+            <AppInner />
+          </AuthProvider>
+        </ApiClientProvider>
+      </SpotlightQueueProvider>
     </ToastProvider>
   );
 }

--- a/apps/web/src/core/hints/HintsOrchestrator.tsx
+++ b/apps/web/src/core/hints/HintsOrchestrator.tsx
@@ -10,6 +10,7 @@ import {
   type KVStore,
 } from "@sergeant/shared";
 import { useToast } from "@shared/hooks/useToast";
+import { useSpotlightQueue } from "@shared/components/ui/SpotlightQueue";
 import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 import { useHubPref } from "../settings/hubPrefs";
 
@@ -49,6 +50,7 @@ export function HintsOrchestrator({
   hasFirstRealEntry,
 }: HintsOrchestratorProps): null {
   const toast = useToast();
+  const { isAnyActive: isSpotlightActive } = useSpotlightQueue();
   const [showHints] = useHubPref<boolean>("showHints", true);
   const shownThisMount = useRef<HintId | null>(null);
 
@@ -80,6 +82,8 @@ export function HintsOrchestrator({
 
   useEffect(() => {
     if (!showHints) return;
+    // Don't show toast hints while a spotlight is active — avoids UI clutter
+    if (isSpotlightActive()) return;
     if (shownThisMount.current) return;
 
     // ── Retention hints (Day 1 / 3 / 7) take priority over general hints
@@ -178,7 +182,7 @@ export function HintsOrchestrator({
           : undefined;
 
     toast.info(msg, 5000, action);
-  }, [candidates, ctx, hasFirstRealEntry, showHints, toast]);
+  }, [candidates, ctx, hasFirstRealEntry, isSpotlightActive, showHints, toast]);
 
   return null;
 }

--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -32,6 +32,7 @@ import {
   recordSessionDay,
 } from "../onboarding/vibePicks";
 import { useFirstEntryCelebration } from "../onboarding/useFirstEntryCelebration";
+import { CelebrationModal } from "../onboarding/CelebrationModal";
 import { DailyNudge } from "../onboarding/DailyNudge";
 import { ReEngagementCard } from "../onboarding/ReEngagementCard";
 import {
@@ -92,7 +93,7 @@ export function HubDashboard({
   );
 
   const hasRealEntry = detectFirstRealEntry();
-  useFirstEntryCelebration(hasRealEntry);
+  const celebration = useFirstEntryCelebration(hasRealEntry);
   const [sessionDays, setSessionDays] = useState(-1);
   useEffect(() => {
     setSessionDays(recordSessionDay() || getSessionDays());
@@ -376,6 +377,13 @@ export function HubDashboard({
 
       {/* Motivational footer */}
       <MotivationalFooter />
+
+      {/* First entry celebration modal */}
+      <CelebrationModal
+        open={celebration.open}
+        onClose={celebration.close}
+        ttvMs={celebration.ttvMs}
+      />
     </div>
   );
 }

--- a/apps/web/src/core/onboarding/CelebrationModal.tsx
+++ b/apps/web/src/core/onboarding/CelebrationModal.tsx
@@ -1,0 +1,165 @@
+/**
+ * CelebrationModal — First entry success celebration
+ *
+ * Full-screen modal celebrating the user's first real entry.
+ * Replaces the brief toast with a more memorable moment.
+ */
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { cn } from "@shared/lib/cn";
+import { Button } from "@shared/components/ui/Button";
+import { hapticTap } from "@shared/lib/haptic";
+
+interface CelebrationModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Time-to-value in milliseconds (null if not measured) */
+  ttvMs: number | null;
+}
+
+export function CelebrationModal({
+  open,
+  onClose,
+  ttvMs,
+}: CelebrationModalProps) {
+  const [visible, setVisible] = useState(false);
+  const [animateOut, setAnimateOut] = useState(false);
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = useCallback(() => {
+    hapticTap();
+    setAnimateOut(true);
+    setTimeout(() => {
+      setVisible(false);
+      onClose();
+    }, 200);
+  }, [onClose]);
+
+  // Sync visibility with open prop
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+      setAnimateOut(false);
+    }
+  }, [open]);
+
+  // Auto-dismiss after 12 seconds
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setTimeout(() => {
+      handleClose();
+    }, 12000);
+    return () => clearTimeout(timer);
+  }, [visible, handleClose]);
+
+  // Handle keyboard
+  useEffect(() => {
+    if (!visible) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [visible, handleClose]);
+
+  // Focus the backdrop for keyboard accessibility
+  useEffect(() => {
+    if (visible && backdropRef.current) {
+      backdropRef.current.focus();
+    }
+  }, [visible]);
+
+  if (!visible) return null;
+
+  // Build headline
+  const headline =
+    ttvMs != null && ttvMs < 60000
+      ? `Готово за ${Math.max(1, Math.round(ttvMs / 1000))} с!`
+      : "Готово!";
+
+  return (
+    <div
+      ref={backdropRef}
+      className={cn(
+        "fixed inset-0 z-[9999] flex items-center justify-center",
+        "bg-bg/80 backdrop-blur-md",
+        animateOut
+          ? "motion-safe:animate-fade-out"
+          : "motion-safe:animate-fade-in",
+      )}
+      onClick={handleClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClose();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label="Закрити святкування"
+    >
+      <div
+        className={cn(
+          "flex flex-col items-center gap-5 p-8 max-w-sm mx-4 text-center",
+          animateOut
+            ? "motion-safe:animate-scale-out"
+            : "motion-safe:animate-scale-in",
+        )}
+        role="presentation"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {/* Success icon */}
+        <div
+          className={cn(
+            "w-20 h-20 rounded-full flex items-center justify-center",
+            "bg-brand-500/20 ring-4 ring-brand-500/30",
+          )}
+        >
+          <svg
+            className="w-10 h-10 text-brand-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline
+              points="20 6 9 17 4 12"
+              className="motion-safe:animate-draw-check"
+              style={{
+                strokeDasharray: 24,
+                strokeDashoffset: 24,
+              }}
+            />
+          </svg>
+        </div>
+
+        {/* Headline */}
+        <h2 id="celebration-headline" className="text-h1 text-text">
+          {headline}
+        </h2>
+
+        {/* Subtext */}
+        <p className="text-body text-muted">
+          Це вже твої дані. Sergeant працює для тебе.
+        </p>
+
+        {/* Dismiss button */}
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={handleClose}
+          className="w-full max-w-[200px] mt-2"
+        >
+          Чудово!
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/core/onboarding/useFirstEntryCelebration.ts
+++ b/apps/web/src/core/onboarding/useFirstEntryCelebration.ts
@@ -1,49 +1,36 @@
-// Fires a one-shot "first success" toast the render after the user logs
+// Shows a one-shot celebration modal the render after the user logs
 // their very first real entry. This is the moment the 30-second FTUX
-// promise actually pays off: demo data becomes *their* data. Without a
-// celebration here the transition is silent and easy to miss.
+// promise actually pays off: demo data becomes *their* data.
 //
 // Contract:
-//   - Consumes the boolean returned by `detectFirstRealEntry()` (already
-//     persists its own idempotency flag).
-//   - Fires exactly once, client-side, per browser profile. Subsequent
-//     sessions (where the flag is already persisted on mount) stay quiet.
-//   - Skipped on the session where the user landed already having real
-//     data — we don't want the toast to congratulate existing users.
+//   - Consumes the boolean returned by `detectFirstRealEntry()`.
+//   - Fires exactly once, client-side, per browser profile.
+//   - Skipped on sessions where the user already has real data on mount.
 
-import { useEffect, useRef } from "react";
-import { useToast } from "@shared/hooks/useToast";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { getTimeToValueMs } from "./vibePicks";
 
-/**
- * Compose the success-moment toast. If we measured a time-to-value
- * within the 30-second window we lead with the number so the user sees
- * the promise literally kept. Outside the window (or for returning
- * users with no stamp) we fall back to the generic copy.
- *
- * @param {number | null} ttvMs
- * @returns {string}
- */
-function buildToastCopy(ttvMs) {
-  if (ttvMs == null) return "Готово. Це вже твої дані.";
-  const sec = Math.max(1, Math.round(ttvMs / 1000));
-  if (sec > 60) return "Готово. Це вже твої дані.";
-  return `Готово за ${sec} с. Це вже твої дані.`;
+interface CelebrationState {
+  /** Whether the celebration modal should be open */
+  open: boolean;
+  /** Time-to-value in milliseconds (null if not measured) */
+  ttvMs: number | null;
+  /** Close the celebration modal */
+  close: () => void;
 }
 
-export function useFirstEntryCelebration(hasRealEntry) {
-  // Narrow to the stable `success` callback rather than the whole
-  // context value: `ToastProvider` re-memos the context on every toast
-  // emission (because `toasts` is in its dep array), so depending on
-  // `toast` would re-run this effect each time any toast appears or
-  // dismisses anywhere in the app. `success` itself is a stable
-  // `useCallback`, so this keeps the effect narrowly reactive.
-  const { success } = useToast();
+export function useFirstEntryCelebration(
+  hasRealEntry: boolean,
+): CelebrationState {
+  const [open, setOpen] = useState(false);
+  const [ttvMs, setTtvMs] = useState<number | null>(null);
   const firedRef = useRef(false);
-  // Snapshot the value at mount. If the user already had real data when
-  // the dashboard first rendered, they're not a FTUX user — suppress the
-  // celebration for good in this session.
+  // Snapshot value at mount — if user already has data, skip celebration
   const initialRef = useRef(hasRealEntry);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, []);
 
   useEffect(() => {
     if (firedRef.current) return;
@@ -53,10 +40,11 @@ export function useFirstEntryCelebration(hasRealEntry) {
     }
     if (!hasRealEntry) return;
     firedRef.current = true;
-    // `detectFirstRealEntry` ran before this effect (the dashboard
-    // calls it synchronously in render), so the TTV value is already
-    // persisted by the time we read it here.
+    // Read TTV value persisted by detectFirstRealEntry
     const ttv = getTimeToValueMs();
-    success(buildToastCopy(ttv), 7000);
-  }, [hasRealEntry, success]);
+    setTtvMs(ttv);
+    setOpen(true);
+  }, [hasRealEntry]);
+
+  return { open, ttvMs, close };
 }

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
@@ -10,6 +10,7 @@ import { cn } from "../../lib/cn";
 import { safeReadStringLS, safeWriteLS, safeRemoveLS } from "../../lib/storage";
 import { Button } from "./Button";
 import { hapticTap } from "../../lib/haptic";
+import { useSpotlightQueue } from "./SpotlightQueue";
 
 /**
  * Sergeant Design System — Feature Spotlight
@@ -64,6 +65,8 @@ export interface FeatureSpotlightProps {
   skipPersist?: boolean;
   /** Children slot for custom content */
   children?: ReactNode;
+  /** Queue priority (higher = shows first) */
+  priority?: number;
 }
 
 const STORAGE_KEY_PREFIX = "sergeant_spotlight_dismissed_";
@@ -89,17 +92,42 @@ export function FeatureSpotlight({
   onDismiss,
   skipPersist = false,
   children,
+  priority = 0,
 }: FeatureSpotlightProps) {
   const [visible, setVisible] = useState(false);
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const [slotId, setSlotId] = useState<string | null>(null);
   const targetRef = useRef<HTMLSpanElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const effectivePlacement = position ?? placement;
   const persistDismissal = showOnce ?? !skipPersist;
 
-  // Check if already dismissed
+  // Queue integration — only one spotlight shows at a time
+  const { requestSlot, releaseSlot, isMyTurn } = useSpotlightQueue();
+
+  // Request queue slot on mount
   useEffect(() => {
     if (persistDismissal && isDismissed(id)) {
+      return;
+    }
+
+    const newSlotId = requestSlot(id, priority);
+    setSlotId(newSlotId);
+
+    return () => {
+      releaseSlot(newSlotId);
+    };
+  }, [id, persistDismissal, priority, requestSlot, releaseSlot]);
+
+  // Show spotlight when it's our turn in the queue
+  useEffect(() => {
+    if (persistDismissal && isDismissed(id)) {
+      return;
+    }
+
+    // Wait for our turn in the queue
+    if (!isMyTurn(id)) {
+      setVisible(false);
       return;
     }
 
@@ -136,7 +164,7 @@ export function FeatureSpotlight({
     // Delay slightly to ensure DOM is ready and layout is stable
     const timer = setTimeout(findTarget, delay);
     return () => clearTimeout(timer);
-  }, [delay, id, persistDismissal, targetSelector]);
+  }, [delay, id, persistDismissal, targetSelector, isMyTurn]);
 
   // Update position on scroll/resize with debouncing
   useEffect(() => {
@@ -183,8 +211,12 @@ export function FeatureSpotlight({
     if (persistDismissal) {
       markDismissed(id);
     }
+    // Release queue slot so next spotlight can show
+    if (slotId) {
+      releaseSlot(slotId);
+    }
     onDismiss?.();
-  }, [id, persistDismissal, onDismiss]);
+  }, [id, persistDismissal, onDismiss, slotId, releaseSlot]);
 
   const target = children ? (
     <span ref={targetRef} className="inline-flex">
@@ -282,11 +314,23 @@ export function FeatureSpotlight({
   return (
     <>
       {target}
-      <div className="fixed inset-0 z-[1000]" role="dialog" aria-modal="true">
-        {/* Overlay with cutout */}
-        <svg
-          className="absolute inset-0 w-full h-full"
+      {/* Portal to body ensures highest stacking context */}
+      <div
+        className="fixed inset-0 z-[9999] pointer-events-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`spotlight-title-${id}`}
+      >
+        {/* Backdrop — intercepts clicks outside tooltip to dismiss */}
+        <div
+          className="absolute inset-0 pointer-events-auto"
           onClick={handleDismiss}
+          aria-hidden="true"
+        />
+
+        {/* Overlay with cutout — purely visual, no pointer events */}
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
           aria-hidden="true"
         >
           <defs>
@@ -313,7 +357,7 @@ export function FeatureSpotlight({
           />
         </svg>
 
-        {/* Spotlight ring */}
+        {/* Spotlight ring — purely visual */}
         <div
           className={cn(
             "absolute pointer-events-none",
@@ -329,7 +373,7 @@ export function FeatureSpotlight({
           aria-hidden="true"
         />
 
-        {/* Tooltip — pointer-events-auto ensures button is clickable */}
+        {/* Tooltip card — interactive, receives pointer events */}
         <div
           ref={tooltipRef}
           className={cn(
@@ -337,9 +381,14 @@ export function FeatureSpotlight({
             "bg-panel border border-line shadow-float",
             "motion-safe:animate-slide-up",
           )}
-          style={tooltipStyle}
+          style={{ ...tooltipStyle, zIndex: 1 }}
         >
-          <h3 className="text-base font-bold text-text mb-1">{title}</h3>
+          <h3
+            id={`spotlight-title-${id}`}
+            className="text-base font-bold text-text mb-1"
+          >
+            {title}
+          </h3>
           <p className="text-sm text-muted mb-4">{description}</p>
           <Button size="sm" onClick={handleDismiss} className="w-full">
             {actionText}

--- a/apps/web/src/shared/components/ui/SpotlightQueue.tsx
+++ b/apps/web/src/shared/components/ui/SpotlightQueue.tsx
@@ -1,0 +1,115 @@
+/**
+ * SpotlightQueue — Coordinates multiple FeatureSpotlight instances
+ *
+ * Only one spotlight should appear at a time. This context provider
+ * manages a priority queue so spotlights display sequentially rather
+ * than stacking on top of each other.
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from "react";
+
+interface QueueSlot {
+  id: string;
+  priority: number;
+  timestamp: number;
+}
+
+interface SpotlightQueueContextValue {
+  /** Request a slot in the queue. Returns slot ID for release. */
+  requestSlot: (id: string, priority?: number) => string;
+  /** Release a slot when spotlight is dismissed. */
+  releaseSlot: (slotId: string) => void;
+  /** Check if this spotlight ID is currently at the front of the queue. */
+  isMyTurn: (id: string) => boolean;
+  /** Check if any spotlight is currently active (for HintsOrchestrator). */
+  isAnyActive: () => boolean;
+}
+
+const SpotlightQueueContext = createContext<SpotlightQueueContextValue | null>(
+  null,
+);
+
+export function SpotlightQueueProvider({ children }: { children: ReactNode }) {
+  const [queue, setQueue] = useState<QueueSlot[]>([]);
+
+  const requestSlot = useCallback((id: string, priority = 0): string => {
+    const slotId = `${id}-${Date.now()}`;
+    setQueue((prev) => {
+      // Don't add duplicate IDs
+      if (prev.some((slot) => slot.id === id)) {
+        return prev;
+      }
+      const newSlot: QueueSlot = {
+        id,
+        priority,
+        timestamp: Date.now(),
+      };
+      // Sort by priority (higher first), then by timestamp (earlier first)
+      return [...prev, newSlot].sort((a, b) => {
+        if (b.priority !== a.priority) return b.priority - a.priority;
+        return a.timestamp - b.timestamp;
+      });
+    });
+    return slotId;
+  }, []);
+
+  const releaseSlot = useCallback((slotId: string) => {
+    const id = slotId.split("-").slice(0, -1).join("-");
+    setQueue((prev) => prev.filter((slot) => slot.id !== id));
+  }, []);
+
+  const isMyTurn = useCallback(
+    (id: string): boolean => {
+      if (queue.length === 0) return false;
+      return queue[0].id === id;
+    },
+    [queue],
+  );
+
+  const isAnyActive = useCallback((): boolean => {
+    return queue.length > 0;
+  }, [queue]);
+
+  const value = useMemo(
+    () => ({
+      requestSlot,
+      releaseSlot,
+      isMyTurn,
+      isAnyActive,
+    }),
+    [requestSlot, releaseSlot, isMyTurn, isAnyActive],
+  );
+
+  return (
+    <SpotlightQueueContext.Provider value={value}>
+      {children}
+    </SpotlightQueueContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the spotlight queue.
+ * Returns no-op functions if used outside provider (graceful degradation).
+ */
+export function useSpotlightQueue(): SpotlightQueueContextValue {
+  const ctx = useContext(SpotlightQueueContext);
+
+  // Graceful fallback if no provider — spotlight works standalone
+  if (!ctx) {
+    return {
+      requestSlot: (id: string) => id,
+      releaseSlot: () => {},
+      isMyTurn: () => true,
+      isAnyActive: () => false,
+    };
+  }
+
+  return ctx;
+}

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -392,6 +392,10 @@ const preset = {
         // Stagger enter — children use animation-delay: ${index * 50}ms
         "stagger-in":
           "fadeSlideUp 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both",
+        // Celebration modal animations
+        "fade-out": "fadeOut 0.2s ease-out forwards",
+        "scale-out": "scaleOut 0.2s ease-out forwards",
+        "draw-check": "drawCheck 0.4s ease-out 0.2s forwards",
       },
       keyframes: {
         fadeIn: {
@@ -443,6 +447,18 @@ const preset = {
         progressFill: {
           "0%": { strokeDashoffset: "100" },
           "100%": { strokeDashoffset: "var(--progress-offset, 0)" },
+        },
+        fadeOut: {
+          "0%": { opacity: "1" },
+          "100%": { opacity: "0" },
+        },
+        scaleOut: {
+          "0%": { opacity: "1", transform: "scale(1)" },
+          "100%": { opacity: "0", transform: "scale(0.95)" },
+        },
+        drawCheck: {
+          "0%": { strokeDashoffset: "24" },
+          "100%": { strokeDashoffset: "0" },
         },
         bounceIn: {
           "0%": { opacity: "0", transform: "scale(0.3)" },


### PR DESCRIPTION
FeatureSpotlight:
- Fixed button clickability: separated backdrop from SVG overlay
- z-index 9999 with proper aria-labelledby
- Integrated with SpotlightQueue for sequential spotlights
- Added priority prop for queue ordering

SpotlightQueue:
- New context provider preventing multiple simultaneous spotlights
- Priority-based ordering with timestamp tiebreaker

CelebrationModal:
- Replaces toast for first entry celebration
- Fullscreen frosted-glass modal with checkmark animation
- Auto-dismiss after 12s, escape/enter/tap dismisses
- Shows time-to-value when measured

design-tokens:
- Added fadeOut, scaleOut, drawCheck animations

HintsOrchestrator:
- Checks isSpotlightActive() before showing toast hints

App.tsx:
- Wrapped with SpotlightQueueProvider

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished onboarding with a priority-based spotlight queue and a celebratory first-entry modal. Users see one spotlight at a time, better focus, and a more memorable first-success moment.

- **New Features**
  - Spotlight queue: global provider shows one spotlight at a time; priority ordering with timestamp tiebreaker. Wrapped app with the provider and added a `priority` prop to spotlights. Hints pause while a spotlight is active.
  - Celebration modal: replaces the first-entry toast with a fullscreen, frosted modal and checkmark animation. Auto-dismisses after 12s; Escape/Enter/tap dismiss. Shows time-to-value when available.
  - `design-tokens`: added `fadeOut`, `scaleOut`, and `drawCheck` animations.

- **Bug Fixes**
  - Spotlight overlay: separated backdrop from SVG so buttons are clickable; raised z-index to 9999 and added proper `aria-labelledby`.

<sup>Written for commit 0cb042898fd0b8a2e1f67fe4f3365180b1455fef. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1073?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature spotlights now use intelligent queuing based on priority level, displaying one at a time to prevent overlapping overlays and improve user experience.
  * First entry celebration now displays as a polished full-screen animated modal with haptic feedback, replacing the previous simple toast approach.

* **Bug Fixes**
  * Hint notifications are now automatically suppressed while feature spotlights are active to minimize visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
