### PR TITLE
feat(web): shape-aware skeletons for tx list / budgets / digest (UI wave-4 #2)

### DIFF
--- a/apps/web/src/core/insights/WeeklyDigestCard.tsx
+++ b/apps/web/src/core/insights/WeeklyDigestCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { cn } from "@shared/lib/cn";
 import { Icon } from "@shared/components/ui/Icon";
+import { Skeleton, SkeletonText } from "@shared/components/ui/Skeleton";
 import { Tooltip } from "@shared/components/ui/Tooltip";
 import {
   useWeeklyDigest,
@@ -130,20 +131,41 @@ function ModuleBlock({ moduleKey, data }) {
   );
 }
 
+// Shape-aware loader: matches the real digest layout — 4 module rows
+// (icon + 2 lines of summary text). When the digest lands, only the
+// content swaps in; the rough shape is already on screen.
 function LoadingSpinner() {
   return (
-    <div className="flex items-center justify-center gap-2 py-6">
-      <svg
-        className="motion-safe:animate-spin w-4 h-4 text-primary"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        aria-hidden
-      >
-        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
-      </svg>
-      <span className="text-xs text-muted">Генерую звіт тижня…</span>
+    <div
+      className="px-4 pb-4 space-y-2.5"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Генеруємо звіт тижня"
+    >
+      <span className="sr-only">Генеруємо звіт тижня…</span>
+      {Array(4)
+        .fill(0)
+        .map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "flex items-start gap-3 p-3 rounded-2xl border border-line bg-panel",
+              i === 0
+                ? "opacity-100"
+                : i === 1
+                  ? "opacity-85"
+                  : i === 2
+                    ? "opacity-65"
+                    : "opacity-45",
+            )}
+          >
+            <Skeleton className="w-9 h-9 rounded-xl shrink-0" />
+            <div className="flex-1 min-w-0 space-y-1.5 pt-0.5">
+              <SkeletonText className="w-1/3 h-3" />
+              <SkeletonText className="w-2/3 h-2.5" />
+            </div>
+          </div>
+        ))}
     </div>
   );
 }

