### PR TITLE
docs(docs): pass3 — CLAUDE/platforms/RN paths sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 - **pnpm 9** + **Turborepo** monorepo, Node 20, TypeScript 6.
 - **Apps:** `apps/web` (Vite + React 18), `apps/server` (Express + PostgreSQL), `apps/mobile` (Expo 52), `apps/mobile-shell` (Capacitor).
-- **Packages:** `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/config`, `@sergeant/design-tokens`, `@sergeant/insights`, 4 domain packages.
+- **Packages:** `@sergeant/shared`, `@sergeant/api-client`, `@sergeant/config`, `@sergeant/design-tokens`, `@sergeant/insights`, `eslint-plugin-sergeant-design`, 4 domain packages (10 total).
 - Language: code in English/Ukrainian mixed; prose docs in **Ukrainian** (see `AGENTS.md` § Soft rules).
 
 ## Quick commands

--- a/docs/architecture/platforms.md
+++ b/docs/architecture/platforms.md
@@ -21,8 +21,9 @@
 
 **Що є:** всі чотири модулі (Фінік, Фізрук, Рутина, Харчування) і весь
 Hub-функціонал (AuthContext, HubSearch, HubChat, HubReports,
-OnboardingWizard, WeeklyDigestCard, CoachInsight, VoiceMicButton,
-HubRecommendations, HubSettingsPage), PWA з SW + Web Push через VAPID,
+OnboardingWizard, WeeklyDigestCard, AssistantAdviceCard (`useCoachInsight`),
+VoiceMicButton, TodayFocusCard + HubInsightsPanel, HubSettingsPage), PWA
+з SW + Web Push через VAPID,
 офлайн-черга через `useCloudSync`. Build artefact — `apps/server/dist`,
 деплой Vercel (статика) → Railway (`/api/*`). Це **головна продакшн-точка**
 Sergeant-а.

--- a/docs/mobile/react-native-migration.md
+++ b/docs/mobile/react-native-migration.md
@@ -349,7 +349,7 @@
   `onBackToHub → router.replace('/')`) + 5 screen-файлів:
   `index.tsx` (Overview, `headerShown: false`), `transactions.tsx`,
   `budgets.tsx`, `analytics.tsx`, `assets.tsx` — кожен із нативним
-  header-titles з `@/theme`. Оверлі Overview — `src/modules/finyk/FinykApp.tsx`
+  header-titles з `@/theme`. Оверлі Overview — `apps/mobile/src/modules/finyk/FinykApp.tsx`
   (хірогард + 2×2 nav-grid `FinykNavGrid` з `router.push` на
   drill-down-и); решта 4 скрини — `FinykPageStub` з plan-фічами
   наступних PR-ів. `FINYK_PAGES` (DOM-free реєстр з `id`/`label`/
@@ -399,9 +399,9 @@
   `index`, `workouts`, `exercise`, `programs`, `progress`, `measurements`,
   `body`, `atlas`, `plan`). Tab-header вимкнено, кожен screen малює власний
   заголовок усередині сторінки. Route-каталог винесено у
-  `src/modules/fizruk/shell/fizrukRoute.ts` (масив `FIZRUK_PAGES`,
+  `apps/mobile/src/modules/fizruk/shell/fizrukRoute.ts` (масив `FIZRUK_PAGES`,
   `fizrukRouteFor` — 1:1 імена web-версії); nav-каталог — у
-  `shell/fizrukNav.ts`. Страницi-компоненти у `src/modules/fizruk/pages/*`:
+  `apps/mobile/src/modules/fizruk/shell/fizrukNav.ts`. Страницi-компоненти у `apps/mobile/src/modules/fizruk/pages/*`:
   `Dashboard` — перший функціональний екран (дата, «Швидкий старт» CTA
   на `/fizruk/workouts`, сітка нав-карток на всі 8 не-dashboard
   сторінок через `router.push(fizrukRouteFor(page))`), решта вісім —
@@ -436,7 +436,7 @@
   `@sergeant/fizruk-domain/lib/restSettings`), щоб хук був
   перевірюваний рукою з реального табу до повного порту
   каталогу вправ у PR-F. Unit-тести —
