### PR TITLE
docs(docs): топ-5 покращень змісту документів та інструкцій

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Quick lookup before editing: which path uses which test stack and which conventi
 | `apps/web/src/shared/**`                              | `@Skords-01` | Vitest                                  | factories defined here                | Pure utils. No React.                                                                                                                                           |
 | `apps/server/src/modules/**`                          | `@Skords-01` | Vitest + Testcontainers (real Postgres) | n/a                                   | Always coerce bigint→number in serializers (rule #1). Update `api-client` types.                                                                                |
 | `apps/server/src/modules/chat/**`                     | `@Skords-01` | Vitest                                  | n/a                                   | Anthropic tool defs split per domain in `toolDefs/`. See Architecture section.                                                                                  |
-| `apps/server/src/migrations/**`                       | `@Skords-01` | n/a                                     | n/a                                   | Sequential `NNN_*.sql` (currently 001–010). No gaps. Two-phase for DROP — see rule #4.                                                                          |
+| `apps/server/src/migrations/**`                       | `@Skords-01` | n/a                                     | n/a                                   | Sequential `NNN_*.sql` (currently 001–015). No gaps. Two-phase for DROP — see rule #4.                                                                          |
 | `apps/mobile/src/core/**`                             | `@Skords-01` | Jest                                    | (mobile RQ uses module-local keys)    | NativeWind (not Tailwind). MMKV (not localStorage). No DOM.                                                                                                     |
 | `apps/mobile/app/**`                                  | `@Skords-01` | Jest                                    | n/a                                   | Expo Router routes. Each `_layout.tsx` is a navigator.                                                                                                          |
 | `apps/mobile-shell/**`                                | `@Skords-01` | none                                    | n/a                                   | Capacitor wrapper around `apps/web`. No app code lives here, only build glue.                                                                                   |
@@ -119,7 +119,7 @@ If you change only one — CI will pass but consumers break. Always do all three
 
 ### 4. SQL migrations: sequential, no gaps, two-phase for DROP
 
-Files in `apps/server/src/migrations/` use the pattern `NNN_description.sql` (currently 001–010). Pre-deploy: `pnpm db:migrate` (Railway). The build step copies them via `apps/server/build.mjs` (fixed in [#704](https://github.com/Skords-01/Sergeant/issues/704)).
+Files in `apps/server/src/migrations/` use the pattern `NNN_description.sql` (currently 001–015). Pre-deploy: `pnpm db:migrate` (Railway). The build step copies them via `apps/server/build.mjs` (fixed in [#704](https://github.com/Skords-01/Sergeant/issues/704)).
 
 - **Adding a column:** single file `NNN_add_foo.sql`. Make it `NULL`-able or `DEFAULT`-ed so old code keeps working.
 - **Renaming/removing a column:** **two phases**, deployed **separately**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ pnpm gen                 # Plop code generators (migration, rq-hook, hubchat-too
 1. Read the relevant playbook in `docs/playbooks/` — pick by trigger phrase (e.g. "нова API-функціональність" → `add-api-endpoint.md`).
 2. Check `AGENTS.md` § Hard rules — especially bigint coercion (#1), RQ keys (#2), migration numbering (#4).
 3. New HubChat tool? Needs **3 coordinated edits** — see `docs/playbooks/add-hubchat-tool.md`.
-4. New migration? Use `pnpm gen migration --name <desc>` — auto-numbers from last migration (`010`).
+4. New migration? Use `pnpm gen migration --name <desc>` — auto-numbers from last migration (`015`).
 
 ## Verification before PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,29 +198,7 @@ chore(config): tune shared eslint config
 
 Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `build`, `ci`.
 
-Use one of these scopes; do not invent scopes like `app`, `core`, `monorepo`, or `all`.
-
-| Scope              | When to use                                                    |
-| ------------------ | -------------------------------------------------------------- |
-| `web`              | `apps/web/**`                                                  |
-| `server`           | `apps/server/**` excluding migrations-only changes             |
-| `mobile`           | `apps/mobile/**`                                               |
-| `mobile-shell`     | `apps/mobile-shell/**`                                         |
-| `shared`           | `packages/shared/**`                                           |
-| `api-client`       | `packages/api-client/**`                                       |
-| `finyk-domain`     | `packages/finyk-domain/**`                                     |
-| `fizruk-domain`    | `packages/fizruk-domain/**`                                    |
-| `nutrition-domain` | `packages/nutrition-domain/**`                                 |
-| `routine-domain`   | `packages/routine-domain/**`                                   |
-| `insights`         | `packages/insights/**`                                         |
-| `design-tokens`    | `packages/design-tokens/**`                                    |
-| `config`           | `packages/config/**`                                           |
-| `eslint-plugins`   | `packages/eslint-plugin-sergeant-design/**`                    |
-| `migrations`       | `apps/server/src/migrations/**` only                           |
-| `deps`             | Renovate / dependency-only PRs                                 |
-| `docs`             | `docs/**`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md`         |
-| `ci`               | `.github/workflows/**`, `turbo.json`, scripts under `scripts/` |
-| `root`             | Repo-level config (`pnpm-workspace.yaml`, root `package.json`) |
+Повний список дозволених scopes — у [`AGENTS.md` § Hard rules #5](AGENTS.md) (single source of truth). Також enforced через [`commitlint.config.js`](commitlint.config.js). Не вигадуй нові scopes (`app`, `core`, `monorepo`, `all`).
 
 If a PR genuinely spans multiple scopes, use the most user-visible scope and explain the rest in the PR body.
 
@@ -316,6 +294,8 @@ These are non-negotiable. Read `AGENTS.md` for full context.
 5. **Conventional Commits** with the allowed type/scope set above.
 6. **No force-push to main.** `--force-with-lease` on feature branches is fine.
 7. **Never skip pre-commit hooks** (`--no-verify` is forbidden).
+8. **Tailwind opacity steps** must be on the registered scale (`0,5,8,10,15,…,100`). Off-scale values silently drop.
+9. **Saturated brand fills behind `text-white`** must use the `-strong` companion for WCAG AA compliance.
 
 ---
 
@@ -327,7 +307,8 @@ Sergeant/
 │   ├── web/            # Vite + React 18 SPA (frontend)
 │   ├── server/         # Express + PostgreSQL + Better Auth (API)
 │   ├── mobile/         # Expo 52 + React Native 0.76
-│   └── mobile-shell/   # Capacitor wrapper for web app
+│   ├── mobile-shell/   # Capacitor wrapper for web app
+│   └── console/        # Telegram bot (grammy + Anthropic) — internal ops/marketing
 ├── packages/
 │   ├── shared/         # @sergeant/shared
 │   ├── api-client/     # @sergeant/api-client

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ apps/
 │   ├── src/config.ts            # Конфіг рантайм-режиму (порт, SPA-static, trust proxy)
 │   ├── src/auth.ts              # Better Auth (спільний pg pool з db.ts)
 │   ├── src/db.ts                # PostgreSQL pool, ensureSchema(), SQL-міграції з migrations/
-│   ├── src/migrations/          # 001_noop.sql … 010_mono_mcc_categorization.sql (sequential, no gaps)
+│   ├── src/migrations/          # 001_noop.sql … 015_n8n_failure_events.sql (sequential, no gaps)
 │   ├── src/routes/              # Express-роутери: auth, me, sync, chat, coach, push, banks, barcode,
 │   │                            #   nutrition, weekly-digest, food-search, web-vitals, transcribe, waitlist,
 │   │                            #   mono-webhook, health, frontend
@@ -65,7 +65,8 @@ apps/
 │   ├── src/http/                # Спільний HTTP-шар (helmet, errorHandler, requireSession, rateLimit)
 │   └── src/obs/, src/email/, src/env/, src/lib/, src/push/, src/test/
 ├── mobile/                      # @sergeant/mobile — Expo SDK 52 + Expo Router + RN 0.76 (internal dev-client)
-└── mobile-shell/                # @sergeant/mobile-shell — Capacitor 7 wrapper навколо @sergeant/web
+├── mobile-shell/                # @sergeant/mobile-shell — Capacitor 7 wrapper навколо @sergeant/web
+└── console/                     # @sergeant/console — Telegram bot (grammy + Anthropic), internal ops/marketing
 
 packages/
 ├── shared/                      # @sergeant/shared — Zod-схеми API, типи, утиліти
@@ -182,8 +183,19 @@ pnpm dev:web    # тільки Vite dev server (фронт, порт 5173)
 | `VITE_NUTRITION_API_TOKEN` | Ні          | Токен Nutritionix для прямих запитів з фронту                                                                                                     |
 | `USDA_FDC_API_KEY`         | Ні          | Ключ USDA FoodData Central для barcode-fallback (безкоштовний на [api.data.gov](https://api.data.gov/signup)); без ключа — `DEMO_KEY` (40 req/hr) |
 | `PORT`                     | Ні          | Порт Express-сервера (типово `3000`)                                                                                                              |
+| `GOOGLE_CLIENT_ID`         | Ні          | Google OAuth client ID — вмикає «Увійти через Google». Redirect URI: `<BETTER_AUTH_URL>/api/auth/callback/google`                                 |
+| `GOOGLE_CLIENT_SECRET`     | Ні          | Google OAuth client secret (пара до `GOOGLE_CLIENT_ID`)                                                                                           |
+| `RESEND_API_KEY`           | Ні          | Resend API-ключ для транзакційних листів (скидання пароля, верифікація email). Без нього листи не відправляються                                  |
+| `RESEND_FROM`              | Ні          | Адреса відправника для Resend (має бути з верифікованого домену)                                                                                  |
+| `GROQ_API_KEY`             | Ні          | Groq API-ключ для Whisper (голосова транскрипція в `/api/transcribe`). Без ключа — fallback на Web Speech API                                     |
+| `BACKEND_URL`              | Для Vercel  | URL Railway-API — Edge Middleware проксує `/api/*` через нього. Без нього OAuth і cookie-сесії не працюють на Vercel                              |
+| `SENTRY_DSN`               | Ні          | Sentry DSN для бекенду (Node.js error tracking)                                                                                                   |
+| `VITE_SENTRY_DSN`          | Ні          | Sentry DSN для фронтенду (React error tracking, потрапляє у бандл)                                                                                |
+| `VITE_POSTHOG_KEY`         | Ні          | PostHog project API key (`phc_…`) — product analytics. Без ключа трекінг лише в локальному ring-buffer                                            |
+| `AI_QUOTA_TOOL_COST`       | Ні          | Вартість одного tool-use виклику в одиницях квоти (за замовч. 3)                                                                                  |
+| `AI_QUOTA_TOOL_LIMITS`     | Ні          | JSON-об'єкт per-tool лімітів (напр. `{"change_category":30}`). Tools поза списком — `AI_QUOTA_TOOL_DEFAULT_LIMIT`                                 |
 
-> `DATABASE_URL` і `BETTER_AUTH_SECRET` не входять до `.env.example` (вони є секретами, а не публічними налаштуваннями). На Replit `DATABASE_URL` надається автоматично при підключенні бази даних. `BETTER_AUTH_SECRET` задається вручну через Secrets.
+> Повний перелік змінних з поясненнями — у [`.env.example`](.env.example). На Replit `DATABASE_URL` надається автоматично при підключенні бази даних. `BETTER_AUTH_SECRET` задається вручну через Secrets.
 
 > Важливо: токени типу `VITE_*` потрапляють у клієнтський бандл — не використовуй їх як повноцінний захист.
 


### PR DESCRIPTION
## What changed

Топ-5 покращень **змісту** (не структури) документів та інструкцій:

1. **CONTRIBUTING.md: scope-таблиця → single source of truth** — замінено дубльовану scope-таблицю на посилання на `AGENTS.md § Hard rules #5` (усунення дрейфу — `console` вже був відсутній)
2. **Міграції 001–010 → 001–015** — оновлено у AGENTS.md (rule #4 + module ownership map), CLAUDE.md, README.md (фактично вже 15 міграцій)
3. **apps/console у дереві структури** — додано до ASCII-дерев у README.md та CONTRIBUTING.md
4. **README.md: +12 env-змінних** — Google OAuth, Resend, Groq, Sentry, PostHog, tool quotas, BACKEND_URL; виправлено неточну примітку про .env.example
5. **CONTRIBUTING.md: hard rules #8 і #9** — додано Tailwind opacity (#8) і WCAG strong companions (#9), яких бракувало

## Why

Документи містили застарілі числа (міграції), неповні таблиці (env vars), дублі з дрейфом (scope-таблиця), і пропуски (console у дереві, hard rules #8-#9). Це вводило в оману розробників і AI-агентів.

## How to test

```bash
pnpm format:check  # має пройти
```
Візуальна перевірка: scope-посилання → AGENTS.md, console у деревах, env-таблиця повна, hard rules 1–9.

---

## How AI-tested this PR

- [x] Manual smoke (which flow?): `pnpm format:check` — green
- [ ] Vitest passes: n/a (docs-only changes)
- [x] No new `AI-DANGER` markers added without justification.
- [x] Docs prose uses Ukrainian where practical, per `AGENTS.md`.

## AGENTS.md updated?

- [x] Yes — migration count 001–015 (rule #4, line ~122; module ownership map, line ~32)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Оновили зміст документації: синхронізували лічильник міграцій до 001–015, уніфікували правила scope й додали `apps/console` у дерева проєкту. README поповнили 12 новими env‑змінними та уточнили примітки.

- **New Features**
  - Scopes: у `CONTRIBUTING.md` — посилання на `AGENTS.md` § Hard rules #5; також enforced через `commitlint`.
  - Міграції: 001–015 у `AGENTS.md`, `CLAUDE.md`, `README.md`; оновлено опис каталогу `apps/server/src/migrations/`.
  - Структура: `apps/console` додано до дерев у `README.md` і `CONTRIBUTING.md`.
  - Env: у `README.md` +12 змінних і виправлена примітка про `.env.example`.

<sup>Written for commit 3f33aed81b53a8001c618470365380ada17e3b79. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

