### PR TITLE
ci(root): fix n8n workflow 04 daily backup verification

### DIFF
--- a/ops/n8n-workflows/04-daily-backup-verification.json
+++ b/ops/n8n-workflows/04-daily-backup-verification.json
@@ -15,25 +15,25 @@
     },
     {
       "parameters": {
-        "method": "GET",
-        "url": "=https://backboard.railway.com/graphql/v2",
+        "method": "POST",
+        "url": "https://backboard.railway.com/graphql/v2",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
-              "name": "Authorization",
-              "value": "=Bearer {{ $env.RAILWAY_TOKEN }}"
+              "name": "Project-Access-Token",
+              "value": "={{ $env.RAILWAY_TOKEN }}"
             },
             { "name": "Content-Type", "value": "application/json" }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={ \"query\": \"{ deployments(first: 1, input: { projectId: \\\"YOUR_PROJECT_ID\\\" }) { edges { node { id status createdAt } } } }\" }",
+        "jsonBody": "={\n  \"query\": \"query LatestDeployments($projectId: String!) { project(id: $projectId) { services { edges { node { name deployments(first: 1) { edges { node { id status createdAt } } } } } } } }\",\n  \"variables\": { \"projectId\": \"{{ $env.RAILWAY_PROJECT_ID }}\" }\n}",
         "options": {}
       },
       "id": "railway-api",
-      "name": "Railway → latest backup",
+      "name": "Railway → latest deployments",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [460, 300]
@@ -41,7 +41,7 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT count(*) AS user_count FROM users; SELECT count(*) AS tx_count FROM module_data WHERE module = 'finyk';",
+        "query": "SELECT (SELECT count(*) FROM \"user\")::int AS user_count, (SELECT count(*) FROM module_data WHERE module = 'finyk')::int AS tx_count;",
         "options": {}
       },
       "id": "sanity-check",
