### PR TITLE
feat(web): compact HubChat header, module accent plumbing, shape-aware skeletons

### DIFF
--- a/apps/web/src/core/hub/HubChat.tsx
+++ b/apps/web/src/core/hub/HubChat.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ApiError, chatApi, isApiError } from "@shared/api";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { Popover } from "@shared/components/ui/Popover";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import { perfMark, perfEnd } from "@shared/lib/perf";
 import { useOnlineStatus } from "@shared/hooks/useOnlineStatus";
@@ -646,14 +647,34 @@ function HubChat({
           <div className="w-10 h-1 bg-line rounded-full" />
         </div>
 
-        {/* Header */}
-        <div className="flex items-start justify-between gap-3 px-4 pb-3 shrink-0 border-b border-line">
-          <div className="flex items-start gap-3 min-w-0">
+        {/* Header — compact: avatar + title + 1-line subtitle.
+            Context status, history counters, and the privacy
+            disclaimer collapse into the "Деталі" popover so the header
+            stays single-row on narrow phones. */}
+        <div className="flex items-center justify-between gap-3 px-4 pb-3 shrink-0 border-b border-line">
+          <div className="flex items-center gap-3 min-w-0">
             <div
-              className="w-9 h-9 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0 mt-0.5"
+              className={cn(
+                "relative w-10 h-10 rounded-xl bg-brand-500/10 flex items-center justify-center shrink-0",
+                contextState.status === "building" &&
+                  "motion-safe:animate-pulse",
+              )}
               aria-hidden
             >
               <Icon name="sparkle" size={18} className="text-brand-500" />
+              {/* Context-status dot anchored on the avatar — replaces the
+                  full pill that used to live below the title. */}
+              <span
+                className={cn(
+                  "absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-bg",
+                  contextState.status === "ready"
+                    ? "bg-brand-500"
+                    : contextState.status === "building"
+                      ? "bg-warning"
+                      : "bg-line",
+                )}
+                aria-hidden
+              />
             </div>
             <div className="min-w-0">
               <div
@@ -664,7 +685,7 @@ function HubChat({
               </div>
               <div
                 className={cn(
-                  "text-2xs leading-snug mt-0.5",
+                  "text-2xs leading-snug truncate",
                   hasData ? "text-subtle" : "text-warning",
                 )}
               >
@@ -672,69 +693,87 @@ function HubChat({
                   ? "Фінік · Фізрук · Рутина · Харчування"
                   : "Mono не підключено"}
               </div>
-              <div className="inline-flex items-center gap-1.5 text-2xs text-subtle mt-1.5 px-2 py-0.5 rounded-full bg-panelHi/60 border border-line/60">
-                <span
-                  className={cn(
-                    "inline-block w-1.5 h-1.5 rounded-full",
-                    contextState.status === "ready"
-                      ? "bg-brand-500"
-                      : contextState.status === "building"
-                        ? "bg-warning motion-safe:animate-pulse"
-                        : "bg-line",
-                  )}
-                />
-                <span>
-                  {contextState.status === "building"
-                    ? "Готую контекст…"
-                    : contextState.status === "ready"
-                      ? "Контекст готовий"
-                      : "Очікую"}
-                </span>
-                <span className="text-line" aria-hidden>
-                  ·
-                </span>
-                <span>
-                  {sessionInfo.historyCount}/10 · ~
-                  {Math.round(sessionInfo.chars / 100) / 10}k
-                </span>
-              </div>
-              <p
-                id="hub-chat-privacy"
-                className="text-2xs text-muted/70 mt-1.5 leading-snug max-w-[min(100%,280px)]"
-              >
-                Контекст (фінанси, тренування, звички, харчування)
-                відправляється до AI.
-              </p>
             </div>
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
+            <Popover
+              placement="bottom-end"
+              className="!min-w-[260px] p-3"
+              trigger={
+                <Tooltip content="Деталі контексту" placement="bottom-center">
+                  <button
+                    type="button"
+                    className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+                    aria-label="Деталі контексту"
+                  >
+                    <Icon name="info" size={16} />
+                  </button>
+                </Tooltip>
+              }
+            >
+              <div
+                role="status"
+                className="space-y-2 text-left"
+                id="hub-chat-privacy"
+              >
+                <div className="flex items-center gap-2 text-xs text-text">
+                  <span
+                    className={cn(
+                      "inline-block w-2 h-2 rounded-full",
+                      contextState.status === "ready"
+                        ? "bg-brand-500"
+                        : contextState.status === "building"
+                          ? "bg-warning motion-safe:animate-pulse"
+                          : "bg-line",
+                    )}
+                    aria-hidden
+                  />
+                  <span className="font-semibold">
+                    {contextState.status === "building"
+                      ? "Готую контекст…"
+                      : contextState.status === "ready"
+                        ? "Контекст готовий"
+                        : "Очікую"}
+                  </span>
+                </div>
+                <p className="text-2xs text-subtle leading-snug">
+                  В контексті: {sessionInfo.historyCount} з останніх 10
+                  повідомлень · ~{Math.round(sessionInfo.chars / 100) / 10}k
+                  символів.
+                </p>
+                <p className="text-2xs text-muted leading-snug">
+                  Контекст (фінанси, тренування, звички, харчування)
+                  відправляється до AI.
+                </p>
+              </div>
+            </Popover>
             <Tooltip content="Усі бесіди" placement="bottom-center">
               <button
                 type="button"
                 onClick={() => setHistoryOpen(true)}
-                className="h-8 w-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+                className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
                 aria-label={`Відкрити список бесід (${sessions.length})`}
                 aria-haspopup="dialog"
                 aria-expanded={historyOpen}
               >
-                <Icon name="list" size={14} />
+                <Icon name="list" size={15} />
               </button>
             </Tooltip>
             <Tooltip content="Почати нову бесіду" placement="bottom-center">
               <button
                 type="button"
                 onClick={clearChat}
-                className="h-8 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
+                className="h-9 px-2.5 flex items-center gap-1.5 rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors text-2xs font-semibold"
                 aria-label="Нова бесіда"
               >
-                <Icon name="plus" size={13} />
+                <Icon name="plus" size={14} />
                 Нова
               </button>
             </Tooltip>
             <button
               type="button"
               onClick={onClose}
-              className="w-8 h-8 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
+              className="w-9 h-9 flex items-center justify-center rounded-xl text-muted hover:text-text hover:bg-panelHi transition-colors"
               aria-label="Закрити асистента"
             >
               <Icon name="close" size={16} />

--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -6,6 +6,7 @@ import { readRaw, writeRaw } from "./lib/finykStorage";
 import { FINYK_MANUAL_ONLY_KEY, enableFinykManualOnly } from "./lib/demoData";
 import { ModuleBottomNav } from "@shared/components/ui/ModuleBottomNav";
 import {
+  ModuleAccentProvider,
   ModuleHeader,
   ModuleHeaderBackButton,
 } from "@shared/components/layout";
@@ -244,7 +245,7 @@ export default function App({
 
   // ── Main app ──────────────────────────────────────────────────────────
   return (
-    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
+    <ModuleAccentProvider module="finyk" asShellRoot>
       <ModuleHeader
         module="finyk"
         left={
@@ -497,6 +498,6 @@ export default function App({
         onChange={navigate}
         module="finyk"
       />
-    </div>
+    </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/modules/fizruk/FizrukApp.tsx
+++ b/apps/web/src/modules/fizruk/FizrukApp.tsx
@@ -71,6 +71,7 @@ export default function FizrukApp({
 
   return (
     <ModuleShell
+      module="fizruk"
       header={
         <FizrukHeader
           page={page}

--- a/apps/web/src/modules/nutrition/NutritionApp.tsx
+++ b/apps/web/src/modules/nutrition/NutritionApp.tsx
@@ -13,6 +13,7 @@ import { LogCard } from "./components/LogCard";
 import { NutritionPantrySelector } from "./components/NutritionPantrySelector";
 import { NutritionOverlays } from "./components/NutritionOverlays";
 import { Banner } from "@shared/components/ui/Banner";
+import { ModuleAccentProvider } from "@shared/components/layout";
 import { Icon } from "@shared/components/ui/Icon";
 import {
   loadNutritionPrefs,
@@ -351,7 +352,7 @@ export default function NutritionApp({
     .join(" ");
 
   return (
-    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
+    <ModuleAccentProvider module="nutrition" asShellRoot>
       <NutritionHeader busy={busy} onBackToHub={onBackToHub} />
 
       <div className="flex-1 overflow-y-auto">
@@ -603,6 +604,6 @@ export default function NutritionApp({
         applyRestorePayload={applyRestorePayload}
         onRequestMealPhoto={handleRequestMealPhoto}
       />
-    </div>
+    </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/modules/routine/RoutineApp.tsx
+++ b/apps/web/src/modules/routine/RoutineApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Banner } from "@shared/components/ui/Banner";
 import {
+  ModuleAccentProvider,
   ModuleHeader,
   ModuleHeaderBackButton,
 } from "@shared/components/layout";
@@ -503,7 +504,7 @@ export default function RoutineApp({
   const listIsEmpty = grouped.length === 0;
 
   return (
-    <div className="h-dvh flex flex-col bg-bg text-text overflow-hidden">
+    <ModuleAccentProvider module="routine" asShellRoot>
       <ModuleHeader
         module="routine"
         left={
@@ -692,6 +693,6 @@ export default function RoutineApp({
         onClose={() => setQuickAddHabitOpen(false)}
         focusTick={quickAddFocusTick}
       />
-    </div>
+    </ModuleAccentProvider>
   );
 }

--- a/apps/web/src/shared/components/layout/ModuleAccentProvider.tsx
+++ b/apps/web/src/shared/components/layout/ModuleAccentProvider.tsx
@@ -1,0 +1,100 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
+import { cn } from "@shared/lib/cn";
+
+/**
+ * Sergeant Design System — Module accent provider.
+ *
+ * Carries the active module's brand color through the React tree so deep
+ * components (CTAs, FABs, page hero gradients, status pills) can stay in
+ * sync with the host module's palette without each component re-deriving
+ * the accent from props.
+ *
+ * Two ways to consume:
+ *
+ * 1. **CSS variable** — `--module-accent-rgb` is written on the wrapper
+ *    `<div>`. Use it directly in Tailwind arbitrary values:
+ *
+ *        className="bg-[rgb(var(--module-accent-rgb))]"
+ *        className="border-[rgb(var(--module-accent-rgb)/0.4)]"
+ *
+ *    This works everywhere inside the provider, including portaled
+ *    overlays that re-mount inside the same DOM subtree.
+ *
+ * 2. **React hook** — `useModuleAccent()` returns the active accent
+ *    (`"finyk" | "fizruk" | "routine" | "nutrition" | null`). Useful
+ *    when a child needs to switch on the module token (e.g. picking a
+ *    Tailwind utility class like `text-finyk` vs `text-fizruk`).
+ *
+ * The accent is intentionally `null` outside of a provider. Hub-level
+ * chrome (header, dashboard, hub-chat) is module-agnostic and should
+ * keep using `bg-brand-*` tokens directly.
+ */
+
+const MODULE_ACCENT_RGB: Record<ModuleAccent, string> = {
+  finyk: "16 185 129", // emerald-500
+  fizruk: "20 184 166", // teal-500
+  routine: "249 112 102", // coral-500
+  nutrition: "132 204 22", // lime-500
+};
+
+const ModuleAccentContext = createContext<ModuleAccent | null>(null);
+
+export interface ModuleAccentProviderProps {
+  module: ModuleAccent;
+  children: ReactNode;
+  /** When true, render as a flex column container that fills the viewport.
+   *  Convenience for module roots that don't already use ModuleShell. */
+  asShellRoot?: boolean;
+  className?: string;
+}
+
+export function ModuleAccentProvider({
+  module,
+  children,
+  asShellRoot = false,
+  className,
+}: ModuleAccentProviderProps) {
+  const style = useMemo<CSSProperties>(
+    () =>
+      ({
+        "--module-accent-rgb": MODULE_ACCENT_RGB[module],
+      }) as CSSProperties,
+    [module],
+  );
+
+  return (
+    <ModuleAccentContext.Provider value={module}>
+      <div
+        data-module-accent={module}
+        style={style}
+        className={cn(
+          asShellRoot && "h-dvh flex flex-col bg-bg text-text overflow-hidden",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </ModuleAccentContext.Provider>
+  );
+}
+
+/**
+ * Read the currently-active module accent. Returns `null` outside of a
+ * `ModuleAccentProvider` (or `ModuleShell` with a `module` prop).
+ */
+export function useModuleAccent(): ModuleAccent | null {
+  return useContext(ModuleAccentContext);
+}
+
+/**
+ * Internal re-export so ModuleShell can wire up the same context without
+ * a circular import.
+ */
+export { ModuleAccentContext };

--- a/apps/web/src/shared/components/layout/ModuleHeader.tsx
+++ b/apps/web/src/shared/components/layout/ModuleHeader.tsx
@@ -37,27 +37,43 @@ export interface ModuleHeaderProps {
 
 const MODULE_HEADER_TOKENS: Record<
   ModuleAccent,
-  { gradient: string; border: string; subtitle: string }
+  {
+    gradient: string;
+    border: string;
+    subtitle: string;
+    /** Title accent — applied as a left accent dot for module identity. */
+    accentDot: string;
+    /** Saturated accent strip below the header. */
+    accentStrip: string;
+  }
 > = {
   finyk: {
     gradient: "from-finyk/[.06]",
     border: "border-finyk/[.14]",
     subtitle: "text-finyk-strong dark:text-finyk/70",
+    accentDot: "bg-finyk",
+    accentStrip: "bg-finyk/45",
   },
   fizruk: {
     gradient: "from-fizruk/[.06]",
     border: "border-fizruk/[.14]",
     subtitle: "text-fizruk-strong dark:text-fizruk/70",
+    accentDot: "bg-fizruk",
+    accentStrip: "bg-fizruk/45",
   },
   routine: {
     gradient: "from-routine/[.06]",
     border: "border-routine/[.14]",
     subtitle: "text-routine-strong dark:text-routine/70",
+    accentDot: "bg-routine",
+    accentStrip: "bg-routine/45",
   },
   nutrition: {
     gradient: "from-nutrition/[.06]",
     border: "border-nutrition/[.14]",
     subtitle: "text-nutrition-strong dark:text-nutrition/70",
+    accentDot: "bg-nutrition",
+    accentStrip: "bg-nutrition/45",
   },
 };
 
@@ -100,8 +116,17 @@ export function ModuleHeader({
                 </span>
               ) : null}
               {title ? (
-                <span className="text-[16px] font-semibold tracking-wide text-text block leading-tight">
-                  {title}
+                <span className="text-[16px] font-semibold tracking-wide text-text leading-tight flex items-center gap-2">
+                  {mt ? (
+                    <span
+                      aria-hidden
+                      className={cn(
+                        "inline-block w-1.5 h-1.5 rounded-full shrink-0",
+                        mt.accentDot,
+                      )}
+                    />
+                  ) : null}
+                  <span className="truncate">{title}</span>
                 </span>
               ) : null}
               {subtitle ? (
@@ -119,6 +144,18 @@ export function ModuleHeader({
         </div>
         {right}
       </div>
+      {/* Saturated accent strip — pinned to the bottom edge so module
+          identity stays visible even when the header gradient is muted
+          (e.g. dark mode, contextual sub-page overrides). */}
+      {mt ? (
+        <span
+          aria-hidden
+          className={cn(
+            "absolute left-0 right-0 -bottom-px h-px",
+            mt.accentStrip,
+          )}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/shared/components/layout/ModuleShell.tsx
+++ b/apps/web/src/shared/components/layout/ModuleShell.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
+import { ModuleAccentProvider } from "./ModuleAccentProvider";
 
 /**
  * Module shell skeleton used by Фінік / Фізрук / Рутина / Харчування.
@@ -9,7 +11,15 @@ import { cn } from "@shared/lib/cn";
  * module-specific bits (header, banner, bottom nav, overlays) composable
  * without forcing each module to re-declare the layout.
  *
+ * Pass `module` to publish the module's accent color on
+ * `--module-accent-rgb` and the `useModuleAccent()` context. Child
+ * components can then opt in to module-tinted backgrounds, borders,
+ * and CTAs via Tailwind arbitrary values:
+ *
+ *     className="bg-[rgb(var(--module-accent-rgb)/0.08)]"
+ *
  *     <ModuleShell
+ *       module="fizruk"
  *       header={<ModuleHeader … />}
  *       banner={<StorageErrorBanner eventName={…} />}
  *       nav={<ModuleBottomNav … />}
@@ -21,6 +31,9 @@ import { cn } from "@shared/lib/cn";
  */
 
 export interface ModuleShellProps {
+  /** Module accent — exposes `--module-accent-rgb` and the
+   *  `useModuleAccent()` context for descendants. */
+  module?: ModuleAccent;
   header?: ReactNode;
   banner?: ReactNode;
   nav?: ReactNode;
@@ -32,6 +45,7 @@ export interface ModuleShellProps {
 }
 
 export function ModuleShell({
+  module,
   header,
   banner,
   nav,
@@ -48,7 +62,7 @@ export function ModuleShell({
     "--bottom-nav-height": nav ? "60px" : "0px",
   } as CSSProperties;
 
-  return (
+  const inner = (
     <div
       style={shellStyle}
       className={cn(
@@ -67,4 +81,18 @@ export function ModuleShell({
       {nav}
     </div>
   );
+
+  if (module) {
+    // The provider only needs to publish the CSS var + context — the
+    // shell itself already owns the viewport sizing, so we render a
+    // pass-through wrapper rather than asking the provider to also
+    // size the box.
+    return (
+      <ModuleAccentProvider module={module} className="contents">
+        {inner}
+      </ModuleAccentProvider>
+    );
+  }
+
+  return inner;
 }

--- a/apps/web/src/shared/components/layout/index.ts
+++ b/apps/web/src/shared/components/layout/index.ts
@@ -9,6 +9,9 @@
 export { ModuleShell } from "./ModuleShell";
 export type { ModuleShellProps } from "./ModuleShell";
 
+export { ModuleAccentProvider, useModuleAccent } from "./ModuleAccentProvider";
+export type { ModuleAccentProviderProps } from "./ModuleAccentProvider";
+
 export {
   ModuleHeader,
   ModuleHeaderBackButton,

--- a/apps/web/src/shared/components/ui/EmptyState.tsx
+++ b/apps/web/src/shared/components/ui/EmptyState.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "./Icon";
 import { Button } from "./Button";
@@ -16,7 +17,33 @@ export interface EmptyStateProps {
   hint?: string;
   /** Optional example data preview */
   examplePreview?: ReactNode;
+  /** When set, the leading icon container and hint icon are tinted with
+   *  the module accent so the empty state visually belongs to its host
+   *  module instead of the neutral grey default. */
+  module?: ModuleAccent;
 }
+
+const MODULE_ICON_TINT: Record<
+  ModuleAccent,
+  { container: string; icon: string }
+> = {
+  finyk: {
+    container: "bg-finyk/10 border-finyk/20 text-finyk",
+    icon: "text-finyk/70",
+  },
+  fizruk: {
+    container: "bg-fizruk/10 border-fizruk/20 text-fizruk",
+    icon: "text-fizruk/70",
+  },
+  routine: {
+    container: "bg-routine/10 border-routine/20 text-routine",
+    icon: "text-routine/70",
+  },
+  nutrition: {
+    container: "bg-nutrition/10 border-nutrition/20 text-nutrition",
+    icon: "text-nutrition/70",
+  },
+};
 
 export function EmptyState({
   icon,
@@ -28,7 +55,9 @@ export function EmptyState({
   disableAnimation = false,
   hint,
   examplePreview,
+  module,
 }: EmptyStateProps) {
+  const accent = module ? MODULE_ICON_TINT[module] : null;
   return (
     <div
       className={cn(
@@ -43,7 +72,8 @@ export function EmptyState({
       {icon && (
         <div
           className={cn(
-            "flex items-center justify-center rounded-2xl bg-panelHi border border-line text-subtle",
+            "flex items-center justify-center rounded-2xl border",
+            accent ? accent.container : "bg-panelHi border-line text-subtle",
             compact ? "w-10 h-10" : "w-14 h-14",
             // Staggered icon animation
             !disableAnimation &&
@@ -106,7 +136,11 @@ export function EmptyState({
               "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-300 motion-safe:delay-200",
           )}
         >
-          <Icon name="lightbulb" size={12} className="text-brand-500/70" />
+          <Icon
+            name="lightbulb"
+            size={12}
+            className={cn(accent ? accent.icon : "text-brand-500/70")}
+          />
           {hint}
         </p>
       )}

--- a/apps/web/src/shared/components/ui/Icon.tsx
+++ b/apps/web/src/shared/components/ui/Icon.tsx
@@ -232,6 +232,13 @@ const PATHS: Record<string, ReactNode> = {
       <line x1="12" y1="16" x2="12.01" y2="16" />
     </>
   ),
+  info: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="16" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12.01" y2="8" />
+    </>
+  ),
   archive: (
     <>
       <polyline points="21 8 21 21 3 21 3 8" />

--- a/apps/web/src/shared/components/ui/Skeleton.tsx
+++ b/apps/web/src/shared/components/ui/Skeleton.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 
 import { cn } from "../../lib/cn";
 
@@ -65,27 +66,213 @@ export function SkeletonText({
   );
 }
 
+// ── Shape-aware skeletons ────────────────────────────────────────────────
+// Per-domain placeholders that mirror the layout of the real components,
+// so the transition from skeleton → real content reflows minimally and
+// users get a stronger "perceived performance" cue (the page already
+// looks like the right shape, content just fills in).
+
+interface ShapeAwareSkeletonProps extends SkeletonProps {
+  /** Optional module accent — tints the leading icon/avatar with the
+   *  module color so loaders feel "at home" inside their module. */
+  module?: ModuleAccent;
+}
+
+const MODULE_ACCENT_TINT: Record<ModuleAccent, string> = {
+  finyk: "bg-finyk/10",
+  fizruk: "bg-fizruk/10",
+  routine: "bg-routine/10",
+  nutrition: "bg-nutrition/10",
+};
+
 /**
- * Pre-composed skeleton for module cards (HubDashboard, StatusRow).
- * Matches the visual structure of real cards for seamless loading states.
+ * SkeletonTransactionRow — placeholder for a Finyk transaction row.
+ * Layout: icon · description (2 lines) · amount on the right.
  */
-export function SkeletonCard({ className, shimmer = false }: SkeletonProps) {
+export function SkeletonTransactionRow({
+  className,
+  shimmer = false,
+  module,
+  style,
+}: ShapeAwareSkeletonProps) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-line bg-panel p-4 space-y-3",
+        "flex items-center gap-3 px-3 py-2.5 rounded-2xl border border-line bg-panel",
+        className,
+      )}
+      style={style}
+      aria-hidden="true"
+    >
+      <div
+        className={cn(
+          "w-10 h-10 rounded-xl shrink-0",
+          shimmer ? "relative overflow-hidden" : "motion-safe:animate-pulse",
+          module ? MODULE_ACCENT_TINT[module] : "bg-panelHi",
+        )}
+      >
+        {shimmer && (
+          <div
+            className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <SkeletonText shimmer={shimmer} className="w-2/3" />
+        <SkeletonText shimmer={shimmer} className="w-1/3 h-2" />
+      </div>
+      <SkeletonText shimmer={shimmer} className="w-16 h-3.5" />
+    </div>
+  );
+}
+
+/**
+ * SkeletonBudgetBar — placeholder for a Finyk budget card with progress
+ * meter underneath.
+ */
+export function SkeletonBudgetBar({
+  className,
+  shimmer = false,
+  module = "finyk",
+}: ShapeAwareSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-line bg-panel p-3.5 space-y-2.5",
         className,
       )}
       aria-hidden="true"
     >
-      <div className="flex items-center gap-3">
-        <Skeleton shimmer={shimmer} className="w-11 h-11 rounded-xl" />
-        <div className="flex-1 space-y-2">
-          <SkeletonText shimmer={shimmer} className="w-24" />
-          <SkeletonText shimmer={shimmer} className="w-32" />
+      <div className="flex items-center justify-between gap-3">
+        <SkeletonText shimmer={shimmer} className="w-24" />
+        <SkeletonText shimmer={shimmer} className="w-16 h-2.5" />
+      </div>
+      {/* Progress track */}
+      <div className="relative h-2 rounded-full overflow-hidden bg-panelHi">
+        <div
+          className={cn(
+            "absolute inset-y-0 left-0 w-2/5 rounded-full",
+            shimmer ? "relative overflow-hidden" : "motion-safe:animate-pulse",
+            module ? MODULE_ACCENT_TINT[module] : "bg-panelHi",
+          )}
+        >
+          {shimmer && (
+            <div
+              className="absolute inset-0 -translate-x-full motion-safe:animate-shimmer bg-gradient-to-r from-transparent via-white/15 to-transparent"
+              aria-hidden="true"
+            />
+          )}
         </div>
       </div>
-      <SkeletonText shimmer={shimmer} className="w-full" />
+      <div className="flex items-center justify-between gap-3">
+        <SkeletonText shimmer={shimmer} className="w-20 h-2" />
+        <SkeletonText shimmer={shimmer} className="w-12 h-2" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SkeletonHabitRow — placeholder for a Routine habit row with a leading
+ * checkbox-like square, label/streak text, and a trailing chip.
+ */
+export function SkeletonHabitRow({
+  className,
+  shimmer = false,
+  module = "routine",
+  style,
+}: ShapeAwareSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-3 py-2.5 rounded-2xl border border-line bg-panel",
+        className,
+      )}
+      style={style}
+      aria-hidden="true"
+    >
+      <Skeleton
+        shimmer={shimmer}
+        className={cn(
+          "w-7 h-7 rounded-lg shrink-0",
+          module ? MODULE_ACCENT_TINT[module] : "bg-panelHi",
+        )}
+      />
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <SkeletonText shimmer={shimmer} className="w-1/2" />
+        <SkeletonText shimmer={shimmer} className="w-1/4 h-2" />
+      </div>
+      <Skeleton shimmer={shimmer} className="w-10 h-5 rounded-full" />
+    </div>
+  );
+}
+
+/**
+ * SkeletonWorkoutSet — placeholder for a Fizruk set row in an exercise log.
+ * Three pill columns (weight × reps × RPE) plus a leading set-number badge.
+ */
+export function SkeletonWorkoutSet({
+  className,
+  shimmer = false,
+  module = "fizruk",
+  style,
+}: ShapeAwareSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 rounded-xl border border-line bg-panel",
+        className,
+      )}
+      style={style}
+      aria-hidden="true"
+    >
+      <Skeleton
+        shimmer={shimmer}
+        className={cn(
+          "w-7 h-7 rounded-lg shrink-0",
+          module ? MODULE_ACCENT_TINT[module] : "bg-panelHi",
+        )}
+      />
+      <Skeleton shimmer={shimmer} className="flex-1 h-7 rounded-lg" />
+      <Skeleton shimmer={shimmer} className="flex-1 h-7 rounded-lg" />
+      <Skeleton shimmer={shimmer} className="flex-1 h-7 rounded-lg" />
+    </div>
+  );
+}
+
+/**
+ * SkeletonMealCard — placeholder for a Nutrition meal entry: thumbnail
+ * tile + name + macro chips row.
+ */
+export function SkeletonMealCard({
+  className,
+  shimmer = false,
+  module = "nutrition",
+}: ShapeAwareSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 p-3 rounded-2xl border border-line bg-panel",
+        className,
+      )}
+      aria-hidden="true"
+    >
+      <Skeleton
+        shimmer={shimmer}
+        className={cn(
+          "w-14 h-14 rounded-xl shrink-0",
+          module ? MODULE_ACCENT_TINT[module] : "bg-panelHi",
+        )}
+      />
+      <div className="flex-1 min-w-0 space-y-2">
+        <SkeletonText shimmer={shimmer} className="w-3/5" />
+        <div className="flex items-center gap-1.5">
+          <Skeleton shimmer={shimmer} className="w-12 h-4 rounded-full" />
+          <Skeleton shimmer={shimmer} className="w-12 h-4 rounded-full" />
+          <Skeleton shimmer={shimmer} className="w-12 h-4 rounded-full" />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/shared/components/ui/index.ts
+++ b/apps/web/src/shared/components/ui/index.ts
@@ -127,7 +127,15 @@ export type {
   ProgressRingVariant,
 } from "./ProgressRing";
 
-export { Skeleton, SkeletonText } from "./Skeleton";
+export {
+  Skeleton,
+  SkeletonText,
+  SkeletonTransactionRow,
+  SkeletonBudgetBar,
+  SkeletonHabitRow,
+  SkeletonWorkoutSet,
+  SkeletonMealCard,
+} from "./Skeleton";
 export type { SkeletonProps } from "./Skeleton";
 
 export { SkeletonCard, SkeletonList } from "./SkeletonCard";


### PR DESCRIPTION
## What changed

Три UI-покращення з топ-5, які ти обрав (UI #3, #4, #5).

**UI #3 — `HubChat` header спрощено.**
Раніше хедер забирав 5 інфо-рядків ще до першого повідомлення (тайл-аватар, заголовок, статус-рядок, контекст-pill `0/10 · ~0k`, privacy-параграф). Тепер це **1 ряд**: аватар з кутовим dot-індикатором стану контексту → заголовок → одно-лінійний статус-рядок («Фінік · Фізрук · Рутина · Харчування» або «Mono не підключено»). Контекст-pill з лічильниками й privacy-disclaimer згорнуті в `Деталі контексту` popover за іконкою info.

**UI #4 — Module accent прокинуто через shell/header.**
- Новий `ModuleAccentProvider` публікує CSS-змінну `--module-accent-rgb` і React-контекст `useModuleAccent()`. Глибокі компоненти можуть тінтуватися Tailwind-arbitrary-value: `bg-[rgb(var(--module-accent-rgb)/0.08)]`.
- `ModuleShell` тепер приймає `module?: ModuleAccent` — якщо переданий, обгортає вміст у провайдер автоматично. Fizruk одразу скористався.
- Finyk / Routine / Nutrition (мають власні shell-роути, не через `ModuleShell`) обгорнуті в `<ModuleAccentProvider module="…" asShellRoot>`.
- `ModuleHeader` отримав `accentDot` (маленький круг кольору модуля перед h1) і `accentStrip` (1px стрічка кольору модуля піксель нижче border-b) — ідентичність модуля видно навіть у dark mode і на sub-pages де gradient прихований.

**UI #5 — Shape-aware skeletons + module-themed empty-state.**
- `SkeletonTransactionRow`, `SkeletonBudgetBar`, `SkeletonHabitRow`, `SkeletonWorkoutSet`, `SkeletonMealCard` — placeholder-форми, що повторюють реальну структуру кожного домену. Стрибків layout при transition skeleton → real немає.
- Кожен приймає `module?: ModuleAccent` — leading icon/avatar тінтується кольором модуля (`bg-finyk/10` etc.). Дефолти за доменом: budget→finyk, habit→routine, set→fizruk, meal→nutrition.
- `EmptyState` отримав `module` prop — icon container і hint-icon тепер тінтуються в колір модуля замість нейтрального сірого.
- Додав `info` icon (для нового HubChat header).

## Why

— UI #3: хедер чату був перевантажений ще до першого повідомлення — 5 рядків інфо проти 1 рядка діалогу.
— UI #4: brand-color модулів (emerald/teal/coral/lime) застосовувався лише в `ModuleBottomNav`. Інша частина сторінки нейтральна — користувач не «відчував», що він у Фізрукові vs Рутині. Тепер є інфраструктура (CSS-var + контекст + dot/strip у хедері) і це plumbing: модулі вже одразу виглядають по-різному в шапці.
— UI #5: однотипні `SkeletonCard` і `EmptyState` дають слабкий сигнал «це сторінка транзакцій». Shape-aware варіанти + module-tinted icon дають впізнаваність ще на стадії завантаження.

## How to test

1. Відкрий HubChat з хабу — порівняй розмір хедера до/після, клацни іконку info → попап має містити статус контексту, лічильник і privacy-disclaimer.
2. Зайди в кожен модуль (Фінік / Фізрук / Рутина / Харчування) → у хедері перед заголовком має бути dot кольору модуля; під border-b — тонка кольорова стрічка.
3. У DevTools підглянь `--module-accent-rgb` на кореневому елементі модуля — має містити RGB-трійку відповідного кольору (`16 185 129` для finyk, `20 184 166` для fizruk, etc).
4. Storybook / DesignShowcase (якщо доступний) — нові skeleton-варіанти візуально мають відрізнятися від generic `SkeletonCard`.

---

## How AI-tested this PR

- [x] Vitest passes: 125 файлів / 1383 тести зелені.
- [x] `pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit` — 0 помилок.
- [x] `pnpm --filter @sergeant/web lint` — 0 помилок (включно з `sergeant-design/valid-tailwind-opacity` — використано лише дозволені opacity-кроки `/45`, `/10`, `/20`, `/70`).
- [ ] Manual smoke — ще не робив (PR створив, далі зроблю PR-2 на UX, потім за потреби можу прогнати руками обидва).
- [x] No new `AI-DANGER` markers added.
- [x] Docs prose uses Ukrainian where practical (this PR description).

## AGENTS.md updated?

- [x] No — no new permanent rules. Опціональні `module` props додані до існуючих компонентів — не змінюють жодне з існуючих правил.

Link to Devin session: https://app.devin.ai/sessions/9bee8c7adf104ab3ba72a2f26f26cd9e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the HubChat header to a single row, added module accent plumbing across the app, and introduced shape-aware skeletons and module-tinted empty states for clearer, faster-feeling UI.

- New Features
  - HubChat: Header is now one row (avatar with status dot → title → 1-line subtitle). Context metrics and privacy text move into a “Деталі контексту” popover behind an info icon.
  - Module accent: New `ModuleAccentProvider` publishes `--module-accent-rgb` and `useModuleAccent()`. `ModuleShell` accepts `module` and wires the provider. `ModuleHeader` adds an accent dot before the title and a 1px accent strip below the border.
  - Modules: Finyk, Routine, and Nutrition wrap roots with `ModuleAccentProvider`; Fizruk passes `module` to `ModuleShell`.
  - Loading states: Added shape-aware skeletons (`SkeletonTransactionRow`, `SkeletonBudgetBar`, `SkeletonHabitRow`, `SkeletonWorkoutSet`, `SkeletonMealCard`) with optional `module` tint. `EmptyState` now accepts `module` to tint the icon area. Added an `info` icon.

<sup>Written for commit e8f20eda50a9aaf663e645ea8238f015d70ee193. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned header UI for narrow screens with compact layout and status indicator on avatar.
  * Added module-based accent colors throughout the app with visual accent indicators.
  * New info button reveals context details and privacy information in a popover.
  * Enhanced loading states with specialized skeleton loaders for transactions, budgets, habits, workouts, and meal cards.
  * New info icon added to the UI components library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->