### PR TITLE
refactor(web): unify copy tone to informal 'ти' across user-facing strings (UX wave-1 bonus)

### DIFF
--- a/apps/web/src/core/auth/AuthContext.tsx
+++ b/apps/web/src/core/auth/AuthContext.tsx
@@ -31,7 +31,7 @@ export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
 /** Translate Better Auth server errors to Ukrainian. */
 function translateAuthError(raw: string): string {
   if (/user already exists/i.test(raw))
-    return "Цей email вже зареєстровано. Спробуйте увійти.";
+    return "Цей email вже зареєстровано. Спробуй увійти.";
   if (/password too short/i.test(raw)) return "Пароль занадто короткий.";
   if (/password too long/i.test(raw)) return "Пароль занадто довгий.";
   if (/invalid email/i.test(raw)) return "Невірний формат email.";

--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -81,7 +81,7 @@ export function AuthPage({ onContinueWithoutAccount }: AuthPageProps) {
     e.preventDefault();
     const target = (forgotEmail || email || "").trim();
     if (!target) {
-      setAuthError("Введіть email, на який відправити лист.");
+      setAuthError("Введи email, на який відправити лист.");
       return;
     }
     setForgotState("sending");
@@ -168,7 +168,7 @@ export function AuthPage({ onContinueWithoutAccount }: AuthPageProps) {
                     type="text"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    placeholder={"Ваше ім'я"}
+                    placeholder={"Твоє ім'я"}
                     autoComplete="name"
                   />
                 </div>

--- a/apps/web/src/core/designShowcase/sections/DataDisplay.tsx
+++ b/apps/web/src/core/designShowcase/sections/DataDisplay.tsx
@@ -72,7 +72,7 @@ export function DataDisplaySection() {
             <EmptyState
               icon={<Icon name="search" size={24} />}
               title="Нічого не знайдено"
-              description="Спробуйте змінити пошуковий запит або скинути фільтри."
+              description="Спробуй змінити пошуковий запит або скинути фільтри."
               action={
                 <Button size="sm" variant="secondary">
                   Скинути

--- a/apps/web/src/core/designShowcase/sections/Forms.tsx
+++ b/apps/web/src/core/designShowcase/sections/Forms.tsx
@@ -44,7 +44,7 @@ export function FormsSection() {
 
       <Group label="Textarea">
         <Textarea
-          placeholder="Введіть текст…"
+          placeholder="Введи текст…"
           rows={3}
           className="w-full max-w-sm"
         />
@@ -70,7 +70,7 @@ export function FormsSection() {
       <Group label="FormField">
         <div className="space-y-4 max-w-sm">
           <FormField label="Стандартне поле" helperText="Підказка під полем">
-            <Input placeholder="Введіть значення" />
+            <Input placeholder="Введи значення" />
           </FormField>
           <FormField label="З помилкою" error="Поле обов'язкове">
             <Input placeholder="Помилка" error />

--- a/apps/web/src/core/hints/HintsOrchestrator.tsx
+++ b/apps/web/src/core/hints/HintsOrchestrator.tsx
@@ -76,7 +76,7 @@ export function HintsOrchestrator({
               recordHintShown(webKVStore, retentionId);
               const def = {
                 retention_day_1:
-                  "Перший день — вже здобуток! Поверніться завтра — звичка формується з трьох повторень.",
+                  "Перший день — вже здобуток! Повернись завтра — звичка формується з трьох повторень.",
                 retention_day_3:
                   "3 дні поспіль — стрік почався. Ще кілька днів і мозок зафіксує нову звичку.",
                 retention_day_7:

--- a/apps/web/src/core/profile/DeleteAccountDialog.tsx
+++ b/apps/web/src/core/profile/DeleteAccountDialog.tsx
@@ -58,7 +58,7 @@ export function DeleteAccountDialog({
           Видалити акаунт назавжди?
         </h2>
         <p id={descriptionId} className="text-sm text-muted mt-2">
-          Введіть пароль для підтвердження. Цю дію неможливо скасувати.
+          Введи пароль для підтвердження. Цю дію неможливо скасувати.
         </p>
         <div className="mt-4 space-y-2">
           <label

--- a/apps/web/src/core/profile/PersonalInfoSection.tsx
+++ b/apps/web/src/core/profile/PersonalInfoSection.tsx
@@ -295,7 +295,7 @@ export function PersonalInfoSection({
                 if (e.key === "Enter" && dirty && !saving && online)
                   handleSave();
               }}
-              placeholder="Ваше ім'я"
+              placeholder="Твоє ім'я"
               autoComplete="name"
               className="flex-1"
             />

--- a/apps/web/src/core/settings/FinykSection.tsx
+++ b/apps/web/src/core/settings/FinykSection.tsx
@@ -75,7 +75,7 @@ export function FinykSection() {
     const cleanId = privatIdInput.trim();
     const cleanToken = privatTokenInput.trim();
     if (!cleanId || !cleanToken) {
-      setPrivatError("Введіть Merchant ID та токен");
+      setPrivatError("Введи Merchant ID та токен");
       return;
     }
     setPrivatConnecting(true);
@@ -148,7 +148,7 @@ export function FinykSection() {
   const connectWebhook = async () => {
     const clean = webhookTokenInput.trim();
     if (!clean) {
-      setWebhookError("Введіть токен");
+      setWebhookError("Введи токен");
       return;
     }
     setWebhookConnecting(true);

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -254,7 +254,7 @@ export function ManualExpenseSheet({
   const handleSubmit = () => {
     const amt = parseFloat(form.amount);
     if (!form.amount || isNaN(amt) || amt <= 0) {
-      setError("Вкажіть суму більше 0");
+      setError("Вкажи суму більше 0");
       return;
     }
     // Description is now optional: if empty we fall back to the category

--- a/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
+++ b/apps/web/src/modules/finyk/hooks/useMonobankWebhook.ts
@@ -268,7 +268,7 @@ export function useMonobankWebhook({
     async (token: string, _forceRefresh?: boolean, _remember?: boolean) => {
       const clean = (token ?? "").trim();
       if (!clean) {
-        setError("Введіть токен");
+        setError("Введи токен");
         return;
       }
       setConnecting(true);

--- a/apps/web/src/modules/finyk/hooks/usePrivatbank.ts
+++ b/apps/web/src/modules/finyk/hooks/usePrivatbank.ts
@@ -247,7 +247,7 @@ export function usePrivatbank(enabled = true) {
     } catch (e) {
       if (e.name === "AuthError") {
         setError(
-          "Невірні credentials PrivatBank. Перевірте Merchant ID та токен.",
+          "Невірні credentials PrivatBank. Перевір Merchant ID та токен.",
         );
         setSyncState((s) => ({
           ...s,
@@ -288,7 +288,7 @@ export function usePrivatbank(enabled = true) {
     const cleanToken = (merchantToken || "").trim();
 
     if (!cleanId || !cleanToken) {
-      setError("Введіть Merchant ID та токен");
+      setError("Введи Merchant ID та токен");
       setConnecting(false);
       return;
     }
@@ -340,7 +340,7 @@ export function usePrivatbank(enabled = true) {
     } catch (e) {
       if (e.name === "AuthError") {
         setError(
-          "Невірні credentials PrivatBank. Перевірте Merchant ID та токен.",
+          "Невірні credentials PrivatBank. Перевір Merchant ID та токен.",
         );
       } else {
         setError(e.message || "Помилка підключення до PrivatBank");

--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -216,7 +216,7 @@ export function WorkoutTemplatesSection({
                     className="text-xs px-2 py-1 rounded-lg border border-success/40 text-success disabled:opacity-40"
                     disabled={groupSelected.size < 2 || groupSelected.size > 3}
                     onClick={() => handleCreateGroup("superset")}
-                    title="Виберіть 2-3 вправи"
+                    title="Обери 2-3 вправи"
                   >
                     Суперсет ({groupSelected.size}/3)
                   </button>
@@ -225,7 +225,7 @@ export function WorkoutTemplatesSection({
                     className="text-xs px-2 py-1 rounded-lg border border-fizruk/40 text-fizruk disabled:opacity-40"
                     disabled={groupSelected.size < 2 || groupSelected.size > 3}
                     onClick={() => handleCreateGroup("circuit")}
-                    title="Виберіть 2-3 вправи"
+                    title="Обери 2-3 вправи"
                   >
                     Коло ({groupSelected.size}/3)
                   </button>

--- a/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
+++ b/apps/web/src/modules/fizruk/components/workouts/ActiveWorkoutPanel.tsx
@@ -389,7 +389,7 @@ export function ActiveWorkoutPanel({
                   className="text-xs px-3 py-1.5 rounded-lg border border-success/40 text-success bg-success/10 hover:bg-success/20 transition-colors disabled:opacity-40"
                   disabled={groupSelected.size < 2 || groupSelected.size > 3}
                   onClick={() => handleCreateSuperset("superset")}
-                  title="Виберіть 2-3 вправи"
+                  title="Обери 2-3 вправи"
                 >
                   Суперсет ({groupSelected.size}/3)
                 </button>
@@ -398,7 +398,7 @@ export function ActiveWorkoutPanel({
                   className="text-xs px-3 py-1.5 rounded-lg border border-fizruk/40 text-fizruk bg-fizruk/10 hover:bg-fizruk/20 transition-colors disabled:opacity-40"
                   disabled={groupSelected.size < 2 || groupSelected.size > 3}
                   onClick={() => handleCreateSuperset("circuit")}
-                  title="Виберіть 2-3 вправи"
+                  title="Обери 2-3 вправи"
                 >
                   Коло ({groupSelected.size}/3)
                 </button>

--- a/apps/web/src/modules/nutrition/components/AddMealSheet.tsx
+++ b/apps/web/src/modules/nutrition/components/AddMealSheet.tsx
@@ -166,7 +166,7 @@ export function AddMealSheet({
       (typeof fromPantryItem === "string" ? fromPantryItem.trim() : "") ||
       (photoResult?.dishName || "").trim();
     if (!name) {
-      setForm((s) => ({ ...s, err: "Введіть назву страви." }));
+      setForm((s) => ({ ...s, err: "Введи назву страви." }));
       return;
     }
     const kcal = form.kcal === "" ? null : Number(form.kcal);

--- a/apps/web/src/modules/nutrition/components/meal-sheet/SaveAsFood.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/SaveAsFood.tsx
@@ -34,7 +34,7 @@ export function SaveAsFood({
           if (!name) {
             setForm((s) => ({
               ...s,
-              err: "Введіть назву, щоб зберегти продукт.",
+              err: "Введи назву, щоб зберегти продукт.",
             }));
             return;
           }

--- a/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
+++ b/apps/web/src/modules/nutrition/hooks/useNutritionCloudBackup.ts
@@ -53,7 +53,7 @@ export function useNutritionCloudBackup({
     setBackupPasswordDialog({
       mode: "upload",
       title: "Пароль для шифрування",
-      description: "Введіть пароль для шифрування бекапу (запам'ятайте його):",
+      description: "Введи пароль для шифрування бекапу (запам'ятай його):",
     });
   }, [cloudBackupBusy, setBackupPasswordDialog]);
 
@@ -62,7 +62,7 @@ export function useNutritionCloudBackup({
     setBackupPasswordDialog({
       mode: "download",
       title: "Пароль для розшифрування",
-      description: "Введіть пароль для розшифрування бекапу:",
+      description: "Введи пароль для розшифрування бекапу:",
     });
   }, [cloudBackupBusy, setBackupPasswordDialog]);
 

--- a/apps/web/src/modules/routine/components/DayProgressRing.tsx
+++ b/apps/web/src/modules/routine/components/DayProgressRing.tsx
@@ -22,7 +22,7 @@ export function DayProgressRing({
       type="button"
       onClick={onClick}
       className="flex flex-col items-center gap-1.5 group cursor-pointer shrink-0"
-      aria-label={`Прогрес дня: ${completed} з ${scheduled}. Натисніть для денного звіту`}
+      aria-label={`Прогрес дня: ${completed} з ${scheduled}. Тапни для денного звіту`}
     >
       <div className="relative" style={{ width: SIZE, height: SIZE }}>
         <svg

--- a/apps/web/src/shared/components/ui/InputDialog.tsx
+++ b/apps/web/src/shared/components/ui/InputDialog.tsx
@@ -27,7 +27,7 @@ export interface InputDialogProps {
 
 export function InputDialog({
   open,
-  title = "Введіть значення",
+  title = "Введи значення",
   description,
   placeholder = "",
   defaultValue = "",

--- a/apps/web/src/shared/components/ui/VoiceMicButton.tsx
+++ b/apps/web/src/shared/components/ui/VoiceMicButton.tsx
@@ -96,7 +96,7 @@ export function useVoiceInput({
       if (e.error === "not-allowed") {
         onError?.("Немає дозволу на використання мікрофону.");
       } else if (e.error === "no-speech") {
-        onError?.("Не вдалося розпізнати мову. Спробуйте ще раз.");
+        onError?.("Не вдалося розпізнати мову. Спробуй ще раз.");
       } else if (e.error !== "aborted") {
         onError?.(`Помилка розпізнавання: ${e.error}`);
       }
@@ -272,7 +272,7 @@ function useGroqVoiceInput({
         }
         if (res.status === 401) {
           onError?.(
-            "Сесія завершилась. Увійдіть знову, щоб користуватись голосом.",
+            "Сесія завершилась. Увійди знову, щоб користуватись голосом.",
           );
           return;
         }
@@ -281,16 +281,16 @@ function useGroqVoiceInput({
           return;
         }
         if (!res.ok) {
-          onError?.(`Помилка розпізнавання (${res.status}). Спробуйте ще раз.`);
+          onError?.(`Помилка розпізнавання (${res.status}). Спробуй ще раз.`);
           return;
         }
         const data = (await res.json()) as { text?: string };
         const text = (data.text || "").trim();
         if (text) onResult?.(text);
-        else onError?.("Не вдалося розпізнати мову. Спробуйте ще раз.");
+        else onError?.("Не вдалося розпізнати мову. Спробуй ще раз.");
       } catch (err) {
         if ((err as { name?: string })?.name === "AbortError") return;
-        onError?.("Не вдалося надіслати аудіо. Перевірте інтернет.");
+        onError?.("Не вдалося надіслати аудіо. Перевір інтернет.");
       } finally {
         setUploading(false);
         abortRef.current = null;


### PR DESCRIPTION
## What changed

19 файлів у `apps/web/src/{core,modules,shared}` — заміна формальних форм («ви») на неформальні («ти»), щоб уніфікувати тон з рештою UI:

| Pattern | Before | After |
| --- | --- | --- |
| 1 | `Введіть` | `Введи` |
| 2 | `Виберіть` | `Обери` |
| 3 | `Натисніть` | `Тапни` (DayProgressRing aria-label) |
| 4 | `Спробуйте` | `Спробуй` |
| 5 | `Увійдіть` | `Увійди` |
| 6 | `Перевірте` | `Перевір` |
| 7 | `Поверніться` | `Повернись` |
| 8 | `Вкажіть` | `Вкажи` |
| 9 | `Ваше імʼя` | `Твоє імʼя` |

Файли: `core/auth/{AuthPage,AuthContext}.tsx`, `core/hints/HintsOrchestrator.tsx`, `core/profile/{DeleteAccountDialog,PersonalInfoSection}.tsx`, `core/settings/FinykSection.tsx`, `core/designShowcase/sections/{DataDisplay,Forms}.tsx`, `modules/finyk/components/ManualExpenseSheet.tsx`, `modules/finyk/hooks/{useMonobankWebhook,usePrivatbank}.ts`, `modules/fizruk/components/{WorkoutTemplatesSection,workouts/ActiveWorkoutPanel}.tsx`, `modules/nutrition/components/{AddMealSheet,meal-sheet/SaveAsFood}.tsx`, `modules/nutrition/hooks/useNutritionCloudBackup.ts`, `modules/routine/components/DayProgressRing.tsx`, `shared/components/ui/{InputDialog,VoiceMicButton}.tsx`.

## Why

`OnboardingWizard` говорить «ти» (`Ти готовий?`, `Спробуй...`), `HubChat`/нуджі/retention-хінти — теж «ти». А `AuthPage`, профіль, помилки модулів — «ви» (`Введіть`, `Ваше ім'я`, `Спробуйте`, `Перевірте`). Перехід тону посеред одного флоу (онбординг → auth → перша операція в Finyk) збиває: юзер не розуміє, наскільки «офіційний» застосунок, і втрачає відчуття персональної комунікації, яке основа Sergeant-у як «персонального хабу».

Уніфікую на **«ти»** як домінувальний регістр і той, який задано брендом (модулі: «Фізрук», «Звіти про твій день», «Твій кашіш»).

Bonus-пункт із [топ-5 UX покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 1 / quick win.

## How to test

1. Відкрити сетинги Finyk, ввести пусті PrivatBank credentials → помилка тепер `«Введи Merchant ID та токен»`.
2. Профіль → personal info → placeholder тепер `«Твоє імʼя»`.
3. Auth → reset-password з порожнім email → `«Введи email…»`.
4. Voice-input на голосовій кнопці → відмова мікрофону → `«Спробуй ще раз»` / `«Перевір інтернет»`.
5. Routine progress ring → screen reader промовляє `«… Тапни для денного звіту»`.

## How AI-tested this PR

- [x] `pnpm exec prettier --write` на всіх 19 файлах — pass / unchanged.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` (з `apps/web`) — pass.
- [x] `grep -rE "Введіть|Виберіть|Натисніть|Спробуйте|Увійдіть|Перевірте|Поверніться|Вкажіть|Ваше ім" apps/web/src` — 0 matches.
- [x] No new `AI-DANGER` markers added.
- [x] Прозовий копірайт лишається українським + лише «ти» тон.

## AGENTS.md updated?

- [x] No — no new permanent rules

## Notes for follow-up

- `packages/finyk-domain/src/domain/budget.ts` — `«Вкажіть суму цілі більше 0»`. Shared package, тестується `apps/mobile/.../ManualExpenseSheet.test.tsx`. Оновлення вимагатиме синхронного оновлення тесту в mobile-частині — винесено в окремий PR.
- `apps/mobile/src/**` — той самий sweep потрібен там, але це окрема юрисдикція (Jest, не Vitest; native tap-handlers), окремий PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Ukrainian UI copy to informal "ти" across `apps/web` for a consistent tone with onboarding and brand. Affects labels, placeholders, errors, and one aria-label; no behavior changes.

- **Refactors**
  - Replaced formal phrases with informal ones (e.g., "Введіть" → "Введи", "Виберіть" → "Обери", "Ваше імʼя" → "Твоє імʼя").
  - Updated routine progress ring aria-label to use touch-friendly wording ("Натисніть" → "Тапни").
  - Follow-ups: leave `packages/finyk-domain` and `apps/mobile/**` for separate PRs.

<sup>Written for commit 01e9dcc638cf1bb745dfcebe882e8aeebeaa7e4e. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

