### PR TITLE
docs(docs): empty-states tier guide + migrate WorkoutTemplates card (UI wave-4 #1)

### DIFF
--- a/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
+++ b/apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx
@@ -4,6 +4,8 @@ import { Input } from "@shared/components/ui/Input";
 import { Button } from "@shared/components/ui/Button";
 import { Card } from "@shared/components/ui/Card";
 import { ConfirmDialog } from "@shared/components/ui/ConfirmDialog";
+import { EmptyState } from "@shared/components/ui/EmptyState";
+import { Icon } from "@shared/components/ui/Icon";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import { useToast } from "@shared/hooks/useToast";
 import { showUndoToast } from "@shared/lib/undoToast";
@@ -376,9 +378,13 @@ export function WorkoutTemplatesSection({
           </SectionHeading>
         </div>
         {(templates || []).length === 0 ? (
-          <div className="p-6 text-center text-sm text-subtle">
-            Поки немає шаблонів
-          </div>
+          <EmptyState
+            compact
+            module="fizruk"
+            icon={<Icon name="dumbbell" size={20} />}
+            title="Поки немає шаблонів"
+            description="Створи свій перший — кнопка вище."
+          />
         ) : (
           (templates || []).map((t) => (
             <div

--- a/docs/design/EMPTY-STATES.md
+++ b/docs/design/EMPTY-STATES.md
@@ -1,0 +1,171 @@
+# Empty states
+
+> **Audience:** anyone writing UI in `apps/web` or `apps/mobile`.
+> **Goal:** consistent treatment of "no data yet" — pick the right
+> tier for the surface, don't invent a one-off.
+
+Sergeant has a fully-featured `<EmptyState>` component
+(`apps/web/src/shared/components/ui/EmptyState.tsx`) with an animated
+icon, title/description/hint/example-preview/action slots, and module-
+accent tinting. Most module entry points already use it
+(`Transactions`, `Budgets`, `WorkoutCatalogSection`, `Exercise`,
+`Progress`, `RoutineCalendarPanel`, `LogCard`, `Analytics`, …).
+
+There are **three tiers** of empty-state treatment. Pick by surface.
+
+## Tier 1 — Full screen / hero
+
+When the module's primary surface has no data yet, use
+`<ModuleEmptyState>` (a curated wrapper over `<EmptyState>`):
+
+```tsx
+<ModuleEmptyState module="finyk" onAction={() => openAddSheet()} />
+```
+
+It comes with module-tuned copy, icon, hint, and an example-preview
+card — all per-module. Use this for the **first run** of a module.
+
+For non-module screens (Hub-search, Reports), use the bare
+`<EmptyState>` and pass copy yourself.
+
+## Tier 2 — Compact / inline-card
+
+When a sub-card inside a populated screen has nothing to show
+(e.g. "Saved templates" card with no templates yet, but the rest of
+the screen has data), use `<EmptyState compact>`:
+
+```tsx
+<EmptyState
+  compact
+  icon={<Icon name="dumbbell" size={20} />}
+  title="Поки немає шаблонів"
+  description="Створи свій перший — кнопка вище."
+  module="fizruk"
+/>
+```
+
+`compact` shrinks the icon (40 px instead of 56 px) and the padding
+(`py-8` instead of `py-14`). It's the right size for a card-internal
+empty surface (~120-180 px tall).
+
+**Don't repeat the action** if a primary CTA is already visible on
+the same screen. The empty state is descriptive, not a duplicate
+button.
+
+## Tier 3 — Inline text (≤ 1 line)
+
+For tiny cards — chart legends, mini-stats inside an analytics grid,
+sheet sub-sections — a single muted line is correct. `EmptyState`
+would dominate an 80 px stat-card.
+
+```tsx
+{statsRows.length === 0 ? (
+  <div className="text-xs text-muted">Поки що порожньо</div>
+) : (
+  …
+)}
+```
+
+Style guide for tier 3:
+
+- `text-xs text-muted` (or `text-subtle` for an even quieter note).
+- Center if the surrounding card centers content; otherwise left-align.
+- One short sentence. No CTA, no icon. If you need either — go up to
+  tier 2.
+
+## When tier 1 vs tier 2 vs tier 3?
+
+Decide by **surface size** and **whether this is the user's first
+time**, not by container type:
+
+| Surface                                                       | Tier   |
+| ------------------------------------------------------------- | ------ |
+| Module landing page, no data yet (first run)                  | 1      |
+| Empty page after a filter (e.g. "no transactions in March")   | 1 or 2 |
+| Card section with no items (e.g. saved templates list)        | 2      |
+| Mini stat-card (40-120 px tall)                               | 3      |
+| Action-sheet sub-section (e.g. "no templates assigned today") | 3      |
+
+## Copy guidelines
+
+- **Ukrainian, "ти" form** (Sergeant tone — see Wave 1 PR #1126).
+- Title is a state, not an instruction: "Поки немає шаблонів", not
+  "Створи шаблон". The action button carries the verb.
+- Description is one sentence; if you can't say it in one, the
+  empty-state is too complex for this surface — ladder to tier 2 / 1.
+- Hint (tier 1) is a _helpful aside_, not a duplicate of description.
+  Good: "Порада: підключи Monobank — імпорт автоматично." Bad:
+  "Тут зараз порожньо."
+
+## Anti-patterns
+
+```tsx
+// ❌ Tier-1 EmptyState inside a 100-px tall stat-card.
+// The icon is bigger than the card, looks broken.
+<div className="bg-panelHi rounded-2xl px-3 py-3">
+  <SectionHeading>Топ страв</SectionHeading>
+  <EmptyState icon={<Icon name="utensils" size={24} />}
+              title="Ще немає улюблених страв"
+              description="…" />
+</div>
+
+// ✅ Tier 3 — one muted line.
+<div className="bg-panelHi rounded-2xl px-3 py-3">
+  <SectionHeading>Топ страв</SectionHeading>
+  {top.length === 0 ? (
+    <div className="text-xs text-muted">Поки що порожньо</div>
+  ) : …}
+</div>
+```
+
+```tsx
+// ❌ Tier-3 bare text on a full module page, first run.
+// User has no idea what this module does or how to start.
+{
+  txs.length === 0 && (
+    <p className="text-xs text-subtle">Транзакцій ще немає.</p>
+  );
+}
+
+// ✅ Tier 1 — ModuleEmptyState with action.
+{
+  txs.length === 0 && (
+    <ModuleEmptyState module="finyk" onAction={() => openManualExpense()} />
+  );
+}
+```
+
+```tsx
+// ❌ Action button duplicated — the page already has a "+ Новий
+// шаблон" button at the top, and the empty state shows another one
+// 60 px below it. Visual noise; user clicks one of them at random.
+<>
+  <Button onClick={startNew}>+ Новий шаблон</Button>
+  <Card>
+    <EmptyState
+      compact title="Поки немає шаблонів"
+      action={<Button onClick={startNew}>Створити</Button>} />
+  </Card>
+</>
+
+// ✅ Empty state is descriptive only; the CTA above is visible.
+<>
+  <Button onClick={startNew}>+ Новий шаблон</Button>
+  <Card>
+    <EmptyState
+      compact title="Поки немає шаблонів"
+      description="Створи свій перший — кнопка вище." />
+  </Card>
+</>
+```
+
+## How this is enforced
+
+Today: code review + this doc.
+
+If empty-state drift becomes a problem, candidate rules:
+
+- Disallow bare `<p>Поки … немає…</p>` patterns outside of files
+  marked with `// eslint-disable-next-line sergeant-design/empty-state-tier`.
+- Warn when `<EmptyState compact>` is used in a container ≥ 250 px tall
+  (probably wants tier 1).


### PR DESCRIPTION
## What changed

1. **`docs/design/EMPTY-STATES.md`** (new) — три-tier-pattern для empty-states:
   - **Tier 1** (`ModuleEmptyState` / `EmptyState`) — module landing, first run.
   - **Tier 2** (`EmptyState compact`) — card sub-section.
   - **Tier 3** (bare `<p className="text-xs text-muted">…</p>`) — tiny stat-card (≤ 120 px).
   - Decision-table (surface size → tier), copy guidelines (ти-форма, title=стан а не інструкція), 3 anti-patterns з прикладами.
2. **`apps/web/src/modules/fizruk/components/WorkoutTemplatesSection.tsx`** — мігрував `<div className="p-6 text-center text-sm text-subtle">Поки немає шаблонів</div>` → `<EmptyState compact module="fizruk" icon={<Icon name="dumbbell" size={20} />} title=… description="Створи свій перший — кнопка вище." />`.

## Why

`<EmptyState>` уже багатий і встановлений (animated icon, title, hint, example-preview, action, module-accent — 20 файлів використовують). Більшість module-screen-ів — `Transactions`, `Budgets`, `WorkoutCatalogSection`, `Exercise`, `Progress`, `RoutineCalendarPanel`, `LogCard`, `Analytics`, … — вже використовують його. Але:
- **Немає документу «коли який tier»** — контрибутори вгадують.
- **Деякі screen-level fallback-и лишилися bare-text** (наприклад, `WorkoutTemplatesSection`'s "Поки немає шаблонів" — centered subtitle у full-card з висотою ~80 px, дисонує з рештою фізрук-сторінок).

Доc-перший підхід (як у [#1132 RADIUS-RHYTHM](https://github.com/Skords-01/Sergeant/pull/1132)): закріплюємо pattern документально + мігруємо одне найвидиміше місце як приклад. Інші bare-text сценарії свідомо лишаю — їх tier обрано правильно (deliberately: LogCard mini-stats, FinykSection settings inline-action, FizrukDayPlanSheet sub-section).

## Decision: чому НЕ мігрую інші bare-texts

| Файл                                       | Decision                       | Reason                                                         |
| ------------------------------------------ | ------------------------------ | -------------------------------------------------------------- |
| `LogCard.tsx` x3 «Поки що порожньо»        | Skip — tier 3 correct          | 80-100 px stat-cards; EmptyState compact дамінує surface       |
| `FinykSection.tsx` «Поки немає категорій…» | Skip — tier 3 correct          | input + «Додати» button вже видимі прямо вище                  |
| `FizrukDayPlanSheet.tsx` «Шаблонів поки…»  | Skip — tier 3 correct          | Sheet sub-section з action-instruction in copy                 |

## How to test

1. Відкрити Fizruk → Тренування. До створення першого шаблону:
   - Up: «+ Новий шаблон» button.
   - Below it: card «Збережені шаблони» з compact EmptyState (dumbbell icon, fizruk-tinted, "Поки немає шаблонів", "Створи свій перший — кнопка вище.").
   - Перевірити: animation entry плавна, accent-tint правильний (fizruk colors), no duplicated CTA inside empty state.
2. Прочитати `docs/design/EMPTY-STATES.md` — впевнитися що table узгоджена з реальним кодом, а anti-patterns відображають реальні случаї.

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass.
- [x] `pnpm exec eslint` — pass.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.

UI new#1 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #3.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a three-tier empty-state guide and updates Fizruk WorkoutTemplates to use `EmptyState compact`, replacing bare text. This aligns empty-state UX and avoids duplicate CTAs.

- **New Features**
  - Added `docs/design/EMPTY-STATES.md` with a 3-tier model (full, compact, inline), a decision table, copy rules, and anti-patterns.

- **Refactors**
  - Replaced inline text in `WorkoutTemplatesSection` with `EmptyState` (`compact`, `module="fizruk"`, dumbbell icon, clear title/description) to match other Fizruk screens.

<sup>Written for commit 9a9ebe709153e13badb3650cf9e2593daa3b195c. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