--- a/apps/web/src/modules/finyk/pages/Budgets.tsx
+++ b/apps/web/src/modules/finyk/pages/Budgets.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { SectionHeading } from "@shared/components/ui/SectionHeading";
-import { Skeleton } from "@shared/components/ui/Skeleton";
+import { Skeleton, SkeletonBudgetBar } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
@@ -372,10 +372,17 @@ export function Budgets({
 
   if (loadingTx && realTx.length === 0) {
     return (
-      <div className="flex-1 overflow-y-auto px-4 pt-4 page-tabbar-pad space-y-3 max-w-4xl mx-auto w-full">
-        <Skeleton className="h-28 rounded-xl" />
-        <Skeleton className="h-20 opacity-80 rounded-xl" />
-        <Skeleton className="h-20 opacity-60 rounded-xl" />
+      <div
+        className="flex-1 overflow-y-auto px-4 pt-4 page-tabbar-pad space-y-3 max-w-4xl mx-auto w-full"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        {/* Shape-aware: header bar + 3 budget rows so the layout doesn't
+            reflow when data lands. */}
+        <Skeleton className="h-28 rounded-2xl" />
+        <SkeletonBudgetBar />
+        <SkeletonBudgetBar className="opacity-80" />
+        <SkeletonBudgetBar className="opacity-60" />
       </div>
     );
   }

--- a/apps/web/src/modules/finyk/pages/Transactions.tsx
+++ b/apps/web/src/modules/finyk/pages/Transactions.tsx
@@ -5,7 +5,7 @@ import { getCategory, getIncomeCategory, fmtAmt } from "../utils";
 import { manualExpenseToTransaction } from "@sergeant/finyk-domain/domain/transactions";
 import { mergeExpenseCategoryDefinitions, CURRENCY } from "../constants";
 import { Card } from "@shared/components/ui/Card";
-import { Skeleton } from "@shared/components/ui/Skeleton";
+import { SkeletonTransactionRow } from "@shared/components/ui/Skeleton";
 import { EmptyState } from "@shared/components/ui/EmptyState";
 import { Icon } from "@shared/components/ui/Icon";
 import { cn } from "@shared/lib/cn";
@@ -543,21 +543,25 @@ export function Transactions({
           </div>
         </Card>
 
-        {/* Skeleton */}
+        {/* Skeleton — shape-aware: matches a real TxRow (icon · 2-line
+            description · amount). Stagger fades down so the list feels
+            like it's "loading from the top" instead of pulsing as a slab. */}
         {activeLoading && activeTx.length === 0 && (
-          <div className="space-y-2">
+          <div className="space-y-2" aria-busy="true" aria-live="polite">
             {Array(10)
               .fill(0)
               .map((_, i) => (
-                <Skeleton
+                <SkeletonTransactionRow
                   key={i}
+                  module="finyk"
                   className={cn(
-                    "h-14",
-                    i % 3 === 0
+                    i < 3
                       ? "opacity-100"
-                      : i % 3 === 1
-                        ? "opacity-70"
-                        : "opacity-40",
+                      : i < 6
+                        ? "opacity-80"
+                        : i < 8
+                          ? "opacity-60"
+                          : "opacity-40",
                   )}
                 />
               ))}


### PR DESCRIPTION
## What changed

3 high-traffic loading surfaces переключив з generic block-skeletons / spinners на shape-aware варіанти, що вже існують в `Skeleton.tsx`:

| Файл                                         | Before                                                   | After                                                                                  |
| -------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| `modules/finyk/pages/Transactions.tsx`       | 10× `<Skeleton className="h-14">` (opacity 100/70/40)    | 10× `<SkeletonTransactionRow module="finyk">` (4-tier opacity 100/80/60/40)            |
| `modules/finyk/pages/Budgets.tsx`            | 3× generic block-skeletons                               | header h-28 + 3× `<SkeletonBudgetBar>` (header text + progress meter + footer chips)   |
| `core/insights/WeeklyDigestCard.tsx`         | `<svg animate-spin>` + "Генерую звіт тижня…"             | 4× module-row skeletons (icon + 2 lines, 4-tier opacity)                               |

Усі додано `aria-busy="true"` + `aria-live="polite"` для screen-reader-ів. WeeklyDigestCard також отримав `<span className="sr-only">Генеруємо звіт тижня…</span>` (раніше message ховався в текстовій ноді біля spinner-а — для assistive tech статус втрачався після переходу на skeleton).

## Why

Skeleton library уже містить shape-aware варіанти (`SkeletonTransactionRow`, `SkeletonBudgetBar`, `SkeletonHabitRow`, `SkeletonWorkoutSet`, `SkeletonMealCard`) — спеціально для того, щоб **layout не reflow-ив**, коли дані лендяться. Коли ці екрани використовують generic `<Skeleton h-14 />`, користувач бачить:

1. Pulsing block-slab → 
2. Все зникає / переставляється → 
3. Реальні рядки з'являються в інших позиціях.

Shape-aware skeleton дає одну фазу: "page вже в потрібній формі, content fills in." Особливо помітно на mono-imports у Finyk, де load-time може бути 1-3 сек.

WeeklyDigestCard окремо: `<svg animate-spin>` + текст — читається як «застрягло» (немає progress feedback). Skeleton рядки дають візуальний сигнал «звіт будується модуль за модулем».

## How to test

1. **Transactions**: Finyk → Транзакції → switch місяць (force re-fetch). Skeleton-list має 10 рядків формою як справжні TxRow (icon-square + 2 текстові лінії + сума справа), що поступово фейдять. Reflow при появі даних = 0 px.
2. **Budgets**: Finyk → Бюджети → cold load (clear localStorage). Page-level loader: hero card + 3 budget-bar skeletons з progress-meter shape. Не slab.
3. **WeeklyDigest**: Hub → Аналітика → Тижневий дайджест → tap «Згенерувати». 4 module-rows skeletons (різний opacity) → swap з real digest content. Screen-reader каже "Генеруємо звіт тижня…".

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass.
- [x] `pnpm exec eslint` — pass.
- [x] `pnpm exec tsc -p tsconfig.json --noEmit` — pass.
- [x] Skeleton-аудит: `WorkoutJournalSection`, `RoutineCalendarPanel`, `LogCard`, `Analytics`, `Progress`, `Measurements`, `Exercise`, `Programs`, `Workouts` — вже використовують shape-aware варіанти. Цей PR заповнює прогалини на 3 high-traffic екранах.

UI new#2 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced generic loaders with shape-aware skeletons for Transactions, Budgets, and Weekly Digest to reduce layout shifts and improve perceived speed. Added `aria-busy`/`aria-live` and sr-only text for better accessibility.

- **New Features**
  - Transactions: 10× `SkeletonTransactionRow` (4-tier opacity) replaces block skeletons; no reflow; `aria-busy`/`aria-live`.
  - Budgets: header skeleton + 3× `SkeletonBudgetBar` replaces block placeholders; `aria-busy`/`aria-live`.
  - Weekly Digest: spinner replaced with 4 module-row skeletons using `Skeleton`/`SkeletonText`; added sr-only status and `aria-busy`/`aria-live`.

<sup>Written for commit 72a92b9f93296f7b4cef3341e61cfdadb0279d3a. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1136?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned loading placeholders across insights, budgets, and transactions pages with layout-aware skeleton designs that better match the final content structure, providing improved visual continuity during data loading.
  * Enhanced accessibility with improved ARIA attributes and live region announcements, making loading states clearer for users relying on assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->