### PR TITLE
fix(web): position assistant FAB above bottom nav in modules

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -561,8 +561,9 @@ function AppInner() {
         })()}
       </Suspense>
       {/* Assistant FAB — available in all module views so the user can
-          reach the AI chat without navigating back to the hub first. */}
-      <HubFloatingActions onOpenChat={ui.openChat} />
+          reach the AI chat without navigating back to the hub first.
+          Positioned above the bottom nav to avoid overlap. */}
+      <HubFloatingActions onOpenChat={ui.openChat} aboveBottomNav />
       <HubModals
         chatOpen={ui.chatOpen}
         onCloseChat={ui.closeChat}

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -20,14 +20,27 @@ import { cn } from "@shared/lib/cn";
  *   users into a conversational flow before they've logged anything.
  * @param {() => void} props.onOpenChat - Opens the hub AI chat panel
  *   (resolves to `ui.openChat()`).
+ * @param {boolean} [props.aboveBottomNav=false] - When true, positions
+ *   the FAB above the ModuleBottomNav (64px + safe-area). Used in module
+ *   views to prevent the FAB from overlapping the navigation tabs.
  */
-export function HubFloatingActions({ hidden = false, onOpenChat }) {
+export function HubFloatingActions({
+  hidden = false,
+  onOpenChat,
+  aboveBottomNav = false,
+}) {
   if (hidden || !onOpenChat) return null;
+
+  // When inside a module with bottom nav, offset by nav height (64px on touch)
+  // plus some breathing room (12px). On hub, just use safe-area + 20px.
+  const bottomOffset = aboveBottomNav
+    ? "calc(76px + env(safe-area-inset-bottom, 0px))"
+    : "calc(1.25rem + env(safe-area-inset-bottom, 0px))";
 
   return (
     <div
       className="fixed right-5 z-40 flex flex-col items-end gap-2 pointer-events-none"
-      style={{ bottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))" }}
+      style={{ bottom: bottomOffset }}
     >
       <FeatureSpotlight
         id="hub-assistant-fab"


### PR DESCRIPTION
Added aboveBottomNav prop to HubFloatingActions that offsets the FAB by 76px (64px nav height + 12px breathing room) when inside module views. This prevents the FAB from overlapping the last navigation tab (Меню) in Nutrition/Routine/Fizruk/Finyk modules.

The hub view continues to use the standard 20px + safe-area offset.

## What changed

<!-- Brief description of the changes. -->

## Why

<!-- Motivation, linked issue, or context. -->

## How to test

<!-- Steps for a reviewer to verify correctness. -->

---

## How AI-tested this PR

<!-- If this PR was created by an AI agent, describe what was verified. -->

- [ ] Manual smoke (which flow?): ...
- [ ] Vitest passes: ...
- [ ] No new `AI-DANGER` markers added without justification.
- [ ] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [ ] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Position the Assistant FAB above the module bottom nav to prevent overlap with the last tab. Adds an `aboveBottomNav` prop to `HubFloatingActions` that sets a 76px (+ safe-area) bottom offset in modules; the hub keeps the standard 20px + safe-area offset.

<sup>Written for commit 18b05d043f68efe442199a7a5c570b0ad36cfc75. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1077?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating action button positioning to appear above the bottom navigation bar, eliminating visual overlap and improving layout clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
