### PR TITLE
chore(web): migrate main.jsx → main.tsx (last .jsx in apps/web/src)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -35,6 +35,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/core/observability/posthog.ts
+++ b/apps/web/src/core/observability/posthog.ts
@@ -13,7 +13,7 @@ import { getPlatform, isCapacitor } from "@sergeant/shared";
  *
  * Контракт:
  *   - `initPostHog()` — викликається один раз після hydration з
- *     `main.jsx` через `requestIdleCallback`. Ідемпотентний.
+ *     `main.tsx` через `requestIdleCallback`. Ідемпотентний.
  *   - `capturePostHogEvent(name, payload)` — fire-and-forget. Події, які
  *     прилетіли ДО завершення init, буферизуються і flush-ються після.
  *   - `identifyPostHogUser(userId)` / `resetPostHog()` — після login /

--- a/apps/web/src/core/onboarding/seedDemoData.ts
+++ b/apps/web/src/core/onboarding/seedDemoData.ts
@@ -13,7 +13,7 @@
 // legacy demo-flagged payload from earlier builds is also left alone.
 //
 // Intended for marketing screenshots / social-media captures — the
-// module is tiny, synchronous and safe to call from `main.jsx` before
+// module is tiny, synchronous and safe to call from `main.tsx` before
 // React hydrates.
 
 const DEMO_FLAG_KEY = "hub_demo_seeded_social_v1";
@@ -869,7 +869,7 @@ export function resetDemoData(): void {
 }
 
 /**
- * Called from `main.jsx` on every cold start. If the current URL has
+ * Called from `main.tsx` on every cold start. If the current URL has
  * `?demo=1` (alias: `?demo=seed`), seed the store and reload onto `/`.
  * `?demo=reset` clears the seeded payload and reloads. All other URLs
  * return immediately.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite-plugin-pwa/client" />
 import { lazy, Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -57,7 +58,12 @@ runDemoSeedFromUrl();
 storageManager.runAll();
 runDemoCleanupOnce();
 
-function ErrorFallback({ error, resetError }) {
+interface ErrorFallbackProps {
+  error: Error;
+  resetError: () => void;
+}
+
+function ErrorFallback({ error, resetError }: ErrorFallbackProps) {
   return (
     <div className="p-8 font-sans">
       <h2 className="text-lg font-semibold text-text">Щось пішло не так</h2>
@@ -78,7 +84,7 @@ function ErrorFallback({ error, resetError }) {
   );
 }
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <ErrorBoundary fallback={ErrorFallback}>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>

--- a/apps/web/src/shared/hooks/useVisualKeyboardInset.ts
+++ b/apps/web/src/shared/hooks/useVisualKeyboardInset.ts
@@ -11,7 +11,7 @@
  *
  * Importing this module has the side-effect of registering the web
  * adapter on the shared contract, so the side-effect import in
- * `apps/web/src/main.jsx` is all the app shell needs. Existing call
+ * `apps/web/src/main.tsx` is all the app shell needs. Existing call
  * sites import the hook from `@sergeant/shared` — not from this file
  * — to stay platform-agnostic.
  */

--- a/apps/web/src/shared/lib/fileDownload.ts
+++ b/apps/web/src/shared/lib/fileDownload.ts
@@ -6,7 +6,7 @@
  * against SSR / jsdom-without-DOM environments.
  *
  * Importing this module has the side-effect of registering the web
- * adapter, so the side-effect import in `apps/web/src/main.jsx` is all
+ * adapter, so the side-effect import in `apps/web/src/main.tsx` is all
  * the app shell needs.
  */
 

--- a/apps/web/src/shared/lib/fileImport.ts
+++ b/apps/web/src/shared/lib/fileImport.ts
@@ -6,7 +6,7 @@
  * the parsed JSON payload. Returns `null` if the user cancels.
  *
  * Importing this module has the side-effect of registering the web
