### PR TITLE
feat(web): bump chrome hit-targets to 48px on mobile + solid focus-ring (UI wave-1 #4)

### DIFF
--- a/apps/web/src/core/app/DarkModeToggle.tsx
+++ b/apps/web/src/core/app/DarkModeToggle.tsx
@@ -1,7 +1,8 @@
 import { Icon } from "@shared/components/ui/Icon";
 
+// Mirror `HubHeader.ICON_BUTTON_CLS`: 48 пкс на мобільному, 44 пкс ≥sm; focus-ring solid brand-500.
 const CLS =
-  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 interface DarkModeToggleProps {
   dark: boolean;

--- a/apps/web/src/core/app/HubFloatingActions.tsx
+++ b/apps/web/src/core/app/HubFloatingActions.tsx
@@ -54,7 +54,11 @@ export function HubFloatingActions({
         // `text-white` at 14px regular weight (≥4.5:1).
         "bg-brand-700 text-white shadow-float",
         "hover:bg-brand-800 hover:shadow-glow active:scale-95 transition-[background-color,box-shadow,opacity,transform]",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+        // Focus-ring: суцільний brand-500 (без /45 альфи) — гарантовано ≥3:1
+        // контраст проти bg в dark-mode (alpha-варіант просідала на panelHi).
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+        // FAB compact-варіант — 48×48 пкс (Material 3 / iOS HIG thumb-baseline);
+        // повний варіант — pill 56 пкс заввишки.
         compact ? "h-12 w-12" : "h-14 pl-4 pr-5 gap-2",
       )}
     >

--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -8,8 +8,13 @@ import { DarkModeToggle } from "./DarkModeToggle";
 import { UserMenuButton } from "./UserMenuButton";
 import type { User } from "@sergeant/shared";
 
+// WCAG 2.5.5 AAA «Target Size (Enhanced)» рекомендує ≥44×44 пкс для hit-areas;
+// Material 3 / iOS HIG — 48 dp / 44 pt як thumb-comfort бейзлайн. На мобільному
+// (палець, без хіт-зони курсору) робимо 48 пкс; ≥sm — 44 пкс достатньо.
+// Focus-ring: суцільний brand-500 (без /45 альфи), щоб гарантовано холдити
+// ≥3:1 контраст до bg в dark-mode (alpha на panelHi-підкладках просідала).
 const ICON_BUTTON_CLS =
-  "w-11 h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
+  "w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-2xl text-muted hover:text-text hover:bg-panelHi transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-bg";
 
 const GREETINGS: Record<string, string> = {
   morning: "Доброго ранку",

--- a/apps/web/src/core/app/HubTabs.tsx
+++ b/apps/web/src/core/app/HubTabs.tsx
@@ -25,8 +25,10 @@ function TabButton({
       role="tab"
       aria-selected={active}
       className={cn(
-        "flex-1 flex items-center justify-center gap-1.5 min-h-[44px] py-2 rounded-xl text-sm font-medium transition-[background-color,color,opacity]",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45",
+        // WCAG 2.5.5 AAA: 48 пкс на мобільному (thumb-zone), 44 пкс на ≥1sm — для desktop вводу
+        // достатньо. Focus-ring без альфи, щоб холдити ≥3:1 контраст до bg.
+        "flex-1 flex items-center justify-center gap-1.5 min-h-[48px] sm:min-h-[44px] py-2 rounded-xl text-sm font-medium transition-[background-color,color,opacity]",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
         active
           ? "bg-panel text-text shadow-card"
           : "text-muted hover:text-text",

--- a/apps/web/src/core/app/UserMenuButton.tsx
+++ b/apps/web/src/core/app/UserMenuButton.tsx
@@ -83,9 +83,10 @@ export function UserMenuButton({
         aria-expanded={open}
         title={user.email ?? undefined}
         className={cn(
-          "relative w-11 h-11 flex items-center justify-center rounded-2xl text-sm font-bold transition-colors",
+          // Mirror `HubHeader.ICON_BUTTON_CLS`: 48 пкс mobile / 44 пкс ≥sm; solid focus-ring.
+          "relative w-12 h-12 sm:w-11 sm:h-11 flex items-center justify-center rounded-2xl text-sm font-bold transition-colors",
           "bg-brand-500/15 text-brand-600 dark:text-brand-400 hover:bg-brand-500/25",
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
           syncing && "motion-safe:animate-pulse",
         )}
       >


### PR DESCRIPTION
## What changed

Чотири місця в hub-chrome шарі (`apps/web/src/core/app/`) — узгодити hit-target і focus-ring:

| File | Before | After |
| --- | --- | --- |
| `HubHeader.tsx` (`ICON_BUTTON_CLS`) | `w-11 h-11 ... ring-brand-500/45` | `w-12 h-12 sm:w-11 sm:h-11 ... ring-brand-500` |
| `DarkModeToggle.tsx` (`CLS`) | `w-11 h-11 ... ring-brand-500/45` | `w-12 h-12 sm:w-11 sm:h-11 ... ring-brand-500` |
| `UserMenuButton.tsx` | `w-11 h-11 ... ring-brand-500/45` | `w-12 h-12 sm:w-11 sm:h-11 ... ring-brand-500` |
| `HubTabs.tsx` (`TabButton`) | `min-h-[44px] ... ring-brand-500/45` | `min-h-[48px] sm:min-h-[44px] ... ring-brand-500` |
| `HubFloatingActions.tsx` (FAB) | `ring-brand-500/45` (FAB compact уже 48 пкс) | `ring-brand-500` (hit-area без змін) |

## Why

Дві WCAG-проблеми у hub-chrome шарі:

1. **Hit-target = 44 пкс** — це WCAG 2.5.5 AA (бейзлайн), але **не AAA** (Enhanced — 44 пкс мінімум, рекомендація вище). Material 3 і iOS HIG рекомендують **48 dp / 44 pt** як thumb-zone baseline на мобільному. На <640px ми лишали мінімум, що зокрема впливає на акуратність FAB і top-nav-кнопок під час швидкої взаємодії однією рукою. Після зміни на мобільному 48 пкс, на ≥sm — 44 пкс (desktop-ввід прецизійний — миша/трекпад).

2. **Focus-ring `ring-brand-500/45`** — `brand-500 @ 45%` альфа на `panelHi` підкладках у dark-mode місцями просідає нижче WCAG-3:1 для focus-indicator (focus area проти adjacent area = «adjacent area» це або панель або bg). Solid `brand-500` + існуюче `ring-offset-2 ring-offset-bg` гарантовано тримає контраст і дає чіткіший keyboard-feedback.

Четвертий пункт із [топ-5 UI покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 1 / quick win.

## How to test

1. Mobile (Chrome DevTools, iPhone 14 Pro 393x852 viewport):
   - Тапнути по логотипу пошуку, акаунт-аватарці, dark-mode toggle, табах HubTabs, FAB. Кнопки помітно більші, легше попадати.
   - Inspect → перевірити `getBoundingClientRect().height === 48` для кожного.
2. Desktop (≥640px):
   - Зменшити вікно до >640px ширини. Кнопки повертаються до 44 пкс.
3. Keyboard (Tab + Shift+Tab):
   - Tab по chrome-кнопках. Focus-ring видно як суцільний синьо-фіолетовий кільце з 2 пкс гепом проти bg.
   - У dark-mode (`localStorage.setItem("sergeant.darkMode", "true"); location.reload()`) ring так само добре видно — раніше альфа гасилась проти `panelHi` підкладок.

## How AI-tested this PR

- [x] `pnpm exec eslint` (з `apps/web`) на всіх 5 файлах — pass.
- [x] `pnpm exec prettier --write` — formatted.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [x] No new `AI-DANGER` markers added.
- [x] Прозовий копірайт лишається українським.
- [ ] Manual smoke (mobile viewport / keyboard nav) — варто перевірити вручну.

## AGENTS.md updated?

- [x] No — no new permanent rules

## Notes for follow-up

20 файлів у `apps/web/src/core/` досі вживають `ring-brand-500/45` (OnboardingWizard, AuthPage, ChatInput, ModuleChecklist, тощо). Свідомо НЕ зачіпаю в цьому PR, щоб diff лишився сфокусованим на hub-chrome. Sweep по решті — окремий PR (`grep -rl "ring-brand-500/45" apps/web/src` + автозаміна), він буде trivial review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps mobile hit-targets in the hub chrome to 48px and switches to a solid focus ring for better contrast. Improves tap accuracy and keyboard focus visibility, especially in dark mode.

- **New Features**
  - Mobile: header icon buttons, user menu, dark mode toggle, and hub tabs are now 48px; revert to 44px on screens ≥640px. FAB size unchanged (compact is already 48px); focus ring updated.
  - Accessibility: replaced translucent `ring-brand-500/45` with solid `ring-brand-500` plus offset to meet 3:1 focus indicator contrast and improve clarity.

<sup>Written for commit d5fd19a7a4f54883b83cc83766ef954258040621. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1123?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

