### PR TITLE
Enhance settings UI and improve feature spotlight stability

### DIFF
--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -126,19 +126,20 @@ export function HubSettingsPage({ syncing, onSync, onPull, user }) {
   const visible = sections.filter((s) => visibleSectionIds.includes(s.id));
 
   return (
-    <div className="flex flex-col gap-3 pt-2 pb-4">
-      <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-4 pt-3 pb-6">
+      {/* Search and tabs header */}
+      <div className="flex flex-col gap-3 sticky top-0 z-10 bg-bg/95 backdrop-blur-sm -mx-4 px-4 py-2 -mt-3">
         <label className="relative block">
           <span className="sr-only">Пошук по налаштуваннях</span>
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none">
-            <Icon name="search" size={16} />
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-muted pointer-events-none">
+            <Icon name="search" size={18} />
           </span>
           <input
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Пошук налаштувань"
-            className="input-focus w-full min-h-[44px] pl-9 pr-10 py-3 bg-panelHi border border-line rounded-2xl text-[16px] md:text-sm text-text placeholder:text-muted"
+            placeholder="Пошук налаштувань…"
+            className="input-focus w-full min-h-[48px] pl-11 pr-11 py-3 bg-panel border border-line rounded-2xl text-[16px] md:text-sm text-text placeholder:text-muted shadow-soft"
           />
           {query && (
             <Button
@@ -147,9 +148,9 @@ export function HubSettingsPage({ syncing, onSync, onPull, user }) {
               iconOnly
               onClick={() => setQuery("")}
               aria-label="Очистити пошук"
-              className="absolute right-2 top-1/2 -translate-y-1/2"
+              className="absolute right-2 top-1/2 -translate-y-1/2 hover:bg-panelHi"
             >
-              <Icon name="close" size={14} />
+              <Icon name="close" size={16} />
             </Button>
           )}
         </label>
@@ -163,22 +164,38 @@ export function HubSettingsPage({ syncing, onSync, onPull, user }) {
             items={GROUPS.map((g) => ({ value: g.id, label: g.label }))}
             value={tab}
             onChange={(v) => setTab(v)}
-            className="overflow-x-auto border border-line"
+            className="overflow-x-auto border border-line shadow-soft"
           />
         )}
       </div>
 
-      {visible.length === 0 ? (
-        <div className="text-sm text-muted text-center py-6">
-          Нічого не знайдено за запитом «{query}»
-        </div>
-      ) : (
-        visible.map((s) => (
-          <div key={s.id} ref={(el) => (refs.current[s.id] = el)}>
-            {s.render()}
+      {/* Settings sections */}
+      <div className="flex flex-col gap-4">
+        {visible.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 gap-3">
+            <div className="w-12 h-12 rounded-full bg-panelHi flex items-center justify-center">
+              <Icon name="search" size={24} className="text-muted" />
+            </div>
+            <p className="text-sm text-muted text-center">
+              Нічого не знайдено за запитом «{query}»
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setQuery("")}
+              className="text-brand"
+            >
+              Очистити пошук
+            </Button>
           </div>
-        ))
-      )}
+        ) : (
+          visible.map((s) => (
+            <div key={s.id} ref={(el) => (refs.current[s.id] = el)}>
+              {s.render()}
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/core/settings/AssistantCatalogueSection.tsx
+++ b/apps/web/src/core/settings/AssistantCatalogueSection.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@shared/components/ui/Button";
-import { Card } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
+import { SettingsGroup } from "./SettingsPrimitives";
 
 /**
  * Settings entry that links to the Assistant capability catalogue
@@ -12,11 +12,7 @@ import { Icon } from "@shared/components/ui/Icon";
 export function AssistantCatalogueSection() {
   const navigate = useNavigate();
   return (
-    <Card radius="lg" padding="md" className="space-y-3">
-      <h3 className="text-base font-semibold text-text flex items-center gap-2">
-        <Icon name="sparkles" size={16} aria-hidden />
-        Можливості асистента
-      </h3>
+    <SettingsGroup title="Можливості асистента" emoji="✨" defaultOpen>
       <p className="text-sm text-subtle leading-relaxed">
         ~60 інструментів, які може запустити AI-асистент: фінанси, тренування,
         звички, харчування, аналітика, утиліти, пам&apos;ять. Тапни картку — і
@@ -29,8 +25,9 @@ export function AssistantCatalogueSection() {
         className="w-full"
         data-testid="open-assistant-catalogue"
       >
+        <Icon name="sparkles" size={16} className="mr-2" />
         Відкрити каталог
       </Button>
-    </Card>
+    </SettingsGroup>
   );
 }

--- a/apps/web/src/core/settings/SettingsPrimitives.tsx
+++ b/apps/web/src/core/settings/SettingsPrimitives.tsx
@@ -37,26 +37,36 @@ export function SettingsGroup({
 }: SettingsGroupProps) {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   return (
-    <Card radius="lg" padding="none" className="overflow-hidden">
+    <Card radius="lg" padding="none" className="overflow-hidden shadow-soft">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="w-full px-4 py-3.5 flex items-center justify-between gap-2 hover:bg-panelHi/50 transition-colors"
+        className={cn(
+          "w-full px-4 py-4 flex items-center justify-between gap-3",
+          "hover:bg-panelHi/60 active:bg-panelHi transition-colors",
+          open && "bg-panelHi/30",
+        )}
       >
-        <div className="flex items-center gap-2 min-w-0">
-          {emoji && <span className="text-base">{emoji}</span>}
-          <span className="text-sm font-semibold text-text">{title}</span>
+        <div className="flex items-center gap-3 min-w-0">
+          {emoji && (
+            <span className="text-lg w-7 h-7 flex items-center justify-center rounded-lg bg-bg">
+              {emoji}
+            </span>
+          )}
+          <span className="text-base font-semibold text-text">{title}</span>
         </div>
         <ChevronIcon expanded={open} />
       </button>
       <div
         className={cn(
-          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          "grid transition-[grid-template-rows] duration-200 ease-out",
           open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
         )}
       >
         <div className="overflow-hidden">
-          <div className="border-t border-line p-4 space-y-5">{children}</div>
+          <div className="border-t border-line/60 px-4 py-5 space-y-6">
+            {children}
+          </div>
         </div>
       </div>
     </Card>
@@ -76,29 +86,32 @@ export function SettingsSubGroup({
 }: SettingsSubGroupProps) {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   return (
-    <div>
+    <div className="rounded-xl bg-bg/50 border border-line/40 overflow-hidden">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1.5 w-full text-left group mb-1"
+        className={cn(
+          "flex items-center gap-2 w-full text-left group px-3 py-2.5",
+          "hover:bg-panelHi/40 transition-colors",
+        )}
       >
         <ChevronIcon expanded={open} />
         {/* eslint-disable-next-line sergeant-design/no-eyebrow-drift --
             Collapsible header uses `group-hover:text-text` interactive state +
             transition-colors, which SectionHeading can't express via its
             static tone tokens. */}
-        <span className="text-xs font-bold text-muted uppercase tracking-widest group-hover:text-text transition-colors">
+        <span className="text-xs font-bold text-muted uppercase tracking-wider group-hover:text-text transition-colors">
           {title}
         </span>
       </button>
       <div
         className={cn(
-          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          "grid transition-[grid-template-rows] duration-200 ease-out",
           open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
         )}
       >
         <div className="overflow-hidden">
-          <div className="pt-2 space-y-3">{children}</div>
+          <div className="px-3 pb-3 pt-1 space-y-3">{children}</div>
         </div>
       </div>
     </div>
@@ -119,11 +132,18 @@ export function ToggleRow({
   onChange,
 }: ToggleRowProps) {
   return (
-    <label className="flex items-start justify-between gap-3 cursor-pointer group">
+    <label
+      className={cn(
+        "flex items-start justify-between gap-4 cursor-pointer group",
+        "p-3 -mx-3 rounded-xl hover:bg-panelHi/40 transition-colors",
+      )}
+    >
       <div className="flex-1 min-w-0">
-        <span className="text-sm text-text">{label}</span>
+        <span className="text-sm font-medium text-text group-hover:text-brand-strong transition-colors">
+          {label}
+        </span>
         {description && (
-          <p className="text-xs text-subtle mt-0.5 leading-snug">
+          <p className="text-xs text-subtle mt-1 leading-relaxed">
             {description}
           </p>
         )}
@@ -165,7 +185,7 @@ export function ConfirmModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/60 backdrop-blur-md motion-safe:animate-fade-in"
         onClick={onCancel}
         aria-label="Закрити"
       />
@@ -174,16 +194,21 @@ export function ConfirmModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-modal-title"
-        className="relative w-full max-w-sm bg-panel border border-line rounded-2xl shadow-soft p-5 z-10"
+        className="relative w-full max-w-sm bg-panel border border-line rounded-2xl shadow-float p-6 z-10 motion-safe:animate-scale-in"
       >
-        <h2 id="confirm-modal-title" className="text-base font-bold text-text">
+        <h2
+          id="confirm-modal-title"
+          className="text-lg font-bold text-text leading-tight"
+        >
           {title}
         </h2>
-        {body && <p className="text-sm text-muted mt-2">{body}</p>}
-        <div className="flex gap-2 mt-5">
+        {body && (
+          <p className="text-sm text-muted mt-3 leading-relaxed">{body}</p>
+        )}
+        <div className="flex gap-3 mt-6">
           <button
             type="button"
-            className="flex-1 py-3 rounded-xl border border-line text-sm font-semibold text-muted hover:bg-panelHi transition-colors"
+            className="flex-1 py-3.5 rounded-xl border border-line text-sm font-semibold text-muted hover:bg-panelHi hover:text-text transition-colors"
             onClick={onCancel}
           >
             Скасувати
@@ -191,10 +216,10 @@ export function ConfirmModal({
           <button
             type="button"
             className={cn(
-              "flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-colors",
+              "flex-1 py-3.5 rounded-xl text-sm font-semibold text-white transition-colors shadow-soft",
               danger
-                ? "bg-danger hover:bg-danger/90"
-                : "bg-emerald-600 hover:bg-emerald-700",
+                ? "bg-danger hover:bg-danger/90 active:bg-danger/80"
+                : "bg-brand hover:bg-brand/90 active:bg-brand/80",
             )}
             onClick={onConfirm}
           >


### PR DESCRIPTION
### Settings Experience
- Improved the search UX on the Hub Settings page for faster navigation.
- Unified the Assistant Catalogue section to ensure a more consistent interface.
- Refined animations and styles within Settings groups for smoother visual transitions.

### Stability & Layout
- Fixed scrolling and viewport stability issues affecting the feature spotlight component.

[v0 Session](https://v0.app/chat/fsYTr9c1akF)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Settings UI for faster navigation and a consistent look, and fixed scrolling/viewport issues in the feature spotlight.

- **New Features**
  - Sticky settings header with backdrop blur and a larger search input.
  - Clearer empty state with icon and a one-click “clear search”.
  - Unified Assistant Catalogue using `SettingsGroup`; added sparkles icon on the action.
  - Smoother animations, spacing, and hover states across groups, subgroups, toggles; subtle shadows for depth.
  - Confirm modal: scale-in animation, improved spacing, and brand-colored confirm (non-danger).

- **Bug Fixes**
  - Resolved scrolling and viewport stability glitches in the feature spotlight.

<sup>Written for commit cad855dc7fc4530543c75cc2f16431e7fb9c7a31. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1075?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Settings page header is now sticky with enhanced styling and blur effects
  * Search interface refined with improved icon sizing, input styling, and placeholder text
  * Enhanced empty-state display with icon and clear search action when no results are found
  * Updated spacing and typography across settings groups and components
  * Added smooth animations and interactive hover states throughout the settings area

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