-  `src/modules/fizruk/__tests__/useActiveFizrukWorkout.test.ts`
+  `apps/mobile/src/modules/fizruk/__tests__/useActiveFizrukWorkout.test.ts`
   (drift-resistance обох таймерів під 30 с та 45 с JS-стальтів,
   `justFinishedNaturally` single-flip, MMKV round-trip,
   keep-awake activate/deactivate через injected adapter; fake

--- a/docs/playbooks/tune-system-prompt.md
+++ b/docs/playbooks/tune-system-prompt.md
@@ -97,7 +97,7 @@ curl -X POST http://localhost:3000/api/chat \
 
 ```bash
 # Кількість символів промпту (грубо ≈ tokens × 3 для української):
-node -e "console.log(require('./apps/server/src/modules/chat/toolDefs/systemPrompt.js').SYSTEM_PREFIX.length)"
+pnpm --filter @sergeant/server exec tsx -e "import('./src/modules/chat/toolDefs/systemPrompt.ts').then(m => console.log(m.SYSTEM_PREFIX.length))"
 ```
 
 Якщо промпт виріс на >10% — це бачити на бюджеті Anthropic. Подумай, чи можна **видалити** щось зайве, перш ніж додавати.


### PR DESCRIPTION
## What changed

Третій прохід по документації — окрема знахідка після мерджа `feat(root): add claude context, plop generators, devcontainer, prometheus/grafana, ci` (2568e4c9):

- **`CLAUDE.md`** — packages snapshot говорив "5 + 4 domain" (= 9). Додав `eslint-plugin-sergeant-design` і явний "10 total" — приводжу у відповідність до `AGENTS.md` / `README.md` / `apps-status-matrix.md`.
- **`docs/architecture/platforms.md` §1** — Hub-функціонал згадував `CoachInsight` (хук, ОК) + `HubRecommendations` (компонент, давно перейменовано). Замінив на актуальні імена: `AssistantAdviceCard (useCoachInsight)`, `TodayFocusCard + HubInsightsPanel`. Перевірено grep'ом `apps/web/src/`: `HubRecommendations` не існує, `CoachInsightCard` не існує (є `AssistantAdviceCard.tsx`).
- **`docs/mobile/react-native-migration.md`** — 4 згадки `src/modules/{finyk,fizruk}/...` без `apps/mobile/` префіксу (рядки 352, 402, 404, 439). Контекст уже про mobile, тож додав префікс.
- **`docs/playbooks/tune-system-prompt.md` §7** — token-cost snippet робив `require('./apps/server/src/modules/chat/toolDefs/systemPrompt.js')`, але джерело — `.ts` і ESM, тож `require` падав на `MODULE_NOT_FOUND`. Замінив на `pnpm --filter @sergeant/server exec tsx -e "import('./src/modules/chat/toolDefs/systemPrompt.ts').then(...)"` — перевірив локально, друкує `2166`.

Решта потенційних знахідок — `docs/tech-debt/backend.md` (`server/*.js` згадки) явно архівні per преамбула; ADR `0023/0024` і `audits/2026-04-26-…` — історичні снапшоти на момент рішення/аудиту, лишені без змін.

## Why

`pass1` (#1062) і `pass2` (#1068) пройшли по основних доках, але:
- `CLAUDE.md` додався пізніше і повторив застарілий рахунок packages.
- `platforms.md` мав ще одне старе ім'я компонента (`HubRecommendations`).
- 4 RN-шляхи без префіксу `apps/mobile/`.
- Snippet перевірки розміру system-prompt був битий від моменту TS-міграції.

Тримаю docs у синку з кодом — щоб AI-агенти / нові розробники не упирались у «файл не знайдено».

## How to test

```bash
pnpm format:check               # green
pnpm --filter @sergeant/server exec tsx -e "import('./src/modules/chat/toolDefs/systemPrompt.ts').then(m => console.log(m.SYSTEM_PREFIX.length))"
# → 2166

# Перевірити що згадані файли існують:
ls apps/web/src/core/insights/AssistantAdviceCard.tsx
ls apps/mobile/src/modules/finyk/FinykApp.tsx
ls apps/mobile/src/modules/fizruk/shell/fizrukRoute.ts
```

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): grep по поточному коду + ls для всіх замінених шляхів; `tsx -e` запускався локально.
- [x] Vitest passes: docs-only, nothing to test.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/524466f12f284049b0464c2ab4afe9de

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Third docs sync pass to align docs with current code. Updates package count, component names, RN paths, and fixes the system‑prompt snippet for TS/ESM.

- **Bug Fixes**
  - `CLAUDE.md`: add `eslint-plugin-sergeant-design`; update packages to 10 total.
  - `docs/architecture/platforms.md`: replace outdated `HubRecommendations`/`CoachInsightCard` with `AssistantAdviceCard` (`useCoachInsight`), `TodayFocusCard`, `HubInsightsPanel`.
  - `docs/mobile/react-native-migration.md`: add `apps/mobile/` prefix to four `finyk`/`fizruk` paths.
  - `docs/playbooks/tune-system-prompt.md`: switch CJS `require` to `pnpm --filter @sergeant/server exec tsx -e "import(...systemPrompt.ts)"` so the snippet works with TS/ESM.

<sup>Written for commit 2efa04f7bbc9f939ddb1065b8608f9e8abb979c9. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1078?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
