### PR TITLE
feat(web): semantic amount-tone helpers + raw-color migrations (UI wave-4 #4)

### DIFF
--- a/apps/web/src/modules/finyk/FinykApp.tsx
+++ b/apps/web/src/modules/finyk/FinykApp.tsx
@@ -253,7 +253,7 @@ export default function App({
             <ModuleHeaderBackButton onClick={onBackToHub} />
           ) : (
             <div
-              className="shrink-0 w-10 h-10 rounded-xl bg-emerald-500/10 flex items-center justify-center text-emerald-600 dark:text-emerald-400 border border-emerald-500/15"
+              className="shrink-0 w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center text-success-strong dark:text-success border border-success/15"
               aria-hidden
             >
               <svg

--- a/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
+++ b/apps/web/src/modules/finyk/components/ManualExpenseSheet.tsx
@@ -322,7 +322,7 @@ export function ManualExpenseSheet({
                     }
                     className={
                       personal
-                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors tabular-nums"
+                        ? "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-success/10 text-success-strong dark:text-success border border-success/30 hover:bg-success/15 transition-colors tabular-nums"
                         : "px-2.5 py-1 rounded-full text-xs font-medium bg-panelHi text-muted border border-line hover:border-muted/50 transition-colors tabular-nums"
                     }
                     aria-label={

--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -209,7 +209,7 @@ function TxRowImpl({
             </span>
           )}
           {tx._source === "privatbank" && (
-            <span className="text-3xs bg-green-500/10 text-green-700 dark:text-green-400 px-1.5 py-0.5 rounded-full font-semibold shrink-0">
+            <span className="text-3xs bg-success/10 text-success-strong dark:text-success px-1.5 py-0.5 rounded-full font-semibold shrink-0">
               П24
             </span>
           )}

--- a/apps/web/src/modules/finyk/pages/Analytics.tsx
+++ b/apps/web/src/modules/finyk/pages/Analytics.tsx
@@ -12,6 +12,7 @@ import { SectionHeading } from "@shared/components/ui/SectionHeading";
 import { Skeleton } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { cn } from "@shared/lib/cn";
+import { signedDeltaClass } from "@shared/lib";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { CategoryPieChart } from "../components/charts/lazy";
 import { ChartFallback } from "../components/charts/ChartFallback";
@@ -175,7 +176,7 @@ const ComparisonRow = memo(function ComparisonRow({
               good === null
                 ? "text-muted"
                 : good
-                  ? "text-emerald-600 dark:text-emerald-400"
+                  ? "text-success-strong dark:text-success"
                   : "text-danger",
             )}
           >
@@ -342,7 +343,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
               </div>
               <div className="text-center">
                 <div className="text-2xs text-subtle mb-1">Дохід</div>
-                <div className="text-sm font-bold tabular-nums text-emerald-600 dark:text-emerald-400">
+                <div className="text-sm font-bold tabular-nums text-success-strong dark:text-success">
                   {summary.income.toLocaleString("uk-UA")} ₴
                 </div>
               </div>
@@ -351,9 +352,7 @@ export function Analytics({ mono, storage }: AnalyticsProps) {
                 <div
                   className={cn(
                     "text-sm font-bold tabular-nums",
-                    summary.balance >= 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : "text-danger",
+                    signedDeltaClass(summary.balance),
                   )}
                 >
                   {summary.balance >= 0 ? "+" : ""}

--- a/apps/web/src/shared/lib/amountTone.ts
+++ b/apps/web/src/shared/lib/amountTone.ts
@@ -1,0 +1,48 @@
+/**
+ * Semantic Tailwind classes for monetary amounts and signed deltas.
+ *
+ * Sergeant's tone palette intentionally distinguishes two intents:
+ *
+ *  1. **Transaction amount** (income vs expense): income gets a positive
+ *     accent, expense stays *neutral*. We don't want every spend to
+ *     feel "alarming red" — most expenses are normal life events.
+ *  2. **Signed delta** (balance, plan-vs-fact, savings): sign carries
+ *     real meaning, so + → success, − → danger, 0 → muted.
+ *
+ * Use the helper that matches your *intent*, not just the value:
+ *
+ *   <span className={transactionAmountClass(tx.amount)}>{fmt(tx.amount)}</span>
+ *   <span className={signedDeltaClass(plan - fact)}>{fmtSigned(...)}</span>
+ *
+ * Both helpers return tokens from `packages/design-tokens` (`success`,
+ * `danger`, `text`, `muted`) — never raw `text-emerald-XXX` /
+ * `text-red-XXX`. The semantic tokens already encode dark-mode
+ * contrast tuning via CSS variables, and they participate in the
+ * WCAG-AA `-strong` companion scheme (see AGENTS.md hard rule #9).
+ *
+ * If you find yourself reaching for `text-emerald-` / `text-green-` /
+ * `text-red-` to colour an amount, that's a code smell — use these
+ * helpers (or `text-success-strong` / `text-danger` directly).
+ */
+
+/**
+ * Класи для signed delta — баланс, дельта плану/факту, дельта ваги,
+ * ROI, savings rate, тощо. + → success, − → danger, 0 → muted.
+ */
+export function signedDeltaClass(value: number): string {
+  if (value > 0) return "text-success-strong dark:text-success";
+  if (value < 0) return "text-danger";
+  return "text-muted";
+}
+
+/**
+ * Класи для суми транзакції за Sergeant-філософією: income (+)
+ * виділяємо успіх-токеном, expense (−) лишаємо нейтральним
+ * `text-text`, бо "кожна витрата = тривога" — це anti-pattern.
+ *
+ * Якщо хочеш виділити over-budget transaction — обгортай у `cn()`
+ * з `signedDeltaClass`-логікою, не міняй цей хелпер.
+ */
+export function transactionAmountClass(amount: number): string {
+  return amount > 0 ? "text-success-strong dark:text-success" : "text-text";
+}

--- a/apps/web/src/shared/lib/index.ts
+++ b/apps/web/src/shared/lib/index.ts
@@ -98,6 +98,8 @@ export {
   pushKeys,
 } from "./queryKeys";
 
+export { signedDeltaClass, transactionAmountClass } from "./amountTone";
+
 export {
   safeReadLS,
   safeReadStringLS,


### PR DESCRIPTION
## What changed

1. **`apps/web/src/shared/lib/amountTone.ts`** (new) — два named-export-и:
   - `transactionAmountClass(amount)` — Sergeant-філософія: income `text-success-strong dark:text-success`, expense `text-text` (нейтральний).
   - `signedDeltaClass(value)` — класичний +/− семантика: `+ → text-success-strong`, `− → text-danger`, `0 → text-muted`.
   - Файл-doc-коментар явно проговорює: «`text-emerald-` / `text-green-` / `text-red-` в amount-контексті — code smell, бери ці хелпери».
2. **Міграції раw-color violations** (4 файли):
   - `Analytics.tsx` — trend-delta (`good → text-emerald-600`), income summary, balance summary → `text-success-strong dark:text-success` (через `signedDeltaClass()` для balance).
   - `TxRow.tsx` — P24 badge `bg-green-500/10 text-green-700 dark:text-green-400` → `bg-success/10 text-success-strong dark:text-success`.
   - `ManualExpenseSheet.tsx` — frequent-amount chip `bg-emerald-500/10 …` → `bg-success/10 text-success-strong …`.
   - `FinykApp.tsx` — fallback module-icon `bg-emerald-500/10 …` → `bg-success/10 …`.

## Why

**Інтент vs значення.** У застосунку розповзалося два різних інтенти кольорування сум, без чіткого розрізнення:
- *Транзакція* (TxRow): income яскраво-зелений, expense нейтральний — свідомий Sergeant-вибір не алярмувати на кожну витрату.
- *Signed delta* (MonthlyPlanCard, balance, savings rate): + green, − red, 0 muted — сигн обов'язково.

Без чітких хелперів контрибутори вгадували: ManualExpenseSheet взяв emerald-500 raw (не на палітрі), Analytics взяв emerald-600/400 raw (правильна тональність, але дублює `text-success-strong`).

**Hard rule #9 (AGENTS.md)** вимагає `-strong` companion для saturated brand fills проти `text-white`. Прямі `text-emerald-XXX` обходять цей контракт — токен `text-success-strong` пов'язаний з `--c-success-strong` CSS-змінною, що вже включає WCAG-AA tuning.

## How to test

1. **TxRow P24 badge** — відкрити Finyk → Транзакції, знайти запис з джерелом privatbank → бачити зелений «П24» pill з тим самим відтінком, що інші success-elements (was: трохи інший emerald-700/400).
2. **Analytics summary** — Finyk → Аналітика → Card з income/balance числами → колір не змінився візуально (bef/aft tonally identical).
3. **ManualExpenseSheet** — Finyk → Додати витрату → frequent-amount chip → консистентна success-границя.
4. **FinykApp fallback header** — якщо `onBackToHub` not provided → fallback emerald icon → success-токени.

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass (4 файли touched).
- [x] `pnpm exec eslint` — pass (без warnings/errors).
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [x] Skipped: `text-blue-400`/`text-yellow-400`/`text-green-400` у `DailyPlanCard.tsx` — це чарт-легенда для макросів (білки/жири/вуглеводи), не amount-sign. Семантично коректний raw-color.

## AGENTS.md updated?

- [x] No code rule changed; `signedDeltaClass`/`transactionAmountClass` — opt-in helpers, не enforced lint-rule. Якщо у майбутньому drift повернеться — easy to add a `sergeant-design/no-raw-amount-colors` rule (мабуть, у форматі `restricted-syntax` з allowlist для chart-legends).

UI new#4 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add semantic helpers for monetary amounts and replace raw green/red classes with design tokens for consistent, accessible styling. This standardizes income/expense and signed delta colors across Finyk and removes direct `emerald/green` usage.

- New Features
  - Added `transactionAmountClass(amount)` and `signedDeltaClass(value)` in `@shared/lib` for amount tone semantics.
  - Helpers return `text-success-strong`, `text-danger`, `text-muted`, or `text-text` (no raw colors).

- Refactors
  - `Analytics.tsx`: trend delta, income, and balance now use `text-success-strong dark:text-success` and `signedDeltaClass`.
  - `TxRow.tsx`: PrivatBank “П24” badge moved to `bg-success/10 text-success-strong dark:text-success`.
  - `ManualExpenseSheet.tsx` and `FinykApp.tsx`: replaced `emerald` variants with `success` tokens for chips and the fallback icon.

<sup>Written for commit 65bb3ce9b4a2841d5b78ffd7cba0326b53936f26. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

