### PR TITLE
feat(web): Button.module prop redirects primary/secondary to module variants (UI wave-4 #5)

### DIFF
--- a/apps/web/src/modules/finyk/components/TxRow.tsx
+++ b/apps/web/src/modules/finyk/components/TxRow.tsx
@@ -437,6 +437,7 @@ function TxRowImpl({
           <div className="flex gap-2 pt-1">
             <Button
               variant="primary"
+              module="finyk"
               size="xs"
               onClick={saveSplits}
               disabled={Math.abs(remaining) >= 0.01}

--- a/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
+++ b/apps/web/src/modules/nutrition/components/meal-sheet/MacrosEditor.tsx
@@ -151,6 +151,7 @@ export function MacrosEditor({
             <Button
               type="button"
               variant="primary"
+              module="nutrition"
               size="sm"
               className="flex-1"
               onClick={confirmUnlink}

--- a/apps/web/src/shared/components/ui/Button.test.tsx
+++ b/apps/web/src/shared/components/ui/Button.test.tsx
@@ -109,4 +109,81 @@ describe("Button", () => {
     expect(cls).toMatch(/\bh-11\b/);
     expect(cls).toMatch(/\bw-11\b/);
   });
+
+  describe("module prop redirects neutral variants", () => {
+    it.each([
+      ["finyk", "bg-finyk-strong"],
+      ["fizruk", "bg-fizruk-strong"],
+      ["routine", "bg-routine-strong"],
+      ["nutrition", "bg-nutrition-strong"],
+    ] as const)(
+      "module=%s + variant=primary → renders %s solid",
+      (module, expectedBg) => {
+        const { getByRole } = render(
+          <Button module={module} variant="primary">
+            Go
+          </Button>,
+        );
+        expect(getByRole("button").className).toContain(expectedBg);
+      },
+    );
+
+    it.each([
+      ["finyk", "text-finyk-strong"],
+      ["fizruk", "text-fizruk-strong"],
+      ["routine", "text-routine-strong"],
+      ["nutrition", "text-nutrition-strong"],
+    ] as const)(
+      "module=%s + variant=secondary → renders %s soft",
+      (module, expectedFg) => {
+        const { getByRole } = render(
+          <Button module={module} variant="secondary">
+            Cancel
+          </Button>,
+        );
+        expect(getByRole("button").className).toContain(expectedFg);
+      },
+    );
+
+    it("destructive variant is NOT redirected even when module is set", () => {
+      // Delete buttons stay red inside any module — destructive intent
+      // overrides module branding.
+      const { getByRole } = render(
+        <Button module="fizruk" variant="destructive">
+          Delete
+        </Button>,
+      );
+      const cls = getByRole("button").className;
+      expect(cls).toContain("bg-danger-strong");
+      expect(cls).not.toContain("bg-fizruk");
+    });
+
+    it("ghost / danger variants are pass-through (not redirected)", () => {
+      const { getByRole, rerender } = render(
+        <Button module="routine" variant="ghost">
+          Skip
+        </Button>,
+      );
+      expect(getByRole("button").className).toContain("bg-transparent");
+
+      rerender(
+        <Button module="routine" variant="danger">
+          Remove
+        </Button>,
+      );
+      expect(getByRole("button").className).toContain("bg-danger-soft");
+    });
+
+    it("explicit module variant ignores the `module` prop entirely", () => {
+      // If a caller already wrote `variant="finyk"`, the `module` prop is
+      // a no-op (no double-mapping or surprise inversion).
+      const { getByRole } = render(
+        <Button module="fizruk" variant="finyk">
+          X
+        </Button>,
+      );
+      expect(getByRole("button").className).toContain("bg-finyk-strong");
+      expect(getByRole("button").className).not.toContain("bg-fizruk-strong");
+    });
+  });
 });

--- a/apps/web/src/shared/components/ui/Button.tsx
+++ b/apps/web/src/shared/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import type { ModuleAccent } from "@sergeant/design-tokens";
 import { cn } from "../../lib/cn";
 
 /**
@@ -103,7 +104,42 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   loading?: boolean;
   /** Progress value 0-100 for determinate loading state */
   progress?: number;
+  /**
+   * When set, redirects the *neutral* `primary` / `secondary` variants to
+   * the host module's branded equivalent (e.g. `module="finyk"` +
+   * `variant="primary"` → renders the `finyk` solid variant; `+
+   * variant="secondary"` → renders the `finyk-soft` variant).
+   *
+   * Other variants (`ghost`, `danger`, `destructive`, `success`, the
+   * already-branded module variants) are passed through unchanged — a
+   * destructive Delete button stays red even inside a Fizruk screen.
+   *
+   * Use this when a CTA lives inside a single module's screen and should
+   * inherit that module's accent without forcing every call-site to
+   * pick the right variant string. Hub-level chrome (HubHeader,
+   * HubChat, dashboard) should leave `module` unset — it's intentionally
+   * brand-emerald so the four modules share a neutral parent.
+   */
+  module?: ModuleAccent;
   children?: ReactNode;
+}
+
+const MODULE_VARIANT_OVERRIDE: Record<
+  ModuleAccent,
+  Partial<Record<ButtonVariant, ButtonVariant>>
+> = {
+  finyk: { primary: "finyk", secondary: "finyk-soft" },
+  fizruk: { primary: "fizruk", secondary: "fizruk-soft" },
+  routine: { primary: "routine", secondary: "routine-soft" },
+  nutrition: { primary: "nutrition", secondary: "nutrition-soft" },
+};
+
+function resolveVariant(
+  variant: ButtonVariant,
+  module: ModuleAccent | undefined,
+): ButtonVariant {
+  if (!module) return variant;
+  return MODULE_VARIANT_OVERRIDE[module][variant] ?? variant;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -116,6 +152,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconOnly = false,
       loading = false,
       progress,
+      module,
       disabled,
       children,
       ...props
@@ -125,6 +162,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const isDisabled = disabled || loading;
     const hasProgress = typeof progress === "number" && progress >= 0;
     const needsCoarseMinTarget = iconOnly || size === "xs" || size === "sm";
+    const resolvedVariant = resolveVariant(variant, module);
 
     return (
       <button
@@ -143,8 +181,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           // Touch / coarse pointer: WCAG 2.5.5 / HIG ≥44×44px for compact controls.
           needsCoarseMinTarget &&
             "[@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px]",
-          // Variant
-          variants[variant],
+          // Variant (potentially redirected by `module` prop — see
+          // resolveVariant for the mapping table).
+          variants[resolvedVariant],
           // Size
           iconOnly ? iconSizes[size] : sizes[size],
           className,


### PR DESCRIPTION
## What changed

Додав `module?: ModuleAccent` prop у `<Button>`. Коли `module` встановлено, *нейтральні* variants `primary` / `secondary` redirect-яться на branded еквіваленти модуля:

| Виклик                                                 | Рендериться як                                                |
| ------------------------------------------------------ | ------------------------------------------------------------- |
| `<Button module="finyk" variant="primary">`            | `finyk` (bg-finyk-strong + emerald hover/active)              |
| `<Button module="finyk" variant="secondary">`          | `finyk-soft` (text-finyk-strong + finyk-soft surface)         |
| `<Button module="fizruk" variant="destructive">`       | `destructive` (bg-danger-strong) — **не** redirect-иться      |
| `<Button module="routine" variant="ghost">`            | `ghost` — pass-through                                        |
| `<Button module="routine" variant="danger">`           | `danger` — pass-through                                       |
| `<Button module="fizruk" variant="finyk">`             | `finyk` — explicit variant перевершує `module` (no double-map) |

Adoption (демонстрація):
- `TxRow.tsx`: split-edit «Зберегти» CTA → `module="finyk"`.
- `MacrosEditor.tsx`: «Відʼєднати» CTA в meal-sheet → `module="nutrition"`.

Решта 118 module-deep `<Button>`-ів **навмисно не мігрую** в цьому PR — це Wave 5 territory (з auto-derivation через `useModuleAccent()` context, з перевіркою кожного CTA, що дійсно `bg-emerald` не був інтенціональним вибором).

## Why

`<Button>` уже має branded variants (`finyk`, `fizruk`, `routine`, `nutrition` + `*-soft`). Інфраструктура є — але adoption-овий розрив:

1. **Module-deep CTA-и часто пишуть `variant="primary"` (default)** → рендерить brand-emerald в усіх 4 модулях. Візуальний дисонанс: ти у Routine (coral), тиснеш Зберегти, кнопка emerald.
2. **118 `<Button>` без `variant`** у `apps/web/src/modules/**` — всі дефолтяться в primary (emerald). Refactor «rename variant=primary → variant=fizruk» у Routine module — 30+ діффів, easy to miss.
3. **Wave 5 (UI#5)** хоче авто-derivation з `useModuleAccent()` context — але це ризиковано (всі 118 Button-ів зміняться скрізь, включно з тими, де emerald CTA був інтенціональний — наприклад, cross-module CTA на Hub).

Цей PR — opt-in перший крок. Дає авторам один-prop інструмент:
```tsx
<Button module="fizruk">Save</Button>  // тепер teal
```
…без зміни існуючої поведінки `<Button>` без `module`.

## Rationale (decisions)

- **Тільки `primary` / `secondary` redirect-яться.** Це єдині «нейтральні» variants, для яких module-color має сенс. `ghost` / `danger` мають свою інтенційну роль.
- **`destructive` НЕ redirect-иться.** Видалити habit у Routine — все ще червоний `bg-danger-strong`. Destructive intent перевершує module branding.
- **Explicit module variant перевершує `module` prop.** `<Button module="fizruk" variant="finyk">` → `finyk` (no surprise inversion / double mapping).
- **NOT auto-derived from `useModuleAccent()` context.** Опційно opt-in. Wave 5 розгляне, чи варто читати context default-но (там 118 Button-ів треба перевірити очима).

## How to test

1. **Нові unit-тести** покривають 11 кейсів (4 modules × 2 variants + 4 pass-through кейси). `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Button.test.tsx`. Усі 23 тести проходять.
2. **Manual:** Finyk → транзакція → Розділити → «Зберегти» — тепер emerald-strong (раніше був теж emerald, бо primary === brand === emerald, але це випадково — fizruk/routine/nutrition не мали б цього).
3. **Manual:** Nutrition → meal-sheet → Прив'язати продукт → Відʼєднати → CTA тепер lime-strong (а не emerald).

## How AI-tested this PR

- [x] `pnpm exec prettier --write` — pass.
- [x] `pnpm exec eslint` (apps/web) — pass.
- [x] `pnpm --filter @sergeant/web exec tsc -p tsconfig.json --noEmit` — pass.
- [x] `pnpm --filter @sergeant/web exec vitest run src/shared/components/ui/Button.test.tsx` — 23/23 pass (incl. 11 new).

UI new#5 з [топ-10 next-tier](https://app.devin.ai/sessions/72493af4308545af9a6e9dfcfd4cbaa0) — wave 4 #5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skords-01/sergeant/pull/1137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `module` prop to `<Button>` that redirects neutral variants `primary`/`secondary` to the screen’s module-branded variants. This enables module-accent CTAs without changing existing buttons and supports UI wave‑4 #5.

- **New Features**
  - `module?: ModuleAccent` on `<Button>`.
  - When set: `primary` → module solid, `secondary` → module soft.
  - `ghost`, `danger`, `destructive` are pass-through; explicit branded variants override `module`.
  - Adopted in `TxRow` (Save split, `module="finyk"`) and `MacrosEditor` (Unlink, `module="nutrition"`). Added 11 unit tests for mappings.

- **Migration**
  - No breaking changes; existing usage stays the same.
  - For module-scoped CTAs, set `module` to match the screen’s accent.

<sup>Written for commit b3773c05ca8c638cd3e44d858bb41f572ac74cd9. Summary will update on new commits. <a href="https://cubic.dev/pr/Skords-01/Sergeant/pull/1137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

