### PR TITLE
feat(web): defer SoftAuthPromptCard so it does not interrupt the celebration moment (UX wave-1 #1)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -100,6 +100,14 @@ export function HubDashboard({
     setSessionDays(recordSessionDay() || getSessionDays());
   }, []);
   const SOFT_AUTH_SESSION_DAYS_THRESHOLD = 3;
+  // Скільки сеансів-днів має минути після першого реального запису, перш
+  // ніж показати SoftAuth. `1` означає «не на тому ж дні»: користувач,
+  // що щойно завершив `FirstActionHeroCard` → `CelebrationModal`, не
+  // отримує одразу прохання створити акаунт. Картка чекає наступного
+  // повернення (sessionDays ≥ 2). Це зберігає «win-момент» цілим, а
+  // самій картці дає вищий signal-to-noise: якщо юзер повернувся —
+  // він уже залучений.
+  const SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS = 2;
   const [softAuthDismissed, setSoftAuthDismissed] = useState(() =>
     isSoftAuthDismissed(),
   );
@@ -108,7 +116,8 @@ export function HubDashboard({
     !user &&
     !softAuthDismissed &&
     typeof onShowAuth === "function" &&
-    (hasRealEntry || sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
+    ((hasRealEntry && sessionDays >= SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS) ||
+      sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
 
   const [reengagement, setReengagement] = useState(() =>
     shouldShowReengagement(localStorageStore),


### PR DESCRIPTION
## What changed

`apps/web/src/core/hub/HubDashboard.tsx`: змінив гейт `showSoftAuth` з `hasRealEntry || sessionDays >= 3` на `(hasRealEntry && sessionDays >= 2) || sessionDays >= 3`.

```diff
- const showSoftAuth =
-   !user &&
-   !softAuthDismissed &&
-   typeof onShowAuth === "function" &&
-   (hasRealEntry || sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
+ const SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS = 2;
+ const showSoftAuth =
+   !user &&
+   !softAuthDismissed &&
+   typeof onShowAuth === "function" &&
+   ((hasRealEntry &&
+     sessionDays >= SOFT_AUTH_AFTER_ENTRY_MIN_SESSION_DAYS) ||
+     sessionDays >= SOFT_AUTH_SESSION_DAYS_THRESHOLD);
```

## Why

Раніше — `hasRealEntry || sessionDays >= 3`. Це означало, що користувач, який щойно завершив `FirstActionHeroCard` → `CelebrationModal`, **на тому самому скрині** одразу бачив прохання створити акаунт. Win-момент перетинався з conversion-prompt-ом, що знижує:

- signal celebration-у (юзеру не дають «насолодитись» першим записом),
- конверсію SoftAuth (запит у момент евфорії менш ефективний за запит у момент «я повернувся ще раз — мабуть, варто зберегти»).

Нова логіка пропускає целебрейшен-день: SoftAuth після першого реального запису чекає **наступного** сеансового дня (`sessionDays ≥ 2`). Користувачі без жодного запису, що повертаються 3+ днів — як і раніше отримують prompt.

Перший пункт із [топ-5 UX покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 1 / quick win.

## How to test

1. Очистити localStorage → відкрити Hub. Hero = `FirstActionHeroCard`.
2. Виконати «Перша витрата» / «Перше тренування» → побачити `CelebrationModal`. Закрити модалку → hero = `TodayFocusCard` (НЕ `SoftAuthPromptCard`).
3. Прокрутити дашборд — `SoftAuthPromptCard` не повинна зʼявлятись як hero сьогодні.
4. Імітувати наступний день: за допомогою `recordSessionDay()` (просто наступного календарного дня візит з тим же localStorage) → hero перемикається на `SoftAuthPromptCard`.
5. Залогінитись → `SoftAuthPromptCard` сховалась.

## How AI-tested this PR

- [x] Vitest passes: тестів специфічно на HubDashboard.tsx у `apps/web` нема (лише на `apps/mobile/src/core/dashboard/HubDashboard.test.tsx`); мобільну версію не зачепило.
- [x] `pnpm exec eslint src/core/hub/HubDashboard.tsx` (з `apps/web`) — 0 issues.
- [x] `pnpm exec prettier --check apps/web/src/core/hub/HubDashboard.tsx` — pass.
- [x] `pnpm typecheck` — pre-existing помилки в інших файлах (`apps/web/src/modules/{finyk,fizruk}/...`, `packages/finyk-domain/src/domain/budget.ts`); HubDashboard.tsx у логах помилок не зʼявляється.
- [ ] Manual smoke (UI flow) — варто перевірити на staging.
- [x] No new `AI-DANGER` markers added.
- [x] Прозовий копірайт лишається українським.

## AGENTS.md updated?

- [x] No — no new permanent rules

## Notes for follow-up

`apps/mobile/src/core/dashboard/HubDashboard.tsx:401` має ту саму структуру (`!firstActionVisible && hasFirstRealEntry && !softAuthDismissed && !signedIn`) **без часового гейту**. Оновлення мобільної версії виносимо окремим PR — потребує синхронізації `recordSessionDay()` через MMKV + оновлення `HubDashboard.test.tsx`. Залишаю TODO для wave-2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `SoftAuthPromptCard` so it doesn’t interrupt the first-entry celebration. After a real entry it now shows on the next session day; users without entries still see it from day 3 (UX wave‑1 #1).

<sup>Written for commit 2a1a24ad33af7fbb3d9c07f401a0249eb1eb0625. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication prompt display logic by adjusting when it appears based on account status and session activity. Users with existing accounts now see the prompt after 2 days of session engagement, while newer users see it after 3 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->