@@ -62,7 +62,7 @@
           "conditions": [
             {
               "id": "has-users",
-              "leftValue": "={{ $json.user_count }}",
+              "leftValue": "={{ Number($json.user_count) }}",
               "rightValue": 0,
               "operator": { "type": "number", "operation": "gt" }
             }
@@ -109,10 +109,16 @@
   "connections": {
     "Cron 03:00 UTC": {
       "main": [
-        [{ "node": "Railway → latest backup", "type": "main", "index": 0 }]
+        [
+          {
+            "node": "Railway → latest deployments",
+            "type": "main",
+            "index": 0
+          }
+        ]
       ]
     },
-    "Railway → latest backup": {
+    "Railway → latest deployments": {
       "main": [[{ "node": "Sanity SQL check", "type": "main", "index": 0 }]]
     },
     "Sanity SQL check": {


### PR DESCRIPTION
## What changed

`ops/n8n-workflows/04-daily-backup-verification.json` — fixes the Railway HTTP node and the sanity SQL so the workflow can actually run end-to-end.

**Railway HTTP node**

- `method: GET` → `POST` (Railway's GraphQL endpoint rejects GET).
- Auth header `Authorization: Bearer …` → `Project-Access-Token: …`. Project tokens are not Bearer tokens — the Bearer form returns "Not Authorized" from `backboard.railway.com/graphql/v2`, which is what was producing the 400 on the live cron.
- Replaced the placeholder GraphQL `deployments(first: 1, input: { projectId: "YOUR_PROJECT_ID" })` (which is also not a real top-level field) with the real `project(id: $projectId) { services { … deployments(first: 1) … } }` query, using a GraphQL variable populated from `$env.RAILWAY_PROJECT_ID`. Both `RAILWAY_TOKEN` and `RAILWAY_PROJECT_ID` are already auto-injected by Railway into the n8n service, so nothing extra to configure.

**Sanity SQL node**

- `FROM users` → `FROM "user"` — Better Auth's table is quoted-lowercase singular per `apps/server/src/migrations/003_baseline_schema.sql`, there is no `users` table in this schema.
- Two `SELECT count(*)` statements are merged into one query so n8n's `executeQuery` returns both `user_count` and `tx_count` in a single row (the pg node otherwise drops the second result set).
- Both counts are cast to `int` so the IF-node sees a number, not a pg-driver string.
- IF condition wraps `$json.user_count` in `Number(…)` defensively (matches the same pattern used in workflow 06 since 43dfe97).

## Why

The cron at 03:00 UTC has been firing since 27 Apr; every run errors with `Bad request - please check your parameters` from `Railway → latest backup`. Verified by inspecting the latest n8n executions via `/api/v1/executions?status=error` on the live `n8n-production-09ac.up.railway.app`.

The other live workflow that's been failing (`06 — Mono Webhook Enrichment`) is **not** touched by this PR — it was already corrected in `43dfe97` (`ci(root): fix n8n workflow node types`); the live instance simply imported the pre-fix version from `d730a6f` and was never re-imported. Re-importing 04 and 06 from `main` after this PR merges should clear both error streams.

## How to test

After merge, in the live n8n UI:

1. Open `04 — Daily Backup Verification` → ⋯ → **Import from File** → upload `ops/n8n-workflows/04-daily-backup-verification.json`.
2. Make sure a Postgres credential named "Sergeant Postgres (staging)" and a Telegram credential "Sergeant Ops Bot" exist (the import-from-file leaves them as `CONFIGURE_ME`).
3. Click **Execute Workflow** (manual run).
   - `Railway → latest deployments` should return `data.project.services.edges[*].node.deployments.edges[0].node.{id,status,createdAt}`.
   - `Sanity SQL check` should return one row `{ user_count, tx_count }`.
   - `Data OK?` routes to `Telegram → backup OK` (assuming user_count > 0).

Reproduced the GraphQL request manually against `backboard.railway.com/graphql/v2` with the project token already in n8n env — returns 200 with both `n8n` and `n8n-db` services and their latest deployments.

## How AI-tested this PR

- [x] Manual smoke: the GraphQL query itself was run against `https://backboard.railway.com/graphql/v2` with the same `Project-Access-Token` that the n8n service uses; returns `{ data: { project: { services: { edges: [...] } } } }`. The full workflow can only be re-tested in n8n once the file is re-imported into the live instance — flagged in the PR description.
- [x] JSON validity: `python3 -m json.tool` round-trips. `prettier --check` passes.
- [x] `pnpm exec lint-staged` runs prettier on the file with no further changes.
- [ ] Vitest: not applicable (no JS/TS code changed).
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian where practical: not applicable — only JSON edited, all human-facing copy in Telegram messages was already in mixed UA/EN and is unchanged.

## AGENTS.md updated?

- [ ] Yes
- [x] No — no new permanent rules; this is a bugfix to an existing workflow.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the n8n “04 — Daily Backup Verification” workflow by correcting the Railway GraphQL request and the SQL sanity check. The 03:00 UTC cron should now run end-to-end without HTTP 400 errors.

- **Bug Fixes**
  - Railway HTTP node: use POST, set `Project-Access-Token` header with `RAILWAY_TOKEN`, and query `project(id: $projectId) { services { … deployments(first: 1) … } }` with `RAILWAY_PROJECT_ID`.
  - Sanity SQL: query `FROM "user"`, combine both counts into one row, cast counts to `int`, and wrap the IF check with `Number($json.user_count)`.

- **Migration**
  - Re-import `ops/n8n-workflows/04-daily-backup-verification.json` in the live n8n instance.
  - Ensure credentials exist: Postgres “Sergeant Postgres (staging)” and Telegram “Sergeant Ops Bot”.

<sup>Written for commit 2740d9468401b4726d973429c95ee8a9f8168920. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1087">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved daily backup verification workflow with enhanced health checks and Railway deployment integration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->