### PR TITLE
feat(web): gate FTUX dashboard noise behind hasRealEntry (UX wave-2 #1)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -337,36 +337,46 @@ export function HubDashboard({
         </StaggerChild>
       )}
 
-      {/* "Твій день" summary strip */}
-      <StaggerChild index={si++}>
-        <TodaySummaryStrip onOpenModule={onOpenModule} />
-      </StaggerChild>
+      {/* FTUX-гейт: до першого реального запису всі data-driven блоки
+       * приховуємо, бо вони порожні / сигнал «advice без даних».
+       * - TodaySummaryStrip — нулі по всіх модулях.
+       * - AssistantAdviceCard — coach працює на історії; нічого корисного.
+       * - DailyNudge — нудж за сценаріями, які ще не існують.
+       * Лишаємо: hero, checklist, module-bento (навігація), digest-fter.
+       * Після `hasRealEntry === true` блок з’являється цілісним пакетом. */}
+      {hasRealEntry && (
+        <>
+          {/* "Твій день" summary strip */}
+          <StaggerChild index={si++}>
+            <TodaySummaryStrip onOpenModule={onOpenModule} />
+          </StaggerChild>
 
-      {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
-       * картки показували пораду на день, але рендерились як два
-       * незалежних блоки з різним візуальним chrome. Об’єднання під
-       * одним SectionHeading знижує card-density і дає зрозуміти,
-       * що ці елементи логічно одного класу — пораджу-стрічка. */}
-      <StaggerChild index={si++}>
-        <section className="space-y-2">
-          <SectionHeading as="h2" size="xs" className="!px-0">
-            Підказки
-          </SectionHeading>
-          <AssistantAdviceCard
-            insight={coachInsightText}
-            loading={coachLoading}
-            error={coachError}
-            onRefresh={coachRefresh}
-          />
-          {activeNudge && !reengagement.show && (
-            <DailyNudge
-              nudge={activeNudge}
-              sessionDays={sessionDays}
-              onDismiss={() => setNudgeDismissed(true)}
-            />
-          )}
-        </section>
-      </StaggerChild>
+          {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
+           * картки показували пораду на день, але рендерились як два
+           * незалежних блоки з різним візуальним chrome. Обʼєднання
+           * під одним SectionHeading знижує card-density (#1130). */}
+          <StaggerChild index={si++}>
+            <section className="space-y-2">
+              <SectionHeading as="h2" size="xs" className="!px-0">
+                Підказки
+              </SectionHeading>
+              <AssistantAdviceCard
+                insight={coachInsightText}
+                loading={coachLoading}
+                error={coachError}
+                onRefresh={coachRefresh}
+              />
+              {activeNudge && !reengagement.show && (
+                <DailyNudge
+                  nudge={activeNudge}
+                  sessionDays={sessionDays}
+                  onDismiss={() => setNudgeDismissed(true)}
+                />
+              )}
+            </section>
+          </StaggerChild>
+        </>
+      )}
 
       {/* MODULE CARDS — 2×2 bento grid */}
       <StaggerChild index={si++}>
@@ -435,32 +445,34 @@ export function HubDashboard({
         </section>
       </StaggerChild>
 
-      {/* «Аналітика» секція: insights-panel + weekly-digest. Обидва —
-       * data-driven блоки на історії, які раніше рендерились без
-       * групувального заголовка і виглядали як ще «дві картки» серед
-       * ~6 інших. Один SectionHeading робить очевидним, що це окремий
-       * шар, на відміну від одноразової «Підказки». */}
-      <StaggerChild index={si++}>
-        <section className="space-y-2">
-          <SectionHeading as="h2" size="xs" className="!px-0">
-            Аналітика
-          </SectionHeading>
-          <HubInsightsPanel
-            items={rest}
-            onOpenModule={openInsightTarget}
-            onDismiss={dismiss}
-          />
-
-          {digestExpanded ? (
-            <WeeklyDigestCard onCollapse={() => setDigestExpanded(false)} />
-          ) : showDigestFooter ? (
-            <WeeklyDigestFooter
-              fresh={digestFresh}
-              onExpand={() => setDigestExpanded(true)}
+      {/* «Аналітика» секція (FTUX-гейт): insights-panel + weekly-digest —
+       * обидва data-driven блоки на історії. До першого реального запису
+       * insights пусті, а digest промовляє «нічого не було за тиждень».
+       * Гейтимо за hasRealEntry. SectionHeading з #1130 знижує
+       * card-density, а гейт — FTUX-noise. */}
+      {hasRealEntry && (
+        <StaggerChild index={si++}>
+          <section className="space-y-2">
+            <SectionHeading as="h2" size="xs" className="!px-0">
+              Аналітика
+            </SectionHeading>
+            <HubInsightsPanel
+              items={rest}
+              onOpenModule={openInsightTarget}
+              onDismiss={dismiss}
             />
-          ) : null}
-        </section>
-      </StaggerChild>
+
+            {digestExpanded ? (
+              <WeeklyDigestCard onCollapse={() => setDigestExpanded(false)} />
+            ) : showDigestFooter ? (
+              <WeeklyDigestFooter
+                fresh={digestFresh}
+                onExpand={() => setDigestExpanded(true)}
+              />
+            ) : null}
+          </section>
+        </StaggerChild>
+      )}
 
       {/* Motivational footer */}
       <MotivationalFooter />


### PR DESCRIPTION
## What changed

`apps/web/src/core/hub/HubDashboard.tsx` — гейтю 5 data-driven блоків за `hasRealEntry`:

- `TodaySummaryStrip`
- `AssistantAdviceCard`
- `DailyNudge`
- `HubInsightsPanel`
- `WeeklyDigestFooter` / `WeeklyDigestCard`

До першого реального запису ці блоки приховані. Після `hasRealEntry === true` вони з'являються разом, як «unlock-пакет».

## Why

Раніше FTUX-юзер бачив на дашборді:

1. StreakIndicator (0 streak)
2. **FirstActionHeroCard** — основний CTA «зроби свій перший запис»
3. ModuleChecklist
4. **TodaySummaryStrip** — порожній рядок з нулями
5. **AssistantAdviceCard** — coach без історії = пуста картка
6. **DailyNudge** — нудж за сценаріями, які ще не існують
7. Module-bento
8. **HubInsightsPanel** — 0 інсайтів
9. **WeeklyDigest** — «за тиждень нічого не сталося»

5 з 9 секцій (виділені) — порожні placeholder-и, що створюють візуальний шум і відволікають від єдиного важливого CTA. Користувач не розуміє, **що саме** робити: «це що, я вже маю якісь нулі? чи треба натиснути hero-кнопку? чи це нудж згори?»

Після гейту FTUX-дашборд лишає тільки релевантне: streak, hero, checklist, module-bento (навігація), footer. Як тільки юзер зробив перший запис — `hasRealEntry` flip-ить → 5 блоків з'являються пакетом, що підсилює celebration-момент і робить «unlock» прикметним.

UX #1 з [топ-5 покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 2 medium.

## How to test

1. `localStorage.clear(); location.reload()` → онбординг → дашборд.
2. Очікування: дашборд показує StreakIndicator + FirstActionHeroCard + ModuleChecklist + Module-bento + Footer. **Жодних нулів у TodaySummary / advice / nudge / insights / digest**.
3. Виконати перший реальний запис (Finyk transaction → manual income/expense).
4. Повернутись на дашборд → 5 нових блоків з'явились разом (TodaySummary, AssistantAdvice, DailyNudge if applicable, HubInsightsPanel, WeeklyDigestFooter).

## How AI-tested this PR

- [x] `pnpm exec eslint src/core/hub/HubDashboard.tsx` — pass.
- [x] `pnpm exec prettier --write` — unchanged.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.

## AGENTS.md updated?

- [x] No
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty, data-driven dashboard blocks for FTUX by gating them behind `hasRealEntry`. After the first real entry, all hidden blocks unlock together.

- **New Features**
  - Gated until `hasRealEntry`: `TodaySummaryStrip`, `AssistantAdviceCard`, `DailyNudge`, `HubInsightsPanel`, `WeeklyDigestFooter`/`WeeklyDigestCard`.
  - Before first entry, show only: `StreakIndicator`, `FirstActionHeroCard`, `ModuleChecklist`, module bento, `MotivationalFooter`.

<sup>Written for commit 12c049170f513c057fd7297e06bfbc7f764dd7a1. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1129?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard now provides a cleaner first-time user experience. Analytics, daily summaries, and suggestions are deferred until after you create your first entry, reducing clutter during onboarding and helping new users focus on essentials first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->