### PR TITLE
chore(web): drop as-unknown-as from Workouts + useBarcodeScanner (11 → 9)

### DIFF
--- a/apps/web/src/modules/fizruk/pages/Workouts.tsx
+++ b/apps/web/src/modules/fizruk/pages/Workouts.tsx
@@ -25,6 +25,15 @@ import {
 } from "@sergeant/fizruk-domain";
 import { computeWorkoutSummary } from "@sergeant/fizruk-domain/domain";
 
+// Legacy Safari (< 14) ships `AudioContext` only as prefixed
+// `webkitAudioContext`. Not in `lib.dom.d.ts`, so we attach it to `Window`
+// via module augmentation rather than relying on a double-cast.
+declare global {
+  interface Window {
+    webkitAudioContext?: typeof AudioContext;
+  }
+}
+
 // Shared AudioContext reused across beeps. Creating/closing one per call
 // races with quick successive rest-timer completions and fights iOS' audio
 // session. Lazily created on first call (after a user gesture) and kept open
@@ -34,10 +43,8 @@ function getAudioCtx(): AudioContext | null {
   try {
     if (sharedAudioCtx && sharedAudioCtx.state !== "closed")
       return sharedAudioCtx;
-    const Ctor =
-      window.AudioContext ||
-      (window as unknown as { webkitAudioContext: typeof AudioContext })
-        .webkitAudioContext;
+    const Ctor = window.AudioContext || window.webkitAudioContext;
+    if (!Ctor) return null;
     sharedAudioCtx = new Ctor();
     return sharedAudioCtx;
   } catch {

--- a/apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts
+++ b/apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts
@@ -7,6 +7,26 @@ import {
 } from "react";
 import { isCapacitor } from "@sergeant/shared";
 
+// Shape of the experimental `BarcodeDetector` Web API. Some Chromium
+// variants expose the global, others don't; Safari/Firefox never do.
+// Not in `lib.dom.d.ts`, so we declare a structural type and attach it
+// to `Window` via module augmentation below.
+interface NativeBarcodeDetector {
+  detect(
+    source: HTMLVideoElement,
+  ): Promise<Array<{ rawValue?: string; format?: string }>>;
+}
+interface NativeBarcodeDetectorCtor {
+  new (opts: { formats: string[] }): NativeBarcodeDetector;
+  getSupportedFormats?: () => Promise<string[]>;
+}
+
+declare global {
+  interface Window {
+    BarcodeDetector?: NativeBarcodeDetectorCtor;
+  }
+}
+
 /**
  * Normalized barcode payload returned by both the native ML Kit plugin
  * and the browser zxing / BarcodeDetector flow. Consumers of the hook
@@ -234,18 +254,7 @@ export function useWebScanner({
       // and the user would stare at a "scanning" UI forever. Verify
       // format support up front and fall through to zxing when the
       // native detector can't actually help us.
-      interface NativeBarcodeDetector {
-        detect(
-          source: HTMLVideoElement,
-        ): Promise<Array<{ rawValue?: string; format?: string }>>;
-      }
-      interface NativeBarcodeDetectorCtor {
-        new (opts: { formats: string[] }): NativeBarcodeDetector;
-        getSupportedFormats?: () => Promise<string[]>;
-      }
-      const BarcodeDetectorCtor = (
-        window as unknown as { BarcodeDetector?: NativeBarcodeDetectorCtor }
-      ).BarcodeDetector;
+      const BarcodeDetectorCtor = window.BarcodeDetector;
 
       let detector: NativeBarcodeDetector | null = null;
       if (usedBarcodeDetector && BarcodeDetectorCtor) {

--- a/docs/tech-debt/frontend.md
+++ b/docs/tech-debt/frontend.md
@@ -318,13 +318,14 @@ Ref: PR-6.F (sergeant-audit-devin.md).
 На момент введення правила (2026-04-26) в production-коді знайдено
 **11 файлів** з `as unknown as X` (інших патернів — 0). Файли додані
 до allowlist у `eslint.config.js`. Міграція файла = видалення рядка
-з allowlist.
+з allowlist. На 2026-04-28 мігровано 2 файли (`Workouts.tsx`,
+`useBarcodeScanner.ts`) — через `declare global { interface Window { … } }`
+module-augmentation для експериментальних / prefixed DOM-глобалів,
+залишилось **9 файлів**.
 
 | Файл                                                                | Патерн          | Кількість |
 | ------------------------------------------------------------------- | --------------- | --------- |
 | `apps/web/src/shared/components/ui/VoiceMicButton.tsx`              | `as unknown as` | 2         |
-| `apps/web/src/modules/fizruk/pages/Workouts.tsx`                    | `as unknown as` | 1         |
-| `apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts`         | `as unknown as` | 1         |
 | `apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts` | `as unknown as` | 1         |
 | `apps/web/src/modules/finyk/hooks/useFinykPersonalization.ts`       | `as unknown as` | 6         |
 | `apps/web/src/core/lib/hubChatUtils.ts`                             | `as unknown as` | 2         |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -384,8 +384,6 @@ export default [
       // ── Existing `as unknown as` call-sites (do not add new ones) ──
       // Web app
       "apps/web/src/shared/components/ui/VoiceMicButton.tsx",
-      "apps/web/src/modules/fizruk/pages/Workouts.tsx",
-      "apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts",
       "apps/web/src/modules/nutrition/hooks/useNutritionRemoteActions.ts",
       "apps/web/src/modules/finyk/hooks/useFinykPersonalization.ts",
       "apps/web/src/core/lib/hubChatUtils.ts",


### PR DESCRIPTION
## What changed

Прибрав `as unknown as X` з двох найменших файлів TODO-списку `sergeant-design/no-strict-bypass` (`eslint.config.js`). Allowlist: **11 → 9 файлів**.

### `modules/fizruk/pages/Workouts.tsx` (1 raw cast → 0)
- Було: `(window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext`.
- Стало: module-scope `declare global { interface Window { webkitAudioContext?: typeof AudioContext; } }` + `window.webkitAudioContext`.
- `getAudioCtx()` тепер додатково повертає `null`, якщо ні `AudioContext`, ні prefixed-variant не доступні — раніше на такій (гіпотетичній) платформі `new Ctor()` впав би з `TypeError`, який глитав зовнішній `try/catch`. Поведінка еквівалентна (`null` → no-op у `playRestCompletionSound`).

### `modules/nutrition/hooks/useBarcodeScanner.ts` (1 raw cast → 0)
- Було: `(window as unknown as { BarcodeDetector?: NativeBarcodeDetectorCtor }).BarcodeDetector`.
- Стало: винесено `NativeBarcodeDetector` / `NativeBarcodeDetectorCtor` interfaces з body функції у module scope + `declare global { interface Window { BarcodeDetector?: NativeBarcodeDetectorCtor; } }` + `window.BarcodeDetector`.
- `BarcodeDetector` — experimental Web API (не в `lib.dom.d.ts`), тож типізувати `Window` через module augmentation канонічніше за double-cast.

### ESLint allowlist + docs
- Прибрані з `eslint.config.js` allowlist: `apps/web/src/modules/fizruk/pages/Workouts.tsx`, `apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts`.
- `docs/tech-debt/frontend.md`: прибрано 2 рядки з таблиці `no-strict-bypass`, лічильник `11 → 9`, додано пояснення підходу (`declare global` → `Window` augmentation).

## Why

PR-6.E audit task — continuous burn-down `as unknown as X` у production-коді. Правило `sergeant-design/no-strict-bypass` блокує нові double-cast, але 11 existing файлів зафіксовано як борг у allowlist. Це два найменші кандидати (по одному `as unknown as` кожен), обидва — типовий кейс "accessing an experimental/prefixed DOM global". У репо вже є prior art для цього патерну: <ref_snippet file="/home/ubuntu/repos/Sergeant/apps/web/src/core/hooks/useSpeech.ts" lines="29-36" /> використовує саме `declare global { interface Window { SpeechRecognition?: …; webkitSpeechRecognition?: …; } }`. Міграція синхронізує два файли з цим prior-art і відкриває шлях до міграції середньо-складних кандидатів (`VoiceMicButton.tsx`, `hubChatUtils.ts`).

## How to test

```bash
pnpm --filter @sergeant/web lint         # green (обидва файли проходять без allowlist)
pnpm --filter @sergeant/web typecheck    # no new errors у зміщених файлах
```

Manual smoke (нутрощі не змінені, лише типи):
1. **Rest-timer beep** (`Workouts.tsx`): `pnpm dev:web` → старт воркаута → завершити set → має пропищати через `AudioContext`. У Safari ≥14 `window.AudioContext` є → no-op change. У legacy Safari (емулюється видаленням `AudioContext` у DevTools) — fallback на `webkitAudioContext`.
2. **Barcode scanner** (`useBarcodeScanner.ts`): Chromium → Nutrition → Scan Barcode → має активувати native `BarcodeDetector` коли той доступний і `getSupportedFormats()` перетинається з `WANTED_FORMATS`, інакше fall-through на zxing. У Firefox / Safari (без `BarcodeDetector`) одразу zxing. `usedBarcodeDetector` guard (`"BarcodeDetector" in window`) не змінено.

---

## How AI-tested this PR

- [x] `pnpm --filter @sergeant/web lint` — green (обидва файли проходять без allowlist)
- [x] `pnpm --filter @sergeant/web typecheck` — no new errors у зміщених файлах
- [x] `grep "as unknown as" apps/web/src/modules/nutrition/hooks/useBarcodeScanner.ts apps/web/src/modules/fizruk/pages/Workouts.tsx` → 0 matches
- [x] Немає юніт-тестів безпосередньо на `useBarcodeScanner` / `Workouts.tsx` (`find …test.*` → порожній) — тест-сторона без змін.
- [x] No new `eslint-disable` comments added
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] No — no new permanent rules


Link to Devin session: https://app.devin.ai/sessions/a313092af5e54332a1ae5e777b6c086d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe `as unknown as` casts in `Workouts.tsx` and `useBarcodeScanner.ts` by augmenting `Window` for `webkitAudioContext` and `BarcodeDetector`. This drops the `sergeant-design/no-strict-bypass` allowlist from 11 to 9 with no behavior changes.

- **Refactors**
  - `Workouts.tsx`: add `declare global` for `window.webkitAudioContext`; use `window.AudioContext || window.webkitAudioContext`; return `null` from `getAudioCtx()` when unavailable to avoid a `TypeError`.
  - `useBarcodeScanner.ts`: move native detector types to module scope; add `declare global` for `window.BarcodeDetector`; use `window.BarcodeDetector` directly; feature detection remains the same.
  - Updated `eslint.config.js` allowlist and `docs/tech-debt/frontend.md` counter and notes.

<sup>Written for commit 06f3363fb07fa40c6b92e21c04c6ea9c181f3836. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1085?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

