### PR TITLE
fix(server): autocreate mono_account stub on FK violation + unblock docker build

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,9 @@ docs/api/openapi.json
 .agents
 artifacts
 mcps
+
+# Plop Handlebars templates — `.hbs` файли містять `{{name}}`-mustache-токени
+# у TypeScript-shape (наприклад, `): Promise<{{returnType}}> {`), які Prettier
+# не може розпарсити (бачить `<{{` як HTML-тег і кидає SyntaxError). Шаблони
+# не є виконуваним кодом і їх не треба форматувати — їх рендерять через plop.
+plop-templates/**/*.hbs

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,18 +6,25 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@9.15.1 --activate
 
 # --- Залежності (кеш-шар) ---
+# `patches/` потрібен ДО `pnpm install`, бо `pnpm.patchedDependencies` у
+# package.json (наразі `@expo/cli@0.22.28`) застосовується завжди — навіть з
+# `--ignore-scripts` — і відсутність патч-файлу валить frozen-install.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/package.json
 COPY packages/config/package.json ./packages/config/package.json
+COPY packages/finyk-domain/package.json ./packages/finyk-domain/package.json
 COPY apps/server/package.json ./apps/server/package.json
 
 RUN pnpm install --frozen-lockfile --ignore-scripts \
       --filter @sergeant/server... \
-      --filter @sergeant/shared...
+      --filter @sergeant/shared... \
+      --filter @sergeant/finyk-domain...
 
 # --- Джерела ---
 COPY packages/shared ./packages/shared
 COPY packages/config ./packages/config
+COPY packages/finyk-domain ./packages/finyk-domain
 COPY apps/server ./apps/server
 
 WORKDIR /app/apps/server
@@ -35,9 +42,12 @@ ENV NODE_ENV=production
 RUN corepack enable && corepack prepare pnpm@9.15.1 --activate
 
 # Install production deps only (keeps runtime small & safer).
+# `patches/` обов'язково ДО `pnpm install` — див. коментар у builder-stage.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY patches ./patches
 COPY packages/shared/package.json ./packages/shared/package.json
 COPY packages/config/package.json ./packages/config/package.json
+COPY packages/finyk-domain/package.json ./packages/finyk-domain/package.json
 COPY apps/server/package.json ./apps/server/package.json
 
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts \

--- a/apps/server/src/modules/mono/webhook.test.ts
+++ b/apps/server/src/modules/mono/webhook.test.ts
@@ -382,4 +382,67 @@ describe("webhookHandler", () => {
 
     expect(counter.inc).toHaveBeenCalledWith({ status: "error" });
   });
+
+  it("FK violation (23503) on tx upsert → autocreates mono_account stub and retries", async () => {
+    // Lookup connection
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+    // First tx upsert attempt fails with FK violation (unknown account)
+    const fkErr = Object.assign(new Error("FK violation"), { code: "23503" });
+    dbQuery.mockRejectedValueOnce(fkErr);
+    // Stub-INSERT into mono_account
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // Retry tx upsert succeeds
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ inserted: true }],
+      rowCount: 1,
+    });
+    // UPDATE balance
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // UPDATE last_event_at
+    dbQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = makeRes();
+    await webhookHandler(makeReq(VALID_SECRET), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(counter.inc).toHaveBeenCalledWith({ status: "account_autocreated" });
+    expect(counter.inc).toHaveBeenCalledWith({ status: "ok" });
+
+    // 6 DB calls: lookup + failed tx upsert + account stub + retry tx upsert
+    //           + balance update + event update
+    expect(dbQuery).toHaveBeenCalledTimes(6);
+
+    // Verify the stub uses StatementItem currency + balance fields.
+    const stubCall = dbQuery.mock.calls[2];
+    expect(stubCall[0]).toMatch(/INSERT INTO mono_account/);
+    expect(stubCall[0]).toMatch(/ON CONFLICT[\s\S]*DO NOTHING/);
+    expect(stubCall[1]).toEqual(["user_1", "acc_uah", 980, 1500000]);
+    expect(stubCall[2]).toEqual({ op: "mono_account_autocreate" });
+  });
+
+  it("non-FK errors are NOT retried (only 23503 triggers autocreate)", async () => {
+    dbQuery.mockResolvedValueOnce({
+      rows: [{ user_id: "user_1", webhook_secret: VALID_SECRET }],
+    });
+    // Some other DB error — must propagate without autocreate retry.
+    const otherErr = Object.assign(new Error("connection lost"), {
+      code: "08006",
+    });
+    dbQuery.mockRejectedValueOnce(otherErr);
+
+    const res = makeRes();
+    await expect(webhookHandler(makeReq(VALID_SECRET), res)).rejects.toThrow(
+      "connection lost",
+    );
+
+    // Only 2 DB calls: lookup + failed tx upsert. No autocreate, no retry.
+    expect(dbQuery).toHaveBeenCalledTimes(2);
+    expect(counter.inc).toHaveBeenCalledWith({ status: "error" });
+    expect(counter.inc).not.toHaveBeenCalledWith({
+      status: "account_autocreated",
+    });
+  });
 });

