### PR TITLE
feat(web): drop 'ОПЕРАТИВНИЙ ЦЕНТР' tagline row in HubHeader (UI wave-2 #1)

### DIFF
--- a/apps/web/src/core/app/HubHeader.tsx
+++ b/apps/web/src/core/app/HubHeader.tsx
@@ -169,27 +169,15 @@ export function HubHeader({
         </div>
       </div>
 
-      {/* ── Row 2: Vertical bar + subtitle (hidden when shrunk) ── */}
-      <div
-        className={cn(
-          "flex items-center gap-1.5 mt-1.5 ml-[3px]",
-          "transition-all duration-300",
-          isShrunk && "opacity-0 h-0 mt-0 overflow-hidden",
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className="inline-block w-[3px] h-[14px] rounded-full bg-brand-500"
-        />
-        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-brand-700 dark:text-brand-400 select-none">
-          Оперативний центр
-        </span>
-      </div>
-
-      {/* ── Row 3: Greeting · date (hidden when shrunk) ───────── */}
+      {/* ── Row 2: Greeting · date (hidden when shrunk) ───────── */}
+      {/* Раніше тут було ще rows-2 з підписом «ОПЕРАТИВНИЙ ЦЕНТР» — */}
+      {/* він дублював wordmark «Sergeant» зверху. Лишаємо лише */}
+      {/* greeting+date, бо це справжній сигнальний шар (час доби, */}
+      {/* персональне звернення), а тег «оперативний центр» — */}
+      {/* брендовий шум, який забирав вертикальний простір. */}
       <p
         className={cn(
-          "mt-1.5 ml-[3px] text-[13px] leading-snug text-muted truncate",
+          "mt-2 ml-[3px] text-[13px] leading-snug text-muted truncate",
           "transition-all duration-300",
           isShrunk && "opacity-0 h-0 mt-0 overflow-hidden",
         )}


### PR DESCRIPTION
## What changed

`apps/web/src/core/app/HubHeader.tsx` — видалено 2-ий ряд header-у з підписом «ОПЕРАТИВНИЙ ЦЕНТР».

Було:
1. Sergeant wordmark + іконки (search, theme, user)
2. Вертикальна рисочка + uppercase «ОПЕРАТИВНИЙ ЦЕНТР»
3. Greeting + дата

Стало:
1. Sergeant wordmark + іконки
2. Greeting + дата

## Why

Ряд 2 дублював сам себе: wordmark на ряду 1 уже промовляв «Sergeant», а підпис «оперативний центр» — це brand-marketing-шум. На мобільному (≤640px) це додавало ~22 пкс вертикалі і піднімало fold-line, через що першу `FirstActionHeroCard` / hub-tabs частково обрізало.

Greeting + date — це справжній сигнальний шар: час доби (`Доброго ранку`/`вечора`) і персональне звернення для лог-інованих користувачів. Зберігаємо.

UI #1 з [топ-5 покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 2 medium.

## How to test

1. Mobile viewport (393×852, iPhone 14 Pro): header займає рівно 2 ряди — wordmark + greeting/date. На <40 пкс scroll headers shrinks (нижній ряд стискається до 0). На <120 пкс — header повністю ховається (`-translate-y-full`).
2. Desktop (≥640px): те саме; greeting лишається 13px / muted, fold-line піднялась ~22 пкс — більше місця під hero/dashboard.
3. Скрін-рідер: тег `<header>` уже має `aria-label`-овані children, додаткового SR-сигналу втрачено не було.

## How AI-tested this PR

- [x] `pnpm exec eslint src/core/app/HubHeader.tsx` — pass.
- [x] `pnpm exec prettier --write apps/web/src/core/app/HubHeader.tsx` — pass.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` (з `apps/web`) — pass.
- [x] `grep -r "Оперативний центр" apps packages` — 0 hits після зміни.

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant 'ОПЕРАТИВНИЙ ЦЕНТР' tagline row from `HubHeader`, leaving just the wordmark/actions and the greeting/date. This trims ~22px on mobile, lifts the fold so hero/tabs aren’t clipped, and keeps screen reader semantics unchanged.

<sup>Written for commit 965ff02f59885b807d398f403a55ae95389bbace. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

