### PR TITLE
chore(root): pin tooling via volta and add dev:db shortcut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ pnpm --version  # має бути 9.15.1
 
 Repo pins `"packageManager": "pnpm@9.15.1"` — Corepack автоматично підхоплює точну версію pnpm. CI також працює на Node 20; Node 22 може давати engine warning і відрізнятися від CI.
 
+Якщо ти користуєшся [Volta](https://volta.sh/), `package.json` містить `volta` блок з точними версіями `node@20.20.2` + `pnpm@9.15.1` — `volta` автоматично перемикає toolchain при `cd` у репо. Альтернатива — `nvm use` (підхопить `.nvmrc`).
+
 ---
 
 ## Before you start
@@ -50,8 +52,8 @@ cp .env.example .env
 echo "AI_QUOTA_DISABLED=1" >> .env
 
 # 3. Database
-pnpm db:up                  # docker compose up -d (Postgres 16 on :5432)
-pnpm db:migrate             # run SQL migrations
+pnpm dev:db                 # docker compose up -d (Postgres 16 on :5432) + run SQL migrations
+# (or run them separately: `pnpm db:up` then `pnpm db:migrate`)
 
 # 4. Dev servers (two terminals)
 pnpm dev:server             # Express API  → http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "pnpm": ">=9"
   },
   "packageManager": "pnpm@9.15.1",
+  "volta": {
+    "node": "20.20.2",
+    "pnpm": "9.15.1"
+  },
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:web": "pnpm --filter @sergeant/web dev",
@@ -35,6 +39,7 @@
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "db:migrate": "pnpm --filter @sergeant/server db:migrate",
+    "dev:db": "pnpm db:up && pnpm db:migrate",
     "licenses:gen": "node scripts/generate-licenses.mjs",
     "licenses:check": "node scripts/generate-licenses.mjs check",
     "strict:coverage": "node scripts/strict-coverage.mjs",


### PR DESCRIPTION
## What changed

- Add a `volta` block to root `package.json` (`node@20.20.2`, `pnpm@9.15.1`) so contributors using [Volta](https://volta.sh/) auto-switch to the pinned toolchain on `cd` into the repo. Complements the existing `.nvmrc` + `"packageManager"` + `"engines"` fields.
- Add a `dev:db` script (`pnpm db:up && pnpm db:migrate`) — single-command local DB bring-up. Existing `db:up` / `db:migrate` scripts are kept untouched.
- Update CONTRIBUTING.md quickstart to use `pnpm dev:db` and mention the new Volta block.

## Why

Two small «залишкових win» items called out explicitly in [`docs/planning/dev-stack-roadmap.md`](docs/planning/dev-stack-roadmap.md) §1.1:

1. **Version pin enforcement** — the roadmap labels `mise / proto / volta` as a «must» tier item. `.nvmrc` exists but isn't enforced; adding the `volta` block costs 4 lines of JSON and unlocks auto-switching for anyone using Volta. nvm users keep working via `.nvmrc`. Corepack continues to handle the pnpm version via `"packageManager"`.
2. **`pnpm dev:db` shortcut** — explicitly flagged («залишковий win — `pnpm dev:db` shortcut + seed-script») in the same section.

Identified as quick wins during a repo scan; no behaviour change, no new dependencies, no changes to CI.

## How to test

```bash
# Volta block doesn't break existing flows:
node --version    # still 20.x via existing toolchain
pnpm --version    # still 9.15.1 via Corepack

# New shortcut works:
pnpm dev:db       # = pnpm db:up && pnpm db:migrate

# Existing scripts untouched:
pnpm db:up
pnpm db:migrate
pnpm db:down
```

If you have Volta installed: `cd` into the repo and run `node --version` — Volta should auto-pin to 20.20.2 (and 9.15.1 for pnpm) without you doing anything else.

---

## How AI-tested this PR

- [x] Manual smoke: `pnpm format:check package.json CONTRIBUTING.md` passes; `lint-staged` (Husky pre-commit) ran cleanly on commit.
- [ ] Vitest passes: not relevant (only `package.json` + `CONTRIBUTING.md` touched; no test surface).
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (CONTRIBUTING update is in Ukrainian).

## AGENTS.md updated?

- [x] No — no new permanent rules; both items are already documented as roadmap commitments.

---

_Devin run: https://app.devin.ai/sessions/559c23f90697434e8600e46c32ec9445_
_Requested by: dmytro.s.stakhov_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the toolchain via a `volta` block in the root `package.json` (`node@20.20.2`, `pnpm@9.15.1`) and adds a `dev:db` script for one-command local DB bring-up. Updates CONTRIBUTING to use the shortcut and note Volta; no CI or runtime changes.

- New Features
  - Volta auto-switching to pinned Node and `pnpm`; complements `.nvmrc`, `"packageManager"`, and `"engines"`.
  - `pnpm dev:db` runs `pnpm db:up && pnpm db:migrate`; existing scripts stay. 
  - CONTRIBUTING quickstart updated to `pnpm dev:db`.

<sup>Written for commit 520280fab72726f5d9b83b006fa3a771745d16a7. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1081?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
