### PR TITLE
Remove spotlight onboarding and improve toast hints

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -46,7 +46,6 @@ import {
   KeyboardShortcutsModal,
   useKeyboardShortcutsModal,
 } from "@shared/components/ui/KeyboardShortcutsModal";
-import { SpotlightQueueProvider } from "@shared/components/ui/SpotlightQueue";
 import { prefetchCriticalModules } from "./hooks/useRoutePrefetch";
 
 const AuthPage = lazy(() =>
@@ -96,26 +95,24 @@ const RoutineApp = lazy(
 export default function App() {
   return (
     <ToastProvider>
-      <SpotlightQueueProvider>
-        <ToastContainer />
-        {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
-            рендериться під <BrowserRouter>), але поза AppInner, щоб
-            bridge переживав ранні return-и в AppInner (/sign-in,
-            /reset-password, /design тощо) — deep link може прилетіти у
-            будь-який із цих станів. */}
-        <ShellDeepLinkBridge />
-        {/* PostHog `$pageview` tracker: монтуємо тут (всередині
-            BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
-            в unauthenticated-шляхах (`/sign-in`, `/welcome`,
-            `/reset-password`) — без цього onboarding / auth funnels
-            у PostHog були б сліпими перед login-ом. */}
-        <PageviewTracker />
-        <ApiClientProvider client={apiClient}>
-          <AuthProvider>
-            <AppInner />
-          </AuthProvider>
-        </ApiClientProvider>
-      </SpotlightQueueProvider>
+      <ToastContainer />
+      {/* Capacitor deep-link bridge: монтуємо ВСЕРЕДИНІ роутера (App
+          рендериться під <BrowserRouter>), але поза AppInner, щоб
+          bridge переживав ранні return-и в AppInner (/sign-in,
+          /reset-password, /design тощо) — deep link може прилетіти у
+          будь-який із цих станів. */}
+      <ShellDeepLinkBridge />
+      {/* PostHog `$pageview` tracker: монтуємо тут (всередині
+          BrowserRouter, поза AuthProvider), щоб фіксувати pathname і
+          в unauthenticated-шляхах (`/sign-in`, `/welcome`,
+          `/reset-password`) — без цього onboarding / auth funnels
+          у PostHog були б сліпими перед login-ом. */}
+      <PageviewTracker />
+      <ApiClientProvider client={apiClient}>
+        <AuthProvider>
+          <AppInner />
+        </AuthProvider>
+      </ApiClientProvider>
     </ToastProvider>
   );
 }

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -1,5 +1,4 @@
 import { Icon } from "@shared/components/ui/Icon";
-import { FeatureSpotlight } from "@shared/components/ui/FeatureSpotlight";
 import { cn } from "@shared/lib/cn";
 
 /**
@@ -71,20 +70,7 @@ export function HubFloatingActions({
       )}
       style={{ bottom: bottomOffset }}
     >
-      {compact ? (
-        fabButton
-      ) : (
-        <FeatureSpotlight
-          id="hub-assistant-fab"
-          title="AI-асистент"
-          description="Запитай будь-що про фінанси, тренування, харчування чи рутину"
-          placement="left"
-          showOnce
-          delay={3000}
-        >
-          {fabButton}
-        </FeatureSpotlight>
-      )}
+      {fabButton}
     </div>
   );
 }

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
 import { Tooltip } from "@shared/components/ui/Tooltip";
-import { FeatureSpotlight } from "@shared/components/ui/FeatureSpotlight";
 import { useScrollHeader } from "@shared/hooks/useScrollHeader";
 import { BrandLogo } from "./BrandLogo";
 import { DarkModeToggle } from "./DarkModeToggle";
@@ -112,25 +111,16 @@ export function HubHeader({
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          <FeatureSpotlight
-            id="hub-search-button"
-            title="Глобальний пошук"
-            description="Знаходь транзакції, тренування та їжу. Також Cmd+K"
-            placement="bottom"
-            showOnce
-            delay={5000}
-          >
-            <Tooltip content="Пошук по всіх модулях" placement="bottom-center">
-              <button
-                type="button"
-                onClick={onOpenSearch}
-                aria-label="Пошук"
-                className={ICON_BUTTON_CLS}
-              >
-                <Icon name="search" size={20} />
-              </button>
-            </Tooltip>
-          </FeatureSpotlight>
+          <Tooltip content="Пошук по всіх модулях (⌘K)" placement="bottom-center">
+            <button
+              type="button"
+              onClick={onOpenSearch}
+              aria-label="Пошук"
+              className={ICON_BUTTON_CLS}
+            >
+              <Icon name="search" size={20} />
+            </button>
+          </Tooltip>
 
           {user ? (
             <UserMenuButton

--- a/apps/web/src/core/hints/HintsOrchestrator.tsx
+++ b/apps/web/src/core/hints/HintsOrchestrator.tsx
@@ -10,7 +10,6 @@ import {
   type KVStore,
 } from "@sergeant/shared";
 import { useToast } from "@shared/hooks/useToast";
-import { useSpotlightQueue } from "@shared/components/ui/SpotlightQueue";
 import { ANALYTICS_EVENTS, trackEvent } from "../observability/analytics";
 import { useHubPref } from "../settings/hubPrefs";
 
@@ -50,7 +49,6 @@ export function HintsOrchestrator({
   hasFirstRealEntry,
 }: HintsOrchestratorProps): null {
   const toast = useToast();
-  const { isAnyActive: isSpotlightActive } = useSpotlightQueue();
   const [showHints] = useHubPref<boolean>("showHints", true);
   const shownThisMount = useRef<HintId | null>(null);
 
@@ -82,107 +80,114 @@ export function HintsOrchestrator({
 
   useEffect(() => {
     if (!showHints) return;
-    // Don't show toast hints while a spotlight is active — avoids UI clutter
-    if (isSpotlightActive()) return;
     if (shownThisMount.current) return;
 
-    // ── Retention hints (Day 1 / 3 / 7) take priority over general hints
-    if (hasFirstRealEntry) {
-      const startedAt = getFirstActionStartedAt(localStorageStore);
-      if (startedAt) {
-        const retentionId = getRetentionHintId(startedAt);
-        if (retentionId) {
-          const res = canShowHint(localStorageStore, retentionId, ctx);
-          if (res.ok) {
-            shownThisMount.current = retentionId;
-            recordHintShown(localStorageStore, retentionId);
-            const def = {
-              retention_day_1:
-                "Перший день — вже здобуток! Поверніться завтра — звичка формується з трьох повторень.",
-              retention_day_3:
-                "3 дні поспіль — стрік почався. Ще кілька днів і мозок зафіксує нову звичку.",
-              retention_day_7:
-                "Тиждень — серйозна заявка! 7 днів поспіль доведено підвищують шанс закріпити звичку.",
-            }[retentionId];
-            if (def) {
-              toast.info(def, 6000);
-              return;
+    // Delay hint showing to let the user orient themselves first
+    const timer = setTimeout(() => {
+      showHintIfEligible();
+    }, 2500);
+
+    return () => clearTimeout(timer);
+
+    function showHintIfEligible() {
+      // ── Retention hints (Day 1 / 3 / 7) take priority over general hints
+      if (hasFirstRealEntry) {
+        const startedAt = getFirstActionStartedAt(localStorageStore);
+        if (startedAt) {
+          const retentionId = getRetentionHintId(startedAt);
+          if (retentionId) {
+            const res = canShowHint(localStorageStore, retentionId, ctx);
+            if (res.ok) {
+              shownThisMount.current = retentionId;
+              recordHintShown(localStorageStore, retentionId);
+              const def = {
+                retention_day_1:
+                  "Перший день — вже здобуток! Поверніться завтра — звичка формується з трьох повторень.",
+                retention_day_3:
+                  "3 дні поспіль — стрік почався. Ще кілька днів і мозок зафіксує нову звичку.",
+                retention_day_7:
+                  "Тиждень — серйозна заявка! 7 днів поспіль доведено підвищують шанс закріпити звичку.",
+              }[retentionId];
+              if (def) {
+                toast.info(def, 6000);
+                return;
+              }
             }
           }
         }
       }
-    }
 
-    if (candidates.length === 0) return;
-    const next = pickNextHint(localStorageStore, candidates, ctx);
-    if (!next) return;
+      if (candidates.length === 0) return;
+      const next = pickNextHint(localStorageStore, candidates, ctx);
+      if (!next) return;
 
-    shownThisMount.current = next;
-    recordHintShown(localStorageStore, next);
-    trackEvent(ANALYTICS_EVENTS.HINT_SHOWN, {
-      id: next,
-      surface: ctx.surface,
-      platform: ctx.platform,
-      inFtuxSession: Boolean(ctx.inFtuxSession),
-      hasFirstRealEntry: Boolean(ctx.hasFirstRealEntry),
-    });
+      shownThisMount.current = next;
+      recordHintShown(localStorageStore, next);
+      trackEvent(ANALYTICS_EVENTS.HINT_SHOWN, {
+        id: next,
+        surface: ctx.surface,
+        platform: ctx.platform,
+        inFtuxSession: Boolean(ctx.inFtuxSession),
+        hasFirstRealEntry: Boolean(ctx.hasFirstRealEntry),
+      });
 
-    const msg = (() => {
-      switch (next) {
-        case "ftux_open_search":
-          return "Порада: відкрий пошук (Ctrl/⌘K) — швидко знаходить модулі та дії.";
-        case "ftux_open_chat":
-          return "Порада: в чаті спитай «Що мені важливо сьогодні?»";
-        case "ftux_switch_modules":
-          return "Перемикай модулі зверху — це один хаб.";
-        case "ftux_reports_unlock":
-          return "Звіти з’являться після першого запису.";
-        case "ftux_quick_add":
-          return "Швидке додавання — найкоротший шлях до результату.";
-        case "module_first_entry":
-          return "Після першого запису спробуй «Звіти» — там найшвидше видно прогрес.";
-        case "hub_reorder_modules":
-          return "Можна переставити модулі: Налаштування → Загальні → Упорядкувати модулі.";
-        default:
-          return null;
-      }
-    })();
+      const msg = (() => {
+        switch (next) {
+          case "ftux_open_search":
+            return "Порада: відкрий пошук (⌘K) — швидко знаходить модулі та дії.";
+          case "ftux_open_chat":
+            return "Порада: спитай у чаті «Що мені важливо сьогодні?»";
+          case "ftux_switch_modules":
+            return "Перемикай модулі зверху — це один хаб.";
+          case "ftux_reports_unlock":
+            return "Звіти з'являться після першого запису.";
+          case "ftux_quick_add":
+            return "Швидке додавання — найкоротший шлях до результату.";
+          case "module_first_entry":
+            return "Після першого запису спробуй «Звіти» — там найшвидше видно прогрес.";
+          case "hub_reorder_modules":
+            return "Можна переставити модулі: Налаштування → Загальні → Упорядкувати.";
+          default:
+            return null;
+        }
+      })();
 
-    if (!msg) return;
+      if (!msg) return;
 
-    const action =
-      next === "ftux_open_chat"
-        ? {
-            label: "Відкрити чат",
-            onClick: () => {
-              try {
-                window.dispatchEvent(
-                  new CustomEvent("hub:openChat", {
-                    detail: "Що мені важливо сьогодні?",
-                  }),
-                );
-                trackEvent(ANALYTICS_EVENTS.HINT_CLICKED, { id: next });
-              } catch {
-                /* noop */
-              }
-            },
-          }
-        : next === "ftux_open_search"
+      const action =
+        next === "ftux_open_chat"
           ? {
-              label: "Пошук",
+              label: "Відкрити чат",
               onClick: () => {
                 try {
-                  window.dispatchEvent(new CustomEvent("hub:openSearch"));
+                  window.dispatchEvent(
+                    new CustomEvent("hub:openChat", {
+                      detail: "Що мені важливо сьогодні?",
+                    }),
+                  );
                   trackEvent(ANALYTICS_EVENTS.HINT_CLICKED, { id: next });
                 } catch {
                   /* noop */
                 }
               },
             }
