### PR TITLE
feat(web): persist OnboardingWizard state + add 'Пропустити' CTA (UX wave-2 #5)

### DIFF
--- a/apps/web/src/core/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/core/onboarding/OnboardingWizard.tsx
@@ -11,6 +11,11 @@ import { Button } from "@shared/components/ui/Button";
 import { Card, type CardVariant } from "@shared/components/ui/Card";
 import { Icon } from "@shared/components/ui/Icon";
 import { useCelebration } from "@shared/components/ui/CelebrationModal";
+import {
+  safeReadStringLS,
+  safeRemoveLS,
+  safeWriteLS,
+} from "@shared/lib/storage";
 import { BrandLogo } from "../app/BrandLogo";
 import { trackEvent, ANALYTICS_EVENTS } from "../observability/analytics";
 import {
@@ -55,6 +60,59 @@ interface WizardState {
   picks: string[];
   goals: OnboardingGoals;
   stepStartedAt: number;
+}
+
+// Персистентний сліпк wizard-state-у. v1 — резерв на майбутнє: якщо
+// форма `WizardState` змінюється, бампаємо ключ в v2/v3, щоб легасі-
+// кеш не поламав візард.
+const ONBOARDING_WIZARD_STATE_KEY = "sergeant.onboarding.wizardState.v1";
+
+interface PersistedWizardState {
+  step: OnboardingStepId;
+  picks: string[];
+  goals: OnboardingGoals;
+}
+
+// Не пишемо `stepStartedAt` в localStorage — він релевантний лише в межах
+// поточного маунту (міряє час на степ для аналітики; посля рефрешу це
+// була б неправдива тривалість «від відкривання вкладки»).
+function loadPersistedWizardState(defaultState: WizardState): WizardState {
+  const raw = safeReadStringLS(ONBOARDING_WIZARD_STATE_KEY);
+  if (!raw) return defaultState;
+  try {
+    const data = JSON.parse(raw) as PersistedWizardState;
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !ONBOARDING_STEPS.includes(data.step) ||
+      !Array.isArray(data.picks) ||
+      !data.goals ||
+      typeof data.goals !== "object"
+    ) {
+      return defaultState;
+    }
+    return {
+      step: data.step,
+      picks: data.picks.filter((p): p is string => typeof p === "string"),
+      goals: { ...EMPTY_GOALS, ...data.goals },
+      stepStartedAt: Date.now(),
+    };
+  } catch {
+    return defaultState;
+  }
+}
+
+function persistWizardState(state: WizardState): void {
+  const payload: PersistedWizardState = {
+    step: state.step,
+    picks: state.picks,
+    goals: state.goals,
+  };
+  safeWriteLS(ONBOARDING_WIZARD_STATE_KEY, payload);
+}
+
+function clearPersistedWizardState(): void {
+  safeRemoveLS(ONBOARDING_WIZARD_STATE_KEY);
 }
 
 type WizardAction =
@@ -642,12 +700,26 @@ export function OnboardingWizard({
   ) => void;
   variant?: "modal" | "fullPage";
 }) {
-  const [state, dispatch] = useReducer(wizardReducer, {
-    step: "welcome",
-    picks: [],
-    goals: { ...EMPTY_GOALS },
-    stepStartedAt: Date.now(),
-  });
+  // Ледача ініціалізація з localStorage: якщо юзер вже починав візард і рефрешнув
+  // вкладку / прийшов знову пізніше — відновлюємо step + picks + goals,
+  // щоб не було «старт з нуля». Раніше рефреш фактично ресетив візард,
+  // роблячи їх лопатою професійної фрустрації.
+  const [state, dispatch] = useReducer(
+    wizardReducer,
+    {
+      step: "welcome",
+      picks: [],
+      goals: { ...EMPTY_GOALS },
+      stepStartedAt: Date.now(),
+    } as WizardState,
+    loadPersistedWizardState,
+  );
+
+  // Пишемо на кожну зміну. Обсяг даних малий (3 фільди) — писати без
+  // дебаунсу безпечно і не впливає на perf-якість.
+  useEffect(() => {
+    persistWizardState(state);
+  }, [state]);
   const [showPermissions, setShowPermissions] = useState(false);
   const { confetti, CelebrationComponent } = useCelebration();
 
@@ -744,6 +816,7 @@ export function OnboardingWizard({
     markFirstActionStartedAt();
     markFirstActionPending();
     markOnboardingDone();
+    clearPersistedWizardState();
 
     // Show celebration before navigating
     confetti("Готово!", "Твій Sergeant налаштовано. Час діяти!", "high");
@@ -753,6 +826,26 @@ export function OnboardingWizard({
       onDone(null, { intent: "vibe_empty", picks: chosen });
     }, 800);
   }, [state.picks, state.goals, onDone, confetti]);
+
+  // «Пропустити онбординг» — хуткий вихід для юзерів, що вже знають
+  // Sergeant або відкрили додаток вдруге (інший браузер / приватний вікно),
+  // єй не варто проходити весь flow знову. Зберігаємо всі модулі (як fallback
+  // в `finish()` при порожньому picks), не пишемо goals, позначаємо
+  // first-action-pending і markOnboardingDone. Без конфетті: юзер вибрав skip
+  // — celebration була б dissonance.
+  const handleSkip = useCallback(() => {
+    saveVibePicks([...ALL_MODULES] as never[]);
+    trackEvent(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+      intent: "skip",
+      picksCount: ALL_MODULES.length,
+      hasGoals: false,
+    });
+    markFirstActionStartedAt();
+    markFirstActionPending();
+    markOnboardingDone();
+    clearPersistedWizardState();
+    onDone(null, { intent: "skip", picks: [...ALL_MODULES] });
+  }, [onDone]);
 
   const stepIdx = ONBOARDING_STEPS.indexOf(state.step);
 
