### PR TITLE
fix(mobile): use index [1] for sized wrapper in Input.test.tsx

### DIFF
--- a/apps/mobile/src/components/ui/Input.test.tsx
+++ b/apps/mobile/src/components/ui/Input.test.tsx
@@ -16,7 +16,9 @@ describe("Input", () => {
 
   it("applies size classes to the wrapper view", () => {
     const { UNSAFE_getAllByType } = render(<Input size="lg" />);
-    const wrapper = UNSAFE_getAllByType(View)[0];
+    // [0] is the outer label/group container (always rendered, holds `gap-1`),
+    // [1] is the inner sized row that owns h-{n} / px-{n} from `sizes[size]`.
+    const wrapper = UNSAFE_getAllByType(View)[1];
     expect(wrapper.props.className).toContain("h-12");
     expect(wrapper.props.className).toContain("px-5");
   });


### PR DESCRIPTION
## What changed

`apps/mobile/src/components/ui/Input.test.tsx` was checking the outer wrapper `View` (`[0]`) for size classes, but `Input.tsx` renders:

```tsx
<View className="gap-1">          // [0] — outer label/group container
  <View ...sizes[size]...>        // [1] — inner sized row owning h-{n} / px-{n}
    ...
  </View>
</View>
```

So on `main` the test fails with:

```
Expected substring: "h-12"
Received string:    "gap-1"
```

This is what's currently breaking the `check` job on `main`. Switching the index from `[0]` to `[1]` targets the sized row directly.

## Why

Subsumes the only still-needed chunk of [PR #1094](https://github.com/Skords-01/Sergeant/pull/1094) — the other 3 chunks of #1094 (ProfilePage tests, FeatureSpotlight tests, `RetentionHintId` extraction in `hints.ts`) are already on `main` via #1067, so #1094 has merge conflicts and is otherwise stale. This PR is the minimal targeted fix to turn `main` green.

## How to test

```bash
pnpm --filter @sergeant/mobile exec jest src/components/ui/Input.test.tsx
```

Now passes 10/10. Locally reproduced: on `main` the test fails as shown above; with this patch it passes.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): Reproduced the failure on `main` HEAD and verified the fix locally with the exact jest command above.
- [x] Vitest passes: N/A — this is a Jest test under `apps/mobile`, not Vitest. Jest passes 10/10.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md` (no prose changes).

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile Input test to target the inner sized wrapper View (index [1]) instead of the outer container, so size class assertions pass and CI on main is unblocked.

- **Bug Fixes**
  - In `apps/mobile/src/components/ui/Input.test.tsx`, switch `UNSAFE_getAllByType(View)[0]` to `[1]` to assert `sizes[size]` classes (`h-12`, `px-5`) on the correct element.

<sup>Written for commit d5318814b9f52a446baae3eee65789463135bea4. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1099?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
