### PR TITLE
feat(web): animate Reports tab reveal + one-time toast hint (UX wave-1 #2)

### DIFF
--- a/apps/web/src/core/app/HubTabs.tsx
+++ b/apps/web/src/core/app/HubTabs.tsx
@@ -1,7 +1,15 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { useToast } from "@shared/hooks/useToast";
+import { safeReadStringLS, safeWriteLS } from "@shared/lib/storage";
 import type { HubView } from "../hooks/useHubUIState";
+
+// Прапор у localStorage: «звіти-таб уже разово розкривався». Зберігаємо
+// timestamp (а не bool), щоб у логах було видно дату розблокування —
+// зручно для аналітики FTUX-воронки і для діагностики «чому юзер не
+// побачив підказку».
+const REPORTS_TAB_REVEALED_AT_KEY = "sergeant.hub.reportsTabRevealedAt";
 
 interface TabButtonProps {
   active: boolean;
@@ -9,6 +17,7 @@ interface TabButtonProps {
   children: ReactNode;
   iconName?: string;
   iconBody?: ReactNode;
+  className?: string;
 }
 
 function TabButton({
@@ -17,6 +26,7 @@ function TabButton({
   children,
   iconName,
   iconBody,
+  className,
 }: TabButtonProps) {
   return (
     <button
@@ -30,6 +40,7 @@ function TabButton({
         active
           ? "bg-panel text-text shadow-card"
           : "text-muted hover:text-text",
+        className,
       )}
     >
       {iconName ? <Icon name={iconName} size={15} strokeWidth={2} /> : iconBody}
@@ -78,6 +89,50 @@ export function HubTabs({
   onChange,
   showReports = true,
 }: HubTabsProps) {
+  const toast = useToast();
+  // Чи був перехід `showReports: false → true` в межах поточного маунту.
+  // Тільки в цьому випадку ми вмикаємо bounce-анімацію + one-time toast.
+  // Якщо компонент маунтиться вже з `showReports === true` без флага в
+  // localStorage — це або легасі-користувач (виставлявся ще до цього
+  // прапора), або повне перезавантаження після розблокування. В обох
+  // сценаріях celebrate-toast у момент перезавантаження виглядав би
+  // невчасно, тож тихо ставимо флаг і нічого не показуємо.
+  const prevShowReportsRef = useRef(showReports);
+  const [animateReveal, setAnimateReveal] = useState(false);
+
+  useEffect(() => {
+    const prevShowReports = prevShowReportsRef.current;
+    prevShowReportsRef.current = showReports;
+
+    if (!showReports) return;
+    if (safeReadStringLS(REPORTS_TAB_REVEALED_AT_KEY)) return;
+
+    if (!prevShowReports) {
+      // Це справжнє розблокування «в реальному часі»: користувач
+      // зробив свій перший реальний запис у поточному сеансі, і
+      // `hasAnyRealEntry()` щойно flip-нув. Запускаємо bounce +
+      // показуємо нав'язливий, але дружній toast із прямою CTA на
+      // вкладку. Toast самозникає за 6с — звідси не лишається
+      // постійного chrome-у, тому ризик заглушити подальші важливі
+      // toast-и низький.
+      safeWriteLS(REPORTS_TAB_REVEALED_AT_KEY, String(Date.now()));
+      setAnimateReveal(true);
+      toast.info(
+        "«Звіти» тепер доступні — короткі зведення по всіх модулях.",
+        6000,
+        {
+          label: "Відкрити",
+          onClick: () => onChange("reports"),
+        },
+      );
+      return;
+    }
+
+    // Migration / cold-start path: tab уже мав бути розблокований
+    // (минулий маунт), просто на ньому не було флага. Ставимо тихо.
+    safeWriteLS(REPORTS_TAB_REVEALED_AT_KEY, String(Date.now()));
+  }, [showReports, onChange, toast]);
+
   return (
     <nav
       aria-label="Розділи хабу"
@@ -100,6 +155,7 @@ export function HubTabs({
             active={hubView === "reports"}
             onClick={() => onChange("reports")}
             iconName="bar-chart"
+            className={animateReveal ? "animate-bounce-in" : undefined}
           >
             Звіти
           </TabButton>


### PR DESCRIPTION
## What changed

`apps/web/src/core/app/HubTabs.tsx`:

- Коли `showReports` транзитує `false → true` в межах одного маунту і `sergeant.hub.reportsTabRevealedAt` ще не виставлено в localStorage:
  - сам tab отримує `animate-bounce-in` (0.5с) — токен з `packages/design-tokens/tailwind-preset.js`;
  - сwfispace one-time toast «"Звіти" тепер доступні — короткі зведення по всіх модулях.» з кнопкою «Відкрити», яка перемикає `hubView` на `reports`.
- Прапор `sergeant.hub.reportsTabRevealedAt` зберігає timestamp розблокування — і блокує повторні toast/animation у наступних сеансах.
- `TabButton` отримав опціональний `className` prop, щоб чисто додати класс анімації лише до табу «Звіти» без зайвої гілки рендеру.
- localStorage-доступ — через `safeReadStringLS` / `safeWriteLS` з `@shared/lib/storage` (вимога ESLint-плагіна `sergeant-design/no-raw-local-storage`).

## Why

Раніше tab «Звіти» зʼявлявся беззвучно, як тільки `hasAnyRealEntry()` повертав true (див. `apps/web/src/core/onboarding/firstRealEntry.ts`). Користувач, що щойно завершив перший реальний запис, **переважно не помічав** появи нового пункту в top-nav — горизонтальна стрічка лишалась візуально такою ж, нова кнопка просто додавалась без анімації чи фокусу.

Це слабкий сигнал важливого розблокування. UX-наслідок: люди годинами/днями не знаходять «Звіти» і втрачають усе, заради чого ця вкладка існує (короткі зведення = мотивація продовжити).

Anti-pattern також: `HintsOrchestrator` має `module_first_entry` хінт, що каже «Після першого запису спробуй "Звіти"». Але це лише один з кандидатів пулу і вибирається випадково — гарантії, що його взагалі покажуть, нема.

Четвертий пункт із [топ-5 UX покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 1 / quick win.

## How to test

1. Очистити localStorage (особливо ключі `sergeant.firstAction.realEntryDone`, `sergeant.hub.reportsTabRevealedAt`).
2. Відкрити Hub (новий користувач → онбординг → дашборд). Tab `Звіти` ВІДСУТНІЙ у top-nav.
3. Виконати перший реальний запис (наприклад, transaction у Finyk → Increment чи скидання Mono транзакцій).
4. Повернутись на дашборд **без** перезавантаження. Очікування: tab `Звіти` зʼявляється з bounce-in-анімацією + одночасно знизу-зправа спливає toast «"Звіти" тепер доступні…» з кнопкою «Відкрити».
5. Тапнути «Відкрити» → перемикається на reports.
6. Перезавантажити сторінку → tab `Звіти` тепер просто є (без bounce, без toast). Прапор у localStorage `sergeant.hub.reportsTabRevealedAt` містить timestamp.
7. Edge case: legacy-користувач. Симуляція: `localStorage.setItem("sergeant.firstAction.realEntryDone", "1"); localStorage.removeItem("sergeant.hub.reportsTabRevealedAt"); location.reload()` → tab показується одразу, без bounce/toast (тихо ставимо флаг — celebrate-момент уже минув в попередній сесії).

## How AI-tested this PR

- [x] `pnpm exec eslint src/core/app/HubTabs.tsx` (з `apps/web`) — pass (включно з кастомним `sergeant-design/no-raw-local-storage`).
- [x] `pnpm exec prettier --check apps/web/src/core/app/HubTabs.tsx` — pass.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` (з `apps/web`) — pass.
- [x] `pnpm exec tsc -p tsconfig.strict.json --noEmit` — HubTabs не зʼявляється в логах помилок (pre-existing помилки в інших файлах не зачеплено).
- [x] No new `AI-DANGER` markers added.
- [x] Прозовий копірайт лишається українським.
- [ ] Manual smoke (UI flow) — варто перевірити на staging.

## AGENTS.md updated?

- [x] No — no new permanent rules

## Notes for follow-up

- Wave-1 PR-1 ([#1121](https://github.com/Skords-01/Sergeant/pull/1121)) — defer SoftAuthPromptCard. Цей PR не залежить від нього і може мерджитися окремо.
- `apps/mobile/src/core/dashboard/HubDashboard.tsx` теж умовно рендерить Reports-вкладку через bottom-nav — додати ту саму анімацію + native toast окремим PR (інша toast-API).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Reports tab noticeable when it unlocks with a bounce-in animation and a one-time toast with an “Open” CTA. Addresses UX wave‑1 #2 by improving discovery right after the first real entry.

- **New Features**
  - When `showReports` flips false→true, animate the tab (0.5s) and show a one-time toast that switches to `reports` on “Open”.
  - Save unlock timestamp in `localStorage` (`sergeant.hub.reportsTabRevealedAt`) to prevent repeats; legacy/reload paths set the flag silently.
  - `TabButton` now accepts `className`; storage uses `safeReadStringLS`/`safeWriteLS` from `@shared/lib/storage`; toast via `@shared/hooks/useToast`.

<sup>Written for commit 77db308840bbb6db84dc9938eab8f8670e3a5f69. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1122?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

