### PR TITLE
fix(web): repair main red checks (typecheck + 5 stale tests)

### DIFF
--- a/apps/mobile/src/components/ui/Input.test.tsx
+++ b/apps/mobile/src/components/ui/Input.test.tsx
@@ -16,7 +16,9 @@ describe("Input", () => {
 
   it("applies size classes to the wrapper view", () => {
     const { UNSAFE_getAllByType } = render(<Input size="lg" />);
-    const wrapper = UNSAFE_getAllByType(View)[0];
+    // [0] is the outer label/group container (always rendered, holds `gap-1`),
+    // [1] is the inner sized row that owns h-{n} / px-{n} from `sizes[size]`.
+    const wrapper = UNSAFE_getAllByType(View)[1];
     expect(wrapper.props.className).toContain("h-12");
     expect(wrapper.props.className).toContain("px-5");
   });

--- a/apps/web/src/core/profile/ProfilePage.test.tsx
+++ b/apps/web/src/core/profile/ProfilePage.test.tsx
@@ -163,16 +163,16 @@ describe("ProfilePage", () => {
     it("shows email verification banner when emailVerified is false", () => {
       mockUser.emailVerified = false;
       renderPage();
-      expect(screen.getByText("Email не підтверджено")).toBeInTheDocument();
+      expect(screen.getByText(/Email не підтверджено/)).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Надіслати лист" }),
+        screen.getByRole("button", { name: "Надіслати" }),
       ).toBeInTheDocument();
     });
 
     it("hides email verification banner when emailVerified is true", () => {
       renderPage();
       expect(
-        screen.queryByText("Email не підтверджено"),
+        screen.queryByText(/Email не підтверджено/),
       ).not.toBeInTheDocument();
     });
 
@@ -181,7 +181,7 @@ describe("ProfilePage", () => {
       renderPage();
       const links = screen.getAllByText("Видалити фото");
       fireEvent.click(links[0]);
-      expect(screen.getByText("Видалити?")).toBeInTheDocument();
+      expect(screen.getByText("Видалити фото?")).toBeInTheDocument();
     });
 
     it("shows change email button", () => {
@@ -249,7 +249,7 @@ describe("ProfilePage", () => {
       useOnlineStatusMock.mockReturnValue(false);
       mockUser.emailVerified = false;
       renderPage();
-      const btn = screen.getByRole("button", { name: "Надіслати лист" });
+      const btn = screen.getByRole("button", { name: "Надіслати" });
       expect(btn).toBeDisabled();
     });
 

--- a/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
+++ b/apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx
@@ -1,9 +1,32 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
 import { FeatureSpotlight } from "./FeatureSpotlight";
 
+// jsdom doesn't compute layout, so getBoundingClientRect() returns a zero-rect
+// for every element. FeatureSpotlight rejects zero-sized targets (treats them
+// as off-screen) — give the wrapped target a plausible rect so the spotlight
+// can decide to render.
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+beforeEach(() => {
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      x: 100,
+      y: 100,
+      top: 100,
+      left: 100,
+      right: 200,
+      bottom: 140,
+      width: 100,
+      height: 40,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+});
+
 afterEach(() => {
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   cleanup();
   vi.useRealTimers();
 });

--- a/packages/shared/src/lib/hints.ts
+++ b/packages/shared/src/lib/hints.ts
@@ -11,6 +11,11 @@
  */
 import { readJSON, writeJSON, type KVStore } from "./kvStore";
 
+export type RetentionHintId =
+  | "retention_day_1"
+  | "retention_day_3"
+  | "retention_day_7";
+
 export type HintId =
   | "ftux_open_search"
   | "ftux_open_chat"
@@ -25,9 +30,7 @@ export type HintId =
   // Contextual onboarding hints
   | "ftux_swipe_to_delete"
   // Retention hooks — shown once on the Nth day after first real entry
-  | "retention_day_1"
-  | "retention_day_3"
-  | "retention_day_7";
+  | RetentionHintId;
 
 export type HintSurface =
   | "welcome"
@@ -381,7 +384,7 @@ const MS_PER_DAY = 86_400_000;
 export function getRetentionHintId(
   firstEntryAt: number,
   now = Date.now(),
-): HintId | null {
+): RetentionHintId | null {
   const daysSince = Math.floor((now - firstEntryAt) / MS_PER_DAY);
   if (daysSince === 0) return "retention_day_1";
   if (daysSince === 3) return "retention_day_3";


### PR DESCRIPTION
## What changed

Main has been red on `Test coverage (vitest)` and the dependent `check` job since #1067. This PR brings them green.

Three classes of regression:

### 1. `packages/shared/src/lib/hints.ts` — narrow `getRetentionHintId` return type

`getRetentionHintId(...)` declared `HintId | null` but only ever returns `retention_day_{1,3,7} | null`. The retention copy maps in `apps/web/src/core/hints/HintsOrchestrator.tsx` and `apps/mobile/src/core/hints/useHints.ts` index by that return value, so under strict TS they fail with errors like:

```
Property 'hub_reorder_modules' does not exist on type
  '{ retention_day_1: string; retention_day_3: string; retention_day_7: string; }'.
```

Fix: add a narrow `RetentionHintId` sub-union, return that from `getRetentionHintId`, leave `HintId` itself unchanged (`HintId` now includes `RetentionHintId` via a union, so all existing callers still type-check).

### 2. `ProfilePage.test.tsx` — copy/UX drifted in #1067

PR #1067 ("redesign profile page") changed three strings without updating tests:

| Test expectation        | Component now renders                                    |
| ----------------------- | -------------------------------------------------------- |
| `Email не підтверджено` | `Email не підтверджено — перевірте вашу поштову скриньку` (single text node) |
| `Надіслати лист`        | `Надіслати`                                              |
| `Видалити?`             | `Видалити фото?`                                         |

Fix: switch the email-banner query to a regex (so it matches the longer text node), update the verify button label to `Надіслати`, update the avatar-removal confirm text to `Видалити фото?`. No production component change.

### 3. `FeatureSpotlight.test.tsx` — jsdom returns zero-rect bounding boxes

`FeatureSpotlight` rejects 0×0 targets as "off-screen" (which it should — that's the production check that prevents misplaced spotlights). jsdom does not compute layout, so every `getBoundingClientRect()` returns zero, and the spotlight never renders even after `vi.advanceTimersByTime(delay)`.

Fix: mock `Element.prototype.getBoundingClientRect` for the duration of the test to return a plausible rect (`100×40` at `(100, 100)`). No production code change.

### 4. `apps/mobile/src/components/ui/Input.test.tsx` — outer `<View>` shifted

`<Input>` now wraps its label + sized row in an outer `<View className="gap-1">` so the optional label can render. The sized row that owns `h-{n}` / `px-{n}` is therefore the second `<View>` returned by `UNSAFE_getAllByType(View)`, not the first.

Fix: change the index from `[0]` to `[1]` (commented in-line).

## Why

Unblocks all open PRs (e.g. #1081, #1086) which are inheriting these failures from main even though they don't touch the affected code.

## How to test

```bash
pnpm --filter @sergeant/shared typecheck         # passes
pnpm --filter @sergeant/web typecheck            # passes (touched files)
pnpm --filter @sergeant/mobile typecheck         # passes
pnpm --filter @sergeant/web test                 # 1382 passed (was 4 failed)
pnpm --filter @sergeant/mobile test              # 617 passed (was 1 failed)
```

---

## How AI-tested this PR

- [x] Manual: `pnpm --filter @sergeant/web test` (1382/1382), `pnpm --filter @sergeant/mobile test` (617/617).
- [x] Manual: `pnpm --filter @sergeant/{shared,web,mobile} typecheck` all clean.
- [x] Lint + Prettier clean on all 4 changed files.
- [x] No production component / route / database change. Pure narrowing + test repair.
- [ ] Vitest passes globally — see commands above (`apps/server` test stack is unchanged, not exercised here).
- [x] No new `AI-DANGER` markers added.

## AGENTS.md updated?

- [x] No — repair PR, no new permanent rules.

---

_Devin run: https://app.devin.ai/sessions/559c23f90697434e8600e46c32ec9445_
_Requested by: dmytro.s.stakhov_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings main back to green by fixing strict type errors and updating stale tests across web and mobile. No production behavior changes.

- **Bug Fixes**
  - Narrowed `getRetentionHintId` in `packages/shared/src/lib/hints.ts` to return `RetentionHintId`; fixes strict TS indexing in `apps/web` and `apps/mobile`.
  - Updated `apps/web/src/core/profile/ProfilePage.test.tsx`: regex match for the email banner, button label to `Надіслати`, confirm text to `Видалити фото?`.
  - Mocked `Element.prototype.getBoundingClientRect` in `apps/web/src/shared/components/ui/FeatureSpotlight.test.tsx` to avoid jsdom zero-rects so the spotlight renders.
  - Adjusted `apps/mobile/src/components/ui/Input.test.tsx` to target the second `View` after the new outer container.

<sup>Written for commit 12988df60ea2987243b8b98a12116de9ba7b4a11. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1094">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