--- a/apps/server/src/modules/mono/webhook.ts
+++ b/apps/server/src/modules/mono/webhook.ts
@@ -188,8 +188,7 @@ export async function webhookHandler(
     // user's correction.
     const categorySlug = categorizeMcc(item.mcc);
 
-    const upsertResult = await query<{ inserted: boolean }>(
-      `INSERT INTO mono_transaction
+    const txUpsertSql = `INSERT INTO mono_transaction
          (user_id, mono_account_id, mono_tx_id, time, amount, operation_amount,
           currency_code, mcc, original_mcc, hold, description, comment,
           cashback_amount, commission_rate, balance, receipt_id, invoice_id,
@@ -211,33 +210,77 @@ export async function webhookHandler(
            ELSE EXCLUDED.category_slug
          END,
          received_at = NOW()
-       RETURNING (xmax = 0) AS inserted`,
-      [
+       RETURNING (xmax = 0) AS inserted`;
+    const txUpsertParams = [
+      userId,
+      monoAccountId,
+      item.id,
+      new Date(item.time * 1000).toISOString(),
+      item.amount,
+      item.operationAmount,
+      item.currencyCode,
+      item.mcc ?? null,
+      item.originalMcc ?? null,
+      item.hold ?? null,
+      item.description ?? null,
+      item.comment ?? null,
+      item.cashbackAmount ?? null,
+      item.commissionRate ?? null,
+      item.balance ?? null,
+      item.receiptId ?? null,
+      item.invoiceId ?? null,
+      item.counterEdrpou ?? null,
+      item.counterIban ?? null,
+      item.counterName ?? null,
+      JSON.stringify(item),
+      categorySlug,
+    ];
+
+    let upsertResult: { rows: Array<{ inserted: boolean }> };
+    try {
+      upsertResult = await query<{ inserted: boolean }>(
+        txUpsertSql,
+        txUpsertParams,
+        { op: "mono_tx_upsert" },
+      );
+    } catch (err) {
+      // Postgres SQLSTATE 23503 = foreign_key_violation. На цьому FK тільки
+      // один зовнішній ключ — `(user_id, mono_account_id)` → `mono_account`.
+      // Падає, коли Monobank доставляє транзакцію по рахунку, який ми ще не
+      // зареєстрували (юзер відкрив нову банку/картку/jar після останнього
+      // `/api/mono/connect` snapshot-у `client-info`). Раніше це валило
+      // вебхук у 500 і Monobank деактивував webhook через ~5 хв ретраїв.
+      // Тепер створюємо stub-запис з полів самого StatementItem (currency
+      // + balance) і ретраїмо upsert один раз. Решта полів (type, masked_pan,
+      // iban, ...) лишаються NULL — наступний `/connect` reconcile або
+      // окремий backfill підтягне їх з `client-info`.
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? (err as { code?: unknown }).code
+          : undefined;
+      if (code !== "23503") throw err;
+      logger.warn({
+        msg: "mono_webhook_account_autocreate",
         userId,
         monoAccountId,
-        item.id,
-        new Date(item.time * 1000).toISOString(),
-        item.amount,
-        item.operationAmount,
-        item.currencyCode,
-        item.mcc ?? null,
-        item.originalMcc ?? null,
-        item.hold ?? null,
-        item.description ?? null,
-        item.comment ?? null,
-        item.cashbackAmount ?? null,
-        item.commissionRate ?? null,
-        item.balance ?? null,
-        item.receiptId ?? null,
-        item.invoiceId ?? null,
-        item.counterEdrpou ?? null,
-        item.counterIban ?? null,
-        item.counterName ?? null,
-        JSON.stringify(item),
-        categorySlug,
-      ],
-      { op: "mono_tx_upsert" },
-    );
+        currencyCode: item.currencyCode,
+        monoTxId: item.id,
+      });
+      await query(
+        `INSERT INTO mono_account
+           (user_id, mono_account_id, currency_code, balance, last_seen_at)
+         VALUES ($1, $2, $3, $4, NOW())
+         ON CONFLICT (user_id, mono_account_id) DO NOTHING`,
+        [userId, monoAccountId, item.currencyCode, item.balance ?? null],
+        { op: "mono_account_autocreate" },
+      );
+      monoWebhookReceivedTotal.inc({ status: "account_autocreated" });
+      upsertResult = await query<{ inserted: boolean }>(
+        txUpsertSql,
+        txUpsertParams,
+        { op: "mono_tx_upsert" },
+      );
+    }
 
     if (item.balance != null) {
       await query(


### PR DESCRIPTION
## What changed

Дві координовані поправки, які повертають Monobank webhook → DB sync на Railway production.

**1. `apps/server/src/modules/mono/webhook.ts` — авто-створення `mono_account` на FK 23503**

На `SQLSTATE 23503` (foreign_key_violation) під час `mono_tx_upsert` ловимо помилку, авто-створюємо stub-запис у `mono_account` з полів `StatementItem` (`currency_code`, `balance`) і ретраїмо upsert один раз. Решта полів лишаються NULL — наступний `/connect`-snapshot або backfill підтягне їх з `client-info`.

Метрика `monoWebhookReceivedTotal{status="account_autocreated"}` дозволяє відстежувати такі випадки.

**2. `Dockerfile.api` — `COPY patches/` + `packages/finyk-domain/`**

Без цього всі Railway-деплої з ~09:48 UTC 28.04 падали:
- `pnpm install --frozen-lockfile` валився на `ENOENT … patches/@expo__cli@0.22.28.patch` (патч додано в `1d5c19b1`, але `patches/` не копіювалися у Docker context).
- `pnpm build` валився на `Could not resolve "@sergeant/finyk-domain/constants"` (імпорт додано в `0efd3e98`, але `packages/finyk-domain/` не був у image).

## Why

Production-баг 28.04.26 08:49 UTC (= 11:49 Київ): Monobank доставив транзакцію по рахунку, якого не було в `mono_account` (юзер відкрив нову банку/картку у Mono після початкового `/connect` snapshot). FK violation:

```
insert or update on table "mono_transaction" violates foreign key constraint
"mono_transaction_user_id_mono_account_id_fkey" (code 23503)
```

Webhook повертав 500, Monobank ретраїв ~5 хв і деактивував webhook на своєму боці. Сторінка Sync теж нічого не давала. Поправка робить webhook толерантним до невідомих рахунків — будь-яка нова банка / картка / jar у Monobank автоматично з’явиться в нашій БД на першій же транзакції.

Docker-фікс розблоковує Railway-деплой, без якого webhook-поправка не доїде до прода.

## How to test

1. **Unit:** `pnpm --filter @sergeant/server exec vitest run src/modules/mono/webhook.test.ts` — 15 тестів, 2 нові (FK-recovery + non-FK помилки не ретраяться).
2. **Build:** Railway-деплой має успішно пройти `pnpm install` і `pnpm build`.
3. **E2E (після деплою):** користувач робить reconnect з валідним Mono-токеном → нові `StatementItem` з нових рахунків ідуть у `mono_transaction` без 500.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/server exec vitest run src/modules/mono/webhook.test.ts` → 15/15.
- [x] Typecheck clean: `pnpm --filter @sergeant/server typecheck`.
- [x] Build clean: `pnpm --filter @sergeant/server build`.
- [x] ESLint clean on touched files.
- [x] Корінь причини знайдено через Railway runtime logs (`db_error` з `code: 23503`, `op: mono_tx_upsert`) на `649646c7-…` deployment, плюс build-логи на свіжих FAILED-деплоях підтвердили `ENOENT patches/…` і `Could not resolve "@sergeant/finyk-domain/constants"`.
- [x] Docs prose uses Ukrainian.

## AGENTS.md updated?

- [x] No — no new permanent rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Monobank webhook resilient to unknown accounts by auto-creating a `mono_account` stub on FK 23503 and retrying once. Also fixes the API Docker image and Prettier config to unblock Railway builds and CI.

- **Bug Fixes**
  - Webhook: on `mono_tx_upsert` FK violation (23503), create a stub in `mono_account` using `currency_code` and `balance`, then retry once; emits `monoWebhookReceivedTotal{status="account_autocreated"}` and prevents 500s when new Mono accounts/cards appear.
  - Docker: copy `patches/` before `pnpm install` and include `packages/finyk-domain/` to fix `ENOENT … patches/@expo__cli@0.22.28.patch` and `Could not resolve "@sergeant/finyk-domain/constants"`, restoring successful Railway installs/builds.
  - CI/Prettier: ignore `plop-templates/**/*.hbs` to avoid parser errors in `pnpm format:check`, unblocking the required check.

<sup>Written for commit 8917d8d55bb88e70c15a5f1724dd4a315c0ee6dd. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1076?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
