### PR TITLE
fix(web): feature spotlight scroll and viewport stability

### DIFF
--- a/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.tsx
@@ -166,6 +166,12 @@ export function FeatureSpotlight({
     return () => clearTimeout(timer);
   }, [delay, id, persistDismissal, targetSelector, isMyTurn]);
 
+  // Track viewport size for SVG viewBox updates
+  const [viewportSize, setViewportSize] = useState({
+    width: typeof window !== "undefined" ? window.innerWidth : 0,
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+  });
+
   // Update position on scroll/resize with debouncing
   useEffect(() => {
     if (!visible) return;
@@ -193,6 +199,12 @@ export function FeatureSpotlight({
         ) {
           setTargetRect(rect);
         }
+
+        // Update viewport size for SVG viewBox
+        setViewportSize({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
       });
     };
 
@@ -311,6 +323,9 @@ export function FeatureSpotlight({
     borderRadius: 12,
   };
 
+  // Use a unique mask ID with a timestamp to avoid conflicts between spotlights
+  const maskId = `spotlight-mask-${id}-${Date.now()}`;
+
   return (
     <>
       {target}
@@ -328,13 +343,18 @@ export function FeatureSpotlight({
           aria-hidden="true"
         />
 
-        {/* Overlay with cutout — purely visual, no pointer events */}
+        {/* Overlay with cutout — use explicit viewBox for stable rendering */}
         <svg
-          className="absolute inset-0 w-full h-full pointer-events-none"
+          className="absolute inset-0 pointer-events-none"
+          width="100%"
+          height="100%"
+          viewBox={`0 0 ${viewportSize.width} ${viewportSize.height}`}
+          preserveAspectRatio="none"
           aria-hidden="true"
+          style={{ overflow: "visible" }}
         >
           <defs>
-            <mask id={`spotlight-mask-${id}`}>
+            <mask id={maskId}>
               <rect x="0" y="0" width="100%" height="100%" fill="white" />
               <rect
                 x={spotlightRect.left}
@@ -352,7 +372,7 @@ export function FeatureSpotlight({
             width="100%"
             height="100%"
             fill="rgba(0, 0, 0, 0.6)"
-            mask={`url(#spotlight-mask-${id})`}
+            mask={`url(#${maskId})`}
             className="motion-safe:animate-fade-in"
           />
         </svg>


### PR DESCRIPTION
- use explicit viewBox with tracked viewport dimensions instead of relying on 100% width/height which caused mask misalignment on scroll
- track viewportSize state that updates on scroll/resize
- generate unique mask IDs with timestamp to avoid SVG mask conflicts
- SVG overlay now correctly follows the target element during scroll

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FeatureSpotlight overlay misalignment during scroll by using an explicit SVG viewBox tied to the viewport and unique mask IDs. The spotlight now stays aligned with the target on scroll and resize.

- **Bug Fixes**
  - Track `viewportSize` and update on scroll/resize.
  - Use explicit SVG `viewBox` with `preserveAspectRatio="none"` instead of 100% width/height.
  - Generate unique mask IDs per instance to prevent SVG mask conflicts.

<sup>Written for commit 55520632338cc5a71d226a65c8d00665e3a5a89f. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1074?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability and visual performance of spotlight features, particularly when multiple spotlights are displayed simultaneously.
  * Enhanced responsiveness to viewport changes during window resizing and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
