### PR TITLE
fix(web): repair ProfilePage and FeatureSpotlight tests after #1067 + 28e69abe

### DIFF
--- a/apps/web/src/core/profile/ProfilePage.test.tsx
+++ b/apps/web/src/core/profile/ProfilePage.test.tsx
@@ -163,16 +163,19 @@ describe("ProfilePage", () => {
     it("shows email verification banner when emailVerified is false", () => {
       mockUser.emailVerified = false;
       renderPage();
-      expect(screen.getByText("Email не підтверджено")).toBeInTheDocument();
+      // Banner copy was extended in #1067 to include the suffix
+      // "— перевірте вашу поштову скриньку"; the action button was renamed
+      // from "Надіслати лист" to "Надіслати". Match the prefix via regex.
+      expect(screen.getByText(/Email не підтверджено/)).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Надіслати лист" }),
+        screen.getByRole("button", { name: "Надіслати" }),
       ).toBeInTheDocument();
     });
 
     it("hides email verification banner when emailVerified is true", () => {
       renderPage();
       expect(
-        screen.queryByText("Email не підтверджено"),
+        screen.queryByText(/Email не підтверджено/),
       ).not.toBeInTheDocument();
     });
 
@@ -181,7 +184,9 @@ describe("ProfilePage", () => {
       renderPage();
       const links = screen.getAllByText("Видалити фото");
       fireEvent.click(links[0]);
-      expect(screen.getByText("Видалити?")).toBeInTheDocument();
+      // Confirm prompt copy changed in #1067 from "Видалити?" to
+      // "Видалити фото?".
+      expect(screen.getByText("Видалити фото?")).toBeInTheDocument();
     });
 
     it("shows change email button", () => {
@@ -249,7 +254,7 @@ describe("ProfilePage", () => {
       useOnlineStatusMock.mockReturnValue(false);
       mockUser.emailVerified = false;
       renderPage();
-      const btn = screen.getByRole("button", { name: "Надіслати лист" });
+      const btn = screen.getByRole("button", { name: "Надіслати" });
       expect(btn).toBeDisabled();
     });
 

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
@@ -1,9 +1,43 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
 import { FeatureSpotlight } from "./FeatureSpotlight";
 
+// jsdom returns a zero-sized rect from `getBoundingClientRect` for unlayouted
+// elements, which trips FeatureSpotlight's viewport-validity check (added in
+// 28e69abe so a fixed-position button with a stale ref doesn't anchor the
+// spotlight off-screen). Stub a realistic rect so the spotlight's "is the
+// target actually visible" guard accepts the test target.
+function stubBoundingClientRect(): () => void {
+  const orig = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function (): DOMRect {
+    return {
+      x: 100,
+      y: 100,
+      top: 100,
+      left: 100,
+      bottom: 140,
+      right: 200,
+      width: 100,
+      height: 40,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect;
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = orig;
+  };
+}
+
+let restoreRect: () => void = () => undefined;
+
+beforeEach(() => {
+  restoreRect = stubBoundingClientRect();
+});
+
 afterEach(() => {
+  restoreRect?.();
   cleanup();
   vi.useRealTimers();
 });


### PR DESCRIPTION
## What changed

Полагодив 4 тести у `apps/web`, які падали на `main` із моменту мержу #1067 і 28e69abe:

- `apps/web/src/core/profile/ProfilePage.test.tsx` — 3 тести (`shows email verification banner…`, `shows avatar removal confirm…`, `disables email verification button when offline`).
- `apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx` — 1 тест (`keeps wrapped target visible…`).

Локально `pnpm --filter @sergeant/web exec vitest run src/core/profile/ProfilePage.test.tsx src/shared/components/ui/FeatureSpotlight.test.tsx` тепер `26/26 passed`.

## Why

**`ProfilePage.test.tsx` — копірайт-дрифт після PR #1067**

PR #1067 розширив текстівки на сторінці профілю:
- Банер "Email не підтверджено" → "Email не підтверджено — перевірте вашу поштову скриньку".
- Confirm-prompt видалення аватара "Видалити?" → "Видалити фото?".
- Кнопка верифікації пошти "Надіслати лист" → "Надіслати".

Тести шукали стару копію через `getByText("Email не підтверджено")` (RTL робить точний матч на повний `textContent` елемента), тому елемент із новим суфіксом не знаходився. Перевів два матчі на regex (`/Email не підтверджено/`), а кнопку — на актуальну назву.

**`FeatureSpotlight.test.tsx` — viewport-validity-guard від 28e69abe**

Commit 28e69abe ("fix(web): onboarding spotlight and toast improvements") додав перевірку `if (rect.width === 0 || rect.height === 0 || …) return null;` щоб spotlight не якорився на off-screen чи неіснуючому елементі. У jsdom `getBoundingClientRect()` для unlayouted-елементів повертає саме zero-rect → guard короткозамикає → spotlight ніколи не показується → `queryByRole("dialog")` повертає `null` після `vi.advanceTimersByTime`.

Тест тепер стабає `Element.prototype.getBoundingClientRect` у `beforeEach` реалістичним прямокутником `(100, 100, 100×40)` і відновлює оригінал у `afterEach`.

## How to test

```bash
pnpm --filter @sergeant/web exec vitest run \
  src/core/profile/ProfilePage.test.tsx \
  src/shared/components/ui/FeatureSpotlight.test.tsx
```

Очікую `26 passed`.

---

## How AI-tested this PR

- [x] Vitest passes: `pnpm --filter @sergeant/web exec vitest run …` → `26/26`
- [x] Підтверджено, що ці ж 4 тести падають на чистому `main` (`git checkout main` + те саме `vitest run`).
- [x] Prettier + eslint чистий на двох змінених файлах.
- [x] Зміни обмежені тестовими файлами — production-код не чіпав.
- [ ] Manual smoke: не виконував — це лише polish тестів.

## AGENTS.md updated?

- [x] No — no new permanent rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four failing tests in `apps/web` by aligning assertions with updated profile copy and stubbing layout metrics so `FeatureSpotlight` passes its visibility check. All 26 tests pass locally; only test files changed.

- Bug Fixes
  - ProfilePage tests: match the email verification banner via regex, update the verify button label to "Надіслати", and confirm prompt to "Видалити фото?".
  - FeatureSpotlight test: stub `Element.prototype.getBoundingClientRect` to a non-zero rect in `beforeEach`, restore in `afterEach`, so the dialog renders under jsdom.

<sup>Written for commit 8ab70727fa7df58fa5400fe1ba1cc6b2e48f1ff4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1079?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for localized UI string values
  * Fixed test environment setup for viewport visibility detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
