### PR TITLE
feat(web): group dashboard cards under 'Підказки'/'Аналітика' headings (UI wave-2 #3)

### DIFF
--- a/apps/web/src/core/hub/HubDashboard.tsx
+++ b/apps/web/src/core/hub/HubDashboard.tsx
@@ -342,25 +342,31 @@ export function HubDashboard({
         <TodaySummaryStrip onOpenModule={onOpenModule} />
       </StaggerChild>
 
-      {/* Assistant advice — hide error state */}
+      {/* «Підказки» секція: AssistantAdvice + DailyNudge — обидві
+       * картки показували пораду на день, але рендерились як два
+       * незалежних блоки з різним візуальним chrome. Об’єднання під
+       * одним SectionHeading знижує card-density і дає зрозуміти,
+       * що ці елементи логічно одного класу — пораджу-стрічка. */}
       <StaggerChild index={si++}>
-        <AssistantAdviceCard
-          insight={coachInsightText}
-          loading={coachLoading}
-          error={coachError}
-          onRefresh={coachRefresh}
-        />
-      </StaggerChild>
-
-      {activeNudge && !reengagement.show && (
-        <StaggerChild index={si++}>
-          <DailyNudge
-            nudge={activeNudge}
-            sessionDays={sessionDays}
-            onDismiss={() => setNudgeDismissed(true)}
+        <section className="space-y-2">
+          <SectionHeading as="h2" size="xs" className="!px-0">
+            Підказки
+          </SectionHeading>
+          <AssistantAdviceCard
+            insight={coachInsightText}
+            loading={coachLoading}
+            error={coachError}
+            onRefresh={coachRefresh}
           />
-        </StaggerChild>
-      )}
+          {activeNudge && !reengagement.show && (
+            <DailyNudge
+              nudge={activeNudge}
+              sessionDays={sessionDays}
+              onDismiss={() => setNudgeDismissed(true)}
+            />
+          )}
+        </section>
+      </StaggerChild>
 
       {/* MODULE CARDS — 2×2 bento grid */}
       <StaggerChild index={si++}>
@@ -429,9 +435,16 @@ export function HubDashboard({
         </section>
       </StaggerChild>
 
-      {/* Secondary content */}
+      {/* «Аналітика» секція: insights-panel + weekly-digest. Обидва —
+       * data-driven блоки на історії, які раніше рендерились без
+       * групувального заголовка і виглядали як ще «дві картки» серед
+       * ~6 інших. Один SectionHeading робить очевидним, що це окремий
+       * шар, на відміну від одноразової «Підказки». */}
       <StaggerChild index={si++}>
-        <div className="space-y-2">
+        <section className="space-y-2">
+          <SectionHeading as="h2" size="xs" className="!px-0">
+            Аналітика
+          </SectionHeading>
           <HubInsightsPanel
             items={rest}
             onOpenModule={openInsightTarget}
@@ -446,7 +459,7 @@ export function HubDashboard({
               onExpand={() => setDigestExpanded(true)}
             />
           ) : null}
-        </div>
+        </section>
       </StaggerChild>
 
       {/* Motivational footer */}


### PR DESCRIPTION
## What changed

`apps/web/src/core/hub/HubDashboard.tsx` — додано візуальне групування карток через `SectionHeading`:

- **«Підказки»**: `AssistantAdviceCard` + `DailyNudge` — обидві порадо-картки на день.
- **«Аналітика»**: `HubInsightsPanel` + `WeeklyDigestFooter`/`WeeklyDigestCard` — data-driven блоки на історії.
- `Модулі` heading вже існував — без змін.

## Why

HubDashboard рендерив 6+ карток без жодної візуальної ієрархії: TodaySummaryStrip, AssistantAdviceCard, DailyNudge, Module-bento, HubInsightsPanel, WeeklyDigest. Вони рендерились як рівноправні плаваючі блоки в `space-y-4` контейнері — `<Card>` з різним внутрішнім chrome, без групування, без заголовків.

Юзер не міг зрозуміти, які з цих карток споріднені:
- AssistantAdviceCard і DailyNudge — обидві видають пораду на день, але виглядали як два конкуруючі блоки.
- HubInsightsPanel і WeeklyDigest — обидва дашбордять історію, але один був над module-bento, інший — внизу.

Заголовки `«Підказки»` та `«Аналітика»` додають миттєвий context: один погляд → один рівень узагальнення. Це класичний UX-патерн для високої щільності інформації — Material Design «card group with heading», iOS HIG «sectioned list».

UI #3 з [топ-5 покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 2 medium.

## How to test

1. Зробити перший реальний запис (transactions у Finyk).
2. На дашборді — пройтись зверху-вниз:
   - StreakIndicator
   - Hero / FirstActionHeroCard
   - ModuleChecklist (FTUX)
   - TodaySummaryStrip
   - **«Підказки»** heading + AssistantAdvice + DailyNudge (якщо активний)
   - **«Модулі»** heading + bento grid (як було)
   - **«Аналітика»** heading + HubInsightsPanel + WeeklyDigest
   - MotivationalFooter
3. Перевірити, що `space-y-2` всередині секцій тримає однакову висоту — heading додає лише 1.5em зверху.
4. Перевірити SR-навігацію: тепер 3 `<h2>` орієнтири на дашборді (Підказки / Модулі / Аналітика).

## How AI-tested this PR

- [x] `pnpm exec eslint src/core/hub/HubDashboard.tsx` — pass.
- [x] `pnpm exec prettier --write` — unchanged.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.

## AGENTS.md updated?

- [x] No

## Notes for follow-up

- TodaySummaryStrip ще не під заголовком — це окремий «glanceable» layer (today's snapshot). Можливо в майбутньому додати «Сьогодні» heading, але зараз він і так візуально ізольований через свій formatting.
- Не зачіпає базовий Card/CardHeader chrome — тут тільки додавання `SectionHeading` обгорток. Можна догіти інакше у наступному PR (наприклад, об'єднати AssistantAdvice + DailyNudge в один компонент, не два).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups dashboard cards into two clear sections — «Підказки» (daily tips) and «Аналітика» (history insights) — to improve scan-ability and reduce clutter in `HubDashboard.tsx`. Supports UI wave‑2 #3.

- **New Features**
  - Grouped `AssistantAdviceCard` + `DailyNudge` under «Підказки» and `HubInsightsPanel` + `WeeklyDigest*` under «Аналітика» using `SectionHeading`.
  - Kept the existing «Модулі» section; normalized spacing with `section.space-y-2`.
  - Added three h2 landmarks for faster navigation and better screen reader support.

<sup>Written for commit f8e271ad89faa088f47a1d7a7c60a99ae9d3ff33. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1130?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard layout improved with dedicated sections for better content organization and navigation
  * New "Tips" section consolidates advice cards and daily recommendations in a grouped area with section heading
  * New "Analytics" section reorganizes insights panel and weekly digest content under a labeled section heading for easier access to performance metrics and data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->