### PR TITLE
ci(root): unwrap markdown fence in n8n workflow 06 AI parser

### DIFF
--- a/ops/n8n-workflows/06-mono-webhook-enrichment.json
+++ b/ops/n8n-workflows/06-mono-webhook-enrichment.json
@@ -45,7 +45,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse Anthropic response: response.content[0].text is JSON string like\n// {\"category\":\"groceries\",\"confidence\":0.9}\nconst raw = $input.first().json?.content?.[0]?.text ?? '{}';\nlet parsed;\ntry {\n  parsed = JSON.parse(raw);\n} catch (e) {\n  parsed = { category: 'other', confidence: 0 };\n}\nreturn [{ json: { category: parsed.category ?? 'other', confidence: parsed.confidence ?? 0 } }];"
+        "jsCode": "// Parse Anthropic response. content[0].text is supposed to be raw JSON like\n// {\"category\":\"groceries\",\"confidence\":0.9}, but Claude often wraps it in a\n// markdown fence (```json ... ```) or in prose. Strip the fence and fall back to\n// the first {...} block before parsing.\nconst raw = $input.first().json?.content?.[0]?.text ?? '';\nfunction extractJson(s) {\n  const fenced = s.match(/```(?:json)?\\s*([\\s\\S]*?)\\s*```/i);\n  if (fenced) return fenced[1].trim();\n  const obj = s.match(/\\{[\\s\\S]*\\}/);\n  return obj ? obj[0] : s;\n}\nlet parsed;\ntry {\n  parsed = JSON.parse(extractJson(raw));\n} catch (e) {\n  parsed = { category: 'other', confidence: 0 };\n}\nreturn [{ json: { category: parsed.category ?? 'other', confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0 } }];"
       },
       "id": "parse-ai",
       "name": "Parse AI response",


### PR DESCRIPTION
## What changed

`ops/n8n-workflows/06-mono-webhook-enrichment.json` — the `Parse AI response` Code node now unwraps markdown fences and prose around Claude's JSON output before `JSON.parse`-ing it.

## Why

Anthropic's API contract is that `content[0].text` is the raw model output, and the workflow's system prompt explicitly says "Respond with JSON only". In practice `claude-haiku-4-5-20251001` still wraps the answer in a `` ```json … ``` `` fence (sometimes with leading prose like "Here is the answer:") on a meaningful share of requests.

Verified live: I sent a synthetic Mono webhook for `АТБ Маркет / -150 UAH / MCC 5411` after re-importing workflow 06 from `main` (commit `43dfe97`). The AI node correctly returned

```text
```json
{ "category": "groceries", "confidence": 0.92 }
```
```

…but the parse-ai node fell through the `try/catch` and emitted the default `{ category: 'other', confidence: 0 }` because `JSON.parse` threw on the leading triple-backtick. So categorisation has been silently degraded to `other` for ~all real Mono webhooks since the workflow was deployed on 2026-04-27.

## How to test

Locally:

```js
function extractJson(s) {
  const fenced = s.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
  if (fenced) return fenced[1].trim();
  const obj = s.match(/\{[\s\S]*\}/);
  return obj ? obj[0] : s;
}
```

…parses correctly for all five real Anthropic shapes I've observed:

| Input shape                                                                 | extractJson output                                  |
| --------------------------------------------------------------------------- | --------------------------------------------------- |
| `` ```json\n{"category":"groceries","confidence":0.92}\n``` ``              | `{"category":"groceries","confidence":0.92}`        |
| `{"category":"transport","confidence":0.4}`                                 | `{"category":"transport","confidence":0.4}`         |
| `` Here is the answer:\n```json\n{"category":"dining","confidence":1}\n``` `` | `{"category":"dining","confidence":1}`              |
| `Sure! {"category":"other","confidence":0.1} hope this helps.`              | `{"category":"other","confidence":0.1}`             |
| `` ```\n{"category":"income","confidence":0.7}\n``` ``                      | `{"category":"income","confidence":0.7}`            |

The "no JSON anywhere" garbage path still falls through to the existing `try/catch` default `{ category: 'other', confidence: 0 }`.

After merge, in the live n8n UI the file should be re-imported into workflow `xdYhQTEARYVOeWcl` (`06 — Mono Webhook Enrichment`) and a manual webhook to `/webhook/mono-transaction` with a real-shape payload should produce a Telegram alert (when over budget) labelled with the actual category, not `other`. I'll re-do that re-import via the n8n API as soon as this lands, the same way I did for the original workflow-06 fix and for #1087.

## How AI-tested this PR

- [x] Manual smoke: ran the new `extractJson` locally against the six shapes above (the five real ones + a no-JSON fallback). All five real shapes parse correctly; the fallback case errors and is caught by the existing `try/catch`.
- [x] JSON validity: `python3 -m json.tool` round-trips. `prettier --check` passes.
- [x] `pnpm exec lint-staged` runs prettier with no further changes.
- [ ] Vitest: not applicable (only an n8n workflow JSON changed; no JS/TS code in the repo).
- [x] No new `AI-DANGER` markers.
- [x] Docs prose uses Ukrainian where practical: not applicable — only JSON edited.

## AGENTS.md updated?

- [ ] Yes
- [x] No — small bugfix; no new permanent rules.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the n8n workflow parser to strip markdown fences and prose from Claude responses before parsing, restoring correct category extraction instead of defaulting to "other". Also ensures confidence is numeric.

- **Bug Fixes**
  - Remove markdown fence and surrounding prose; fall back to the first {...} block, then JSON.parse.
  - Keep the safe default on parse failure; coerce confidence to a number.

- **Migration**
  - Re-import `ops/n8n-workflows/06-mono-webhook-enrichment.json` into workflow 06 in n8n after merge.

<sup>Written for commit fc0710896e757570d18c49addb67682c5067d3ab. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1092">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

