### PR TITLE
feat(web): rename auth skip CTA to 'Поки що пропустити' + back-nav (UX wave-2 #3)

### DIFF
--- a/apps/web/src/core/App.tsx
+++ b/apps/web/src/core/App.tsx
@@ -163,17 +163,26 @@ function AppInner() {
     navigate(SIGN_IN_PATH);
   }, [navigate]);
 
-  // «Продовжити без акаунту» на /sign-in для cold-start користувача має
-  // завести його у FTUX splash (/welcome), а не на порожній дашборд.
-  // Інакше тап «Вже маю акаунт» → назад стає тихим dead-end-ом, який
-  // пропускає онбординг назавжди.
+  // «Поки що пропустити» на /sign-in:
+  // 1. cold-start (онбординг не завершений) → /welcome (replace) — як раніше,
+  //    щоб не «з’їсти» FTUX splash.
+  // 2. warm-start, юзер прийшов з застосунку (натиснув user-icon у HubHeader,
+  //    `location.key !== "default"`) → `navigate(-1)`. Це повертає на ту саму
+  //    сторінку, з якої прийшов (наприклад, дашборд або сторінку модуля),
+  //    а не до replace-/, який для повторного юзера виглядає як no-op.
+  // 3. fallback (deep-link або refresh на /sign-in, `location.key === "default"`):
+  //    `navigate("/", { replace: true })` — як раніше.
   const leaveAuth = useCallback(() => {
     if (shouldShowOnboarding()) {
       navigate(WELCOME_PATH, { replace: true });
-    } else {
-      navigate("/", { replace: true });
+      return;
     }
-  }, [navigate]);
+    if (location.key !== "default") {
+      navigate(-1);
+      return;
+    }
+    navigate("/", { replace: true });
+  }, [navigate, location.key]);
 
   const leaveWelcome = useCallback(() => {
     navigate("/", { replace: true });

--- a/apps/web/src/core/auth/AuthPage.tsx
+++ b/apps/web/src/core/auth/AuthPage.tsx
@@ -411,7 +411,7 @@ export function AuthPage({ onContinueWithoutAccount }: AuthPageProps) {
                 className="w-full"
                 onClick={onContinueWithoutAccount}
               >
-                Продовжити без акаунту
+                Поки що пропустити
               </Button>
               <p className="text-center text-xs text-subtle leading-relaxed px-2">
                 Все працює локально. Акаунт потрібен лише для синхронізації між


### PR DESCRIPTION
## What changed

`apps/web/src/core/App.tsx` (`leaveAuth`) і `apps/web/src/core/auth/AuthPage.tsx` (CTA-копі):

- Кнопка `«Продовжити без акаунту»` → `«Поки що пропустити»`. Нова копія коректніше передає **тимчасовість** дії; «продовжити без акаунту» звучить як остаточне рішення.
- `leaveAuth()` отримав 3-rule logic:
  1. Cold-start (`shouldShowOnboarding()` → true) → `/welcome` (replace). Без змін.
  2. Warm-start (юзер прийшов на `/sign-in` із застосунку: натиснув user-icon у HubHeader; `location.key !== "default"`) → `navigate(-1)`. Повертає на ту саму сторінку, з якої прийшов (дашборд / сторінка модуля).
  3. Deep-link або refresh на `/sign-in` (`location.key === "default"`) → `navigate("/", { replace: true })` як fallback. Як раніше.

## Why

Раніше натискання `«Продовжити без акаунту»` для повторного юзера завжди робило `navigate("/", { replace: true })`. Якщо юзер уже на дашборді натиснув user-icon → відкрилась /sign-in → тапнув цю кнопку — back-nav сприймався як no-op: візуально на тій самій сторінці, без видимих змін.

`navigate(-1)` для warm-start зберігає очікувану модель: «я відкрив auth-екран, передумав, повернувся».

Cold-start гілка лишається без змін: для першого запуску (`shouldShowOnboarding()` true) — все одно ведемо у FTUX splash `/welcome`, інакше пропустимо онбординг назавжди.

UX #3 з [топ-5 покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 2 medium.

## How to test

Cold-start (новий юзер):
1. `localStorage.clear(); location.reload()` → `/welcome`.
2. Skip wizard. На дашборді — user-icon (auth ніколи не запускали).
3. Натиснути user-icon → `/sign-in`. Тап `«Поки що пропустити»` → `/welcome` (бо `shouldShowOnboarding()` все ще true для cold-start без локалки). Як раніше.

Warm-start (юзер з історією):
1. Закінчити онбординг.
2. На дашборді натиснути user-icon → `/sign-in`.
3. Тап `«Поки що пропустити»` → `navigate(-1)` повертає на дашборд. URL у history bar повинен показати рух назад, не replace.

Deep-link:
1. У новій вкладці прямо ввести `/sign-in` → `location.key === "default"`.
2. Тап `«Поки що пропустити»` → fallback `navigate("/", { replace: true })`.

## How AI-tested this PR

- [x] `pnpm exec eslint` (з `apps/web`) на `App.tsx` + `AuthPage.tsx` — pass.
- [x] `pnpm exec prettier --write` — unchanged.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [ ] Manual smoke (3 сценарії вище) — варто перевірити вручну.

## AGENTS.md updated?

- [x] No — no new permanent rules
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the auth skip button to "Поки що пропустити" and makes skipping on /sign-in navigate back when appropriate (UX wave‑2 #3). On skip: cold-start goes to /welcome (replace); warm-start returns to the previous page (navigate(-1)); deep-link/refresh falls back to "/" with replace.

<sup>Written for commit 414a66b7e1b7cc06bdcc7a57304dba5cb679bf75. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1128?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

