### PR TITLE
feat(mobile): add nutrition reminder settings

### DIFF
--- a/apps/mobile/src/core/settings/NotificationsSection.test.tsx
+++ b/apps/mobile/src/core/settings/NotificationsSection.test.tsx
@@ -10,11 +10,14 @@
  *    and flips the status label;
  *  - the routine-reminders toggle persists into the shared
  *    `@routine_prefs_v1` MMKV slice;
- *  - the Fizruk and Nutrition sub-groups surface their deferred-port
- *    placeholder strings (Phase 6 / Phase 7).
+ *  - the nutrition reminder toggle/hour picker persists into the shared
+ *    nutrition prefs MMKV slice;
+ *  - the Fizruk sub-group surfaces its deferred-port placeholder string.
  */
 
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { STORAGE_KEYS } from "@sergeant/shared";
 
 import { _getMMKVInstance } from "@/lib/storage";
 
@@ -60,7 +63,7 @@ describe("NotificationsSection", () => {
     expect(queryByText("Push-сповіщення")).toBeNull();
   });
 
-  it("expands to reveal the permission card, toggle and deferred sub-groups", async () => {
+  it("expands to reveal the permission card, toggles and deferred sub-groups", async () => {
     mockedGetPerms.mockResolvedValueOnce({
       granted: true,
       status: "granted",
@@ -85,11 +88,8 @@ describe("NotificationsSection", () => {
       ),
     ).toBeTruthy();
     expect(getByText("Харчування")).toBeTruthy();
-    expect(
-      getByText(
-        "Нагадування про їжу підключаться з портом модуля Харчування (Phase 7).",
-      ),
-    ).toBeTruthy();
+    expect(getByText("Нагадування про їжу")).toBeTruthy();
+    expect(getByTestId("notifications-nutrition-toggle")).toBeTruthy();
   });
 
   it("requests permissions when 'Дозволити' is tapped and updates the label", async () => {
@@ -150,6 +150,41 @@ describe("NotificationsSection", () => {
     expect(stored).toBeTruthy();
     expect(JSON.parse(stored as string)).toMatchObject({
       routineRemindersEnabled: true,
+    });
+  });
+
+  it("persists nutrition reminder toggle and hour into nutrition prefs", async () => {
+    mockedGetPerms.mockResolvedValueOnce({
+      granted: true,
+      status: "granted",
+    });
+    const { getByText, getByTestId } = render(<NotificationsSection />);
+
+    fireEvent.press(getByText("Сповіщення"));
+
+    await waitFor(() => {
+      expect(getByTestId("notifications-nutrition-toggle")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(
+        getByTestId("notifications-nutrition-toggle"),
+        "valueChange",
+        true,
+      );
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("notifications-nutrition-hour")).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId("notifications-nutrition-hour"), "25");
+
+    const stored = _getMMKVInstance().getString(STORAGE_KEYS.NUTRITION_PREFS);
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored as string)).toMatchObject({
+      reminderEnabled: true,
+      reminderHour: 23,
     });
   });
 });

--- a/apps/mobile/src/core/settings/NotificationsSection.tsx
+++ b/apps/mobile/src/core/settings/NotificationsSection.tsx
@@ -29,8 +29,6 @@
  *    users don't expect reminders to fire from this screen alone.
  *  - **Fizruk monthly-plan reminder** (web `useMonthlyPlan` — toggle +
  *    hour/minute picker). Ports with the Fizruk module (Phase 6).
- *  - **Nutrition reminders** (web `loadNutritionPrefs` / toggle + hour
- *    input). Ports with the Nutrition module (Phase 7).
  *
  * Notes on the permission-status model:
  *  - `expo-notifications` returns a `PermissionStatus` of
@@ -44,12 +42,13 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Linking, Text, View } from "react-native";
+import { Linking, Text, TextInput, View } from "react-native";
 import * as Notifications from "expo-notifications";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { useLocalStorage } from "@/lib/storage";
+import { useNutritionPrefs } from "@/modules/nutrition/hooks/useNutritionPrefs";
 
 import {
   SettingsGroup,
@@ -103,12 +102,19 @@ function toStatus(
   return "undetermined";
 }
 
+function clampReminderHour(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(23, Math.max(0, Math.trunc(value)));
+}
+
 export function NotificationsSection() {
   const [permStatus, setPermStatus] = useState<PermStatus>("undetermined");
   const [routinePrefs, setRoutinePrefs] = useLocalStorage<RoutinePrefs>(
     ROUTINE_PREFS_KEY,
     {},
   );
+  const { prefs: nutritionPrefs, updatePrefs: updateNutritionPrefs } =
+    useNutritionPrefs();
 
   const refreshPermissions = useCallback(async () => {
     try {
@@ -126,14 +132,21 @@ export function NotificationsSection() {
     void refreshPermissions();
   }, [refreshPermissions]);
 
-  const requestPermission = useCallback(async () => {
+  const requestPermissionStatus = useCallback(async (): Promise<PermStatus> => {
     try {
       const perm = await Notifications.requestPermissionsAsync();
-      setPermStatus(toStatus(perm));
+      const nextStatus = toStatus(perm);
+      setPermStatus(nextStatus);
+      return nextStatus;
     } catch {
       setPermStatus("denied");
+      return "denied";
     }
   }, []);
+
+  const requestPermission = useCallback(() => {
+    void requestPermissionStatus();
+  }, [requestPermissionStatus]);
 
   const openSystemSettings = useCallback(() => {
     // `Linking.openSettings()` is the RN-standard way to jump to the
@@ -143,7 +156,27 @@ export function NotificationsSection() {
     void Linking.openSettings();
   }, []);
 
+  const handleNutritionToggle = useCallback(
+    async (next: boolean) => {
+      if (next && permStatus !== "granted") {
+        const nextStatus = await requestPermissionStatus();
+        if (nextStatus !== "granted") return;
+      }
+      updateNutritionPrefs({ reminderEnabled: next });
+    },
+    [permStatus, requestPermissionStatus, updateNutritionPrefs],
+  );
+
+  const handleNutritionHourChange = useCallback(
+    (value: string) => {
+      updateNutritionPrefs({ reminderHour: clampReminderHour(Number(value)) });
+    },
+    [updateNutritionPrefs],
+  );
+
   const routineEnabled = routinePrefs.routineRemindersEnabled === true;
+  const nutritionReminderEnabled = nutritionPrefs.reminderEnabled === true;
+  const nutritionReminderHour = nutritionPrefs.reminderHour ?? 12;
 
   return (
     <SettingsGroup title="Сповіщення" emoji="🔔">
@@ -214,14 +247,39 @@ export function NotificationsSection() {
         </DeferredNotice>
       </SettingsSubGroup>
 
-      {/* TODO(mobile-migration, Phase 7): wire to the nutrition-prefs
-          slice once the Nutrition module is ported — reminderEnabled +
-          reminderHour picker, analogue to web `NotificationsSection`
-          Харчування sub-group. */}
       <SettingsSubGroup title="Харчування">
-        <DeferredNotice>
-          Нагадування про їжу підключаться з портом модуля Харчування (Phase 7).
-        </DeferredNotice>
+        <ToggleRow
+          label="Нагадування про їжу"
+          description="Зберігає щоденне нагадування у nutrition prefs: toggle + година, як у web settings. Якщо push-дозвіл ще не виданий, спершу попросимо його."
+          checked={nutritionReminderEnabled}
+          onChange={(next) => {
+            void handleNutritionToggle(next);
+          }}
+          testID="notifications-nutrition-toggle"
+        />
+        {nutritionReminderEnabled ? (
+          <View className="flex-row items-center justify-between gap-3">
+            <View className="flex-1 min-w-0">
+              <Text className="text-sm text-fg">Година нагадування</Text>
+              <Text className="text-xs text-fg-muted mt-0.5 leading-snug">
+                Від 0 до 23, синхронізується разом із налаштуваннями харчування.
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <TextInput
+                value={String(nutritionReminderHour)}
+                onChangeText={handleNutritionHourChange}
+                keyboardType="number-pad"
+                inputMode="numeric"
+                selectTextOnFocus
+                maxLength={2}
+                className="w-16 h-10 rounded-xl border border-cream-300 dark:border-cream-700 bg-cream-50 dark:bg-cream-800 px-3 text-center text-sm text-fg"
+                testID="notifications-nutrition-hour"
+              />
+              <Text className="text-xs text-fg-muted">год.</Text>
+            </View>
+          </View>
+        ) : null}
       </SettingsSubGroup>
     </SettingsGroup>
   );


### PR DESCRIPTION
## What changed

Adds the mobile Nutrition reminder controls to `NotificationsSection`:

- replaces the Phase 7 deferred Nutrition notice with a real `ToggleRow`
- stores `reminderEnabled` via `useNutritionPrefs`
- shows an hour input when enabled
- clamps reminder hour values to `0..23`
- asks for push permission before enabling the reminder when needed
- updates `NotificationsSection` tests to cover persistence into `STORAGE_KEYS.NUTRITION_PREFS`

## Why

Nutrition has enough native settings/storage plumbing now to expose the same reminder preference shape used by web settings. This moves the mobile settings screen one step closer to Nutrition parity.

## How to test

1. Open mobile Settings → `Сповіщення`.
2. Expand the group.
3. Under `Харчування`, toggle `Нагадування про їжу`.
4. If push permission is not granted, confirm the OS permission prompt path is shown first.
5. Verify the hour input appears and accepts/clamps values between `0` and `23`.

---

## How AI-tested this PR

- [ ] Manual smoke (which flow?): not run yet
- [x] Vitest passes: `pnpm --filter @sergeant/mobile test -- NotificationsSection.test.tsx`
- [x] Mobile lint passes: `pnpm --filter @sergeant/mobile lint`
- [x] Mobile typecheck passes: `pnpm --filter @sergeant/mobile typecheck`
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/3069a7aa3034418096152b8bb6414f3e
Requested by: @Skords-01
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Nutrition reminder settings to the mobile Notifications screen. Users can enable a daily reminder and set the hour; we request push permission first and persist the preference.

- **New Features**
  - Added “Нагадування про їжу” toggle under “Харчування” with hour input (0–23).
  - Persists via `useNutritionPrefs` into `STORAGE_KEYS.NUTRITION_PREFS`.
  - Requests push permission before enabling the reminder.
  - Updated tests to cover persistence and hour clamping.

<sup>Written for commit ed7164cad28a484c2cd4a7a0913fc3f78888e3b5. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1115?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