-          : undefined;
+          : next === "ftux_open_search"
+            ? {
+                label: "Пошук",
+                onClick: () => {
+                  try {
+                    window.dispatchEvent(new CustomEvent("hub:openSearch"));
+                    trackEvent(ANALYTICS_EVENTS.HINT_CLICKED, { id: next });
+                  } catch {
+                    /* noop */
+                  }
+                },
+              }
+            : undefined;
 
-    toast.info(msg, 5000, action);
-  }, [candidates, ctx, hasFirstRealEntry, isSpotlightActive, showHints, toast]);
+      toast.info(msg, 5000, action);
+    }
+  }, [candidates, ctx, hasFirstRealEntry, showHints, toast]);
 
   return null;
 }


### PR DESCRIPTION
- Removed the "Feature Spotlight" onboarding components from the Hub header and floating action menus.
- Cleaned up the global application state by removing the `SpotlightQueueProvider`.
- Updated toast hints in the `HintsOrchestrator` with improved messaging and adjusted timing delays.

[v0 Session](https://v0.app/chat/jjyb98gYeg5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the spotlight onboarding and shifted guidance to improved toast hints to reduce UI clutter and simplify app state.

- **Refactors**
  - Removed `FeatureSpotlight` from `HubHeader` and `HubFloatingActions`.
  - Dropped `SpotlightQueueProvider` from `App` and related logic.

- **New Features**
  - Enhanced `HintsOrchestrator`: 2.5s delay before showing hints and clearer copy (e.g., "⌘K" for search).
  - Hints now include quick actions to open search or chat with click tracking.
  - Retention hints still take priority, and only one hint shows per mount.

<sup>Written for commit afebb6390665b68d8db35952c0d3b05836e9fb6b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1103?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Search button tooltip now displays the keyboard shortcut hint (⌘K) for quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->