### PR TITLE
docs(docs): add sync-rn-progress, prettier-pass, fix-failing-ci playbooks

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -41,6 +41,9 @@ New playbooks should follow the decision-tree template: [`_TEMPLATE-decision-tre
 | [add-push-notification.md](add-push-notification.md)                               | «Надсилай push коли X» / нагадування / реакція на подію (Mono webhook, AI insight, scheduler)                   |
 | [enable-prompt-caching.md](enable-prompt-caching.md)                               | «Зменшити cost Anthropic» / `SYSTEM_PREFIX` повторюється на кожному запиті — ввімкнути prompt caching           |
 | 🌳 [stabilize-flaky-test.md](stabilize-flaky-test.md)                              | «Тест X падає 1 з 5 разів» / тест у AGENTS.md flaky-list                                                        |
+| [sync-rn-migration-progress.md](sync-rn-migration-progress.md)                     | RN-міграційні PR-и змерджені, треба оновити tracker `docs/mobile/react-native-migration.md`                     |
+| [prettier-pass-on-docs.md](prettier-pass-on-docs.md)                               | `format:check` червоний на `docs/**` / точковий prettier-прохід по doc-файлах                                   |
+| 🌳 [fix-failing-ci.md](fix-failing-ci.md)                                          | CI-чек червоний на PR (commitlint / format:check / lint / typecheck / test / build / a11y / smoke-e2e / bundle) |
 | [../observability/error-budget-policy.md](../observability/error-budget-policy.md) | Error budget вигорає / burn-rate alert / треба визначити чи дозволена зміна під час freeze                      |
 
 ## How to Use

--- a/docs/playbooks/fix-failing-ci.md
+++ b/docs/playbooks/fix-failing-ci.md
@@ -1,0 +1,263 @@
+# Playbook: Fix Failing CI on a PR
+
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-28.
+
+**Trigger:** один або кілька CI-чеків червоні на відкритому PR (`commitlint`, `check`, `coverage`, `a11y`, `smoke-e2e`, Detox/mobile-shell, bundle-size, audit, license-check). НЕ для прод-інцидентів — для них див. [`hotfix-prod-regression.md`](hotfix-prod-regression.md).
+
+---
+
+## Decision Tree
+
+> Follow this tree from Q1 downward. Each leaf node (→ **ACTION**) links to the detailed steps below.
+
+**Q1: Який job червоний?**
+
+- `commitlint` → [§4 Commit message / scope](#4-commitlint--commit-message--scope)
+- `check` (`format:check`, `lint`, `typecheck`, `test`, `build` всередині нього) → перейди до Q2
+- `coverage` → [§5 Coverage floor](#5-coverage--coverage-floor)
+- `a11y` (Playwright + axe-core) → [§6 a11y](#6-a11y-axe-core)
+- `smoke-e2e` (Playwright + real Postgres) → [§7 smoke-e2e](#7-smoke-e2e)
+- Detox Android/iOS / mobile-shell — [§8 Mobile workflows](#8-detox--mobile-shell)
+- `pnpm audit` (high) → [§9 Audit](#9-audit-exception-flow)
+- `pnpm licenses:check` → [§10 Licenses](#10-licenses-check)
+- `size-limit` (bundle) → [§11 Bundle budget](#11-bundle-size-budget)
+- Незрозуміло / infra-flake → [§1 Прочитати логи](#1-прочитати-логи) → знову Q1
+
+**Q2: Який саме крок `check`-job-а?**
+
+- `format:check` → [§2 Prettier](#2-formatcheck--prettier) (часто — використати [`prettier-pass-on-docs.md`](prettier-pass-on-docs.md), якщо тільки docs)
+- `lint` (eslint, import-checker, plugin tests) → [§3 Lint](#3-lint-eslint--imports--plugin-tests)
+- `typecheck` (tsc) → [§3.b Typecheck](#3b-typecheck-tsc)
+- `test` (vitest) → [§3.c Test](#3c-test-vitest)
+- `build` (turbo) → [§3.d Build](#3d-build-turbo)
+
+**Q3: Скільки разів я вже пушив фікс і CI знову червоний?**
+
+- 0–2 → продовжуй цикл fix → push → recheck
+- **3+** → **STOP** → ескалейт юзеру з: список червоних чеків, що вже спробував, виноска з логів, гіпотеза.
+
+```mermaid
+flowchart TD
+    Q1{"Q1: Який job?"}
+    Q1 -- "commitlint" --> S4["§4 Commit / scope"]
+    Q1 -- "check" --> Q2
+    Q1 -- "coverage" --> S5["§5 Coverage floor"]
+    Q1 -- "a11y" --> S6["§6 a11y"]
+    Q1 -- "smoke-e2e" --> S7["§7 smoke-e2e"]
+    Q1 -- "mobile" --> S8["§8 Detox / shell"]
+    Q1 -- "audit" --> S9["§9 Audit"]
+    Q1 -- "licenses" --> S10["§10 Licenses"]
+    Q1 -- "size-limit" --> S11["§11 Bundle"]
+    Q1 -- "Unclear" --> S1["§1 Read logs"] --> Q1
+
+    Q2{"Q2: Який крок?"}
+    Q2 -- "format:check" --> S2["§2 Prettier"]
+    Q2 -- "lint" --> S3["§3 Lint"]
+    Q2 -- "typecheck" --> S3B["§3.b Typecheck"]
+    Q2 -- "test" --> S3C["§3.c Vitest"]
+    Q2 -- "build" --> S3D["§3.d Build"]
+
+    S4 --> VERIFY["§Verification"]
+    S2 --> VERIFY
+    S3 --> VERIFY
+    S3B --> VERIFY
+    S3C --> VERIFY
+    S3D --> VERIFY
+    S5 --> VERIFY
+    S6 --> VERIFY
+    S7 --> VERIFY
+    S8 --> VERIFY
+    S9 --> VERIFY
+    S10 --> VERIFY
+    S11 --> VERIFY
+
+    Q3{"Q3: 3+ невдалих push-ів?"}
+    VERIFY --> Q3
+    Q3 -- "Так" --> ESCALATE["🔴Escalate to user"]
+    Q3 -- "Ні" --> DONE["🟢Зелено"]
+```
+
+---
+
+## Background (Original Steps)
+
+### 1. Прочитати логи
+
+```bash
+git view_pr <repo> <pr_number>
+git pr_checks <repo> <pr_number> wait_mode=none
+git ci_job_logs <repo> <job_id>
+```
+
+Не вгадуй за назвою чека — більшість CI-фейлів мають 1–2 рядки root-cause-у в довгому лозі. `grep`-інь у завантаженому лозі.
+
+### 2. `format:check` → prettier
+
+Якщо тільки `docs/**` — використай [`prettier-pass-on-docs.md`](prettier-pass-on-docs.md).
+
+В інших випадках:
+
+```bash
+pnpm exec prettier --check <path>            # подивитись
+pnpm exec prettier --write <path>            # фіксити (тільки на торкнутих файлах)
+```
+
+Не запускай на всьому репо — це може зачепити несвідомо ignored / hand-formatted файли.
+
+### 3. lint (eslint + imports + plugin tests)
+
+```bash
+pnpm lint                                    # full
+pnpm --filter <pkg> exec eslint <path> --fix # точково
+```
+
+Окремі кроки lint-job:
+
+- `pnpm lint:plugins` — кастомні rules в `packages/eslint-plugin-sergeant-design`.
+- import-checker — `scripts/check-imports.*` (заборонені cross-package імпорти, raw `localStorage`, etc.).
+
+Гарди, які часто впадають:
+
+- `sergeant-design/no-raw-local-storage` — заміни на `ls`/`lsSet`/`safeReadLS`/`safeWriteLS`/`createModuleStorage` (AGENTS.md anti-pattern #6).
+- `sergeant-design/rq-keys-only-from-factory` — використай factory з `apps/web/src/shared/lib/queryKeys.ts` (AGENTS.md rule #2).
+- `sergeant-design/valid-tailwind-opacity` — лише дозволені кроки шкали (AGENTS.md rule #8).
+- `sergeant-design/no-low-contrast-text-on-fill` — використай `*-strong` варіант кольору (AGENTS.md rule #9).
+- `sergeant-design/ai-marker-syntax` — точно один із 5 префіксів (AGENTS.md § AI markers).
+
+### 3.b typecheck (tsc)
+
+```bash
+pnpm typecheck                                  # all
+pnpm --filter <pkg> exec tsc --noEmit           # точково
+```
+
+**Заборонено** глушити помилки через `any`, `@ts-ignore`, `@ts-expect-error`, `getattr/setattr`-style. Виправ типи реально.
+
+### 3.c test (vitest)
+
+```bash
+pnpm --filter <pkg> exec vitest run <path>      # точково
+pnpm test                                       # all
+```
+
+Перевір flaky-список ([CONTRIBUTING.md § Known flaky mobile tests](../../CONTRIBUTING.md#known-flaky-mobile-tests), [AGENTS.md § Pre-existing flaky tests](../../AGENTS.md#pre-existing-flaky-tests-do-not-block-merge)) — якщо червоний саме там і твій PR не чіпає `apps/mobile/**`, зробі retry job-а через UI **раз** перед тим як міняти код.
+
+### 3.d build (turbo)
+
+```bash
+pnpm build                                       # all
+pnpm --filter @sergeant/<pkg> build              # точково
+```
+
+Часто валиться через циклічну залежність або відсутній `exports` в `package.json`-і пакета. Подивись на конкретну помилку turbo — вона чітко вказує на пакет.
+
+### 4. commitlint — commit message / scope
+
+```bash
+pnpm exec commitlint --last
+pnpm exec commitlint --from origin/main --to HEAD
+```
+
+Часті проблеми:
+
+- **Невідомий scope** (наприклад `mobile/core`, `app`, `monorepo`, `all`). Дозволені scope-и — лише ті, що в [AGENTS.md hard rule #5](../../AGENTS.md#5-conventional-commits-explicit-scope-enum). Якщо scope справді не покривається — додай новий **в одному PR** і в `AGENTS.md`, і в `commitlint.config.js`.
+- **Невідомий type** — лише `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `build`, `ci`.
+- **Відсутність scope** — формат `<type>(<scope>): <subject>` обовʼязковий.
+
+Фікс: запушити **новий** commit з виправленим message-ом (бажано `fix(<scope>): correct previous commit message`), не amend і не force-push (`AGENTS.md` rule #6).
+
+### 5. coverage — coverage floor
+
+```bash
+pnpm test:coverage
+```
+
+Якщо CI каже про падіння під поріг — додай тести під торкнутий код (мета: повернутись на цифру до твого PR-у або вище). Не «тестуй тест, що тестує тест» — пиши тести з користю.
+
+### 6. a11y (axe-core)
+
+```bash
+pnpm --filter @sergeant/web exec playwright install --with-deps chromium
+pnpm --filter @sergeant/web a11y                  # або відповідний script
+```
+
+Часто фейлять: відсутній `aria-label` на кнопках без видимого тексту, низький контраст (див. AGENTS.md rule #9), відсутній `<label>` для `<input>`, неправильний heading order.
+
+### 7. smoke-e2e
+
+```bash
+docker compose up -d postgres
+pnpm --filter @sergeant/server db:migrate:dev
+pnpm --filter @sergeant/server build && pnpm --filter @sergeant/server start &
+pnpm --filter @sergeant/web build && pnpm --filter @sergeant/web preview &
+pnpm --filter @sergeant/web e2e                   # або відповідний script
+```
+
+Перевір логи Postgres (`docker logs <pg>`), серверні логи (стдаут), і Playwright trace.
+
+### 8. Detox / mobile-shell
+
+Окремі workflow-и для `apps/mobile` (Expo Detox iOS/Android) і `apps/mobile-shell` (Capacitor Android/iOS). Якщо твій PR не чіпає `apps/mobile/**` або `apps/mobile-shell/**` — це майже завжди infra-flake; перезапусти job через UI. Якщо чіпає — читай Detox-репорт + ілеустрації артефактів.
+
+### 9. Audit (`pnpm audit --audit-level=high`)
+
+Дотримуйся [`CONTRIBUTING.md` § Audit exception workflow](../../CONTRIBUTING.md#audit-exception-workflow):
+
+1. Задокументуй вразливість у [`docs/security/audit-exceptions.md`](../security/audit-exceptions.md) (advisory, package, severity, mitigation, due, owner).
+2. Додай label `audit-exception` до PR — це скіпає high-severity audit-кроки, але не critical.
+3. Видали label, коли вразливість закрита.
+
+### 10. licenses-check
+
+```bash
+pnpm licenses:check
+# зазвичай треба регенерувати:
+pnpm licenses:generate                            # перевір реальну назву script-а
+git add THIRD_PARTY_LICENSES.md
+```
+
+Закомітити в **тому ж** PR, де зміна lock-файлу.
+
+### 11. bundle size budget
+
+`apps/web` JS ≤ 615 kB brotli, CSS ≤ 18 kB brotli (AGENTS.md § Performance budgets, CONTRIBUTING.md § Performance budgets).
+
+```bash
+pnpm --filter @sergeant/web exec size-limit
+pnpm --filter @sergeant/web build && pnpm --filter @sergeant/web exec size-limit --json
+```
+
+Опції:
+
+- Видалити випадковий import, що тягне велику бібліотеку (динамічний імпорт замість статичного).
+- Розбити route-bundle через `React.lazy`.
+- Якщо ріст обґрунтований — підняти бюджет у `apps/web/package.json` → `size-limit`, з поясненням у PR-body.
+
+---
+
+## Verification
+
+- [ ] Усі required-чеки на PR — зелені.
+- [ ] Жодних `--no-verify`, `--amend`, force-push шерех-гілки (`AGENTS.md` rule #6, #7).
+- [ ] У фікс-комітах **тільки** релевантні для CI-фейлу зміни.
+- [ ] Якщо знадобився `audit-exception` — entry додано в `docs/security/audit-exceptions.md` із due-date.
+- [ ] commit messages — Conventional Commits з scope із AGENTS.md rule #5.
+- [ ] Якщо було 3+ невдалих push-и — користувача **повідомлено**, а не тиха ескалація.
+
+## Notes
+
+- Логи > здогадки. Вживай `git ci_job_logs job_id=<id>` і читай повністю.
+- Failures often cluster — фікси root-cause, а не симптом.
+- Flaky retry — **раз**, не нескінченно.
+- Якщо тести почали падати після dep-bump-у — окремий PR з фіксом, не змішувати з твоєю фічею (AGENTS.md soft rule).
+- Не міняй тести, щоб вони стали зеленими, без явного запиту користувача.
+
+## See also
+
+- [hotfix-prod-regression.md](hotfix-prod-regression.md) — для прод-інцидентів (інша decision-tree).
+- [stabilize-flaky-test.md](stabilize-flaky-test.md) — якщо зрозуміло, що це справжня flake.
+- [bump-dep-safely.md](bump-dep-safely.md) — якщо CI впав через dep-bump.
+- [pre-merge-migration-checklist.md](pre-merge-migration-checklist.md) — якщо PR із міграцією.
+- [prettier-pass-on-docs.md](prettier-pass-on-docs.md) — точковий prettier-fix для `docs/**`.
+- [AGENTS.md](../../AGENTS.md) — rules #5 (scope enum), #6 (no force-push), #7 (no `--no-verify`).
+- [CONTRIBUTING.md § CI Pipeline](../../CONTRIBUTING.md#ci-pipeline) — повний перелік jobs.

--- a/docs/playbooks/prettier-pass-on-docs.md
+++ b/docs/playbooks/prettier-pass-on-docs.md
@@ -1,0 +1,82 @@
+# Playbook: Prettier Pass on `docs/`
+
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-28.
+
+**Trigger:** `pnpm format:check` фейлиться на `docs/**/*.md` / треба прогнати prettier по одному / кільком doc-файлах (як [PR #447](https://github.com/Skords-01/Sergeant/pull/447)).
+
+---
+
+## Steps
+
+### 1. Підтвердити, що target не в `.prettierignore`
+
+```bash
+cat .prettierignore | grep -E "docs|\.md"
+```
+
+Якщо файл явно ignored — STOP. Не форсуй формат для ignored-файлів; спершу зʼясуй із власником, чому ігнор там стоїть.
+
+### 2. Подивитись, що саме non-conforming
+
+```bash
+pnpm exec prettier --check '<target-glob>'
+# Приклади:
+pnpm exec prettier --check 'docs/mobile/react-native-migration.md'
+pnpm exec prettier --check 'docs/**/*.md'
+```
+
+Запиши вивід — список файлів = очікуваний обсяг diff-у.
+
+### 3. Прогнати prettier
+
+```bash
+pnpm exec prettier --write '<target-glob>'
+git diff --stat '<target-glob>'
+```
+
+### 4. Перевірити diff на semantic-зміни
+
+```bash
+git diff '<target-glob>' | head -80
+```
+
+Має бути **тільки**:
+
+- Whitespace / line-wrap.
+- Перестановка markdown table column padding.
+- Marker-перестановка списків (`-` ↔ `*`, нумерація).
+- Blank-line normalisation.
+
+Якщо бачиш зміну тексту, посилань, заголовків — відкоти цей файл і досліди (`prettier` так не робить за замовчуванням; може бути конфлікт із markdownlint або inline-HTML).
+
+### 5. Створити PR
+
+- Branch: `devin/<unix-ts>-chore-docs-prettier`.
+- Commit: `chore(docs): apply prettier to <path-or-glob>` (scope `docs`, AGENTS.md rule #5; саме така форма використана в [PR #447](https://github.com/Skords-01/Sergeant/pull/447)).
+- PR description (`.github/PULL_REQUEST_TEMPLATE.md`):
+  - Target glob / path.
+  - Явно: «formatting-only, no content changes».
+  - Список модифікованих файлів.
+
+---
+
+## Verification
+
+- [ ] `pnpm exec prettier --check '<target>'` — green на гілці.
+- [ ] `git diff` проти base показує тільки форматування (нічого з контенту).
+- [ ] PR-діф містить **тільки** файли під `docs/`.
+- [ ] CI: `format:check` зелений в `check` job.
+- [ ] Branch і commit conform до AGENTS.md rule #5 (scope `docs`).
+
+## Notes
+
+- Завжди запускай prettier через `pnpm exec prettier` (бере pinned версію `prettier@^3.8.2` з repo, не глобальну).
+- НЕ розширюй glob: якщо користувач сказав один файл — формат тільки його.
+- НЕ змішуй з lint-фіксами або dep-bump-ами — окремий PR.
+- Якщо diff несподівано великий і чіпає файли, які виглядають свідомо вручну вирівняними (ASCII-діаграми, alignment-sensitive таблиці) — додай їх до `.prettierignore` в **окремому** PR замість того, щоб ламати їхнє форматування.
+
+## See also
+
+- [sync-rn-migration-progress.md](sync-rn-migration-progress.md) — частий випадок, коли цей playbook треба відразу після sync-у.
+- [`.prettierrc.json`](../../.prettierrc.json), [`.prettierignore`](../../.prettierignore) — конфіг.
+- [AGENTS.md](../../AGENTS.md) — rule #5 (commit scope), rule #7 (no `--no-verify`).

--- a/docs/playbooks/sync-rn-migration-progress.md
+++ b/docs/playbooks/sync-rn-migration-progress.md
@@ -1,0 +1,83 @@
+# Playbook: Sync RN Migration Progress
+
+> **Last validated:** 2026-04-28 by @Skords-01. **Next review:** 2026-07-28.
+
+**Trigger:** один або кілька PR-ів із `port-web-screen-to-mobile.md` ([#445](https://github.com/Skords-01/Sergeant/pull/445), [#446](https://github.com/Skords-01/Sergeant/pull/446), …) змерджені, треба оновити tracker [`docs/mobile/react-native-migration.md`](../mobile/react-native-migration.md).
+
+---
+
+## Steps
+
+### 1. Зібрати список merged PR-ів
+
+```bash
+# Або від користувача (наприклад: «синкни прогрес по #443, #444, #445»),
+# або через GitHub UI / git CLI:
+git log --oneline --merges main | head -20
+```
+
+Кожен PR має відповідати щонайбільше одному ряду / чекбоксу в трекері.
+
+### 2. Прочитати `docs/mobile/react-native-migration.md`
+
+Знайти **точне місце** (рядок таблиці, чекбокс, фазову секцію), яке відповідає кожному merged PR-у.
+
+```bash
+grep -n "<screen-or-section-keyword>" docs/mobile/react-native-migration.md
+```
+
+Не покладайся лише на назву PR-а — переконайся, що порт реально wired in:
+
+```bash
+# Чи компонент справді існує і використовується в apps/mobile?
+find apps/mobile/src apps/mobile/app -name "*<keyword>*"
+grep -rn "<ComponentName>" apps/mobile/app apps/mobile/src
+```
+
+### 3. Оновити рядки в трекері
+
+- Постав чекбокс / переміщай item у відповідну фазу.
+- Додай номер merged PR-а поруч із item-ом, якщо це конвенція документа (перевір сусідні рядки).
+- Якщо PR покрив **частину** секції — постав тільки відповідні sub-items.
+- Не реструктуруй секції, не зачеплені цим sync-ом.
+
+### 4. Прогнати prettier
+
+```bash
+pnpm exec prettier --write docs/mobile/react-native-migration.md
+git diff docs/mobile/react-native-migration.md
+```
+
+Diff має містити **тільки** zміни прогресу + автоформатування. Якщо бачиш semantic-зміни — відкоти і досліди.
+
+### 5. Створити PR
+
+- Branch: `devin/<unix-ts>-docs-rn-progress-sync`.
+- Commit: `docs(docs): sync rn-migration progress (PR #X/#Y/#Z)` (scope `docs`, AGENTS.md rule #5).
+- PR description (`.github/PULL_REQUEST_TEMPLATE.md`):
+  - Перерахуй кожен merged PR з one-liner-ом, що він портнув.
+  - Явно: «docs-only — без code diff-ів».
+  - Лінк на [`docs/playbooks/port-web-screen-to-mobile.md`](port-web-screen-to-mobile.md), якщо PR-и слідували йому.
+
+---
+
+## Verification
+
+- [ ] Кожен листед PR відображено точно одним апдейтом у трекері.
+- [ ] Кожний апдейт відповідає реально wired-in коду в `apps/mobile/`.
+- [ ] `pnpm format:check docs/mobile/react-native-migration.md` — green.
+- [ ] PR-діф містить **тільки** `docs/mobile/react-native-migration.md` (нічого більше).
+- [ ] CI-job `commitlint` — green (scope `docs`, тип `docs`).
+
+## Notes
+
+- Якщо під час sync-у виявив **інші** неточності в трекері (не повʼязані з listed PR-ами) — НЕ виправляй у цьому PR. Відкрий окремий sync, щоб blast radius лишався мінімальним.
+- Якщо merged PR не змінив реальний код в `apps/mobile/` (наприклад, був чисто docs-only) — не став чекбокс «ported» лише через те, що merge відбувся.
+- Anti-pattern: одночасний sync і «причепити кілька дрібних правок doc-tree-у» — рев'юер не зможе швидко перевірити «це справді просто sync».
+
+## See also
+
+- [port-web-screen-to-mobile.md](port-web-screen-to-mobile.md) — як зробити сам порт (single source of truth).
+- [prettier-pass-on-docs.md](prettier-pass-on-docs.md) — якщо CI лає prettier на цьому doc-у поза sync-flow.
+- [`docs/mobile/react-native-migration.md`](../mobile/react-native-migration.md) — сам tracker.
+- [AGENTS.md](../../AGENTS.md) — rule #5 (commit scope enum), rule #7 (no `--no-verify`).


### PR DESCRIPTION
## What changed

Три нових playbook-и під `docs/playbooks/`, які кодифікують повторювані процедури, що раніше жили лише в чат-діалогах / Devin webapp playbook-ах:

- **`sync-rn-migration-progress.md`** — оновлення `docs/mobile/react-native-migration.md` після того, як один або кілька port-web-screen-to-mobile PR-ів змерджено (mirrors [PR #446](https://github.com/Skords-01/Sergeant/pull/446)).
- **`prettier-pass-on-docs.md`** — точковий `prettier --write` над `docs/**`, formatting-only, scope `docs` (mirrors [PR #447](https://github.com/Skords-01/Sergeant/pull/447)).
- **`fix-failing-ci.md`** — 🌳 decision-tree playbook, що покриває кожен CI-job (`commitlint`, `format:check`, `lint`, `typecheck`, `vitest`, `build`, `coverage`, `a11y`, `smoke-e2e`, Detox / mobile-shell, `audit`, `licenses:check`, `size-limit`) з явними посиланнями на hard-rules з `AGENTS.md` (no `--no-verify`, no force-push, scope enum, тощо).

`docs/playbooks/README.md` оновлено — додано три нові рядки в індекс-таблицю (із 🌳 для `fix-failing-ci.md`).

## Why

Усі три кейси виявились повторюваними при роботі з Sergeant (RN-міграція ведеться фазами; prettier-фейли в CI час від часу; CI-фейли різного типу — норма). Раніше я виносив їх у Devin webapp playbook-и (`!rn_sync`, `!docs_prettier`, `!fix_ci`), але `docs/playbooks/README.md` явно зазначає Option A — markdown файли in-repo як основний формат, а Devin webapp як можливий import. Тримаючи їх у репо, ми отримуємо single source of truth, version control, і автоматичну видимість у CODEOWNERS / quarterly review cadence.

## How to test

Це docs-only PR — без code-діфів. Reviewer має перевірити:

1. Усі три нові файли мають правильний `Last validated:` header і дотримуються format-а існуючих playbook-ів (порівняй з `add-sql-migration.md` для simple-формату і `hotfix-prod-regression.md` для decision-tree формату).
2. Тригери в `docs/playbooks/README.md` достатньо чіткі, щоб AI-агент міг зматчити запит на конкретний playbook.
3. `pnpm format:check` на змінених файлах — green.
4. Лінки всередині кожного playbook-а працюють (з `fix-failing-ci.md` на `prettier-pass-on-docs.md`, на `AGENTS.md`, на `CONTRIBUTING.md`).

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): прогнав `pnpm exec prettier --check` на всіх 4 змінених файлах — green.
- [x] Vitest passes: N/A, docs-only.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules (тільки нові playbook-и, не нові hard rules)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three docs playbooks to codify repeatable workflows: syncing RN migration progress, running targeted Prettier on docs, and a decision-tree for fixing failing CI. Updates the playbooks index to include all three.

- New Features
  - `sync-rn-migration-progress.md`: steps to update `docs/mobile/react-native-migration.md` after port-to-mobile PRs merge.
  - `prettier-pass-on-docs.md`: targeted `prettier --write` for `docs/**` to fix `format:check` without content changes.
  - `fix-failing-ci.md`: decision-tree covering CI jobs (`commitlint`, `format:check`, `lint`, `typecheck`, `vitest`, `build`, `coverage`, `a11y`, `smoke-e2e`, Detox/mobile-shell, `audit`, `licenses:check`, `size-limit`) with links to `AGENTS.md` rules.

<sup>Written for commit 89b499d7a99700d5592fddc17147a171312b23b1. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1097?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