- * adapter, so the side-effect import in `apps/web/src/main.jsx` is all
+ * adapter, so the side-effect import in `apps/web/src/main.tsx` is all
  * the app shell needs.
  */
 

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => {
   // (`apps/mobile-shell`): native WebView і без того ігнорує
   // `navigator.serviceWorker.register`, тому `vite-plugin-pwa`,
   // згенерований `sw.js` і `manifest.webmanifest` — dead weight у
-  // shell-бандлі. Відключаємо плагін повністю, а `main.jsx` під
+  // shell-бандлі. Відключаємо плагін повністю, а `main.tsx` під
   // build-time прапором викидає динамічний `import("virtual:pwa-register")`
   // через DCE — щоб Rollup не намагався резолвити virtual-модуль, якого
   // тепер немає у graph-і. Веб-деплой (Vercel) продовжує білдитись як
@@ -37,7 +37,7 @@ export default defineConfig(({ mode }) => {
   return {
     define: {
       // Пробрасуємо значення у клієнтський бандл як статичний літерал,
-      // щоб `main.jsx` міг DCE-вирізати SW-гілку у capacitor-білді.
+      // щоб `main.tsx` міг DCE-вирізати SW-гілку у capacitor-білді.
       "import.meta.env.VITE_TARGET": JSON.stringify(
         isCapacitorBuild ? "capacitor" : "web",
       ),
@@ -162,7 +162,7 @@ export default defineConfig(({ mode }) => {
               // `@sergeant/mobile-shell/barcodeNative` (→
               // `useBarcodeScanner`), `@sergeant/mobile-shell/auth-storage`
               // (→ `apps/web/src/shared/lib/bearerToken.ts`) і
-              // `@sergeant/mobile-shell` (→ `main.jsx` під guard-ом
+              // `@sergeant/mobile-shell` (→ `main.tsx` під guard-ом
               // `isCapacitor()`). Без цього catch-all нижче загнав би
               // Capacitor-код у загальний `vendor`, який жадібно
               // підвантажується браузерами.

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
         ...baseCoverageConfig.exclude,
         "src/test/**",
         "src/sw.ts",
-        "src/main.jsx",
+        "src/main.tsx",
       ],
       thresholds: {
         // Baseline (2026-04-25): lines 17.42 / branches 65.51 / fns 52.42.


### PR DESCRIPTION
## What changed

Renamed `apps/web/src/main.jsx` → `apps/web/src/main.tsx` — the last `.jsx` file in `apps/web/src/` after the codemod migration. Post this PR, `apps/web/src` is 100 % TypeScript.

### Source
- `git mv apps/web/src/main.jsx apps/web/src/main.tsx`
- Typed `ErrorFallback` props (`{ error: Error; resetError: () => void }`).
- Added non-null assertion on `document.getElementById("root")!` to satisfy `createRoot` signature.
- Added `/// <reference types="vite-plugin-pwa/client" />` so the dynamic `import("virtual:pwa-register")` resolves its module declaration (from `vanillajs.d.ts`).

### Build glue
- `apps/web/index.html`: `src/main.jsx` → `src/main.tsx`.
- `apps/web/vitest.config.js`: coverage exclude `src/main.jsx` → `src/main.tsx`.
- `apps/web/vite.config.js`: updated 3 comments referring to `main.jsx` → `main.tsx`.
- Updated 5 in-source comments (`useVisualKeyboardInset.ts`, `fileDownload.ts`, `fileImport.ts`, `posthog.ts`, `seedDemoData.ts`) so `grep main.jsx` no longer hits the filename in the active source tree.

## Why

Крок до **PR-6.C** (`strict: true` + remove `allowJs` у `apps/web/tsconfig.json`). Поки `main.jsx` жив, обидва зміни були неможливі: `allowJs: true` тягнула JS-файл у tsc-граф, а повноцінний `strict: true` на `.jsx` без анотацій дав би шквал помилок. Після цього PR `apps/web/src/` — виключно `.ts` / `.tsx`, тож наступний PR може перевести конфіг на строгий режим без колатералів.

## How to test

```bash
pnpm --filter @sergeant/web lint           # green
pnpm --filter @sergeant/web typecheck      # no new errors attributable to main.tsx
pnpm --filter @sergeant/web build          # vite build passes (SPA + SW bundles)
```

Sanity locally:
1. `pnpm dev:web` → `http://localhost:5173` грузиться; React-root маунтиться, `ErrorBoundary`/`BrowserRouter`/`QueryClientProvider` працюють.
2. Перевірити в browser Network, що `/src/main.tsx` тягне Vite dev server (а не `main.jsx`).
3. PWA update toast (`__pwaUpdateReady` / `window.__pwaUpdateSW`) сигналить через вже існуючу декларацію в `core/app/useSWUpdate.ts`.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web lint` — green
- [x] `pnpm --filter @sergeant/web typecheck` — `src/main.tsx` compiles cleanly; pre-existing HintsOrchestrator errors are on `main` and not introduced here
- [x] `pnpm --filter @sergeant/web build` — vite build + SW bundle succeed
- [x] No new `eslint-disable` comments added
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a313092af5e54332a1ae5e777b6c086d

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `apps/web/src/main.jsx` to `apps/web/src/main.tsx`, finishing the TypeScript transition for `apps/web/src`. This unblocks enabling `strict: true` and removing `allowJs` in the web `tsconfig`.

- **Refactors**
  - Renamed entry file and updated references in `index.html`, Vitest coverage exclude, and Vite config/comments to `.tsx`.
  - Typed `ErrorFallback` props (`{ error: Error; resetError: () => void }`).
  - Added non-null assertion on `document.getElementById("root")!` for `createRoot`.
  - Added `/// <reference types="vite-plugin-pwa/client" />` to type `import("virtual:pwa-register")`.

<sup>Written for commit aa6015dd24c88830673672d38f10a2a950da46ba. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1080?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