@@ -805,7 +898,23 @@ export function OnboardingWizard({
   const currentStepIdx = showPermissions ? ONBOARDING_STEPS.length : stepIdx;
   const content = (
     <div className="space-y-4">
-      <StepIndicator current={currentStepIdx} total={totalSteps} />
+      <div className="flex items-center justify-between gap-3">
+        <StepIndicator current={currentStepIdx} total={totalSteps} />
+        {/* Skip-CTA: прибирає 3-крокову опору, дає юзеру вийти у дашборд
+         * за один тап. Зберігає всі модулі (як fallback `finish()`),
+         * але без goals і без celebration. Показ — на всіх степах,
+         * крім останнього (permissions): там є власний onComplete,
+         * skip туди б додав 3-й конкуруючий CTA. */}
+        {!showPermissions && (
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="text-xs font-medium text-muted hover:text-text underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded-md px-1.5 py-0.5"
+          >
+            Пропустити
+          </button>
+        )}
+      </div>
       <div key={stepKeyRef.current} className={transitionClass}>
         {!showPermissions && state.step === "welcome" && (
           <WelcomeStep onContinue={animatedNext} />


### PR DESCRIPTION
## What changed

`apps/web/src/core/onboarding/OnboardingWizard.tsx`:

**Персистенція state:**
- Новий ключ localStorage `sergeant.onboarding.wizardState.v1` (versioned для майбутніх schema-bump-ів).
- `loadPersistedWizardState(default)` — lazy initializer для `useReducer`. Читає `{step, picks, goals}`, валідує (`ONBOARDING_STEPS.includes(step)`, `Array.isArray(picks)`, …), при неуспіху повертає default.
- `useEffect(() => persistWizardState(state), [state])` — sync на кожну зміну.
- `clearPersistedWizardState()` викликається у `finish()` і у новому `handleSkip()`.
- `stepStartedAt` **не** персистимо — це метрика часу на крок, після рефрешу була б фіктивна тривалість.

**Skip-CTA:**
- Нова кнопка `«Пропустити»` справа над контентом, поряд з `StepIndicator`.
- Показ: всі степи окрім `permissions` (там вже є `onComplete`, skip додав би 3-й конкуруючий CTA).
- Дія: `saveVibePicks([...ALL_MODULES])` як fallback (як `finish()` при порожньому picks), `markFirstActionStartedAt() + markFirstActionPending() + markOnboardingDone()`, `clearPersistedWizardState()`, `trackEvent(ONBOARDING_COMPLETED, {intent: 'skip', picksCount: 4, hasGoals: false})`, `onDone(null, {intent: 'skip', picks: ALL_MODULES})`.
- Без celebration: юзер свідомо обрав skip, конфетті були б dissonance.

## Why

OnboardingWizard працював на чистому `useReducer` без жодної персистенції — будь-який рефреш / переключення вкладки = wizard стартував з нульового кроку, втрачаючи всі вже зроблені picks і goals. Frustration-точка для юзерів з crash-ом браузера або просто випадковим reload.

Skip був відсутній зовсім: щоб дістатися дашборду, треба було пройти 3 кроки. Це особливо важливо для юзерів, які вже знайомі з Sergeant (запустили на іншому пристрої / приватному вікні) — їм не потрібен onboarding-tour.

UX #5 з [топ-5 покращень](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 2 medium.

## How to test

**Persistence:**
1. `localStorage.clear(); location.reload()` → відкриється wizard з welcome.
2. Натиснути «Далі» → modules.
3. Обрати 2 модулі.
4. Натиснути «Далі» → goals.
5. Refresh сторінки (`Ctrl+R`).
6. Очікування: wizard відкривається на step `goals` з тими самими 2-ма обраними модулями. Якщо щось не так — fallback у welcome (з лагами treats як corrupt-state).
7. Завершити → перевірити, що `localStorage.getItem('sergeant.onboarding.wizardState.v1') === null`.

**Skip:**
1. На будь-якому з кроків `welcome / modules / goals` натиснути `«Пропустити»` (top-right).
2. Очікування: wizard зникає, юзер на дашборді, `shouldShowOnboarding() === false`. У devtools localStorage — `sergeant.vibePicks` має всі 4 модулі, `sergeant.onboarding.wizardState.v1` видалений. Аналітика — `onboarding_completed` event з `intent: 'skip'`.
3. На кроці `permissions` кнопки `«Пропустити»` немає (як задумано).

## How AI-tested this PR

- [x] `pnpm exec eslint src/core/onboarding/OnboardingWizard.tsx` — pass (no `no-raw-local-storage` issue: всі звернення через `safeReadStringLS` / `safeWriteLS` / `safeRemoveLS`).
- [x] `pnpm exec prettier --write` — applied.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [ ] Manual smoke (persistence + skip сценарії) — варто перевірити вручну.

## AGENTS.md updated?

- [x] No
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the onboarding wizard state and add a “Пропустити” (Skip) button so users can resume after refresh or exit onboarding in one click. Addresses UX wave‑2 #5 by reducing friction for returning users.

- **New Features**
  - Persist step, picks, and goals in localStorage under 'sergeant.onboarding.wizardState.v1' with lazy init, validation, write-through on changes, and clearing on finish/skip (do not persist step timing).
  - Add Skip CTA next to the step indicator on all steps except permissions; selects all modules, marks onboarding done and first action pending, clears persisted state, and fires an analytics event with intent: 'skip' (no celebration).

<sup>Written for commit 22415665d8d311992faa3bc3036295dce41396d3. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

