### PR TITLE
docs(docs): document border-radius rhythm + annotate preset (UI wave-4 #3)

### DIFF
--- a/docs/design/RADIUS-RHYTHM.md
+++ b/docs/design/RADIUS-RHYTHM.md
@@ -1,0 +1,108 @@
+# Border-radius rhythm
+
+> **Audience:** anyone writing UI in `apps/web` or `apps/mobile`.
+> **Goal:** prevent border-radius drift — pick the right radius from a small,
+> size-driven scale instead of inventing a one-off value.
+
+Sergeant uses a **size-driven** radius scale: bigger element = bigger
+radius. The scale is already encoded in shared components
+(`Button`, `Card`, `Modal`, …) — you almost never need to write
+`rounded-*` directly. When you do, pick from this table.
+
+## The scale
+
+| Token                   | Tailwind class | px    | Where to use                                                                                         |
+| ----------------------- | -------------- | ----- | ---------------------------------------------------------------------------------------------------- |
+| **Swatch**              | `rounded-sm`   | 2 px  | Tiny coloured markers (heatmap cells, chart legend dots, macro-pie swatches).                        |
+| **Marker**              | `rounded-md`   | 6 px  | 5 × 5 / 6 × 6 px elements (checkbox squares, badge chips, in-place pill labels).                     |
+| **Control (sm)**        | `rounded-xl`   | 12 px | `Button` size `xs`/`sm`; icon-buttons `≤ 40 px`; small input chips; `IconButton` rail.               |
+| **Card / Control (md)** | `rounded-2xl`  | 16 px | `Button` size `md`/`lg`; `Card` `radius="lg"` (default content surfaces); `IconButton` ≥ 44 px.      |
+| **Hero / Control (xl)** | `rounded-3xl`  | 24 px | `Button` size `xl`; `Card` `radius="xl"` (hero / module-branded); `Modal` shell; bottom-sheet shell. |
+| **Pill**                | `rounded-full` | ∞     | FAB; circular avatars; status dots; module-bento tile gradients; toggle pills.                       |
+
+There is **no** semantic alias layer (`rounded-card` / `rounded-control`).
+Tailwind already gives you the right primitive — adding aliases just
+creates two names for the same thing, which causes more drift, not less.
+
+## The rules
+
+1. **Prefer the component, not the class.** If a `Button`/`Card`/`Modal`
+   already exists, use it with the appropriate size/variant. Don't
+   re-create one with raw `<div className="bg-panel rounded-2xl …">`.
+
+2. **Match the size to the element.** A 48 × 48 px icon-button uses
+   `rounded-2xl`, not `rounded-xl` (too sharp for that footprint) and
+   not `rounded-3xl` (over-rounded — it starts looking like a pill).
+   A 32 × 32 icon-button uses `rounded-xl`, not `rounded-2xl`.
+
+3. **Don't introduce `rounded-lg` (8 px)** — it sits between Marker and
+   Control with no clear semantic role. The 53 existing usages are a
+   legacy of pre-rhythm code; new code should round up to `rounded-xl`
+   or down to `rounded-md` based on the element's footprint.
+
+4. **Don't introduce `rounded-4xl` / `rounded-5xl`** — those tokens
+   exist in the Tailwind preset for one-off illustration uses (e.g.
+   onboarding hero blob). They are **not** part of the regular rhythm.
+
+5. **`rounded-full` is reserved for circles, FABs, and pills.** Don't
+   use it on rectangular surfaces "to look modern" — that's a different
+   visual language (Memoji-iOS) and clashes with Sergeant's bento.
+
+## Anti-patterns
+
+```tsx
+// ❌ Hardcoded `rounded-md` on a 48-px icon-button — too sharp,
+// looks like a chunky checkbox.
+<button className="w-12 h-12 rounded-md …" />
+
+// ✅ 48-px → `rounded-2xl` (matches Card / Button size=md).
+<button className="w-12 h-12 rounded-2xl …" />
+```
+
+```tsx
+// ❌ Inline 12-px button with `rounded-3xl` — over-rounded; reads as
+// a pill, conflicts with the Button component's xl size mapping.
+<button className="h-9 px-3 rounded-3xl …" />
+
+// ✅ Use the existing Button.
+<Button size="sm">…</Button>
+```
+
+```tsx
+// ❌ Ad-hoc rounded-lg for an inline chip — sits between Marker and
+// Control with no clear role.
+<span className="px-1.5 py-0.5 rounded-lg bg-brand-500/10 …" />
+
+// ✅ Marker (`rounded-md`) for chip-sized labels.
+<span className="px-1.5 py-0.5 rounded-md bg-brand-500/10 …" />
+```
+
+## How this is enforced
+
+Today: code review + this doc. There is no lint rule yet.
+
+If radius drift becomes a problem in the future, candidate rules:
+
+- Disallow `rounded-lg` outside of `packages/design-tokens` migration
+  paths.
+- Warn when raw `rounded-2xl` / `rounded-3xl` is used instead of
+  `<Card>` / `<Button>` for 100 × 100+ surfaces.
+- Disallow `rounded-4xl` / `rounded-5xl` outside of
+  `apps/web/src/core/onboarding/**`.
+
+## Why no semantic aliases?
+
+We considered adding `rounded-control` / `rounded-card` / `rounded-pill`
+in the Tailwind preset. We chose **not** to:
+
+- Aliases create two names for the same primitive (`rounded-card` and
+  `rounded-2xl`). New contributors search for one or the other and end
+  up with mixed usage — actively worse than the status quo.
+- The radius scale is already short (5 active steps); naming it twice
+  doesn't reduce cognitive load.
+- The component layer (`Card`, `Button`, `Modal`) already provides the
+  semantic indirection: `<Card radius="lg">` not
+  `<Card radius="rounded-2xl">`. That's where naming should live.
+
+If a future shape changes (e.g. all cards become 18 px instead of 16 px),
+the change happens in the component, not at the token level.

--- a/packages/design-tokens/tailwind-preset.js
+++ b/packages/design-tokens/tailwind-preset.js
@@ -236,7 +236,21 @@ const preset = {
       },
 
       // ═══════════════════════════════════════════════════════════════════
-      // BORDER RADIUS — Soft, organic, friendly shapes
+      // BORDER RADIUS — size-driven rhythm (see docs/design/RADIUS-RHYTHM.md)
+      //
+      // The active scale is intentionally short:
+      //   sm   →  2 px   swatch  (heatmap cells, chart legend dots)
+      //   md   →  6 px   marker  (checkbox squares, badge chips, <kbd>)
+      //   xl   → 12 px   control sm (Button xs/sm, icon-buttons ≤ 40 px)
+      //   2xl  → 16 px   control md / card (Button md/lg, Card default)
+      //   3xl  → 24 px   hero / sheet (Button xl, Card xl, Modal, sheets)
+      //   full →  ∞       pill (FAB, avatars, status dots)
+      //
+      // 4xl / 5xl exist for one-off illustration surfaces (onboarding
+      // hero blob); they are NOT part of the regular rhythm.
+      //
+      // Avoid `rounded-lg` (8 px) in new code — it sits between marker
+      // and control with no clear semantic role.
       // ═══════════════════════════════════════════════════════════════════
       borderRadius: {
         "2xl": "16px",


### PR DESCRIPTION
## What changed

1. **`docs/design/RADIUS-RHYTHM.md`** (new) — документує існуючий **size-driven** radius-scale: swatch / marker / control-sm / control-md / hero / pill. Включає таблицю use-cases, 5 правил, anti-patterns, і пояснення чому **не** додаємо semantic-aliases (`rounded-card`, `rounded-control`) — компонентний шар (`Card` / `Button` / `Modal`) уже забезпечує semantic indirection.
2. **`packages/design-tokens/tailwind-preset.js`** — inline-коментар над `borderRadius` блоком, що резюмує rhythm: `sm/md/xl/2xl/3xl/full` — активна шкала; `4xl/5xl` — one-off ілюстрації; `rounded-lg` — legacy.

## Why

Існуючий код уже має solid size-driven rhythm:
- `Card` (`radius="md/lg/xl"` → `rounded-xl/2xl/3xl`)
- `Button` (size → відповідний radius)
- `Modal` (`rounded-3xl`)
- FAB / avatars / dots (`rounded-full`)

Але це **не задокументовано**. У Tailwind preset немає жодного коментаря, чому є `4xl/5xl`, або чому Card має 3 розміри. Контрибутори приходять і пишуть raw `rounded-lg` (8 px — між marker і control, без semantic ролі — 53 файли в codebase) або інвент-ять `rounded-md` для 48-px hit-area (повинно бути `rounded-2xl` згідно з component scale).

19 файлів у `apps/web/src/core/` зараз вживають `rounded-lg`. Це не критично — більшість виглядає ок візуально — але **rhythm документально не закріплений**, тому drift лише прискорюється.

Цей PR — **soft-fix**: фіксує rhythm, дає контрибуторам референс, **не зачіпає існуючі файли**. Migration окремих outliers — окремо за потребою (можна robot-style через codemod, коли rhythm закріпиться у свідомості команди).

UI new#3 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #1.

## How to test

- Прочитати `docs/design/RADIUS-RHYTHM.md` end-to-end. Перевірити, що приклади відображають реальну дійсність (`Button` size mapping, `Card` radius prop, FAB `rounded-full`).
- Перевірити, що inline-коментар у preset не зламав Tailwind generation: `pnpm typecheck` pass, `pnpm lint` pass.

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [x] Жодних code-changes в існуючих компонентах — risk surface = 0 (новий .md + коментар у .js).

## AGENTS.md updated?

- [x] No — RADIUS-RHYTHM.md саме є документацією. AGENTS.md може на нього посилатися окремим PR при потребі.

## Notes for follow-up

Якщо у майбутньому потрібно мігрувати `rounded-lg` outliers до `rounded-xl`/`rounded-md`:
- 19 файлів у `apps/web/src/core/`, ~98 occurrences total.
- Безпечніше йти через codemod (jscodeshift), не sed.
- Перевіряти візуально кожне місце — деякі `rounded-lg` могли бути свідомим вибором (наприклад, mid-sized chip).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the border‑radius rhythm and clarified the Tailwind preset to prevent radius drift and standardize usage. Adds `docs/design/RADIUS-RHYTHM.md` (size‑driven scale, rules, anti‑patterns) and inline comments in `packages/design-tokens/tailwind-preset.js` that define the active tokens (`sm/md/xl/2xl/3xl/full`) and mark `rounded-lg` and `4xl/5xl` as legacy/one‑off.

<sup>Written for commit ee17c804dc428e5c317f24c089e4d4f72f70b84b. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1132?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design system guidelines for border-radius standards across components
  * Updated developer documentation with approved token values and usage recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->