### PR TITLE
feat(web): group dashboard settings; split PWA & JSON backup into Advanced

### DIFF
--- a/apps/web/src/core/hub/HubSettingsPage.tsx
+++ b/apps/web/src/core/hub/HubSettingsPage.tsx
@@ -5,12 +5,15 @@ import { Icon } from "@shared/components/ui/Icon";
 import { Tabs } from "@shared/components/ui/Tabs";
 import { AIDigestSection } from "../settings/AIDigestSection";
 import { AssistantCatalogueSection } from "../settings/AssistantCatalogueSection";
+import { DashboardSection } from "../settings/DashboardSection";
+import { DataExportSection } from "../settings/DataExportSection";
 import { ExperimentalSection } from "../settings/ExperimentalSection";
 import { FinykSection } from "../settings/FinykSection";
 import { FizrukSection } from "../settings/FizrukSection";
 import { GeneralSection } from "../settings/GeneralSection";
 import { NotificationsSection } from "../settings/NotificationsSection";
 import { NutritionSection } from "../settings/NutritionSection";
+import { PWASection } from "../settings/PWASection";
 import { RoutineSection } from "../settings/RoutineSection";
 
 interface SettingsSection {
@@ -27,7 +30,7 @@ const GROUPS = [
   {
     id: "general",
     label: "Загальні",
-    sections: ["general", "notifications", "ai", "assistant"],
+    sections: ["dashboard", "general", "notifications", "ai", "assistant"],
   },
   {
     id: "modules",
@@ -37,7 +40,7 @@ const GROUPS = [
   {
     id: "advanced",
     label: "Додатково",
-    sections: ["experimental"],
+    sections: ["pwa", "dataExport", "experimental"],
   },
 ] as const;
 
@@ -63,10 +66,17 @@ export function HubSettingsPage({
   const sections = useMemo(
     () => [
       {
-        id: "general",
-        title: "Інтерфейс і синхронізація",
+        id: "dashboard",
+        title: "Дашборд",
         keywords:
-          "загальні мова інтерфейс синхронізація акаунт sync cloud backup",
+          "дашборд dashboard підказки щільність density вигляд активні модулі порядок упорядкувати reorder hide inactive приховати",
+        render: () => <DashboardSection />,
+      },
+      {
+        id: "general",
+        title: "Загальні",
+        keywords:
+          "загальні онбординг onboarding welcome синхронізація акаунт sync cloud",
         render: () => (
           <GeneralSection
             syncing={syncing}
@@ -122,6 +132,20 @@ export function HubSettingsPage({
         keywords:
           "харчування їжа nutrition meals food kбжу калорії kcal білки жири вуглеводи вода комора pantry скан штрихкод barcode",
         render: () => <NutritionSection />,
+      },
+      {
+        id: "pwa",
+        title: "PWA та офлайн",
+        keywords:
+          "pwa офлайн offline service worker sw кеш cache діагностика скинути reset",
+        render: () => <PWASection />,
+      },
+      {
+        id: "dataExport",
+        title: "Експорт/імпорт JSON",
+        keywords:
+          "експорт імпорт export import json резервна копія backup hub дані data перенос",
+        render: () => <DataExportSection />,
       },
       {
         id: "experimental",

--- a/apps/web/src/core/settings/DashboardSection.tsx
+++ b/apps/web/src/core/settings/DashboardSection.tsx
@@ -1,0 +1,247 @@
+import { useCallback, useState } from "react";
+import { cn } from "@shared/lib/cn";
+import { Icon } from "@shared/components/ui/Icon";
+import { Button } from "@shared/components/ui/Button";
+import { useToast } from "@shared/hooks/useToast";
+import { safeReadStringLS, safeWriteLS, webKVStore } from "@shared/lib/storage";
+import {
+  ALL_MODULES,
+  DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
+  DASHBOARD_DENSITIES,
+  DASHBOARD_DENSITY_LABELS,
+  DASHBOARD_DENSITY_DESCRIPTIONS,
+  DEFAULT_DASHBOARD_DENSITY,
+  normalizeDashboardDensity,
+  STORAGE_KEYS,
+  getActiveModules,
+  getHideInactiveModules,
+  setActiveModules,
+  setHideInactiveModules,
+  type DashboardDensity,
+  type DashboardModuleId,
+} from "@sergeant/shared";
+import {
+  DASHBOARD_MODULE_LABELS,
+  loadDashboardOrder,
+  resetDashboardOrder,
+  saveDashboardOrder,
+} from "../hub/HubDashboard";
+import {
+  SettingsGroup,
+  SettingsSubGroup,
+  ToggleRow,
+} from "./SettingsPrimitives";
+import { useHubPref } from "./hubPrefs";
+
+type ModuleId = keyof typeof DASHBOARD_MODULE_LABELS;
+
+interface ModuleReorderListProps {
+  order: ModuleId[];
+  onMove: (index: number, direction: -1 | 1) => void;
+}
+
+function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
+  return (
+    <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
+      {order.map((id, index) => {
+        const isFirst = index === 0;
+        const isLast = index === order.length - 1;
+        return (
+          <li key={id} className="flex items-center gap-2 px-3 py-2 bg-panel">
+            <span className="text-xs font-semibold text-muted tabular-nums w-4">
+              {index + 1}
+            </span>
+            <span className="flex-1 text-sm text-text truncate">
+              {DASHBOARD_MODULE_LABELS[id]}
+            </span>
+            <button
+              type="button"
+              onClick={() => onMove(index, -1)}
+              disabled={isFirst}
+              aria-label={`Підняти ${DASHBOARD_MODULE_LABELS[id]} вище`}
+              className={cn(
+                "w-8 h-8 rounded-lg flex items-center justify-center",
+                "text-muted hover:text-text hover:bg-panelHi transition-colors",
+                "disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+              )}
+            >
+              <Icon name="chevron-up" size={16} strokeWidth={2.5} />
+            </button>
+            <button
+              type="button"
+              onClick={() => onMove(index, 1)}
+              disabled={isLast}
+              aria-label={`Опустити ${DASHBOARD_MODULE_LABELS[id]} нижче`}
+              className={cn(
+                "w-8 h-8 rounded-lg flex items-center justify-center",
+                "text-muted hover:text-text hover:bg-panelHi transition-colors",
+                "disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed",
+              )}
+            >
+              <Icon name="chevron-down" size={16} strokeWidth={2.5} />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function DashboardSection() {
+  const [orderReset, setOrderReset] = useState(false);
+  const [showHints, setShowHints] = useHubPref<boolean>("showHints", true);
+  const [density, setDensityState] = useState<DashboardDensity>(() => {
+    const raw = safeReadStringLS(STORAGE_KEYS.DASHBOARD_DENSITY);
+    return raw === null
+      ? DEFAULT_DASHBOARD_DENSITY
+      : normalizeDashboardDensity(raw);
+  });
+  const handleDensityChange = useCallback((next: DashboardDensity) => {
+    setDensityState(next);
+    safeWriteLS(STORAGE_KEYS.DASHBOARD_DENSITY, next);
+  }, []);
+  const [order, setOrder] = useState<ModuleId[]>(
+    () => loadDashboardOrder() as ModuleId[],
+  );
+  const toast = useToast();
+
+  const [activeModules, setActiveModulesState] = useState<DashboardModuleId[]>(
+    () => getActiveModules(webKVStore),
+  );
+  const [hideInactive, setHideInactiveState] = useState(() =>
+    getHideInactiveModules(webKVStore),
+  );
+  const toggleActive = useCallback(
+    (id: DashboardModuleId) => {
+      setActiveModulesState((prev) => {
+        const isActive = prev.includes(id);
+        if (isActive && prev.length === 1) {
+          toast.error("Щонайменше один модуль має бути активним");
+          return prev;
+        }
+        const next = isActive
+          ? prev.filter((x) => x !== id)
+          : ALL_MODULES.filter((x) => prev.includes(x) || x === id);
+        setActiveModules(webKVStore, next);
+        return next;
+      });
+    },
+    [toast],
+  );
+  const toggleHideInactive = useCallback((next: boolean) => {
+    setHideInactiveState(next);
+    setHideInactiveModules(webKVStore, next);
+  }, []);
+
+  const handleMove = useCallback((index: number, direction: -1 | 1) => {
+    setOrder((prev) => {
+      const next = prev.slice();
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      saveDashboardOrder(next);
+      return next;
+    });
+  }, []);
+
+  const handleResetOrder = () => {
+    resetDashboardOrder();
+    setOrder(loadDashboardOrder() as ModuleId[]);
+    setOrderReset(true);
+    setTimeout(() => setOrderReset(false), 2000);
+  };
+
+  return (
+    <SettingsGroup title="Дашборд" emoji="🧭">
+      <SettingsSubGroup title="Вигляд">
+        <ToggleRow
+          label="Показувати підказки"
+          description="Короткі підказки в моменті (без спаму)."
+          checked={showHints !== false}
+          onChange={setShowHints}
+        />
+        <div className="space-y-2">
+          <p className="text-xs text-subtle leading-snug">
+            Скільки простору між картками на головному екрані.
+          </p>
+          <div className="flex gap-2">
+            {DASHBOARD_DENSITIES.map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => handleDensityChange(d)}
+                className={cn(
+                  "flex-1 rounded-xl border px-3 py-2.5 text-left transition-colors",
+                  d === density
+                    ? "border-brand bg-brand/8 ring-1 ring-brand/30"
+                    : "border-line bg-panel hover:bg-panelHi",
+                )}
+              >
+                <span
+                  className={cn(
+                    "block text-sm font-medium",
+                    d === density ? "text-brand-strong" : "text-text",
+                  )}
+                >
+                  {DASHBOARD_DENSITY_LABELS[d]}
+                </span>
+                <span className="block text-xs text-muted mt-0.5">
+                  {DASHBOARD_DENSITY_DESCRIPTIONS[d]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </SettingsSubGroup>
+      <SettingsSubGroup title="Модулі дашборду">
+        <p className="text-xs text-subtle leading-snug">
+          Які модулі показувати на дашборді й у якому порядку. Неактивні модулі
+          відображаються приглушено — без кнопки швидкого додавання. Щонайменше
+          один модуль має залишатися активним.
+        </p>
+        <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
+          {ALL_MODULES.map((id) => {
+            const checked = activeModules.includes(id);
+            return (
+              <li key={id} className="px-3 py-2 bg-panel">
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleActive(id)}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  <span className="flex-1 text-sm text-text">
+                    {SHARED_DASHBOARD_MODULE_LABELS[id]}
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+        <ToggleRow
+          label="Приховати неактивні модулі"
+          description="Повністю ховає неактивні плитки з дашборду."
+          checked={hideInactive}
+          onChange={toggleHideInactive}
+        />
+        <div className="space-y-2 pt-2 border-t border-line/40">
+          <p className="text-xs text-subtle leading-snug">
+            Порядок модулів у списку «Сьогодні» на дашборді.
+          </p>
+          <ModuleReorderList order={order} onMove={handleMove} />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-10 w-full"
+            onClick={handleResetOrder}
+            disabled={orderReset}
+          >
+            {orderReset ? "✓ Порядок скинуто" : "Скинути до за промовчання"}
+          </Button>
+        </div>
+      </SettingsSubGroup>
+    </SettingsGroup>
+  );
+}

--- a/apps/web/src/core/settings/DataExportSection.tsx
+++ b/apps/web/src/core/settings/DataExportSection.tsx
@@ -1,0 +1,16 @@
+import { HubBackupPanel } from "../hub/HubBackupPanel";
+import { SettingsGroup } from "./SettingsPrimitives";
+
+export function DataExportSection() {
+  return (
+    <SettingsGroup title="Експорт/імпорт JSON" emoji="💾">
+      <p className="text-xs text-subtle leading-snug">
+        Локальна резервна копія всього Hub у JSON-файл. Стане в нагоді, якщо
+        треба перенести дані без хмари (наприклад, без логіну) або зберегти
+        копію «на руках». Залогіненим користувачам зазвичай достатньо хмарної
+        синхронізації.
+      </p>
+      <HubBackupPanel className="" />
+    </SettingsGroup>
+  );
+}

--- a/apps/web/src/core/settings/GeneralSection.tsx
+++ b/apps/web/src/core/settings/GeneralSection.tsx
@@ -1,99 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
-import { cn } from "@shared/lib/cn";
-import { Icon } from "@shared/components/ui/Icon";
 import { Button } from "@shared/components/ui/Button";
 import { useToast } from "@shared/hooks/useToast";
-import {
-  ALL_MODULES,
-  DASHBOARD_MODULE_LABELS as SHARED_DASHBOARD_MODULE_LABELS,
-  DASHBOARD_DENSITIES,
-  DASHBOARD_DENSITY_LABELS,
-  DASHBOARD_DENSITY_DESCRIPTIONS,
-  DEFAULT_DASHBOARD_DENSITY,
-  normalizeDashboardDensity,
-  STORAGE_KEYS,
-  getActiveModules,
-  getHideInactiveModules,
-  resetOnboardingState,
-  setActiveModules,
-  setHideInactiveModules,
-  type DashboardDensity,
-  type DashboardModuleId,
-  type KVStore,
-  type User,
-} from "@sergeant/shared";
-import { HubBackupPanel } from "../hub/HubBackupPanel";
-import {
-  swClearCaches,
-  swGetDebugSnapshot,
-  swSetDebug,
-} from "../app/swControl";
-import {
-  DASHBOARD_MODULE_LABELS,
-  loadDashboardOrder,
-  resetDashboardOrder,
-  saveDashboardOrder,
-} from "../hub/HubDashboard";
-import {
-  SettingsGroup,
-  SettingsSubGroup,
-  ToggleRow,
-} from "./SettingsPrimitives";
-import { useHubPref } from "./hubPrefs";
-
-type ModuleId = keyof typeof DASHBOARD_MODULE_LABELS;
-
-interface ModuleReorderListProps {
-  order: ModuleId[];
-  onMove: (index: number, direction: -1 | 1) => void;
-}
-
-function ModuleReorderList({ order, onMove }: ModuleReorderListProps) {
-  return (
-    <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
-      {order.map((id, index) => {
-        const isFirst = index === 0;
-        const isLast = index === order.length - 1;
-        return (
-          <li key={id} className="flex items-center gap-2 px-3 py-2 bg-panel">
-            <span className="text-xs font-semibold text-muted tabular-nums w-4">
-              {index + 1}
-            </span>
-            <span className="flex-1 text-sm text-text truncate">
-              {DASHBOARD_MODULE_LABELS[id]}
-            </span>
-            <button
-              type="button"
-              onClick={() => onMove(index, -1)}
-              disabled={isFirst}
-              aria-label={`Підняти ${DASHBOARD_MODULE_LABELS[id]} вище`}
-              className={cn(
-                "w-8 h-8 rounded-lg flex items-center justify-center",
-                "text-muted hover:text-text hover:bg-panelHi transition-colors",
-                "disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed",
-              )}
-            >
-              <Icon name="chevron-up" size={16} strokeWidth={2.5} />
-            </button>
-            <button
-              type="button"
-              onClick={() => onMove(index, 1)}
-              disabled={isLast}
-              aria-label={`Опустити ${DASHBOARD_MODULE_LABELS[id]} нижче`}
-              className={cn(
-                "w-8 h-8 rounded-lg flex items-center justify-center",
-                "text-muted hover:text-text hover:bg-panelHi transition-colors",
-                "disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed",
-              )}
-            >
-              <Icon name="chevron-down" size={16} strokeWidth={2.5} />
-            </button>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
+import { webKVStore } from "@shared/lib/storage";
+import { resetOnboardingState, type User } from "@sergeant/shared";
+import { SettingsGroup, SettingsSubGroup } from "./SettingsPrimitives";
 
 export interface GeneralSectionProps {
   syncing: boolean;
@@ -108,150 +17,10 @@ export function GeneralSection({
   onPull,
   user,
 }: GeneralSectionProps) {
-  const [orderReset, setOrderReset] = useState(false);
-  const [showHints, setShowHints] = useHubPref<boolean>("showHints", true);
-  const [density, setDensityState] = useState<DashboardDensity>(() => {
-    try {
-      return normalizeDashboardDensity(
-        localStorage.getItem(STORAGE_KEYS.DASHBOARD_DENSITY),
-      );
-    } catch {
-      return DEFAULT_DASHBOARD_DENSITY;
-    }
-  });
-  const handleDensityChange = useCallback((next: DashboardDensity) => {
-    setDensityState(next);
-    try {
-      localStorage.setItem(STORAGE_KEYS.DASHBOARD_DENSITY, next);
-    } catch {
-      /* noop */
-    }
-  }, []);
-  const [order, setOrder] = useState<ModuleId[]>(
-    () => loadDashboardOrder() as ModuleId[],
-  );
   const toast = useToast();
-  const [swBusy, setSwBusy] = useState(false);
-
-  const localStorageStore: KVStore = useMemo(
-    () => ({
-      getString(key) {
-        try {
-          return localStorage.getItem(key);
-        } catch {
-          return null;
-        }
-      },
-      setString(key, value) {
-        try {
-          localStorage.setItem(key, value);
-        } catch {
-          /* noop */
-        }
-      },
-      remove(key) {
-        try {
-          localStorage.removeItem(key);
-        } catch {
-          /* noop */
-        }
-      },
-    }),
-    [],
-  );
-  const [activeModules, setActiveModulesState] = useState<DashboardModuleId[]>(
-    () => getActiveModules(localStorageStore),
-  );
-  const [hideInactive, setHideInactiveState] = useState(() =>
-    getHideInactiveModules(localStorageStore),
-  );
-  const toggleActive = useCallback(
-    (id: DashboardModuleId) => {
-      setActiveModulesState((prev) => {
-        const isActive = prev.includes(id);
-        // Keep at least one module active so the dashboard never
-        // collapses to an empty grid.
-        if (isActive && prev.length === 1) {
-          toast.error("Щонайменше один модуль має бути активним");
-          return prev;
-        }
-        const next = isActive
-          ? prev.filter((x) => x !== id)
-          : ALL_MODULES.filter((x) => prev.includes(x) || x === id);
-        setActiveModules(localStorageStore, next);
-        return next;
-      });
-    },
-    [localStorageStore, toast],
-  );
-  const toggleHideInactive = useCallback(
-    (next: boolean) => {
-      setHideInactiveState(next);
-      setHideInactiveModules(localStorageStore, next);
-    },
-    [localStorageStore],
-  );
-
-  const handleMove = useCallback((index: number, direction: -1 | 1) => {
-    setOrder((prev) => {
-      const next = prev.slice();
-      const target = index + direction;
-      if (target < 0 || target >= next.length) return prev;
-      [next[index], next[target]] = [next[target], next[index]];
-      saveDashboardOrder(next);
-      return next;
-    });
-  }, []);
-
-  const handleResetOrder = () => {
-    resetDashboardOrder();
-    setOrder(loadDashboardOrder() as ModuleId[]);
-    setOrderReset(true);
-    setTimeout(() => setOrderReset(false), 2000);
-  };
 
   return (
     <SettingsGroup title="Загальні" emoji="⚙️">
-      <SettingsSubGroup title="Дашборд">
-        <ToggleRow
-          label="Показувати підказки"
-          description="Короткі підказки в моменті (без спаму)."
-          checked={showHints !== false}
-          onChange={setShowHints}
-        />
-      </SettingsSubGroup>
-      <SettingsSubGroup title="Щільність дашборду">
-        <p className="text-xs text-subtle leading-snug">
-          Скільки простору між картками на головному екрані.
-        </p>
-        <div className="flex gap-2">
-          {DASHBOARD_DENSITIES.map((d) => (
-            <button
-              key={d}
-              type="button"
-              onClick={() => handleDensityChange(d)}
-              className={cn(
-                "flex-1 rounded-xl border px-3 py-2.5 text-left transition-colors",
-                d === density
-                  ? "border-brand bg-brand/8 ring-1 ring-brand/30"
-                  : "border-line bg-panel hover:bg-panelHi",
-              )}
-            >
-              <span
-                className={cn(
-                  "block text-sm font-medium",
-                  d === density ? "text-brand-strong" : "text-text",
-                )}
-              >
-                {DASHBOARD_DENSITY_LABELS[d]}
-              </span>
-              <span className="block text-xs text-muted mt-0.5">
-                {DASHBOARD_DENSITY_DESCRIPTIONS[d]}
-              </span>
-            </button>
-          ))}
-        </div>
-      </SettingsSubGroup>
       <SettingsSubGroup title="Онбординг">
         <p className="text-xs text-subtle leading-snug">
           Перезапуск не видаляє твої дані — лише повертає вітальний екран та
@@ -263,7 +32,7 @@ export function GeneralSection({
           size="sm"
           className="h-10 w-full"
           onClick={() => {
-            resetOnboardingState(localStorageStore);
+            resetOnboardingState(webKVStore);
             toast.success("Онбординг перезапущено");
             try {
               window.location.assign("/welcome");
@@ -275,110 +44,12 @@ export function GeneralSection({
           Перезапустити онбординг
         </Button>
       </SettingsSubGroup>
-      <SettingsSubGroup title="PWA та офлайн">
-        <p className="text-xs text-subtle leading-snug">
-          Якщо після оновлення щось «застрягло» (стара версія або дивні дані),
-          можна скинути кеш Service Worker і перезавантажити застосунок.
-        </p>
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-10 flex-1"
-            disabled={swBusy || !("serviceWorker" in navigator)}
-            onClick={async () => {
-              setSwBusy(true);
-              try {
-                await swSetDebug(true);
-                const snap = await swGetDebugSnapshot();
-                console.log("[sw] snapshot", snap);
-                toast.success("SW-діагностика виведена в консоль");
-              } catch (err) {
-                toast.error("Не вдалося отримати діагностику SW");
-                console.warn("[sw] debug failed", err);
-              } finally {
-                setSwBusy(false);
-              }
-            }}
-          >
-            Діагностика SW
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-10 flex-1"
-            disabled={swBusy || !("serviceWorker" in navigator)}
-            onClick={async () => {
-              setSwBusy(true);
-              try {
-                const res = await swClearCaches();
-                console.log("[sw] caches cleared", res);
-                toast.success("Кеш PWA скинуто. Перезавантажуємо…", 4000);
-                setTimeout(() => window.location.reload(), 300);
-              } catch (err) {
-                toast.error("Не вдалося скинути кеш PWA");
-                console.warn("[sw] clear caches failed", err);
-              } finally {
-                setSwBusy(false);
-              }
-            }}
-          >
-            Скинути кеш PWA
-          </Button>
-        </div>
-      </SettingsSubGroup>
-      <SettingsSubGroup title="Активні модулі">
-        <p className="text-xs text-subtle leading-snug">
-          Неактивні модулі відображаються на дашборді приглушено — без кнопки
-          швидкого додавання. Чонайменше один модуль має залишатися активним.
-        </p>
-        <ul className="rounded-xl border border-line divide-y divide-line/60 overflow-hidden">
-          {ALL_MODULES.map((id) => {
-            const checked = activeModules.includes(id);
-            return (
-              <li key={id} className="px-3 py-2 bg-panel">
-                <label className="flex items-center gap-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => toggleActive(id)}
-                    className="h-4 w-4 accent-primary"
-                  />
-                  <span className="flex-1 text-sm text-text">
-                    {SHARED_DASHBOARD_MODULE_LABELS[id]}
-                  </span>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-        <ToggleRow
-          label="Приховати неактивні модулі"
-          description="Повністю ховає неактивні плитки з дашборду."
-          checked={hideInactive}
-          onChange={toggleHideInactive}
-        />
-      </SettingsSubGroup>
-      <SettingsSubGroup title="Упорядкувати модулі">
-        <p className="text-xs text-subtle leading-snug">
-          Порядок модулів у списку «Сьогодні» на дашборді.
-        </p>
-        <ModuleReorderList order={order} onMove={handleMove} />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-10 w-full"
-          onClick={handleResetOrder}
-          disabled={orderReset}
-        >
-          {orderReset ? "✓ Порядок скинуто" : "Скинути до за промовчання"}
-        </Button>
-      </SettingsSubGroup>
       {user && (
-        <SettingsSubGroup title="Хмарна синхронізація">
+        <SettingsSubGroup title="Хмарна синхронізація" defaultOpen>
+          <p className="text-xs text-subtle leading-snug">
+            Основний спосіб зберегти дані — синхронізація з твоїм акаунтом.
+            Покриває Фінік, Фізрук, Рутину та Харчування.
+          </p>
           <div className="flex gap-2">
             <Button
               type="button"
@@ -403,9 +74,6 @@ export function GeneralSection({
           </div>
         </SettingsSubGroup>
       )}
-      <SettingsSubGroup title="Резервна копія Hub" defaultOpen>
-        <HubBackupPanel className="" />
-      </SettingsSubGroup>
     </SettingsGroup>
   );
 }

--- a/apps/web/src/core/settings/PWASection.tsx
+++ b/apps/web/src/core/settings/PWASection.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Button } from "@shared/components/ui/Button";
+import { useToast } from "@shared/hooks/useToast";
+import {
+  swClearCaches,
+  swGetDebugSnapshot,
+  swSetDebug,
+} from "../app/swControl";
+import { SettingsGroup } from "./SettingsPrimitives";
+
+export function PWASection() {
+  const toast = useToast();
+  const [swBusy, setSwBusy] = useState(false);
+
+  return (
+    <SettingsGroup title="PWA та офлайн" emoji="📡">
+      <p className="text-xs text-subtle leading-snug">
+        Якщо після оновлення щось «застрягло» (стара версія або дивні дані),
+        можна скинути кеш Service Worker і перезавантажити застосунок.
+      </p>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-10 flex-1"
+          disabled={swBusy || !("serviceWorker" in navigator)}
+          onClick={async () => {
+            setSwBusy(true);
+            try {
+              await swSetDebug(true);
+              const snap = await swGetDebugSnapshot();
+              console.log("[sw] snapshot", snap);
+              toast.success("SW-діагностика виведена в консоль");
+            } catch (err) {
+              toast.error("Не вдалося отримати діагностику SW");
+              console.warn("[sw] debug failed", err);
+            } finally {
+              setSwBusy(false);
+            }
+          }}
+        >
+          Діагностика SW
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-10 flex-1"
+          disabled={swBusy || !("serviceWorker" in navigator)}
+          onClick={async () => {
+            setSwBusy(true);
+            try {
+              const res = await swClearCaches();
+              console.log("[sw] caches cleared", res);
+              toast.success("Кеш PWA скинуто. Перезавантажуємо…", 4000);
+              setTimeout(() => window.location.reload(), 300);
+            } catch (err) {
+              toast.error("Не вдалося скинути кеш PWA");
+              console.warn("[sw] clear caches failed", err);
+            } finally {
+              setSwBusy(false);
+            }
+          }}
+        >
+          Скинути кеш PWA
+        </Button>
+      </div>
+    </SettingsGroup>
+  );
+}


### PR DESCRIPTION
## What changed

Перегрупував `HubSettingsPage` так, щоб усе, що стосується дашборду, жило в одній згортній групі, а технічне/портабельне сховище переїхало у вкладку «Додатково».

**Нова структура (вкладка «Загальні»):**

- **Дашборд** (нова `DashboardSection`) — одна группа з двома підгрупами:
  - _Вигляд_ — «Показувати підказки» + щільність дашборду.
  - _Модулі дашборду_ — активні модулі + «Приховати неактивні» + порядок модулів + «Скинути порядок».
- **Загальні** (стиснута `GeneralSection`) — лише Онбординг + Хмарна синхронізація.
- Нагадування / AI-дайджести / Можливості асистента — без змін.

**Нова структура (вкладка «Додатково»):**

- **PWA та офлайн** — нова `PWASection` (Діагностика SW / Скинути кеш PWA), переїхала з «Загальні».
- **Експорт/імпорт JSON** — нова `DataExportSection`, обгортає існуючу `HubBackupPanel`. Перейменовано з «Резервна копія Hub», додано пояснення, що це для випадків без логіну / переносу між акаунтами.
- **Експериментальні** — без змін.

Також почистив `GeneralSection`/`DashboardSection`: замість локального інлайн-`KVStore` та сирих `localStorage.*` тепер `webKVStore` + `safeReadStringLS` / `safeWriteLS` з `@shared/lib/storage` (рекомендований шлях за `sergeant-design/no-raw-local-storage`).

## Why

У вкладці «Загальні» було 8 однорівневих сабгруп — дашбордових налаштувань (підказки, щільність, активні модулі, порядок) було чотири, і вони губилися серед онбордингу, PWA та хмари. Користувач (@Skords-01) попросив зібрати все «дашбордове» в один пункт із підпунктами.

По JSON-бекапу: покриття `hubBackup` ≈ покриттю `cloudSync` (finyk + fizruk + routine + nutrition), але JSON працює без логіну, офлайн і дозволяє перенос між акаунтами — лишаю його як запасний шлях, але прибираю з основної вкладки в «Додатково» і перейменовую, щоб не конкурував з хмарою візуально.

## How to test

1. `pnpm dev:web`, відкрити `/hub` → Налаштування.
2. Вкладка «Загальні»:
   - Перша картка — «Дашборд». Розгорнути → видно підгрупи «Вигляд» та «Модулі дашборду».
   - У «Вигляді» працює тогл «Показувати підказки» і вибір щільності (зберігається в `localStorage` через `safeWriteLS`).
   - У «Модулях дашборду» працюють чекбокси активних модулів, «Приховати неактивні», стрілки порядку, кнопка «Скинути».
   - Картка «Загальні» нижче містить лише Онбординг + Хмарна синхронізація (для залогінених).
3. Вкладка «Додатково»:
   - «PWA та офлайн» — кнопки «Діагностика SW» / «Скинути кеш PWA».
   - «Експорт/імпорт JSON» — кнопки «Експорт JSON» / «Імпорт…» працюють як раніше.
4. Пошук: ввести «упорядкувати» → знаходить «Дашборд». Ввести «JSON» → знаходить «Експорт/імпорт JSON». Ввести «PWA» → знаходить «PWA та офлайн».

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): не тестував у браузері — суто реструктуризація з перевіркою lint/typecheck/тестів. Реальна логіка зберігання/читання залишилася ідентичною (ті самі STORAGE_KEYS, ті самі helpers зі `@sergeant/shared`).
- [x] Vitest passes: `pnpm --filter @sergeant/web test` — 125 файлів / 1383 тестів зелені.
- [x] `pnpm --filter @sergeant/web lint` зелений; `pnpm --filter @sergeant/web exec tsc --noEmit` зелений.
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [ ] Yes — link to changed line(s)
- [x] No — no new permanent rules

Link to Devin session: https://app.devin.ai/sessions/38797477ed0943e894a21c1b6437c18a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouped all dashboard settings into one collapsible section and moved PWA tools and JSON backup to Advanced to simplify the General tab. Switched settings persistence to shared storage helpers for safer, consistent behavior.

- New Features
  - Added DashboardSection with two subgroups: Appearance (hints, density) and Dashboard modules (enable/disable, hide inactive, reorder, reset).
  - GeneralSection now only includes Onboarding and Cloud Sync (for signed-in users).
  - Added PWASection under Advanced with Service Worker diagnostics and “Clear PWA cache”.
  - Added DataExportSection under Advanced, wrapping the existing backup UI; renamed to “Експорт/імпорт JSON” with clearer guidance.
  - Updated search keywords so queries like “упорядкувати”, “JSON”, “PWA” find the right sections.

- Refactors
  - Replaced inline KV/localStorage usage with `webKVStore` and `safeReadStringLS`/`safeWriteLS` from `@shared/lib/storage` and aligned settings code with `@sergeant/shared` helpers.

<sup>Written for commit 44f818796a696df2ce06a6ee8019814f53d110d5. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

